### PR TITLE
Documentation TOC bug fix

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -216,7 +216,6 @@ echo -ne "- Hacking netdata:
     - CONTRIBUTORS.md
 "
 navpart 2 makeself "" "" 4
-navpart 2 packaging "" "" 4
 navpart 2 libnetdata "" "libnetdata" 4
 navpart 2 contrib
 navpart 2 tests


### PR DESCRIPTION
Docker installation readme appeared twice in TOC, causing the first link to break

