### PR TITLE
x509check: add last_collected alarm

### DIFF
--- a/health/health.d/x509check.conf
+++ b/health/health.d/x509check.conf
@@ -1,4 +1,18 @@
 
+# make sure x509check is running
+
+template: x509check_days_until_expiration
+      on: x509check.time_until_expiration
+    calc: $now - $last_collected_t
+   units: seconds ago
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: webmaster
+
+
 template: x509check_days_until_expiration
       on: x509check.time_until_expiration
    calc:  $expiry

--- a/health/health.d/x509check.conf
+++ b/health/health.d/x509check.conf
@@ -1,7 +1,7 @@
 
 # make sure x509check is running
 
-template: x509check_days_until_expiration
+template: x509check_last_collected_secs
       on: x509check.time_until_expiration
     calc: $now - $last_collected_t
    units: seconds ago


### PR DESCRIPTION
##### Summary

ssia

Fixes: #5851

> Hi, my case is the first one: if something is wrong with the cert, I don't see any metric at all, and can't use it in alerting. So yes, creating an empty metric is fine, I think.

##### Component Name

[/health](https://github.com/netdata/netdata/tree/master/health)

##### Additional Information

