### PR TITLE
Fix crash in mdstat module

### DIFF
--- a/collectors/proc.plugin/proc_mdstat.c
+++ b/collectors/proc.plugin/proc_mdstat.c
@@ -361,9 +361,9 @@ int do_proc_mdstat(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(likely(do_health)) {
+    if(likely(do_health && redundant_num)) {
         static RRDSET *st_mdstat_health = NULL;
-        if(unlikely(!st_mdstat_health && redundant_num)) {
+        if(unlikely(!st_mdstat_health)) {
             st_mdstat_health = rrdset_create_localhost(
                     "mdstat"
                     , "mdstat_health"


### PR DESCRIPTION
##### Summary
The module was crashing on Netdata start if raid0 was the only array in the list.

Fixes #4990
 
##### Component Name
`proc` plugin