### PR TITLE
netdata/packaging: Remove .tar.gz on distclean

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,9 @@ MAINTAINERCLEANFILES= \
 	$(srcdir)/m4/ltoptions.m4 \
 	$(srcdir)/pkcs11-helper.spec $(srcdir)/config-w32-vc.h
 
+CLEANFILES= \
+	$(srcdir)/netdata-v*.*.*.tar.gz
+
 EXTRA_DIST = \
 	.gitignore \
 	.codacy.yml \

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ MAINTAINERCLEANFILES= \
 	$(srcdir)/pkcs11-helper.spec $(srcdir)/config-w32-vc.h
 
 CLEANFILES= \
-	$(srcdir)/netdata-v*.*.*.tar.gz
+	$(srcdir)/$(distdir).tar.gz
 
 EXTRA_DIST = \
 	.gitignore \


### PR DESCRIPTION
##### Summary
Don't forget to remove the generated .tar.gz upon cleanup with distclean

##### Component Name
netdata/packaging

##### Additional Information
None
