### PR TITLE
Fix alerta notifications

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1398,8 +1398,8 @@ send_alerta() {
     case "${status}" in
         CRITICAL) severity="critical" ;;
         WARNING)  severity="warning" ;;
-        CLEAR)    severity="cleared" ;;
-        *)        severity="indeterminate" ;;
+        CLEAR)    severity="ok" ;;
+        *)        severity="unknown" ;;
     esac
 
     if [[ "${chart}" == httpcheck* ]]


### PR DESCRIPTION
##### Summary

Fixes: #5152 

##### Component Name
Health notifications

##### Additional Information
Align passed values for `CLEAR` and `*` to the default values `ok` and `unknown` of alerta's SEVERITY_MAP https://docs.alerta.io/en/latest/gettingstarted/tutorial-1-deploy-alerta.html#tutorial-1

