### PR TITLE
netdata/packaging/docker: Fix docker documentation and a fix to avoid failures

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -50,7 +50,6 @@ services:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /path/to/actual/docker/on/the/host:/usr/bin/docker
 ```
 
 ### Docker container names resolution

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -42,7 +42,7 @@ if [ -S "${DOCKER_SOCKET}" ] && [ -n "${PGID}" ]; then
 	GRP=$(create_group_and_assign_to_user "${DOCKER_GROUP}" "${PGID}" "${DOCKER_USR}")
 	if [ -n "${GRP}" ]; then
 		echo "Adjusting ownership of mapped docker socket '${DOCKER_SOCKET}' to root:${GRP}"
-		chown "root:${GRP}" "${DOCKER_SOCKET}"
+		chown "root:${GRP}" "${DOCKER_SOCKET}" || echo "Failed to change ownership on docker socket, container name resolution might not work"
 	fi
 fi
 


### PR DESCRIPTION
#### Summary
netdata docker image does not depend on the docker binary any more.
There is a legacy implementation left in place that uses the docker binary as a fail over solution, to support older docker versions.  So we remove the reference from the documentation as this is not needed on the latest version.

At this PR, we also adding a patch top stop failures of docker container when socket ownership can't change.  Rather warn the user and let the start up continue properly.

##### Component Name

##### Additional Information
References #6293 
