### PR TITLE
Added TLS connection support for openldap collector

### DIFF
--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -14,6 +14,8 @@ from bases.FrameworkServices.SimpleService import SimpleService
 
 DEFAULT_SERVER = 'localhost'
 DEFAULT_PORT = '389'
+DEFAULT_TLS = False
+DEFAULT_CERT_CHECK = True
 DEFAULT_TIMEOUT = 1
 
 ORDER = [
@@ -139,6 +141,8 @@ class Service(SimpleService):
         self.username = configuration.get('username')
         self.password = configuration.get('password')
         self.timeout = configuration.get('timeout', DEFAULT_TIMEOUT)
+        self.tls = configuration.get('tls', DEFAULT_TLS)
+        self.cert_check = configuration.get('cert_check', DEFAULT_CERT_CHECK)
         self.alive = False
         self.conn = None
 
@@ -150,8 +154,13 @@ class Service(SimpleService):
 
     def connect(self):
         try:
-            self.conn = ldap.initialize('ldap://%s:%s' % (self.server, self.port))
+            if self.tls:
+                self.conn = ldap.initialize('ldaps://%s:%s' % (self.server, self.port))
+            else:
+                self.conn = ldap.initialize('ldap://%s:%s' % (self.server, self.port))
             self.conn.set_option(ldap.OPT_NETWORK_TIMEOUT, self.timeout)
+            if self.tls and not self.cert_check:
+                self.conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
             if self.username and self.password:
                 self.conn.simple_bind(self.username, self.password)
         except ldap.LDAPError as error:

--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -141,7 +141,7 @@ class Service(SimpleService):
         self.username = configuration.get('username')
         self.password = configuration.get('password')
         self.timeout = configuration.get('timeout', DEFAULT_TIMEOUT)
-        self.tls = configuration.get('tls', DEFAULT_TLS)
+        self.use_tls = configuration.get('use_tls', DEFAULT_TLS)
         self.cert_check = configuration.get('cert_check', DEFAULT_CERT_CHECK)
         self.alive = False
         self.conn = None
@@ -154,12 +154,12 @@ class Service(SimpleService):
 
     def connect(self):
         try:
-            if self.tls:
+            if self.use_tls:
                 self.conn = ldap.initialize('ldaps://%s:%s' % (self.server, self.port))
             else:
                 self.conn = ldap.initialize('ldap://%s:%s' % (self.server, self.port))
             self.conn.set_option(ldap.OPT_NETWORK_TIMEOUT, self.timeout)
-            if self.tls and not self.cert_check:
+            if self.use_tls and not self.cert_check:
                 self.conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
             if self.username and self.password:
                 self.conn.simple_bind(self.username, self.password)

--- a/collectors/python.d.plugin/openldap/openldap.conf
+++ b/collectors/python.d.plugin/openldap/openldap.conf
@@ -67,6 +67,8 @@ update_every: 10
 
 #username : "cn=admin,dc=example,dc=com"   # The bind user with right to access monitor statistics
 #password : "yourpass"                     # The password for the binded user
-#server   : 'localhost'                    # The listening address of the LDAP server
-#port     : 389                            # The listening port of the LDAP server
-#timeout  : 1                              # Seconds to timeout if no connection exists
+#server   : 'localhost'                    # The listening address of the LDAP server. In case of TLS, use the hostname which the certificate is published for.
+#port     : 389                            # The listening port of the LDAP server. Change to 636 port in case of TLS connection
+#tls      : False                          # Make True if a TLS connection is used
+#cert_check : True                         # False if you want to ignore certificate check
+#timeout  : 1                              # Seconds to timeout if no connection exi

--- a/collectors/python.d.plugin/openldap/openldap.conf
+++ b/collectors/python.d.plugin/openldap/openldap.conf
@@ -69,6 +69,6 @@ update_every: 10
 #password : "yourpass"                     # The password for the binded user
 #server   : 'localhost'                    # The listening address of the LDAP server. In case of TLS, use the hostname which the certificate is published for.
 #port     : 389                            # The listening port of the LDAP server. Change to 636 port in case of TLS connection
-#tls      : False                          # Make True if a TLS connection is used
+#use_tls  : False                          # Make True if a TLS connection is used
 #cert_check : True                         # False if you want to ignore certificate check
 #timeout  : 1                              # Seconds to timeout if no connection exi


### PR DESCRIPTION
## openldap collector

##### Summary
Added support to make secure LDAP TLS connections. User can also choose to skip certificate check in case self signed ones are used.



Fixes: #5783