### PR TITLE
sslcheck module: (remote) SSL certificate expiry time check

### DIFF
--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -96,6 +96,7 @@ include smartd_log/Makefile.inc
 include spigotmc/Makefile.inc
 include springboot/Makefile.inc
 include squid/Makefile.inc
+include sslcheck/Makefile.inc
 include tomcat/Makefile.inc
 include tor/Makefile.inc
 include traefik/Makefile.inc

--- a/collectors/python.d.plugin/sslcheck/Makefile.inc
+++ b/collectors/python.d.plugin/sslcheck/Makefile.inc
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_python_DATA       += sslcheck/sslcheck.chart.py
+dist_pythonconfig_DATA += sslcheck/sslcheck.conf
+
+# do not install these files, but include them in the distribution
+dist_noinst_DATA       += sslcheck/README.md sslcheck/Makefile.inc

--- a/collectors/python.d.plugin/sslcheck/README.md
+++ b/collectors/python.d.plugin/sslcheck/README.md
@@ -13,9 +13,10 @@ update_every : 60
 
 example_org:
   host: 'example.org'
-  days_until_expiration_warning: 5
+  days_until_expiration_warning: 15
 
 my_site_org:
   host: 'my-site.org'
-  days_until_expiration_warning: 5
+  days_until_expiration_warning: 10
+  days_until_expiration_critical: 1
 ```

--- a/collectors/python.d.plugin/sslcheck/README.md
+++ b/collectors/python.d.plugin/sslcheck/README.md
@@ -13,7 +13,6 @@ update_every : 60
 
 example_org:
   host: 'example.org'
-  days_until_expiration_warning: 15
 
 my_site_org:
   host: 'my-site.org'

--- a/collectors/python.d.plugin/sslcheck/README.md
+++ b/collectors/python.d.plugin/sslcheck/README.md
@@ -1,9 +1,26 @@
-### configuration
+# SSL certificate expiry check
+
+Checks the time until a remote SSL certificate expires in days.
+
+## Requirements
+
+None
+
+## Example configuration
 
 ```yaml
-master:
-  host: www.my-netdata.io
-  port: 443
-  timeout: 10
+job_name:
+  name: myname                 # [optional] the JOB's name as it will appear at the
+                               # dashboard (by default is the job_name)
+  host: 'my-netdata.io'        # [required] the remote host address in either IPv4, IPv6 or as DNS name
+  port: 443                    # [required] the port number to check. Specify an integer, not service name
+  daysuntilexpiration: 5       # [required] days before the status is critical?
+  timeout: 10                  # [optional] the socket timeout when connecting
+  update_every: 120            # [optional] the JOB's data collection frequency. As the chart is in days
+                               # remaining, a high value should be chosen
+  priority: 60000              # [optional] the JOB's order on the dashboard
+  penalty: yes                 # [optional] the JOB's penalty
 ```
+
+
 

--- a/collectors/python.d.plugin/sslcheck/README.md
+++ b/collectors/python.d.plugin/sslcheck/README.md
@@ -1,0 +1,9 @@
+### configuration
+
+```yaml
+master:
+  host: www.my-netdata.io
+  port: 443
+  timeout: 10
+```
+

--- a/collectors/python.d.plugin/sslcheck/README.md
+++ b/collectors/python.d.plugin/sslcheck/README.md
@@ -1,26 +1,21 @@
 # SSL certificate expiry check
 
-Checks the time until a remote SSL certificate expires in days.
+Checks the time until a remote SSL certificate expires.
 
 ## Requirements
 
 None
 
-## Example configuration
+### configuration
 
 ```yaml
