### PR TITLE
Fix coverity warnings

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -674,12 +674,15 @@ int get_system_info () {
             if (*value=='=') {
                 *value='\0';
                 value++;
-                char *newline = value + strlen(value) - 1;
-                (*newline)='\0';
-            }
-            if (name && value && *name && *value) {
-                info("%s=%s", name, value);
-                setenv(name, value, 1);
+                if (strlen(value)>1) {
+                    char *newline = value + strlen(value) - 1;
+                    (*newline) = '\0';
+                }
+                char n[51], v[51];
+                snprintfz(n,50,"%s",name);
+                snprintfz(v,50,"%s",value);
+                info("%s=%s", n, v);
+                setenv(n, v, 1);
             }
         }
         mypclose(fp, command_pid);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -678,9 +678,9 @@ int get_system_info () {
                     char *newline = value + strlen(value) - 1;
                     (*newline) = '\0';
                 }
-                char n[51], v[51];
+                char n[51], v[101];
                 snprintfz(n,50,"%s",name);
-                snprintfz(v,50,"%s",value);
+                snprintfz(v,101,"%s",value);
                 info("%s=%s", n, v);
                 setenv(n, v, 1);
             }


### PR DESCRIPTION
##### Summary
Fixes #5937 

##### Component Name
daemon

##### Additional Information
Fix tainted string usage and warning on checking `value`. 
