### PR TITLE
Fix error with apcupsd_status

### DIFF
--- a/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
+++ b/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
@@ -47,8 +47,8 @@ apcupsd_check() {
 			error "cannot get information for apcupsd server ${host} on ${apcupsd_sources[${host}]}."
 			failed=$((failed + 1))
 		else
-			apcupsd_status = "$(apcupsd_get ${apcupsd_sources[${host}]} | awk '/^STATUS.*/{ print $3 }')"
-			if [ ${apcupsd_status} != "ONLINE" ]  && [ ${apcupsd_status} != "ONBATT" ]; then
+			apcupsd_status=$(apcupsd_get ${apcupsd_sources[${host}]} | awk '/^STATUS.*/{ print $3 }')
+			if [ "$apcupsd_status" != "ONLINE" ]  && [ "$apcupsd_status" != "ONBATT" ]; then
 				error "APC UPS ${host} on ${apcupsd_sources[${host}]} is not online."
 				failed=$((failed + 1))
 			else


### PR DESCRIPTION
apcupsd_status fails to run.
Fixes the following errors in log:
/usr/libexec/netdata/plugins.d/../charts.d/apcupsd.chart.sh: line 50: apcupsd_status: command not found
/usr/libexec/netdata/plugins.d/../charts.d/apcupsd.chart.sh: line 51: [: !=: unary operator expected

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

