### PR TITLE
support filtering of charts during streaming;

### DIFF
--- a/conf.d/stream.conf
+++ b/conf.d/stream.conf
@@ -39,17 +39,25 @@
     # If the destination line above does not specify a port, use this
     default port = 19999
 
+    # filter the charts to be streamed
+    # netdata SIMPLE PATTERN:
+    # - space separated list of patterns (use \ to include spaces in patterns)
+    # - use * as wildcard, any number of times within each pattern
+    # - prefix a pattern with ! for a negative match (ie not stream the charts it matches)
+    # - the order of patterns is important (left to right)
+    # To send all except a few, use: !this !that *   (ie append a wildcard pattern)
+    send charts matching = *
+
     # The buffer to use for sending metrics.
-    # 1MB is good for 10-20 seconds of data, so increase this
-    # if you expect latencies.
+    # 1MB is good for 10-20 seconds of data, so increase this if you expect latencies.
+    # The buffer is flushed on reconnects (this will not prevent gaps at the charts).
     buffer size bytes = 1048576
 
     # If the connection fails, or it disconnects,
     # retry after that many seconds.
     reconnect delay seconds = 5
 
-    # Attempt to sync the clock the of the master with the clock of the
-    # slave for that many iterations, when starting.
+    # Sync the clock of the charts for that many iterations, when starting.
     initial clock resync iterations = 60
 
 
@@ -62,8 +70,9 @@
 #    netdata searches for options in this order:
 #
 #    a) master netdata settings (netdata.conf)
-#    b) [API_KEY] section       (below, settings for the API key)
-#    c) [MACHINE_GUID] section  (below, settings for each machine)
+#    b) [stream] section        (above)
+#    c) [API_KEY] section       (below, settings for the API key)
+#    d) [MACHINE_GUID] section  (below, settings for each machine)
 #
 #    You can combine the above (the more specific setting will be used).
 
@@ -95,7 +104,7 @@
     # If you don't set it here, the memory mode of netdata.conf will be used.
     # Valid modes:
     #    save    save on exit, load on start
-    #    map     like swap (continuously syncing to disks)
+    #    map     like swap (continuously syncing to disks - you need SSD)
     #    ram     keep it in RAM, don't touch the disk
     #    none    no database at all (use this on headless proxies)
     default memory mode = ram
@@ -106,7 +115,7 @@
     #    no      do not enable alarms
     #    auto    enable alarms, only when the sending netdata is connected
     # You can also set it per host, below.
-    # The default is the same as to netdata.conf
+    # The default is taken from [health].enabled of netdata.conf
     health enabled by default = auto
 
     # postpone alarms for a short period after the sender is connected
@@ -120,15 +129,16 @@
     multiple connections = allow
 
     # need to route metrics differently? set these.
-    # the defaults are the ones at the [stream] section
+    # the defaults are the ones at the [stream] section (above)
     #default proxy enabled = yes | no
     #default proxy destination = IP:PORT IP:PORT ...
     #default proxy api key = API_KEY
+    #default proxy send charts matching = *
 
 
 # -----------------------------------------------------------------------------
 # 3. PER SENDING HOST SETTINGS, ON MASTER NETDATA
-#    THIS IS OPTIONAL - YOU DON'T NEED IT
+#    THIS IS OPTIONAL - YOU DON'T HAVE TO CONFIGURE IT
 
 # This section exists to give you finer control of the master settings for each
 # slave host, when the same API key is used by many netdata slaves / proxies.
@@ -174,6 +184,8 @@
     multiple connections = allow
 
     # need to route metrics differently?
+    # the defaults are the ones at the [API KEY] section
     #proxy enabled = yes | no
     #proxy destination = IP:PORT IP:PORT ...
     #proxy api key = API_KEY
+    #proxy send charts matching = *

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -49,7 +49,7 @@ inline int rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name) {
     rd->hash_name = simple_hash(rd->name);
     rrddimvar_rename_all(rd);
     rd->exposed = 0;
-    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
+    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
     return 1;
 }
 
@@ -61,7 +61,7 @@ inline int rrddim_set_algorithm(RRDSET *st, RRDDIM *rd, RRD_ALGORITHM algorithm)
     rd->algorithm = algorithm;
     rd->exposed = 0;
     rrdset_flag_set(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
-    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
+    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
     return 1;
 }
 
@@ -73,7 +73,7 @@ inline int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, collected_number multip
     rd->multiplier = multiplier;
     rd->exposed = 0;
     rrdset_flag_set(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
-    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
+    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
     return 1;
 }
 
@@ -85,7 +85,7 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
     rd->divisor = divisor;
     rd->exposed = 0;
     rrdset_flag_set(st, RRDSET_FLAG_HOMEGENEOUS_CHECK);
