### PR TITLE
Improve configure.ac mnl and netfilter_acc checks for static builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -462,14 +462,24 @@ AC_CHECK_HEADERS_ONCE([linux/netfilter/nfnetlink_conntrack.h])
 PKG_CHECK_MODULES(
     [NFACCT],
     [libnetfilter_acct],
-    [have_libnetfilter_acct=yes],
+    [AC_CHECK_LIB(
+         [netfilter_acct],
+         [nfacct_alloc],
+         [have_libnetfilter_acct=yes],
+         [have_libnetfilter_acct=no]
+     )],
     [have_libnetfilter_acct=no]
 )
 
 PKG_CHECK_MODULES(
     [LIBMNL],
     [libmnl],
-    [have_libmnl=yes],
+    [AC_CHECK_LIB(
+         [mnl],
+         [mnl_socket_open],
+         [have_libmnl=yes],
+         [have_libmnl=no]
+     )],
     [have_libmnl=no]
 )
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Improve configure.ac mnl and netfilter_acc checks for static builds.
##### Component Name
collectors
##### Additional Information
Add additional checks for the nfacct plugin in configure.ac so that netdata builds correctly even in the absence of static libraries.