### PR TITLE
netdata/packaging: Fix broken netdata docker image for dbengine-enabled code

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -5,7 +5,9 @@
 # It is automated in `build.sh` script
 ARG ARCH=amd64
 # This image contains preinstalled dependecies
-FROM netdata/builder:${ARCH} as builder 
+FROM netdata/builder:${ARCH} as builder
+
+ENV JUDY_VER 1.0.5
 
 # Copy source
 COPY . /opt/netdata.git
@@ -29,6 +31,7 @@ RUN mkdir -p /app/usr/sbin/ \
     mv /var/lib/netdata     /app/var/lib/ && \
     mv /etc/netdata         /app/etc/ && \
     mv /usr/sbin/netdata    /app/usr/sbin/ && \
+    mv /judy-${JUDY_VER}    /app/judy-${JUDY_VER} && \
     mv packaging/docker/run.sh        /app/usr/sbin/ && \
     chmod +x /app/usr/sbin/run.sh
 
@@ -51,7 +54,6 @@ RUN if [ "$(uname -m)" == "x86_64" ]; then \
 # Copy files over
 RUN mkdir -p /opt/src
 COPY --from=builder /app /
-COPY --from=builder /opt/src /opt/src
 
 # Configure system
 ARG NETDATA_UID=201
@@ -59,7 +61,9 @@ ARG NETDATA_GID=201
 RUN \
     # provide judy installation to base image
     apk add make alpine-sdk && \
-    cd /opt/src/judy-1.0.5 && make install && cd - && \
+    cd /judy-${JUDY_VER} && make install && cd / && \
+    # Clean the source stuff once judy is installed
+    rm -rf /judy-${JUDY_VER} && apk del make alpine-sdk && \
     # fping from alpine apk is on a different location. Moving it.
     mv /usr/sbin/fping /usr/local/bin/fping && \
     chmod 4755 /usr/local/bin/fping && \


### PR DESCRIPTION
##### Summary

1) Do not double COPY stuff at the second layer, that does not work like that.
    The right way to do it is install judy on /, then move over the folder just like we did with netdata to bring everything over with one COPY command.
2) After you do `make install` for judy, remove the stuff you bring in to make install command work for judy, we need to keep image size optimal

The image has been tested with the latest fixes from the helper-images side.
This change should be merged in AFTER we merge in helper-images fix

##### Component Name
netdata/packaging/docker

##### Additional Information
This PR should be merged *AFTER* https://github.com/netdata/helper-images/pull/5 has been merged and new images has been prepared.

Also Fixes #6018 