### PR TITLE
alarm-notify: Add Prowl integration for iOS users.

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1626,7 +1626,7 @@ send_prowl() {
         message="description=${message}"
         keys="$(urlencode "$(echo "${1}" | tr ' ' ,)")"
         keys="apikey=${keys}"
-        app="$(urlencode "application=Netdata")"
+        app="application=Netdata"
 
         case "${status}" in
             CRITICAL)
@@ -1643,9 +1643,9 @@ send_prowl() {
         event="$(urlencode "${host} ${status_message}")"
         event="event=${event}"
 
-        data="${keys}&${pri}&${alarm_url}&${application}&${event}&${message}"
+        data="${keys}&${pri}&${alarm_url}&${app}&${event}&${message}"
 
-        httpcode=$(docurl -X POST --data "${data}" "https://api.prowlapp.com/publicapp/add")
+        httpcode=$(docurl -X POST --data "${data}" "https://api.prowlapp.com/publicapi/add")
 
         if [ "${httpcode}" = "200" ]  ; then
             info "sent prowl data for: ${host} ${chart}.${name} is ${status}"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -27,6 +27,7 @@
 #  - messagebird.com notifications by @tech_no_logical #1453
 #  - hipchat notifications by @ktsaou #1561
 #  - fleep notifications by @Ferroin
+#  - prowlapp.com notifications by @Ferroin
 #  - custom notifications by @ktsaou
 #  - syslog messages by @Ferroin
 #  - Microsoft Team notification by @tioumen
@@ -164,6 +165,7 @@ syslog
 custom
 msteam
 kavenegar
+prowl
 "
 
 # -----------------------------------------------------------------------------
@@ -519,6 +521,7 @@ if [ \( \
         -o "${SEND_PUSHBULLET}"  = "YES" \
         -o "${SEND_KAFKA}"       = "YES" \
         -o "${SEND_FLEEP}"       = "YES" \
+        -o "${SEND_PROWL}"       = "YES" \
         -o "${SEND_CUSTOM}"      = "YES" \
         -o "${SEND_MSTEAM}"        = "YES" \
     \) -a -z "${curl}" ]
@@ -543,6 +546,7 @@ if [ \( \
         SEND_KAVENEGAR="NO"
         SEND_KAFKA="NO"
         SEND_FLEEP="NO"
+        SEND_PROWL="NO"
         SEND_CUSTOM="NO"
     fi
 fi
@@ -662,6 +666,7 @@ if [   "${SEND_EMAIL}"          != "YES" \
     -a "${SEND_CUSTOM}"         != "YES" \
     -a "${SEND_IRC}"            != "YES" \
     -a "${SEND_AWSSNS}"         != "YES" \
+    -o "${SEND_PROWL}"          != "YES" \
     -a "${SEND_SYSLOG}"         != "YES" \
     -a "${SEND_MSTEAM}"         != "YES" \
     ]
@@ -1612,6 +1617,50 @@ send_fleep() {
 }
 
 # -----------------------------------------------------------------------------
+# Prowl sender
+
+send_prowl() {
+    local httpcode sent=0 data message keys prio=0 alarm_url event
+    if [ "${SEND_PROWL}" = "YES" ] ; then
+        message="$(urlencode "${host} ${status_message}, \`${chart}\` (${family}), *${alarm}*\\n${info}")"
+        message="description=${message}"
+        keys="$(urlencode "$(echo "${1}" | tr ' ' ,)")"
+        keys="apikey=${keys}"
+        app="$(urlencode "application=Netdata")"
+
+        case "${status}" in
+            CRITICAL)
+                prio=2
+                ;;
+            WARNING)
+                prio=1
+                ;;
+        esac
+        pri="priority=${pri}"
+
+        alarm_url="$(urlencode ${goto_url})"
+        alarm_url="url=${alarm_url}"
+        event="$(urlencode "${host} ${status_message}")"
+        event="event=${event}"
+
+        data="${keys}&${pri}&${alarm_url}&${application}&${event}&${message}"
+
+        httpcode=$(docurl -X POST --data "${data}" "https://api.prowlapp.com/publicapp/add")
+
+        if [ "${httpcode}" = "200" ]  ; then
+            info "sent prowl data for: ${host} ${chart}.${name} is ${status}"
+            sent=1
+        else
+            error "failed to send prowl data for: ${host} ${chart}.${name} is ${status} with with error code ${httpcode}."
+        fi
+
+        [ ${sent} -gt 0 ] && return 0
+    fi
+
+    return 1
+}
+
+# -----------------------------------------------------------------------------
 # irc sender
 
 send_irc() {
@@ -1990,6 +2039,12 @@ send_fleep "${to_fleep}"
 SENT_FLEEP=$?
 
 # -----------------------------------------------------------------------------
+# send the Prowl message
+
+send_prowl "${to_prowl}"
+SENT_PROWL=$?
+
+# -----------------------------------------------------------------------------
 # send the irc message
 
 send_irc "${IRC_NICKNAME}" "${IRC_REALNAME}" "${to_irc}" "${IRC_NETWORK}" "${host}" "${host} ${status_message} - ${name//_/ } - ${chart} ----- ${alarm}
@@ -2215,6 +2270,7 @@ if [   ${SENT_EMAIL}        -eq 0 \
     -o ${SENT_KAFKA}        -eq 0 \
     -o ${SENT_PD}           -eq 0 \
     -o ${SENT_FLEEP}        -eq 0 \
+    -o ${SENT_PROWL}        -eq 0 \
     -o ${SENT_IRC}          -eq 0 \
     -o ${SENT_AWSSNS}       -eq 0 \
     -o ${SENT_CUSTOM}       -eq 0 \

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -14,6 +14,7 @@
 # - sms messages to your cell phone or any sms enabled device (twilio.com)
 # - sms messages to your cell phone or any sms enabled device (messagebird.com)
 # - notifications to users on pagerduty.com
+# - push notifications to iOS devices (via prowlapp.com)
 # - notifications to Amazon SNS topics (aws.amazon.com)
 # - messages to your irc channel on your selected network
 # - messages to a local or remote syslog daemon
@@ -654,6 +655,22 @@ SYSLOG_FACILITY=''
 DEFAULT_RECIPIENT_SYSLOG="netdata"
 
 #------------------------------------------------------------------------------
+# iOS Push Notifications
+
+# enable/disable sending iOS push notifications
+SEND_PROWL="YES"
+
+# If a role's recipients are not configured, use the following,
+# (empty = do not send a notiication for unconfigured roles)
+#
+# Recipients for iOS push notifications are Prowl API keys.
+#
+# A recipient may also consist of multiple Prowl API keys separated by
+# commas, in which case notifications will be simultaneously sent for all
+# of those API keys.
+DEFAULT_RECIPIENT_PROWL=""
+
+#------------------------------------------------------------------------------
 # Amazon SNS notifications
 #
 # This method requires potentially complex manual configuration.  See the
@@ -776,6 +793,8 @@ role_recipients_irc[sysadmin]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[sysadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
 
+role_recipients_prowl[sysadming]="${DEFAULT_RECIPIENT_PROWL}"
+
 role_recipients_awssns[sysadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[sysadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
@@ -816,6 +835,8 @@ role_recipients_fleep[domainadmin]="${DEFAULT_RECIPIENT_FLEEP}"
 role_recipients_irc[domainadmin]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[domainadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
+
+role_recipients_prowl[domainadmin]="${DEFAULT_RECIPIENT_PROWL}"
 
 role_recipients_awssns[domainadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
@@ -859,6 +880,8 @@ role_recipients_irc[dba]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[dba]="${DEFAULT_RECIPIENT_SYSLOG}"
 
+role_recipients_prowl[dba]="${DEFAULT_RECIPIENT_PROWL}"
+
 role_recipients_awssns[dba]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[dba]="${DEFAULT_RECIPIENT_CUSTOM}"
@@ -900,6 +923,8 @@ role_recipients_fleep[webmaster]="${DEFAULT_RECIPIENT_FLEEP}"
 role_recipients_irc[webmaster]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[webmaster]="${DEFAULT_RECIPIENT_SYSLOG}"
+
+role_recipients_prowl[webmaster]="${DEFAULT_RECIPIENT_PROWL}"
 
 role_recipients_awssns[webmaster]="${DEFAULT_RECIPIENT_AWSSNS}"
 
@@ -943,6 +968,8 @@ role_recipients_irc[proxyadmin]="${DEFAULT_RECIPIENT_IRC}"
 
 role_recipients_syslog[proxyadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
 
+role_recipients_prowl[proxyadmin]="${DEFAULT_RECIPIENT_PROWL}"
+
 role_recipients_awssns[porxyadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[proxyadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
@@ -982,6 +1009,8 @@ role_recipients_pd[sitemgr]="${DEFAULT_RECIPIENT_PD}"
 role_recipients_fleep[sitemgr]="${DEFAULT_RECIPIENT_FLEEP}"
 
 role_recipients_syslog[sitemgr]="${DEFAULT_RECIPIENT_SYSLOG}"
+
+role_recipients_prowl[sitemgr]="${DEFAULT_RECIPIENT_PROWL}"
 
 role_recipients_awssns[sitemgr]="${DEFAULT_RECIPIENT_AWSSNS}"
 

--- a/health/notifications/prowl/Makefile.inc
+++ b/health/notifications/prowl/Makefile.inc
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_noinst_DATA += \
+	prowl/README.md \
+	prowl/Makefile.inc \
+	$(NULL)
+

--- a/health/notifications/prowl/README.md
+++ b/health/notifications/prowl/README.md
@@ -1,0 +1,22 @@
+# prowl
+
+(Prowl)[1] is a push notification service for iOS devices.  Netdata
+supprots delivering notifications to iOS devices through Prowl.
+
+Because of how Netdata integrates with Prowl, there is a hard limit of
+at most 1000 notifications per hour (starting from the first notification
+sent).  Any alerts beyond the first thousand in an hour will be dropped.
+
+Warning messages will be sent with the 'High' priority, critical messages
+will be sent with the 'Emergency' priority, and all other messages will
+be sent with the normal priority.  Opening the notification's associated
+URL will take you to the Netdata dashboard of the system that issued
+the alert, directly to the chart that it triggered on.
+
+## configuration
+
+To use this, you will need a Prowl API key, which can be rquested through
+the Prowl website after registering.
+
+Once you have an API key, simply specify that as a recipient for Prowl
+notifications.


### PR DESCRIPTION
##### Summary

This adds the ability for Netdata to send push notifications to iOS devices via prowlapp.com.

##### Component Name

area/health

##### Additional Information

Delivered notifications have a similar format to that used with Fleep.io, and include a URL that links back to the Netdata system that originally issued the alert.

There is a hard limit on API calls to Prowl of 1000 per IP per hour. Prowl provides support for issuing notifications to multiple recipients simultaneously by specifying more than one API key with a request, and this code takes advantage of that so that any notification only results in at most one API call.

Fixes: #3788

--------

As I do not have any iOS devices myself, I can't really test this.

@P3PSIE, If you could take a look at this and see if it works for you, that would be greatly appreciated.