### PR TITLE
UrlService: add min required version check

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -17,7 +17,7 @@ except AttributeError:
 
 
 # https://github.com/urllib3/urllib3/blob/master/CHANGES.rst#19-2014-07-04
-# New retry logic and urllib3.util.retry.Retry configuration object. (Issue #326)
+# New retry logic and urllib3.util.retry.Retry configuration object. (Issue https://github.com/urllib3/urllib3/pull/326)
 URLLIB3_MIN_REQUIRED_VERSION = '1.9'
 URLLIB3_VERSION = urllib3.__version__
 URLLIB3 = 'urllib3'

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -6,6 +6,8 @@
 
 import urllib3
 
+from distutils.version import StrictVersion as version
+
 from bases.FrameworkServices.SimpleService import SimpleService
 
 try:
@@ -14,9 +16,24 @@ except AttributeError:
     pass
 
 
+# https://github.com/urllib3/urllib3/blob/master/CHANGES.rst#19-2014-07-04
+# New retry logic and urllib3.util.retry.Retry configuration object. (Issue #326)
+URLLIB3_MIN_REQUIRED_VERSION = '1.9'
+URLLIB3_VERSION = urllib3.__version__
+URLLIB3 = 'urllib3'
+
+
 class UrlService(SimpleService):
     def __init__(self, configuration=None, name=None):
+        if version(URLLIB3_VERSION) < version(URLLIB3_MIN_REQUIRED_VERSION):
+            err = '{0} version: {1}, minimum required version: {2}, please upgrade'.format(
+                URLLIB3,
+                URLLIB3_VERSION,
+                URLLIB3_MIN_REQUIRED_VERSION,
+            )
+            raise Exception(err)
         SimpleService.__init__(self, configuration=configuration, name=name)
+        self.debug("{0} version: {1}".format(URLLIB3, URLLIB3_VERSION))
         self.url = self.configuration.get('url')
         self.user = self.configuration.get('user')
         self.password = self.configuration.get('pass')

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -23,15 +23,21 @@ URLLIB3_VERSION = urllib3.__version__
 URLLIB3 = 'urllib3'
 
 
+def version_check():
+    if version(URLLIB3_VERSION) >= version(URLLIB3_MIN_REQUIRED_VERSION):
+        return
+
+    err = '{0} version: {1}, minimum required version: {2}, please upgrade'.format(
+        URLLIB3,
+        URLLIB3_VERSION,
+        URLLIB3_MIN_REQUIRED_VERSION,
+    )
+    raise Exception(err)
+
+
 class UrlService(SimpleService):
     def __init__(self, configuration=None, name=None):
-        if version(URLLIB3_VERSION) < version(URLLIB3_MIN_REQUIRED_VERSION):
-            err = '{0} version: {1}, minimum required version: {2}, please upgrade'.format(
-                URLLIB3,
-                URLLIB3_VERSION,
-                URLLIB3_MIN_REQUIRED_VERSION,
-            )
-            raise Exception(err)
+        version_check()
         SimpleService.__init__(self, configuration=configuration, name=name)
         self.debug("{0} version: {1}".format(URLLIB3, URLLIB3_VERSION))
         self.url = self.configuration.get('url')


### PR DESCRIPTION
##### Summary

Fixes: #6248
Related: #5182, #5108

Min required version is `1.9`

> https://github.com/urllib3/urllib3/blob/master/CHANGES.rst#19-2014-07-04
> New retry logic and urllib3.util.retry.Retry configuration object. (Issue #326)

##### Component Name
[/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/dockerd/dockerd.chart.py)

##### Additional Information

