### PR TITLE
x509check alarm fix

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -68,7 +68,6 @@ dist_healthconfig_DATA = \
     health.d/retroshare.conf \
     health.d/softnet.conf \
     health.d/squid.conf \
-    health.d/sslcheck.conf \
     health.d/stiebeleltron.conf \
     health.d/swap.conf \
     health.d/tcp_conn.conf \
@@ -79,5 +78,6 @@ dist_healthconfig_DATA = \
     health.d/udp_errors.conf \
     health.d/varnish.conf \
     health.d/web_log.conf \
+    health.d/x509check.conf \
     health.d/zfs.conf \
     $(NULL)

--- a/health/health.d/x509check.conf
+++ b/health/health.d/x509check.conf
@@ -1,7 +1,7 @@
 
 template: x509check_days_until_expiration
       on: x509check.time_until_expiration
-   calc:  $time
+   calc:  $expiry
    units: seconds
    every: 60s
     warn: $this < $days_until_expiration_warning*24*60*60

--- a/health/health.d/x509check.conf
+++ b/health/health.d/x509check.conf
@@ -1,6 +1,6 @@
 
-template: sslcheck_days_until_expiration
-      on: sslcheck.time_until_expiration
+template: x509check_days_until_expiration
+      on: x509check.time_until_expiration
    calc:  $time
    units: seconds
    every: 60s


### PR DESCRIPTION
##### Summary

rename

> health/health.d/sslcheck.conf → health/health.d/x509check.conf

**Why**

sslcheck module (#5365) was removed(#5626) because of memory leak bug (#5624).

The module was rewritten in go (#5631, https://github.com/netdata/go.d.plugin/pull/166). New module name - `x509check`. 

This PR changes name of the alarm.


