### PR TITLE
netdata/packaging/installer: Dont use --always in git describe.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 AC_PREREQ(2.60)
 
 # We do not use m4_esyscmd_s to support older autoconf.
-define([VERSION_STRING], m4_esyscmd([git describe --always 2>/dev/null | tr -d '\n']))
+define([VERSION_STRING], m4_esyscmd([git describe 2>/dev/null | tr -d '\n']))
 define([VERSION_FROM_FILE], m4_esyscmd([cat packaging/version | tr -d '\n']))
 m4_ifval(VERSION_STRING, [], [define([VERSION_STRING], VERSION_FROM_FILE)])
 

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -8,7 +8,7 @@ run cd "${NETDATA_SOURCE_PATH}" || exit 1
 # -----------------------------------------------------------------------------
 # find the netdata version
 
-VERSION="$(git describe --always 2>/dev/null)"
+VERSION="$(git describe 2>/dev/null)"
 if [ -z "${VERSION}" ]; then
     VERSION=$(cat packaging/version)
 fi


### PR DESCRIPTION
##### Summary
Dont use --always in git describe.
When git describe can't find a tag, we have the alternative of packaging/version content file.

When we use --always we break the configure mechanism and we end up with broken version information if git describe doesn't reach out to a tag (for example when a small number is given to --depth during git clone)

##### Component Name
netdata/packaging/installer

##### Additional Information
Fixes #5855