### PR TITLE
Move changelog generation to the end in release pipeline

### DIFF
--- a/.travis/releaser.sh
+++ b/.travis/releaser.sh
@@ -40,9 +40,6 @@ echo "---- FIGURING OUT TAGS ----"
 #shellcheck source=/dev/null
 source .travis/tagger.sh || exit 0
 
-echo "---- GENERATING CHANGELOG -----"
-./.travis/generate_changelog.sh
-
 echo "---- CREATING TAGGED DOCKER CONTAINERS ----"
 export REPOSITORY="netdata/netdata"
 ./docker/build.sh
@@ -67,3 +64,7 @@ if [ -z ${RC+x} ]; then
 else
 	hub release create --draft -a "netdata-${GIT_TAG}.tar.gz" -a "netdata-${GIT_TAG}.gz.run" -a "sha256sums.txt" -m "${GIT_TAG}" "${GIT_TAG}"
 fi
+
+# Changelog needs to be created AFTER new release to avoid problems with circular dependencies and wrong entries in changelog file
+echo "---- GENERATING CHANGELOG -----"
+./.travis/generate_changelog.sh

--- a/.travis/releaser.sh
+++ b/.travis/releaser.sh
@@ -59,6 +59,10 @@ if [ -z ${GIT_TAG+x} ]; then
 	echo "Variable GIT_TAG is not set. Something went terribly wrong! Exiting."
 	exit 1
 fi
+if [ "${GIT_TAG}" != "$(git tag --points-at)" ]; then
+	echo "ERROR! Current commit is not tagged. Stopping release creation."
+	exit 1
+fi
 if [ -z ${RC+x} ]; then
 	hub release create --prerelease --draft -a "netdata-${GIT_TAG}.tar.gz" -a "netdata-${GIT_TAG}.gz.run" -a "sha256sums.txt" -m "${GIT_TAG}" "${GIT_TAG}"
 else

--- a/.travis/tagger.sh
+++ b/.travis/tagger.sh
@@ -28,7 +28,7 @@ function embed_version {
 	VERSION="$1"
 	MAJOR=$(echo "$GIT_TAG" | cut -d . -f 1 | cut -d v -f 2)
 	MINOR=$(echo "$GIT_TAG" | cut -d . -f 2)
-	PATCH=$(echo "$GIT_TAG" | cut -d . -f 3)
+	PATCH=$(echo "$GIT_TAG" | cut -d . -f 3 | cut -d '-' -f 1)
 	sed -i "s/\\[VERSION_MAJOR\\], \\[.*\\]/\\[VERSION_MAJOR\\], \\[$MAJOR\\]/" configure.ac
 	sed -i "s/\\[VERSION_MINOR\\], \\[.*\\]/\\[VERSION_MINOR\\], \\[$MINOR\\]/" configure.ac
 	sed -i "s/\\[VERSION_PATCH\\], \\[.*\\]/\\[VERSION_PATCH\\], \\[$PATCH\\]/" configure.ac

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ(2.60)
 
 define([VERSION_MAJOR], [1])
 define([VERSION_MINOR], [11])
-define([VERSION_FIX], [1])
+define([VERSION_FIX], [0])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
 define([VERSION_SUFFIX], [_rolling])
 


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
This solves circular dependency problem in release pipeline by moving changelog generation to the end.

This should be merged ASAP since due to failed release of 1.11.1 we have incorrect `configure.ac` file referring to non-existing release.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
CI

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Since we were first creating a tag and pushing it along a new commit (to fix `configure.ac`) and just after that we were creating a new commit with changelog it caused problem that last tag wasn't referring to last commit. This in turn caused scripts to fails since in release pipeline we expect (as a safety measure) to have tag relating to currently building commit.

Moving changelog generation to be executed essentially **after** new release is created mitigates that problem and also ensures that changelog has correct entries.