### PR TITLE
libapache2-mod-proxy-html was a transitional package for apache2-bin

### DIFF
--- a/docs/Running-behind-apache.md
+++ b/docs/Running-behind-apache.md
@@ -15,7 +15,7 @@ Make sure your apache has installed `mod_proxy` and `mod_proxy_http`.
 On debian/ubuntu systems, install them with this: 
 
 ```sh
-sudo apt-get install libapache2-mod-proxy-html
+sudo apt-get install apache2-bin
 ```
 
 Also make sure they are enabled:


### PR DESCRIPTION
Since the translation is completed it should be already included in the apache2-bin Xenial package. In fact you can find the mod_proxy_html.so file in the apache2-bin file list (Xenial).

Source: https://stackoverflow.com/a/40263887

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

