### PR TITLE
[wip] allow updater to recover from master breaking changes

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1209,13 +1209,16 @@ update() {
 
         if [ \$pulled -eq 0 ]
         then
-            error "git pull failed, trying a full repo sync..."
+            error "FAILED TO PULL REPO FROM GITHUB... trying full re-sync..."
 
-            # make sure we have the latest info
-            git fetch --all  >&3 2>&3 || failed "FAILED TO FETCH THE LATEST SOURCE FROM GITHUB"
+            info "fetching latest repo data from github..."
+            git fetch --all >&3 2>&3 || failed "FAILED TO FETCH THE LATEST SOURCE FROM GITHUB"
 
-            # reset the local clone to match the origin
-            git reset --hard  >&3 2>&3 || failed "CANNOT GET THE LATEST SOURCE FROM GITHUB"
+            info "checking out master branch..."
+            git checkout master >&3 2>&3 || error "FAILED TO CHECKOUT master BRANCH"
+
+            info "resetting local master to origin/master..."
+            git reset --hard origin/master >&3 2>&3 || failed "FAILED TO RESET LOCAL master TO origin/master"
             pulled=1
         fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1207,11 +1207,15 @@ update() {
         # pull any updates
         git pull >&3 2>&3 || pulled=0
 
-        if [ \$fetched -eq 1 ] && [ \$pulled -eq 0 ]
+        if [ \$pulled -eq 0 ]
         then
-            # we fetched the repo, but we failed to pull changes
-            # so, reset the local clone to match the origin
-            git reset --hard || failed "CANNOT FETCH LATEST SOURCE (use -f for force re-install)"
+            error "git pull failed, trying a full repo sync..."
+
+            # make sure we have the latest info
+            git fetch --all  >&3 2>&3 || failed "FAILED TO FETCH THE LATEST SOURCE FROM GITHUB"
+
+            # reset the local clone to match the origin
+            git reset --hard  >&3 2>&3 || failed "CANNOT GET THE LATEST SOURCE FROM GITHUB"
             pulled=1
         fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1215,7 +1215,7 @@ update() {
             git fetch --all >&3 2>&3 || failed "FAILED TO FETCH THE LATEST SOURCE FROM GITHUB"
 
             info "checking out master branch..."
-            git checkout master >&3 2>&3 || error "FAILED TO CHECKOUT master BRANCH"
+            git checkout -f master >&3 2>&3 || error "FAILED TO CHECKOUT master BRANCH"
 
             info "resetting local master to origin/master..."
             git reset --hard origin/master >&3 2>&3 || failed "FAILED TO RESET LOCAL master TO origin/master"


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

This PR will allow the `netdata-updater.sh` script to:

1. fetch the repo tags
2. update netdata, when there is a breaking change to the repo

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
