### PR TITLE
Fix cmake build on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,19 @@ IF(LINUX)
     # ${NFACCT_INCLUDE_DIRS}
 ENDIF(LINUX)
 
+
+# -----------------------------------------------------------------------------
+# Detect MacOS IOKit/Foundation framework
+
+IF(MACOS)
+    find_library(IOKIT IOKit)
+    find_library(FOUNDATION Foundation)
+    # later we use:
+    # ${FOUNDATION}
+    # ${IOKIT}
+ENDIF(MACOS)
+
+
 # -----------------------------------------------------------------------------
 # netdata files
 
@@ -474,7 +487,7 @@ ELSEIF(FREEBSD)
 
 ELSEIF(MACOS)
     add_executable(netdata config.h ${NETDATA_FILES} ${MACOS_PLUGIN_FILES})
-    target_link_libraries (netdata libnetdata ${NETDATA_COMMON_LIBRARIES})
+    target_link_libraries (netdata libnetdata ${NETDATA_COMMON_LIBRARIES} ${IOKIT} ${FOUNDATION})
     target_include_directories(netdata PUBLIC ${NETDATA_COMMON_INCLUDE_DIRS})
     target_compile_options(netdata PUBLIC ${NETDATA_COMMON_CFLAGS})
     SET(ENABLE_PLUGIN_CGROUP_NETWORK False)


### PR DESCRIPTION
macos cmake build missing undefined symbol
steps to reproduce:

```
autoreconf -ivf
./configure --with-zlib --with-math CFLAGS="-O2"
mkdir -p cbuild && cd cbuild
cmake .. && make
```

Output:
```
[100%] Linking C executable netdata
undef: ___CFConstantStringClassReference
undef: _CFStringGetCString
undef: _IOIteratorNext
undef: _IOServiceMatching
undef: _IOIteratorReset
undef: _CFNumberGetValue
undef: _IOServiceGetMatchingServices
undef: _IORegistryEntryGetChildEntry
undef: _kCFAllocatorDefault
undef: _IORegistryEntryCreateCFProperties
undef: _CFDictionaryGetValue
undef: _IOMasterPort
undef: _CFRelease
undef: _IOObjectRelease
Undefined symbols for architecture x86_64:
  "___CFConstantStringClassReference", referenced from:
      CFString in lto.o
      CFString in lto.o
      CFString in lto.o
      CFString in lto.o
      CFString in lto.o
      CFString in lto.o
      CFString in lto.o
      ...
  "_CFStringGetCString", referenced from:
      _do_macos_iokit in lto.o
  "_IOIteratorNext", referenced from:
      _do_macos_iokit in lto.o
  "_IOServiceMatching", referenced from:
      _do_macos_iokit in lto.o
  "_IOIteratorReset", referenced from:
      _do_macos_iokit in lto.o
  "_CFNumberGetValue", referenced from:
      _do_macos_iokit in lto.o
  "_IOServiceGetMatchingServices", referenced from:
      _do_macos_iokit in lto.o
  "_IORegistryEntryGetChildEntry", referenced from:
      _do_macos_iokit in lto.o
  "_kCFAllocatorDefault", referenced from:
      _do_macos_iokit in lto.o
  "_IORegistryEntryCreateCFProperties", referenced from:
      _do_macos_iokit in lto.o
  "_CFDictionaryGetValue", referenced from:
      _do_macos_iokit in lto.o
  "_IOMasterPort", referenced from:
      _do_macos_iokit in lto.o
  "_CFRelease", referenced from:
      _do_macos_iokit in lto.o
  "_IOObjectRelease", referenced from:
      _do_macos_iokit in lto.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [netdata] Error 1
make[1]: *** [CMakeFiles/netdata.dir/all] Error 2
make: *** [all] Error 2
```