### PR TITLE
Python.d PEP 8 cleanup, modules A-C

### DIFF
--- a/python.d/apache.chart.py
+++ b/python.d/apache.chart.py
@@ -26,63 +26,65 @@ CHARTS = {
         'options': [None, 'apache Lifetime Avg. Response Size', 'bytes/request',
                     'statistics', 'apache.bytesperreq', 'area'],
         'lines': [
-            ["size_req"]
+            ['size_req']
         ]},
     'workers': {
         'options': [None, 'apache Workers', 'workers', 'workers', 'apache.workers', 'stacked'],
         'lines': [
-            ["idle"],
-            ["busy"],
+            ['idle'],
+            ['busy'],
         ]},
     'reqpersec': {
         'options': [None, 'apache Lifetime Avg. Requests/s', 'requests/s', 'statistics',
                     'apache.reqpersec', 'area'],
         'lines': [
-            ["requests_sec"]
+            ['requests_sec']
         ]},
     'bytespersec': {
         'options': [None, 'apache Lifetime Avg. Bandwidth/s', 'kilobits/s', 'statistics',
                     'apache.bytesperreq', 'area'],
         'lines': [
-            ["size_sec", None, 'absolute', 8, 1000]
+            ['size_sec', None, 'absolute', 8, 1000]
         ]},
     'requests': {
         'options': [None, 'apache Requests', 'requests/s', 'requests', 'apache.requests', 'line'],
         'lines': [
-            ["requests", None, 'incremental']
+            ['requests', None, 'incremental']
         ]},
     'net': {
         'options': [None, 'apache Bandwidth', 'kilobits/s', 'bandwidth', 'apache.net', 'area'],
         'lines': [
-            ["sent", None, 'incremental', 8, 1]
+            ['sent', None, 'incremental', 8, 1]
         ]},
     'connections': {
         'options': [None, 'apache Connections', 'connections', 'connections', 'apache.connections', 'line'],
         'lines': [
-            ["connections"]
+            ['connections']
         ]},
     'conns_async': {
         'options': [None, 'apache Async Connections', 'connections', 'connections', 'apache.conns_async', 'stacked'],
         'lines': [
-            ["keepalive"],
-            ["closing"],
-            ["writing"]
+            ['keepalive'],
+            ['closing'],
+            ['writing']
         ]}
 }
 
-ASSIGNMENT = {"BytesPerReq": 'size_req',
-              "IdleWorkers": 'idle',
-              "IdleServers": 'idle_servers',
-              "BusyWorkers": 'busy',
-              "BusyServers": 'busy_servers',
-              "ReqPerSec": 'requests_sec',
-              "BytesPerSec": 'size_sec',
-              "Total Accesses": 'requests',
-              "Total kBytes": 'sent',
-              "ConnsTotal": 'connections',
-              "ConnsAsyncKeepAlive": 'keepalive',
-              "ConnsAsyncClosing": 'closing',
-              "ConnsAsyncWriting": 'writing'}
+ASSIGNMENT = {
+    'BytesPerReq': 'size_req',
+    'IdleWorkers': 'idle',
+    'IdleServers': 'idle_servers',
+    'BusyWorkers': 'busy',
+    'BusyServers': 'busy_servers',
+    'ReqPerSec': 'requests_sec',
+    'BytesPerSec': 'size_sec',
+    'Total Accesses': 'requests',
+    'Total kBytes': 'sent',
+    'ConnsTotal': 'connections',
+    'ConnsAsyncKeepAlive': 'keepalive',
+    'ConnsAsyncClosing': 'closing',
+    'ConnsAsyncWriting': 'writing'
+}
 
 
 class Service(UrlService):
@@ -103,8 +105,8 @@ class Service(UrlService):
             for chart in self.definitions:
                 if chart == 'workers':
                     lines = self.definitions[chart]['lines']
-                    lines[0] = ["idle_servers", 'idle']
-                    lines[1] = ["busy_servers", 'busy']
+                    lines[0] = ['idle_servers', 'idle']
+                    lines[1] = ['busy_servers', 'busy']
                 opts = self.definitions[chart]['options']
                 opts[1] = opts[1].replace('apache', 'lighttpd')
                 opts[4] = opts[4].replace('apache', 'lighttpd')
@@ -121,7 +123,7 @@ class Service(UrlService):
         data = dict()
 
         for row in raw_data.split('\n'):
-            tmp = row.split(":")
+            tmp = row.split(':')
             if tmp[0] in ASSIGNMENT:
                 try:
                     data[ASSIGNMENT[tmp[0]]] = int(float(tmp[1]))

