### PR TITLE
Patch the netdata-installer.sh script, so that it provides accurate input during stock config cleanup

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -550,7 +550,7 @@ if [ ! -f "${NETDATA_PREFIX}/etc/netdata/.installer-cleanup-of-stock-configs-don
 					deleted_stock_configs=$((deleted_stock_configs + 1))
 				else
 					# edited by user - keep it
-					echo >&2 "File '${TPUT_CYAN}${x}${TPUT_RESET}' ${TPUT_RED} does not match stock of '${t}'${TPUT_RESET}. Keeping it."
+					echo >&2 "File '${TPUT_CYAN}${x}${TPUT_RESET}' ${TPUT_RED} does not match stock of${TPUT_RESET} ${TPUT_CYAN}'${t}'${TPUT_RESET}. Keeping it."
 				fi
 			fi
 		fi

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -525,7 +525,7 @@ if [ ! -f "${NETDATA_PREFIX}/etc/netdata/.installer-cleanup-of-stock-configs-don
 	}
 
 	# clean up stock config files from the user configuration directory
-	for x in $(find -L "${NETDATA_PREFIX}/etc/netdata" -type f); do
+	for x in $(find -L "${NETDATA_PREFIX}/etc/netdata" -type f -not path '*/\.*' -name '*.conf'); do
 		if [ -f "${x}" ]; then
 			# find it relative filename
 			f="${x/${NETDATA_PREFIX}\/etc\/netdata\//}"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -525,7 +525,7 @@ if [ ! -f "${NETDATA_PREFIX}/etc/netdata/.installer-cleanup-of-stock-configs-don
 	}
 
 	# clean up stock config files from the user configuration directory
-	for x in $(find -L "${NETDATA_PREFIX}/etc/netdata" -type f -not path '*/\.*' -name '*.conf'); do
+	for x in $(find -L "${NETDATA_PREFIX}/etc/netdata" -type f -not -path '*/\.*' \( -name '*.conf.old' -o -name '*.conf' -o -name '*.conf.orig' -o -name '*.conf.installer_backup.*' \)); do
 		if [ -f "${x}" ]; then
 			# find it relative filename
 			f="${x/${NETDATA_PREFIX}\/etc\/netdata\//}"
@@ -534,6 +534,7 @@ if [ ! -f "${NETDATA_PREFIX}/etc/netdata/.installer-cleanup-of-stock-configs-don
 			t="${f/.conf.installer_backup.*/.conf}"
 			t="${t/.conf.old/.conf}"
 			t="${t/.conf.orig/.conf}"
+			t="${t/orig\//}"
 
 			if [ -z "${md5sum}" -o ! -x "${md5sum}" ]; then
 				# we don't have md5sum - keep it


### PR DESCRIPTION
##### Summary
As a result of the investigation of #5039, we identified cases were our installer wasn't able to understand if a config file was part of stock or not. The root cause of this problem was the fact that we re-arrange our configuration files placing, thus resulting on out-dating the validity of this code that was parsing all configuration files and based on md5 checksums deciding whether the files should remain or be deleted.

Briefly the fixes in this PR include:
1) Adjusted the find command, so that it only fetches the relative `.conf,` `.conf.orig.` `.conf.old` and `.backup_installer.` files, to reduce noise during parsing

2) Added extra handling to remove the 'orig' part from the filename path, so that look up on configs.signatures will work successfully.

##### Component Name
netdata/installer

##### Additional Information
None