### PR TITLE
Correct docs: apps plugin is not an internal collector

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -167,7 +167,7 @@ navpart 1 collectors "" "Data collection" 1
 echo -ne "    - 'docs/Add-more-charts-to-netdata.md'
     - Internal plugins:
 "
-navpart 3 collectors/apps.plugin
+
 navpart 3 collectors/proc.plugin
 navpart 3 collectors/statsd.plugin
 navpart 3 collectors/cgroups.plugin
@@ -221,10 +221,12 @@ echo -ne "        - BASH:
                 - 'collectors/charts.d.plugin/phpfpm/README.md'
 "
 
+navpart 3 collectors/apps.plugin
+navpart 3 collectors/cups.plugin
 navpart 3 collectors/fping.plugin
 navpart 3 collectors/freeipmi.plugin
-navpart 3 collectors/cups.plugin
 navpart 3 collectors/nfacct.plugin
+
 
 echo -ne "    - 'docs/Third-Party-Plugins.md'
 "


### PR DESCRIPTION
Fix the position of apps in the hierarchy and alphabetize the list of the other individual external collectors 