-job_name:
-  name: myname                 # [optional] the JOB's name as it will appear at the
-                               # dashboard (by default is the job_name)
-  host: 'my-netdata.io'        # [required] the remote host address in either IPv4, IPv6 or as DNS name
-  port: 443                    # [required] the port number to check. Specify an integer, not service name
-  daysuntilexpiration: 5       # [required] days before the status is critical?
-  timeout: 10                  # [optional] the socket timeout when connecting
-  update_every: 120            # [optional] the JOB's data collection frequency. As the chart is in days
-                               # remaining, a high value should be chosen
-  priority: 60000              # [optional] the JOB's order on the dashboard
-  penalty: yes                 # [optional] the JOB's penalty
+update_every : 60
+
+example_org:
+  host: 'example.org'
+  days_until_expiration_warning: 5
+
+my_site_org:
+  host: 'my-site.org'
+  days_until_expiration_warning: 5
 ```
-
-
-

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -56,7 +56,7 @@ class Service(SimpleService):
         self.debug('run check : host {host}:{port}, update every {update}s, timeout {timeout}s'.format(
             host=self.host, port=self.port, update=self.update_every, timeout=self.timeout))
 
-        return True
+        return bool(self.get_data())
 
     def get_data(self):
         conn = create_ssl_conn(self.host, self.timeout)

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Description: simple ssl expiration check netdata python.d module
-# Original Author: ccremer (github.com/ccremer)
+# Original Author: Peter Thurner (github.com/p-thurner)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -10,6 +10,9 @@ import ssl
 from bases.FrameworkServices.SimpleService import SimpleService
 
 
+update_every = 60
+
+
 ORDER = [
     'time_until_expiration',
 ]

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -21,7 +21,7 @@ DAYS_UNTIL_EXPIRATION = 'whatisthis'
 ORDER = ['daysuntilexpiration']
 
 CHARTS = {
-    'daysvalid': {
+    'daysuntilexpiration': {
         'options': [None, 'Days until expiration', 'days', 'daysuntilexpiration', 'sslcheck.daysuntilexpiration', 'line'],
         'lines': [
             [DAYS_UNTIL_EXPIRATION, 'days until expiration', 'absolute', 100, 1000]
@@ -65,7 +65,7 @@ class Service(SimpleService):
         :return: dict
         """
         data = dict()
-        data[DAYS_UNTIL_EXPIRATION] = self.ssl_valid_time_remaining(self.host)
+        data[DAYS_UNTIL_EXPIRATION] = self.ssl_valid_time_remaining(self.host, self.port)
 
         return data
 

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+# Description: simple ssl expiration check netdata python.d module
+# Original Author: ccremer (github.com/ccremer)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import ssl
+import socket
+
+import datetime
+
+try:
+    from time import monotonic as time
+except ImportError:
+    from time import time
+
+from bases.FrameworkServices.SimpleService import SimpleService
+
+
+DAYS_UNTIL_EXPIRATION = 'whatisthis'
+
+ORDER = ['daysuntilexpiration']
+
+CHARTS = {
+    'daysvalid': {
+        'options': [None, 'Days until expiration', 'days', 'daysuntilexpiration', 'sslcheck.daysuntilexpiration', 'line'],
+        'lines': [
+            [DAYS_UNTIL_EXPIRATION, 'days until expiration', 'absolute', 100, 1000]
+        ]
+    }
+}
+
+
+# Not deriving from SocketService, too much is different
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.host = self.configuration.get('host')
+        self.port = self.configuration.get('port')
+        self.timeout = self.configuration.get('timeout', 3)
+
+    def check(self):
+        """
+        Parse configuration, check if configuration is available, and dynamically create chart lines data
+        :return: boolean
+        """
+        if self.host is None or self.port is None:
+            self.error('Host or port missing')
+            return False
+        if not isinstance(self.port, int):
+            self.error('"port" is not an integer. Specify a numerical value, not service name.')
+            return False
+
+        self.debug('Enabled sslcheck: {host}:{port}, update every {update}s, timeout: {timeout}s'.format(
+            host=self.host, port=self.port, update=self.update_every, timeout=self.timeout
+        ))
+        # We will accept any (valid-ish) configuration, even if initial connection fails (a service
+        # might be down from the beginning)
+        return True
+
+    def _get_data(self):
+        """
+        Get number of days until the certificate for the configured hostname expires
+        :return: dict
+        """
+        data = dict()
+        data[DAYS_UNTIL_EXPIRATION] = self.ssl_valid_time_remaining(self.host)
+
+        return data
+
+    def ssl_expiry_datetime(self, hostname, port):
+        ssl_date_fmt = r'%b %d %H:%M:%S %Y %Z'
+
+        context = ssl.create_default_context()
+        conn = context.wrap_socket(
+            socket.socket(socket.AF_INET),
+            server_hostname=hostname,
+        )
+
+        conn.settimeout(self.timeout)
+
+        conn.connect((hostname, port))
+        ssl_info = conn.getpeercert()
+        # parse the string from the certificate into a Python datetime object
+        return datetime.datetime.strptime(ssl_info['notAfter'], ssl_date_fmt)
+
+    def ssl_valid_time_remaining(self, hostname, port):
+        """Get the number of days left in a cert's lifetime."""
+        expires = self.ssl_expiry_datetime(hostname, port)
+        return expires - datetime.datetime.utcnow()
+
+    # def ssl_expires_in(self, hostname, buffer_days=14):
+    #    """
+    #    Check if `hostname` SSL cert expires within `buffer_days`.
+    #    :return: Bool
+    #    """
+    #    remaining = self.ssl_valid_time_remaining(hostname)
+
+    #    # if the cert expires in less than two weeks or is already expired, return True
+    #    if remaining < datetime.timedelta(days=0):
+    #        # cert has already expired
+    #        return True
+    #    elif remaining < datetime.timedelta(days=buffer_days):
+    #        # expires sooner than the buffer
+    #        return True
+    #    else:
+    #        # everything is fine
+    #        return False
+

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -5,7 +5,13 @@
 
 import ssl
 import socket
+
 import datetime
+
+#try:
+#    from time import monotonic as time
+#except ImportError:
+#    from time import time
 
 from bases.FrameworkServices.SimpleService import SimpleService
 
@@ -18,7 +24,7 @@ CHARTS = {
     'daysuntilexpiration': {
         'options': [None, 'days until certificate expiration', 'days', 'days until expiration', 'sslcheck.daysuntilexpiration', 'line'],
         'lines': [
-            [DAYS_UNTIL_EXPIRATION, 'days until expiration', 'absolute', 100, 1000]
+            [DAYS_UNTIL_EXPIRATION, 'days until expiration', 'absolute', 10, 0]
         ]
     }
 }
@@ -82,4 +88,6 @@ class Service(SimpleService):
     def ssl_valid_time_remaining(self, hostname, port):
         """Get the number of days left in a cert's lifetime."""
         expires = self.ssl_expiry_datetime(hostname, port)
+#        print ((expires - datetime.datetime.utcnow()).days * 1.0)
+#        return ((expires - datetime.datetime.utcnow()).days * 10.0)
         return (expires - datetime.datetime.utcnow()).days

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -40,6 +40,11 @@ CHARTS = {
 
 SSL_DATE_FMT = r'%b %d %H:%M:%S %Y %Z'
 
+DEFAULT_PORT = 443
+DEFAULT_CONN_TIMEOUT = 3
+DEFAULT_DAYS_UNTIL_WARN_LIMIT = 14
+DEFAULT_DAYS_UNTIL_CRIT_LIMIT = 7
+
 
 class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
@@ -47,10 +52,10 @@ class Service(SimpleService):
         self.order = ORDER
         self.definitions = CHARTS
         self.host = configuration.get('host')
-        self.port = configuration.get('port', 443)
-        self.timeout = configuration.get('timeout', 3)
-        self.days_warn = configuration.get('days_until_expiration_warning', 14)
-        self.days_crit = configuration.get('days_until_expiration_critical', 7)
+        self.port = configuration.get('port', DEFAULT_PORT)
+        self.timeout = configuration.get('timeout', DEFAULT_CONN_TIMEOUT)
+        self.days_warn = configuration.get('days_until_expiration_warning', DEFAULT_DAYS_UNTIL_WARN_LIMIT)
+        self.days_crit = configuration.get('days_until_expiration_critical', DEFAULT_DAYS_UNTIL_CRIT_LIMIT)
 
     def check(self):
         if not self.host:

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -16,7 +16,7 @@ except ImportError:
 from bases.FrameworkServices.SimpleService import SimpleService
 
 
-DAYS_UNTIL_EXPIRATION = 'whatisthis'
+DAYS_UNTIL_EXPIRATION = 'daysuntilexpiration'
 
 ORDER = ['daysuntilexpiration']
 
@@ -88,7 +88,7 @@ class Service(SimpleService):
     def ssl_valid_time_remaining(self, hostname, port):
         """Get the number of days left in a cert's lifetime."""
         expires = self.ssl_expiry_datetime(hostname, port)
-        return expires - datetime.datetime.utcnow()
+        return (expires - datetime.datetime.utcnow()).days
 
     # def ssl_expires_in(self, hostname, buffer_days=14):
     #    """

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -18,23 +18,22 @@ ORDER = [
 ]
 
 CHARTS = {
-        'time_until_expiration': {
-            'options': [
-                None,
-                'Time Until Certificate Expiration',
-                'seconds',
-                'certificate expiration',
-                'sslcheck.time_until_expiration',
-                'line',
-            ],
-            'lines': [
-                ['time'],
-            ],
-            'variables': [
-                ['days_until_expiration_warning'],
-            ],
-
-        },
+    'time_until_expiration': {
+        'options': [
+            None,
+            'Time Until Certificate Expiration',
+            'seconds',
+            'certificate expiration time',
+            'sslcheck.time_until_expiration',
+            'line',
+        ],
+        'lines': [
+            ['time'],
+        ],
+        'variables': [
+            ['days_until_expiration_warning'],
+        ],
+    },
 }
 
 

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -49,7 +49,7 @@ class Service(SimpleService):
         self.host = configuration.get('host')
         self.port = configuration.get('port', 443)
         self.timeout = configuration.get('timeout', 3)
-        self.days_warn = configuration.get('days_until_expiration_warning', 30)
+        self.days_warn = configuration.get('days_until_expiration_warning', 14)
         self.days_crit = configuration.get('days_until_expiration_critical', 7)
 
     def check(self):

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -3,15 +3,9 @@
 # Original Author: ccremer (github.com/ccremer)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import ssl
-import socket
-
 import datetime
-
-#try:
-#    from time import monotonic as time
-#except ImportError:
-#    from time import time
+import socket
+import ssl
 
 from bases.FrameworkServices.SimpleService import SimpleService
 
@@ -88,6 +82,4 @@ class Service(SimpleService):
     def ssl_valid_time_remaining(self, hostname, port):
         """Get the number of days left in a cert's lifetime."""
         expires = self.ssl_expiry_datetime(hostname, port)
-#        print ((expires - datetime.datetime.utcnow()).days * 1.0)
-#        return ((expires - datetime.datetime.utcnow()).days * 10.0)
         return (expires - datetime.datetime.utcnow()).days

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -5,13 +5,7 @@
 
 import ssl
 import socket
-
 import datetime
-
-try:
-    from time import monotonic as time
-except ImportError:
-    from time import time
 
 from bases.FrameworkServices.SimpleService import SimpleService
 
@@ -22,7 +16,7 @@ ORDER = ['daysuntilexpiration']
 
 CHARTS = {
     'daysuntilexpiration': {
-        'options': [None, 'Days until expiration', 'days', 'daysuntilexpiration', 'sslcheck.daysuntilexpiration', 'line'],
+        'options': [None, 'days until certificate expiration', 'days', 'days until expiration', 'sslcheck.daysuntilexpiration', 'line'],
         'lines': [
             [DAYS_UNTIL_EXPIRATION, 'days until expiration', 'absolute', 100, 1000]
         ]
@@ -89,22 +83,3 @@ class Service(SimpleService):
         """Get the number of days left in a cert's lifetime."""
         expires = self.ssl_expiry_datetime(hostname, port)
         return (expires - datetime.datetime.utcnow()).days
-
-    # def ssl_expires_in(self, hostname, buffer_days=14):
-    #    """
-    #    Check if `hostname` SSL cert expires within `buffer_days`.
-    #    :return: Bool
-    #    """
-    #    remaining = self.ssl_valid_time_remaining(hostname)
-
-    #    # if the cert expires in less than two weeks or is already expired, return True
-    #    if remaining < datetime.timedelta(days=0):
-    #        # cert has already expired
-    #        return True
-    #    elif remaining < datetime.timedelta(days=buffer_days):
-    #        # expires sooner than the buffer
-    #        return True
-    #    else:
-    #        # everything is fine
-    #        return False
-

--- a/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.chart.py
@@ -32,6 +32,7 @@ CHARTS = {
         ],
         'variables': [
             ['days_until_expiration_warning'],
+            ['days_until_expiration_critical'],
         ],
     },
 }
@@ -48,7 +49,8 @@ class Service(SimpleService):
         self.host = configuration.get('host')
         self.port = configuration.get('port', 443)
         self.timeout = configuration.get('timeout', 3)
-        self.days_warn = configuration.get('days_until_expiration_warning', 5)
+        self.days_warn = configuration.get('days_until_expiration_warning', 30)
+        self.days_crit = configuration.get('days_until_expiration_critical', 7)
 
     def check(self):
         if not self.host:
@@ -82,6 +84,7 @@ class Service(SimpleService):
         return {
             'time': cert_expiration_seconds(peer_cert),
             'days_until_expiration_warning': self.days_warn,
+            'days_until_expiration_critical': self.days_crit,
         }
 
 

--- a/collectors/python.d.plugin/sslcheck/sslcheck.conf
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.conf
@@ -64,7 +64,7 @@
 #     host: 'host'                      # [required] the remote host address in either IPv4, IPv6 or as DNS name
 #     port: 443                         # [optional] the port number to check. Specify an integer, not service name. Default is 443.
 #     timeout: 3                        # [optional] the socket timeout when connecting
-#     days_until_expiration_warning: 5  # [optional] days before the status is warning. Default is 5.
+#     days_until_expiration_warning: 5  # [optional] days before the status is warning (alarm). Default is 5.
 #
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS

--- a/collectors/python.d.plugin/sslcheck/sslcheck.conf
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.conf
@@ -65,7 +65,8 @@ job_name:
   port: 443                    # [required] the port number to check. Specify an integer, not service name
   daysuntilexpiration: 5       # [required] days before the status is critical?
   timeout: 10                  # [optional] the socket timeout when connecting
-  update_every: 2              # [optional] the JOB's data collection frequency
+  update_every: 3600           # [optional] the JOB's data collection frequency. As the chart is in days
+                               # remaining, a high value should be chosen
   priority: 60000              # [optional] the JOB's order on the dashboard
   penalty: yes                 # [optional] the JOB's penalty
 

--- a/collectors/python.d.plugin/sslcheck/sslcheck.conf
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.conf
@@ -71,5 +71,5 @@
 # only one of them will run (they have the same name)
 
 # example_org:
-#   host : example_org
+#   host : 'example.org'
 #   days_until_expiration_warning: 10

--- a/collectors/python.d.plugin/sslcheck/sslcheck.conf
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.conf
@@ -1,0 +1,70 @@
+# netdata python.d.plugin configuration for sslcheck
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# penalty indicates whether to apply penalty to update_every in case of failures.
+# Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
+# penalty: yes
+
+# chart_cleanup sets the default chart cleanup interval in iterations.
+# A chart is marked as obsolete if it has not been updated
+# 'chart_cleanup' iterations in a row.
+# They will be hidden immediately (not offered to dashboard viewer,
+# streamed upstream and archived to backends) and deleted one hour
+# later (configurable from netdata.conf).
+# -- For this plugin, cleanup MUST be disabled, otherwise we lose latency chart
+chart_cleanup: 0
+
+# Autodetection and retries do not work for this plugin
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# -------------------------------
+# ATTENTION: Any valid configuration will be accepted, even if initial connection fails!
+# -------------------------------
+#
+# There is intentionally no default config for 'localhost'
+
+# job_name:
+#     name: myname            # [optional] the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # [optional] the JOB's data collection frequency
+#     priority: 60000         # [optional] the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     timeout: 1              # [optional] the socket timeout when connecting
+#     host: 'dns or ip'       # [required] the remote host address in either IPv4, IPv6 or as DNS name.
+#     port: 22                # [required] the port number to check. Specify an integer, not service name.

--- a/collectors/python.d.plugin/sslcheck/sslcheck.conf
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.conf
@@ -31,16 +31,11 @@
 # Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
 # penalty: yes
 
-# chart_cleanup sets the default chart cleanup interval in iterations.
-# A chart is marked as obsolete if it has not been updated
-# 'chart_cleanup' iterations in a row.
-# They will be hidden immediately (not offered to dashboard viewer,
-# streamed upstream and archived to backends) and deleted one hour
-# later (configurable from netdata.conf).
-# -- For this plugin, cleanup MUST be disabled, otherwise we lose latency chart
-chart_cleanup: 0
-
-# Autodetection and retries do not work for this plugin
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
 
 # ----------------------------------------------------------------------
 # JOBS (data collection sources)
@@ -52,21 +47,29 @@ chart_cleanup: 0
 #
 # Any number of jobs is supported.
 #
-# -------------------------------
-# ATTENTION: Any valid configuration will be accepted, even if initial connection fails!
-# -------------------------------
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
 #
-# There is intentionally no default config for 'localhost'
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, sslcheck also supports the following:
+#
+#     host: 'host'                      # [required] the remote host address in either IPv4, IPv6 or as DNS name
+#     port: 443                         # [optional] the port number to check. Specify an integer, not service name. Default is 443.
+#     timeout: 3                        # [optional] the socket timeout when connecting
+#     days_until_expiration_warning: 5  # [optional] days before the status is warning. Default is 5.
+#
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+# only one of them will run (they have the same name)
 
-job_name:
-  name: myname                 # [optional] the JOB's name as it will appear at the
-                               # dashboard (by default is the job_name)
-  host: 'my-netdata.io'        # [required] the remote host address in either IPv4, IPv6 or as DNS name
-  port: 443                    # [required] the port number to check. Specify an integer, not service name
-  daysuntilexpiration: 5       # [required] days before the status is critical?
-  timeout: 10                  # [optional] the socket timeout when connecting
-  update_every: 3600           # [optional] the JOB's data collection frequency. As the chart is in days
-                               # remaining, a high value should be chosen
-  priority: 60000              # [optional] the JOB's order on the dashboard
-  penalty: yes                 # [optional] the JOB's penalty
-
+# example_org:
+#   host : example_org
+#   days_until_expiration_warning: 10

--- a/collectors/python.d.plugin/sslcheck/sslcheck.conf
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.conf
@@ -58,13 +58,14 @@ chart_cleanup: 0
 #
 # There is intentionally no default config for 'localhost'
 
-# job_name:
-#     name: myname            # [optional] the JOB's name as it will appear at the
-#                             # dashboard (by default is the job_name)
-#                             # JOBs sharing a name are mutually exclusive
-#     update_every: 1         # [optional] the JOB's data collection frequency
-#     priority: 60000         # [optional] the JOB's order on the dashboard
-#     penalty: yes            # the JOB's penalty
-#     timeout: 1              # [optional] the socket timeout when connecting
-#     host: 'dns or ip'       # [required] the remote host address in either IPv4, IPv6 or as DNS name.
-#     port: 22                # [required] the port number to check. Specify an integer, not service name.
+job_name:
+  name: myname                 # [optional] the JOB's name as it will appear at the
+                               # dashboard (by default is the job_name)
+  host: 'my-netdata.io'        # [required] the remote host address in either IPv4, IPv6 or as DNS name
+  port: 443                    # [required] the port number to check. Specify an integer, not service name
+  daysuntilexpiration: 5       # [required] days before the status is critical?
+  timeout: 10                  # [optional] the socket timeout when connecting
+  update_every: 2              # [optional] the JOB's data collection frequency
+  priority: 60000              # [optional] the JOB's order on the dashboard
+  penalty: yes                 # [optional] the JOB's penalty
+

--- a/collectors/python.d.plugin/sslcheck/sslcheck.conf
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.conf
@@ -64,7 +64,7 @@
 #     host: 'host'                      # [required] the remote host address in either IPv4, IPv6 or as DNS name
 #     port: 443                         # [optional] the port number to check. Specify an integer, not service name. Default is 443.
 #     timeout: 3                        # [optional] the socket timeout when connecting
-#     days_until_expiration_warning: 30 # [optional] days before the alarm status is warning. Default is 30.
+#     days_until_expiration_warning: 14 # [optional] days before the alarm status is warning. Default is 14.
 #     days_until_expiration_critical: 7 # [optional] days before the alarm status is critical. Default is 7.
 #
 # ----------------------------------------------------------------------

--- a/collectors/python.d.plugin/sslcheck/sslcheck.conf
+++ b/collectors/python.d.plugin/sslcheck/sslcheck.conf
@@ -64,7 +64,8 @@
 #     host: 'host'                      # [required] the remote host address in either IPv4, IPv6 or as DNS name
 #     port: 443                         # [optional] the port number to check. Specify an integer, not service name. Default is 443.
 #     timeout: 3                        # [optional] the socket timeout when connecting
-#     days_until_expiration_warning: 5  # [optional] days before the status is warning (alarm). Default is 5.
+#     days_until_expiration_warning: 30 # [optional] days before the alarm status is warning. Default is 30.
+#     days_until_expiration_critical: 7 # [optional] days before the alarm status is critical. Default is 7.
 #
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS

--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -68,6 +68,7 @@ dist_healthconfig_DATA = \
     health.d/retroshare.conf \
     health.d/softnet.conf \
     health.d/squid.conf \
+    health.d/sslcheck.conf \
     health.d/stiebeleltron.conf \
     health.d/swap.conf \
     health.d/tcp_conn.conf \

--- a/health/health.d/sslcheck.conf
+++ b/health/health.d/sslcheck.conf
@@ -1,0 +1,9 @@
+
+template: sslcheck_days_until_expiration
+      on: sslcheck.time_until_expiration
+   calc:  $time
+   units: seconds
+   every: 60s
+    warn: $this < $days_until_expiration_warning*24*60*60
+    info: certificate time until expiration
+      to: webmaster

--- a/health/health.d/sslcheck.conf
+++ b/health/health.d/sslcheck.conf
@@ -5,5 +5,6 @@ template: sslcheck_days_until_expiration
    units: seconds
    every: 60s
     warn: $this < $days_until_expiration_warning*24*60*60
+    crit: $this < $days_until_expiration_critical*24*60*60
     info: certificate time until expiration
       to: webmaster


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Hi Netdata community!

So I think we need to graph the days until ssl certificates expire. I have forked the portcheck plugin to do that.

##### Component Name
collector/sslcheck

##### Additional Information
After lots of trying around, reading the doc and some similar issues I can just not get this plugin to graph anything.
I have done this on a fresh netdata setup with `curl | bash` setup of netdata on a Debian 9 server:
- created `/etc/netdata/python.d/sslcheck.conf`
- `git clone https://github.com/blunix/netdata-plugin-sslcheck /usr/src/netdata/collectors/python.d.plugin/sslcheck/` - thats the same code there as in this PR
- `systemctl restart netdata.service`

But it neither shows errors or any mention of the sslcheck plugin in the logs, nor does it show anything in the WebUI. I must be missing something.. Do you guys have any idea?

Thanks a lot in advance!