### PR TITLE
spec: fixed template issue for netdata source.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -85,7 +85,7 @@ Version:	1.12.0
 Release:	1%{?dist}
 License:	GPLv3+
 Group:		Applications/System
-Source0:	https://github.com/netdata/%{name}/releases/download/v@PACKAGE_VERSION@/%{name}-@PACKAGE_VERSION@.tar.gz
+Source0:	https://github.com/netdata/%{name}/releases/download/@PACKAGE_VERSION@/%{name}-@PACKAGE_VERSION@.tar.gz
 URL:		http://my-netdata.io
 BuildRequires:	pkgconfig
 BuildRequires:	xz


### PR DESCRIPTION
##### Summary

![selection_001](https://user-images.githubusercontent.com/7759548/53019255-eee8b180-3486-11e9-87ab-954d4c420d70.png)

##### Component Name
spec

##### Additional Information

When I downloaded tarball with 1.12 I was found this issue:

```shell
[k0ste@mon SPECS]$ spectool -g netdata.spec 
Getting https://github.com/netdata/netdata/releases/download/vv1.12.0/netdata-v1.12.0.tar.gz to ./netdata-v1.12.0.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
```