### PR TITLE
nightly build only when sth changed

### DIFF
--- a/.travis/nightlies.sh
+++ b/.travis/nightlies.sh
@@ -16,6 +16,10 @@ git config user.name "${GIT_USER}"
 echo "--- UPDATE VERSION FILE ---"
 LAST_TAG=$(git describe --abbrev=0 --tags)
 NO_COMMITS=$(git rev-list "$LAST_TAG"..HEAD --count)
+if [ "$NO_COMMITS" == "$(rev <packaging/version | cut -d- -f 2 | rev)" ]; then
+	echo "Nothing changed since last nightly build"
+	exit 0
+fi
 echo "$LAST_TAG-$((NO_COMMITS + 1))-nightly" >packaging/version
 git add packaging/version
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Proceed with nightly build when sth changed since last nightly build.

Mechanism is extracting number of commits since last tag from `packaging/version` and comparing it with git. If both numbers match, then it exits cleanly and doesn't build new packages as nothing new was added to `master` branch.

Desired effect: no builds which just bump `packaging/version` like it was happening from  Jan 11, 2019 to  Jan 13, 2019

##### Component Name
ci

##### Additional Information

