### PR TITLE
Fix firehol image tagging

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -72,6 +72,6 @@ if [ "$REPOSITORY" != "netdata" ]; then
         docker tag "${REPOSITORY}:${VERSION}-${ARCH}" "firehol/netdata:${ARCH}"
         docker push "firehol/netdata:${ARCH}"
     done
-    docker tag "${REPOSITORY}:${VERSION}" "firehol/netdata:${VERSION}"
+    docker tag "${REPOSITORY}:amd64" "firehol/netdata:latest"
     docker push "firehol/netdata:latest"
 fi


### PR DESCRIPTION
As we use manifests, firehol image tagging broke. This should fix it.

Bear in mind that this part of code should be deleted after we release v1.12 and close firehol/netdata docker repository.