### PR TITLE
Create missing /etc/netdata/custom-plugins.d

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -403,6 +403,15 @@ progress "Compile netdata"
 run make -j$(find_processors) || exit 1
 
 # -----------------------------------------------------------------------------
+progress "Create custom-plugins.d"
+if [ -d "${NETDATA_PREFIX}/etc/netdata" ]; then
+	# the configuration directory exists
+
+	if [ ! -d "${NETDATA_PREFIX}/etc/netdata/charts.d" ]; then
+		run mkdir "${NETDATA_PREFIX}/etc/netdata/custom-plugins.d"
+	fi
+	
+# -----------------------------------------------------------------------------
 progress "Migrate configuration files for node.d.plugin and charts.d.plugin"
 
 # migrate existing configuration files


### PR DESCRIPTION
Not sure if this is the right place to put this but it would seem to be an easy fix for the error that shows up in the log files:
netdata ERROR : PLUGINSD : cannot open plugins directory '/etc/netdata/custom-plugins.d' (errno 2, No such file or directory)

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

