### PR TITLE
Fix curl download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,8 @@ collectors/fping.plugin/fping.plugin
 collectors/go.d.plugin
 
 # installer generated files
-netdata-uninstaller.sh
+/netdata-uninstaller.sh
+/netdata-updater.sh
 
 # cmake files
 cmake-build-debug/
@@ -164,5 +165,4 @@ docs/generator/src
 docs/generator/build
 docs/generator/mkdocs.yml
 
-netdata-updater.sh
 .environment.sh

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -50,7 +50,7 @@ download() {
 			run wget --progress=dot:mega -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
 		fi
 	elif command -v curl >/dev/null 2>&1; then
-		run curl "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		run curl -L "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	else
 		fatal "I need curl or wget to proceed, but neither is available on this system."
 	fi

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -86,7 +86,7 @@ download() {
 	if command -v wget >/dev/null 2>&1; then
 		run wget -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	elif command -v curl >/dev/null 2>&1; then
-		run curl "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		run curl -L "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	else
 		fatal "I need curl or wget to proceed, but neither is available on this system."
 	fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -118,7 +118,7 @@ download() {
 	if command -v wget >/dev/null 2>&1; then
 		run wget -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	elif command -v curl >/dev/null 2>&1; then
-		run curl "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		run curl -L "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	else
 		fatal "I need curl or wget to proceed, but neither is available on this system."
 	fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -37,7 +37,7 @@ download() {
 	if command -v wget >/dev/null 2>&1; then
 		wget -O - "${url}" >"${dest}" 2>&3 || echo >&2 "Cannot download ${url}" >&3 2>&3
 	elif command -v curl >/dev/null 2>&1; then
-		curl "${url}" >"${dest}" 2>&3 || echo "Cannot download ${url}" >&3 2>&3
+		curl -L "${url}" >"${dest}" 2>&3 || echo "Cannot download ${url}" >&3 2>&3
 	else
 		failed "curl or wget is needed to proceed, but neither is available on this system."
 	fi


### PR DESCRIPTION
##### Summary

This should fix a minor installation/update issue when only **curl** is available during install/update as described in #5411.

##### Component Name

* Installer
* Updater
* Kickstart

##### Additional Information

This PR adds the `-L` argument to **curl**-calls in all instances of `download()` used by the `netdata-installer.sh`, `netdata-updater.sh` and `kickstart*.sh` scripts. This _should_ cover all occurrences.

~~I was wondering, why do [kickstart.sh](https://github.com/netdata/netdata/blob/45bf6721ae81c6845fd31c1abbc88cb0bec04231/packaging/installer/kickstart.sh) and [kickstart-static64.sh](https://github.com/netdata/netdata/blob/45bf6721ae81c6845fd31c1abbc88cb0bec04231/packaging/installer/kickstart-static64.sh) not include/source [functions.sh](https://github.com/netdata/netdata/blob/45bf6721ae81c6845fd31c1abbc88cb0bec04231/packaging/installer/functions.sh) so we could share more code?~~  
**EDIT:** Ah ok, this is the single-file downloader/installer, makes sence! :smile: 

Additionally I noticed that the `.gitignore` rules for the auto-generated `netdata-updater.sh` and `netdata-uninstaller.sh` also matched files under **/packaging/installer**. This is not a huge issue, since `.gitignore` only affects uncommited files but might cause some headaches later down the line.  

**Note:** _There might be more entries that could be changed to paths relative to the `.gitignore` file._