### PR TITLE
Better changelog generation when releasing new version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ jobs:
     env: REPOSITORY="netdata/netdata"
   - name: changelog generation
     script: ".travis/generate_changelog.sh"
+    env: COMMIT_AND_PUSH=1
     git:
       depth: false
   - name: labeler # This job should be replaced with GitHub Actions when they hit GA

--- a/.travis/generate_changelog.sh
+++ b/.travis/generate_changelog.sh
@@ -34,8 +34,8 @@ docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest
                                                         --token "${GITHUB_TOKEN}" \
                                                         --since-tag "v1.10.0" \
                                                         --unreleased-label "**Next release**" \
-                                                        --no-compare-link \
-                                                        --exclude-labels "duplicate,question,invalid,wontfix,discussion,area/docs,needs triage" ${OPTS}
+                                                        --exclude-labels "stale,duplicate,question,invalid,wontfix,discussion,area/docs,needs triage" \
+                                                        --no-compare-link ${OPTS}
 
 echo "--- Uploading changelog ---"
 git add CHANGELOG.md

--- a/.travis/generate_changelog.sh
+++ b/.travis/generate_changelog.sh
@@ -8,10 +8,17 @@ then
   exit 1
 fi
 
+COMMIT_AND_PUSH=${COMMIT_AND_PUSH:-0}
 ORGANIZATION=$(echo "$TRAVIS_REPO_SLUG" | awk -F '/' '{print $1}')
 PROJECT=$(echo "$TRAVIS_REPO_SLUG" | awk -F '/' '{print $2}')
 GIT_MAIL=${GIT_MAIL:-"pawel+bot@netdata.cloud"}
 GIT_USER=${GIT_USER:-"netdatabot"}
+
+if [ -z ${GIT_TAG+x} ]; then
+	OPTS=""
+else
+	OPTS="--future-release ${GIT_TAG}"
+fi
 
 echo "--- Initialize git configuration ---"
 git config user.email "${GIT_MAIL}"
@@ -28,9 +35,11 @@ docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest
                                                         --since-tag "v1.10.0" \
                                                         --unreleased-label "**Next release**" \
                                                         --no-compare-link \
-                                                        --exclude-labels duplicate,question,invalid,wontfix,discussion,documentation
+                                                        --exclude-labels "duplicate,question,invalid,wontfix,discussion,area/docs,needs triage" ${OPTS}
 
 echo "--- Uploading changelog ---"
 git add CHANGELOG.md
-git commit -m '[ci skip] Automatic changelog update' || exit 0
-git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')"
+if [ "${COMMIT_AND_PUSH}" == "1" ]; then
+	git commit -m '[ci skip] Automatic changelog update' || exit 0
+	git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')"
+fi

--- a/.travis/tagger.sh
+++ b/.travis/tagger.sh
@@ -62,20 +62,8 @@ if [ -z "${GIT_TAG}" ]; then
 	*"[netdata minor release]"*) GIT_TAG="v$(git semver --next-minor)" ;;
 	*"[netdata major release]"*) GIT_TAG="v$(git semver --next-major)" ;;
 	*"[netdata release candidate]"*) release_candidate ;;
-	*) echo "Keyword not detected. Exiting..."; exit 1;;
+	*) echo "Keyword not detected. Exiting..."; exit 0;;
 	esac
-	# Tag it!
-	if [ "$GIT_TAG" != "HEAD" ]; then
-		echo "Assigning a new tag: $GIT_TAG"
-		embed_version "$GIT_TAG"
-		git commit -m "[ci skip] release $GIT_TAG"
-		git tag "$GIT_TAG" -a -m "Automatic tag generation for travis build no. $TRAVIS_BUILD_NUMBER"
-		git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')"
-		git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')" --tags
-	fi
-else
-	embed_version "$GIT_TAG"
-	git commit -m "[ci skip] release $GIT_TAG"
-	git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')"
 fi
+embed_version "$GIT_TAG"
 export GIT_TAG

--- a/.travis/tagger.sh
+++ b/.travis/tagger.sh
@@ -40,14 +40,14 @@ function embed_version {
 function release_candidate {
 	LAST_TAG=$(git semver)
 	if [[ $LAST_TAG =~ -rc* ]]; then
-		LAST_RELEASE=$(echo "$LAST_TAG" | cut -d'-' -f 1)
+		VERSION=$(echo "$LAST_TAG" | cut -d'-' -f 1)
 		LAST_RC=$(echo "$LAST_TAG" | cut -d'c' -f 2)
 		RC=$((LAST_RC + 1))
 	else
-		LAST_RELEASE=$LAST_TAG
+		VERSION="$(git semver --next-minor)"
 		RC=0
 	fi
-	GIT_TAG="v$LAST_RELEASE-rc$RC"
+	GIT_TAG="v$VERSION-rc$RC"
 	export GIT_TAG
 }
 


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
- Allow to generate changelog for tag which doesn't yet exist

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #4718 

##### Component Name
<!--- Write the short name of the module or plugin below -->
CI

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Move changelog generation to be before creating release artifacts
- Fix problem with failing CI system on master branch
- Create only one commit when creating a release
- Exempt issues with `stale` label from changelog
- Fix rc0 version tag. Use next minor release for release candidates