### PR TITLE
python.d.plugin: py2 fix crash on macos

### DIFF
--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-'''':; exec "$(command -v python || command -v python3 || command -v python2 ||
+'''':;
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+fi
+exec "$(command -v python || command -v python3 || command -v python2 ||
 echo "ERROR python IS NOT AVAILABLE IN THIS SYSTEM")" "$0" "$@" # '''
 
 # -*- coding: utf-8 -*-


### PR DESCRIPTION
##### Summary

Fixes: #5821

similar issue: https://github.com/ansible/ansible/issues/32499

> This is apparently due to some new security changes made in High Sierra that are breaking lots of Python things that use fork(). Rumor has it that adding
export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES before your Ansible run should clear it up. The code that's causing issues is well below Ansible in the stack.

^^

multiprocessing broken on macOS
python.d.plugin uses multiprocessing package

Fix:
 - export `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` in case of MacOS

##### Component Name

[/collectors/python.d.plugin](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin)

##### Additional Information

