### PR TITLE
netdata/packaging: Fix makeself packaging

### DIFF
--- a/.travis/create_artifacts.sh
+++ b/.travis/create_artifacts.sh
@@ -1,11 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Artifacts creation script.
+# This script generates two things:
+#   1) The static binary that can run on all linux distros (built-in dependencies etc)
+#   2) The distribution source tarbal
+#
+# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author: Paul Emm. Katsoulakis <paul@netdata.cloud>
+#
 # shellcheck disable=SC2230
 
 set -e
 
-if [ ! -f .gitignore ]; then
-	echo "Run as ./travis/$(basename "$0") from top level directory of git repository"
-	exit 1
+# If we are not in netdata git repo, at the top level directory, fail
+TOP_LEVEL=$(basename "$(git rev-parse --show-toplevel)")
+CWD=$(git rev-parse --show-cdup || echo "")
+if [ -n "${CWD}" ] || [ ! "${TOP_LEVEL}" == "netdata" ]; then
+    echo "Run as .travis/$(basename "$0") from top level directory of netdata git repository"
+    exit 1
 fi
 
 if [ ! "${TRAVIS_REPO_SLUG}" == "netdata/netdata" ]; then
@@ -13,8 +26,9 @@ if [ ! "${TRAVIS_REPO_SLUG}" == "netdata/netdata" ]; then
 	exit 0
 fi;
 
+
 echo "--- Initialize git configuration ---"
-git checkout master
+git checkout "${1-master}"
 git pull
 
 # Everything from this directory will be uploaded to GCS

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env sh
-# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Installation script for the alpine host
+# to prepare the static binary
+#
+# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author: Paul Emm. Katsoulakis <paul@netdata.cloud>
 
-# this script should be running in alpine linux
-# install the required packages
+# Packaging update
 apk update
+
+# Add required APK packages
 apk add --no-cache \
     bash \
     wget \
@@ -24,4 +31,18 @@ apk add --no-cache \
     zlib-dev \
     libmnl-dev \
     libnetfilter_acct-dev \
+    libuv-dev \
+    lz4-dev \
+    openssl-dev \
     || exit 1
+
+# Judy doesnt seem to be available on the repositories, download manually and install it
+export JUDY_VER="1.0.5"
+wget -O /judy.tar.gz http://downloads.sourceforge.net/project/judy/judy/Judy-${JUDY_VER}/Judy-${JUDY_VER}.tar.gz
+cd /
+tar -xf judy.tar.gz
+rm judy.tar.gz
+cd /judy-${JUDY_VER}
+CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure
+make
+make install;


### PR DESCRIPTION
##### Summary
This PR is enabling new database engine capabilities of netdata within the static binary.
On top of that there are a couple more changes:
1) fixed comments
2) Changed that weird .gitignore check with a more robust
3) Added the option to pass the desired branch to build artifacts from, defaulting being master 

##### Component Name
netdata/packaging
netdata/dbengine
##### Additional Information
None