### PR TITLE
health: change x509check_last_collected_secs alarm every to 60s

### DIFF
--- a/health/health.d/x509check.conf
+++ b/health/health.d/x509check.conf
@@ -5,7 +5,7 @@ template: x509check_last_collected_secs
       on: x509check.time_until_expiration
     calc: $now - $last_collected_t
    units: seconds ago
-   every: 10s
+   every: 60s
     warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
     crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
    delay: down 5m multiplier 1.5 max 1h


### PR DESCRIPTION
##### Summary

`x509check` collector default update every is 60

> netdata ERROR : PLUGINSD[go.d] : Health alarm > 'x509check_example.site.time_until_expiration.x509check_last_collected_secs' has update every 10, less than chart update every 60. Setting alarm update frequency to 60.

Fixes: #6193

##### Component Name

[/health/health.d/x509check.conf](https://github.com/netdata/netdata/blob/master/health/health.d/x509check.conf)

##### Additional Information

