### PR TITLE
netdata/packaging: Fix RPM packaging workflow issues, plus draft changes for .DEB packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ install:
 - export DEPLOY_REPO="netdata" # Default production packaging repository
 - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export DEPLOY_REPO="netdata-edge"; fi;
 - export PACKAGING_USER="$(echo ${TRAVIS_REPO_SLUG} | cut -d'/' -f1)"
-- export DEV_CODE_REPO="binary-packages-deb-cleanup"
-- export PROD_CODE_REPO="master"
 
 
 
@@ -66,44 +64,44 @@ stages:
   # Build DEB packages under special conditions
   # Ubuntu
 - name: "Package ubuntu/disco"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/cosmic"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/bionic"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/artful"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 
   # Debian
 - name: "Package debian/buster"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/stretch"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/jessie"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/wheezy"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 
   # Build RPM packages under special conditions
   # Enterprise linux (Covers CentOS, Redhat, Amazon linux)
 - name: "Package Enterprise Linux 7"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM Enterprise Linux\]|\[Package arm64 RPM\]|\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Enterprise Linux\]|\[Package arm64 RPM\]|\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
 - name: "Package Enterprise linux 6"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
 
   # Fedora
 - name: "Package Fedora 30"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 - name: "Package Fedora 29"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 - name: "Package Fedora 28"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 
   # OpenSuSE
 - name: "Package OpenSuSE 15.1"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
 - name: "Package OpenSuSE 15.0"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
 
 
 
@@ -142,7 +140,7 @@ stages:
         on:
           # Only deploy on ${USER}/netdata, master branch, when packages directory is created
           repo: ${TRAVIS_REPO_SLUG}
-          branch: "${DEV_CODE_REPO}"
+          branch: "master"
           condition: -d "${PACKAGES_DIRECTORY}"
       # Production release packages deployment
       - provider: packagecloud
@@ -155,7 +153,7 @@ stages:
         on:
           # Only deploy on ${USER}/netdata, master branch, when packages directory is created
           repo: "netdata/netdata"
