### PR TITLE
Add missing quote to tc-qos-helper.sh.in

### DIFF
--- a/collectors/tc.plugin/tc-qos-helper.sh.in
+++ b/collectors/tc.plugin/tc-qos-helper.sh.in
@@ -100,7 +100,7 @@ if [ ! -d "${fireqos_run_dir}" ]
             warning "Although FireQoS is installed on this system as '${fireqos}', I cannot find/read its installation configuration at '${fireqos_exec_dir}/install.config'."
         fi
     else
-        warning "FireQoS is not installed on this system. Use FireQoS to apply traffic QoS and expose the class names to netdata. Check https://github.com/netdata/netdata/tree/master/collectors/tc.plugin#tcplugin
+        warning "FireQoS is not installed on this system. Use FireQoS to apply traffic QoS and expose the class names to netdata. Check https://github.com/netdata/netdata/tree/master/collectors/tc.plugin#tcplugin"
     fi
 fi
 


### PR DESCRIPTION
Missing trailing quote in this file was causing QoS graphs to not show up.

Before the change, the following errors were added to /var/log/netdata/error.log once every second:

```
/usr/libexec/netdata/plugins.d/tc-qos-helper.sh: line 310: unexpected EOF while looking for matching `"'
/usr/libexec/netdata/plugins.d/tc-qos-helper.sh: line 316: syntax error: unexpected end of file
```

After change no more errors and QoS graphs reappeared.