### PR TITLE
Move call to send_statistics later, to get more events from docker

### DIFF
--- a/.travis/run_install_with_dist_file.sh
+++ b/.travis/run_install_with_dist_file.sh
@@ -39,7 +39,7 @@ fi
 
 echo "Entering ${NETDATA_DIST_FOLDER} and starting docker compilation"
 cd ${NETDATA_DIST_FOLDER}
-docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:centos7" /bin/bash -c "./netdata-installer.sh --dont-wait --install /tmp && echo \"Validating netdata instance is running\" && wget -O'-' 'http://127.0.0.1:19999/api/v1/info' | grep version"
+docker run -it -v "${PWD}:/code:rw" -w /code "netdata/os-test:centos7" /bin/bash -c "./netdata-installer.sh --dont-wait --install /tmp && echo \"Validating netdata instance is running\" && wget -O'-' 'http://localhost:19999/api/v1/info' | grep version"
 
 echo "Installation completed with no errors! Removing temporary folders"
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1136,7 +1136,6 @@ int main(int argc, char **argv) {
 
 	netdata_anonymous_statistics_enabled=-1;
     struct rrdhost_system_info *system_info = calloc(1, sizeof(struct rrdhost_system_info));
-    if (get_system_info(system_info) == 0) send_statistics("START","-", "-");
 
 #ifdef NETDATA_INTERNAL_CHECKS
     if(debug_flags != 0) {
@@ -1196,6 +1195,7 @@ int main(int argc, char **argv) {
 
     info("netdata initialization completed. Enjoy real-time performance monitoring!");
     netdata_ready = 1;
+    if (get_system_info(system_info) == 0) send_statistics("START","-", "-");
 
     // ------------------------------------------------------------------------
     // unblock signals


### PR DESCRIPTION
##### Summary
Fixes #6095 

##### Additional Information
Moved the call to send_statistics as late in the startup process as possible. Got events from all containers in the k8s cluster. It may not be enough for all Docker container startup processes, but any other solution will be much more difficult. 
