### PR TITLE
netdata/packaging: Make docker image bring onboard the required packages for the new DB

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -49,12 +49,17 @@ RUN if [ "$(uname -m)" == "x86_64" ]; then \
     fi
 
 # Copy files over
+RUN mkdir -p /opt/src
 COPY --from=builder /app /
+COPY --from=builder /opt/src /opt/src
 
 # Configure system
 ARG NETDATA_UID=201
 ARG NETDATA_GID=201
 RUN \
+    # provide judy installation to base image
+    apk add make alpine-sdk && \
+    cd /opt/src/judy-1.0.5 && make install && cd - && \
     # fping from alpine apk is on a different location. Moving it.
     mv /usr/sbin/fping /usr/local/bin/fping && \
     chmod 4755 /usr/local/bin/fping && \


### PR DESCRIPTION
##### Summary
Having completed https://github.com/netdata/helper-images/pull/3 to build Judy within our docker builder images, we need to pull Judy binaries in from the builder image.

This PR does exactly that and it is required, in order to merge #5282 that is actually consuming these new packages that we have built on  https://github.com/netdata/helper-images/pull/3

##### Component Name
netdata/packaging

##### Additional Information
