### PR TITLE
Python.d PEP 8 cleanup, modules D-H

### DIFF
--- a/python.d/dns_query_time.chart.py
+++ b/python.d/dns_query_time.chart.py
@@ -4,18 +4,22 @@
 # SPDX-License-Identifier: GPL-3.0+
 
 from random import choice
-from threading import Thread
 from socket import getaddrinfo, gaierror
+from threading import Thread
 
 try:
     from time import monotonic as time
 except ImportError:
     from time import time
+
 try:
-    import dns.message, dns.query, dns.name
+    import dns.message
+    import dns.query
+    import dns.name
     DNS_PYTHON = True
 except ImportError:
     DNS_PYTHON = False
+
 try:
     from queue import Queue
 except ImportError:
@@ -118,8 +122,12 @@ def check_ns(ns):
 def create_charts(aggregate, server_list):
     if aggregate:
         order = ['dns_group']
-        definitions = {'dns_group': {'options': [None, 'DNS Response Time', 'ms', 'name servers',
-                                                 'dns_query_time.response_time', 'line'], 'lines': []}}
+        definitions = {
+            'dns_group': {
+                'options': [None, 'DNS Response Time', 'ms', 'name servers', 'dns_query_time.response_time', 'line'],
+                'lines': []
+            }
+        }
         for ns in server_list:
             definitions['dns_group']['lines'].append(['_'.join(['ns', ns.replace('.', '_')]), ns, 'absolute'])
 
@@ -128,8 +136,10 @@ def create_charts(aggregate, server_list):
         order = [''.join(['dns_', ns.replace('.', '_')]) for ns in server_list]
         definitions = dict()
         for ns in server_list:
-            definitions[''.join(['dns_', ns.replace('.', '_')])] = {'options': [None, 'DNS Response Time', 'ms', ns,
-                                                                                'dns_query_time.response_time', 'area'],
-                                                                    'lines': [['_'.join(['ns', ns.replace('.', '_')]),
-                                                                               ns, 'absolute']]}
+            definitions[''.join(['dns_', ns.replace('.', '_')])] = {
+                'options': [None, 'DNS Response Time', 'ms', ns, 'dns_query_time.response_time', 'area'],
+                'lines': [
+                    ['_'.join(['ns', ns.replace('.', '_')]), ns, 'absolute']
+                ]
+            }
         return order, definitions

--- a/python.d/dnsdist.chart.py
+++ b/python.d/dnsdist.chart.py
@@ -1,102 +1,133 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: GPL-3.0+
+
 from json import loads
+
 from bases.FrameworkServices.UrlService import UrlService
 
-ORDER = ['queries', 'queries_dropped', 'packets_dropped', 'answers', 'backend_responses', 'backend_commerrors', 'backend_errors', 'cache', 'servercpu', 'servermem', 'query_latency', 'query_latency_avg']
+
+ORDER = [
+    'queries',
+    'queries_dropped',
+    'packets_dropped',
+    'answers',
+    'backend_responses',
+    'backend_commerrors',
+    'backend_errors',
+    'cache',
+    'servercpu',
+    'servermem',
+    'query_latency',
+    'query_latency_avg'
+]
+
+
 CHARTS = {
-	'queries': {
-		'options': [None, 'Client queries received', 'queries/s', 'queries', 'dnsdist.queries', 'line'],
-		'lines': [
-			['queries', 'all', 'incremental'],
-			['rdqueries', 'recursive', 'incremental'],
-			['empty-queries', 'empty', 'incremental']
-	]},
-	'queries_dropped': {
-		'options': [None, 'Client queries dropped', 'queries/s', 'queries', 'dnsdist.queries_dropped', 'line'],
-		'lines': [
-			['rule-drop', 'rule drop', 'incremental'],
-			['dyn-blocked', 'dynamic block', 'incremental'],
-			['no-policy', 'no policy', 'incremental'],
-			['noncompliant-queries', 'non compliant', 'incremental']
-	]},
-	'packets_dropped': {
-		'options': [None, 'Packets dropped', 'packets/s', 'packets', 'dnsdist.packets_dropped', 'line'],
-		'lines': [
-			['acl-drops', 'acl', 'incremental']
-	]},
-	'answers': {
-		'options': [None, 'Answers statistics', 'answers/s', 'answers', 'dnsdist.answers', 'line'],
-		'lines': [
-			['self-answered', 'self answered', 'incremental'],
-			['rule-nxdomain', 'nxdomain', 'incremental', -1],
-			['rule-refused', 'refused', 'incremental', -1],
-			['trunc-failures', 'trunc failures', 'incremental', -1]
-	]},
-	'backend_responses': {
-		'options': [None, 'Backend responses', 'responses/s', 'backends', 'dnsdist.backend_responses', 'line'],
-		'lines': [
-			['responses', 'responses', 'incremental']
-	]},
-	'backend_commerrors': {
-		'options': [None, 'Backend Communication Errors', 'errors/s', 'backends', 'dnsdist.backend_commerrors', 'line'],
-		'lines': [
-			['downstream-send-errors', 'send errors', 'incremental']
-	]},
-	'backend_errors': {
-		'options': [None, 'Backend error responses', 'responses/s', 'backends', 'dnsdist.backend_errors', 'line'],
-		'lines': [
-			['downstream-timeouts', 'timeout', 'incremental'],
-			['servfail-responses', 'servfail', 'incremental'],
-			['noncompliant-responses', 'non compliant', 'incremental']
-	]},
-	'cache': {
-		'options': [None, 'Cache performance', 'answers/s', 'cache', 'dnsdist.cache', 'area'],
-		'lines': [
-			['cache-hits', 'hits', 'incremental'],
-			['cache-misses', 'misses', 'incremental', -1]
-	]},
-	'servercpu': {
-		'options': [None, 'DNSDIST server CPU utilization', 'ms/s', 'server', 'dnsdist.servercpu', 'stacked'],
-		'lines': [
-			['cpu-sys-msec', 'system state', 'incremental'],
-			['cpu-user-msec', 'user state', 'incremental']
-	]},
-	'servermem': {
-		'options': [None, 'DNSDIST server memory utilization', 'MB', 'server', 'dnsdist.servermem', 'area'],
-		'lines': [
-			['real-memory-usage', 'memory usage', 'absolute', 1, 1048576]
-	]},
-	'query_latency': {
-		'options': [None, 'Query latency', 'queries/s', 'latency', 'dnsdist.query_latency', 'stacked'],
-		'lines': [
-			['latency0-1', '1ms', 'incremental'],
-			['latency1-10', '10ms', 'incremental'],
-			['latency10-50', '50ms', 'incremental'],
-			['latency50-100', '100ms', 'incremental'],
-			['latency100-1000', '1sec', 'incremental'],
-			['latency-slow', 'slow', 'incremental']
-	]},
-	'query_latency_avg': {
-		'options': [None, 'Average latency for the last N queries', 'ms/query', 'latency', 'dnsdist.query_latency_avg', 'line'],
-		'lines': [
-			['latency-avg100', '100', 'absolute'],
-			['latency-avg1000', '1k', 'absolute'],
-			['latency-avg10000', '10k', 'absolute'],
-			['latency-avg1000000', '1000k', 'absolute']
-	]}
+    'queries': {
+        'options': [None, 'Client queries received', 'queries/s', 'queries', 'dnsdist.queries', 'line'],
+        'lines': [
+            ['queries', 'all', 'incremental'],
+            ['rdqueries', 'recursive', 'incremental'],
+            ['empty-queries', 'empty', 'incremental']
+        ]
+    },
+    'queries_dropped': {
+        'options': [None, 'Client queries dropped', 'queries/s', 'queries', 'dnsdist.queries_dropped', 'line'],
+        'lines': [
+            ['rule-drop', 'rule drop', 'incremental'],
+            ['dyn-blocked', 'dynamic block', 'incremental'],
+            ['no-policy', 'no policy', 'incremental'],
+            ['noncompliant-queries', 'non compliant', 'incremental']
+        ]
+    },
+    'packets_dropped': {
+        'options': [None, 'Packets dropped', 'packets/s', 'packets', 'dnsdist.packets_dropped', 'line'],
+        'lines': [
+            ['acl-drops', 'acl', 'incremental']
+        ]
+    },
+    'answers': {
+        'options': [None, 'Answers statistics', 'answers/s', 'answers', 'dnsdist.answers', 'line'],
+        'lines': [
+            ['self-answered', 'self answered', 'incremental'],
+            ['rule-nxdomain', 'nxdomain', 'incremental', -1],
+            ['rule-refused', 'refused', 'incremental', -1],
+            ['trunc-failures', 'trunc failures', 'incremental', -1]
+        ]
+    },
+    'backend_responses': {
+        'options': [None, 'Backend responses', 'responses/s', 'backends', 'dnsdist.backend_responses', 'line'],
+        'lines': [
+            ['responses', 'responses', 'incremental']
+        ]
+    },
+    'backend_commerrors': {
+        'options': [None, 'Backend Communication Errors', 'errors/s', 'backends', 'dnsdist.backend_commerrors', 'line'],
+        'lines': [
+            ['downstream-send-errors', 'send errors', 'incremental']
+        ]
+    },
+    'backend_errors': {
+        'options': [None, 'Backend error responses', 'responses/s', 'backends', 'dnsdist.backend_errors', 'line'],
+        'lines': [
+            ['downstream-timeouts', 'timeout', 'incremental'],
+            ['servfail-responses', 'servfail', 'incremental'],
+            ['noncompliant-responses', 'non compliant', 'incremental']
+        ]
+    },
+    'cache': {
+        'options': [None, 'Cache performance', 'answers/s', 'cache', 'dnsdist.cache', 'area'],
+        'lines': [
+            ['cache-hits', 'hits', 'incremental'],
+            ['cache-misses', 'misses', 'incremental', -1]
+        ]
+    },
+    'servercpu': {
+        'options': [None, 'DNSDIST server CPU utilization', 'ms/s', 'server', 'dnsdist.servercpu', 'stacked'],
+        'lines': [
+            ['cpu-sys-msec', 'system state', 'incremental'],
+            ['cpu-user-msec', 'user state', 'incremental']
+        ]
+    },
+    'servermem': {
+        'options': [None, 'DNSDIST server memory utilization', 'MB', 'server', 'dnsdist.servermem', 'area'],
+        'lines': [
+            ['real-memory-usage', 'memory usage', 'absolute', 1, 1048576]
+        ]
+    },
+    'query_latency': {
+        'options': [None, 'Query latency', 'queries/s', 'latency', 'dnsdist.query_latency', 'stacked'],
+        'lines': [
+            ['latency0-1', '1ms', 'incremental'],
+            ['latency1-10', '10ms', 'incremental'],
+            ['latency10-50', '50ms', 'incremental'],
+            ['latency50-100', '100ms', 'incremental'],
+            ['latency100-1000', '1sec', 'incremental'],
+            ['latency-slow', 'slow', 'incremental']
+        ]
+    },
+    'query_latency_avg': {
+        'options': [None, 'Average latency for the last N queries', 'ms/query', 'latency',
+                    'dnsdist.query_latency_avg', 'line'],
+        'lines': [
+            ['latency-avg100', '100', 'absolute'],
+            ['latency-avg1000', '1k', 'absolute'],
+            ['latency-avg10000', '10k', 'absolute'],
+            ['latency-avg1000000', '1000k', 'absolute']
+        ]
+    }
 }
 
