### PR TITLE
Make use of GCC's __attribute__((unused))

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -2006,7 +2006,7 @@ static inline int debug_print_process_and_parents(struct pid_stat *p, usec_t tim
     return indent + 1;
 }
 
-static inline void debug_print_process_tree(struct pid_stat *p, char *msg) {
+static inline void debug_print_process_tree(struct pid_stat *p, char *msg __maybe_unused) {
     debug_log("%s: process %s (%d, %s) with parents:", msg, p->comm, p->pid, p->updated?"running":"exited");
     debug_print_process_and_parents(p, p->stat_collected_usec);
 }

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -86,7 +86,7 @@ unsigned int read_iface_ifindex(const char *prefix, const char *iface) {
     return (unsigned int)ifindex;
 }
 
-struct iface *read_proc_net_dev(const char *scope, const char *prefix) {
+struct iface *read_proc_net_dev(const char *scope __maybe_unused, const char *prefix) {
     if(!prefix) prefix = "";
 
     procfile *ff = NULL;

--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -1067,7 +1067,7 @@ static const char *valuetype2string(STATSD_APP_CHART_DIM_VALUE_TYPE type) {
 }
 
 static STATSD_APP_CHART_DIM *add_dimension_to_app_chart(
-        STATSD_APP *app
+        STATSD_APP *app __maybe_unused
         , STATSD_APP_CHART *chart
         , const char *metric_name
         , const char *dim_name

--- a/configure.ac
+++ b/configure.ac
@@ -437,6 +437,14 @@ else
     AC_DEFINE_UNQUOTED([unlikely(x)], [(x)], [gcc branch optimization])
 fi
 
+if test "${GCC}" = "yes"; then
+    AC_DEFINE([__always_unused], [__attribute__((unused))], [gcc unused attribute])
+    AC_DEFINE([__maybe_unused], [__attribute__((unused))], [gcc unused attribute])
+else
+    AC_DEFINE([__always_unused], [], [dummy unused attribute])
+    AC_DEFINE([__maybe_unused], [], [dummy unused attribute])
+fi
+
 if test "${enable_pedantic}" = "yes"; then
     enable_strict="yes"
     CFLAGS="${CFLAGS} -pedantic -Wall -Wextra -Wno-long-long"

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -466,7 +466,7 @@ inline void rrddim_is_obsolete(RRDSET *st, RRDDIM *rd) {
     rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS);
 }
 
-inline void rrddim_isnot_obsolete(RRDSET *st, RRDDIM *rd) {
+inline void rrddim_isnot_obsolete(RRDSET *st __maybe_unused, RRDDIM *rd) {
     debug(D_RRD_CALLS, "rrddim_isnot_obsolete() for chart %s, dimension %s", st->name, rd->name);
 
     rrddim_flag_clear(rd, RRDDIM_FLAG_OBSOLETE);
@@ -475,7 +475,7 @@ inline void rrddim_isnot_obsolete(RRDSET *st, RRDDIM *rd) {
 // ----------------------------------------------------------------------------
 // RRDDIM - collect values for a dimension
 
-inline collected_number rrddim_set_by_pointer(RRDSET *st, RRDDIM *rd, collected_number value) {
+inline collected_number rrddim_set_by_pointer(RRDSET *st __maybe_unused, RRDDIM *rd, collected_number value) {
     debug(D_RRD_CALLS, "rrddim_set_by_pointer() for chart %s, dimension %s, value " COLLECTED_NUMBER_FORMAT, st->name, rd->name, value);
 
     now_realtime_timeval(&rd->last_collected_time);

--- a/database/rrdvar.c
+++ b/database/rrdvar.c
@@ -68,7 +68,8 @@ inline void rrdvar_free(RRDHOST *host, avl_tree_lock *tree, RRDVAR *rv) {
     freez(rv);
 }
 
-inline RRDVAR *rrdvar_create_and_index(const char *scope, avl_tree_lock *tree, const char *name, RRDVAR_TYPE type, RRDVAR_OPTIONS options, void *value) {
+inline RRDVAR *rrdvar_create_and_index(const char *scope __maybe_unused, avl_tree_lock *tree, const char *name,
+                                       RRDVAR_TYPE type, RRDVAR_OPTIONS options, void *value) {
     char *variable = strdupz(name);
     rrdvar_fix_name(variable);
     uint32_t hash = simple_hash(variable);

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -82,7 +82,8 @@ int __netdata_mutex_unlock(netdata_mutex_t *mutex) {
     return ret;
 }
 
-int netdata_mutex_init_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
+int netdata_mutex_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                             const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
     usec_t start = 0;
     (void)start;
 
@@ -98,7 +99,8 @@ int netdata_mutex_init_debug( const char *file, const char *function, const unsi
     return ret;
 }
 
-int netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
+int netdata_mutex_lock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                             const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
     usec_t start = 0;
     (void)start;
 
@@ -114,7 +116,8 @@ int netdata_mutex_lock_debug( const char *file, const char *function, const unsi
     return ret;
 }
 
-int netdata_mutex_trylock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
+int netdata_mutex_trylock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                                const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
     usec_t start = 0;
     (void)start;
 
@@ -130,7 +133,8 @@ int netdata_mutex_trylock_debug( const char *file, const char *function, const u
     return ret;
 }
 
-int netdata_mutex_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex) {
+int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                               const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
     usec_t start = 0;
     (void)start;
 
@@ -219,7 +223,8 @@ int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock) {
 }
 
 
-int netdata_rwlock_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
     usec_t start = 0;
     (void)start;
 
@@ -235,7 +240,8 @@ int netdata_rwlock_destroy_debug( const char *file, const char *function, const 
     return ret;
 }
 
-int netdata_rwlock_init_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                              const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
     usec_t start = 0;
     (void)start;
 
@@ -251,7 +257,8 @@ int netdata_rwlock_init_debug( const char *file, const char *function, const uns
     return ret;
 }
 
-int netdata_rwlock_rdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                                const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
     usec_t start = 0;
     (void)start;
 
@@ -267,7 +274,8 @@ int netdata_rwlock_rdlock_debug( const char *file, const char *function, const u
     return ret;
 }
 
-int netdata_rwlock_wrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                                const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
     usec_t start = 0;
     (void)start;
 
@@ -283,7 +291,8 @@ int netdata_rwlock_wrlock_debug( const char *file, const char *function, const u
     return ret;
 }
 
-int netdata_rwlock_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                                const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
     usec_t start = 0;
     (void)start;
 
@@ -299,7 +308,8 @@ int netdata_rwlock_unlock_debug( const char *file, const char *function, const u
     return ret;
 }
 
-int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                                   const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
     usec_t start = 0;
     (void)start;
 
@@ -315,7 +325,8 @@ int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, cons
     return ret;
 }
 
-int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+int netdata_rwlock_trywrlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                                   const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
     usec_t start = 0;
     (void)start;
 

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -20,7 +20,7 @@ int netdata_validate_server =  NETDATA_SSL_VALID_CERTIFICATE;
  * @param where the variable with the flags set.
  * @param ret the return of the caller
  */
-static void security_info_callback(const SSL *ssl, int where, int ret) {
+static void security_info_callback(const SSL *ssl, int where, int ret __maybe_unused) {
     (void)ssl;
     if (where & SSL_CB_ALERT) {
         debug(D_WEB_CLIENT,"SSL INFO CALLBACK %s %s", SSL_alert_type_string(ret), SSL_alert_desc_string_long(ret));


### PR DESCRIPTION
This pull request comprises eight commits

This updated pull request obeys the coding style and converts tabs to spaces.

Updated again for coding style consistency with surrounding code.

configure.ac: Add support for GCC's __attribute__((unused))
collectors/statsd.plugin: Mark a function argument as __maybe_unused
collectors/apps.plugin: Mark a function argument as __maybe_unused
libnetdata/locks/locks: Mark function arguments as __maybe_unused
libnetdata/socket/security: Mark a function argument as __maybe_unused
collectors/cgroups.plugin: Mark a function argument as __maybe_unused
database/rrddim: Mark function arguments as __maybe_unused
database/rrdvar: Mark a function argument as __maybe_unused

I like compiling with -Wall and -Wextra to catch various classes of potential problems.

While -Wall doesn't actually introduce any compiler warnings, -Wextra (along with -Wall) produces quite a few of "warning: unused parameter ‘XXXX’ [-Wunused-parameter]"

Now we could just use -Wno-unused-parameter but this can catch legitimate bugs. So instead, we can make use of GCC's __attribute__((unused)), now, that's quite a mouthful, so we create aliases __always_unused and __maybe_unused for it instead. These are set in configure.ac and for non GCC compilers they are just set empty.

See the first commit message for more details.

The rest of the commits make use of the new defines.

I'd like to see us using -Wall & -Wextra by default, if this pull request is accepted I'll perhaps try for that next.

Updated again just to expand on the commit message introducing the new macros to note that they can be used on objects other than function parameters and to also note that clang has support for this attribute also.

Cheers,
Andrew