### PR TITLE
Python.d PEP 8 cleanup, modules N-O

### DIFF
--- a/python.d/nginx.chart.py
+++ b/python.d/nginx.chart.py
@@ -26,28 +26,32 @@ CHARTS = {
         'options': [None, 'nginx Active Connections', 'connections', 'active connections',
                     'nginx.connections', 'line'],
         'lines': [
-            ["active"]
-        ]},
+            ['active']
+        ]
+    },
     'requests': {
         'options': [None, 'nginx Requests', 'requests/s', 'requests', 'nginx.requests', 'line'],
         'lines': [
-            ["requests", None, 'incremental']
-        ]},
+            ['requests', None, 'incremental']
+        ]
+    },
     'connection_status': {
         'options': [None, 'nginx Active Connections by Status', 'connections', 'status',
                     'nginx.connection_status', 'line'],
         'lines': [
-            ["reading"],
-            ["writing"],
-            ["waiting", "idle"]
-        ]},
+            ['reading'],
+            ['writing'],
+            ['waiting', 'idle']
+        ]
+    },
     'connect_rate': {
         'options': [None, 'nginx Connections Rate', 'connections/s', 'connections rate',
                     'nginx.connect_rate', 'line'],
         'lines': [
-            ["accepts", "accepted", "incremental"],
-            ["handled", None, "incremental"]
-        ]}
+            ['accepts', 'accepted', 'incremental'],
+            ['handled', None, 'incremental']
+        ]
+    }
 }
 
 

--- a/python.d/nginx_plus.chart.py
+++ b/python.d/nginx_plus.chart.py
@@ -22,63 +22,71 @@ priority = 60000
 retries = 60
 
 # charts order (can be overridden if you want less charts, or different order)
-ORDER = ['requests_total', 'requests_current',
-         'connections_statistics', 'connections_workers',
-         'ssl_handshakes', 'ssl_session_reuses', 'ssl_memory_usage',
-         'processes']
+ORDER = [
+    'requests_total',
+    'requests_current',
+    'connections_statistics',
+    'connections_workers',
+    'ssl_handshakes',
+    'ssl_session_reuses',
+    'ssl_memory_usage',
+    'processes'
+]
 
 CHARTS = {
     'requests_total': {
-        'options': [None, 'Requests Total', 'requests/s',
-                    'requests', 'nginx_plus.requests_total', 'line'],
+        'options': [None, 'Requests Total', 'requests/s', 'requests', 'nginx_plus.requests_total', 'line'],
         'lines': [
             ['requests_total', 'total', 'incremental']
-        ]},
+        ]
+    },
     'requests_current': {
-        'options': [None, 'Requests Current', 'requests',
-                    'requests', 'nginx_plus.requests_current', 'line'],
+        'options': [None, 'Requests Current', 'requests', 'requests', 'nginx_plus.requests_current', 'line'],
         'lines': [
             ['requests_current', 'current']
-        ]},
+        ]
+    },
     'connections_statistics': {
         'options': [None, 'Connections Statistics', 'connections/s',
                     'connections', 'nginx_plus.connections_statistics', 'stacked'],
         'lines': [
             ['connections_accepted', 'accepted', 'incremental'],
             ['connections_dropped', 'dropped', 'incremental']
-        ]},
+        ]
+    },
     'connections_workers': {
         'options': [None, 'Workers Statistics', 'workers',
                     'connections', 'nginx_plus.connections_workers', 'stacked'],
         'lines': [
             ['connections_idle', 'idle'],
             ['connections_active', 'active']
-        ]},
+        ]
+    },
     'ssl_handshakes': {
-        'options': [None, 'SSL Handshakes', 'handshakes/s',
-                    'ssl', 'nginx_plus.ssl_handshakes', 'stacked'],
+        'options': [None, 'SSL Handshakes', 'handshakes/s', 'ssl', 'nginx_plus.ssl_handshakes', 'stacked'],
         'lines': [
             ['ssl_handshakes', 'successful', 'incremental'],
             ['ssl_handshakes_failed', 'failed', 'incremental']
-        ]},
+        ]
+    },
     'ssl_session_reuses': {
-        'options': [None, 'Session Reuses', 'sessions/s',
-                    'ssl', 'nginx_plus.ssl_session_reuses', 'line'],
+        'options': [None, 'Session Reuses', 'sessions/s', 'ssl', 'nginx_plus.ssl_session_reuses', 'line'],
         'lines': [
             ['ssl_session_reuses', 'reused', 'incremental']
-        ]},
+        ]
+    },
     'ssl_memory_usage': {
-        'options': [None, 'Memory Usage', '%',
-                    'ssl', 'nginx_plus.ssl_memory_usage', 'area'],
+        'options': [None, 'Memory Usage', '%', 'ssl', 'nginx_plus.ssl_memory_usage', 'area'],
         'lines': [
             ['ssl_memory_usage', 'usage', 'absolute', 1, 100]
-        ]},
+        ]
+    },
     'processes': {
-        'options': [None, 'Processes', 'processes',
-                    'processes', 'nginx_plus.processes', 'line'],
+        'options': [None, 'Processes', 'processes', 'processes', 'nginx_plus.processes', 'line'],
         'lines': [
             ['processes_respawned', 'respawned']
-        ]}
+        ]
+    }
 }
 
 
