### PR TITLE
Optimize calls that gather system info

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -670,7 +670,7 @@ static int load_netdata_conf(char *filename, char overwrite_used) {
     return ret;
 }
 
-int get_system_info(RRDHOST* host, struct rrdhost_system_info *system_info) {
+int get_system_info(struct rrdhost_system_info *system_info) {
     char *script;
     script = mallocz(sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("system-info.sh") + 2));
     sprintf(script, "%s/%s", netdata_configured_primary_plugins_dir, "system-info.sh");
@@ -701,7 +701,7 @@ int get_system_info(RRDHOST* host, struct rrdhost_system_info *system_info) {
                 char n[51], v[101];
                 snprintfz(n, 50,"%s",name);
                 snprintfz(v, 101,"%s",value);
-                if(unlikely(rrdhost_set_system_info_variable(host, system_info, n, v))) {
+                if(unlikely(rrdhost_set_system_info_variable(system_info, n, v))) {
                     info("Unexpected environment variable %s=%s", n, v);
                 }
                 else {
@@ -1169,7 +1169,7 @@ int main(int argc, char **argv) {
 
 	netdata_anonymous_statistics_enabled=-1;
     struct rrdhost_system_info *system_info = calloc(1, sizeof(struct rrdhost_system_info));
-    get_system_info(NULL, system_info);
+    get_system_info(system_info);
 
     rrd_init(netdata_configured_hostname, system_info);
     // ------------------------------------------------------------------------
@@ -1196,7 +1196,7 @@ int main(int argc, char **argv) {
     info("netdata initialization completed. Enjoy real-time performance monitoring!");
     netdata_ready = 1;
   
-    if (get_system_info(localhost, system_info) == 0) send_statistics("START","-", "-");
+    send_statistics("START","-", "-");
 
     // ------------------------------------------------------------------------
     // unblock signals

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -780,7 +780,7 @@ extern RRDHOST *rrdhost_find_or_create(
         , struct rrdhost_system_info *system_info
 );
 
-extern int rrdhost_set_system_info_variable(RRDHOST *host, struct rrdhost_system_info *system_info, char *name, char *value);
+extern int rrdhost_set_system_info_variable(struct rrdhost_system_info *system_info, char *name, char *value);
 
 #if defined(NETDATA_INTERNAL_CHECKS) && defined(NETDATA_VERIFY_LOCKS)
 extern void __rrdhost_check_wrlock(RRDHOST *host, const char *file, const char *function, const unsigned long line);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -811,10 +811,8 @@ restart_after_removal:
 // ----------------------------------------------------------------------------
 // RRDHOST - set system info from environment variables
 
-int rrdhost_set_system_info_variable(RRDHOST *host, struct rrdhost_system_info *system_info, char *name, char *value) {
+int rrdhost_set_system_info_variable(struct rrdhost_system_info *system_info, char *name, char *value) {
     int res = 0;
-
-    if(host) rrdhost_wrlock(host);
 
     if(!strcmp(name, "NETDATA_SYSTEM_OS_NAME")){
         freez(system_info->os_name);
@@ -871,8 +869,6 @@ int rrdhost_set_system_info_variable(RRDHOST *host, struct rrdhost_system_info *
     else {
         res = 1;
     }
-
-    if(host) rrdhost_unlock(host);
 
     return res;
 }

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -1178,7 +1178,7 @@ int rrdpush_receiver_thread_spawn(RRDHOST *host, struct web_client *w, char *url
         else if(!strcmp(name, "tags"))
             tags = value;
         else
-            if(unlikely(rrdhost_set_system_info_variable(NULL, system_info, name, value))) {
+            if(unlikely(rrdhost_set_system_info_variable(system_info, name, value))) {
                 info("STREAM [receive from [%s]:%s]: request has parameter '%s' = '%s', which is not used.", w->client_ip, w->client_port, key, value);
             }
     }


### PR DESCRIPTION
##### Summary
Fixes #6130 
Remove unecessary 2nd call of get_system_info at startup

##### Component Name
daemon

##### Additional Information
There is no need to have a second call to the system-info.sh script. 
