### PR TITLE
automatic shellchecking on .sh.in scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
     env: CFLAGS='-O1 -DNETDATA_INTERNAL_CHECKS=1 -DNETDATA_VERIFY_LOCKS=1'
   - name: dashboard.js
     script: cp web/gui/dashboard.js /tmp/dashboard.js && ./build/build.sh && diff /tmp/dashboard.js web/gui/dashboard.js
+  - name: lint .sh.in files
+    script: shellcheck --format=gcc $(find . -name '*.sh.in' -not -iwholename '*.git*')
   - name: coverity
     install: sudo apt-get install -y zlib1g-dev uuid-dev libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev
     script: ./coverity-scan.sh || echo "Coverity failed :("

--- a/collectors/tc.plugin/tc-qos-helper.sh.in
+++ b/collectors/tc.plugin/tc-qos-helper.sh.in
@@ -216,6 +216,7 @@ show_fireqos_names() {
 		#shellcheck source=/dev/null
 		source "${fireqos_run_dir}/${name}.conf"
 		for n in ${interface_classes_monitor}; do
+			# shellcheck disable=SC2086
 			setclassname ${n//|/ }
 		done
 		[ -n "${interface_dev}" ] && echo "SETDEVICEGROUP ${interface_dev}"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -111,7 +111,7 @@ debug() {
 
 docurl() {
 	if [ -z "${curl}" ]; then
-		error '${curl} is unset.'
+		error "${curl} is unset."
 		return 1
 	fi
 
@@ -216,7 +216,8 @@ else
 	units="${17}"              # the units of the value
 	info="${18}"               # a short description of the alarm
 	value_string="${19}"       # friendly value (with units)
-	# shellcheck disable=SC2034 variable is unused, but https://github.com/netdata/netdata/pull/5164#discussion_r255572947
+	# shellcheck disable=SC2034
+	# variable is unused, but https://github.com/netdata/netdata/pull/5164#discussion_r255572947
 	old_value_string="${20}"   # friendly old value (with units), previously named "old_value_string"
 	calc_expression="${21}"    # contains the expression that was evaluated to trigger the alarm
 	calc_param_values="${22}"  # the values of the parameters in the expression, at the time of the evaluation

--- a/tests/health_mgmtapi/health-cmdapi-test.sh.in
+++ b/tests/health_mgmtapi/health-cmdapi-test.sh.in
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1117,SC2034,SC2059,SC2086,SC2181
 
 NETDATA_USER_CONFIG_DIR="@configdir_POST@"
 NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Unfortunately codacy doesn't check for code quality in this file due to wrong file extension. This adds mechanism to do shell code linting in travis as a blocking mechanism.

##### Component Name
ci

##### Additional Information
Part of larger effort to cleanup bash scripts with file extension ending in `.sh.in`.

Blocked by:
#5162
#5163
#5164