--- a/python.d/beanstalk.chart.py
+++ b/python.d/beanstalk.chart.py
@@ -115,7 +115,7 @@ def tube_chart_template(name):
              '{0}_connections'.format(name),
              '{0}_commands'.format(name),
              '{0}_pause'.format(name)
-             ]
+    ]
     family = 'tube {0}'.format(name)
 
     charts = {
@@ -123,7 +123,8 @@ def tube_chart_template(name):
             'options': [None, 'Job Rate', 'jobs/s', family, 'beanstalk.jobs_rate', 'area'],
             'lines': [
                 ['_'.join([name, 'total-jobs']), 'jobs', 'incremental']
-            ]},
+            ]
+        },
         order[1]: {
             'options': [None, 'Jobs', 'jobs', family, 'beanstalk.jobs', 'stacked'],
             'lines': [
@@ -132,27 +133,30 @@ def tube_chart_template(name):
                 ['_'.join([name, 'current-jobs-reserved']), 'reserved'],
                 ['_'.join([name, 'current-jobs-delayed']), 'delayed'],
                 ['_'.join([name, 'current-jobs-buried']), 'buried']
-            ]},
+            ]
+        },
         order[2]: {
             'options': [None, 'Connections', 'connections', family, 'beanstalk.connections', 'stacked'],
             'lines': [
                 ['_'.join([name, 'current-using']), 'using'],
                 ['_'.join([name, 'current-waiting']), 'waiting'],
                 ['_'.join([name, 'current-watching']), 'watching']
-            ]},
+            ]
+        },
         order[3]: {
             'options': [None, 'Commands', 'commands/s', family, 'beanstalk.commands', 'stacked'],
             'lines': [
                 ['_'.join([name, 'cmd-delete']), 'deletes', 'incremental'],
                 ['_'.join([name, 'cmd-pause-tube']), 'pauses', 'incremental']
-            ]},
+            ]
+        },
         order[4]: {
             'options': [None, 'Pause', 'seconds', family, 'beanstalk.pause', 'stacked'],
             'lines': [
                 ['_'.join([name, 'pause']), 'since'],
                 ['_'.join([name, 'pause-time-left']), 'left']
-            ]}
-
+            ]
+        }
     }
 
     return order, charts

--- a/python.d/bind_rndc.chart.py
+++ b/python.d/bind_rndc.chart.py
@@ -36,56 +36,50 @@ CHARTS = {
             ['nms_dropped_queries', 'dropped_queries', 'incremental'],
         ]},
     'incoming_queries': {
-        'options': [None, 'Incoming Queries', 'queries', 'incoming queries',
-                    'bind_rndc.incoming_queries', 'line'],
+        'options': [None, 'Incoming Queries', 'queries', 'incoming queries', 'bind_rndc.incoming_queries', 'line'],
         'lines': [
         ]},
     'outgoing_queries': {
-        'options': [None, 'Outgoing Queries', 'queries', 'outgoing queries',
-                    'bind_rndc.outgoing_queries', 'line'],
+        'options': [None, 'Outgoing Queries', 'queries', 'outgoing queries', 'bind_rndc.outgoing_queries', 'line'],
         'lines': [
         ]},
     'named_stats_size': {
-        'options': [None, 'Named Stats File Size', 'MB', 'file size',
-                    'bind_rndc.stats_size', 'line'],
+        'options': [None, 'Named Stats File Size', 'MB', 'file size', 'bind_rndc.stats_size', 'line'],
         'lines': [
             ['stats_size', None, 'absolute', 1, 1 << 20]
-        ]}
+        ]
+    }
 }
 
 NMS = {
-    'nms_requests':
-        ['IPv4 requests received',
-         'IPv6 requests received',
-         'TCP requests received',
-         'requests with EDNS(0) receive'],
-    'nms_responses':
-        ['responses sent',
-         'truncated responses sent',
-         'responses with EDNS(0) sent',
-         'requests with unsupported EDNS version received'],
-    'nms_failure':
-        ['other query failures',
-         'queries resulted in SERVFAIL'],
-    'nms_auth_answer':
-        ['queries resulted in authoritative answer'],
-    'nms_non_auth_answer':
-        ['queries resulted in non authoritative answer'],
-    'nms_nxrrset':
-        ['queries resulted in nxrrset'],
-    'nms_success':
-        ['queries resulted in successful answer'],
-    'nms_nxdomain':
-        ['queries resulted in NXDOMAIN'],
-    'nms_recursion':
-        ['queries caused recursion'],
-    'nms_duplicate':
-        ['duplicate queries received'],
-    'nms_rejected_queries':
-        ['auth queries rejected',
-         'recursive queries rejected'],
-    'nms_dropped_queries':
-        ['queries dropped']
+    'nms_requests': [
+        'IPv4 requests received',
+        'IPv6 requests received',
+        'TCP requests received',
+        'requests with EDNS(0) receive'
+    ],
+    'nms_responses': [
+        'responses sent',
+        'truncated responses sent',
+        'responses with EDNS(0) sent',
+        'requests with unsupported EDNS version received'
+    ],
+    'nms_failure': [
+        'other query failures',
+        'queries resulted in SERVFAIL'
+    ],
+    'nms_auth_answer': ['queries resulted in authoritative answer'],
+    'nms_non_auth_answer': ['queries resulted in non authoritative answer'],
+    'nms_nxrrset': ['queries resulted in nxrrset'],
+    'nms_success': ['queries resulted in successful answer'],
+    'nms_nxdomain': ['queries resulted in NXDOMAIN'],
+    'nms_recursion': ['queries caused recursion'],
+    'nms_duplicate': ['duplicate queries received'],
+    'nms_rejected_queries': [
+        'auth queries rejected',
+        'recursive queries rejected'
+    ],
+    'nms_dropped_queries': ['queries dropped']
 }
 
 STATS = ['Name Server Statistics', 'Incoming Queries', 'Outgoing Queries']

