### PR TITLE
NEW: authdb option for MongoDB collector

### DIFF
--- a/collectors/python.d.plugin/mongodb/README.md
+++ b/collectors/python.d.plugin/mongodb/README.md
@@ -156,6 +156,7 @@ Sample:
 ```yaml
 local:
     name : 'local'
+    authdb: 'admin'
     host : '127.0.0.1'
     port : 27017
     user : 'netdata'

--- a/collectors/python.d.plugin/mongodb/mongodb.chart.py
+++ b/collectors/python.d.plugin/mongodb/mongodb.chart.py
@@ -424,6 +424,7 @@ class Service(SimpleService):
         SimpleService.__init__(self, configuration=configuration, name=name)
         self.order = ORDER[:]
         self.definitions = deepcopy(CHARTS)
+        self.authdb = self.configuration.get('authdb', 'admin')
         self.user = self.configuration.get('user')
         self.password = self.configuration.get('pass')
         self.host = self.configuration.get('host', '127.0.0.1')
@@ -707,7 +708,7 @@ class Service(SimpleService):
         try:
             connection = MongoClient(**conn_vars)
             if self.user and self.password:
-                connection.admin.authenticate(name=self.user, password=self.password)
+                connection[self.authdb].authenticate(name=self.user, password=self.password)
             # elif self.user:
             #     connection.admin.authenticate(name=self.user, mechanism='MONGODB-X509')
             server_status = connection.admin.command('serverStatus')

--- a/collectors/python.d.plugin/mongodb/mongodb.chart.py
+++ b/collectors/python.d.plugin/mongodb/mongodb.chart.py
@@ -708,7 +708,7 @@ class Service(SimpleService):
         try:
             connection = MongoClient(**conn_vars)
             if self.user and self.password:
-                connection[self.authdb].authenticate(name=self.user, password=self.password)
+                getattr(connection, self.authdb).authenticate(name=self.user, password=self.password)
             # elif self.user:
             #     connection.admin.authenticate(name=self.user, mechanism='MONGODB-X509')
             server_status = connection.admin.command('serverStatus')

--- a/collectors/python.d.plugin/mongodb/mongodb.conf
+++ b/collectors/python.d.plugin/mongodb/mongodb.conf
@@ -83,10 +83,10 @@ local:
     host : '127.0.0.1'
     port : 27017
 
-authsample:
-    name : 'secure'
-    host : 'mongodb.example.com'
-    port : 27017
-    authdb : 'admin'
-    user : 'monitor'
-    password : 'supersecret'
+# authsample:
+#     name : 'secure'
+#     host : 'mongodb.example.com'
+#     port : 27017
+#     authdb : 'admin'
+#     user : 'monitor'
+#     password : 'supersecret'

--- a/collectors/python.d.plugin/mongodb/mongodb.conf
+++ b/collectors/python.d.plugin/mongodb/mongodb.conf
@@ -66,6 +66,8 @@
 #
 #  in all cases, the following can also be set:
 #
+#     authdb: 'dbname'       # database to authenticate the user against,
+#                            # defaults to "admin".
 #     user: 'username'       # the mongodb username to use
 #     pass: 'password'       # the mongodb password to use
 #
@@ -80,3 +82,11 @@ local:
     name : 'local'
     host : '127.0.0.1'
     port : 27017
+
+authsample:
+    name : 'secure'
+    host : 'mongodb.example.com'
+    port : 27017
+    authdb : 'admin'
+    user : 'monitor'
+    password : 'supersecret'


### PR DESCRIPTION
##### Summary

MongoDB has users bound to particular database. There are cases when monitoring user is outside of the default "admin" database, but has all required roles granted.

This PR adds a simple "authdb" parameter to use for authentication. The parameter defaults to the original "admin" value. The rest is left as is.

##### Component Name

MongoDB python collector.

##### Additional Information

N/A

