### PR TITLE
dns_query_time py module: saving dns request in 'r', checking response for answer, recording '-…

### DIFF
--- a/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
+++ b/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
@@ -85,7 +85,7 @@ def dns_request(server_list, timeout, domains):
 
         try:
             resp = dns.query.udp(request, ns, timeout=t)
-            if not (resp.rcode == dns.rcode.NOERROR or resp.answer):
+            if (resp.rcode == dns.rcode.NOERROR and not resp.answer):
                 query_time = -100
             else:
                 query_time = resp.time * 1000

--- a/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
+++ b/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
@@ -85,10 +85,10 @@ def dns_request(server_list, timeout, domains):
 
         try:
             resp = dns.query.udp(request, ns, timeout=t)
-            if (resp.rcode == dns.rcode.NOERROR and not resp.answer):
-                query_time = -100
-            else:
+            if (resp.rcode() == dns.rcode.NOERROR and resp.answer):
                 query_time = resp.time * 1000
+            else:
+                query_time = -100
         except dns.exception.Timeout:
             query_time = -100
         finally:

--- a/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
+++ b/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
@@ -143,8 +143,6 @@ def create_charts(aggregate, server_list):
                         '_'.join(['ns', ns.replace('.', '_')]),
                         ns,
                         'absolute',
-                        1,
-                        100,
                     ]
                 ]
             }

--- a/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
+++ b/collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py
@@ -90,10 +90,13 @@ def dns_request(server_list, timeout, domains):
 
         try:
             dns_start = time()
-            dns.query.udp(request, ns, timeout=t)
+            r = dns.query.udp(request, ns, timeout=t)
             dns_end = time()
-            query_time = round((dns_end - dns_start) * 1000)
-            q.put({'_'.join(['ns', ns.replace('.', '_')]): query_time})
+            if not r.answer:
+                q.put({'_'.join(['ns', ns.replace('.', '_')]): -50})
+            else:
+                query_time = round((dns_end - dns_start) * 1000)
+                q.put({'_'.join(['ns', ns.replace('.', '_')]): query_time})
         except dns.exception.Timeout:
             q.put({'_'.join(['ns', ns.replace('.', '_')]): -100})
 


### PR DESCRIPTION
##### Summary
Currently dns_query_time.py will record the time delta for DNS queries that return no values in the 'answer', this commit checks for a null value in 'answer' and records a -50 if true. Open to suggestions on other ways to handle non-answer responses, but this works for my current use case.

##### Component Name
collectors/python.d.plugin/dns_query_time/dns_query_time.chart.py 

##### Additional Information
Image of DNS Response Time graph with code change in place recording -50 for intermittent requests returning no answer:
![DNS Response Time](https://user-images.githubusercontent.com/1903102/59071396-4878be80-8873-11e9-8fc1-a54fba92e851.png)
