### PR TITLE
bug fix: conntrack_max alarm was accessing invalid variable

### DIFF
--- a/collectors/proc.plugin/proc_net_stat_conntrack.c
+++ b/collectors/proc.plugin/proc_net_stat_conntrack.c
@@ -50,7 +50,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
         if(!do_sockets && !read_full)
             return 1;
 
-        rrdvar_max = rrdvar_custom_host_variable_create(localhost, "netfilter.conntrack.max");
+        rrdvar_max = rrdvar_custom_host_variable_create(localhost, "netfilter_conntrack_max");
     }
 
     if(likely(read_full)) {


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

The alarm that calculated the conntrack max was accessing the variable:

```
netfilter_conntrack_max
```

but the variable was named:

```
netfilter.conntrack.max
```

Fixed the generated variable to be with underscores.



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
