### PR TITLE
Add debug instructions for python modules

### DIFF
--- a/collectors/python.d.plugin/README.md
+++ b/collectors/python.d.plugin/README.md
@@ -63,7 +63,14 @@ other_job:
 
 `update_every`, `retries`, and `priority` are always optional.
 
----
+## How to debug a python module
+
+Depending on where Netdata was installed, you can execute one of the following commands to trace the execution of a python module:
+```
+/opt/netdata/usr/libexec/netdata/plugins.d/python.d.plugin <module> debug trace
+/usr/libexec/netdata/plugins.d/python.d.plugin <module> debug trace
+```
+Where `[module]` is the directory name under https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin 
 
 ## How to write a new module
 

--- a/collectors/python.d.plugin/README.md
+++ b/collectors/python.d.plugin/README.md
@@ -65,8 +65,14 @@ other_job:
 
 ## How to debug a python module
 
-Depending on where Netdata was installed, you can execute one of the following commands to trace the execution of a python module:
 ```
+# become user netdata
+sudo su -s /bin/bash netdata
+```
+Depending on where Netdata was installed, execute one of the following commands to trace the execution of a python module:
+
+```
+# execute the plugin in debug mode, for a specific module
 /opt/netdata/usr/libexec/netdata/plugins.d/python.d.plugin <module> debug trace
 /usr/libexec/netdata/plugins.d/python.d.plugin <module> debug trace
 ```


### PR DESCRIPTION
Used instruction from @ilyam8 in #4085 to add a (How to debug python modules) section.
