### PR TITLE
netdata/packaging: Adjust auto-updater installation logic

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -958,39 +958,58 @@ To start netdata run:
 
   ${TPUT_YELLOW}${TPUT_BOLD}${NETDATA_START_CMD}${TPUT_RESET}
 
-
 END
 echo >&2 "Uninstall script copied to: ${TPUT_RED}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata-uninstaller.sh${TPUT_RESET}"
+echo >&2
 
-if [ "${AUTOUPDATE}" = "1" ]; then
-	if [ "${UID}" -ne "0" ]; then
-		echo >&2 "You need to run the installer as root for auto-updating via cron."
+progress "Install netdata updater tool"
+
+if [ -f "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" ]; then
+	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata-updater" || exit 1
+else
+	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata-updater" || exit 1
+fi
+
+chmod 0755 ${NETDATA_PREFIX}/usr/libexec/netdata-updater
+echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata-updater${TPUT_RESET}"
+echo >&2
+
+# Figure out the cron directory for the distro
+crondir=
+[ -d "/etc/periodic/daily" ] && crondir="/etc/periodic/daily"
+[ -d "/etc/cron.daily" ] && crondir="/etc/cron.daily"
+
+if [ -z "${crondir}" ]; then
+	echo >&2 "Cannot figure out the cron directory to handle netdata-updater activation/deactivation"
+elif [ "${UID}" -ne "0" ]; then
+	# We cant touch cron if we are not running as root
+	echo >&2 "You need to run the installer as root for auto-updating via cron."
+else
+	progress "Check if we must netdata-updater"
+	if [ "${AUTOUPDATE}" = "1" ]; then
+		if [ -f "${crondir}/netdata-updater.sh" ]; then
+			progress "Removing incorrect netdata-updater filename in cron"
+			rm -f "${crondir}/netdata-updater.sh"
+		fi
+
+		echo >&2 "Adding to cron"
+
+		rm -f "${crondir}/netdata-updater"
+		ln -sf "${NETDATA_PREFIX}/usr/libexec/netdata-updater" "${crondir}/netdata-updater"
+
+		echo >&2 "Auto-updating has been enabled. Updater script linked to: ${TPUT_RED}${TPUT_BOLD}${crondir}/netdata-update${TPUT_RESET}"
+		echo >&2
+		echo >&2 "${TPUT_DIM}${TPUT_BOLD}netdata-updater${TPUT_RESET}${TPUT_DIM} works from cron. It will trigger an email from cron"
+		echo >&2 "only if it fails (it should not print anything when it can update netdata).${TPUT_RESET}"
 	else
-		crondir=
-		[ -d "/etc/periodic/daily" ] && crondir="/etc/periodic/daily"
-		[ -d "/etc/cron.daily" ] && crondir="/etc/cron.daily"
+		echo >&2 "You chose *NOT* to enable auto-update, removing any links to the updater from cron (it may have happened if you are reinstalling)"
+		echo >&2
 
-		if [ -z "${crondir}" ]; then
-			echo >&2 "Cannot figure out the cron directory to install netdata-updater"
-		else
-			if [ -f "${crondir}/netdata-updater.sh" ]; then
-				progress "Removing incorrect netdata-updater filename in cron"
-				rm -f "${crondir}/netdata-updater.sh"
-			fi
-			progress "Installing new netdata-updater in cron"
-
+		if [ -f "${crondir}/netdata-updater" ]; then
+			echo >&2 "Removing cron reference: ${crondir}/netdata-updater"
 			rm -f "${crondir}/netdata-updater"
-			if [ -f "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" ]; then
-				sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${crondir}/netdata-updater" || exit 1
-			else
-				sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${crondir}/netdata-updater" || exit 1
-			fi
-
-			chmod 0755 ${crondir}/netdata-updater
-			echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${crondir}/netdata-updater${TPUT_RESET}"
-			echo >&2
-			echo >&2 "${TPUT_DIM}${TPUT_BOLD}netdata-updater${TPUT_RESET}${TPUT_DIM} works from cron. It will trigger an email from cron"
-			echo >&2 "only if it fails (it should not print anything when it can update netdata).${TPUT_RESET}"
+		else
+			echo >&2 "Did not find any cron entries to remove"
 		fi
 	fi
 fi

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -965,13 +965,13 @@ echo >&2
 progress "Install netdata updater tool"
 
 if [ -f "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" ]; then
-	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata-updater" || exit 1
+	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh" || exit 1
 else
-	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata-updater" || exit 1
+	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh" || exit 1
 fi
 
-chmod 0755 ${NETDATA_PREFIX}/usr/libexec/netdata-updater
-echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata-updater${TPUT_RESET}"
+chmod 0755 ${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh
+echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh${TPUT_RESET}"
 echo >&2
 
 # Figure out the cron directory for the distro
@@ -980,12 +980,12 @@ crondir=
 [ -d "/etc/cron.daily" ] && crondir="/etc/cron.daily"
 
 if [ -z "${crondir}" ]; then
-	echo >&2 "Cannot figure out the cron directory to handle netdata-updater activation/deactivation"
+	echo >&2 "Cannot figure out the cron directory to handle netdata-updater.sh activation/deactivation"
 elif [ "${UID}" -ne "0" ]; then
 	# We cant touch cron if we are not running as root
 	echo >&2 "You need to run the installer as root for auto-updating via cron."
 else
-	progress "Check if we must netdata-updater"
+	progress "Check if we must enable/disable the netdata updater"
 	if [ "${AUTOUPDATE}" = "1" ]; then
 		if [ -f "${crondir}/netdata-updater.sh" ]; then
 			progress "Removing incorrect netdata-updater filename in cron"
@@ -995,11 +995,11 @@ else
 		echo >&2 "Adding to cron"
 
 		rm -f "${crondir}/netdata-updater"
-		ln -sf "${NETDATA_PREFIX}/usr/libexec/netdata-updater" "${crondir}/netdata-updater"
+		ln -sf "${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh" "${crondir}/netdata-updater"
 
 		echo >&2 "Auto-updating has been enabled. Updater script linked to: ${TPUT_RED}${TPUT_BOLD}${crondir}/netdata-update${TPUT_RESET}"
 		echo >&2
-		echo >&2 "${TPUT_DIM}${TPUT_BOLD}netdata-updater${TPUT_RESET}${TPUT_DIM} works from cron. It will trigger an email from cron"
+		echo >&2 "${TPUT_DIM}${TPUT_BOLD}netdata-updater.sh${TPUT_RESET}${TPUT_DIM} works from cron. It will trigger an email from cron"
 		echo >&2 "only if it fails (it should not print anything when it can update netdata).${TPUT_RESET}"
 	else
 		echo >&2 "You chose *NOT* to enable auto-update, removing any links to the updater from cron (it may have happened if you are reinstalling)"


### PR DESCRIPTION
##### Summary
1) Always install updater script under libexec, together with the uninstall script
2) When the user asks for auto-update, then just link the script to the cron directory
3) When the user hasnt asked for auto-update, make sure the cron link is removed

Added extra info along all those lines.
There was also an algorithmic cleanup, in the way we do the checks so things are clearer

Note: When user hasnt provided auto-update flag, means he doesnt want auto-update so we remove it.
The automatic run of the updater knows it has to use the flag (its saved in .environment), so we wont face problems there

##### Component Name
netdata/packaging/installer

##### Additional Information
Fixes #5673
