### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.c	diff=cpp
+*.h	diff=cpp


### PR DESCRIPTION
This is just a single commit that sets the git diff driver for C source code files.

Git can be told to apply language-specific rules when generating diffs.
Enabling this for C source code files (*.c and *.h) means that function
names are printed correctly. Specifically, doing so prevents "git diff"
from mistakenly considering unindented goto labels as function names.

See the commit message for some more details.

Cheers,
Andrew
