### PR TITLE
netdata/packaging/installer: HoS situation - Fix broken install-or-update script

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -614,11 +614,11 @@ portable_add_user() {
 portable_add_group() {
 	local groupname="${1}"
 
-    # Check if group exist
+	# Check if group exist
 	if cut -d ':' -f 1 </etc/group | grep "^${groupname}$" 1>/dev/null 2>&1; then
-        echo >&2 "Group '${groupname}' already exists."
-        return 0
-    fi
+		echo >&2 "Group '${groupname}' already exists."
+		return 0
+	fi
 
 	echo >&2 "Adding ${groupname} user group ..."
 
@@ -644,13 +644,13 @@ portable_add_group() {
 portable_add_user_to_group() {
 	local groupname="${1}" username="${2}"
 
-    # Check if group exist
+	# Check if group exist
 	if ! cut -d ':' -f 1 </etc/group | grep "^${groupname}$" >/dev/null 2>&1; then
-        echo >&2 "Group '${groupname}' does not exist."
-        return 1
-    fi
+		echo >&2 "Group '${groupname}' does not exist."
+		return 1
+	fi
 
-    # Check if user is in group
+	# Check if user is in group
 	if [[ ",$(grep "^${groupname}:" </etc/group | cut -d ':' -f 4)," =~ ,${username}, ]]; then
 		# username is already there
 		echo >&2 "User '${username}' is already in group '${groupname}'."


### PR DESCRIPTION
##### Summary
During the last major installer refactoring, we managed to break (again) the static64 installer.
We modified the code that defines user/group ownerships for netdata installation,
forcing the install to end up with a process running as netdata and files set as root

To fix this, we re-instate default NETDATA_USER/NETDATA_GROUP to root, as it should be.
Then we attempt group netadata creation. If that succeeds, we attempt user netdata creation.
If that succeeds, we attempt secondary groups addition.

Report errors on all otherwise situations from each step.

##### Component Name
netdata/installer/kickstart-static64.sh

##### Additional Information
This Fixes #5803 
