### PR TITLE
Fix lifecycle script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,13 +86,13 @@ jobs:
     - echo "Last commit:" && git log -1
     - echo "GIT Describe:" && git describe
     - echo "packaging/version:" && cat packaging/version
-    - docker run -it -v "${PWD}:/code:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /code "netdata/os-test:ubuntu1804" make clean || echo "Nothing to clean"
-    - docker run -it -v "${PWD}:/code:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /code "netdata/os-test:ubuntu1804" make distclean || echo "Nothing to distclean"
-    - docker run -it -v "${PWD}:/code:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /code "netdata/os-test:ubuntu1804" autoreconf -ivf && ./configure --prefix=/netdata_install/usr --sysconfdir=/netdata_install/etc --localstatedir=/netdata_install/var --with-zlib --with-math --with-user=netdata CFLAGS=-O2
-    - docker run -it -v "${PWD}:/code:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /code "netdata/os-test:ubuntu1804" make dist
-    - docker run -it -v "${PWD}:/code:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /code "netdata/os-test:ubuntu1804" ls -ltr ./netdata-$(git describe).tar.gz || ls -ltr ./netdata-$(cat packaging/version | tr -d '\n').tar.gz
+    - docker run -it -v "${PWD}:/netdata:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /netdata "netdata/os-test:ubuntu1804" make clean || echo "Nothing to clean"
+    - docker run -it -v "${PWD}:/netdata:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /netdata "netdata/os-test:ubuntu1804" make distclean || echo "Nothing to distclean"
+    - docker run -it -v "${PWD}:/netdata:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /netdata "netdata/os-test:ubuntu1804" autoreconf -ivf && ./configure --prefix=/netdata_install/usr --sysconfdir=/netdata_install/etc --localstatedir=/netdata_install/var --with-zlib --with-math --with-user=netdata CFLAGS=-O2
+    - docker run -it -v "${PWD}:/netdata:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /netdata "netdata/os-test:ubuntu1804" make dist
+    - docker run -it -v "${PWD}:/netdata:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /netdata "netdata/os-test:ubuntu1804" ls -ltr ./netdata-$(git describe).tar.gz || ls -ltr ./netdata-$(cat packaging/version | tr -d '\n').tar.gz
     - .travis/run_install_with_dist_file.sh
-    - docker run -it -v "${PWD}:/code:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /code "netdata/os-test:ubuntu1804" make distclean
+    - docker run -it -v "${PWD}:/netdata:rw" -v "/tmp/netdata-makedist-test:/netdata_install:rw" -w /netdata "netdata/os-test:ubuntu1804" make distclean
     git:
       depth: false
     after_script: rm -rf /tmp/netdata-makedist-test
@@ -118,15 +118,19 @@ jobs:
     after_failure: post_message "TRAVIS_MESSAGE" "Build/Install failed on ubuntu 18.04"
 
   - name: Run netdata lifecycle, on ubuntu 18.04 (Containerized)
-    script: docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:ubuntu1804" bats --tap tests/lifecycle.bats
+    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "netdata/os-test:ubuntu1804" bats --tap tests/lifecycle.bats
     after_failure: post_message "TRAVIS_MESSAGE" "Netdata lifecycle test script failed on ubuntu 18.04"
 
+  - name: Run netdata lifecycle from stable to current, on CentOS 7 (Containerized)
+    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "netdata/os-test:centos7" bats --tap tests/updater_checks.bats
+    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on CentOS 7"
+
   - name: Build/install for CentOS 6 (Containerized)
-    script: docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:centos6" ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp
+    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "netdata/os-test:centos6" ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp
     after_failure: post_message "TRAVIS_MESSAGE" "Build/Install failed on CentOS 6"
 
   - name: Build/install for CentOS 7 (Containerized)
-    script: docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:centos7" ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp
+    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "netdata/os-test:centos7" ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp
     after_failure: post_message "TRAVIS_MESSAGE" "Build/Install failed on CentOS 7"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ jobs:
     after_failure: post_message "TRAVIS_MESSAGE" "Netdata lifecycle test script failed on ubuntu 18.04"
 
   - name: Run netdata lifecycle from stable to current, on CentOS 7 (Containerized)
-    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "netdata/os-test:centos7" bats --tap tests/updater_checks.bats
+    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "netdata/os-test:centos7" tests/updater_checks.sh
     after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on CentOS 7"
 
   - name: Build/install for CentOS 6 (Containerized)

--- a/tests/lifecycle.bats
+++ b/tests/lifecycle.bats
@@ -1,4 +1,12 @@
 #!/usr/bin/env bats
+#
+# Netdata installation lifecycle testing script.
+# This is to validate the install, update and uninstall of netdata
+#
+# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author  : Pavlos Emm. Katsoulakis <paul@netdata.cloud)
+#
 
 INSTALLATION="$BATS_TMPDIR/installation"
 ENV="${INSTALLATION}/netdata/etc/netdata/.environment"
@@ -8,8 +16,19 @@ FILES="usr/libexec/netdata/plugins.d/go.d.plugin
        usr/libexec/netdata/plugins.d/python.d.plugin
        usr/libexec/netdata/plugins.d/node.d.plugin"
 
