### PR TITLE
dnsmasq_dhcp: dhcp-range utilization alarm

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -35,6 +35,7 @@ dist_healthconfig_DATA = \
     health.d/cpu.conf \
     health.d/couchdb.conf \
     health.d/disks.conf \
+    health.d/dnsmasq_dhcp.conf \
     health.d/dockerd.conf \
     health.d/elasticsearch.conf \
     health.d/entropy.conf \

--- a/health/health.d/dnsmasq_dhcp.conf
+++ b/health/health.d/dnsmasq_dhcp.conf
@@ -1,0 +1,12 @@
+ # dhcp-range utilization
+
+ template: dnsmasq_dhcp_dhcp_range_utilization
+      on: dnsmasq_dhcp.dhcp_range_utilization
+   every: 10s
+   units: %
+    calc: $used
+    warn: $this > ( ($status >= $WARNING ) ? ( 80 ) : ( 90 ) )
+    crit: $this > ( ($status >= $CRITICAL) ? ( 90 ) : ( 95 ) )
+   delay: down 5m
+    info: dhcp-range utilization above threshold!
+      to: sysadmin


### PR DESCRIPTION
##### Summary
Alarm for [`dnsmasq_dhcp`](https://github.com/netdata/go.d.plugin/tree/master/modules/dnsmasq_dhcp) collector.

The alarm monitors dhcp-range utilization.


The alarm:

```
 template: dnsmasq_dhcp_dhcp_range_utilization
      on: dnsmasq_dhcp.dhcp_range_utilization
   every: 10s
   units: %
    calc: $used
    warn: $this > ( ($status >= $WARNING ) ? ( 80 ) : ( 90 ) )
    crit: $this > ( ($status >= $CRITICAL) ? ( 90 ) : ( 95 ) )
   delay: down 5m
    info: dhcp-range utilization above threshold!
      to: sysadmin
```


##### Component Name

[health/](https://github.com/netdata/netdata/tree/master/health)


##### Additional Information

Test:
 - i installed the branch
 - checked the dashboard alarm section

Alarms are there.


___