### PR TITLE
netdata-openrc: Move check from depends() to start_pre()

### DIFF
--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -35,7 +35,9 @@ depend() {
     use logger
     need net
     after ${NETDATA_START_AFTER_SERVICES}
+}
 
+start_pre() {
     checkpath -o ${NETDATA_OWNER} -d @localstatedir_POST@/cache/netdata @localstatedir_POST@/run/netdata
 }
 


### PR DESCRIPTION
Check should be in `start_pre()` as its only needed when starting the service
as opposed to `depends()` which can be called anytime to evaluate service dependencies.