+DIRS="usr/sbin/netdata
+      etc/netdata
+      usr/share/netdata
+      usr/libexec/netdata
+      var/cache/netdata
+      var/lib/netdata
+      var/log/netdata"
+
 setup() {
-	if [ ! -f .gitignore ];	then
+	# If we are not in netdata git repo, at the top level directory, fail
+	TOP_LEVEL=$(basename "$(git rev-parse --show-toplevel)")
+	CWD=$(git rev-parse --show-cdup || echo "")
+	if [ -n "${CWD}" ] || [ ! "${TOP_LEVEL}" == "netdata" ]; then
 		echo "Run as ./tests/lifecycle/$(basename "$0") from top level directory of git repository"
 		exit 1
 	fi
@@ -17,8 +36,15 @@ setup() {
 
 @test "install netdata" {
 	./netdata-installer.sh  --dont-wait --dont-start-it --auto-update --install "${INSTALLATION}"
+
+	# Validate particular files
 	for file in $FILES; do
 		[ ! -f "$BATS_TMPDIR/$file" ]
+	done
+
+	# Validate particular directories
+	for a_dir in $DIRS; do
+		[ ! -d "$BATS_TMPDIR/$a_dir" ]
 	done
 }
 

--- a/tests/updater_checks.bats
+++ b/tests/updater_checks.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+#
+# This script is responsible for validating
+# updater capabilities after a change
+#
+# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author  : Pavlos Emm. Katsoulakis <paul@netdata.cloud)
+#
+
+INSTALLATION="$BATS_TMPDIR/installation"
+ENV="${INSTALLATION}/netdata/etc/netdata/.environment"
+# list of files which need to be checked. Path cannot start from '/'
+FILES="usr/libexec/netdata/plugins.d/go.d.plugin
+       usr/libexec/netdata/plugins.d/charts.d.plugin
+       usr/libexec/netdata/plugins.d/python.d.plugin
+       usr/libexec/netdata/plugins.d/node.d.plugin"
+
+DIRS="usr/sbin/netdata
+      etc/netdata
+      usr/share/netdata
+      usr/libexec/netdata
+      var/cache/netdata
+      var/lib/netdata
+      var/log/netdata"
+
+setup() {
+	# If we are not in netdata git repo, at the top level directory, fail
+	TOP_LEVEL=$(basename "$(git rev-parse --show-toplevel)")
+	CWD=$(git rev-parse --show-cdup || echo "")
+	if [ -n "${CWD}" ] || [ ! "${TOP_LEVEL}" == "netdata" ]; then
+		echo "Run as ./tests/$(basename "$0") from top level directory of git repository"
+		exit 1
+	fi
+}
+
+@test "install stable netdata using kickstart" {
+	kickstart_file="/tmp/kickstart.$$"
+	curl -Ss -o ${kickstart_file} https://my-netdata.io/kickstart.sh
+	chmod +x ${kickstart_file}
+	${kickstart_file} --dont-wait --dont-start-it --auto-update --install ${INSTALLATION}
+
+	# Validate particular files
+	for file in $FILES; do
+		[ ! -f "$BATS_TMPDIR/$file" ]
+	done
+
+	# Validate particular directories
+	for a_dir in $DIRS; do
+		[ ! -d "$BATS_TMPDIR/$a_dir" ]
+	done
+
+	# Cleanup
+	rm -rf ${kickstart_file}
+}
+
+@test "update netdata using the new updater" {
+	export ENVIRONMENT_FILE="${ENV}"
+	# Run the updater, with the override so that it uses the local repo we have at hand
+	# Try to run the installed, if any, otherwise just run the one from the repo
+	export NETDATA_LOCAL_TARBAL_OVERRIDE="${PWD}"
+	/etc/cron.daily/netdata-updater || ./packaging/installer/netdata-updater.sh
+	! grep "new_installation" "${ENV}"
+}
+
+@test "uninstall netdata using latest uninstaller" {
+	./packaging/installer/netdata-uninstaller.sh --yes --force --env "${ENV}"
+	[ ! -f "${INSTALLATION}/netdata/usr/sbin/netdata" ]
+	[ ! -f "/etc/cron.daily/netdata-updater" ]
+}

--- a/tests/updater_checks.bats
+++ b/tests/updater_checks.bats
@@ -25,6 +25,7 @@ DIRS="usr/sbin/netdata
       var/log/netdata"
 
 setup() {
+
 	# If we are not in netdata git repo, at the top level directory, fail
 	TOP_LEVEL=$(basename "$(git rev-parse --show-toplevel)")
 	CWD=$(git rev-parse --show-cdup || echo "")

--- a/tests/updater_checks.sh
+++ b/tests/updater_checks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Wrapper script that installs the required dependencies
+# for the BATS script to run successfully
+#
+# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author  : Pavlos Emm. Katsoulakis <paul@netdata.cloud)
+#
+
+echo "Installing extra dependencies.."
+yum install -y epel-release
+yum install -y git bats
+
+echo "Running BATS file.."
+bats --tap tests/updater_checks.bats


### PR DESCRIPTION
##### Summary
The aim on this PR is to attempt a small enrichment on the tests we execute during our CI testing, to guarantee stable release generation for our customers.
In brief this PR includes the following changes/additions:
1. Introduce `tests/updater_checks.bats`, use it within travis a separate job in our testing stage.
    Within this BATS we basically use the stable tarball to perform a netdata install and then we use the latest tarball to perform the update.
2. We adjusted our updater script, so that we can override with a parameter the source tarball selection. We introduced variable `NETDATA_LOCAL_TARBAL_OVERRIDE` that is basically instructing the updater to use that path as TARBALL context for the update. This way we let the updater run with whatever latest code we want to verify works to transition from stable version.
3. Within this PR we also have some side fixes like renames, checks for execution paths (remove that gitignore check and use the other approach) and also extra validations on the existing lifecycle script (check all expected folders existence, apart from specific file checks)

##### Component Name
netdata/packaging/ci

##### Additional Information
Fixes #5786 