+
 class Service(UrlService):
-	def __init__(self, configuration=None, name=None):
-		UrlService.__init__(self, configuration=configuration, name=name)
-		self.order = ORDER
-		self.definitions = CHARTS
+    def __init__(self, configuration=None, name=None):
+        UrlService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
 
-	def _get_data(self):
-		data = self._get_raw_data()
-		if not data:
-			return None
+    def _get_data(self):
+        data = self._get_raw_data()
+        if not data:
+            return None
 
-		return loads(data)
-
+        return loads(data)

--- a/python.d/dockerd.chart.py
+++ b/python.d/dockerd.chart.py
@@ -24,19 +24,22 @@ ORDER = [
 
 CHARTS = {
     'running_containers': {
-        'options': [None, 'Number of running containers', 'running containers', 'running containers', 'docker.running_containers', 'line'],
+        'options': [None, 'Number of running containers', 'running containers', 'running containers',
+                    'docker.running_containers', 'line'],
         'lines': [
             ['running_containers', 'running']
         ]
     },
     'healthy_containers': {
-        'options': [None, 'Number of healthy containers', 'healthy containers', 'healthy containers', 'docker.healthy_containers', 'line'],
+        'options': [None, 'Number of healthy containers', 'healthy containers', 'healthy containers',
+                    'docker.healthy_containers', 'line'],
         'lines': [
             ['healthy_containers', 'healthy']
         ]
     },
     'unhealthy_containers': {
-        'options': [None, 'Number of unhealthy containers', 'unhealthy containers', 'unhealthy containers', 'docker.unhealthy_containers', 'line'],
+        'options': [None, 'Number of unhealthy containers', 'unhealthy containers', 'unhealthy containers',
+                    'docker.unhealthy_containers', 'line'],
         'lines': [
             ['unhealthy_containers', 'unhealthy']
         ]
@@ -72,4 +75,3 @@ class Service(SimpleService):
         data['unhealthy_containers'] = len(self.client.containers.list(filters={'health': 'unhealthy'}, sparse=True))
 
         return data or None
-

--- a/python.d/dovecot.chart.py
+++ b/python.d/dovecot.chart.py
@@ -11,93 +11,113 @@ priority = 60000
 retries = 60
 
 # charts order (can be overridden if you want less charts, or different order)
-ORDER = ['sessions', 'logins', 'commands',
-         'faults',
-         'context_switches',
-         'io', 'net', 'syscalls',
-         'lookup', 'cache',
-         'auth', 'auth_cache']
+ORDER = [
+    'sessions',
+    'logins',
+    'commands',
+    'faults',
+    'context_switches',
+    'io',
+    'net',
+    'syscalls',
+    'lookup',
+    'cache',
+    'auth',
+    'auth_cache'
+]
 
 CHARTS = {
     'sessions': {
-        'options': [None, "Dovecot Active Sessions", 'number', 'sessions', 'dovecot.sessions', 'line'],
+        'options': [None, 'Dovecot Active Sessions', 'number', 'sessions', 'dovecot.sessions', 'line'],
         'lines': [
             ['num_connected_sessions', 'active sessions', 'absolute']
-        ]},
+        ]
+    },
     'logins': {
-        'options': [None, "Dovecot Logins", 'number', 'logins', 'dovecot.logins', 'line'],
+        'options': [None, 'Dovecot Logins', 'number', 'logins', 'dovecot.logins', 'line'],
         'lines': [
             ['num_logins', 'logins', 'absolute']
-        ]},
+        ]
+    },
     'commands': {
-        'options': [None, "Dovecot Commands", "commands", 'commands', 'dovecot.commands', 'line'],
+        'options': [None, 'Dovecot Commands', 'commands', 'commands', 'dovecot.commands', 'line'],
         'lines': [
             ['num_cmds', 'commands', 'absolute']
-        ]},
+        ]
+    },
     'faults': {
-        'options': [None, "Dovecot Page Faults", "faults", 'page faults', 'dovecot.faults', 'line'],
+        'options': [None, 'Dovecot Page Faults', 'faults', 'page faults', 'dovecot.faults', 'line'],
         'lines': [
             ['min_faults', 'minor', 'absolute'],
             ['maj_faults', 'major', 'absolute']
-        ]},
+        ]
+    },
     'context_switches': {
-        'options': [None, "Dovecot Context Switches", '', 'context switches', 'dovecot.context_switches', 'line'],
+        'options': [None, 'Dovecot Context Switches', '', 'context switches', 'dovecot.context_switches', 'line'],
         'lines': [
             ['vol_cs', 'voluntary', 'absolute'],
             ['invol_cs', 'involuntary', 'absolute']
-        ]},
+        ]
+    },
     'io': {
-        'options': [None, "Dovecot Disk I/O", 'kilobytes/s', 'disk', 'dovecot.io', 'area'],
+        'options': [None, 'Dovecot Disk I/O', 'kilobytes/s', 'disk', 'dovecot.io', 'area'],
         'lines': [
             ['disk_input', 'read', 'incremental', 1, 1024],
             ['disk_output', 'write', 'incremental', -1, 1024]
-        ]},
+        ]
+    },
     'net': {
-        'options': [None, "Dovecot Network Bandwidth", 'kilobits/s', 'network', 'dovecot.net', 'area'],
+        'options': [None, 'Dovecot Network Bandwidth', 'kilobits/s', 'network', 'dovecot.net', 'area'],
         'lines': [
             ['read_bytes', 'read', 'incremental', 8, 1024],
             ['write_bytes', 'write', 'incremental', -8, 1024]
-        ]},
+        ]
+    },
     'syscalls': {
-        'options': [None, "Dovecot Number of SysCalls", 'syscalls/s', 'system', 'dovecot.syscalls', 'line'],
+        'options': [None, 'Dovecot Number of SysCalls', 'syscalls/s', 'system', 'dovecot.syscalls', 'line'],
         'lines': [
             ['read_count', 'read', 'incremental'],
             ['write_count', 'write', 'incremental']
-        ]},
+        ]
+    },
     'lookup': {
-        'options': [None, "Dovecot Lookups", 'number/s', 'lookups', 'dovecot.lookup', 'stacked'],
+        'options': [None, 'Dovecot Lookups', 'number/s', 'lookups', 'dovecot.lookup', 'stacked'],
         'lines': [
             ['mail_lookup_path', 'path', 'incremental'],
             ['mail_lookup_attr', 'attr', 'incremental']
-        ]},
+        ]
+    },
     'cache': {
-        'options': [None, "Dovecot Cache Hits", 'hits/s', 'cache', 'dovecot.cache', 'line'],
+        'options': [None, 'Dovecot Cache Hits', 'hits/s', 'cache', 'dovecot.cache', 'line'],
         'lines': [
             ['mail_cache_hits', 'hits', 'incremental']
-        ]},
+        ]
+    },
     'auth': {
-        'options': [None, "Dovecot Authentications", 'attempts', 'logins', 'dovecot.auth', 'stacked'],
+        'options': [None, 'Dovecot Authentications', 'attempts', 'logins', 'dovecot.auth', 'stacked'],
         'lines': [
             ['auth_successes', 'ok', 'absolute'],
             ['auth_failures', 'failed', 'absolute']
-        ]},
+        ]
+    },
     'auth_cache': {
-        'options': [None, "Dovecot Authentication Cache", 'number', 'cache', 'dovecot.auth_cache', 'stacked'],
+        'options': [None, 'Dovecot Authentication Cache', 'number', 'cache', 'dovecot.auth_cache', 'stacked'],
         'lines': [
             ['auth_cache_hits', 'hit', 'absolute'],
             ['auth_cache_misses', 'miss', 'absolute']
-        ]}
+        ]
+    }
 }
 
 
 class Service(SocketService):
     def __init__(self, configuration=None, name=None):
         SocketService.__init__(self, configuration=configuration, name=name)
