### PR TITLE
[freeipmi] Remove id in sensor name when already unique

### DIFF
--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -407,6 +407,7 @@ static void send_chart_to_netdata_for_units(int units) {
             switch(sn->sensor_reading_type) {
                 case IPMI_MONITORING_SENSOR_READING_TYPE_DOUBLE:
                     multiplier = 1000;
+                    // fallthrough
                 case IPMI_MONITORING_SENSOR_READING_TYPE_UNSIGNED_INTEGER8_BOOL:
                 case IPMI_MONITORING_SENSOR_READING_TYPE_UNSIGNED_INTEGER32:
                     for (sn_stored = sensors_root; sn_stored; sn_stored = sn_stored->next) {


### PR DESCRIPTION
##### Summary
Feature #6284 : do not append the sensor ID when the name is already unique.

##### Component Name
collector/freeipmi.plugin

##### Additional Information
When deployed to any parc with different hardware, same hardware but different generation or even different bios updates, the ID of the sensors is not the same.
The sensor Name is provided by freeipmi, and can be overriden in freeipmi.conf

However, freeipmi.plugin appends the sensor ID in the displayed name. This is an issue when sending centralizing data in a backend: you'll have multiple fields like
"Inlet Temp i4" and "Inlet Temp i5" while they are the same metric, just from different hardware generations.  

Regarding implementation, I took 2 values from freeipmi source: 
```
// From libipmimonitoring/ipmi_monitoring_defs.h
#define IPMI_MONITORING_MAX_SENSOR_NAME_LENGTH      32

// From toolcommon/tool-sensor-common.h
#define MAX_SENSOR_RECORD_IDS               4096
```
The first for the max size of calloc, the second for the max size of the array containing the names already used.

Remaining tasks are simple: just push all displayed name in this array. If the name of the sensor being added is already in the array, add the sensor ID again.
It's hardware responsible duty to correct freeipmi.conf to put a more meaningful name to this sensor.


To avoid duplicating existing code between DOUBLE & INT32, as the only difference between the 2 was the multiplier value, I reused the same code with a "multiplier" variable.

I've pushed it on 10 different servers, looks good so far. Pushing on my remaining 900 for validation.