### PR TITLE
Add "custom-plugins.d" to fix error in log file

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -175,7 +175,7 @@ fi
 
 progress "create user config directories"
 
-for x in "python.d" "charts.d" "node.d" "health.d" "statsd.d"
+for x in "python.d" "charts.d" "node.d" "health.d" "statsd.d" "custom-plugins.d"
 do
     if [ ! -d "etc/netdata/${x}" ]
         then


### PR DESCRIPTION
default netdata.conf file references this dir but installer doesn't create it. Trying to get rid of the following error from /var/log/netdata/error.log
ERROR : PLUGINSD : cannot open plugins directory '/etc/netdata/custom-plugins.d' (errno 2, No such file or directory)

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

