### PR TITLE
wmi collector: `fa-server` icon

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -461,6 +461,12 @@ netdataDashboard.menu = {
         title: '',
         icon: '<i class="fas fa-th-large"></i>',
         info: 'Xen domain resource utilization metrics. Netdata reads this information using <b>xenstat</b> library which gives access to the resource usage information (CPU, memory, disk I/O, network) for a virtual machine.'
+    },
+
+    'wmi': {
+        title: 'wmi',
+        icon: '<i class="fas fa-server"></i>',
+        info: undefined
     }
 };
 

--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -1371,6 +1371,6 @@
     </div>
     <iframe id="ssoifrm" width="0" height="0"></iframe>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20190130-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20190306-1"></script>
 </body>
 </html>


### PR DESCRIPTION

##### Summary

Add `wmi` collector to the `dashboard_info.js`

I wanted to use `fa-windows` brand icon, but...

![Screenshot_20190531_130750](https://user-images.githubusercontent.com/22274335/58797727-66db8180-8609-11e9-96a4-915150b7e300.png)


so `fa-server` :smile: 	

##### Component Name

[/web/gui](https://github.com/netdata/netdata/tree/master/web/gui)

##### Additional Information

