### PR TITLE
added edit-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ system/netdata.service
 system/netdata.plist
 system/netdata-freebsd
 
+conf.d/edit-config
 plugins.d/alarm-notify.sh
 plugins.d/cgroup-name.sh
 plugins.d/charts.d.plugin

--- a/conf.d/Makefile.am
+++ b/conf.d/Makefile.am
@@ -3,6 +3,21 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 MAINTAINERCLEANFILES= $(srcdir)/Makefile.in
+CLEANFILES = \
+    edit-config \
+	$(NULL)
+
+include $(top_srcdir)/build/subst.inc
+
+SUFFIXES = .in
+
+dist_config_SCRIPTS = \
+    edit-config \
+    $(NULL)
+
+dist_noinst_DATA = \
+    edit-config.in \
+	$(NULL)
 
 dist_libconfig_DATA = \
     apps_groups.conf \
@@ -17,6 +32,10 @@ dist_libconfig_DATA = \
 
 nodeconfigdir=$(libconfigdir)/node.d
 dist_nodeconfig_DATA = \
+    $(NULL)
+
+usernodeconfigdir=$(configdir)/node.d
+dist_usernodeconfig_DATA = \
     node.d/README.md \
     node.d/fronius.conf.md \
     node.d/named.conf.md \

--- a/conf.d/edit-config.in
+++ b/conf.d/edit-config.in
@@ -1,0 +1,94 @@
+#!/usr/bin/env sh
+
+[ -f /etc/profile ] && source /etc/profile
+
+file="${1}"
+
+EDITOR="${EDITOR-vi}"
+[ -z "${NETDATA_USER_CONFIG_DIR}"  ] && NETDATA_USER_CONFIG_DIR="@configdir_POST@"
+[ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
+
+if [ -z "${file}" ]
+then
+	cat <<USAGE
+
+USAGE:
+  ${0} FILENAME
+
+  Find the stock config file named FILENAME and edit it.
+
+  Stock config files at: '${NETDATA_STOCK_CONFIG_DIR}'
+  User  config files at: '${NETDATA_USER_CONFIG_DIR}'
+
+  Available files in '${NETDATA_STOCK_CONFIG_DIR}' to copy and edit:
+
+USAGE
+
+	cd "${NETDATA_STOCK_CONFIG_DIR}" || exit 1
+	ls >&2 -R *.conf */*.conf
+	exit 1
+
+fi
+
+file_is_in_path() {
+	local file path real
+	file="${1}"
+	path="${2}"
+	
+	real="$(readlink -f "${file}")"
+
+	# we don't have working readlink
+	[ -z "${real}" ] && return 0
+
+	if [ ! -z "${real}" ] && [ -z "$(echo "${real}" | grep -E "^${path}.*$")" ]
+	then
+		echo >&2 "File '${file}' is physically at '${real}', which is not in '${path}'. Aborting."
+		exit 1
+	fi
+
+	return 0
+}
+
+edit() {
+	echo >&2 "Editing '${1}' ..."
+
+	# check we can edit
+	file_is_in_path "${1}" "${NETDATA_USER_CONFIG_DIR}" || exit 1
+
+	"${EDITOR}" "${1}"
+	exit $?
+}
+
+copy_and_edit() {
+	# check we can copy
+	file_is_in_path "${NETDATA_STOCK_CONFIG_DIR}/${1}" "${NETDATA_STOCK_CONFIG_DIR}" || exit 1
+
+	if [ ! -f "${NETDATA_USER_CONFIG_DIR}/${1}" ]
+	then
+		echo >&2 "Copying '${NETDATA_STOCK_CONFIG_DIR}/${1}' to '${NETDATA_USER_CONFIG_DIR}/${1}' ... "
+		cp -p "${NETDATA_STOCK_CONFIG_DIR}/${1}" "${NETDATA_USER_CONFIG_DIR}/${1}" || exit 1
+	fi
+
+	edit "${NETDATA_USER_CONFIG_DIR}/${1}"
+}
+
+# make sure it is not absolute filename
+c1="$(echo "${file}" | cut -b 1)"
+if [ "${c1}" = "/" ] || [ "${c1}" = "." ]
+then
+	echo >&2 "Please don't use filenames starting with '/' or '.'"
+	exit 1
+fi
+
+# already exists
+if [ -f "${NETDATA_USER_CONFIG_DIR}/${file}" ]
+then
+	echo >&2 "Editing existing file '${NETDATA_USER_CONFIG_DIR}/${file}' ... "
+	edit "${NETDATA_USER_CONFIG_DIR}/${file}"
+fi
+
+[ -f "${NETDATA_USER_CONFIG_DIR}/${file}"  ] && edit "${NETDATA_USER_CONFIG_DIR}/${file}"
+[ -f "${NETDATA_STOCK_CONFIG_DIR}/${file}" ] && copy_and_edit "${file}"
+
+echo >&2 "File '${file}' is not found in '${NETDATA_STOCK_CONFIG_DIR}'"
+exit 1

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -745,6 +745,7 @@ done
 run chown -R "${ROOT_USER}:${NETDATA_GROUP}" "${NETDATA_USER_CONFIG_DIR}"
 run find "${NETDATA_USER_CONFIG_DIR}" -type f -exec chmod 0640 {} \;
 run find "${NETDATA_USER_CONFIG_DIR}" -type d -exec chmod 0755 {} \;
+run chmod 755 "${NETDATA_USER_CONFIG_DIR}/edit-config"
 
 # --- stock conf dir ----
 


### PR DESCRIPTION
To help users edit netdata config files now that they are moved to `/usr/libexec/netdata/conf.d`, this PR adds a script as `/etc/netdata/edit-config`.

When run without arguments:

```sh
#  /etc/netdata/edit-config 

USAGE:
  /etc/netdata/edit-config FILENAME

  Find the stock config file named FILENAME and edit it.

  Stock config files at: '/usr/lib/netdata/conf.d'
  User  config files at: '/etc/netdata'

  Available files in '/usr/lib/netdata/conf.d' to copy and edit:

apps_groups.conf	     health.d/load.conf		   python.d/example.conf
charts.d/apache.conf	     health.d/mdstat.conf	   python.d/exim.conf
charts.d/ap.conf	     health.d/megacli.conf	   python.d/fail2ban.conf
charts.d/apcupsd.conf	     health.d/memcached.conf	   python.d/freeradius.conf
charts.d.conf		     health.d/memory.conf	   python.d/go_expvar.conf
charts.d/cpu_apps.conf	     health.d/mongodb.conf	   python.d/haproxy.conf
charts.d/cpufreq.conf	     health.d/mysql.conf	   python.d/hddtemp.conf
charts.d/example.conf	     health.d/named.conf	   python.d/httpcheck.conf
charts.d/exim.conf	     health.d/net.conf		   python.d/icecast.conf
charts.d/hddtemp.conf	     health.d/netfilter.conf	   python.d/ipfs.conf
charts.d/libreswan.conf      health.d/nginx.conf	   python.d/isc_dhcpd.conf
charts.d/load_average.conf   health.d/nginx_plus.conf	   python.d/litespeed.conf
charts.d/mem_apps.conf	     health.d/portcheck.conf	   python.d/logind.conf
charts.d/mysql.conf	     health.d/postgres.conf	   python.d/mdstat.conf
charts.d/nginx.conf	     health.d/qos.conf		   python.d/megacli.conf
charts.d/nut.conf	     health.d/ram.conf		   python.d/memcached.conf
charts.d/opensips.conf	     health.d/redis.conf	   python.d/mongodb.conf
charts.d/phpfpm.conf	     health.d/retroshare.conf	   python.d/monit.conf
charts.d/postfix.conf	     health.d/softnet.conf	   python.d/mysql.conf
charts.d/sensors.conf	     health.d/squid.conf	   python.d/nginx.conf
charts.d/squid.conf	     health.d/stiebeleltron.conf   python.d/nginx_plus.conf
charts.d/tomcat.conf	     health.d/swap.conf		   python.d/nsd.conf
fping.conf		     health.d/tcp_conn.conf	   python.d/ntpd.conf
health_alarm_notify.conf     health.d/tcp_listen.conf	   python.d/ovpn_status_log.conf
health.d/apache.conf	     health.d/tcp_mem.conf	   python.d/phpfpm.conf
health.d/apcupsd.conf	     health.d/tcp_orphans.conf	   python.d/portcheck.conf
health.d/backend.conf	     health.d/tcp_resets.conf	   python.d/postfix.conf
health.d/bcache.conf	     health.d/udp_errors.conf	   python.d/postgres.conf
health.d/beanstalkd.conf     health.d/varnish.conf	   python.d/powerdns.conf
health.d/bind_rndc.conf      health.d/web_log.conf	   python.d/puppet.conf
health.d/boinc.conf	     health.d/zfs.conf		   python.d/rabbitmq.conf
health.d/btrfs.conf	     health_email_recipients.conf  python.d/redis.conf
health.d/ceph.conf	     node.d.conf		   python.d/rethinkdbs.conf
health.d/couchdb.conf	     python.d/apache.conf	   python.d/retroshare.conf
health.d/cpu.conf	     python.d/beanstalk.conf	   python.d/samba.conf
health.d/disks.conf	     python.d/bind_rndc.conf	   python.d/sensors.conf
health.d/dockerd.conf	     python.d/boinc.conf	   python.d/smartd_log.conf
health.d/elasticsearch.conf  python.d/ceph.conf		   python.d/spigotmc.conf
health.d/entropy.conf	     python.d/chrony.conf	   python.d/springboot.conf
health.d/fping.conf	     python.d.conf		   python.d/squid.conf
health.d/fronius.conf	     python.d/couchdb.conf	   python.d/tomcat.conf
health.d/haproxy.conf	     python.d/cpufreq.conf	   python.d/traefik.conf
health.d/httpcheck.conf      python.d/cpuidle.conf	   python.d/unbound.conf
health.d/ipc.conf	     python.d/dnsdist.conf	   python.d/varnish.conf
health.d/ipfs.conf	     python.d/dns_query_time.conf  python.d/w1sensor.conf
health.d/ipmi.conf	     python.d/dockerd.conf	   python.d/web_log.conf
health.d/isc_dhcpd.conf      python.d/dovecot.conf	   statsd.d/example.conf
health.d/lighttpd.conf	     python.d/elasticsearch.conf   stream.conf
```


And when run with one of these files as a parameter, it copies the stock config to `/etc/netdata` and calls the `$EDITOR` variable to edit the copied file.

It can be used on already copied files to edit them.

It has checks to make sure it only copies netdata stock files and copies them to `/etc/netdata`.
