### PR TITLE
kickstart: noexec detection

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -41,7 +41,7 @@ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 Verify the integrity of the script with this:
 
 ```bash
-[ "f16d433f3fc86264fa2e05808369c54b" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "b4632ca6c651de0f667e6d4f6e1015fe" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 *It should print `OK, VALID` if the script is the one we ship.*
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -216,7 +216,14 @@ Machine           : ${MACHINE}
 BASH major version: ${BASH_MAJOR_VERSION}
 EOF
 
-tmpdir="$(mktemp -d /tmp/netdata-kickstart-XXXXXX)"
+# Check if tmp is mounted as noexec
+if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
+	pattern="/opt/netdata-kickstart-XXXXXX"
+else
+	pattern="/tmp/netdata-kickstart-XXXXXX"
+fi
+
+tmpdir="$(mktemp -d $pattern)"
 cd "${tmpdir}" || :
 
 if [ "${OS}" != "GNU/Linux" ] && [ "${SYSTEM}" != "Linux" ]; then


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Detect if `/tmp` is mounted with `noexec` flag and change tmporary directory location if that is the case.

Fixes #5251

##### Component Name
installer/kickstart

##### Additional Information

