### PR TITLE
Fix clock_gettime() failures with the CLOCK_BOOTTIME argument

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -955,6 +955,7 @@ int main(int argc, char **argv) {
         if(i > 0)
             mallopt(M_ARENA_MAX, 1);
 #endif
+        test_clock_boottime();
 
         // prepare configuration environment variables for the plugins
 

--- a/libnetdata/clocks/clocks.h
+++ b/libnetdata/clocks/clocks.h
@@ -130,4 +130,10 @@ extern usec_t heartbeat_monotonic_dt_to_now_usec(heartbeat_t *hb);
 
 extern int sleep_usec(usec_t usec);
 
+/*
+ * When running a binary with CLOCK_BOOTTIME defined on a system with a linux kernel older than Linux 2.6.39 the
+ * clock_gettime(2) system call fails with EINVAL. In that case it must fall-back to CLOCK_MONOTONIC.
+ */
+void test_clock_boottime(void);
+
 #endif /* NETDATA_CLOCKS_H */


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->
##### Summary
Fixes #5367
##### Component Name
daemon
##### Additional Information
When running a binary with CLOCK_BOOTTIME defined on a system with a linux kernel older than Linux 2.6.39 the clock_gettime(2) system call fails with EINVAL. In that case it must fall-back to CLOCK_MONOTONIC.