### PR TITLE
Health could not read properly the health silencers file

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -53,11 +53,16 @@ void health_silencers_init(void) {
             if (fd) {
                 char *str = mallocz((length+1)* sizeof(char));
                 if(str) {
-                    fread(str, sizeof(char), length, fd);
-                    str[length] = 0x00;
-                    json_parse(str, NULL, health_silencers_json_read_callback);
-                    freez(str);
-                    info("Parsed health silencers file %s", silencers_filename);
+                    size_t copied;
+                    copied = fread(str, sizeof(char), length, fd);
+                    if (copied == (length* sizeof(char))) {
+                        str[length] = 0x00;
+                        json_parse(str, NULL, health_silencers_json_read_callback);
+                        freez(str);
+                        info("Parsed health silencers file %s", silencers_filename);
+                    } else {
+                        error("Cannot read the data from health silencers file %s", silencers_filename);
+                    }
                 }
                 fclose(fd);
             } else {

--- a/health/health.c
+++ b/health/health.c
@@ -58,11 +58,11 @@ void health_silencers_init(void) {
                     if (copied == (length* sizeof(char))) {
                         str[length] = 0x00;
                         json_parse(str, NULL, health_silencers_json_read_callback);
-                        freez(str);
                         info("Parsed health silencers file %s", silencers_filename);
                     } else {
                         error("Cannot read the data from health silencers file %s", silencers_filename);
                     }
+                    freez(str);
                 }
                 fclose(fd);
             } else {


### PR DESCRIPTION
##### Summary
The health was not checking the size returned by fread, so it could work with less data than available. Considering that the next steps would be to parser the JSON content, this mean that it would not start correctly the SILENCERS.
##### Component Name
Health
##### Additional Information
To test whether everything is ok, run the script to test stopping in sometime before a RESET command, stop and restart the Netdata. It cannot display the error message of the code, instead it must give the info message.