### PR TITLE
[WIP] add healthcheck command to docker image

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -101,4 +101,8 @@ RUN \
 ENV NETDATA_PORT 19999
 EXPOSE $NETDATA_PORT
 
+# Assume everything works fine when netdata presents metrics api enpoint.
+HEALTHCHECK --interval=3s --timeout=5s \
+    CMD [ "curl", "-f", "localhost:$NETDATA_PORT/api/v1/allmetrics" ]
+
 ENTRYPOINT ["/usr/sbin/run.sh"]


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Adding a rudimentary healthchecking command to docker image.

##### Component Name
docker packaging

##### Additional Information
According to documentation there is no `/health` or similar endpoint, so this is checking if netdata returns 200 on `/api/v1/allmetrics` endpoint. In the future it would be good to replace this command with a more adequate implementation which includes internal healthchecking.
