### PR TITLE
Fix segmentation fault in streaming

### DIFF
--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -151,13 +151,15 @@ static inline void rrdpush_send_chart_definition_nolock(RRDSET *st) {
 
     // properly set the name for the remote end to parse it
     char *name = "";
-    if(unlikely(strcmp(st->id, st->name))) {
-        // they differ
-        name = strchr(st->name, '.');
-        if(name)
-            name++;
-        else
-            name = "";
+    if(likely(st->name)) {
+        if(unlikely(strcmp(st->id, st->name))) {
+            // they differ
+            name = strchr(st->name, '.');
+            if(name)
+                name++;
+            else
+                name = "";
+        }
     }
 
     // info("CHART '%s' '%s'", st->id, name);


### PR DESCRIPTION
##### Summary
Chart names should be checked if they are missing while sending data to a master.

Fixes #5829

##### Component Name
streaming