### PR TITLE
netdata/packaging/ci: Do not trigger deployment if certain conditions are not met

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,11 @@ jobs:
       bucket: "netdata-nightlies"
       skip_cleanup: true
       local_dir: "artifacts"
+      on:
+        # Only deploy on netdata/netdata, master branch, when artifacts directory is created
+        repo: netdata/netdata
+        branch: master
+        condition: -d "artifacts"
     after_deploy: rm -f .travis/gcs-credentials.json
 
   - stage: Integrity testing


### PR DESCRIPTION
##### Summary
I noticed the following scenario: https://api.travis-ci.com/v3/job/190900752/log.txt
Basically nightlies run without any changes being committed, which resulted in job to fail.
The GCS provider tried to push artifacts directory while the folder is not created, that should not happen. This is to protect triggering the GCS deploy operation if not needed.

Changes, deploy only when:
1) repo is netdata/netdata
2) branch is master
3) artifacts directory exists

Note: I have also send an email to travis, because i am not sure why we see builds running on commits with "[ci skip]" set.

Related to #5815
##### Component Name
netdata/packaging/ci

##### Additional Information
