### PR TITLE
Fix check for install-required-packages.sh

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -227,7 +227,8 @@ else
 			warning "Downloaded dependency installation script is empty."
 		else
 			progress "Running downloaded script to detect required packages..."
-			if run ${sudo} "${bash}" "${tmpdir}/install-required-packages.sh" ${PACKAGES_INSTALLER_OPTIONS}; then
+			run ${sudo} "${bash}" "${tmpdir}/install-required-packages.sh" ${PACKAGES_INSTALLER_OPTIONS}
+			if [ $? -ne 0 ] ; then
 				warning "It failed to install all the required packages, but installation might still be possible."
 			fi
 		fi


### PR DESCRIPTION

##### Summary
Fixes #5240

##### Component Name
kickstart installer

##### Additional Information

functions in bash used in if have peculiar behavior. Testing for $? works in the tests I've done.
