### PR TITLE
Feat: detect NIC speed and alarm on each device for net traffic overflow

### DIFF
--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -4,19 +4,34 @@
 # -----------------------------------------------------------------------------
 # net traffic overflow
 
- template: 10s_net_traffic_overflow
+ template: 1m_received_traffic_overflow
        on: net.net
        os: linux
     hosts: *
  families: *
-   lookup: average -10s unaligned absolute of sent,received
+   lookup: average -1m unaligned absolute of received
      calc: $this * 100 / ($nic_speed_max * 1000)
     units: %
     every: 10s
-     warn: $this > (($status >= $WARNING)  ? (50) : (70))
-     crit: $this > (($status == $CRITICAL) ? (70) : (90))
+     warn: $this > (($status >= $WARNING)  ? (80) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (90))
     delay: down 1m multiplier 1.5 max 1h
-     info: network traffic percentile of total NIC speed
+     info: interface received bandwidth usage over net device speed max
+       to: sysadmin
+
+ template: 1m_sent_traffic_overflow
+       on: net.net
+       os: linux
+    hosts: *
+ families: *
+   lookup: average -1m unaligned absolute of sent
+     calc: $this * 100 / ($nic_speed_max * 1000)
+    units: %
+    every: 10s
+     warn: $this > (($status >= $WARNING)  ? (80) : (85))
+     crit: $this > (($status == $CRITICAL) ? (85) : (90))
+    delay: down 1m multiplier 1.5 max 1h
+     info: interface sent bandwidth usage over net device speed max
        to: sysadmin
 
 # -----------------------------------------------------------------------------

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -10,7 +10,7 @@
     hosts: *
  families: *
    lookup: average -1m unaligned absolute of received
-     calc: $this * 100 / ($nic_speed_max * 1000)
+     calc: ($nic_speed_max > 0) ? ($this * 100 / ($nic_speed_max * 1000)) : ( nan )
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (80) : (85))
@@ -25,7 +25,7 @@
     hosts: *
  families: *
    lookup: average -1m unaligned absolute of sent
-     calc: $this * 100 / ($nic_speed_max * 1000)
+     calc: ($nic_speed_max > 0) ? ($this * 100 / ($nic_speed_max * 1000)) : ( nan )
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (80) : (85))

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -2,6 +2,24 @@
 # you can disable an alarm notification by setting the 'to' line to: silent
 
 # -----------------------------------------------------------------------------
+# net traffic overflow
+
+ template: 10s_net_traffic_overflow
+       on: net.net
+       os: linux
+    hosts: *
+ families: *
+   lookup: average -10s unaligned absolute of sent,received
+     calc: $this * 100 / ($nic_speed_max * 1000)
+    units: %
+    every: 10s
+     warn: $this > (($status >= $WARNING)  ? (50) : (70))
+     crit: $this > (($status == $CRITICAL) ? (70) : (90))
+    delay: down 1m multiplier 1.5 max 1h
+     info: network traffic percentile of total NIC speed
+       to: sysadmin
+
+# -----------------------------------------------------------------------------
 # dropped packets
 
 # check if an interface is dropping packets


### PR DESCRIPTION
##### Summary

- add a local variable in net.net chart for nic speed
- add alarm template for net traffic overflow on each device

##### Component Name
<!--- Write the short name of the module or plugin below -->

proc_net_dev

##### Additional Information

![screen shot 2018-10-18 at 2 09 48 pm](https://user-images.githubusercontent.com/7362589/47134503-8d011b00-d2df-11e8-97e5-4df6bf14f05d.png)

