### PR TITLE
decouple nightly cron jobs from packaging stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ stages:
 - test
 - build
 - name: packaging
-  if: branch = master AND type != pull_request
+  if: branch = master AND type != pull_request AND type != cron
+- name: nightlies
+  if: branch = master AND type = cron
 
 jobs:
   include:
@@ -47,22 +49,19 @@ jobs:
     script: ".travis/releaser.sh"
     git:
       depth: false
-    if: type != cron
-  - name: Nightly tarball and self-extractor build
+
+  - stage: nightlies
+    name: tarball and self-extractor build
     install: sudo apt-get install -y gnupg libcap2-bin zlib1g-dev uuid-dev fakeroot
     script: ".travis/firehol_create_artifacts.sh"
-    if: type = cron
-  - name: Nightly docker images
+  - name: docker images
     install: sudo apt update -y && sudo apt install -y --only-upgrade docker-ce && docker info
     script: "docker/build.sh"
     env: REPOSITORY="netdata/netdata"
-    if: type = cron
-  - name: Nightly changelog generation
+  - name: changelog generation
     script: ".travis/generate_changelog.sh"
-    if: type = cron
   - name: labeler # This job should be replaced with GitHub Actions when they hit GA
     script: ".travis/labeler.sh"
-    if: type = cron
 
 notifications:
   webhooks: https://app.fossa.io/hooks/travisci

--- a/.travis/generate_changelog.sh
+++ b/.travis/generate_changelog.sh
@@ -32,5 +32,5 @@ docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest
 
 echo "--- Uploading changelog ---"
 git add CHANGELOG.md
-git commit -m '[ci skip] Automatic changelog update'
+git commit -m '[ci skip] Automatic changelog update' || exit 0
 git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')"


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
Create separate stage for nightly jobs
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
CI

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Due to a way of how travis handles conditionals all cron jobs from "packaging" stage need to be moved to a separate stage. Otherwise we end up with things like this: https://travis-ci.com/netdata/netdata/builds/90130962
