### PR TITLE
better artifacts uploading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ sha256sums.txt
 netdata
 !netdata/
 upload/
+artifacts/
 
 apps.plugin
 !apps.plugin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
       credentials: .travis/gcs-credentials.json
       bucket: "netdata-nightlies"
       skip_cleanup: true
-      local_dir: "upload"
+      local_dir: "artifacts"
 
 notifications:
   webhooks: https://app.fossa.io/hooks/travisci

--- a/.travis/create_artifacts.sh
+++ b/.travis/create_artifacts.sh
@@ -17,10 +17,17 @@ echo "--- Create self-extractor ---"
 ./packaging/makeself/build-x86_64-static.sh
 
 # Needed fo GCS
-echo "--- Copy artifacts to bin ---"
-mkdir upload
-cp ./*.tar.gz ./*.gz.run upload/
+echo "--- Copy artifacts to separate directory ---"
+mkdir -p artifacts
+BASENAME="netdata-$(git describe)"
+mv "${BASENAME}".* artifacts/
+cd artifacts
+ln -s "${BASENAME}.tar.gz" netdata-latest.tar.gz
+ln -s "${BASENAME}.gz.run" netdata-latest.gz.run
+sha256sum -b ./* >"sha256sums.txt"
+cd ../
 
+# TODO(paulfantom): remove this section after releasing v1.12 and always use "artifacts" directory
 echo "--- Create checksums ---"
 GIT_TAG=$(git tag --points-at)
 if [ "${GIT_TAG}" != "" ]; then


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Since we already unified versioning then artifact basename can be always determined before creating that artifact. This allows for better automated handling of which artifacts should be uploaded and better creation of `netdata-latest.<ext>` packages. We are already uploading `netdata-latest.gz.run` makeself package, but this PR also allows to upload tarball.

##### Component Name
packaging
ci

##### Additional Information
Since `netdata-nightlies` GCS is public, then latest artifacts will be available to download by using one of the following commands:
```bash
# makeself package:
wget https://www.googleapis.com/storage/v1/b/netdata-nightlies/o/netdata-latest.gz.run?alt=media
# tarball:
wget https://www.googleapis.com/storage/v1/b/netdata-nightlies/o/netdata-latest.tar.gz?alt=media
```

Makeself link is already active, tarball link should be active on midnight of the day this PR is merged.