### PR TITLE
allow less verbose container image build

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -6,6 +6,7 @@
 ARG ARCH=amd64-v3.8
 FROM multiarch/alpine:${ARCH} as builder
 
+ARG OUTPUT="/dev/stdout"
 # Install prerequisites
 RUN apk --no-cache add alpine-sdk \
                        autoconf \
@@ -33,8 +34,7 @@ WORKDIR /opt/netdata.git
 
 # Install from source
 RUN chmod +x netdata-installer.sh && \
-    sync && sleep 1 && \
-    ./netdata-installer.sh --dont-wait --dont-start-it
+    ./netdata-installer.sh --dont-wait --dont-start-it &>${OUTPUT}
 
 # files to one directory
 RUN mkdir -p /app/usr/sbin/ \

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -39,9 +39,11 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 # Build images using multi-arch Dockerfile.
 for ARCH in "${ARCHITECTURES[@]}"; do
-     eval docker build --build-arg ARCH="${ARCH}-v3.8" \
-                  --tag "${REPOSITORY}:${VERSION}-${ARCH}" \
-                  --file packaging/docker/Dockerfile ./ ${BG}
+     eval docker build \
+     		--build-arg ARCH="${ARCH}-v3.8" \
+     		--build-arg OUTPUT=/dev/null \
+     		--tag "${REPOSITORY}:${VERSION}-${ARCH}" \
+     		--file packaging/docker/Dockerfile ./ ${BG}
 done
 wait
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
With very verbose builds we are quickly approaching 10k lines limit on travis which is a little bit troublesome when debugging. This PR adds a way to redirect shell installer output to other place so we can reduce verbosity and enables it in our build script.

Fixes #4545

##### Component Name
packaging
ci

##### Additional Information
Direct build will be verbose, ex.: `docker build -f packaging/docker/Dockerfile .`, but building with a shell script wrapper won't be as verbose.

