### PR TITLE
copy artifacts to 'upload/'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ sha256sums.txt
 # netdata binaries
 netdata
 !netdata/
+upload/
 
 apps.plugin
 !apps.plugin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,7 @@ jobs:
       credentials: .travis/gcs-credentials.json
       bucket: "netdata-nightlies"
       skip_cleanup: true
-      file_glob: true
-      file: "netdata*.tar.gz"
+      local_dir: "upload"
   - name: changelog generation
     script: ".travis/generate_changelog.sh"
     env: COMMIT_AND_PUSH=1

--- a/.travis/create_artifacts.sh
+++ b/.travis/create_artifacts.sh
@@ -16,6 +16,11 @@ make dist
 echo "--- Create self-extractor ---"
 ./makeself/build-x86_64-static.sh
 
+# Needed fo GCS
+echo "--- Copy artifacts to bin ---"
+mkdir upload
+cp ./*.tar.gz ./*.gz.run upload/
+
 echo "--- Create checksums ---"
 GIT_TAG=$(git tag --points-at)
 if [ "${GIT_TAG}" != "" ]; then


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
GCS-ng doesn't respect uploading per file and wants to upload everything from a directory. This creates a temporary `upload` directory which contains nightly artifacts.

Fixes #4919

##### Component Name
CI

##### Additional Information

Configuration schema taken from https://github.com/travis-ci/dpl/issues/792#issuecomment-437486639