--- a/python.d/ceph.chart.py
+++ b/python.d/ceph.chart.py
@@ -18,10 +18,22 @@ update_every = 10
 priority = 60000
 retries = 60
 
-ORDER = ['general_usage', 'general_objects', 'general_bytes', 'general_operations',
-         'general_latency', 'pool_usage', 'pool_objects', 'pool_read_bytes',
-         'pool_write_bytes', 'pool_read_operations', 'pool_write_operations', 'osd_usage',
-         'osd_apply_latency', 'osd_commit_latency']
+ORDER = [
+    'general_usage',
+    'general_objects',
+    'general_bytes',
+    'general_operations',
+    'general_latency',
+    'pool_usage',
+    'pool_objects',
+    'pool_read_bytes',
+    'pool_write_bytes',
+    'pool_read_operations',
+    'pool_write_operations',
+    'osd_usage',
+    'osd_apply_latency',
+    'osd_commit_latency'
+]
 
 CHARTS = {
     'general_usage': {
@@ -164,11 +176,11 @@ class Service(SimpleService):
                                                                  pool['name'],
                                                                  'absolute', 1, 1024])
             self.definitions['pool_read_operations']['lines'].append(['read_operations_{0}'.format(pool['name']),
-                                                                pool['name'],
-                                                                'absolute'])
+                                                                     pool['name'],
+                                                                     'absolute'])
             self.definitions['pool_write_operations']['lines'].append(['write_operations_{0}'.format(pool['name']),
-                                                                 pool['name'],
-                                                                 'absolute'])
+                                                                      pool['name'],
+                                                                      'absolute'])
 
         # OSD lines
         for osd in sorted(self._get_osd_df()['nodes']):
@@ -230,16 +242,17 @@ class Service(SimpleService):
             apply_latency += perf['perf_stats']['apply_latency_ms']
             commit_latency += perf['perf_stats']['commit_latency_ms']
 
-        return {'general_usage': int(status['kb_used']),
-                'general_available': int(status['kb_avail']),
-                'general_objects': int(status['num_objects']),
-                'general_read_bytes': read_bytes_sec,
-                'general_write_bytes': write_bytes_sec,
-                'general_read_operations': read_op_per_sec,
-                'general_write_operations': write_op_per_sec,
-                'general_apply_latency': apply_latency,
-                'general_commit_latency': commit_latency
-                }
+        return {
+            'general_usage': int(status['kb_used']),
+            'general_available': int(status['kb_avail']),
+            'general_objects': int(status['num_objects']),
+            'general_read_bytes': read_bytes_sec,
+            'general_write_bytes': write_bytes_sec,
+            'general_read_operations': read_op_per_sec,
+            'general_write_operations': write_op_per_sec,
+            'general_apply_latency': apply_latency,
+            'general_commit_latency': commit_latency
+        }
 
     @staticmethod
     def _get_pool_usage(pool):
