### PR TITLE
Reduce HTML documentation font size

### DIFF
--- a/docs/generator/custom/css/netdata.css
+++ b/docs/generator/custom/css/netdata.css
@@ -3,5 +3,5 @@
 }
 
 .md-typeset {
-    font-size: .7rem
+    font-size: .75rem
 }

--- a/docs/generator/custom/css/netdata.css
+++ b/docs/generator/custom/css/netdata.css
@@ -1,3 +1,7 @@
 .md-nav__link {
     white-space: nowrap;
 }
+
+.md-typeset {
+    font-size: .7rem
+}


### PR DESCRIPTION
##### Summary
Slightly HTML docs font size to fit .md lines.

##### Component Name
docs

##### Additional Information
The editors used to create the .md documents expect a certain number of chars to fit on every screen. The produced HTML docs take more space per line, thus breaking some lines, with a poor result.