### PR TITLE
add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,24 @@
+<!--- Verify first that your issue is not already reported on GitHub -->
+<!--- Also test if the latest release and devel branch are affected too -->
+
+##### Bug report summary
+<!-- A clear and concise description of what the bug is. -->
+
+###### OS / Environment
+<!--- Provide all relevant information below, e.g. OS distribution, running in container, etc. -->
+
+##### Component Name
+<!--- Write the short name of the module or plugin below -->
+
+##### Steps To Reproduce
+<!--- Describe exactly how to reproduce the problem, using a minimal test-case -->
+
+<!--- Paste configuration you used between quotes below -->
+```yaml
+
+```
+
+<!--- HINT: You can paste gist.github.com links for larger files -->
+
+###### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,7 @@
+<!--- Verify first that your issue is not already reported on GitHub -->
+
+##### Feature idea summary
+<!--- Explain new feature briefly below -->
+
+###### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/QUESTION.md
@@ -1,0 +1,13 @@
+<!--- Verify first that your question wasn't asked before on GitHub -->
+
+##### Question summary
+<!--- Briefly exmplain what is the problem you are having -->
+
+###### OS / Environment
+<!--- Provide all relevant information below, e.g. OS distribution, running in container, etc. -->
+
+##### Component Name
+<!--- Write the short name of the module or plugin below -->
+
+###### Expected results
+<!-- A clear and concise description of what you expected to happen. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+##### Summary
+<!--- Describe the change below, including rationale and design decisions -->
+
+<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
+
+##### Component Name
+<!--- Write the short name of the module or plugin below -->
+
+##### Additional Information
+<!--- Include additional information to help people understand the change here -->
+<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
+
+<!--- Paste log output below, e.g. before and after your change -->
+```paste below
+
+```


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Add github templates for issues and PRs

##### Component Name
<!--- Write the short name of the module or plugin below -->
GitHub management

##### Additional Information

Github allows to customize and standardize issue reports and pull requests. It even allows to have [multiple templates for multiple issues type](https://blog.github.com/2018-01-25-multiple-issue-and-pull-request-templates/) which I also use in this PR. Later on we could use those for minimal automated labeling system using @netdatabot account.