### PR TITLE
Daemon fix double kills of collection threads on shutdown

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -554,7 +554,7 @@ void *pluginsd_worker_thread(void *arg) {
             }
 
             if(likely(cd->serial_failures <= SERIAL_FAILURES_THRESHOLD)) {
-                infoerr("'%s' (pid %d) does not generate useful output but it reports success (exits with 0). %s.",
+                info("'%s' (pid %d) does not generate useful output but it reports success (exits with 0). %s.",
                     cd->fullfilename, cd->pid,
                     cd->enabled ?
                         "Waiting a bit before starting it again." :

--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -556,6 +556,7 @@ void *pluginsd_worker_thread(void *arg) {
                 // we have collected something
 
                 if(likely(cd->serial_failures <= 10)) {
+                    if (code == -1) cd->enabled = 0;
                     error("'%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). %s", cd->fullfilename, cd->pid, code, cd->successful_collections, cd->enabled?"Waiting a bit before starting it again.":"Will not start it again - it is disabled.");
                     sleep((unsigned int) (cd->update_every * 10));
                 }

--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -521,6 +521,7 @@ static void pluginsd_worker_thread_cleanup(void *arg) {
     }
 }
 
+#define SERIAL_FAILURES_THRESHOLD 10
 void *pluginsd_worker_thread(void *arg) {
     netdata_thread_cleanup_push(pluginsd_worker_thread_cleanup, arg);
 
@@ -544,54 +545,77 @@ void *pluginsd_worker_thread(void *arg) {
         // get the return code
         int code = mypclose(fp, cd->pid);
 
+        if (likely(code == 0)) {
+            // the plugin reports success
+
+            if (likely(cd->successful_collections)) {
+                sleep((unsigned int) cd->update_every);
+                goto exit_code_analyzed;
+            }
+
+            if(likely(cd->serial_failures <= SERIAL_FAILURES_THRESHOLD)) {
+                infoerr("'%s' (pid %d) does not generate useful output but it reports success (exits with 0). %s.",
+                    cd->fullfilename, cd->pid,
+                    cd->enabled ?
+                        "Waiting a bit before starting it again." :
+                        "Will not start it again - it is now disabled.");
+                sleep((unsigned int) (cd->update_every * 10));
+                goto exit_code_analyzed;
+            }
+
+            if (cd->serial_failures > SERIAL_FAILURES_THRESHOLD) {
+                error("'%s' (pid %d) does not generate useful output, although it reports success (exits with 0)."
+                    "We have tried to collect something %zu times - unsuccessfully. Disabling it.",
+                    cd->fullfilename, cd->pid, cd->serial_failures);
+                cd->enabled = 0;
+                goto exit_code_analyzed;
+            }
+        }
+
         if(code != 0) {
             // the plugin reports failure
 
-            if(likely(!cd->successful_collections)) {
-                // nothing collected - disable it
-                error("'%s' (pid %d) exited with error code %d. Disabling it.", cd->fullfilename, cd->pid, code);
+            if (code == -1) {
+                infoerr("'%s' (pid %d) was killed with SIGTERM. Disabling it.", cd->fullfilename, cd->pid);
                 cd->enabled = 0;
+                goto exit_code_analyzed;
             }
-            else {
-                // we have collected something
 
-                if(likely(cd->serial_failures <= 10)) {
-                    if (code == -1) cd->enabled = 0;
-                    error("'%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). %s", cd->fullfilename, cd->pid, code, cd->successful_collections, cd->enabled?"Waiting a bit before starting it again.":"Will not start it again - it is disabled.");
-                    sleep((unsigned int) (cd->update_every * 10));
-                }
-                else {
-                    error("'%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). We tried %zu times to restart it, but it failed to generate data. Disabling it.", cd->fullfilename, cd->pid, code, cd->successful_collections, cd->serial_failures);
-                    cd->enabled = 0;
-                }
+            if (!cd->successful_collections) {
+                error("'%s' (pid %d) exited with error code %d and haven't collected any data. Disabling it.",
+                    cd->fullfilename, cd->pid, code);
+                cd->enabled = 0;
+                goto exit_code_analyzed;
+            }
+
+            if (cd->successful_collections && cd->serial_failures <= SERIAL_FAILURES_THRESHOLD) {
+                error("'%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). %s",
+                    cd->fullfilename, cd->pid, code, cd->successful_collections,
+                    cd->enabled ?
+                        "Waiting a bit before starting it again." :
+                        "Will not start it again - it is disabled.");
+                sleep((unsigned int) (cd->update_every * 10));
+                goto exit_code_analyzed;
+            }
+
+            if (cd->successful_collections && cd->serial_failures > SERIAL_FAILURES_THRESHOLD) {
+                error("'%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times)."
+                    "We tried to restart it %zu times, but it failed to generate data. Disabling it.",
+                    cd->fullfilename, cd->pid, code, cd->successful_collections, cd->serial_failures);
+                cd->enabled = 0;
+                goto exit_code_analyzed;
             }
         }
-        else {
-            // the plugin reports success
 
-            if(unlikely(!cd->successful_collections)) {
-                // we have collected nothing so far
-
-                if(likely(cd->serial_failures <= 10)) {
-                    error("'%s' (pid %d) does not generate useful output but it reports success (exits with 0). %s.", cd->fullfilename, cd->pid, cd->enabled?"Waiting a bit before starting it again.":"Will not start it again - it is now disabled.");
-                    sleep((unsigned int) (cd->update_every * 10));
-                }
-                else {
-                    error("'%s' (pid %d) does not generate useful output, although it reports success (exits with 0), but we have tried %zu times to collect something. Disabling it.", cd->fullfilename, cd->pid, cd->serial_failures);
-                    cd->enabled = 0;
-                }
-            }
-            else
-                sleep((unsigned int) cd->update_every);
-        }
+exit_code_analyzed:
         cd->pid = 0;
-
         if(unlikely(!cd->enabled)) break;
     }
 
     netdata_thread_cleanup_pop(1);
     return NULL;
 }
+#undef SERIAL_FAILURES_THRESHOLD
 
 static void pluginsd_main_cleanup(void *data) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)data;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Disables collection threads killed with `SIGTERM` to stop the cleanup function from attempting to kill them again.

##### Component Name
daemon

##### Additional Information
Fixes #6190
