### PR TITLE
Fix GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+
+---
+
 <!--- Verify first that your issue is not already reported on GitHub -->
 <!--- Also test if the latest release and devel branch are affected too -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,9 @@
+---
+name: Feature request
+about: Suggest an idea for our project
+
+---
+
 <!--- Verify first that your issue is not already reported on GitHub -->
 
 ##### Feature idea summary

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,3 +1,8 @@
+---
+name: Question
+about: You just want to ask a question? Go on.
+---
+
 <!--- Verify first that your question wasn't asked before on GitHub -->
 
 ##### Question summary


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
Potential fix to issue templates
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
GitHub management

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Issue templates introduced in #4424 doesn't show up when creating issue. This might be because those templates doesn't have headers and/or filenames are in uppercase. GitHub interface for creating such files creates them in a way which can be seen in #4426. This is also tested and proven to work on my fork https://github.com/paulfantom/netdata
