### PR TITLE
Fix memory leaks

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -101,11 +101,13 @@ static inline int quoted_strings_splitter(char *str, char **words, int max_words
 
 inline int pluginsd_initialize_plugin_directories() {
     char plugins_dirs[(FILENAME_MAX * 2) + 1];
-    char *plugins_dir_list = NULL;
+    static char *plugins_dir_list = NULL;
 
     // Get the configuration entry
-    snprintfz(plugins_dirs, FILENAME_MAX * 2, "\"%s\" \"%s/custom-plugins.d\"", PLUGINS_DIR, CONFIG_DIR);
-    plugins_dir_list = strdupz(config_get(CONFIG_SECTION_GLOBAL, "plugins directory",  plugins_dirs));
+    if(likely(!plugins_dir_list)) {
+        snprintfz(plugins_dirs, FILENAME_MAX * 2, "\"%s\" \"%s/custom-plugins.d\"", PLUGINS_DIR, CONFIG_DIR);
+        plugins_dir_list = strdupz(config_get(CONFIG_SECTION_GLOBAL, "plugins directory",  plugins_dirs));
+    }
 
     // Parse it and store it to plugin directories
     return quoted_strings_splitter(plugins_dir_list, plugin_directories, PLUGINSD_MAX_DIRECTORIES, config_isspace);

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -404,8 +404,8 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
         }
         snprintfz(next_state_filename, FILENAME_MAX, cpuidle_name_filename, core, cc->cpuidle_state_len);
 
-        cc->cpuidle_state = callocz(cc->cpuidle_state_len, sizeof(struct cpuidle_state));
-        memset(cc->cpuidle_state, 0, sizeof(struct cpuidle_state) * cc->cpuidle_state_len);
+        if(likely(cc->cpuidle_state_len))
+            cc->cpuidle_state = callocz(cc->cpuidle_state_len, sizeof(struct cpuidle_state));
 
         for(state = 0; state < cc->cpuidle_state_len; state++) {
             char name_buf[50 + 1];


### PR DESCRIPTION
##### Summary
- [x] Fix a 0 bytes memory leak in the cpuidle module
- [x] Fix a valgrind warning for a possible memory leak in the `pluginsd_initialize_plugin_directories()`

##### Component Name
proc.plugin
plugins.d