### PR TITLE
netdata/packaging: Fix non compatible function declaration

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -42,7 +42,7 @@ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 Verify the integrity of the script with this:
 
 ```bash
-[ "4e339c2e66192c122484476ef48b6843" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "15c688e7228ebee83ace1811273cd089" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 *It should print `OK, VALID` if the script is the one we ship.*
 
@@ -96,7 +96,7 @@ To install Netdata with a binary package on any Linux distro, any kernel version
 Verify the integrity of the script with this:
 
 ```bash
-[ "9a8fec4af9aba11614381f9cd187a68b" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "97427a0fc5a52593b603c2ae887d4466" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -680,7 +680,7 @@ portable_add_user_to_group() {
 }
 
 
-function safe_sha256sum() {
+safe_sha256sum() {
 	# Within the contexct of the installer, we only use -c option that is common between the two commands
 	# We will have to reconsider if we start non-common options
 	if command -v sha256sum >/dev/null 2>&1; then

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -111,7 +111,7 @@ set_tarball_urls() {
 	fi
 }
 
-function safe_sha256sum() {
+safe_sha256sum() {
 	# Within the contexct of the installer, we only use -c option that is common between the two commands
 	# We will have to reconsider if we start non-common options
 	if command -v sha256sum >/dev/null 2>&1; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -204,7 +204,7 @@ dependencies() {
 	fi
 }
 
-function safe_sha256sum() {
+safe_sha256sum() {
 	# Within the contexct of the installer, we only use -c option that is common between the two commands
 	# We will have to reconsider if we start non-common options
 	if command -v sha256sum >/dev/null 2>&1; then

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -20,7 +20,7 @@ error() {
 	echo >&3 "$(date) : ERROR: " "${@}"
 }
 
-function safe_sha256sum() {
+safe_sha256sum() {
 	# Within the contexct of the installer, we only use -c option that is common between the two commands
 	# We will have to reconsider if we start non-common options
 	if command -v sha256sum >/dev/null 2>&1; then


### PR DESCRIPTION
##### Summary
Basically we broke compatibility by adding the 'function' keyword.
With this PR:
1)we remove function keyword
2)We update README.md with the new MD5 for the kickstarts

Raised by #5788 

##### Component Name
netdata/packaging/installer

##### Additional Information
None