### PR TITLE
Add comments about AWS SDK for C++ installation

### DIFF
--- a/backends/aws_kinesis/README.md
+++ b/backends/aws_kinesis/README.md
@@ -4,7 +4,11 @@
 
 To use AWS Kinesis as a backend AWS SDK for C++ should be [installed](https://docs.aws.amazon.com/en_us/sdk-for-cpp/v1/developer-guide/setup.html) first. `libcrypto`, `libssl`, and `libcurl` are also required to compile netdata with Kinesis support enabled. Next, netdata should be re-installed from the source. The installer will detect that the required libraries are now available.
 
-If AWS SDK for C++ is being installed from sources, it is useful to set `-DBUILD_ONLY="kinesis"`. Otherwise, the building process could take a very long time.
+If the AWS SDK for C++ is being installed from source, it is useful to set `-DBUILD_ONLY="kinesis"`. Otherwise, the building process could take a very long time. Take a note, that the default installation path for the libraries is `/usr/local/lib64`. Many Linux distributions don't include this path as the default one for a library search, so it is advisable to use the following options to `cmake` while building the AWS SDK:
+
+```
+cmake -DCMAKE_INSTALL_LIBDIR=/usr/lib -DCMAKE_INSTALL_INCLUDEDIR=/usr/include -DBUILD_SHARED_LIBS=OFF -DBUILD_ONLY=kinesis <aws-sdk-cpp sources>
+```
 
 ## Configuration
 


### PR DESCRIPTION
##### Summary
By default, AWS SDK for C++ is installed to `/usr/local/lib64`. There are Linux distributions which don't have this path as a default one for the library search. We are adding a comment to the Netdata documentation to help users install the SDK correctly.

Fixes #6002

##### Component Name
kinesis backend