### PR TITLE
netdata/daemon/backends: Fix AWS Kinesis link error

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -508,9 +508,9 @@ netdata_LDADD = \
 	$(NETDATA_COMMON_LIBS) \
 	$(NULL)
 if ENABLE_BACKEND_KINESIS
-    netdata_LINK = $(CXXLD) $(CXXFLAGS) -o $@
+    netdata_LINK = $(CXXLD) $(CXXFLAGS) $(LDFLAGS) -o $@
 else
-    netdata_LINK = $(CCLD) $(CFLAGS) -o $@
+    netdata_LINK = $(CCLD) $(CFLAGS) $(LDFLAGS) -o $@
 endif
 
 if ENABLE_PLUGIN_APPS


### PR DESCRIPTION
##### Summary
Fix AWS Kinesis link error when building on Mac OS

##### Component Name
netdata/backends

##### Additional Information
Fixes #6043 

https://www.gnu.org/software/automake/manual/html_node/Program-and-Library-Variables.html

```
maude_LINK
You can override the linker on a per-program basis. 
By default the linker is chosen according to the languages used by the program. 
For instance, a program that includes C++ source code would use the C++ compiler to link. 
The _LINK variable must hold the name of a command that can be passed all the .o file names
and libraries to link against as arguments.
Note that the name of the underlying program is not passed to _LINK; typically one uses ‘$@’:

maude_LINK = $(CCLD) -magic -o $@
If a _LINK variable is not supplied, it may still be generated and used by Automake 
due to the use of per-target link flags such as _CFLAGS, _LDFLAGS or _LIBTOOLFLAGS,
in cases where they apply.
```