### PR TITLE
web log pattern fix

### DIFF
--- a/collectors/python.d.plugin/web_log/web_log.chart.py
+++ b/collectors/python.d.plugin/web_log/web_log.chart.py
@@ -659,7 +659,7 @@ class Web:
                                        r' (?P<bytes_sent>\d+)'
                                        r' (?P<resp_length>\d+)'
                                        r' (?P<resp_time>\d+\.\d+)'
-                                       r' "?(?P<resp_time_upstream>[\d.-]+)')
+                                       r' (?P<resp_time_upstream>[\d.-]+)')
 
         nginx_ext_append = re.compile(r'(?P<address>[\da-f.:]+)'
                                       r' -.*?"(?P<request>[^"]*)"'

--- a/collectors/python.d.plugin/web_log/web_log.conf
+++ b/collectors/python.d.plugin/web_log/web_log.conf
@@ -97,7 +97,7 @@
 # nginx:
 #   log_format netdata '$remote_addr - $remote_user [$time_local] '
 #                      '"$request" $status $body_bytes_sent '
-#                      '$request_length $request_time "$upstream_response_time" '
+#                      '$request_length $request_time $upstream_response_time '
 #                      '"$http_referer" "$http_user_agent"';
 #   access_log /var/log/nginx/access.log netdata;
 #


### PR DESCRIPTION
##### Summary

http://london.my-netdata.io/#menu_web_log_nginx_submenu_responses;theme=slate;help=true

fixes the bug introduced in #6138

the problem that `"-"` can be either `$http_referer` or `$upstream_response_time`

`web_log` choose wrong regexp due to `?"`

> 127.0.0.1 - - [31/May/2019:06:34:06 +0000] "GET /stub_status HTTP/1.1" 200 123 97 0.000 "-" "-"

___

autodetection algorithm should be improved

##### Component Name
[/collectors/python.d.plugin/web_log](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/web_log)

##### Additional Information

