### PR TITLE
apps.plugin: detect openldap server processes by default on Debian

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -88,7 +88,7 @@ go.d.plugin: *go.d.plugin*
 # -----------------------------------------------------------------------------
 # authentication/authorization related servers
 
-auth: radius* openldap* ldap*
+auth: radius* openldap* ldap* slapd
 fail2ban: fail2ban*
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

This adds the `slapd` process to the default `auth:` process group configured for apps.plugin.
Debian provides openldap server as `/usr/sbin/slapd` hence this process was not detected by default.

https://packages.debian.org/stretch/amd64/slapd/filelist  
https://packages.debian.org/stretch/slapd

##### Component Name

apps.plugin (configuration change)

