### PR TITLE
netdata/packaging/docker: fix docker permissions and other things

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN \
     chown -R root:netdata /etc/netdata && \
     chown -R netdata:netdata /var/cache/netdata /var/lib/netdata /usr/share/netdata && \
     chown -R root:netdata /usr/lib/netdata && \
-    chown -R root:netdata /usr/libexec/netdata/plugins.d/apps.plugin /usr/libexec/netdata/plugins.d/cgroup-network && \
+    chown -R root:netdata /usr/libexec/netdata/ && \
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network /usr/libexec/netdata/plugins.d/apps.plugin && \
     chmod 0750 /var/lib/netdata /var/cache/netdata && \
     # Link log files to stdout

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Cross-arch docker build helper script
 #
 # Copyright: SPDX-License-Identifier: GPL-3.0-or-later
@@ -14,11 +14,15 @@ if [ "${BASH_VERSINFO[0]}" -lt "4" ]; then
 fi
 
 VERSION="$1"
-REPOSITORY="${REPOSITORY:-netdata}"
 declare -A ARCH_MAP
 ARCH_MAP=(["i386"]="386" ["amd64"]="amd64" ["armhf"]="arm" ["aarch64"]="arm64")
 DEVEL_ARCHS=(amd64)
 ARCHS="${!ARCH_MAP[@]}"
+
+if [ -z ${REPOSITORY} ]; then
+	echo "REPOSITORY not set, build cannot proceed"
+	exit 1
+fi
 
 # When development mode is set, build on DEVEL_ARCHS
 if [ ! -z ${DEVEL+x} ]; then
@@ -53,7 +57,7 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset
 for ARCH in ${ARCHS[@]}; do
      TAG="${REPOSITORY}:${VERSION}-${ARCH}"
      echo "Building tag ${TAG}.."
-     eval docker build \
+     eval docker build --no-cache \
           --build-arg ARCH="${ARCH}" \
           --tag "${TAG}" \
           --file packaging/docker/Dockerfile ./

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -20,8 +20,13 @@ DEVEL_ARCHS=(amd64)
 ARCHS="${!ARCH_MAP[@]}"
 
 if [ -z ${REPOSITORY} ]; then
-	echo "REPOSITORY not set, build cannot proceed"
-	exit 1
+	REPOSITORY="${TRAVIS_REPO_SLUG}"
+	if [ -z ${REPOSITORY} ]; then
+		echo "REPOSITORY not set, build cannot proceed"
+		exit 1
+	else
+		echo "REPOSITORY was not detected, attempted to use TRAVIS_REPO_SLUG setting: ${TRAVIS_REPO_SLUG}"
+	fi
 fi
 
 # When development mode is set, build on DEVEL_ARCHS

--- a/packaging/docker/publish.sh
+++ b/packaging/docker/publish.sh
@@ -22,8 +22,13 @@ ARCHS="${!ARCH_MAP[@]}"
 DOCKER_CMD="docker --config ${WORKDIR}"
 
 if [ -z ${REPOSITORY} ]; then
-	echo "REPOSITORY not set, publishing cannot proceed"
-	exit 1
+	REPOSITORY="${TRAVIS_REPO_SLUG}"
+	if [ -z ${REPOSITORY} ]; then
+		echo "REPOSITORY not set, publish cannot proceed"
+		exit 1
+	else
+		echo "REPOSITORY was not detected, attempted to use TRAVIS_REPO_SLUG setting: ${TRAVIS_REPO_SLUG}"
+	fi
 fi
 
 # When development mode is set, build on DEVEL_ARCHS

--- a/packaging/docker/publish.sh
+++ b/packaging/docker/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Cross-arch docker publish helper script
 # Needs docker in version >18.02 due to usage of manifests
 #
@@ -15,12 +15,16 @@ fi
 
 WORKDIR="$(mktemp -d)" # Temporary folder, removed after script is done
 VERSION="$1"
-REPOSITORY="${REPOSITORY:-netdata}"
 declare -A ARCH_MAP
 ARCH_MAP=(["i386"]="386" ["amd64"]="amd64" ["armhf"]="arm" ["aarch64"]="arm64")
 DEVEL_ARCHS=(amd64)
 ARCHS="${!ARCH_MAP[@]}"
 DOCKER_CMD="docker --config ${WORKDIR}"
+
+if [ -z ${REPOSITORY} ]; then
+	echo "REPOSITORY not set, publishing cannot proceed"
+	exit 1
+fi
 
 # When development mode is set, build on DEVEL_ARCHS
 if [ ! -z ${DEVEL+x} ]; then


### PR DESCRIPTION
##### Summary
1. User more consistent shebangs
2. Do not use default values on REPOSITORY, its confusing. Just fail with a message if REPOSITORY not there
3. Do not use cache on build
4. Set the ownership to root:netdata on the whole /usr/libexec/netdata directory

##### Component Name
netdata/packaging/docker

##### Additional Information
Fixes #5890 