### PR TITLE
Correct SNMP module name in plugin error handling

### DIFF
--- a/collectors/node.d.plugin/snmp/snmp.node.js
+++ b/collectors/node.d.plugin/snmp/snmp.node.js
@@ -265,7 +265,7 @@ netdata.processors.snmp = {
                         if(__DEBUG === true)
                             netdata.debug(service.module.name + ': ' + service.name + ': failed ' + service.module.name + ' get for OIDs ' + varbinds[i].oid);
 
-                        service.error('OID ' + varbinds[i].oid + ' gave error: ' + snmp.varbindError(varbinds[i]));
+                        service.error('OID ' + varbinds[i].oid + ' gave error: ' + net_snmp.varbindError(varbinds[i]));
                         value = null;
                         failed++;
                     }


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR corrects an error in the net_snmp module name in snmp.node.js plugin.

Each time there is an error in the SNMP get process, for example due a non existing OID, the plugin execution breaks.

If several charts have been defined for a host only the ones processed before the error are gathered properly.

Once the module is properly named in the plugin source the real error is shown and all other chart dimensions are obtained properly.

##### Component Name

* snmp.node.js

##### Additional Information

The error shown before changing the code:

```
2019-01-10 15:27:45: node.d.plugin: ERROR: snmp: *.*.*.*: Received error = TypeError: snmp.varbindError is not a function
    at Object.responseCb (/opt/netdata/netdata/usr/libexec/netdata/node.d/snmp.node.js:267:89)                    
    at Object.feedCb (/opt/netdata/netdata/usr/libexec/netdata/node.d/node_modules/net-snmp.js:637:8)                                                                                                                                                            
    at Object.Session.onSimpleGetResponse [as onResponse] (/opt/netdata/netdata/usr/libexec/netdata/node.d/node_modules/net-snmp.js:951:7)
    at Session.onMsg (/opt/netdata/netdata/usr/libexec/netdata/node.d/node_modules/net-snmp.js:920:9)                                                                                                                                                            
    at emitTwo (events.js:106:13)                                                           
    at Socket.emit (events.js:191:7)                                                                                                                                                        
    at UDP.onMessage (dgram.js:561:8) varbinds = undefined
```

Once the SNMP module is renamed:

```
2019-01-10 16:05:55: node.d.plugin: ERROR: snmp: *.*.*.*: OID 1.3.6.1.2.1.15.3.1.2.*.*.*.*. gave error: NoSuchInstance: 1.3.6.1.2.1.15.3.1.2.*.*.*.*
```
