### PR TITLE
Fix documentation in beanstalk.conf.

### DIFF
--- a/collectors/python.d.plugin/beanstalk/beanstalk.conf
+++ b/collectors/python.d.plugin/beanstalk/beanstalk.conf
@@ -72,7 +72,7 @@
 #     autodetection_retry: 0  # the JOB's re-check interval in seconds
 #     chart_cleanup: 10       # the JOB's chart cleanup interval in iterations
 #
-# Additionally to the above, apache also supports the following:
+# Additionally to the above, beanstalk also supports the following:
 #
 #     host: 'host'       # Server ip address or hostname. Default: 127.0.0.1
 #     port: port         # Beanstalkd port. Default:


### PR DESCRIPTION
The beanstalk module's config file was referencing the apache module, this fixes that.