### PR TITLE
allow development build

### DIFF
--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -27,8 +27,8 @@ if [ -z ${DEVEL+x} ]; then
     BG="&"
 else
     declare -a ARCHITECTURES=(amd64)
-    DOCKER_PASSWORD=""
-    DOCKER_USERNAME=""
+    unset DOCKER_PASSWORD
+    unset DOCKER_USERNAME
     BG=""
 fi
 

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -20,20 +20,26 @@ if [ "${VERSION}" == "" ]; then
     VERSION="latest"
 fi
 
-REPOSITORY="${REPOSITORY:-netdata}"
-
-echo "Building $VERSION of netdata container"
-
 declare -A ARCH_MAP
 ARCH_MAP=( ["i386"]="386" ["amd64"]="amd64" ["armhf"]="arm" ["aarch64"]="arm64")
+if [ -z ${DEVEL+x} ]; then
+    declare -a ARCHITECTURES=(i386 armhf aarch64 amd64)
+else
+    declare -a ARCHITECTURES=(amd64)
+    DOCKER_PASSWORD=""
+    DOCKER_USERNAME=""
+fi
+
+REPOSITORY="${REPOSITORY:-netdata}"
+echo "Building ${VERSION} of ${REPOSITORY} container"
 
 docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 # Build images using multi-arch Dockerfile.
-for ARCH in i386 armhf aarch64 amd64; do
+for ARCH in "${ARCHITECTURES[@]}"; do
      docker build --build-arg ARCH="${ARCH}-v3.8" \
                   --tag "${REPOSITORY}:${VERSION}-${ARCH}" \
-                  --file packaging/docker/Dockerfile ./ &
+                  --file packaging/docker/Dockerfile ./
 done
 wait
 

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -24,10 +24,12 @@ declare -A ARCH_MAP
 ARCH_MAP=( ["i386"]="386" ["amd64"]="amd64" ["armhf"]="arm" ["aarch64"]="arm64")
 if [ -z ${DEVEL+x} ]; then
     declare -a ARCHITECTURES=(i386 armhf aarch64 amd64)
+    BG="&"
 else
     declare -a ARCHITECTURES=(amd64)
     DOCKER_PASSWORD=""
     DOCKER_USERNAME=""
+    BG=""
 fi
 
 REPOSITORY="${REPOSITORY:-netdata}"
@@ -37,9 +39,9 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 # Build images using multi-arch Dockerfile.
 for ARCH in "${ARCHITECTURES[@]}"; do
-     docker build --build-arg ARCH="${ARCH}-v3.8" \
+     eval docker build --build-arg ARCH="${ARCH}-v3.8" \
                   --tag "${REPOSITORY}:${VERSION}-${ARCH}" \
-                  --file packaging/docker/Dockerfile ./
+                  --file packaging/docker/Dockerfile ./ ${BG}
 done
 wait
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Allow to build only single (development) image of netdata.
This allows to reproduce locally any PR with a couple of simple steps:
```bash
# Checkout a PR, for example by using [hub](https://github.com/github/hub):
hub pr  checkout <PR_NUMBER>

# Build docker image for this PR
export DEVEL=true
./packaging/docker/build.sh

# Run just built image
docker run -d --name=netdata -p 19999:19999 -v /proc:/host/proc:ro -v /sys:/host/sys:ro -v /var/run/docker.sock:/var/run/docker.sock:ro --cap-add SYS_PTRACE --security-opt apparmor=unconfined netdata:latest-amd64

# Go into a container or go to localhost:19999 to see netdata dashboard
docker exec -it netdata bash
```

##### Component Name
packaging
docker

##### Additional Information

