### PR TITLE
Fix telemetry config in netdata-installer

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -540,6 +540,7 @@ progress "Install logrotate configuration for netdata"
 
 install_netdata_logrotate
 
+
 # -----------------------------------------------------------------------------
 progress "Read installation options from netdata.conf"
 
@@ -812,6 +813,16 @@ install_go() {
 install_go
 
 # -----------------------------------------------------------------------------
+progress "Telemetry configuration"
+
+# Opt-out from telemetry program
+if [ -n "${NETDATA_DISABLE_TELEMETRY+x}" ]; then
+	run touch "${NETDATA_USER_CONFIG_DIR}/.opt-out-from-anonymous-statistics"
+else
+	printf "You can opt out from anonymous statistics via the --disable-telemetry option, or by creating an empty file ${NETDATA_USER_CONFIG_DIR}/.opt-out-from-anonymous-statistics \n\n"
+fi
+
+# -----------------------------------------------------------------------------
 progress "Install netdata at system init"
 
 NETDATA_START_CMD="${NETDATA_PREFIX}/usr/sbin/netdata"
@@ -1035,12 +1046,6 @@ RELEASE_CHANNEL="${RELEASE_CHANNEL}"
 NETDATA_TARBALL_CHECKSUM="new_installation"
 EOF
 
-# Opt-out from telemetry program
-if [ -n "${NETDATA_DISABLE_TELEMETRY+x}" ]; then
-	touch "${NETDATA_USER_CONFIG_DIR}/.opt-out-from-anonymous-statistics"
-else
-	progress "You can opt out from anonymous statistics via the --disable-telemetry option, or by creating an empty file ${NETDATA_USER_CONFIG_DIR}/.opt-out-from-anonymous-statistics"
-fi
 
 # -----------------------------------------------------------------------------
 echo >&2


### PR DESCRIPTION
##### Summary
Fixes #6129 
Move telemetry config before netdata is restarted and fix the console message

##### Component Name
installer

##### Additional Information
The config option --disable-telemetry was being checked after restarting netdata, which means that we would still send anonymous statistics the first time netdata was started.

The new message had the wrong format.
