### PR TITLE
"Network Traffic (system.net)" is always zero on FreeBSD virtual machines if hypervisor uses VirtIO NIC

### DIFF
--- a/collectors/freebsd.plugin/freebsd_getifaddrs.c
+++ b/collectors/freebsd.plugin/freebsd_getifaddrs.c
@@ -144,7 +144,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
     (void)dt;
 
 #define DEFAULT_EXLUDED_INTERFACES "lo*"
-#define DEFAULT_PHYSICAL_INTERFACES "igb* ix* cxl* em* ixl* ixlv* bge* ixgbe*"
+#define DEFAULT_PHYSICAL_INTERFACES "igb* ix* cxl* em* ixl* ixlv* bge* ixgbe* vtnet*"
 #define CONFIG_SECTION_GETIFADDRS "plugin:freebsd:getifaddrs"
 
     static int enable_new_interfaces = -1;


### PR DESCRIPTION
Add "vtnet" interface name into the list of "system.net" interfaces

vtnet is "VirtIO Ethernet driver".
This interface appears and usually acts as the only non-loopback interface when FreeBSD node runs as a virtual machine under KVM/QEMU/VirtualBox (or other hypervisor supporting and exposing VirtIO as a feature).

This fixes "Network Traffic (system.net) graph in the dashboard is always zero"
![screenshot](https://user-images.githubusercontent.com/1396877/50969007-a59b5e80-14e5-11e9-8f13-5e0a29faa67b.png)

##### Summary
Add "vtnet" interface name into the list of "system.net" interfaces

##### Component Name
FreeBSD + Dashboard

##### Additional Information

