### PR TITLE
New option clear_alarm_always

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -243,7 +243,7 @@ then
 fi
 
 # don't do anything if this is CLEAR, but it was not WARNING or CRITICAL
-if [ "${old_status}" != "WARNING" -a "${old_status}" != "CRITICAL" -a "${status}" = "CLEAR" ]
+if [ "${clear_alarm_always}" != "YES" -a "${old_status}" != "WARNING" -a "${old_status}" != "CRITICAL" -a "${status}" = "CLEAR" ]
 then
     info "not sending notification for ${status} of '${host}.${chart}.${name}' (last status was ${old_status})"
     exit 1

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -127,6 +127,14 @@ aws=""
 #logger_options=""
 
 #------------------------------------------------------------------------------
+# extra options
+
+# By default don't do anything if this is CLEAR, but it was not WARNING or CRITICAL.
+# You can send it always if your system makes deduplication for alarms.
+#clear_alarm_always='YES'
+
+#
+#------------------------------------------------------------------------------
 # NOTE ABOUT RECIPIENTS
 #
 # When you define recipients (all types):


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Netdata after restart might clear the status of previous alarm to UNINITIALIZED. In that case in Alerta we can have a status not cleared correctly. It is not a problem to send it once again because Alerta does deduplication of alerts by itself.

##### Component Name

health/notifications

##### Additional Information

It is just additional variable in health_alarm_notify.conf
