### PR TITLE
Fix FreeBSD plugin Codacy issues

### DIFF
--- a/collectors/freebsd.plugin/freebsd_kstat_zfs.c
+++ b/collectors/freebsd.plugin/freebsd_kstat_zfs.c
@@ -104,11 +104,11 @@ int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt) {
         // int arc_loaned_bytes[5];
         // int arc_prune[5];
         // int arc_meta_used[5];
-        int arc_meta_limit[5];
-        int arc_meta_max[5];
-        int arc_meta_min[5];
-        int arc_need_free[5];
-        int arc_sys_free[5];
+        // int arc_meta_limit[5];
+        // int arc_meta_max[5];
+        // int arc_meta_min[5];
+        // int arc_need_free[5];
+        // int arc_sys_free[5];
     } mibs;
 
     arcstats.l2exist = -1;

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -590,7 +590,6 @@ int do_hw_intcnt(int update_every, usec_t dt) {
         unsigned long nintr = 0;
         static unsigned long old_nintr = 0;
         static unsigned long *intrcnt = NULL;
-        unsigned long i;
 
         nintr = intrcnt_size / sizeof(u_long);
         if (unlikely(nintr != old_nintr))
@@ -602,6 +601,7 @@ int do_hw_intcnt(int update_every, usec_t dt) {
             return 1;
         } else {
             unsigned long long totalintr = 0;
+            unsigned long i;
 
             for (i = 0; i < nintr; i++)
                 totalintr += intrcnt[i];


### PR DESCRIPTION
##### Summary
Fix `variable is never used` and `scope of the variable can be reduced` issues.

##### Component Name
`freebsd` plugin