### PR TITLE
incremental overflows should not show zeros values

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -176,7 +176,9 @@ struct rrddim {
     char *cache_filename;                           // the filename we load/save from/to this set
 
     size_t collections_counter;                     // the number of times we added values to this rrdim
-    size_t unused[10];
+    size_t unused[9];
+
+    collected_number collected_value_max;           // the absolute maximum of the collected value
 
     unsigned int updated:1;                         // 1 when the dimension has been updated since the last processing
     unsigned int exposed:1;                         // 1 when set what have sent this dimension to the central netdata

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -239,6 +239,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     rd->last_calculated_value = 0;
     rd->collected_value = 0;
     rd->last_collected_value = 0;
+    rd->collected_value_max = 0;
     rd->collected_volume = 0;
     rd->stored_volume = 0;
     rd->last_stored_value = 0;
@@ -379,6 +380,9 @@ inline collected_number rrddim_set_by_pointer(RRDSET *st, RRDDIM *rd, collected_
     rd->updated = 1;
 
     rd->collections_counter++;
+
+    collected_number v = (value >= 0) ? value : -value;
+    if(unlikely(v > rd->collected_value_max)) rd->collected_value_max = v;
 
     // fprintf(stderr, "%s.%s %llu " COLLECTED_NUMBER_FORMAT " dt %0.6f" " rate " CALCULATED_NUMBER_FORMAT "\n", st->name, rd->name, st->usec_since_last_update, value, (float)((double)st->usec_since_last_update / (double)1000000), (calculated_number)((value - rd->last_collected_value) * (calculated_number)rd->multiplier / (calculated_number)rd->divisor * 1000000.0 / (calculated_number)st->usec_since_last_update));
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1080,7 +1080,7 @@ static inline size_t rrdset_done_interpolate(
                       , get_storage_number_flags(rd->values[current_entry])
                       , t1
                       , accuracy
-                      , (accuracy > ACCURACY_LOSS) ? " **TOO BIG** " : ""
+                      , (accuracy > ACCURACY_LOSS_ACCEPTED_PERCENT) ? " **TOO BIG** " : ""
                 );
 
                 rd->collected_volume += t1;
@@ -1093,7 +1093,7 @@ static inline size_t rrdset_done_interpolate(
                       , rd->stored_volume
                       , rd->collected_volume
                       , accuracy
-                      , (accuracy > ACCURACY_LOSS) ? " **TOO BIG** " : ""
+                      , (accuracy > ACCURACY_LOSS_ACCEPTED_PERCENT) ? " **TOO BIG** " : ""
                 );
             }
             #endif
@@ -1381,13 +1381,29 @@ void rrdset_done(RRDSET *st) {
                     if(!(rrddim_flag_check(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS)))
                         storage_flags = SN_EXISTS_RESET;
 
-                    rd->last_collected_value = rd->collected_value;
-                }
+                    uint64_t last = (uint64_t)rd->last_collected_value;
+                    uint64_t new = (uint64_t)rd->collected_value;
+                    uint64_t max = (new > last) ? new : last;
+                    uint64_t cap = 0;
 
-                rd->calculated_value +=
-                        (calculated_number)(rd->collected_value - rd->last_collected_value)
-                        * (calculated_number)rd->multiplier
-                        / (calculated_number)rd->divisor;
+                         if(max > 0x00000000FFFFFFFFULL) cap = 0xFFFFFFFFFFFFFFFFULL;
+                    else if(max > 0x000000000000FFFFULL) cap = 0x00000000FFFFFFFFULL;
+                    else if(max > 0x00000000000000FFULL) cap = 0x000000000000FFFFULL;
+                    else                                 cap = 0x00000000000000FFULL;
+
+                    uint64_t delta = cap - last + new;
+
+                    rd->calculated_value +=
+                            (calculated_number) delta
+                            * (calculated_number) rd->multiplier
+                            / (calculated_number) rd->divisor;
+                }
+                else {
+                    rd->calculated_value +=
+                            (calculated_number) (rd->collected_value - rd->last_collected_value)
+                            * (calculated_number) rd->multiplier
+                            / (calculated_number) rd->divisor;
+                }
 
                 #ifdef NETDATA_INTERNAL_CHECKS
                 rrdset_debug(st, "%s: CALC INC PRE "

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1383,7 +1383,7 @@ void rrdset_done(RRDSET *st) {
 
                     uint64_t last = (uint64_t)rd->last_collected_value;
                     uint64_t new = (uint64_t)rd->collected_value;
-                    uint64_t max = (new > last) ? new : last;
+                    uint64_t max = (uint64_t)rd->collected_value_max;
                     uint64_t cap = 0;
 
                          if(max > 0x00000000FFFFFFFFULL) cap = 0xFFFFFFFFFFFFFFFFULL;


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

Incremental values in netdata presented a zero point when overflown.
This caused issues in a few cases, like the one presented in #4533 .

The problem is that netdata does not know the size of the counter (8bit, 16bit, 32bit, 64bit).

This PR detects the size of the overflown counter, by maintaining the max value shown for the counter. Based on the max value seen in the past, it assumes the counter will either be 8, 16, 32, or 64 bit.

---

This PR also uses the last unused bit of the storage number format, to support x100 multipliers. This makes netdata support numbers above 64 bit.

Unit tests have been added to verify the above work properly.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

core/database

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
