### PR TITLE
Added README templates and filled in examples for freeipmi and nginx

### DIFF
--- a/collectors/README-TEMPLATE.md
+++ b/collectors/README-TEMPLATE.md
@@ -1,0 +1,54 @@
+# Collector Plugin README template
+
+_The title must be replaced with the plugin name_
+
+_For a filled in sample, see the [freeipmi plugin](freeipmi.plugin/README.md)_
+
+Parameter | Value |
+:---------|:------|
+Short Description | SHORT_DESCRIPTION |
+Category | CATEGORY |
+Sub-Category | SUBCATEGORY | 
+Plugin | COLLECTOR_IDENTIFIER.plugin |
+Prog. Language | PROG_LANGUAGE | 
+Config file | CONFIG_FILE |
+Alarms config | ALARM_CONFIG_FILE |
+Dependencies |  DEPENDENCIES |
+Live Demo | URL_OR_SUBURL |
+
+_The README always starts with the table above after the main header. Any other content in this section will not be present in the documentation.
+- CATEGORY is one of the following: Web, Cloud, Data Store, Messaging (Queues), Monitoring Tools, Operating System, Application Instrumentation, Other
+- SUBCATEGORY could be Application, Metric type (e.g.) 
+- COLLECTOR_IDENTIFIER is the first part of the directory the plugin is in. e.g. freeipmi, python.d etc.
+- DEPENDENCIES contains a one line description of what is needed outside of netdata for the plugin to work
+- URL_OR_SUBURL: If a full URL appears here, we will show it as is and also parse the path after the hash tag. If it's not a link format, we'll assume that we are given the path after the hash tag.
+_
+
+## Introduction
+
+_This can contain subsections and will appear as is. It should give a high level explanation of what is monitored and how, without going into extreme details._
+
+## Charts
+
+_Detailed list of metrics collected, one line per type of CHART generated. Notice the exact match with the parameters expected to the CHART output line. The "options" column does not need to be detailed, but we want the table to explain what we will see in each chart, so use your judgement _
+
+type.id | name | title | units | family | context | charttype | options |
+:-------|:-----|:------|:------|:-------|:--------|:----------|:------|
+ipmi.temperatures_c | | System Celcius Temperatures read by IPMI | Celcius | temperatures | ipmi.temperatures_c | line | |
+ipmi.volts | | System Voltages read by IPMI | Volts | voltages | ipmi.voltages | line | |
+
+## Alarms
+
+_Explanation of the default alarms configured in the ALARM_CONFIG_FILE_
+
+## Installation
+
+_e.g. do I need to install an external application, do I need to configure my application so it can be monitored by netdata, do I need to restart netdata etc._
+
+## Usage
+
+_Anything specific that we want to say about what we see in the charts, disclaimers, use cases in which the data may be misinterpreted etc. May include screenshots of charts._
+
+## Notes
+
+_Anything additional we believe the users should know about this plugin_

