### PR TITLE
Move cpuidle python module to proc plugin

### DIFF
--- a/collectors/all.h
+++ b/collectors/all.h
@@ -69,6 +69,7 @@
 #define NETDATA_CHART_PRIO_CPU_PER_CORE               1000 // +1 per core
 #define NETDATA_CHART_PRIO_CPU_TEMPERATURE            1050 // freebsd only
 #define NETDATA_CHART_PRIO_CPUFREQ_SCALING_CUR_FREQ   5003 // freebsd only
+#define NETDATA_CHART_PRIO_CPUIDLE                    6100
 
 #define NETDATA_CHART_PRIO_CORE_THROTTLING            5001
 #define NETDATA_CHART_PRIO_PACKAGE_THROTTLING         5002

--- a/collectors/all.h
+++ b/collectors/all.h
@@ -69,7 +69,7 @@
 #define NETDATA_CHART_PRIO_CPU_PER_CORE               1000 // +1 per core
 #define NETDATA_CHART_PRIO_CPU_TEMPERATURE            1050 // freebsd only
 #define NETDATA_CHART_PRIO_CPUFREQ_SCALING_CUR_FREQ   5003 // freebsd only
-#define NETDATA_CHART_PRIO_CPUIDLE                    6100
+#define NETDATA_CHART_PRIO_CPUIDLE                    6000
 
 #define NETDATA_CHART_PRIO_CORE_THROTTLING            5001
 #define NETDATA_CHART_PRIO_PACKAGE_THROTTLING         5002

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -265,7 +265,6 @@ static int wake_cpu(size_t core) {
     (void) core;
     // TODO: run in another thread
     // TODO: wait for the end of the job
-info("CPUIDLE wake_cpu(%zu)", core);
 
     return 0;
 }
@@ -279,7 +278,6 @@ static int read_schedstat(char* schedstat_filename, struct per_core_cpuidle_char
         ff = procfile_open(schedstat_filename, " \t:", PROCFILE_FLAG_DEFAULT);
         if(unlikely(!ff)) return 1;
     }
-
 
     ff = procfile_readall(ff);
     if(unlikely(!ff)) return 1;
@@ -317,7 +315,7 @@ static int read_schedstat(char* schedstat_filename, struct per_core_cpuidle_char
     return 0;
 }
 
-static int read_one_state(char *buf, const char *filename, int *fd, int keep_per_core_fds_open) {
+static int read_one_state(char *buf, const char *filename, int *fd) {
     ssize_t ret = read(*fd, buf, 50);
 
     if(unlikely(ret <= 0)) {
@@ -329,6 +327,7 @@ static int read_one_state(char *buf, const char *filename, int *fd, int keep_per
     }
     else {
         // successful read
+
         // terminate the buffer
         buf[ret - 1] = '\0';
 
@@ -357,9 +356,8 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
 
         while(likely(stat_file_found)) {
             snprintfz(filename, FILENAME_MAX, cpuidle_name_filename, core, cc->cpuidle_state_len);
-            if (stat(filename, &stbuf) == 0) {
+            if (stat(filename, &stbuf) == 0)
                 cc->cpuidle_state_len++;
-            }
             else
                 stat_file_found = 0;
         }
@@ -394,8 +392,8 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
         }
 
         char name_buf[50 + 1], time_buf[50 + 1];
-        if(likely(read_one_state(name_buf, cs->name_filename, &cs->name_fd, keep_per_core_fds_open) \
-           && read_one_state(time_buf, cs->time_filename, &cs->time_fd, keep_per_core_fds_open))) {
+        if(likely(read_one_state(name_buf, cs->name_filename, &cs->name_fd) \
+           && read_one_state(time_buf, cs->time_filename, &cs->time_fd))) {
             cs->name = strdupz(name_buf);
             cs->value = str2ll(time_buf, NULL);
         }

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -56,7 +56,7 @@ BASE_CONFIG = {'update_every': os.getenv('NETDATA_UPDATE_EVERY', 1),
 
 
 MODULE_EXTENSION = '.chart.py'
-OBSOLETE_MODULES = ['apache_cache', 'gunicorn_log', 'nginx_log', 'cpufreq']
+OBSOLETE_MODULES = ['apache_cache', 'gunicorn_log', 'nginx_log', 'cpufreq', 'cpuidle']
 
 
 def module_ok(m):


### PR DESCRIPTION
##### Summary
`cpuidle` python module reads data from files:
`/proc/schedstat`
`/sys/devices/system/cpu/cpu*/cpuidle/state*/name`
`/sys/devices/system/cpu/cpu*/cpuidle/state*/time`
Since we already have a C plugin that parses files in `/proc` and `/sys`, it is natural to move python code with similar functionality into it.

Partly implements #4541

##### Component Name
`cpuidle` python module
`proc` plugin