### PR TITLE
fixed vulnerabilities identified by red4sec.com

### DIFF
--- a/libnetdata/url/url.c
+++ b/libnetdata/url/url.c
@@ -60,7 +60,9 @@ char *url_decode_r(char *to, char *url, size_t size) {
     while(*s && d < e) {
         if(unlikely(*s == '%')) {
             if(likely(s[1] && s[2])) {
-                *d++ = from_hex(s[1]) << 4 | from_hex(s[2]);
+                char t = from_hex(s[1]) << 4 | from_hex(s[2]);
+                // avoid HTTP header injection
+                *d++ = (char)((isprint(t))? t : ' ');
                 s += 2;
             }
         }

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -233,6 +233,15 @@ inline int web_client_api_request_v1_chart(RRDHOST *host, struct web_client *w, 
     return web_client_api_request_single_chart(host, w, url, rrd_stats_api_v1_chart);
 }
 
+void fix_google_param(char *s) {
+    if(unlikely(!s)) return;
+
+    for( ; *s ;s++) {
+        if(!isalnum(*s) && *s != '.' && *s != '_' && *s != '-')
+            *s = '_';
+    }
+}
+
 // returns the HTTP code
 inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, char *url) {
     debug(D_WEB_CLIENT, "%llu: API v1 data with URL '%s'", w->id, url);
@@ -331,6 +340,14 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
             }
         }
     }
+
+    // validate the google parameters given
+    fix_google_param(google_out);
+    fix_google_param(google_sig);
+    fix_google_param(google_reqId);
+    fix_google_param(google_version);
+    fix_google_param(responseHandler);
+    fix_google_param(outFileName);
 
     if(!chart || !*chart) {
         buffer_sprintf(w->response.data, "No chart id is given at the request.");


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

I received an email by Red4Sec.com that identified 4 security issues on the netdata web server:

1. HTTP header injection (make the web server return a specific HTTP header)
2. LOG injection (make the web server log a line at its logs)
3. JSON injection (make the web server return a JSON response)
4. Full Path Disclosure

This PR fixes the 3 first of them.

The 4th one is intentional.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

core/webserver

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
