### PR TITLE
Fixed safe_sha256sum() function declaration

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -204,7 +204,7 @@ dependencies() {
 	fi
 }
 
-function safe_sha256sum() {
+safe_sha256sum() {
 	# Within the contexct of the installer, we only use -c option that is common between the two commands
 	# We will have to reconsider if we start non-common options
 	if command -v sha256sum >/dev/null 2>&1; then


### PR DESCRIPTION
#### Summary
Fixes safe_sha256sum() function declaration introduced in #5771. Using the `function` keyword does not work for all shells. #5771 did break our Ansible playbooks. Maybe some sort of linting would prevent such issues in the future.

#### Component Name
netdata/packaging/kickstart
