### PR TITLE
Support configurable syslog facilities

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -355,6 +355,10 @@ void log_init(void) {
     snprintfz(filename, FILENAME_MAX, "%s/access.log", netdata_configured_log_dir);
     stdaccess_filename = config_get(CONFIG_SECTION_GLOBAL, "access log", filename);
 
+	char deffacility[8];
+	snprintfz(deffacility,7,"%s","daemon");
+	facility_log = config_get(CONFIG_SECTION_GLOBAL, "facility log",  deffacility);
+
     error_log_throttle_period = config_get_number(CONFIG_SECTION_GLOBAL, "errors flood protection period", error_log_throttle_period);
     error_log_errors_per_period = (unsigned long)config_get_number(CONFIG_SECTION_GLOBAL, "errors to trigger flood protection", (long long int)error_log_errors_per_period);
     error_log_errors_per_period_backup = error_log_errors_per_period;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -434,12 +434,10 @@ char *log_facility_name(int code)
 
 // ----------------------------------------------------------------------------
 
-//void syslog_init(void) {
 void syslog_init(int facility) {
     static int i = 0;
 
     if(!i) {
-        //openlog(program_name, LOG_PID, LOG_DAEMON);
         openlog(program_name, LOG_PID, facility);
         i = 1;
     }
@@ -489,7 +487,6 @@ static FILE *open_log_file(int fd, FILE *fp, const char *filename, int *enabled_
         devnull = 1;
 
 		syslog_init(log_facility_id(facility_log));
-        //syslog_init();
         if(enabled_syslog) *enabled_syslog = 1;
     }
     else if(enabled_syslog) *enabled_syslog = 0;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -28,7 +28,7 @@ const char *stdout_filename = NULL;
 // 	sys/sys/syslog.h (FreeBSD)
 // 	bsd/sys/syslog.h (darwin-xnu)
 
-int log_facility_id(char *facility_name)
+static int log_facility_id(char *facility_name)
 {
 	if ( !(strcmp(facility_name,"auth") ) )
 	{

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -486,7 +486,7 @@ static FILE *open_log_file(int fd, FILE *fp, const char *filename, int *enabled_
         filename = "/dev/null";
         devnull = 1;
 
-		syslog_init(log_facility_id(facility_log));
+	syslog_init(log_facility_id(facility_log));
         if(enabled_syslog) *enabled_syslog = 1;
     }
     else if(enabled_syslog) *enabled_syslog = 0;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -69,7 +69,7 @@ const char *facility_log = NULL;
 #define LOG_LOCAL6_KEY "local6"
 #define LOG_LOCAL7_KEY "local7"
 
-static int log_facility_id(char *facility_name)
+static int log_facility_id(const char *facility_name)
 {
 	static int 
 		hash_auth = 0,
@@ -434,11 +434,11 @@ char *log_facility_name(int code)
 
 // ----------------------------------------------------------------------------
 
-void syslog_init(int facility) {
+void syslog_init() {
     static int i = 0;
 
     if(!i) {
-        openlog(program_name, LOG_PID, facility);
+        openlog(program_name, LOG_PID,log_facility_id(facility_log));
         i = 1;
     }
 }
@@ -486,7 +486,7 @@ static FILE *open_log_file(int fd, FILE *fp, const char *filename, int *enabled_
         filename = "/dev/null";
         devnull = 1;
 
-	syslog_init(log_facility_id(facility_log));
+	syslog_init();
         if(enabled_syslog) *enabled_syslog = 1;
     }
     else if(enabled_syslog) *enabled_syslog = 0;

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -54,6 +54,7 @@ extern FILE *stdaccess;
 extern const char *stdaccess_filename;
 extern const char *stderr_filename;
 extern const char *stdout_filename;
+extern const char *facility_log;
 
 extern int access_log_syslog;
 extern int error_log_syslog;


### PR DESCRIPTION
##### Summary

Fixes #5717 

In the link https://github.com/netdata/netdata/issues/5717 there was a request for the system admin to select the facility that he wanna have in syslog. In this commit I am creating two functions and I am also changing two to solve the described issue. 

The function log_facility_id is the unique that is really necessary to fix the problem. When I created it I used all the facilities that are listed in the operate system headers, including the facility that is not available(mark) and it was commented due this or it is considered deprecated(security). This situation happens, because I am considering possible mistakes in the configure file. When someone chooses a facility that is not available, I am starting the syslog with the default that was present in the log.c previously.

The function log_facility_name was created to keep the same pattern that I found inside the file web/server/web_server.c . This function is not necessary to fix the problem, but it helps with possible future features.

The function syslog_init now has an argument, the argument is an integer that represents the facility that will be set.

Finally I had to append few lines of code inside the function open_log_file. I am considering that the config file will have a configuration variable "facility log" for the user to set the facility that is wished. I called three functions in the same line, instead to create variables to store the results, because the return of the called function is direct the input for the new function, so I am considering that there is not any necessity to extract results from the registers to put in memory addresses.

##### Component Name
I am changing the file libnetdata/log/log.c

##### Additional Information

