### PR TITLE
netdata/packaging/installer: correlate permissions amongst plugins to 0750

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -683,7 +683,7 @@ if [ "${UID}" -eq 0 ]; then
 	run chown -R "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata"
 	run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type d -exec chmod 0755 {} \;
 	run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -exec chmod 0644 {} \;
-	run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -a -name \*.plugin -exec chmod 0755 {} \;
+	run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -a -name \*.plugin -exec chmod 0750 {} \;
 	run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -a -name \*.sh -exec chmod 0755 {} \;
 
 	if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/apps.plugin" ]; then


### PR DESCRIPTION
##### Summary
We have agreed as part of #5586 to adjust the default plugins permission to 0750, as testing showed that this is sufficient for the plugins to run.

End result of plugin permissions after install as root would be:
```
[root@d28c32151328 plugins.d]# ls -ltr *plugin
-rwxr-x--- 1 root netdata    19123 Apr 12 15:11 charts.d.plugin
-rwxr-x--- 1 root netdata     5516 Apr 12 15:11 fping.plugin
-rwxr-x--- 1 root netdata    11060 Apr 12 15:11 node.d.plugin
-rwxr-x--- 1 root netdata    21336 Apr 12 15:11 python.d.plugin
-rwsr-x--- 1 root netdata    89976 Apr 12 15:11 apps.plugin
-rwxr-x--- 1 root netdata 14818313 Apr 12 15:11 go.d.plugin
[root@d28c32151328 plugins.d]# 
```
##### Component Name
netdata/packaging/installer

##### Additional Information
Fixes #5858
Referring #5586  