### PR TITLE
Cppcheck fixes

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -230,7 +230,6 @@ static struct ns {
 };
 
 int switch_namespace(const char *prefix, pid_t pid) {
-    if(!prefix) prefix = "";
 
 #ifdef HAVE_SETNS
 

--- a/tests/profile/benchmark-line-parsing.c
+++ b/tests/profile/benchmark-line-parsing.c
@@ -643,11 +643,6 @@ void main(void)
     total_active_file_hash = simple_hash("total_active_file");
     total_unevictable_hash = simple_hash("total_unevictable");
 
-    // cache functions
-    (void)simple_hash2("hello world");
-    (void)strcmp("1", "2");
-    (void)strtoull("123", NULL, 0);
-
   unsigned long i, c1 = 0, c2 = 0, c3 = 0, c4 = 0, c5 = 0, c6 = 0, c7;
   unsigned long max = 1000000;
 


### PR DESCRIPTION
This comprises a couple of commits

collector: cgroups: Fix a cppcheck warning
tests/profile: Remove somewhat redundant code

The first removes a superfluous line from a function. This should not be controversial.

The second commit also removes some code, that *I* believe is somewhat redundant. See the commit message for the details and also https://github.com/netdata/netdata/issues/6378

Yes, this one may be more controversial...

Cheers,
Andrew
