### PR TITLE
fix #5430 - LogService._get_raw_data under python3 fails on undecodable data

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/LogService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/LogService.py
@@ -18,6 +18,7 @@ class LogService(SimpleService):
         self.__glob_path = self.log_path
         self._last_position = 0
         self.__re_find = dict(current=0, run=0, maximum=60)
+        self.open_args = {'errors': 'replace'} if sys.version_info[0] > 2 else {}
 
     def _get_raw_data(self):
         """
@@ -35,8 +36,7 @@ class LogService(SimpleService):
             elif size < self._last_position:
                 self._last_position = 0  # read from beginning if file has shrunk
 
-            open_args = {'errors': 'replace'} if sys.version_info[0] > 2 else {}
-            with open(self.log_path, **open_args) as fp:
+            with open(self.log_path, **self.open_args) as fp:
                 fp.seek(self._last_position)
                 for line in fp:
                     lines.append(line)

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/LogService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/LogService.py
@@ -18,7 +18,7 @@ class LogService(SimpleService):
         self.__glob_path = self.log_path
         self._last_position = 0
         self.__re_find = dict(current=0, run=0, maximum=60)
-        self.open_args = {'errors': 'replace'} if sys.version_info[0] > 2 else {}
+        self.__open_args = {'errors': 'replace'} if sys.version_info[0] > 2 else {}
 
     def _get_raw_data(self):
         """
@@ -36,7 +36,7 @@ class LogService(SimpleService):
             elif size < self._last_position:
                 self._last_position = 0  # read from beginning if file has shrunk
 
-            with open(self.log_path, **self.open_args) as fp:
+            with open(self.log_path, **self.__open_args) as fp:
                 fp.seek(self._last_position)
                 for line in fp:
                     lines.append(line)

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/LogService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/LogService.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from glob import glob
+import sys
 import os
 
 from bases.FrameworkServices.SimpleService import SimpleService
@@ -34,7 +35,8 @@ class LogService(SimpleService):
             elif size < self._last_position:
                 self._last_position = 0  # read from beginning if file has shrunk
 
-            with open(self.log_path) as fp:
+            open_args = {'errors': 'replace'} if sys.version_info[0] > 2 else {}
+            with open(self.log_path, **open_args) as fp:
                 fp.seek(self._last_position)
                 for line in fp:
                     lines.append(line)


### PR DESCRIPTION
##### Summary
Fixes: #5430
A quick fix for #5430 - set decoding error handling to `replace` instead of the default `None`/`strict` for python3

##### Component Name
collectors/python.d.plugin

##### Additional Information
in the reported bug: #5430 
