### PR TITLE
Prevent netdata-updater.sh from sending cron report for git stash entries

### DIFF
--- a/installer/netdata-updater.sh
+++ b/installer/netdata-updater.sh
@@ -93,7 +93,11 @@ update() {
 			failed "CANNOT GET LAST COMMIT ID (use -f for force re-install)"
 		fi
 
-		info "Stashing local git changes. You can use $(git stash pop) to reapply your changes."
+		popmsg="$(git stash pop 2>&1)"
+		if [ $? -eq 0 ] ; then 
+			info "Stashing local git changes. You can use ${popmsg} to reapply your changes."
+		fi
+
 		git stash 2>&3 >&3
 		git fetch --all 2>&3 >&3
 		git fetch --tags 2>&3 >&3


### PR DESCRIPTION
##### Summary
Fixes: #4950 

##### Component Name
installer

##### Additional Information
Separate the git pop command and capture its output. Show info message only if it exits with a 0
