### PR TITLE
Move cpufreq python module to proc plugin

### DIFF
--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -48,7 +48,7 @@ struct cpu_chart {
 
     struct per_core_single_number_file files[PER_CORE_FILES];
 
-    struct per_core_time_in_state_file time_in_state_files[PER_CORE_FILES];
+    struct per_core_time_in_state_file time_in_state_files;
 };
 
 static int keep_per_core_fds_open = CONFIG_BOOLEAN_YES;
@@ -121,7 +121,7 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
 
     for(x = 0; x < len ; x++) {
         struct per_core_single_number_file *f = &all_cpu_charts[x].files[index];
-        struct per_core_time_in_state_file *tsf = &all_cpu_charts[x].time_in_state_files[index];
+        struct per_core_time_in_state_file *tsf = &all_cpu_charts[x].time_in_state_files;
 
         f->found = 0;
 
@@ -411,8 +411,8 @@ int do_proc_stat(int update_every, usec_t dt) {
                             snprintfz(filename, FILENAME_MAX, time_in_state_filename, id);
 
                             if (stat(filename, &stbuf) == 0) {
-                                cpu_chart->time_in_state_files[CPU_FREQ_INDEX].filename = strdupz(filename);
-                                cpu_chart->time_in_state_files[CPU_FREQ_INDEX].ff = NULL;
+                                cpu_chart->time_in_state_files.filename = strdupz(filename);
+                                cpu_chart->time_in_state_files.ff = NULL;
                                 do_cpu_freq = CONFIG_BOOLEAN_YES;
                                 accurate_freq_avail = 1;
                             }

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -694,11 +694,11 @@ int do_proc_stat(int update_every, usec_t dt) {
                 if(unlikely(!st_scaling_cur_freq))
                     st_scaling_cur_freq = rrdset_create_localhost(
                             "cpu"
-                            , "scaling_cur_freq" // TODO: disable python module and rename chart
+                            , "cpufreq"
                             , NULL
                             , "cpufreq"
-                            , "cpu.scaling_cur_freq" // TODO: disable python module and rename chart
-                            , "Per CPU Core, Current CPU Scaling Frequency"
+                            , "cpufreq.cpufreq"
+                            , "Current CPU Frequency"
                             , "MHz"
                             , PLUGIN_PROC_NAME
                             , PLUGIN_PROC_MODULE_STAT_NAME

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -56,7 +56,7 @@ BASE_CONFIG = {'update_every': os.getenv('NETDATA_UPDATE_EVERY', 1),
 
 
 MODULE_EXTENSION = '.chart.py'
-OBSOLETE_MODULES = ['apache_cache', 'gunicorn_log', 'nginx_log']
+OBSOLETE_MODULES = ['apache_cache', 'gunicorn_log', 'nginx_log', 'cpufreq']
 
 
 def module_ok(m):


### PR DESCRIPTION
##### Summary
`cpufreq` python module reads data from files:
`/sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq`
`/sys/devices//system/cpu/cpu*/cpufreq/stats/time_in_state`
Since we already have a C plugin that parses files in `/proc` and `/sys`, it is natural to move python code with similar functionality into it. 

Partly implements #4541

##### Component Name
`cpufreq` python module
`proc` plugin

##### Additional Information
`scaling_cur_freq` was implemented a year ago, but was disabled by default. `time_in_state` provides more accurate statistics and should be chosen for data acquisition if available.