### PR TITLE
Unify versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,17 +56,15 @@ jobs:
       depth: false
 
   - stage: nightlies
-    name: docker images
+    name: Nightly build
+    before_install: openssl aes-256-cbc -K $encrypted_8daf19481253_key -iv $encrypted_8daf19481253_iv -in .travis/gcs-credentials.json.enc -out .travis/gcs-credentials.json -d
     install:
-    - sudo apt update
+    - sudo apt-get install -y gnupg libcap2-bin zlib1g-dev uuid-dev fakeroot
     - sudo apt install -y --only-upgrade docker-ce
     - docker info
-    script: "packaging/docker/build.sh"
-    env: REPOSITORY="netdata/netdata"
-  - name: tarball and self-extractor build
-    before_install: openssl aes-256-cbc -K $encrypted_8daf19481253_key -iv $encrypted_8daf19481253_iv -in .travis/gcs-credentials.json.enc -out .travis/gcs-credentials.json -d
-    install: sudo apt-get install -y gnupg libcap2-bin zlib1g-dev uuid-dev fakeroot
-    script: ".travis/create_artifacts.sh"
+    script: ".travis/nightlies.sh"
+    git:
+      depth: false
     deploy:
       provider: gcs
       edge:
@@ -76,11 +74,6 @@ jobs:
       bucket: "netdata-nightlies"
       skip_cleanup: true
       local_dir: "upload"
-  - name: changelog generation
-    script: ".travis/generate_changelog.sh"
-    env: COMMIT_AND_PUSH=1
-    git:
-      depth: false
 
 notifications:
   webhooks: https://app.fossa.io/hooks/travisci

--- a/.travis/generate_changelog.sh
+++ b/.travis/generate_changelog.sh
@@ -7,7 +7,6 @@ if [ ! -f .gitignore ]; then
 	exit 1
 fi
 
-COMMIT_AND_PUSH=${COMMIT_AND_PUSH:-0}
 ORGANIZATION=$(echo "$TRAVIS_REPO_SLUG" | awk -F '/' '{print $1}')
 PROJECT=$(echo "$TRAVIS_REPO_SLUG" | awk -F '/' '{print $2}')
 GIT_MAIL=${GIT_MAIL:-"pawel+bot@netdata.cloud"}
@@ -18,10 +17,6 @@ if [ -z ${GIT_TAG+x} ]; then
 else
 	OPTS="--future-release ${GIT_TAG}"
 fi
-
-echo "--- Initialize git configuration ---"
-git config user.email "${GIT_MAIL}"
-git config user.name "${GIT_USER}"
 
 echo "--- Creating changelog ---"
 git checkout master
@@ -36,9 +31,3 @@ docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest
 	--exclude-labels "stale,duplicate,question,invalid,wontfix,discussion,no changelog" \
 	--no-compare-link ${OPTS}
 
-echo "--- Uploading changelog ---"
-git add CHANGELOG.md
-if [ "${COMMIT_AND_PUSH}" == "1" ]; then
-	git commit -m '[ci skip] Automatic changelog update' || exit 0
-	git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')"
-fi

--- a/.travis/nightlies.sh
+++ b/.travis/nightlies.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -f .gitignore ]; then
+	echo "Run as ./travis/$(basename "$0") from top level directory of git repository"
+	exit 1
+fi
+
+export GIT_MAIL="pawel+bot@netdata.cloud"
+export GIT_USER="netdatabot"
+echo "--- Initialize git configuration ---"
+git config user.email "${GIT_MAIL}"
+git config user.name "${GIT_USER}"
+
+echo "--- UPDATE VERSION FILE ---"
+LAST_TAG=$(git describe --abbrev=0 --tags)
+NO_COMMITS=$(git rev-list "$LAST_TAG"..HEAD --count)
+echo "$LAST_TAG-$((NO_COMMITS + 1))-nightly" >packaging/version
+git add packaging/version
+
+echo "---- GENERATE CHANGELOG -----"
+.travis/generate_changelog.sh
+git add CHANGELOG.md
+
+echo "---- UPLOAD FILE CHANGES ----"
+git commit -m '[ci skip] create nightly packages and update changelog'
+git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')"
+
+echo "---- BUILD & PUBLISH DOCKER IMAGES ----"
+export REPOSITORY="netdata/netdata"
+packaging/docker/build.sh
+
+echo "---- BUILD ARTIFACTS ----"
+.travis/create_artifacts.sh

