### PR TITLE
add a description how to achieve vhost access logs with nginx in web_log

### DIFF
--- a/collectors/python.d.plugin/web_log/web_log.conf
+++ b/collectors/python.d.plugin/web_log/web_log.conf
@@ -117,6 +117,21 @@
 #  custom_log_format:
 #     pattern: '(?P<vhost>[a-zA-Z\d.-_]+) (?P<port>\d+) (?P<address>[\da-f.:]+) \[.*\] "(?P<method>[A-Z]+)[^"]*" (?P<code>[1-9]\d{2}) (?P<bytes_sent>\d+) (?P<resp_length>\d+) (?P<resp_time>\d+)'
 
+# in nginx: ($host or $http_host give the hostname, $server_port the port number)
+#   log_format netdatavhost '$host $server_port $remote_addr - $remote_user [$time_local] '
+#                      '"$request" $status $body_bytes_sent '
+#                      '$request_length $request_time $upstream_response_time '
+#                      '"$http_referer" "$http_user_agent"';
+#
+#   access_log /var/log/nginx/access.log netdatavhost;
+#
+#   be aware that the access_log directive in a server{} block overwrites the one in http{}, if your vhosts have individual log
+#   files, you have to specify the general netdata log in each vhost as a second access_log statement.
+#
+# and in this file in nginx_log section, add :
+#  custom_log_format:
+#     pattern: '(?P<vhost>[a-zA-Z\d.-_\[\]]+) (?P<port>\d+) (?P<address>[\da-f.:]+) .* "(?P<method>[A-Z]+)[^"]*" (?P<code>[1-9]\d{2}) (?P<bytes_sent>\d+) (?P<resp_length>\d+) (?P<resp_time>\d+)'
+
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
 # only one of them per web server will run (when they have the same name)


### PR DESCRIPTION
##### Summary
I found out by trial and error how to make nginx log vhosts in an additional file and then how to make netdata read that file and wanted to share that with future users.

##### Component Name

web_log.conf in python collector

##### Additional Information
A minor thing: At least nginx writes IPv6 addresses in the $host variable in square brackets, so I included them in the pattern.

fixes: #5693