### PR TITLE
netdata/web/gui/dashboard: do not remove the dashboard upon make clean

### DIFF
--- a/web/gui/Makefile.am
+++ b/web/gui/Makefile.am
@@ -4,7 +4,6 @@
 #
 MAINTAINERCLEANFILES= $(srcdir)/Makefile.in
 CLEANFILES = \
-	dashboard.js \
 	version.txt \
 	$(NULL)
 


### PR DESCRIPTION
##### Summary
This is primarily a developer convenience change.
The dashboard.js file is always regenerated upon compilation, so having it removed upon make clean does not provide any benefit.

The problem it solves, is risking to remove the file from the repository when the developer attempts a make clean command on the top level of the directory.

##### Component Name
netdata/web/gui/dashboard

##### Additional Information
None
