### PR TITLE
Fix phpfpm ipv6 configuration

### DIFF
--- a/conf.d/python.d/phpfpm.conf
+++ b/conf.d/python.d/phpfpm.conf
@@ -86,5 +86,5 @@ localipv4:
 
 localipv6:
   name : 'local'
-  url  : "http://::1/status?full&json"
+  url  : "http://[::1]/status?full&json"
 


### PR DESCRIPTION
IPv6 literals in URLs must be enclosed in square brackets

Without this change, this error results when running `/usr/libexec/netdata/plugins.d/python.d.plugin 1 debug trace phpfpm`:
```
  File "/usr/libexec/netdata/python.d/python_modules/bases/FrameworkServices/UrlService.py", line 96, in _get_raw_data
    status, data = self._get_raw_data_with_status(url, manager)
  File "/usr/libexec/netdata/python.d/python_modules/bases/FrameworkServices/UrlService.py", line 119, in _get_raw_data_with_status
    redirect=redirect)
  File "/usr/lib/python3.7/site-packages/urllib3/request.py", line 68, in request
    **urlopen_kw)
  File "/usr/lib/python3.7/site-packages/urllib3/request.py", line 89, in request_encode_url
    return self.urlopen(method, url, **extra_kw)
  File "/usr/lib/python3.7/site-packages/urllib3/poolmanager.py", line 310, in urlopen
    u = parse_url(url)
  File "/usr/lib/python3.7/site-packages/urllib3/util/url.py", line 199, in parse_url
    raise LocationParseError(url)
urllib3.exceptions.LocationParseError: Failed to parse: ::1
```