-          branch: "${PROD_CODE_REPO}"
+          branch: "master"
           condition: -d "${PACKAGES_DIRECTORY}"
     after_deploy:
       - if [ -n "${BUILDER_NAME}" ]; then rm -rf /home/${BUILDER_NAME}/* && echo "Cleared /home/${BUILDER_NAME} directory" || echo "Failed to clean /home/${BUILDER_NAME} directory"; fi;
@@ -198,7 +196,7 @@ stages:
         on:
           # Only deploy on ${USER}/netdata, master branch, when build-area directory is created
           repo: ${TRAVIS_REPO_SLUG}
-          branch: "${DEV_CODE_REPO}"
+          branch: "master"
           condition: -d "${PACKAGES_DIRECTORY}"
       # Production release packages deployment
       - provider: packagecloud
@@ -211,7 +209,7 @@ stages:
         on:
           # Only deploy on ${USER}/netdata, master branch, when build-area directory is created
           repo: "netdata/netdata"
-          branch: "${PROD_CODE_REPO}"
+          branch: "master"
           condition: -d "${PACKAGES_DIRECTORY}"
     after_deploy:
       - if [ -n "${BUILDER_NAME}" ]; then rm -rf /home/${BUILDER_NAME}/* && echo "Cleared /home/${BUILDER_NAME} directory" || echo "Failed to clean /home/${BUILDER_NAME} directory"; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,10 @@ stages:
     - post_message "TRAVIS_MESSAGE" "Starting package preparation and publishing for ${BUILD_STRING}.${BUILD_ARCH}" "${NOTIF_CHANNEL}"
     - export PACKAGES_DIRECTORY="$(mktemp -d -t netdata-packaging-contents-dir-XXXXXX)" && echo "Created packaging directory ${PACKAGES_DIRECTORY}"
     script:
+    - echo "GIT Branch:" && git branch
+    - echo "Last commit:" && git log -1
+    - echo "GIT Describe:" && git describe
+    - echo "packaging/version:" && cat packaging/version
     - echo "Creating LXC environment for the build" && sudo -E .travis/package_management/create_lxc_for_build.sh
     - echo "Building package in container" && sudo -E .travis/package_management/build_package_in_container.sh
     - sudo chmod -R 755 "/var/lib/lxc"
@@ -169,6 +173,10 @@ stages:
     - post_message "TRAVIS_MESSAGE" "Starting package preparation and publishing for ${BUILD_STRING}.${BUILD_ARCH}" "${NOTIF_CHANNEL}"
     - export PACKAGES_DIRECTORY="$(mktemp -d -t netdata-packaging-contents-dir-XXXXXX)" && echo "Created packaging directory ${PACKAGES_DIRECTORY}"
     script:
+    - echo "GIT Branch:" && git branch
+    - echo "Last commit:" && git log -1
+    - echo "GIT Describe:" && git describe
+    - echo "packaging/version:" && cat packaging/version
     - echo "Creating LXC environment for the build" && sudo -E .travis/package_management/create_lxc_for_build.sh
     - echo "Building package in container" && sudo -E .travis/package_management/build_package_in_container.sh
     - sudo chmod -R 755 "/var/lib/lxc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,44 +64,44 @@ stages:
   # Build DEB packages under special conditions
   # Ubuntu
 - name: "Package ubuntu/disco"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/cosmic"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/bionic"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/artful"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 
   # Debian
 - name: "Package debian/buster"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/stretch"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/jessie"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/wheezy"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 
   # Build RPM packages under special conditions
   # Enterprise linux (Covers CentOS, Redhat, Amazon linux)
 - name: "Package Enterprise Linux 7"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Enterprise Linux\]|\[Package arm64 RPM\]|\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 RPM Enterprise Linux\]|\[Package arm64 RPM\]|\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
 - name: "Package Enterprise linux 6"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
 
   # Fedora
 - name: "Package Fedora 30"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 - name: "Package Fedora 29"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 - name: "Package Fedora 28"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 
   # OpenSuSE
 - name: "Package OpenSuSE 15.1"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
 - name: "Package OpenSuSE 15.0"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
+  if: type != cron AND type != pull_request AND branch = master AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,23 +87,23 @@ stages:
   # Build RPM packages under special conditions
   # Enterprise linux (Covers CentOS, Redhat, Amazon linux)
 - name: "Package Enterprise Linux 7"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Enterprise Linux\]|\[Package arm64 RPM\]|\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM Enterprise Linux\]|\[Package arm64 RPM\]|\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
 - name: "Package Enterprise linux 6"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
 
   # Fedora
 - name: "Package Fedora 30"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 - name: "Package Fedora 29"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 - name: "Package Fedora 28"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 
   # OpenSuSE
 - name: "Package OpenSuSE 15.1"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
 - name: "Package OpenSuSE 15.0"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ stages:
     - sudo chmod -R 755 "/var/lib/lxc"
     - echo "Preparing RPM packaging contents for upload" && sudo -E .travis/package_management/prepare_packages.sh
     git:
-      depth: 250
+      depth: false
     after_failure: post_message "TRAVIS_MESSAGE" "Failed to build RPM for ${BUILD_STRING}.${BUILD_ARCH}"
     before_deploy:
     - .travis/package_management/yank_stale_rpm.sh "${PACKAGES_DIRECTORY}" "${BUILD_STRING}" || echo "No stale RPM found"
@@ -182,7 +182,7 @@ stages:
     - sudo chmod -R 755 "/var/lib/lxc"
     - echo "Preparing DEB packaging contents for upload" && sudo -E .travis/package_management/prepare_packages.sh
     git:
-      depth: 250
+      depth: false
     after_failure: post_message "TRAVIS_MESSAGE" "Failed to build DEB for ${BUILD_STRING}.${BUILD_ARCH}"
     before_deploy:
     - .travis/package_management/yank_stale_rpm.sh "${PACKAGES_DIRECTORY}" "${BUILD_STRING}" || echo "No stale DEB found"

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,8 +121,9 @@ stages:
     - echo "Building package in container" && sudo -E .travis/package_management/build_package_in_container.sh
     - sudo chmod -R 755 "/var/lib/lxc"
     - echo "Preparing RPM packaging contents for upload" && sudo -E .travis/package_management/prepare_packages.sh
+    git:
+      depth: false
     after_failure: post_message "TRAVIS_MESSAGE" "Failed to build RPM for ${BUILD_STRING}.${BUILD_ARCH}"
-
     before_deploy:
     - .travis/package_management/yank_stale_rpm.sh "${PACKAGES_DIRECTORY}" "${BUILD_STRING}" || echo "No stale RPM found"
     deploy:
@@ -172,6 +173,8 @@ stages:
     - echo "Building package in container" && sudo -E .travis/package_management/build_package_in_container.sh
     - sudo chmod -R 755 "/var/lib/lxc"
     - echo "Preparing DEB packaging contents for upload" && sudo -E .travis/package_management/prepare_packages.sh
+    git:
+      depth: false
     after_failure: post_message "TRAVIS_MESSAGE" "Failed to build DEB for ${BUILD_STRING}.${BUILD_ARCH}"
     before_deploy:
     - .travis/package_management/yank_stale_rpm.sh "${PACKAGES_DIRECTORY}" "${BUILD_STRING}" || echo "No stale DEB found"

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ stages:
     - sudo chmod -R 755 "/var/lib/lxc"
     - echo "Preparing RPM packaging contents for upload" && sudo -E .travis/package_management/prepare_packages.sh
     git:
-      depth: false
+      depth: 250
     after_failure: post_message "TRAVIS_MESSAGE" "Failed to build RPM for ${BUILD_STRING}.${BUILD_ARCH}"
     before_deploy:
     - .travis/package_management/yank_stale_rpm.sh "${PACKAGES_DIRECTORY}" "${BUILD_STRING}" || echo "No stale RPM found"
@@ -182,7 +182,7 @@ stages:
     - sudo chmod -R 755 "/var/lib/lxc"
     - echo "Preparing DEB packaging contents for upload" && sudo -E .travis/package_management/prepare_packages.sh
     git:
-      depth: false
+      depth: 250
     after_failure: post_message "TRAVIS_MESSAGE" "Failed to build DEB for ${BUILD_STRING}.${BUILD_ARCH}"
     before_deploy:
     - .travis/package_management/yank_stale_rpm.sh "${PACKAGES_DIRECTORY}" "${BUILD_STRING}" || echo "No stale DEB found"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ install:
 - export DEPLOY_REPO="netdata" # Default production packaging repository
 - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export DEPLOY_REPO="netdata-edge"; fi;
 - export PACKAGING_USER="$(echo ${TRAVIS_REPO_SLUG} | cut -d'/' -f1)"
+- export DEV_CODE_REPO="binary-packages-deb-cleanup"
+- export PROD_CODE_REPO="master"
 
 
 
@@ -64,23 +66,23 @@ stages:
   # Build DEB packages under special conditions
   # Ubuntu
 - name: "Package ubuntu/disco"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/cosmic"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/bionic"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/artful"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 
   # Debian
 - name: "Package debian/buster"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/stretch"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/jessie"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/wheezy"
-  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 
   # Build RPM packages under special conditions
   # Enterprise linux (Covers CentOS, Redhat, Amazon linux)
@@ -135,7 +137,7 @@ stages:
         on:
           # Only deploy on ${USER}/netdata, master branch, when packages directory is created
           repo: ${TRAVIS_REPO_SLUG}
-          branch: master
+          branch: "${DEV_CODE_REPO}"
           condition: -d "${PACKAGES_DIRECTORY}"
       # Production release packages deployment
       - provider: packagecloud
@@ -148,11 +150,12 @@ stages:
         on:
           # Only deploy on ${USER}/netdata, master branch, when packages directory is created
           repo: "netdata/netdata"
-          branch: "master"
+          branch: "${PROD_CODE_REPO}"
           condition: -d "${PACKAGES_DIRECTORY}"
     after_deploy:
       - if [ -n "${BUILDER_NAME}" ]; then rm -rf /home/${BUILDER_NAME}/* && echo "Cleared /home/${BUILDER_NAME} directory" || echo "Failed to clean /home/${BUILDER_NAME} directory"; fi;
       - if [ -d "${PACKAGES_DIRECTORY}" ]; then rm -rf "${PACKAGES_DIRECTORY}"; fi;
+
 
 
   # TODO: This section is stale, will be aligned with the RPM implementation when we get to DEB packaging
@@ -184,7 +187,7 @@ stages:
         on:
           # Only deploy on ${USER}/netdata, master branch, when build-area directory is created
           repo: ${TRAVIS_REPO_SLUG}
-          branch: master
+          branch: "${DEV_CODE_REPO}"
           condition: -d "${PACKAGES_DIRECTORY}"
       # Production release packages deployment
       - provider: packagecloud
@@ -197,7 +200,7 @@ stages:
         on:
           # Only deploy on ${USER}/netdata, master branch, when build-area directory is created
           repo: "netdata/netdata"
-          branch: master
+          branch: "${PROD_CODE_REPO}"
           condition: -d "${PACKAGES_DIRECTORY}"
     after_deploy:
       - if [ -n "${BUILDER_NAME}" ]; then rm -rf /home/${BUILDER_NAME}/* && echo "Cleared /home/${BUILDER_NAME} directory" || echo "Failed to clean /home/${BUILDER_NAME} directory"; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,23 +64,23 @@ stages:
   # Build DEB packages under special conditions
   # Ubuntu
 - name: "Package ubuntu/disco"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/cosmic"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/bionic"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/artful"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 
   # Debian
 - name: "Package debian/buster"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/stretch"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/jessie"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/wheezy"
-  if: type != cron AND branch = master AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 
   # Build RPM packages under special conditions
   # Enterprise linux (Covers CentOS, Redhat, Amazon linux)

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,44 +66,44 @@ stages:
   # Build DEB packages under special conditions
   # Ubuntu
 - name: "Package ubuntu/disco"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/cosmic"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/bionic"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 - name: "Package ubuntu/artful"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Ubuntu\]|\[Package arm64 DEB\]|\[Package i386 DEB Ubuntu\]|\[Package i386 DEB\]|\[Package AMD64 DEB Ubuntu\]|\[Package AMD64 DEB\])/
 
   # Debian
 - name: "Package debian/buster"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/stretch"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/jessie"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 - name: "Package debian/wheezy"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 DEB Debian\]|\[Package arm64 DEB\]|\[Package i386 DEB Debian\]|\[Package i386 DEB\]|\[Package AMD64 DEB Debian\]|\[Package AMD64 DEB\])/
 
   # Build RPM packages under special conditions
   # Enterprise linux (Covers CentOS, Redhat, Amazon linux)
 - name: "Package Enterprise Linux 7"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM Enterprise Linux\]|\[Package arm64 RPM\]|\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM Enterprise Linux\]|\[Package arm64 RPM\]|\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
 - name: "Package Enterprise linux 6"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package i386 RPM Enterprise Linux\]|\[Package i386 RPM\]|\[Package AMD64 RPM Enterprise Linux\]|\[Package AMD64 RPM\])/
 
   # Fedora
 - name: "Package Fedora 30"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 - name: "Package Fedora 29"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 - name: "Package Fedora 28"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM Fedora\]|\[Package arm64 RPM\]|\[Package AMD64 RPM Fedora\]|\[Package AMD64 RPM\])/
 
   # OpenSuSE
 - name: "Package OpenSuSE 15.1"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
 - name: "Package OpenSuSE 15.0"
-  if: type != cron AND branch = ${DEV_CODE_REPO} AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
+  if: type != cron AND branch = binary-packages-deb-cleanup AND commit_message =~ /(\[Package arm64 RPM openSuSE\]|\[Package arm64 RPM\]|\[Package AMD64 RPM openSuSE\]|\[Package AMD64 RPM\])/
 
 
 

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -55,7 +55,8 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
         run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
     else:
         print(".1 Checking out tag %s" % tag)
-        run_command_in_host(['git', 'checkout', '%s' % pkg_friendly_version])
+        # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
+        run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
 
     print(".2 Run autoreconf -ivf")
     run_command_in_host(['autoreconf', '-ivf'])

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -58,6 +58,7 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
         print(".1 Checking out tag %s" % tag)
         # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
         run_command_in_host(['git', 'fetch', '--all'])
+        run_command_in_host(['git', 'checkout', 'master'])
         run_command_in_host(['git', 'pull'])
         run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
 

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -57,7 +57,8 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     else:
         print(".1 Checking out tag %s" % tag)
         # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
-        run_command_in_host(['git', 'fetch'])
+        run_command_in_host(['git', 'fetch', '--all'])
+        run_command_in_host(['git', 'pull'])
         run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
 
     print(".2 Run autoreconf -ivf")

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -55,6 +55,8 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
         run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
     else:
         print(".1 Checking out tag %s" % tag)
+        run_command_in_host(['git', 'fetch', '--all'])
+
         # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
         run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
 

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -50,30 +50,30 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     print(".0 Preparing local latest implementation tarball for version %s" % pkg_friendly_version)
     tar_file = os.environ['LXC_CONTAINER_ROOT'] + dest_archive
 
-    if tag is None:
-        print(".1 Tagging the code with latest version: %s" % pkg_friendly_version)
-        run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
-    else:
+    if tag is not None:
         print(".1 Checking out tag %s" % tag)
         run_command_in_host(['git', 'fetch', '--all'])
 
         # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
         run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
 
-    print(".2 Run autoreconf -ivf")
+    print(".2 Tagging the code with version: %s" % pkg_friendly_version)
+    run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
+ 
+    print(".3 Run autoreconf -ivf")
     run_command_in_host(['autoreconf', '-ivf'])
 
-    print(".3 Run configure")
+    print(".4 Run configure")
     run_command_in_host(['./configure', '--with-math', '--with-zlib', '--with-user=netdata'])
 
-    print(".4 Run make dist")
+    print(".5 Run make dist")
     run_command_in_host(['make', 'dist'])
 
-    print(".5 Copy generated tarbal to desired path")
+    print(".6 Copy generated tarbal to desired path")
     if os.path.exists('netdata-%s.tar.gz' % pkg_friendly_version):
         run_command_in_host(['sudo', 'cp', 'netdata-%s.tar.gz' % pkg_friendly_version, tar_file])
 
-        print(".6 Fixing permissions on tarball")
+        print(".7 Fixing permissions on tarball")
         run_command_in_host(['sudo', 'chmod', '777', tar_file])
     else:
         print("I could not find (%s) on the disk, stopping the build. Kindly check the logs and try again" % 'netdata-%s.tar.gz' % pkg_friendly_version)

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -55,11 +55,6 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
         run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
     else:
         print(".1 Checking out tag %s" % tag)
-        run_command_in_host(['git', 'fetch', '--all'])
-        print("   Checking out '%s'" % os.environ['TRAVIS_BRANCH'])
-        run_command_in_host(['git', 'checkout', os.environ['TRAVIS_BRANCH']])
-        run_command_in_host(['git', 'pull'])
-
         # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
         run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
 

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -46,6 +46,30 @@ def run_command_in_host(cmd):
     print('Error: '  + e.decode('ascii'))
     print('code: ' + str(proc.returncode))
 
+def install_common_dependendencies():
+    if str(os.environ["REPO_TOOL"]).count("zypper") == 1:
+        run_command(container, [os.environ["REPO_TOOL"], "clean", "-a"])
+        run_command(container, [os.environ["REPO_TOOL"], "--no-gpg-checks", "update", "-y"])
+        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-glib-devel"])
+
+    elif str(os.environ["REPO_TOOL"]).count("yum") == 1:
+        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
+        run_command(container, [os.environ["REPO_TOOL"], "clean", "all"])
+        run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
+        if os.environ["BUILD_STRING"].count("el/7") == 1 and os.environ["BUILD_ARCH"].count("i386") == 1:
+            print ("Skipping epel-release install for %s-%s" % (os.environ["BUILD_STRING"], os.environ["BUILD_ARCH"]))
+        else:
+            run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "epel-release"])
+    else:
+        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
+        run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
+
+    run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "sudo"])
+    run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "wget"])
+    run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "bash"])
+    run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "freeipmi-devel"])
+    run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups-devel"])
+
 def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     print(".0 Preparing local implementation tarball for version %s" % pkg_friendly_version)
     tar_file = os.environ['LXC_CONTAINER_ROOT'] + dest_archive

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -6,6 +6,7 @@
 
 import lxc
 import subprocess
+import os
 
 def replace_tag(tag_name, spec, new_tag_content):
     print("Fixing tag %s in %s" % (tag_name, spec))
@@ -45,12 +46,16 @@ def run_command_in_host(cmd):
     print('Error: '  + e.decode('ascii'))
     print('code: ' + str(proc.returncode))
 
-def prepare_latest_version_source(dest_archive, pkg_friendly_version):
+def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     print(".0 Preparing local latest implementation tarball for version %s" % pkg_friendly_version)
     tar_file = os.environ['LXC_CONTAINER_ROOT'] + dest_archive
 
-    print(".1 Tagging the code with latest version: %s" % pkg_friendly_version)
-    run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
+    if tag is None:
+        print(".1 Tagging the code with latest version: %s" % pkg_friendly_version)
+        run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
+    else:
+        print(".1 Checking out tag %s" % tag)
+        run_command_in_host(['git', 'checkout', '%s' % pkg_friendly_version])
 
     print(".2 Run autoreconf -ivf")
     run_command_in_host(['autoreconf', '-ivf'])

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -52,10 +52,12 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
 
     if tag is None:
         print(".1 Tagging the code with latest version: %s" % pkg_friendly_version)
+        run_command_in_host(['git', 'fetch'])
         run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
     else:
         print(".1 Checking out tag %s" % tag)
         # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
+        run_command_in_host(['git', 'fetch'])
         run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
 
     print(".2 Run autoreconf -ivf")

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -44,3 +44,29 @@ def run_command_in_host(cmd):
     print('Output: ' + o.decode('ascii'))
     print('Error: '  + e.decode('ascii'))
     print('code: ' + str(proc.returncode))
+
+def prepare_latest_version_source(dest_archive, pkg_friendly_version):
+    print(".0 Preparing local latest implementation tarball for version %s" % pkg_friendly_version)
+    tar_file = os.environ['LXC_CONTAINER_ROOT'] + dest_archive
+
+    print(".1 Tagging the code with latest version: %s" % pkg_friendly_version)
+    run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
+
+    print(".2 Run autoreconf -ivf")
+    run_command_in_host(['autoreconf', '-ivf'])
+
+    print(".3 Run configure")
+    run_command_in_host(['./configure', '--with-math', '--with-zlib', '--with-user=netdata'])
+
+    print(".4 Run make dist")
+    run_command_in_host(['make', 'dist'])
+
+    print(".5 Copy generated tarbal to desired path")
+    if os.path.exists('netdata-%s.tar.gz' % pkg_friendly_version):
+        run_command_in_host(['sudo', 'cp', 'netdata-%s.tar.gz' % pkg_friendly_version, tar_file])
+
+        print(".6 Fixing permissions on tarball")
+        run_command_in_host(['sudo', 'chmod', '777', tar_file])
+    else:
+        print("I could not find (%s) on the disk, stopping the build. Kindly check the logs and try again" % 'netdata-%s.tar.gz' % pkg_friendly_version)
+        sys.exit(1)

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -47,7 +47,7 @@ def run_command_in_host(cmd):
     print('code: ' + str(proc.returncode))
 
 def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
-    print(".0 Preparing local latest implementation tarball for version %s" % pkg_friendly_version)
+    print(".0 Preparing local implementation tarball for version %s" % pkg_friendly_version)
     tar_file = os.environ['LXC_CONTAINER_ROOT'] + dest_archive
 
     if tag is not None:
@@ -59,7 +59,7 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
 
     print(".2 Tagging the code with version: %s" % pkg_friendly_version)
     run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
- 
+
     print(".3 Run autoreconf -ivf")
     run_command_in_host(['autoreconf', '-ivf'])
 

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -52,14 +52,10 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
 
     if tag is None:
         print(".1 Tagging the code with latest version: %s" % pkg_friendly_version)
-        run_command_in_host(['git', 'fetch'])
         run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
     else:
         print(".1 Checking out tag %s" % tag)
         # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
-        run_command_in_host(['git', 'fetch', '--all'])
-        run_command_in_host(['git', 'checkout', 'master'])
-        run_command_in_host(['git', 'pull'])
         run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
 
     print(".2 Run autoreconf -ivf")

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -55,6 +55,11 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
         run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
     else:
         print(".1 Checking out tag %s" % tag)
+        run_command_in_host(['git', 'fetch', '--all'])
+        print("   Checking out '%s'" % os.environ['TRAVIS_BRANCH'])
+        run_command_in_host(['git', 'checkout', os.environ['TRAVIS_BRANCH']])
+        run_command_in_host(['git', 'pull'])
+
         # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
         run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
 

--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -46,28 +46,33 @@ common.run_command(container, ["useradd", "-m", os.environ['BUILDER_NAME']])
 
 # Fetch package dependencies for the build
 print("2. Installing package dependencies within LXC container")
-common.run_command(container, ["apt-get", "update", "-y"])
-common.run_command(container, ["apt-get", "install", "-y", "sudo"])
-common.run_command(container, ["apt-get", "install", "-y", "wget"])
-common.run_command(container, ["apt-get", "install", "-y", "bash"])
+common.run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
+common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "sudo"])
+common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "wget"])
+common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "bash"])
 
 print ("3. Run install-required-packages scriptlet")
 common.run_command(container, ["wget", "-T", "15", "-O", "/home/%s/.install-required-packages.sh" % (os.environ['BUILDER_NAME']), "https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh"])
 common.run_command(container, ["bash", "/home/%s/.install-required-packages.sh" % (os.environ['BUILDER_NAME']), "netdata", "--dont-wait", "--non-interactive"])
 
+friendly_version=""
+dest_archive=""
+download_url=""
+tag = None
 
-# Download the source
-
+# TODO: Checksum validations
 if str(os.environ['BUILD_VERSION']).count(".latest") == 1:
-    print ("TODO!")
+    version_list=str(os.environ['BUILD_VERSION']).replace('v', '').split('.')
+    friendly_version='.'.join(version_list[0:3]) + "." + version_list[3]
 else:
-    dest_archive="/home/%s/netdata-%s.tar.gz" % (os.environ['BUILDER_NAME'],os.environ['BUILD_VERSION'])
-    release_url="https://github.com/netdata/netdata/releases/download/%s/netdata-%s.tar.gz" % (os.environ['BUILD_VERSION'], os.environ['BUILD_VERSION'])
+    friendly_version = os.environ['BUILD_VERSION'].replace('v', '')
+    tag = friendly_version # Go to stable tag
 
-    print("4. Fetch netdata source (%s -> %s)" % (release_url, dest_archive))
-    common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "wget", "-T", "15", "--output-document=" + dest_archive, release_url])
+tar_file="%s/netdata-%s.tar.gz" % (os.path.dirname(dest_archive), friendly_version)
 
-    print("5. Extracting directory contents to /home " + os.environ['BUILDER_NAME'])
-    common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "tar", "xf", dest_archive, "-C", "/home/" + os.environ['BUILDER_NAME']])
+print("5. I will be building version '%s' of netdata." % os.environ['BUILD_VERSION'])
+dest_archive="/home/%s/netdata-%s.tar.gz" % (os.environ['BUILDER_NAME'], friendly_version)
+
+common.prepare_version_source(dest_archive, friendly_version, tag=tag)
 
 print("Done!")

--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -50,16 +50,24 @@ common.run_command(container, ["apt-get", "update", "-y"])
 common.run_command(container, ["apt-get", "install", "-y", "sudo"])
 common.run_command(container, ["apt-get", "install", "-y", "wget"])
 common.run_command(container, ["apt-get", "install", "-y", "bash"])
-common.run_command(container, ["wget", "-T", "15", "-O", "~/.install-required-packages.sh", "https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh"])
-common.run_command(container, ["bash", "~/.install-required-packages.sh", "netdata", "--dont-wait", "--non-interactive"])
+
+print ("3. Run install-required-packages scriptlet")
+common.run_command(container, ["wget", "-T", "15", "-O", "/home/%s/.install-required-packages.sh" % (os.environ['BUILDER_NAME']), "https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh"])
+common.run_command(container, ["bash", "/home/%s/.install-required-packages.sh" % (os.environ['BUILDER_NAME']), "netdata", "--dont-wait", "--non-interactive"])
+
 
 # Download the source
-dest_archive="/home/%s/netdata-%s.tar.gz" % (os.environ['BUILDER_NAME'],os.environ['BUILD_VERSION'])
-release_url="https://github.com/netdata/netdata/releases/download/%s/netdata-%s.tar.gz" % (os.environ['BUILD_VERSION'], os.environ['BUILD_VERSION'])
-print("3. Fetch netdata source (%s -> %s)" % (release_url, dest_archive))
-common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "wget", "-T", "15", "--output-document=" + dest_archive, release_url])
 
-print("4. Extracting directory contents to /home " + os.environ['BUILDER_NAME'])
-common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "tar", "xf", dest_archive, "-C", "/home/" + os.environ['BUILDER_NAME']])
+if str(os.environ['BUILD_VERSION']).count(".latest") == 1:
+    print ("TODO!")
+else:
+    dest_archive="/home/%s/netdata-%s.tar.gz" % (os.environ['BUILDER_NAME'],os.environ['BUILD_VERSION'])
+    release_url="https://github.com/netdata/netdata/releases/download/%s/netdata-%s.tar.gz" % (os.environ['BUILD_VERSION'], os.environ['BUILD_VERSION'])
+
+    print("4. Fetch netdata source (%s -> %s)" % (release_url, dest_archive))
+    common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "wget", "-T", "15", "--output-document=" + dest_archive, release_url])
+
+    print("5. Extracting directory contents to /home " + os.environ['BUILDER_NAME'])
+    common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "tar", "xf", dest_archive, "-C", "/home/" + os.environ['BUILDER_NAME']])
 
 print("Done!")

--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -46,10 +46,7 @@ common.run_command(container, ["useradd", "-m", os.environ['BUILDER_NAME']])
 
 # Fetch package dependencies for the build
 print("2. Installing package dependencies within LXC container")
-common.run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
-common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "sudo"])
-common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "wget"])
-common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "bash"])
+common.install_common_dependendencies()
 
 print ("3. Run install-required-packages scriptlet")
 common.run_command(container, ["wget", "-T", "15", "-O", "/home/%s/.install-required-packages.sh" % (os.environ['BUILDER_NAME']), "https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh"])

--- a/.travis/package_management/configure_rpm_lxc_environment.py
+++ b/.travis/package_management/configure_rpm_lxc_environment.py
@@ -112,7 +112,7 @@ else:
 
 tar_file="%s/netdata-%s.tar.gz" % (os.path.dirname(dest_archive), rpm_friendly_version)
 
-print("5. I will be building latest nightly version of netdata..(%s)" % os.environ['BUILD_VERSION'])
+print("5. I will be building version '%s' of netdata." % os.environ['BUILD_VERSION'])
 dest_archive="/home/%s/rpmbuild/SOURCES/netdata-%s.tar.gz" % (os.environ['BUILDER_NAME'], rpm_friendly_version)
 
 common.prepare_version_source(dest_archive, rpm_friendly_version, tag=tag)

--- a/.travis/package_management/configure_rpm_lxc_environment.py
+++ b/.travis/package_management/configure_rpm_lxc_environment.py
@@ -57,6 +57,8 @@ elif str(os.environ["REPO_TOOL"]).count("yum") == 1:
     common.run_command(container, [os.environ["REPO_TOOL"], "clean", "all"])
     common.run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
     if os.environ["BUILD_STRING"].count("el/7") == 1 and os.environ["BUILD_ARCH"].count("i386") == 1:
+        print ("Skipping epel-release install for %s-%s" % (os.environ["BUILD_STRING"], os.environ["BUILD_ARCH"]))
+    else:
         common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "epel-release"])
 else:
     common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])

--- a/.travis/package_management/configure_rpm_lxc_environment.py
+++ b/.travis/package_management/configure_rpm_lxc_environment.py
@@ -100,40 +100,29 @@ rpm_friendly_version=""
 dest_archive=""
 download_url=""
 spec_file="/home/%s/rpmbuild/SPECS/netdata.spec" % os.environ['BUILDER_NAME']
+tag = None
 
 # TODO: Checksum validations
 if str(os.environ['BUILD_VERSION']).count(".latest") == 1:
     version_list=str(os.environ['BUILD_VERSION']).replace('v', '').split('.')
     rpm_friendly_version='.'.join(version_list[0:3]) + "." + version_list[3]
-
-    print("5. I will be building latest nightly version of netdata..(%s)" % os.environ['BUILD_VERSION'])
-    dest_archive="/home/%s/rpmbuild/SOURCES/netdata-%s.tar.gz" % (os.environ['BUILDER_NAME'], rpm_friendly_version)
-
-    prepare_latest_version_source(dest_archive)
-
-    # Extract the spec file in place
-    print("6. Extract spec file from the source")
-    common.run_command_in_host(['sudo', 'cp', 'netdata.spec', os.environ['LXC_CONTAINER_ROOT'] + spec_file])
-    common.run_command_in_host(['sudo', 'chmod', '777', os.environ['LXC_CONTAINER_ROOT'] + spec_file])
-
-    print("7. Temporary hack: Change Source0 to %s on spec file %s" % (dest_archive, spec_file))
-    common.replace_tag("Source0", os.environ['LXC_CONTAINER_ROOT'] + spec_file, tar_file)
 else:
     rpm_friendly_version = os.environ['BUILD_VERSION'].replace('v', '')
+    tag = rpm_friendly_version # Go to stable tag
 
-    print("5. I will be building latest stable version of netdata.. (%s)" % os.environ['BUILD_VERSION'])
-    dest_archive="/home/%s/rpmbuild/SOURCES/netdata-%s.tar.gz" % (os.environ['BUILDER_NAME'],os.environ['BUILD_VERSION'])
-    download_url="https://github.com/netdata/netdata/releases/download/%s/netdata-%s.tar.gz" % (os.environ['BUILD_VERSION'], os.environ['BUILD_VERSION'])
+tar_file="%s/netdata-%s.tar.gz" % (os.path.dirname(dest_archive), rpm_friendly_version)
 
-    print("6. Fetch netdata source into the repo structure(%s -> %s)" % (download_url, dest_archive))
-    tar_file="%s/netdata-%s.tar.gz" % (os.path.dirname(dest_archive), rpm_friendly_version)
-    common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "wget", "-T", "15", "--output-document=" + dest_archive, download_url])
+print("5. I will be building latest nightly version of netdata..(%s)" % os.environ['BUILD_VERSION'])
+dest_archive="/home/%s/rpmbuild/SOURCES/netdata-%s.tar.gz" % (os.environ['BUILDER_NAME'], rpm_friendly_version)
 
-    print("7.Extract spec file from the source")
-    common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "tar", "--to-command=cat > %s" % spec_file, "-xvf", dest_archive, "netdata-%s/netdata.spec" % os.environ['BUILD_VERSION']])
+common.prepare_version_source(dest_archive, rpm_friendly_version, tag=tag)
 
-    print("8. Temporary hack: Adjust version string on the spec file (%s) to %s and Source0 to %s" % (os.environ['LXC_CONTAINER_ROOT'] + spec_file, rpm_friendly_version, download_url))
-    common.replace_tag("Version", os.environ['LXC_CONTAINER_ROOT'] + spec_file, rpm_friendly_version)
-    common.replace_tag("Source0", os.environ['LXC_CONTAINER_ROOT'] + spec_file, tar_file)
+# Extract the spec file in place
+print("6. Extract spec file from the source")
+common.run_command_in_host(['sudo', 'cp', 'netdata.spec', os.environ['LXC_CONTAINER_ROOT'] + spec_file])
+common.run_command_in_host(['sudo', 'chmod', '777', os.environ['LXC_CONTAINER_ROOT'] + spec_file])
+
+print("7. Temporary hack: Change Source0 to %s on spec file %s" % (dest_archive, spec_file))
+common.replace_tag("Source0", os.environ['LXC_CONTAINER_ROOT'] + spec_file, tar_file)
 
 print('Done!')

--- a/.travis/package_management/configure_rpm_lxc_environment.py
+++ b/.travis/package_management/configure_rpm_lxc_environment.py
@@ -56,7 +56,8 @@ elif str(os.environ["REPO_TOOL"]).count("yum") == 1:
     common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
     common.run_command(container, [os.environ["REPO_TOOL"], "clean", "all"])
     common.run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
-    common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "epel-release"])
+    if os.environ["BUILD_STRING"].count("el/7") == 1 and os.environ["BUILD_ARCH"].count("i386") == 1:
+        common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "epel-release"])
 else:
     common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
     common.run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])

--- a/.travis/package_management/configure_rpm_lxc_environment.py
+++ b/.travis/package_management/configure_rpm_lxc_environment.py
@@ -47,11 +47,10 @@ common.run_command(container, ["useradd", "-m", os.environ['BUILDER_NAME']])
 
 # Fetch package dependencies for the build
 print("2. Installing package dependencies within LXC container")
-install_common_dependendencies()
+common.install_common_dependendencies()
 
 # Exceptional cases, not available everywhere
 #
-
 # Not on Centos-7
 if os.environ["BUILD_STRING"].count("el/7") <= 0:
     common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libnetfilter_acct-devel"])

--- a/.travis/package_management/configure_rpm_lxc_environment.py
+++ b/.travis/package_management/configure_rpm_lxc_environment.py
@@ -47,28 +47,7 @@ common.run_command(container, ["useradd", "-m", os.environ['BUILDER_NAME']])
 
 # Fetch package dependencies for the build
 print("2. Installing package dependencies within LXC container")
-if str(os.environ["REPO_TOOL"]).count("zypper") == 1:
-    common.run_command(container, [os.environ["REPO_TOOL"], "clean", "-a"])
-    common.run_command(container, [os.environ["REPO_TOOL"], "--no-gpg-checks", "update", "-y"])
-    common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-glib-devel"])
-
-elif str(os.environ["REPO_TOOL"]).count("yum") == 1:
-    common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
-    common.run_command(container, [os.environ["REPO_TOOL"], "clean", "all"])
-    common.run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
-    if os.environ["BUILD_STRING"].count("el/7") == 1 and os.environ["BUILD_ARCH"].count("i386") == 1:
-        print ("Skipping epel-release install for %s-%s" % (os.environ["BUILD_STRING"], os.environ["BUILD_ARCH"]))
-    else:
-        common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "epel-release"])
-else:
-    common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
-    common.run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
-
-common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "sudo"])
-common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "wget"])
-common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "bash"])
-common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "freeipmi-devel"])
-common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups-devel"])
+install_common_dependendencies()
 
 # Exceptional cases, not available everywhere
 #


### PR DESCRIPTION
#### Summary
With this PR we attempting to fix the following two issues with RPM packaging generation:
1) It was impossible to produce the binaries prior to publishing a release, because we fetched the tarbal from the github release page (No BUG report, bumped into it when i went ahed to generate the packages and started fixing it asap)
     To mitigate this problem, we took the obvious step of generating the tarball for the stable line, the same way we do for the nightlies, from the repo.  That way we decouple packaging from github releases.

2) Stable RPM package was still having the 'v' keyword which was wrong #6409 
    By following the same process of nightlies for the tarball generation, it was easier to mitigate the elimination of 'v' from the generated package too.  So basically with a single change hopefully we nailed two problems

##### Component Name
netdata/packaging

##### Additional Information
Fixes #6409