### PR TITLE
Fix cached memory calculation

### DIFF
--- a/collectors/proc.plugin/proc_meminfo.c
+++ b/collectors/proc.plugin/proc_meminfo.c
@@ -146,7 +146,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
     // --------------------------------------------------------------------
 
     // http://stackoverflow.com/questions/3019748/how-to-reliably-measure-available-memory-in-linux
-    unsigned long long MemCached = Cached + Slab;
+    unsigned long long MemCached = Cached + SReclaimable;
     unsigned long long MemUsed = MemTotal - MemFree - MemCached - Buffers;
 
     if(do_ram) {


### PR DESCRIPTION
##### Summary
Exclude `SUnreclaim` from the cache memory calculation.

Fixes #3929

##### Component Name
`proc` plugin