### PR TITLE
netdata/packaging/ci:  Make timeout usage more cross-distro compliant

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -76,17 +76,6 @@ debug() {
 	[ $debug -eq 1 ] && log DEBUG "${@}"
 }
 
-os_version() {
-	OS_VERSION="unknown"
-	OS_FILE="/etc/os-release"
-	info "Detecting OS version"
-
-	[ -f ${OS_FILE} ] && OS_VERSION=$(cat ${OS_FILE} | grep '^ID=' | sed -e 's/ID=//g')
-
-	info "Detected OS version: ${OS_VERSION}"
-	echo ${OS_VERSION}
-}
-
 # -----------------------------------------------------------------------------
 # check a few commands
 
@@ -292,7 +281,7 @@ run() {
 	if [ "z${1}" = "z-t" -a "${2}" != "0" ]; then
 		t="${2}"
 		shift 2
-		case "$(os_version)" in
+		case "${NETDATA_SYSTEM_OS_ID}" in
 		"alpine")
 			timeout -t ${t} "${@}" 2>"${TMP_DIR}/run.${pid}"
 			;;

--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -76,6 +76,17 @@ debug() {
 	[ $debug -eq 1 ] && log DEBUG "${@}"
 }
 
+os_version() {
+	OS_VERSION="unknown"
+	OS_FILE="/etc/os-release"
+	info "Detecting OS version"
+
+	[ -f ${OS_FILE} ] && OS_VERSION=$(cat ${OS_FILE} | grep '^ID=' | sed -e 's/ID=//g')
+
+	info "Detected OS version: ${OS_VERSION}"
+	echo ${OS_VERSION}
+}
+
 # -----------------------------------------------------------------------------
 # check a few commands
 
@@ -281,7 +292,14 @@ run() {
 	if [ "z${1}" = "z-t" -a "${2}" != "0" ]; then
 		t="${2}"
 		shift 2
-		timeout ${t} "${@}" 2>"${TMP_DIR}/run.${pid}"
+		case "$(os_version)" in
+		"alpine")
+			timeout -t ${t} "${@}" 2>"${TMP_DIR}/run.${pid}"
+			;;
+		*)
+			timeout ${t} "${@}" 2>"${TMP_DIR}/run.${pid}"
+			;;
+		esac
 		ret=$?
 	else
 		"${@}" 2>"${TMP_DIR}/run.${pid}"


### PR DESCRIPTION
##### Summary
It has been identified that `timeout` command used within charts.d, has different syntax on Alpine linux, thus causing failures. With this change we attempt to use make timeout command usage cross-distribution compatible.

##### Testing
Installed netdata within a container, started it up and confirmed from the logs that charts.d is running properly.

Logs:
```
2019-04-30 10:26:27: charts.d: INFO: main: started from '/usr/libexec/netdata/plugins.d/charts.d.plugin' with options: 1
2019-04-30 10:26:27: charts.d: INFO: main: Configuration file '/usr/lib/netdata/conf.d/charts.d.conf' loaded.
2019-04-30 10:26:27: charts.d: WARNING: main: Configuration file '/etc/netdata/charts.d.conf' not found.
2019-04-30 10:26:27: charts.d: INFO: apache: is disabled. Add a line with apache=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: cpu_apps: is disabled. Add a line with cpu_apps=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: cpufreq: is disabled. Add a line with cpufreq=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: example: is disabled. Add a line with example=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: exim: is disabled. Add a line with exim=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: hddtemp: is disabled. Add a line with hddtemp=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: load_average: is disabled. Add a line with load_average=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: mem_apps: is disabled. Add a line with mem_apps=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: mysql: is disabled. Add a line with mysql=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: nginx: is disabled. Add a line with nginx=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: phpfpm: is disabled. Add a line with phpfpm=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: postfix: is disabled. Add a line with postfix=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: sensors: is disabled. Add a line with sensors=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: squid: is disabled. Add a line with squid=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: INFO: tomcat: is disabled. Add a line with tomcat=force in '/etc/netdata/charts.d.conf' to enable it (or remove the line that disables it).
2019-04-30 10:26:27: charts.d: WARNING: ap: command 'iw' is not found in /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin.
2019-04-30 10:26:27: charts.d: ERROR: ap: module's 'ap' check() function reports failure.
2019-04-30 10:26:27: python.d INFO: plugin[main] : using python v2
2019-04-30 10:26:27: charts.d: WARNING: apcupsd: command 'apcaccess' is not found in /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin.
2019-04-30 10:26:27: charts.d: ERROR: apcupsd: module's 'apcupsd' check() function reports failure.
2019-04-30 10:26:27: charts.d: WARNING: libreswan: command 'ipsec' is not found in /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin.
2019-04-30 10:26:27: charts.d: ERROR: libreswan: module's 'libreswan' check() function reports failure.
2019-04-30 10:26:27: charts.d: WARNING: nut: command 'upsc' is not found in /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin.
2019-04-30 10:26:27: charts.d: ERROR: nut: module's 'nut' check() function reports failure.
2019-04-30 10:26:27: charts.d: WARNING: opensips: command 'opensipsctl' is not found in /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin.
2019-04-30 10:26:27: charts.d: ERROR: opensips: module's 'opensips' check() function reports failure.
2019-04-30 10:26:27: charts.d: FATAL: main: No charts to collect data from.
```
##### Component Name
netdata/collectors

##### Additional Information
Fixes #5935 