### PR TITLE
Fix variable namespace in memory health check

### DIFF
--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -27,7 +27,7 @@
       on: mem.available
       os: linux
    hosts: *
-    calc: ($avail + $used_ram_to_ignore) * 100 / ($system.ram.used + $system.ram.cached + $system.ram.free + $system.ram.buffers)
+    calc: ($avail + $system.ram.used_ram_to_ignore) * 100 / ($system.ram.used + $system.ram.cached + $system.ram.free + $system.ram.buffers)
    units: %
    every: 10s
     warn: $this < (($status >= $WARNING)  ? (15) : (10))


### PR DESCRIPTION

##### Summary

`$used_ram_to_ignore` was empty in `mem.available` health check on Linux, probably because of a namespace issue

##### Component Name

netdata health check

##### Additional Information

I was positively surprised to see that netdata already takes ZFS arc into account when calculating available memory (:+1:) for the health check. Unfortunately the alarm did not work for me and reported the much lower `mem.available` value. I suspect it was just a namespace issue, because the check works on `mem.available` and not on `system.ram`. A quick test fixed the value for me at least.