### PR TITLE
Fix incorrect module name: energi

### DIFF
--- a/collectors/python.d.plugin/python.d.conf
+++ b/collectors/python.d.plugin/python.d.conf
@@ -41,7 +41,7 @@ chrony: no
 # dockerd: yes
 # dovecot: yes
 # elasticsearch: yes
-# energi: yes
+# energid: yes
 
 # this is just an example
 example: no


### PR DESCRIPTION
I think this should be "energid" because that is the name of the module and currently setting it to "no" in the config file does not turn it off.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

