### PR TITLE
Add doc before path to GA in static site

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -52,7 +52,6 @@ docs_dir: src
 site_dir: build
 #use_directory_urls: false
 strict: true
-google_analytics: ["UA-64295674-3", ""]
 extra:
   social:
     - type: "github"

--- a/docs/generator/custom/themes/material/partials/footer.html
+++ b/docs/generator/custom/themes/material/partials/footer.html
@@ -51,3 +51,4 @@
     </div>
   </div>
 </footer>
+<script>!function(e,a,t,n,o,c,i){e.GoogleAnalyticsObject=o,e.ga=e.ga||function(){(e.ga.q=e.ga.q||[]).push(arguments)},e.ga.l=1*new Date,c=a.createElement(t),i=a.getElementsByTagName(t)[0],c.async=1,c.src="https://www.google-analytics.com/analytics.js",i.parentNode.insertBefore(c,i)}(window,document,"script",0,"ga"),ga("create","UA-64295674-3",""),ga("set","anonymizeIp",!0),ga("send","pageview","/doc"+window.location.pathname);var links=document.getElementsByTagName("a");if(Array.prototype.map.call(links,function(a){a.host!=document.location.host&&a.addEventListener("click",function(){var e=a.getAttribute("data-md-action")||"follow";ga("send","event","outbound",e,a.href)})}),document.forms.search){var query=document.forms.search.query;query.addEventListener("blur",function(){if(this.value){var e=document.location.pathname;ga("send","pageview",e+"?q="+this.value)}})}</script>


### PR DESCRIPTION
##### Summary
Remove mkdocs GA generator (can't be customized)
Add GA code to mkdocs-material footer.html and customize it to add '/doc' before the path, so we can distinguish these hits in GA.

##### Component Name
docs


