### PR TITLE
Add link to go.d README.md

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -173,6 +173,8 @@ navpart 3 collectors/freebsd.plugin
 navpart 3 collectors/macos.plugin
 
 navpart 2 collectors/plugins.d "" "External plugins"
+echo -ne "        - go.d modules: 'https://github.com/netdata/go.d.plugin#godplugin'
+"
 navpart 3 collectors/python.d.plugin "" "Python modules" 3
 navpart 3 collectors/node.d.plugin "" "Node.js modules" 3
 echo -ne "        - BASH modules:
@@ -229,7 +231,7 @@ echo -ne "- Hacking netdata:
     - 'docs/Netdata-Security-and-Disclosure-Information.md'
     - CONTRIBUTORS.md
 "
-navpart 2 makeself "" "" 4
+navpart 2 packaging/makeself "" "" 4
 navpart 2 libnetdata "" "libnetdata" 4
 navpart 2 contrib
 navpart 2 tests "" "" 2


### PR DESCRIPTION


##### Summary
Add a plain link to the main README of the go.d plugin,  until a new docs site is built, or we find a way to incorporate those docs into our  main docs site.

##### Component Name
docs


