### PR TITLE
Delay renaming for docker containers

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -175,4 +175,10 @@ if [ -z "${NAME}" ]; then
 fi
 
 info "cgroup '${CGROUP}' is called '${NAME}'"
-echo "${NAME_NOT_FOUND}" "${NAME}"
+echo "${NAME}"
+
+if [ "${NAME_NOT_FOUND}" -eq 1 ]; then
+	exit 2
+else
+	exit 0
+fi

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -73,6 +73,7 @@ function docker_get_name() {
 	fi
 	if [ -z "${NAME}" ]; then
 		warning "cannot find the name of docker container '${id}'"
+		NAME_NOT_FOUND=1
 		NAME="${id:0:12}"
 	else
 		info "docker container '${id}' is named '${NAME}'"
@@ -95,6 +96,7 @@ function docker_validate_id() {
 
 DOCKER_HOST="${DOCKER_HOST:=/var/run/docker.sock}"
 CGROUP="${1}"
+NAME_NOT_FOUND=0
 NAME=
 
 # -----------------------------------------------------------------------------
@@ -173,4 +175,4 @@ if [ -z "${NAME}" ]; then
 fi
 
 info "cgroup '${CGROUP}' is called '${NAME}'"
-echo "${NAME}"
+echo "${NAME_NOT_FOUND}" "${NAME}"

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -897,16 +897,15 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
         char buffer[CGROUP_CHARTID_LINE_MAX + 1];
         char *s = fgets(buffer, CGROUP_CHARTID_LINE_MAX, fp);
         // debug(D_CGROUP, "closing command for cgroup '%s'", cg->id);
-        mypclose(fp, cgroup_pid);
+        int name_error = mypclose(fp, cgroup_pid);
         // debug(D_CGROUP, "closed command for cgroup '%s'", cg->id);
 
         if(s && *s && *s != '\n') {
             debug(D_CGROUP, "cgroup '%s' should be renamed to '%s'", cg->id, s);
 
-            char *name_error = mystrsep(&s, " ");
             s = trim(s);
             if (s) {
-                if(likely(*name_error == '0'))
+                if(likely(!name_error))
                     cg->pending_renames = 0;
 
                 freez(cg->chart_title);


### PR DESCRIPTION
##### Summary
When a docker container is starting there is a possibility that the `docker ps` command will not return the name of the container. An additional renaming attempt after a delay was introduced to deal with the docker lag.

Fixes #5512

##### Component Name
`cgroups.plugin`