### PR TITLE
Fix path to pidfile in FreeBSD rc.d file

### DIFF
--- a/system/netdata-freebsd.in
+++ b/system/netdata-freebsd.in
@@ -7,7 +7,7 @@ name=netdata
 rcvar=netdata_enable
 
 piddir="@localstatedir_POST@/run/netdata"
-pidfile="${pidfile}/netdata.pid"
+pidfile="${piddir}/netdata.pid"
 
 command="@sbindir_POST@/netdata"
 command_args="-P ${pidfile}"


### PR DESCRIPTION
Fix `pidfile="${pidfile}/netdata.pid"` instead of `pidfile="${piddir}/netdata.pid"`.