### PR TITLE
Added Legal section to documentation, added missing link for apps.plugin

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -42,12 +42,12 @@ navpart() {
 	done
 }
 
-echo -e 'site_name: NetData Documentation
+echo -e 'site_name: Netdata Documentation
 repo_url: https://github.com/netdata/netdata
 repo_name: GitHub
 edit_uri: blob/master
-site_description: NetData Documentation
-copyright: NetData, 2018
+site_description: Netdata Documentation
+copyright: Netdata, 2018
 docs_dir: src
 site_dir: build
 #use_directory_urls: false
@@ -147,6 +147,7 @@ navpart 1 collectors "" "Data collection" 1
 echo -ne "    - 'docs/Add-more-charts-to-netdata.md'
     - Internal plugins:
 "
+navpart 3 collectors/apps.plugin
 navpart 3 collectors/proc.plugin
 navpart 3 collectors/statsd.plugin
 navpart 3 collectors/cgroups.plugin
@@ -220,3 +221,8 @@ navpart 2 libnetdata "" "libnetdata" 4
 navpart 2 contrib
 navpart 2 tests
 navpart 2 diagrams/data_structures
+
+echo -ne "- Legal:
+    - 'docs/privacy-policy.md'
+    - 'docs/terms-of-use.md'
+"

--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -52,6 +52,15 @@ docs_dir: src
 site_dir: build
 #use_directory_urls: false
 strict: true
+google_analytics: ["UA-64295674-3", "docs.netdata.cloud"]
+extra:
+  social:
+    - type: "github"
+      link: "https://github.com/netdata/netdata"
+    - type: "twitter"
+      link: "https://twitter.com/linuxnetdata"
+    - type: "facebook"
+      link: "https://www.facebook.com/linuxnetdata/"
 theme:
     name: "material"
     custom_dir: themes/material
@@ -221,8 +230,3 @@ navpart 2 libnetdata "" "libnetdata" 4
 navpart 2 contrib
 navpart 2 tests
 navpart 2 diagrams/data_structures
-
-echo -ne "- Legal:
-    - 'docs/privacy-policy.md'
-    - 'docs/terms-of-use.md'
-"

--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -52,7 +52,7 @@ docs_dir: src
 site_dir: build
 #use_directory_urls: false
 strict: true
-google_analytics: ["UA-64295674-3", "docs.netdata.cloud"]
+google_analytics: ["UA-64295674-3", ""]
 extra:
   social:
     - type: "github"

--- a/docs/generator/themes/material/partials/footer.html
+++ b/docs/generator/themes/material/partials/footer.html
@@ -41,13 +41,9 @@
       <div class="md-footer-copyright">
         {% if config.copyright %}
           <div class="md-footer-copyright__highlight">
-            {{ config.copyright }}
+            {{ config.copyright }} | <a href="/docs/privacy-policy/">Privacy Policy</a> | <a href="/docs/terms-of-use/">Terms of Use</a>
           </div>
         {% endif %}
