### PR TITLE
do not overflow incremental values after gaps

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -757,6 +757,50 @@ struct test test5d = {
 };
 
 // --------------------------------------------------------------------------------------------------------------------
+// test5e - 64 bit prevent overflow on gaps
+
+struct feed_values test5e_feed[] = {
+        { 0,       0xFFFFFFFFFFFFFFFFULL / 3 * 0 },
+        { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 1 },
+        { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 2 },
+        { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 0 },
+        { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 1 },
+        { 2000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 2 },
+        { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 0 },
+        { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 1 },
+        { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 2 },
+        { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 0 },
+};
+
+calculated_number test5e_results[] = {
+        0xFFFFFFFFFFFFFFFFULL / 3,
+        0xFFFFFFFFFFFFFFFFULL / 3,
+        0xFFFFFFFFFFFFFFFFULL / 3,
+        0xFFFFFFFFFFFFFFFFULL / 3,
+        0,
+        0xFFFFFFFFFFFFFFFFULL / 6,
+        0xFFFFFFFFFFFFFFFFULL / 3,
+        0xFFFFFFFFFFFFFFFFULL / 3,
+        0xFFFFFFFFFFFFFFFFULL / 3,
+        0xFFFFFFFFFFFFFFFFULL / 3,
+};
+
+struct test test5e = {
+        "test5e",            // name
+        "test 64-bit incremental values overflow prevention",
+        1,                  // update_every
+        1,                  // multiplier
+        1,                  // divisor
+        RRD_ALGORITHM_INCREMENTAL, // algorithm
+        10,                 // feed entries
+        10,                  // result entries
+        test5e_feed,        // feed
+        test5e_results,     // results
+        NULL,               // feed2
+        NULL                // results2
+};
+
+// --------------------------------------------------------------------------------------------------------------------
 // test6
 
 struct feed_values test6_feed[] = {
@@ -1421,6 +1465,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(run_test(&test5d))
+        return 1;
+
+    if(run_test(&test5e))
         return 1;
 
     if(run_test(&test6))

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1394,7 +1394,7 @@ void rrdset_done(RRDSET *st) {
                     uint64_t delta = cap - last + new;
 
                     // when there will be gaps in the charts, don't wrap overflown incremental values
-                    if((next_store_ut - last_stored_ut) > (gap_when_lost_iterations_above * update_every_ut))
+                    if((st->counter_done < 3) || ((next_store_ut - last_stored_ut) > (gap_when_lost_iterations_above * update_every_ut)))
                         delta = 0;
 
                     rd->calculated_value +=

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1393,6 +1393,10 @@ void rrdset_done(RRDSET *st) {
 
                     uint64_t delta = cap - last + new;
 
+                    // when there will be gaps in the charts, don't wrap overflown incremental values
+                    if((next_store_ut - last_stored_ut) > (gap_when_lost_iterations_above * update_every_ut))
+                        delta = 0;
+
                     rd->calculated_value +=
                             (calculated_number) delta
                             * (calculated_number) rd->multiplier


### PR DESCRIPTION
Improves the situation for #5297 
Improves the situtation for #4962 

##### Summary

PR #4538 allowed netdata to detect the size of incremental values and properly rotate them (calculate the delta after an overflow).

Issue #5297 describes that the code above had a side effect: after data collection gaps (slave restart, system reboot, etc), netdata was again calculating the overflown delta, giving unrealistic spikes.

This PR detects that an overflown value happens after a data collection gaps, so that instead of calculating the overflown delta, netdata now shows zero.

##### Component Name

data collection interpolation

##### Additional Information

Added also a unit test to verify this works properly.
