### PR TITLE
Use newer docker in CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ jobs:
 #      script: ./.travis/containerized_build.sh alpine
     - stage: "release"
       name: "Docker"
+      install: sudo apt update -y && sudo apt install -y --only-upgrade docker-ce && docker info
       script: docker/build.sh
       env: REPOSITORY="netdata/netdata"
     - name: "GitHub"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0+
 # Author  : Pawel Krupa (paulfantom)
 # Cross-arch docker build helper script
+# Needs docker in version >18.02 due to usage of manifests
 
 set -e
 


### PR DESCRIPTION
Travis uses too old docker version for our needs (manifests). This should allow us to update docker in jobs which need it.