### PR TITLE
cleanup FIXME tags

### DIFF
--- a/src/apps_plugin.c
+++ b/src/apps_plugin.c
@@ -1023,7 +1023,7 @@ static inline int read_proc_pid_status(struct pid_stat *p, void *ptr) {
     p->gid                  = proc_info->ki_groups[0];
     p->status_vmsize        = proc_info->ki_size / 1024; // in kB
     p->status_vmrss         = proc_info->ki_rssize * pagesize / 1024; // in kB
-    // FIXME: what about shared and swap memory on FreeBSD?
+    // TODO: what about shared and swap memory on FreeBSD?
     return 1;
 #else
     (void)ptr;
@@ -1578,13 +1578,13 @@ static inline int file_descriptor_find_or_add(const char *name, uint32_t hash) {
         else if(strcmp(t, "[timerfd]") == 0) type = FILETYPE_TIMERFD;
         else if(strcmp(t, "[signalfd]") == 0) type = FILETYPE_SIGNALFD;
         else {
-            debug_log("FIXME: unknown anonymous inode: %s", name);
+            debug_log("UNKNOWN anonymous inode: %s", name);
             type = FILETYPE_OTHER;
         }
     }
     else if(likely(strcmp(name, "inotify") == 0)) type = FILETYPE_INOTIFY;
     else {
-        debug_log("FIXME: cannot understand linkname: %s", name);
+        debug_log("UNKNOWN linkname: %s", name);
         type = FILETYPE_OTHER;
     }
 
@@ -3049,7 +3049,7 @@ static void normalize_utilization(struct target *root) {
     // if(gtime_fix_ratio  < 0.0) gtime_fix_ratio  = 0.0;
     // if(cgtime_fix_ratio < 0.0) cgtime_fix_ratio = 0.0;
 
-    // FIXME
+    // TODO
     // we use cpu time to normalize page faults
     // the problem is that to find the proper max values
     // for page faults we have to parse /proc/vmstat

--- a/src/backends.c
+++ b/src/backends.c
@@ -804,7 +804,7 @@ void *backends_main(void *ptr) {
 
         if(unlikely(netdata_exit)) break;
 
-        //fprintf(stderr, "\nBACKEND BEGIN:\n%s\nBACKEND END\n", buffer_tostring(b)); // FIXME
+        //fprintf(stderr, "\nBACKEND BEGIN:\n%s\nBACKEND END\n", buffer_tostring(b));
         //fprintf(stderr, "after = %lu, before = %lu\n", after, before);
 
         // prepare for the next iteration

--- a/src/cgroup-network.c
+++ b/src/cgroup-network.c
@@ -217,8 +217,8 @@ int switch_namespace(const char *prefix, pid_t pid) {
     // 2 passes - found it at nsenter source code
     // this is related CLONE_NEWUSER functionality
 
-    // FIXME: this code cannot switch user namespace
-    // Fortunately, we don't need it.
+    // This code cannot switch user namespace (it can all the other namespaces)
+    // Fortunately, we don't need to switch user namespaces.
 
     int pass, errors = 0;
     for(pass = 0; pass < 2 ;pass++) {

--- a/src/plugin_nfacct.c
+++ b/src/plugin_nfacct.c
@@ -21,7 +21,7 @@ static inline size_t mnl_buffer_size() {
 #define DO_NFSTAT 1
 
 #define RRD_TYPE_NET_STAT_NETFILTER "netfilter"
-#define RRD_TYPE_NET_STAT_CONNTRACK "netlink" // FIXME: should be "conntrack" when merged with the /proc plugin
+#define RRD_TYPE_NET_STAT_CONNTRACK "netlink"
 
 #include <linux/netfilter/nfnetlink_conntrack.h>
 
@@ -592,7 +592,7 @@ static void nfacct_cleanup() {
     nfacct_root.buf = NULL;
     nfacct_root.buf_size = 0;
 
-    // FIXME: cleanup the metrics linked list
+    // TODO: cleanup the metrics linked list
 }
 
 static int nfacct_callback(const struct nlmsghdr *nlh, void *data) {

--- a/src/plugin_tc.c
+++ b/src/plugin_tc.c
@@ -404,7 +404,7 @@ static inline void tc_device_commit(struct tc_device *d) {
             rrdset_next(d->st_bytes);
             if(unlikely(d->name_updated)) rrdset_set_name(d->st_bytes, d->name);
 
-            // FIXME
+            // TODO
             // update the family
         }
 
@@ -457,7 +457,7 @@ static inline void tc_device_commit(struct tc_device *d) {
                 rrdset_set_name(d->st_packets, name);
             }
 
-            // FIXME
+            // TODO
             // update the family
         }
 
@@ -510,7 +510,7 @@ static inline void tc_device_commit(struct tc_device *d) {
                 rrdset_set_name(d->st_dropped, name);
             }
 
-            // FIXME
+            // TODO
             // update the family
         }
 
@@ -563,7 +563,7 @@ static inline void tc_device_commit(struct tc_device *d) {
                 rrdset_set_name(d->st_tokens, name);
             }
 
-            // FIXME
+            // TODO
             // update the family
         }
 
@@ -618,7 +618,7 @@ static inline void tc_device_commit(struct tc_device *d) {
                 rrdset_set_name(d->st_ctokens, name);
             }
 
-            // FIXME
+            // TODO
             // update the family
         }
 

--- a/src/proc_stat.c
+++ b/src/proc_stat.c
@@ -250,8 +250,8 @@ int do_proc_stat(int update_every, usec_t dt) {
                         family = "utilization";
                         priority = 1000;
 
-                        // FIXME: check for /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq
-                        // FIXME: check for /sys/devices/system/cpu/cpu*/cpufreq/stats/time_in_state
+                        // TODO: check for /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq
+                        // TODO: check for /sys/devices/system/cpu/cpu*/cpufreq/stats/time_in_state
 
                         char filename[FILENAME_MAX + 1];
                         struct stat stbuf;

--- a/src/rrdvar.c
+++ b/src/rrdvar.c
@@ -110,7 +110,7 @@ inline RRDVAR *rrdvar_create_and_index(const char *scope, avl_tree_lock *tree, c
 }
 
 void rrdvar_free_remaining_variables(RRDHOST *host, avl_tree_lock *tree_lock) {
-    // FIXME: this is not bullet proof - avl should support some means to destroy it
+    // This is not bullet proof - avl should support some means to destroy it
     // with a callback for each item already in the index
 
     RRDVAR *rv, *last = NULL;

--- a/src/socket.c
+++ b/src/socket.c
@@ -1292,7 +1292,9 @@ static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, sho
 
                     debug(D_POLLFD, "POLLFD: LISTENER: reading data from UDP slot %zu (fd %d)", i, fd);
 
-                    // FIXME: access_list is not applied to UDP
+                    // TODO: access_list is not applied to UDP
+                    // but checking the access list on every UDP packet will destroy
+                    // performance, especially for statsd.
 
                     pf->events = 0;
                     pi->rcv_callback(pi, &pf->events);

--- a/src/web_api_v1.c
+++ b/src/web_api_v1.c
@@ -827,7 +827,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
 
     debug(D_WEB_CLIENT, "%llu: API v1 registry with URL '%s'", w->id, url);
 
-    // FIXME
+    // TODO
     // The browser may send multiple cookies with our id
 
     char *cookie = strstr(w->response.data->buffer, NETDATA_REGISTRY_COOKIE_NAME "=");

--- a/src/web_client.c
+++ b/src/web_client.c
@@ -908,7 +908,7 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 *ue = ' ';
                 
                 // copy the URL - we are going to overwrite parts of it
-                // FIXME -- we should avoid it
+                // TODO -- ideally we we should avoid copying buffers around
                 strncpyz(w->last_url, w->decoded_url, NETDATA_WEB_REQUEST_URL_SIZE);
 
                 w->header_parse_tries = 0;

--- a/web/dashboard.js
+++ b/web/dashboard.js
@@ -563,7 +563,7 @@ var NETDATA = window.NETDATA || {};
             focus:              false,
             visibility:         false,
             chart_data_url:     false,
-            chart_errors:       true, // FIXME: remember to set it to false before merging
+            chart_errors:       false, // remember to set it to false before merging
             chart_timing:       false,
             chart_calls:        false,
             libraries:          false,
@@ -1784,7 +1784,7 @@ var NETDATA = window.NETDATA || {};
     // ----------------------------------------------------------------------------------------------------------------
     // dimensions selection
 
-    // FIXME
+    // TODO
     // move color assignment to dimensions, here
 
     var dimensionStatus = function(parent, label, name_div, value_div, color) {
@@ -8967,7 +8967,8 @@ var NETDATA = window.NETDATA || {};
 
             /*
             // cleanup old notifications with the same alarm_id as this one
-            // FIXME: it does not seem to work on any web browser!
+            // it does not seem to work on any web browser - so notifications cannot be removed
+
             var len = NETDATA.alarms.notifications_shown.length;
             while(len--) {
                 var n = NETDATA.alarms.notifications_shown[len];

--- a/web/index.html
+++ b/web/index.html
@@ -1560,7 +1560,7 @@
 
         // enrich the data structure returned by netdata
         // to reflect our menu system and content
-        // FIXME: this is a shame - we should fix charts naming (issue #807)
+        // TODO: this is a shame - we should fix charts naming (issue #807)
         function enrichChartData(chart) {
             var parts = chart.type.split('_');
             var tmp = parts[0];
@@ -4457,7 +4457,7 @@
             });
 
             NETDATA.requiredJs.push({
-                url: NETDATA.serverStatic + 'dashboard_info.js?v20180926-3',
+                url: NETDATA.serverStatic + 'dashboard_info.js?v20180928-1',
                 async: false,
                 isAlreadyLoaded: function() { return false; }
             });


### PR DESCRIPTION
This PR:

1. converts all `FIXME` tags that are actually a to-do, to `TODO`
2. removes `FIXME` tags for which nothing can be done
3. removes `FIXME` tags which are no longer valid
4. renames error messages that were printing `FIXME` to match impossible situations to have a better alternative message describing the situation.