### PR TITLE
introduce stable installation channel

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1053,9 +1053,7 @@ NETDATA_ADDED_TO_GROUPS="${NETDATA_ADDED_TO_GROUPS}"
 INSTALL_UID="${UID}"
 REINSTALL_COMMAND="${REINSTALL_COMMAND}"
 RELEASE_CHANNEL="${RELEASE_CHANNEL}"
-# next 3 values are meant to be populated by autoupdater (if enabled)
-NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.tar.gz"
-NETDATA_TARBALL_CHECKSUM_URL="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
+# This value is meant to be populated by autoupdater (if enabled)
 NETDATA_TARBALL_CHECKSUM="new_installation"
 EOF
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -41,7 +41,7 @@ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 Verify the integrity of the script with this:
 
 ```bash
-[ "be79f884bceedadd4bc1b8634cca9c2d" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "b66c99c065abe1cf104c11236d4e8747" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 *It should print `OK, VALID` if the script is the one we ship.*
 
@@ -95,7 +95,7 @@ To install Netdata with a binary package on any Linux distro, any kernel version
 Verify the integrity of the script with this:
 
 ```bash
-[ "7fd4c1df7b6ced3a4c3e5142d743e275" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "8e6df9b6f6cc7de0d73f6e5e51a3c8c2" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -41,7 +41,7 @@ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 Verify the integrity of the script with this:
 
 ```bash
-[ "b06a2d788c7da5998cb34c30b0a132d8" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "be79f884bceedadd4bc1b8634cca9c2d" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 *It should print `OK, VALID` if the script is the one we ship.*
 
@@ -95,7 +95,7 @@ To install Netdata with a binary package on any Linux distro, any kernel version
 Verify the integrity of the script with this:
 
 ```bash
-[ "e3819fc861f2383521423deb69f6cab7" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "7fd4c1df7b6ced3a4c3e5142d743e275" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -103,10 +103,10 @@ set_tarball_urls() {
 		# Simple version
 		# latest="$(curl -sSL https://api.github.com/repos/netdata/netdata/releases/latest | grep tag_name | cut -d'"' -f4)"
 		latest="$(download "https://api.github.com/repos/netdata/netdata/releases/latest" /dev/stdout | grep tag_name | cut -d'"' -f4)"
-		export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.tar.gz"
+		export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.run.gz"
 		export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
 	else
-		export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.tar.gz"
+		export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.run.gz"
 		export NETDATA_TARBALL_CHECKSUM_URL="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
 	fi
 }
@@ -139,9 +139,7 @@ while [ -n "${1}" ]; do
 	elif [ "${1}" = "--dont-start-it" ]; then
 		inner_opts="${inner_opts} ${1}"
 	elif [ "${1}" = "--stable-channel" ]; then
-		# echo >&2 "netdata will not auto-update"
 		RELEASE_CHANNEL="stable"
-		shift 1
 	else
 		echo >&2 "Unknown option '${1}'"
 		exit 1

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -103,10 +103,10 @@ set_tarball_urls() {
 		# Simple version
 		# latest="$(curl -sSL https://api.github.com/repos/netdata/netdata/releases/latest | grep tag_name | cut -d'"' -f4)"
 		latest="$(download "https://api.github.com/repos/netdata/netdata/releases/latest" /dev/stdout | grep tag_name | cut -d'"' -f4)"
-		export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.run.gz"
+		export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.gz.run"
 		export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
 	else
-		export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.run.gz"
+		export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.gz.run"
 		export NETDATA_TARBALL_CHECKSUM_URL="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
 	fi
 }

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -2,10 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # shellcheck disable=SC1117,SC2039,SC2059,SC2086
 
-# External files
-NIGHTLY_PACKAGE_TARBALL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.gz.run"
-NIGHTLY_PACKAGE_CHECKSUM="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
-
 # ---------------------------------------------------------------------------------------------------------------------
 # library functions copied from packaging/installer/functions.sh
 
@@ -73,11 +69,20 @@ run() {
 	return ${ret}
 }
 
-# ---------------------------------------------------------------------------------------------------------------------
-
 fatal() {
 	printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
 	exit 1
+}
+
+create_tmp_directory() {
+	# Check if tmp is mounted as noexec
+	if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
+		pattern="$(pwd)/netdata-kickstart-XXXXXX"
+	else
+		pattern="/tmp/netdata-kickstart-XXXXXX"
+	fi
+
+	mktemp -d $pattern
 }
 
 download() {
@@ -92,6 +97,21 @@ download() {
 	fi
 }
 
+set_tarball_urls() {
+	if [ "$1" == "stable" ]; then
+		local latest
+		# Simple version
+		# latest="$(curl -sSL https://api.github.com/repos/netdata/netdata/releases/latest | grep tag_name | cut -d'"' -f4)"
+		latest="$(download "https://api.github.com/repos/netdata/netdata/releases/latest" /dev/stdout | grep tag_name | cut -d'"' -f4)"
+		export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.tar.gz"
+		export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
+	else
+		export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.tar.gz"
+		export NETDATA_TARBALL_CHECKSUM_URL="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
+	fi
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 umask 022
 
 sudo=""
@@ -101,7 +121,6 @@ sudo=""
 setup_terminal || echo >/dev/null
 
 # ---------------------------------------------------------------------------------------------------------------------
-
 if [ "$(uname -m)" != "x86_64" ]; then
 	fatal "Static binary versions of netdata are available only for 64bit Intel/AMD CPUs (x86_64), but yours is: $(uname -m)."
 fi
@@ -111,51 +130,47 @@ if [ "$(uname -s)" != "Linux" ]; then
 fi
 
 # ---------------------------------------------------------------------------------------------------------------------
-
-# Check if tmp is mounted as noexec
-if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
-	pattern="$(pwd)/netdata-kickstart-static-XXXXXX"
-else
-	pattern="/tmp/netdata-kickstart-static-XXXXXX"
-fi
-
-tmpdir="$(mktemp -d $pattern)"
-cd "${tmpdir}" || :
-
-progress "Downloading static netdata binary: ${NIGHTLY_PACKAGE_TARBALL}"
-
-download "${NIGHTLY_PACKAGE_CHECKSUM}" "${tmpdir}/sha256sum.txt"
-download "${NIGHTLY_PACKAGE_TARBALL}" "${tmpdir}/netdata-latest.gz.run"
-if ! grep netdata-latest.gz.run sha256sum.txt | sha256sum --check - >/dev/null 2>&1; then
-	failed "Static binary checksum validation failed. Stopping netdata installation and leaving binary in ${tmpdir}"
-fi
-
-# ---------------------------------------------------------------------------------------------------------------------
-
 opts=
 inner_opts=
-while [ ! -z "${1}" ]; do
+RELEASE_CHANNEL="nightly"
+while [ -n "${1}" ]; do
 	if [ "${1}" = "--dont-wait" ] || [ "${1}" = "--non-interactive" ] || [ "${1}" = "--accept" ]; then
 		opts="${opts} --accept"
 	elif [ "${1}" = "--dont-start-it" ]; then
 		inner_opts="${inner_opts} ${1}"
+	elif [ "${1}" = "--stable-channel" ]; then
+		# echo >&2 "netdata will not auto-update"
+		RELEASE_CHANNEL="stable"
+		shift 1
 	else
 		echo >&2 "Unknown option '${1}'"
 		exit 1
 	fi
 	shift
 done
-[ ! -z "${inner_opts}" ] && inner_opts="-- ${inner_opts}"
+[ -n "${inner_opts}" ] && inner_opts="-- ${inner_opts}"
 
 # ---------------------------------------------------------------------------------------------------------------------
+TMPDIR=$(create_tmp_directory)
+cd "${TMPDIR}" || :
 
+set_tarball_urls "${RELEASE_CHANNEL}"
+progress "Downloading static netdata binary: ${NETDATA_TARBALL_URL}"
+
+download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
+download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.gz.run"
+if ! grep netdata-latest.gz.run "${TMPDIR}/sha256sum.txt" | sha256sum --check - >/dev/null 2>&1; then
+	fatal "Static binary checksum validation failed. Stopping netdata installation and leaving binary in ${TMPDIR}"
+fi
+
+# ---------------------------------------------------------------------------------------------------------------------
 progress "Installing netdata"
 
-run ${sudo} sh "${tmpdir}/netdata-latest.gz.run" ${opts} ${inner_opts}
+run ${sudo} sh "${TMPDIR}/netdata-latest.gz.run" ${opts} ${inner_opts}
 
 #shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
-	rm "${tmpdir}/netdata-latest.gz.run"
+	rm "${TMPDIR}/netdata-latest.gz.run"
 else
-	echo >&2 "NOTE: did not remove: ${tmpdir}/netdata-latest.gz.run"
+	echo >&2 "NOTE: did not remove: ${TMPDIR}/netdata-latest.gz.run"
 fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -27,8 +27,6 @@
 
 # External files
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh"
-NIGHTLY_PACKAGE_TARBALL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.tar.gz"
-NIGHTLY_PACKAGE_CHECKSUM="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
 
 # ---------------------------------------------------------------------------------------------------------------------
 # library functions copied from packaging/installer/functions.sh
@@ -97,6 +95,11 @@ run() {
 	return ${ret}
 }
 
+fatal() {
+	printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
+	exit 1
+}
+
 warning() {
 	printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*} \n\n"
 	if [ "${INTERACTIVE}" = "0" ]; then
@@ -107,9 +110,15 @@ warning() {
 	fi
 }
 
-fatal() {
-	printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
-	exit 1
+create_tmp_directory() {
+	# Check if tmp is mounted as noexec
+	if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
+		pattern="$(pwd)/netdata-kickstart-XXXXXX"
+	else
+		pattern="/tmp/netdata-kickstart-XXXXXX"
+	fi
+
+	mktemp -d $pattern
 }
 
 download() {
@@ -121,6 +130,20 @@ download() {
 		run wget -T 15 -O - "${url}" >"${dest}" || fatal "Cannot download ${url}"
 	else
 		fatal "I need curl or wget to proceed, but neither is available on this system."
+	fi
+}
+
+set_tarball_urls() {
+	if [ "$1" == "stable" ]; then
+		local latest
+		# Simple version
+		# latest="$(curl -sSL https://api.github.com/repos/netdata/netdata/releases/latest | grep tag_name | cut -d'"' -f4)"
+		latest="$(download "https://api.github.com/repos/netdata/netdata/releases/latest" /dev/stdout | grep tag_name | cut -d'"' -f4)"
+		export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.tar.gz"
+		export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
+	else
+		export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.tar.gz"
+		export NETDATA_TARBALL_CHECKSUM_URL="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
 	fi
 }
 
@@ -145,6 +168,40 @@ detect_bash4() {
 		return 1
 	fi
 	return 0
+}
+
+dependencies() {
+	SYSTEM="$(uname -s)"
+	OS="$(uname -o)"
+	MACHINE="$(uname -m)"
+
+	echo "System            : ${SYSTEM}"
+	echo "Operating System  : ${OS}"
+	echo "Machine           : ${MACHINE}"
+	echo "BASH major version: ${BASH_MAJOR_VERSION}"
+
+	if [ "${OS}" != "GNU/Linux" ] && [ "${SYSTEM}" != "Linux" ]; then
+		warning "Cannot detect the packages to be installed on a ${SYSTEM} - ${OS} system."
+	else
+		bash="$(command -v bash 2>/dev/null)"
+		if ! detect_bash4 "${bash}"; then
+			warning "Cannot detect packages to be installed in this system, without BASH v4+."
+		else
+			progress "Downloading script to detect required packages..."
+			download "${PACKAGES_SCRIPT}" "${TMPDIR}/install-required-packages.sh"
+			if [ ! -s "${TMPDIR}/install-required-packages.sh" ]; then
+				warning "Downloaded dependency installation script is empty."
+			else
+				progress "Running downloaded script to detect required packages..."
+				run ${sudo} "${bash}" "${TMPDIR}/install-required-packages.sh" ${PACKAGES_INSTALLER_OPTIONS}
+				# shellcheck disable=SC2181
+				if [ $? -ne 0 ] ; then
+					warning "It failed to install all the required packages, but installation might still be possible."
+				fi
+			fi
+
+		fi
+	fi
 }
 
 umask 022
@@ -181,6 +238,7 @@ INTERACTIVE=1
 PACKAGES_INSTALLER_OPTIONS="netdata"
 NETDATA_INSTALLER_OPTIONS=""
 NETDATA_UPDATES="--auto-update"
+RELEASE_CHANNEL="nightly"
 while [ -n "${1}" ]; do
 	if [ "${1}" = "all" ]; then
 		PACKAGES_INSTALLER_OPTIONS="netdata-all"
@@ -192,6 +250,10 @@ while [ -n "${1}" ]; do
 		# echo >&2 "netdata will not auto-update"
 		NETDATA_UPDATES=
 		shift 1
+	elif [ "${1}" = "--stable-channel" ]; then
+		# echo >&2 "netdata will not auto-update"
+		RELEASE_CHANNEL="stable"
+		shift 1
 	else
 		break
 	fi
@@ -202,59 +264,20 @@ if [ "${INTERACTIVE}" = "0" ]; then
 	NETDATA_INSTALLER_OPTIONS="--dont-wait"
 fi
 
-# ---------------------------------------------------------------------------------------------------------------------
-# detect system parameters and install dependencies
+TMPDIR=$(create_tmp_directory)
+cd ${TMPDIR} || :
 
-SYSTEM="$(uname -s)"
-OS="$(uname -o)"
-MACHINE="$(uname -m)"
-
-cat <<EOF
-System            : ${SYSTEM}
-Operating System  : ${OS}
-Machine           : ${MACHINE}
-BASH major version: ${BASH_MAJOR_VERSION}
-EOF
-
-# Check if tmp is mounted as noexec
-if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
-	pattern="$(pwd)/netdata-kickstart-XXXXXX"
-else
-	pattern="/tmp/netdata-kickstart-XXXXXX"
-fi
-
-tmpdir="$(mktemp -d $pattern)"
-cd "${tmpdir}" || :
-
-if [ "${OS}" != "GNU/Linux" ] && [ "${SYSTEM}" != "Linux" ]; then
-	warning "Cannot detect the packages to be installed on a ${SYSTEM} - ${OS} system."
-else
-	bash="$(command -v bash 2>/dev/null)"
-	if ! detect_bash4 "${bash}"; then
-		warning "Cannot detect packages to be installed in this system, without BASH v4+."
-	else
-		progress "Downloading script to detect required packages..."
-		download "${PACKAGES_SCRIPT}" "${tmpdir}/install-required-packages.sh"
-		if [ ! -s "${tmpdir}/install-required-packages.sh" ]; then
-			warning "Downloaded dependency installation script is empty."
-		else
-			progress "Running downloaded script to detect required packages..."
-			run ${sudo} "${bash}" "${tmpdir}/install-required-packages.sh" ${PACKAGES_INSTALLER_OPTIONS}
-			if [ $? -ne 0 ] ; then
-				warning "It failed to install all the required packages, but installation might still be possible."
-			fi
-		fi
-
-	fi
-fi
+dependencies
 
 # ---------------------------------------------------------------------------------------------------------------------
-# download netdata nightly package
+# download netdata package
 
-download "${NIGHTLY_PACKAGE_CHECKSUM}" "${tmpdir}/sha256sum.txt"
-download "${NIGHTLY_PACKAGE_TARBALL}" "${tmpdir}/netdata-latest.tar.gz"
-if ! grep netdata-latest.tar.gz sha256sum.txt | sha256sum --check - >/dev/null 2>&1; then
-	failed "Tarball checksum validation failed. Stopping netdata installation and leaving tarball in ${tmpdir}"
+set_tarball_urls "${RELEASE_CHANNEL}"
+
+download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
+download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.tar.gz"
+if ! grep netdata-latest.tar.gz "${TMPDIR}/sha256sum.txt" | sha256sum --check - >/dev/null 2>&1; then
+	failed "Tarball checksum validation failed. Stopping netdata installation and leaving tarball in ${TMPDIR}"
 fi
 run tar -xf netdata-latest.tar.gz
 rm -rf netdata-latest.tar.gz >/dev/null 2>&1
@@ -266,7 +289,7 @@ cd netdata-* || fatal "Cannot cd to netdata source tree"
 if [ -x netdata-installer.sh ]; then
 	progress "Installing netdata..."
 	run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS} "${@}" || fatal "netdata-installer.sh exited with error"
-	rm -rf "${tmpdir}" >/dev/null 2>&1
+	rm -rf "${TMPDIR}" >/dev/null 2>&1
 else
-	fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${tmpdir}"
+	fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${TMPDIR}"
 fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -251,7 +251,6 @@ while [ -n "${1}" ]; do
 		NETDATA_UPDATES=
 		shift 1
 	elif [ "${1}" = "--stable-channel" ]; then
-		# echo >&2 "netdata will not auto-update"
 		RELEASE_CHANNEL="stable"
 		shift 1
 	else
@@ -277,7 +276,7 @@ set_tarball_urls "${RELEASE_CHANNEL}"
 download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
 download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.tar.gz"
 if ! grep netdata-latest.tar.gz "${TMPDIR}/sha256sum.txt" | sha256sum --check - >/dev/null 2>&1; then
-	failed "Tarball checksum validation failed. Stopping netdata installation and leaving tarball in ${TMPDIR}"
+	fatal "Tarball checksum validation failed. Stopping netdata installation and leaving tarball in ${TMPDIR}"
 fi
 run tar -xf netdata-latest.tar.gz
 rm -rf netdata-latest.tar.gz >/dev/null 2>&1

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -102,7 +102,7 @@ update() {
 	fi
 
 	info "Re-installing netdata..."
-	eval "${REINSTALL_COMMAND} --dont-wait ${do_not_start}" >&3 2>&3 || failed "FAILED TO COMPILE/INSTALL NETDATA"
+	eval "${REINSTALL_COMMAND} --dont-wait ${do_not_start}" >&3 2>&3 || fatal "FAILED TO COMPILE/INSTALL NETDATA"
 	sed -i '/NETDATA_TARBALL/d' "${ENVIRONMENT_FILE}"
 	cat <<EOF >>"${ENVIRONMENT_FILE}"
 NETDATA_TARBALL_CHECKSUM="$NEW_CHECKSUM"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -31,6 +31,17 @@ fatal() {
 	exit 1
 }
 
+create_tmp_directory() {
+	# Check if tmp is mounted as noexec
+	if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
+		pattern="$(pwd)/netdata-updater-XXXXXX"
+	else
+		pattern="/tmp/netdata-updater-XXXXXX"
+	fi
+
+	mktemp -d "$pattern"
+}
+
 download() {
 	url="${1}"
 	dest="${2}"
@@ -43,18 +54,24 @@ download() {
 	fi
 }
 
+set_tarball_urls() {
+	if [ "$1" == "stable" ]; then
+		local latest
+		# Simple version
+		# latest="$(curl -sSL https://api.github.com/repos/netdata/netdata/releases/latest | grep tag_name | cut -d'"' -f4)"
+		latest="$(download "https://api.github.com/repos/netdata/netdata/releases/latest" /dev/stdout | grep tag_name | cut -d'"' -f4)"
+		export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.tar.gz"
+		export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
+	else
+		export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.tar.gz"
+		export NETDATA_TARBALL_CHECKSUM_URL="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
+	fi
+}
+
 update() {
 	[ -z "${logfile}" ] && info "Running on a terminal - (this script also supports running headless from crontab)"
 
-	# Check if tmp is mounted as noexec
-	if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
-		pattern="$(pwd)/netdata-updater-XXXXXX"
-	else
-		pattern="/tmp/netdata-updater-XXXXXX"
-	fi
-
-	dir=$(mktemp -d "$pattern")
-
+	dir=$(create_tmp_directory)
 	cd "$dir"
 
 	download "${NETDATA_TARBALL_CHECKSUM_URL}" "${dir}/sha256sum.txt" >&3 2>&3
@@ -88,8 +105,6 @@ update() {
 	eval "${REINSTALL_COMMAND} --dont-wait ${do_not_start}" >&3 2>&3 || failed "FAILED TO COMPILE/INSTALL NETDATA"
 	sed -i '/NETDATA_TARBALL/d' "${ENVIRONMENT_FILE}"
 	cat <<EOF >>"${ENVIRONMENT_FILE}"
-NETDATA_TARBALL_URL="$NETDATA_TARBALL_URL"
-NETDATA_TARBALL_CHECKSUM_URL="$NETDATA_TARBALL_CHECKSUM_URL"
 NETDATA_TARBALL_CHECKSUM="$NEW_CHECKSUM"
 EOF
 
@@ -120,6 +135,8 @@ else
 	# open fd 3 and send it to logfile
 	exec 3>"${logfile}"
 fi
+
+set_tarball_urls "${RELEASE_CHANNEL}"
 
 # the installer updates this script - so we run and exit in a single line
 update && exit 0


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
This introduces a switch `--stable-channel` to `netdata-installer.sh` and all kickstart scripts. Also updater is affected and channel can be changed by modifying variable `RELEASE_CHANNEL` in `.environment` file.

Fixes #5410

##### Component Name
packaging/installer

##### Additional Information

Moving parts of installations into functions so it will be easier to refactor later.

Needs A LOT of testing.