### PR TITLE
monit: obsolete service in runtime

### DIFF
--- a/collectors/python.d.plugin/monit/monit.chart.py
+++ b/collectors/python.d.plugin/monit/monit.chart.py
@@ -6,7 +6,6 @@
 import xml.etree.ElementTree as ET
 
 from collections import namedtuple
-from copy import deepcopy
 
 from bases.FrameworkServices.UrlService import UrlService
 
@@ -203,8 +202,8 @@ class HostMonitService(BaseMonitService):
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
-        self.order = list(ORDER)
-        self.definitions = deepcopy(CHARTS)
+        self.order = ORDER
+        self.definitions = CHARTS
         base_url = self.configuration.get('url', "http://localhost:2812")
         self.url = '{0}/_status?format=xml&level=full'.format(base_url)
         self.active_services = list()

--- a/collectors/python.d.plugin/monit/monit.chart.py
+++ b/collectors/python.d.plugin/monit/monit.chart.py
@@ -122,7 +122,7 @@ CHARTS = {
 }
 
 
-class BaseMonitService:
+class BaseMonitService(object):
     def __init__(self, typ, name,  status, monitor):
         self.type = typ
         self.name = name

--- a/collectors/python.d.plugin/monit/monit.chart.py
+++ b/collectors/python.d.plugin/monit/monit.chart.py
@@ -140,6 +140,9 @@ class BaseMonitService(object):
     def __ne__(self, other):
         return not self == other
 
+    def __hash__(self):
+        return hash(repr(self))
+
     def is_running(self):
         return self.status == '0' and self.monitor == '1'
 

--- a/collectors/python.d.plugin/monit/monit.chart.py
+++ b/collectors/python.d.plugin/monit/monit.chart.py
@@ -4,23 +4,50 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import xml.etree.ElementTree as ET
+
+from collections import namedtuple
+from copy import deepcopy
+
 from bases.FrameworkServices.UrlService import UrlService
 
 
-# see enum State_Type from monit.h (https://bitbucket.org/tildeslash/monit/src/master/src/monit.h)
-MONIT_SERVICE_NAMES = [
-    'Filesystem',
-    'Directory',
-    'File',
-    'Process',
-    'Host',
-    'System',
-    'Fifo',
-    'Program',
-    'Net',
-]
+MonitType = namedtuple('MonitType', ('index', 'name'))
 
