### PR TITLE
mysql module add ssl connection support

### DIFF
--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -7,7 +7,7 @@ Module monitors one or more mysql servers
 
 It will produce following charts (if data is available):
 
-1. **Bandwidth** in kbps
+1. **Bandwidth** in kilobits/s
  * in
  * out
 
@@ -16,9 +16,15 @@ It will produce following charts (if data is available):
  * questions
  * slow queries
 
-3. **Operations** in operations/sec
- * opened tables
- * flush
+3. **Queries By Type** in queries/s
+ * select
+ * delete
+ * update
+ * insert
+ * cache hits
+ * replace
+
+4. **Handlerse** in handlers/s
  * commit
  * delete
  * prepare
@@ -26,28 +32,191 @@ It will produce following charts (if data is available):
  * read key
  * read next
  * read prev
- * read random
- * read random next
+ * read rnd
+ * read rnd next
  * rollback
- * save point
+ * savepoint
+ * savepoint rollback
  * update
  * write
 
-4. **Table Locks** in locks/sec
+4. **Table Locks** in locks/s
  * immediate
  * waited
 
-5. **Select Issues** in issues/sec
+5. **Table Select Join Issuess** in joins/s
  * full join
  * full range join
  * range
  * range check
  * scan
 
-6. **Sort Issues** in issues/sec
+6. **Table Sort Issuess** in joins/s
  * merge passes
  * range
  * scan
+
+7. **Tmp Operations** in created/s
+ * disk tables
+ * files
+ * tables
+
+8. **Connections** in connections/s
+ * all
+ * aborted
+
+9. **Connections Active** in connections/s
+ * active
+ * limit
+ * max active
+
+10. **Binlog Cache** in threads
+ * disk
+ * all
+
+11. **Threads** in transactions/s
+ * connected
+ * cached
+ * running
+
+12. **Threads Creation Rate** in threads/s
+ * created
+
+13. **Threads Cache Misses** in misses
+ * misses
+
+14. **InnoDB I/O Bandwidth** in KiB/s
+ * read
+ * write
+
+15. **InnoDB I/O Operations** in operations/s
+ * reads
+ * writes
+ * fsyncs
+
+16. **InnoDB Pending I/O Operations** in operations/s
+ * reads
+ * writes
+ * fsyncs
+
+17. **InnoDB Log Operations** in operations/s
+ * waits
+ * write requests
+ * writes
+
+18. **InnoDB OS Log Pending Operations** in operations
+ * fsyncs
+ * writes
+
+19. **InnoDB OS Log Operations** in operations/s
+ * fsyncs
+
+20. **InnoDB OS Log Bandwidth** in KiB/s
+ * write
+
+21. **InnoDB Current Row Locks** in operations
+ * current waits
+
+22. **InnoDB Row Operations** in operations/s
+ * inserted
+ * read
+ * updated
+ * deleted
+
+23. **InnoDB Buffer Pool Pagess** in pages
+ * data
+ * dirty
+ * free
+ * misc
+ * total
+
+24. **InnoDB Buffer Pool Flush Pages Requests** in requests/s
+ * flush pages
+
+25. **InnoDB Buffer Pool Bytes** in MiB
+ * data
+ * dirty
+
+26. **InnoDB Buffer Pool Operations** in operations/s
+ * disk reads
+ * wait free
+
+27. **QCache Operations** in queries/s
+ * hits
+ * lowmem prunes
+ * inserts
+ * no caches
+
+28. **QCache Queries in Cache** in queries
+ * queries
+
+29. **QCache Free Memory** in MiB
+ * free
+
+30. **QCache Memory Blocks** in blocks
+ * free
+ * total
+
+31. **MyISAM Key Cache Blocks** in blocks
+ * unused
+ * used
+ * not flushed
+
+32. **MyISAM Key Cache Requests** in requests/s
+ * reads
+ * writes
+
+33. **MyISAM Key Cache Requests** in requests/s
+ * reads
+ * writes
+
+34. **MyISAM Key Cache Disk Operations** in operations/s
+ * reads
+ * writes
+
+35. **Open Files** in files
+ * files
+
+36. **Opened Files Rate** in files/s
+ * files
+
+37. **Binlog Statement Cache** in statements/s
+ * disk
+ * all
+
+38. **Connection Errors** in errors/s
+ * accept
+ * internal
+ * max
+ * peer addr
+ * select
+ * tcpwrap
+
+39. **Slave Behind Seconds** in seconds
+ * time
+
+40. **I/O / SQL Thread Running State** in bool
+ * sql
+ * io
+
+41. **Replicated Writesets** in writesets/s
+ * rx
+ * tx
+
+42. **Replicated Bytes** in KiB/s
+ * rx
+ * tx
+
+43. **Galera Queue** in writesets
+ * rx
+ * tx
+
+44. **Replication Conflicts** in transactions
+ * bf aborts
+ * cert fails
+
+45. **Flow Control** in ms
+ * paused
 
 ### configuration
 
