### PR TITLE
temporary disable OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,13 @@ jobs:
     if: type = cron
 
   - stage: build
-    name: OSX
-    install: brew install fakeroot ossp-uuid
-    script: fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it
-    os: osx
-  - name: ubuntu 14.04 (not containerized)
+# TODO(paulfantom): enable when travis OSX become stable. Probably after 12.01.2019
+#    name: OSX
+#    install: brew install fakeroot ossp-uuid
+#    script: fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it
+#    os: osx
+#  - name: ubuntu 14.04 (not containerized)
+    name: ubuntu 14.04 (not containerized)
     install: sudo apt-get install -y libcap2-bin zlib1g-dev uuid-dev fakeroot
     script: fakeroot ./netdata-installer.sh --dont-wait --dont-start-it --install $HOME
   - name: alpine + lifecycle


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
For unknown reason OSX builds are failing which blocks all PRs. This issue should go away after travis upgrades their OSX infrastructure (first part planned on 11.01).

##### Component Name
ci

##### Additional Information
Merge when ready, do not wait for me :smile:
