### PR TITLE
Update cgroup-name.sh.in

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -133,6 +133,19 @@ if [ -z "${NAME}" ]
         else
             error "a docker id cannot be extracted from docker cgroup '${CGROUP}'."
         fi
+    elif [[ "${CGROUP}" =~ ^.*ecs[-_/\.][a-fA-F0-9]+[-_\.]?.*$ ]]
+        then
+        # ECS
+
+        DOCKERID="$( echo "${CGROUP}" | sed "s|^.*ecs[-_/].*[-_/]\([a-fA-F0-9]\+\)[-_\.]\?.*$|\1|" )"
+        # echo "DOCKERID=${DOCKERID}"
+
+        if [ ! -z "${DOCKERID}" -a \( ${#DOCKERID} -eq 64 -o ${#DOCKERID} -eq 12 \) ]
+            then
+            docker_get_name "${DOCKERID}"
+        else
+            error "a docker id cannot be extracted from docker cgroup '${CGROUP}'."
+        fi 
     elif [[ "${CGROUP}" =~ ^.*kubepods[_/].*[_/]pod[a-fA-F0-9-]+[_/][a-fA-F0-9]+$ ]]
         then
         # kubernetes


### PR DESCRIPTION
##### Summary
Not a perfect fix, but does get the container name if using ECS into netdata graphs. See #4981 
##### Component Name
collectors/cgropus.plugin/cgroup-name.sh.in
##### Additional Information
I'm not familiar enough with the way this gets called so it's tough to test, but this changes the random string of numbers currently being pulled when using ECS to the actual container name.
