### PR TITLE
python.d.plugin: allow delete dimension in runtime

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/charts.py
+++ b/collectors/python.d.plugin/python_modules/bases/charts.py
@@ -203,7 +203,6 @@ class Chart:
     def del_dimension(self, dimension_id):
         if dimension_id not in self:
             return
-
         idx = self.dimensions.index(dimension_id)
         dimension = self.dimensions[idx]
         dimension.params['hidden'] = 'hidden'
@@ -212,11 +211,12 @@ class Chart:
         self.dimensions.remove(dimension)
 
     def hide_dimension(self, dimension_id, reverse=False):
-        if dimension_id in self:
-            idx = self.dimensions.index(dimension_id)
-            dimension = self.dimensions[idx]
-            dimension.params['hidden'] = 'hidden' if not reverse else str()
-            self.refresh()
+        if dimension_id not in self:
+            return
+        idx = self.dimensions.index(dimension_id)
+        dimension = self.dimensions[idx]
+        dimension.params['hidden'] = 'hidden' if not reverse else str()
+        self.refresh()
 
     def create(self):
         """

--- a/collectors/python.d.plugin/python_modules/bases/charts.py
+++ b/collectors/python.d.plugin/python_modules/bases/charts.py
@@ -19,7 +19,7 @@ CHART_OBSOLETE = "CHART {type}.{id} '{name}' '{title}' '{units}' '{family}' '{co
                "{chart_type} {priority} {update_every} '{hidden} obsolete'\n"
 
 
-DIMENSION_CREATE = "DIMENSION '{id}' '{name}' {algorithm} {multiplier} {divisor} '{hidden}'\n"
+DIMENSION_CREATE = "DIMENSION '{id}' '{name}' {algorithm} {multiplier} {divisor} '{hidden} {obsolete}'\n"
 DIMENSION_SET = "SET '{id}' = {value}\n"
 
 CHART_VARIABLE_SET = "VARIABLE CHART '{id}' = {value}\n"
@@ -200,6 +200,17 @@ class Chart:
         self.dimensions.append(dim)
         return dim
 
+    def del_dimension(self, dimension_id):
+        if dimension_id not in self:
+            return
+
+        idx = self.dimensions.index(dimension_id)
+        dimension = self.dimensions[idx]
+        dimension.params['hidden'] = 'hidden'
+        dimension.params['obsolete'] = 'obsolete'
+        self.create()
+        self.dimensions.remove(dimension)
+
     def hide_dimension(self, dimension_id, reverse=False):
         if dimension_id in self:
             idx = self.dimensions.index(dimension_id)
@@ -288,6 +299,7 @@ class Dimension:
         if not isinstance(self.params.get('divisor'), int):
             self.params['divisor'] = 1
         self.params.setdefault('hidden', '')
+        self.params.setdefault('obsolete', '')
 
     def __getattr__(self, item):
         try:


### PR DESCRIPTION
##### Summary
Fixes: #5793

add `del_dimension` method to Chart class.

method does:
 - sets dimension `hidden` option
 - sets dimension `obsolete` option
 - pushes chart to netdata (write to stdout)
 - deletes dimension from chart.dimensions

##### Component Name

[`/collectors/python.d.plugin/python_modules/bases/charts.py`](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/python_modules/bases/charts.py)

##### Additional Information

