### PR TITLE
Add proxysql in python.d.plugin Makefile.am

### DIFF
--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -81,6 +81,7 @@ include portcheck/Makefile.inc
 include postfix/Makefile.inc
 include postgres/Makefile.inc
 include powerdns/Makefile.inc
+include proxysql/Makefile.inc
 include puppet/Makefile.inc
 include rabbitmq/Makefile.inc
 include redis/Makefile.inc


### PR DESCRIPTION
I forgot to add Proxysql to `python.d.plugin/Makefile.am` in PR #4112. This PR fixes this issue :)

(I'm sorry about it :( )