### PR TITLE
Fix BIND outgoing stats in a multiview environment

### DIFF
--- a/python.d/bind_rndc.chart.py
+++ b/python.d/bind_rndc.chart.py
@@ -210,7 +210,9 @@ def parse_stats(field, named_stats):
                 if '[' in line:
                     continue
                 v, k = line.strip().split(' ', 1)
-                data[k] = int(v)
+                if k not in data:
+                    data[k] = 0
+                data[k] += int(v)
                 continue
             break
         break


### PR DESCRIPTION
This is how my outgoing stats look like:

```
++ Outgoing Queries ++
[View: view-1]
              132399 A
               75132 NS
                 624 CNAME
                1062 PTR
                5969 MX
              102881 AAAA
                   3 SRV
[View: view-2]
                 737 A
                 718 NS
                  35 PTR
                 561 AAAA
[View: view-3]
                 725 A
                 703 NS
                  36 PTR
                 561 AAAA
[View: view-4]
                8409 A
                5707 NS
                  65 CNAME
                  38 PTR
                6882 AAAA
[View: view-5]
[View: view-6]
               54239 A
               25890 NS
                  23 CNAME
                  32 SOA
                  73 PTR
                  30 TXT
                 380 AAAA
                   1 SRV
[View: _bind]
```

Currently is counter for the `A` record set to `54239` instead of `132399 + 737 + 725 + 8409 + 54239`