-        self.request = "EXPORT\tglobal\r\n"
+        self.request = 'EXPORT\tglobal\r\n'
         self.host = None  # localhost
         self.port = None  # 24242
         # self._keep_alive = True
-        self.unix_socket = "/var/run/dovecot/stats"
+        self.unix_socket = '/var/run/dovecot/stats'
         self.order = ORDER
         self.definitions = CHARTS
 
@@ -112,7 +132,7 @@ class Service(SocketService):
             return None
 
         if raw is None:
-            self.debug("dovecot returned no data")
+            self.debug('dovecot returned no data')
             return None
 
         data = raw.split('\n')[:2]

--- a/python.d/elasticsearch.chart.py
+++ b/python.d/elasticsearch.chart.py
@@ -110,18 +110,22 @@ HEALTH_STATS = [
 ]
 
 LATENCY = {
-    'query_latency':
-        {'total': 'indices_search_query_total',
-         'spent_time': 'indices_search_query_time_in_millis'},
-    'fetch_latency':
-        {'total': 'indices_search_fetch_total',
-         'spent_time': 'indices_search_fetch_time_in_millis'},
-    'indexing_latency':
-        {'total': 'indices_indexing_index_total',
-         'spent_time': 'indices_indexing_index_time_in_millis'},
-    'flushing_latency':
-        {'total': 'indices_flush_total',
-         'spent_time': 'indices_flush_total_time_in_millis'}
+    'query_latency': {
+        'total': 'indices_search_query_total',
+        'spent_time': 'indices_search_query_time_in_millis'
+    },
+    'fetch_latency': {
+        'total': 'indices_search_fetch_total',
+        'spent_time': 'indices_search_fetch_time_in_millis'
+    },
+    'indexing_latency': {
+        'total': 'indices_indexing_index_total',
+        'spent_time': 'indices_indexing_index_time_in_millis'
+    },
+    'flushing_latency': {
+        'total': 'indices_flush_total',
+        'spent_time': 'indices_flush_total_time_in_millis'
+    }
 }
 
 # charts order (can be overridden if you want less charts, or different order)
