### PR TITLE
fixed wrong annotations given to google charts

### DIFF
--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -155,6 +155,8 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
                 // google supports one annotation per row
                 int annotation_found = 0;
                 for(c = 0, rd = r->st->dimensions; rd ;c++, rd = rd->next) {
+                    if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
+
                     if(co[c] & RRDR_VALUE_RESET) {
                         buffer_strcat(wb, overflow_annotation);
                         annotation_found = 1;

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -871,8 +871,11 @@ RRDR *rrd2rrdr(
     for(rd = st->dimensions, c = 0 ; rd && c < dimensions_count ; rd = rd->next, c++) {
 
         // if we need a percentage, we need to calculate all dimensions
-        if(unlikely(!(options & RRDR_OPTION_PERCENTAGE) && (r->od[c] & RRDR_DIMENSION_HIDDEN)))
+        if(unlikely(!(options & RRDR_OPTION_PERCENTAGE) && (r->od[c] & RRDR_DIMENSION_HIDDEN))) {
+            if(unlikely(r->od[c] & RRDR_DIMENSION_SELECTED)) r->od[c] &= ~RRDR_DIMENSION_SELECTED;
             continue;
+        }
+        r->od[c] |= RRDR_DIMENSION_SELECTED;
 
         // reset the grouping for the new dimension
         r->internal.grouping_reset(r);

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -126,7 +126,7 @@ RRDR *rrdr_create(RRDSET *st, long n)
         if(unlikely(rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN)))
             r->od[c] = RRDR_DIMENSION_HIDDEN;
         else
-            r->od[c] = 0;
+            r->od[c] = RRDR_DIMENSION_DEFAULT;
     }
 
     r->group = 1;

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -31,6 +31,7 @@ typedef enum rrdr_value_flag {
 } RRDR_VALUE_FLAGS;
 
 typedef enum rrdr_dimension_flag {
+    RRDR_DIMENSION_DEFAULT  = 0x00,
     RRDR_DIMENSION_HIDDEN   = 0x04, // the dimension is hidden (not to be presented to callers)
     RRDR_DIMENSION_NONZERO  = 0x08, // the dimension is non zero (contains non-zero values)
     RRDR_DIMENSION_SELECTED = 0x10, // the dimension is selected for evaluation in this RRDR

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -25,21 +25,21 @@ typedef enum rrdr_options {
 } RRDR_OPTIONS;
 
 typedef enum rrdr_value_flag {
-    RRDR_VALUE_NOTHING      = 0x00, // no flag set
-    RRDR_VALUE_EMPTY        = 0x01, // the value is empty
-    RRDR_VALUE_RESET        = 0x02, // the value has been reset
+    RRDR_VALUE_NOTHING      = 0x00, // no flag set (a good default)
+    RRDR_VALUE_EMPTY        = 0x01, // the database value is empty
+    RRDR_VALUE_RESET        = 0x02, // the database value is marked as reset (overflown)
 } RRDR_VALUE_FLAGS;
 
 typedef enum rrdr_dimension_flag {
-    RRDR_DIMENSION_HIDDEN   = 0x04, // the dimension is hidden
-    RRDR_DIMENSION_NONZERO  = 0x08, // the dimension non zero
-    RRDR_DIMENSION_SELECTED = 0x10, // the dimension is selected
+    RRDR_DIMENSION_HIDDEN   = 0x04, // the dimension is hidden (not to be presented to callers)
+    RRDR_DIMENSION_NONZERO  = 0x08, // the dimension is non zero (contains non-zero values)
+    RRDR_DIMENSION_SELECTED = 0x10, // the dimension is selected for evaluation in this RRDR
 } RRDR_DIMENSION_FLAGS;
 
 // RRDR result options
 typedef enum rrdr_result_flags {
-    RRDR_RESULT_OPTION_ABSOLUTE = 0x00000001,
-    RRDR_RESULT_OPTION_RELATIVE = 0x00000002,
+    RRDR_RESULT_OPTION_ABSOLUTE = 0x00000001, // the query uses absolute time-frames (can be cached by browsers and proxies)
+    RRDR_RESULT_OPTION_RELATIVE = 0x00000002, // the query uses relative time-frames (should not to be cached by browsers and proxies)
 } RRDR_RESULT_FLAGS;
 
 typedef struct rrdresult {


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

Google charts generated by netdata had a false annotation in them, about the value reset or overflown, like this:

![image](https://user-images.githubusercontent.com/2662304/47812065-07a24f80-dd50-11e8-803d-b00988b275d3.png)

The problem was that hidden dimensions (like the `idle` dimension in CPU charts), was evaluated, which had unset its memory. So, netdata was randomly sending wrong annotations, based on the previous memory contents.

This bug was introduced with the new query engine.

This PR fixes it.


btw, google charts should show this annotation vertically, not horizontally. Apparently something has evolved in google charts.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
