### PR TITLE
nightly builds + coverity scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
     - name: "coverity"
       script: ./coverity-scan.sh
       env: INSTALL_COVERITY="true"
-      if: type = "cron"
+      if: type = cron
     - stage: "build"
       name: "ubuntu 14.04 (not containerized)"
       install: sudo apt-get install -y libcap2-bin zlib1g-dev uuid-dev fakeroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ stages:
   - name: release
     if: branch = master AND \
         type != pull_request AND \
-        ( type = cron OR commit_message =~ /[(major|minor|patch)]/ )
+        type = cron
+#        ( type = cron OR commit_message =~ /[(major|minor|patch)]/ ) # TODO allow creating release on commit message
 
 jobs:
   include:
@@ -40,7 +41,8 @@ jobs:
 #    - name: "Node.js"
 #      script: tests/run_nodejs.sh
     - name: "coverity"
-      script: INSTALL_COVERITY="true" ./coverity-scan.sh
+      script: ./coverity-scan.sh
+      env: INSTALL_COVERITY="true"
       if: type = "cron"
     - stage: "build"
       name: "ubuntu 14.04 (not containerized)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ jobs:
 #      env: CFLAGS='-O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1'
 #    - name: "Node.js"
 #      script: tests/run_nodejs.sh
+    - name: "coverity"
+      script: coverity-scan.sh || echo "FAILED"
+      if: type == "cron"
     - stage: "build"
       name: "ubuntu 14.04 (not containerized)"
       install: sudo apt-get install -y libcap2-bin zlib1g-dev uuid-dev fakeroot
@@ -52,16 +55,17 @@ jobs:
 #      script: ./.travis/containerized_build.sh alpine
     - name: "OSX"
       install: brew install fakeroot ossp-uuid
-      script: 
-        - fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it
+      script: fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it
       os: osx
     - stage: "release"
       name: "Docker"
       script: docker/build.sh
       env: REPOSITORY="netdata/netdata"
+      if: type == "cron"
     - name: "GitHub"
       install: sudo apt-get install -y gnupg libcap2-bin zlib1g-dev uuid-dev fakeroot
-      script: ./.travis/create_artifacts.sh
+      script: .travis/create_artifacts.sh
+      if: type == "cron"
       deploy:
         - provider: releases
           draft: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ stages:
   - test
   - build
   - name: release
-    if: branch = master AND \
-        type != pull_request AND \
-        type = cron
-#        ( type = cron OR commit_message =~ /[(major|minor|patch)]/ ) # TODO allow creating release on commit message
+    if: branch = master AND type = cron
+# TODO allow creating release on commit message
+#        type = master AND \    
+#        type != pull_request AND \
+#        ( type = cron OR commit_message =~ /[(major|minor|patch)]/ )
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
 #    - name: "Node.js"
 #      script: tests/run_nodejs.sh
     - name: "coverity"
-      script: coverity-scan.sh || echo "FAILED"
+      script: INSTALL_COVERITY="true" ./coverity-scan.sh
       if: type = "cron"
     - stage: "build"
       name: "ubuntu 14.04 (not containerized)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ stages:
   - test
   - build
   - name: release
-    if: branch = master AND type != pull_request
+    if: branch = master AND \
+        type != pull_request AND \
+        ( type = cron OR commit_message =~ /[(major|minor|patch)]/ )
 
 jobs:
   include:
@@ -39,7 +41,7 @@ jobs:
 #      script: tests/run_nodejs.sh
     - name: "coverity"
       script: coverity-scan.sh || echo "FAILED"
-      if: type == "cron"
+      if: type = "cron"
     - stage: "build"
       name: "ubuntu 14.04 (not containerized)"
       install: sudo apt-get install -y libcap2-bin zlib1g-dev uuid-dev fakeroot
@@ -61,11 +63,9 @@ jobs:
       name: "Docker"
       script: docker/build.sh
       env: REPOSITORY="netdata/netdata"
-      if: type == "cron"
     - name: "GitHub"
       install: sudo apt-get install -y gnupg libcap2-bin zlib1g-dev uuid-dev fakeroot
       script: .travis/create_artifacts.sh
-      if: type == "cron"
       deploy:
         - provider: releases
           draft: true

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
 
