### PR TITLE
Improve paragraphs in HTML docs

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -87,7 +87,6 @@ markdown_extensions:
  - admonition
  - codehilite
  - meta
- - nl2br
  - sane_lists
  - smarty
  - toc:


### PR DESCRIPTION
##### Summary
Remove nl2brt mkdocs addon to get the same view in html docs as in markdown

##### Component Name
docs

##### Additional Information
github needs two successive new lines to break a paragraph. The nl2brt mkdocs addon converts every new line to a paragraph. Remove it to get consistent views.
