### PR TITLE
Fix integer out of range error on Postgres 11

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -261,7 +261,7 @@ WHERE application_name IS NOT NULL;
     'REPSLOT_FILES': """
 WITH wal_size AS (
   SELECT
-    current_setting('wal_block_size')::INT * setting::INT AS val
+    current_setting('wal_block_size')::BIGINT * setting::BIGINT AS val
   FROM pg_settings
   WHERE name = 'wal_segment_size'
   )


### PR DESCRIPTION

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fix integer out of range error on Postgres 11

##### Component Name
collectors/python.d.plugin/postgres/postgres.chart.py

##### Additional Information
On PostgreSQL 11 (haven't tested on other versions) an integer out of range error is thrown due to casting to INT:
```
2018-12-03 03:22:25: python.d ERROR: postgres: socket: update() unhandled exception: integer out of range
```
Casting to BIGINT solves this error.
The PostgreSQL Docs do not list wal_block_size as bigint, so I do not fully understand why this is required.
https://www.postgresql.org/docs/11/functions-info.html

Netdata: 1.11.1-68-g0fad9bf5
OS: 	Ubuntu 18.10
PostgreSQL: PostgreSQL 11.1 (Ubuntu 11.1-1.pgdg18.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0, 64-bit