### PR TITLE
netdata/packaging/installer: fix sha256sum failure on freeBSD

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -775,7 +775,7 @@ install_go() {
 		grep "config.tar.gz" "${INSTALLER_DIR}/packaging/go.d.checksums" >> "${tmp}/sha256sums.txt" 2>/dev/null
 
 		# Checksum validation
-		if ! (cd "${tmp}" && sha256sum -c "sha256sums.txt"); then
+		if ! (cd "${tmp}" && safe_sha256sum -c "sha256sums.txt"); then
 			run_failed "go.d.plugin package files checksum validation failed."
 			return 1
 		fi

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -42,7 +42,7 @@ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 Verify the integrity of the script with this:
 
 ```bash
-[ "e051d1baed4c69653b5d3e4588696466" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "dec269c623667e132b4b179b9b77fcaf" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 *It should print `OK, VALID` if the script is the one we ship.*
 
@@ -96,7 +96,7 @@ To install Netdata with a binary package on any Linux distro, any kernel version
 Verify the integrity of the script with this:
 
 ```bash
-[ "8e6df9b6f6cc7de0d73f6e5e51a3c8c2" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "9f5e63e50ec4322f65064b446cff8dc5" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -678,3 +678,16 @@ portable_add_user_to_group() {
 		return 1
 	fi
 }
+
+
+function safe_sha256sum() {
+	# Within the contexct of the installer, we only use -c option that is common between the two commands
+	# We will have to reconsider if we start non-common options
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum $@
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -b 256 $@
+	else
+		fatal "I could not find a suitable checksum binary to use"
+	fi
+}

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -686,7 +686,7 @@ function safe_sha256sum() {
 	if command -v sha256sum >/dev/null 2>&1; then
 		sha256sum $@
 	elif command -v shasum >/dev/null 2>&1; then
-		shasum -b 256 $@
+		shasum -a 256 $@
 	else
 		fatal "I could not find a suitable checksum binary to use"
 	fi

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -157,7 +157,7 @@ progress "Downloading static netdata binary: ${NETDATA_TARBALL_URL}"
 
 download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
 download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.gz.run"
-if ! grep netdata-latest.gz.run "${TMPDIR}/sha256sum.txt" | sha256sum --check - >/dev/null 2>&1; then
+if ! grep netdata-latest.gz.run "${TMPDIR}/sha256sum.txt" | safe_sha256sum -c - >/dev/null 2>&1; then
 	fatal "Static binary checksum validation failed. Stopping netdata installation and leaving binary in ${TMPDIR}"
 fi
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -275,7 +275,7 @@ set_tarball_urls "${RELEASE_CHANNEL}"
 
 download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
 download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.tar.gz"
-if ! grep netdata-latest.tar.gz "${TMPDIR}/sha256sum.txt" | sha256sum --check - >/dev/null 2>&1; then
+if ! grep netdata-latest.tar.gz "${TMPDIR}/sha256sum.txt" | safe_sha256sum -c - >/dev/null 2>&1; then
 	fatal "Tarball checksum validation failed. Stopping netdata installation and leaving tarball in ${TMPDIR}"
 fi
 run tar -xf netdata-latest.tar.gz

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -79,10 +79,10 @@ update() {
 		info "Newest version is already installed"
 	else
 		download "${NETDATA_TARBALL_URL}" "${dir}/netdata-latest.tar.gz"
-		if ! grep netdata-latest.tar.gz sha256sum.txt | sha256sum --check - >&3 2>&3; then
+		if ! grep netdata-latest.tar.gz sha256sum.txt | safe_sha256sum -c - >&3 2>&3; then
 			failed "Tarball checksum validation failed. Stopping netdata upgrade and leaving tarball in ${dir}"
 		fi
-		NEW_CHECKSUM="$(sha256sum netdata-latest.tar.gz 2>/dev/null| cut -d' ' -f1)"
+		NEW_CHECKSUM="$(safe_sha256sum netdata-latest.tar.gz 2>/dev/null| cut -d' ' -f1)"
 		tar -xf netdata-latest.tar.gz >&3 2>&3
 		rm netdata-latest.tar.gz >&3 2>&3
 		cd netdata-*


### PR DESCRIPTION
##### Summary
Triggered by #5747 we had to provide a more flexible method of checksum checking because it seems that sha256sum is not available on freeBSD (at least not on all versions of it).

With this fix we maintain usage of sha256sum, but we failover to shasum if available or fatal error when none is available.

##### Component Name
netdata/packaging/installer

##### Additional Information
None