### PR TITLE
Return responses even in memory mode none

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -565,11 +565,11 @@ void buffer_data_options2string(BUFFER *wb, uint32_t options) {
 }
 
 static inline int check_host_and_call(RRDHOST *host, struct web_client *w, char *url, int (*func)(RRDHOST *, struct web_client *, char *)) {
-    if(unlikely(host->rrd_memory_mode == RRD_MEMORY_MODE_NONE)) {
-        buffer_flush(w->response.data);
-        buffer_strcat(w->response.data, "This host does not maintain a database");
-        return 400;
-    }
+    //if(unlikely(host->rrd_memory_mode == RRD_MEMORY_MODE_NONE)) {
+    //    buffer_flush(w->response.data);
+    //    buffer_strcat(w->response.data, "This host does not maintain a database");
+    //    return 400;
+    //}
 
     return func(host, w, url);
 }


### PR DESCRIPTION
##### Summary
Fixes #5764 
Do not check if memory mode = None to decide whether to return a response.

##### Component Name
daemon

##### Additional Information
I don't see why this code is useful, netdata actually seems to be working better with it (instead of an error when bringing up the UI, we get a page with nothing in it). I will check with @ktsaou and if we're ok, I may remove the function completely. 
