### PR TITLE
netdata/build: A small house keeping around coverity scan (no functional  or process change)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ jobs:
     script: ./tests/installer/checksums.sh
   - name: coverity
     install: sudo apt-get install -y zlib1g-dev uuid-dev libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev
-    script: ./coverity-scan.sh || echo "Coverity failed :("
-    env: INSTALL_COVERITY="true"
+    script: ./coverity-install.sh && ./coverity-scan.sh || echo "Coverity failed :("
     if: type = cron
 
   - stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
   - name: coverity
     install: sudo apt-get install -y zlib1g-dev uuid-dev libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev
     script: ./coverity-install.sh && ./coverity-scan.sh || echo "Coverity failed :("
-    if: type = cron
+#   if: type = cron
 
   - stage: build
 # TODO: enable when travis OSX become stable. Probably after 12.01.2019

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
   - name: coverity
     install: sudo apt-get install -y zlib1g-dev uuid-dev libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev
     script: ./coverity-install.sh && ./coverity-scan.sh || echo "Coverity failed :("
-#   if: type = cron
+    if: type = cron
 
   - stage: build
 # TODO: enable when travis OSX become stable. Probably after 12.01.2019

--- a/.travis/nightlies.sh
+++ b/.travis/nightlies.sh
@@ -36,7 +36,6 @@ else
 fi
 
 echo "--- BUILD & PUBLISH DOCKER IMAGES ---"
-export REPOSITORY="netdata/netdata"
 packaging/docker/build.sh || BAD_THING_HAPPENED=1
 
 echo "--- BUILD ARTIFACTS ---"

--- a/.travis/releaser.sh
+++ b/.travis/releaser.sh
@@ -64,7 +64,6 @@ if [[ $(git describe) =~ -rc* ]]; then
 fi
 
 echo "---- CREATING TAGGED DOCKER CONTAINERS ----"
-export REPOSITORY="netdata/netdata"
 ./packaging/docker/build.sh
 
 echo "---- CREATING RELEASE ARTIFACTS -----"

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,7 @@ dist_noinst_DATA= \
 # should be proper init.d/openrc/systemd usable
 dist_noinst_SCRIPTS= \
 	coverity-scan.sh \
+	coverity-install.sh \
 	packaging/installer/netdata-updater.sh \
 	packaging/installer/kickstart.sh \
 	packaging/installer/kickstart-static64.sh \

--- a/coverity-install.sh
+++ b/coverity-install.sh
@@ -22,7 +22,7 @@ fi
 echo >&2 "Installing coverity..."
 WORKDIR="/opt/coverity-source"
 
-curl -SL --data "token=${token}&project=netdata%2Fnetdata" https://scan.coverity.com/download/linux64 > "${WORKDIR}/coverity_tool.tar.gz"
+curl -SL --data "token=${token}&project=${REPOSITORY}" https://scan.coverity.com/download/linux64 > "${WORKDIR}/coverity_tool.tar.gz"
 tar -x -C "${WORKDIR}/coverity-install" -f "${WORKDIR}/coverity_tool.tar.gz"
 sudo mv "${WORKDIR}/coverity-install/cov-analysis-linux64-2017.07" /opt/coverity
 export PATH=${PATH}:/opt/coverity/bin/

--- a/coverity-install.sh
+++ b/coverity-install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Coverity installation script
+#
+# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author: Pavlos Emm. Katsoulakis (paul@netdata.cloud)
+
+token="${COVERITY_SCAN_TOKEN}"
+([ -z "${token}" ] && [ -f .coverity-token ]) && token="$(<.coverity-token)"
+if [ -z "${token}" ]; then
+	echo >&2 "Save the coverity token to .coverity-token or export it as COVERITY_SCAN_TOKEN."
+	exit 1
+fi
+
+covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
+([ -z "${covbuild}" ] && [ -f .coverity-build ]) && covbuild="$(<.coverity-build)"
+if [ ! -z "${covbuild}" ]; then
+	echo >&2 "Coverity already installed, nothing to do!"
+	exit 0
+fi
+
+echo >&2 "Installing coverity..."
+WORKDIR=$(mktemp -d)
+
+curl -SL --data "token=${token}&project=netdata%2Fnetdata" https://scan.coverity.com/download/linux64 > "${WORKDIR}/coverity_tool.tar.gz"
+tar -x -C "${WORKDIR}/coverity-install" -f "${WORKDIR}/coverity_tool.tar.gz"
+sudo mv "${WORKDIR}/coverity-install/cov-analysis-linux64-2017.07" /opt/coverity
+export PATH=${PATH}:/opt/coverity/bin/
+
+covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
+
+echo >&2 "Coverity scan installed!"

--- a/coverity-install.sh
+++ b/coverity-install.sh
@@ -30,3 +30,4 @@ export PATH=${PATH}:/opt/coverity/bin/
 covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
 
 echo >&2 "Coverity scan installed!"
+rm -r "${WORKDIR}"

--- a/coverity-install.sh
+++ b/coverity-install.sh
@@ -21,12 +21,22 @@ fi
 
 echo >&2 "Installing coverity..."
 WORKDIR="/opt/coverity-source"
