### PR TITLE
Always run make clean before make

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -421,7 +421,7 @@ trap - EXIT
 # -----------------------------------------------------------------------------
 progress "Cleanup compilation directory"
 
-[ -f src/netdata ] && run make clean
+run make clean
 
 # -----------------------------------------------------------------------------
 progress "Compile netdata"


### PR DESCRIPTION
##### Summary
Fixes #5252 

##### Component Name
installer

##### Additional Information
The installer had an invalid check before `make clean`, which caused some paths to differ when getting the nightly tarball. 
