### PR TITLE
Account "Laundry" pages on FreeBSD

### DIFF
--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -41,7 +41,7 @@ alarm: ram_in_use
    on: system.ram
    os: freebsd
 hosts: *
- calc: ($active + $wired + $buffers - $used_ram_to_ignore) * 100 / ($active + $wired + $buffers - $used_ram_to_ignore + $cache + $free + $inactive)
+ calc: ($active + $wired + $laundry + $buffers - $used_ram_to_ignore) * 100 / ($active + $wired + $laundry + $buffers - $used_ram_to_ignore + $cache + $free + $inactive)
 units: %
 every: 10s
  warn: $this > (($status >= $WARNING)  ? (80) : (90))
@@ -54,7 +54,7 @@ delay: down 15m multiplier 1.5 max 1h
     on: system.ram
     os: freebsd
  hosts: *
-  calc: ($free + $inactive + $used_ram_to_ignore) * 100 / ($free + $active + $inactive + $wired + $cache + $buffers)
+  calc: ($free + $inactive + $used_ram_to_ignore) * 100 / ($free + $active + $inactive + $wired + $cache + $laundry + $buffers)
  units: %
  every: 10s
   warn: $this < (($status >= $WARNING)  ? ( 5) : (10))


### PR DESCRIPTION
Account "Laundry" pages as a separate RAM dimension on FreeBSD.

Laundry pages are dirty pages queued for laundering.
"Laundry" page queue was introduces in FreeBSD CURRENT about two years ago and later this was backported to FreeBSD 11 branch.

Below laundry pages could be seen in `top` header:
```
last pid: 66514;  load averages:  0.39,  0.51,  0.53            up 6+13:59:13  18:33:23
50 processes:  2 running, 48 sleeping
CPU:  2.9% user,  2.9% nice,  2.0% system,  0.0% interrupt, 92.2% idle
Mem: 179M Active, 714M Inact, **69M Laundry**, 418M Wired, 196M Buf, 536M Free
Swap: 1024M Total, 48M Used, 975M Free, 4% Inuse
```
And here is screenshot with current patch applied:
![screenshot_20181013_193622](https://user-images.githubusercontent.com/1396877/46907711-60d04d80-cf1f-11e8-9377-3521d4240e54.png)