--- a/collectors/charts.d.plugin/README-TEMPLATE.md
+++ b/collectors/charts.d.plugin/README-TEMPLATE.md
@@ -1,0 +1,54 @@
+# BASH Module README Template
+
+_The title must be replaced with the plugin name_
+
+Parameter | Value |
+:---------|:------|
+Short Description | SHORT_DESCRIPTION |
+Category | CATEGORY |
+Sub-Category | SUBCATEGORY | 
+Orchestrator | charts.d.plugin |
+Module | COLLECTOR_IDENTIFIER |
+Prog. Language | BASH | 
+Config file | CONFIG_FILE |
+Alarms config | ALARM_CONFIG_FILE |
+Dependencies |  DEPENDENCIES |
+Live Demo | URL_OR_SUBURL |
+
+
+_The README always starts with the table above after the main header. Any other content in this section will not be present in the documentation.
+- CATEGORY is one of the following: Web, Cloud, Data Store, Messaging (Queues), Monitoring Tools, Operating System, Application Instrumentation, Other
+- SUBCATEGORY could be Application, Metric type (e.g.) 
+- PLUGIN_IDENTIFIER The first part of the directory the plugin is in. e.g. freeipmi, python.d etc.
+- DEPENDENCIES contains a one line description of what is needed outside of netdata for the plugin to work
+- URL_OR_SUBURL: If a full URL appears here, we will show it as is and also parse the path after the hash tag. If it's not a link format, we'll assume that we are given the path after the hash tag.
+_
+
+## Introduction
+
+_This can contain subsections and will appear as is. It should give a high level explanation of what is monitored and how, without going into extreme details._
+
+## Charts
+
+_Detailed list of metrics collected, one line per type of CHART generated. Notice the exact match with the parameters expected to the CHART output line. The "options" column does not need to be detailed, but we want the table to explain what we will see in each chart, so use your judgement _
+
+type.id | name | title | units | family | context | charttype | options |
+:-------|:-----|:------|:------|:-------|:--------|:----------|:------|
+ipmi.temperatures_c | | System Celcius Temperatures read by IPMI | Celcius | temperatures | ipmi.temperatures_c | line | |
+ipmi.volts | | System Voltages read by IPMI | Volts | voltages | ipmi.voltages | line | |
+
+## Alarms
+
+_Explanation of the default alarms configured in the ALARM_CONFIG_FILE_
+
+## Installation
+
+_e.g. do I need to install an external application, do I need to configure my application so it can be monitored by netdata, do I need to restart netdata etc._
+
+## Usage
+
+_Anything specific that we want to say about what we see in the charts, disclaimers, use cases in which the data may be misinterpreted etc. May include screenshots of charts._
+
+## Notes
+
+_Anything additional we believe the users should know about this plugin_

