### PR TITLE
netdata/packaging/ci: Add kickstart execution integrity tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,12 @@ jobs:
     after_deploy: rm -f .travis/gcs-credentials.json
 
   - stage: Integrity testing
-    name: Kickstart files integrity testing
+    name: Kickstart: Files integrity testing
     script: ./tests/installer/checksums.sh
+  - name: Kickstart: Execution integrity
+    script:
+    - docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:centos7" packaging/installer/kickstart.sh --dont-wait --dont-start-it --install /tmp
+    - docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:centos7" packaging/installer/kickstart-static64.sh --dont-wait --dont-start-it --install /tmp
 
 notifications:
   webhooks: https://app.fossa.io/hooks/travisci

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ jobs:
   - name: check checksums for kickstart files
     script: ./tests/installer/checksums.sh
     env: LOCAL_ONLY="true"
+  - name: Kickstart: Script execution integrity
+    script: docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:centos7" packaging/installer/kickstart.sh --dont-wait --dont-start-it --install /tmp
+  - name: Kickstart-static64: Script execution integrity
+    script: docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:centos7" packaging/installer/kickstart-static64.sh --dont-wait --dont-start-it --install /tmp
   - name: coverity
     install: sudo apt-get install -y zlib1g-dev uuid-dev libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev
     script: ./coverity-install.sh && ./coverity-scan.sh || echo "Coverity failed :("


### PR DESCRIPTION
##### Summary
There are times that we fall into the trap of breaking our installer at the kickstart side.
Add steps that validate kickstart at travis build to mitigate the risk of breaking the script.

Fixes #5769 

Note: This will be also included on the pipeline redesign and will probably extended to a more sophisticated test than just expect an exit 0 from the script

##### Component Name
netdata/packaging/kickstart
netdata/packaging/ci

##### Additional Information
None
