### PR TITLE
Tomcat status invalid XML fix

### DIFF
--- a/collectors/python.d.plugin/tomcat/tomcat.chart.py
+++ b/collectors/python.d.plugin/tomcat/tomcat.chart.py
@@ -105,8 +105,11 @@ class Service(UrlService):
         data = None
         raw_data = self._get_raw_data()
         if raw_data:
-            # Fix attributes ending with single quote content
-            raw_data = re.sub(r"='([^']+)'([^']+)''", r"='\g<1>\g<2>'", raw_data)
+            # Fix XML attributes ending with single quote content, ie. <memorypool name='CodeHeap 'non-nmethods'' ... />
+            # Cf. Issue https://github.com/netdata/netdata/issues/6343
+            pattern = re.compile(r"='([^']+)'([^']+)''")
+            raw_data = pattern.sub(r"='\g<1>\g<2>'", raw_data)
+
             try:
                 xml = ET.fromstring(raw_data)
             except ET.ParseError:

--- a/collectors/python.d.plugin/tomcat/tomcat.chart.py
+++ b/collectors/python.d.plugin/tomcat/tomcat.chart.py
@@ -14,7 +14,6 @@ MiB = 1 << 20
 # Regex fix for Tomcat single quote XML attributes
 # affecting Tomcat < 8.5.24 & 9.0.2 running with Java > 9
 # cf. https://bz.apache.org/bugzilla/show_bug.cgi?id=61603