+# To run this script you need to provide API token. This can be done either by:
+#  - Putting token in ".coverity-token" file
+#  - Assigning token value to COVERITY_SCAN_TOKEN environment variable
+# Additionally script can install coverity tool on your computer. To do this just set environment variable INSTALL_COVERITY to "true"
+
 cpus=$(grep -c ^processor </proc/cpuinfo)
 [ -z "${cpus}" ] && cpus=1
 
 token="${COVERITY_SCAN_TOKEN}"
 ([ -z "${token}" ] && [ -f .coverity-token ]) && token="$(<.coverity-token)"
-[ -z "${token}" ] && \
-	echo >&2 "Save the coverity token to .coverity-token or export it as COVERITY_SCAN_TOKEN." && \
+if [ -z "${token}" ]; then
+	echo >&2 "Save the coverity token to .coverity-token or export it as COVERITY_SCAN_TOKEN."
 	exit 1
-
-# echo >&2 "Coverity token: ${token}"
+fi
 
 covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
 ([ -z "${covbuild}" ] && [ -f .coverity-build ]) && covbuild="$(<.coverity-build)"
-[ -z "${covbuild}" ] && \
-	echo "Save command the full filename of cov-build in .coverity-build" && \
-	exit 1
+if [ -z "${covbuild}" ]; then
+	echo "Cannot find 'cov-build' binary in \$PATH."
+	if [ $INSTALL_COVERITY != "" ]; then
+		echo "Installing coverity..."
+		mkdir /tmp/coverity
+        	curl -SL --data "token=${token}&project=netdata%2Fnetdata" https://scan.coverity.com/download/linux64 > /tmp/coverity_tool.tar.gz
+        	tar -x-C /tmp/coverity/ -f /tmp/coverity_tool.tar.gz
+	        sudo mv /tmp/coverity/cov-analysis-linux64-2017.07 /opt/coverity
+        	export PATH=${PATH}:/opt/coverity/bin/
+        else
+		echo "Saving command the full filename of cov-build in .coverity-build"
+		exit 1
+	fi
+fi
 
-[ ! -x "${covbuild}" ] && \
-	echo "The command ${covbuild} is not executable. Save command the full filename of cov-build in .coverity-build" && \
+if [ ! -x "${covbuild}" ]; then
+	echo "The command ${covbuild} is not executable. Save command the full filename of cov-build in .coverity-build"
 	exit 1
+fi
 
 version="$(grep "^#define PACKAGE_VERSION" config.h | cut -d '"' -f 2)"
 echo >&2 "Working on netdata version: ${version}"
@@ -27,12 +43,12 @@ echo >&2 "Working on netdata version: ${version}"
 echo >&2 "Cleaning up old builds..."
 make clean || exit 1
 
-[ -d "cov-int" ] && \
-	rm -rf "cov-int"
+[ -d "cov-int" ] && rm -rf "cov-int"
 
-[ -f netdata-coverity-analysis.tgz ] && \
-	rm netdata-coverity-analysis.tgz
+[ -f netdata-coverity-analysis.tgz ] && rm netdata-coverity-analysis.tgz
 
+autoreconf -ivf
+./configure --enable-plugin-nfacct --enable-plugin-freeipmi
 "${covbuild}" --dir cov-int make -j${cpus} || exit 1
 
 echo >&2 "Compressing data..."
@@ -44,4 +60,4 @@ curl --progress-bar --form token="${token}" \
   --form file=@netdata-coverity-analysis.tgz \
   --form version="${version}" \
   --form description="netdata, real-time performance monitoring, done right." \
-  https://scan.coverity.com/builds?project=firehol%2Fnetdata
+  https://scan.coverity.com/builds?project=netdata%2Fnetdata

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -27,7 +27,7 @@ if [ -z "${covbuild}" ]; then
 	        sudo mv /tmp/coverity/cov-analysis-linux64-2017.07 /opt/coverity
         	export PATH=${PATH}:/opt/coverity/bin/
         else
-		echo "Saving command the full filename of cov-build in .coverity-build"
+		echo "Save command the full filename of cov-build in .coverity-build"
 		exit 1
 	fi
 fi


### PR DESCRIPTION
- Stabilizes number of builds
- Enables automatic coverity scans and closes #4190

Two things needs to be done via travis GUI:
- enable cron based builds
- add `COVERITY_SCAN_TOKEN` variable