### PR TITLE
log flood should not be disabled; 

### DIFF
--- a/conf.d/edit-config.in
+++ b/conf.d/edit-config.in
@@ -15,7 +15,10 @@ then
 USAGE:
   ${0} FILENAME
 
-  Find the stock config file named FILENAME and edit it.
+  Copy and edit the stock config file named: FILENAME
+  if FILENAME is already copied, it will be edited as-is.
+
+  The EDITOR shell variable is used to define the editor to be used.
 
   Stock config files at: '${NETDATA_STOCK_CONFIG_DIR}'
   User  config files at: '${NETDATA_USER_CONFIG_DIR}'
@@ -83,7 +86,6 @@ fi
 # already exists
 if [ -f "${NETDATA_USER_CONFIG_DIR}/${file}" ]
 then
-	echo >&2 "Editing existing file '${NETDATA_USER_CONFIG_DIR}/${file}' ... "
 	edit "${NETDATA_USER_CONFIG_DIR}/${file}"
 fi
 

--- a/src/log.c
+++ b/src/log.c
@@ -161,13 +161,15 @@ void open_all_log_files() {
 // ----------------------------------------------------------------------------
 // error log throttling
 
-time_t error_log_throttle_period_backup = 0;
 time_t error_log_throttle_period = 1200;
 unsigned long error_log_errors_per_period = 200;
+unsigned long error_log_errors_per_period_backup = 0;
 
 int error_log_limit(int reset) {
     static time_t start = 0;
     static unsigned long counter = 0, prevented = 0;
+
+    // fprintf(stderr, "FLOOD: counter=%lu, allowed=%lu, backup=%lu, period=%llu\n", counter, error_log_errors_per_period, error_log_errors_per_period_backup, (unsigned long long)error_log_throttle_period);
 
     // do not throttle if the period is 0
     if(error_log_throttle_period == 0)
@@ -188,7 +190,7 @@ int error_log_limit(int reset) {
         if(prevented) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH);
-            fprintf(stderr, "%s: %s Resetting logging for process '%s' (prevented %lu logs in the last %ld seconds).\n"
+            fprintf(stderr, "%s: %s LOG FLOOD PROTECTION reset for process '%s' (prevented %lu logs in the last %ld seconds).\n"
                     , date
                     , program_name
                     , program_name
@@ -209,7 +211,7 @@ int error_log_limit(int reset) {
         if(prevented) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH);
-            fprintf(stderr, "%s: %s Resuming logging from process '%s' (prevented %lu logs in the last %ld seconds).\n"
+            fprintf(stderr, "%s: %s LOG FLOOD PROTECTION resuming logging from process '%s' (prevented %lu logs in the last %ld seconds).\n"
                     , date
                     , program_name
                     , program_name
@@ -231,7 +233,7 @@ int error_log_limit(int reset) {
         if(!prevented) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH);
-            fprintf(stderr, "%s: %s Too many logs (%lu logs in %ld seconds, threshold is set to %lu logs in %ld seconds). Preventing more logs from process '%s' for %ld seconds.\n"
+            fprintf(stderr, "%s: %s LOG FLOOD PROTECTION too many logs (%lu logs in %ld seconds, threshold is set to %lu logs in %ld seconds). Preventing more logs from process '%s' for %ld seconds.\n"
                     , date
                     , program_name
                     , counter

--- a/src/log.h
+++ b/src/log.h
@@ -59,8 +59,8 @@ extern int access_log_syslog;
 extern int error_log_syslog;
 extern int output_log_syslog;
 
-extern time_t error_log_throttle_period, error_log_throttle_period_backup;
-extern unsigned long error_log_errors_per_period;
+extern time_t error_log_throttle_period;
+extern unsigned long error_log_errors_per_period, error_log_errors_per_period_backup;
 extern int error_log_limit(int reset);
 
 extern void open_all_log_files();
@@ -68,8 +68,8 @@ extern void reopen_all_log_files();
 
 static inline void debug_dummy(void) {}
 
-#define error_log_limit_reset() do { error_log_throttle_period = error_log_throttle_period_backup; error_log_limit(1); } while(0)
-#define error_log_limit_unlimited() do { error_log_throttle_period = 0; } while(0)
+#define error_log_limit_reset() do { error_log_errors_per_period = error_log_errors_per_period_backup; error_log_limit(1); } while(0)
+#define error_log_limit_unlimited() do { error_log_limit_reset(); error_log_errors_per_period = 10000; } while(0)
 
 #ifdef NETDATA_INTERNAL_CHECKS
 #define debug(type, args...) do { if(unlikely(debug_flags & type)) debug_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)

--- a/src/log.h
+++ b/src/log.h
@@ -69,7 +69,10 @@ extern void reopen_all_log_files();
 static inline void debug_dummy(void) {}
 
 #define error_log_limit_reset() do { error_log_errors_per_period = error_log_errors_per_period_backup; error_log_limit(1); } while(0)
-#define error_log_limit_unlimited() do { error_log_limit_reset(); error_log_errors_per_period = 10000; } while(0)
+#define error_log_limit_unlimited() do { \
+        error_log_limit_reset(); \
+        error_log_errors_per_period = ((error_log_errors_per_period_backup * 10) < 10000) ? 10000 : (error_log_errors_per_period_backup * 10); \
+    } while(0)
 
 #ifdef NETDATA_INTERNAL_CHECKS
 #define debug(type, args...) do { if(unlikely(debug_flags & type)) debug_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)

--- a/src/main.c
+++ b/src/main.c
@@ -359,9 +359,9 @@ void log_init(void) {
     snprintfz(filename, FILENAME_MAX, "%s/access.log", netdata_configured_log_dir);
     stdaccess_filename = config_get(CONFIG_SECTION_GLOBAL, "access log", filename);
 
-    error_log_throttle_period_backup =
     error_log_throttle_period = config_get_number(CONFIG_SECTION_GLOBAL, "errors flood protection period", error_log_throttle_period);
     error_log_errors_per_period = (unsigned long)config_get_number(CONFIG_SECTION_GLOBAL, "errors to trigger flood protection", (long long int)error_log_errors_per_period);
+    error_log_errors_per_period_backup = error_log_errors_per_period;
 
     setenv("NETDATA_ERRORS_THROTTLE_PERIOD", config_get(CONFIG_SECTION_GLOBAL, "errors flood protection period"    , ""), 1);
     setenv("NETDATA_ERRORS_PER_PERIOD",      config_get(CONFIG_SECTION_GLOBAL, "errors to trigger flood protection", ""), 1);


### PR DESCRIPTION
https://github.com/netdata/netdata/issues/4312#issuecomment-426098788

There are a few cases that we have decided to have log flood protection disabled.
It seem that this was a bad decision, since an error in netdata in that parts of the code, will lead to massive amount of logs written to disk.

This PR sets the `unlimited` log flood protection to be 10x the one set in netdata.conf, with minimum of `10000` log entries.

So, log flood protection is always active, with different thresholds.