### PR TITLE
Add sendmail into the list of mail servers

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -107,7 +107,7 @@ timedb: prometheus *carbon-cache.py* *carbon-aggregator.py* *graphite/manage.py*
 # -----------------------------------------------------------------------------
 # email servers
 
-email: dovecot imapd pop3d amavis* master zmstat* zmmailboxdmgr qmgr oqmgr saslauthd opendkim clamd freshclam unbound tlsmgr postfwd2 postscreen postfix smtp* lmtp*
+email: dovecot imapd pop3d amavis* master zmstat* zmmailboxdmgr qmgr oqmgr saslauthd opendkim clamd freshclam unbound tlsmgr postfwd2 postscreen postfix smtp* lmtp* sendmail
 
 # -----------------------------------------------------------------------------
 # network, routing, VPN


### PR DESCRIPTION
I didn't manage to rebase without closing original pull request (https://github.com/netdata/netdata/pull/4389), so I created new one.

There are two reasons for this change:
 - some systems still use sendmail as default MTA;
 - some MTAs maintain binary called "sendmail" to mimic sendmail's
command line interface, which might be used by 3rd party tools to create
outgoing messages. When mentioned CLI app is being used it would be
correct to identify and account such processes as email-related.