@@ -170,27 +174,31 @@ CHARTS = {
         'lines': [
             ['indices_search_query_total', 'queries', 'incremental'],
             ['indices_search_fetch_total', 'fetches', 'incremental']
-        ]},
+        ]
+    },
     'search_performance_current': {
         'options': [None, 'Queries and  Fetches In Progress', 'number of', 'search performance',
                     'elastic.search_performance_current', 'stacked'],
         'lines': [
             ['indices_search_query_current', 'queries', 'absolute'],
             ['indices_search_fetch_current', 'fetches', 'absolute']
-        ]},
+        ]
+    },
     'search_performance_time': {
         'options': [None, 'Time Spent On Queries And Fetches', 'seconds', 'search performance',
                     'elastic.search_performance_time', 'stacked'],
         'lines': [
             ['indices_search_query_time_in_millis', 'query', 'incremental', 1, 1000],
             ['indices_search_fetch_time_in_millis', 'fetch', 'incremental', 1, 1000]
-        ]},
+        ]
+    },
     'search_latency': {
         'options': [None, 'Query And Fetch Latency', 'ms', 'search performance', 'elastic.search_latency', 'stacked'],
         'lines': [
             ['query_latency', 'query', 'absolute', 1, 1000],
             ['fetch_latency', 'fetch', 'absolute', 1, 1000]
-        ]},
+        ]
+    },
     'index_performance_total': {
         'options': [None, 'Indexed Documents, Index Refreshes, Index Flushes To Disk', 'number of',
                     'indexing performance', 'elastic.index_performance_total', 'stacked'],
@@ -198,13 +206,15 @@ CHARTS = {
             ['indices_indexing_index_total', 'indexed', 'incremental'],
             ['indices_refresh_total', 'refreshes', 'incremental'],
             ['indices_flush_total', 'flushes', 'incremental']
-        ]},
+        ]
+    },
     'index_performance_current': {
         'options': [None, 'Number Of Documents Currently Being Indexed', 'currently indexed',
                     'indexing performance', 'elastic.index_performance_current', 'stacked'],
         'lines': [
             ['indices_indexing_index_current', 'documents', 'absolute']
-        ]},
+        ]
+    },
     'index_performance_time': {
         'options': [None, 'Time Spent On Indexing, Refreshing, Flushing', 'seconds', 'indexing performance',
                     'elastic.index_performance_time', 'stacked'],
@@ -212,40 +222,46 @@ CHARTS = {
             ['indices_indexing_index_time_in_millis', 'indexing', 'incremental', 1, 1000],
             ['indices_refresh_total_time_in_millis', 'refreshing', 'incremental', 1, 1000],
             ['indices_flush_total_time_in_millis', 'flushing', 'incremental', 1, 1000]
-        ]},
+        ]
+    },
     'index_latency': {
         'options': [None, 'Indexing And Flushing Latency', 'ms', 'indexing performance',
                     'elastic.index_latency', 'stacked'],
         'lines': [
             ['indexing_latency', 'indexing', 'absolute', 1, 1000],
             ['flushing_latency', 'flushing', 'absolute', 1, 1000]
-        ]},
+        ]
+    },
     'index_translog_operations': {
         'options': [None, 'Translog Operations', 'count', 'translog',
                     'elastic.index_translog_operations', 'area'],
         'lines': [
             ['indices_translog_operations', 'total', 'absolute'],
             ['indices_translog_uncommitted_operations', 'uncommited', 'absolute']
-        ]},
+        ]
+    },
     'index_translog_size': {
         'options': [None, 'Translog Size', 'MB', 'translog',
                     'elastic.index_translog_size', 'area'],
         'lines': [
             ['indices_translog_size_in_bytes', 'total', 'absolute', 1, 1048567],
             ['indices_translog_uncommitted_size_in_bytes', 'uncommited', 'absolute', 1, 1048567]
-        ]},
+        ]
+    },
     'index_segments_count': {
         'options': [None, 'Total Number Of Indices Segments', 'count', 'indices segments',
                     'elastic.index_segments_count', 'line'],
         'lines': [
             ['indices_segments_count', 'segments', 'absolute']
-        ]},
+        ]
+    },
     'index_segments_memory_writer': {
         'options': [None, 'Index Writer Memory Usage', 'MB', 'indices segments',
                     'elastic.index_segments_memory_writer', 'area'],
         'lines': [
             ['indices_segments_index_writer_memory_in_bytes', 'total', 'absolute', 1, 1048567]
-        ]},
+        ]
+    },
     'index_segments_memory': {
         'options': [None, 'Indices Segments Memory Usage', 'MB', 'indices segments',
                     'elastic.index_segments_memory', 'stacked'],
@@ -258,54 +274,62 @@ CHARTS = {
             ['indices_segments_doc_values_memory_in_bytes', 'doc values', 'absolute', 1, 1048567],
             ['indices_segments_version_map_memory_in_bytes', 'version map', 'absolute', 1, 1048567],
             ['indices_segments_fixed_bit_set_memory_in_bytes', 'fixed bit set', 'absolute', 1, 1048567]
-        ]},
+        ]
+    },
     'jvm_mem_heap': {
         'options': [None, 'JVM Heap Percentage Currently in Use', 'percent', 'memory usage and gc',
                     'elastic.jvm_heap', 'area'],
         'lines': [
             ['jvm_mem_heap_used_percent', 'inuse', 'absolute']
-        ]},
+        ]
+    },
     'jvm_mem_heap_bytes': {
         'options': [None, 'JVM Heap Commit And Usage', 'MB', 'memory usage and gc',
                     'elastic.jvm_heap_bytes', 'area'],
         'lines': [
             ['jvm_mem_heap_committed_in_bytes', 'commited', 'absolute', 1, 1048576],
             ['jvm_mem_heap_used_in_bytes', 'used', 'absolute', 1, 1048576]
-        ]},
+        ]
+    },
     'jvm_buffer_pool_count': {
         'options': [None, 'JVM Buffers', 'count', 'memory usage and gc',
                     'elastic.jvm_buffer_pool_count', 'line'],
         'lines': [
             ['jvm_buffer_pools_direct_count', 'direct', 'absolute'],
             ['jvm_buffer_pools_mapped_count', 'mapped', 'absolute']
-        ]},
+        ]
+    },
     'jvm_direct_buffers_memory': {
         'options': [None, 'JVM Direct Buffers Memory', 'MB', 'memory usage and gc',
                     'elastic.jvm_direct_buffers_memory', 'area'],
         'lines': [
             ['jvm_buffer_pools_direct_used_in_bytes', 'used', 'absolute', 1, 1048567],
             ['jvm_buffer_pools_direct_total_capacity_in_bytes', 'total capacity', 'absolute', 1, 1048567]
-        ]},
+        ]
+    },
     'jvm_mapped_buffers_memory': {
         'options': [None, 'JVM Mapped Buffers Memory', 'MB', 'memory usage and gc',
                     'elastic.jvm_mapped_buffers_memory', 'area'],
         'lines': [
             ['jvm_buffer_pools_mapped_used_in_bytes', 'used', 'absolute', 1, 1048567],
             ['jvm_buffer_pools_mapped_total_capacity_in_bytes', 'total capacity', 'absolute', 1, 1048567]
-        ]},
+        ]
+    },
     'jvm_gc_count': {
         'options': [None, 'Garbage Collections', 'counts', 'memory usage and gc', 'elastic.gc_count', 'stacked'],
         'lines': [
             ['jvm_gc_collectors_young_collection_count', 'young', 'incremental'],
             ['jvm_gc_collectors_old_collection_count', 'old', 'incremental']
-        ]},
+        ]
+    },
     'jvm_gc_time': {
         'options': [None, 'Time Spent On Garbage Collections', 'ms', 'memory usage and gc',
                     'elastic.gc_time', 'stacked'],
         'lines': [
             ['jvm_gc_collectors_young_collection_time_in_millis', 'young', 'incremental'],
             ['jvm_gc_collectors_old_collection_time_in_millis', 'old', 'incremental']
-        ]},
+        ]
+    },
     'thread_pool_queued': {
         'options': [None, 'Number Of Queued Threads In Thread Pool', 'queued threads', 'queues and rejections',
                     'elastic.thread_pool_queued', 'stacked'],
@@ -315,7 +339,8 @@ CHARTS = {
             ['thread_pool_index_queue', 'index', 'absolute'],
             ['thread_pool_search_queue', 'search', 'absolute'],
             ['thread_pool_merge_queue', 'merge', 'absolute']
-        ]},
+        ]
+    },
     'thread_pool_rejected': {
         'options': [None, 'Rejected Threads In Thread Pool', 'rejected threads', 'queues and rejections',
                     'elastic.thread_pool_rejected', 'stacked'],
@@ -325,19 +350,22 @@ CHARTS = {
             ['thread_pool_index_rejected', 'index', 'absolute'],
             ['thread_pool_search_rejected', 'search', 'absolute'],
             ['thread_pool_merge_rejected', 'merge', 'absolute']
-        ]},
+        ]
+    },
     'fielddata_cache': {
         'options': [None, 'Fielddata Cache', 'MB', 'fielddata cache', 'elastic.fielddata_cache', 'line'],
         'lines': [
             ['indices_fielddata_memory_size_in_bytes', 'cache', 'absolute', 1, 1048576]
-        ]},
+        ]
+    },
     'fielddata_evictions_tripped': {
         'options': [None, 'Fielddata Evictions And Circuit Breaker Tripped Count', 'number of events',
                     'fielddata cache', 'elastic.fielddata_evictions_tripped', 'line'],
         'lines': [
             ['indices_fielddata_evictions', 'evictions', 'incremental'],
             ['indices_fielddata_tripped', 'tripped', 'incremental']
-        ]},
+        ]
+    },
     'cluster_health_nodes': {
         'options': [None, 'Nodes And Tasks Statistics', 'units', 'cluster health API',
                     'elastic.cluster_health_nodes', 'stacked'],
@@ -346,7 +374,8 @@ CHARTS = {
             ['number_of_data_nodes', 'data_nodes', 'absolute'],
             ['number_of_pending_tasks', 'pending_tasks', 'absolute'],
             ['number_of_in_flight_fetch', 'in_flight_fetch', 'absolute']
-        ]},
+        ]
+    },
     'cluster_health_status': {
         'options': [None, 'Cluster Status', 'status', 'cluster health API',
                     'elastic.cluster_health_status', 'area'],
@@ -357,7 +386,8 @@ CHARTS = {
             ['status_foo2', None, 'absolute'],
             ['status_foo3', None, 'absolute'],
             ['status_yellow', 'yellow', 'absolute']
-        ]},
+        ]
+    },
     'cluster_health_shards': {
         'options': [None, 'Shards Statistics', 'shards', 'cluster health API',
                     'elastic.cluster_health_shards', 'stacked'],
@@ -368,7 +398,8 @@ CHARTS = {
             ['delayed_unassigned_shards', 'delayed_unassigned', 'absolute'],
             ['initializing_shards', 'initializing', 'absolute'],
             ['active_shards_percent_as_number', 'active_percent', 'absolute']
-        ]},
+        ]
+    },
     'cluster_stats_nodes': {
         'options': [None, 'Nodes Statistics', 'nodes', 'cluster stats API',
                     'elastic.cluster_nodes', 'stacked'],
@@ -378,52 +409,60 @@ CHARTS = {
             ['nodes_count_total', 'total', 'absolute'],
             ['nodes_count_master_only', 'master_only', 'absolute'],
             ['nodes_count_client', 'client', 'absolute']
-        ]},
+        ]
+    },
     'cluster_stats_query_cache': {
         'options': [None, 'Query Cache Statistics', 'queries', 'cluster stats API',
                     'elastic.cluster_query_cache', 'stacked'],
         'lines': [
             ['indices_query_cache_hit_count', 'hit', 'incremental'],
             ['indices_query_cache_miss_count', 'miss', 'incremental']
-        ]},
+        ]
+    },
     'cluster_stats_docs': {
         'options': [None, 'Docs Statistics', 'count', 'cluster stats API',
                     'elastic.cluster_docs', 'line'],
         'lines': [
             ['indices_docs_count', 'docs', 'absolute']
-        ]},
+        ]
+    },
     'cluster_stats_store': {
         'options': [None, 'Store Statistics', 'MB', 'cluster stats API',
                     'elastic.cluster_store', 'line'],
         'lines': [
             ['indices_store_size_in_bytes', 'size', 'absolute', 1, 1048567]
-        ]},
+        ]
+    },
     'cluster_stats_indices_shards': {
         'options': [None, 'Indices And Shards Statistics', 'count', 'cluster stats API',
                     'elastic.cluster_indices_shards', 'stacked'],
         'lines': [
             ['indices_count', 'indices', 'absolute'],
             ['indices_shards_total', 'shards', 'absolute']
-        ]},
+        ]
+    },
     'host_metrics_transport': {
         'options': [None, 'Cluster Communication Transport Metrics', 'kilobit/s', 'host metrics',
                     'elastic.host_transport', 'area'],
         'lines': [
             ['transport_rx_size_in_bytes', 'in', 'incremental', 8, 1000],
             ['transport_tx_size_in_bytes', 'out', 'incremental', -8, 1000]
-        ]},
+        ]
+    },
     'host_metrics_file_descriptors': {
         'options': [None, 'Available File Descriptors In Percent', 'percent', 'host metrics',
                     'elastic.host_descriptors', 'area'],
         'lines': [
             ['file_descriptors_used', 'used', 'absolute', 1, 10]
-        ]},
+        ]
+    },
     'host_metrics_http': {
         'options': [None, 'Opened HTTP Connections', 'connections', 'host metrics',
                     'elastic.host_http_connections', 'line'],
         'lines': [
             ['http_current_open', 'opened', 'absolute', 1, 1]
-        ]}
+        ]
+    }
 }
 
 

