### PR TITLE
Correct version check in UI

### DIFF
--- a/web/api/formatters/charts2json.c
+++ b/web/api/formatters/charts2json.c
@@ -6,9 +6,9 @@
 
 static inline const char* get_release_channel() {
     static int use_stable = -1;
-    char filename[FILENAME_MAX + 1];
 
     if (use_stable == -1) {
+		char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s/.environment", netdata_configured_user_config_dir);
         procfile *ff = procfile_open(filename, "=", PROCFILE_FLAG_DEFAULT);
         if(!ff) {

--- a/web/api/formatters/charts2json.c
+++ b/web/api/formatters/charts2json.c
@@ -4,6 +4,41 @@
 
 // generate JSON for the /api/v1/charts API call
 
+static inline const char* get_release_channel() {
+    static int use_stable = -1;
+    char filename[FILENAME_MAX + 1];
+
+    if (use_stable == -1) {
+        snprintfz(filename, FILENAME_MAX, "%s/.environment", netdata_configured_user_config_dir);
+        procfile *ff = procfile_open(filename, "=", PROCFILE_FLAG_DEFAULT);
+        if(!ff) {
+            use_stable=1;
+        } else {
+            ff = procfile_readall(ff);
+            if(!ff) {
+                use_stable=1;
+            } else {
+                unsigned int i;
+                for(i = 0; i < procfile_lines(ff); i++) {
+                    if (!procfile_linewords(ff, i)) continue;
+
+                    if (!strcmp(procfile_lineword(ff, i, 0), "RELEASE_CHANNEL") && (
+                            !strcmp(procfile_lineword(ff, i, 1), "stable") ||
+                            !strcmp(procfile_lineword(ff, i, 1), "'stable'") ||
+                            !strcmp(procfile_lineword(ff, i, 1), "\"stable\"")
+                    )) {
+                        use_stable = 1;
+                        break;
+                    }
+                }
+                procfile_close(ff);
+                if (use_stable == -1) use_stable = 0;
+            }
+        }
+    }
+    return (use_stable)?"stable":"nightly";
+}
+
 void charts2json(RRDHOST *host, BUFFER *wb) {
     static char *custom_dashboard_info_js_filename = NULL;
     size_t c, dimensions = 0, memory = 0, alarms = 0;
@@ -17,6 +52,7 @@ void charts2json(RRDHOST *host, BUFFER *wb) {
     buffer_sprintf(wb, "{\n"
                        "\t\"hostname\": \"%s\""
                        ",\n\t\"version\": \"%s\""
+                       ",\n\t\"release_channel\": \"%s\""
                        ",\n\t\"os\": \"%s\""
                        ",\n\t\"timezone\": \"%s\""
                        ",\n\t\"update_every\": %d"
@@ -25,6 +61,7 @@ void charts2json(RRDHOST *host, BUFFER *wb) {
                        ",\n\t\"charts\": {"
                    , host->hostname
                    , host->program_version
+                   , get_release_channel()
                    , host->os
                    , host->timezone
                    , host->rrd_update_every

--- a/web/api/formatters/charts2json.c
+++ b/web/api/formatters/charts2json.c
@@ -14,6 +14,7 @@ static inline const char* get_release_channel() {
         if(!ff) {
             use_stable=1;
         } else {
+            procfile_set_quotes(ff, "'\"");
             ff = procfile_readall(ff);
             if(!ff) {
                 use_stable=1;
@@ -22,11 +23,7 @@ static inline const char* get_release_channel() {
                 for(i = 0; i < procfile_lines(ff); i++) {
                     if (!procfile_linewords(ff, i)) continue;
 
-                    if (!strcmp(procfile_lineword(ff, i, 0), "RELEASE_CHANNEL") && (
-                            !strcmp(procfile_lineword(ff, i, 1), "stable") ||
-                            !strcmp(procfile_lineword(ff, i, 1), "'stable'") ||
-                            !strcmp(procfile_lineword(ff, i, 1), "\"stable\"")
-                    )) {
+                    if (!strcmp(procfile_lineword(ff, i, 0), "RELEASE_CHANNEL") && !strcmp(procfile_lineword(ff, i, 1), "stable")) {
                         use_stable = 1;
                         break;
                     }

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -2885,19 +2885,29 @@ function getGithubLatestVersion(callback) {
 
 function getGCSLatestVersion(callback) {
     versionLog('Downloading latest version id from GCS...');
-
     $.ajax({
-        url: 'https://storage.googleapis.com/netdata-nightlies/latest-version.txt',
-        async: false,
+        url: "https://www.googleapis.com/storage/v1/b/netdata-nightlies/o/latest-version.txt",
+        async: true,
         cache: false
     })
-        .done(function (data) {
-            data = data.replace(/(\r\n|\n|\r| |\t)/gm, "");
-            versionLog('Latest nightly version from GCS is ' + data);
-            callback(data);
+        .done(function (response) {
+            $.ajax({
+                url: response.mediaLink,
+                async: true,
+                cache: false
+            })
+                .done(function (data) {
+                    data = data.replace(/(\r\n|\n|\r| |\t)/gm, "");
+                    versionLog('Latest nightly version from GCS is ' + data);
+                    callback(data);
+                })
+                .fail(function (xhr, textStatus, errorThrown) {
+                    versionLog('Failed to download the latest nightly version id from GCS!');
+                    callback(null);
+                });
         })
         .fail(function (xhr, textStatus, errorThrown) {
-            versionLog('Failed to download the latest nightly version id from GCS!');
+            versionLog('Failed to download the latest nightly version from GCS!');
             callback(null);
         });
 }
@@ -2947,7 +2957,7 @@ function notifyForUpdate(force) {
             versionLog('<p><big>Failed to get the latest netdata version.</big></p><p>You can always get the latest netdata from <a href="https://github.com/netdata/netdata" target="_blank">its github page</a>.</p>');
         } else if (versionsMatch(sha1, sha2)) {
             save = true;
-            versionLog('<p><big>You already have the latest netdata!</big></p><p>No update yet?<br/>Probably, we need some motivation to keep going on!</p><p>If you haven\'t already, <a href="https://github.com/netdata/netdata" target="_blank">give netdata a <b><i class="fas fa-star"></i></b> at its github page</a>.</p>');
+            versionLog('<p><big>You already have the latest netdata!</big></p><p>No update yet?<br/>We probably need some motivation to keep going on!</p><p>If you haven\'t already, <a href="https://github.com/netdata/netdata" target="_blank">give netdata a <b><i class="fas fa-star"></i></b> at its github page</a>.</p>');
         } else {
             save = true;
             var compare = 'https://docs.netdata.cloud/changelog/';

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -1037,6 +1037,7 @@ var options = {
     data: null,
     hostname: 'netdata_server', // will be overwritten by the netdata server
     version: 'unknown',
+    release_channel: 'unknown',
     hosts: [],
 
     duration: 0, // the default duration of the charts
@@ -2700,6 +2701,7 @@ function initializeDynamicDashboardWithData(data) {
         options.hostname = data.hostname;
         options.data = data;
         options.version = data.version;
+        options.release_channel = data.release_channel;
         netdataDashboard.os = data.os;
 
         if (typeof data.hosts !== 'undefined') {
@@ -2832,12 +2834,33 @@ function versionsMatch(v1, v2) {
     if (v1 == v2) {
         return true;
     } else {
-        var s1=v1.split('-');
-        var s2=v2.split('-');
-        if (s1.length !== s2.length) return false;
-        if (s1.length === 4) s1.pop();
-        if (s2.length === 4) s2.pop();
-        return (s1.join('-') === s2.join('-'));
+        let s1=v1.split('.');
+        let s2=v2.split('.');
+        // Check major version
+        let n1 = parseInt(s1[0].substring(1,2),10);
+        let n2 = parseInt(s2[0].substring(1,2), 10);
+        if ( n1 < n2 ) return false;
+        else if ( n1 > n2 ) return true;
+
+        // Check minor version
+        n1 = parseInt(s1[1],10);
+        n2 = parseInt(s2[1],10);
+        if ( n1 < n2 ) return false;
+        else if ( n1 > n2 ) return true;
+
+        // Split patch: format could be e.g. 0-22-nightly
+        s1=s1[2].split('-');
+        s2=s2[2].split('-');
+
+        n1 = parseInt(s1[0],10);
+        n2 = parseInt(s2[0],10);
+        if ( n1 < n2 ) return false;
+        else if ( n1 > n2 ) return true;
+
+        n1 = (s1.length > 1)?parseInt(s1[1],10):0;
+        n2 = (s2.length > 1)?parseInt(s2[1],10):0;
+        if ( n1 < n2 ) return false;
+        else return true;
     }
 }
 
@@ -2845,26 +2868,51 @@ function getGithubLatestVersion(callback) {
     versionLog('Downloading latest version id from github...');
 
     $.ajax({
-        url: 'https://api.github.com/repositories/10744183/contents/packaging/version?ref=master',
+        url: 'https://api.github.com/repos/netdata/netdata/releases/latest',
         async: true,
         cache: false
     })
         .done(function (data) {
-            data = atob(data.content).replace(/(\r\n|\n|\r| |\t)/gm, "");
-            versionLog('Latest version from github is ' + data);
+            data = data.tag_name.replace(/(\r\n|\n|\r| |\t)/gm, "");
+            versionLog('Latest stable version from github is ' + data);
             callback(data);
         })
         .fail(function () {
-            versionLog('Failed to download the latest version id from github!');
+            versionLog('Failed to download the latest stable version id from github!');
             callback(null);
         });
 }
 
-function checkForUpdateByVersion(force, callback) {
-    getGithubLatestVersion(function (sha2) {
-            callback(options.version, sha2);
-    });
+function getGCSLatestVersion(callback) {
+    versionLog('Downloading latest version id from GCS...');
 
+    $.ajax({
+        url: 'https://storage.googleapis.com/netdata-nightlies/latest-version.txt',
+        async: false,
+        cache: false
+    })
+        .done(function (data) {
+            data = data.replace(/(\r\n|\n|\r| |\t)/gm, "");
+            versionLog('Latest nightly version from GCS is ' + data);
+            callback(data);
+        })
+        .fail(function (xhr, textStatus, errorThrown) {
+            versionLog('Failed to download the latest nightly version id from GCS!');
+            callback(null);
+        });
+}
+
+
+function checkForUpdateByVersion(force, callback) {
+    if (options.release_channel === 'stable') {
+        getGithubLatestVersion(function (sha2) {
+            callback(options.version, sha2);
+        });
+    } else {
+        getGCSLatestVersion(function (sha2) {
+            callback(options.version, sha2);
+        });
+    }
     return null;
 }
 
@@ -2896,7 +2944,7 @@ function notifyForUpdate(force) {
             versionLog('<p><big>Failed to get your netdata version!</big></p><p>You can always get the latest netdata from <a href="https://github.com/netdata/netdata" target="_blank">its github page</a>.</p>');
         } else if (sha2 === null) {
             save = false;
-            versionLog('<p><big>Failed to get the latest netdata version github.</big></p><p>You can always get the latest netdata from <a href="https://github.com/netdata/netdata" target="_blank">its github page</a>.</p>');
+            versionLog('<p><big>Failed to get the latest netdata version.</big></p><p>You can always get the latest netdata from <a href="https://github.com/netdata/netdata" target="_blank">its github page</a>.</p>');
         } else if (versionsMatch(sha1, sha2)) {
             save = true;
             versionLog('<p><big>You already have the latest netdata!</big></p><p>No update yet?<br/>Probably, we need some motivation to keep going on!</p><p>If you haven\'t already, <a href="https://github.com/netdata/netdata" target="_blank">give netdata a <b><i class="fas fa-star"></i></b> at its github page</a>.</p>');

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -2857,8 +2857,8 @@ function versionsMatch(v1, v2) {
         if ( n1 < n2 ) return false;
         else if ( n1 > n2 ) return true;
 
-        n1 = (s1.length > 1)?parseInt(s1[1],10):0;
-        n2 = (s2.length > 1)?parseInt(s2[1],10):0;
+        n1 = (s1.length > 1) ? parseInt(s1[1],10) : 0;
+        n2 = (s2.length > 1) ? parseInt(s2[1],10) : 0;
         if ( n1 < n2 ) return false;
         else return true;
     }


### PR DESCRIPTION
##### Summary
Fixes #5405

##### Component Name
daemon, web

##### Additional Information
Support stable and nightly release channel.
Use github releases instead of latest versions, get nightlies from GCS

It's WIP because it can't be merged until we get GCS configured to permit cross-origin requests, but otherwise it's ok. @paulfantom please check the version comparison logic, the old one didn't work any more. I think that this one is fine, it has passed all the tests I did.