-		<a href="https://twitter.com/linuxnetdata" rel="nofollow"><img src="https://img.shields.io/twitter/follow/linuxnetdata.svg?style=social&amp;label=New%20-%20stay%20in%20touch%20-%20follow%20netdata%20on%20twitter"></a>
-		<img src="https://www.google-analytics.com/collect?v=1&amp;t=pageview&amp;_s=1&amp;ds=github&amp;dr=https%3A%2F%2Fgithub.com%2Ffirehol%2Fnetdata%2Fwiki&amp;dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fwiki&amp;_u=MAC%7E&amp;cid=8c51788e-8721-45e3-ae8c-e7c63ba8236b&amp;tid=UA-64295674-3">
-
-
       </div>
       {% block social %}
         {% include "partials/social.html" %}

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,93 @@
+# Privacy policy
+
+## 1. Preamble
+
+This Privacy Policy explains the collection, use, processing, transferring and disclosure of personal information by Netdata, Inc (“ND” or “Netdata”), a Delaware corporation.
+
+This Privacy Policy is incorporated into and made part of Netdata Master Terms of Use (“Master Terms”) located [here](terms-of-use.md).
+
+Unless otherwise noted on a particular website or service hosted by Netdata, this Privacy Policy applies to your use of all websites that Netdata operates. These include https://netdata.io and https://netdata.cloud, together with all other subdomains thereof, (collectively, the “Websites”). This Privacy Policy also applies to all products, information, and services provided through the Websites, including without limitation the license chooser, legal tools, the ND Login Services (defined below), and the ND Global Network community website (together with the Websites, the “Services”).
+
+In addition, supplemental Privacy Policy terms (“Supplemental Privacy Policy Terms”) may apply to a particular Service. All such Supplemental Privacy Policy Terms will be accessible for you to read either within, or through your use of, that particular Service.
+
+By accessing or using any of the Services, you are accepting and agreeing to the practices described in this Privacy Policy.
+
+## 2. Our Principles
+
+Netdata has designed this policy to be consistent with the following principles:
+
+Privacy policies should be human readable and easy to find.
+Data collection, storage, and processing should be simplified as much as possible to enhance security, ensure consistency, and make the practices easy for users to understand.
+Data practices should always meet the reasonable expectations of users.
+
+## 3. Personal Information ND Collects and How it is Used
+
+As used in this policy, “personal information” means information that would allow someone to identify you, including your name, email address, IP address, or other information from which someone could deduce your identity.
+
+ND collects and uses personal information in the following ways:
+
+Website and Fundraising Analytics: When you visit our Websites and use our Services, ND collects some information about your activities through tools such as Google Analytics. The type of information that we collect focuses on general information such as country or city where you are located, pages visited, time spent on pages, heat-map of visitors’ activity on the site, information about the browser you are using, etc. ND collects and uses this information pursuant to our legitimate interest in enhancing the security and utility of our Services. The information we gather and process is used in the aggregate to spot trends without deliberately identifying individuals, except in cases where you engage in a transaction with Netdata by donating money, or purchasing services. In those cases, ND retains certain information about your visit to the Services pursuant to its legitimate interest in understanding its community of supporters for fundraising purposes, and this information is stored in connection with other personal information you provide to ND.
+
+Note that you can learn about Google’s practices in connection with its analytics services and how to opt out of it by downloading the Google Analytics opt-out browser add-on, available at https://tools.google.com/dlpage/gaoptout. If you would like to opt out of ND’s fundraising analytics, please contact legal@netdata.cloud with your request.
+
+Information from Cookies: We and our service providers (for example, Google Analytics as described above) may collect information using cookies or similar technologies for the purposes described above and below. Cookies are pieces of information that are stored by your browser on the hard drive or memory of your computer or other Internet access device.  Cookies may enable us to personalize your experience on the Services, maintain a persistent session, passively collect demographic information about your computer, and monitor advertisements and other activities. The Websites may use different kinds of cookies and other types of local storage (such as browser-based or plugin-based local storage).
+
+Log-In Services: When you register to obtain a user account on any of the Services (any such person, a “Registered User”), including but not limited to the NDID service, you will be asked to provide personal information to create your account and establish a password and profile. ND collects and uses this personal information pursuant to its legitimate interest in establishing and maintaining your account providing you with the features we provide Registered Users. We may use your email address to contact you regarding changes to this policy or other applicable policies. The name or nickname you provide in connection with your account may be used to attribute you in connection with any content you submit to any Service. In addition, whenever you use a ND Login Service to log into a Website or use the Services, our servers keep a plain text log of the Websites you visit and when you visit them.
+
+Emails and Newsletters: When you sign up to receive updates from Netdata or otherwise subscribe to one of our mailing lists, you will be asked to provide some personal information. ND collects and uses this personal information pursuant to its legitimate interest in providing news and updates to, and collaborating with, its supporters and volunteers.
+
+Email Analytics: When you receive communications from ND after signing up for the ND newsletter, campaign updates, or other ongoing email communications from ND, we may use analytics to track whether you open the mail, click on the links, and otherwise interact with what we send. You may opt out of this tracking by choosing to get plain-text emails from ND. ND collects and uses this personal information pursuant to its legitimate interest in understanding the interests of its community of supporters and volunteers in order to provide more relevant news and updates.
+
+Donations: When you donate money to Netdata or purchase Services, you will be asked to provide personal information, including payment information. ND collects and uses this personal information pursuant to its legitimate interest in raising funds to ensure the sustainability of our nonprofit organization and, where applicable, to provide you with the merchandise, event, or program you purchased.
+
+Other Voluntarily Provided Information: When you provide feedback to Netdata, sign a petition distributed by ND, or otherwise submit personal information to Netdata, ND collects and uses this personal information pursuant to its legitimate interest in better understanding our community of supporters and volunteers and in furtherance of the particular program or activity to which you provided feedback or other input.
+
+## 4. Retention of Personal Information
+
+The majority of the personal information collected and used as explained in Section 3 above is aggregated and stored in a central database provided by a third party service provider. ND aggregates this data pursuant to its legitimate interest in having information stored in a single location to minimize complexity, increase consistency in internal practices, better understand its community of supporters and volunteers, and enhance the security of the data.  
+
+ND erases the web browser logs described above on a regular, rolling basis.
+
+## 5. Access to Your Personal Information
+
+You are generally entitled to access personal information that Netdata holds and to have inaccurate data corrected or removed to the extent ND still maintains it. In certain circumstances, you also may have the right to object for legitimate reasons to the processing or transfer of personal information. If you wish to exercise any of these rights, please write to legal@netdata.cloud explaining your request.
+
+## 6. Disclosure of Your Personal Information
+
+ND does not disclose personal information to third parties except as specified elsewhere in this policy and in the following instances:
+
+Netdata may share personal information with our contractors and service providers in order to undertake the activities described in Section 3. 
+
+We may disclose your personal information to third parties in a good faith belief that such disclosure is reasonably necessary to (a) take action regarding suspected illegal activities; (b) enforce or apply our Master Terms and this Privacy Policy; (c) enforce our Charter, including the Code of Conduct and policies contained and incorporated therein, or (d) comply with legal process, such as a search warrant, subpoena, statute, or court order.
+
+## 7. Security of Your Personal Information
+
+Netdata has implemented reasonable physical, technical, and organizational security measures for personal information that Netdata processes against accidental or unlawful destruction, or accidental loss, alteration, unauthorized disclosure or access, in compliance with applicable law. However, no website can fully eliminate security risks. Third parties may circumvent our security measures to unlawfully intercept or access transmissions or private communications. If any data breach occurs, we will post a reasonably prominent notice to the Websites and comply with all other applicable data privacy requirements including, when required, personal notice to you if you have provided and we have maintained an email address for you.
+
+The ND Login Services account systems have security risks in addition to those described above. Among other things, they are vulnerable to DNS attacks, and using any ND Login Service may increase the risk of phishing.
+
+## 8. Children
+
+The Services are not directed at children under the age of 13. Consistent with the U.S. federal Children’s Online Privacy Protection Act of 1998 (COPPA), we will never knowingly request personal information from anyone under the age of 13 without requiring parental consent. Our Master Terms specifically prohibit anyone using our Services from submitting any personally identifiable information about persons under 13 years of age. Any person who provides their personal information to ND through the Services represents that they are 13 years of age or older.
+
+## 9. Third Party Service Providers
+
+Netdata uses many third party service providers in connection with the Services, including website hosting services, database management, credit card processing, and many more. Some of these service providers may place session cookies on your computer, and they may collect and store your personal information on our behalf in accordance with the data practices and purposes explained above in Section 3.
+
+## 10. Third Party Sites
+
+The Services may provide links to a wide variety of third party websites. You should consult the respective privacy policies of these third-party websites. This Privacy Policy does not apply to, and we cannot control the activities of, such other websites.
+
+## 11. Transferring Data to Other Countries
+
+If you are accessing or using the Services in regions with laws governing data collection, processing, transfer and use, please note that when we use and share your data as specified in this policy, we may transfer your information to recipients in countries other than the country in which the information was originally collected. Those countries may not have the same data protection laws as the country in which you initially provided the information.
+
+The Services are currently hosted in the United States and the United Kingdom, which means your personal information may be located on servers in the United States and/or the United Kingdom. The majority of contractors that Netdata is using as of the effective date of this Privacy Policy are located in the United States and in Canada, but this may change from time to time.
+
+Data transferred from the European Union to the United States or outside the European Union will be made on the grounds of a certification to the E.U./U.S. Privacy Shield regime and/or a data transfer agreement based on the Standard Contractual Clauses approved of by the European Commission respectively, consistent with applicable data privacy requirements.
+
+## 12. Changes to this Privacy Policy
+
+We may occasionally update this Privacy Policy. When we do, we will provide you with notice of such update through (at a minimum) a reasonably prominent notice on the Websites and Services, and will revise the Effective Date below. We encourage you to periodically review this Privacy Policy to stay informed about how we are protecting, using, processing and transferring the personal information we collect.
+
+***Effective Date: 10 November 2018.***