--- a/python.d/exim.chart.py
+++ b/python.d/exim.chart.py
@@ -15,17 +15,18 @@ ORDER = ['qemails']
 
 CHARTS = {
     'qemails': {
-        'options': [None, "Exim Queue Emails", "emails", 'queue', 'exim.qemails', 'line'],
+        'options': [None, 'Exim Queue Emails', 'emails', 'queue', 'exim.qemails', 'line'],
         'lines': [
             ['emails', None, 'absolute']
-        ]}
+        ]
+    }
 }
 
 
 class Service(ExecutableService):
     def __init__(self, configuration=None, name=None):
         ExecutableService.__init__(self, configuration=configuration, name=name)
-        self.command = "exim -bpc"
+        self.command = 'exim -bpc'
         self.order = ORDER
         self.definitions = CHARTS
 

--- a/python.d/fail2ban.chart.py
+++ b/python.d/fail2ban.chart.py
@@ -24,19 +24,16 @@ def charts(jails):
     """
 
     ch = {
-        ORDER[0]:
-            {
+        ORDER[0]: {
                 'options':
                     [None, 'Jails Ban Rate', 'bans/s', 'bans', 'jail.bans', 'line'],
                 'lines': []
-            },
-        ORDER[1]:
-            {
-                'options':
-                    [None, 'Banned IPs (since the last restart of netdata)', 'IPs','in jail', 'jail.in_jail', 'line'],
-                'lines':
-                    []
-            },
+        },
+        ORDER[1]: {
+                'options': [None, 'Banned IPs (since the last restart of netdata)', 'IPs', 'in jail',
+                            'jail.in_jail', 'line'],
+                'lines': []
+        },
     }
     for jail in jails:
         ch[ORDER[0]]['lines'].append([jail, jail, 'incremental'])
@@ -53,7 +50,7 @@ RE_JAILS = re.compile(r'\[([a-zA-Z0-9_-]+)\][^\[\]]+?enabled\s+= (true|false)')
 RE_DATA = re.compile(r'\[(?P<jail>[A-Za-z-_0-9]+)\] (?P<action>Unban|Ban) (?P<ip>[a-f0-9.:]+)')
 
 DEFAULT_JAILS = [
-    "ssh",
+    'ssh',
 ]
 
 
@@ -76,8 +73,8 @@ class Service(LogService):
         """
         :return: bool
         """
-        if not self.conf_path.endswith((".conf", ".local")):
-            self.error("{0} is a wrong conf path name, must be *.conf or *.local".format(self.conf_path))
+        if not self.conf_path.endswith(('.conf', '.local')):
+            self.error('{0} is a wrong conf path name, must be *.conf or *.local'.format(self.conf_path))
             return False
 
         if not os.access(self.log_path, os.R_OK):
@@ -91,7 +88,7 @@ class Service(LogService):
         self.monitoring_jails = self.jails_auto_detection()
         for jail in self.monitoring_jails:
             self.data[jail] = 0
-            self.data["{0}_in_jail".format(jail)] = 0
+            self.data['{0}_in_jail'.format(jail)] = 0
 
         self.definitions = charts(self.monitoring_jails)
         self.info('monitoring jails: {0}'.format(self.monitoring_jails))
@@ -115,20 +112,20 @@ class Service(LogService):
 
             match = match.groupdict()
 
-            if match["jail"] not in self.monitoring_jails:
+            if match['jail'] not in self.monitoring_jails:
                 continue
 
             jail, action, ip = match['jail'], match['action'], match['ip']
 
-            if action == "Ban":
+            if action == 'Ban':
                 self.data[jail] += 1
                 if ip not in self.banned_ips[jail]:
                     self.banned_ips[jail].add(ip)
-                    self.data["{0}_in_jail".format(jail)] += 1
+                    self.data['{0}_in_jail'.format(jail)] += 1
             else:
                 if ip in self.banned_ips[jail]:
                     self.banned_ips[jail].remove(ip)
-                    self.data["{0}_in_jail".format(jail)] -= 1
+                    self.data['{0}_in_jail'.format(jail)] -= 1
 
             return self.data
 
@@ -137,28 +134,28 @@ class Service(LogService):
         :return: list
         """
         if not os.path.isdir(dir_path):
