### PR TITLE
buildhtml.sh should exit with 1 if anything fails

### DIFF
--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -3,6 +3,9 @@
 # buildhtml.sh
 
 # Builds the html static site, using mkdocs
+
+set -e
+
 # Assumes that the script is executed either from the htmldoc folder (by netlify), or from the root repo dir (as originally intended)
 currentdir=$(pwd | awk -F '/' '{print $NF}')
 echo "$currentdir"
@@ -16,12 +19,9 @@ echo "Copying files"
 rm -rf ${GENERATOR_DIR}/src
 find . -type d \( -path ./${GENERATOR_DIR} -o -path ./node_modules \) -prune -o -name "*.md" -print | cpio -pd ${GENERATOR_DIR}/src
 
-if [ $? -ne 0 ]; then exit 1; fi
-
 # Modify the first line of the main README.md, to enable proper static html generation
 echo "Modifying README header"
 sed -i '0,/# netdata /s//# Introduction\n\n/' ${GENERATOR_DIR}/src/README.md
-if [ $? -ne 0 ]; then exit 1; fi
 
 # Remove specific files that don't belong in the documentation
 declare -a EXCLUDE_LIST=(
@@ -35,18 +35,15 @@ echo "Creating mkdocs.yaml"
 
 # Generate mkdocs.yaml
 ${GENERATOR_DIR}/buildyaml.sh >${GENERATOR_DIR}/mkdocs.yml
-if [ $? -ne 0 ]; then exit 1; fi
 
 echo "Fixing links"
 
 # Fix links (recursively, all types, executing replacements)
 ${GENERATOR_DIR}/checklinks.sh -rax
-if [ $? -ne 0 ]; then exit 1; fi
 
 echo "Calling mkdocs"
 
 # Build html docs
 mkdocs build --config-file=${GENERATOR_DIR}/mkdocs.yml
-if [ $? -ne 0 ]; then exit 1; fi
 
 echo "Finished"

--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -16,8 +16,12 @@ echo "Copying files"
 rm -rf ${GENERATOR_DIR}/src
 find . -type d \( -path ./${GENERATOR_DIR} -o -path ./node_modules \) -prune -o -name "*.md" -print | cpio -pd ${GENERATOR_DIR}/src
 
+if [ $? -ne 0 ]; then exit 1; fi
+
 # Modify the first line of the main README.md, to enable proper static html generation
+echo "Modifying README header"
 sed -i '0,/# netdata /s//# Introduction\n\n/' ${GENERATOR_DIR}/src/README.md
+if [ $? -ne 0 ]; then exit 1; fi
 
 # Remove specific files that don't belong in the documentation
 declare -a EXCLUDE_LIST=(
@@ -31,16 +35,18 @@ echo "Creating mkdocs.yaml"
 
 # Generate mkdocs.yaml
 ${GENERATOR_DIR}/buildyaml.sh >${GENERATOR_DIR}/mkdocs.yml
+if [ $? -ne 0 ]; then exit 1; fi
 
 echo "Fixing links"
 
 # Fix links (recursively, all types, executing replacements)
 ${GENERATOR_DIR}/checklinks.sh -rax
-if [ $? -eq 1 ]; then exit 1; fi
+if [ $? -ne 0 ]; then exit 1; fi
 
 echo "Calling mkdocs"
 
 # Build html docs
 mkdocs build --config-file=${GENERATOR_DIR}/mkdocs.yml
+if [ $? -ne 0 ]; then exit 1; fi
 
 echo "Finished"


### PR DESCRIPTION
The Netlify checks appear successful even if mkdocs exits with 1, which is wrong. Added checks for the exit code after each command in buildhtml.sh to ensure we catch the issues.