### PR TITLE
Python.d PEP 8 cleanup, modules I-L

### DIFF
--- a/python.d/icecast.chart.py
+++ b/python.d/icecast.chart.py
@@ -16,10 +16,10 @@ ORDER = ['listeners']
 
 CHARTS = {
     'listeners': {
-        'options': [None, 'Number Of Listeners', 'listeners',
-                    'listeners', 'icecast.listeners', 'line'],
+        'options': [None, 'Number Of Listeners', 'listeners', 'listeners', 'icecast.listeners', 'line'],
         'lines': [
-        ]}
+        ]
+    }
 }
 
 
@@ -87,7 +87,7 @@ class Service(UrlService):
         try:
             data = json.loads(raw_data)
         except ValueError as error:
-            self.error("JSON decode error:", error)
+            self.error('JSON decode error:', error)
             return None
 
         return data['icestats'].get('source')

--- a/python.d/ipfs.chart.py
+++ b/python.d/ipfs.chart.py
@@ -27,31 +27,43 @@ CHARTS = {
     'bandwidth': {
         'options': [None, 'IPFS Bandwidth', 'kbits/s', 'Bandwidth', 'ipfs.bandwidth', 'line'],
         'lines': [
-            ["in", None, "absolute", 8, 1000],
-            ["out", None, "absolute", -8, 1000]
-        ]},
+            ['in', None, 'absolute', 8, 1000],
+            ['out', None, 'absolute', -8, 1000]
+        ]
+    },
     'peers': {
         'options': [None, 'IPFS Peers', 'peers', 'Peers', 'ipfs.peers', 'line'],
         'lines': [
-            ["peers", None, 'absolute']
-        ]},
+            ['peers', None, 'absolute']
+        ]
+    },
     'repo_size': {
         'options': [None, 'IPFS Repo Size', 'GB', 'Size', 'ipfs.repo_size', 'area'],
         'lines': [
-            ["avail", None, "absolute", 1, 1e9],
-            ["size", None, "absolute", 1, 1e9],
-        ]},
+            ['avail', None, 'absolute', 1, 1e9],
+            ['size', None, 'absolute', 1, 1e9],
+        ]
+    },
     'repo_objects': {
         'options': [None, 'IPFS Repo Objects', 'objects', 'Objects', 'ipfs.repo_objects', 'line'],
         'lines': [
-            ["objects", None, "absolute", 1, 1],
-            ["pinned", None, "absolute", 1, 1],
-            ["recursive_pins", None, "absolute", 1, 1]
-        ]},
+            ['objects', None, 'absolute', 1, 1],
+            ['pinned', None, 'absolute', 1, 1],
+            ['recursive_pins', None, 'absolute', 1, 1]
+        ]
+    }
 }
 
-SI_zeroes = {'k': 3, 'm': 6, 'g': 9, 't': 12,
-             'p': 15, 'e': 18, 'z': 21, 'y': 24}
+SI_zeroes = {
+    'k': 3,
+    'm': 6,
+    'g': 9,
+    't': 12,
+    'p': 15,
+    'e': 18,
+    'z': 21,
+    'y': 24
+}
 
 
 class Service(UrlService):
@@ -75,7 +87,7 @@ class Service(UrlService):
 
     @staticmethod
     def _recursive_pins(keys):
-        return sum( 1 for k in keys if keys[k]["Type"] == b"recursive" )
+        return sum(1 for k in keys if keys[k]['Type'] == b'recursive')
 
     @staticmethod
     def _dehumanize(store_max):