-fix_tomcat_single_quote = True
 single_quote_regex = re.compile(r"='([^']+)'([^']+)''")
 
 ORDER = [
@@ -122,12 +121,12 @@ class Service(UrlService):
         if not raw_data:
             return False
 
-        if fix_tomcat_single_quote and single_quote_regex.search(raw_data):
+        if single_quote_regex.search(raw_data):
             self.warning('Tomcat status page is returning invalid single quote XML, please consider upgrading '
                          'your Tomcat installation. See https://bz.apache.org/bugzilla/show_bug.cgi?id=61603')
             self.parse = self.xml_single_quote_fix_parse
 
-        return True
+        return self.parse(raw_data)
 
     def _get_data(self):
         """

--- a/collectors/python.d.plugin/tomcat/tomcat.chart.py
+++ b/collectors/python.d.plugin/tomcat/tomcat.chart.py
@@ -126,7 +126,7 @@ class Service(UrlService):
                          'your Tomcat installation. See https://bz.apache.org/bugzilla/show_bug.cgi?id=61603')
             self.parse = self.xml_single_quote_fix_parse
 
-        return bool(self.parse(raw_data))
+        return self.parse(raw_data) is not None
 
     def _get_data(self):
         """

--- a/collectors/python.d.plugin/tomcat/tomcat.chart.py
+++ b/collectors/python.d.plugin/tomcat/tomcat.chart.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import xml.etree.ElementTree as ET
+import re
 
 from bases.FrameworkServices.UrlService import UrlService
 
@@ -104,6 +105,8 @@ class Service(UrlService):
         data = None
         raw_data = self._get_raw_data()
         if raw_data:
+            # Fix attributes ending with single quote content
+            raw_data = re.sub(r"='([^']+)'([^']+)''", r"='\g<1>\g<2>'", raw_data)
             try:
                 xml = ET.fromstring(raw_data)
             except ET.ParseError:

--- a/collectors/python.d.plugin/tomcat/tomcat.chart.py
+++ b/collectors/python.d.plugin/tomcat/tomcat.chart.py
@@ -11,6 +11,9 @@ from bases.FrameworkServices.UrlService import UrlService
 
 MiB = 1 << 20
 
+# Regex fix for Tomcat single quote XML attributes
+single_quote_regex = re.compile(r"='([^']+)'([^']+)''")
+
 ORDER = [
     'accesses',
     'bandwidth',
@@ -96,7 +99,6 @@ class Service(UrlService):
         self.definitions = CHARTS
         self.url = self.configuration.get('url', 'http://127.0.0.1:8080/manager/status?XML=true')
         self.connector_name = self.configuration.get('connector_name', None)
-        self.single_quote_regex = re.compile(r"='([^']+)'([^']+)''")
 
     def _get_data(self):
         """
@@ -108,7 +110,7 @@ class Service(UrlService):
         if raw_data:
             # Fix XML attributes ending with single quote content, ie. <memorypool name='CodeHeap 'non-nmethods'' ... />
             # Cf. Issue https://github.com/netdata/netdata/issues/6343
-            raw_data = self.single_quote_regex.sub(r"='\g<1>\g<2>'", raw_data)
+            raw_data = single_quote_regex.sub(r"='\g<1>\g<2>'", raw_data)
 
             try:
                 xml = ET.fromstring(raw_data)

--- a/collectors/python.d.plugin/tomcat/tomcat.chart.py
+++ b/collectors/python.d.plugin/tomcat/tomcat.chart.py
@@ -161,7 +161,7 @@ class Service(UrlService):
                     data['metaspace_committed'] = pool.get('usageCommitted')
                     data['metaspace_max'] = pool.get('usageMax')
 
-            if connector:
+            if connector is not None:
                 thread_info = connector.find('threadInfo')
                 data['currentThreadsBusy'] = thread_info.get('currentThreadsBusy')
                 data['currentThreadCount'] = thread_info.get('currentThreadCount')

--- a/collectors/python.d.plugin/tomcat/tomcat.chart.py
+++ b/collectors/python.d.plugin/tomcat/tomcat.chart.py
@@ -126,7 +126,7 @@ class Service(UrlService):
                          'your Tomcat installation. See https://bz.apache.org/bugzilla/show_bug.cgi?id=61603')
             self.parse = self.xml_single_quote_fix_parse
 
-        return self.parse(raw_data)
+        return bool(self.parse(raw_data))
 
     def _get_data(self):
         """

--- a/collectors/python.d.plugin/tomcat/tomcat.chart.py
+++ b/collectors/python.d.plugin/tomcat/tomcat.chart.py
@@ -107,7 +107,7 @@ class Service(UrlService):
             try:
                 xml = ET.fromstring(raw_data)
             except ET.ParseError:
-                self.debug('%s is not a vaild XML page. Please add "?XML=true" to tomcat status page.' % self.url)
+                self.debug('%s is not a valid XML page. Please add "?XML=true" to tomcat status page.' % self.url)
                 return None
             data = {}
 

--- a/collectors/python.d.plugin/tomcat/tomcat.chart.py
+++ b/collectors/python.d.plugin/tomcat/tomcat.chart.py
@@ -96,6 +96,7 @@ class Service(UrlService):
         self.definitions = CHARTS
         self.url = self.configuration.get('url', 'http://127.0.0.1:8080/manager/status?XML=true')
         self.connector_name = self.configuration.get('connector_name', None)
+        self.single_quote_regex = re.compile(r"='([^']+)'([^']+)''")
 
     def _get_data(self):
         """
@@ -107,8 +108,7 @@ class Service(UrlService):
         if raw_data:
             # Fix XML attributes ending with single quote content, ie. <memorypool name='CodeHeap 'non-nmethods'' ... />
             # Cf. Issue https://github.com/netdata/netdata/issues/6343
-            pattern = re.compile(r"='([^']+)'([^']+)''")
-            raw_data = pattern.sub(r"='\g<1>\g<2>'", raw_data)
+            raw_data = self.single_quote_regex.sub(r"='\g<1>\g<2>'", raw_data)
 
             try:
                 xml = ET.fromstring(raw_data)


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Quick fix to replace single quotes ending content in single quote attributes in Tomcat status XML response, as it would produce an error when parsing the XML.
This is a tentative fix, a more robust approach would be to replace the single quote attributes by double quotes, but it can't be done via a simple regular expression.
Fixes #6343

##### Component Name
`collectors/python.d.plugin/tomcat/tomcat.chart.py`

##### Additional Information

