### PR TITLE
Fix coverity defect CID 332280:  Control flow issues  (DEADCODE)

### DIFF
--- a/web/server/web_server.c
+++ b/web/server/web_server.c
@@ -41,13 +41,16 @@ void debug_sockets() {
 	int i;
 
 	for(i = 0 ; i < (int)api_sockets.opened ; i++) {
-		buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_NOCHECK)?"NONE ":"");
-		buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_DASHBOARD)?"dashboard ":"");
-		buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_REGISTRY)?"registry ":"");
-		buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_BADGE)?"badges ":"");
-		buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_MGMT)?"management ":"");
-		buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_STREAMING)?"streaming ":"");
-		buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_NETDATACONF)?"netdata.conf ":"");
+		if (api_sockets.fds_acl_flags[i]) {
+			buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_DASHBOARD) ? "dashboard " : "");
+			buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_REGISTRY) ? "registry " : "");
+			buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_BADGE) ? "badges " : "");
+			buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_MGMT) ? "management " : "");
+			buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_STREAMING) ? "streaming " : "");
+			buffer_strcat(wb, (api_sockets.fds_acl_flags[i] & WEB_CLIENT_ACL_NETDATACONF) ? "netdata.conf " : "");
+		} else {
+			buffer_strcat(wb, "NONE");
+		}
 		debug(D_WEB_CLIENT, "Socket fd %d name '%s' acl_flags: %s",
 			  i,
 			  api_sockets.fds_names[i],


### PR DESCRIPTION
##### Summary
debug message construction would never show "NONE" for listen socket permissions, even if the flag was set to 0.
changed the conditions to construct the message properly.


