### PR TITLE
postgres : fix WAL query

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -154,7 +154,7 @@ FROM
           ELSE 'written'
         END AS type
     FROM pg_catalog.pg_ls_dir('pg_wal') AS wal(name)
-    WHERE name ~ '^[0-9A-F]{{24}}$'
+    WHERE name ~ '^[0-9A-F]{24}$'
     ORDER BY
         (pg_stat_file('pg_wal/'||name)).modification,
         wal.name DESC) sub;
@@ -181,7 +181,7 @@ FROM
           ELSE 'written'
         END AS type
     FROM pg_catalog.pg_ls_dir('pg_xlog') AS wal(name)
-    WHERE name ~ '^[0-9A-F]{{24}}$'
+    WHERE name ~ '^[0-9A-F]{24}$'
     ORDER BY
         (pg_stat_file('pg_xlog/'||name)).modification,
         wal.name DESC) sub;


### PR DESCRIPTION
##### Summary

Since previous refactor (d0de3356f3d83d273b2a6a19dfd5920b54a6f391) we forgot to remove extra bracket (needed to escape single bracket in original query). Due to this, the query returned 0.

This PR fix the query.

##### Component Name

Postgres

cc @ilyam8 

