### PR TITLE
saving dns request in 'r', checking response for answer, recording '-…

### DIFF
--- a/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
+++ b/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
@@ -90,10 +90,13 @@ def dns_request(server_list, timeout, domains):
 
         try:
             dns_start = time()
-            dns.query.udp(request, ns, timeout=t)
+            r = dns.query.udp(request, ns, timeout=t)
             dns_end = time()
-            query_time = round((dns_end - dns_start) * 1000)
-            q.put({'_'.join(['ns', ns.replace('.', '_')]): query_time})
+            if not r.answer:
+                q.put({'_'.join(['ns', ns.replace('.', '_')]): -50})
+            else:
+                query_time = round((dns_end - dns_start) * 1000, 2)
+                q.put({'_'.join(['ns', ns.replace('.', '_')]): query_time})
         except dns.exception.Timeout:
             q.put({'_'.join(['ns', ns.replace('.', '_')]): -100})
 


### PR DESCRIPTION
##### Summary
Currently this plugin records the time for the dns request regardless of an 'answer', this change checks for an 'answer' and records a -50 value if not found. Open to other design ideas.

##### Component Name
collectorys/python.d.plugin/dns_query_time/dns_query_time.chart.py

##### Additional Information
Picture of  DNS response time including "no answer" values:
![DNS Response Time](https://user-images.githubusercontent.com/1903102/59070198-b40c5d00-886e-11e9-922e-47dfbb586d29.png)
