### PR TITLE
Ignore /dev and /run space/inode usage

### DIFF
--- a/health/health.d/disks.conf
+++ b/health/health.d/disks.conf
@@ -13,7 +13,7 @@ template: disk_space_usage
       on: disk.space
       os: linux freebsd
    hosts: *
-families: *
+families: !/dev !/dev/* !/run !/run/* *
     calc: $used * 100 / ($avail + $used)
    units: %
    every: 1m
@@ -27,7 +27,7 @@ template: disk_inode_usage
       on: disk.inodes
       os: linux freebsd
    hosts: *
-families: *
+families: !/dev !/dev/* !/run !/run/* *
     calc: $used * 100 / ($avail + $used)
    units: %
    every: 1m


### PR DESCRIPTION
##### Summary
There were useless alerts for `/dev` and `/run` space/inode usage on a fresh Debian 9 installation. We are disabling these checks by default.

Fixes #6361

##### Component Name
health