### PR TITLE
Updated Polyverse reinstall commands in Dockerfile

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -73,8 +73,10 @@ RUN apk --no-cache add curl \
 
 # Subscribe to Polyverse's Polymorphic Linux repositories and reinstall all packages, so they are scrambled
 RUN curl https://sh.polyverse.io | sh -s install gcxce5byVQbtRz0iwfGkozZwy support+netdata@polyverse.io && \
-    sed -n -i '/repo.polyverse.io/p' /etc/apk/repositories && \
-    apk upgrade --update-cache --available
+    apk update && \
+    apk upgrade --available --no-cache && \
+    sed -in 's/^#//g' /etc/apk/repositories
+
 
 # Copy files over
 COPY --from=builder /app /


### PR DESCRIPTION
The problem:

After this PR was merged (https://github.com/netdata/netdata/pull/5137),
we noticed on our end that the default Polyverse install script
had room for improvement to ensure there's reliability.

To be more specific, we noticed that while we only expose x86_64 packages,
we noticed a pull to an x86 (32-bit package) that was not expected.

What this meant was, during our first update, we were completely removing
existing mirrors/packages in the install script.

The fix:

Our install script now merely comments out the existing repos/mirrors.

The install instructions then merely update/upgrade all packages in-place,
this preferring our packages as a priority, and the final command
uncomments all the other mirrors/repos that may exist.

The outcome:

Due to this step, ALL existing repos stay on the host after Polymorphic
repositories are sbuscribed. Everything works as expected. However,
the host will prefer Polymorphic repositories above others.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

