### PR TITLE
force symlink of netdata-updater.sh

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1290,16 +1290,16 @@ REINSTALL
                 if [ "${AUTOUPDATE}" = "1" ]
                 then
                     progress "Installing netdata-updater at cron"
-                    run ln -s "${PWD}/netdata-updater.sh" "${crondir}/netdata-updater"
+                    run ln -fs "${PWD}/netdata-updater.sh" "${crondir}/netdata-updater"
                 else
                     echo >&2 "${TPUT_DIM}Run this to automatically check and install netdata updates once per day:${TPUT_RESET}"
                     echo >&2
-                    echo >&2 "${TPUT_YELLOW}${TPUT_BOLD}sudo ln -s ${PWD}/netdata-updater.sh ${crondir}/netdata-updater${TPUT_RESET}"
+                    echo >&2 "${TPUT_YELLOW}${TPUT_BOLD}sudo ln -fs ${PWD}/netdata-updater.sh ${crondir}/netdata-updater${TPUT_RESET}"
                 fi
             else
                 progress "Refreshing netdata-updater at cron"
                 run rm "${crondir}/netdata-updater"
-                run ln -s "${PWD}/netdata-updater.sh" "${crondir}/netdata-updater"
+                run ln -fs "${PWD}/netdata-updater.sh" "${crondir}/netdata-updater"
             fi
         else
             [ "${AUTOUPDATE}" = "1" ] && echo >&2 "Cannot figure out the cron directory to install netdata-updater."


### PR DESCRIPTION
Today I moved the netdata git to another directory. I ran the installer to refresh the files with the new path but the script failed when it tried to (re)create the symlink for the cronjob. This fix just adds the force flag to ln.