### PR TITLE
Fix Raw_Read_Error_Rate and Seek_Error_Rate

### DIFF
--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -440,6 +440,16 @@ class AtaNormalized(BaseAtaSmartAttribute):
         return self.normalized_value
 
 
+class Ata1(BaseAtaSmartAttribute):
+    def value(self):
+        return min(int(self.normalized_value), int(self.raw_value))
+
+
+class Ata7(BaseAtaSmartAttribute):
+    def value(self):
+        return min(int(self.normalized_value), int(self.raw_value))
+
+
 class Ata9(BaseAtaSmartAttribute):
     def value(self):
         value = int(self.raw_value)
@@ -475,6 +485,10 @@ class SCSIRaw(BaseSCSISmartAttribute):
 def ata_attribute_factory(value):
     name = value[0]
 
+    if name == ATTR1:
+        return Ata1(*value)
+    if name == ATTR7:
+        return Ata7(*value)
     if name == ATTR9:
         return Ata9(*value)
     elif name == ATTR190:
@@ -482,7 +496,6 @@ def ata_attribute_factory(value):
     elif name == ATTR194:
         return Ata194(*value)
     elif name in [
-        ATTR1,
         ATTR7,
         ATTR202,
         ATTR206,


### PR DESCRIPTION
My Western Digital Red report raw values and netdata shows that I had 200 reading errors when it is incorrect..

ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  1 Raw_Read_Error_Rate     0x002f   200   200   051    Pre-fail  Always       -       0
  7 Seek_Error_Rate         0x002e   100   253   000    Old_age   Always       -       0

With this approach (the same as the issue #4908 for attr 194), if I had more than 200 errors, I would report 200, but since any value greater than 0 is important, I guess this is acceptable.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

