### PR TITLE
Convert SpigotMC module to use regexes for parsing.

### DIFF
--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -107,9 +107,9 @@ class Service(SimpleService):
             raw = self.console.command('tps')
             match = _TPS_REGEX.match(raw)
             if match:
-                data['tps1'] = int(match.group(1)) * PRECISION
-                data['tps5'] = int(match.group(2)) * PRECISION
-                data['tps15'] = int(match.group(3)) * PRECISION
+                data['tps1'] = int(float(match.group(1)) * PRECISION)
+                data['tps5'] = int(float(match.group(2)) * PRECISION)
+                data['tps15'] = int(float(match.group(3)) * PRECISION)
             else:
                 self.error('Unable to process TPS values.')
         except mcrcon.MCRconException:

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -118,8 +118,6 @@ class Service(SimpleService):
             self.error('Connection is dead.')
             self.alive = False
             return None
-        except (TypeError, LookupError, IndexError):
-            self.error('Unable to process TPS values.')
         try:
             raw = self.console.command('list')
             match = _LIST_REGEX.match(raw)
@@ -133,6 +131,4 @@ class Service(SimpleService):
             self.error('Connection is dead.')
             self.alive = False
             return None
-        except (TypeError, LookupError):
-            self.error('Unable to process user counts.')
         return data

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -46,9 +46,7 @@ _TPS_REGEX = re.compile(
     re.X | re.A
 )
 _LIST_REGEX = re.compile(
-    r'^.*?'       # Message lead-in
-    r'(\d+)'      # Current user count.
-    r'.*?\d*.*$', # Rest of the line, which should include another number.
+    r'(\d+)', # Current user count.
     re.X | re.A
 )
 
@@ -120,10 +118,10 @@ class Service(SimpleService):
             return None
         try:
             raw = self.console.command('list')
-            match = _LIST_REGEX.match(raw)
+            match = _LIST_REGEX.search(raw)
             if not match:
                 raw = self.console.command('online')
-                match = _LIST_REGEX.match(raw)
+                match = _LIST_REGEX.search(raw)
             if match:
                 data['users'] = int(match.group(1))
             else:

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -39,17 +39,17 @@ CHARTS = {
     }
 }
 _TPS_REGEX = re.compile(
-    r'^.*: .*?'                 # Message lead-in
-    r'([0-9]{1,2}.[0-9]+), .*?' # 1-minute TPS value
-    r'([0-9]{1,2}.[0-9]+), .*?' # 5-minute TPS value
-    r'([0-9]{1,2}\.[0-9]+).*$', # 15-minute TPS value
-    re.X
+    r'^.*: .*?'           # Message lead-in
+    r'(\d{1,2}.\d+), .*?' # 1-minute TPS value
+    r'(\d{1,2}.\d+), .*?' # 5-minute TPS value
+    r'(\d{1,2}\.\d+).*$', # 15-minute TPS value
+    re.X | re.A
 )
 _LIST_REGEX = re.compile(
-    r'^.*?'          # Message lead-in
-    r'([0-9]*)'      # Current user count.
-    r'.*?[0-9]*.*$', # Rest of the line, which should include another number.
-    re.X
+    r'^.*?'       # Message lead-in
+    r'(\d+)'      # Current user count.
+    r'.*?\d*.*$', # Rest of the line, which should include another number.
+    re.X | re.A
 )
 
 

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -121,6 +121,9 @@ class Service(SimpleService):
         try:
             raw = self.console.command('list')
             match = _LIST_REGEX.match(raw)
+            if !match:
+                raw = self.console.command('online')
+                match = _LIST_REGEX.match(raw)
             if match:
                 data['users'] = int(match.group(1))
             else:

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -39,16 +39,16 @@ CHARTS = {
     }
 }
 _TPS_REGEX = re.compile(
-    '^.*: .*?'                     # Message lead-in
-    '([0-9]{1,2}.[0-9]{1,2}), .*?' # 1-minute TPS value
-    '([0-9]{1,2}.[0-9]{1,2}), .*?' # 5-minute TPS value
-    '([0-9]{1,2}.[0-9]{1,2}).*$',  # 15-minute TPS value
+    r'^.*: .*?'                 # Message lead-in
+    r'([0-9]{1,2}.[0-9]+), .*?' # 1-minute TPS value
+    r'([0-9]{1,2}.[0-9]+), .*?' # 5-minute TPS value
+    r'([0-9]{1,2}\.[0-9]+).*$', # 15-minute TPS value
     re.X
 )
 _LIST_REGEX = re.compile(
-    '^.*?'          # Message lead-in
-    '([0-9]*)'      # Current user count.
-    '.*?[0-9]*.*$', # Rest of the line, which should include another number.
+    r'^.*?'          # Message lead-in
+    r'([0-9]*)'      # Current user count.
+    r'.*?[0-9]*.*$', # Rest of the line, which should include another number.
     re.X
 )
 

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -121,7 +121,7 @@ class Service(SimpleService):
         try:
             raw = self.console.command('list')
             match = _LIST_REGEX.match(raw)
-            if !match:
+            if not match:
                 raw = self.console.command('online')
                 match = _LIST_REGEX.match(raw)
             if match:


### PR DESCRIPTION
##### Summary

This converts the SpigotMC python module to use regular expressions for parsing, which makes the parsing a bit more robust at the cost of some performance.

Additionally, this relaxes the parsing logic surrounding the handling of the user counts to just grab the first integer after the timestamp and treat it as the count of users.

##### Component Name

python.d.plugin / spigotmc.chart.py

##### Additional Information

Fixes: #4131

-----

I've verified the regexes against sample console output I had saved for testing though, as well as the console outputs posted in #4131, so while I haven't directly tested the code myself (I don't have a working SpigotMC installation that I can test against right now, and I unfortunately don't have the time to get one working right now either) it _should_ work, but it would be good to have someone who has a working SpigotMC installation test this.