### PR TITLE
Correct PLUGINS_DIR flag in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,7 @@ add_definitions(
         -DCONFIG_DIR="/etc/netdata"
         -DLIBCONFIG_DIR="/usr/lib/netdata/conf.d"
         -DLOG_DIR="/var/log/netdata"
-        -DPLUGINS_DIR="/usr/libexec/netdata"
+        -DPLUGINS_DIR="/usr/libexec/netdata/plugins.d"
         -DWEB_DIR="/usr/share/netdata/web"
         -DVARLIB_DIR="/var/lib/netdata"
 )


### PR DESCRIPTION
##### Summary

-DPLUGINS_DIR in Makefile is `${exec_prefix}/libexec/netdata/plugins.d`, but in CMakeLists.txt it is `/usr/libexec/netdata/`. This aligns CMake to make.

##### Component Name
CMake

##### Additional Information

The path has been the same for a very long time and I was not able to figure out the exact point when the errors started appearing when running a binary compiled using CMake. The error today is that no external plugin is loaded, when running the binary created by CMake. You can immediately tell if you have the error, because netdata will immediately notify you that the anonymous statistics script can't be found. 


