### PR TITLE
Increase timeout for download of go.d.plugin

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -44,7 +44,7 @@ download() {
 	url="${1}"
 	dest="${2}"
 	if command -v curl >/dev/null 2>&1; then
-		run curl -L --connect-timeout 5 --retry 3 "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		run curl -L --connect-timeout 10 --retry 3 "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	elif command -v wget >/dev/null 2>&1; then
 		run wget -T 15 -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	else


### PR DESCRIPTION
Fixes https://github.com/netdata/netdata/issues/5467

##### Summary
Increase curl timeout from 5 to 10s so as to to give more time for download to initiate over a poor network connection

##### Component Name
Installer
##### Additional Information