+mkdir -p "${WORKDIR}"
 
 curl -SL --data "token=${token}&project=${REPOSITORY}" https://scan.coverity.com/download/linux64 > "${WORKDIR}/coverity_tool.tar.gz"
-tar -x -C "${WORKDIR}/coverity-install" -f "${WORKDIR}/coverity_tool.tar.gz"
-sudo mv "${WORKDIR}/coverity-install/cov-analysis-linux64-2017.07" /opt/coverity
-export PATH=${PATH}:/opt/coverity/bin/
+if [ -f "${WORKDIR}/coverity_tool.tar.gz" ]; then
+	tar -x -C "${WORKDIR}" -f "${WORKDIR}/coverity_tool.tar.gz"
+	sudo mv "${WORKDIR}/cov-analysis-linux64-2017.07" /opt/coverity
+	export PATH=${PATH}:/opt/coverity/bin/
+else
+	echo "Failed to download coverity tool tarball!"
+fi
 
+# Validate the installation
 covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
-
-echo >&2 "Coverity scan installed!"
+if [ -z "$covbuild" ]; then
+	echo "Failed to install coverity!"
+	exit 1
+else
+	echo >&2 "Coverity scan installed!"
+fi

--- a/coverity-install.sh
+++ b/coverity-install.sh
@@ -20,7 +20,7 @@ if [ ! -z "${covbuild}" ]; then
 fi
 
 echo >&2 "Installing coverity..."
-WORKDIR=$(mktemp -d)
+WORKDIR="/opt/coverity-source"
 
 curl -SL --data "token=${token}&project=netdata%2Fnetdata" https://scan.coverity.com/download/linux64 > "${WORKDIR}/coverity_tool.tar.gz"
 tar -x -C "${WORKDIR}/coverity-install" -f "${WORKDIR}/coverity_tool.tar.gz"
@@ -30,4 +30,3 @@ export PATH=${PATH}:/opt/coverity/bin/
 covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
 
 echo >&2 "Coverity scan installed!"
-rm -r "${WORKDIR}"

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -51,10 +51,10 @@ tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
 
 echo >&2 "Sending analysis for version ${version} ..."
 curl --progress-bar --form token="${token}" \
-  --form email=costa@tsaousis.gr \
+  --form email=${COVERITY_SCAN_SUBMIT_MAIL} \
   --form file=@netdata-coverity-analysis.tgz \
   --form version="${version}" \
   --form description="netdata, real-time performance monitoring, done right." \
-  https://scan.coverity.com/builds?project=netdata%2Fnetdata
+  https://scan.coverity.com/builds?project=${REPOSITORY}
 
-echo >&2 "Coverity scan submitted!"
+echo >&2 "\n\nCoverity scan submitted!"

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -21,6 +21,7 @@ if [ -z "${token}" ]; then
 	exit 1
 fi
 
+export PATH=${PATH}:/opt/coverity/bin/
 covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
 ([ -z "${covbuild}" ] && [ -f .coverity-build ]) && covbuild="$(<.coverity-build)"
 if [ -z "${covbuild}" ]; then

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -57,4 +57,4 @@ curl --progress-bar --form token="${token}" \
   --form description="netdata, real-time performance monitoring, done right." \
   https://scan.coverity.com/builds?project=${REPOSITORY}
 
-echo >&2 "\n\nCoverity scan submitted!"
+echo -e >&2 "\n\nCoverity scan submitted!"

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -50,11 +50,13 @@ echo >&2 "Compressing data..."
 tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
 
 echo >&2 "Sending analysis for version ${version} ..."
-curl --progress-bar --form token="${token}" \
+COVERITY_SUBMIT_RESULT=$(curl --progress-bar --form token="${token}" \
   --form email=${COVERITY_SCAN_SUBMIT_MAIL} \
   --form file=@netdata-coverity-analysis.tgz \
   --form version="${version}" \
   --form description="netdata, real-time performance monitoring, done right." \
-  https://scan.coverity.com/builds?project=${REPOSITORY}
+  https://scan.coverity.com/builds?project=${REPOSITORY})
 
-echo -e >&2 "\n\nCoverity scan submitted!"
+echo ${COVERITY_SUBMIT_RESULT} | grep -q -e 'Build successfully submitted' || echo >&2 "scan results were not pushed to coverity. Message was: ${COVERITY_SUBMIT_RESULT}"
+
+echo >&2 "Coverity scan mechanism completed"


### PR DESCRIPTION
##### Summary
This is a small cleanup on the coverity scan scriptlet.
The idea is to separate the install process from the actual scanning to distinct and simplify the two mechanisms, so that they can be reusable separately.

1) Split coverity install on seperate scriptlet, call it through travis when needed
2) Remove shellcheck exclussions, they dont seem to be raised any more (i might be using wrong version of shellcheck, will see)
3) Fix authors,copyrights etc
4) Make sure all echo goes to stderr
5) When installing, use mktemp for the temporary directory and put everything there. Remove afterwards

##### Component Name
netdata/build

##### Additional Information
None