### PR TITLE
netdata/packaging/ci: Add lifecycle checks to bare operating system installations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ jobs:
   - stage: "Artifacts validation on bare OS, stable to current lifecycle checks"
 
     name: Run netdata lifecycle on Ubuntu 16.04 (xenial)
-    script: tests/updater_checks.sh
+    script: sudo -E tests/updater_checks.sh
     after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Ubuntu 16.04"
 
   - name: Run netdata lifecycle on CentOS 7 (Containerized)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ stages:
 - name: Code quality, linting, syntax, code style
 - name: Build process
 - name: Artifacts validation
+- name: Artifacts validation on bare OS, stable to current lifecycle checks
 
   # Nightly operations
 - name: Nightly operations
@@ -133,21 +134,29 @@ jobs:
     script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "netdata/os-test:centos7" ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp
     after_failure: post_message "TRAVIS_MESSAGE" "Build/Install failed on CentOS 7"
 
-  - name: Run netdata lifecycle from stable to current, on CentOS 7 bare OS (Containerized)
+
+
+  - stage: "Artifacts validation on bare OS, stable to current lifecycle checks"
+
+    name: Run netdata lifecycle on Ubuntu 16.04 (xenial)
+    script: tests/updater_checks.sh
+    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Ubuntu 16.04"
+
+  - name: Run netdata lifecycle on CentOS 7 (Containerized)
     script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "centos:7" tests/updater_checks.sh
     after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare CentOS 7"
 
-  - name: Run netdata lifecycle from stable to current, on Debian 9 bare OS (Containerized)
+  - name: Run netdata lifecycle, on Debian 9 (Containerized)
     script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "debian:stretch" tests/updater_checks.sh
-    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare CentOS 7"
+    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Debian 9 (stretch)"
 
-  - name: Run netdata lifecycle from stable to current, on Ubuntu 1904 bare OS (Containerized)
+  - name: Run netdata lifecycle, on Ubuntu 19.04 (Containerized)
     script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "ubuntu:19.04" tests/updater_checks.sh
-    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare CentOS 7"
+    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Ubuntu 19.04"
 
-  - name: Run netdata lifecycle from stable to current, on Fedora 30 bare OS (Containerized)
+  - name: Run netdata lifecycle, on Fedora 30 (Containerized)
     script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "fedora:30" tests/updater_checks.sh
-    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare CentOS 7"
+    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Fedora 30"
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: true
 language: c
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ stages:
 - name: Build process
 - name: Artifacts validation
 - name: Artifacts validation on bare OS, stable to current lifecycle checks
+  if: branch = master AND (type = pull_request OR type = cron)
 
   # Nightly operations
 - name: Nightly operations

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,22 @@ jobs:
     script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "netdata/os-test:centos7" ./netdata-installer.sh --dont-wait --dont-start-it --install /tmp
     after_failure: post_message "TRAVIS_MESSAGE" "Build/Install failed on CentOS 7"
 
+  - name: Run netdata lifecycle from stable to current, on CentOS 7 bare OS (Containerized)
+    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "centos:7" tests/updater_checks.sh
+    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare CentOS 7"
+
+  - name: Run netdata lifecycle from stable to current, on Debian 9 bare OS (Containerized)
+    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "debian:stretch" tests/updater_checks.sh
+    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare CentOS 7"
+
+  - name: Run netdata lifecycle from stable to current, on Ubuntu 1904 bare OS (Containerized)
+    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "ubuntu:19.04" tests/updater_checks.sh
+    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare CentOS 7"
+
+  - name: Run netdata lifecycle from stable to current, on Fedora 30 bare OS (Containerized)
+    script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "fedora:30" tests/updater_checks.sh
+    after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare CentOS 7"
+
 
 
   - stage: Packaging for release

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1790,7 +1790,7 @@ if [ "${NETDATA_REGISTRY_URL}" == "https://registry.my-netdata.io" ]; then
 			NETDATA_REGISTRY_UNIQUE_ID="$(cat "@registrydir_POST@/netdata.public.unique.id")"
 		fi
 	fi
-	if [ ! -z "${NETDATA_REGISTRY_UNIQUE_ID}" ]; then
+	if [ -n "${NETDATA_REGISTRY_UNIQUE_ID}" ]; then
 		GOTOCLOUD=1
 	fi
 fi

--- a/tests/updater_checks.sh
+++ b/tests/updater_checks.sh
@@ -8,6 +8,10 @@
 # Author  : Pavlos Emm. Katsoulakis <paul@netdata.cloud)
 #
 
+echo "Syncing/updating repository.."
+yum clean all
+yum update -y
+
 echo "Installing extra dependencies.."
 yum install -y epel-release
 yum install -y git bats

--- a/tests/updater_checks.sh
+++ b/tests/updater_checks.sh
@@ -19,12 +19,12 @@ case "${running_os}" in
 
 	echo "Installing extra dependencies.."
 	yum install -y epel-release
-	yum install -y git bats
+	yum install -y git bats curl
 	;;
 "debian"|"ubuntu")
 	echo "Running ${running_os}, updating APT repository"
 	apt-get update -y
-	apt-get install -y git bats
+	apt-get install -y git bats curl
 	;;
 *)
 	echo "Running on ${running_os}, no repository preparation done"

--- a/tests/updater_checks.sh
+++ b/tests/updater_checks.sh
@@ -24,6 +24,7 @@ case "${running_os}" in
 "debian"|"ubuntu")
 	echo "Running ${running_os}, updating APT repository"
 	apt-get update -y
+	apt-get install -y git bats
 	;;
 *)
 	echo "Running on ${running_os}, no repository preparation done"

--- a/tests/updater_checks.sh
+++ b/tests/updater_checks.sh
@@ -9,12 +9,26 @@
 #
 
 echo "Syncing/updating repository.."
-yum clean all
-yum update -y
+running_os="$(cat /etc/os-release |grep '^ID=' | cut -d'=' -f2)"
 
-echo "Installing extra dependencies.."
-yum install -y epel-release
-yum install -y git bats
+case "${running_os}" in
+"centos"|"fedora")
+	echo "Running on CentOS, updating YUM repository.."
+	yum clean all
+	yum update -y
+
+	echo "Installing extra dependencies.."
+	yum install -y epel-release
+	yum install -y git bats
+	;;
+"debian"|"ubuntu")
+	echo "Running ${running_os}, updating APT repository"
+	apt-get update -y
+	;;
+*)
+	echo "Running on ${running_os}, no repository preparation done"
+	;;
+esac
 
 echo "Running BATS file.."
 bats --tap tests/updater_checks.bats

--- a/tests/updater_checks.sh
+++ b/tests/updater_checks.sh
@@ -9,7 +9,7 @@
 #
 
 echo "Syncing/updating repository.."
-running_os="$(cat /etc/os-release |grep '^ID=' | cut -d'=' -f2)"
+running_os="$(cat /etc/os-release |grep '^ID=' | cut -d'=' -f2 | sed -e 's/"//g')"
 
 case "${running_os}" in
 "centos"|"fedora")


### PR DESCRIPTION
##### Summary
As part of #6102 we had to introduce more cross-distribution runs, to guarantee that we don't allow failed code reaching our users.
On top of that, through #6200 we realised that our current CI infrastructure did not provide enough visibility on possible issues coming from missing package dependencies.
Until now we used our own pre-compiled docker images to run our installers, which was hiding possible issues like the one on #6200.

Hopefully  with this PR we put an end to such issues and we get closer in the cross-distro builds

##### Component Name
netdata/packaging

##### Additional Information
References #6102 