@@ -263,11 +276,12 @@ class Service(SimpleService):
         Get read/write kb and operations in a pool
         :return: A pool dict with both read/write bytes and operations.
         """
-        return {'read_{0}'.format(pool['pool_name']): int(pool['client_io_rate'].get('read_bytes_sec', 0)),
-                'write_{0}'.format(pool['pool_name']): int(pool['client_io_rate'].get('write_bytes_sec', 0)),
-                'read_operations_{0}'.format(pool['pool_name']): int(pool['client_io_rate'].get('read_op_per_sec', 0)),
-                'write_operations_{0}'.format(pool['pool_name']): int(pool['client_io_rate'].get('write_op_per_sec', 0))
-                }
+        return {
+            'read_{0}'.format(pool['pool_name']): int(pool['client_io_rate'].get('read_bytes_sec', 0)),
+            'write_{0}'.format(pool['pool_name']): int(pool['client_io_rate'].get('write_bytes_sec', 0)),
+            'read_operations_{0}'.format(pool['pool_name']): int(pool['client_io_rate'].get('read_op_per_sec', 0)),
+            'write_operations_{0}'.format(pool['pool_name']): int(pool['client_io_rate'].get('write_op_per_sec', 0))
+        }
 
     @staticmethod
     def _get_osd_usage(osd):
@@ -283,8 +297,10 @@ class Service(SimpleService):
         Get ceph osd apply and commit latency
         :return: A osd dict with osd name's key with both apply and commit latency values
         """
