### PR TITLE
strictier use of URL separators

### DIFF
--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -1114,7 +1114,7 @@ int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url
     char buf[GUID_LEN + 1];
 
     while(url) {
-        char *value = mystrsep(&url, "?&");
+        char *value = mystrsep(&url, "&");
         if(!value || !*value) continue;
 
         char *name = mystrsep(&value, "=");

--- a/web/api/badges/README.md
+++ b/web/api/badges/README.md
@@ -261,24 +261,6 @@ character|name|escape sequence
 ` \ `|backslash (when you need a `/`)|`%5C`
 ` \| `|pipe (delimiting parameters)|`%7C`
 
----
-
-## Using the path instead of the query string
-
-The badges can also be generated using the URL path for passing parameters. The format is exactly the same.
-
-So instead of:
-
-  `http://your.netdata:19999/api/v1/badge.svg?option1&option2&option3&...`
-
-you can write:
-
-  `http://your.netdata:19999/api/v1/badge.svg/option1/option2/option3/...`
-
-You can also append anything else you like, like this:
-
-  `http://your.netdata:19999/api/v1/badge.svg/option1/option2/option3/my-super-badge.svg`
-
 ## FAQ
 
 #### Is it fast?

--- a/web/api/badges/web_buffer_svg.c
+++ b/web/api/badges/web_buffer_svg.c
@@ -913,7 +913,7 @@ int web_client_api_request_v1_badge(RRDHOST *host, struct web_client *w, char *u
     uint32_t options = 0x00000000;
 
     while(url) {
-        char *value = mystrsep(&url, "/?&");
+        char *value = mystrsep(&url, "&");
         if(!value || !*value) continue;
 
         char *name = mystrsep(&value, "=");

--- a/web/api/exporters/allmetrics.c
+++ b/web/api/exporters/allmetrics.c
@@ -24,7 +24,7 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
     const char *prometheus_prefix = global_backend_prefix;
 
     while(url) {
-        char *value = mystrsep(&url, "?&");
+        char *value = mystrsep(&url, "&");
         if (!value || !*value) continue;
 
         char *name = mystrsep(&value, "=");

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -136,7 +136,7 @@ inline int web_client_api_request_v1_alarms(RRDHOST *host, struct web_client *w,
     int all = 0;
 
     while(url) {
-        char *value = mystrsep(&url, "?&");
+        char *value = mystrsep(&url, "&");
         if (!value || !*value) continue;
 
         if(!strcmp(value, "all")) all = 1;
@@ -153,7 +153,7 @@ inline int web_client_api_request_v1_alarm_log(RRDHOST *host, struct web_client 
     uint32_t after = 0;
 
     while(url) {
-        char *value = mystrsep(&url, "?&");
+        char *value = mystrsep(&url, "&");
         if (!value || !*value) continue;
 
         char *name = mystrsep(&value, "=");
@@ -176,7 +176,7 @@ inline int web_client_api_request_single_chart(RRDHOST *host, struct web_client 
     buffer_flush(w->response.data);
 
     while(url) {
-        char *value = mystrsep(&url, "?&");
+        char *value = mystrsep(&url, "&");
         if(!value || !*value) continue;
 
         char *name = mystrsep(&value, "=");
@@ -271,7 +271,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     uint32_t options = 0x00000000;
 
     while(url) {
-        char *value = mystrsep(&url, "?&");
+        char *value = mystrsep(&url, "&");
         if(!value || !*value) continue;
 
         char *name = mystrsep(&value, "=");
@@ -489,7 +489,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
 */
 
     while(url) {
-        char *value = mystrsep(&url, "?&");
+        char *value = mystrsep(&url, "&");
         if (!value || !*value) continue;
 
         char *name = mystrsep(&value, "=");
@@ -652,7 +652,7 @@ inline int web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *
     }
 
     // get the command
-    char *tok = mystrsep(&url, "/?&");
+    char *tok = mystrsep(&url, "?");
     if(tok && *tok) {
         debug(D_WEB_CLIENT, "%llu: Searching for API v1 command '%s'.", w->id, tok);
         uint32_t hash = simple_hash(tok);

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -580,7 +580,7 @@ static inline int check_host_and_dashboard_acl_and_call(RRDHOST *host, struct we
 int web_client_api_request(RRDHOST *host, struct web_client *w, char *url)
 {
     // get the api version
-    char *tok = mystrsep(&url, "/?&");
+    char *tok = mystrsep(&url, "/");
     if(tok && *tok) {
         debug(D_WEB_CLIENT, "%llu: Searching for API version '%s'.", w->id, tok);
         if(strcmp(tok, "v1") == 0)
@@ -1071,7 +1071,7 @@ static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, ch
         return 400;
     }
 
-    char *tok = mystrsep(&url, "/?&");
+    char *tok = mystrsep(&url, "/");
     if(tok && *tok) {
         debug(D_WEB_CLIENT, "%llu: Searching for host with name '%s'.", w->id, tok);
 
@@ -1163,7 +1163,7 @@ static inline int web_client_process_url(RRDHOST *host, struct web_client *w, ch
             buffer_flush(w->response.data);
 
             // get the name of the data to show
-            tok = mystrsep(&url, "/?&");
+            tok = mystrsep(&url, "&");
             if(tok && *tok) {
                 debug(D_WEB_CLIENT, "%llu: Searching for RRD data with name '%s'.", w->id, tok);
 


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

traced it to find the issue.

The bug is at the internal web server of netdata. It parses the URLs like this:

1. a request comes

2. it checks it received the whole of it (it searches for `\r\n\r\n` - i.e. an empty line as defined in the spec)

3. BUG 1: it decodes the whole URL. This is a bug since any `/` or `?` URL encoded will be decoded before actually parsing the URL. To work properly it should decode the URL part by part (i.e. first split it in its parts and then decode each part of it). **The way it is now, URL encoding cannot be used to encode characters that are URL control characters (`/`, `?`, `&`, `%`).** Even when URL encoded, these character will still play an important role in URL parsing (although they are escaped).

4. BUG 2: it does not separate URL `path` from URL `query string`. It treats the whole URL as a continuous string, separated by `/?&`, which of course leads to bugs like the one we face here.

So, the right flow should be like this:

1. receive the request

2. make sure it received the whole of it

3. split the path from the query string

4. URL decode the path to find the API command or the filename to be served

5. split the query string in its parts (separated with `&`)

6. for each part of the query string, split it at the `=` sign to find the `name` and `value` and decode both of them.

I think the whole HTTP parser needs to be rewritten.

In the mean time this PR uses separators depending on the position of the parsing.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

fixes #3253; fixes #4714

Since this PR does a strict checking on URL separators, the ability to embed query string parameters into the path is now lost (it was a side effect after all).

##### Component Name
<!--- Write the short name of the module or plugin below -->

internal web server

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
