### PR TITLE
Add support of tera-byte size for Linux bcache. (#4719)

### DIFF
--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -180,6 +180,8 @@ static unsigned long long int bcache_read_number_with_units(const char *filename
                 return (unsigned long long int)(value * 1024.0 * 1024.0);
             else if(*end == 'G')
                 return (unsigned long long int)(value * 1024.0 * 1024.0 * 1024.0);
+            else if(*end == 'T')
+                return (unsigned long long int)(value * 1024.0 * 1024.0 * 1024.0 * 1024.0);
             else if(unknown_units_error > 0) {
                 error("bcache file '%s' provides value '%s' with unknown units '%s'", filename, buffer, end);
                 unknown_units_error--;


### PR DESCRIPTION
<!--
The code for parsing T as a unit has been added.
-->

##### Summary
The code for parsing T as a unit has been added. Fixes #4719.

##### Component Name
Collectors.Linux.ProcPlugin.DiskStat.bcache

##### Additional Information
I didn't write any unit test for it since the fix seems to be straight forward.
