### PR TITLE
netdata/packaging/installer: Fix updater issue on empty config value

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -95,7 +95,7 @@ update() {
 
 	if [ -z "${NETDATA_LOCAL_TARBAL_OVERRIDE}" ]; then
 		download "${NETDATA_TARBALL_CHECKSUM_URL}" "${tmpdir}/sha256sum.txt" >&3 2>&3
-		if grep "${NETDATA_TARBALL_CHECKSUM}" sha256sum.txt >&3 2>&3; then
+		if [[ -n "${NETDATA_TARBALL_CHECKSUM}" ]] && grep "${NETDATA_TARBALL_CHECKSUM}" sha256sum.txt >&3 2>&3; then
 			info "Newest version is already installed"
 		else
 			download "${NETDATA_TARBALL_URL}" "${tmpdir}/netdata-latest.tar.gz"


### PR DESCRIPTION
##### Summary
Problem reported on #6170 indicated that updater was failing to correctly identify it needs to update when a variable was incorrectly set in .environment.
To overcome this, we allow triggering the update when the variable is empty or unset.

##### Component Name
netdata/packaging/installer

##### Additional Information
Fixes #6170
