### PR TITLE
Add perforce server process monitoring

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -124,5 +124,6 @@ username|name|email (optional)
 @gmosx|George Moschovitis
 @adherzog|Adam Herzog|adam@adamherzog.com
 @skrzyp1|Jerzy S.|
+@akwan|Alan Kwan|
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2FCONTRIBUTORS&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)]()

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -301,3 +301,5 @@ ipfs: ipfs
 
 node: node*
 factorio: factorio
+
+p4: p4*


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Perforce Helix has a variety of [Linux server processes](http://filehost.perforce.com/perforce/r18.2/bin.linux26x86_64/) named `p4d` (server daemon), `p4broker` (broker daemon), `p4p` (proxy daemon). Under production scenarios, only one of these would likely be running on a server or container.

##### Component Name

collectors/apps.plugin/apps_groups.conf

##### Additional Information

