### PR TITLE
docker: use base images build by us

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -4,37 +4,18 @@
 # Cross-arch building is achieved by specifying ARCH as a build parameter with `--build-arg` option.
 # It is automated in `build.sh` script
 ARG ARCH=amd64-v3.8
-FROM multiarch/alpine:${ARCH} as builder
+# This image contains preinstalled dependecies
+FROM netdata/builder:${ARCH} as builder 
 
+# TODO(paulfantom): Remove this when netdata-installer.sh is supporting less verbose mode
 ARG OUTPUT="/dev/stdout"
-# Install prerequisites
-RUN apk --no-cache add alpine-sdk \
-                       autoconf \
-                       automake \
-                       bash \
-                       build-base \
-                       curl \
-                       jq \
-                       libmnl-dev \
-                       libuuid \
-                       lm_sensors \
-                       netcat-openbsd \
-                       nodejs \
-                       pkgconfig \
-                       py-mysqldb \
-                       py-psycopg2 \
-                       py-yaml \
-                       python \
-                       util-linux-dev \
-                       zlib-dev
 
 # Copy source
 COPY . /opt/netdata.git
 WORKDIR /opt/netdata.git
 
 # Install from source
-RUN chmod +x netdata-installer.sh && \
-    ./netdata-installer.sh --dont-wait --dont-start-it &>${OUTPUT}
+RUN chmod +x netdata-installer.sh && ./netdata-installer.sh --dont-wait --dont-start-it &>${OUTPUT}
 
 # files to one directory
 RUN mkdir -p /app/usr/sbin/ \
@@ -56,20 +37,8 @@ RUN mkdir -p /app/usr/sbin/ \
 
 #####################################################################
 ARG ARCH
-FROM multiarch/alpine:${ARCH}
-
-# Install some prerequisites
-RUN apk --no-cache add curl \
-                       fping \
-                       jq \
-                       libuuid \
-                       lm_sensors \
-                       netcat-openbsd \
-                       nodejs \
-                       py-mysqldb \
-                       py-psycopg2 \
-                       py-yaml \
-                       python
+# This image contains preinstalled dependecies
+FROM netdata/base:${ARCH}
 
 # Conditional subscribiton to Polyverse's Polymorphic Linux repositories
 RUN if [ "$(uname -m)" == "x86_64" ]; then \
@@ -78,7 +47,6 @@ RUN if [ "$(uname -m)" == "x86_64" ]; then \
         apk upgrade --available --no-cache; \
         sed -in 's/^#//g' /etc/apk/repositories; \
     fi
-
 
 # Copy files over
 COPY --from=builder /app /

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -3,19 +3,16 @@
 
 # Cross-arch building is achieved by specifying ARCH as a build parameter with `--build-arg` option.
 # It is automated in `build.sh` script
-ARG ARCH=amd64-v3.8
+ARG ARCH=amd64
 # This image contains preinstalled dependecies
 FROM netdata/builder:${ARCH} as builder 
-
-# TODO(paulfantom): Remove this when netdata-installer.sh is supporting less verbose mode
-ARG OUTPUT="/dev/stdout"
 
 # Copy source
 COPY . /opt/netdata.git
 WORKDIR /opt/netdata.git
 
 # Install from source
-RUN chmod +x netdata-installer.sh && ./netdata-installer.sh --dont-wait --dont-start-it &>${OUTPUT}
+RUN chmod +x netdata-installer.sh && ./netdata-installer.sh --dont-wait --dont-start-it
 
 # files to one directory
 RUN mkdir -p /app/usr/sbin/ \

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -38,7 +38,7 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset
 # Build images using multi-arch Dockerfile.
 for ARCH in "${ARCHITECTURES[@]}"; do
      eval docker build \
-     		--build-arg ARCH="${ARCH}-v3.8" \
+     		--build-arg ARCH="${ARCH}" \
      		--build-arg OUTPUT=/dev/null \
      		--tag "${REPOSITORY}:${VERSION}-${ARCH}" \
      		--file packaging/docker/Dockerfile ./

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -39,7 +39,6 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset
 for ARCH in "${ARCHITECTURES[@]}"; do
      eval docker build \
      		--build-arg ARCH="${ARCH}" \
-     		--build-arg OUTPUT=/dev/null \
      		--tag "${REPOSITORY}:${VERSION}-${ARCH}" \
      		--file packaging/docker/Dockerfile ./
 done


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Use base images provided by us (Dockerfiles located in https://github.com/netdata/helper-images). This should result in simplification of Dockerfile present here and in speed up of CI builds.

##### Component Name
packaging/docker

##### Additional Information

