### PR TITLE
Disable python sudo modules by default

### DIFF
--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -3,7 +3,9 @@
 Module collects logical and physical devices health metrics.
 
 **Requirements:**
- * `netdata` user needs to be able to sudo the `arcconf` program without password
+* `arrconf` program
+* `sudo` program
+* `netdata` user needs to be able to sudo the `arcconf` program without password
 
 To grab stats it executes:
  * `sudo -n arcconf GETCONFIG 1 LD`
@@ -20,7 +22,19 @@ It produces:
 
 4. **Physical Device Temperature**
 
-Screenshot:
+#### configuration
+**adaptec_raid** is disabled by default. Should be explicitly enabled in `python.d.conf`.
+
+This module uses `arcconf` which can only be executed by root.  It uses
+`sudo` and assumes that it is configured such that the `netdata` user can
+execute `arcconf` as root without password.
+
+Add to `sudoers`:
+
+    netdata ALL=(ALL)       NOPASSWD: /path/to/arcconf
+
+
+#### Screenshot:
 
 ![image](https://user-images.githubusercontent.com/22274335/47278133-6d306680-d601-11e8-87c2-cc9c0f42d686.png)
 

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -22,7 +22,7 @@ It produces:
 
 4. **Physical Device Temperature**
 
-#### configuration
+### prerequisite
 This module uses `arcconf` which can only be executed by root.  It uses
 `sudo` and assumes that it is configured such that the `netdata` user can
 execute `arcconf` as root without password.
@@ -31,7 +31,13 @@ Add to `sudoers`:
 
     netdata ALL=(root)       NOPASSWD: /path/to/arcconf
 
+### configuration
+
  **adaptec_raid** is disabled by default. Should be explicitly enabled in `python.d.conf`.
+
+```yaml
+adapterc_raid: yes
+```
 
 #### Screenshot:
 

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -23,16 +23,15 @@ It produces:
 4. **Physical Device Temperature**
 
 #### configuration
-**adaptec_raid** is disabled by default. Should be explicitly enabled in `python.d.conf`.
-
 This module uses `arcconf` which can only be executed by root.  It uses
 `sudo` and assumes that it is configured such that the `netdata` user can
 execute `arcconf` as root without password.
 
 Add to `sudoers`:
 
-    netdata ALL=(ALL)       NOPASSWD: /path/to/arcconf
+    netdata ALL=(root)       NOPASSWD: /path/to/arcconf
 
+ **adaptec_raid** is disabled by default. Should be explicitly enabled in `python.d.conf`.
 
 #### Screenshot:
 

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -3,7 +3,7 @@
 Module collects logical and physical devices health metrics.
 
 **Requirements:**
-* `arrconf` program
+* `arcconf` program
 * `sudo` program
 * `netdata` user needs to be able to sudo the `arcconf` program without password
 
@@ -36,7 +36,7 @@ Add to `sudoers`:
  **adaptec_raid** is disabled by default. Should be explicitly enabled in `python.d.conf`.
 
 ```yaml
-adapterc_raid: yes
+adaptec_raid: yes
 ```
 
 #### Screenshot:

--- a/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
+++ b/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
@@ -158,6 +158,11 @@ class Service(ExecutableService):
         return self._get_raw_data(command=command, stderr=stderr)
 
     def check(self):
+        arcconf = find_binary(ARCCONF)
+        if not arcconf:
+            self.error('can\'t locate "{0}" binary'.format(ARCCONF))
+            return False
+
         sudo = find_binary(SUDO)
         if self.use_sudo:
             if not sudo:
@@ -167,11 +172,6 @@ class Service(ExecutableService):
             if err:
                 self.error(' '.join(err))
                 return False
-
-        arcconf = find_binary(ARCCONF)
-        if not arcconf:
-            self.error('can\'t locate "{0}" binary'.format(ARCCONF))
-            return False
 
         if self.use_sudo:
             self.arcconf = SudoArcconf(arcconf, sudo)

--- a/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
+++ b/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
@@ -12,6 +12,8 @@ from bases.FrameworkServices.ExecutableService import ExecutableService
 from bases.collection import find_binary
 
 
+disabled_by_default = True
+
 update_every = 5
 
 ORDER = [

--- a/collectors/python.d.plugin/adaptec_raid/adaptec_raid.conf
+++ b/collectors/python.d.plugin/adaptec_raid/adaptec_raid.conf
@@ -53,7 +53,3 @@
 #     retries: 60             # the JOB's number of restoration attempts
 #     autodetection_retry: 0  # the JOB's re-check interval in seconds
 # ----------------------------------------------------------------------
-
-# IMPORTANT
-# The netdata user needs to be able to sudo the arcconf program without password:
-# netdata ALL=(root)       NOPASSWD: /path/to/arcconf

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -3,6 +3,8 @@
 Module collects adapter, physical drives and battery stats.
 
 **Requirements:**
+ * `megacli` program
+ * `sudo` program
  * `netdata` user needs to be able to be able to sudo the `megacli` program without password
 
 To grab stats it executes:
@@ -23,6 +25,16 @@ It produces:
 5. **Battery Cycle Count**
 
 ### configuration
+This module uses `megacli` which can only be executed by root.  It uses
+`sudo` and assumes that it is configured such that the `netdata` user can
+execute `megacli` as root without password.
+
+Add to `sudoers`:
+
+    netdata ALL=(root)       NOPASSWD: /path/to/megacli
+
+**megacli** is disabled by default. Should be explicitly enabled in `python.d.conf`.
+
 Battery stats disabled by default in the module configuration file.
 
 ---

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -24,7 +24,7 @@ It produces:
 
 5. **Battery Cycle Count**
 
-### configuration
+### prerequisite
 This module uses `megacli` which can only be executed by root.  It uses
 `sudo` and assumes that it is configured such that the `netdata` user can
 execute `megacli` as root without password.
@@ -33,8 +33,16 @@ Add to `sudoers`:
 
     netdata ALL=(root)       NOPASSWD: /path/to/megacli
 
-**megacli** is disabled by default. Should be explicitly enabled in `python.d.conf`.
+### configuration
 
-Battery stats disabled by default in the module configuration file.
+**megacli** is disabled by default. Should be explicitly enabled in `python.d.conf`.
+```yaml
+megacli: yes
+```
+
+Battery stats disabled by default. To enable them modify `megacli.conf`.
+```yaml
+do_battery: yes
+```
 
 ---

--- a/collectors/python.d.plugin/megacli/megacli.chart.py
+++ b/collectors/python.d.plugin/megacli/megacli.chart.py
@@ -10,6 +10,8 @@ from bases.FrameworkServices.ExecutableService import ExecutableService
 from bases.collection import find_binary
 
 
+disabled_by_default = True
+
 update_every = 5
 
 

--- a/collectors/python.d.plugin/megacli/megacli.conf
+++ b/collectors/python.d.plugin/megacli/megacli.conf
@@ -58,11 +58,5 @@
 #     do_battery: yes/no      # default is no. Battery stats (adds additional call to megacli `megacli -AdpBbuCmd -a0`).
 #
 # ----------------------------------------------------------------------
-
-# IMPORTANT
-# The netdata user needs to be able to be able to sudo the megacli program without password:
-# netdata ALL=(root)       NOPASSWD: /path/to/megacli
-
-
 # uncomment the line below to collect battery statistics
 # do_battery: yes

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -47,7 +47,7 @@ It produces the following charts:
  * break
  * sessetup
 
-### configuration
+### prerequisite
 This module uses `smbstatus` which can only be executed by root.  It uses
 `sudo` and assumes that it is configured such that the `netdata` user can
 execute `smbstatus` as root without password.
@@ -56,10 +56,12 @@ Add to `sudoers`:
 
     netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
 
+### configuration
+
  **samba** is disabled by default. Should be explicitly enabled in `python.d.conf`.
 
 ```yaml
-update_every : 5 # update frequency
+samba: yes
 ```
 
 ---

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -2,6 +2,13 @@
 
 Performance metrics of Samba file sharing.
 
+**Requirements:**
+* `smbstatus` program
+* `sudo` program
+* `smbd` must be compiled with profiling enabled
+* `smbd` must be started either with the `-P 1` option or inside `smb.conf` using `smbd profiling level`
+* `netdata` user needs to be able to sudo the `smbstatus` program without password
+
 It produces the following charts:
 
 1. **Syscall R/Ws** in kilobytes/s
@@ -41,18 +48,15 @@ It produces the following charts:
  * sessetup
 
 ### configuration
+This module uses `smbstatus` which can only be executed by root.  It uses
+`sudo` and assumes that it is configured such that the `netdata` user can
+execute `smbstatus` as root without password.
 
-Requires that smbd has been compiled with profiling enabled.  Also required
-that `smbd` was started either with the `-P 1` option or inside `smb.conf`
-using `smbd profiling level`.
+Add to `sudoers`:
 
-This plugin uses `smbstatus -P` which can only be executed by root.  It uses
-sudo and assumes that it is configured such that the `netdata` user can
-execute smbstatus as root without password.
+    netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
 
-For example:
-
-    netdata ALL=(ALL)       NOPASSWD: /usr/bin/smbstatus -P
+ **samba** is disabled by default. Should be explicitly enabled in `python.d.conf`.
 
 ```yaml
 update_every : 5 # update frequency

--- a/collectors/python.d.plugin/samba/samba.chart.py
+++ b/collectors/python.d.plugin/samba/samba.chart.py
@@ -21,6 +21,9 @@ import re
 from bases.collection import find_binary
 from bases.FrameworkServices.ExecutableService import ExecutableService
 
+
+disabled_by_default = True
+
 # default module values (can be overridden per job in `config`)
 update_every = 5
 priority = 60000


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #4473
- adaptec_raid fix: check if `arcconf` is available before `sudo` checks
- disable python modules which use `sudo` by default  (adaptec_raid, megacli, samba)
- update readme

##### Component Name
<!--- Write the short name of the module or plugin below -->
:snake: python.d modules: :snake:

- adaptec_raid
- megacli
- samba

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```