### PR TITLE
smartd_log: ata 194 attr fix

### DIFF
--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -453,6 +453,11 @@ class Ata190(BaseAtaSmartAttribute):
         return 100 - int(self.normalized_value)
 
 
+class Ata194(BaseAtaSmartAttribute):
+    def value(self):
+        return min(int(self.normalized_value), int(self.raw_value))
+
+
 class BaseSCSISmartAttribute:
     def __init__(self, name, raw_value):
         self.name = name
@@ -474,10 +479,11 @@ def ata_attribute_factory(value):
         return Ata9(*value)
     elif name == ATTR190:
         return Ata190(*value)
+    elif name == ATTR194:
+        return Ata194(*value)
     elif name in [
         ATTR1,
         ATTR7,
-        ATTR194,
         ATTR202,
         ATTR206,
     ]:


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fix : #3041

##### Component Name

python.d `smartd_log` module

##### Additional Information
```
if disk_name like "Seagate*" get 2nd value from the csv column.
194;43;73014444075;
if disk_name like "WD*" get 3rd value from the csv column.
194;110;37;
```

Fix - use `min` value as temperature


@terba 