### PR TITLE
use flake8 instead of pylint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
     - stage: "lint"
       name: "python"
       install: skip
-      script: docker run --rm -v $(pwd):/code eeacms/pylint || echo "OK"
+      script: docker run -ti --rm -v $(pwd):/apps alpine/flake8:3.5.0 --max-line-length=120 --exclude=third_party,urllib3,pyyaml3,pyyaml2 python.d/ plugins.d/python.d.plugin || echo "OK"
     - name: "javascript"
       install: skip
       script: docker run -it --rm -v $(pwd)/web:/code eeacms/jslint --color /code/web/*.js /code/plugins.d/node.d.plugin/*.js /code/node.d/*.js /code/node.d/node_modules/netdata.js


### PR DESCRIPTION
pylint produces too much not needed noise. Using flake8 is much faster and gives better UX.

Also changed max line length to 120 chars.

Relates to #4167