--- a/python.d/isc_dhcpd.chart.py
+++ b/python.d/isc_dhcpd.chart.py
@@ -26,17 +26,18 @@ ORDER = ['pools_utilization', 'pools_active_leases', 'leases_total']
 
 CHARTS = {
     'pools_utilization': {
-        'options': [None, 'Pools Utilization', '%', 'utilization',
-                    'isc_dhcpd.utilization', 'line'],
-        'lines': []},
+        'options': [None, 'Pools Utilization', '%', 'utilization', 'isc_dhcpd.utilization', 'line'],
+        'lines': []
+    },
     'pools_active_leases': {
-        'options': [None, 'Active Leases Per Pool', 'leases', 'active leases',
-                    'isc_dhcpd.active_leases', 'line'],
-        'lines': []},
+        'options': [None, 'Active Leases Per Pool', 'leases', 'active leases', 'isc_dhcpd.active_leases', 'line'],
+        'lines': []
+    },
     'leases_total': {
-        'options': [None, 'All Active Leases', 'leases', 'active leases',
-                    'isc_dhcpd.leases_total', 'line'],
-        'lines': [['leases_total', 'leases', 'absolute']],
+        'options': [None, 'All Active Leases', 'leases', 'active leases', 'isc_dhcpd.leases_total', 'line'],
+        'lines': [
+            ['leases_total', 'leases', 'absolute']
+        ],
         'variables': [
             ['leases_size']
         ]

--- a/python.d/litespeed.chart.py
+++ b/python.d/litespeed.chart.py
@@ -25,95 +25,102 @@ ORDER = [
 
 CHARTS = {
     'net_throughput_http': {
-        'options': [
-            None, 'Network Throughput HTTP', 'kilobits/s', 'net throughput', 'litespeed.net_throughput', 'area'],
+        'options': [None, 'Network Throughput HTTP', 'kilobits/s', 'net throughput',
+                    'litespeed.net_throughput', 'area'],
         'lines': [
-            ["bps_in", "in", "absolute"],
-            ["bps_out", "out", "absolute", -1]
-        ]},
+            ['bps_in', 'in', 'absolute'],
+            ['bps_out', 'out', 'absolute', -1]
+        ]
+    },
     'net_throughput_https': {
-        'options': [
-            None, 'Network Throughput HTTPS', 'kilobits/s', 'net throughput', 'litespeed.net_throughput', 'area'],
+        'options': [None, 'Network Throughput HTTPS', 'kilobits/s', 'net throughput',
+                    'litespeed.net_throughput', 'area'],
         'lines': [
-            ["ssl_bps_in", "in", "absolute"],
-            ["ssl_bps_out", "out", "absolute", -1]
-        ]},
+            ['ssl_bps_in', 'in', 'absolute'],
+            ['ssl_bps_out', 'out', 'absolute', -1]
+        ]
+    },
     'connections_http': {
-        'options': [
-            None, 'Connections HTTP', 'conns', 'connections', 'litespeed.connections', 'stacked'],
+        'options': [None, 'Connections HTTP', 'conns', 'connections', 'litespeed.connections', 'stacked'],
         'lines': [
-            ["conn_free", "free", "absolute"],
-            ["conn_used", "used", "absolute"]
-        ]},
+            ['conn_free', 'free', 'absolute'],
+            ['conn_used', 'used', 'absolute']
+        ]
+    },
     'connections_https': {
-        'options': [
-            None, 'Connections HTTPS', 'conns', 'connections', 'litespeed.connections', 'stacked'],
+        'options': [None, 'Connections HTTPS', 'conns', 'connections', 'litespeed.connections', 'stacked'],
         'lines': [
-            ["ssl_conn_free", "free", "absolute"],
-            ["ssl_conn_used", "used", "absolute"]
-        ]},
+            ['ssl_conn_free', 'free', 'absolute'],
+            ['ssl_conn_used', 'used', 'absolute']
+        ]
+    },
     'requests': {
         'options': [None, 'Requests', 'requests/s', 'requests', 'litespeed.requests', 'line'],
         'lines': [
-            ["requests", None, "absolute", 1, 100]
-        ]},
+            ['requests', None, 'absolute', 1, 100]
+        ]
+    },
     'requests_processing': {
         'options': [None, 'Requests In Processing', 'requests', 'requests', 'litespeed.requests_processing', 'line'],
         'lines': [
-            ["requests_processing", "processing", "absolute"]
-        ]},
+            ['requests_processing', 'processing', 'absolute']
+        ]
+    },
     'pub_cache_hits': {
         'options': [None, 'Public Cache Hits', 'hits/s', 'cache', 'litespeed.cache', 'line'],
         'lines': [
-            ["pub_cache_hits", "hits", "absolute", 1, 100]
-        ]},
+            ['pub_cache_hits', 'hits', 'absolute', 1, 100]
+        ]
+    },
     'private_cache_hits': {
         'options': [None, 'Private Cache Hits', 'hits/s', 'cache', 'litespeed.cache', 'line'],
         'lines': [
-            ["private_cache_hits", "hits", "absolute", 1, 100]
-        ]},
+            ['private_cache_hits', 'hits', 'absolute', 1, 100]
+        ]
+    },
     'static_hits': {
         'options': [None, 'Static Hits', 'hits/s', 'static', 'litespeed.static', 'line'],
         'lines': [
-            ["static_hits", "hits", "absolute", 1, 100]
-        ]},
+            ['static_hits', 'hits', 'absolute', 1, 100]
+        ]
+    }
 }
 
