### PR TITLE
Don't send host/port in to anonymous stats in fatal of STREAM_RECEIVER

### DIFF
--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -406,7 +406,7 @@ void fatal_int( const char *file, const char *function, const unsigned long line
     char action_data[70+1];
 	snprintfz(action_data, 70, "%04lu@%-10.10s:%-15.15s/%d", line, file, function, __errno);
 	char action_result[60+1];
-	snprintfz(action_result, 60, "%s:%s",program_name, netdata_thread_tag());
+	snprintfz(action_result, 60, "%s:%s",program_name, strcmp(program_name,"STREAM_RECEIVER")?netdata_thread_tag():"[x]");
 	send_statistics("FATAL", action_result, action_data);
 
     netdata_cleanup_and_exit(1);


### PR DESCRIPTION
##### Summary
STREAM_RECEIVER has host and port in the thread name. In fatal replace them with `[x]` so we don't send them in anonymous statistics.

##### Component Name
daemon


