### PR TITLE
diskspace plugin should not stat() excluded mountpoints

### DIFF
--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -133,7 +133,8 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
         }
 
         // check if the mount point is a directory #2407
-        {
+        // but only when it is enabled by default #4491
+        if(def_space != CONFIG_BOOLEAN_YES || def_inodes != CONFIG_BOOLEAN_YES) {
             struct stat bs;
             if(stat(mi->mount_point, &bs) == -1) {
                 error("DISKSPACE: Cannot stat() mount point '%s' (disk '%s', filesystem '%s', root '%s')."

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -134,7 +134,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
         // check if the mount point is a directory #2407
         // but only when it is enabled by default #4491
-        if(def_space != CONFIG_BOOLEAN_YES || def_inodes != CONFIG_BOOLEAN_YES) {
+        if(def_space != CONFIG_BOOLEAN_NO || def_inodes != CONFIG_BOOLEAN_NO) {
             struct stat bs;
             if(stat(mi->mount_point, &bs) == -1) {
                 error("DISKSPACE: Cannot stat() mount point '%s' (disk '%s', filesystem '%s', root '%s')."


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

diskspace plugin should not stat() excluded mountpoints
fixes #4491

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
