### PR TITLE
fix AC_CHECK_LIB to work correctly with cups library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -409,19 +409,7 @@ AM_CONDITIONAL([ENABLE_PLUGIN_FREEIPMI], [test "${enable_plugin_freeipmi}" = "ye
 # -----------------------------------------------------------------------------
 # cups.plugin - libmnl, libnetfilter_acct
 
- AC_CHECK_LIB([cups], [
-    cupsEncryption,
-    cupsFreeDests,
-    cupsFreeJobs,
-    cupsGetDests2,
-    cupsGetIntegerOption,
-    cupsGetJobs2,
-    cupsGetOption,
-    cupsServer,
-    httpClose,
-    httpConnect2,
-    ippPort
-],
+ AC_CHECK_LIB([cups], [cupsGetIntegerOption],
     [AC_CHECK_HEADER(
         [cups/cups.h],
         [have_cups=yes],


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->
Fixes #5324 
##### Summary
Fixes problem with old cups library breaking netdata compilation and subsequently installation and #5324 
##### Component Name
Cups plugin.
##### Additional Information

AC_CHECK_LIB does not seem to work correctly with a list of functions. Using just one function instead seems like it fixes the problem.