-DEFAULT_SERVICES_IDS = [0, 1, 2, 3, 4, 6, 7, 8]
+# see enum Service_Type from monit.h (https://bitbucket.org/tildeslash/monit/src/master/src/monit.h)
+# typedef enum {
+#         Service_Filesystem = 0,
+#         Service_Directory,
+#         Service_File,
+#         Service_Process,
+#         Service_Host,
+#         Service_System,
+#         Service_Fifo,
+#         Service_Program,
+#         Service_Net,
+#         Service_Last = Service_Net
+# } __attribute__((__packed__)) Service_Type;
+
+TYPE_FILESYSTEM = MonitType(0, 'filesystem')
+TYPE_DIRECTORY = MonitType(1, 'directory')
+TYPE_FILE = MonitType(2, 'file')
+TYPE_PROCESS = MonitType(3, 'process')
+TYPE_HOST = MonitType(4, 'host')
+TYPE_SYSTEM = MonitType(5, 'system')
+TYPE_FIFO = MonitType(6, 'fifo')
+TYPE_PROGRAM = MonitType(7, 'program')
+TYPE_NET = MonitType(8, 'net')
+
+TYPES = (
+    TYPE_FILESYSTEM,
+    TYPE_DIRECTORY,
+    TYPE_FILE,
+    TYPE_PROCESS,
+    TYPE_HOST,
+    TYPE_SYSTEM,
+    TYPE_FIFO,
+    TYPE_PROGRAM,
+    TYPE_NET,
+)
 
 # charts order (can be overridden if you want less charts, or different order)
 ORDER = [
@@ -38,6 +65,7 @@ ORDER = [
     'program',
     'net'
 ]
+
 CHARTS = {
     'filesystem': {
         'options': ['filesystems', 'Filesystems', 'filesystems', 'filesystem', 'monit.filesystems', 'line'],
@@ -83,7 +111,7 @@ CHARTS = {
         'lines': []
     },
     'host_latency': {
-        'options': ['hosts latency', 'Hosts latency', 'milliseconds/s', 'network', 'monit.host_latency', 'line'],
+        'options': ['hosts latency', 'Hosts latency', 'milliseconds', 'network', 'monit.host_latency', 'line'],
         'lines': []
     },
     'net': {
@@ -94,85 +122,223 @@ CHARTS = {
 }
 
 
+class BaseMonitService:
+    def __init__(self, typ, name,  status, monitor):
+        self.type = typ
+        self.name = name
+        self.status = status
+        self.monitor = monitor
+
+    def __repr__(self):
+        return 'MonitService({0}:{1})'.format(self.type.name, self.name)
+
+    def __eq__(self, other):
+        if not isinstance(other, BaseMonitService):
+            return False
+        return self.type == other.type and self.name == other.name
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash(repr(self))
+
+    def is_running(self):
+        return self.status == '0' and self.monitor == '1'
+
+    def key(self):
+        return '{0}_{1}'.format(self.type.name, self.name)
+
+    def data(self):
+        return {self.key(): int(self.is_running())}
+
+
+class ProcessMonitService(BaseMonitService):
+    def __init__(self, typ, name,  status, monitor):
+        BaseMonitService.__init__(self, typ, name,  status, monitor)
+        self.uptime = None
+        self.threads = None
+        self.children = None
+
+    def uptime_key(self):
+        return 'process_uptime_{0}'.format(self.name)
+
+    def threads_key(self):
+        return 'process_threads_{0}'.format(self.name)
+
+    def children_key(self):
+        return 'process_children_{0}'.format(self.name)
+
+    def data(self):
+        base = BaseMonitService.data(self)
+        # skipping bugged metrics with negative uptime (monit before v5.16)
+        data = {
+            self.uptime_key(): self.uptime if self.uptime and int(self.uptime) >= 0 else None,
+            self.threads_key(): self.threads,
+            self.children_key(): self.children,
+        }
+        data.update(base)
+
+        return data
+
+
+class HostMonitService(BaseMonitService):
+    def __init__(self, typ, name,  status, monitor):
+        BaseMonitService.__init__(self, typ, name,  status, monitor)
+        self.latency = None
+
+    def latency_key(self):
+        return 'host_latency_{0}'.format(self.name)
+
+    def data(self):
+        base = BaseMonitService.data(self)
+        latency = float(self.latency) * 1000000 if self.latency  else None
+        data = {self.latency_key(): latency}
+        data.update(base)
+
+        return data
+
+
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
-        self.order = ORDER
-        self.definitions = CHARTS
-        base_url = self.configuration.get('url', 'http://localhost:2812')
+        self.order = list(ORDER)
+        self.definitions = deepcopy(CHARTS)
+        base_url = self.configuration.get('url', "http://localhost:2812")
         self.url = '{0}/_status?format=xml&level=full'.format(base_url)
+        self.collected_services = list()
 
-    def parse(self, data):
+    def parse_xml(self, raw):
         try:
-            xml = ET.fromstring(data)
+            root = ET.fromstring(raw)
         except ET.ParseError:
             self.error("URL {0} didn't return a vaild XML page. Please check your settings.".format(self.url))
             return None
-        return xml
-
-    def check(self):
-        self._manager = self._build_manager()
-
-        raw_data = self._get_raw_data()
-        if not raw_data:
-            return None
-
-        return bool(self.parse(raw_data))
+        return root
 
     def _get_data(self):
-        raw_data = self._get_raw_data()
-
-        if not raw_data:
+        raw = self._get_raw_data()
+        if not raw:
             return None
 
-        xml = self.parse(raw_data)
-        if not xml:
+        root = self.parse_xml(raw)
+        if root is None:
             return None
 
-        data = {}
-        for service_id in DEFAULT_SERVICES_IDS:
-            service_category = MONIT_SERVICE_NAMES[service_id].lower()
+        services = self.get_services(root)
+        if not services:
+            return None
 
-            if service_category == 'system':
-                self.debug("Skipping service from 'System' category, because it's useless in graphs")
+        if len(self.charts) > 0:
+            self.update_charts(services)
+
+        data = dict()
+
+        for svc in services:
+            data.update(svc.data())
+
+        return data
+
+    def get_services(self, root):
+        services = list()
+
+        for typ in TYPES:
+            if typ == TYPE_SYSTEM:
+                self.debug("skipping service from '{0}' category, it's useless in graphs".format(TYPE_SYSTEM.name))
                 continue
 
-            xpath_query = "./service[@type='{0}']".format(service_id)
-            self.debug('Searching for {0} as {1}'.format(service_category, xpath_query))
-            for service_node in xml.findall(xpath_query):
+            xpath_query = "./service[@type='{0}']".format(typ.index)
+            self.debug('Searching for {0} as {1}'.format(typ.name, xpath_query))
 
-                service_name = service_node.find('name').text
-                service_status = service_node.find('status').text
-                service_monitoring = service_node.find('monitor').text
-                self.debug('=> found {0} with type={1}, status={2}, monitoring={3}'.format(service_name,
-                           service_id, service_status, service_monitoring))
+            for svc_root in root.findall(xpath_query):
+                svc = get_service(svc_root, typ)
+                self.debug('=> found {0} with type={1}, status={2}, monitoring={3}'.format(
+                    svc.name, svc.type.name, svc.status, svc.monitor))
 
-                dimension_key = service_category + '_' + service_name
-                if dimension_key not in self.charts[service_category]:
-                    self.charts[service_category].add_dimension([dimension_key, service_name, 'absolute'])
-                data[dimension_key] = 1 if service_status == '0' and service_monitoring == '1' else 0
+                services.append(svc)
 
-                if service_category == 'process':
-                    for subnode in ('uptime', 'threads', 'children'):
-                        subnode_value = service_node.find(subnode)
-                        if subnode_value is None:
-                            continue
-                        if subnode == 'uptime' and int(subnode_value.text) < 0:
-                            self.debug('Skipping bugged metrics with negative uptime (monit before v5.16')
-                            continue
-                        dimension_key = 'process_{0}_{1}'.format(subnode, service_name)
-                        if dimension_key not in self.charts['process_' + subnode]:
-                            self.charts['process_' + subnode].add_dimension([dimension_key, service_name, 'absolute'])
-                        data[dimension_key] = int(subnode_value.text)
+        return services
 
-                if service_category == 'host':
-                    subnode_value = service_node.find('./icmp/responsetime')
-                    if subnode_value is None:
-                        continue
-                    dimension_key = 'host_latency_{0}'.format(service_name)
-                    if dimension_key not in self.charts['host_latency']:
-                        self.charts['host_latency'].add_dimension([dimension_key, service_name,
-                                                                   'absolute', 1000, 1000000])
-                    data[dimension_key] = float(subnode_value.text) * 1000000
+    def update_charts(self, services):
+        remove = [svc for svc in self.collected_services if svc not in services]
+        add = [svc for svc in services if svc not in self.collected_services]
 
-        return data or None
+        self.remove_service_from_charts(remove)
+        self.add_service_to_charts(add)
+
+        self.collected_services = services
+
+    def add_service_to_charts(self, services):
+        for svc in services:
+            if svc.type == TYPE_HOST:
+                self.charts['host_latency'].add_dimension([svc.latency_key(), svc.name, 'absolute', 1000, 1000000])
+            if svc.type == TYPE_PROCESS:
+                self.charts['process_uptime'].add_dimension([svc.uptime_key(), svc.name])
+                self.charts['process_threads'].add_dimension([svc.threads_key(), svc.name])
+                self.charts['process_children'].add_dimension([svc.children_key(), svc.name])
+            self.charts[svc.type.name].add_dimension([svc.key(), svc.name])
+
+    def remove_service_from_charts(self, services):
+        for svc in services:
+            if svc.type == TYPE_HOST:
+                self.charts['host_latency'].del_dimension(svc.latency_key(), False)
+            if svc.type == TYPE_PROCESS:
+                self.charts['process_uptime'].del_dimension(svc.uptime_key(), False)
+                self.charts['process_threads'].del_dimension(svc.threads_key(), False)
+                self.charts['process_children'].del_dimension(svc.children_key(), False)
+            self.charts[svc.type.name].del_dimension(svc.key(), False)
+
+
+def get_service(root, typ):
+    if typ == TYPE_HOST:
+        return get_host_service(root)
+    elif typ == TYPE_PROCESS:
+        return get_process_service(root)
+    return get_base_service(root, typ)
+
+
+def get_host_service(root):
+    svc = HostMonitService(
+        TYPE_HOST,
+        root.find('name').text,
+        root.find('status').text,
+        root.find('monitor').text,
+    )
+
+    latency = root.find('./icmp/responsetime')
+    if latency is not None:
+        svc.latency = latency.text
+
+    return svc
+
+
+def get_process_service(root):
+    svc = ProcessMonitService(
+        TYPE_PROCESS,
+        root.find('name').text,
+        root.find('status').text,
+        root.find('monitor').text,
+    )
+
+    uptime = root.find('uptime')
+    if uptime is not None:
+        svc.uptime = uptime.text
+
+    threads = root.find('threads')
+    if threads is not None:
+        svc.threads = threads.text
+
+    children = root.find('children')
+    if children is not None:
+        svc.children = children.text
+
+    return svc
+
+
+def get_base_service(root, typ):
+    return BaseMonitService(
+        typ,
+        root.find('name').text,
+        root.find('status').text,
+        root.find('monitor').text,
+    )


### PR DESCRIPTION
##### Summary

Fixes: #5074

monit module collects [monit](https://mmonit.com/monit/) service checks statistics.

These checks can be added/removed during runtime, current implementation is unable to obsolete removed service.

This PR fixes the problem.

 - module mantains a list of active services
 - on every iteration it checks if there are any missing services on the list
 - if there are any it sets obsolete flag for the services and removes them from the charts



##### Component Name
[/collectors/python.d.plugin/monit](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/monit)

##### Additional Information

@n0guest @ossjet


I tested the PR with py2.7, py3.5, no problem for me.