### PR TITLE
generate changelogs only in nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,9 @@ jobs:
     - sudo apt install -y --only-upgrade docker-ce
     - docker info
     before_script: sudo pip install git-semver
-    script: ".travis/releaser.sh && .travis/labeler.sh" # labeler should be replaced with GitHub Actions when they hit GA
+    script: 
+    - .travis/labeler.sh # labeler should be replaced with GitHub Actions when they hit GA
+    - .travis/releaser.sh
     git:
       depth: false
 

--- a/.travis/releaser.sh
+++ b/.travis/releaser.sh
@@ -47,10 +47,6 @@ echo "---- UPDATE VERSION FILE ----"
 echo "$GIT_TAG" >packaging/version
 git add packaging/version
 
-echo "---- GENERATE CHANGELOG -----"
-./.travis/generate_changelog.sh
-git add CHANGELOG.md
-
 echo "---- COMMIT AND PUSH CHANGES ----"
 git commit -m "[ci skip] release $GIT_TAG"
 git tag "$GIT_TAG" -a -m "Automatic tag generation for travis build no. $TRAVIS_BUILD_NUMBER"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
1. Remove changelog regeneration from release pipeline
2. Bring back old `nightlies.sh` behavior with addition of changelog generation not being crucial
3. Refactor packaging stage to run labeler before releaser scripts

Fixes #5580

##### Component Name
ci

##### Additional Information

