### PR TITLE
web_log: remove trailing space from nginx_ext2 pattern

### DIFF
--- a/collectors/python.d.plugin/web_log/web_log.chart.py
+++ b/collectors/python.d.plugin/web_log/web_log.chart.py
@@ -4,9 +4,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import bisect
-import re
 import os
-
+import re
 from collections import namedtuple, defaultdict
 from copy import deepcopy
 
@@ -660,7 +659,7 @@ class Web:
                                        r' (?P<bytes_sent>\d+)'
                                        r' (?P<resp_length>\d+)'
                                        r' (?P<resp_time>\d+\.\d+)'
-                                       r' (?P<resp_time_upstream>[\d.-]+)')
+                                       r' "?(?P<resp_time_upstream>[\d.-]+)')
 
         nginx_ext_append = re.compile(r'(?P<address>[\da-f.:]+)'
                                       r' -.*?"(?P<request>[^"]*)"'

--- a/collectors/python.d.plugin/web_log/web_log.chart.py
+++ b/collectors/python.d.plugin/web_log/web_log.chart.py
@@ -660,7 +660,7 @@ class Web:
                                        r' (?P<bytes_sent>\d+)'
                                        r' (?P<resp_length>\d+)'
                                        r' (?P<resp_time>\d+\.\d+)'
-                                       r' (?P<resp_time_upstream>[\d.-]+) ')
+                                       r' (?P<resp_time_upstream>[\d.-]+)')
 
         nginx_ext_append = re.compile(r'(?P<address>[\da-f.:]+)'
                                       r' -.*?"(?P<request>[^"]*)"'

--- a/collectors/python.d.plugin/web_log/web_log.conf
+++ b/collectors/python.d.plugin/web_log/web_log.conf
@@ -97,7 +97,7 @@
 # nginx:
 #   log_format netdata '$remote_addr - $remote_user [$time_local] '
 #                      '"$request" $status $body_bytes_sent '
-#                      '$request_length $request_time $upstream_response_time '
+#                      '$request_length $request_time "$upstream_response_time" '
 #                      '"$http_referer" "$http_user_agent"';
 #   access_log /var/log/nginx/access.log netdata;
 #


### PR DESCRIPTION
##### Summary
ssia 

Fixes: #6125

> upstream_response_time may contain "," if first upstream server return error and nginx request to second server.

##### Component Name

[/collectors/python.d.plugin/web_log](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/web_log)

##### Additional Information

