### PR TITLE
stale bot limits update

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,7 +12,7 @@ exemptMilestones: true
 staleLabel: stale
 markComment: >
   This issue has been inactive for 30 days.
-  It will be closed in one week, unless it is updated
+  It will be closed in one week, unless it is updated.
 closeComment: >
   This issue has been automatically closed due to extended period of inactivity.
   Please reopen if it is still valid. Thank you for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,8 @@
 ---
 only: issues
 limitPerRun: 30
-daysUntilStale: 45
-daysUntilClose: 60
+daysUntilStale: 30
+daysUntilClose: 7
 exemptLabels:
   - bug
   - help wanted
@@ -11,9 +11,8 @@ exemptProjects: true
 exemptMilestones: true
 staleLabel: stale
 markComment: >
-  Currently netdata team doesn't have enough capacity to work on this issue.
-  We will be more than glad to accept a pull request with a solution to problem described here.
-  This issue will be closed after another 60 days of inactivity.
+  This issue has been inactive for 30 days.
+  It will be closed in one week, unless it is updated
 closeComment: >
   This issue has been automatically closed due to extended period of inactivity.
   Please reopen if it is still valid. Thank you for your contributions.


### PR DESCRIPTION
##### Summary

Fixes: #6280
 - change `daysUntilStale` from 45 to 30
 - change `daysUntilClose` from 60 to 7
 - update `markComment`

##### Component Name

[stale bot](https://github.com/apps/stale)

##### Additional Information

