### PR TITLE
Fix changelog path, add all README.md files to Debian package doc

### DIFF
--- a/contrib/debian/netdata.docs
+++ b/contrib/debian/netdata.docs
@@ -1,1 +1,1 @@
-ChangeLog
+CHANGELOG.md

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -54,16 +54,14 @@ override_dh_install: debian/netdata.postinst
 override_dh_installdocs:
 	dh_installdocs
 
-	# Docs should not be under /usr/lib
-	#
-	mv $(TOP)/usr/lib/$(DEB_HOST_MULTIARCH)/netdata/plugins.d/README.md \
-		$(TOP)/usr/share/doc/netdata/README.plugins.md
-	mv $(TOP)/usr/lib/$(DEB_HOST_MULTIARCH)/netdata/charts.d/README.md \
-		$(TOP)/usr/share/doc/netdata/README.charts.md
-
-	# This doc is currently empty, so no point installing it.
-	#
-	rm $(TOP)/usr/lib/$(DEB_HOST_MULTIARCH)/netdata/node.d/README.md
+	find . \
+		-name README.md \
+		-not -path './.travis/*' \
+		-not -path './debian/*' \
+		-exec cp \
+						--parents \
+						--target $(TOP)/usr/share/doc/netdata/ \
+						{} \;
 
 override_dh_fixperms:
 	dh_fixperms


### PR DESCRIPTION
##### Summary
Recent changes to changelog and documentation structure have caused Debian packaging to break. This PR fixes the path to changelog and adds all `README.md` files to the Debian package.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->