### PR TITLE
Update apps_groups.conf for time group

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -189,7 +189,7 @@ print: cups* lpd lpq
 # -----------------------------------------------------------------------------
 # time servers and clients
 
-time: ntp* systemd-timesyncd chronyd
+time: ntp* systemd-timesyn* chronyd
 
 # -----------------------------------------------------------------------------
 # dhcp servers and clients


### PR DESCRIPTION
For Ubuntu 16.04 encountered this:
* The output for the 'ps -e' and '/proc/PID/stat' is "systemd-timesyn".
* The output for the substring mode '/proc/PID/cmdline' is "systemd-timesyn" as well

In order to check this group correctly systemd-timesyncd service has to be searched as substring with value "systemd-timesyn*"

Update apps_groups.conf

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

