### PR TITLE
do not show the modal on demo sites

### DIFF
--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -51,7 +51,7 @@
     <meta name="twitter:description"       content="Unparalleled insights, in real-time, of everything happening on your Linux systems and applications, with stunning, interactive web dashboards and powerful performance and health alarms." />
     <meta name="twitter:image"             content="https://cloud.githubusercontent.com/assets/2662304/14092712/93b039ea-f551-11e5-822c-beadbf2b2a2e.gif" />
 
-    <script src="main.js?v=5"></script>
+    <script src="main.js?v=7"></script>
 </head>
 
 <body data-spy="scroll" data-target="#sidebar" data-offset="100">

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -4369,12 +4369,6 @@ function finalizePage() {
         // do not to give errors on netdata demo servers for 60 seconds
         NETDATA.options.current.retries_on_data_failures = 60;
 
-        if (urlOptions.nowelcome !== true) {
-            setTimeout(function () {
-                $('#welcomeModal').modal();
-            }, 1000);
-        }
-
         // google analytics when this is used for the home page of the demo sites
         // this does not run on user's installations
         setTimeout(function () {
@@ -4412,6 +4406,12 @@ function finalizePage() {
     if (netdataSnapshotData !== null) {
         NETDATA.globalPanAndZoom.setMaster(NETDATA.options.targets[0], netdataSnapshotData.after_ms, netdataSnapshotData.before_ms);
     }
+
+    //if (urlOptions.nowelcome !== true) {
+    //    setTimeout(function () {
+    //        $('#welcomeModal').modal();
+    //    }, 2000);
+    //}
 
     // var netdataEnded = performance.now();
     // console.log('start up time: ' + (netdataEnded - netdataStarted).toString() + ' ms');


### PR DESCRIPTION
##### Summary

This PR removes the welcome modal shown on netdata demo sites.

There is an issue with bootstrap scrollspy, that incorrectly highlights entries at the netdata menu, when the welcome modal is shown.

Also, the information provided on the modal does not reflect the current status of netdata, so the obvious choice is to remove it.

##### Component Name

web/gui

##### Additional Information