--- a/.travis/releaser.sh
+++ b/.travis/releaser.sh
@@ -42,8 +42,13 @@ echo "---- FIGURING OUT TAGS ----"
 #shellcheck source=/dev/null
 source .travis/tagger.sh || exit 0
 
-echo "---- GENERATING CHANGELOG -----"
+echo "---- UPDATE VERSION FILE ----"
+echo "$GIT_TAG" >packaging/version
+git add packaging/version
+
+echo "---- GENERATE CHANGELOG -----"
 ./.travis/generate_changelog.sh
+git add CHANGELOG.md
 
 echo "---- COMMIT AND PUSH CHANGES ----"
 git commit -m "[ci skip] release $GIT_TAG"

--- a/.travis/tagger.sh
+++ b/.travis/tagger.sh
@@ -24,19 +24,6 @@ if [ ! -f .gitignore ]; then
 	exit 1
 fi
 
-# Embed new version in files which need it.
-# This wouldn't be needed if we could use `git tag` everywhere.
-function embed_version() {
-	VERSION="$1"
-	MAJOR=$(echo "$GIT_TAG" | cut -d . -f 1 | cut -d v -f 2)
-	MINOR=$(echo "$GIT_TAG" | cut -d . -f 2)
-	PATCH=$(echo "$GIT_TAG" | cut -d . -f 3 | cut -d '-' -f 1)
-	sed -i "s/\\[VERSION_MAJOR\\], \\[.*\\]/\\[VERSION_MAJOR\\], \\[$MAJOR\\]/" configure.ac
-	sed -i "s/\\[VERSION_MINOR\\], \\[.*\\]/\\[VERSION_MINOR\\], \\[$MINOR\\]/" configure.ac
-	sed -i "s/\\[VERSION_PATCH\\], \\[.*\\]/\\[VERSION_PATCH\\], \\[$PATCH\\]/" configure.ac
-	git add configure.ac
-}
-
 # Figure out what will be new release candidate tag based only on previous ones.
 # This assumes that RELEASES are in format of "v0.1.2" and prereleases (RCs) are using "v0.1.2-rc0"
 function release_candidate() {
@@ -71,5 +58,4 @@ if [ -z "${GIT_TAG}" ]; then
 		;;
 	esac
 fi
-embed_version "$GIT_TAG"
 export GIT_TAG

--- a/configure.ac
+++ b/configure.ac
@@ -4,24 +4,17 @@
 #
 AC_PREREQ(2.60)
 
-define([VERSION_MAJOR], [1])
-define([VERSION_MINOR], [12])
-define([VERSION_FIX], [1])
-define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
-
 # We do not use m4_esyscmd_s to support older autoconf.
-define([VERSION_STRING], m4_esyscmd(git describe 2>/dev/null | sed 's/^v//' | tr -d '\n'))
-m4_ifval(VERSION_STRING, [], [define([VERSION_STRING], VERSION_NUMBER)])
+define([VERSION_STRING], m4_esyscmd([git describe 2>/dev/null | tr -d '\n']))
 
 AC_INIT([netdata], VERSION_STRING[])
 
 AM_MAINTAINER_MODE([disable])
 if test x"$USE_MAINTAINER_MODE" = xyes; then
 AC_MSG_NOTICE(***************** MAINTAINER MODE *****************)
-PACKAGE_BUILT_DATE=$(date '+%d %b %Y')
 fi
 
-PACKAGE_RPM_VERSION="VERSION_NUMBER"
+PACKAGE_RPM_VERSION="VERSION_STRING"
 AC_SUBST([PACKAGE_RPM_VERSION])
 
 # -----------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AC_PREREQ(2.60)
 
 # We do not use m4_esyscmd_s to support older autoconf.
 define([VERSION_STRING], m4_esyscmd([git describe 2>/dev/null | tr -d '\n']))
+define([VERSION_FROM_FILE], m4_esyscmd([cat packaging/version | tr -d '\n']))
+m4_ifval(VERSION_STRING, [], [define([VERSION_STRING], VERSION_FROM_FILE)])
 
 AC_INIT([netdata], VERSION_STRING[])
 

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -87,4 +87,4 @@ run rm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
 FILE="netdata-${FILE_VERSION}.gz.run"
 
 run mv "${NETDATA_INSTALL_PATH}.gz.run" "${FILE}"
-echo >&2 "Self-extracting installer copied to '${FILE}'"
+echo >&2 "Self-extracting installer moved to '${FILE}'"

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -8,8 +8,12 @@ run cd "${NETDATA_SOURCE_PATH}" || exit 1
 # -----------------------------------------------------------------------------
 # find the netdata version
 
-FILE_VERSION="$(git describe 2>/dev/null)"
-if [ -z "${FILE_VERSION}" ]; then
+VERSION="$(git describe 2>/dev/null)"
+if [ -z "${VERSION}" ]; then
+    VERSION=$(cat packaging/version)
+fi
+
+if [ "${VERSION}" == "" ]; then
     echo >&2 "Cannot find version number. Create makeself executable from source code with git tree structure."
     exit 1
 fi
@@ -61,7 +65,7 @@ run rm "${NETDATA_INSTALL_PATH}/sbin" \
 # -----------------------------------------------------------------------------
 # create the makeself archive
 
-run sed "s|NETDATA_VERSION|${FILE_VERSION}|g" <"${NETDATA_MAKESELF_PATH}/makeself.lsm" >"${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
+run sed "s|NETDATA_VERSION|${VERSION}|g" <"${NETDATA_MAKESELF_PATH}/makeself.lsm" >"${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
 
 run "${NETDATA_MAKESELF_PATH}/makeself.sh" \
     --gzip \
@@ -84,7 +88,7 @@ run rm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
 # -----------------------------------------------------------------------------
 # copy it to the netdata build dir
 
-FILE="netdata-${FILE_VERSION}.gz.run"
+FILE="netdata-${VERSION}.gz.run"
 
 run mv "${NETDATA_INSTALL_PATH}.gz.run" "${FILE}"
 echo >&2 "Self-extracting installer moved to '${FILE}'"

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -8,34 +8,11 @@ run cd "${NETDATA_SOURCE_PATH}" || exit 1
 # -----------------------------------------------------------------------------
 # find the netdata version
 
-NOWNER="unknown"
-ORIGIN="$(git config --get remote.origin.url || echo "unknown")"
-if [[ "${ORIGIN}" =~ ^git@github.com:.*/netdata.*$ ]]
-    then
-    NOWNER="${ORIGIN/git@github.com:/}"
-    NOWNER="$( echo ${NOWNER} | cut -d '/' -f 1 )"
-
-elif [[ "${ORIGIN}" =~ ^https://github.com/.*/netdata.*$ ]]
-    then
-    NOWNER="${ORIGIN/https:\/\/github.com\//}"
-    NOWNER="$( echo ${NOWNER} | cut -d '/' -f 1 )"
+FILE_VERSION="$(git describe 2>/dev/null)"
+if [ -z "${FILE_VERSION}" ]; then
+    echo >&2 "Cannot find version number. Create makeself executable from source code with git tree structure."
+    exit 1
 fi
-
-# make sure it does not have any slashes in it
-NOWNER="${NOWNER//\//_}"
-
-if [ "${NOWNER}" = "netdata" ]
-    then
-    NOWNER=
-else
-    NOWNER="-${NOWNER}"
-fi
-
-VERSION="$(git describe || echo "undefined")"
-[ -z "${VERSION}" ] && VERSION="undefined"
-
-FILE_VERSION="${VERSION}-$(uname -m)-$(date +"%Y%m%d-%H%M%S")${NOWNER}"
-
 
 # -----------------------------------------------------------------------------
 # copy the files needed by makeself installation
@@ -109,9 +86,5 @@ run rm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
 
 FILE="netdata-${FILE_VERSION}.gz.run"
 
-run cp "${NETDATA_INSTALL_PATH}.gz.run" "${FILE}"
+run mv "${NETDATA_INSTALL_PATH}.gz.run" "${FILE}"
 echo >&2 "Self-extracting installer copied to '${FILE}'"
-
-[ -f netdata-latest.gz.run ] && rm netdata-latest.gz.run
-run ln -s "${FILE}" netdata-latest.gz.run
-echo >&2 "Self-extracting installer linked to 'netdata-latest.gz.run'"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
This is a PoC of how can we use consistent versioning between various scenarios.
It directly affects 2 packaging scenarios (bash installer, makeself) and indirectly rpm creation as well as deb packages. Docker image versioning is not affected as it follows different principles, but netdata version installed inside a container is still affected.

As a bonus it also simplifies releasing new packages as we don't need to modify `configure.ac` when releasing new packages.

This can be tested by running:
`.travis/create_artifacts.sh` - this will create makeself and tarball archives

Solves #5044

##### Component Name
packaging
ci

##### Additional Information

