### PR TITLE
Fix nightly builds and cron autoupdater

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -926,12 +926,20 @@ if [ "${AUTOUPDATE}" = "1" ]; then
 				rm -f "${crondir}/netdata-updater.sh"
 			fi
 			progress "Installing new netdata-updater in cron"
+	
+			rm ${installer_dir}/netdata-updater.sh || : #TODO(paulfantom): this workaround should be removed after v1.13.0-rc1. It just needs to be propagated
+
 			rm -f "${crondir}/netdata-updater"
 			if [ -f "${installer_dir}/packaging/installer/netdata-updater.sh" ]; then
 				sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${installer_dir}/packaging/installer/netdata-updater.sh" > ${crondir}/netdata-updater || exit 1
+				 #TODO(paulfantom): Following line is a workaround and should be removed after v1.13.0-rc1. It just needs time to be propagated.
+				sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${installer_dir}/packaging/installer/netdata-updater.sh" > ${installer_dir}/netdata-updater.sh || exit 1
 			else
 				sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${netdata_source_dir}/packaging/installer/netdata-updater.sh" > ${crondir}/netdata-updater || exit 1
+				 #TODO(paulfantom): Following line is a workaround and should be removed after v1.13.0-rc1. It just needs time to be propagated.
+				sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${netdata_source_dir}/packaging/installer/netdata-updater.sh" > ${installer_source_dir}/netdata-updater.sh || exit 1
 			fi
+
 			chmod 0755 ${crondir}/netdata-updater
 			echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${crondir}/netdata-updater${TPUT_RESET}"
 			echo >&2

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -71,11 +71,13 @@ RUN apk --no-cache add curl \
                        py-yaml \
                        python
 
-# Subscribe to Polyverse's Polymorphic Linux repositories and reinstall all packages, so they are scrambled
-RUN curl https://sh.polyverse.io | sh -s install gcxce5byVQbtRz0iwfGkozZwy support+netdata@polyverse.io && \
-    apk update && \
-    apk upgrade --available --no-cache && \
-    sed -in 's/^#//g' /etc/apk/repositories
+# Conditional subscribiton to Polyverse's Polymorphic Linux repositories
+RUN if [ "$(uname -m)" == "x86_64" ]; then \
+        curl https://sh.polyverse.io | sh -s install gcxce5byVQbtRz0iwfGkozZwy support+netdata@polyverse.io; \
+        apk update; \
+        apk upgrade --available --no-cache; \
+        sed -in 's/^#//g' /etc/apk/repositories; \
+    fi
 
 
 # Copy files over

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -71,7 +71,14 @@ failed() {
 update() {
 	[ -z "${tmp}" ] && info "Running on a terminal - (this script also supports running headless from crontab)"
 
-	dir=$(mktemp -d)
+	# Check if tmp is mounted as noexec
+	if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
+		pattern="/opt/netdata-updater-XXXXXX"
+	else
+		pattern="/tmp/netdata-updater-XXXXXX"
+	fi
+
+	dir=$(mktemp -d "$pattern")
 
 	cd "$dir"
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
- Add gating stage to run polyverse scrambling only on x86_64. Closes #5225 
- Installer copies updater script to top level directory so if someone is still using old updater, then it will allow for better migration path. Should fix issue #5229
- Updater downloads package to `/opt` if `/tmp` is mounted with `noexec` flag. Should fix issue #5208

##### Component Name
packaging

##### Additional Information
Needs to go in ASAP
