### PR TITLE
Fix curl timeout

### DIFF
--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -84,7 +84,7 @@ download() {
 	url="${1}"
 	dest="${2}"
 	if command -v curl >/dev/null 2>&1; then
-		run curl -L --connect-timeout 5 --retry 3 "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		run curl -L --connect-timeout 10 --retry 3 "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	elif command -v wget >/dev/null 2>&1; then
 		run wget -T 15 -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	else

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -116,7 +116,7 @@ download() {
 	url="${1}"
 	dest="${2}"
 	if command -v curl >/dev/null 2>&1; then
-		run curl -L --connect-timeout 5 --retry 3 "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		run curl -L --connect-timeout 10 --retry 3 "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	elif command -v wget >/dev/null 2>&1; then
 		run wget -T 15 -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	else

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -35,7 +35,7 @@ download() {
 	url="${1}"
 	dest="${2}"
 	if command -v curl >/dev/null 2>&1; then
-		curl -L --connect-timeout 5 --retry 3 "${url}" >"${dest}" || fatal "Cannot download ${url}"
+		curl -L --connect-timeout 10 --retry 3 "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	elif command -v wget >/dev/null 2>&1; then
 		wget -T 15 -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	else


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes [timeout issue for spotty network connections](https://github.com/netdata/netdata/issues/5467#issuecomment-466582869). Previous fix #5468 did not address curl commands in other parts  of netdata. This has lead to installation failures

This PR increases curl timeout to address those failures

##### Component Name
Installer
##### Additional Information

