### PR TITLE
fix warning condition for mem.available

### DIFF
--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -30,7 +30,7 @@
     calc: ($avail + $used_ram_to_ignore) * 100 / ($system.ram.used + $system.ram.cached + $system.ram.free + $system.ram.buffers)
    units: %
    every: 10s
-    warn: $this < (($status >= $WARNING)  ? ( 5) : (10))
+    warn: $this < (($status >= $WARNING)  ? (15) : (10))
     crit: $this < (($status == $CRITICAL) ? (10) : ( 5))
    delay: down 15m multiplier 1.5 max 1h
     info: estimated amount of RAM available for userspace processes, without causing swapping

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -57,7 +57,7 @@ delay: down 15m multiplier 1.5 max 1h
   calc: ($free + $inactive + $used_ram_to_ignore) * 100 / ($free + $active + $inactive + $wired + $cache + $laundry + $buffers)
  units: %
  every: 10s
-  warn: $this < (($status >= $WARNING)  ? ( 5) : (10))
+  warn: $this < (($status >= $WARNING)  ? (15) : (10))
   crit: $this < (($status == $CRITICAL) ? (10) : ( 5))
  delay: down 15m multiplier 1.5 max 1h
   info: estimated amount of RAM available for userspace processes, without causing swapping


### PR DESCRIPTION
##### Summary
Fixes: #5346

##### Component Name
health

##### Additional Information
Warning limit for mem.available was wrong, causing flapping alarms.

