### PR TITLE
Switch e-mail threading to be enabled by default.

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -896,7 +896,7 @@ date=$(date --date=@${when} "${date_format}" 2>/dev/null)
 
 # ----------------------------------------------------------------------------
 # prepare some extra headers if we've been asked to thread e-mails
-if [ "${SEND_EMAIL}" == "YES" -a "${EMAIL_THREADING}" == "YES" ] ; then
+if [ "${SEND_EMAIL}" == "YES" -a "${EMAIL_THREADING}" != "NO" ] ; then
     email_thread_headers="In-Reply-To: <${chart}-${name}@${host}>\nReferences: <${chart}-${name}@${host}>"
 else
     email_thread_headers=

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -183,8 +183,9 @@ DEFAULT_RECIPIENT_EMAIL="root"
 # chart+alarm+host combination as a single thread.  This can help
 # simplify tracking of alarms, as it provides an easy wway for scripts
 # to corelate messages and also will cause most clients to group all the
-# messages together.  THis is off by default.
-#EMAIL_THREADING="YES"
+# messages together.  This is enabled by default, uncomment the line
+# below if you want to disable it.
+#EMAIL_THREADING="NO"
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
As discussed in PR #3768, email threading will be the default behavior after release 1.11.  This PR includes that change, and is intended to be merged once 1.11 has been released.  I've created it here simply so it doesn't get forgotten (and to hopefully make things a bit simpler for @ktsaou).