### PR TITLE
Evaluate $used_ram_to_ignore on FreeBSD

### DIFF
--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -3,7 +3,7 @@
 
    alarm: used_ram_to_ignore
       on: system.ram
-      os: linux
+      os: linux freebsd
    hosts: *
     calc: ($zfs.arc_size.arcsz = nan)?(0):($zfs.arc_size.arcsz)
    every: 10s


### PR DESCRIPTION
Fix un-evaluated $used_ram_to_ignore variable on FreeBSD.