### PR TITLE
Add note to make smartd directory

### DIFF
--- a/collectors/python.d.plugin/smartd_log/README.md
+++ b/collectors/python.d.plugin/smartd_log/README.md
@@ -85,7 +85,8 @@ For this you need to set `smartd_opts` (or `SMARTD_ARGS`, check _smartd.service_
 # dump smartd attrs info every 600 seconds
 smartd_opts="-A /var/log/smartd/ -i 600"
 ```
-
+You may need to create the smartd directory before smartd will write to it:  
+`mkdir -p /var/log/smartd`
 
 `smartd` appends logs at every run. It's strongly recommended to use `logrotate` for smartd files.
 


### PR DESCRIPTION
At least on Ubuntu if you do not create this dir manually, all the .csv files get written to /var/lib/smartmontools as the default location.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

