### PR TITLE
Fix for: postgres: socket: update() unhandled exception: integer out of range

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -430,7 +430,7 @@ GROUP BY
     V10: """
 WITH wal_size AS (
   SELECT
-    current_setting('wal_block_size')::INT * setting::INT AS val
+    current_setting('wal_block_size')::BIGINT * setting::INT AS val
   FROM pg_settings
   WHERE name = 'wal_segment_size'
   )


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
When running netdata on the PostgreSQL 11 install on a FreeBSD 11.2 system I got the error:

```
postgres: socket: update() unhandled exception: integer out of range
```

##### Component Name
PostgreSQL

##### Additional Information

The fix is rather simple. Calculate the result using a `BIGINT` instead of an `INT to avoid out-of-range issues.