### PR TITLE
adaptec_raid: logical device regex fix

### DIFF
--- a/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
+++ b/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
@@ -56,8 +56,8 @@ GOOD_PD_STATUS = (
 )
 
 RE_LD = re.compile(
-    r'Logical device number\s+([0-9]+).*?'
-    r'Status of logical device\s+: ([a-zA-Z]+)'
+    r'Logical [dD]evice number\s+([0-9]+).*?'
+    r'Status of [lL]ogical [dD]evice\s+: ([a-zA-Z]+)'
 )
 
 


### PR DESCRIPTION
##### Summary

Fixes: #6337

This PR fixes `arcconf GETCONFIG 1 LD` output


old output:
```
Logical device number 0
   Logical Device name                      : LogicalDrv 0
   Block Size of member drives              : 512 Bytes
   RAID level                               : 10
   Unique Identifier                        : 488046B2
   Status of logical device                 : Optimal
```

new output:
```
Logical Device number 0
   Logical Device name                      : LogicalDrv 0
   Block Size of member drives              : 512 Bytes
   RAID level                               : 10
   Unique Identifier                        : 488046B2
   Status of Logical Device                 : Optimal
```

New regex is able to parse both outputs

##### Component Name

[collectors/python.d.plugin/adaptec_raid](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/adaptec_raid)

##### Additional Information

I didnt test it myself.

@petarkozic please check the fix
