### PR TITLE
Minor fixes around plugin_directories initialization

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -210,10 +210,10 @@ void read_cgroup_plugin_configuration() {
                     " * "
             ), NULL, SIMPLE_PATTERN_EXACT);
 
-    snprintfz(filename, FILENAME_MAX, "%s/cgroup-name.sh", netdata_configured_plugins_dir);
+    snprintfz(filename, FILENAME_MAX, "%s/cgroup-name.sh", netdata_configured_primary_plugins_dir);
     cgroups_rename_script = config_get("plugin:cgroups", "script to get cgroup names", filename);
 
-    snprintfz(filename, FILENAME_MAX, "%s/cgroup-network", netdata_configured_plugins_dir);
+    snprintfz(filename, FILENAME_MAX, "%s/cgroup-network", netdata_configured_primary_plugins_dir);
     cgroups_network_interface_script = config_get("plugin:cgroups", "script to get cgroup network interfaces", filename);
 
     enabled_cgroup_renames = simple_pattern_create(

--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -34,7 +34,7 @@ inline int config_isspace(char c) {
 }
 
 // split a text into words, respecting quotes
-inline int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char)) {
+static inline int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char)) {
     char *s = str, quote = 0;
     int i = 0, j;
 

--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -108,7 +108,7 @@ inline int pluginsd_initialize_plugin_directories() {
     plugins_dir_list = strdupz(config_get(CONFIG_SECTION_GLOBAL, "plugins directory",  plugins_dirs));
 
     // Parse it and store it to plugin directories
-    quoted_strings_splitter(plugins_dir_list, plugin_directories, PLUGINSD_MAX_DIRECTORIES, config_isspace);
+    return quoted_strings_splitter(plugins_dir_list, plugin_directories, PLUGINSD_MAX_DIRECTORIES, config_isspace);
 }
 
 inline int pluginsd_split_words(char *str, char **words, int max_words) {

--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -3,8 +3,6 @@
 #include "plugins_d.h"
 
 char *plugin_directories[PLUGINSD_MAX_DIRECTORIES] = { NULL };
-char *netdata_configured_plugins_dir_base;
-
 struct plugind *pluginsd_root = NULL;
 
 static inline int pluginsd_space(char c) {
@@ -99,6 +97,18 @@ inline int quoted_strings_splitter(char *str, char **words, int max_words, int (
     while(likely(j < max_words)) words[j++] = NULL;
 
     return i;
+}
+
+inline int pluginsd_initialize_plugin_directories() {
+    char plugins_dirs[(FILENAME_MAX * 2) + 1];
+    char *plugins_dir_list = NULL;
+
+    // Get the configuration entry
+    snprintfz(plugins_dirs, FILENAME_MAX * 2, "\"%s\" \"%s/custom-plugins.d\"", PLUGINS_DIR, CONFIG_DIR);
+    plugins_dir_list = strdupz(config_get(CONFIG_SECTION_GLOBAL, "plugins directory",  plugins_dirs));
+
+    // Parse it and store it to plugin directories
+    quoted_strings_splitter(plugins_dir_list, plugin_directories, PLUGINSD_MAX_DIRECTORIES, config_isspace);
 }
 
 inline int pluginsd_split_words(char *str, char **words, int max_words) {

--- a/collectors/plugins.d/plugins_d.h
+++ b/collectors/plugins.d/plugins_d.h
@@ -68,7 +68,6 @@ extern void *pluginsd_main(void *ptr);
 extern size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int trust_durations);
 extern int pluginsd_split_words(char *str, char **words, int max_words);
 
-extern int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char));
 extern int pluginsd_initialize_plugin_directories();
 
 extern int config_isspace(char c);

--- a/collectors/plugins.d/plugins_d.h
+++ b/collectors/plugins.d/plugins_d.h
@@ -20,6 +20,7 @@
 #define PLUGINSD_FILE_SUFFIX ".plugin"
 #define PLUGINSD_FILE_SUFFIX_LEN strlen(PLUGINSD_FILE_SUFFIX)
 #define PLUGINSD_CMD_MAX (FILENAME_MAX*2)
+#define PLUGINSD_STOCK_PLUGINS_DIRECTORY_PATH 0
 
 #define PLUGINSD_KEYWORD_CHART "CHART"
 #define PLUGINSD_KEYWORD_DIMENSION "DIMENSION"
@@ -68,6 +69,8 @@ extern size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
 extern int pluginsd_split_words(char *str, char **words, int max_words);
 
 extern int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char));
