### PR TITLE
properly parse network interface names with colon on them

### DIFF
--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -637,6 +637,7 @@ if (typeof String.prototype.startsWith !== 'function') {
 NETDATA.name2id = function (s) {
     return s
         .replace(/ /g, '_')
+        .replace(/:/g, '_')
         .replace(/\(/g, '_')
         .replace(/\)/g, '_')
         .replace(/\./g, '_')

--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -1298,6 +1298,6 @@
         </div>
     </div>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20181013-2"></script>
+    <script type="text/javascript" src="dashboard.js?v20181114-1"></script>
 </body>
 </html>

--- a/web/gui/src/dashboard.js/compatibility.js
+++ b/web/gui/src/dashboard.js/compatibility.js
@@ -32,6 +32,7 @@ if (typeof String.prototype.startsWith !== 'function') {
 NETDATA.name2id = function (s) {
     return s
         .replace(/ /g, '_')
+        .replace(/:/g, '_')
         .replace(/\(/g, '_')
         .replace(/\)/g, '_')
         .replace(/\./g, '_')


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

fixes #4536

This PR fixes 2 bugs:

1. Network interface names may have a colon (`:`) in them. Netdata was incorrectly parsing these network interface names (`:` was assumed to be a separator).

   The effect of this was twofold:

   - the collected values was totally wrong (all values were shifted).
   - when interfaces sharing the same prefix, the same chart was updated multiple times per iteration, resulting in totally crazy values.

2. Families that had `:` in them, resulted in DOM element IDs with `:` in them. This crashed jquery.

This PR fixed them both.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
