### PR TITLE
RabbitMQ chart for message rates should be "line"

### DIFF
--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -111,7 +111,7 @@ CHARTS = {
         ]
     },
     'message_rates': {
-        'options': [None, 'Message Rates', 'messages/s', 'overview', 'rabbitmq.message_rates', 'stacked'],
+        'options': [None, 'Message Rates', 'messages/s', 'overview', 'rabbitmq.message_rates', 'line'],
         'lines': [
             ['message_stats_ack', 'ack', 'incremental'],
             ['message_stats_redeliver', 'redeliver', 'incremental'],

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -64,13 +64,13 @@ CHARTS = {
         ]
     },
     'memory': {
-        'options': [None, 'Memory', 'MB', 'overview', 'rabbitmq.memory', 'line'],
+        'options': [None, 'Memory', 'MB', 'overview', 'rabbitmq.memory', 'area'],
         'lines': [
             ['mem_used', 'used', 'absolute', 1, 1024 << 10]
         ]
     },
     'disk_space': {
-        'options': [None, 'Disk Space', 'GB', 'overview', 'rabbitmq.disk_space', 'line'],
+        'options': [None, 'Disk Space', 'GB', 'overview', 'rabbitmq.disk_space', 'area'],
         'lines': [
             ['disk_free', 'free', 'absolute', 1, 1024 ** 3]
         ]


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

I changed a types of chars for RabbitMQ.

Chart for message rates should be "line". It is because for correct system the "ack", "deliver" and "publish" should be similar and it is much easier to notice it with "line" type of chart.

Usually for memory and disk space we use "area" type so it is changed too.

##### Component Name

collector rabbitmq
