### PR TITLE
moved stream.conf initialization after log files have been open

### DIFF
--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -353,6 +353,7 @@ static struct statsd {
         .threads = 0,
         .collection_threads_status = NULL,
         .sockets = {
+                .config          = &netdata_config,
                 .config_section  = CONFIG_SECTION_STATSD,
                 .default_bind_to = "udp:localhost tcp:localhost",
                 .default_port    = STATSD_LISTEN_PORT,

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -6,6 +6,28 @@
 #include "../libnetdata/libnetdata.h"
 
 // ----------------------------------------------------------------------------
+// shortcuts for the default netdata configuration
+
+#define config_load(filename, overwrite_used) appconfig_load(&netdata_config, filename, overwrite_used)
+#define config_get(section, name, default_value) appconfig_get(&netdata_config, section, name, default_value)
+#define config_get_number(section, name, value) appconfig_get_number(&netdata_config, section, name, value)
+#define config_get_float(section, name, value) appconfig_get_float(&netdata_config, section, name, value)
+#define config_get_boolean(section, name, value) appconfig_get_boolean(&netdata_config, section, name, value)
+#define config_get_boolean_ondemand(section, name, value) appconfig_get_boolean_ondemand(&netdata_config, section, name, value)
+
+#define config_set(section, name, default_value) appconfig_set(&netdata_config, section, name, default_value)
+#define config_set_default(section, name, value) appconfig_set_default(&netdata_config, section, name, value)
+#define config_set_number(section, name, value) appconfig_set_number(&netdata_config, section, name, value)
+#define config_set_float(section, name, value) appconfig_set_float(&netdata_config, section, name, value)
+#define config_set_boolean(section, name, value) appconfig_set_boolean(&netdata_config, section, name, value)
+
+#define config_exists(section, name) appconfig_exists(&netdata_config, section, name)
+#define config_move(section_old, name_old, section_new, name_new) appconfig_move(&netdata_config, section_old, name_old, section_new, name_new)
+
+#define config_generate(buffer, only_changed) appconfig_generate(&netdata_config, buffer, only_changed)
+
+
+// ----------------------------------------------------------------------------
 // netdata include files
 
 #include "global_statistics.h"

--- a/daemon/main.h
+++ b/daemon/main.h
@@ -5,6 +5,8 @@
 
 #include "common.h"
 
+extern struct config netdata_config;
+
 #define NETDATA_MAIN_THREAD_RUNNING   CONFIG_BOOLEAN_YES
 #define NETDATA_MAIN_THREAD_EXITING  (CONFIG_BOOLEAN_YES + 1)
 #define NETDATA_MAIN_THREAD_EXITED    CONFIG_BOOLEAN_NO

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -42,31 +42,6 @@ struct section {
                             // readers are protected using the rwlock in avl_tree_lock
 };
 
-static int appconfig_section_compare(void *a, void *b);
-
-struct config netdata_config = {
-        .sections = NULL,
-        .mutex = NETDATA_MUTEX_INITIALIZER,
-        .index = {
-            .avl_tree = {
-                .root = NULL,
-                .compar = appconfig_section_compare
-            },
-            .rwlock = AVL_LOCK_INITIALIZER
-        }
-};
-
-struct config stream_config = {
-        .sections = NULL,
-        .mutex = NETDATA_MUTEX_INITIALIZER,
-        .index = {
-                .avl_tree = {
-                    .root = NULL,
-                    .compar = appconfig_section_compare
-                },
-                .rwlock = AVL_LOCK_INITIALIZER
-        }
-};
 
 // ----------------------------------------------------------------------------
 // locking
@@ -112,7 +87,7 @@ static struct config_option *appconfig_option_index_find(struct section *co, con
 // ----------------------------------------------------------------------------
 // config sections index
 
-static int appconfig_section_compare(void *a, void *b) {
+int appconfig_section_compare(void *a, void *b) {
     if(((struct section *)a)->hash < ((struct section *)b)->hash) return -1;
     else if(((struct section *)a)->hash > ((struct section *)b)->hash) return 1;
     else return strcmp(((struct section *)a)->name, ((struct section *)b)->name);

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -102,10 +102,6 @@ struct config {
     avl_tree_lock index;
 };
 
-extern struct config
-        netdata_config,
-        stream_config;
-
 #define CONFIG_BOOLEAN_NO   0
 #define CONFIG_BOOLEAN_YES  1
 
@@ -132,25 +128,6 @@ extern int appconfig_move(struct config *root, const char *section_old, const ch
 
 extern void appconfig_generate(struct config *root, BUFFER *wb, int only_changed);
 
-// ----------------------------------------------------------------------------
-// shortcuts for the default netdata configuration
-
-#define config_load(filename, overwrite_used) appconfig_load(&netdata_config, filename, overwrite_used)
-#define config_get(section, name, default_value) appconfig_get(&netdata_config, section, name, default_value)
-#define config_get_number(section, name, value) appconfig_get_number(&netdata_config, section, name, value)
-#define config_get_float(section, name, value) appconfig_get_float(&netdata_config, section, name, value)
-#define config_get_boolean(section, name, value) appconfig_get_boolean(&netdata_config, section, name, value)
-#define config_get_boolean_ondemand(section, name, value) appconfig_get_boolean_ondemand(&netdata_config, section, name, value)
-
-#define config_set(section, name, default_value) appconfig_set(&netdata_config, section, name, default_value)
-#define config_set_default(section, name, value) appconfig_set_default(&netdata_config, section, name, value)
-#define config_set_number(section, name, value) appconfig_set_number(&netdata_config, section, name, value)
-#define config_set_float(section, name, value) appconfig_set_float(&netdata_config, section, name, value)
-#define config_set_boolean(section, name, value) appconfig_set_boolean(&netdata_config, section, name, value)
-
-#define config_exists(section, name) appconfig_exists(&netdata_config, section, name)
-#define config_move(section_old, name_old, section_new, name_new) appconfig_move(&netdata_config, section_old, name_old, section_new, name_new)
-
-#define config_generate(buffer, only_changed) appconfig_generate(&netdata_config, buffer, only_changed)
+extern int appconfig_section_compare(void *a, void *b);
 
 #endif /* NETDATA_CONFIG_H */

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -448,19 +448,19 @@ static inline int bind_to_this(LISTEN_SOCKETS *sockets, const char *definition, 
 int listen_sockets_setup(LISTEN_SOCKETS *sockets) {
     listen_sockets_init(sockets);
 
-    sockets->backlog = (int) config_get_number(sockets->config_section, "listen backlog", sockets->backlog);
+    sockets->backlog = (int) appconfig_get_number(sockets->config, sockets->config_section, "listen backlog", sockets->backlog);
 
     long long int old_port = sockets->default_port;
-    long long int new_port = config_get_number(sockets->config_section, "default port", sockets->default_port);
+    long long int new_port = appconfig_get_number(sockets->config, sockets->config_section, "default port", sockets->default_port);
     if(new_port < 1 || new_port > 65535) {
         error("LISTENER: Invalid listen port %lld given. Defaulting to %lld.", new_port, old_port);
-        sockets->default_port = (uint16_t) config_set_number(sockets->config_section, "default port", old_port);
+        sockets->default_port = (uint16_t) appconfig_set_number(sockets->config, sockets->config_section, "default port", old_port);
     }
     else sockets->default_port = (uint16_t)new_port;
 
     debug(D_OPTIONS, "LISTENER: Default listen port set to %d.", sockets->default_port);
 
-    char *s = config_get(sockets->config_section, "bind to", sockets->default_bind_to);
+    char *s = appconfig_get(sockets->config, sockets->config_section, "bind to", sockets->default_bind_to);
     while(*s) {
         char *e = s;
 

--- a/libnetdata/socket/socket.h
+++ b/libnetdata/socket/socket.h
@@ -10,6 +10,7 @@
 #endif
 
 typedef struct listen_sockets {
+    struct config *config;              // the config file to use
     const char *config_section;         // the netdata configuration section to read settings from
     const char *default_bind_to;        // the default bind to configuration string
     uint16_t default_port;              // the default port to use

--- a/web/server/web_server.c
+++ b/web/server/web_server.c
@@ -45,6 +45,7 @@ const char *web_server_mode_name(WEB_SERVER_MODE id) {
 // API sockets
 
 LISTEN_SOCKETS api_sockets = {
+        .config          = &netdata_config,
         .config_section  = CONFIG_SECTION_WEB,
         .default_bind_to = "*",
         .default_port    = API_LISTEN_PORT,


### PR DESCRIPTION
fixes #4403

Also fixed an issue that `libnetdata` was incorrectly referencing `daemon` structures. Parameterized all these references, so that `libnetdata` is daemon agnostic.
