### PR TITLE
Active processes number alert

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -65,6 +65,7 @@ dist_healthconfig_DATA = \
     health.d/phpfpm.conf \
     health.d/portcheck.conf \
     health.d/postgres.conf \
+    health.d/processes.conf \
     health.d/qos.conf \
     health.d/ram.conf \
     health.d/redis.conf \

--- a/health/health.d/processes.conf
+++ b/health/health.d/processes.conf
@@ -1,0 +1,27 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+   alarm: active_processes_limit_freebsd
+      on: system.active_processes
+      os: freebsd
+   hosts: *
+    calc: $active
+   units: processes
+   every: 5s
+    warn: $this > (($status >= $WARNING)  ? (75000) : (80000))
+    crit: $this > (($status == $CRITICAL) ? (85000) : (90000))
+   delay: down 5m multiplier 1.5 max 1h
+    info: the number of active processes
+      to: sysadmin
+
+   alarm: active_processes_limit
+      on: system.active_processes
+      os: linux
+   hosts: *
+    calc: $active
+   units: processes
+   every: 5s
+    warn: $this > (($status >= $WARNING)  ? (25000) : (26000))
+    crit: $this > (($status == $CRITICAL) ? (28000) : (30000))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of active processes
+      to: sysadmin


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Resolves #2239

This PR adds an alarm on abnormally high number of active processes.

The thresholds are as follow (roughly 80% and 90% of max pid value):
* FreeBSD (max process number: 999999, hardcoded):
  * WARNING: 80000 (clear alarm on 75000)
  * CRITICAL: 90000 (clear alarm on 85000)
* Linux (default max process number: 32768, can be manually changed with sysctl, up to 2^22 on 64-bit kernels and 32768 on 32-bit):
  * WARNING: 26000 (clear alarm on 25000)
  * CRITICAL: 30000 (clear alarm on 28000)

The value is taken from `system.active_processes.active`, measured every 5s (should be enough to send a notification before the limit is reached unless someone launches an exponential fork-bomb). There is no alarm for Mac OS X as the macos.plugin does not seem to return `system.active_processes`. 

##### Component Name
health

##### Additional Information
Values from:
* https://www.freebsd.org/cgi/man.cgi?query=intro&apropos=0&sektion=2&manpath=FreeBSD+12.0-RELEASE&arch=default&format=html (Process ID)
* https://github.com/torvalds/linux/blob/master/include/linux/threads.h (PID_MAX_LIMIT)


