### PR TITLE
Allow user to override the default behavior for read-only mounts

### DIFF
--- a/collectors/diskspace.plugin/README.md
+++ b/collectors/diskspace.plugin/README.md
@@ -2,6 +2,33 @@
 
 This plugin monitors the disk space usage of mounted disks, under Linux.
 
+Two charts are available for every mount:
+ - Disk Space Usage
+ - Disk Files (inodes) Usage
+
+## configuration
+
+Simple patterns can be used to exclude mounts from showed statistics based on path or filesystem. By default read-only mounts are not displayed. To display them `yes` should be set for a chart instead of `auto`.
+
+```
+[plugin:proc:diskspace]
+    # remove charts of unmounted disks = yes
+    # update every = 1
+    # check for new mount points every = 15
+    # exclude space metrics on paths = /proc/* /sys/* /var/run/user/* /run/user/* /snap/* /var/lib/docker/*
+    # exclude space metrics on filesystems = *gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl
+    # space usage for all disks = auto
+    # inodes usage for all disks = auto
+```
+
+Charts can be enabled/disabled for every mount separately:
+
+```
+[plugin:proc:diskspace:/]
+    # space usage = auto
+    # inodes usage = auto
+```
+
 > for disks performance monitoring, see the `proc` plugin, [here](../proc.plugin/#monitoring-disks)
 
 

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -190,7 +190,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
     if(unlikely(m->do_space == CONFIG_BOOLEAN_NO && m->do_inodes == CONFIG_BOOLEAN_NO))
         return;
 
-    if(unlikely(mi->flags & MOUNTINFO_READONLY && !m->collected))
+    if(unlikely(mi->flags & MOUNTINFO_READONLY && !m->collected && m->do_space != CONFIG_BOOLEAN_YES && m->do_inodes != CONFIG_BOOLEAN_YES))
         return;
 
     struct statvfs buff_statvfs;


### PR DESCRIPTION
##### Summary
When netdata runs in a container, it is desirable to have a possibility of displaying statistics for read-only mounts. By default charts for these mounts are disabled. This PR allows to enable them in `netdata.conf`
```
[plugin:proc:diskspace:/host]
	space usage = yes
	inodes usage = yes
```

Fixes #5071
Fixes #5231

##### Component Name
`diskspace` plugin