### PR TITLE
add tor python module

### DIFF
--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -95,6 +95,7 @@ include spigotmc/Makefile.inc
 include springboot/Makefile.inc
 include squid/Makefile.inc
 include tomcat/Makefile.inc
+include tor/Makefile.inc
 include traefik/Makefile.inc
 include unbound/Makefile.inc
 include uwsgi/Makefile.inc

--- a/collectors/python.d.plugin/python.d.conf
+++ b/collectors/python.d.plugin/python.d.conf
@@ -90,6 +90,7 @@ nginx_log: no
 # springboot: yes
 # squid: yes
 # tomcat: yes
+# tor: yes
 unbound: no
 # uwsgi: yes
 # varnish: yes

--- a/collectors/python.d.plugin/tor/Makefile.inc
+++ b/collectors/python.d.plugin/tor/Makefile.inc
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_python_DATA       += tor/tor.chart.py
+dist_pythonconfig_DATA += tor/tor.conf
+
+# do not install these files, but include them in the distribution
+dist_noinst_DATA       += tor/README.md tor/Makefile.inc
+

--- a/collectors/python.d.plugin/tor/README.md
+++ b/collectors/python.d.plugin/tor/README.md
@@ -1,0 +1,48 @@
+# tor
+
+Module connects to tor control port to collect traffic statistics.
+
+**Requirements:**
+* `tor` program
+* `stem` python package
+
+It produces only one chart:
+
+1. **Traffic**
+ * read
+ * write
+
+### configuration
+
+Needs `control_port` and `password`
+
+Here is an example for local server:
+
+```yaml
+update_every : 1
+priority     : 60000
+
+local_tcp:
+ name: 'local'
+ control_port: 9051
+ password: 'password'
+
+local_socket:
+ name: 'local'
+ control_port: '/var/run/tor/control'
+ password: 'password'
+```
+
+### prerequisite
+
+Add to `/etc/tor/torrc`:
+
+```
+ControlPort 9051
+```
+
+For more options please read the manual.
+
+Without configuration, module attempts to connect to `127.0.0.1:9051`.
+
+---

--- a/collectors/python.d.plugin/tor/README.md
+++ b/collectors/python.d.plugin/tor/README.md
@@ -14,7 +14,7 @@ It produces only one chart:
 
 ### configuration
 
-Needs `control_port` and `password`
+Needs only `control_port`
 
 Here is an example for local server:
 
@@ -25,12 +25,10 @@ priority     : 60000
 local_tcp:
  name: 'local'
  control_port: 9051
- password: 'password'
 
 local_socket:
  name: 'local'
  control_port: '/var/run/tor/control'
