### PR TITLE
Expand dashboard auto-scaling and convertible units

### DIFF
--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -868,6 +868,13 @@ NETDATA.unitsConversion = {
             'TiB': 1024,
             'PiB': 1024 * 1024,
             'EiB': 1024 * 1024 * 1024
+        },
+        'num': {
+            'num': 1,
+            'num (K)': 1000,
+            'num (M)': 1000000,
+            'num (G)': 1000000000,
+            'num (T)': 1000000000000
         }
         /*
         'milliseconds': {

--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -974,6 +974,72 @@ NETDATA.unitsConversion = {
                         + NETDATA.zeropad(milliseconds);
                 }
             }
+        },
+        'nanoseconds': {
+            'nanoseconds': {
+                check: function (max) {
+                    return NETDATA.options.current.seconds_as_time && max < 1000;
+                },
+                convert: function (nanoseconds) {
+                    let tms = Math.round(nanoseconds * 10);
+                    nanoseconds = Math.floor(tms / 10);
+
+                    tms -= nanoseconds * 10;
+
+                    return (nanoseconds).toString() + '.' + tms.toString();
+                }
+            },
+            'microseconds': {
+                check: function (max) {
+                    return NETDATA.options.current.seconds_as_time
+                           && max >= 1000 && max < 1000 * 1000;
+                },
+                convert: function (nanoseconds) {
+                    nanoseconds = Math.round(nanoseconds);
+
+                    let microseconds = Math.floor(nanoseconds / 1000);
+                    nanoseconds -= microseconds * 1000;
+
+                    nanoseconds = Math.round(nanoseconds / 10 );
+
+                    return microseconds.toString() + '.'
+                        + NETDATA.zeropad(nanoseconds);
+                }
+            },
+            'milliseconds': {
+                check: function (max) {
+                    return NETDATA.options.current.seconds_as_time
+                           && max >= 1000 * 1000 && max < 1000 * 1000 * 1000;
+                },
+                convert: function (nanoseconds) {
+                    nanoseconds = Math.round(nanoseconds);
+
+                    let milliseconds = Math.floor(nanoseconds / 1000 / 1000);
+                    nanoseconds -= milliseconds * 1000 * 1000;
+
+                    nanoseconds = Math.round(nanoseconds / 1000 / 10);
+
+                    return milliseconds.toString() + '.'
+                        + NETDATA.zeropad(nanoseconds);
+                }
+            },
+            'seconds': {
+                check: function (max) {
+                    return NETDATA.options.current.seconds_as_time
+                           && max >= 1000 * 1000 * 1000;
+                },
+                convert: function (nanoseconds) {
+                    nanoseconds = Math.round(nanoseconds);
+
+                    let seconds = Math.floor(nanoseconds / 1000 / 1000 / 1000);
+                    nanoseconds -= seconds * 1000 * 1000 * 1000;
+
+                    nanoseconds = Math.round(nanoseconds / 1000 / 1000 / 10);
+
+                    return seconds.toString() + '.'
+                        + NETDATA.zeropad(nanoseconds);
+                }
+            },
         }
     },
 

--- a/web/gui/src/dashboard.js/units-conversion.js
+++ b/web/gui/src/dashboard.js/units-conversion.js
@@ -101,6 +101,13 @@ NETDATA.unitsConversion = {
             'TiB': 1024,
             'PiB': 1024 * 1024,
             'EiB': 1024 * 1024 * 1024
+        },
+        'num': {
+            'num': 1,
+            'num (K)': 1000,
+            'num (M)': 1000000,
+            'num (G)': 1000000000,
+            'num (T)': 1000000000000
         }
         /*
         'milliseconds': {

--- a/web/gui/src/dashboard.js/units-conversion.js
+++ b/web/gui/src/dashboard.js/units-conversion.js
@@ -207,6 +207,72 @@ NETDATA.unitsConversion = {
                         + NETDATA.zeropad(milliseconds);
                 }
             }
+        },
+        'nanoseconds': {
+            'nanoseconds': {
+                check: function (max) {
+                    return NETDATA.options.current.seconds_as_time && max < 1000;
+                },
+                convert: function (nanoseconds) {
+                    let tms = Math.round(nanoseconds * 10);
+                    nanoseconds = Math.floor(tms / 10);
+
+                    tms -= nanoseconds * 10;
+
+                    return (nanoseconds).toString() + '.' + tms.toString();
+                }
+            },
+            'microseconds': {
+                check: function (max) {
+                    return NETDATA.options.current.seconds_as_time
+                           && max >= 1000 && max < 1000 * 1000;
+                },
+                convert: function (nanoseconds) {
+                    nanoseconds = Math.round(nanoseconds);
+
+                    let microseconds = Math.floor(nanoseconds / 1000);
+                    nanoseconds -= microseconds * 1000;
+
+                    nanoseconds = Math.round(nanoseconds / 10 );
+
+                    return microseconds.toString() + '.'
+                        + NETDATA.zeropad(nanoseconds);
+                }
+            },
+            'milliseconds': {
+                check: function (max) {
+                    return NETDATA.options.current.seconds_as_time
+                           && max >= 1000 * 1000 && max < 1000 * 1000 * 1000;
+                },
+                convert: function (nanoseconds) {
+                    nanoseconds = Math.round(nanoseconds);
+
+                    let milliseconds = Math.floor(nanoseconds / 1000 / 1000);
+                    nanoseconds -= milliseconds * 1000 * 1000;
+
+                    nanoseconds = Math.round(nanoseconds / 1000 / 10);
+
+                    return milliseconds.toString() + '.'
+                        + NETDATA.zeropad(nanoseconds);
+                }
+            },
+            'seconds': {
+                check: function (max) {
+                    return NETDATA.options.current.seconds_as_time
+                           && max >= 1000 * 1000 * 1000;
+                },
+                convert: function (nanoseconds) {
+                    nanoseconds = Math.round(nanoseconds);
+
+                    let seconds = Math.floor(nanoseconds / 1000 / 1000 / 1000);
+                    nanoseconds -= seconds * 1000 * 1000 * 1000;
+
+                    nanoseconds = Math.round(nanoseconds / 1000 / 1000 / 10);
+
+                    return seconds.toString() + '.'
+                        + NETDATA.zeropad(nanoseconds);
+                }
+            },
         }
     },
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Add a two more units that allow auto-scaling and conversion: nanoseconds and num.

As a result, e.g. 1000 nanoseconds -> 1 microseconds, 1000000 nanoseconds -> 1 milliseconds, 1000 num -> 1 num (K) etc.

##### Component Name

web/gui/dashboard

##### Additional Information

This PR just expands the existing auto-scaling units (e.g. packets/s, milliseconds, etc.) and follow the corresponding coding style.