### PR TITLE
Do not cache alarms and info api calls. Extend no-cache headers.

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -208,6 +208,7 @@ inline int web_client_api_request_v1_alarms(RRDHOST *host, struct web_client *w,
     buffer_flush(w->response.data);
     w->response.data->contenttype = CT_APPLICATION_JSON;
     health_alarms2json(host, w->response.data, all);
+    buffer_no_cacheable(w->response.data);
     return 200;
 }
 
@@ -754,6 +755,7 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
     buffer_strcat(wb, "\n\t]\n");
 
     buffer_strcat(wb, "}");
+    buffer_no_cacheable(wb);
     return 200;
 }
 

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1006,7 +1006,7 @@ static inline void web_client_send_http_header(struct web_client *w) {
         buffer_sprintf(w->response.header_output,
                 "Cache-Control: %s\r\n"
                         "Expires: %s\r\n",
-                (w->response.data->options & WB_CONTENT_NO_CACHEABLE)?"no-cache":"public",
+                (w->response.data->options & WB_CONTENT_NO_CACHEABLE)?"no-cache, no-store, must-revalidate\r\nPragma: no-cache":"public",
                 edate);
     }
 


### PR DESCRIPTION
##### Summary
`/api/v1/info` and `/api/v1/alarms` are very important, time-sensitive calls that shouldn't be cached. 
Also modified the headers in all cases no no-cache to the following:
```
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
```
##### Component Name
web/server/api


