### PR TITLE
Fix typo and py2 compatibility issue.

### DIFF
--- a/collectors/python.d.plugin/python_modules/third_party/lm_sensors.py
+++ b/collectors/python.d.plugin/python_modules/third_party/lm_sensors.py
@@ -35,39 +35,39 @@ class ErrorNoEntry(SensorsError):
     pass
 
 
-class ErrorAccessRead(SensorsError, PermissionError):
+class ErrorAccessRead(SensorsError, OSError):
     pass
 
 
-class ErrorKernel(SensorError, OSError):
+class ErrorKernel(SensorsError, OSError):
     pass
 
 
-class ErrorDivZero(SensorError, ZeroDivisionError):
+class ErrorDivZero(SensorsError, ZeroDivisionError):
     pass
 
 
-class ErrorChipName(SensorError):
+class ErrorChipName(SensorsError):
     pass
 
 
-class ErrorBusName(SensorError):
+class ErrorBusName(SensorsError):
     pass
 
 
-class ErrorParse(SensorError):
+class ErrorParse(SensorsError):
     pass
 
 
-class ErrorAccessWrite(SensorError, PermissionError):
+class ErrorAccessWrite(SensorsError, OSError):
     pass
 
 
-class ErrorIO(SensorError, IOError):
+class ErrorIO(SensorsError, IOError):
     pass
 
 
-class ErrorRecursion(SensorError):
+class ErrorRecursion(SensorsError):
     pass
 
 


### PR DESCRIPTION


##### Summary
PR #4667 accidentally introduced a py2 compatibility issue and a typo, both of which break the sensors module.  This fixes both.

Fixes: #4692 

##### Component Name
collectors/python.d.plugin