### PR TITLE
Small cleanups to python.d plugin module code.

### DIFF
--- a/python.d/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/python.d/python_modules/bases/FrameworkServices/SimpleService.py
@@ -43,7 +43,7 @@ class RuntimeCounters:
         return self.START_RUN < self.NEXT_RUN
 
 
-class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility, object):
+class SimpleService(Thread, PythonDLimitedLogger, OldVersionCompatibility):
     """
     Prototype of Service class.
     Implemented basic functionality to run jobs by `python.d.plugin`

--- a/python.d/python_modules/bases/loggers.py
+++ b/python.d/python_modules/bases/loggers.py
@@ -77,7 +77,7 @@ class LoggerCounters:
                                                                             dropped=self.dropped)
 
 
-class BaseLogger(object):
+class BaseLogger:
     def __init__(self, logger_name, log_fmt=DEFAULT_LOG_LINE_FORMAT, date_fmt=DEFAULT_LOG_TIME_FORMAT,
                  handler=logging.StreamHandler):
         """
@@ -140,7 +140,7 @@ class BaseLogger(object):
         self.logger.critical(' '.join(map(str, msg)), **kwargs)
 
 
-class PythonDLogger(object):
+class PythonDLogger:
     def __init__(self, logger_name=PYTHON_D_LOG_NAME, log_fmt=PYTHON_D_LOG_LINE_FORMAT):
         """
         :param logger_name: <str>

--- a/python.d/smartd_log.chart.py
+++ b/python.d/smartd_log.chart.py
@@ -129,7 +129,7 @@ def handle_os_error(method):
     return on_call
 
 
-class SmartAttribute(object):
+class SmartAttribute:
     def __init__(self, idx, normalized, raw):
         self.id = idx
         self.normalized = normalized


### PR DESCRIPTION
This removes unnecessary explicit inheritance from the builtin `object` type.  As explained in the commit, this inheritance is implicit in all Python classes, and thus making it explicit is generally discouraged.  Our own code only did it in 3 files.  The PyYAML and urllib3 modules bundled with Netdata do this all over the place, but I opted not to change those so that they are kept as close to the upstream versions as possible.
