### PR TITLE
Add driver-type option to the freeipmi plugin

### DIFF
--- a/collectors/freeipmi.plugin/README.md
+++ b/collectors/freeipmi.plugin/README.md
@@ -68,6 +68,12 @@ The plugin supports a few options. To see them, run:
   password PASS           connect to remote IPMI host
                           default: local IPMI processor
 
+  driver-type IPMIDRIVER
+                          Specify the driver type to use instead of doing an auto selection. 
+                          The currently available outofband drivers are LAN and  LAN_2_0,
+                          which  perform  IPMI  1.5  and  IPMI  2.0 respectively. 
+                          The currently available inband drivers are KCS, SSIF, OPENIPMI and SUNBMC.
+
   sdr-cache-dir PATH      directory for SDR cache files
                           default: /tmp
 


### PR DESCRIPTION
##### Summary
Fixes: #5344 
Permit processing of a `driver-type`  directive, that `ipmimonitoring` uses to set the protocol version for outband (different host) or driver type for inband (same host) communications.

##### Component Name
freeipmi.plugin

##### Additional Information
See `man ipmimonitoring`. The parser functions are based on the code in `freeipmi-1.6.3/common/parsecommon` from https://www.gnu.org/software/freeipmi/download.html. The difference is that `/usr/include/ipmi_monitoring.h` defines different enums, so the return values changed and the `INTELCMD` driver type isn't supported.