-            self.error("{0} is not a directory".format(dir_path))
+            self.error('{0} is not a directory'.format(dir_path))
             return list()
 
-        return glob("{0}/*.{1}".format(self.conf_dir, suffix))
+        return glob('{0}/*.{1}'.format(self.conf_dir, suffix))
 
     def get_jails_from_file(self, file_path):
         """
         :return: list
         """
         if not os.access(file_path, os.R_OK):
-            self.error("{0} is not readable or not exist".format(file_path))
+            self.error('{0} is not readable or not exist'.format(file_path))
             return list()
 
         with open(file_path, 'rt') as f:
             lines = f.readlines()
-            raw = " ".join(line for line in lines if line.startswith(('[', 'enabled')))
+            raw = ' '.join(line for line in lines if line.startswith(('[', 'enabled')))
 
         match = RE_JAILS.findall(raw)
         # Result: [('ssh', 'true'), ('dropbear', 'true'), ('pam-generic', 'true'), ...]
 
         if not match:
-            self.debug("{0} parse failed".format(file_path))
+            self.debug('{0} parse failed'.format(file_path))
             return list()
 
         return match
@@ -176,12 +173,12 @@ class Service(LogService):
         """
         jails_files, all_jails, active_jails = list(), list(), list()
 
-        jails_files.append("{0}.conf".format(self.conf_path.rsplit(".")[0]))
-        jails_files.extend(self.get_files_from_dir(self.conf_dir, "conf"))
-        jails_files.append("{0}.local".format(self.conf_path.rsplit(".")[0]))
-        jails_files.extend(self.get_files_from_dir(self.conf_dir, "local"))
+        jails_files.append('{0}.conf'.format(self.conf_path.rsplit('.')[0]))
+        jails_files.extend(self.get_files_from_dir(self.conf_dir, 'conf'))
+        jails_files.append('{0}.local'.format(self.conf_path.rsplit('.')[0]))
+        jails_files.extend(self.get_files_from_dir(self.conf_dir, 'local'))
 
-        self.debug("config files to parse: {0}".format(jails_files))
+        self.debug('config files to parse: {0}'.format(jails_files))
 
         for f in jails_files:
             all_jails.extend(self.get_jails_from_file(f))
@@ -192,9 +189,9 @@ class Service(LogService):
             if name in exclude:
                 continue
 
-            if status == "true" and name not in active_jails:
+            if status == 'true' and name not in active_jails:
                 active_jails.append(name)
-            elif status == "false" and name in active_jails:
+            elif status == 'false' and name in active_jails:
                 active_jails.remove(name)
 
         return active_jails or DEFAULT_JAILS

--- a/python.d/freeradius.chart.py
+++ b/python.d/freeradius.chart.py
@@ -21,7 +21,7 @@ ORDER = ['authentication', 'accounting', 'proxy-auth', 'proxy-acct']
 
 CHARTS = {
     'authentication': {
-        'options': [None, "Authentication", "packets/s", 'Authentication', 'freerad.auth', 'line'],
+        'options': [None, 'Authentication', 'packets/s', 'Authentication', 'freerad.auth', 'line'],
         'lines': [
             ['access-accepts', None, 'incremental'],
             ['access-rejects', None, 'incremental'],
@@ -30,9 +30,10 @@ CHARTS = {
             ['auth-invalid-requests', 'invalid-requests', 'incremental'],
             ['auth-malformed-requests', 'malformed-requests', 'incremental'],
             ['auth-unknown-types', 'unknown-types', 'incremental']
-            ]},
+        ]
+    },
     'accounting': {
-        'options': [None, "Accounting", "packets/s", 'Accounting', 'freerad.acct', 'line'],
+        'options': [None, 'Accounting', 'packets/s', 'Accounting', 'freerad.acct', 'line'],
         'lines': [
             ['accounting-requests', 'requests', 'incremental'],
             ['accounting-responses', 'responses', 'incremental'],
@@ -41,9 +42,10 @@ CHARTS = {
             ['acct-invalid-requests', 'invalid-requests', 'incremental'],
             ['acct-malformed-requests', 'malformed-requests', 'incremental'],
             ['acct-unknown-types', 'unknown-types', 'incremental']
-        ]},
+        ]
+    },
     'proxy-auth': {
-        'options': [None, "Proxy Authentication", "packets/s", 'Authentication', 'freerad.proxy.auth', 'line'],
+        'options': [None, 'Proxy Authentication', 'packets/s', 'Authentication', 'freerad.proxy.auth', 'line'],
         'lines': [
             ['proxy-access-accepts', 'access-accepts', 'incremental'],
             ['proxy-access-rejects', 'access-rejects', 'incremental'],
@@ -52,9 +54,10 @@ CHARTS = {
             ['proxy-auth-invalid-requests', 'invalid-requests', 'incremental'],
             ['proxy-auth-malformed-requests', 'malformed-requests', 'incremental'],
             ['proxy-auth-unknown-types', 'unknown-types', 'incremental']
-        ]},
+        ]
+    },
     'proxy-acct': {
-        'options': [None, "Proxy Accounting", "packets/s", 'Accounting', 'freerad.proxy.acct', 'line'],
+        'options': [None, 'Proxy Accounting', 'packets/s', 'Accounting', 'freerad.proxy.acct', 'line'],
         'lines': [
             ['proxy-accounting-requests', 'requests', 'incremental'],
             ['proxy-accounting-responses', 'responses', 'incremental'],
@@ -63,8 +66,8 @@ CHARTS = {
             ['proxy-acct-invalid-requests', 'invalid-requests', 'incremental'],
             ['proxy-acct-malformed-requests', 'malformed-requests', 'incremental'],
             ['proxy-acct-unknown-types', 'unknown-types', 'incremental']
-        ]}
-
+        ]
+    }
 }
 
 
@@ -106,7 +109,7 @@ class Service(SimpleService):
         """
         result = self._get_raw_data()
         return dict([(elem[0].lower(), int(elem[1])) for elem in findall(r'((?<=-)[AP][a-zA-Z-]+) = (\d+)', result)])