-t = namedtuple("T", ["key", "id", "mul"])
+t = namedtuple('T', ['key', 'id', 'mul'])
 
 T = [
-    t("BPS_IN", "bps_in", 8),
-    t("BPS_OUT", "bps_out", 8),
-    t("SSL_BPS_IN", "ssl_bps_in", 8),
-    t("SSL_BPS_OUT", "ssl_bps_out", 8),
-    t("REQ_PER_SEC", "requests", 100),
-    t("REQ_PROCESSING", "requests_processing", 1),
-    t("PUB_CACHE_HITS_PER_SEC", "pub_cache_hits", 100),
-    t("PRIVATE_CACHE_HITS_PER_SEC", "private_cache_hits", 100),
-    t("STATIC_HITS_PER_SEC", "static_hits", 100),
-    t("PLAINCONN", "conn_used", 1),
-    t("AVAILCONN", "conn_free", 1),
-    t("SSLCONN", "ssl_conn_used", 1),
-    t("AVAILSSL", "ssl_conn_free", 1),
+    t('BPS_IN', 'bps_in', 8),
+    t('BPS_OUT', 'bps_out', 8),
+    t('SSL_BPS_IN', 'ssl_bps_in', 8),
+    t('SSL_BPS_OUT', 'ssl_bps_out', 8),
+    t('REQ_PER_SEC', 'requests', 100),
+    t('REQ_PROCESSING', 'requests_processing', 1),
+    t('PUB_CACHE_HITS_PER_SEC', 'pub_cache_hits', 100),
+    t('PRIVATE_CACHE_HITS_PER_SEC', 'private_cache_hits', 100),
+    t('STATIC_HITS_PER_SEC', 'static_hits', 100),
+    t('PLAINCONN', 'conn_used', 1),
+    t('AVAILCONN', 'conn_free', 1),
+    t('SSLCONN', 'ssl_conn_used', 1),
+    t('AVAILSSL', 'ssl_conn_free', 1),
 ]
 
 RE = re.compile(r'([A-Z_]+): ([0-9.]+)')
 
 ZERO_DATA = {
-    "bps_in": 0,
-    "bps_out": 0,
-    "ssl_bps_in": 0,
-    "ssl_bps_out": 0,
-    "requests": 0,
-    "requests_processing": 0,
-    "pub_cache_hits": 0,
-    "private_cache_hits": 0,
-    "static_hits": 0,
-    "conn_used": 0,
-    "conn_free": 0,
-    "ssl_conn_used": 0,
-    "ssl_conn_free": 0,
-    }
+    'bps_in': 0,
+    'bps_out': 0,
+    'ssl_bps_in': 0,
+    'ssl_bps_out': 0,
+    'requests': 0,
+    'requests_processing': 0,
+    'pub_cache_hits': 0,
+    'private_cache_hits': 0,
+    'static_hits': 0,
+    'conn_used': 0,
+    'conn_free': 0,
+    'ssl_conn_used': 0,
+    'ssl_conn_free': 0,
+}
 
 
 class Service(SimpleService):
@@ -121,7 +128,7 @@ class Service(SimpleService):
         SimpleService.__init__(self, configuration=configuration, name=name)
         self.order = ORDER
         self.definitions = CHARTS
-        self.path = self.configuration.get('path', "/tmp/lshttpd/")
+        self.path = self.configuration.get('path', '/tmp/lshttpd/')
         self.files = list()
 
     def check(self):
@@ -129,17 +136,17 @@ class Service(SimpleService):
             self.error('"path" not specified')
             return False
 
-        fs = glob.glob(os.path.join(self.path, ".rtreport*"))
+        fs = glob.glob(os.path.join(self.path, '.rtreport*'))
 
         if not fs:
             self.error('"{0}" has no "rtreport" files or dir is not readable'.format(self.path))
             return None
 
-        self.debug("stats files:", fs)
+        self.debug('stats files:', fs)
 
         for f in fs:
             if not is_readable_file(f):
-                self.error("{0} is not readable".format(f))
+                self.error('{0} is not readable'.format(f))
                 continue
             self.files.append(f)
 
@@ -167,7 +174,7 @@ class Service(SimpleService):
 
 def parse_file(data, lines):
     for line in lines:
-        if not line.startswith(("BPS_IN:", "MAXCONN:", "REQ_RATE []:")):
+        if not line.startswith(('BPS_IN:', 'MAXCONN:', 'REQ_RATE []:')):
             continue
         m = dict(RE.findall(line))
         for v in T:


### PR DESCRIPTION
PEP 8 compliance cleanups for python.d modules with names starting with I, J, K, and L (though we only have ones with I and L)..

Relevant: #4167