### PR TITLE
Add python names for FreeBSD

### DIFF
--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-'''':; exec "$(command -v python || command -v python3 || coommand -v python3.6 || command -v python2 || command -v python2.7 ||
+'''':; exec "$(command -v python || command -v python3 || command -v python3.6 || command -v python2 || command -v python2.7 ||
 echo "ERROR python IS NOT AVAILABLE IN THIS SYSTEM")" "$0" "$@" # '''
 
 # -*- coding: utf-8 -*-

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-'''':; exec "$(command -v python || command -v python3 || command -v python2 ||
+'''':; exec "$(command -v python || command -v python3 || coommand -v python3.6 || command -v python2 || command -v python2.7 ||
 echo "ERROR python IS NOT AVAILABLE IN THIS SYSTEM")" "$0" "$@" # '''
 
 # -*- coding: utf-8 -*-


### PR DESCRIPTION
In FreeBSD python is flavored and installed as python2.7 or python3.6 etc. 
So add these names to the script so it can correctly execute.

Without this; the script fails with "error python is not..." when it actually is.
Altough under the name of python3.6 or python2.7.