### PR TITLE
SSL_fix_format Fix wrong format used with SSL!

### DIFF
--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -13,7 +13,7 @@ int netdata_validate_server =  NETDATA_SSL_VALID_CERTIFICATE;
 static void security_info_callback(const SSL *ssl, int where, int ret) {
     (void)ssl;
     if (where & SSL_CB_ALERT) {
-        debug(D_WEB_CLIENT,"SSL INFO CALLBACK %s %s",SSL_alert_type_string(ret),SSL_alert_desc_string_long(ret));
+        debug(D_WEB_CLIENT,"SSL INFO CALLBACK %s %s", SSL_alert_type_string(ret), SSL_alert_desc_string_long(ret));
     }
 }
 
@@ -119,7 +119,7 @@ static SSL_CTX * security_initialize_openssl_server() {
 void security_start_ssl(int type) {
     if (!type) {
         struct stat statbuf;
-        if ((stat(security_key,&statbuf)) || (stat(security_cert,&statbuf))) {
+        if (stat(security_key,&statbuf) || stat(security_cert,&statbuf)) {
             info("To use encryption it is necessary to set \"ssl certificate\" and \"ssl key\" in [web] !\n");
             return;
         }
@@ -161,12 +161,12 @@ int security_process_accept(SSL *ssl,int msg) {
          switch(sslerrno) {
              case SSL_ERROR_WANT_READ:
              {
-                 error("SSL handshake did not finish and it wanna read on socket %d!",sock);
+                 error("SSL handshake did not finish and it wanna read on socket %d!", sock);
                  return NETDATA_SSL_WANT_READ;
              }
              case SSL_ERROR_WANT_WRITE:
              {
-                 error("SSL handshake did not finish and it wanna read on socket %d!",sock);
+                 error("SSL handshake did not finish and it wanna read on socket %d!", sock);
                  return NETDATA_SSL_WANT_WRITE;
              }
              case SSL_ERROR_NONE:
@@ -179,7 +179,7 @@ int security_process_accept(SSL *ssl,int msg) {
                  int counter = 0;
                  while ((err = ERR_get_error()) != 0) {
                      ERR_error_string_n(err, buf, sizeof(buf));
-                     info("%d SSL Handshake error (%s) on socket %d ",counter++,ERR_error_string((long)SSL_get_error(ssl,test),NULL),sock);
+                     info("%d SSL Handshake error (%s) on socket %d ", counter++, ERR_error_string((long)SSL_get_error(ssl, test), NULL), sock);
 			     }
                  return NETDATA_SSL_NO_HANDSHAKE;
 			 }
@@ -188,7 +188,7 @@ int security_process_accept(SSL *ssl,int msg) {
 
     if (SSL_is_init_finished(ssl))
     {
-        debug(D_WEB_CLIENT_ACCESS,"SSL Handshake finished %s errno %d on socket fd %d",ERR_error_string((long)SSL_get_error(ssl,test),NULL),errno,sock);
+        debug(D_WEB_CLIENT_ACCESS,"SSL Handshake finished %s errno %d on socket fd %d", ERR_error_string((long)SSL_get_error(ssl, test), NULL), errno, sock);
     }
 
     return 0;
@@ -207,7 +207,7 @@ int security_test_certificate(SSL *ssl) {
     {
         char error[512];
         ERR_error_string_n(ERR_get_error(),error,sizeof(error));
-        error("SSL RFC4158 check:  We have a invalid certificate, the tests result with %ld and message %s",status,error);
+        error("SSL RFC4158 check:  We have a invalid certificate, the tests result with %ld and message %s", status, error);
         ret = -1;
     }
     else {

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -30,7 +30,7 @@ void security_openssl_library()
 
     SSL_library_init();
 #else
-    if (OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG,NULL) != 1) {
+    if (OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL) != 1) {
         error("SSL library cannot be initialized.");
     }
 #endif
@@ -43,15 +43,15 @@ void security_openssl_common_options(SSL_CTX *ctx) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     SSL_CTX_set_options (ctx,SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_COMPRESSION);
 #else
-    SSL_CTX_set_min_proto_version(ctx,TLS1_2_VERSION);
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
     //We are avoiding the TLS v1.3 for while, because Google Chrome
     //is giving the message net::ERR_SSL_VERSION_INTERFERENCE with it.
-    SSL_CTX_set_max_proto_version(ctx,TLS1_2_VERSION);
+    SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION);
 #endif
     SSL_CTX_set_mode(ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-    if (!SSL_CTX_set_cipher_list(ctx,ciphers)) {
+    if (!SSL_CTX_set_cipher_list(ctx, ciphers)) {
         error("SSL error. cannot set the cipher list");
     }
 #endif
@@ -206,11 +206,10 @@ int security_test_certificate(SSL *ssl) {
     if((X509_V_OK != status))
     {
         char error[512];
-        ERR_error_string_n(ERR_get_error(),error,sizeof(error));
+        ERR_error_string_n(ERR_get_error(), error, sizeof(error));
         error("SSL RFC4158 check:  We have a invalid certificate, the tests result with %ld and message %s", status, error);
         ret = -1;
-    }
-    else {
+    } else {
         ret = 0;
     }
     return ret;

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -12,8 +12,8 @@ int netdata_validate_server =  NETDATA_SSL_VALID_CERTIFICATE;
 
 static void security_info_callback(const SSL *ssl, int where, int ret) {
     (void)ssl;
-    if ( where & SSL_CB_ALERT ) {
-        debug(D_WEB_CLIENT,"SSL INFO CALLBACK %s %s",SSL_alert_type_string( ret ),SSL_alert_desc_string_long(ret));
+    if (where & SSL_CB_ALERT) {
+        debug(D_WEB_CLIENT,"SSL INFO CALLBACK %s %s",SSL_alert_type_string(ret),SSL_alert_desc_string_long(ret));
     }
 }
 
@@ -30,7 +30,7 @@ void security_openssl_library()
 
     SSL_library_init();
 #else
-    if ( OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG,NULL) != 1 ) {
+    if (OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG,NULL) != 1) {
         error("SSL library cannot be initialized.");
     }
 #endif
@@ -51,7 +51,7 @@ void security_openssl_common_options(SSL_CTX *ctx) {
     SSL_CTX_set_mode(ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-    if (!SSL_CTX_set_cipher_list(ctx,ciphers) ) {
+    if (!SSL_CTX_set_cipher_list(ctx,ciphers)) {
         error("SSL error. cannot set the cipher list");
     }
 #endif
@@ -79,7 +79,7 @@ static SSL_CTX * security_initialize_openssl_server() {
     //TO DO: Confirm the necessity to check return for other OPENSSL function
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 	ctx = SSL_CTX_new(SSLv23_server_method());
-    if ( !ctx ) {
+    if (!ctx) {
 		error("Cannot create a new SSL context, netdata won't encrypt communication");
         return NULL;
     }
@@ -87,18 +87,18 @@ static SSL_CTX * security_initialize_openssl_server() {
     SSL_CTX_use_certificate_file(ctx, security_cert, SSL_FILETYPE_PEM);
 #else
     ctx = SSL_CTX_new(TLS_server_method());
-    if ( !ctx ) {
+    if (!ctx) {
 		error("Cannot create a new SSL context, netdata won't encrypt communication");
         return NULL;
     }
 
-    SSL_CTX_use_certificate_chain_file(ctx, security_cert );
+    SSL_CTX_use_certificate_chain_file(ctx, security_cert);
 #endif
     security_openssl_common_options(ctx);
 
     SSL_CTX_use_PrivateKey_file(ctx,security_key,SSL_FILETYPE_PEM);
 
-    if ( !SSL_CTX_check_private_key(ctx) ) {
+    if (!SSL_CTX_check_private_key(ctx)) {
         ERR_error_string_n(ERR_get_error(),lerror,sizeof(lerror));
 		error("SSL cannot check the private key: %s",lerror);
         SSL_CTX_free(ctx);
@@ -117,9 +117,9 @@ static SSL_CTX * security_initialize_openssl_server() {
 }
 
 void security_start_ssl(int type) {
-    if ( !type) {
+    if (!type) {
         struct stat statbuf;
-        if ( (stat(security_key,&statbuf)) || (stat(security_cert,&statbuf)) ) {
+        if ((stat(security_key,&statbuf)) || (stat(security_cert,&statbuf))) {
             info("To use encryption it is necessary to set \"ssl certificate\" and \"ssl key\" in [web] !\n");
             return;
         }
@@ -132,12 +132,12 @@ void security_start_ssl(int type) {
 }
 
 void security_clean_openssl() {
-	if ( netdata_srv_ctx )
+	if (netdata_srv_ctx)
 	{
 		SSL_CTX_free(netdata_srv_ctx);
 	}
 
-    if ( netdata_cli_ctx )
+    if (netdata_cli_ctx)
     {
         SSL_CTX_free(netdata_cli_ctx);
     }
@@ -186,7 +186,7 @@ int security_process_accept(SSL *ssl,int msg) {
          }
     }
 
-    if ( SSL_is_init_finished(ssl) )
+    if (SSL_is_init_finished(ssl))
     {
         debug(D_WEB_CLIENT_ACCESS,"SSL Handshake finished %s errno %d on socket fd %d",ERR_error_string((long)SSL_get_error(ssl,test),NULL),errno,sock);
     }

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -30,13 +30,13 @@ void security_openssl_library()
 
     SSL_library_init();
 #else
-    if ( OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG,NULL) != 1 ){
+    if ( OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG,NULL) != 1 ) {
         error("SSL library cannot be initialized.");
     }
 #endif
 }
 
-void security_openssl_common_options(SSL_CTX *ctx){
+void security_openssl_common_options(SSL_CTX *ctx) {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
     static char *ciphers = {"ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA"};
 #endif
@@ -51,7 +51,7 @@ void security_openssl_common_options(SSL_CTX *ctx){
     SSL_CTX_set_mode(ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-    if (!SSL_CTX_set_cipher_list(ctx,ciphers) ){
+    if (!SSL_CTX_set_cipher_list(ctx,ciphers) ) {
         error("SSL error. cannot set the cipher list");
     }
 #endif
@@ -71,7 +71,7 @@ static SSL_CTX * security_initialize_openssl_client() {
     return ctx;
 }
 
-static SSL_CTX * security_initialize_openssl_server(){
+static SSL_CTX * security_initialize_openssl_server() {
     SSL_CTX *ctx;
     char lerror[512];
 	static int netdata_id_context = 1;
@@ -87,7 +87,7 @@ static SSL_CTX * security_initialize_openssl_server(){
     SSL_CTX_use_certificate_file(ctx, security_cert, SSL_FILETYPE_PEM);
 #else
     ctx = SSL_CTX_new(TLS_server_method());
-    if ( !ctx ){
+    if ( !ctx ) {
 		error("Cannot create a new SSL context, netdata won't encrypt communication");
         return NULL;
     }
@@ -98,7 +98,7 @@ static SSL_CTX * security_initialize_openssl_server(){
 
     SSL_CTX_use_PrivateKey_file(ctx,security_key,SSL_FILETYPE_PEM);
 
-    if ( !SSL_CTX_check_private_key(ctx) ){
+    if ( !SSL_CTX_check_private_key(ctx) ) {
         ERR_error_string_n(ERR_get_error(),lerror,sizeof(lerror));
 		error("SSL cannot check the private key: %s",lerror);
         SSL_CTX_free(ctx);
@@ -116,10 +116,10 @@ static SSL_CTX * security_initialize_openssl_server(){
     return ctx;
 }
 
-void security_start_ssl(int type){
-    if ( !type){
+void security_start_ssl(int type) {
+    if ( !type) {
         struct stat statbuf;
-        if ( (stat(security_key,&statbuf)) || (stat(security_cert,&statbuf)) ){
+        if ( (stat(security_key,&statbuf)) || (stat(security_cert,&statbuf)) ) {
             info("To use encryption it is necessary to set \"ssl certificate\" and \"ssl key\" in [web] !\n");
             return;
         }
@@ -131,7 +131,7 @@ void security_start_ssl(int type){
     }
 }
 
-void security_clean_openssl(){
+void security_clean_openssl() {
 	if ( netdata_srv_ctx )
 	{
 		SSL_CTX_free(netdata_srv_ctx);
@@ -177,7 +177,7 @@ int security_process_accept(SSL *ssl,int msg) {
                  u_long err;
                  char buf[256];
                  int counter = 0;
-                 while ((err = ERR_get_error()) != 0){
+                 while ((err = ERR_get_error()) != 0) {
                      ERR_error_string_n(err, buf, sizeof(buf));
                      info("%d SSL Handshake error (%s) on socket %d ",counter++,ERR_error_string((long)SSL_get_error(ssl,test),NULL),sock);
 			     }
@@ -194,11 +194,11 @@ int security_process_accept(SSL *ssl,int msg) {
     return 0;
 }
 
-int security_test_certificate(SSL *ssl){
+int security_test_certificate(SSL *ssl) {
     X509* cert = SSL_get_peer_certificate(ssl);
     int ret;
     long status;
-    if (!cert){
+    if (!cert) {
         return -1;
     }
 

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -320,7 +320,7 @@ WEB_CLIENT_ACL read_acl(char *st) {
     char *ssl = strchr(st,'^');
     if (ssl) {
         ssl++;
-        if ( !strncmp("SSL=",ssl,4)) {
+        if (!strncmp("SSL=",ssl,4)) {
             ssl += 4;
         }
         socket_ssl_acl(ssl);

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -301,13 +301,13 @@ void listen_sockets_close(LISTEN_SOCKETS *sockets) {
     sockets->failed = 0;
 }
 
-WEB_CLIENT_ACL socket_ssl_acl(char *ssl){
+WEB_CLIENT_ACL socket_ssl_acl(char *ssl) {
 #ifdef ENABLE_HTTPS
-    if (!strcmp(ssl,"optional")){
+    if (!strcmp(ssl,"optional")) {
         netdata_use_ssl_on_http = NETDATA_SSL_OPTIONAL;
         return WEB_CLIENT_ACL_DASHBOARD | WEB_CLIENT_ACL_REGISTRY | WEB_CLIENT_ACL_BADGE | WEB_CLIENT_ACL_MGMT | WEB_CLIENT_ACL_NETDATACONF | WEB_CLIENT_ACL_STREAMING;
     }
-    else if (!strcmp(ssl,"force")){
+    else if (!strcmp(ssl,"force")) {
         netdata_use_ssl_on_stream = NETDATA_SSL_FORCE;
         return WEB_CLIENT_ACL_DASHBOARD | WEB_CLIENT_ACL_REGISTRY | WEB_CLIENT_ACL_BADGE | WEB_CLIENT_ACL_MGMT | WEB_CLIENT_ACL_NETDATACONF | WEB_CLIENT_ACL_STREAMING;
     }
@@ -318,9 +318,9 @@ WEB_CLIENT_ACL socket_ssl_acl(char *ssl){
 
 WEB_CLIENT_ACL read_acl(char *st) {
     char *ssl = strchr(st,'^');
-    if (ssl){
+    if (ssl) {
         ssl++;
-        if ( !strncmp("SSL=",ssl,4)){
+        if ( !strncmp("SSL=",ssl,4)) {
             ssl += 4;
         }
         socket_ssl_acl(ssl);
@@ -883,8 +883,8 @@ ssize_t recv_timeout(int sockfd, void *buf, size_t len, int flags, int timeout) 
     }
 
 #ifdef ENABLE_HTTPS
-    if (ssl->conn){
-        if (!ssl->flags){
+    if (ssl->conn) {
+        if (!ssl->flags) {
             return SSL_read(ssl->conn,buf,len);
         }
     }
@@ -926,8 +926,8 @@ ssize_t send_timeout(int sockfd, void *buf, size_t len, int flags, int timeout) 
     }
 
 #ifdef ENABLE_HTTPS
-    if(ssl->conn){
-        if (!ssl->flags){
+    if(ssl->conn) {
+        if (!ssl->flags) {
             return SSL_write(ssl->conn, buf, len);
         }
     }


### PR DESCRIPTION
##### Summary
The two files that I am doing the pull do not have the proper format that we agreed when we write C code, so I am creating this PR to fix this.

##### Component Name
libnetdata/socket/security.c
libnetdata/socket/socket.c

##### Additional Information
PR #6212
