### PR TITLE
pihole collector: add alarms

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -62,6 +62,7 @@ dist_healthconfig_DATA = \
     health.d/netfilter.conf \
     health.d/nginx.conf \
     health.d/nginx_plus.conf \
+    health.d/pihole.conf \
     health.d/phpfpm.conf \
     health.d/portcheck.conf \
     health.d/postgres.conf \

--- a/health/health.d/pihole.conf
+++ b/health/health.d/pihole.conf
@@ -1,10 +1,67 @@
- template: pihole_blocked_queries
-      on: pihole.dns_queries_percentage
+
+ # Make sure Pi-hole is responding.
+
+template: pihole_last_collected_secs
+      on: pihole.dns_queries_total
+    calc: $now - $last_collected_t
+   units: seconds ago
    every: 10s
-   units: %
-    calc: $blocked
-    warn: $this > ( ($status >= $WARNING ) ? ( 50 ) : ( 75 ) )
-    crit: $this > ( ($status >= $CRITICAL) ? ( 75 ) : ( 100 ) )
-   delay: down 5m
-    info: dhcp-range utilization above threshold!
-      to: sysadmin
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: webmaster
+
+  # Blocked DNS queries.
+
+ template: pihole_blocked_queries
+       on: pihole.dns_queries_percentage
+    every: 10s
+    units: %
+     calc: $blocked
+     warn: $this > ( ($status >= $WARNING ) ? ( 50 ) : ( 75 ) )
+     crit: $this > ( ($status >= $CRITICAL) ? ( 75 ) : ( 85 ) )
+    delay: delay 2m down 5m
+     info: percentage of blocked dns queries for the last 24 hour
+       to: sysadmin
+
+
+  # Blocklist last update time.
+  # Default update interval is a week.
+
+ template: pihole_blocklist_last_update
+       on: pihole.blocklist_last_update
+    every: 10s
+    units: seconds
+     calc: $ago
+     warn: $this > 60 * 60 * 24 * 8
+     crit: $this > 60 * 60 * 24 * 8 * 2
+     info: blocklist last update time
+       to: sysadmin
+
+
+  # Gravity file check (gravity.list).
+
+ template: pihole_blocklist_gravity_file
+       on: pihole.blocklist_last_update
+    every: 10s
+    units: boolean
+     calc: $file_exists
+     crit: $this != 1
+    delay: delay 2m down 5m
+     info: gravity file existence
+       to: sysadmin
+
+
+  # Pi-hole's ability to block unwanted domains.
+  # Should be enabled. The whole point of Pi-hole!
+
+ template: pihole_status
+       on: pihole.unwanted_domains_blocking_status
+    every: 10s
+    units: boolean
+     calc: $enabled
+     warn: $this != 1
+    delay: delay 2m down 5m
+     info: unwanted domains blocking status
+       to: sysadmin

--- a/health/health.d/pihole.conf
+++ b/health/health.d/pihole.conf
@@ -19,8 +19,8 @@ template: pihole_last_collected_secs
     every: 10s
     units: %
      calc: $blocked
-     warn: $this > ( ($status >= $WARNING ) ? ( 50 ) : ( 75 ) )
-     crit: $this > ( ($status >= $CRITICAL) ? ( 75 ) : ( 85 ) )
+     warn: $this > ( ($status >= $WARNING ) ? ( 45 ) : ( 55 ) )
+     crit: $this > ( ($status >= $CRITICAL) ? ( 55 ) : ( 75 ) )
     delay: delay 2m down 5m
      info: percentage of blocked dns queries for the last 24 hour
        to: sysadmin

--- a/health/health.d/pihole.conf
+++ b/health/health.d/pihole.conf
@@ -1,0 +1,10 @@
+ template: pihole_blocked_queries
+      on: pihole.dns_queries_percentage
+   every: 10s
+   units: %
+    calc: $blocked
+    warn: $this > ( ($status >= $WARNING ) ? ( 50 ) : ( 75 ) )
+    crit: $this > ( ($status >= $CRITICAL) ? ( 75 ) : ( 100 ) )
+   delay: down 5m
+    info: dhcp-range utilization above threshold!
+      to: sysadmin


### PR DESCRIPTION
##### Summary
Alarm for [`pihole`](https://github.com/netdata/go.d.plugin/tree/master/modules/pihole) collector.

Arlarms to monitor:
 - Pi-hole availability
 - blocked dns queries precentage
 - blocklist last update time
 - gravity.list file existence
 - Pi-hole blocking functionality status (on/off)


Related: #6204

##### Component Name
[health/](https://github.com/netdata/netdata/tree/master/health)

##### Additional Information

Test:
 - i installed the branch
 - checked the dashboard alarm section

Alarms are there.
