### PR TITLE
Changed swagger editor url to the correct one

### DIFF
--- a/web/api/README.md
+++ b/web/api/README.md
@@ -1,6 +1,6 @@
 # netdata REST API
 
-The complete documentation of the netdata API is available at the **[Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/netdata/netdata/master/web/netdata-swagger.yaml)**.
+The complete documentation of the netdata API is available at the **[Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/netdata/netdata/master/web/api/netdata-swagger.yaml)**.
 
 If your prefer it over the Swagger Editor, you can also use **[Swagger UI](https://registry.my-netdata.io/swagger/#!/default/get_data)**. This however does not provide all the information available.
 


### PR DESCRIPTION
https://editor.swagger.io/?url=https://raw.githubusercontent.com/netdata/netdata/master/web/api/netdata-swagger.yaml is the correct url

##### Summary
<!--- Describe the change below, including rationale and design decisions -->
The link in readme,md pointed to an older location of the file netdata-swagger.yaml file changed this to the correct one. The api subfolder was missing from the path.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
Readme.md in /web/api


<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->

