### PR TITLE
fix: wget log spam in headless mode (fixes #5356)

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -44,7 +44,11 @@ download() {
 	url="${1}"
 	dest="${2}"
 	if command -v wget >/dev/null 2>&1; then
-		run wget -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		if [ -t 1 ]; then
+			run wget -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		else
+			run wget --progress=dot:mega -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		fi
 	elif command -v curl >/dev/null 2>&1; then
 		run curl "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	else


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fixes too much output created by wget if installer output is piped during a headless install

##### Component Name

`installer`

##### Additional Information

Fixes #5356