### PR TITLE
Better context name to client context

### DIFF
--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -2,7 +2,7 @@
 
 #ifdef ENABLE_HTTPS
 
-SSL_CTX *netdata_cli_ctx=NULL;
+SSL_CTX *netdata_client_ctx=NULL;
 SSL_CTX *netdata_srv_ctx=NULL;
 const char *security_key=NULL;
 const char *security_cert=NULL;
@@ -127,7 +127,7 @@ void security_start_ssl(int type) {
         netdata_srv_ctx =  security_initialize_openssl_server();
     }
     else {
-        netdata_cli_ctx =  security_initialize_openssl_client();
+        netdata_client_ctx =  security_initialize_openssl_client();
     }
 }
 
@@ -137,9 +137,9 @@ void security_clean_openssl() {
 		SSL_CTX_free(netdata_srv_ctx);
 	}
 
-    if (netdata_cli_ctx)
+    if (netdata_client_ctx)
     {
-        SSL_CTX_free(netdata_cli_ctx);
+        SSL_CTX_free(netdata_client_ctx);
     }
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -24,7 +24,7 @@ struct netdata_ssl{
     int flags;
 };
 
-extern SSL_CTX *netdata_cli_ctx;
+extern SSL_CTX *netdata_client_ctx;
 extern SSL_CTX *netdata_srv_ctx;
 extern const char *security_key;
 extern const char *security_cert;

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -463,10 +463,10 @@ static int rrdpush_sender_thread_connect_to_master(RRDHOST *host, int default_po
     info("STREAM %s [send to %s]: initializing communication...", host->hostname, connected_to);
 
 #ifdef ENABLE_HTTPS
-    if( netdata_cli_ctx ){
+    if( netdata_client_ctx ){
         host->ssl.flags = NETDATA_SSL_START;
         if (!host->ssl.conn){
-            host->ssl.conn = SSL_new(netdata_cli_ctx);
+            host->ssl.conn = SSL_new(netdata_client_ctx);
             if(!host->ssl.conn){
                 error("Failed to allocate SSL structure.");
                 host->ssl.flags = NETDATA_SSL_NO_HANDSHAKE;


### PR DESCRIPTION
##### Summary
During the talks to bring SSL to the backends, it was asked by @vlvkobal the change of name of the context used by client , because the previous name was not clear. This PR fixes this problem.
##### Component Name
stream
##### Additional Information
Talk happened in #6220
