### PR TITLE
Correct date used in pushbullet notifications

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1953,7 +1953,7 @@ send_pushbullet "${PUSHBULLET_ACCESS_TOKEN}" "${PUSHBULLET_SOURCE_DEVICE}" "${to
 Severity: ${severity}\\n
 Chart: ${chart}\\n
 Family: ${family}\\n
-$(date -d @${when})\\n
+${date}\\n
 The source of this alarm is line ${src}"
 
 SENT_PUSHBULLET=$?


### PR DESCRIPTION
##### Summary
Fixes #6178

##### Component Name
health

##### Additional Information
Use the `date` variable filled in in a cross-platform way instead of a single `date -d` call that fails at least in MacOS (probably a lot of other OSs as well).
