### PR TITLE
Minor updates to anonymous statistics

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -16,6 +16,9 @@ void netdata_cleanup_and_exit(int ret) {
 }
 
 void send_statistics( const char *action, const char *action_result, const char *action_data) {
+    (void) action;
+    (void) action_result;
+    (void) action_data;
     return;
 }
 // callbacks required by popen()

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -25,6 +25,9 @@ void netdata_cleanup_and_exit(int ret) {
 }
 
 void send_statistics( const char *action, const char *action_result, const char *action_data) {
+    (void) action;
+    (void) action_result;
+    (void) action_data;
     return;
 }
 

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -67,10 +67,14 @@ ARCHITECTURE="$(uname -m)"
 
 VIRTUALIZATION="unknown"
 VIRT_DETECTION="none"
+CONTAINER="unknown"
+CONT_DETECTION="none"
 
 if [ -n "$(command -v systemd-detect-virt 2>/dev/null)" ]; then
-	VIRTUALIZATION="$(systemd-detect-virt)"
+	VIRTUALIZATION="$(systemd-detect-virt -v)"
 	VIRT_DETECTION="systemd-detect-virt"
+	CONTAINER="$(systemd-detect-virt -c)"
+	CONT_DETECTION="systemd-detect-virt"
 else
 	if grep -q "^flags.*hypervisor" /proc/cpuinfo 2>/dev/null; then
 		VIRTUALIZATION="hypervisor"
@@ -79,36 +83,35 @@ else
 fi
 
 # -------------------------------------------------------------------------------------------------
-# detect containers
+# detect containers with heuristics
 
-CONTAINER="none"
-CONT_DETECTION="none"
+if [ "${CONTAINER}" = "unknown" ] ; then
+	IFS='(, ' read -r process _ </proc/1/sched
+	if [ "${process}" = "netdata" ]; then
+		CONTAINER="container"
+		CONT_DETECTION="process"
+	fi
 
-IFS='(, ' read -r process _ </proc/1/sched
-if [ "${process}" = "netdata" ]; then
-	CONTAINER="container"
-	CONT_DETECTION="process"
-fi
+	# ubuntu and debian supply /bin/running-in-container
+	# https://www.apt-browse.org/browse/ubuntu/trusty/main/i386/upstart/1.12.1-0ubuntu4/file/bin/running-in-container
+	if /bin/running-in-container >/dev/null 2>&1; then
+		CONTAINER="container"
+		CONT_DETECTION="/bin/running-in-container"
+	fi
 
-# ubuntu and debian supply /bin/running-in-container
-# https://www.apt-browse.org/browse/ubuntu/trusty/main/i386/upstart/1.12.1-0ubuntu4/file/bin/running-in-container
-if /bin/running-in-container >/dev/null 2>&1; then
-	CONTAINER="container"
-	CONT_DETECTION="/bin/running-in-container"
-fi
+	# lxc sets environment variable 'container'
+	#shellcheck disable=SC2154
+	if [ -n "${container}" ]; then
+		CONTAINER="lxc"
+		CONT_DETECTION="containerenv"
+	fi
 
-# lxc sets environment variable 'container'
-#shellcheck disable=SC2154
-if [ -n "${container}" ]; then
-	CONTAINER="lxc"
-	CONT_DETECTION="containerenv"
-fi
-
-# docker creates /.dockerenv
-# http://stackoverflow.com/a/25518345
-if [ -f "/.dockerenv" ]; then
-	CONTAINER="docker"
-	CONT_DETECTION="dockerenv"
+	# docker creates /.dockerenv
+	# http://stackoverflow.com/a/25518345
+	if [ -f "/.dockerenv" ]; then
+		CONTAINER="docker"
+		CONT_DETECTION="dockerenv"
+	fi
 fi
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
Remove warnings from dummy send_statistics functions.
Use systemd-detect-virt where possible for both virtualization and containers
Separate systemd-detect-virt calls to two, one for virtualization, one for containers.

##### Component Name
anonymous statistics

##### Additional Information

