### PR TITLE
coverity should still use firehol/netdata until we find a solution

### DIFF
--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -44,4 +44,4 @@ curl --progress-bar --form token="${token}" \
   --form file=@netdata-coverity-analysis.tgz \
   --form version="${version}" \
   --form description="netdata, real-time performance monitoring, done right." \
-  https://scan.coverity.com/builds?project=netdata%2Fnetdata
+  https://scan.coverity.com/builds?project=firehol%2Fnetdata


### PR DESCRIPTION
related to #4190