### PR TITLE
Fix smstools3 error handling

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1740,7 +1740,7 @@ send_syslog() {
 # SMS sender
 
 send_sms() {
-	local recipients="${1}" exitcode sent=0
+	local recipients="${1}" errcode errmessage sent=0
 
     # Human readable SMS
     local msg="${host} ${status_message}: ${chart} (${family}), ${alarm}"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1751,12 +1751,13 @@ send_sms() {
 	if [ "${SEND_SMS}" = "YES" ] && [ -n "${sendsms}" ] && [ -n "${recipients}" ] && [ -n "${msg}" ]; then
 		# http://api.kavenegar.com/v1/{API-KEY}/sms/send.json
 		for phone in ${recipients}; do
-			exitcode=$($sendsms $phone "$msg")
-			if [ ${exitcode} -eq 0 ]; then
+			errmessage=$($sendsms $phone "$msg" 2>&1)
+			errcode=$?
+			if [ ${errcode} -eq 0 ]; then
 				info "sent smstools3 SMS for: ${host} ${chart}.${name} is ${status} to '${user}'"
 				sent=$((sent + 1))
 			else
-				error "failed to send smstools3 SMS for: ${host} ${chart}.${name} is ${status} to '${user}' with error code ${exitcode}."
+				error "failed to send smstools3 SMS for: ${host} ${chart}.${name} is ${status} to '${user}' with error code ${errcode}: ${errmessage}."
 			fi
 		done
 

--- a/health/notifications/smstools3/README.md
+++ b/health/notifications/smstools3/README.md
@@ -5,8 +5,8 @@ The [SMS Server Tools 3](http://smstools3.kekekasvi.com/) is a SMS Gateway softw
 To have netdata send notifications via SMS Server Tools 3, you'll first need to [install](http://smstools3.kekekasvi.com/index.php?p=compiling) and [configure](http://smstools3.kekekasvi.com/index.php?p=configure) smsd.
 
 Ensure that the user `netdata` can execute `sendsms`. Any user executing `sendsms` needs to:
-- Have write permissions to `/tmp` and `/var/spool/sms/outgoing`
-- Be a member of group `smsd`
+  - Have write permissions to `/tmp` and `/var/spool/sms/outgoing`
+  - Be a member of group `smsd`
 
 To ensure that the steps above are successful, just `su netdata` and execute `sendsms phone message`.
 

--- a/health/notifications/smstools3/README.md
+++ b/health/notifications/smstools3/README.md
@@ -4,7 +4,7 @@ The [SMS Server Tools 3](http://smstools3.kekekasvi.com/) is a SMS Gateway softw
 
 To have netdata send notifications via SMS Server Tools 3, you'll first need to [install](http://smstools3.kekekasvi.com/index.php?p=compiling) and [configure](http://smstools3.kekekasvi.com/index.php?p=configure) smsd.
 
-Ensure that the user `netdata` can execute `smssend`. Any user executing `smssend` needs to:
+Ensure that the user `netdata` can execute `sendsms`. Any user executing `sendsms` needs to:
 - Have write permissions to `/tmp` and `/var/spool/sms/outgoing`
 - Be a member of group `smsd`
 

--- a/health/notifications/smstools3/README.md
+++ b/health/notifications/smstools3/README.md
@@ -5,8 +5,8 @@ The [SMS Server Tools 3](http://smstools3.kekekasvi.com/) is a SMS Gateway softw
 To have netdata send notifications via SMS Server Tools 3, you'll first need to [install](http://smstools3.kekekasvi.com/index.php?p=compiling) and [configure](http://smstools3.kekekasvi.com/index.php?p=configure) smsd.
 
 Ensure that the user `netdata` can execute `sendsms`. Any user executing `sendsms` needs to:
-  - Have write permissions to `/tmp` and `/var/spool/sms/outgoing`
-  - Be a member of group `smsd`
+-  Have write permissions to `/tmp` and `/var/spool/sms/outgoing`
+-  Be a member of group `smsd`
 
 To ensure that the steps above are successful, just `su netdata` and execute `sendsms phone message`.
 

--- a/health/notifications/smstools3/README.md
+++ b/health/notifications/smstools3/README.md
@@ -4,6 +4,12 @@ The [SMS Server Tools 3](http://smstools3.kekekasvi.com/) is a SMS Gateway softw
 
 To have netdata send notifications via SMS Server Tools 3, you'll first need to [install](http://smstools3.kekekasvi.com/index.php?p=compiling) and [configure](http://smstools3.kekekasvi.com/index.php?p=configure) smsd.
 
+Ensure that the user `netdata` can execute `smssend`. Any user executing `smssend` needs to:
+- Have write permissions to `/tmp` and `/var/spool/sms/outgoing`
+- Be a member of group `smsd`
+
+To ensure that the steps above are successful, just `su netdata` and execute `sendsms phone message`.
+
 You then just need to configure the recipient phone numbers in `health_alarm_notify.conf`:
 
 ```sh

--- a/health/notifications/smstools3/README.md
+++ b/health/notifications/smstools3/README.md
@@ -5,8 +5,9 @@ The [SMS Server Tools 3](http://smstools3.kekekasvi.com/) is a SMS Gateway softw
 To have netdata send notifications via SMS Server Tools 3, you'll first need to [install](http://smstools3.kekekasvi.com/index.php?p=compiling) and [configure](http://smstools3.kekekasvi.com/index.php?p=configure) smsd.
 
 Ensure that the user `netdata` can execute `sendsms`. Any user executing `sendsms` needs to:
--  Have write permissions to `/tmp` and `/var/spool/sms/outgoing`
--  Be a member of group `smsd`
+
+* Have write permissions to `/tmp` and `/var/spool/sms/outgoing`
+* Be a member of group `smsd`
 
 To ensure that the steps above are successful, just `su netdata` and execute `sendsms phone message`.
 


### PR DESCRIPTION
##### Summary
Fixes #5767 

Also added info to README, for the necessary permissions for netdata to properly execute `sendsms`

