### PR TITLE
smartd_log: skip non-CSVs early

### DIFF
--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -650,6 +650,10 @@ class Service(SimpleService):
         return len(self.disks)
 
     def create_disk_from_file(self, full_name,  current_time):
+        if not full_name.endswith(CSV):
+            self.debug('skipping {0}: not a csv file'.format(full_name))
+            return None
+
         name = os.path.basename(full_name).split('.')[-3]
         path = os.path.join(self.log_path, full_name)
 
@@ -657,10 +661,6 @@ class Service(SimpleService):
             return None
 
         if [p for p in self.exclude if p in name]:
-            return None
-
-        if not full_name.endswith(CSV):
-            self.debug('skipping {0}: not a csv file'.format(full_name))
             return None
 
         if not os.access(path, os.R_OK):


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
The smartd_log plugin may see files that don't fit the expected CSV format, in which case the filename decomposition is likely to fail. We can move the "CSV file check" code earlier in the necessary code to avoid this.

Fixes #5079 

##### Component Name
smartd_log plugin

##### Additional Information

