### PR TITLE
ExecutableService: return [] instead of None if no data.

### DIFF
--- a/python.d/python_modules/bases/FrameworkServices/ExecutableService.py
+++ b/python.d/python_modules/bases/FrameworkServices/ExecutableService.py
@@ -36,7 +36,7 @@ class ExecutableService(SimpleService):
             except TypeError:
                 continue
 
-        return data or None
+        return data
 
     def check(self):
         """


### PR DESCRIPTION
This fixes a bug in the logind module causing it to throw errors when there are no users logged in.

No net change for any other in-tree ExecutableService users.  All of them either use truth value testing or depend on errors being thrown when trying to subscript the return value, both of which behave the same
for an empty list and None.

Fixes: #4230 
Relevant: #4236 