### PR TITLE
GUI Update check - use version instead of commit

### DIFF
--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -1199,7 +1199,6 @@
                 </div>
                 <div class="modal-body">
                     Your netdata version: <b><code><span id="netdataVersion">Unknown</span></code></b><br/>
-                    Your netdata commit: <b><code><span id="netdataCommitId">Unknown</span></code></b>
                     <br/>
                     <div style="padding: 10px;"></div>
                     <div id="versionCheckLog">Not checked yet. Please press the Check Now button.</div>

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -2895,7 +2895,7 @@ function notifyForUpdate(force) {
             versionLog('<p><big>You already have the latest netdata!</big></p><p>No update yet?<br/>Probably, we need some motivation to keep going on!</p><p>If you haven\'t already, <a href="https://github.com/netdata/netdata" target="_blank">give netdata a <b><i class="fas fa-star"></i></b> at its github page</a>.</p>');
         } else {
             save = true;
-            var compare = 'https://github.com/netdata/netdata/blob/master/CHANGELOG.md';
+            var compare = 'https://docs.netdata.cloud/changelog/';
             versionLog('<p><big><strong>New version of netdata available!</strong></big></p><p>Latest version: <b><code>' + sha2 + '</code></b></p><p><a href="' + compare + '" target="_blank">Click here for the changes log</a> and<br/><a href="https://github.com/netdata/netdata/tree/master/packaging/installer/UPDATE.md" target="_blank">click here for directions on updating</a> your netdata installation.</p><p>We suggest to review the changes log for new features you may be interested, or important bug fixes you may need.<br/>Keeping your netdata updated is generally a good idea.</p>');
 
             document.getElementById('update_badge').innerHTML = '!';

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -2819,89 +2819,43 @@ function versionLog(msg) {
     document.getElementById('versionCheckLog').innerHTML = msg;
 }
 
-function getNetdataCommitIdFromVersion() {
-    var s = options.version.split('-');
+// New way of checking for updates, based only on versions
 
-    if (s.length !== 3) {
-        return null;
+function versionsMatch(v1, v2) {
+    if (v1 == v2) {
+        return true;
+    } else {
+        var s1=v1.split('-');
+        var s2=v2.split('-');
+        if (s1.length !== s2.length) return false;
+        if (s1.length === 4) s1.pop();
+        if (s2.length === 4) s2.pop();
+        return (s1.join('-') === s2.join('-'));
     }
-    if (s[2][0] === 'g') {
-        var v = s[2].split('_')[0].substring(1, 8);
-        if (v.length === 7) {
-            versionLog('Installed git commit id of netdata is ' + v);
-            document.getElementById('netdataCommitId').innerHTML = v;
-            return v;
-        }
-    }
-    return null;
 }
 
-function getNetdataCommitId(force, callback) {
-    versionLog('Downloading installed git commit id from netdata...');
+function getGithubLatestVersion(callback) {
+    versionLog('Downloading latest version id from github...');
 
     $.ajax({
-        url: 'version.txt',
-        async: true,
-        cache: false,
-        xhrFields: {withCredentials: true} // required for the cookie
-    })
-        .done(function (data) {
-            data = data.replace(/(\r\n|\n|\r| |\t)/gm, "");
-
-            var c = getNetdataCommitIdFromVersion();
-            if (c !== null && data.length === 40 && data.substring(0, 7) !== c) {
-                versionLog('Installed files commit id and internal netdata git commit id do not match');
-                data = c;
-            }
-
-            if (data.length >= 7) {
-                versionLog('Installed git commit id of netdata is ' + data);
-                document.getElementById('netdataCommitId').innerHTML = data.substring(0, 7);
-                callback(data);
-            }
-        })
-        .fail(function () {
-            versionLog('Failed to download installed git commit id from netdata!');
-
-            if (force === true) {
-                var c = getNetdataCommitIdFromVersion();
-                if (c === null) {
-                    versionLog('Cannot find the git commit id of netdata.');
-                }
-                callback(c);
-            } else {
-                callback(null);
-            }
-        });
-}
-
-function getGithubLatestCommit(callback) {
-    versionLog('Downloading latest git commit id info from github...');
-
-    $.ajax({
-        url: 'https://api.github.com/repos/netdata/netdata/commits',
+        url: 'https://api.github.com/repositories/10744183/contents/packaging/version?ref=master',
         async: true,
         cache: false
     })
         .done(function (data) {
-            versionLog('Latest git commit id from github is ' + data[0].sha);
-            callback(data[0].sha);
+            data = atob(data.content.replace(/(\r\n|\n|\r| |\t)/gm, ""));
+            versionLog('Latest version from github is ' + data);
+            callback(data);
         })
         .fail(function () {
-            versionLog('Failed to download installed git commit id from github!');
+            versionLog('Failed to download the latest version id from github!');
             callback(null);
         });
 }
 
-function checkForUpdate(force, callback) {
-    getNetdataCommitId(force, function (sha1) {
-        if (sha1 === null) {
-            callback(null, null);
-        }
-
-        getGithubLatestCommit(function (sha2) {
-            callback(sha1, sha2);
-        });
+function checkForUpdateByVersion(force, callback) {
+    getGithubLatestVersion(function (sha2) {
+            callback(options.version, sha2);
     });
 
     return null;
@@ -2927,23 +2881,22 @@ function notifyForUpdate(force) {
         }
     }
 
-    checkForUpdate(force, function (sha1, sha2) {
+    checkForUpdateByVersion(force, function (sha1, sha2) {
         var save = false;
 
         if (sha1 === null) {
             save = false;
-            versionLog('<p><big>Failed to get your netdata git commit id!</big></p><p>You can always get the latest netdata from <a href="https://github.com/netdata/netdata" target="_blank">its github page</a>.</p>');
+            versionLog('<p><big>Failed to get your netdata version!</big></p><p>You can always get the latest netdata from <a href="https://github.com/netdata/netdata" target="_blank">its github page</a>.</p>');
         } else if (sha2 === null) {
             save = false;
-            versionLog('<p><big>Failed to get the latest git commit id from github.</big></p><p>You can always get the latest netdata from <a href="https://github.com/netdata/netdata" target="_blank">its github page</a>.</p>');
-        } else if (sha1 === sha2) {
+            versionLog('<p><big>Failed to get the latest netdata version github.</big></p><p>You can always get the latest netdata from <a href="https://github.com/netdata/netdata" target="_blank">its github page</a>.</p>');
+        } else if (versionsMatch(sha1, sha2)) {
             save = true;
             versionLog('<p><big>You already have the latest netdata!</big></p><p>No update yet?<br/>Probably, we need some motivation to keep going on!</p><p>If you haven\'t already, <a href="https://github.com/netdata/netdata" target="_blank">give netdata a <b><i class="fas fa-star"></i></b> at its github page</a>.</p>');
         } else {
             save = true;
-            var compare = 'https://github.com/netdata/netdata/compare/' + sha1.toString() + '...' + sha2.toString();
-
-            versionLog('<p><big><strong>New version of netdata available!</strong></big></p><p>Latest commit: <b><code>' + sha2.substring(0, 7).toString() + '</code></b></p><p><a href="' + compare + '" target="_blank">Click here for the changes log</a> since your installed version, and<br/><a href="https://github.com/netdata/netdata/tree/master/packaging/installer/UPDATE.md" target="_blank">click here for directions on updating</a> your netdata installation.</p><p>We suggest to review the changes log for new features you may be interested, or important bug fixes you may need.<br/>Keeping your netdata updated, is generally a good idea.</p>');
+            var compare = 'https://github.com/netdata/netdata/blob/master/CHANGELOG.md';
+            versionLog('<p><big><strong>New version of netdata available!</strong></big></p><p>Latest version: <b><code>' + sha2 + '</code></b></p><p><a href="' + compare + '" target="_blank">Click here for the changes log</a> and<br/><a href="https://github.com/netdata/netdata/tree/master/packaging/installer/UPDATE.md" target="_blank">click here for directions on updating</a> your netdata installation.</p><p>We suggest to review the changes log for new features you may be interested, or important bug fixes you may need.<br/>Keeping your netdata updated is generally a good idea.</p>');
 
             document.getElementById('update_badge').innerHTML = '!';
         }


### PR DESCRIPTION
##### Summary
Fixes #5201 

##### Component Name
web/gui

##### Additional Information
With the new update process that is based on nightly builds instead of commits, the `Update` button on the web GUI is corrected to compare versions.

Possible netdata version formats are:
- `v1.12.0-rc3-37-nightly`
- `v1.12.0-rc3-37-a576f52`
- `v1.12.0-rc3`
- `v1.12.0`

Possible formats of https://github.com/netdata/netdata/blob/master/packaging/version are:
- `v1.12.0-rc3-37-nightly`
- `v1.12.0-rc3`
- `v1.12.0`
