### PR TITLE
Snapshot uniqueId fix

### DIFF
--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -8118,10 +8118,10 @@ let chartState = function (element) {
     };
 
     this.chartDataUniqueID = function () {
-        return this.id + ',' + this.library_name + ',' + this.dimensions + ',' + this.chartURLOptions();
+        return this.id + ',' + this.library_name + ',' + this.dimensions + ',' + this.chartURLOptions(true);
     };
 
-    this.chartURLOptions = function () {
+    this.chartURLOptions = function (isForUniqueId) {
         let ret = '';
 
         if (this.override_options !== null) {
@@ -8136,7 +8136,7 @@ let chartState = function (element) {
 
         ret += '%7C' + 'jsonwrap';
 
-        if (NETDATA.options.current.eliminate_zero_dimensions) {
+        if (!isForUniqueId && NETDATA.options.current.eliminate_zero_dimensions) {
             ret += '%7C' + 'nonzero';
         }
 

--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -8136,7 +8136,9 @@ let chartState = function (element) {
 
         ret += '%7C' + 'jsonwrap';
 
-        if (!isForUniqueId && NETDATA.options.current.eliminate_zero_dimensions) {
+        // always add `nonzero` when it's used to create a chartDataUniqueID
+        // we cannot just remove `nonzero` because of backwards compatibility with old snapshots
+        if (isForUniqueId || NETDATA.options.current.eliminate_zero_dimensions) {
             ret += '%7C' + 'nonzero';
         }
 

--- a/web/gui/src/dashboard.js/main.js
+++ b/web/gui/src/dashboard.js/main.js
@@ -3071,10 +3071,10 @@ let chartState = function (element) {
     };
 
     this.chartDataUniqueID = function () {
-        return this.id + ',' + this.library_name + ',' + this.dimensions + ',' + this.chartURLOptions();
+        return this.id + ',' + this.library_name + ',' + this.dimensions + ',' + this.chartURLOptions(true);
     };
 
-    this.chartURLOptions = function () {
+    this.chartURLOptions = function (isForUniqueId) {
         let ret = '';
 
         if (this.override_options !== null) {
@@ -3089,7 +3089,7 @@ let chartState = function (element) {
 
         ret += '%7C' + 'jsonwrap';
 
-        if (NETDATA.options.current.eliminate_zero_dimensions) {
+        if (!isForUniqueId && NETDATA.options.current.eliminate_zero_dimensions) {
             ret += '%7C' + 'nonzero';
         }
 

--- a/web/gui/src/dashboard.js/main.js
+++ b/web/gui/src/dashboard.js/main.js
@@ -3089,7 +3089,9 @@ let chartState = function (element) {
 
         ret += '%7C' + 'jsonwrap';
 
-        if (!isForUniqueId && NETDATA.options.current.eliminate_zero_dimensions) {
+        // always add `nonzero` when it's used to create a chartDataUniqueID
+        // we cannot just remove `nonzero` because of backwards compatibility with old snapshots
+        if (isForUniqueId || NETDATA.options.current.eliminate_zero_dimensions) {
             ret += '%7C' + 'nonzero';
         }
 


### PR DESCRIPTION
Fixes #6384 

##### Summary
When generating uniqueId for the snapshot, `NETDATA.options.current.eliminate_zero_dimensions` was taken into account and in some scenarios the keys were not matching (for example when exporting the snapshot `eliminate_zero_dimensions` were always `true`). I've removed the presence of `nonzero` key, so there's no conflict now.

Also, from what I understand `All` / `Non Zero` option in "Which dimensions to show?" option should not result in different representation in charts.