### PR TITLE
Fix checking of grouping time

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -451,7 +451,7 @@ RRDR *rrd2rrdr(
         else {
             // the points we should group to satisfy gtime
             group_points = group_time_requested / st->update_every;
-            if(unlikely(group_time_requested % group_points)) {
+            if(unlikely(group_time_requested % st->update_every)) {
                 #ifdef NETDATA_INTERNAL_CHECKS
                 info("INTERNAL CHECK: %s: requested gtime %ld secs, is not a multiple of the chart's data collection frequency %d secs", st->id, group_time_requested, st->update_every);
                 #endif


### PR DESCRIPTION
##### Summary
Fixes bug in checking of requested grouping time variable

##### Component Name
Query API

##### Additional Information
`group_time_requested` should be checked if it is a multiple of the chart's update interval.