### PR TITLE
Add cgroup cpu and memory limits and alarms

### DIFF
--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -89,6 +89,10 @@ The whole point for the additional pattern list, is to limit the number of times
 
 The above pattern list is matched against the path of the cgroup. For matched cgroups, netdata calls the script [cgroup-name.sh](cgroup-name.sh.in) to get its name. This script queries `docker`, or applies heuristics to find give a name for the cgroup.
 
+### alarms
+
+CPU and memory limits are watched and used to rise alarms. Memory usage for every cgroup is checked against `ram` and `ram+swap` limits. CPU usage for every cgroup is checked against `cpuset.cpus` and `cpu.cfs_period_us` + `cpu.cfs_quota_us` pair assigned for the cgroup. Configuration for the alarms is available in `health.d/cgroups.conf` file.
+
 ## Monitoring systemd services
 
 netdata monitors **systemd services**. Example:

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2468,22 +2468,19 @@ void update_cgroup_charts(int update_every) {
                                     , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
                                     , NETDATA_CHART_PRIO_CGROUPS_CONTAINERS - 1
                                     , update_every
-                                    , RRDSET_TYPE_STACKED
+                                    , RRDSET_TYPE_LINE
                             );
 
-                            rrddim_add(cg->st_cpu_limit, "available", NULL, 1, 1, RRD_ALGORITHM_PCENT_OVER_ROW_TOTAL);
-                            rrddim_add(cg->st_cpu_limit, "used", NULL, 1, 1, RRD_ALGORITHM_PCENT_OVER_ROW_TOTAL);
+                            rrddim_add(cg->st_cpu_limit, "used", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
                         }
                         else
                             rrdset_next(cg->st_cpu_limit);
 
                         calculated_number cpu_usage = (cg->cpuacct_stat.user + cg->cpuacct_stat.system) * 100 / system_hz;
-                        calculated_number cpu_available = value * 100 / system_hz * update_every - (cpu_usage - cg->prev_cpu_usage);
-                        calculated_number cpu_used = cpu_usage - cg->prev_cpu_usage;
+                        calculated_number cpu_used = 100 * (cpu_usage - cg->prev_cpu_usage) / (value * update_every);
 
                         rrdset_isnot_obsolete(cg->st_cpu_limit);
 
-                        rrddim_set(cg->st_cpu_limit, "available", (cpu_available > 0)?cpu_available:0);
                         rrddim_set(cg->st_cpu_limit, "used", (cpu_used > 0)?cpu_used:0);
 
                         cg->prev_cpu_usage = cpu_usage;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2736,7 +2736,7 @@ void update_cgroup_charts(int update_every) {
                                 , "mem"
                                 , "cgroup.mem_usage_limit"
                                 , title
-                                , "percentage"
+                                , "MiB"
                                 , PLUGIN_CGROUPS_NAME
                                 , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
                                 , NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 199
@@ -2744,8 +2744,8 @@ void update_cgroup_charts(int update_every) {
                                 , RRDSET_TYPE_STACKED
                         );
 
-                        rrddim_add(cg->st_mem_usage_limit, "available", NULL, 1, 1, RRD_ALGORITHM_PCENT_OVER_ROW_TOTAL);
-                        rrddim_add(cg->st_mem_usage_limit, "used", NULL, 1, 1, RRD_ALGORITHM_PCENT_OVER_ROW_TOTAL);
+                        rrddim_add(cg->st_mem_usage_limit, "available", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
+                        rrddim_add(cg->st_mem_usage_limit, "used", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
                     }
                     else
                         rrdset_next(cg->st_mem_usage_limit);

--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -31,6 +31,7 @@ dist_healthconfig_DATA = \
     health.d/boinc.conf \
     health.d/btrfs.conf \
     health.d/ceph.conf \
+    health.d/cgroups.conf \
     health.d/cpu.conf \
     health.d/couchdb.conf \
     health.d/disks.conf \

--- a/health/health.d/cgroups.conf
+++ b/health/health.d/cgroups.conf
@@ -1,0 +1,28 @@
+
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+template: cgroup_ram_in_use
+      on: cgroup.mem_usage
+      os: linux
+   hosts: *
+    calc: ($ram) * 100 / $memory_limit
+   units: %
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? (80) : (90))
+    crit: $this > (($status == $CRITICAL) ? (90) : (98))
+   delay: down 15m multiplier 1.5 max 1h
+    info: RAM used by cgroup
+      to: sysadmin
+
+template: cgroup_ram_and_swap_in_use
+      on: cgroup.mem_usage
+      os: linux
+   hosts: *
+    calc: ($ram + $swap) * 100 / $memory_and_swap_limit
+   units: %
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? (80) : (90))
+    crit: $this > (($status == $CRITICAL) ? (90) : (98))
+   delay: down 15m multiplier 1.5 max 1h
+    info: RAM and Swap used by cgroup
+      to: sysadmin

