### PR TITLE
Add more info on the stream.conf health enabled by default = auto option

### DIFF
--- a/streaming/README.md
+++ b/streaming/README.md
@@ -342,6 +342,10 @@ If you used many API keys, you can add one such section for each API key.
 
 When done, restart netdata on the `master` node. It is now ready to receive metrics.
 
+Note that `health enabled by default = auto` will still trigger `last_collected` alarms, if a connected slave does not exit gracefully. If the netdata running on the slave is 
+stopped, it will close the connection to the master, ensuring that no `last_collected` alarms are triggered. For example, a proper container restart would first terminate 
+the netdata process, but a system power issue would leave the connection open on the master side. In the second case, you will still receive alarms. 
+
 #### Configuring the `slaves`
 
 On each of the slaves, edit `/etc/netdata/stream.conf` (to edit it on your system run `/etc/netdata/edit-config stream.conf`) and set these:

--- a/streaming/stream.conf
+++ b/streaming/stream.conf
@@ -125,7 +125,8 @@
     # 3 possible values:
     #    yes     enable alarms
     #    no      do not enable alarms
-    #    auto    enable alarms, only when the sending netdata is connected
+    #    auto    enable alarms, only when the sending netdata is connected. For ephemeral slaves or slave system restarts,
+    #            ensure that the netdata process on the slave is gracefully stopped, to prevent invalid last_collected alarms
     # You can also set it per host, below.
     # The default is taken from [health].enabled of netdata.conf
     health enabled by default = auto


### PR DESCRIPTION
##### Summary
Fixes #6266 

##### Component Name
docs

##### Additional Information
Update streaming documentation and config file with more info on how health enabled by default = auto works, so that users know to gracefully terminate slave netdata instances to prevent `last_collected` alarms.
