### PR TITLE
docker: correct invalid syntax

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,7 @@ RUN mv /usr/sbin/fping /usr/local/bin/fping && \
     mkdir -p /var/log/netdata && \
     # Add netdata user
     addgroup -g ${NETDATA_GID} -S netdata && \
-    adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G netdata netdata && \
+    adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G netdata netdata
 
 # Copy files over
 COPY --from=builder /app /


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
Fix invalid dockerfile syntax detected in nightly job.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
packaging/docker

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Bug was accidentally introduced in #4722

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