+extern int pluginsd_initialize_plugin_directories();
+
 extern int config_isspace(char c);
 
 #endif /* NETDATA_PLUGINS_D_H */

--- a/collectors/tc.plugin/plugin_tc.c
+++ b/collectors/tc.plugin/plugin_tc.c
@@ -879,7 +879,7 @@ void *tc_main(void *ptr) {
 #endif
     uint32_t first_hash;
 
-    snprintfz(command, TC_LINE_MAX, "%s/tc-qos-helper.sh", netdata_configured_plugins_dir);
+    snprintfz(command, TC_LINE_MAX, "%s/tc-qos-helper.sh", netdata_configured_primary_plugins_dir);
     char *tc_script = config_get("plugin:tc", "script to run to get tc values", command);
 
     while(!netdata_exit) {

--- a/daemon/common.c
+++ b/daemon/common.c
@@ -2,15 +2,15 @@
 
 #include "common.h"
 
-char *netdata_configured_hostname         = NULL;
-char *netdata_configured_user_config_dir  = CONFIG_DIR;
-char *netdata_configured_stock_config_dir = LIBCONFIG_DIR;
-char *netdata_configured_log_dir          = LOG_DIR;
-char *netdata_configured_plugins_dir      = NULL;
-char *netdata_configured_web_dir          = WEB_DIR;
-char *netdata_configured_cache_dir        = CACHE_DIR;
-char *netdata_configured_varlib_dir       = VARLIB_DIR;
-char *netdata_configured_home_dir         = CACHE_DIR;
-char *netdata_configured_host_prefix      = NULL;
-char *netdata_configured_timezone         = NULL;
+char *netdata_configured_hostname            = NULL;
+char *netdata_configured_user_config_dir     = CONFIG_DIR;
+char *netdata_configured_stock_config_dir    = LIBCONFIG_DIR;
+char *netdata_configured_log_dir             = LOG_DIR;
+char *netdata_configured_primary_plugins_dir = NULL;
+char *netdata_configured_web_dir             = WEB_DIR;
+char *netdata_configured_cache_dir           = CACHE_DIR;
+char *netdata_configured_varlib_dir          = VARLIB_DIR;
+char *netdata_configured_home_dir            = CACHE_DIR;
+char *netdata_configured_host_prefix         = NULL;
+char *netdata_configured_timezone            = NULL;
 

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -70,7 +70,6 @@ extern char *netdata_configured_hostname;
 extern char *netdata_configured_user_config_dir;
 extern char *netdata_configured_stock_config_dir;
 extern char *netdata_configured_log_dir;
-extern char *netdata_configured_plugins_dir_base;
 extern char *netdata_configured_plugins_dir;
 extern char *netdata_configured_web_dir;
 extern char *netdata_configured_cache_dir;

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -70,7 +70,7 @@ extern char *netdata_configured_hostname;
 extern char *netdata_configured_user_config_dir;
 extern char *netdata_configured_stock_config_dir;
 extern char *netdata_configured_log_dir;
-extern char *netdata_configured_plugins_dir;
+extern char *netdata_configured_primary_plugins_dir;
 extern char *netdata_configured_web_dir;
 extern char *netdata_configured_cache_dir;
 extern char *netdata_configured_varlib_dir;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -458,12 +458,8 @@ static void get_netdata_configured_variables() {
     netdata_configured_home_dir         = config_get(CONFIG_SECTION_GLOBAL, "home directory",         netdata_configured_home_dir);
 
     {
-        char plugins_dirs[(FILENAME_MAX * 2) + 1];
-        snprintfz(plugins_dirs, FILENAME_MAX * 2, "\"%s\" \"%s/custom-plugins.d\"", PLUGINS_DIR, CONFIG_DIR);
-        netdata_configured_plugins_dir_base = strdupz(config_get(CONFIG_SECTION_GLOBAL, "plugins directory",  plugins_dirs));
-        quoted_strings_splitter(netdata_configured_plugins_dir_base, plugin_directories, PLUGINSD_MAX_DIRECTORIES, config_isspace);
-        netdata_configured_plugins_dir = plugin_directories[0];
-
+        pluginsd_initialize_plugin_directories();
+        netdata_configured_plugins_dir = plugin_directories[PLUGINSD_STOCK_PLUGINS_DIRECTORY_PATH];
     }
 
     // ------------------------------------------------------------------------

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -459,7 +459,7 @@ static void get_netdata_configured_variables() {
 
     {
         pluginsd_initialize_plugin_directories();
-        netdata_configured_plugins_dir = plugin_directories[PLUGINSD_STOCK_PLUGINS_DIRECTORY_PATH];
+        netdata_configured_primary_plugins_dir = plugin_directories[PLUGINSD_STOCK_PLUGINS_DIRECTORY_PATH];
     }
 
     // ------------------------------------------------------------------------
@@ -588,7 +588,7 @@ void set_global_environment() {
     setenv("NETDATA_CONFIG_DIR"       , verify_required_directory(netdata_configured_user_config_dir),  1);
     setenv("NETDATA_USER_CONFIG_DIR"  , verify_required_directory(netdata_configured_user_config_dir),  1);
     setenv("NETDATA_STOCK_CONFIG_DIR" , verify_required_directory(netdata_configured_stock_config_dir), 1);
-    setenv("NETDATA_PLUGINS_DIR"      , verify_required_directory(netdata_configured_plugins_dir),      1);
+    setenv("NETDATA_PLUGINS_DIR"      , verify_required_directory(netdata_configured_primary_plugins_dir),      1);
     setenv("NETDATA_WEB_DIR"          , verify_required_directory(netdata_configured_web_dir),          1);
     setenv("NETDATA_CACHE_DIR"        , verify_required_directory(netdata_configured_cache_dir),        1);
     setenv("NETDATA_LIB_DIR"          , verify_required_directory(netdata_configured_varlib_dir),       1);
@@ -653,8 +653,8 @@ void send_statistics( const char *action, const char *action_result, const char 
         char *optout_file = mallocz(sizeof(char) * (strlen(netdata_configured_user_config_dir) +strlen(".opt-out-from-anonymous-statistics") + 2));
         sprintf(optout_file, "%s/%s", netdata_configured_user_config_dir, ".opt-out-from-anonymous-statistics");
         if (likely(access(optout_file, R_OK) != 0)) {
-            as_script = mallocz(sizeof(char) * (strlen(netdata_configured_plugins_dir) + strlen("anonymous-statistics.sh") + 2));
-            sprintf(as_script, "%s/%s", netdata_configured_plugins_dir, "anonymous-statistics.sh");
+            as_script = mallocz(sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("anonymous-statistics.sh") + 2));
+            sprintf(as_script, "%s/%s", netdata_configured_primary_plugins_dir, "anonymous-statistics.sh");
 			if (unlikely(access(as_script, R_OK) != 0)) {
 				netdata_anonymous_statistics_enabled=0;
 				info("Anonymous statistics script %s not found.",as_script);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -229,7 +229,7 @@ RRDHOST *rrdhost_create(const char *hostname,
     snprintfz(filename, FILENAME_MAX, "%s/health/health-log.db", host->varlib_dir);
     host->health_log_filename = strdupz(filename);
 
-    snprintfz(filename, FILENAME_MAX, "%s/alarm-notify.sh", netdata_configured_plugins_dir);
+    snprintfz(filename, FILENAME_MAX, "%s/alarm-notify.sh", netdata_configured_primary_plugins_dir);
     host->health_default_exec = strdupz(config_get(CONFIG_SECTION_HEALTH, "script to execute on alarm", filename));
     host->health_default_recipient = strdupz("root");
 


### PR DESCRIPTION
##### Summary
This is a small PR attempting to simplify and clarify the plugin_directories initialization process within daemon. No functional changes should be included within this change. Feel free to recommend further adjustments or even reject the PR if it does not comply with any policy.

The changes include:

1) Removal of a magic number, primarily because magic numbers are evil and we need to know why we treat the first entry differently (using 0 is counter intuitive)

2) pull the initialization logic of the plugin_directories variable within the pluginsd scope, only expose a method to trigger it, nothing else needed as it seems (removed a couple of useless globals too)

3) renamed **netdata_configured_plugins_dir** to **netdata_configured_primary_plugins_dir**, because we have multiple directories for the plugins and that parameter actually contains our primary (or stock? not sure its clear to me yet what is the conceptual classification of that first dir)

##### Component Name
netdata/daemon
netdata/collectors/plugins.d

##### Additional Information