### PR TITLE
netdata/packaging: Do not install netdata service when within docker

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -805,7 +805,12 @@ install_go
 progress "Install netdata at system init"
 
 NETDATA_START_CMD="${NETDATA_PREFIX}/usr/sbin/netdata"
-install_netdata_service || run_failed "Cannot install netdata init service."
+
+if grep -q docker /proc/1/cgroup >/dev/null 2>&1; then
+	echo >&2 "We are running within a docker container, will not be installing netdata service"
+else
+	install_netdata_service || run_failed "Cannot install netdata init service."
+fi
 
 # -----------------------------------------------------------------------------
 # check if we can re-start netdata

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -310,7 +310,7 @@ install_non_systemd_init() {
 				run update-rc.d netdata defaults &&
 				run update-rc.d netdata enable &&
 				return 0
-		elif [[ ${key} =~ ^(amzn-201[5678]|ol|CentOS release 6|Red Hat Enterprise Linux Server release 6|Scientific Linux CERN SLC release 6|CloudLinux Server release 6).* ]]; then
+		elif [[ ${key} =~ ^(amzn-201[5678]|ol|centos-[67]|CentOS release 6*|CentOS release 7*|Red Hat Enterprise Linux Server release 6|Scientific Linux CERN SLC release 6|CloudLinux Server release 6).* ]]; then
 			echo >&2 "Installing init.d file..."
 			run cp system/netdata-init-d /etc/init.d/netdata &&
 				run chmod 755 /etc/init.d/netdata &&

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -310,7 +310,7 @@ install_non_systemd_init() {
 				run update-rc.d netdata defaults &&
 				run update-rc.d netdata enable &&
 				return 0
-		elif [[ ${key} =~ ^(amzn-201[5678]|ol|centos-[67]|CentOS release 6*|CentOS release 7*|Red Hat Enterprise Linux Server release 6|Scientific Linux CERN SLC release 6|CloudLinux Server release 6).* ]]; then
+		elif [[ ${key} =~ ^(amzn-201[5678]|ol|CentOS release 6|Red Hat Enterprise Linux Server release 6|Scientific Linux CERN SLC release 6|CloudLinux Server release 6).* ]]; then
 			echo >&2 "Installing init.d file..."
 			run cp system/netdata-init-d /etc/init.d/netdata &&
 				run chmod 755 /etc/init.d/netdata &&


### PR DESCRIPTION
##### Summary
Fixes #5474 

After investigating more carefully the issue, the only problem that needs to be fixed on the latest version is the fact that we try to install the service scripts when running within docker.

Conceptually, docker containers do not run systemd or init and our process is not possible to succeed, plus we don't need a service script within docker.

##### Component Name
netdata/packaging

##### Additional Information
None
