### PR TITLE
Documentation: Correct example list for python.d SimpleService

### DIFF
--- a/collectors/python.d.plugin/README.md
+++ b/collectors/python.d.plugin/README.md
@@ -150,7 +150,7 @@ Classes implement `_get_raw_data` which should be used to grab raw data. This me
 
 _This is last resort class, if a new module cannot be written by using other framework class this one can be used._
 
-_Example: `mysql`, `sensors`_
+_Example: `ceph`, `sensors`_
 
 It is the lowest-level class which implements most of module logic, like:
 - threading


### PR DESCRIPTION
MySQL is not using SimpleService, however - ceph is an example that does.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