--- a/collectors/freeipmi.plugin/README.md
+++ b/collectors/freeipmi.plugin/README.md
@@ -1,8 +1,43 @@
-netdata has a [freeipmi](https://www.gnu.org/software/freeipmi/) plugin.
+# IPMI
 
-> FreeIPMI provides in-band and out-of-band IPMI software based on the IPMI v1.5/2.0 specification. The IPMI specification defines a set of interfaces for platform management and is implemented by a number vendors for system management. The features of IPMI that most users will be interested in are sensor monitoring, system event monitoring, power control, and serial-over-LAN (SOL).
+Parameter | Value |
+:---------|:------|
+Short Description | This plugin uses the IPMI protocol to monitor sensors, system events, power, serial-over-LAN etc. |
+Category | Monitoring Tools |
+Sub-Category | Hardware | 
+Plugin | freeipmi.plugin |
+Prog. Language | C | 
+Config file | /etc/netdata/netdata.conf |
+Alarms config | health.d/ipmi.conf |
+Dependencies |  `libipmimonitoring-dev` or `libipmimonitoring-devel` |
+Live Demo | menu_ipmi |
 
-## compile `freeipmi.plugin`
+## Introduction
+
+[FreeIPMI](https://www.gnu.org/software/freeipmi/) provides in-band and out-of-band IPMI software based on the IPMI v1.5/2.0 specification. The IPMI specification defines a set of interfaces for platform management and is implemented by a number vendors for system management. The features of IPMI that most users will be interested in are sensor monitoring, system event monitoring, power control, and serial-over-LAN (SOL).
+
+## Charts
+
+type.id | name | title | units | family | context | charttype | options |
+:-------|:-----|:------|:------|:-------|:--------|:----------|:------|
+ipmi.temperatures_c | | System Celcius Temperatures read by IPMI | Celcius | temperatures | ipmi.temperatures_c | line | |
+ipmi.volts | | System Voltages read by IPMI | Volts | voltages | ipmi.voltages | line | |
+ipmi.amps | | System Current read by IPMI | Amps | current | ipmi.amps | line | |
+ipmi.rpm | | System Fans read by IPMI | RPM | fans | ipmi.rpm | line | |
+ipmi.percent | | System Metrics read by IPMI | | other | ipmi.percent | line | |
+
+## Alarms
+
+The plugin adds 2 alarms:
+
+1. Sensors in non-nominal state (i.e. warning and critical)
+2. SEL is non empty
+
+![image](https://cloud.githubusercontent.com/assets/2662304/23674138/88926a20-037d-11e7-89c0-20e74ee10cd1.png)
+
+## Installation
+
+_e.g. do I need to install an external application, do I need to configure my application so it can be monitored by netdata, do I need to restart netdata etc._
 
 1. install `libipmimonitoring-dev` or `libipmimonitoring-devel` (`freeipmi-devel` on RHEL based OS) using the package manager of your system.
 
@@ -12,30 +47,7 @@ Keep in mind IPMI requires root access, so the plugin is setuid to root.
 
 If you just installed the required IPMI tools, please run at least once the command `ipmimonitoring` and verify it returns sensors information. This command initialises IPMI configuration, so that the netdata plugin will be able to work.
 
-## netdata use
-
-The plugin creates (up to) 8 charts, based on the information collected from IPMI:
-
-1. number of sensors by state
-2. number of events in SEL
-3. Temperatures CELCIUS
-4. Temperatures FAHRENHEIT
-5. Voltages
-6. Currents
-7. Power
-8. Fans
-
-
-It also adds 2 alarms:
-
-1. Sensors in non-nominal state (i.e. warning and critical)
-2. SEL is non empty
-
-![image](https://cloud.githubusercontent.com/assets/2662304/23674138/88926a20-037d-11e7-89c0-20e74ee10cd1.png)
-
-The plugin does a speed test when it starts, to find out the duration needed by the IPMI processor to respond. Depending on the speed of your IPMI processor, charts may need several seconds to show up on the dashboard.
-
-## `freeipmi.plugin` configuration
+## Configuration
 
 The plugin supports a few options. To see them, run:
 
@@ -101,7 +113,7 @@ You can set these options in `/etc/netdata/netdata.conf` at this section:
 
 Append to `command options = ` the settings you need. The minimum `update every` is 5 (enforced internally by the plugin). IPMI is slow and CPU hungry. So, once every 5 seconds is pretty acceptable.
 
-## ignoring specific sensors
+### Ignoring specific sensors
 
 Specific sensor IDs can be excluded from freeipmi tools by editing `/etc/freeipmi/freeipmi.conf` and setting the IDs to be ignored at `ipmi-sensors-exclude-record-ids`. **However this file is not used by `libipmimonitoring`** (the library used by netdata's `freeipmi.plugin`).
 
@@ -134,8 +146,22 @@ ID  | Name             | Type                     | State    | Reading    | Unit
 ...
 ```
 
+## Usage
 
-## debugging
+The plugin creates (up to) 8 charts, based on the information collected from IPMI:
+
+1. number of sensors by state
+2. number of events in SEL
+3. Temperatures CELCIUS
+4. Temperatures FAHRENHEIT
+5. Voltages
+6. Currents
+7. Power
+8. Fans
+
+The plugin does a speed test when it starts, to find out the duration needed by the IPMI processor to respond. Depending on the speed of your IPMI processor, charts may need several seconds to show up on the dashboard.
+
+### Debugging
 
 You can run the plugin by hand:
 
@@ -149,7 +175,9 @@ sudo su -s /bin/sh netdata
 
 You will get verbose output on what the plugin does.
 
-## kipmi0 CPU usage
+## Notes
+
+### kipmi0 CPU usage
 
 There have been reports that kipmi is showing increased CPU when the IPMI is queried.
 

--- a/collectors/node.d.plugin/README-TEMPLATE.md
+++ b/collectors/node.d.plugin/README-TEMPLATE.md
@@ -1,0 +1,54 @@
+# Node.js Module README Template
+
+_The title must be replaced with the plugin name_
+
+Parameter | Value |
+:---------|:------|
+Short Description | SHORT_DESCRIPTION |
+Category | CATEGORY |
+Sub-Category | SUBCATEGORY | 
+Orchestrator | node.d.plugin |
+Module | COLLECTOR_IDENTIFIER |
+Prog. Language | JavaScript | 
+Config file | CONFIG_FILE |
+Alarms config | ALARM_CONFIG_FILE |
+Dependencies |  DEPENDENCIES |
+Live Demo | URL_OR_SUBURL |
+
+
+_The README always starts with the table above after the main header. Any other content in this section will not be present in the documentation.
+- CATEGORY is one of the following: Web, Cloud, Data Store, Messaging (Queues), Monitoring Tools, Operating System, Application Instrumentation, Other
+- SUBCATEGORY could be Application, Metric type (e.g.) 
+- PLUGIN_IDENTIFIER The first part of the directory the plugin is in. e.g. freeipmi, python.d etc.
+- DEPENDENCIES contains a one line description of what is needed outside of netdata for the plugin to work
+- URL_OR_SUBURL: If a full URL appears here, we will show it as is and also parse the path after the hash tag. If it's not a link format, we'll assume that we are given the path after the hash tag.
+_
+
+## Introduction
+
+_This can contain subsections and will appear as is. It should give a high level explanation of what is monitored and how, without going into extreme details._
+
+## Charts
+
+_Detailed list of metrics collected, one line per type of CHART generated. Notice the exact match with the parameters expected to the CHART output line. The "options" column does not need to be detailed, but we want the table to explain what we will see in each chart, so use your judgement _
+
+type.id | name | title | units | family | context | charttype | options |
+:-------|:-----|:------|:------|:-------|:--------|:----------|:------|
+ipmi.temperatures_c | | System Celcius Temperatures read by IPMI | Celcius | temperatures | ipmi.temperatures_c | line | |
+ipmi.volts | | System Voltages read by IPMI | Volts | voltages | ipmi.voltages | line | |
+
+## Alarms
+
+_Explanation of the default alarms configured in the ALARM_CONFIG_FILE_
+
+## Installation
+
+_e.g. do I need to install an external application, do I need to configure my application so it can be monitored by netdata, do I need to restart netdata etc._
+
+## Usage
+
+_Anything specific that we want to say about what we see in the charts, disclaimers, use cases in which the data may be misinterpreted etc. May include screenshots of charts._
+
+## Notes
+
+_Anything additional we believe the users should know about this plugin_

--- a/collectors/python.d.plugin/README-TEMPLATE.md
+++ b/collectors/python.d.plugin/README-TEMPLATE.md
@@ -1,0 +1,56 @@
+# Python Module README Template
+
+_The title must be replaced with the plugin name_
+
+_For a filled in sample, see the python [nginx module](nginx/README.md)_
+
+Parameter | Value |
+:---------|:------|
+Short Description | SHORT_DESCRIPTION |
+Category | CATEGORY |
+Sub-Category | SUBCATEGORY | 
+Orchestrator | python.d.plugin |
+Module | COLLECTOR_IDENTIFIER |
+Prog. Language | Python | 
+Config file | CONFIG_FILE |
+Alarms config | ALARM_CONFIG_FILE |
+Dependencies |  DEPENDENCIES |
+Live Demo | URL_OR_SUBURL |
+
+
+_The README always starts with the table above after the main header. Any other content in this section will not be present in the documentation.
+- CATEGORY is one of the following: Web, Cloud, Data Store, Messaging (Queues), Monitoring Tools, Operating System, Application Instrumentation, Other
+- SUBCATEGORY could be Application, Metric type (e.g.) 
+- PLUGIN_IDENTIFIER The first part of the directory the plugin is in. e.g. freeipmi, python.d etc.
+- DEPENDENCIES contains a one line description of what is needed outside of netdata for the plugin to work
+- URL_OR_SUBURL: If a full URL appears here, we will show it as is and also parse the path after the hash tag. If it's not a link format, we'll assume that we are given the path after the hash tag.
+_
+
+## Introduction
+
+_This can contain subsections and will appear as is. It should give a high level explanation of what is monitored and how, without going into extreme details._
+
+## Charts
+
+_Detailed list of metrics collected, one line per type of CHART generated. Notice the exact match with the parameters expected to the CHART output line. The "options" column does not need to be detailed, but we want the table to explain what we will see in each chart, so use your judgement _
+
+type.id | name | title | units | family | context | charttype | options |
+:-------|:-----|:------|:------|:-------|:--------|:----------|:------|
+ipmi.temperatures_c | | System Celcius Temperatures read by IPMI | Celcius | temperatures | ipmi.temperatures_c | line | |
+ipmi.volts | | System Voltages read by IPMI | Volts | voltages | ipmi.voltages | line | |
+
+## Alarms
+
+_Explanation of the default alarms configured in the ALARM_CONFIG_FILE_
+
+## Installation
+
+_e.g. do I need to install an external application, do I need to configure my application so it can be monitored by netdata, do I need to restart netdata etc._
+
+## Usage
+
+_Anything specific that we want to say about what we see in the charts, disclaimers, use cases in which the data may be misinterpreted etc. May include screenshots of charts._
+
+## Notes
+
+_Anything additional we believe the users should know about this plugin_

--- a/collectors/python.d.plugin/nginx/README.md
+++ b/collectors/python.d.plugin/nginx/README.md
@@ -1,31 +1,55 @@
-# nginx
+# nginx module
 
-This module will monitor one or more nginx servers depending on configuration. Servers can be either local or remote.
+Parameter | Value |
+:---------|:------|
+Short Description | This module will monitor one or more nginx servers depending on configuration. Servers can be either local or remote. |
+Category | Web |
+Sub-Category | nginx | 
+Orchestrator | python.d.plugin |
+Module  | nginx/nginx.chart.py |
+Prog. Language | Python | 
+Config file | python.d/nginx.conf |
+Alarms config | health.d/nginx.conf |
+Dependencies |  nginx with configured 'ngx_http_stub_status_module' |
+Live Demo | [See it live](https://singapore.my-netdata.io/#menu_nginx_local) |
 
-**Requirements:**
- * nginx with configured 'ngx_http_stub_status_module'
- * 'location /stub_status'
 
-Example nginx configuration can be found in 'python.d/nginx.conf'
+## Introduction
 
-It produces following charts:
+Retrieves connection and request information from the nging servers configured in python.d/nginx.conf, using the [nginx http stub_status module](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html)
 
-1. **Active Connections**
- * active
+## Charts
 
-2. **Requests** in requests/s
- * requests
+type.id | name | title | units | family | context | charttype | options |
+:-------|:-----|:------|:------|:-------|:--------|:----------|:--------|
+nginx_local.connections | None | nginx Active Connections | connections | active connections | nginx.connections | line | lines: active |
+nginx_local.requests | None | nginx Requests | requests/s | requests | nginx.requests | line | requests ((incremental)) | |
+nginx_local.connection_status | None | nginx Active Connections by Status | connections | status | nginx.connection_status | line | lines: reading, writing, waiting/idle |
+nginx_local.connect_rate | None | nginx Connections Rate | connections/s | connections rate','nginx.connect_rate | line | lines: accepts, accepted ((incremental)), handled ((incremental)) |
 
-3. **Active Connections by Status**
- * reading
- * writing
- * waiting
 
-4. **Connections Rate** in connections/s
- * accepts
- * handled
+## Alarms
 
-### configuration
+The only preconfigured alarm makes sure nginx is running:
+
+```yaml
+template: nginx_last_collected_secs
+      on: nginx.requests
+    calc: $now - $last_collected_t
+   units: seconds ago
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: webmaster
+```
+
+## Installation
+
+nginx should have the [ngx_http_stub_status_module](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) configured. 
+
+## Configuration
 
 Needs only `url` to server's `stub_status`
 
@@ -40,6 +64,8 @@ local:
   retries : 10
 ```
 
-Without configuration, module attempts to connect to `http://localhost/stub_status`
+Without configuration, the plugin attempts to connect to `http://localhost/stub_status`
 
----
+## Usage
+
+## Notes


### PR DESCRIPTION
##### Summary

Closes #4394.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name

Collector Documentation

##### Additional Information
Adds collector README templa
tes for plugins and for orchestrator plugin modules. Also replaces README files in freeipmi and nginx to align with the templates. 
collectors/README-TEMPLATE.md provides freeipmi.plugin/README.md as an example.
collectors/python.d.plugin/README-TEMPLATE.md provides nginx/README.md as an example
