### PR TITLE
Fix creating chart directories when not necessary with memory mode dbengine

### DIFF
--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -287,8 +287,6 @@ void *rrdeng_create_page(uuid_t *id, struct rrdeng_page_cache_descr **ret_descr)
 {
     struct rrdeng_page_cache_descr *descr;
     void *page;
-    int ret;
-
     /* TODO: check maximum number of pages in page cache limit */
 
     page = mallocz(RRDENG_BLOCK_SIZE); /*TODO: add page size */

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -146,8 +146,7 @@ char *rrdset_cache_dir(RRDHOST *host, const char *id, const char *config_section
     snprintfz(n, FILENAME_MAX, "%s/%s", host->cache_dir, b);
     ret = config_get(config_section, "cache directory", n);
 
-    if(host->rrd_memory_mode == RRD_MEMORY_MODE_MAP || host->rrd_memory_mode == RRD_MEMORY_MODE_SAVE ||
-       host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+    if(host->rrd_memory_mode == RRD_MEMORY_MODE_MAP || host->rrd_memory_mode == RRD_MEMORY_MODE_SAVE) {
         int r = mkdir(ret, 0775);
         if(r != 0 && errno != EEXIST)
             error("Cannot create directory '%s'", ret);


### PR DESCRIPTION
Fix creating chart directories when not necessary with memory mode dbengine.

Fixes #6067, Fixes #6075.

##### Component Name

database/engine

