### PR TITLE
move build Dockerfiles to external repo

### DIFF
--- a/.travis/README.md
+++ b/.travis/README.md
@@ -29,6 +29,9 @@ installations of netdata. Jobs are run on following operating systems:
   - CentOS 7 (containerized)
   - alpine (containerized)
 
+Images for system containers are stored on dockerhub and are created from Dockerfiles located in 
+[netdata/helper-images](https://github.com/netdata/helper-images) repository.
+
 ### Packaging
 
 This stage is executed only on "master" brach and allows us to create a new tag just looking at git commit message.

--- a/.travis/containerized_build.sh
+++ b/.travis/containerized_build.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-docker build -t dev-image -f ".travis/images/Dockerfile.$1" .
-
-docker run -it -w /code dev-image ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp
+docker run -it -w /code "netdata/os-test:$1" ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp

--- a/.travis/containerized_build.sh
+++ b/.travis/containerized_build.sh
@@ -2,4 +2,10 @@
 
 set -e
 
-docker run -it -w /code "netdata/os-test:$1" ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp
+if [ ! -f .gitignore ]
+then
+  echo "Run as ./travis/$(basename "$0") from top level directory of git repository"
+  exit 1
+fi
+
+docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:$1" ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp

--- a/.travis/images/Dockerfile.alpine
+++ b/.travis/images/Dockerfile.alpine
@@ -1,5 +1,0 @@
-FROM alpine:latest
-
-RUN apk add bash gcc make autoconf automake pkgconfig zlib-dev libuuid git libmnl-dev util-linux-dev build-base
-
-COPY . /code

--- a/.travis/images/Dockerfile.centos6
+++ b/.travis/images/Dockerfile.centos6
@@ -1,5 +1,0 @@
-FROM centos:6
-
-RUN yum install -y gcc make autoconf automake pkg-config zlib-devel libuuid-devel git
-
-COPY . /code

--- a/.travis/images/Dockerfile.centos7
+++ b/.travis/images/Dockerfile.centos7
@@ -1,5 +1,0 @@
-FROM centos:7
-
-RUN yum install -y gcc make autoconf automake pkg-config zlib-devel libuuid-devel git
-
-COPY . /code

--- a/.travis/images/Dockerfile.ubuntu1804
+++ b/.travis/images/Dockerfile.ubuntu1804
@@ -1,6 +1,0 @@
-FROM ubuntu:18.04
-
-RUN apt-get update && \
-    apt-get install -y gcc make autoconf automake pkg-config zlib1g-dev uuid-dev git
-
-COPY . /code

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,0 @@
-FROM gcc:8
-
-RUN apt-get update && apt-get install -y \
-    autoconf-archive \
-    autogen \
-    libmnl-dev \
-    uuid-dev \
- && rm -rf /var/lib/apt/lists/*

--- a/build/build.sh
+++ b/build/build.sh
@@ -10,13 +10,10 @@ if [ "$IS_CONTAINER" != "" ]; then
   make dist
   rm -rf autom4te.cache
 else
-  if [[ "$(docker images -q netdata-builder:latest 2> /dev/null)" == "" ]]; then
-      docker build -t netdata-builder:latest -f build/Dockerfile .
-  fi
   docker run --rm -it \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/project:Z" \
     --workdir "/project" \
-    netdata-builder:latest \
+    netdata/builder:gcc \
     ./build/build.sh
 fi


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
Use prebuilt docker images to speed up CI pipelines, reduce flakiness and make builds reproducible by using common environment.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
CI

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste log output below, e.g. before and after your change -->
```paste below

```
