### PR TITLE
tmp file not created

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -17,7 +17,7 @@ export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 
 PROGRAM_FILE="$0"
 PROGRAM_NAME="$(basename $0)"
-PROGRAM_NAME="${PROGRAM_NAME/.plugin/}"
+PROGRAM_NAME="${PROGRAM_NAME}/.plugin/"
 MODULE_NAME="main"
 
 # -----------------------------------------------------------------------------
@@ -39,7 +39,7 @@ trap chartsd_cleanup EXIT QUIT HUP INT TERM
 if [ $UID = "0" ]; then
 	TMP_DIR="$(mktemp -d /var/run/netdata-${PROGRAM_NAME}-XXXXXXXXXX)"
 else
-	TMP_DIR="$(mktemp -d /tmp/.netdata-${PROGRAM_NAME}-XXXXXXXXXX)"
+	TMP_DIR="$(mktemp -d /tmp/netdata-${PROGRAM_NAME}-XXXXXXXXXX)"
 fi
 
 logdate() {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Trying to fix the following error:

> rm: cannot remove '/tmp/.netdata-charts.d-p2IviKryfN/run.8500': No such file or directory

I'm pretty sure what I have fixed was incorrect but the error still persists.
With my changes charts.d will create the dir /tmp/netdata-charts.d-XXXXXX
However, there is no "run.XXXX' file written into it.
Hopefully someone can look at this and see what else is wrong.

##### Component Name
charts.d
##### Additional Information

