### PR TITLE
postgres module: connect via uri

### DIFF
--- a/collectors/python.d.plugin/postgres/README.md
+++ b/collectors/python.d.plugin/postgres/README.md
@@ -49,6 +49,8 @@ Following charts are drawn:
 
 ### configuration
 
+For all available options please see module [configuration file](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/postgres/postgres.conf).
+
 ```yaml
 socket:
   name         : 'socket'

--- a/collectors/python.d.plugin/postgres/README.md
+++ b/collectors/python.d.plugin/postgres/README.md
@@ -49,7 +49,7 @@ Following charts are drawn:
 
 ### configuration
 
-For all available options please see module [configuration file](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/postgres/postgres.conf).
+For all available options please see module [configuration file](postgres.conf).
 
 ```yaml
 socket:

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -23,6 +23,7 @@ DEFAULT_CONNECT_TIMEOUT = 2       # seconds
 DEFAULT_STATEMENT_TIMEOUT = 5000  # ms
 
 
+CONN_PARAM_DSN = 'dsn'
 CONN_PARAM_HOST = 'host'
 CONN_PARAM_PORT = 'port'
 CONN_PARAM_DATABASE = 'database'
@@ -823,6 +824,10 @@ class Service(SimpleService):
 
     def build_conn_params(self):
         conf = self.configuration
+
+        # connection URIs: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+        if conf.get(CONN_PARAM_DSN):
+            return {'dsn': conf[CONN_PARAM_DSN]}
 
         params = {
             CONN_PARAM_HOST: conf.get(CONN_PARAM_HOST),

--- a/collectors/python.d.plugin/postgres/postgres.conf
+++ b/collectors/python.d.plugin/postgres/postgres.conf
@@ -63,6 +63,10 @@
 #
 # Connections can be configured with the following options:
 #
+#     dsn                 : 'connection URI'  # see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+#
+#     OR
+#
 #     database            : 'example_db_name'
 #     user                : 'example_user'
 #     password            : 'example_pass'
@@ -70,13 +74,13 @@
 #     port                : 5432
 #     connect_timeout     : 2                  # in seconds, default is 2
 #     statement_timeout   : 2000               # in ms, default is 2000
-#
-# SSL connection parameters (https://www.postgresql.org/docs/current/libpq-ssl.html)
 #     sslmode             : mode               # one of [disable, allow, prefer, require, verify-ca, verify-full]
 #     sslrootcert         : path/to/rootcert   # the location of the root certificate file
 #     sslcrl              : path/to/crl        # the location of the CRL file
 #     sslcert             : path/to/cert       # the location of the client certificate file
 #     sslkey              : path/to/key        # the location of the client key file
+#
+# SSL connection parameters description: https://www.postgresql.org/docs/current/libpq-ssl.html
 #
 # Additionally, the following options allow selective disabling of charts
 #
@@ -128,4 +132,3 @@ tcpipv6:
     user     : 'postgres'
     host     : '::1'
     port     : 5432
-


### PR DESCRIPTION
##### Summary

Fixes: #5684

Connection URIs support added
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING

##### Component Name
[/collectors/python.d.plugin/postgres](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/postgres)

##### Additional Information

tested with

```yaml
socket:
    dsn: 'postgresql://postgres@'
```

which is equivalent of 

```yaml
socket:
    name     : 'local'
    user     : 'postgres'
    database : 'postgres'
```

it works