### PR TITLE
Add more debug messages for pluginsd pipe errors

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -154,7 +154,12 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
 
         char *r = fgets(line, PLUGINSD_LINE_MAX, fp);
         if(unlikely(!r)) {
-            error("read failed");
+            if(feof(fp))
+                error("read failed: end of file");
+            else if(ferror(fp))
+                error("read failed: input error");
+            else
+                error("read failed: unknown error");
             break;
         }
 


### PR DESCRIPTION
##### Summary
To debug the root cause of the #6371 issue we need to know more about an error on pipe close.

##### Component Name
pluginsd orchestrator