--- a/health/health.d/cgroups.conf
+++ b/health/health.d/cgroups.conf
@@ -2,14 +2,14 @@
 # you can disable an alarm notification by setting the 'to' line to: silent
 
 template: cgroup_10min_cpu_usage
-      on: cgroup.cpu
+      on: cgroup.cpu_limit
       os: linux
    hosts: *
   lookup: average -10m unaligned
    units: %
    every: 1m
-    warn: $this > (($status >= $WARNING)  ? (0.75 * $cpu_limit) : (0.85 * $cpu_limit))
-    crit: $this > (($status == $CRITICAL) ? (0.85 * $cpu_limit) : (0.95 * $cpu_limit))
+    warn: $this > (($status >= $WARNING)  ? (75) : (85))
+    crit: $this > (($status == $CRITICAL) ? (85) : (95))
    delay: down 15m multiplier 1.5 max 1h
     info: cpu utilization for the last 10 minutes
       to: sysadmin

--- a/health/health.d/cgroups.conf
+++ b/health/health.d/cgroups.conf
@@ -1,6 +1,19 @@
 
 # you can disable an alarm notification by setting the 'to' line to: silent
 
+template: cgroup_10min_cpu_usage
+      on: cgroup.cpu
+      os: linux
+   hosts: *
+  lookup: average -10m unaligned
+   units: %
+   every: 1m
+    warn: $this > (($status >= $WARNING)  ? (0.75 * $cpu_limit) : (0.85 * $cpu_limit))
+    crit: $this > (($status == $CRITICAL) ? (0.85 * $cpu_limit) : (0.95 * $cpu_limit))
+   delay: down 15m multiplier 1.5 max 1h
+    info: cpu utilization for the last 10 minutes
+      to: sysadmin
+
 template: cgroup_ram_in_use
       on: cgroup.mem_usage
       os: linux

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1421,13 +1421,13 @@ netdataDashboard.context = {
     // containers
 
     'cgroup.cpu_limit': {
+        valueRange: "[0, null]",
         mainheads: [
             function (os, id) {
                 void(os);
                 cgroupCPULimitIsSet = 1;
                 return '<div data-netdata="' + id + '"'
                     + ' data-dimensions="used"'
-                    + ' data-append-options="percentage"'
                     + ' data-gauge-max-value="100"'
                     + ' data-chart-library="gauge"'
                     + ' data-title="CPU"'

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -618,6 +618,10 @@ netdataDashboard.submenu = {
 // colors: the dimension colors of the chart (the default colors are appended)
 // height: the ratio of the chart height relative to the default
 //
+
+var cgroup_cpu_limit_is_set = 0;
+var cgroup_mem_limit_is_set = 0;
+
 netdataDashboard.context = {
     'system.cpu': {
         info: function (os) {
@@ -1416,11 +1420,15 @@ netdataDashboard.context = {
     // ------------------------------------------------------------------------
     // containers
 
-    'cgroup.cpu': {
+    'cgroup.cpu_limit': {
         mainheads: [
             function (os, id) {
                 void(os);
+                cgroup_cpu_limit_is_set = 1;
                 return '<div data-netdata="' + id + '"'
+                    + ' data-dimensions="used"'
+                    + ' data-append-options="percentage"'
+                    + ' data-gauge-max-value="100"'
                     + ' data-chart-library="gauge"'
                     + ' data-title="CPU"'
                     + ' data-units="%"'
@@ -1435,14 +1443,40 @@ netdataDashboard.context = {
         ]
     },
 
-    'cgroup.mem_usage': {
+    'cgroup.cpu': {
         mainheads: [
             function (os, id) {
                 void(os);
+                if (cgroup_cpu_limit_is_set === 0) {
+                    return '<div data-netdata="' + id + '"'
+                        + ' data-chart-library="gauge"'
+                        + ' data-title="CPU"'
+                        + ' data-units="%"'
+                        + ' data-gauge-adjust="width"'
+                        + ' data-width="12%"'
+                        + ' data-before="0"'
+                        + ' data-after="-CHART_DURATION"'
+                        + ' data-points="CHART_DURATION"'
+                        + ' data-colors="' + NETDATA.colors[4] + '"'
+                        + ' role="application"></div>';
+                } else
+                    return '';
+            }
+        ]
+    },
+
+    'cgroup.mem_usage_limit': {
+        mainheads: [
+            function (os, id) {
+                void(os);
+                cgroup_mem_limit_is_set = 1;
                 return '<div data-netdata="' + id + '"'
+                    + ' data-dimensions="used"'
+                    + ' data-append-options="percentage"'
+                    + ' data-gauge-max-value="100"'
                     + ' data-chart-library="gauge"'
                     + ' data-title="Memory"'
-                    + ' data-units="MB"'
+                    + ' data-units="%"'
                     + ' data-gauge-adjust="width"'
                     + ' data-width="12%"'
                     + ' data-before="0"'
@@ -1450,6 +1484,28 @@ netdataDashboard.context = {
                     + ' data-points="CHART_DURATION"'
                     + ' data-colors="' + NETDATA.colors[1] + '"'
                     + ' role="application"></div>';
+            }
+        ]
+    },
+
+    'cgroup.mem_usage': {
+        mainheads: [
+            function (os, id) {
+                void(os);
+                if (cgroup_mem_limit_is_set === 0) {
+                    return '<div data-netdata="' + id + '"'
+                        + ' data-chart-library="gauge"'
+                        + ' data-title="Memory"'
+                        + ' data-units="MB"'
+                        + ' data-gauge-adjust="width"'
+                        + ' data-width="12%"'
+                        + ' data-before="0"'
+                        + ' data-after="-CHART_DURATION"'
+                        + ' data-points="CHART_DURATION"'
+                        + ' data-colors="' + NETDATA.colors[1] + '"'
+                        + ' role="application"></div>';
+                } else
+                    return '';
             }
         ]
     },

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -619,8 +619,8 @@ netdataDashboard.submenu = {
 // height: the ratio of the chart height relative to the default
 //
 
-var cgroup_cpu_limit_is_set = 0;
-var cgroup_mem_limit_is_set = 0;
+var cgroupCPULimitIsSet = 0;
+var cgroupMemLimitIsSet = 0;
 
 netdataDashboard.context = {
     'system.cpu': {
@@ -1424,7 +1424,7 @@ netdataDashboard.context = {
         mainheads: [
             function (os, id) {
                 void(os);
-                cgroup_cpu_limit_is_set = 1;
+                cgroupCPULimitIsSet = 1;
                 return '<div data-netdata="' + id + '"'
                     + ' data-dimensions="used"'
                     + ' data-append-options="percentage"'
@@ -1447,7 +1447,7 @@ netdataDashboard.context = {
         mainheads: [
             function (os, id) {
                 void(os);
-                if (cgroup_cpu_limit_is_set === 0) {
+                if (cgroupCPULimitIsSet === 0) {
                     return '<div data-netdata="' + id + '"'
                         + ' data-chart-library="gauge"'
                         + ' data-title="CPU"'
@@ -1459,7 +1459,8 @@ netdataDashboard.context = {
                         + ' data-points="CHART_DURATION"'
                         + ' data-colors="' + NETDATA.colors[4] + '"'
                         + ' role="application"></div>';
-                } else
+                }
+                else
                     return '';
             }
         ]
@@ -1469,7 +1470,7 @@ netdataDashboard.context = {
         mainheads: [
             function (os, id) {
                 void(os);
-                cgroup_mem_limit_is_set = 1;
+                cgroupMemLimitIsSet = 1;
                 return '<div data-netdata="' + id + '"'
                     + ' data-dimensions="used"'
                     + ' data-append-options="percentage"'
@@ -1492,7 +1493,7 @@ netdataDashboard.context = {
         mainheads: [
             function (os, id) {
                 void(os);
-                if (cgroup_mem_limit_is_set === 0) {
+                if (cgroupMemLimitIsSet === 0) {
                     return '<div data-netdata="' + id + '"'
                         + ' data-chart-library="gauge"'
                         + ' data-title="Memory"'
@@ -1504,7 +1505,8 @@ netdataDashboard.context = {
                         + ' data-points="CHART_DURATION"'
                         + ' data-colors="' + NETDATA.colors[1] + '"'
                         + ' role="application"></div>';
-                } else
+                }
+                else
                     return '';
             }
         ]


### PR DESCRIPTION
##### Summary
Add limit variables to cgroup charts. Provide alarms for limited resources. Add charts for resource usage within cgroup limits.
- [x] CPU
- [x] memory

Partly implements #2401

##### Component Name
`cgroups` plugin

##### Additional Information
Disk limits can't be implemented on the existing charts. If we decide to implement them, it will be done in another PR.