### PR TITLE
hddtemp fix: don't use disk model as dim name

### DIFF
--- a/collectors/python.d.plugin/hddtemp/hddtemp.chart.py
+++ b/collectors/python.d.plugin/hddtemp/hddtemp.chart.py
@@ -91,8 +91,7 @@ class Service(SocketService):
             return False
 
         for d in disks:
-            n = d.id if d.id.startswith('sd') else d.name
-            dim = [d.id, n]
+            dim = [d.id]
             self.definitions['temperatures']['lines'].append(dim)
 
         return True


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes: #5129

##### Component Name
https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/hddtemp
##### Additional Information

