### PR TITLE
cups.plugin: Support older versions

### DIFF
--- a/collectors/cups.plugin/README.md
+++ b/collectors/cups.plugin/README.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-This plugin needs a running local CUPS daemon (`cupsd`). This plugin does not need any configuration.
+This plugin needs a running local CUPS daemon (`cupsd`). This plugin does not need any configuration. Supports cups since version 1.7.
 
 ## Charts
 

--- a/collectors/cups.plugin/cups_plugin.c
+++ b/collectors/cups.plugin/cups_plugin.c
@@ -136,6 +136,37 @@ void parse_command_line(int argc, char **argv) {
     }
 }
 
+/*
+ * 'cupsGetIntegerOption()' - Get an integer option value.
+ *
+ * INT_MIN is returned when the option does not exist, is not an integer, or
+ * exceeds the range of values for the "int" type.
+ *
+ * @since CUPS 2.2.4/macOS 10.13@
+ */
+
+int					/* O - Option value or @code INT_MIN@ */
+getIntegerOption(
+    const char    *name,		/* I - Name of option */
+    int           num_options,		/* I - Number of options */
+    cups_option_t *options)		/* I - Options */
+{
+  const char	*value = cupsGetOption(name, num_options, options);
+					/* String value of option */
+  char		*ptr;			/* Pointer into string value */
+  long		intvalue;		/* Integer value */
+
+
+  if (!value || !*value)
+    return (INT_MIN);
+
+  intvalue = strtol(value, &ptr, 10);
+  if (intvalue < INT_MIN || intvalue > INT_MAX || *ptr)
+    return (INT_MIN);
+
+  return ((int)intvalue);
+}
+
 int reset_job_metrics(void *entry, void *data) {
     (void)data;
 
@@ -303,8 +334,7 @@ int main(int argc, char **argv) {
                 num_dest_shared++;
             }
 
-            // TODO use cupsGetIntegerOption
-            int printer_state = cupsGetIntegerOption("printer-state", curr_dest->num_options, curr_dest->options);
+            int printer_state = getIntegerOption("printer-state", curr_dest->num_options, curr_dest->options);
             switch (printer_state) {
                 case 3:
                     num_dest_idle++;

--- a/configure.ac
+++ b/configure.ac
@@ -409,7 +409,8 @@ AM_CONDITIONAL([ENABLE_PLUGIN_FREEIPMI], [test "${enable_plugin_freeipmi}" = "ye
 # -----------------------------------------------------------------------------
 # cups.plugin - libmnl, libnetfilter_acct
 
- AC_CHECK_LIB([cups], [cupsGetIntegerOption],
+# Only check most recently added method of cups
+ AC_CHECK_LIB([cups], [httpConnect2],
     [AC_CHECK_HEADER(
         [cups/cups.h],
         [have_cups=yes],


### PR DESCRIPTION


<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

The usage of cupsGetIntegerOption did block users using older cups
versions than 2.2.4. After redistribution this method all cups versions
since 1.7 can be used. httpConnect2 is now the most recently added
method in cups.h.

##### Component Name

`cups.plugin`

##### Additional Information

Addition to #5324 