### PR TITLE
Turn tv.html links to https

### DIFF
--- a/web/gui/tv.html
+++ b/web/gui/tv.html
@@ -94,7 +94,7 @@ setTimeout(function(){
         <div style="width: 100%; height: calc(100% - 15px); text-align: center; display: inline-block;">
             <br/>
             <div data-netdata="system.cpu"
-                    data-host="http://registry.my-netdata.io"
+                    data-host="https://registry.my-netdata.io"
                     data-title="CPU usage of registry.my-netdata.io"
                     data-chart-library="dygraph"
                     data-width="49%"
@@ -120,7 +120,7 @@ setTimeout(function(){
         </div>
         <div style="width: 100%; height: calc(100% - 15px); text-align: center; display: inline-block;">
             <div data-netdata="system.io"
-                    data-host="http://registry.my-netdata.io"
+                    data-host="https://registry.my-netdata.io"
                     data-common-max="io"
                     data-common-min="io"
                     data-title="I/O on registry.my-netdata.io"
@@ -148,7 +148,7 @@ setTimeout(function(){
         </div>
         <div style="width: 100%; height: calc(100% - 15px); text-align: center; display: inline-block;">
             <div data-netdata="system.net"
-                    data-host="http://registry.my-netdata.io"
+                    data-host="https://registry.my-netdata.io"
                     data-common-max="traffic"
                     data-common-min="traffic"
                     data-title="Network traffic on registry.my-netdata.io"
@@ -178,7 +178,7 @@ setTimeout(function(){
                 registry.my-netdata.io
                 <br/>
                 <div data-netdata="netdata.requests"
-                        data-host="http://registry.my-netdata.io"
+                        data-host="https://registry.my-netdata.io"
                         data-common-max="netdata-requests"
                         data-decimal-digits="0"
                         data-title="Chart Refreshes/s"
@@ -189,7 +189,7 @@ setTimeout(function(){
                         data-points="300"
                         ></div>
                 <div data-netdata="netdata.clients"
-                        data-host="http://registry.my-netdata.io"
+                        data-host="https://registry.my-netdata.io"
                         data-common-max="netdata-clients"
                         data-decimal-digits="0"
                         data-title="Sockets"
@@ -204,7 +204,7 @@ setTimeout(function(){
                         data-dimensions="in"
                         data-common-max="netdata-net-in"
                         data-decimal-digits="0"
-                        data-host="http://registry.my-netdata.io"
+                        data-host="https://registry.my-netdata.io"
                         data-title="Requests Traffic"
                         data-chart-library="easypiechart"
                         data-width="15%"
@@ -216,7 +216,7 @@ setTimeout(function(){
                         data-dimensions="out"
                         data-common-max="netdata-net-out"
                         data-decimal-digits="0"
-                        data-host="http://registry.my-netdata.io"
+                        data-host="https://registry.my-netdata.io"
                         data-title="Chart Data Traffic"
                         data-chart-library="easypiechart"
                         data-width="15%"


### PR DESCRIPTION
##### Summary
Fixes #6188 

##### Component Name
web

##### Additional Information
Now that netdata can serve https requests, the custom dashboard example should be pointing to https://my-netdata.io. 