- password: 'password'
 ```
 
 ### prerequisite

--- a/collectors/python.d.plugin/tor/tor.chart.py
+++ b/collectors/python.d.plugin/tor/tor.chart.py
@@ -41,7 +41,7 @@ class Service(SimpleService):
         self.definitions = CHARTS
 
         self.port = self.configuration.get('control_port', DEF_PORT)
-        self.password = self.configuration.get('pass')
+        self.password = self.configuration.get('password')
 
         self.use_socket = isinstance(self.port, str) and self.port != DEF_PORT and not self.port.isdigit()
         self.conn = None

--- a/collectors/python.d.plugin/tor/tor.chart.py
+++ b/collectors/python.d.plugin/tor/tor.chart.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# Description: adaptec_raid netdata python.d module
+# Author: Federico Ceratto <federico.ceratto@gmail.com>
+# Author: Ilya Mashchenko (l2isbad)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from bases.FrameworkServices.SimpleService import SimpleService
+
+try:
+    import stem
+    import stem.connection
+    import stem.control
+    STEM_AVAILABLE = True
+except ImportError:
+    ControllerError = Exception
+    STEM_AVAILABLE = False
+
+import stem
+import stem.connection
+import stem.control
+
+
+DEF_PORT = 'default'
+
+ORDER = [
+    'traffic',
+]
+
+CHARTS = {
+    'traffic': {
+        'options': [None, 'Tor Traffic', 'KB/s', 'traffic', 'tor.traffic', 'area'],
+        'lines': [
+            ['read', 'read', 'incremental', 1, 1024],
+            ['write', 'write', 'incremental', 1, -1024],
+        ]
+    }
+}
+
+
+class Service(SimpleService):
+    """Provide netdata service for Tor"""
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+
+        self.port = self.configuration.get('control_port', DEF_PORT)
+        self.password = self.configuration.get('pass')
+
+        self.use_socket = isinstance(self.port, str) and self.port != DEF_PORT and not self.port.isdigit()
+        self.conn = None
+        self.alive = False
+
+    def check(self):
+        if not STEM_AVAILABLE:
+            self.error('the stem library is missing')
+            return False
+
+        return self.connect()
+
+    def get_data(self):
+        if not self.alive and not self.reconnect():
+            return None
+
+        data = dict()
+
+        try:
+            data['read'] = self.conn.get_info('traffic/read')
+            data['write'] = self.conn.get_info('traffic/written')
+        except stem.ControllerError as error:
+            self.debug(error)
+            self.alive = False
+
+        return data or None
+
+    def authenticate(self):
+        try:
+            self.conn.authenticate(password=self.password)
+        except stem.connection.AuthenticationFailure as error:
+            self.error('authentication error: {0}'.format(error))
+            return False
+        return True
+
+    def connect_via_port(self):
+        try:
+            self.conn = stem.control.Controller.from_port(port=self.port)
+        except (stem.SocketError, ValueError) as error:
+            self.error(error)
+
+    def connect_via_socket(self):
+        try:
+            self.conn = stem.control.Controller.from_socket_file(path=self.port)
+        except (stem.SocketError, ValueError) as error:
+            self.error(error)
+
+    def connect(self):
+        if self.conn:
+            self.conn.close()
+            self.conn = None
+
+        if self.use_socket:
+            self.connect_via_socket()
+        else:
+            self.connect_via_port()
+
+        if self.conn and self.authenticate():
+            self.alive = True
+
+        return self.alive
+
+    def reconnect(self):
+        return self.connect()

--- a/collectors/python.d.plugin/tor/tor.chart.py
+++ b/collectors/python.d.plugin/tor/tor.chart.py
@@ -15,10 +15,6 @@ try:
 except ImportError:
     STEM_AVAILABLE = False
 
-import stem
-import stem.connection
-import stem.control
-
 
 DEF_PORT = 'default'
 

--- a/collectors/python.d.plugin/tor/tor.chart.py
+++ b/collectors/python.d.plugin/tor/tor.chart.py
@@ -36,7 +36,7 @@ CHARTS = {
 class Service(SimpleService):
     """Provide netdata service for Tor"""
     def __init__(self, configuration=None, name=None):
-        SimpleService.__init__(self, configuration=configuration, name=name)
+        super(Service, self).__init__(configuration=configuration, name=name)
         self.order = ORDER
         self.definitions = CHARTS
 

--- a/collectors/python.d.plugin/tor/tor.chart.py
+++ b/collectors/python.d.plugin/tor/tor.chart.py
@@ -13,7 +13,6 @@ try:
     import stem.control
     STEM_AVAILABLE = True
 except ImportError:
-    ControllerError = Exception
     STEM_AVAILABLE = False
 
 import stem

--- a/collectors/python.d.plugin/tor/tor.conf
+++ b/collectors/python.d.plugin/tor/tor.conf
@@ -64,7 +64,7 @@
 # Additionally to the above, tor plugin also supports the following:
 #
 #     control_port: 'port'    # tor control port
-#     pass: 'password'        # tor control password
+#     password: 'password'    # tor control password
 #
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS

--- a/collectors/python.d.plugin/tor/tor.conf
+++ b/collectors/python.d.plugin/tor/tor.conf
@@ -1,0 +1,81 @@
+# netdata python.d.plugin configuration for tor
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# retries sets the number of retries to be made in case of failures.
+# If unset, the default for python.d.plugin is used.
+# Attempts to restore the service are made once every update_every
+# and only if the module has collected values in the past.
+# retries: 60
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     retries: 10             # the JOB's number of restoration attempts
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, tor plugin also supports the following:
+#
+#     control_port: 'port'    # tor control port
+#     pass: 'password'        # tor control password
+#
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+# only one of them will run (they have the same name)
+#
+# local_tcp:
+#  name: 'local'
+#  control_port: 9051
+#  password: 'password'
+#
+# local_socket:
+#  name: 'local'
+#  control_port: '/var/run/tor/control'
+#  password: 'password'

--- a/collectors/python.d.plugin/tor/tor.conf
+++ b/collectors/python.d.plugin/tor/tor.conf
@@ -73,9 +73,7 @@
 # local_tcp:
 #  name: 'local'
 #  control_port: 9051
-#  password: 'password'
 #
 # local_socket:
 #  name: 'local'
 #  control_port: '/var/run/tor/control'
-#  password: 'password'


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

Fix: #2908
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
:snake:  tor module :snake: 

Module connects to tor control port to collect traffic statistics.

**Requirements:**
* `tor` program
* `stem` python package

It produces only one chart:

1. **Traffic**
 * read
 * write

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

@FedericoCeratto i used part of your code, are you ok with that?

@candrews it seems you are interested in this module, please test