### PR TITLE
Fix #5402: sensors plugin only plots sensors that have hard-coded limits

### DIFF
--- a/collectors/python.d.plugin/sensors/sensors.chart.py
+++ b/collectors/python.d.plugin/sensors/sensors.chart.py
@@ -41,7 +41,7 @@ CHARTS = {
     'power': {
         'options': [None, ' power', 'Watt', 'power', 'sensors.power', 'line'],
         'lines': [
-            [None, None, 'absolute', 1, 1000000]
+            [None, None, 'absolute', 1, 1000]
         ]
     },
     'fan': {
@@ -53,7 +53,7 @@ CHARTS = {
     'energy': {
         'options': [None, ' energy', 'Joule', 'energy', 'sensors.energy', 'areastack'],
         'lines': [
-            [None, None, 'incremental', 1, 1000000]
+            [None, None, 'incremental', 1, 1000]
         ]
     },
     'humidity': {
@@ -115,7 +115,7 @@ class Service(SimpleService):
                         limit = LIMITS[type_name]
                         if val < limit[0] or val > limit[1]:
                             continue
-                        data[prefix + '_' + str(feature.name.decode())] = int(val * 1000)
+                    data[prefix + '_' + str(feature.name.decode())] = int(val * 1000)
         except sensors.SensorsError as error:
             self.error(error)
             return None


### PR DESCRIPTION
`sensors.chart.py` has hard-coded limits for some sensor types. When querying sensor values, the `get_data` method checks whether there is a limit for them and discards values that are out of range. However, due to an indentation mistake, it also discards values if there are no limits for its sensor type. This is clearly not intentional, since the script has extensive code parts for other sensor types as well.

This issue can easily be fixed by correcting the indentation of the misindented line, which reveals another problem: `get_data` scales values by 1000 but the `CHARTS` constant specifies a scale factor of 1000000 for some sensors, resulting in plotting 1/1000th of the actual values for affected sensors.

Fixes #5402.