### PR TITLE
Remove duplicated entry and put modules in order in python.d.conf

### DIFF
--- a/collectors/python.d.plugin/python.d.conf
+++ b/collectors/python.d.plugin/python.d.conf
@@ -71,7 +71,6 @@ logind: no
 
 # nginx_log has been replaced by web_log
 nginx_log: no
-# ntpd: yes
 # ovpn_status_log: yes
 # phpfpm: yes
 # postfix: yes

--- a/collectors/python.d.plugin/python.d.conf
+++ b/collectors/python.d.plugin/python.d.conf
@@ -25,9 +25,10 @@ gc_run: yes
 # Garbage collection interval in seconds. Default is 300.
 gc_interval: 300
 
+# apache: yes
+
 # apache_cache has been replaced by web_log
 apache_cache: no
-# apache: yes
 # beanstalk: yes
 # bind_rndc: yes
 # boinc: yes
@@ -47,10 +48,10 @@ example: no
 # exim: yes
 # fail2ban: yes
 # freeradius: yes
+go_expvar: no
 
 # gunicorn_log has been replaced by web_log
 gunicorn_log: no
-go_expvar: no
 # haproxy: yes
 # hddtemp: yes
 # icecast: yes
@@ -66,11 +67,11 @@ logind: no
 # mysql: yes
 # nginx: yes
 # nginx_plus: yes
-# nsd: yes
-# ntpd: yes
 
 # nginx_log has been replaced by web_log
 nginx_log: no
+# nsd: yes
+# ntpd: yes
 # ovpn_status_log: yes
 # phpfpm: yes
 # postfix: yes
@@ -81,15 +82,15 @@ nginx_log: no
 # redis: yes
 # rethinkdbs: yes
 # retroshare: yes
-# sensors: yes
-# spigotmc: yes
 # samba: yes
+# sensors: yes
 # smartd_log: yes
-# squid: yes
+# spigotmc: yes
 # springboot: yes
+# squid: yes
 # tomcat: yes
 unbound: no
 # uwsgi: yes
 # varnish: yes
-# web_log: yes
 # w1sensor: yes
+# web_log: yes


### PR DESCRIPTION
##### Summary
* Remove duplicated `ntpd` entry
* Sort modules in alphabetical order to reduce chance of appearance of duplicated records in future

##### Component Name
`python.d.conf`
