### PR TITLE
netdata/daemon: SSL fix - broken compilation case when ssl library not present!

### DIFF
--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -298,7 +298,9 @@ extern char *netdata_configured_host_prefix;
 #include "clocks/clocks.h"
 #include "popen/popen.h"
 #include "simple_pattern/simple_pattern.h"
-#include "socket/security.h"
+#ifdef ENABLE_HTTPS
+# include "socket/security.h"
+#endif
 #include "socket/socket.h"
 #include "config/appconfig.h"
 #include "log/log.h"

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -1,5 +1,7 @@
 #include "../libnetdata.h"
 
+#ifdef ENABLE_HTTPS
+
 SSL_CTX *netdata_cli_ctx=NULL;
 SSL_CTX *netdata_srv_ctx=NULL;
 const char *security_key=NULL;
@@ -213,3 +215,5 @@ int security_test_certificate(SSL *ssl){
     }
     return ret;
 }
+
+#endif

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -1,21 +1,24 @@
 #ifndef NETDATA_SECURITY_H
 # define NETDATA_SECURITY_H
 
-# include <openssl/ssl.h>
-# include <openssl/err.h>
-# if (SSLEAY_VERSION_NUMBER >= 0x0907000L) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
-#  include <openssl/conf.h>
-# endif
+# define NETDATA_SSL_HANDSHAKE_COMPLETE 0    //All the steps were successful
+# define NETDATA_SSL_START 1                 //Starting handshake, conn variable is NULL
+# define NETDATA_SSL_WANT_READ 2             //The connection wanna read from socket
+# define NETDATA_SSL_WANT_WRITE 4            //The connection wanna write on socket
+# define NETDATA_SSL_NO_HANDSHAKE 8          //Continue without encrypt connection.
+# define NETDATA_SSL_OPTIONAL 16             //Flag to define the HTTP request
+# define NETDATA_SSL_FORCE 32                //We only accepts HTTPS request
+# define NETDATA_SSL_INVALID_CERTIFICATE 64  //Accepts invalid certificate
+# define NETDATA_SSL_VALID_CERTIFICATE 128  //Accepts invalid certificate
 
-#define NETDATA_SSL_HANDSHAKE_COMPLETE 0    //All the steps were successful
-#define NETDATA_SSL_START 1                 //Starting handshake, conn variable is NULL
-#define NETDATA_SSL_WANT_READ 2             //The connection wanna read from socket
-#define NETDATA_SSL_WANT_WRITE 4            //The connection wanna write on socket
-#define NETDATA_SSL_NO_HANDSHAKE 8          //Continue without encrypt connection.
-#define NETDATA_SSL_OPTIONAL 16             //Flag to define the HTTP request
-#define NETDATA_SSL_FORCE 32                //We only accepts HTTPS request
-#define NETDATA_SSL_INVALID_CERTIFICATE 64  //Accepts invalid certificate
-#define NETDATA_SSL_VALID_CERTIFICATE 128  //Accepts invalid certificate
+# ifdef ENABLE_HTTPS
+
+#  include <openssl/ssl.h>
+#  include <openssl/err.h>
+#  if (SSLEAY_VERSION_NUMBER >= 0x0907000L) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+#   include <openssl/conf.h>
+#  endif
+
 struct netdata_ssl{
     SSL *conn; //SSL connection
     int flags;
@@ -35,4 +38,5 @@ void security_start_ssl(int type);
 int security_process_accept(SSL *ssl,int msg);
 int security_test_certificate(SSL *ssl);
 
+# endif //ENABLE_HTTPS
 #endif //NETDATA_SECURITY_H

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -302,6 +302,7 @@ void listen_sockets_close(LISTEN_SOCKETS *sockets) {
 }
 
 WEB_CLIENT_ACL socket_ssl_acl(char *ssl){
+#ifdef ENABLE_HTTPS
     if (!strcmp(ssl,"optional")){
         netdata_use_ssl_on_http = NETDATA_SSL_OPTIONAL;
         return WEB_CLIENT_ACL_DASHBOARD | WEB_CLIENT_ACL_REGISTRY | WEB_CLIENT_ACL_BADGE | WEB_CLIENT_ACL_MGMT | WEB_CLIENT_ACL_NETDATACONF | WEB_CLIENT_ACL_STREAMING;
@@ -310,6 +311,7 @@ WEB_CLIENT_ACL socket_ssl_acl(char *ssl){
         netdata_use_ssl_on_stream = NETDATA_SSL_FORCE;
         return WEB_CLIENT_ACL_DASHBOARD | WEB_CLIENT_ACL_REGISTRY | WEB_CLIENT_ACL_BADGE | WEB_CLIENT_ACL_MGMT | WEB_CLIENT_ACL_NETDATACONF | WEB_CLIENT_ACL_STREAMING;
     }
+#endif
 
     return WEB_CLIENT_ACL_NONE;
 }

--- a/libnetdata/socket/socket.h
+++ b/libnetdata/socket/socket.h
@@ -3,7 +3,9 @@
 #ifndef NETDATA_SOCKET_H
 #define NETDATA_SOCKET_H
 
-#include <openssl/ossl_typ.h>
+#if defined(ENABLE_HTTPS) || defined(ENABLE_DBENGINE)
+# include <openssl/ossl_typ.h>
+#endif
 #include "../libnetdata.h"
 
 #ifndef MAX_LISTEN_FDS

--- a/libnetdata/socket/socket.h
+++ b/libnetdata/socket/socket.h
@@ -3,9 +3,6 @@
 #ifndef NETDATA_SOCKET_H
 #define NETDATA_SOCKET_H
 
-#if defined(ENABLE_HTTPS) || defined(ENABLE_DBENGINE)
-# include <openssl/ossl_typ.h>
-#endif
 #include "../libnetdata.h"
 
 #ifndef MAX_LISTEN_FDS

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -1210,7 +1210,9 @@ static void *rrdpush_receiver_thread(void *ptr) {
 	    , rpt->update_every
 	    , rpt->client_ip
 	    , rpt->client_port
+#ifdef ENABLE_HTTPS
 	    , &rpt->ssl
+#endif
     );
 
     netdata_thread_cleanup_pop(1);


### PR DESCRIPTION
#### Summary
Some users are reporting that they can't compile Netdata successfully when no SSL support present. The unique files that did not have any verification of the SSL were the following two files, so I changed them to fix the problem.

```
libnetdata/socket/security.h
libnetdata/socket/security.c
```

##### Component Name
netdata/daemon
netdata/packaging

##### Additional Information
Fixes #6200 