### PR TITLE
SocketService: set socket operation timeout before connecting

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -16,6 +16,9 @@ else:
 from bases.FrameworkServices.SimpleService import SimpleService
 
 
+DEFAULT_SOCKET_TIMEOUT = 3
+
+
 class SocketService(SimpleService):
     def __init__(self, configuration=None, name=None):
         self._sock = None
@@ -86,6 +89,9 @@ class SocketService(SimpleService):
 
         try:
             self.debug('connecting socket to "{address}", port {port}'.format(address=sa[0], port=sa[1]))
+            self._sock.setblocking(False)
+            self._sock.settimeout(DEFAULT_SOCKET_TIMEOUT)
+            self.debug('set socket timeout to: {0}'.format(self._sock.gettimeout()))
             self._sock.connect(sa)
         except (socket.error, ssl.SSLError) as error:
             self.error('Failed to connect to "{address}", port {port}, error: {error}'.format(address=sa[0],
@@ -111,6 +117,9 @@ class SocketService(SimpleService):
         try:
             self.debug('attempting DGRAM unix socket "{0}"'.format(self.unix_socket))
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            self._sock.setblocking(False)
+            self._sock.settimeout(DEFAULT_SOCKET_TIMEOUT)
+            self.debug('set socket timeout to: {0}'.format(self._sock.gettimeout()))
             self._sock.connect(self.unix_socket)
             self.debug('connected DGRAM unix socket "{0}"'.format(self.unix_socket))
             return True
@@ -121,6 +130,9 @@ class SocketService(SimpleService):
         try:
             self.debug('attempting STREAM unix socket "{0}"'.format(self.unix_socket))
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._sock.setblocking(False)
+            self._sock.settimeout(DEFAULT_SOCKET_TIMEOUT)
+            self.debug('set socket timeout to: {0}'.format(self._sock.gettimeout()))
             self._sock.connect(self.unix_socket)
             self.debug('connected STREAM unix socket "{0}"'.format(self.unix_socket))
             return True
@@ -155,11 +167,6 @@ class SocketService(SimpleService):
         except Exception:
             self._sock = None
             self.__socket_config = None
-
-        if self._sock is not None:
-            self._sock.setblocking(0)
-            self._sock.settimeout(5)
-            self.debug('set socket timeout to: {0}'.format(self._sock.gettimeout()))
 
     def _disconnect(self):
         """

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -16,7 +16,9 @@ else:
 from bases.FrameworkServices.SimpleService import SimpleService
 
 
-DEFAULT_SOCKET_TIMEOUT = 3
+DEFAULT_CONNECT_TIMEOUT = 3.0
+DEFAULT_READ_TIMEOUT = 3.0
+DEFAULT_WRITE_TIMEOUT = 3.0
 
 
 class SocketService(SimpleService):
@@ -34,6 +36,9 @@ class SocketService(SimpleService):
         self.__socket_config = None
         self.__empty_request = "".encode()
         SimpleService.__init__(self, configuration=configuration, name=name)
+        self.connect_timeout = configuration.get('connect_timeout', DEFAULT_CONNECT_TIMEOUT)
+        self.read_timeout = configuration.get('read_timeout', DEFAULT_READ_TIMEOUT)
+        self.write_timeout = configuration.get('write_timeout', DEFAULT_WRITE_TIMEOUT)
 
     def _socket_error(self, message=None):
         if self.unix_socket is not None:
@@ -89,9 +94,9 @@ class SocketService(SimpleService):
 
         try:
             self.debug('connecting socket to "{address}", port {port}'.format(address=sa[0], port=sa[1]))
-            self._sock.setblocking(False)
-            self._sock.settimeout(DEFAULT_SOCKET_TIMEOUT)
-            self.debug('set socket timeout to: {0}'.format(self._sock.gettimeout()))
+            # self._sock.setblocking(False)
+            self._sock.settimeout(self.connect_timeout)
+            self.debug('set socket connect timeout to: {0}'.format(self._sock.gettimeout()))
             self._sock.connect(sa)
         except (socket.error, ssl.SSLError) as error:
             self.error('Failed to connect to "{address}", port {port}, error: {error}'.format(address=sa[0],
@@ -117,9 +122,9 @@ class SocketService(SimpleService):
         try:
             self.debug('attempting DGRAM unix socket "{0}"'.format(self.unix_socket))
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-            self._sock.setblocking(False)
-            self._sock.settimeout(DEFAULT_SOCKET_TIMEOUT)
-            self.debug('set socket timeout to: {0}'.format(self._sock.gettimeout()))
+            # self._sock.setblocking(False)
+            self._sock.settimeout(self.connect_timeout)
+            self.debug('set socket connect timeout to: {0}'.format(self._sock.gettimeout()))
             self._sock.connect(self.unix_socket)
             self.debug('connected DGRAM unix socket "{0}"'.format(self.unix_socket))
             return True
@@ -131,8 +136,8 @@ class SocketService(SimpleService):
             self.debug('attempting STREAM unix socket "{0}"'.format(self.unix_socket))
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self._sock.setblocking(False)
-            self._sock.settimeout(DEFAULT_SOCKET_TIMEOUT)
-            self.debug('set socket timeout to: {0}'.format(self._sock.gettimeout()))
+            self._sock.settimeout(self.connect_timeout)
+            self.debug('set socket connect timeout to: {0}'.format(self._sock.gettimeout()))
             self._sock.connect(self.unix_socket)
             self.debug('connected STREAM unix socket "{0}"'.format(self.unix_socket))
             return True
@@ -190,6 +195,8 @@ class SocketService(SimpleService):
         # Send request if it is needed
         if self.request != self.__empty_request:
             try:
+                self.debug('set socket write timeout to: {0}'.format(self._sock.gettimeout()))
+                self._sock.settimeout(self.write_timeout)
                 self.debug('sending request: {0}'.format(request or self.request))
                 self._sock.send(request or self.request)
             except Exception as error:
@@ -210,6 +217,8 @@ class SocketService(SimpleService):
         while True:
             self.debug('receiving response')
             try:
+                self.debug('set socket read timeout to: {0}'.format(self._sock.gettimeout()))
+                self._sock.settimeout(self.read_timeout)
                 buf = self._sock.recv(4096)
             except Exception as error:
                 self._socket_error('failed to receive response: {0}'.format(error))

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -94,7 +94,6 @@ class SocketService(SimpleService):
 
         try:
             self.debug('connecting socket to "{address}", port {port}'.format(address=sa[0], port=sa[1]))
-            # self._sock.setblocking(False)
             self._sock.settimeout(self.connect_timeout)
             self.debug('set socket connect timeout to: {0}'.format(self._sock.gettimeout()))
             self._sock.connect(sa)
@@ -122,7 +121,6 @@ class SocketService(SimpleService):
         try:
             self.debug('attempting DGRAM unix socket "{0}"'.format(self.unix_socket))
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-            # self._sock.setblocking(False)
             self._sock.settimeout(self.connect_timeout)
             self.debug('set socket connect timeout to: {0}'.format(self._sock.gettimeout()))
             self._sock.connect(self.unix_socket)
@@ -135,7 +133,6 @@ class SocketService(SimpleService):
         try:
             self.debug('attempting STREAM unix socket "{0}"'.format(self.unix_socket))
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self._sock.setblocking(False)
             self._sock.settimeout(self.connect_timeout)
             self.debug('set socket connect timeout to: {0}'.format(self._sock.gettimeout()))
             self._sock.connect(self.unix_socket)

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -16,9 +16,9 @@ else:
 from bases.FrameworkServices.SimpleService import SimpleService
 
 
-DEFAULT_CONNECT_TIMEOUT = 3.0
-DEFAULT_READ_TIMEOUT = 3.0
-DEFAULT_WRITE_TIMEOUT = 3.0
+DEFAULT_CONNECT_TIMEOUT = 2.0
+DEFAULT_READ_TIMEOUT = 2.0
+DEFAULT_WRITE_TIMEOUT = 2.0
 
 
 class SocketService(SimpleService):


### PR DESCRIPTION
##### Summary
Fixes: #5541

This PR:
 - removes `setblocking` calls

```python
    def setblocking(self, v):
        if v:
            self.settimeout(None)
        else:
            self.settimeout(0.0)
```

 - sets socket timeout before call to `connect`

 - adds separate `connect`, `read` and `write` timeouts. Default is 2 seconds for all.

> socket.settimeout(value)
Set a timeout on blocking socket operations. The value argument can be a nonnegative float expressing seconds, or None. If a float is given, subsequent socket operations will raise a timeout exception if the timeout period value has elapsed before the operation has completed. Setting a timeout of None disables timeouts on socket operations. s.settimeout(0.0) is equivalent to s.setblocking(0); s.settimeout(None) is equivalent to s.setblocking(1).

##### Component Name
[`/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService`](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py)
##### Additional Information
