### PR TITLE
[WIP] LGTM tag classification

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,6 +3,7 @@
 path_classifiers:
   library:
     - python.d/python_modules/third_party/*
+    - python.d/python_modules/urllib3/
     - python.d/python_modules/urllib3/*
     - python.d/python_modules/urllib3/util/*
     - python.d/python_modules/urllib3/packages/*

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,28 +1,29 @@
 # docs: https://lgtm.com/help/lgtm/lgtm.yml-configuration-file
 
 path_classifiers:
+  library:
+    - python.d/python_modules/third_party/*
+    - python.d/python_modules/urllib3/*
+    - python.d/python_modules/urllib3/util/*
+    - python.d/python_modules/urllib3/packages/*
+    - python.d/python_modules/urllib3/packages/backports/*
+    - python.d/python_modules/urllib3/packages/ssl_match_hostname/*
+    - python.d/python_modules/urllib3/contrib/*
+    - python.d/python_modules/urllib3/contrib/_securetransport/*
+    - python.d/python_modules/pyyaml2/*
+    - python.d/python_modules/pyyaml3/*
+    - node.d/node_modules/lib/*
+    - node.d/node_modules/lib/ber/*
+    - node.d/node_modules/asn1-ber.js
+    - node.d/node_modules/extend.js
+    - node.d/node_modules/net-snmp.js
+    - node.d/node_modules/pixl-xml.js
+    - web/lib/*
+    - web/css/*
   test:
-    - exclude: python.d/python_modules/third_party/*
-    - exclude: python.d/python_modules/urllib3/*
-    - exclude: python.d/python_modules/urllib3/util/*
-    - exclude: python.d/python_modules/urllib3/packages/*
-    - exclude: python.d/python_modules/urllib3/packages/backports/*
-    - exclude: python.d/python_modules/urllib3/packages/ssl_match_hostname/*
-    - exclude: python.d/python_modules/urllib3/contrib/*
-    - exclude: python.d/python_modules/urllib3/contrib/_securetransport/*
-    - exclude: python.d/python_modules/pyyaml2/*
-    - exclude: python.d/python_modules/pyyaml3/*
-    - exclude: node.d/node_modules/lib/*
-    - exclude: node.d/node_modules/lib/ber/*
-    - exclude: node.d/node_modules/asn1-ber.js
-    - exclude: node.d/node_modules/extend.js
-    - exclude: node.d/node_modules/net-snmp.js
-    - exclude: node.d/node_modules/pixl-xml.js
-    - exclude: web/lib/*
-    - exclude: web/css/*
-    - exclude: tests/web/*
-    - exclude: tests/web/lib/*
-    - exclude: tests/web/fixtures/*
-    - exclude: tests/profile/*
-    - exclude: tests/node.d/*
-    - exclude: tests/*
+    - tests/web/*
+    - tests/web/lib/*
+    - tests/web/fixtures/*
+    - tests/profile/*
+    - tests/node.d/*
+    - tests/*


### PR DESCRIPTION
According to this doc: https://help.semmle.com/lgtm-enterprise/user/help/file-classification.html#built-in-tags we need to classify files to tell LGTM what they are for, this way it can exclude them from alerts.

> As you can see, file classification is really a question of identifying the source or purpose of a file, and giving it a meaningful tag. Currently, the built-in tags are: docs, generated, library, template and test.

> These tags can then be used to determine which files should have their results hidden. Currently, if a file has any classification (that is, at least one tag), its results are filtered out from results and statistics.