### PR TITLE
pihole: add to the dashboard_info

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -288,7 +288,7 @@ netdataDashboard.menu = {
     'pihole': {
         title: 'Pi-hole',
         icon: '<i class="fas fa-ban"></i>',
-        info: 'Metrics for <a href="https://pi-hole.net/" target="_blank">Pi-hole</a>, A black hole for Internet advertisements.' +
+        info: 'Metrics for <a href="https://pi-hole.net/" target="_blank">Pi-hole</a>, a black hole for Internet advertisements.' +
             ' The metrics returned by Pi-Hole API is all from the last 24 hours.'
     },
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -285,6 +285,13 @@ netdataDashboard.menu = {
         info: 'Performance metrics for <b>PHP-FPM</b>, an alternative FastCGI implementation for PHP.'
     },
 
+    'pihole': {
+        title: 'Pi-hole',
+        icon: '<i class="fas fa-ban"></i>',
+        info: 'Metrics for <a href="https://pi-hole.net/" target="_blank">Pi-hole</a>, A black hole for Internet advertisements.' +
+            ' The metrics returned by Pi-Hole API is all from the last 24 hours.'
+    },
+
     'portcheck': {
         title: 'Port Check',
         icon: '<i class="fas fa-heartbeat"></i>',

--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -1371,6 +1371,6 @@
     </div>
     <iframe id="ssoifrm" width="0" height="0"></iframe>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
-    <script type="text/javascript" src="dashboard.js?v20190306-1"></script>
+    <script type="text/javascript" src="dashboard.js?v20190621-1"></script>
 </body>
 </html>


### PR DESCRIPTION
##### Summary

This PR adds `Pi-hole` section to the [dashboard_info.js](https://github.com/netdata/netdata/blob/master/web/gui/dashboard_info.js)

 - changes icon to `fa-ban`
 - adds some info

##### Component Name

[web/gui](https://github.com/netdata/netdata/tree/master/web/gui)

##### Additional Information

I installed the branch, it works w/o problem for me.

