### PR TITLE
exclude 'docs' directory from build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,29 +58,7 @@ dist_noinst_DATA= \
 	netdata.cppcheck \
 	netdata.spec \
 	package.json \
-	docs/Add-more-charts-to-netdata.md \
-	docs/Demo-Sites.md \
-	docs/Donations-netdata-has-received.md \
-	docs/Netdata-Security-and-Disclosure-Information.md \
-	docs/Performance.md \
-	docs/Running-behind-apache.md \
-	docs/Running-behind-caddy.md \
-	docs/Running-behind-lighttpd.md \
-	docs/Running-behind-nginx.md \
-	docs/Third-Party-Plugins.md \
-	docs/a-github-star-is-important.md \
-	docs/high-performance-netdata.md \
-	docs/netdata-for-IoT.md \
-	docs/netdata-security.md \
-	docs/why-netdata/README.md \
-	docs/why-netdata/1s-granularity.md \
-	docs/why-netdata/unlimited-metrics.md \
-	docs/why-netdata/meaningful-presentation.md \
-	docs/why-netdata/immediate-results.md \
-	docs/GettingStarted.md \
-	docs/Charts.md \
-	docs/configuration-guide.md \
-	docs/generator/custom \
+	docs \
 	packaging/installer/README.md \
 	packaging/installer/UNINSTALL.md \
 	packaging/installer/UPDATE.md \


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
`docs/` directory doesn't contain any files which are needed in the build system and it also doesn't use a build system. This excludes whole `docs/` directory from `Makefile.am`.

##### Component Name
build system

##### Additional Information
This also causes that I am not required as a code owner to review new documentation files like ones from #5097.
