### PR TITLE
Disallow stale bot from removing labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,7 @@ daysUntilStale: 60
 daysUntilClose: false
 exemptLabels:
   - bug
+  - "help wanted"
 exemptProjects: true
 exemptMilestones: true
 staleLabel: help wanted


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
Disallow stale bot from removing "help wanted" label
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
GitHub management

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Currently stale bot can add and remove `help wanted` label. This change should disallow label removal.
