### PR TITLE
Fix py2-psycopg2 right after upgrade

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -43,6 +43,7 @@ RUN if [ "$(uname -m)" == "x86_64" ]; then \
         apk update; \
         apk upgrade --available --no-cache; \
         sed -in 's/^#//g' /etc/apk/repositories; \
+        apk fix py2-psycopg2; \
     fi
 
 # Copy files over


### PR DESCRIPTION


##### Summary
Fixes #5588 

The Issue https://github.com/netdata/netdata/issues/5588 is caused because,
right after Polyverse packages are reinstalled, there is an install trigger failure in
one package which puts APK (Alpine Package Manager) in a bad state.

This prevents any downstream Docker images that extend `netdata/netdata`,
i.e., `FROM netdata/netdata`, from running any `apk` commands without generating an error.

This is a singular package and the fix is targeted and focussed to ensure downstream consumers
are unblocked ASAP.

##### Component Name

Docker Packaging

##### Additional Information

