### PR TITLE
do not send duplicate chart names while streaming metrics

### DIFF
--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -149,12 +149,25 @@ static inline void rrdpush_send_chart_definition_nolock(RRDSET *st) {
 
     rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
 
+    // properly set the name for the remote end to parse it
+    char *name = "";
+    if(unlikely(strcmp(st->id, st->name))) {
+        // they differ
+        name = strchr(st->name, '.');
+        if(name)
+            name++;
+        else
+            name = "";
+    }
+
+    // info("CHART '%s' '%s'", st->id, name);
+
     // send the chart
     buffer_sprintf(
             host->rrdpush_sender_buffer
             , "CHART \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" %ld %d \"%s %s %s %s\" \"%s\" \"%s\"\n"
             , st->id
-            , st->name
+            , name
             , st->title
             , st->units
             , st->family


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes duplicate chart names sent via streaming.
Fixes #4468

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

In PR #2749 we tried to fix that at the master side. Unfortunately, this cannot be fixed reliable at that side, because the `type` chart of the chart name may not match the chart `type` of id (i.e. the user at issue #4468 found a corner case, that names are left intect but hyphens in ids are changed to underscores).

So, this PR attempts to fix it at the slave side.

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
