### PR TITLE
pihole: alarms delay fix

### DIFF
--- a/health/health.d/pihole.conf
+++ b/health/health.d/pihole.conf
@@ -21,7 +21,7 @@ template: pihole_last_collected_secs
      calc: $blocked
      warn: $this > ( ($status >= $WARNING ) ? ( 45 ) : ( 55 ) )
      crit: $this > ( ($status >= $CRITICAL) ? ( 55 ) : ( 75 ) )
-    delay: delay 2m down 5m
+    delay: up 2m down 5m
      info: percentage of blocked dns queries for the last 24 hour
        to: sysadmin
 
@@ -48,7 +48,7 @@ template: pihole_last_collected_secs
     units: boolean
      calc: $file_exists
      crit: $this != 1
-    delay: delay 2m down 5m
+    delay: up 2m down 5m
      info: gravity file existence
        to: sysadmin
 
@@ -62,6 +62,6 @@ template: pihole_last_collected_secs
     units: boolean
      calc: $enabled
      warn: $this != 1
-    delay: delay 2m down 5m
+    delay: up 2m down 5m
      info: unwanted domains blocking status
        to: sysadmin


### PR DESCRIPTION
##### Summary

Fixes pihole collector alarms `delay`lines , somehow i used wrong keyword.

I didn't notice the bug, because alarms were up and running, just delay option was not applied.

##### Component Name

[/health/health.d/pihole.conf](https://github.com/netdata/netdata/blob/master/health/health.d/pihole.conf)
##### Additional Information

i tested these changes:
 - installed the branch
 - checked error.log
 - checked alarms section on the dashboard

Delay option works correctly.