-        
+
     def _get_raw_data(self):
         """
         The following code is equivalent to

--- a/python.d/go_expvar.chart.py
+++ b/python.d/go_expvar.chart.py
@@ -21,43 +21,50 @@ MEMSTATS_CHARTS = {
         'lines': [
             ['memstats_heap_alloc', 'alloc', 'absolute', 1, 1024],
             ['memstats_heap_inuse', 'inuse', 'absolute', 1, 1024]
-        ]},
+        ]
+    },
     'memstats_stack': {
         'options': ['stack', 'memory: size of stack memory structures', 'kB', 'memstats',
                     'expvar.memstats.stack', 'line'],
         'lines': [
             ['memstats_stack_inuse', 'inuse', 'absolute', 1, 1024]
-        ]},
+        ]
+    },
     'memstats_mspan': {
         'options': ['mspan', 'memory: size of mspan memory structures', 'kB', 'memstats',
                     'expvar.memstats.mspan', 'line'],
         'lines': [
             ['memstats_mspan_inuse', 'inuse', 'absolute', 1, 1024]
-        ]},
+        ]
+    },
     'memstats_mcache': {
         'options': ['mcache', 'memory: size of mcache memory structures', 'kB', 'memstats',
                     'expvar.memstats.mcache', 'line'],
         'lines': [
             ['memstats_mcache_inuse', 'inuse', 'absolute', 1, 1024]
-        ]},
+        ]
+    },
     'memstats_live_objects': {
         'options': ['live_objects', 'memory: number of live objects', 'objects', 'memstats',
                     'expvar.memstats.live_objects', 'line'],
         'lines': [
             ['memstats_live_objects', 'live']
-        ]},
+        ]
+    },
     'memstats_sys': {
         'options': ['sys', 'memory: size of reserved virtual address space', 'kB', 'memstats',
                     'expvar.memstats.sys', 'line'],
         'lines': [
             ['memstats_sys', 'sys', 'absolute', 1, 1024]
-        ]},
+        ]
+    },
     'memstats_gc_pauses': {
         'options': ['gc_pauses', 'memory: average duration of GC pauses', 'ns', 'memstats',
                     'expvar.memstats.gc_pauses', 'line'],
         'lines': [
             ['memstats_gc_pauses', 'avg']
-        ]},
+        ]
+    }
 }
 
 MEMSTATS_ORDER = ['memstats_heap', 'memstats_stack', 'memstats_mspan', 'memstats_mcache',

--- a/python.d/haproxy.chart.py
+++ b/python.d/haproxy.chart.py
@@ -21,155 +21,185 @@ priority = 60000
 retries = 60
 
 # charts order (can be overridden if you want less charts, or different order)
-ORDER = ['fbin', 'fbout', 'fscur', 'fqcur',
-         'fhrsp_1xx', 'fhrsp_2xx', 'fhrsp_3xx', 'fhrsp_4xx', 'fhrsp_5xx', 'fhrsp_other', 'fhrsp_total',
-         'bbin', 'bbout', 'bscur', 'bqcur',
-         'bhrsp_1xx', 'bhrsp_2xx', 'bhrsp_3xx', 'bhrsp_4xx', 'bhrsp_5xx', 'bhrsp_other', 'bhrsp_total',
-         'bqtime', 'bttime', 'brtime', 'bctime',
-         'health_sup', 'health_sdown', 'health_bdown', 'health_idle']
+ORDER = [
+    'fbin',
+    'fbout',
+    'fscur',
+    'fqcur',
+    'fhrsp_1xx',
+    'fhrsp_2xx',
+    'fhrsp_3xx',
+    'fhrsp_4xx',
+    'fhrsp_5xx',
+    'fhrsp_other',
+    'fhrsp_total',
+    'bbin',
+    'bbout',
+    'bscur',
+    'bqcur',
+    'bhrsp_1xx',
+    'bhrsp_2xx',
+    'bhrsp_3xx',
+    'bhrsp_4xx',
+    'bhrsp_5xx',
+    'bhrsp_other',
+    'bhrsp_total',
+    'bqtime',
+    'bttime',
+    'brtime',
+    'bctime',
+    'health_sup',
+    'health_sdown',
+    'health_bdown',
+    'health_idle'
+]
 
 CHARTS = {
     'fbin': {
-        'options': [None, "Kilobytes In", "KB/s", 'frontend', 'haproxy_f.bin', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'Kilobytes In', 'KB/s', 'frontend', 'haproxy_f.bin', 'line'],
+        'lines': []
+    },
     'fbout': {
-        'options': [None, "Kilobytes Out", "KB/s", 'frontend', 'haproxy_f.bout', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'Kilobytes Out', 'KB/s', 'frontend', 'haproxy_f.bout', 'line'],
+        'lines': []
+    },
     'fscur': {
-        'options': [None, "Sessions Active", "sessions", 'frontend', 'haproxy_f.scur', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'Sessions Active', 'sessions', 'frontend', 'haproxy_f.scur', 'line'],
+        'lines': []
+    },
     'fqcur': {
-        'options': [None, "Session In Queue", "sessions", 'frontend', 'haproxy_f.qcur', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'Session In Queue', 'sessions', 'frontend', 'haproxy_f.qcur', 'line'],
+        'lines': []
+    },
     'fhrsp_1xx': {
-        'options': [None, "HTTP responses with 1xx code", "responses/s", 'frontend', 'haproxy_f.hrsp_1xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 1xx code', 'responses/s', 'frontend', 'haproxy_f.hrsp_1xx', 'line'],
+        'lines': []
+    },
     'fhrsp_2xx': {
-        'options': [None, "HTTP responses with 2xx code", "responses/s", 'frontend', 'haproxy_f.hrsp_2xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 2xx code', 'responses/s', 'frontend', 'haproxy_f.hrsp_2xx', 'line'],
+        'lines': []
+    },
     'fhrsp_3xx': {
-        'options': [None, "HTTP responses with 3xx code", "responses/s", 'frontend', 'haproxy_f.hrsp_3xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 3xx code', 'responses/s', 'frontend', 'haproxy_f.hrsp_3xx', 'line'],
+        'lines': []
+    },
     'fhrsp_4xx': {
-        'options': [None, "HTTP responses with 4xx code", "responses/s", 'frontend', 'haproxy_f.hrsp_4xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 4xx code', 'responses/s', 'frontend', 'haproxy_f.hrsp_4xx', 'line'],
+        'lines': []
+    },
     'fhrsp_5xx': {
-        'options': [None, "HTTP responses with 5xx code", "responses/s", 'frontend', 'haproxy_f.hrsp_5xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 5xx code', 'responses/s', 'frontend', 'haproxy_f.hrsp_5xx', 'line'],
+        'lines': []
+    },
     'fhrsp_other': {
-        'options': [None, "HTTP responses with other codes (protocol error)", "responses/s", 'frontend', 'haproxy_f.hrsp_other', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with other codes (protocol error)', 'responses/s', 'frontend',
+                    'haproxy_f.hrsp_other', 'line'],
+        'lines': []
+    },
     'fhrsp_total': {
-        'options': [None, "HTTP responses", "responses", 'frontend', 'haproxy_f.hrsp_total', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses', 'responses', 'frontend', 'haproxy_f.hrsp_total', 'line'],
+        'lines': []
+    },
     'bbin': {
-        'options': [None, "Kilobytes In", "KB/s", 'backend', 'haproxy_b.bin', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'Kilobytes In', 'KB/s', 'backend', 'haproxy_b.bin', 'line'],
+        'lines': []
+    },
     'bbout': {
-        'options': [None, "Kilobytes Out", "KB/s", 'backend', 'haproxy_b.bout', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'Kilobytes Out', 'KB/s', 'backend', 'haproxy_b.bout', 'line'],
+        'lines': []
+    },
     'bscur': {
-        'options': [None, "Sessions Active", "sessions", 'backend', 'haproxy_b.scur', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'Sessions Active', 'sessions', 'backend', 'haproxy_b.scur', 'line'],
+        'lines': []
+    },
     'bqcur': {
-        'options': [None, "Sessions In Queue", "sessions", 'backend', 'haproxy_b.qcur', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'Sessions In Queue', 'sessions', 'backend', 'haproxy_b.qcur', 'line'],
+        'lines': []
+    },
     'bhrsp_1xx': {
-        'options': [None, "HTTP responses with 1xx code", "responses/s", 'backend', 'haproxy_b.hrsp_1xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 1xx code', 'responses/s', 'backend', 'haproxy_b.hrsp_1xx', 'line'],
+        'lines': []
+    },
     'bhrsp_2xx': {
-        'options': [None, "HTTP responses with 2xx code", "responses/s", 'backend', 'haproxy_b.hrsp_2xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 2xx code', 'responses/s', 'backend', 'haproxy_b.hrsp_2xx', 'line'],
+        'lines': []
+    },
     'bhrsp_3xx': {
-        'options': [None, "HTTP responses with 3xx code", "responses/s", 'backend', 'haproxy_b.hrsp_3xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 3xx code', 'responses/s', 'backend', 'haproxy_b.hrsp_3xx', 'line'],
+        'lines': []
+    },
     'bhrsp_4xx': {
-        'options': [None, "HTTP responses with 4xx code", "responses/s", 'backend', 'haproxy_b.hrsp_4xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 4xx code', 'responses/s', 'backend', 'haproxy_b.hrsp_4xx', 'line'],
+        'lines': []
+    },
     'bhrsp_5xx': {
-        'options': [None, "HTTP responses with 5xx code", "responses/s", 'backend', 'haproxy_b.hrsp_5xx', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses with 5xx code', 'responses/s', 'backend', 'haproxy_b.hrsp_5xx', 'line'],
+        'lines': []
+    },
     'bhrsp_other': {
-        'options': [None, "HTTP responses with other codes (protocol error)", "responses/s", 'backend',
+        'options': [None, 'HTTP responses with other codes (protocol error)', 'responses/s', 'backend',
                     'haproxy_b.hrsp_other', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'bhrsp_total': {
-        'options': [None, "HTTP responses (total)", "responses/s", 'backend', 'haproxy_b.hrsp_total', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'HTTP responses (total)', 'responses/s', 'backend', 'haproxy_b.hrsp_total', 'line'],
+        'lines': []
+    },
     'bqtime': {
-        'options': [None, "The average queue time over the 1024 last requests", "ms", 'backend', 'haproxy_b.qtime', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'The average queue time over the 1024 last requests', 'ms', 'backend',
+                    'haproxy_b.qtime', 'line'],
+        'lines': []
+    },
     'bctime': {
-        'options': [None, "The average connect time over the 1024 last requests", "ms", 'backend',
+        'options': [None, 'The average connect time over the 1024 last requests', 'ms', 'backend',
                     'haproxy_b.ctime', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'brtime': {
-        'options': [None, "The average response time over the 1024 last requests", "ms", 'backend',
+        'options': [None, 'The average response time over the 1024 last requests', 'ms', 'backend',
                     'haproxy_b.rtime', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'bttime': {
-        'options': [None, "The average total session time over the 1024 last requests", "ms", 'backend',
+        'options': [None, 'The average total session time over the 1024 last requests', 'ms', 'backend',
                     'haproxy_b.ttime', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'health_sdown': {
-        'options': [None, "Backend Servers In DOWN State", "failed servers", 'health',
+        'options': [None, 'Backend Servers In DOWN State', 'failed servers', 'health',
                     'haproxy_hs.down', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'health_sup': {
-        'options': [None, "Backend Servers In UP State", "health servers", 'health',
+        'options': [None, 'Backend Servers In UP State', 'health servers', 'health',
                     'haproxy_hs.up', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'health_bdown': {
-        'options': [None, "Is Backend Alive? 1 = DOWN", "failed backend", 'health', 'haproxy_hb.down', 'line'],
-        'lines': [
-        ]},
+        'options': [None, 'Is Backend Alive? 1 = DOWN', 'failed backend', 'health', 'haproxy_hb.down', 'line'],
+        'lines': []
+    },
     'health_idle': {
-        'options': [None, "The Ratio Of Polling Time Vs Total Time", "percent", 'health', 'haproxy.idle', 'line'],
+        'options': [None, 'The Ratio Of Polling Time Vs Total Time', 'percent', 'health', 'haproxy.idle', 'line'],
         'lines': [
             ['idle', None, 'absolute']
-        ]}
+        ]
+    }
 }
 
 
-METRICS = {'bin': {'algorithm': 'incremental', 'divisor': 1024},
-           'bout': {'algorithm': 'incremental', 'divisor': 1024},
-           'scur': {'algorithm': 'absolute', 'divisor': 1},
-           'qcur': {'algorithm': 'absolute', 'divisor': 1},
-           'hrsp_1xx': {'algorithm': 'incremental', 'divisor': 1},
-           'hrsp_2xx': {'algorithm': 'incremental', 'divisor': 1},
-           'hrsp_3xx': {'algorithm': 'incremental', 'divisor': 1},
-           'hrsp_4xx': {'algorithm': 'incremental', 'divisor': 1},
-           'hrsp_5xx': {'algorithm': 'incremental', 'divisor': 1},
-           'hrsp_other': {'algorithm': 'incremental', 'divisor': 1},
-           }
+METRICS = {
+    'bin': {'algorithm': 'incremental', 'divisor': 1024},
+    'bout': {'algorithm': 'incremental', 'divisor': 1024},
+    'scur': {'algorithm': 'absolute', 'divisor': 1},
+    'qcur': {'algorithm': 'absolute', 'divisor': 1},
+    'hrsp_1xx': {'algorithm': 'incremental', 'divisor': 1},
+    'hrsp_2xx': {'algorithm': 'incremental', 'divisor': 1},
+    'hrsp_3xx': {'algorithm': 'incremental', 'divisor': 1},
+    'hrsp_4xx': {'algorithm': 'incremental', 'divisor': 1},
+    'hrsp_5xx': {'algorithm': 'incremental', 'divisor': 1},
+    'hrsp_other': {'algorithm': 'incremental', 'divisor': 1}
+}
 
 
 BACKEND_METRICS = {

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -36,12 +36,14 @@ CHARTS = {
         'options': [None, 'HTTP response time', 'ms', 'response', 'httpcheck.responsetime', 'line'],
         'lines': [
             [HTTP_RESPONSE_TIME, 'time', 'absolute', 100, 1000]
-        ]},
+        ]
+    },
     'response_length': {
         'options': [None, 'HTTP response body length', 'characters', 'response', 'httpcheck.responselength', 'line'],
         'lines': [
             [HTTP_RESPONSE_LENGTH, 'length', 'absolute']
-        ]},
+        ]
+    },
     'status': {
         'options': [None, 'HTTP status', 'boolean', 'status', 'httpcheck.status', 'line'],
         'lines': [
@@ -50,7 +52,8 @@ CHARTS = {
             [HTTP_BAD_STATUS, 'bad status', 'absolute'],
             [HTTP_TIMEOUT, 'timeout', 'absolute'],
             [HTTP_NO_CONNECTION, 'no connection', 'absolute']
-        ]}
+        ]
+    }
 }
 
 
@@ -88,15 +91,15 @@ class Service(UrlService):
             self.process_response(content, data, status)
 
         except urllib3.exceptions.NewConnectionError as error:
-            self.debug("Connection failed: {url}. Error: {error}".format(url=url, error=error))
+            self.debug('Connection failed: {url}. Error: {error}'.format(url=url, error=error))
             data[HTTP_NO_CONNECTION] = 1
 
         except (urllib3.exceptions.TimeoutError, urllib3.exceptions.PoolError) as error:
-            self.debug("Connection timed out: {url}. Error: {error}".format(url=url, error=error))
+            self.debug('Connection timed out: {url}. Error: {error}'.format(url=url, error=error))
             data[HTTP_TIMEOUT] = 1
 
         except urllib3.exceptions.HTTPError as error:
-            self.debug("Connection failed: {url}. Error: {error}".format(url=url, error=error))
+            self.debug('Connection failed: {url}. Error: {error}'.format(url=url, error=error))
             data[HTTP_NO_CONNECTION] = 1
 
         except (TypeError, AttributeError) as error:
@@ -110,7 +113,7 @@ class Service(UrlService):
         self.debug('Content: \n\n{content}\n'.format(content=content))
         if status in self.status_codes_accepted:
             if self.regex and self.regex.search(content) is None:
-                self.debug("No match for regex '{regex}' found".format(regex=self.regex.pattern))
+                self.debug('No match for regex '{regex}' found'.format(regex=self.regex.pattern))
                 data[HTTP_BAD_CONTENT] = 1
             else:
                 data[HTTP_SUCCESS] = 1

--- a/python.d/httpcheck.chart.py
+++ b/python.d/httpcheck.chart.py
@@ -113,7 +113,7 @@ class Service(UrlService):
         self.debug('Content: \n\n{content}\n'.format(content=content))
         if status in self.status_codes_accepted:
             if self.regex and self.regex.search(content) is None:
-                self.debug('No match for regex '{regex}' found'.format(regex=self.regex.pattern))
+                self.debug('No match for regex "{regex}" found'.format(regex=self.regex.pattern))
                 data[HTTP_BAD_CONTENT] = 1
             else:
                 data[HTTP_SUCCESS] = 1


### PR DESCRIPTION
PEP 8 compliance cleanups for python.d modules with names starting with D, E, F, G, and H.

Relevant: #4167