### PR TITLE
Fix link in streaming hosts list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -121,5 +121,6 @@ username|name|email (optional)
 @pohzipohzi|Poh Zi How
 @vladmovchan|Vladyslav Movchan|vladislav.movchan@gmail.com
 @gmosx|George Moschovitis
+@adherzog|Adam Herzog|adam@adamherzog.com
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2FCONTRIBUTORS&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)]()

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -517,7 +517,7 @@ function renderStreamedHosts(options) {
         const hostname = s.hostname;
 
         if (hostname === master) {
-            url = `base${'/'}`;
+            url = `${base}/`;
             icon = 'home';
         } else {
             url = `${base}/host/${hostname}/`;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

In the 'my-netdata' menu, under the list of streamed hosts, the URL for the 'master' host is incorrect. This fixes the URL so that the link works as intended.

##### Component Name

web

##### Additional Information

This looks like it was just incorrectly interpolating vars when building URL. The diff here is straightforward enough that I don't think it warrants much more explanation.

The list of streamed hosts only appears on hosts that receive streaming data.

I believe this bug was introduced as part of #4590.