### PR TITLE
packaging/installer/kickstart{,-static64}.sh: colorize run() function…again

### DIFF
--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -55,7 +55,7 @@ run() {
 		info_console="[${TPUT_DIM}${dir}${TPUT_RESET}]$ "
 	fi
 
-	escaped_print "${info_console}${TPUT_BOLD}${TPUT_YELLOW}" "${@}" "${TPUT_RESET}\n" >&2
+	print >&2 "%s " "${info_console}${TPUT_BOLD}${TPUT_YELLOW}" "${@}" "${TPUT_RESET}"
 
 	"${@}"
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -81,7 +81,7 @@ run() {
 		info_console="[${TPUT_DIM}${dir}${TPUT_RESET}]$ "
 	fi
 
-	escaped_print "${info_console}${TPUT_BOLD}${TPUT_YELLOW}" "${@}" "${TPUT_RESET}\n" >&2
+	printf >&2 "%s " "${info_console}${TPUT_BOLD}${TPUT_YELLOW}" "${@}" "${TPUT_RESET}"
 
 	${@}
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
I'm a new user, but when I did "bash <(curl -Ss https://my-netdata.io/kickstart.sh)", the colorized output was escaped when it should have been interpreted:

 --- Downloading script to detect required packages... --- 
$'[\E[2m/tmp/netdata-kickstart-2loeEO\E(B\E[0m]$ \E[1m\E[33m' curl -sSL --connect-timeout 10 --retry 3 https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh $'\E(B\E[0m\\n'  OK  curl -sSL --connect-timeout 10 --retry 3 https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh 

With this change, the output is colorized again.

##### Component Name
https://github.com/netdata/netdata/blob/master/packaging/installer/kickstart.sh#L84
https://github.com/netdata/netdata/blob/master/packaging/installer/kickstart-static64.sh#L58

##### Additional Information

