### PR TITLE
Prevent invalid Linux power supply alarms during startup

### DIFF
--- a/health/health.d/linux_power_supply.conf
+++ b/health/health.d/linux_power_supply.conf
@@ -7,6 +7,6 @@ template: linux_power_supply_capacity
    every: 10s
     warn: $this < 10
     crit: $this < 5
-   delay: up 0 down 5m multiplier 1.2 max 1h
+   delay: up 30s down 5m multiplier 1.2 max 1h
     info: the percentage remaining capacity of the power supply
       to: sysadmin


### PR DESCRIPTION
##### Summary
For some reason I've been getting an invalid alarm of 0% charge on my battery every time I restart netdata. 
Delay raising the alarm by 30s, to prevent errors during netdata startup

##### Component Name
proc.plugin, linux_power_supply


