### PR TITLE
postgres timeouts

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -17,6 +17,12 @@ except ImportError:
 from bases.FrameworkServices.SimpleService import SimpleService
 
 
+DEFAULT_PORT = 5432
+DEFAULT_USER = 'postgres'
+DEFAULT_CONNECT_TIMEOUT = 2       # seconds
+DEFAULT_STATEMENT_TIMEOUT = 2000  # ms
+
+
 WAL = 'WAL'
 ARCHIVE = 'ARCHIVE'
 BACKENDS = 'BACKENDS'
@@ -787,6 +793,7 @@ class Service(SimpleService):
         self.do_table_stats = configuration.pop('table_stats', False)
         self.do_index_stats = configuration.pop('index_stats', False)
         self.databases_to_poll = configuration.pop('database_poll', None)
+        self.statement_timeout = configuration.pop('statement_timeout', DEFAULT_STATEMENT_TIMEOUT)
         self.configuration = configuration
 
         self.conn = None
@@ -811,11 +818,15 @@ class Service(SimpleService):
             self.conn = None
 
         try:
-            params = dict(user='postgres',
-                          database=None,
-                          password=None,
-                          host=None,
-                          port=5432)
+            params = dict(
+                host=None,
+                port=DEFAULT_PORT,
+                database=None,
+                user=DEFAULT_USER,
+                password=None,
+                connect_timeout=DEFAULT_CONNECT_TIMEOUT,
+                options='-c statement_timeout={0}'.format(self.statement_timeout),
+            )
             params.update(self.configuration)
 
             self.conn = psycopg2.connect(**params)

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -20,7 +20,7 @@ from bases.FrameworkServices.SimpleService import SimpleService
 DEFAULT_PORT = 5432
 DEFAULT_USER = 'postgres'
 DEFAULT_CONNECT_TIMEOUT = 2       # seconds
-DEFAULT_STATEMENT_TIMEOUT = 2000  # ms
+DEFAULT_STATEMENT_TIMEOUT = 5000  # ms
 
 
 WAL = 'WAL'

--- a/collectors/python.d.plugin/postgres/postgres.conf
+++ b/collectors/python.d.plugin/postgres/postgres.conf
@@ -63,11 +63,13 @@
 #
 # Connections can be configured with the following options:
 #
-#     database    : 'example_db_name'
-#     user        : 'example_user'
-#     password    : 'example_pass'
-#     host        : 'localhost'
-#     port        : 5432
+#     database            : 'example_db_name'
+#     user                : 'example_user'
+#     password            : 'example_pass'
+#     host                : 'localhost'
+#     port                : 5432
+#     connect_timeout     : 2     # in seconds, default is 2
+#     statement_timeout   : 2000  # in ms, default is 2000
 #
 # Additionally, the following options allow selective disabling of charts
 #


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
added to postgres module

- `connect_timeout` (default is 2 sec)
- `statement_timeout` (default is 5000ms)

##### Component Name

`netdata/collectors/python.d.plugin/postgres`

##### Additional Information

Based on 
https://github.com/netdata/netdata/pull/4944#issuecomment-446754970
https://github.com/netdata/netdata/pull/4944#issuecomment-447258227

@anayrat 

`connect_timeout` works nice

But i have problems with `statement_timeout`. 

I tried to emulate network/other delay/issues with iptables - `iptables -A INPUT -p tcp --dport 5432 -j DROP`. Module hangs forever, `statement_timeout` doesn't help.

But

```
>>> import os
>>> os.environ['PGOPTIONS'] = '-c statement_timeout=1000'
>>> import psycopg2
>>> cnn = psycopg2.connect("dbname=test")
>>> cur = cnn.cursor()
>>> cur.execute("select pg_sleep(2000)")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
psycopg2.extensions.QueryCanceledError: canceling statement due to statement timeout
```

it works in such cases^^
