### PR TITLE
Create missing /etc/netdata/custom-plugins.d

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -628,7 +628,7 @@ fi
 
 # --- conf dir ----
 
-for x in "python.d" "charts.d" "node.d" "health.d" "statsd.d" "go.d"; do
+for x in "python.d" "charts.d" "node.d" "health.d" "statsd.d" "go.d" "custom-plugins.d"; do
 	if [ ! -d "${NETDATA_USER_CONFIG_DIR}/${x}" ]; then
 		echo >&2 "Creating directory '${NETDATA_USER_CONFIG_DIR}/${x}'"
 		run mkdir -p "${NETDATA_USER_CONFIG_DIR}/${x}" || exit 1


### PR DESCRIPTION
Fix Error message in error.log:
netdata ERROR : PLUGINSD : cannot open plugins directory '/etc/netdata/custom-plugins.d' (errno 2, No such file or directory)

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

