### PR TITLE
spigotmc: py2 compatibility fix

### DIFF
--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -78,7 +78,8 @@ class Service(SimpleService):
             self.error('Error connecting.')
             self.error(repr(err))
             return False
-        return True
+
+        return self._get_data()
 
     def connect(self):
         self.console.connect(self.host, self.port, self.password)
@@ -123,6 +124,8 @@ class Service(SimpleService):
                 data['tps15'] = int(float(match.group(3)) * PRECISION)
             else:
                 self.error('Unable to process TPS values.')
+                if not raw:
+                    self.error("'{0}' command returned no value, make sure you set correct password".format(COMMAND_TPS))
         except mcrcon.MCRconException:
             self.error('Unable to fetch TPS values.')
         except socket.error:
@@ -141,6 +144,9 @@ class Service(SimpleService):
             if match:
                 data['users'] = int(match.group(1))
             else:
+                if not raw:
+                    self.error("'{0}' and '{1}' commands returned no value, make sure you set correct password".format(
+                        COMMAND_LIST, COMMAND_ONLINE))
                 self.error('Unable to process user counts.')
         except mcrcon.MCRconException:
             self.error('Unable to fetch user counts.')

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -43,11 +43,11 @@ _TPS_REGEX = re.compile(
     r'(\d{1,2}.\d+), .*?' # 1-minute TPS value
     r'(\d{1,2}.\d+), .*?' # 5-minute TPS value
     r'(\d{1,2}\.\d+).*$', # 15-minute TPS value
-    re.X | re.A
+    re.X
 )
 _LIST_REGEX = re.compile(
     r'(\d+)', # Current user count.
-    re.X | re.A
+    re.X
 )
 
 

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -12,10 +12,14 @@ from bases.FrameworkServices.SimpleService import SimpleService
 from third_party import mcrcon
 
 # Update only every 5 seconds because collection takes in excess of
-# 100ms sometimes, and mos tpeople won't care about second-by-second data.
+# 100ms sometimes, and most people won't care about second-by-second data.
 update_every = 5
 
 PRECISION = 100
+
+COMMAND_TPS = 'tps'
+COMMAND_LIST = 'list'
+COMMAND_ONLINE = 'online'
 
 ORDER = [
     'tps',
@@ -38,15 +42,17 @@ CHARTS = {
         ]
     }
 }
+
+
 _TPS_REGEX = re.compile(
-    r'^.*: .*?'           # Message lead-in
-    r'(\d{1,2}.\d+), .*?' # 1-minute TPS value
-    r'(\d{1,2}.\d+), .*?' # 5-minute TPS value
-    r'(\d{1,2}\.\d+).*$', # 15-minute TPS value
+    r'^.*: .*?'            # Message lead-in
+    r'(\d{1,2}.\d+), .*?'  # 1-minute TPS value
+    r'(\d{1,2}.\d+), .*?'  # 5-minute TPS value
+    r'(\d{1,2}\.\d+).*$',  # 15-minute TPS value
     re.X
 )
 _LIST_REGEX = re.compile(
-    r'(\d+)', # Current user count.
+    r'(\d+)',  # Current user count.
     re.X
 )
 
@@ -92,17 +98,24 @@ class Service(SimpleService):
         return True
 
     def is_alive(self):
-        if (not self.alive) or \
-           self.console.socket.getsockopt(socket.IPPROTO_TCP, socket.TCP_INFO, 0) != 1:
+        if not any(
+            [
+                not self.alive,
+                self.console.socket.getsockopt(socket.IPPROTO_TCP, socket.TCP_INFO, 0) != 1
+            ]
+        ):
             return self.reconnect()
         return True
 
     def _get_data(self):
         if not self.is_alive():
             return None
+
         data = {}
+
         try:
-            raw = self.console.command('tps')
+            raw = self.console.command(COMMAND_TPS)
+            self.debug("'{0}' command output : {1}".format(COMMAND_TPS, raw))
             match = _TPS_REGEX.match(raw)
             if match:
                 data['tps1'] = int(float(match.group(1)) * PRECISION)
@@ -116,11 +129,14 @@ class Service(SimpleService):
             self.error('Connection is dead.')
             self.alive = False
             return None
+
         try:
-            raw = self.console.command('list')
+            raw = self.console.command(COMMAND_LIST)
+            self.debug("'{0}' command output : {1}".format(COMMAND_LIST, raw))
             match = _LIST_REGEX.search(raw)
             if not match:
-                raw = self.console.command('online')
+                raw = self.console.command(COMMAND_ONLINE)
+                self.debug("'{0}' command output : {1}".format(COMMAND_ONLINE, raw))
                 match = _LIST_REGEX.search(raw)
             if match:
                 data['users'] = int(match.group(1))
@@ -132,4 +148,5 @@ class Service(SimpleService):
             self.error('Connection is dead.')
             self.alive = False
             return None
+
         return data


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes: #5595

The bug was added in #5507

There is no `re.A` in python2 (regexp package)

##### Component Name

[`collectors/python.d.plugin/spigotmc`](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/spigotmc)

##### Additional Information
 - py2 comp fix
 - minor changes (more debug output, etc)
 - make sure `_get_data` returns data in check

