### PR TITLE
Fix typo in docs/configuration-guide.md

### DIFF
--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -1,6 +1,6 @@
 # Configuration guide
 
-No configuration is required to run netdata, but you fill find plenty of options to tweak, so that you can adapt it to your particular needs.
+No configuration is required to run netdata, but you will find plenty of options to tweak, so that you can adapt it to your particular needs.
 
 <details markdown="1"><summary>Configuration files are placed in `/etc/netdata`.</summary>
 Depending on your installation method, Netdata will have been installed either directly under `/`, or under `/opt/netdata`. The paths mentioned here and in the documentation in general assume that your installation is under `/`. If it is not, you will find the exact same paths under `/opt/netdata` as well. (i.e. `/etc/netdata` will be `/opt/netdata/etc/netdata`).</details>


### PR DESCRIPTION
##### Summary
Fix typo in `docs/configuration-guide.md`.

