### PR TITLE
fixed max interface speed calculation

### DIFF
--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -58,7 +58,7 @@ struct rrdcalctemplate {
     struct rrdcalctemplate *next;
 };
 
-#define RRDCALCTEMPLATE_HAS_CALCULATION(rt) ((rt)->after)
+#define RRDCALCTEMPLATE_HAS_DB_LOOKUP(rt) ((rt)->after)
 
 extern void rrdcalctemplate_link_matching(RRDSET *st);
 

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -4,13 +4,23 @@
 # -----------------------------------------------------------------------------
 # net traffic overflow
 
+ template: interface_speed
+       on: net.net
+       os: *
+    hosts: *
+ families: *
+     calc: ( $nic_speed_max > 0 ) ? ( $nic_speed_max) : ( nan )
+    units: Mbit
+    every: 10s
+     info: The current speed of the physical network interface
+
  template: 1m_received_traffic_overflow
        on: net.net
        os: linux
     hosts: *
  families: *
    lookup: average -1m unaligned absolute of received
-     calc: ($nic_speed_max > 0) ? ($this * 100 / ($nic_speed_max * 1000)) : ( nan )
+     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (80) : (85))
@@ -25,7 +35,7 @@
     hosts: *
  families: *
    lookup: average -1m unaligned absolute of sent
-     calc: ($nic_speed_max > 0) ? ($this * 100 / ($nic_speed_max * 1000)) : ( nan )
+     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (80) : (85))

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -84,7 +84,7 @@ static inline int rrdcalctemplate_add_template_from_config(RRDHOST *host, RRDCAL
         return 0;
     }
 
-    if(unlikely(!RRDCALCTEMPLATE_HAS_CALCULATION(rt) && !rt->warning && !rt->critical)) {
+    if(unlikely(!RRDCALCTEMPLATE_HAS_DB_LOOKUP(rt) && !rt->calculation && !rt->warning && !rt->critical)) {
         error("Health configuration for template '%s' is useless (no calculation, no warning and no critical evaluation)", rt->name);
         return 0;
     }


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

Fixes #4577 

The previous code had 2 bugs.

1. The one that affected #4577 was that it was incorrectly using a config variable to store the filename required to read the interface speed. Since this was read via a `netdata.conf` option, the filename of the first interface was used to read the speed of all network interfaces.

The problem was due to this line:

```c
path_to_sys_net_speed = config_get(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "path to get net device speed", buffer);
```

The `netdata.conf` setting used was a global for `/proc/net/dev` (for all interfaces), so the first call determined the setting for all network interfaces.

2. There was another bug that affected health configuration templates. Netdata was complaining that a template is useless, even though there was a calculation defined.

Both fixed.


Also, modified the alarms, so that the network interface speed now has a silent alarm, like this:

![image](https://user-images.githubusercontent.com/2662304/48292282-610e2b00-e482-11e8-95e6-478094160f4f.png)



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

collectors/proc:/proc/net/dev

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
