### PR TITLE
Add mdstat to CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ set(PROC_PLUGIN_FILES
         collectors/proc.plugin/plugin_proc.c
         collectors/proc.plugin/plugin_proc.h
         collectors/proc.plugin/proc_diskstats.c
+        collectors/proc.plugin/proc_mdstat.c
         collectors/proc.plugin/proc_interrupts.c
         collectors/proc.plugin/proc_softirqs.c
         collectors/proc.plugin/proc_loadavg.c


### PR DESCRIPTION
##### Summary
Fix building error when using CMake

##### Component Name
CMake configuration