### PR TITLE
Start Netdata after monitored systemd services

### DIFF
--- a/collectors/node.d.plugin/README.md
+++ b/collectors/node.d.plugin/README.md
@@ -22,6 +22,7 @@ At minimum, to be buildable and testable, the PR needs to include:
 * A line for the plugin in the appropriate `Makefile.am` file: `node.d/Makefile.am` under `dist_node_DATA`.
 * A line for the plugin configuration file in `conf.d/Makefile.am`: under `dist_nodeconfig_DATA`
 * Optionally, chart information in `web/dashboard_info.js`.  This generally involves specifying a name and icon for the section, and may include descriptions for the section or individual charts.
+* If the plugin requires a systemd service to be running before Netdata starts add it to `After=` in `system/netdata.service.in`.
 
 ## Motivation
 

--- a/collectors/python.d.plugin/README.md
+++ b/collectors/python.d.plugin/README.md
@@ -221,5 +221,6 @@ At minimum, to be buildable and testable, the PR needs to include:
 * A line for the plugin in `python.d/Makefile.am` under `dist_python_DATA`.
 * A line for the plugin configuration file in `conf.d/Makefile.am`, under `dist_pythonconfig_DATA`
 * Optionally, chart information in `web/dashboard_info.js`.  This generally involves specifying a name and icon for the section, and may include descriptions for the section or individual charts.
+* If the plugin requires a systemd service to be running before Netdata starts add it to `After=` in `system/netdata.service.in`.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)]()

--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -3,7 +3,16 @@
 Description=Real time performance monitoring
 
 # append here other services you want netdata to wait for them to start
-After=network.target httpd.service squid.service nfs-server.service mysqld.service mysql.service named.service postfix.service chronyd.service
+After=apache2.service beanstalkd.service bind9.service boinc-client.service chronyd.service chrony.service
+After=couchdb.service cups.service dhcpd6.service dhcpd.service dnsdist.service docker.service dovecot.service
+After=elasticsearch.service energid.service exim4.service exim.service fail2ban.service freeradius.service
+After=haproxy.service hddtemp.service httpd.service icecast2.service icecast.service ipfs.service isc-dhcp-server.service
+After=lm-sensors.service lm_sensors.service lshttpd.service mariadb.service memcached.service mongodb.service
+After=mongod.service monit.service mysql.service named.service network.target nfs-server.service nginx.service nsd.service
+After=ntpd.service ntp.service openvpn.service pdns.service php-fpm.service postfix.service postgresql.service
+After=proxysql.service puppet-master.service puppetmaster.service rabbitmq-server.service radiusd.service redis-server.service
+After=redis.service slapd.service smartd.service smbd.service smb.service squid.service tomcat.service tor.service
+After=unbound.service uwsgi.service varnish.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Resolves #4266 

This PR extends the list of systemd services that should be started before netdata.service to cover all python.d and node.d plugins. Names taken from debian and fedora repository. New point is added to `Pull Request Checklist` for node.d.plugin and python.d.plugin to ensure that future plugins are also added to netdata.service start order.

##### Component Name
system

##### Additional Information
On Debian some services (namely tomcat and php-fpm) have version numbers in their names. Since systemd does not support wildcards or regexes for dependencies I had to leave them out. The same issue applies to instantiated services (e.g. openvpn-client@config-name) https://github.com/systemd/systemd/issues/5388

List of services:
https://docs.google.com/spreadsheets/d/1sL7ubNlaxzEArEesxv5DT5NcHrHPS0vlBc-38apeLn0/edit?usp=sharing

