### PR TITLE
[wip] python.d.plugin: calc_next fix

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
@@ -39,8 +39,9 @@ class RuntimeCounters:
         self.runs = 1
 
     def calc_next(self):
+        freq = 1 if self.start_mono == 0 else self.update_every
         self.start_mono = monotonic()
-        return self.start_mono - (self.start_mono % self.update_every) + self.update_every + self.penalty
+        return self.start_mono - (self.start_mono % freq) + freq + self.penalty
 
     def sleep_until_next(self):
         next_time = self.calc_next()

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
@@ -45,10 +45,9 @@ class RuntimeCounters:
             return self.next
 
         while True:
-            self.next = self.next + self.update_every + self.penalty
-            if self.start_mono > self.next:
-                continue
-            break
+            self.next += self.update_every + self.penalty
+            if self.start_mono < self.next:
+                break
         return self.next
 
     def sleep_until_next(self):

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
@@ -40,14 +40,13 @@ class RuntimeCounters:
 
     def calc_next(self):
         self.start_mono = monotonic()
+
         if self.runs == 0:
             self.next = self.start_mono - (self.start_mono % 1) + 1
             return self.next
 
-        while True:
+        while self.start_mono > self.next:
             self.next += self.update_every + self.penalty
-            if self.start_mono < self.next:
-                break
         return self.next
 
     def sleep_until_next(self):


### PR DESCRIPTION
##### Summary

Fix: #5616

Suggested `next_run` calculation method has bug - first run is delayed up to `update_every` seconds, which is a problem if `update_every` value is high. 

```java
       /*
        * find the time of the next loop
        * this makes sure we are always aligned
        * with the netdata daemon
        */
       next_run = now - (now % update_every) + update_every;
```

This PR fixes the bug for `python.d.plugin`. 
`now - (now % 1) + 1` is used for first run calculation regardless of the `update_every` value.

##### Component Name

[`collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService`](collectors/python.d.plugin/python_modules/bases/FrameworkServices)

