### PR TITLE
Health giving wrong message

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -438,14 +438,20 @@ void rrdcalc_unlink_and_free(RRDHOST *host, RRDCALC *rc) {
     }
 
     if (rc) {
-        RRDCALC *rdcmp = (RRDCALC *) avl_remove_lock(&(host)->alarms_idx_health_log, (avl *)rc);
-        if (!rdcmp) {
-            error("Cannot remove the health alarm index");
+        RRDCALC *rdcmp = (RRDCALC *) avl_search_lock(&(host)->alarms_idx_health_log, (avl *)rc);
+        if (rdcmp) {
+            rdcmp = (RRDCALC *) avl_remove_lock(&(host)->alarms_idx_health_log, (avl *)rc);
+            if (!rdcmp) {
+                error("Cannot remove the health alarm index from health_log");
+            }
         }
 
-        rdcmp = (RRDCALC *) avl_remove_lock(&(host)->alarms_idx_name, (avl *)rc);
-        if (!rdcmp) {
-            error("Cannot remove the health alarm index");
+        rdcmp = (RRDCALC *) avl_search_lock(&(host)->alarms_idx_name, (avl *)rc);
+        if (rdcmp) {
+            rdcmp = (RRDCALC *) avl_remove_lock(&(host)->alarms_idx_name, (avl *)rc);
+            if (!rdcmp) {
+                error("Cannot remove the health alarm index from idx_name");
+            }
         }
     }
 


### PR DESCRIPTION
##### Summary
The health was given wrong message when the Netdata was closed, because there was not a proper check of  the index before to clean it. This PR fix the appear of improper  "ERROR : MAIN : Cannot remove the health alarm index" that was happening when we close netdata, no less important it let more clear which index is raising errors when they really happen.

##### Component Name
Health
##### Additional Information

