### PR TITLE
sensors: don't ignore 0 RPM funs on start

### DIFF
--- a/collectors/python.d.plugin/sensors/sensors.chart.py
+++ b/collectors/python.d.plugin/sensors/sensors.chart.py
@@ -139,7 +139,7 @@ class Service(SimpleService):
                         except sensors.SensorsError as error:
                             self.error('{0}: {1}'.format(sf.name, error))
                             continue
-                    if not vals:
+                    if not vals or (vals[0] == 0 and feature.type != 1):
                         continue
                     if TYPE_MAP[feature.type] == sensor:
                         # create chart

--- a/collectors/python.d.plugin/sensors/sensors.chart.py
+++ b/collectors/python.d.plugin/sensors/sensors.chart.py
@@ -139,7 +139,7 @@ class Service(SimpleService):
                         except sensors.SensorsError as error:
                             self.error('{0}: {1}'.format(sf.name, error))
                             continue
-                    if not vals or vals[0] == 0:
+                    if not vals:
                         continue
                     if TYPE_MAP[feature.type] == sensor:
                         # create chart


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
> sensors.chart.py ignores fans running at 0 RPM when netdata was started

Fixes: #4158

##### Component Name
<!--- Write the short name of the module or plugin below -->

`sensors` python module

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


@cobrafast  please test it