### PR TITLE
Make method in url service configurable

### DIFF
--- a/conf.d/python.d/httpcheck.conf
+++ b/conf.d/python.d/httpcheck.conf
@@ -66,6 +66,7 @@ chart_cleanup: 0
 #     url: 'http[s]://host-ip-or-dns[:port][path]'
 #                             # [required] the remote host url to connect to. If [:port] is missing, it defaults to 80
 #                             #   for HTTP and 443 for HTTPS. [path] is optional too, defaults to /
+#     method: GET             # [optional] the HTTP request method (POST, PUT, DELETE, HEAD etc.)
 #     redirect: yes           # [optional] If the remote host returns 3xx status codes, the redirection url will be
 #                             #   followed (default).
 #     status_accepted:        # [optional] By default, 200 is accepted. Anything else will result in 'bad status' in the

--- a/python.d/python_modules/bases/FrameworkServices/UrlService.py
+++ b/python.d/python_modules/bases/FrameworkServices/UrlService.py
@@ -23,6 +23,7 @@ class UrlService(SimpleService):
         self.proxy_user = self.configuration.get('proxy_user')
         self.proxy_password = self.configuration.get('proxy_pass')
         self.proxy_url = self.configuration.get('proxy_url')
+        self.method = self.configuration.get('method', 'GET')
         self.header = self.configuration.get('header')
         self.request_timeout = self.configuration.get('timeout', 1)
         self.tls_verify = self.configuration.get('tls_verify')
@@ -110,7 +111,7 @@ class UrlService(SimpleService):
         """
         url = url or self.url
         manager = manager or self._manager
-        response = manager.request(method='GET',
+        response = manager.request(method=self.method,
                                    url=url,
                                    timeout=self.request_timeout,
                                    retries=retries,


### PR DESCRIPTION
Fixes #4127

I took matter in my own hands :)
Verified working:
```yaml
service:
  url: http://localhost:8080/
  method: POST
```
with and without commented method parameter produces the following output on my nginx docker:
```
172.17.0.1 - - [22/Sep/2018:18:38:56 +0000] "GET / HTTP/1.1" 200 612 "-" "-" "-"
172.17.0.1 - - [22/Sep/2018:18:38:57 +0000] "GET / HTTP/1.1" 200 612 "-" "-" "-"
172.17.0.1 - - [22/Sep/2018:18:43:52 +0000] "POST / HTTP/1.1" 405 173 "-" "-" "-"
172.17.0.1 - - [22/Sep/2018:18:43:54 +0000] "POST / HTTP/1.1" 405 173 "-" "-" "-"
172.17.0.1 - - [22/Sep/2018:18:44:39 +0000] "GET / HTTP/1.1" 200 612 "-" "-" "-"
172.17.0.1 - - [22/Sep/2018:18:44:39 +0000] "GET / HTTP/1.1" 200 612 "-" "-" "-"
```
@l2isbad please review