### PR TITLE
Fix apache ipv6 configuration

### DIFF
--- a/conf.d/python.d/apache.conf
+++ b/conf.d/python.d/apache.conf
@@ -84,4 +84,4 @@ localipv4:
 
 localipv6:
   name : 'local'
-  url  : 'http://::1/server-status?auto'
+  url  : 'http://[::1]/server-status?auto'


### PR DESCRIPTION
IPv6 literals in URLs must be enclosed in square brackets