### PR TITLE
Fix missing method_name: kavenegar

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -163,6 +163,7 @@ fleep
 syslog
 custom
 msteam
+kavenegar
 "
 
 # -----------------------------------------------------------------------------
@@ -318,8 +319,8 @@ MESSAGEBIRD_ACCESS_KEY=
 MESSAGEBIRD_NUMBER=
 
 # kavenegar configs
-KAVENEGAR_API_KEY=""
-KAVENEGAR_SENDER=""
+KAVENEGAR_API_KEY=
+KAVENEGAR_SENDER=
 
 # telegram configs
 TELEGRAM_BOT_TOKEN=


### PR DESCRIPTION


<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Kavenegar was missing in new alarm-notify.sh

##### Just method_names has been changed and related configs.

##### Add missing kavenegar in method_names variable

