### PR TITLE
Don't use IE11 incompatible for-const #4710

### DIFF
--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -512,7 +512,7 @@ function renderStreamedHosts(options) {
         return naturalSortCompare(a.hostname, b.hostname);
     });
 
-    for (const s of sorted) {
+    for (s of sorted) {
         let url, icon;
         const hostname = s.hostname;
 
@@ -560,7 +560,7 @@ function renderMachines(machinesArray) {
             return naturalSortCompare(a.name, b.name);
         });
 
-        for (const machine of machines) {
+        for (machine of machines) {
             found = true;
 
             const alternateUrlItems = (
@@ -625,7 +625,7 @@ function renderMachines(machinesArray) {
 
         ]
 
-        for (const server of demoServers) {
+        for (server of demoServers) {
             html += (
                 `<div class="agent-item">
                     <i class="fas fa-chart-bar" color: #fff"></i>

--- a/web/gui/src/dashboard.js/common.js
+++ b/web/gui/src/dashboard.js/common.js
@@ -56,7 +56,7 @@ NETDATA.commonMin = {
         // for (let i in t) {
         //     if (t.hasOwnProperty(i) && t[i] < m) m = t[i];
         // }
-        for (const ti of Object.values(t)) {
+        for (ti of Object.values(t)) {
             if (ti < m) {
                 m = ti;
             }
@@ -120,7 +120,7 @@ NETDATA.commonMax = {
         // for (let i in t) {
         //     if (t.hasOwnProperty(i) && t[i] > m) m = t[i];
         // }
-        for (const ti of Object.values(t)) {
+        for (ti of Object.values(t)) {
             if (ti > m) {
                 m = ti;
             }

--- a/web/gui/src/dashboard.js/options.js
+++ b/web/gui/src/dashboard.js/options.js
@@ -18,7 +18,7 @@ if (typeof netdataIcons === 'object') {
     //     if (NETDATA.icons.hasOwnProperty(icon) && typeof(netdataIcons[icon]) === 'string')
     //         NETDATA.icons[icon] = netdataIcons[icon];
     // }
-    for (const icon of Object.keys(NETDATA.icons)) {
+    for (icon of Object.keys(NETDATA.icons)) {
         if (typeof(netdataIcons[icon]) === 'string') {
             NETDATA.icons[icon] = netdataIcons[icon]
         }

--- a/web/gui/src/dashboard.js/units-conversion.js
+++ b/web/gui/src/dashboard.js/units-conversion.js
@@ -269,7 +269,7 @@ NETDATA.unitsConversion = {
                 //     }
                 // }
                 const sunit = this.scalableUnits[units];
-                for (const x of Object.keys(sunit)) {
+                for (x of Object.keys(sunit)) {
                     let m = sunit[x];
                     if (m <= max && m > tdivider) {
                         tunits = x;
@@ -305,7 +305,7 @@ NETDATA.unitsConversion = {
 
                     // find the max divider of all charts
                     let common_units = t[uuid];
-                    for (const x in t) {
+                    for (x in t) {
                         if (t.hasOwnProperty(x) && t[x].divider > common_units.divider) {
                             common_units = t[x];
                         }
@@ -372,7 +372,7 @@ NETDATA.unitsConversion = {
         } else if (typeof this.convertibleUnits[units] !== 'undefined') {
             // units that can be converted
             if (desired_units === 'auto') {
-                for (const x in this.convertibleUnits[units]) {
+                for (x in this.convertibleUnits[units]) {
                     if (this.convertibleUnits[units].hasOwnProperty(x)) {
                         if (this.convertibleUnits[units][x].check(max)) {
                             //console.log('DEBUG: ' + uuid.toString() + ' converting ' + units.toString() + ' to: ' + x.toString());

--- a/web/gui/src/dashboard.js/utils.js
+++ b/web/gui/src/dashboard.js/utils.js
@@ -75,7 +75,7 @@ NETDATA.seconds4human = function (seconds, options) {
     if (typeof options !== 'object') {
         options = defaultOptions;
     } else {
-        for (const x in defaultOptions) {
+        for (x in defaultOptions) {
             if (typeof options[x] !== 'string') {
                 options[x] = defaultOptions[x];
             }

--- a/web/gui/src/dashboard.js/xss.js
+++ b/web/gui/src/dashboard.js/xss.js
@@ -42,7 +42,7 @@ NETDATA.xss = {
                 } else {
                     // console.log('checking object "' + name + '"');
 
-                    for (const i in obj) {
+                    for (i in obj) {
                         if (obj.hasOwnProperty(i) === false) {
                             continue;
                         }


### PR DESCRIPTION
IE11 seems to have problems with the `for (const...` construct. This commit removes all occurrences of  this construct.