### PR TITLE
fix query sum

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -145,7 +145,17 @@ static struct {
                 .hash  = 0,
                 .value = RRDR_GROUPING_CV,
                 .init  = NULL,
-                .create= grouping_create_stddev,   // not an error, stddev calculates this too
+                .create= grouping_create_stddev, // not an error, stddev calculates this too
+                .reset = grouping_reset_stddev,  // not an error, stddev calculates this too
+                .free  = grouping_free_stddev,   // not an error, stddev calculates this too
+                .add   = grouping_add_stddev,    // not an error, stddev calculates this too
+                .flush = grouping_flush_coefficient_of_variation
+        },
+        {.name = "rsd",                          // alias of 'cv'
+                .hash  = 0,
+                .value = RRDR_GROUPING_CV,
+                .init  = NULL,
+                .create= grouping_create_stddev, // not an error, stddev calculates this too
                 .reset = grouping_reset_stddev,  // not an error, stddev calculates this too
                 .free  = grouping_free_stddev,   // not an error, stddev calculates this too
                 .add   = grouping_add_stddev,    // not an error, stddev calculates this too

--- a/web/api/queries/stddev/README.md
+++ b/web/api/queries/stddev/README.md
@@ -41,7 +41,9 @@ Check [https://en.wikipedia.org/wiki/Standard_deviation](https://en.wikipedia.or
 
 # Coefficient of variation (`cv`)
 
-The coefficient of variation (`cv``), also known as relative standard deviation (RSD),
+> This query is also available as `rsd`.
+
+The coefficient of variation (`cv`), also known as relative standard deviation (`rsd`),
 is a standardized measure of dispersion of a probability distribution or frequency distribution.
 
 It is defined as the ratio of the **standard deviation** to the **mean**.  

--- a/web/api/queries/sum/sum.c
+++ b/web/api/queries/sum/sum.c
@@ -31,11 +31,8 @@ void grouping_free_sum(RRDR *r) {
 void grouping_add_sum(RRDR *r, calculated_number value) {
     if(!isnan(value)) {
         struct grouping_sum *g = (struct grouping_sum *)r->internal.grouping_data;
-
-        if(!g->count || calculated_number_fabs(value) > calculated_number_fabs(g->sum)) {
-            g->sum += value;
-            g->count++;
-        }
+        g->sum += value;
+        g->count++;
     }
 }
 


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

A copy-paste in #4443 broke `sum` queries.
The code was filtering values, like `min` and `max` do.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
