### PR TITLE
Add "text-only" chart renderer

### DIFF
--- a/web/gui/Makefile.am
+++ b/web/gui/Makefile.am
@@ -29,6 +29,7 @@ DASHBOARD_JS_FILES = \
     src/dashboard.js/charting/d3pie.js \
     src/dashboard.js/charting/d3.js \
     src/dashboard.js/charting/peity.js \
+    src/dashboard.js/charting/textonly.js \
     src/dashboard.js/charting.js \
     src/dashboard.js/chart-registry.js \
     src/dashboard.js/common.js \

--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -4198,8 +4198,15 @@ NETDATA.peityChartCreate = function (state, data) {
 // "Text-only" chart - Just renders the raw value to the DOM
 
 NETDATA.textOnlyCreate = function(state, data) {
-    // Round to one decimal place
-    state.element.innerHTML = Math.round(data.result[0] * 10) / 10;
+    var decimalPlaces = NETDATA.dataAttribute(state.element, 'textonly-decimal-places', 1);
+    var prefix = NETDATA.dataAttribute(state.element, 'textonly-prefix', '');
+    var suffix = NETDATA.dataAttribute(state.element, 'textonly-suffix', '');
+
+    // Round based on number of decimal places to show
+    var precision = Math.pow(10, decimalPlaces);
+    var value = Math.round(data.result[0] * precision) / precision;
+
+    state.element.textContent = prefix + value + suffix;
     return true;
 }
 

--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -4194,6 +4194,16 @@ NETDATA.peityChartCreate = function (state, data) {
     return true;
 };
 
+// ----------------------------------------------------------------------------------------------------------------
+// "Text-only" chart - Just renders the raw value to the DOM
+
+NETDATA.textOnlyCreate = function(state, data) {
+    // Round to one decimal place
+    state.element.innerHTML = Math.round(data.result[0] * 10) / 10;
+    return true;
+}
+
+NETDATA.textOnlyUpdate = NETDATA.textOnlyCreate;
 // Charts Libraries Registration
 
 NETDATA.chartLibraries = {
@@ -4631,6 +4641,48 @@ NETDATA.chartLibraries = {
             void(state);
             return 'netdata-container-gauge';
         }
+    },
+    "textonly": {
+        autoresize: function (state) {
+            void(state);
+            return false;
+        },
+        container_class: function (state) {
+            void(state);
+            return 'netdata-container';
+        },
+        create: NETDATA.textOnlyCreate,
+        enabled: true,
+        format: function (state) {
+            void(state);
+            return 'array';
+        },
+        initialized: true,
+        initialize: function (callback) {
+            callback();
+        },
+        legend: function (state) {
+            void(state);
+            return null;
+        },
+        max_updates_to_recreate: function (state) {
+            void(state);
+            return 5000;
+        },
+        options: function (state) {
+            void(state);
+            return 'absolute';
+        },
+        pixels_per_point: function (state) {
+            void(state);
+            return 3;
+        },
+        track_colors: function (state) {
+            void(state);
+            return false;
+        },
+        update: NETDATA.textOnlyUpdate,
+        xssRegexIgnore: new RegExp('^/api/v1/data\.result$'),
     }
 };
 

--- a/web/gui/src/dashboard.js/charting.js
+++ b/web/gui/src/dashboard.js/charting.js
@@ -436,6 +436,48 @@ NETDATA.chartLibraries = {
             void(state);
             return 'netdata-container-gauge';
         }
+    },
+    "textonly": {
+        autoresize: function (state) {
+            void(state);
+            return false;
+        },
+        container_class: function (state) {
+            void(state);
+            return 'netdata-container';
+        },
+        create: NETDATA.textOnlyCreate,
+        enabled: true,
+        format: function (state) {
+            void(state);
+            return 'array';
+        },
+        initialized: true,
+        initialize: function (callback) {
+            callback();
+        },
+        legend: function (state) {
+            void(state);
+            return null;
+        },
+        max_updates_to_recreate: function (state) {
+            void(state);
+            return 5000;
+        },
+        options: function (state) {
+            void(state);
+            return 'absolute';
+        },
+        pixels_per_point: function (state) {
+            void(state);
+            return 3;
+        },
+        track_colors: function (state) {
+            void(state);
+            return false;
+        },
+        update: NETDATA.textOnlyUpdate,
+        xssRegexIgnore: new RegExp('^/api/v1/data\.result$'),
     }
 };
 

--- a/web/gui/src/dashboard.js/charting/textonly.js
+++ b/web/gui/src/dashboard.js/charting/textonly.js
@@ -1,0 +1,11 @@
+
+// ----------------------------------------------------------------------------------------------------------------
+// "Text-only" chart - Just renders the raw value to the DOM
+
+NETDATA.textOnlyCreate = function(state, data) {
+    // Round to one decimal place
+    state.element.innerHTML = Math.round(data.result[0] * 10) / 10;
+    return true;
+}
+
+NETDATA.textOnlyUpdate = NETDATA.textOnlyCreate;

--- a/web/gui/src/dashboard.js/charting/textonly.js
+++ b/web/gui/src/dashboard.js/charting/textonly.js
@@ -3,8 +3,15 @@
 // "Text-only" chart - Just renders the raw value to the DOM
 
 NETDATA.textOnlyCreate = function(state, data) {
-    // Round to one decimal place
-    state.element.innerHTML = Math.round(data.result[0] * 10) / 10;
+    var decimalPlaces = NETDATA.dataAttribute(state.element, 'textonly-decimal-places', 1);
+    var prefix = NETDATA.dataAttribute(state.element, 'textonly-prefix', '');
+    var suffix = NETDATA.dataAttribute(state.element, 'textonly-suffix', '');
+
+    // Round based on number of decimal places to show
+    var precision = Math.pow(10, decimalPlaces);
+    var value = Math.round(data.result[0] * precision) / precision;
+
+    state.element.textContent = prefix + value + suffix;
     return true;
 }
 


### PR DESCRIPTION
##### Summary
Adds a "text-only" chart renderer. The idea is that you can do something like this:

```html
<div data-netdata="system.cpu" data-chart-library="textonly"></div>
```

And it'll just show the raw value within the element. Probably worth adding more options, but this is just a basic implementation to start with.

Demo: https://d.ls/netdata/textonly-test.htm

Fixes #5578 

##### Component Name
web/gui

##### Additional Information

