### PR TITLE
Read all data from the socket when the data is larger than 4096 bytes.

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -217,7 +217,7 @@ class SocketService(SimpleService):
 
             self.debug('received data')
             data += buf.decode('utf-8', 'ignore') if not raw else buf
-            if self._check_raw_data(data):
+            if len(buf) < 4096:
                 break
 
         self.debug('final response: {0}'.format(data))


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

The current check does not handle the scenario when attempting to read more than 4096 bytes from a socket.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

SocketService.py

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