-    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
+    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
     return 1;
 }
 
@@ -96,7 +96,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     rrdset_wrlock(st);
 
     rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
-    rrdset_flag_clear(st, RRDSET_FLAG_EXPOSED_UPSTREAM);
+    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
 
     RRDDIM *rd = rrddim_find(st, id);
     if(unlikely(rd)) {

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -122,6 +122,7 @@ RRDHOST *rrdhost_create(const char *hostname,
                         unsigned int rrdpush_enabled,
                         char *rrdpush_destination,
                         char *rrdpush_api_key,
+                        char *rrdpush_send_charts_matching,
                         int is_localhost
 ) {
     debug(D_RRDHOST, "Host '%s': adding with guid '%s'", hostname, guid);
@@ -137,6 +138,7 @@ RRDHOST *rrdhost_create(const char *hostname,
     host->rrdpush_send_enabled     = (rrdpush_enabled && rrdpush_destination && *rrdpush_destination && rrdpush_api_key && *rrdpush_api_key) ? 1 : 0;
     host->rrdpush_send_destination = (host->rrdpush_send_enabled)?strdupz(rrdpush_destination):NULL;
     host->rrdpush_send_api_key     = (host->rrdpush_send_enabled)?strdupz(rrdpush_api_key):NULL;
+    host->rrdpush_send_charts_matching = simple_pattern_create(rrdpush_send_charts_matching, NULL, SIMPLE_PATTERN_EXACT);
 
     host->rrdpush_sender_pipe[0] = -1;
     host->rrdpush_sender_pipe[1] = -1;
@@ -329,6 +331,7 @@ RRDHOST *rrdhost_find_or_create(
         , unsigned int rrdpush_enabled
         , char *rrdpush_destination
         , char *rrdpush_api_key
+        , char *rrdpush_send_charts_matching
 ) {
     debug(D_RRDHOST, "Searching for host '%s' with guid '%s'", hostname, guid);
 
@@ -351,6 +354,7 @@ RRDHOST *rrdhost_find_or_create(
                 , rrdpush_enabled
                 , rrdpush_destination
                 , rrdpush_api_key
+                , rrdpush_send_charts_matching
                 , 0
         );
     }
@@ -463,6 +467,7 @@ void rrd_init(char *hostname) {
             , default_rrdpush_enabled
             , default_rrdpush_destination
             , default_rrdpush_api_key
+            , default_rrdpush_send_charts_matching
             , 1
     );
     rrd_unlock();
@@ -576,6 +581,7 @@ void rrdhost_free(RRDHOST *host) {
     freez(host->health_log_filename);
     freez(host->hostname);
     freez(host->registry_hostname);
+    simple_pattern_free(host->rrdpush_send_charts_matching);
     rrdhost_unlock(host);
     netdata_rwlock_destroy(&host->health_log.alarm_log_rwlock);
     netdata_rwlock_destroy(&host->rrdhost_rwlock);

--- a/src/database/rrdsetvar.c
+++ b/src/database/rrdsetvar.c
@@ -183,7 +183,7 @@ void rrdsetvar_custom_chart_variable_set(RRDSETVAR *rs, calculated_number value)
             *v = value;
 
             // mark the chart to be sent upstream
-            rrdset_flag_clear(rs->rrdset, RRDSET_FLAG_EXPOSED_UPSTREAM);
+            rrdset_flag_clear(rs->rrdset, RRDSET_FLAG_UPSTREAM_EXPOSED);
         }
     }
 }

--- a/src/streaming/rrdpush.h
+++ b/src/streaming/rrdpush.h
@@ -9,11 +9,12 @@
 extern unsigned int default_rrdpush_enabled;
 extern char *default_rrdpush_destination;
 extern char *default_rrdpush_api_key;
+extern char *default_rrdpush_send_charts_matching;
 extern unsigned int remote_clock_resync_iterations;
 
 extern int rrdpush_init();
 extern void rrdset_done_push(RRDSET *st);
-extern void rrdset_push_chart_definition(RRDSET *st);
+extern void rrdset_push_chart_definition_now(RRDSET *st);
 extern void *rrdpush_sender_thread(void *ptr);
 
 extern int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url);


### PR DESCRIPTION
 fixes #4223 

This PR introduces a few `stream.conf` options to select the charts that will be stream to the remote netdata.

Like most `stream.conf` options, filtering can be defined at the `[stream]` section (the global default), with this:

```
[stream]
    send charts matching = *
```

Then per API KEY (for proxies, during re-transmission), with this:

```
[API_KEY]
    default proxy send charts matching = *
```

And then per MACHINE GUID (for proxies, during re-transmission), this this:

```
[MACHINE_GUID]
    proxy send charts matching = *
```

