### PR TITLE
Remove warnings for send_statistics

### DIFF
--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -36,6 +36,9 @@ void netdata_cleanup_and_exit(int ret) {
 }
 
 void send_statistics( const char *action, const char *action_result, const char *action_data) {
+    (void)action;
+    (void)action_result;
+    (void)action_data;
     return;
 }
 


### PR DESCRIPTION
##### Summary
Remove warning from the freeipmi plugin, by adding (void).

##### Component Name
daemon

