### PR TITLE
fix permissions for log files when building rpms

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -211,7 +211,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %endif
 
 %attr(0770,netdata,netdata) %dir %{_localstatedir}/cache/%{name}
-%attr(0770,netdata,netdata) %dir %{_localstatedir}/log/%{name}
+%attr(0755,netdata,root) %dir %{_localstatedir}/log/%{name}
 %attr(0770,netdata,netdata) %dir %{_localstatedir}/lib/%{name}
 
 %dir %{_datadir}/%{name}
@@ -242,3 +242,5 @@ rm -rf "${RPM_BUILD_ROOT}"
 %changelog
 * Sun Nov 15 2015 Alon Bar-Lev <alonbl@redhat.com> - 0.0.0-1
 - Initial add.
+* Wed Jan 02 2019 Pawel Krupa <pkrupa@redhat.com> - 0.0.0-2
+- Fix permissions for log files


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fix permissions for log directory in RPM build system

Fixes #4963

##### Component Name
packaging

##### Additional Information

