### PR TITLE
Redirect old site to new site at www.netdata.cloud

### DIFF
--- a/web/gui/demosites.html
+++ b/web/gui/demosites.html
@@ -2,6 +2,7 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <html lang=en-us xmlns="http://www.w3.org/1999/html">
 <head>
+    <meta http-equiv="Refresh" content="0; url=https://www.netdata.cloud">
     <meta charset=utf-8>
     <title>NetData: Get control of your Linux Servers. Simple. Effective. Awesome.</title>
     <meta name=author content="Costa Tsaousis">


### PR DESCRIPTION
##### Summary
Set an html redirect to point to the new Netdata web site, hosted on Netlify.

##### Component Name
web
