### PR TITLE
Fix broken links

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,7 +10,7 @@ This agreement is part of the legal framework of the open-source ecosystem
 that adds some red tape, but protects both the contributor and the project.
 
 To understand why this is needed, please read [a well-written chapter from
-Karl Fogel’s Producing Open Source Software on CLAs](http://producingoss.com/en/copyright-assignment.html).
+Karl Fogel’s Producing Open Source Software on CLAs](https://producingoss.com/en/copyright-assignment.html).
 
 By signing this agreement, you do not change your rights to use your own
 contributions for any other purpose.

--- a/REDISTRIBUTED.md
+++ b/REDISTRIBUTED.md
@@ -187,10 +187,10 @@ connectivity is not available.
     [MIT License](https://github.com/lgarron/clipboard-polyfill/blob/master/LICENSE.md)
 
 
-- [Utilities for writing code that runs on Python 2 and 3](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/python_modules/urllib3/packages/six.py)
+- [Utilities for writing code that runs on Python 2 and 3](collectors/python.d.plugin/python_modules/urllib3/packages/six.py)
 
     Copyright (c) 2010-2015 Benjamin Peterson
-    [MIT License](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/python_modules/urllib3/packages/six.py)
+    [MIT License](https://github.com/benjaminp/six/blob/master/LICENSE)
 
 
 - [mcrcon](https://github.com/barneygale/MCRcon)

--- a/REDISTRIBUTED.md
+++ b/REDISTRIBUTED.md
@@ -31,7 +31,7 @@ connectivity is not available.
 - [Gauge.js](http://bernii.github.io/gauge.js/)
 
     Copyright, Bernard Kobos
-    [MIT License](http://bernii.github.io/gauge.js/)
+    [MIT License](https://github.com/getgauge/gauge-js/blob/master/LICENSE)
 
 
 - [d3pie](https://github.com/benkeen/d3pie)
@@ -85,7 +85,7 @@ connectivity is not available.
 - [Bootstrap](http://getbootstrap.com/getting-started/)
 
     Copyright 2015, Twitter
-    [MIT License](http://getbootstrap.com/getting-started/#license-faqs)
+    [MIT License](https://github.com/twbs/bootstrap/blob/v4-dev/LICENSE)
 
 
 - [Bootstrap Toggle](http://www.bootstraptoggle.com/)
@@ -109,7 +109,7 @@ connectivity is not available.
 - [tableExport.jquery.plugin](https://github.com/hhurz/tableExport.jquery.plugin)
 
     Copyright (c) 2015,2016 hhurz
-    [MIT License](http://rawgit.com/hhurz/tableExport.jquery.plugin/master/tableExport.js)
+    [MIT License](https://github.com/hhurz/tableExport.jquery.plugin/blob/master/LICENSE)
 
 
 - [perfect-scrollbar](https://jamesflorentino.github.io/nanoScrollerJS/)
@@ -135,20 +135,20 @@ connectivity is not available.
 - [node-net-snmp](https://github.com/stephenwvickers/node-net-snmp)
 
     Copyright 2013, Stephen Vickers
-    [MIT License](https://github.com/stephenwvickers/node-net-snmp)
+    [MIT License](https://github.com/nospaceships/node-net-snmp#license)
 
 
 - [node-asn1-ber](https://github.com/stephenwvickers/node-asn1-ber)
 
     Copyright 2017, Stephen Vickers
     Copyright 2011, Mark Cavage
-    [MIT License](https://github.com/stephenwvickers/node-asn1-ber)
+    [MIT License](https://github.com/nospaceships/node-asn1-ber#license)
 
 
 - [pixl-xml](https://github.com/jhuckaby/pixl-xml)
 
     Copyright 2015, Joseph Huckaby
-    [MIT License](https://github.com/jhuckaby/pixl-xml)
+    [MIT License](https://github.com/jhuckaby/pixl-xml#license)
 
 
 - [sensors](https://github.com/paroj/sensors.py)
@@ -160,7 +160,7 @@ connectivity is not available.
 - [PyYAML](https://bitbucket.org/blackjack/pysensors)
 
     Copyright 2006, Kirill Simonov
-    [MIT License](https://github.com/yaml/pyyaml)
+    [MIT License](https://github.com/yaml/pyyaml/blob/master/LICENSE)
 
 
 - [urllib3](https://github.com/shazow/urllib3)

--- a/REDISTRIBUTED.md
+++ b/REDISTRIBUTED.md
@@ -187,10 +187,10 @@ connectivity is not available.
     [MIT License](https://github.com/lgarron/clipboard-polyfill/blob/master/LICENSE.md)
 
 
-- [Utilities for writing code that runs on Python 2 and 3](https://github.com/netdata/netdata/blob/master/python.d/python_modules/urllib3/packages/six.py)
+- [Utilities for writing code that runs on Python 2 and 3](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/python_modules/urllib3/packages/six.py)
 
     Copyright (c) 2010-2015 Benjamin Peterson
-    [MIT License](https://github.com/netdata/netdata/blob/master/python.d/python_modules/urllib3/packages/six.py)
+    [MIT License](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/python_modules/urllib3/packages/six.py)
 
 
 - [mcrcon](https://github.com/barneygale/MCRcon)

--- a/collectors/freeipmi.plugin/README.md
+++ b/collectors/freeipmi.plugin/README.md
@@ -87,7 +87,7 @@ The plugin supports a few options. To see them, run:
  options ipmi_si kipmid_max_busy_us=10
 
  For more information:
- https://github.com/ktsaou/netdata/tree/master/plugins/freeipmi.plugin
+ https://github.com/netdata/netdata/tree/master/collectors/freeipmi.plugin
 
 ```
 

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1624,7 +1624,7 @@ int main (int argc, char **argv) {
                     " options ipmi_si kipmid_max_busy_us=10\n"
                     "\n"
                     " For more information:\n"
-                    " https://github.com/ktsaou/netdata/tree/master/plugins/freeipmi.plugin\n"
+                    " https://github.com/netdata/netdata/tree/master/collectors/freeipmi.plugin\n"
                     "\n"
                     , VERSION
                     , netdata_update_every

--- a/collectors/python.d.plugin/web_log/README.md
+++ b/collectors/python.d.plugin/web_log/README.md
@@ -23,11 +23,11 @@ If netdata is installed on a system running a web server, it will detect it and 
 ![image](https://cloud.githubusercontent.com/assets/2662304/22900686/e283f636-f237-11e6-93d2-cbdf63de150c.png)
 *[**netdata**](https://my-netdata.io/) charts based on metrics collected by querying the `nginx` API (i.e. `/stab_status`).*
 
-> [**netdata**](https://my-netdata.io/) supports `apache`, `nginx`, `lighttpd` and `tomcat`. To obtain real-time information from a web server API, the web server needs to expose it. For directions on configuring your web server, check [`/etc/netdata/python.d/`](https://github.com/netdata/netdata/tree/master/conf.d/python.d). There is a file there for each web server.
+> [**netdata**](https://my-netdata.io/) supports `apache`, `nginx`, `lighttpd` and `tomcat`. To obtain real-time information from a web server API, the web server needs to expose it. For directions on configuring your web server, check the config files for each web server. There is a directory with a config file for each web server under [`/etc/netdata/python.d/`](../). 
 
 ## Configuration
 
-[**netdata**](https://my-netdata.io/) has a powerful `web_log` plugin, capable of incrementally parsing any number of web server log files. This plugin is automatically started with [**netdata**](https://my-netdata.io/) and comes, pre-configured, for finding web server log files on popular distributions. Its configuration is at [`/etc/netdata/python.d/web_log.conf`](https://github.com/netdata/netdata/blob/master/conf.d/python.d/web_log.conf), like this:
+[**netdata**](https://my-netdata.io/) has a powerful `web_log` plugin, capable of incrementally parsing any number of web server log files. This plugin is automatically started with [**netdata**](https://my-netdata.io/) and comes, pre-configured, for finding web server log files on popular distributions. Its configuration is at [`/etc/netdata/python.d/web_log.conf`](web_log.conf), like this:
 
 
 ```yaml
@@ -184,7 +184,7 @@ The last charts are about the unique IPs accessing your web server.
 
 ## Alarms
 
-The magic of [**netdata**](https://my-netdata.io/) is that all metrics are collected per second, and all metrics can be used or correlated to provide real-time alarms. Out of the box, [**netdata**](https://my-netdata.io/) automatically attaches the [following alarms](https://github.com/netdata/netdata/blob/master/conf.d/health.d/web_log.conf) to all `web_log` charts (i.e. to all log files configured, individually):
+The magic of [**netdata**](https://my-netdata.io/) is that all metrics are collected per second, and all metrics can be used or correlated to provide real-time alarms. Out of the box, [**netdata**](https://my-netdata.io/) automatically attaches the [following alarms](../../../health/health.d/web_log.conf) to all `web_log` charts (i.e. to all log files configured, individually):
 
 alarm|description|minimum<br/>requests|warning|critical
 :-------|-------|:------:|:-----:|:------:
@@ -197,5 +197,5 @@ alarm|description|minimum<br/>requests|warning|critical
 
 The column `minimum requests` state the minimum number of requests required for the alarm to be evaluated. We found that when the site is receiving requests above this rate, these alarms are pretty accurate (i.e. no false-positives).
 
-[**netdata**](https://my-netdata.io/) alarms are [user configurable](https://github.com/netdata/netdata/tree/master/conf.d/health.d). So, even [`web_log` alarms can be adapted to your needs](https://github.com/netdata/netdata/blob/master/conf.d/health.d/web_log.conf).
+[**netdata**](https://my-netdata.io/) alarms are [user configurable](../../../health/health.d). So, even [`web_log` alarms can be adapted to your needs](../../../health/health.d/web_log.conf).
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -113,7 +113,7 @@ The command line options of the netdata 1.10.0 version are the following:
  Source Code: https://github.com/netdata/netdata
  Wiki / Docs: https://github.com/netdata/netdata/wiki
  Support    : https://github.com/netdata/netdata/issues
- License    : https://github.com/netdata/netdata/blob/master/LICENSE.md
+ License    : https://github.com/netdata/netdata/blob/master/LICENSE
 
  Twitter    : https://twitter.com/linuxnetdata
  Facebook   : https://www.facebook.com/linuxnetdata/

--- a/doc/Netdata-Security-and-Disclosure-Information.md
+++ b/doc/Netdata-Security-and-Disclosure-Information.md
@@ -10,7 +10,7 @@ Every time a security issue is fixed in netdata, we immediately release a new ve
 
 We’re extremely grateful for security researchers and users that report vulnerabilities to Netdata Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
 
-To make a report, please email the private [security@netdata.cloud](mailto:security@netdata.cloud) list with the security details and the details expected for [all netdata bug reports](https://github.com/netdata/netdata/.github/ISSUE_TEMPLATE.md).
+To make a report, please email the private [security@netdata.cloud](mailto:security@netdata.cloud) list with the security details and the details expected for [all netdata bug reports](https://github.com/netdata/netdata/tree/master/.github/ISSUE_TEMPLATE.md).
 
 ## When Should I Report a Vulnerability?
 

--- a/doc/Netdata-Security-and-Disclosure-Information.md
+++ b/doc/Netdata-Security-and-Disclosure-Information.md
@@ -10,7 +10,7 @@ Every time a security issue is fixed in netdata, we immediately release a new ve
 
 We’re extremely grateful for security researchers and users that report vulnerabilities to Netdata Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
 
-To make a report, please email the private [security@netdata.cloud](mailto:security@netdata.cloud) list with the security details and the details expected for [all netdata bug reports](https://github.com/netdata/netdata/tree/master/.github/ISSUE_TEMPLATE.md).
+To make a report, please email the private [security@netdata.cloud](mailto:security@netdata.cloud) list with the security details and the details expected for [all netdata bug reports](../.github/ISSUE_TEMPLATE/bug_report.md).
 
 ## When Should I Report a Vulnerability?
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -86,7 +86,7 @@ The static binary files are kept in repo [binary-packages](https://github.com/ne
     - [Enable netdata on FreeNAS Corral](#freenas)
     - [Install from package or source, on macOS (OS X)](#macos)
 
-    See also the list of netdata [package maintainers](https://github.com/netdata/netdata/blob/master/MAINTAINERS.md) for ASUSTOR NAS, OpenWRT, ReadyNAS, etc.
+    See also the list of netdata [package maintainers](../packaging/maintainers) for ASUSTOR NAS, OpenWRT, ReadyNAS, etc.
  
 ## Install netdata on Linux manually
 
@@ -238,7 +238,7 @@ Note first three packages are downloaded from the pfSense repository for maintai
 pkg install pkgconf
 pkg install bash
 pkg install e2fsprogs-libuuid
-pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/netdata-1.10.0.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/netdata-1.11.0.txz
 ```
 To start netdata manually run `service netdata onestart`
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -49,4 +49,4 @@ instructions upon success.
 Once pushed the infrastructure will build a set of tar-files on the server.
 For information on how to verify, sign and make these available, see:
 
-    https://github.com/firehol/infrastructure/raw/master/doc/release.txt
+    https://github.com/firehol/infrastructure#firehol-infrastructure

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -47,6 +47,4 @@ Otherwise you can just push the results; the script outputs the required
 instructions upon success.
 
 Once pushed the infrastructure will build a set of tar-files on the server.
-For information on how to verify, sign and make these available, see:
-
-    https://github.com/firehol/infrastructure#firehol-infrastructure
+For information on how to verify, sign and make these available, see [here](https://github.com/firehol/infrastructure#firehol-infrastructure)


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
Fixes #4672 

The name of the branch is misleading, don't worry about it. Details on the fixes below.

##### Additional Information
> Checking links in ./doc/Netdata-Security-and-Disclosure-Information.md
>  1. [L13] 404 https://github.com/netdata/netdata/.github/ISSUE_TEMPLATE.md  

Fixed

> Checking links in ./REDISTRIBUTED.md
>  1. [L190] 404 https://github.com/netdata/netdata/blob/master/python.d/python_modules/urllib3/packages/six.py  

Fixed

> Checking links in ./web/api/queries/ses/README.md
>  1. [L53]  https://en.wikipedia.org/wiki/Moving_average#exponential-moving-average](https://en.wikipedia.org/wiki/Moving_average bad URI(is not URI?): https://en.wikipedia.org/wiki/Moving_average#exponential-moving-average](https://en.wikipedia.org/wiki/Moving_average 

False, link works

> Checking links in ./packaging/README.md
>  1. [L52] 404 https://github.com/firehol/infrastructure/raw/master/doc/release.txt  

Fixed 

> Checking links in ./installer/README.md
>  1. [L089] 404 https://github.com/netdata/netdata/blob/master/MAINTAINERS.md  

Fixed

>  2. [L241] 404 http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/netdata-1.10.0.txz  

Fixed 

> Checking links in ./daemon/README.md
>  1. [L080] 404 https://github.com/netdata/netdata/pull/403_ 

False. The URL is without the underscore
 
>  2. [L116] 404 https://github.com/netdata/netdata/blob/master/LICENSE.md  

Fixed 

> Checking links in ./collectors/python.d.plugin/web_log/README.md
>  1. [L026] 404 https://github.com/netdata/netdata/tree/master/conf.d/python.d 

Fixed 

> 2. [L030] 404 https://github.com/netdata/netdata/blob/master/conf.d/python.d/web_log.conf  

Fixed

>  3. [L187] 404 https://github.com/netdata/netdata/blob/master/conf.d/health.d/web_log.conf 

Fixed
 
>  4. [L200] 404 https://github.com/netdata/netdata/tree/master/conf.d/health.d  

Fixed

> Checking links in ./collectors/python.d.plugin/apache/README.md
>  1. [L52] 404 http://www.apache.org/server-status?auto  

Can't fix. Can't find a URL that will return server-status

> Checking links in ./collectors/freeipmi.plugin/README.md
>  1. [L090] 404 https://github.com/ktsaou/netdata/tree/master/plugins/freeipmi.plugin

Fixed (also in the c code)

> Checking links in ./CONTRIBUTORS.md
>   1. [L013]  http://producingoss.com/en/copyright-assignment.html Failed to open TCP connection to producingoss.com:80 (Connection refused - connect(2) for "producingoss.com" port 80) 

Fixed