### PR TITLE
fix incorrect use of isnormal()

### DIFF
--- a/libnetdata/statistical/statistical.c
+++ b/libnetdata/statistical/statistical.c
@@ -23,7 +23,7 @@ inline LONG_DOUBLE sum_and_count(const LONG_DOUBLE *series, size_t entries, size
     size_t c = 0;
 
     for(value = series; value < end ; value++) {
-        if(isnormal(*value)) {
+        if(calculated_number_isnumber(*value)) {
             sum += *value;
             c++;
         }
@@ -62,7 +62,7 @@ LONG_DOUBLE moving_average(const LONG_DOUBLE *series, size_t entries, size_t per
 
     for(i = 0, count = 0; i < entries; i++) {
         LONG_DOUBLE value = series[i];
-        if(unlikely(!isnormal(value))) continue;
+        if(unlikely(!calculated_number_isnumber(value))) continue;
 
         if(unlikely(count < period)) {
             sum += value;
@@ -173,7 +173,7 @@ LONG_DOUBLE running_median_estimate(const LONG_DOUBLE *series, size_t entries) {
 
     for(i = 0; i < entries ; i++) {
         LONG_DOUBLE value = series[i];
-        if(unlikely(!isnormal(value))) continue;
+        if(unlikely(!calculated_number_isnumber(value))) continue;
 
         average += ( value - average ) * 0.1f; // rough running average.
         median += copysignl( average * 0.01, value - median );
@@ -193,7 +193,7 @@ LONG_DOUBLE standard_deviation(const LONG_DOUBLE *series, size_t entries) {
     LONG_DOUBLE sum;
 
     for(count = 0, sum = 0, value = series ; value < end ;value++) {
-        if(likely(isnormal(*value))) {
+        if(likely(calculated_number_isnumber(*value))) {
             count++;
             sum += *value;
         }
@@ -205,7 +205,7 @@ LONG_DOUBLE standard_deviation(const LONG_DOUBLE *series, size_t entries) {
     LONG_DOUBLE average = sum / (LONG_DOUBLE)count;
 
     for(count = 0, sum = 0, value = series ; value < end ;value++) {
-        if(isnormal(*value)) {
+        if(calculated_number_isnumber(*value)) {
             count++;
             sum += powl(*value - average, 2);
         }
@@ -232,7 +232,7 @@ LONG_DOUBLE single_exponential_smoothing(const LONG_DOUBLE *series, size_t entri
     LONG_DOUBLE level = (1.0 - alpha) * (*value);
 
     for(value++ ; value < end; value++) {
-        if(likely(isnormal(*value)))
+        if(likely(calculated_number_isnumber(*value)))
             level = alpha * (*value) + (1.0 - alpha) * level;
     }
 
@@ -250,7 +250,7 @@ LONG_DOUBLE single_exponential_smoothing_reverse(const LONG_DOUBLE *series, size
     LONG_DOUBLE level = (1.0 - alpha) * (*value);
 
     for(value++ ; value >= series; value--) {
-        if(likely(isnormal(*value)))
+        if(likely(calculated_number_isnumber(*value)))
             level = alpha * (*value) + (1.0 - alpha) * level;
     }
 
@@ -281,7 +281,7 @@ LONG_DOUBLE double_exponential_smoothing(const LONG_DOUBLE *series, size_t entri
 
     const LONG_DOUBLE *value = series;
     for(value++ ; value >= series; value--) {
-        if(likely(isnormal(*value))) {
+        if(likely(calculated_number_isnumber(*value))) {
 
             LONG_DOUBLE last_level = level;
             level = alpha * *value + (1.0 - alpha) * (level + trend);

--- a/libnetdata/statistical/statistical.h
+++ b/libnetdata/statistical/statistical.h
@@ -5,10 +5,6 @@
 
 #include "../libnetdata.h"
 
-#ifndef isnormal
-#define isnormal(x) (fpclassify(x) == FP_NORMAL)
-#endif
-
 extern void log_series_to_stderr(LONG_DOUBLE *series, size_t entries, calculated_number result, const char *msg);
 
 extern LONG_DOUBLE average(const LONG_DOUBLE *series, size_t entries);

--- a/libnetdata/storage_number/storage_number.h
+++ b/libnetdata/storage_number/storage_number.h
@@ -55,6 +55,8 @@ typedef long double collected_number;
 
 #define calculated_number_equal(a, b) (calculated_number_fabs((a) - (b)) < calculated_number_epsilon)
 
+#define calculated_number_isnumber(a) (!(fpclassify(a) & (FP_NAN|FP_INFINITE)))
+
 typedef uint32_t storage_number;
 #define STORAGE_NUMBER_FORMAT "%u"
 

--- a/web/api/queries/des/des.c
+++ b/web/api/queries/des/des.c
@@ -99,7 +99,7 @@ void grouping_free_des(RRDR *r) {
 void grouping_add_des(RRDR *r, calculated_number value) {
     struct grouping_des *g = (struct grouping_des *)r->internal.grouping_data;
 
-    if(isnormal(value)) {
+    if(calculated_number_isnumber(value)) {
         if(likely(g->count > 0)) {
             // we have at least a number so far
 
@@ -128,7 +128,7 @@ void grouping_add_des(RRDR *r, calculated_number value) {
 calculated_number grouping_flush_des(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
     struct grouping_des *g = (struct grouping_des *)r->internal.grouping_data;
 
-    if(unlikely(!g->count || !isnormal(g->level))) {
+    if(unlikely(!g->count || !calculated_number_isnumber(g->level))) {
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
         return 0.0;
     }

--- a/web/api/queries/median/median.c
+++ b/web/api/queries/median/median.c
@@ -42,7 +42,7 @@ void grouping_add_median(RRDR *r, calculated_number value) {
         error("INTERNAL ERROR: median buffer overflow on chart '%s' - next_pos = %zu, series_size = %zu, r->group = %ld.", r->st->name, g->next_pos, g->series_size, r->group);
     }
     else {
-        if(isnormal(value))
+        if(calculated_number_isnumber(value))
             g->series[g->next_pos++] = (LONG_DOUBLE)value;
     }
 }
@@ -64,7 +64,7 @@ calculated_number grouping_flush_median(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_op
         else
             value = (calculated_number)g->series[0];
 
-        if(!isnormal(value)) {
+        if(!calculated_number_isnumber(value)) {
             value = 0.0;
             *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
         }

--- a/web/api/queries/ses/ses.c
+++ b/web/api/queries/ses/ses.c
@@ -71,7 +71,7 @@ void grouping_free_ses(RRDR *r) {
 void grouping_add_ses(RRDR *r, calculated_number value) {
     struct grouping_ses *g = (struct grouping_ses *)r->internal.grouping_data;
 
-    if(isnormal(value)) {
+    if(calculated_number_isnumber(value)) {
         if(unlikely(!g->count))
             g->level = value;
 
@@ -83,7 +83,7 @@ void grouping_add_ses(RRDR *r, calculated_number value) {
 calculated_number grouping_flush_ses(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
     struct grouping_ses *g = (struct grouping_ses *)r->internal.grouping_data;
 
-    if(unlikely(!g->count || !isnormal(g->level))) {
+    if(unlikely(!g->count || !calculated_number_isnumber(g->level))) {
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
         return 0.0;
     }

--- a/web/api/queries/stddev/stddev.c
+++ b/web/api/queries/stddev/stddev.c
@@ -36,7 +36,7 @@ void grouping_free_stddev(RRDR *r) {
 void grouping_add_stddev(RRDR *r, calculated_number value) {
     struct grouping_stddev *g = (struct grouping_stddev *)r->internal.grouping_data;
 
-    if(isnormal(value)) {
+    if(calculated_number_isnumber(value)) {
         g->count++;
 
         // See Knuth TAOCP vol 2, 3rd edition, page 232
@@ -74,7 +74,7 @@ calculated_number grouping_flush_stddev(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_op
     if(likely(g->count > 1)) {
         value = stddev(g);
 
-        if(!isnormal(value)) {
+        if(!calculated_number_isnumber(value)) {
             value = 0.0;
             *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
         }
@@ -102,7 +102,7 @@ calculated_number grouping_flush_coefficient_of_variation(RRDR *r, RRDR_VALUE_FL
         calculated_number m = mean(g);
         value = 100.0 * stddev(g) / ((m < 0)? -m : m);
 
-        if(unlikely(!isnormal(value))) {
+        if(unlikely(!calculated_number_isnumber(value))) {
             value = 0.0;
             *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
         }


### PR DESCRIPTION
##### Summary

netdata since v1.12 is incorrectly using the math function `isnormal()`.
The `isnormal()` function returns false when the number supplied is zero. This resulted in wrong calculations of `sum`, `average`, `median`, `ses` and `des` when zeros are included in the values.

The standard `isnormal()` function is now replaced with `calculated_number_isnumber()` that returns false only when the supplied number is `NAN` or `INF`.

##### Component Name

statsd (timers and histograms), API query engine, alarms.

##### Additional Information