@@ -59,7 +228,13 @@ You can provide, per server, the following:
 4. mysql socket (optional)
 5. mysql host (ip or hostname)
 6. mysql port (defaults to 3306)
-
+7. ssl connection parameters
+ - key: the path name of the client private key file.
+ - cert: the path name of the client public key certificate file.
+ - ca: the path name of the Certificate Authority (CA) certificate file. This option, if used, must specify the same certificate used by the server.
+ - capath: the path name of the directory that contains trusted SSL CA certificate files.
+ - cipher: the list of permitted ciphers for SSL encryption.
+ 
 Here is an example for 3 servers:
 
 ```yaml

--- a/collectors/python.d.plugin/mysql/mysql.conf
+++ b/collectors/python.d.plugin/mysql/mysql.conf
@@ -73,6 +73,14 @@
 #     user: 'username'       # the mysql username to use
 #     pass: 'password'       # the mysql password to use
 #
+#  ssl connection parameters
+#
+#  ssl:
+#    key:    'key'      # the path name of the client private key file.
+#    cert:   'cert'     # the path name of the client public key certificate file.
+#    ca:     'ca'       # the path name of the Certificate Authority (CA) certificate file. This option, if used, must specify the same certificate used by the server.
+#    capath: 'capath'   # the path name of the directory that contains trusted SSL CA certificate files.
+#    cipher: [ciphers]  # the list of permitted ciphers for SSL encryption.
 
 # ----------------------------------------------------------------------
 # mySQL CONFIGURATION

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py
@@ -52,6 +52,7 @@ class MySQLService(SimpleService):
                 properties['port'] = int(conf.get('port', 3306))
             elif conf.get('my.cnf'):
                 if MySQLdb.__name__ == 'pymysql':
+                    # TODO: this is probablt wrong, it depends on version
                     self.error('"my.cnf" parsing is not working for pymysql')
                 else:
                     properties['read_default_file'] = conf['my.cnf']

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py
@@ -44,6 +44,7 @@ class MySQLService(SimpleService):
                 properties['user'] = conf['user']
             if conf.get('pass'):
                 properties['passwd'] = conf['pass']
+
             if conf.get('socket'):
                 properties['unix_socket'] = conf['socket']
             elif conf.get('host'):
@@ -54,6 +55,10 @@ class MySQLService(SimpleService):
                     self.error('"my.cnf" parsing is not working for pymysql')
                 else:
                     properties['read_default_file'] = conf['my.cnf']
+
+            if conf.get('ssl'):
+                properties['ssl'] = conf['ssl']
+
             if isinstance(extra_conf, dict) and extra_conf:
                 properties.update(extra_conf)
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fixes: #5608 

Add ssl connection support to MySQLService

> python-mysqlclient connection

```
        :param dict ssl:                                                                            
            dictionary or mapping contains SSL connection parameters;                               
            see the MySQL documentation for more details                                            
            (mysql_ssl_set()).  If this is set, and the client does not                             
            support SSL, NotSupportedError will be raised.
```

[SSL connection parameters:](https://dev.mysql.com/doc/refman/5.6/en/mysql-ssl-set.html)

 - **key**: The path name of the client private key file.
 - **cert**: The path name of the client public key certificate file.
 - **ca**: The path name of the Certificate Authority (CA) certificate file. This option, if used, must specify the same certificate used by the server.
 - **capath**: The path name of the directory that contains trusted SSL CA certificate files.
 - **cipher**: The list of permitted ciphers for SSL encryption.

##### Component Name

[`collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService`](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py)

___

@woosley please test it

```yaml
tcp:
  name     : 'local'
  user     : 'user'
  pass     : 'pass'
  host     : 'localhost'
  port     : '3306'
  ssl:
    key:   'path/to/key'
    cert:  'path/to/cet'
    ca:    'path/to/ca'
```
