### PR TITLE
Fix devuan support for initd

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -303,7 +303,7 @@ install_non_systemd_init() {
 				run rc-update add netdata default &&
 				return 0
 
-		elif [ "${key}" = "debian-7" ] || [ "${key}" = "ubuntu-12.04" ] || [ "${key}" = "ubuntu-14.04" ]; then
+		elif [ "${key}" =~ ^devuan* ] || [ "${key}" = "debian-7" ] || [ "${key}" = "ubuntu-12.04" ] || [ "${key}" = "ubuntu-14.04" ]; then
 			echo >&2 "Installing LSB init file..."
 			run cp system/netdata-lsb /etc/init.d/netdata &&
 				run chmod 755 /etc/init.d/netdata &&

--- a/system/netdata-lsb.in
+++ b/system/netdata-lsb.in
@@ -1,10 +1,18 @@
-#!/bin/bash
-# SPDX-License-Identifier: GPL-3.0-or-later
+#!/usr/bin/env bash
 #
+# Netdata LSB start script
+#
+# Copyright:
+#         SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author:
+#         Costa Tsaousis  <costa@netdata.cloud>
+#         Pavlos Emm. Katsoulakis <paul@netdata.cloud>
+
 ### BEGIN INIT INFO
 # Provides:          netdata
-# Required-Start:    $local_fs $remote_fs $network $named $time apache2 httpd squid nginx mysql named opensips upsd hostapd postfix lm_sensors
-# Required-Stop:     $local_fs $remote_fs $network $named $time apache2 httpd squid nginx mysql named opensips upsd hostapd postfix lm_sensors
+# Required-Start:    $local_fs $remote_fs $network $named $time
+# Required-Stop:     $local_fs $remote_fs $network $named $time
 # Should-Start:      $local_fs $network $named $remote_fs $time $all
 # Should-Stop:       $local_fs $network $named $remote_fs $time $all
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
##### Summary
There is a debian derivative distribution that we want to support on installing netdata service on it.
It is a non-systemd machine, thus we need to do the following for installer to work:

* Make the installer libraries aware of devuan, so that the right workflow is triggered

* Do some fixes for the netdata LSB init scriptlet, seems to be out of date. In detail:
  1) Dont depend on services we may or may NOT have available for monitoring
  2) Fix comments
  3) Use a more standard shebang, that will provide the right bash version

##### Component Name
netdata/packaging/installer

##### Additional Information
Fixes #6230 
