### PR TITLE
Render MyNetdata menu after fetching hosts info #5370

### DIFF
--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -2740,6 +2740,9 @@ function initializeDynamicDashboardWithData(data) {
 
         // render all charts
         renderChartsAndMenu(data);
+
+        // Ensure MyNetdata menu is rendered with latest host info #5370
+        renderMyNetdataMenu(isSignedIn() ? cloudAgents : registryAgents);
     }
 }
 


### PR DESCRIPTION
Ensure the idempotent method `renderMyNetdataMenu` is called after hosts info is fetched. Resolves a race condition.

Fixes: #5364
Fixes: #5370 