### PR TITLE
cleanup updater script and no `/opt` usage

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -218,7 +218,7 @@ EOF
 
 # Check if tmp is mounted as noexec
 if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
-	pattern="/opt/netdata-kickstart-XXXXXX"
+	pattern="$(pwd)/netdata-kickstart-XXXXXX"
 else
 	pattern="/tmp/netdata-kickstart-XXXXXX"
 fi


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
- Moving code around to have function declarations at the top.
- Adding `eval` when running `${REINSTALL_COMMAND}...`
- More robust download
- Use `$(pwd)` instead of `/opt`

##### Component Name
packaging

##### Additional Information

