### PR TITLE
Fix slack notifications footer and set cloud redirect URL to http

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1242,7 +1242,7 @@ send_slack() {
                         }
                     ],
                     "thumb_url": "${image}",
-                    "footer": "by <${goto_url}|${host}>",
+                    "footer": "by ${host}",
                     "ts": ${when}
                 }
             ]
@@ -1756,7 +1756,7 @@ fi
 if [ ${GOTOCLOUD} -eq 0 ]; then
 	goto_url="${NETDATA_REGISTRY_URL}/goto-host-from-alarm.html?${redirect_params}"
 else
-	goto_url="https://netdata.cloud/alarms/redirect?agentID=${NETDATA_REGISTRY_UNIQUE_ID}&${redirect_params}"
+	goto_url="http://netdata.cloud/alarms/redirect?agentID=${NETDATA_REGISTRY_UNIQUE_ID}&${redirect_params}"
 fi
 
 # the severity of the alarm

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1756,7 +1756,7 @@ fi
 if [ ${GOTOCLOUD} -eq 0 ]; then
 	goto_url="${NETDATA_REGISTRY_URL}/goto-host-from-alarm.html?${redirect_params}"
 else
-	goto_url="http://netdata.cloud/alarms/redirect?agentID=${NETDATA_REGISTRY_UNIQUE_ID}&${redirect_params}"
+	goto_url="https://netdata.cloud/alarms/redirect?agentID=${NETDATA_REGISTRY_UNIQUE_ID}&${redirect_params}"
 fi
 
 # the severity of the alarm


### PR DESCRIPTION
##### Summary
Related to #5280 
Fixes #5654 

##### Component Name
alarm-notify

##### Additional Information
- Removes the link from the slack notifications footer. The footer has limited width that is supposed to be 300 chars, but slack arbitrarily truncates the content, supposedly based on the user's screen size, without realizing that all they need to show is a link. A bug was reported to slack, but we need to remove this functionality until it the Slack bug is fixed.
