### PR TITLE
fix command not found error when run script under root user.

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -41,7 +41,7 @@ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 Verify the integrity of the script with this:
 
 ```bash
-[ "b66c99c065abe1cf104c11236d4e8747" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "e051d1baed4c69653b5d3e4588696466" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 *It should print `OK, VALID` if the script is the one we ship.*
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -83,7 +83,7 @@ run() {
 
 	escaped_print "${info_console}${TPUT_BOLD}${TPUT_YELLOW}" "${@}" "${TPUT_RESET}\n" >&2
 
-	"${@}"
+	${@}
 
 	local ret=$?
 	if [ ${ret} -ne 0 ]; then


### PR DESCRIPTION
##### Summary
Fixes #5584 
When i run kickstart script under root user, it will raise command not found exception.
Cause when we are run "${@}" it will start with a space. which bash will raise exception.

##### Component Name
packing/installer/kickstart.sh

##### Additional Information
Error:
 --- Re-installing netdata... --- 
$'[\E[2m/tmp\E[0m\017]# \E[1m\E[33m' '' /etc/cron.daily/netdata-updater -f $'\E[0m\017\\n' kickstart.sh: line 86: : command not found
 FAILED   /etc/cron.daily/netdata-updater -f 

 ABORTED  Failed to forcefully update netdata 


