### PR TITLE
netdata update instructions after recent changes

### DIFF
--- a/packaging/installer/UPDATE.md
+++ b/packaging/installer/UPDATE.md
@@ -9,65 +9,47 @@ The update procedure depends on how you installed it:
 
 ## You downloaded it from github using git
 
-### Manual update
+### Manual update to get the latest git commit
 
-The installer `netdata-installer.sh` generates a `netdata-updater.sh` script in the directory you downloaded netdata.
-You can use this script to update your netdata installation with the same options you used to install it in the first place.
-Just run it and it will download and install the latest version of netdata. The same script can be put in a cronjob to update your netdata at regular intervals.
+netdata versions older than `v1.12.0-rc2-52` had a `netdata-installer.sh` script in the root directory of the source code, which has now been deprecated. The manual process that works for all versions to get the latest commit in git is to use the `netdata-installer.sh`. The installer preserves your configuration. You just need to be mindful of any installer options you may have used to customize your original installation. 
 
 ```sh
 # go to the git downloaded directory
 cd /path/to/git/downloaded/netdata
 
-# run the updater
-./netdata-updater.sh
-```
-
-_Netdata will be restarted with the new version._
-
-If you don't have this script (e.g. you deleted the directory where you downloaded netdata), just follow the **[[Installation]]** instructions again. The installer preserves your configuration. You can also update netdata to the latest version by hand, using this:
-
-```sh
-# go to the git downloaded directory
-cd /path/to/git/downloaded/netdata
-
-# download the latest version
+# update your local copy
 git pull
 
-# rebuild it, install it, run it
-./netdata-installer.sh
+# run the netdata installer
+sudo ./netdata-installer.sh
 ```
 
 _Netdata will be restarted with the new version._
 
 Keep in mind, netdata may now have new features, or certain old features may now behave differently. So pay some attention to it after updating.
 
+### Manual update to get the latest nightly build
+
+The `kickstart.sh` one-liner will do a one-time update to the latest nightly build, if executed as follows:
+```
+bash <(curl -Ss https://my-netdata.io/kickstart.sh --no-updates)
+```
+
 ### Auto-update
 
 _Please, consider the risks of running an auto-update. Something can always go wrong. Keep an eye on your installation, and run a manual update if something ever fails._
 
-You can call `netdata-updater.sh` from a cron-job. A successful update will not trigger an email from cron.
+Calling the `netdata-installer.sh` with the `--auto-update` or `-u` option will create an `auto-updater` script under 
+either  `/etc/cron.daily/`, or `/etc/periodic/daily/`. Whenever the `auto-updater` is executed, it checks if a newer nightly build is available and then handles the download, installation and netdata restart.  
 
-```sh
-# Edit your cron-jobs
-crontab -e
+Note that after Jan 2019, the `kickstart.sh` one-liner `bash <(curl -Ss https://my-netdata.io/kickstart.sh)` calls the `netdata-installer.sh` with the auto-update option. So if you just run the one-liner without options once, your netdata will be kept auto-updated.
 
-# add a cron-job at the bottom. This one will update netdata every day at 6:00AM:
-# update netdata
-0 6 * * * /path/to/git/downloaded/netdata/netdata-updater.sh
-```
 
 ## You downloaded a binary package
 
 If you installed it from a binary package, the best way is to **obtain a newer copy** from the source you got it in the first place.
 
 If a newer version of netdata is not available from the source you got it, we suggest to uninstall the version you have and follow the **[[Installation]]** instructions for installing a fresh version of netdata.
-
-
-
-
-
-
 
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Finstaller%2FUPDATE&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)]()


### PR DESCRIPTION
##### Summary
Reconcile UPDATE.md with how the update system works currently

##### Component Name
packaging/installation

##### Additional Information
There is a discrepancy between kickstart.sh that enables auto-updates by default and the installer script, which doesn't. This causes confusing documentation and possibly unintended auto-updates. Please review and let's discuss. 