### PR TITLE
Terminate email header lines with \r\n

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -681,7 +681,7 @@ date=$(date --date=@${when} "${date_format}" 2>/dev/null)
 # ----------------------------------------------------------------------------
 # prepare some extra headers if we've been asked to thread e-mails
 if [ "${SEND_EMAIL}" == "YES" ] && [ "${EMAIL_THREADING}" != "NO" ]; then
-	email_thread_headers="In-Reply-To: <${chart}-${name}@${host}>\\nReferences: <${chart}-${name}@${host}>"
+	email_thread_headers="In-Reply-To: <${chart}-${name}@${host}>\\r\\nReferences: <${chart}-${name}@${host}>"
 else
 	email_thread_headers=
 fi


### PR DESCRIPTION
##### Summary
https://tools.ietf.org/html/rfc2822#section-2.2
> Header fields are lines composed of a field name, followed by a colon (":"), followed by a field body, and terminated by CRLF

I guess most clients handle it fine anyway if the threading is working, I saw it in BSD mailx which doesn't support threading.
##### Component Name
Emails sent when alarms change state.

##### Additional Information
Introduced in https://github.com/netdata/netdata/pull/3768