### PR TITLE
Fix CMake warning for nfacct plugin

### DIFF
--- a/collectors/nfacct.plugin/plugin_nfacct.c
+++ b/collectors/nfacct.plugin/plugin_nfacct.c
@@ -903,6 +903,9 @@ int main(int argc, char **argv) {
 #else // !HAVE_LIBMNL
 
 int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+
     fatal("nfacct.plugin is not compiled.");
 }
 


### PR DESCRIPTION
##### Summary
Cast unused variables to void.

##### Component Name
`nfacct.plugin`