### PR TITLE
Add support for providing FQDN in alarm notifications.

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -198,7 +198,7 @@ if [ ${1} = "unittest" ] ; then
     old_status="${5}"          # the previous status: REMOVED, UNINITIALIZED, UNDEFINED, CLEAR, WARNING, CRITICAL
 else
     roles="${1}"               # the roles that should be notified for this event
-    host="${2}"                # the host generated this event
+    args_host="${2}"                # the host generated this event
     unique_id="${3}"           # the unique id of this event
     alarm_id="${4}"            # the unique id of the alarm that generated this event
     event_id="${5}"            # the incremental id of the event, for this alarm id
@@ -222,9 +222,14 @@ fi
 # -----------------------------------------------------------------------------
 # find a suitable hostname to use, if netdata did not supply a hostname
 
-this_host=$(hostname -s 2>/dev/null)
-[ -z "${host}" ] && host="${this_host}"
-args_host="${host}"
+if [ -z ${args_host} ]
+    then
+    this_host=$(hostname -s 2>/dev/null)
+    host="${this_host}"
+    args_host="${this_host}"
+else
+    host="${args_host}"
+fi
 
 # -----------------------------------------------------------------------------
 # screen statuses we don't need to send a notification
@@ -383,8 +388,7 @@ fi
 # FQDN of easily.
 if [ "${use_fqdn}" = "YES" -a "${host}" = "$(hostname -s 2>/dev/null)" ]
     then
-    this_host=$(hostname -f 2>/dev/null)
-    host="${this_host:-${host}}"
+    host="$(hostname -f 2>/dev/null)"
 fi
 
 # -----------------------------------------------------------------------------

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -224,6 +224,7 @@ fi
 
 this_host=$(hostname -s 2>/dev/null)
 [ -z "${host}" ] && host="${this_host}"
+args_host="${host}"
 
 # -----------------------------------------------------------------------------
 # screen statuses we don't need to send a notification
@@ -253,6 +254,9 @@ images_base_url="https://registry.my-netdata.io"
 
 # curl options to use
 curl_options=""
+
+# hostname handling
+use_fqdn="NO"
 
 # needed commands
 # if empty they will be searched in the system path
@@ -372,6 +376,15 @@ fi
 if [ -z ${EMAIL_CHARSET} ]
     then
     EMAIL_CHARSET="UTF-8"
+fi
+
+# If we've been asked to use FQDN's for the URL's in the alarm, do so,
+# unless we're sending an alarm for a slave system which we can't get the
+# FQDN of easily.
+if [ "${use_fqdn}" = "YES" -a "${host}" = "$(hostname -s 2>/dev/null)" ]
+    then
+    this_host=$(hostname -f 2>/dev/null)
+    host="${this_host:-${host}}"
 fi
 
 # -----------------------------------------------------------------------------
@@ -1277,7 +1290,7 @@ send_slack() {
                         }
                     ],
                     "thumb_url": "${image}",
-                    "footer": "by <${goto_url}|${this_host}>",
+                    "footer": "by <${goto_url}|${host}>",
                     "ts": ${when}
                 }
             ]
@@ -1410,7 +1423,7 @@ send_alerta() {
                 "source": "${src}",
                 "moreInfo": "<a href=\"${goto_url}\">View Netdata</a>"
             },
-            "origin": "netdata/${this_host}",
+            "origin": "netdata/${host}",
             "type": "netdataAlarm",
             "rawData": "${BASH_ARGV[@]}"
         }
@@ -1536,7 +1549,7 @@ send_discord() {
                     ],
                     "thumb_url": "${image}",
                     "footer_icon": "${images_base_url}/images/banner-icon-144x144.png",
-                    "footer": "${this_host}",
+                    "footer": "${host}",
                     "ts": ${when}
                 }
             ]
@@ -1734,7 +1747,7 @@ send_syslog() {
 # prepare the content of the notification
 
 # the url to send the user on click
-urlencode "${host}" >/dev/null; url_host="${REPLY}"
+urlencode "${args_host}" >/dev/null; url_host="${REPLY}"
 urlencode "${chart}" >/dev/null; url_chart="${REPLY}"
 urlencode "${family}" >/dev/null; url_family="${REPLY}"
 urlencode "${name}" >/dev/null; url_name="${REPLY}"
@@ -2055,7 +2068,7 @@ Severity: ${severity}
 URL     : ${goto_url}
 Source  : ${src}
 Date    : ${date}
-Notification generated on ${this_host}
+Notification generated on ${host}
 
 --multipart-boundary
 Content-Type: text/html; encoding=${EMAIL_CHARSET}
@@ -2128,7 +2141,7 @@ Content-Transfer-Encoding: 8bit
                                     </tr>
                                     <tr style="text-align: center; margin: 0; padding: 0;">
                                         <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 12px; vertical-align: top; margin:0; padding: 20px 0 0 0; color: #666666; border-top: 1px solid #f0f0f0;" align="center" valign="bottom">Sent by
-                                            <a href="https://mynetdata.io/" target="_blank">netdata</a>, the real-time performance and health monitoring, on <code>${this_host}</code>.
+                                            <a href="https://mynetdata.io/" target="_blank">netdata</a>, the real-time performance and health monitoring, on <code>${host}</code>.
                                         </td>
                                     </tr>
                                     </tbody>

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -64,6 +64,17 @@ date_format=''
 
 
 #------------------------------------------------------------------------------
+# hostname handling
+#
+# By default, Netdata will use the simple hostname for the system (the
+# hostname with everything after the first `.` removed) when displaying
+# the hostname in alert notifications.  If you prefer, you can uncomment
+# the line below to have Netdata instead use the host's fully qualified
+# domain name.  This only works for alerts for the local system.
+#use_fqdn='YES'
+
+
+#------------------------------------------------------------------------------
 # external commands
 
 # The full path to the sendmail command.

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -70,7 +70,14 @@ date_format=''
 # hostname with everything after the first `.` removed) when displaying
 # the hostname in alert notifications.  If you prefer, you can uncomment
 # the line below to have Netdata instead use the host's fully qualified
-# domain name.  This only works for alerts for the local system.
+# domain name.
+#
+# This does not report correct FQDN's for slave systems for which this
+# sytem is a master.
+#
+# Additionally, if the system host name is overridden in /etc/netdata.conf
+# with the `hostname` option, that name will be used unconditionally
+# instead of this.
 #use_fqdn='YES'
 
 


### PR DESCRIPTION
##### Summary
This adds an option to alarm-notify.sh to make it use the system's FQDN instead of it's simple hostname when sending alarm notifications.  This can be enabled by adding `use_fqdn="YES"` to `health_alarm_notify.conf`.

This does not work correctly for alarms being sent by a master node on behalf of a slave system, and includes an explicit check so that it falls back to just sending the simple hostname in such cases.

This commit also cleans up misuse of the `${this_host}` variable, which is supposed to just be a temporary variable.

##### Component Name
health

##### Additional Information
Minimally tested, it runs correctly on my systems and does as advertised.

Relevant to:#809

Fixes: #2477 
