### PR TITLE
enable issue closing with stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,16 +2,17 @@
 only: issues
 limitPerRun: 30
 daysUntilStale: 60
-daysUntilClose: false
+daysUntilClose: 60
 exemptLabels:
   - bug
-  - "help wanted"
+  - help wanted
 exemptProjects: true
 exemptMilestones: true
-staleLabel: help wanted
+staleLabel: stale
 markComment: >
   Currently netdata team doesn't have enough capacity to work on this issue.
   We will be more than glad to accept a pull request with a solution to problem described here.
-# closeComment: >
-#   This issue has been automatically closed due to extended period of inactivity.
-#   Please reopen if it is still valid. Thank you for your contributions.
+  This issue will be closed after another 60 days of inactivity.
+closeComment: >
+  This issue has been automatically closed due to extended period of inactivity.
+  Please reopen if it is still valid. Thank you for your contributions.


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
Allow stale bot to close issues after they are inactive for 120 days. It will tag stale issues after 60 days.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
GitHub management

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
