### PR TITLE
Prevent data corruption upon GUID duplication between master and slave netdata instances

### DIFF
--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -868,9 +868,7 @@ static int rrdpush_receive(int fd
     tags = appconfig_set_default(&stream_config, machine_guid, "host tags", (tags)?tags:"");
     if(tags && !*tags) tags = NULL;
 
-    if(!strcmp(machine_guid, "localhost"))
-        host = localhost;
-    else if (strcmp(machine_guid, localhost->machine_guid) == 0) {
+    if (strcmp(machine_guid, localhost->machine_guid) == 0) {
         log_stream_connection(client_ip, client_port, key, machine_guid, hostname, "DENIED - ATTEMPT TO RECEIVE METRICS FROM MACHINE_GUID IDENTICAL TO MASTER");
         error("STREAM %s [receive from %s:%s]: denied to receive metrics, machine GUID [%s] is my own. Did you copy the master/proxy machine guid to a slave?", hostname, client_ip, client_port, machine_guid);
         close(fd);
@@ -1056,24 +1054,24 @@ static void rrdpush_receiver_thread_cleanup(void *ptr) {
 static void *rrdpush_receiver_thread(void *ptr) {
     netdata_thread_cleanup_push(rrdpush_receiver_thread_cleanup, ptr);
 
-        struct rrdpush_thread *rpt = (struct rrdpush_thread *)ptr;
-        info("STREAM %s [%s]:%s: receive thread created (task id %d)", rpt->hostname, rpt->client_ip, rpt->client_port, gettid());
+    struct rrdpush_thread *rpt = (struct rrdpush_thread *)ptr;
+    info("STREAM %s [%s]:%s: receive thread created (task id %d)", rpt->hostname, rpt->client_ip, rpt->client_port, gettid());
 
-        rrdpush_receive(
-                rpt->fd
-                , rpt->key
-                , rpt->hostname
-                , rpt->registry_hostname
-                , rpt->machine_guid
-                , rpt->os
-                , rpt->timezone
-                , rpt->tags
-                , rpt->program_name
-                , rpt->program_version
-                , rpt->update_every
-                , rpt->client_ip
-                , rpt->client_port
-        );
+    rrdpush_receive(
+	    rpt->fd
+	    , rpt->key
+	    , rpt->hostname
+	    , rpt->registry_hostname
+	    , rpt->machine_guid
+	    , rpt->os
+	    , rpt->timezone
+	    , rpt->tags
+	    , rpt->program_name
+	    , rpt->program_version
+	    , rpt->update_every
+	    , rpt->client_ip
+	    , rpt->client_port
+    );
 
     netdata_thread_cleanup_pop(1);
     return NULL;

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -870,6 +870,11 @@ static int rrdpush_receive(int fd
 
     if(!strcmp(machine_guid, "localhost"))
         host = localhost;
+    else if (strcmp(machine_guid, localhost->machine_guid) == 0) {
+        log_stream_connection(client_ip, client_port, key, machine_guid, hostname, "DENIED - ATTEMPT TO RECEIVE METRICS FROM MACHINE_GUID IDENTICAL TO MASTER");
+        error("STREAM %s [receive from %s:%s]: denied to receive metrics, machine GUID [%s] is my own. Did you copy the master/proxy machine guid to a slave?", hostname, client_ip, client_port, machine_guid);
+        return 1;
+    }
     else
         host = rrdhost_find_or_create(
                 hostname

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -873,6 +873,7 @@ static int rrdpush_receive(int fd
     else if (strcmp(machine_guid, localhost->machine_guid) == 0) {
         log_stream_connection(client_ip, client_port, key, machine_guid, hostname, "DENIED - ATTEMPT TO RECEIVE METRICS FROM MACHINE_GUID IDENTICAL TO MASTER");
         error("STREAM %s [receive from %s:%s]: denied to receive metrics, machine GUID [%s] is my own. Did you copy the master/proxy machine guid to a slave?", hostname, client_ip, client_port, machine_guid);
+        close(fd);
         return 1;
     }
     else


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
patch to mitigate data corruption during replication of metrics, when duplication of machine GUID occurs between master/slave instances of netdata.
Reference issue #5488

##### Component Name
netdata/netdata/streaming

##### Additional Information
None