@@ -87,17 +95,15 @@ def cache_charts(cache):
     charts = OrderedDict()
 
     charts['{0}_traffic'.format(cache.name)] = {
-        'options': [None, 'Traffic', 'KB', family,
-                    'nginx_plus.cache_traffic', 'stacked'],
+        'options': [None, 'Traffic', 'KB', family, 'nginx_plus.cache_traffic', 'stacked'],
         'lines': [
             ['_'.join([cache.name, 'hit_bytes']), 'served', 'absolute', 1, 1024],
             ['_'.join([cache.name, 'miss_bytes_written']), 'written', 'absolute', 1, 1024],
             ['_'.join([cache.name, 'miss_bytes']), 'bypass', 'absolute', 1, 1024]
-            ]
+        ]
     }
     charts['{0}_memory_usage'.format(cache.name)] = {
-        'options': [None, 'Memory Usage', '%', family,
-                    'nginx_plus.cache_memory_usage', 'area'],
+        'options': [None, 'Memory Usage', '%', family, 'nginx_plus.cache_memory_usage', 'area'],
         'lines': [
             ['_'.join([cache.name, 'memory_usage']), 'usage', 'absolute', 1, 100],
         ]
@@ -161,8 +167,7 @@ def web_upstream_charts(wu):
 
     # Requests
     charts['web_upstream_{name}_requests'.format(name=wu.name)] = {
-        'options': [None, 'Peers Requests', 'requests/s', family,
-                    'nginx_plus.web_upstream_requests', 'line'],
+        'options': [None, 'Peers Requests', 'requests/s', family, 'nginx_plus.web_upstream_requests', 'line'],
         'lines': dimensions('requests', 'incremental')
     }
     # Responses Codes
@@ -191,19 +196,16 @@ def web_upstream_charts(wu):
         }
     # Connections
     charts['web_upstream_{name}_connections'.format(name=wu.name)] = {
-        'options': [None, 'Peers Connections', 'active', family,
-                    'nginx_plus.web_upstream_connections', 'line'],
+        'options': [None, 'Peers Connections', 'active', family, 'nginx_plus.web_upstream_connections', 'line'],
         'lines': dimensions('active')
     }
     charts['web_upstream_{name}_connections_usage'.format(name=wu.name)] = {
-        'options': [None, 'Peers Connections Usage', '%', family,
-                    'nginx_plus.web_upstream_connections_usage', 'line'],
+        'options': [None, 'Peers Connections Usage', '%', family, 'nginx_plus.web_upstream_connections_usage', 'line'],
         'lines': dimensions('connections_usage', d=100)
     }
     # Traffic
     charts['web_upstream_{0}_all_net'.format(wu.name)] = {
-        'options': [None, 'All Peers Traffic', 'kilobits/s', family,
-                    'nginx_plus.web_upstream_all_net', 'area'],
+        'options': [None, 'All Peers Traffic', 'kilobits/s', family, 'nginx_plus.web_upstream_all_net', 'area'],
         'lines': [
             ['{0}_received'.format(wu.name), 'received', 'incremental', 1, 1000],
             ['{0}_sent'.format(wu.name), 'sent', 'incremental', -1, 1000]
@@ -230,30 +232,27 @@ def web_upstream_charts(wu):
         }
     # Memory Usage
     charts['web_upstream_{name}_memory_usage'.format(name=wu.name)] = {
-        'options': [None, 'Memory Usage', '%', family,
-                    'nginx_plus.web_upstream_memory_usage', 'area'],
+        'options': [None, 'Memory Usage', '%', family, 'nginx_plus.web_upstream_memory_usage', 'area'],
         'lines': [
             ['_'.join([wu.name, 'memory_usage']), 'usage', 'absolute', 1, 100]
         ]
     }
     # State
     charts['web_upstream_{name}_status'.format(name=wu.name)] = {
-        'options': [None, 'Peers Status', 'state', family,
-                    'nginx_plus.web_upstream_status', 'line'],
+        'options': [None, 'Peers Status', 'state', family, 'nginx_plus.web_upstream_status', 'line'],
         'lines': dimensions('state')
     }
     # Downtime
     charts['web_upstream_{name}_downtime'.format(name=wu.name)] = {
-        'options': [None, 'Peers Downtime', 'seconds', family,
-                    'nginx_plus.web_upstream_peer_downtime', 'line'],
+        'options': [None, 'Peers Downtime', 'seconds', family, 'nginx_plus.web_upstream_peer_downtime', 'line'],
         'lines': dimensions('downtime', d=1000)
     }
 
     return charts
 
 
-METRICS = dict(
-    SERVER=[
+METRICS = {
+    'SERVER': [
         'processes.respawned',
         'connections.accepted',
         'connections.dropped',
@@ -267,7 +266,7 @@ METRICS = dict(
         'slabs.SSL.pages.free',
         'slabs.SSL.pages.used'
     ],
-    WEB_ZONE=[
+    'WEB_ZONE': [
         'processing',
         'requests',
         'responses.1xx',
@@ -279,7 +278,7 @@ METRICS = dict(
         'received',
         'sent'
     ],
-    WEB_UPSTREAM_PEER=[
+    'WEB_UPSTREAM_PEER': [
         'id',
         'server',
         'name',
@@ -298,7 +297,7 @@ METRICS = dict(
         'received',
         'downtime'
     ],
-    WEB_UPSTREAM_SUMMARY=[
+    'WEB_UPSTREAM_SUMMARY': [
         'responses.1xx',
         'responses.2xx',
         'responses.3xx',
@@ -307,13 +306,13 @@ METRICS = dict(
         'sent',
         'received'
     ],
-    CACHE=[
+    'CACHE': [
         'hit.bytes',  # served
         'miss.bytes_written',  # written
         'miss.bytes'  # bypass
 
     ]
-)
+}
 
 BAD_SYMBOLS = re.compile(r'[:/.-]+')
 

--- a/python.d/nsd.chart.py
+++ b/python.d/nsd.chart.py
@@ -17,27 +17,29 @@ ORDER = ['queries', 'zones', 'protocol', 'type', 'transfer', 'rcode']
 
 CHARTS = {
     'queries': {
-        'options': [
-            None, "queries", 'queries/s', 'queries', 'nsd.queries', 'line'],
+        'options': [None, 'queries', 'queries/s', 'queries', 'nsd.queries', 'line'],
         'lines': [
-            ['num_queries', 'queries', 'incremental'],]},
+            ['num_queries', 'queries', 'incremental']
+        ]
+    },
     'zones': {
-        'options': [
-            None, "zones", 'zones', 'zones', 'nsd.zones', 'stacked'],
+        'options': [None, 'zones', 'zones', 'zones', 'nsd.zones', 'stacked'],
         'lines': [
             ['zone_master', 'master', 'absolute'],
-            ['zone_slave', 'slave', 'absolute'],]},
+            ['zone_slave', 'slave', 'absolute']
+        ]
+    },
     'protocol': {
-        'options': [
-            None, "protocol", 'queries/s', 'protocol', 'nsd.protocols', 'stacked'],
+        'options': [None, 'protocol', 'queries/s', 'protocol', 'nsd.protocols', 'stacked'],
         'lines': [
             ['num_udp', 'udp', 'incremental'],
             ['num_udp6', 'udp6', 'incremental'],
             ['num_tcp', 'tcp', 'incremental'],
-            ['num_tcp6', 'tcp6', 'incremental'],]},
+            ['num_tcp6', 'tcp6', 'incremental']
+        ]
+    },
     'type': {
-        'options': [
-            None, "query type", 'queries/s', 'query type', 'nsd.type', 'stacked'],
+        'options': [None, 'query type', 'queries/s', 'query type', 'nsd.type', 'stacked'],
         'lines': [
             ['num_type_A', 'A', 'incremental'],
             ['num_type_NS', 'NS', 'incremental'],
@@ -50,16 +52,18 @@ CHARTS = {
             ['num_type_TXT', 'TXT', 'incremental'],
             ['num_type_AAAA', 'AAAA', 'incremental'],
             ['num_type_SRV', 'SRV', 'incremental'],
-            ['num_type_TYPE255', 'ANY', 'incremental'],]},
+            ['num_type_TYPE255', 'ANY', 'incremental']
+        ]
+    },
     'transfer': {
-        'options': [
-            None, "transfer", 'queries/s', 'transfer', 'nsd.transfer', 'stacked'],
+        'options': [None, 'transfer', 'queries/s', 'transfer', 'nsd.transfer', 'stacked'],
         'lines': [
             ['num_opcode_NOTIFY', 'NOTIFY', 'incremental'],
-            ['num_type_TYPE252', 'AXFR', 'incremental'],]},
+            ['num_type_TYPE252', 'AXFR', 'incremental']
+        ]
+    },
     'rcode': {
-        'options': [
-            None, "return code", 'queries/s', 'return code', 'nsd.rcode', 'stacked'],
+        'options': [None, 'return code', 'queries/s', 'return code', 'nsd.rcode', 'stacked'],
         'lines': [
             ['num_rcode_NOERROR', 'NOERROR', 'incremental'],
             ['num_rcode_FORMERR', 'FORMERR', 'incremental'],
@@ -67,7 +71,9 @@ CHARTS = {
             ['num_rcode_NXDOMAIN', 'NXDOMAIN', 'incremental'],
             ['num_rcode_NOTIMP', 'NOTIMP', 'incremental'],
             ['num_rcode_REFUSED', 'REFUSED', 'incremental'],
-            ['num_rcode_YXDOMAIN', 'YXDOMAIN', 'incremental'],]}
+            ['num_rcode_YXDOMAIN', 'YXDOMAIN', 'incremental']
+        ]
+    }
 }
 
 
