### PR TITLE
netdata/packaging: Fix failing CI nightly process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -231,6 +231,8 @@ jobs:
     - packaging/docker/build.sh
     - packaging/docker/publish.sh
     after_failure: post_message "TRAVIS_MESSAGE" "<!here> Nightly docker image publish failed"
+    git:
+      depth: false
     env: ALLOW_SOFT_FAILURE_HERE=true
 
   - name: Create nightly release artifacts, publish to GCS
@@ -242,6 +244,8 @@ jobs:
     - echo "packaging/version:" && cat packaging/version
     - .travis/create_artifacts.sh
     after_failure: post_message "TRAVIS_MESSAGE" "<!here> Nightly artifacts generation failed"
+    git:
+      depth: false
     before_deploy:
       echo "Preparing creds under ${TRAVIS_REPO_SLUG}";
       if [ "${TRAVIS_REPO_SLUG}" == "netdata/netdata" ]; then


### PR DESCRIPTION
##### Summary
I noticed the build failed last night due to the way travis pulls repository content for each job.
`git describe` failed to resolve the required information because of the insufficient repo depth when fetch (--depth=50 is by default for travis in clone command)

Not 100% sure why it didn't fail before, on that step.
The last successful cron job had an increasing number less than 50, so i can only think that depth is affecting the amount of metadata historically available, thus popped now and not earlier

##### Component Name
netdata/packaging

##### Additional Information
None