### PR TITLE
edit-config: Better support for custom editors.

### DIFF
--- a/system/edit-config.in
+++ b/system/edit-config.in
@@ -4,7 +4,12 @@
 
 file="${1}"
 
-EDITOR="${EDITOR-vi}"
+if [ $(command -v editor) ] ; then
+    EDITOR="${EDITOR-editor}"
+else
+    EDITOR="${EDITOR-vi}"
+fi
+
 [ -z "${NETDATA_USER_CONFIG_DIR}"  ] && NETDATA_USER_CONFIG_DIR="@configdir_POST@"
 [ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
 

--- a/system/edit-config.in
+++ b/system/edit-config.in
@@ -4,7 +4,7 @@
 
 file="${1}"
 
-if [ $(command -v editor) ] ; then
+if [ "$(command -v editor)" ] ; then
     EDITOR="${EDITOR-editor}"
 else
     EDITOR="${EDITOR-vi}"


### PR DESCRIPTION
##### Summary
Some systems (Debian for example) don't use the `$EDITOR` environment
variable to specify the preferred default editor.  On most such systems,
there is instead a symbolic link (or a shell script) called `editor`
located somewhere in `$PATH` which will invoke the appropriate command.

This updates the `edit-config` script to use this command if present in
preference to just invoking `vi` as the editor.

Fixes #4549 

##### Component Name
system/edit-config