@@ -75,7 +81,7 @@ class Service(ExecutableService):
     def __init__(self, configuration=None, name=None):
         ExecutableService.__init__(
             self, configuration=configuration, name=name)
-        self.command = "nsd-control stats_noreset"
+        self.command = 'nsd-control stats_noreset'
         self.order = ORDER
         self.definitions = CHARTS
         self.regex = re.compile(r'([A-Za-z0-9.]+)=(\d+)')

--- a/python.d/ntpd.chart.py
+++ b/python.d/ntpd.chart.py
@@ -57,108 +57,117 @@ CHARTS = {
         'options': [None, 'Combined offset of server relative to this host', 'ms', 'system', 'ntpd.sys_offset', 'area'],
         'lines': [
             ['offset', 'offset', 'absolute', 1, PRECISION]
-        ]},
+        ]
+    },
     'sys_jitter': {
         'options': [None, 'Combined system jitter and clock jitter', 'ms', 'system', 'ntpd.sys_jitter', 'line'],
         'lines': [
             ['sys_jitter', 'system', 'absolute', 1, PRECISION],
             ['clk_jitter', 'clock', 'absolute', 1, PRECISION]
-        ]},
+        ]
+    },
     'sys_frequency': {
         'options': [None, 'Frequency offset relative to hardware clock', 'ppm', 'system', 'ntpd.sys_frequency', 'area'],
         'lines': [
             ['frequency', 'frequency', 'absolute', 1, PRECISION]
-        ]},
+        ]
+    },
     'sys_wander': {
         'options': [None, 'Clock frequency wander', 'ppm', 'system', 'ntpd.sys_wander', 'area'],
         'lines': [
             ['clk_wander', 'clock', 'absolute', 1, PRECISION]
-        ]},
+        ]
+    },
     'sys_rootdelay': {
         'options': [None, 'Total roundtrip delay to the primary reference clock', 'ms', 'system',
                     'ntpd.sys_rootdelay', 'area'],
         'lines': [
             ['rootdelay', 'delay', 'absolute', 1, PRECISION]
-        ]},
+        ]
+    },
     'sys_rootdisp': {
         'options': [None, 'Total root dispersion to the primary reference clock', 'ms', 'system',
                     'ntpd.sys_rootdisp', 'area'],
         'lines': [
             ['rootdisp', 'dispersion', 'absolute', 1, PRECISION]
-        ]},
+        ]
+    },
     'sys_stratum': {
         'options': [None, 'Stratum (1-15)', 'stratum', 'system', 'ntpd.sys_stratum', 'line'],
         'lines': [
             ['stratum', 'stratum', 'absolute', 1, PRECISION]
-        ]},
+        ]
+    },
     'sys_tc': {
         'options': [None, 'Time constant and poll exponent (3-17)', 'log2 s', 'system', 'ntpd.sys_tc', 'line'],
         'lines': [
             ['tc', 'current', 'absolute', 1, PRECISION],
             ['mintc', 'minimum', 'absolute', 1, PRECISION]
-        ]},
+        ]
+    },
     'sys_precision': {
         'options': [None, 'Precision', 'log2 s', 'system', 'ntpd.sys_precision', 'line'],
         'lines': [
             ['precision', 'precision', 'absolute', 1, PRECISION]
-        ]}
+        ]
+    }
 }
 
 PEER_CHARTS = {
     'peer_offset': {
         'options': [None, 'Filter offset', 'ms', 'peers', 'ntpd.peer_offset', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_delay': {
         'options': [None, 'Filter delay', 'ms', 'peers', 'ntpd.peer_delay', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_dispersion': {
         'options': [None, 'Filter dispersion', 'ms', 'peers', 'ntpd.peer_dispersion', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_jitter': {
         'options': [None, 'Filter jitter', 'ms', 'peers', 'ntpd.peer_jitter', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_xleave': {
         'options': [None, 'Interleave delay', 'ms', 'peers', 'ntpd.peer_xleave', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_rootdelay': {
         'options': [None, 'Total roundtrip delay to the primary reference clock', 'ms', 'peers',
                     'ntpd.peer_rootdelay', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_rootdisp': {
         'options': [None, 'Total root dispersion to the primary reference clock', 'ms', 'peers',
                     'ntpd.peer_rootdisp', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_stratum': {
         'options': [None, 'Stratum (1-15)', 'stratum', 'peers', 'ntpd.peer_stratum', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_hmode': {
         'options': [None, 'Host mode (1-6)', 'hmode', 'peers', 'ntpd.peer_hmode', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_pmode': {
         'options': [None, 'Peer mode (1-5)', 'pmode', 'peers', 'ntpd.peer_pmode', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_hpoll': {
         'options': [None, 'Host poll exponent', 'log2 s', 'peers', 'ntpd.peer_hpoll', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_ppoll': {
         'options': [None, 'Peer poll exponent', 'log2 s', 'peers', 'ntpd.peer_ppoll', 'line'],
-        'lines': [
-        ]},
+        'lines': []
+    },
     'peer_precision': {
         'options': [None, 'Precision', 'log2 s', 'peers', 'ntpd.peer_precision', 'line'],
-        'lines': [
-        ]}
+        'lines': []
+    }
 }
 
 

--- a/python.d/ovpn_status_log.chart.py
+++ b/python.d/ovpn_status_log.chart.py
@@ -27,6 +27,9 @@ CHARTS = {
     }
 }
 
+TLS_REGEX = r_compile(r'(?:[0-9a-f:]+|(?:\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?)) (?P<bytes_in>\d+) (?P<bytes_out>\d+)')
+STATIC_KEY_REGEX = r_compile(r'TCP/[A-Z]+ (?P<direction>(?:read|write)) bytes,(?P<bytes>\d+)')
+
 
 class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
@@ -35,8 +38,8 @@ class Service(SimpleService):
         self.definitions = CHARTS
         self.log_path = self.configuration.get('log_path')
         self.regex = {
-            'tls': r_compile(r'(?:[0-9a-f:]+|(?:\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?)) (?P<bytes_in>\d+) (?P<bytes_out>\d+)'),
-            'static_key': r_compile(r'TCP/[A-Z]+ (?P<direction>(?:read|write)) bytes,(?P<bytes>\d+)')
+            'tls': TLS_REGEX,
+            'static_key': STATIC_KEY_REGEX
         }
 
     def check(self):

--- a/python.d/ovpn_status_log.chart.py
+++ b/python.d/ovpn_status_log.chart.py
@@ -17,13 +17,14 @@ CHARTS = {
         'options': [None, 'OpenVPN Active Users', 'active users', 'users', 'openvpn_status.users', 'line'],
         'lines': [
             ['users', None, 'absolute'],
-        ]},
+        ]
+    },
     'traffic': {
         'options': [None, 'OpenVPN Traffic', 'KB/s', 'traffic', 'openvpn_status.traffic', 'area'],
         'lines': [
             ['bytes_in', 'in', 'incremental', 1, 1 << 10], ['bytes_out', 'out', 'incremental', 1, -1 << 10]
-        ]},
-
+        ]
+    }
 }
 
 
@@ -33,8 +34,10 @@ class Service(SimpleService):
         self.order = ORDER
         self.definitions = CHARTS
         self.log_path = self.configuration.get('log_path')
-        self.regex = dict(tls=r_compile(r'(?:[0-9a-f:]+|(?:\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?)) (?P<bytes_in>\d+) (?P<bytes_out>\d+)'),
-                          static_key=r_compile(r'TCP/[A-Z]+ (?P<direction>(?:read|write)) bytes,(?P<bytes>\d+)'))
+        self.regex = {
+            'tls': r_compile(r'(?:[0-9a-f:]+|(?:\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?)) (?P<bytes_in>\d+) (?P<bytes_out>\d+)'),
+            'static_key': r_compile(r'TCP/[A-Z]+ (?P<direction>(?:read|write)) bytes,(?P<bytes>\d+)')
+        }
 
     def check(self):
         if not (self.log_path and isinstance(self.log_path, str)):
@@ -58,7 +61,7 @@ class Service(SimpleService):
                 break
         if found:
             return True
-        self.error("Failed to parse ovpenvpn log file")
+        self.error('Failed to parse ovpenvpn log file')
         return False
 
     def _get_raw_data(self):
@@ -109,7 +112,9 @@ class Service(SimpleService):
         data = dict(users=0, bytes_in=0, bytes_out=0)
         for row in raw_data:
             columns = row.split(',') if ',' in row else row.split()
-            if 'UNDEF' in columns: continue # see https://openvpn.net/archive/openvpn-users/2004-08/msg00116.html
+            if 'UNDEF' in columns:
+                # see https://openvpn.net/archive/openvpn-users/2004-08/msg00116.html
+                continue
 
             match = self.regex['tls'].search(' '.join(columns))
             if match:


### PR DESCRIPTION
PEP 8 compliance cleanups for python.d modules with names starting with N and O.

Relevant: #4167

The `ovpn_status_log.chart.py` module has one remaining instance of a line over 120 characters in length.  The lin in question is 122 characters, and consists predominantly of a rather large regex.  Any of the options I could come up with for splitting this line so it's shorter either looked odd or made the code noticeably less readable, so I left it in under the assumption that we're taking the same approach here for long lines that the Linux Kernel devs do (if it's only a few characters longer than the limit and it's more readable than the alternatives, keep it that way).