### PR TITLE
Remove registrypath from alarm-notify

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1827,8 +1827,7 @@ fi
 if [ ${GOTOCLOUD} -eq 0 ] ; then
 	goto_url="${NETDATA_REGISTRY_URL}/goto-host-from-alarm.html?${redirect_params}"
 else
-	urlencode "${NETDATA_REGISTRY_URL}/goto-host-from-alarm.html" >/dev/null; url_registrypath="${REPLY}"
-	goto_url="https://netdata.cloud/alarms/redirect?agentID=${NETDATA_REGISTRY_UNIQUE_ID}&registrypath=${url_registrypath}&${redirect_params}"
+	goto_url="https://netdata.cloud/alarms/redirect?agentID=${NETDATA_REGISTRY_UNIQUE_ID}&${redirect_params}"
 fi
 
 # the severity of the alarm


### PR DESCRIPTION
##### Summary
Fixes #5301.

##### Component Name
health

##### Additional Information
Registrypath is not used and causes issues in slack, probably because it's already urlencoded. If we are to add registry path in the future, it will need to be in separate param, so that it doesn't require url encoding.