### PR TITLE
netdata/packaging: During install,  many file not found were raised

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -394,6 +394,7 @@ run ./configure \
 	--prefix="${NETDATA_PREFIX}/usr" \
 	--sysconfdir="${NETDATA_PREFIX}/etc" \
 	--localstatedir="${NETDATA_PREFIX}/var" \
+	--libexecdir="${NETDATA_PREFIX}/usr/libexec" \
 	--with-zlib \
 	--with-math \
 	--with-user=netdata \


### PR DESCRIPTION
##### Summary
It seems that --libexecdir may deviate the expected path. 
Explicitly set this on configure, to avoid uncomfortable situations because throughout our installation we expect libexecdir to be /usr/libexec/netdata already.

There are multiple different strategies to this, but this change seems to have the smallest impact to existing installations

##### Component Name
netdata/packaging

##### Additional Information
Fixes #6153