-        return {'apply_latency_osd.{0}'.format(osd['id']): osd['perf_stats']['apply_latency_ms'],
-                'commit_latency_osd.{0}'.format(osd['id']): osd['perf_stats']['commit_latency_ms']}
+        return {
+            'apply_latency_osd.{0}'.format(osd['id']): osd['perf_stats']['apply_latency_ms'],
+            'commit_latency_osd.{0}'.format(osd['id']): osd['perf_stats']['commit_latency_ms']
+        }
 
     def _get_df(self):
         """

--- a/python.d/chrony.chart.py
+++ b/python.d/chrony.chart.py
@@ -14,66 +14,70 @@ retries = 10
 ORDER = ['system', 'offsets', 'stratum', 'root', 'frequency', 'residualfreq', 'skew']
 
 CHARTS = {
-    # id: {
-    #     'options': [name, title, units, family, context, charttype],
-    #     'lines': [
-    #         [unique_dimension_name, name, algorithm, multiplier, divisor]
-    #     ]}
     'system': {
-        'options': [None, "Chrony System Time Deltas", "microseconds", 'system', 'chrony.system', 'area'],
+        'options': [None, 'Chrony System Time Deltas', 'microseconds', 'system', 'chrony.system', 'area'],
         'lines': [
-            ['timediff',   'system time', 'absolute', 1, 1000]
-        ]},
+            ['timediff', 'system time', 'absolute', 1, 1000]
+        ]
+    },
     'offsets': {
-        'options': [None, "Chrony System Time Offsets", "microseconds", 'system', 'chrony.offsets', 'area'],
+        'options': [None, 'Chrony System Time Offsets', 'microseconds', 'system', 'chrony.offsets', 'area'],
         'lines': [
             ['lastoffset', 'last offset', 'absolute', 1, 1000],
-            ['rmsoffset',  'RMS offset',  'absolute', 1, 1000]
-        ]},
+            ['rmsoffset', 'RMS offset', 'absolute', 1, 1000]
+        ]
+    },
     'stratum': {
-        'options': [None, "Chrony Stratum", "stratum", 'root', 'chrony.stratum', 'line'],
+        'options': [None, 'Chrony Stratum', 'stratum', 'root', 'chrony.stratum', 'line'],
         'lines': [
             ['stratum', None, 'absolute', 1, 1]
-        ]},
+        ]
+    },
     'root': {
-        'options': [None, "Chrony Root Delays", "milliseconds", 'root', 'chrony.root', 'line'],
+        'options': [None, 'Chrony Root Delays', 'milliseconds', 'root', 'chrony.root', 'line'],
         'lines': [
-            ['rootdelay',      'delay',      'absolute', 1, 1000000],
+            ['rootdelay', 'delay', 'absolute', 1, 1000000],
             ['rootdispersion', 'dispersion', 'absolute', 1, 1000000]
-        ]},
+        ]
+    },
     'frequency': {
-        'options': [None, "Chrony Frequency", "ppm", 'frequencies', 'chrony.frequency', 'area'],
+        'options': [None, 'Chrony Frequency', 'ppm', 'frequencies', 'chrony.frequency', 'area'],
         'lines': [
             ['frequency', None, 'absolute', 1, 1000]
-        ]},
+        ]
+    },
     'residualfreq': {
-        'options': [None, "Chrony Residual frequency", "ppm", 'frequencies', 'chrony.residualfreq', 'area'],
+        'options': [None, 'Chrony Residual frequency', 'ppm', 'frequencies', 'chrony.residualfreq', 'area'],
         'lines': [
             ['residualfreq', 'residual frequency', 'absolute', 1, 1000]
-        ]},
+        ]
+    },
     'skew': {
-        'options': [None, "Chrony Skew, error bound on frequency", "ppm", 'frequencies', 'chrony.skew', 'area'],
+        'options': [None, 'Chrony Skew, error bound on frequency', 'ppm', 'frequencies', 'chrony.skew', 'area'],
         'lines': [
             ['skew', None, 'absolute', 1, 1000]
-        ]}
+        ]
+    }
 }
 
-CHRONY = [('Frequency', 'frequency', 1e3),
-          ('Last offset', 'lastoffset', 1e9),
-          ('RMS offset', 'rmsoffset', 1e9),
-          ('Residual freq', 'residualfreq', 1e3),
-          ('Root delay', 'rootdelay', 1e9),
-          ('Root dispersion', 'rootdispersion', 1e9),
-          ('Skew', 'skew', 1e3),
-          ('Stratum', 'stratum', 1),
-          ('System time', 'timediff', 1e9)]
+CHRONY = [
+    ('Frequency', 'frequency', 1e3),
+    ('Last offset', 'lastoffset', 1e9),
+    ('RMS offset', 'rmsoffset', 1e9),
+    ('Residual freq', 'residualfreq', 1e3),
+    ('Root delay', 'rootdelay', 1e9),
+    ('Root dispersion', 'rootdispersion', 1e9),
+    ('Skew', 'skew', 1e3),
+    ('Stratum', 'stratum', 1),
+    ('System time', 'timediff', 1e9)
+]
 
 
 class Service(ExecutableService):
     def __init__(self, configuration=None, name=None):
         ExecutableService.__init__(
             self, configuration=configuration, name=name)
-        self.command = "chronyc -n tracking"
+        self.command = 'chronyc -n tracking'
         self.order = ORDER
         self.definitions = CHARTS
 

--- a/python.d/cpufreq.chart.py
+++ b/python.d/cpufreq.chart.py
@@ -18,7 +18,8 @@ CHARTS = {
         'options': [None, 'CPU Clock', 'MHz', 'cpufreq', 'cpufreq.cpufreq', 'line'],
         'lines': [
             # lines are created dynamically in `check()` method
-        ]}
+        ]
+    }
 }
 
 
@@ -93,7 +94,7 @@ class Service(SimpleService):
             self.assignment[cpu]['accurate'] = path
             self.accurate_last[cpu] = {}
 
-        if len(self.assignment) == 0:
+        if not self.assignment:
             self.accurate_exists = False
 
         for path in glob.glob(self.sys_dir + '/system/cpu/cpu*/cpufreq/scaling_cur_freq'):
@@ -103,7 +104,7 @@ class Service(SimpleService):
                 self.assignment[cpu] = {}
             self.assignment[cpu]['inaccurate'] = path
 
-        if len(self.assignment) == 0:
+        if not self.assignment:
             self.error("couldn't find a method to read cpufreq statistics")
             return False
 
@@ -111,4 +112,3 @@ class Service(SimpleService):
             self.definitions[ORDER[0]]['lines'].append([name, name, 'absolute', 1, 1000])
 
         return True
-

--- a/python.d/cpuidle.chart.py
+++ b/python.d/cpuidle.chart.py
@@ -3,13 +3,13 @@
 # Author: Steven Noonan (tycho)
 # SPDX-License-Identifier: GPL-3.0+
 
+import ctypes
 import glob
 import os
 import platform
 
 from bases.FrameworkServices.SimpleService import SimpleService
 
-import ctypes
 syscall = ctypes.CDLL('libc.so.6').syscall
 
 # default module values (can be overridden per job in `config`)
@@ -108,7 +108,7 @@ class Service(SimpleService):
 
     def check(self):
         if self.__gettid() is None:
-            self.error("Cannot get thread ID. Stats would be completely broken.")
+            self.error('Cannot get thread ID. Stats would be completely broken.')
             return False
 
         for path in sorted(glob.glob(self.sys_dir + '/cpu*/cpuidle/state*/name')):
@@ -141,9 +141,8 @@ class Service(SimpleService):
         # Sort order by kernel-specified CPU index
         self.order.sort(key=lambda x: int(x.split('_')[0][3:]))
 
-        if len(self.definitions) == 0:
+        if not self.definitions:
             self.error("couldn't find cstate stats")
             return False
 
         return True
-


### PR DESCRIPTION
PEP 8 compliance cleanups for python.d modules with names starting with A, B, or C

Touches all modules except couchdb, which is already compliant (but may not quite fit our coding standards).

Relevant: #4167 