### PR TITLE
remove rolling version suffix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,16 +8,12 @@ define([VERSION_MAJOR], [1])
 define([VERSION_MINOR], [11])
 define([VERSION_FIX], [1])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
-define([VERSION_SUFFIX], [_rolling])
-
-dnl Set to "1" for a first RPM release of a new version
-PACKAGE_RPM_RELEASE="0.0.$(echo VERSION_SUFFIX | sed s/^_//)"
 
 # We do not use m4_esyscmd_s to support older autoconf.
 define([VERSION_STRING], m4_esyscmd(git describe 2>/dev/null | sed 's/^v//' | tr -d '\n'))
 m4_ifval(VERSION_STRING, [], [define([VERSION_STRING], VERSION_NUMBER)])
 
-AC_INIT([netdata], VERSION_STRING[]VERSION_SUFFIX)
+AC_INIT([netdata], VERSION_STRING[])
 
 AM_MAINTAINER_MODE([disable])
 if test x"$USE_MAINTAINER_MODE" = xyes; then
@@ -27,8 +23,6 @@ fi
 
 PACKAGE_RPM_VERSION="VERSION_NUMBER"
 AC_SUBST([PACKAGE_RPM_VERSION])
-AC_SUBST([PACKAGE_RPM_RELEASE])
-
 
 # -----------------------------------------------------------------------------
 # autoconf initialization


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
Remove `_rolling` suffix from version string.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #4570

##### Component Name
<!--- Write the short name of the module or plugin below -->
packaging

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Effect will be seen in next release.

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
