### PR TITLE
easier artifact management

### DIFF
--- a/.travis/releaser.sh
+++ b/.travis/releaser.sh
@@ -41,6 +41,7 @@ echo "---- FIGURING OUT TAGS ----"
 # tagger.sh is sourced since we need environment variables it sets
 #shellcheck source=/dev/null
 source .travis/tagger.sh || exit 0
+# variable GIT_TAG is produced by tagger.sh script
 
 echo "---- UPDATE VERSION FILE ----"
 echo "$GIT_TAG" >packaging/version
@@ -55,8 +56,9 @@ git commit -m "[ci skip] release $GIT_TAG"
 git tag "$GIT_TAG" -a -m "Automatic tag generation for travis build no. $TRAVIS_BUILD_NUMBER"
 git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')"
 git push "https://${GITHUB_TOKEN}:@$(git config --get remote.origin.url | sed -e 's/^https:\/\///')" --tags
+# After those operations output of command `git describe` should be identical with a value of GIT_TAG
 
-if [ -z ${RC+x} ]; then
+if [[ $(git describe) =~ -rc* ]]; then
 	echo "This is a release candidate tag, exiting without artifact building"
 	exit 0
 fi
@@ -66,6 +68,7 @@ export REPOSITORY="netdata/netdata"
 ./packaging/docker/build.sh
 
 echo "---- CREATING RELEASE ARTIFACTS -----"
+# Artifacts are stored in `artifacts/` directory
 ./.travis/create_artifacts.sh
 
 echo "---- CREATING RELEASE DRAFT WITH ASSETS -----"
@@ -84,4 +87,8 @@ if [ "${GIT_TAG}" != "$(git tag --points-at)" ]; then
 	echo "ERROR! Current commit is not tagged. Stopping release creation."
 	exit 1
 fi
-hub release create --draft -a "netdata-${GIT_TAG}.tar.gz" -a "netdata-${GIT_TAG}.gz.run" -a "sha256sums.txt" -m "${GIT_TAG}" "${GIT_TAG}"
+hub release create --draft \
+		-a "artifacts/netdata-${GIT_TAG}.tar.gz" \
+		-a "artifacts/netdata-${GIT_TAG}.gz.run" \
+		-a "artifacts/sha256sums.txt" \
+		-m "${GIT_TAG}" "${GIT_TAG}"

--- a/.travis/tagger.sh
+++ b/.travis/tagger.sh
@@ -37,8 +37,6 @@ function release_candidate() {
 		RC=0
 	fi
 	GIT_TAG="v$VERSION-rc$RC"
-	export GIT_TAG
-	export RC
 }
 
 # Check if current commit is tagged or not

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -90,5 +90,6 @@ run rm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
 
 FILE="netdata-${VERSION}.gz.run"
 
-run mv "${NETDATA_INSTALL_PATH}.gz.run" "${FILE}"
-echo >&2 "Self-extracting installer moved to '${FILE}'"
+run mkdir -p artifacts
+run mv "${NETDATA_INSTALL_PATH}.gz.run" "artifacts/${FILE}"
+echo >&2 "Self-extracting installer moved to 'artifacts/${FILE}'"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Simplify code responsible for releasing new netdata version.
Packaging scripts should put artifacts into `artifacts/` directory where possible. This ensures easier artifact management and simplifies GCS upload procedure.

##### Component Name
ci
packaging

##### Additional Information
Do not merge before v1.12.0
