### PR TITLE
Installer - Handle cases when go.d plugin can't be downloaded 

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -45,14 +45,14 @@ download() {
 	dest="${2}"
 	if command -v wget >/dev/null 2>&1; then
 		if [ -t 1 ]; then
-			run wget -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
+			run wget --timeout=5 --tries=3 -O - "${url}" >"${dest}"
 		else
-			run wget --progress=dot:mega -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
+			run wget --timeout=5 --tries=3 --progress=dot:mega -O - "${url}" >"${dest}"
 		fi
 	elif command -v curl >/dev/null 2>&1; then
-		run curl -L "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		run curl -L --connect-timeout 10 --retry 3 "${url}" >"${dest}"
 	else
-		fatal "I need curl or wget to proceed, but neither is available on this system."
+		echo >&2 "I need curl or wget to proceed, but neither is available on this system."
 	fi
 }
 
@@ -814,8 +814,18 @@ install_go() {
 		done
 		tmp=$(mktemp -d /tmp/netdata-go-XXXXXX)
 		GO_PACKAGE_BASENAME="go.d.plugin-$GO_PACKAGE_VERSION.$OS-$ARCH"
+
 		download "https://github.com/netdata/go.d.plugin/releases/download/$GO_PACKAGE_VERSION/$GO_PACKAGE_BASENAME" "${tmp}/$GO_PACKAGE_BASENAME"
+		if [ $? ] ; then
+			echo >&2 "go.d.plugin package could not be downloaded"
+			return 1
+		fi
+
 		download "https://github.com/netdata/go.d.plugin/releases/download/$GO_PACKAGE_VERSION/config.tar.gz" "${tmp}/config.tar.gz"
+		if [ $? ] ; then
+			echo >&2 "go.d.plugin config could not be downloaded"
+			return 1
+		fi
 		grep "${GO_PACKAGE_BASENAME}" "${installer_dir}/packaging/go.d.checksums" > "${tmp}/sha256sums.txt" 2>/dev/null
 		grep "config.tar.gz" "${installer_dir}/packaging/go.d.checksums" >> "${tmp}/sha256sums.txt" 2>/dev/null
 


### PR DESCRIPTION
##### Summary
On machines with no connection to the internet, go.d plugin files fetches do not timeout.

##### Component Name
netdata-installer.sh

##### Additional Information
Add timeouts and retries to wget and curl.
Handle errors without showing duplicate FAILED messages.
Remove calls to `fatal` which wasn't defined anyway. 

This means we can proceed without the go.d plugin