### PR TITLE
Correct info on what kickstart.sh does

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 The above command will:
 
 1. install any required packages on your system (it will ask you to confirm before doing so),
-2. download netdata source to `/usr/src/netdata.git`
-3. compile it, install it and start it
+2. compile it, install it and start it
 
 More installation methods and additional options can be found at the [installation page](packaging/installer/#installation).
 


### PR DESCRIPTION
##### Summary
kickstart.sh no longer leaves the source in the system.

##### Component Name
docs
##### Additional Information

