### PR TITLE
UrlService dont respect Retry-After header by default

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -26,6 +26,7 @@ class UrlService(SimpleService):
         self.method = self.configuration.get('method', 'GET')
         self.header = self.configuration.get('header')
         self.request_timeout = self.configuration.get('timeout', 1)
+        self.respect_retry_after_header = self.configuration.get('respect_retry_after_header')
         self.tls_verify = self.configuration.get('tls_verify')
         self.tls_ca_file = self.configuration.get('tls_ca_file')
         self.tls_key_file = self.configuration.get('tls_key_file')
@@ -111,10 +112,14 @@ class UrlService(SimpleService):
         """
         url = url or self.url
         manager = manager or self._manager
+        retry = urllib3.Retry(retries)
+        if hasattr(retries, 'respect_retry_after_header'):
+            retry.respect_retry_after_header = bool(self.respect_retry_after_header)
+
         response = manager.request(method=self.method,
                                    url=url,
                                    timeout=self.request_timeout,
-                                   retries=retries,
+                                   retries=retry,
                                    headers=manager.headers,
                                    redirect=redirect)
         if isinstance(response.data, str):

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -113,15 +113,17 @@ class UrlService(SimpleService):
         url = url or self.url
         manager = manager or self._manager
         retry = urllib3.Retry(retries)
-        if hasattr(retries, 'respect_retry_after_header'):
+        if hasattr(retry, 'respect_retry_after_header'):
             retry.respect_retry_after_header = bool(self.respect_retry_after_header)
 
-        response = manager.request(method=self.method,
-                                   url=url,
-                                   timeout=self.request_timeout,
-                                   retries=retry,
-                                   headers=manager.headers,
-                                   redirect=redirect)
+        response = manager.request(
+            method=self.method,
+            url=url,
+            timeout=self.request_timeout,
+            retries=retry,
+            headers=manager.headers,
+            redirect=redirect,
+        )
         if isinstance(response.data, str):
             return response.status, response.data
         return response.status, response.data.decode()


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
> The Retry-After response HTTP header indicates how long the user agent should wait before making a follow-up request. 

Fixes #5078 

`UrlService` defaults:
 * retries 1
 * [respect_retry_header](https://github.com/pypa/pip/blob/master/src/pip/_vendor/urllib3/util/retry.py#L139-L141) True

Result:
`python.d.plugin` doesn't start and hangs for N seconds if response header contains `Retry-After: N`.
(it was `Retry-After: 3600` in #5078)

___

This PR sets `respect_retry_after_header` to False by default. 

The problem with `respect_retry_after_header` that old version of urllib3 doesn't contain it, so it will work only for new version.

##### Component Name
`/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py`
##### Additional Information

