### PR TITLE
netdata/packaging: Fix netdata/netdata docker image failure, when users passing PGID that already exists on the system

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -22,7 +22,7 @@ create_group_and_assign_to_user() {
 	addgroup -g "${local_DOCKER_GID}" "${local_DOCKER_GROUP}" || echo >&2 "Could not add group ${local_DOCKER_GROUP} with ID ${local_DOCKER_GID}, its already there probably"
 
 	echo >&2 "Adding user '${local_DOCKER_USR}' to group '${local_DOCKER_GROUP}/${local_DOCKER_GID}'"
-	sed -i "s/${local_DOCKER_GID}:$/${local_DOCKER_GID}:${local_DOCKER_USR}/g" /etc/group
+	sed -i "s/:${local_DOCKER_GID}:$/:${local_DOCKER_GID}:${local_DOCKER_USR}/g" /etc/group
 
 	# Make sure we use the right docker group
 	GRP_TO_ASSIGN="$(grep ":x:${local_DOCKER_GID}:" /etc/group | cut -d':' -f1)"

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -13,19 +13,34 @@ if [ ${RESCRAMBLE+x} ]; then
     apk upgrade --update-cache --available
 fi
 
+create_group_and_assign_to_user() {
+	local local_DOCKER_GROUP="$1"
+	local local_DOCKER_GID="$2"
+	local local_DOCKER_USR="$3"
+
+	echo >&2 "Adding group with ID ${local_DOCKER_GID} and name '${local_DOCKER_GROUP}'"
+	addgroup -g "${local_DOCKER_GID}" "${local_DOCKER_GROUP}" || echo >&2 "Could not add group ${local_DOCKER_GROUP} with ID ${local_DOCKER_GID}, its already there probably"
+
+	echo >&2 "Adding user '${local_DOCKER_USR}' to group '${local_DOCKER_GROUP}/${local_DOCKER_GID}'"
+	sed -i "s/${local_DOCKER_GID}:$/${local_DOCKER_GID}:${local_DOCKER_USR}/g" /etc/group
+
+	# Make sure we use the right docker group
+	GRP_TO_ASSIGN="$(grep ":x:${local_DOCKER_GID}:" /etc/group | cut -d':' -f1)"
+	echo >&2 "Group creation and assignment completed, netdata was assigned to group ${GRP_TO_ASSIGN}/${local_DOCKER_GID}"
+
+	echo "${GRP_TO_ASSIGN}"
+}
+
 DOCKER_USR="netdata"
 DOCKER_SOCKET="/var/run/docker.sock"
 DOCKER_GROUP="docker"
 
 if [ -S "${DOCKER_SOCKET}" ] && [ -n "${PGID}" ]; then
-	echo "Adding group with ID ${PGID} and name '${DOCKER_GROUP}'"
-	addgroup -g "${PGID}" "${DOCKER_GROUP}"
 
-	echo "Adding user '${DOCKER_USR}' to group '${DOCKER_GROUP}'"
-	sed -i "s/${DOCKER_GID}:$/${DOCKER_GID}:${DOCKER_USR}/g" /etc/group
+	GRP=$(create_group_and_assign_to_user "${DOCKER_GROUP}" "${PGID}" "${DOCKER_USR}")
 
-	echo "Adjusting ownership of mapped docker socket '${DOCKER_SOCKET}'"
-	chown "root:${DOCKER_GROUP}" "${DOCKER_SOCKET}"
+	echo "Adjusting ownership of mapped docker socket '${DOCKER_SOCKET}' to root:${GRP}"
+	chown "root:${GRP}" "${DOCKER_SOCKET}"
 fi
 
 exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_PORT}" "$@"


### PR DESCRIPTION
##### Summary
During the latest fixes for the container name resolution on our  docker image, we introduced a hidden bug. Users have been creating groups with ID 999, while group ID 999 already exist on Alpine thus resulting into failing to start the docker image successfully.

To work around this problem, we make group creation failure a soft error and attempt to consume whatever group exists with the user-provided ID


##### Component Name
netdata/packaging/docker

##### Additional Information
Fixes #6251 