### PR TITLE
Fix linters in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,16 @@ jobs:
     - stage: "lint"
       name: "python"
       install: skip
-      script: docker run -ti --rm -v $(pwd):/apps alpine/flake8:3.5.0 --max-line-length=120 --exclude=third_party,urllib3,pyyaml3,pyyaml2 /apps/
-    - name: "javascript"
-      install: skip
-      script: docker run -it --rm -v $(pwd)/web:/code eeacms/jslint --color /code/web/*.js /code/plugins.d/node.d.plugin/*.js /code/node.d/*.js /code/node.d/node_modules/netdata.js
-    - name: "css"
-      install: skip
-      script: docker run --rm -v $(pwd)/web:/code eeacms/csslint sh -c "csslint /code/*.css" || echo "OK"
+      script: docker run -ti --rm -v $(pwd):/code alpine/flake8:3.5.0 --max-line-length=120 --exclude=third_party,urllib3,pyyaml3,pyyaml2 /code/
+#    - name: "javascript"
+#      install: skip
+#      script: docker run -it --rm -v $(pwd)/web:/code eeacms/jslint --color /code/web/*.js /code/plugins.d/node.d.plugin/*.js /code/node.d/*.js /code/node.d/node_modules/netdata.js
+#    - name: "css"
+#      install: skip
+#      script: docker run --rm -v $(pwd)/web:/code eeacms/csslint sh -c "csslint /code/*.css" || echo "OK"
     - name: "bash"
       install: skip
-      script: docker run --rm --volume "$(pwd)":/project:ro --entrypoint sh koalaman/shellcheck-alpine:v0.5.0 -c 'for file in $(find /project/ -type f -name "*.sh" ! -path "*/makeself/*" ); do if ! shellcheck --format=gcc $file; then export FAILED=true; fi; done; if [ "$FAILED" != "" ]; then exit 1; fi'
+      script: docker run --rm --volume "$(pwd)":/code:ro --entrypoint sh koalaman/shellcheck-alpine:v0.5.0 -c 'for file in $(find /code/ -type f -name "*.sh" ! -path "*/makeself/*" ); do if ! shellcheck --format=gcc $file; then export FAILED=true; fi; done; if [ "$FAILED" != "" ]; then exit 1; fi'
     - stage: "test"
       name: "C"
       install: sudo apt-get install -y libcap2-bin zlib1g-dev uuid-dev fakeroot libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
     - stage: "lint"
       name: "python"
       install: skip
-      script: docker run -ti --rm -v $(pwd):/apps alpine/flake8:3.5.0 --max-line-length=120 --exclude=third_party,urllib3,pyyaml3,pyyaml2 python.d/ plugins.d/python.d.plugin
+      script: docker run -ti --rm -v $(pwd):/apps alpine/flake8:3.5.0 --max-line-length=120 --exclude=third_party,urllib3,pyyaml3,pyyaml2 /apps/
     - name: "javascript"
       install: skip
       script: docker run -it --rm -v $(pwd)/web:/code eeacms/jslint --color /code/web/*.js /code/plugins.d/node.d.plugin/*.js /code/node.d/*.js /code/node.d/node_modules/netdata.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
     - stage: "lint"
       name: "python"
       install: skip
-      script: docker run -ti --rm -v $(pwd):/code alpine/flake8:3.5.0 --max-line-length=120 --exclude=third_party,urllib3,pyyaml3,pyyaml2 /code/
+      script: docker run -ti --rm -v $(pwd):/code alpine/flake8:3.5.0 --max-line-length=120 --exclude=third_party,urllib3,pyyaml3,pyyaml2 /code/collectors/python.d.plugin/python.d.plugin.in /code/
     - name: "css"
       install: skip
       script: docker run --rm -v $(pwd):/code eeacms/csslint sh -c "csslint /code/web/gui/*.css" || echo "OK"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,9 @@ jobs:
       name: "python"
       install: skip
       script: docker run -ti --rm -v $(pwd):/code alpine/flake8:3.5.0 --max-line-length=120 --exclude=third_party,urllib3,pyyaml3,pyyaml2 /code/
-#    - name: "javascript"
-#      install: skip
-#      script: docker run -it --rm -v $(pwd)/web:/code eeacms/jslint --color /code/web/*.js /code/plugins.d/node.d.plugin/*.js /code/node.d/*.js /code/node.d/node_modules/netdata.js
-#    - name: "css"
-#      install: skip
-#      script: docker run --rm -v $(pwd)/web:/code eeacms/csslint sh -c "csslint /code/*.css" || echo "OK"
+    - name: "css"
+      install: skip
+      script: docker run --rm -v $(pwd):/code eeacms/csslint sh -c "csslint /code/web/gui/*.css" || echo "OK"
     - name: "bash"
       install: skip
       script: docker run --rm --volume "$(pwd)":/code:ro --entrypoint sh koalaman/shellcheck-alpine:v0.5.0 -c 'for file in $(find /code/ -type f -name "*.sh" ! -path "*/makeself/*" ); do if ! shellcheck --format=gcc $file; then export FAILED=true; fi; done; if [ "$FAILED" != "" ]; then exit 1; fi'

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -38,9 +38,9 @@ PYTHON_MODULES_DIR = os.path.join(PLUGINS_DIR, 'python_modules')
 
 sys.path.append(PYTHON_MODULES_DIR)
 
-from bases.loaders import ModuleAndConfigLoader
-from bases.loggers import PythonDLogger
-from bases.collection import setdefault_values, run_and_exit
+from bases.loaders import ModuleAndConfigLoader  # noqa: E402
+from bases.loggers import PythonDLogger  # noqa: E402
+from bases.collection import setdefault_values, run_and_exit  # noqa: E402
 
 try:
     from collections import OrderedDict


### PR DESCRIPTION
- remove JS linting as we have codacy and LGTM
- unify mountpoints to always use `/code` directory
- add `python.d.plugin.in` to be linted with flake8


Relates to #4391