### PR TITLE
cups.plugin: remove flag -cupsimage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -443,7 +443,7 @@ if test "${enable_plugin_cups}" != "no" -a "${have_cups}" = "yes"; then
     AC_DEFINE([HAVE_CUPS], [1], [cups usability])
 
     CUPS_CFLAGS="${CUPS_CFLAGS} `$CUPSCONFIG --cflags`"
-    CUPS_LIBS="${CUPS_LIBS} `$CUPSCONFIG --image --libs`"
+    CUPS_LIBS="${CUPS_LIBS} `$CUPSCONFIG --libs`"
 
     OPTIONAL_CUPS_CLFAGS="${CUPS_CFLAGS}"
     OPTIONAL_CUPS_LIBS="${CUPS_LIBS}"


### PR DESCRIPTION

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Option `-lcupsimage` was present but not needed for compiling cups.plugin

##### Component Name

cups.plugin

##### Additional Information

Fixes #5426 

