### PR TITLE
Have the debug option set the freeipmi debug flags

### DIFF
--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1790,7 +1790,10 @@ int main (int argc, char **argv) {
 
     _init_ipmi_config(&ipmi_config);
 
-    if(debug) fprintf(stderr, "freeipmi.plugin: calling ipmi_monitoring_init()\n");
+    if(debug) {
+        fprintf(stderr, "freeipmi.plugin: calling ipmi_monitoring_init()\n");
+        ipmimonitoring_init_flags|=IPMI_MONITORING_FLAGS_DEBUG|IPMI_MONITORING_FLAGS_DEBUG_IPMI_PACKETS;
+    }
 
     if(ipmi_monitoring_init(ipmimonitoring_init_flags, &errnum) < 0)
         fatal("ipmi_monitoring_init: %s", ipmi_monitoring_ctx_strerror(errnum));


### PR DESCRIPTION
##### Summary
See freeipmi debug output when running the collector in debug mode

##### Component Name
freeipmi

##### Additional Information
When the freeipmi plugin is called with debug, add IPMI_MONITORING_FLAGS_DEBUG
and IPMI_MONITORING_FLAGS_DEBUG_IPMI_PACKETS to ipmimonitoring_init_flags, so that we get debug output from freeipmi itself as well.
That output will go to error.log, if the debug option is provided as an option in netdata.conf