### PR TITLE
run CI builds on alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,8 @@ jobs:
       script: ./.travis/containerized_build.sh centos7
     - name: "CentOS 6"
       script: ./.travis/containerized_build.sh centos6
-# TODO: cannot run installer without bash
-#    - name: "alpine"
-#      script: ./.travis/containerized_build.sh alpine
+    - name: "alpine"
+      script: ./.travis/containerized_build.sh alpine
     - stage: "release"
       name: "Docker"
       script: docker/build.sh

--- a/.travis/images/Dockerfile.alpine
+++ b/.travis/images/Dockerfile.alpine
@@ -1,5 +1,5 @@
 FROM alpine:latest
 
-RUN apk add bash gcc make autoconf automake pkgconfig zlib-dev libuuid git
+RUN apk add bash gcc make autoconf automake pkgconfig zlib-dev libuuid git libmnl-dev util-linux-dev build-base
 
 COPY . /code

--- a/.travis/images/Dockerfile.alpine
+++ b/.travis/images/Dockerfile.alpine
@@ -1,5 +1,5 @@
 FROM alpine:latest
 
-RUN apk add gcc make autoconf automake pkgconfig zlib-dev libuuid git
+RUN apk add bash gcc make autoconf automake pkgconfig zlib-dev libuuid git
 
 COPY . /code


### PR DESCRIPTION
Enable alpine in build stage tests. To do this I needed to add `bash` to available packages in alpine as installer doesn't support installation without bash.