### PR TITLE
netdata/packaging: install/uninstall fixes for macOS case

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -606,6 +606,11 @@ portable_add_user() {
 		run adduser -h "${homedir}" -s "${nologin}" -D -G "${username}" "${username}" && return 0
 	fi
 
+	# mac OS
+	if command -v sysadminctl 1> /dev/null 2>&1; then
+		run sysadminctl -addUser  ${username} && return 0
+	fi
+
 	echo >&2 "Failed to add ${username} user account !"
 
 	return 1
@@ -635,6 +640,11 @@ portable_add_group() {
 	# BusyBox
 	if command -v addgroup 1>/dev/null 2>&1; then
 		run addgroup "${groupname}" && return 0
+	fi
+
+	# mac OS
+	if command -v dseditgroup 1> /dev/null 2>&1; then
+		dseditgroup -o create "${groupname}" && return 0
 	fi
 
 	echo >&2 "Failed to add ${groupname} user group !"
@@ -674,6 +684,10 @@ portable_add_user_to_group() {
 			run addgroup "${username}" "${groupname}" && return 0
 		fi
 
+		# mac OS
+		if command -v dseditgroup 1> /dev/null 2>&1; then
+			dseditgroup -u "${username}" "${groupname}" && return 0
+		fi
 		echo >&2 "Failed to add user ${username} to group ${groupname} !"
 		return 1
 	fi

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 #shellcheck disable=SC2181
-
-# this script will uninstall netdata
-
+#
+# This is the netdata uninstaller script
 # Variables needed by script and taken from '.environment' file:
 #  - NETDATA_PREFIX
 #  - NETDATA_ADDED_TO_GROUPS
+#
+# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author: Paul Emm. Katsoulakis <paul@netdata.cloud>
+#
 
 usage="$(basename "$0") [-h] [-f ] -- program to calculate the answer to life, the universe and everything
 
@@ -46,13 +50,13 @@ while :; do
 done
 
 if [ "$YES" != "1" ]; then
-	echo "This script will REMOVE netdata from your system."
-	echo "Run it again with --yes to do it."
+	echo >&2 "This script will REMOVE netdata from your system."
+	echo >&2 "Run it again with --yes to do it."
 	exit 1
 fi
 
 if [[ $EUID -ne 0 ]]; then
-	echo "This script SHOULD be run as root or otherwise it won't delete all installed components."
+	echo >&2 "This script SHOULD be run as root or otherwise it won't delete all installed components."
 	key="n"
 	read -r -s -n 1 -p "Do you want to continue as non-root user [y/n] ? " key
 	if [ "$key" != "y" ] && [ "$key" != "Y" ]; then
@@ -60,34 +64,227 @@ if [[ $EUID -ne 0 ]]; then
 	fi
 fi
 
-function quit_msg() {
+# -----------------------------------------------------------------------------
+
+setup_terminal() {
+	TPUT_RESET=""
+	TPUT_BLACK=""
+	TPUT_RED=""
+	TPUT_GREEN=""
+	TPUT_YELLOW=""
+	TPUT_BLUE=""
+	TPUT_PURPLE=""
+	TPUT_CYAN=""
+	TPUT_WHITE=""
+	TPUT_BGBLACK=""
+	TPUT_BGRED=""
+	TPUT_BGGREEN=""
+	TPUT_BGYELLOW=""
+	TPUT_BGBLUE=""
+	TPUT_BGPURPLE=""
+	TPUT_BGCYAN=""
+	TPUT_BGWHITE=""
+	TPUT_BOLD=""
+	TPUT_DIM=""
+	TPUT_UNDERLINED=""
+	TPUT_BLINK=""
+	TPUT_INVERTED=""
+	TPUT_STANDOUT=""
+	TPUT_BELL=""
+	TPUT_CLEAR=""
+
+	# Is stderr on the terminal? If not, then fail
+	test -t 2 || return 1
+
+	if command -v tput 1>/dev/null 2>&1; then
+		if [ $(($(tput colors 2>/dev/null))) -ge 8 ]; then
+			# Enable colors
+			TPUT_RESET="$(tput sgr 0)"
+			TPUT_BLACK="$(tput setaf 0)"
+			TPUT_RED="$(tput setaf 1)"
+			TPUT_GREEN="$(tput setaf 2)"
+			TPUT_YELLOW="$(tput setaf 3)"
+			TPUT_BLUE="$(tput setaf 4)"
+			TPUT_PURPLE="$(tput setaf 5)"
+			TPUT_CYAN="$(tput setaf 6)"
+			TPUT_WHITE="$(tput setaf 7)"
+			TPUT_BGBLACK="$(tput setab 0)"
+			TPUT_BGRED="$(tput setab 1)"
+			TPUT_BGGREEN="$(tput setab 2)"
+			TPUT_BGYELLOW="$(tput setab 3)"
+			TPUT_BGBLUE="$(tput setab 4)"
+			TPUT_BGPURPLE="$(tput setab 5)"
+			TPUT_BGCYAN="$(tput setab 6)"
+			TPUT_BGWHITE="$(tput setab 7)"
+			TPUT_BOLD="$(tput bold)"
+			TPUT_DIM="$(tput dim)"
+			TPUT_UNDERLINED="$(tput smul)"
+			TPUT_BLINK="$(tput blink)"
+			TPUT_INVERTED="$(tput rev)"
+			TPUT_STANDOUT="$(tput smso)"
+			TPUT_BELL="$(tput bel)"
+			TPUT_CLEAR="$(tput clear)"
+		fi
+	fi
+
+	return 0
+}
+setup_terminal || echo >/dev/null
+
+run_ok() {
+	printf >&2 "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD} OK ${TPUT_RESET} ${*} \n\n"
+}
+
+run_failed() {
+	printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET} ${*} \n\n"
+}
+
+ESCAPED_PRINT_METHOD=
+printf "%q " test >/dev/null 2>&1
+[ $? -eq 0 ] && ESCAPED_PRINT_METHOD="printfq"
+escaped_print() {
+	if [ "${ESCAPED_PRINT_METHOD}" = "printfq" ]; then
+		printf "%q " "${@}"
+	else
+		printf "%s" "${*}"
+	fi
+	return 0
+}
+
+run_logfile="/dev/null"
+run() {
+	local user="${USER--}" dir="${PWD}" info info_console
+
+	if [ "${UID}" = "0" ]; then
+		info="[root ${dir}]# "
+		info_console="[${TPUT_DIM}${dir}${TPUT_RESET}]# "
+	else
+		info="[${user} ${dir}]$ "
+		info_console="[${TPUT_DIM}${dir}${TPUT_RESET}]$ "
+	fi
+
+	printf >>"${run_logfile}" "${info}"
+	escaped_print >>"${run_logfile}" "${@}"
+	printf >>"${run_logfile}" " ... "
+
+	printf >&2 "${info_console}${TPUT_BOLD}${TPUT_YELLOW}"
+	escaped_print >&2 "${@}"
+	printf >&2 "${TPUT_RESET}\n"
+
+	"${@}"
+
+	local ret=$?
+	if [ ${ret} -ne 0 ]; then
+		run_failed
+		printf >>"${run_logfile}" "FAILED with exit code ${ret}\n"
+	else
+		run_ok
+		printf >>"${run_logfile}" "OK\n"
+	fi
+
+	return ${ret}
+}
+
+portable_del_group() {
+	local groupname="${1}"
+
+	# Check if group exist
+	echo >&2 "Removing ${groupname} user group ..."
+
+	# Linux
+	if command -v groupdel 1>/dev/null 2>&1; then
+		run groupdel -f "${groupname}" && return 0
+	fi
+
+	# mac OS
+	if command -v dseditgroup 1> /dev/null 2>&1; then
+		if dseditgroup -o read netdata 1> /dev/null 2>&1; then
+			run dseditgroup -o delete "${groupname}" && return 0
+		else
+			echo >&2 "Could not find group ${groupname}, nothing to do"
+		fi
+	fi
+
+	echo >&2 "Group ${groupname} was not automatically removed, you might have to remove it manually"
+	return 1
+}
+
+portable_del_user() {
+	local username="${1}"
+	echo >&2 "Deleting ${username} user account ..."
+
+	# Linux
+	if command -v userdel 1>/dev/null 2>&1; then
+		run userdel -f "${username}" && return 0
+	fi
+
+	# mac OS
+	if command -v sysadminctl 1>/dev/null 2>&1; then
+		run sysadminctl -deleteUser "${username}" && return 0
+	fi
+
+	echo >&2 "User ${username} could not be deleted from system, you might have to remove it manually"
+	return 1
+}
+
+portable_del_user_from_group() {
+	local groupname="${1}" username="${2}"
+
+	# username is not in group
+	echo >&2 "Deleting ${username} user from ${groupname} group ..."
+
+	# Linux
+	if command -v gpasswd 1>/dev/null 2>&1; then
+		run gpasswd -d "netdata" "${group}" && return 0
+	fi
+
+	# FreeBSD
+	if command -v pw 1>/dev/null 2>&1; then
+		run pw groupmod "${groupname}" -d "${username}" && return 0
+	fi
+
+	# BusyBox
+	if command -v delgroup 1>/dev/null 2>&1; then
+		run delgroup "${username}" "${groupname}" && return 0
+	fi
+
+	# mac OS
+	if command -v dseditgroup 1> /dev/null 2>&1; then
+		run dseditgroup -o delete -u "${username}" "${groupname}" && return 0
+	fi
+
+	echo >&2 "Failed to delete user ${username} from group ${groupname} !"
+	return 1
+}
+
+quit_msg() {
 	echo
 	if [ "$FILE_REMOVAL_STATUS" -eq 0 ]; then
-		echo "Something went wrong :("
+		echo >&2 "Something went wrong :("
 	else
-		echo "Netdata files were successfully removed from your system"
+		echo >&2 "Netdata files were successfully removed from your system"
 	fi
 }
 
-function user_input() {
+user_input() {
 	TEXT="$1"
 	if [ "${INTERACTIVITY}" == "-i" ]; then
 		read -r -p "$TEXT" >&2
 	fi
 }
 
-function rm_file() {
+rm_file() {
 	FILE="$1"
 	if [ -f "${FILE}" ]; then
-		rm -v ${INTERACTIVITY} "${FILE}"
+		run rm -v ${INTERACTIVITY} "${FILE}"
 	fi
 }
 
-function rm_dir() {
+rm_dir() {
 	DIR="$1"
 	if [ -n "$DIR" ] && [ -d "$DIR" ]; then
 		user_input "Press ENTER to recursively delete directory '$DIR' > "
-		rm -v -f -R "${DIR}"
+		run rm -v -f -R "${DIR}"
 	fi
 }
 
@@ -116,14 +313,14 @@ trap quit_msg EXIT
 source "${ENVIRONMENT_FILE}" || exit 1
 
 #### STOP NETDATA
-echo "Stopping a possibly running netdata..."
+echo >&2 "Stopping a possibly running netdata..."
 for p in $(netdata_pids); do
 	i=0
 	while kill "${p}" 2>/dev/null; do
 		if [ "$i" -gt 30 ]; then
-			echo "Forcefully stopping netdata with pid ${p}"
-			kill -9 "${p}"
-			sleep 2
+			echo >&2 "Forcefully stopping netdata with pid ${p}"
+			run kill -9 "${p}"
+			run sleep 2
 			break
 		fi
 		sleep 1
@@ -155,15 +352,18 @@ fi
 
 FILE_REMOVAL_STATUS=1
 
-#### REMOVE NETDATA USER & GROUP
+#### REMOVE NETDATA USER FROM ADDED GROUPS
 if [ -n "$NETDATA_ADDED_TO_GROUPS" ]; then
 	user_input "Press ENTER to delete 'netdata' from following groups: '$NETDATA_ADDED_TO_GROUPS' > "
 	for group in $NETDATA_ADDED_TO_GROUPS; do
-		gpasswd -d netdata "${group}"
+		portable_del_user_from_group "${group}" "netdata"
 	done
 fi
 
+#### REMOVE USER
 user_input "Press ENTER to delete 'netdata' system user > "
-userdel -f netdata || :
+portable_del_user "netdata" || :
+
+### REMOVE GROUP
 user_input "Press ENTER to delete 'netdata' system group > "
-groupdel -f netdata || :
+portable_del_group "netdata" || :

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -68,30 +68,12 @@ fi
 
 setup_terminal() {
 	TPUT_RESET=""
-	TPUT_BLACK=""
-	TPUT_RED=""
-	TPUT_GREEN=""
 	TPUT_YELLOW=""
-	TPUT_BLUE=""
-	TPUT_PURPLE=""
-	TPUT_CYAN=""
 	TPUT_WHITE=""
-	TPUT_BGBLACK=""
 	TPUT_BGRED=""
 	TPUT_BGGREEN=""
-	TPUT_BGYELLOW=""
-	TPUT_BGBLUE=""
-	TPUT_BGPURPLE=""
-	TPUT_BGCYAN=""
-	TPUT_BGWHITE=""
 	TPUT_BOLD=""
 	TPUT_DIM=""
-	TPUT_UNDERLINED=""
-	TPUT_BLINK=""
-	TPUT_INVERTED=""
-	TPUT_STANDOUT=""
-	TPUT_BELL=""
-	TPUT_CLEAR=""
 
 	# Is stderr on the terminal? If not, then fail
 	test -t 2 || return 1
@@ -100,30 +82,12 @@ setup_terminal() {
 		if [ $(($(tput colors 2>/dev/null))) -ge 8 ]; then
 			# Enable colors
 			TPUT_RESET="$(tput sgr 0)"
-			TPUT_BLACK="$(tput setaf 0)"
-			TPUT_RED="$(tput setaf 1)"
-			TPUT_GREEN="$(tput setaf 2)"
 			TPUT_YELLOW="$(tput setaf 3)"
-			TPUT_BLUE="$(tput setaf 4)"
-			TPUT_PURPLE="$(tput setaf 5)"
-			TPUT_CYAN="$(tput setaf 6)"
 			TPUT_WHITE="$(tput setaf 7)"
-			TPUT_BGBLACK="$(tput setab 0)"
 			TPUT_BGRED="$(tput setab 1)"
 			TPUT_BGGREEN="$(tput setab 2)"
-			TPUT_BGYELLOW="$(tput setab 3)"
-			TPUT_BGBLUE="$(tput setab 4)"
-			TPUT_BGPURPLE="$(tput setab 5)"
-			TPUT_BGCYAN="$(tput setab 6)"
-			TPUT_BGWHITE="$(tput setab 7)"
 			TPUT_BOLD="$(tput bold)"
 			TPUT_DIM="$(tput dim)"
-			TPUT_UNDERLINED="$(tput smul)"
-			TPUT_BLINK="$(tput blink)"
-			TPUT_INVERTED="$(tput rev)"
-			TPUT_STANDOUT="$(tput smso)"
-			TPUT_BELL="$(tput bel)"
-			TPUT_CLEAR="$(tput clear)"
 		fi
 	fi
 


### PR DESCRIPTION

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
1) fix add/remove user and add/remove group to handle when running on mac
2) fix uninstaller to be more portable (function declarations that wont work everywhere)
3) add some portability code in the uninstaller, for add/remove user. Previously we just attempd a blind delete for linux
4) colorize uninstaller a little bit

##### Component Name
netdata/packaging

##### Additional Information
Fixes #5737 

Was tested on mac OS 10.14.4 and also on Gentoo, CentOS 7 and Ubuntu 1804 to catch a broad variety of distros (Changes are not so much version specific, more like distro specific)