### PR TITLE
Some cleanup to tests/profile/benchmark-line-parsing.c

### DIFF
--- a/tests/profile/benchmark-line-parsing.c
+++ b/tests/profile/benchmark-line-parsing.c
@@ -571,26 +571,6 @@ void test7() {
 
 // ----------------------------------------------------------------------------
 
-
-// ==============
-// --- Poor man cycle counting.
-static unsigned long tsc;
-
-static void begin_tsc(void)
-{
-  unsigned long a, d;
-  asm volatile ("cpuid\nrdtsc" : "=a" (a), "=d" (d) : "0" (0) : "ebx", "ecx");
-  tsc = ((unsigned long)d << 32) | (unsigned long)a;
-}
-
-static unsigned long end_tsc(void)
-{
-  unsigned long a, d;
-  asm volatile ("rdtscp" : "=a" (a), "=d" (d) : : "ecx");
-  return (((unsigned long)d << 32) | (unsigned long)a) - tsc;
-}
-// ===============
-
 static unsigned long long clk;
 
 static void begin_clock() {

--- a/tests/profile/benchmark-line-parsing.c
+++ b/tests/profile/benchmark-line-parsing.c
@@ -607,7 +607,7 @@ static unsigned long long end_clock() {
     return clk = tv.tv_sec  * 1000000 + tv.tv_usec - clk;
 }
 
-void main(void)
+int main(void)
 {
     cache_hash = simple_hash("cache");
     rss_hash = simple_hash("rss");
@@ -704,4 +704,5 @@ void main(void)
          , c7
          );
 
+    exit(EXIT_SUCCESS);
 }

--- a/tests/profile/benchmark-line-parsing.c
+++ b/tests/profile/benchmark-line-parsing.c
@@ -1,13 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "config.h"
+
 #include <stdio.h>
 #include <inttypes.h>
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <sys/time.h>
-
-#define likely(x) __builtin_expect(!!(x), 1)
-#define unlikely(x) __builtin_expect(!!(x), 0)
 
 #define simple_hash(name) ({                                         \
     register unsigned char *__hash_source = (unsigned char *)(name); \


### PR DESCRIPTION
This pull request comprises three commits

tests/profile: Make use of config.h in benchmark-line-parsing.c
tests/profile: Fix return type of main() in b-l-p.c
tests/profile: Remove a couple of unused functions in b-l-p.c

The first one removes some macro definitions which are available in config.h

The other two fix some compiler warnings. 

Cheers,
Andrew
