### PR TITLE
Add tor to the default app groups

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -120,6 +120,7 @@ vpn: openvpn pptp* cjdroute gvpe tincd
 wifi: hostapd wpa_supplicant NetworkManager
 routing: ospfd* ospf6d* bgpd isisd ripd ripngd pimd ldpd zebra vtysh bird*
 modem: ModemManager
+tor: tor
 
 # -----------------------------------------------------------------------------
 # high availability and balancers


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
This PR adds tor to the default app groups

##### Component Name
collectors/apps.plugin

##### Additional Information
I host a relay and I wanted to be able to differenciate between the usage of tor and other, this accomplishes that
