### PR TITLE
Added missing BuildRequires for autoconf, automake

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -91,6 +91,8 @@ BuildRequires:	pkgconfig
 BuildRequires:	xz
 BuildRequires:	zlib-devel
 BuildRequires:	libuuid-devel
+BuildRequires:	autoconf
+BuildRequires:	automake
 Requires:	zlib
 Requires:	libuuid
 


### PR DESCRIPTION
The build process uses  autoconf and automake, but does not list them in BuildRequires.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
As reported is issue 5362 the spec file for the RPM is missing BuildRequires for autoconf, automake

##### Component Name
netdata.spec.in 

##### Additional Information

