### PR TITLE
create better issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,27 +4,29 @@ about: Create a bug report to help us improve
 
 ---
 
-<!--- Verify first that your issue is not already reported on GitHub -->
-<!--- Also test if the latest release and devel branch are affected too -->
+<!---
+When creating a bug report please:
+- Verify first that your issue is not already reported on GitHub
+- Test if the latest release and master branch are affected too.
+- Provide a clear and concise description of what the bug is in "Bug report 
+  summary" section.
+- Try to provide as much information about your environment (OS distribution,
+  running in container, etc.) as possible to allow us reproduce this bug faster.
+- Write which component is affected. We group our components the same way our
+  code is structured so basically:
+  component name = dir in top level directory of repository
+- Describe how you found this bug and how we can reproduce it. Preferable with
+  a minimal test-case scenario. You can paste gist.github.com links for larger
+  files
+- Provide a clear and concise description of what you expected to happen.
+-->
 
 ##### Bug report summary
-<!-- A clear and concise description of what the bug is. -->
 
 ##### OS / Environment
-<!--- Provide all relevant information below, e.g. OS distribution, running in container, etc. -->
 
 ##### Component Name
-<!--- Write the short name of the module or plugin below -->
 
 ##### Steps To Reproduce
-<!--- Describe exactly how to reproduce the problem, using a minimal test-case -->
-
-<!--- Paste configuration you used between quotes below -->
-```yaml
-
-```
-
-<!--- HINT: You can paste gist.github.com links for larger files -->
 
 ##### Expected behavior
-<!-- A clear and concise description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,10 +4,13 @@ about: Suggest an idea for our project
 
 ---
 
-<!--- Verify first that your issue is not already reported on GitHub -->
+<!---
+When creating a feature request please:
+- Verify first that your issue is not already reported on GitHub
+- Explain new feature briefly in "Feature idea summary" section
+- Provide a clear and concise description of what you expect to happen.
+--->
 
 ##### Feature idea summary
-<!--- Explain new feature briefly below -->
 
 ##### Expected behavior
-<!-- A clear and concise description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,10 @@
+<!---
+This is a generic issue template. We usually prefer contributors to use one
+of 3 other specific issue templates (bug report, feature request, question)
+to allow our automation classify those so you can get response faster.
+However if your issue doesn't fall into either one of those 3 categories
+use this generic template.
+--->
+
+#### Summary
+

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -3,16 +3,23 @@ name: Question
 about: You just want to ask a question? Go on.
 ---
 
-<!--- Verify first that your question wasn't asked before on GitHub -->
+<!---
+When asking a new question please:
+- Verify first that your question wasn't asked before on GitHub. 
+  HINT: Use label "question" when searching for such issues.
+- Briefly explain what is the problem you are having
+- Try to provide as much information about your environment (OS distribution,
+  running in container, etc.) as possible to allow us reproduce this bug faster.
+- Write which component is affected. We group our components the same way our
+  code is structured so basically:
+    component name = dir in top level directory of repository
+- Provide a clear and concise description of what you expected to happen.
+-->
 
 ##### Question summary
-<!--- Briefly exmplain what is the problem you are having -->
 
 ##### OS / Environment
-<!--- Provide all relevant information below, e.g. OS distribution, running in container, etc. -->
 
 ##### Component Name
-<!--- Write the short name of the module or plugin below -->
 
 ##### Expected results
-<!-- A clear and concise description of what you expected to happen. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,19 @@
-##### Summary
-<!--- Describe the change below, including rationale and design decisions -->
+<!--
+Describe the change in summary section, including rationale and degin decisions.
+Include "Fixes #nnn" if you are fixing an existing issue.
 
-<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
+In "Component Name" section write which component is changed in this PR. This
+will help us review your PR quicker.
+
+If you have more information you want to add, write them in "Additional
+Information" section. This is usually used to help others understand your
+motivation behind this change. A step-by-step reproduction of the problem is
+helpful if there is no related issue.
+-->
+
+##### Summary
 
 ##### Component Name
-<!--- Write the short name of the module or plugin below -->
 
 ##### Additional Information
-<!--- Include additional information to help people understand the change here -->
-<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
 
-<!--- Paste log output below, e.g. before and after your change -->
-```paste below
-
-```


### PR DESCRIPTION
##### Summary
<!--- Describe the change below, including rationale and design decisions -->
Provide cleaner issue and PR templates by merging multiple comments into one comment section at the beginning.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### Component Name
<!--- Write the short name of the module or plugin below -->
github

##### Additional Information
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I found that templates with multiple comments are confusing to some people and make writing issues harder. This is an attempt at fixing that problem.
Also this adds another template for generic issue which should discourage people from creating generic issues and direct them towards using specific ones. This in turn should allow automation to work better at classifying new issues.