--- a/docs/terms-of-use.md
+++ b/docs/terms-of-use.md
@@ -1,6 +1,6 @@
 # Terms of use
 
-Netdata Terms of Use for the sites https://my-netdata.io and https://netdata.cloud and their subdomains. For the Netdata agent and the included redistributed software terms of use,  refer to [Redistributed software](redistributed/)
+Netdata Terms of Use for the sites https://my-netdata.io and https://netdata.cloud and their subdomains. For the Netdata agent and the included redistributed software terms of use,  refer to [Redistributed software](../REDISTRIBUTED.md)
 
 Effective as of 25 May 2018
 

--- a/docs/terms-of-use.md
+++ b/docs/terms-of-use.md
@@ -1,6 +1,7 @@
 # Terms of use
 
-Netdata Master Terms of Use
+Netdata Terms of Use for the sites https://my-netdata.io and https://netdata.cloud and their subdomains. For the Netdata agent and the included redistributed software terms of use,  refer to [Redistributed software](redistributed/)
+
 Effective as of 25 May 2018
 
 ## 1. General Information Regarding These Terms of Use

--- a/docs/terms-of-use.md
+++ b/docs/terms-of-use.md
@@ -1,0 +1,159 @@
+# Terms of use
+
+Netdata Master Terms of Use
+Effective as of 25 May 2018
+
+## 1. General Information Regarding These Terms of Use
+
+Master terms: Welcome, and thank you for your interest in Netdata (“Netdata,” “ND,” “we,” “our,” or “us”). Unless otherwise noted on a particular site or service, these master terms of use (“Master Terms”) apply to your use of all of the websites that Netdata Corporation operates. These include https://my-netdata.io and https://netdata.cloud, together with all other subdomains thereof, (collectively, the “Websites”). The Master Terms also apply to all products, information, and services provided through the Websites, such as the NDID Login Service.
+
+Additional terms: In addition to the Master Terms, your use of any Services may also be subject to specific terms applicable to a particular Service (“Additional Terms”). If there is any conflict between the Additional Terms and the Master Terms, then the Additional Terms apply in relation to the relevant Service.
+
+Collectively, the Terms: The Master Terms, together with any Additional Terms, form a binding legal agreement between you and Netdata in relation to your use of the Services. Collectively, this legal agreement is referred to below as the “Terms.”
+
+Human-readable summary of Sec 1: These terms, together with any special terms for particular websites, create a contract between you and Netdata. The contract governs your use of all websites operated by Netdata, unless a particular website indicates otherwise. These human-readable summaries of each section are not part of the contract, but are intended to help you understand its terms.
+
+## 2. Your Agreement to the Terms
+
+BY ACCESSING OR USING ANY OF THE SERVICES, YOU ACKNOWLEDGE THAT YOU HAVE READ, UNDERSTOOD, AND AGREED TO BE BOUND BY THE TERMS. By accessing or using any Services you also represent that you have the legal authority to accept the Terms on behalf of yourself and any party you represent in connection with your use of any Services. If you do not agree to the Terms, you are not authorized to use any Services. If you are an individual who is entering into these Terms on behalf of an entity, you represent and warrant that you have the power to bind that entity, and you hereby agree on that entity’s behalf to be bound by these Terms, with the terms “you,” and “your” applying to you, that entity, and other users accessing the Services on behalf of that entity.
+
+Human-readable summary of Sec 2: Please read these terms and only use our sites and services if you agree to them.
+
+## 3. Changes to the Terms
+
+From time to time, Netdata may change, remove, or add to the Terms, and reserves the right to do so in its discretion. In that case, we will post updated Terms and indicate the date of revision. If we feel the modifications are material, we will make reasonable efforts to post a prominent notice on the relevant Website(s) and notify those of you with a current NDID Login Service account via email. All new and/or revised Terms take effect immediately and apply to your use of the Services from that date on, except that material changes will take effect 30 days after the change is made and identified as material. Your continued use of any Services after new and/or revised Terms are effective indicates that you have read, understood, and agreed to those Terms.
+
+Human-readable summary of Sec 3: These terms may change. When the changes are important, we will put a notice on the website. If you continue to use the sites after the changes are made, you agree to the changes.
+
+## 4. No Legal Advice
+
+Netdata is not a law firm, does not provide legal advice, and is not a substitute for a law firm. Sending us an email or using any of the Services, including the licenses, public domain tools, and choosers, does not constitute legal advice or create an attorney-client relationship.
+
+Human-readable summary of Sec 4: Some of us are lawyers, but we aren’t your lawyer. Please consult your own attorney if you need legal advice.
+
+## 5. Content Available through the Services
+
+Provided as-is: You acknowledge that Netdata does not make any representations or warranties about the material, data, and information, such as data files, text, computer software, code, music, audio files or other sounds, photographs, videos, or other images (collectively, the “Content”) which you may have access to as part of, or through your use of, the Services. Under no circumstances is Netdata liable in any way for any Content, including, but not limited to: any infringing Content, any errors or omissions in Content, or for any loss or damage of any kind incurred as a result of the use of any Content posted, transmitted, linked from, or otherwise accessible through or made available via the Services. You understand that by using the Services, you may be exposed to Content that is offensive, indecent, or objectionable.
+
+You agree that you are solely responsible for your reuse of Content made available through the Services, including providing proper attribution. You should review the terms of the applicable license before you use the Content so that you know what you can and cannot do.
+
+Licensing: ND-Owned Content: Other than the text of Netdata licenses, CC licenses, and other legal tools and the text of the deeds for all legal tools (all of which are made available under the CC Public Domain Dedication), Netdata trademarks (subject to the Trademark Policy), and the software code, all Content on the Websites is licensed under the Creative Commons Attribution 4.0 license, unless otherwise marked. See the ND Policies page for more information.
+
+ND-Owned Code: All of CC’s software code is free software; please check our code repository for the specific license on software you want to reuse.
+
+Search Tools: On some of its Websites, Netdata provides website search tools, including ND Search, which return Content based on any information our search tools are able to locate and interpret. Those search tools may return Content that is not ND licensed, and you should independently verify the terms of the license attached to any Content you intend to use.
+
+Human-readable summary of Sec 5: We try our best to have useful information on our sites, but we cannot promise that everything is accurate or appropriate for your situation. Content on the site is licensed under CC BY 4.0 unless it says it is available under different terms. If you find content through a link on our websites, be sure to check the license terms before using it.
+
+## 6. Content Supplied by You
+
+Your responsibility: You represent, warrant, and agree that no Content posted or otherwise shared by you on or through any of the Services (“Your Content”), violates or infringes upon the rights of any third party, including copyright, trademark, privacy, publicity, or other personal or proprietary rights, breaches or conflicts with any obligation, such as a confidentiality obligation, or contains libelous, defamatory, or otherwise unlawful material.
+
+Licensing Your Content: You retain any copyright that you may have in Your Content. You hereby agree that Your Content: (a) is hereby licensed under the CC Attribution 4.0 License and may be used under the terms of that license or any later version of a CC Attribution License, or (b) is in the public domain (such as Content that is not copyrightable or Content you make available under CC0), or (c) if not owned by you, (i) is available under a CC Attribution 4.0 License or (ii) is a media file that is available under any CC license or that you are authorized by law to post or share through any of the Services, such as under the fair use doctrine, and that is prominently marked as being subject to third party copyright. All of Your Content must be appropriately marked with licensing (or other permission status such as fair use) and attribution information.
+
+Removal: Netdata may, but is not obligated to, review Your Content and may delete or remove Your Content (without notice) from any of the Services in its sole discretion. Removal of any of Your Content from the Services (by you or Netdata) does not impact any rights you granted in Your Content under the terms of a Netdata license.
+
+Human-readable summary of Sec 6: We do not take any ownership of your content when you post it on our sites. If you post content you own, you agree it can be used under the terms of CC BY 4.0 or any future version of that license. If you do not own the content, then you should not post it unless it is in the public domain or licensed CC BY 4.0, except that you may also post pictures and videos if you are authorized to use them under law (e.g. fair use) or if they are available under any CC license. You must note that information on the file when you upload it. You are responsible for any content you upload to our sites.
+
+## 7. Prohibited Conduct
+
+You agree not to engage in any of the following activities:
+
+### 1. Violating laws and rights:
+
+You may not (a) use any Service for any illegal purpose or in violation of any local, state, national, or international laws, (b) violate or encourage others to violate any right of or obligation to a third party, including by infringing, misappropriating, or violating intellectual property, confidentiality, or privacy rights.
+
+### 2. Solicitation:
+
+You may not use the Services or any information provided through the Services for the transmission of advertising or promotional materials, including junk mail, spam, chain letters, pyramid schemes, or any other form of unsolicited or unwelcome solicitation.
+
+### 3. Disruption:
+
+You may not use the Services in any manner that could disable, overburden, damage, or impair the Services, or interfere with any other party’s use and enjoyment of the Services; including by (a) uploading or otherwise disseminating any virus, adware, spyware, worm or other malicious code, or (b) interfering with or disrupting any network, equipment, or server connected to or used to provide any of the Services, or violating any regulation, policy, or procedure of any network, equipment, or server.
+
+### 4. Harming others:
+
+You may not post or transmit Content on or through the Services that is harmful, offensive, obscene, abusive, invasive of privacy, defamatory, hateful or otherwise discriminatory, false or misleading, or incites an illegal act;
+You may not intimidate or harass another through the Services; and, you may not post or transmit any personally identifiable information about persons under 13 years of age on or through the Services.
+
+### 5. Impersonation or unauthorized access:
+
+You may not impersonate another person or entity, or misrepresent your affiliation with a person or entity when using the Services;
+You may not use or attempt to use another’s account or personal information without authorization; and
+You may not attempt to gain unauthorized access to the Services, or the computer systems or networks connected to the Services, through hacking password mining or any other means.
+
+Human-readable summary of Sec 7: Play nice. Be yourself. Don’t break the law or be disruptive.
+
+## 8. DISCLAIMER OF WARRANTIES
+
+TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, NETDATA OFFERS THE SERVICES (INCLUDING ALL CONTENT AVAILABLE ON OR THROUGH THE SERVICES) AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE SERVICES, EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. NETDATA DOES NOT WARRANT THAT THE FUNCTIONS OF THE SERVICES WILL BE UNINTERRUPTED OR ERROR-FREE, THAT CONTENT MADE AVAILABLE ON OR THROUGH THE SERVICES WILL BE ERROR-FREE, THAT DEFECTS WILL BE CORRECTED, OR THAT ANY SERVERS USED BY ND ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. NETDATA DOES NOT WARRANT OR MAKE ANY REPRESENTATION REGARDING USE OF THE CONTENT AVAILABLE THROUGH THE SERVICES IN TERMS OF ACCURACY, RELIABILITY, OR OTHERWISE.
+
+Human-readable summary of Sec 8: ND does not make any guarantees about the sites, services, or content available on the sites.
+
+## 9. LIMITATION OF LIABILITY
+
+TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL NETDATA BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY INCIDENTAL, DIRECT, INDIRECT, PUNITIVE, ACTUAL, CONSEQUENTIAL, SPECIAL, EXEMPLARY, OR OTHER DAMAGES, INCLUDING WITHOUT LIMITATION, LOSS OF REVENUE OR INCOME, LOST PROFITS, PAIN AND SUFFERING, EMOTIONAL DISTRESS, COST OF SUBSTITUTE GOODS OR SERVICES, OR SIMILAR DAMAGES SUFFERED OR INCURRED BY YOU OR ANY THIRD PARTY THAT ARISE IN CONNECTION WITH THE SERVICES (OR THE TERMINATION THEREOF FOR ANY REASON), EVEN IF NETDATA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, NETDATA IS NOT RESPONSIBLE OR LIABLE WHATSOEVER IN ANY MANNER FOR ANY CONTENT POSTED ON OR AVAILABLE THROUGH THE SERVICES (INCLUDING CLAIMS OF INFRINGEMENT RELATING TO THAT CONTENT), FOR YOUR USE OF THE SERVICES, OR FOR THE CONDUCT OF THIRD PARTIES ON OR THROUGH THE SERVICES.
+
+Certain jurisdictions do not permit the exclusion of certain warranties or limitation of liability for incidental or consequential damages, which means that some of the above limitations may not apply to you. IN THESE JURISDICTIONS, THE FOREGOING EXCLUSIONS AND LIMITATIONS WILL BE ENFORCED TO THE GREATEST EXTENT PERMITTED BY APPLICABLE LAW.
+
+Human-readable summary of Sec 9: ND is not responsible for the content on the sites, your use of our services, or for the conduct of others on our sites.
+
+## 10. Indemnification
+
+To the extent authorized by law, you agree to indemnify and hold harmless Netdata, its employees, officers, directors, affiliates, and agents from and against any and all claims, losses, expenses, damages, and costs, including reasonable attorneys’ fees, resulting directly or indirectly from or arising out of (a) your violation of the Terms, (b) your use of any of the Services, and/or (c) the Content you make available on any of the Services.
+
+Human-readable summary of Sec 10: If something happens because you violate these terms, because of your use of the services, or because of the content you post on the sites, you agree to repay ND for the damage it causes.
+
+## 11. Privacy Policy
+
+Netdata is committed to responsibly handling the information and data we collect through our Services in compliance with our Privacy Policy, which is incorporated by reference into these Master Terms. Please review the Privacy Policy so you are aware of how we collect and use your personal information.
+
+Human-readable summary of Sec 11: Please read our Privacy Policy. It is part of these terms, too.
+
+## 12. Trademark Policy
+
+ND’s name, logos, icons, and other trademarks may only be used in accordance with our Trademark Policy, which is incorporated by reference into these Master Terms. Please review the Trademark Policy so you understand how ND’s trademarks may be used.
+
+Human-readable summary of Sec 12: Please read our Trademark Policy. It is part of these terms, too.
+
+## 13. Copyright Complaints
+
+Netdata respects copyright, and we prohibit users of the Services from submitting, uploading, posting, or otherwise transmitting any Content on the Services that violates another person’s proprietary rights.
+
+To report allegedly infringing Content hosted on a website owned or controlled by ND, send a Notice of Infringing Materials to info@netdata.cloud.
+
+Please note that Netdata does not host the Content made available through ND Search. You should contact the web site or service hosting the Content to have it removed.
+
+Human-readable summary of Sec 13: Please let us know if you find infringing content on our websites.
+
+## 14. Termination
+
+By Netdata: Netdata may modify, suspend, or terminate the operation of, or access to, all or any portion of the Services at any time for any reason. Additionally, your individual access to, and use of, the Services may be terminated by Netdata at any time and for any reason.
+
+By you: If you wish to terminate this agreement, you may immediately stop accessing or using the Services at any time.
+
+Automatic upon breach: Your right to access and use the Services (including use of your ND Login Service account) automatically upon your breach of any of the Terms. For the avoidance of doubt, termination of the Terms does not require you to remove or delete any reference to previously-applied ND legal tools from your own Content.
+
+Survival: The disclaimer of warranties, the limitation of liability, and the jurisdiction and applicable law provisions will survive any termination. The license grants applicable to Your Content are not impacted by the termination of the Terms and shall continue in effect subject to the terms of the applicable license. Your warranties and indemnification obligations will survive for one year after termination.
+
+Human-readable summary of Sec 14: If you violate these terms, you may no longer use our sites.
+
+## 15. Miscellaneous Terms
+
+Choice of law: The Terms are governed by and construed by the laws of the State of Delaware in the United States, not including its choice of law rules.
+
+Dispute resolution: The parties agree that any disputes between Netdata and you concerning these Terms, and/or any of the Services may only brought in a federal or state court of competent jurisdiction sitting in the State of Delaware, and you hereby consent to the personal jurisdiction and venue of such court.
+
+If you are an authorized agent of a government or intergovernmental entity using the Services in your official capacity, including an authorized agent of the federal, state, or local government in the United States, and you are legally restricted from accepting the controlling law, jurisdiction, or venue clauses above, then those clauses do not apply to you. For any such U.S. federal government entities, these Terms and any action related thereto will be governed by the laws of the United States of America (without reference to conflict of laws) and, in the absence of federal law and to the extent permitted under federal law, the laws of the State of Delaware (excluding its choice of law rules).
+
+No waiver: Either party’s failure to insist on or enforce strict performance of any of the Terms will not be construed as a waiver of any provision or right.
+
+Severability: If any part of the Terms is held to be invalid or unenforceable by any law or regulation or final determination of a competent court or tribunal, that provision will be deemed severable and will not affect the validity and enforceability of the remaining provisions.
+
+No agency relationship: The parties agree that no joint venture, partnership, employment, or agency relationship exists between you and Netdata as a result of the Terms or from your use of any of the Services.
+
+Integration: These Master Terms and any applicable Additional Terms constitute the entire agreement between you and Netdata relating to this subject matter and supersede any and all prior communications and/or agreements between you and Netdata relating to access and use of the Services.
+
+Human-readable summary of Sec 15: If there is a lawsuit arising from these terms, it should be in Delaware and governed by Delaware law. We are glad you use our sites, but this agreement does not mean we are partners.


### PR DESCRIPTION
- Added terms of use and privacy documentation. The links don't appear in the docs navigation, but in the footer. 
- Added missing link to apps.plugin
- Replaced the hardcoded Google Analytics img with mkdocs config `google_analytics: ["UA-64295674-3", "docs.netdata.cloud"]`
- Replaced the hardcoded twitter badge with the mkdocs supported "social links" for github, facebook and twitter.

