### PR TITLE
Fix Postgres connect, incorrect port value

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -815,7 +815,7 @@ class Service(SimpleService):
 
         params = {
             'host': conf.get('host'),
-            'port': conf.get('host', DEFAULT_PORT),
+            'port': conf.get('port', DEFAULT_PORT),
             'database': conf.get('database'),
             'user': conf.get('user', DEFAULT_USER),
             'password': conf.get('password'),


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fix postgres connection, port value was incorrect, it was taking host value instead of port.

##### Component Name
[collectors/python.d.plugin/postgres](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/postgres)

##### Additional Information

