### PR TITLE
netdata/packaging/docker: Fix build - typo on array iteration

### DIFF
--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -45,7 +45,7 @@ echo "Architectures : ${ARCHS}"
 docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 # Build images using multi-arch Dockerfile.
-for ARCH in "${ARCHS[@]}"; do
+for ARCH in ${ARCHS[@]}; do
      TAG="${REPOSITORY}:${VERSION}-${ARCH}"
      echo "Building tag ${TAG}.."
      eval docker build \


### PR DESCRIPTION
##### Summary
Detected the build error while evaluating nightly builds.
There was a typo on the array iteration, missed unneeded quotations that broke the for loop

##### Component Name
netdata/packaging/docker/build

##### Additional Information
None