### PR TITLE
Add global configuration option for zero metrics

### DIFF
--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -110,6 +110,8 @@ By default, Netdata will enable monitoring metrics only when they are not zero. 
 	enable memory (used mem including cache) = yes
 ```
 
+You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero metrics for all internal Netdata plugins.
+
 ### alarms
 
 CPU and memory limits are watched and used to rise alarms. Memory usage for every cgroup is checked against `ram` and `ram+swap` limits. CPU usage for every cgroup is checked against `cpuset.cpus` and `cpu.cfs_period_us` + `cpu.cfs_quota_us` pair assigned for the cgroup. Configuration for the alarms is available in `health.d/cgroups.conf` file.

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -575,7 +575,8 @@ static inline void cgroup_read_cpuacct_stat(struct cpuacct_stat *cp) {
 
         cp->updated = 1;
 
-        if(unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO && (cp->user || cp->system)))
+        if(unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO &&
+                    (cp->user || cp->system || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             cp->enabled = CONFIG_BOOLEAN_YES;
     }
 }
@@ -611,7 +612,8 @@ static inline void cgroup2_read_cpuacct_stat(struct cpuacct_stat *cp) {
 
         cp->updated = 1;
 
-        if(unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO && (cp->user || cp->system)))
+        if(unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO &&
+                    (cp->user || cp->system || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             cp->enabled = CONFIG_BOOLEAN_YES;
     }
 }
@@ -668,7 +670,8 @@ static inline void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
 
         ca->updated = 1;
 
-        if(unlikely(ca->enabled == CONFIG_BOOLEAN_AUTO && total))
+        if(unlikely(ca->enabled == CONFIG_BOOLEAN_AUTO &&
+                    (total || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             ca->enabled = CONFIG_BOOLEAN_YES;
     }
 }
@@ -737,7 +740,7 @@ static inline void cgroup_read_blkio(struct blkio *io) {
         io->updated = 1;
 
         if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO)) {
-            if(unlikely(io->Read || io->Write))
+            if(unlikely(io->Read || io->Write || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
                 io->enabled = CONFIG_BOOLEAN_YES;
             else
                 io->delay_counter = cgroup_recheck_zero_blkio_every_iterations;
@@ -787,7 +790,7 @@ static inline void cgroup2_read_blkio(struct blkio *io, unsigned int word_offset
             io->updated = 1;
 
             if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO)) {
-                if(unlikely(io->Read || io->Write))
+                if(unlikely(io->Read || io->Write || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
                     io->enabled = CONFIG_BOOLEAN_YES;
                 else
                     io->delay_counter = cgroup_recheck_zero_blkio_every_iterations;
@@ -881,7 +884,8 @@ static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unif
             if(( (!parent_cg_is_unified) && ( mem->total_cache || mem->total_dirty || mem->total_rss || mem->total_rss_huge || mem->total_mapped_file || mem->total_writeback
                     || mem->total_swap || mem->total_pgpgin || mem->total_pgpgout || mem->total_pgfault || mem->total_pgmajfault))
                || (parent_cg_is_unified && ( mem->anon || mem->total_dirty || mem->kernel_stack || mem->slab || mem->sock || mem->total_writeback
-                    || mem->anon_thp || mem->total_pgfault || mem->total_pgmajfault)))
+                    || mem->anon_thp || mem->total_pgfault || mem->total_pgmajfault))
+               || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)
                 mem->enabled_detailed = CONFIG_BOOLEAN_YES;
             else
                 mem->delay_counter_detailed = cgroup_recheck_zero_mem_detailed_every_iterations;
@@ -893,14 +897,16 @@ memory_next:
     // read usage_in_bytes
     if(likely(mem->filename_usage_in_bytes)) {
         mem->updated_usage_in_bytes = !read_single_number_file(mem->filename_usage_in_bytes, &mem->usage_in_bytes);
-        if(unlikely(mem->updated_usage_in_bytes && mem->enabled_usage_in_bytes == CONFIG_BOOLEAN_AUTO && mem->usage_in_bytes))
+        if(unlikely(mem->updated_usage_in_bytes && mem->enabled_usage_in_bytes == CONFIG_BOOLEAN_AUTO &&
+                    (mem->usage_in_bytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             mem->enabled_usage_in_bytes = CONFIG_BOOLEAN_YES;
     }
 
     // read msw_usage_in_bytes
     if(likely(mem->filename_msw_usage_in_bytes)) {
         mem->updated_msw_usage_in_bytes = !read_single_number_file(mem->filename_msw_usage_in_bytes, &mem->msw_usage_in_bytes);
-        if(unlikely(mem->updated_msw_usage_in_bytes && mem->enabled_msw_usage_in_bytes == CONFIG_BOOLEAN_AUTO && mem->msw_usage_in_bytes))
+        if(unlikely(mem->updated_msw_usage_in_bytes && mem->enabled_msw_usage_in_bytes == CONFIG_BOOLEAN_AUTO &&
+                    (mem->msw_usage_in_bytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             mem->enabled_msw_usage_in_bytes = CONFIG_BOOLEAN_YES;
     }
 
@@ -913,10 +919,10 @@ memory_next:
         else {
             mem->updated_failcnt = !read_single_number_file(mem->filename_failcnt, &mem->failcnt);
             if(unlikely(mem->updated_failcnt && mem->enabled_failcnt == CONFIG_BOOLEAN_AUTO)) {
-                if(unlikely(!mem->failcnt))
-                    mem->delay_counter_failcnt = cgroup_recheck_zero_mem_failcnt_every_iterations;
-                else
+                if(unlikely(mem->failcnt || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
                     mem->enabled_failcnt = CONFIG_BOOLEAN_YES;
+                else
+                    mem->delay_counter_failcnt = cgroup_recheck_zero_mem_failcnt_every_iterations;
             }
         }
     }

--- a/collectors/diskspace.plugin/README.md
+++ b/collectors/diskspace.plugin/README.md
@@ -10,7 +10,7 @@ Two charts are available for every mount:
 
 Simple patterns can be used to exclude mounts from showed statistics based on path or filesystem. By default read-only mounts are not displayed. To display them `yes` should be set for a chart instead of `auto`.
 
-By default, Netdata will enable monitoring metrics only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a chart instead of `auto` to enable it permanently.
+By default, Netdata will enable monitoring metrics only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a chart instead of `auto` to enable it permanently. You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero metrics for all internal Netdata plugins.
 
 
 ```

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -249,9 +249,8 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
     int rendered = 0;
 
-    if(m->do_space == CONFIG_BOOLEAN_YES ||
-       (m->do_space == CONFIG_BOOLEAN_AUTO && (bavail || breserved_root || bused)) ||
-       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES) {
+    if(m->do_space == CONFIG_BOOLEAN_YES || (m->do_space == CONFIG_BOOLEAN_AUTO &&
+                                             (bavail || breserved_root || bused || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         if(unlikely(!m->st_space)) {
             m->do_space = CONFIG_BOOLEAN_YES;
             m->st_space = rrdset_find_bytype_localhost("disk_space", disk);
@@ -291,9 +290,8 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
     // --------------------------------------------------------------------------
 
-    if(m->do_inodes == CONFIG_BOOLEAN_YES ||
-       (m->do_inodes == CONFIG_BOOLEAN_AUTO && (favail || freserved_root || fused)) ||
-       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES) {
+    if(m->do_inodes == CONFIG_BOOLEAN_YES || (m->do_inodes == CONFIG_BOOLEAN_AUTO &&
+                                              (favail || freserved_root || fused || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         if(unlikely(!m->st_inodes)) {
             m->do_inodes = CONFIG_BOOLEAN_YES;
             m->st_inodes = rrdset_find_bytype_localhost("disk_inodes", disk);

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -250,7 +250,8 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
     int rendered = 0;
 
     if(m->do_space == CONFIG_BOOLEAN_YES || (m->do_space == CONFIG_BOOLEAN_AUTO &&
-                                             (bavail || breserved_root || bused || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                             (bavail || breserved_root || bused ||
+                                              netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         if(unlikely(!m->st_space)) {
             m->do_space = CONFIG_BOOLEAN_YES;
             m->st_space = rrdset_find_bytype_localhost("disk_space", disk);
@@ -291,7 +292,8 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
     // --------------------------------------------------------------------------
 
     if(m->do_inodes == CONFIG_BOOLEAN_YES || (m->do_inodes == CONFIG_BOOLEAN_AUTO &&
-                                              (favail || freserved_root || fused || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                              (favail || freserved_root || fused ||
+                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         if(unlikely(!m->st_inodes)) {
             m->do_inodes = CONFIG_BOOLEAN_YES;
             m->st_inodes = rrdset_find_bytype_localhost("disk_inodes", disk);

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -249,7 +249,9 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
     int rendered = 0;
 
-    if(m->do_space == CONFIG_BOOLEAN_YES || (m->do_space == CONFIG_BOOLEAN_AUTO && (bavail || breserved_root || bused))) {
+    if(m->do_space == CONFIG_BOOLEAN_YES ||
+       (m->do_space == CONFIG_BOOLEAN_AUTO && (bavail || breserved_root || bused)) ||
+       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES) {
         if(unlikely(!m->st_space)) {
             m->do_space = CONFIG_BOOLEAN_YES;
             m->st_space = rrdset_find_bytype_localhost("disk_space", disk);
@@ -289,7 +291,9 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
     // --------------------------------------------------------------------------
 
-    if(m->do_inodes == CONFIG_BOOLEAN_YES || (m->do_inodes == CONFIG_BOOLEAN_AUTO && (favail || freserved_root || fused))) {
+    if(m->do_inodes == CONFIG_BOOLEAN_YES ||
+       (m->do_inodes == CONFIG_BOOLEAN_AUTO && (favail || freserved_root || fused)) ||
+       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES) {
         if(unlikely(!m->st_inodes)) {
             m->do_inodes = CONFIG_BOOLEAN_YES;
             m->st_inodes = rrdset_find_bytype_localhost("disk_inodes", disk);

--- a/collectors/freebsd.plugin/README.md
+++ b/collectors/freebsd.plugin/README.md
@@ -2,4 +2,6 @@
 
 Collects resource usage and performance data on FreeBSD systems
 
+By default, Netdata will enable monitoring metrics for disks, memory, and network only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Use `yes` instead of `auto` in plugin configuration sections to enable these charts permanently. You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero metrics for all internal Netdata plugins.
+
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Ffreebsd.plugin%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)]()

--- a/collectors/freebsd.plugin/freebsd_devstat.c
+++ b/collectors/freebsd.plugin/freebsd_devstat.c
@@ -352,7 +352,8 @@ int do_kern_devstat(int update_every, usec_t dt) {
                         if(dm->do_io == CONFIG_BOOLEAN_YES || (dm->do_io == CONFIG_BOOLEAN_AUTO &&
                                                                (dstat[i].bytes[DEVSTAT_READ] ||
                                                                 dstat[i].bytes[DEVSTAT_WRITE] ||
-                                                                dstat[i].bytes[DEVSTAT_FREE]))) {
+                                                                dstat[i].bytes[DEVSTAT_FREE] ||
+                                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                             if (unlikely(!dm->st_io)) {
                                 dm->st_io = rrdset_create_localhost("disk",
                                                                     disk,
@@ -389,7 +390,8 @@ int do_kern_devstat(int update_every, usec_t dt) {
                                                                 (dstat[i].operations[DEVSTAT_READ] ||
                                                                  dstat[i].operations[DEVSTAT_WRITE] ||
                                                                  dstat[i].operations[DEVSTAT_NO_DATA] ||
-                                                                 dstat[i].operations[DEVSTAT_FREE]))) {
+                                                                 dstat[i].operations[DEVSTAT_FREE] ||
+                                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                             if (unlikely(!dm->st_ops)) {
                                 dm->st_ops = rrdset_create_localhost("disk_ops",
                                                                      disk,
@@ -428,7 +430,9 @@ int do_kern_devstat(int update_every, usec_t dt) {
                         // --------------------------------------------------------------------
 
                         if(dm->do_qops == CONFIG_BOOLEAN_YES || (dm->do_qops == CONFIG_BOOLEAN_AUTO &&
-                                                                 (dstat[i].start_count || dstat[i].end_count))) {
+                                                                 (dstat[i].start_count ||
+                                                                  dstat[i].end_count ||
+                                                                  netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                             if (unlikely(!dm->st_qops)) {
                                 dm->st_qops = rrdset_create_localhost("disk_qops",
                                                                       disk,
@@ -457,7 +461,8 @@ int do_kern_devstat(int update_every, usec_t dt) {
                         // --------------------------------------------------------------------
 
                         if(dm->do_util == CONFIG_BOOLEAN_YES || (dm->do_util == CONFIG_BOOLEAN_AUTO &&
-                                                                 cur_dstat.busy_time_ms)) {
+                                                                 (cur_dstat.busy_time_ms ||
+                                                                  netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                             if (unlikely(!dm->st_util)) {
                                 dm->st_util = rrdset_create_localhost("disk_util",
                                                                       disk,
@@ -490,7 +495,8 @@ int do_kern_devstat(int update_every, usec_t dt) {
                                                                    (cur_dstat.duration_read_ms ||
                                                                     cur_dstat.duration_write_ms ||
                                                                     cur_dstat.duration_other_ms ||
-                                                                    cur_dstat.duration_free_ms))) {
+                                                                    cur_dstat.duration_free_ms ||
+                                                                    netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                             if (unlikely(!dm->st_iotime)) {
                                 dm->st_iotime = rrdset_create_localhost("disk_iotime",
                                                                         disk,
@@ -538,7 +544,8 @@ int do_kern_devstat(int update_every, usec_t dt) {
                                                                       (dstat[i].operations[DEVSTAT_READ] ||
                                                                        dstat[i].operations[DEVSTAT_WRITE] ||
                                                                        dstat[i].operations[DEVSTAT_NO_DATA] ||
-                                                                       dstat[i].operations[DEVSTAT_FREE]))) {
+                                                                       dstat[i].operations[DEVSTAT_FREE] ||
+                                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                                 if (unlikely(!dm->st_await)) {
                                     dm->st_await = rrdset_create_localhost("disk_await",
                                                                            disk,
@@ -603,7 +610,8 @@ int do_kern_devstat(int update_every, usec_t dt) {
                             if(dm->do_avagsz == CONFIG_BOOLEAN_YES || (dm->do_avagsz == CONFIG_BOOLEAN_AUTO &&
                                                                        (dstat[i].operations[DEVSTAT_READ] ||
                                                                         dstat[i].operations[DEVSTAT_WRITE] ||
-                                                                        dstat[i].operations[DEVSTAT_FREE]))) {
+                                                                        dstat[i].operations[DEVSTAT_FREE] ||
+                                                                        netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                                 if (unlikely(!dm->st_avagsz)) {
                                     dm->st_avagsz = rrdset_create_localhost("disk_avgsz",
                                                                             disk,
@@ -660,7 +668,8 @@ int do_kern_devstat(int update_every, usec_t dt) {
                                                                       (dstat[i].operations[DEVSTAT_READ] ||
                                                                        dstat[i].operations[DEVSTAT_WRITE] ||
                                                                        dstat[i].operations[DEVSTAT_NO_DATA] ||
-                                                                       dstat[i].operations[DEVSTAT_FREE]))) {
+                                                                       dstat[i].operations[DEVSTAT_FREE] ||
+                                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                                 if (unlikely(!dm->st_svctm)) {
                                     dm->st_svctm = rrdset_create_localhost("disk_svctm",
                                                                            disk,

--- a/collectors/freebsd.plugin/freebsd_getifaddrs.c
+++ b/collectors/freebsd.plugin/freebsd_getifaddrs.c
@@ -440,7 +440,9 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 // --------------------------------------------------------------------
 
                 if (ifm->do_bandwidth == CONFIG_BOOLEAN_YES || (ifm->do_bandwidth == CONFIG_BOOLEAN_AUTO &&
-                                                                (IFA_DATA(ibytes) || IFA_DATA(obytes)))) {
+                                                                (IFA_DATA(ibytes) ||
+                                                                 IFA_DATA(obytes) ||
+                                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                     if (unlikely(!ifm->st_bandwidth)) {
                         ifm->st_bandwidth = rrdset_create_localhost("net",
                                                                     ifa->ifa_name,
@@ -469,7 +471,11 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 // --------------------------------------------------------------------
 
                 if (ifm->do_packets == CONFIG_BOOLEAN_YES || (ifm->do_packets == CONFIG_BOOLEAN_AUTO &&
-                                                              (IFA_DATA(ipackets) || IFA_DATA(opackets) || IFA_DATA(imcasts) || IFA_DATA(omcasts)))) {
+                                                              (IFA_DATA(ipackets) ||
+                                                               IFA_DATA(opackets) ||
+                                                               IFA_DATA(imcasts) ||
+                                                               IFA_DATA(omcasts) ||
+                                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                     if (unlikely(!ifm->st_packets)) {
                         ifm->st_packets = rrdset_create_localhost("net_packets",
                                                                   ifa->ifa_name,
@@ -508,7 +514,9 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 // --------------------------------------------------------------------
 
                 if (ifm->do_errors == CONFIG_BOOLEAN_YES || (ifm->do_errors == CONFIG_BOOLEAN_AUTO &&
-                                                             (IFA_DATA(ierrors) || IFA_DATA(oerrors)))) {
+                                                             (IFA_DATA(ierrors) ||
+                                                              IFA_DATA(oerrors) ||
+                                                              netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                     if (unlikely(!ifm->st_errors)) {
                         ifm->st_errors = rrdset_create_localhost("net_errors",
                                                                  ifa->ifa_name,
@@ -538,11 +546,11 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 // --------------------------------------------------------------------
 
                 if (ifm->do_drops == CONFIG_BOOLEAN_YES || (ifm->do_drops == CONFIG_BOOLEAN_AUTO &&
-                                                            (IFA_DATA(iqdrops)
+                                                            (IFA_DATA(iqdrops) ||
                                                              #if __FreeBSD__ >= 11
-                                                             || IFA_DATA(oqdrops)
-#endif
-                ))) {
+                                                             IFA_DATA(oqdrops) ||
+                                                             #endif
+                                                             netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                     if (unlikely(!ifm->st_drops)) {
                         ifm->st_drops = rrdset_create_localhost("net_drops",
                                                                 ifa->ifa_name,
@@ -577,7 +585,8 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 // --------------------------------------------------------------------
 
                 if (ifm->do_events == CONFIG_BOOLEAN_YES || (ifm->do_events == CONFIG_BOOLEAN_AUTO &&
-                                                             IFA_DATA(collisions))) {
+                                                             (IFA_DATA(collisions) ||
+                                                              netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                     if (unlikely(!ifm->st_events)) {
                         ifm->st_events = rrdset_create_localhost("net_events",
                                                                  ifa->ifa_name,

--- a/collectors/freebsd.plugin/freebsd_getmntinfo.c
+++ b/collectors/freebsd.plugin/freebsd_getmntinfo.c
@@ -216,7 +216,9 @@ int do_getmntinfo(int update_every, usec_t dt) {
 
                 int rendered = 0;
 
-                if (m->do_space == CONFIG_BOOLEAN_YES || (m->do_space == CONFIG_BOOLEAN_AUTO && (mntbuf[i].f_blocks > 2))) {
+                if (m->do_space == CONFIG_BOOLEAN_YES || (m->do_space == CONFIG_BOOLEAN_AUTO &&
+                                                          (mntbuf[i].f_blocks > 2 ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                     if (unlikely(!m->st_space)) {
                         snprintfz(title, 4096, "Disk Space Usage for %s [%s]",
                                   mntbuf[i].f_mntonname, mntbuf[i].f_mntfromname);
@@ -255,7 +257,9 @@ int do_getmntinfo(int update_every, usec_t dt) {
 
                 // --------------------------------------------------------------------------
 
-                if (m->do_inodes == CONFIG_BOOLEAN_YES || (m->do_inodes == CONFIG_BOOLEAN_AUTO && (mntbuf[i].f_files > 1))) {
+                if (m->do_inodes == CONFIG_BOOLEAN_YES || (m->do_inodes == CONFIG_BOOLEAN_AUTO &&
+                                                           (mntbuf[i].f_files > 1 ||
+                                                            netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                     if (unlikely(!m->st_inodes)) {
                         snprintfz(title, 4096, "Disk Files (inodes) Usage for %s [%s]",
                                   mntbuf[i].f_mntonname, mntbuf[i].f_mntfromname);

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -1941,7 +1941,13 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_tcpext_connaborts == CONFIG_BOOLEAN_YES || (do_tcpext_connaborts == CONFIG_BOOLEAN_AUTO && (tcpstat.tcps_rcvpackafterwin || tcpstat.tcps_rcvafterclose || tcpstat.tcps_rcvmemdrop || tcpstat.tcps_persistdrop || tcpstat.tcps_finwait2_drops))) {
+            if (do_tcpext_connaborts == CONFIG_BOOLEAN_YES || (do_tcpext_connaborts == CONFIG_BOOLEAN_AUTO &&
+                                                               (tcpstat.tcps_rcvpackafterwin ||
+                                                                tcpstat.tcps_rcvafterclose ||
+                                                                tcpstat.tcps_rcvmemdrop ||
+                                                                tcpstat.tcps_persistdrop ||
+                                                                tcpstat.tcps_finwait2_drops ||
+                                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_connaborts = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -1982,7 +1988,9 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_tcpext_ofo == CONFIG_BOOLEAN_YES || (do_tcpext_ofo == CONFIG_BOOLEAN_AUTO && tcpstat.tcps_rcvoopack)) {
+            if (do_tcpext_ofo == CONFIG_BOOLEAN_YES || (do_tcpext_ofo == CONFIG_BOOLEAN_AUTO &&
+                                                        (tcpstat.tcps_rcvoopack ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_ofo = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -2014,7 +2022,11 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_tcpext_syncookies == CONFIG_BOOLEAN_YES || (do_tcpext_syncookies == CONFIG_BOOLEAN_AUTO && (tcpstat.tcps_sc_sendcookie || tcpstat.tcps_sc_recvcookie || tcpstat.tcps_sc_zonefail))) {
+            if (do_tcpext_syncookies == CONFIG_BOOLEAN_YES || (do_tcpext_syncookies == CONFIG_BOOLEAN_AUTO &&
+                                                               (tcpstat.tcps_sc_sendcookie ||
+                                                                tcpstat.tcps_sc_recvcookie ||
+                                                                tcpstat.tcps_sc_zonefail ||
+                                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_syncookies = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -2050,7 +2062,9 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcpext_listen == CONFIG_BOOLEAN_YES || (do_tcpext_listen == CONFIG_BOOLEAN_AUTO && tcpstat.tcps_listendrop)) {
+            if(do_tcpext_listen == CONFIG_BOOLEAN_YES || (do_tcpext_listen == CONFIG_BOOLEAN_AUTO &&
+                                                          (tcpstat.tcps_listendrop ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_listen = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_listen = NULL;
@@ -2085,7 +2099,11 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_ecn == CONFIG_BOOLEAN_YES || (do_ecn == CONFIG_BOOLEAN_AUTO && (tcpstat.tcps_ecn_ce || tcpstat.tcps_ecn_ect0 || tcpstat.tcps_ecn_ect1))) {
+            if (do_ecn == CONFIG_BOOLEAN_YES || (do_ecn == CONFIG_BOOLEAN_AUTO &&
+                                                 (tcpstat.tcps_ecn_ce ||
+                                                  tcpstat.tcps_ecn_ect0 ||
+                                                  tcpstat.tcps_ecn_ect1 ||
+                                                  netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ecn = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -2626,8 +2644,11 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
             // --------------------------------------------------------------------
 
             if (do_ip6_packets == CONFIG_BOOLEAN_YES || (do_ip6_packets == CONFIG_BOOLEAN_AUTO &&
-                                                         (ip6stat.ip6s_localout || ip6stat.ip6s_total ||
-                                                          ip6stat.ip6s_forward || ip6stat.ip6s_delivered))) {
+                                                         (ip6stat.ip6s_localout ||
+                                                          ip6stat.ip6s_total ||
+                                                          ip6stat.ip6s_forward ||
+                                                          ip6stat.ip6s_delivered ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip6_packets = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -2666,8 +2687,10 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
             // --------------------------------------------------------------------
 
             if (do_ip6_fragsout == CONFIG_BOOLEAN_YES || (do_ip6_fragsout == CONFIG_BOOLEAN_AUTO &&
-                                                          (ip6stat.ip6s_fragmented || ip6stat.ip6s_cantfrag ||
-                                                           ip6stat.ip6s_ofragments))) {
+                                                          (ip6stat.ip6s_fragmented ||
+                                                           ip6stat.ip6s_cantfrag ||
+                                                           ip6stat.ip6s_ofragments ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip6_fragsout = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -2706,8 +2729,11 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
             // --------------------------------------------------------------------
 
             if (do_ip6_fragsin == CONFIG_BOOLEAN_YES || (do_ip6_fragsin == CONFIG_BOOLEAN_AUTO &&
-                                                         (ip6stat.ip6s_reassembled || ip6stat.ip6s_fragdropped ||
-                                                          ip6stat.ip6s_fragtimeout || ip6stat.ip6s_fragments))) {
+                                                         (ip6stat.ip6s_reassembled ||
+                                                          ip6stat.ip6s_fragdropped ||
+                                                          ip6stat.ip6s_fragtimeout ||
+                                                          ip6stat.ip6s_fragments ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip6_fragsin = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -2747,16 +2773,17 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_ip6_errors == CONFIG_BOOLEAN_YES || (do_ip6_errors == CONFIG_BOOLEAN_AUTO && (
-                    ip6stat.ip6s_toosmall ||
-                    ip6stat.ip6s_odropped ||
-                    ip6stat.ip6s_badoptions ||
-                    ip6stat.ip6s_badvers ||
-                    ip6stat.ip6s_exthdrtoolong ||
-                    ip6stat.ip6s_sources_none ||
-                    ip6stat.ip6s_tooshort ||
-                    ip6stat.ip6s_cantforward ||
-                    ip6stat.ip6s_noroute))) {
+            if (do_ip6_errors == CONFIG_BOOLEAN_YES || (do_ip6_errors == CONFIG_BOOLEAN_AUTO &&
+                                                        (ip6stat.ip6s_toosmall ||
+                                                         ip6stat.ip6s_odropped ||
+                                                         ip6stat.ip6s_badoptions ||
+                                                         ip6stat.ip6s_badvers ||
+                                                         ip6stat.ip6s_exthdrtoolong ||
+                                                         ip6stat.ip6s_sources_none ||
+                                                         ip6stat.ip6s_tooshort ||
+                                                         ip6stat.ip6s_cantforward ||
+                                                         ip6stat.ip6s_noroute ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip6_errors = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -2872,7 +2899,10 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6 == CONFIG_BOOLEAN_YES || (do_icmp6 == CONFIG_BOOLEAN_AUTO && (icmp6_total.msgs_in || icmp6_total.msgs_out))) {
+            if (do_icmp6 == CONFIG_BOOLEAN_YES || (do_icmp6 == CONFIG_BOOLEAN_AUTO &&
+                                                   (icmp6_total.msgs_in ||
+                                                    icmp6_total.msgs_out ||
+                                                    netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6 = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -2907,7 +2937,10 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_redir == CONFIG_BOOLEAN_YES || (do_icmp6_redir == CONFIG_BOOLEAN_AUTO && (icmp6stat.icp6s_inhist[ND_REDIRECT] || icmp6stat.icp6s_outhist[ND_REDIRECT]))) {
+            if (do_icmp6_redir == CONFIG_BOOLEAN_YES || (do_icmp6_redir == CONFIG_BOOLEAN_AUTO &&
+                                                         (icmp6stat.icp6s_inhist[ND_REDIRECT] ||
+                                                          icmp6stat.icp6s_outhist[ND_REDIRECT] ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_redir = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -2941,18 +2974,19 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_errors == CONFIG_BOOLEAN_YES || (do_icmp6_errors == CONFIG_BOOLEAN_AUTO && (
-                    icmp6stat.icp6s_badcode ||
-                    icmp6stat.icp6s_badlen ||
-                    icmp6stat.icp6s_checksum ||
-                    icmp6stat.icp6s_tooshort ||
-                    icmp6stat.icp6s_error ||
-                    icmp6stat.icp6s_inhist[ICMP6_DST_UNREACH] ||
-                    icmp6stat.icp6s_inhist[ICMP6_TIME_EXCEEDED] ||
-                    icmp6stat.icp6s_inhist[ICMP6_PARAM_PROB] ||
-                    icmp6stat.icp6s_outhist[ICMP6_DST_UNREACH] ||
-                    icmp6stat.icp6s_outhist[ICMP6_TIME_EXCEEDED] ||
-                    icmp6stat.icp6s_outhist[ICMP6_PARAM_PROB]))) {
+            if (do_icmp6_errors == CONFIG_BOOLEAN_YES || (do_icmp6_errors == CONFIG_BOOLEAN_AUTO &&
+                                                          (icmp6stat.icp6s_badcode ||
+                                                           icmp6stat.icp6s_badlen ||
+                                                           icmp6stat.icp6s_checksum ||
+                                                           icmp6stat.icp6s_tooshort ||
+                                                           icmp6stat.icp6s_error ||
+                                                           icmp6stat.icp6s_inhist[ICMP6_DST_UNREACH] ||
+                                                           icmp6stat.icp6s_inhist[ICMP6_TIME_EXCEEDED] ||
+                                                           icmp6stat.icp6s_inhist[ICMP6_PARAM_PROB] ||
+                                                           icmp6stat.icp6s_outhist[ICMP6_DST_UNREACH] ||
+                                                           icmp6stat.icp6s_outhist[ICMP6_TIME_EXCEEDED] ||
+                                                           icmp6stat.icp6s_outhist[ICMP6_PARAM_PROB] ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_errors = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -3005,11 +3039,12 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_echos == CONFIG_BOOLEAN_YES || (do_icmp6_echos == CONFIG_BOOLEAN_AUTO && (
-                    icmp6stat.icp6s_inhist[ICMP6_ECHO_REQUEST] ||
-                    icmp6stat.icp6s_outhist[ICMP6_ECHO_REQUEST] ||
-                    icmp6stat.icp6s_inhist[ICMP6_ECHO_REPLY] ||
-                    icmp6stat.icp6s_outhist[ICMP6_ECHO_REPLY]))) {
+            if (do_icmp6_echos == CONFIG_BOOLEAN_YES || (do_icmp6_echos == CONFIG_BOOLEAN_AUTO &&
+                                                         (icmp6stat.icp6s_inhist[ICMP6_ECHO_REQUEST] ||
+                                                          icmp6stat.icp6s_outhist[ICMP6_ECHO_REQUEST] ||
+                                                          icmp6stat.icp6s_inhist[ICMP6_ECHO_REPLY] ||
+                                                          icmp6stat.icp6s_outhist[ICMP6_ECHO_REPLY] ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_echos = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -3047,11 +3082,12 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_router == CONFIG_BOOLEAN_YES || (do_icmp6_router == CONFIG_BOOLEAN_AUTO && (
-                    icmp6stat.icp6s_inhist[ND_ROUTER_SOLICIT] ||
-                    icmp6stat.icp6s_outhist[ND_ROUTER_SOLICIT] ||
-                    icmp6stat.icp6s_inhist[ND_ROUTER_ADVERT] ||
-                    icmp6stat.icp6s_outhist[ND_ROUTER_ADVERT]))) {
+            if (do_icmp6_router == CONFIG_BOOLEAN_YES || (do_icmp6_router == CONFIG_BOOLEAN_AUTO &&
+                                                          (icmp6stat.icp6s_inhist[ND_ROUTER_SOLICIT] ||
+                                                           icmp6stat.icp6s_outhist[ND_ROUTER_SOLICIT] ||
+                                                           icmp6stat.icp6s_inhist[ND_ROUTER_ADVERT] ||
+                                                           icmp6stat.icp6s_outhist[ND_ROUTER_ADVERT] ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_router = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -3090,11 +3126,12 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_neighbor == CONFIG_BOOLEAN_YES || (do_icmp6_neighbor == CONFIG_BOOLEAN_AUTO && (
-                    icmp6stat.icp6s_inhist[ND_NEIGHBOR_SOLICIT] ||
-                    icmp6stat.icp6s_outhist[ND_NEIGHBOR_SOLICIT] ||
-                    icmp6stat.icp6s_inhist[ND_NEIGHBOR_ADVERT] ||
-                    icmp6stat.icp6s_outhist[ND_NEIGHBOR_ADVERT]))) {
+            if (do_icmp6_neighbor == CONFIG_BOOLEAN_YES || (do_icmp6_neighbor == CONFIG_BOOLEAN_AUTO &&
+                                                            (icmp6stat.icp6s_inhist[ND_NEIGHBOR_SOLICIT] ||
+                                                             icmp6stat.icp6s_outhist[ND_NEIGHBOR_SOLICIT] ||
+                                                             icmp6stat.icp6s_inhist[ND_NEIGHBOR_ADVERT] ||
+                                                             icmp6stat.icp6s_outhist[ND_NEIGHBOR_ADVERT] ||
+                                                             netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_neighbor = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -3133,17 +3170,18 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_types == CONFIG_BOOLEAN_YES || (do_icmp6_types == CONFIG_BOOLEAN_AUTO && (
-                    icmp6stat.icp6s_inhist[1] ||
-                    icmp6stat.icp6s_inhist[128] ||
-                    icmp6stat.icp6s_inhist[129] ||
-                    icmp6stat.icp6s_inhist[136] ||
-                    icmp6stat.icp6s_outhist[1] ||
-                    icmp6stat.icp6s_outhist[128] ||
-                    icmp6stat.icp6s_outhist[129] ||
-                    icmp6stat.icp6s_outhist[133] ||
-                    icmp6stat.icp6s_outhist[135] ||
-                    icmp6stat.icp6s_outhist[136]))) {
+            if (do_icmp6_types == CONFIG_BOOLEAN_YES || (do_icmp6_types == CONFIG_BOOLEAN_AUTO &&
+                                                         (icmp6stat.icp6s_inhist[1] ||
+                                                          icmp6stat.icp6s_inhist[128] ||
+                                                          icmp6stat.icp6s_inhist[129] ||
+                                                          icmp6stat.icp6s_inhist[136] ||
+                                                          icmp6stat.icp6s_outhist[1] ||
+                                                          icmp6stat.icp6s_outhist[128] ||
+                                                          icmp6stat.icp6s_outhist[129] ||
+                                                          icmp6stat.icp6s_outhist[133] ||
+                                                          icmp6stat.icp6s_outhist[135] ||
+                                                          icmp6stat.icp6s_outhist[136] ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_types = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;

--- a/collectors/macos.plugin/README.md
+++ b/collectors/macos.plugin/README.md
@@ -2,4 +2,6 @@
 
 Collects resource usage and performance data on MacOS systems
 
+By default, Netdata will enable monitoring metrics for disks, memory, and network only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Use `yes` instead of `auto` in plugin configuration sections to enable these charts permanently. You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero metrics for all internal Netdata plugins.
+
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fmacos.plugin%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)]()

--- a/collectors/macos.plugin/macos_sysctl.c
+++ b/collectors/macos.plugin/macos_sysctl.c
@@ -479,7 +479,12 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_tcpext_connaborts == CONFIG_BOOLEAN_YES || (do_tcpext_connaborts == CONFIG_BOOLEAN_AUTO && (tcpstat.tcps_rcvpackafterwin || tcpstat.tcps_rcvafterclose || tcpstat.tcps_rcvmemdrop || tcpstat.tcps_persistdrop))) {
+            if (do_tcpext_connaborts == CONFIG_BOOLEAN_YES || (do_tcpext_connaborts == CONFIG_BOOLEAN_AUTO &&
+                                                               (tcpstat.tcps_rcvpackafterwin ||
+                                                                tcpstat.tcps_rcvafterclose ||
+                                                                tcpstat.tcps_rcvmemdrop ||
+                                                                tcpstat.tcps_persistdrop ||
+                                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_connaborts = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv4.tcpconnaborts");
                 if (unlikely(!st)) {
@@ -514,7 +519,9 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_tcpext_ofo == CONFIG_BOOLEAN_YES || (do_tcpext_ofo == CONFIG_BOOLEAN_AUTO && tcpstat.tcps_rcvoopack)) {
+            if (do_tcpext_ofo == CONFIG_BOOLEAN_YES || (do_tcpext_ofo == CONFIG_BOOLEAN_AUTO &&
+                                                        (tcpstat.tcps_rcvoopack ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_ofo = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv4.tcpofo");
                 if (unlikely(!st)) {
@@ -543,7 +550,11 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_tcpext_syscookies == CONFIG_BOOLEAN_YES || (do_tcpext_syscookies == CONFIG_BOOLEAN_AUTO && (tcpstat.tcps_sc_sendcookie || tcpstat.tcps_sc_recvcookie || tcpstat.tcps_sc_zonefail))) {
+            if (do_tcpext_syscookies == CONFIG_BOOLEAN_YES || (do_tcpext_syscookies == CONFIG_BOOLEAN_AUTO &&
+                                                               (tcpstat.tcps_sc_sendcookie ||
+                                                                tcpstat.tcps_sc_recvcookie ||
+                                                                tcpstat.tcps_sc_zonefail ||
+                                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_syscookies = CONFIG_BOOLEAN_YES;
 
                 st = rrdset_find_localhost("ipv4.tcpsyncookies");
@@ -579,7 +590,10 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
 
 #if (defined __MAC_OS_X_VERSION_MIN_REQUIRED && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
-            if (do_ecn == CONFIG_BOOLEAN_YES || (do_ecn == CONFIG_BOOLEAN_AUTO && (tcpstat.tcps_ecn_recv_ce || tcpstat.tcps_ecn_not_supported))) {
+            if (do_ecn == CONFIG_BOOLEAN_YES || (do_ecn == CONFIG_BOOLEAN_AUTO &&
+                                                 (tcpstat.tcps_ecn_recv_ce ||
+                                                  tcpstat.tcps_ecn_not_supported ||
+                                                  netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ecn = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv4.ecnpkts");
                 if (unlikely(!st)) {
@@ -980,8 +994,11 @@ int do_macos_sysctl(int update_every, usec_t dt) {
             error("DISABLED: ipv6.errors");
         } else {
             if (do_ip6_packets == CONFIG_BOOLEAN_YES || (do_ip6_packets == CONFIG_BOOLEAN_AUTO &&
-                                                          (ip6stat.ip6s_localout || ip6stat.ip6s_total ||
-                                                           ip6stat.ip6s_forward || ip6stat.ip6s_delivered))) {
+                                                         (ip6stat.ip6s_localout ||
+                                                          ip6stat.ip6s_total ||
+                                                          ip6stat.ip6s_forward ||
+                                                          ip6stat.ip6s_delivered ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip6_packets = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.packets");
                 if (unlikely(!st)) {
@@ -1017,8 +1034,10 @@ int do_macos_sysctl(int update_every, usec_t dt) {
             // --------------------------------------------------------------------
 
             if (do_ip6_fragsout == CONFIG_BOOLEAN_YES || (do_ip6_fragsout == CONFIG_BOOLEAN_AUTO &&
-                                                           (ip6stat.ip6s_fragmented || ip6stat.ip6s_cantfrag ||
-                                                            ip6stat.ip6s_ofragments))) {
+                                                          (ip6stat.ip6s_fragmented ||
+                                                           ip6stat.ip6s_cantfrag ||
+                                                           ip6stat.ip6s_ofragments ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip6_fragsout = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.fragsout");
                 if (unlikely(!st)) {
@@ -1053,8 +1072,11 @@ int do_macos_sysctl(int update_every, usec_t dt) {
             // --------------------------------------------------------------------
 
             if (do_ip6_fragsin == CONFIG_BOOLEAN_YES || (do_ip6_fragsin == CONFIG_BOOLEAN_AUTO &&
-                                                          (ip6stat.ip6s_reassembled || ip6stat.ip6s_fragdropped ||
-                                                           ip6stat.ip6s_fragtimeout || ip6stat.ip6s_fragments))) {
+                                                         (ip6stat.ip6s_reassembled ||
+                                                          ip6stat.ip6s_fragdropped ||
+                                                          ip6stat.ip6s_fragtimeout ||
+                                                          ip6stat.ip6s_fragments ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip6_fragsin = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.fragsin");
                 if (unlikely(!st)) {
@@ -1090,16 +1112,17 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_ip6_errors == CONFIG_BOOLEAN_YES || (do_ip6_errors == CONFIG_BOOLEAN_AUTO && (
-                    ip6stat.ip6s_toosmall ||
-                    ip6stat.ip6s_odropped ||
-                    ip6stat.ip6s_badoptions ||
-                    ip6stat.ip6s_badvers ||
-                    ip6stat.ip6s_exthdrtoolong ||
-                    ip6stat.ip6s_sources_none ||
-                    ip6stat.ip6s_tooshort ||
-                    ip6stat.ip6s_cantforward ||
-                    ip6stat.ip6s_noroute))) {
+            if (do_ip6_errors == CONFIG_BOOLEAN_YES || (do_ip6_errors == CONFIG_BOOLEAN_AUTO &&
+                                                        (ip6stat.ip6s_toosmall ||
+                                                         ip6stat.ip6s_odropped ||
+                                                         ip6stat.ip6s_badoptions ||
+                                                         ip6stat.ip6s_badvers ||
+                                                         ip6stat.ip6s_exthdrtoolong ||
+                                                         ip6stat.ip6s_sources_none ||
+                                                         ip6stat.ip6s_tooshort ||
+                                                         ip6stat.ip6s_cantforward ||
+                                                         ip6stat.ip6s_noroute ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip6_errors = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.errors");
                 if (unlikely(!st)) {
@@ -1158,7 +1181,10 @@ int do_macos_sysctl(int update_every, usec_t dt) {
                 icmp6_total.msgs_out += icmp6stat.icp6s_outhist[i];
             }
             icmp6_total.msgs_in += icmp6stat.icp6s_badcode + icmp6stat.icp6s_badlen + icmp6stat.icp6s_checksum + icmp6stat.icp6s_tooshort;
-            if (do_icmp6 == CONFIG_BOOLEAN_YES || (do_icmp6 == CONFIG_BOOLEAN_AUTO && (icmp6_total.msgs_in || icmp6_total.msgs_out))) {
+            if (do_icmp6 == CONFIG_BOOLEAN_YES || (do_icmp6 == CONFIG_BOOLEAN_AUTO &&
+                                                   (icmp6_total.msgs_in ||
+                                                    icmp6_total.msgs_out ||
+                                                    netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6 = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.icmp");
                 if (unlikely(!st)) {
@@ -1189,7 +1215,10 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_redir == CONFIG_BOOLEAN_YES || (do_icmp6_redir == CONFIG_BOOLEAN_AUTO && (icmp6stat.icp6s_inhist[ND_REDIRECT] || icmp6stat.icp6s_outhist[ND_REDIRECT]))) {
+            if (do_icmp6_redir == CONFIG_BOOLEAN_YES || (do_icmp6_redir == CONFIG_BOOLEAN_AUTO &&
+                                                         (icmp6stat.icp6s_inhist[ND_REDIRECT] ||
+                                                          icmp6stat.icp6s_outhist[ND_REDIRECT] ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_redir = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.icmpredir");
                 if (unlikely(!st)) {
@@ -1220,18 +1249,19 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_errors == CONFIG_BOOLEAN_YES || (do_icmp6_errors == CONFIG_BOOLEAN_AUTO && (
-                                                                            icmp6stat.icp6s_badcode ||
-                                                                            icmp6stat.icp6s_badlen ||
-                                                                            icmp6stat.icp6s_checksum ||
-                                                                            icmp6stat.icp6s_tooshort ||
-                                                                            icmp6stat.icp6s_error ||
-                                                                            icmp6stat.icp6s_inhist[ICMP6_DST_UNREACH] ||
-                                                                            icmp6stat.icp6s_inhist[ICMP6_TIME_EXCEEDED] ||
-                                                                            icmp6stat.icp6s_inhist[ICMP6_PARAM_PROB] ||
-                                                                            icmp6stat.icp6s_outhist[ICMP6_DST_UNREACH] ||
-                                                                            icmp6stat.icp6s_outhist[ICMP6_TIME_EXCEEDED] ||
-                                                                            icmp6stat.icp6s_outhist[ICMP6_PARAM_PROB]))) {
+            if (do_icmp6_errors == CONFIG_BOOLEAN_YES || (do_icmp6_errors == CONFIG_BOOLEAN_AUTO &&
+                                                          (icmp6stat.icp6s_badcode ||
+                                                           icmp6stat.icp6s_badlen ||
+                                                           icmp6stat.icp6s_checksum ||
+                                                           icmp6stat.icp6s_tooshort ||
+                                                           icmp6stat.icp6s_error ||
+                                                           icmp6stat.icp6s_inhist[ICMP6_DST_UNREACH] ||
+                                                           icmp6stat.icp6s_inhist[ICMP6_TIME_EXCEEDED] ||
+                                                           icmp6stat.icp6s_inhist[ICMP6_PARAM_PROB] ||
+                                                           icmp6stat.icp6s_outhist[ICMP6_DST_UNREACH] ||
+                                                           icmp6stat.icp6s_outhist[ICMP6_TIME_EXCEEDED] ||
+                                                           icmp6stat.icp6s_outhist[ICMP6_PARAM_PROB] ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_errors = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.icmperrors");
                 if (unlikely(!st)) {
@@ -1279,11 +1309,12 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_echos == CONFIG_BOOLEAN_YES || (do_icmp6_echos == CONFIG_BOOLEAN_AUTO && (
-                                                                 icmp6stat.icp6s_inhist[ICMP6_ECHO_REQUEST] ||
-                                                                 icmp6stat.icp6s_outhist[ICMP6_ECHO_REQUEST] ||
-                                                                 icmp6stat.icp6s_inhist[ICMP6_ECHO_REPLY] ||
-                                                                 icmp6stat.icp6s_outhist[ICMP6_ECHO_REPLY]))) {
+            if (do_icmp6_echos == CONFIG_BOOLEAN_YES || (do_icmp6_echos == CONFIG_BOOLEAN_AUTO &&
+                                                         (icmp6stat.icp6s_inhist[ICMP6_ECHO_REQUEST] ||
+                                                          icmp6stat.icp6s_outhist[ICMP6_ECHO_REQUEST] ||
+                                                          icmp6stat.icp6s_inhist[ICMP6_ECHO_REPLY] ||
+                                                          icmp6stat.icp6s_outhist[ICMP6_ECHO_REPLY] ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_echos = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.icmpechos");
                 if (unlikely(!st)) {
@@ -1318,11 +1349,12 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_router == CONFIG_BOOLEAN_YES || (do_icmp6_router == CONFIG_BOOLEAN_AUTO && (
-                                                                    icmp6stat.icp6s_inhist[ND_ROUTER_SOLICIT] ||
-                                                                    icmp6stat.icp6s_outhist[ND_ROUTER_SOLICIT] ||
-                                                                    icmp6stat.icp6s_inhist[ND_ROUTER_ADVERT] ||
-                                                                    icmp6stat.icp6s_outhist[ND_ROUTER_ADVERT]))) {
+            if (do_icmp6_router == CONFIG_BOOLEAN_YES || (do_icmp6_router == CONFIG_BOOLEAN_AUTO &&
+                                                          (icmp6stat.icp6s_inhist[ND_ROUTER_SOLICIT] ||
+                                                           icmp6stat.icp6s_outhist[ND_ROUTER_SOLICIT] ||
+                                                           icmp6stat.icp6s_inhist[ND_ROUTER_ADVERT] ||
+                                                           icmp6stat.icp6s_outhist[ND_ROUTER_ADVERT] ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_router = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.icmprouter");
                 if (unlikely(!st)) {
@@ -1357,11 +1389,12 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_neighbor == CONFIG_BOOLEAN_YES || (do_icmp6_neighbor == CONFIG_BOOLEAN_AUTO && (
-                                                                    icmp6stat.icp6s_inhist[ND_NEIGHBOR_SOLICIT] ||
-                                                                    icmp6stat.icp6s_outhist[ND_NEIGHBOR_SOLICIT] ||
-                                                                    icmp6stat.icp6s_inhist[ND_NEIGHBOR_ADVERT] ||
-                                                                    icmp6stat.icp6s_outhist[ND_NEIGHBOR_ADVERT]))) {
+            if (do_icmp6_neighbor == CONFIG_BOOLEAN_YES || (do_icmp6_neighbor == CONFIG_BOOLEAN_AUTO &&
+                                                            (icmp6stat.icp6s_inhist[ND_NEIGHBOR_SOLICIT] ||
+                                                             icmp6stat.icp6s_outhist[ND_NEIGHBOR_SOLICIT] ||
+                                                             icmp6stat.icp6s_inhist[ND_NEIGHBOR_ADVERT] ||
+                                                             icmp6stat.icp6s_outhist[ND_NEIGHBOR_ADVERT] ||
+                                                             netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_neighbor = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.icmpneighbor");
                 if (unlikely(!st)) {
@@ -1396,17 +1429,18 @@ int do_macos_sysctl(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if (do_icmp6_types == CONFIG_BOOLEAN_YES || (do_icmp6_types == CONFIG_BOOLEAN_AUTO && (
-                                                                    icmp6stat.icp6s_inhist[1] ||
-                                                                    icmp6stat.icp6s_inhist[128] ||
-                                                                    icmp6stat.icp6s_inhist[129] ||
-                                                                    icmp6stat.icp6s_inhist[136] ||
-                                                                    icmp6stat.icp6s_outhist[1] ||
-                                                                    icmp6stat.icp6s_outhist[128] ||
-                                                                    icmp6stat.icp6s_outhist[129] ||
-                                                                    icmp6stat.icp6s_outhist[133] ||
-                                                                    icmp6stat.icp6s_outhist[135] ||
-                                                                    icmp6stat.icp6s_outhist[136]))) {
+            if (do_icmp6_types == CONFIG_BOOLEAN_YES || (do_icmp6_types == CONFIG_BOOLEAN_AUTO &&
+                                                         (icmp6stat.icp6s_inhist[1] ||
+                                                          icmp6stat.icp6s_inhist[128] ||
+                                                          icmp6stat.icp6s_inhist[129] ||
+                                                          icmp6stat.icp6s_inhist[136] ||
+                                                          icmp6stat.icp6s_outhist[1] ||
+                                                          icmp6stat.icp6s_outhist[128] ||
+                                                          icmp6stat.icp6s_outhist[129] ||
+                                                          icmp6stat.icp6s_outhist[133] ||
+                                                          icmp6stat.icp6s_outhist[135] ||
+                                                          icmp6stat.icp6s_outhist[136] ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp6_types = CONFIG_BOOLEAN_YES;
                 st = rrdset_find_localhost("ipv6.icmptypes");
                 if (unlikely(!st)) {

--- a/collectors/proc.plugin/README.md
+++ b/collectors/proc.plugin/README.md
@@ -75,7 +75,7 @@ netdata will automatically set the name of disks on the dashboard, from the moun
 
 ### performance metrics
 
-By default, Netdata will enable monitoring metrics only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a chart instead of `auto` to enable it permanently.
+By default, Netdata will enable monitoring metrics only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a chart instead of `auto` to enable it permanently. You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero metrics for all internal Netdata plugins.
 
 netdata categorizes all block devices in 3 categories:
 

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -974,7 +974,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         // Do performance metrics
 
         if(d->do_io == CONFIG_BOOLEAN_YES || (d->do_io == CONFIG_BOOLEAN_AUTO &&
-                                              (readsectors || writesectors || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                              (readsectors || writesectors ||
+                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             d->do_io = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_io)) {
@@ -1207,9 +1208,11 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
         if(likely(dt)) {
             if( (d->do_iotime == CONFIG_BOOLEAN_YES || (d->do_iotime == CONFIG_BOOLEAN_AUTO &&
-                                                        (readms || writems || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
+                                                        (readms || writems ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
                 (d->do_ops    == CONFIG_BOOLEAN_YES || (d->do_ops    == CONFIG_BOOLEAN_AUTO &&
-                                                        (reads || writes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
+                                                        (reads || writes ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
 
                 if(unlikely(!d->st_await)) {
                     d->st_await = rrdset_create_localhost(
@@ -1273,9 +1276,11 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             }
 
             if( (d->do_util == CONFIG_BOOLEAN_YES || (d->do_util == CONFIG_BOOLEAN_AUTO &&
-                                                      (busy_ms || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
+                                                      (busy_ms ||
+                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
                 (d->do_ops  == CONFIG_BOOLEAN_YES || (d->do_ops  == CONFIG_BOOLEAN_AUTO &&
-                                                      (reads || writes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
+                                                      (reads || writes ||
+                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
 
                 if(unlikely(!d->st_svctm)) {
                     d->st_svctm = rrdset_create_localhost(
@@ -1596,7 +1601,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
     // update the system total I/O
 
     if(global_do_io == CONFIG_BOOLEAN_YES || (global_do_io == CONFIG_BOOLEAN_AUTO &&
-                                              (system_read_kb || system_write_kb || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                              (system_read_kb || system_write_kb ||
+                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         static RRDSET *st_io = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -973,7 +973,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         // --------------------------------------------------------------------------
         // Do performance metrics
 
-        if(d->do_io == CONFIG_BOOLEAN_YES || (d->do_io == CONFIG_BOOLEAN_AUTO && (readsectors || writesectors))) {
+        if(d->do_io == CONFIG_BOOLEAN_YES || (d->do_io == CONFIG_BOOLEAN_AUTO &&
+                                              (readsectors || writesectors || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             d->do_io = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_io)) {
@@ -1004,7 +1005,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(d->do_ops == CONFIG_BOOLEAN_YES || (d->do_ops == CONFIG_BOOLEAN_AUTO && (reads || writes))) {
+        if(d->do_ops == CONFIG_BOOLEAN_YES || (d->do_ops == CONFIG_BOOLEAN_AUTO &&
+                                               (reads || writes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             d->do_ops = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_ops)) {
@@ -1037,7 +1039,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(d->do_qops == CONFIG_BOOLEAN_YES || (d->do_qops == CONFIG_BOOLEAN_AUTO && queued_ios)) {
+        if(d->do_qops == CONFIG_BOOLEAN_YES || (d->do_qops == CONFIG_BOOLEAN_AUTO &&
+                                                (queued_ios || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             d->do_qops = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_qops)) {
@@ -1068,7 +1071,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(d->do_backlog == CONFIG_BOOLEAN_YES || (d->do_backlog == CONFIG_BOOLEAN_AUTO && backlog_ms)) {
+        if(d->do_backlog == CONFIG_BOOLEAN_YES || (d->do_backlog == CONFIG_BOOLEAN_AUTO &&
+                                                   (backlog_ms || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             d->do_backlog = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_backlog)) {
@@ -1099,7 +1103,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(d->do_util == CONFIG_BOOLEAN_YES || (d->do_util == CONFIG_BOOLEAN_AUTO && busy_ms)) {
+        if(d->do_util == CONFIG_BOOLEAN_YES || (d->do_util == CONFIG_BOOLEAN_AUTO &&
+                                                (busy_ms || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             d->do_util = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_util)) {
@@ -1130,7 +1135,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(d->do_mops == CONFIG_BOOLEAN_YES || (d->do_mops == CONFIG_BOOLEAN_AUTO && (mreads || mwrites))) {
+        if(d->do_mops == CONFIG_BOOLEAN_YES || (d->do_mops == CONFIG_BOOLEAN_AUTO &&
+                                                (mreads || mwrites || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             d->do_mops = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_mops)) {
@@ -1163,7 +1169,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(d->do_iotime == CONFIG_BOOLEAN_YES || (d->do_iotime == CONFIG_BOOLEAN_AUTO && (readms || writems))) {
+        if(d->do_iotime == CONFIG_BOOLEAN_YES || (d->do_iotime == CONFIG_BOOLEAN_AUTO &&
+                                                  (readms || writems || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             d->do_iotime = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_iotime)) {
@@ -1199,8 +1206,10 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         // only if this is not the first time we run
 
         if(likely(dt)) {
-            if( (d->do_iotime == CONFIG_BOOLEAN_YES || (d->do_iotime == CONFIG_BOOLEAN_AUTO && (readms || writems))) &&
-                (d->do_ops    == CONFIG_BOOLEAN_YES || (d->do_ops    == CONFIG_BOOLEAN_AUTO && (reads || writes)))) {
+            if( (d->do_iotime == CONFIG_BOOLEAN_YES || (d->do_iotime == CONFIG_BOOLEAN_AUTO &&
+                                                        (readms || writems || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
+                (d->do_ops    == CONFIG_BOOLEAN_YES || (d->do_ops    == CONFIG_BOOLEAN_AUTO &&
+                                                        (reads || writes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
 
                 if(unlikely(!d->st_await)) {
                     d->st_await = rrdset_create_localhost(
@@ -1230,8 +1239,10 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 rrdset_done(d->st_await);
             }
 
-            if( (d->do_io  == CONFIG_BOOLEAN_YES || (d->do_io  == CONFIG_BOOLEAN_AUTO && (readsectors || writesectors))) &&
-                (d->do_ops == CONFIG_BOOLEAN_YES || (d->do_ops == CONFIG_BOOLEAN_AUTO && (reads || writes)))) {
+            if( (d->do_io  == CONFIG_BOOLEAN_YES || (d->do_io  == CONFIG_BOOLEAN_AUTO &&
+                                                     (readsectors || writesectors || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
+                (d->do_ops == CONFIG_BOOLEAN_YES || (d->do_ops == CONFIG_BOOLEAN_AUTO &&
+                                                     (reads || writes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
 
                 if(unlikely(!d->st_avgsz)) {
                     d->st_avgsz = rrdset_create_localhost(
@@ -1261,8 +1272,10 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 rrdset_done(d->st_avgsz);
             }
 
-            if( (d->do_util == CONFIG_BOOLEAN_YES || (d->do_util == CONFIG_BOOLEAN_AUTO && busy_ms)) &&
-                (d->do_ops  == CONFIG_BOOLEAN_YES || (d->do_ops  == CONFIG_BOOLEAN_AUTO && (reads || writes)))) {
+            if( (d->do_util == CONFIG_BOOLEAN_YES || (d->do_util == CONFIG_BOOLEAN_AUTO &&
+                                                      (busy_ms || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
+                (d->do_ops  == CONFIG_BOOLEAN_YES || (d->do_ops  == CONFIG_BOOLEAN_AUTO &&
+                                                      (reads || writes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
 
                 if(unlikely(!d->st_svctm)) {
                     d->st_svctm = rrdset_create_localhost(
@@ -1505,7 +1518,11 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 rrdset_done(d->st_bcache_cache_read_races);
             }
 
-            if(d->do_bcache == CONFIG_BOOLEAN_YES || (d->do_bcache == CONFIG_BOOLEAN_AUTO && (stats_total_cache_hits != 0 || stats_total_cache_misses != 0 || stats_total_cache_miss_collisions != 0))) {
+            if(d->do_bcache == CONFIG_BOOLEAN_YES || (d->do_bcache == CONFIG_BOOLEAN_AUTO &&
+                                                      (stats_total_cache_hits ||
+                                                       stats_total_cache_misses ||
+                                                       stats_total_cache_miss_collisions ||
+                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
 
                 if(unlikely(!d->st_bcache)) {
                     d->st_bcache = rrdset_create_localhost(
@@ -1539,7 +1556,10 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 rrdset_done(d->st_bcache);
             }
 
-            if(d->do_bcache == CONFIG_BOOLEAN_YES || (d->do_bcache == CONFIG_BOOLEAN_AUTO && (stats_total_cache_bypass_hits != 0 || stats_total_cache_bypass_misses != 0))) {
+            if(d->do_bcache == CONFIG_BOOLEAN_YES || (d->do_bcache == CONFIG_BOOLEAN_AUTO &&
+                                                      (stats_total_cache_bypass_hits ||
+                                                       stats_total_cache_bypass_misses ||
+                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
 
                 if(unlikely(!d->st_bcache_bypass)) {
                     d->st_bcache_bypass = rrdset_create_localhost(
@@ -1575,7 +1595,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
     // update the system total I/O
 
-    if(global_do_io == CONFIG_BOOLEAN_YES || (global_do_io == CONFIG_BOOLEAN_AUTO && (system_read_kb || system_write_kb))) {
+    if(global_do_io == CONFIG_BOOLEAN_YES || (global_do_io == CONFIG_BOOLEAN_AUTO &&
+                                              (system_read_kb || system_write_kb || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         static RRDSET *st_io = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 

--- a/collectors/proc.plugin/proc_meminfo.c
+++ b/collectors/proc.plugin/proc_meminfo.c
@@ -219,7 +219,8 @@ int do_proc_meminfo(int update_every, usec_t dt) {
 
     unsigned long long SwapUsed = SwapTotal - SwapFree;
 
-    if(do_swap == CONFIG_BOOLEAN_YES || SwapTotal || SwapUsed || SwapFree) {
+    if(do_swap == CONFIG_BOOLEAN_YES || (do_swap == CONFIG_BOOLEAN_AUTO &&
+                                         (SwapTotal || SwapUsed || SwapFree || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_swap = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_system_swap = NULL;
@@ -256,7 +257,9 @@ int do_proc_meminfo(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(arl_hwcorrupted->flags & ARL_ENTRY_FLAG_FOUND && (do_hwcorrupt == CONFIG_BOOLEAN_YES || (do_hwcorrupt == CONFIG_BOOLEAN_AUTO && HardwareCorrupted > 0))) {
+    if(arl_hwcorrupted->flags & ARL_ENTRY_FLAG_FOUND &&
+       (do_hwcorrupt == CONFIG_BOOLEAN_YES || (do_hwcorrupt == CONFIG_BOOLEAN_AUTO &&
+                                               (HardwareCorrupted > 0 || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
         do_hwcorrupt = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_mem_hwcorrupt = NULL;
@@ -438,7 +441,9 @@ int do_proc_meminfo(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_hugepages == CONFIG_BOOLEAN_YES || (do_hugepages == CONFIG_BOOLEAN_AUTO && Hugepagesize != 0 && HugePages_Total != 0)) {
+    if(do_hugepages == CONFIG_BOOLEAN_YES || (do_hugepages == CONFIG_BOOLEAN_AUTO &&
+                                              ((Hugepagesize && HugePages_Total) ||
+                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_hugepages = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_mem_hugepages = NULL;
@@ -479,7 +484,10 @@ int do_proc_meminfo(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_transparent_hugepages == CONFIG_BOOLEAN_YES || (do_transparent_hugepages == CONFIG_BOOLEAN_AUTO && (AnonHugePages != 0 || ShmemHugePages != 0))) {
+    if(do_transparent_hugepages == CONFIG_BOOLEAN_YES || (do_transparent_hugepages == CONFIG_BOOLEAN_AUTO &&
+                                                          (AnonHugePages ||
+                                                           ShmemHugePages ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_transparent_hugepages = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_mem_transparent_hugepages = NULL;

--- a/collectors/proc.plugin/proc_meminfo.c
+++ b/collectors/proc.plugin/proc_meminfo.c
@@ -220,7 +220,8 @@ int do_proc_meminfo(int update_every, usec_t dt) {
     unsigned long long SwapUsed = SwapTotal - SwapFree;
 
     if(do_swap == CONFIG_BOOLEAN_YES || (do_swap == CONFIG_BOOLEAN_AUTO &&
-                                         (SwapTotal || SwapUsed || SwapFree || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                         (SwapTotal || SwapUsed || SwapFree ||
+                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_swap = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_system_swap = NULL;
@@ -259,7 +260,8 @@ int do_proc_meminfo(int update_every, usec_t dt) {
 
     if(arl_hwcorrupted->flags & ARL_ENTRY_FLAG_FOUND &&
        (do_hwcorrupt == CONFIG_BOOLEAN_YES || (do_hwcorrupt == CONFIG_BOOLEAN_AUTO &&
-                                               (HardwareCorrupted > 0 || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
+                                               (HardwareCorrupted > 0 ||
+                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
         do_hwcorrupt = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_mem_hwcorrupt = NULL;

--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -601,7 +601,8 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(unlikely((d->do_bandwidth == CONFIG_BOOLEAN_AUTO && (d->rbytes || d->tbytes))))
+        if(unlikely(d->do_bandwidth == CONFIG_BOOLEAN_AUTO &&
+                    (d->rbytes || d->tbytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             d->do_bandwidth = CONFIG_BOOLEAN_YES;
 
         if(d->do_bandwidth == CONFIG_BOOLEAN_YES) {
@@ -671,7 +672,8 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(unlikely((d->do_packets == CONFIG_BOOLEAN_AUTO && (d->rpackets || d->tpackets || d->rmulticast))))
+        if(unlikely(d->do_packets == CONFIG_BOOLEAN_AUTO &&
+           (d->rpackets || d->tpackets || d->rmulticast || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             d->do_packets = CONFIG_BOOLEAN_YES;
 
         if(d->do_packets == CONFIG_BOOLEAN_YES) {
@@ -716,7 +718,8 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(unlikely((d->do_errors == CONFIG_BOOLEAN_AUTO && (d->rerrors || d->terrors))))
+        if(unlikely(d->do_errors == CONFIG_BOOLEAN_AUTO &&
+                    (d->rerrors || d->terrors || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             d->do_errors = CONFIG_BOOLEAN_YES;
 
         if(d->do_errors == CONFIG_BOOLEAN_YES) {
@@ -759,7 +762,8 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(unlikely((d->do_drops == CONFIG_BOOLEAN_AUTO && (d->rdrops || d->tdrops))))
+        if(unlikely(d->do_drops == CONFIG_BOOLEAN_AUTO &&
+                    (d->rdrops || d->tdrops || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             d->do_drops = CONFIG_BOOLEAN_YES;
 
         if(d->do_drops == CONFIG_BOOLEAN_YES) {
@@ -802,7 +806,8 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(unlikely((d->do_fifo == CONFIG_BOOLEAN_AUTO && (d->rfifo || d->tfifo))))
+        if(unlikely(d->do_fifo == CONFIG_BOOLEAN_AUTO &&
+                    (d->rfifo || d->tfifo || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             d->do_fifo = CONFIG_BOOLEAN_YES;
 
         if(d->do_fifo == CONFIG_BOOLEAN_YES) {
@@ -845,7 +850,8 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(unlikely((d->do_compressed == CONFIG_BOOLEAN_AUTO && (d->rcompressed || d->tcompressed))))
+        if(unlikely(d->do_compressed == CONFIG_BOOLEAN_AUTO &&
+                    (d->rcompressed || d->tcompressed || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             d->do_compressed = CONFIG_BOOLEAN_YES;
 
         if(d->do_compressed == CONFIG_BOOLEAN_YES) {
@@ -888,7 +894,8 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        if(unlikely((d->do_events == CONFIG_BOOLEAN_AUTO && (d->rframe || d->tcollisions || d->tcarrier))))
+        if(unlikely(d->do_events == CONFIG_BOOLEAN_AUTO &&
+                    (d->rframe || d->tcollisions || d->tcarrier || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
             d->do_events = CONFIG_BOOLEAN_YES;
 
         if(d->do_events == CONFIG_BOOLEAN_YES) {
@@ -924,7 +931,8 @@ int do_proc_net_dev(int update_every, usec_t dt) {
         }
     }
 
-    if(do_bandwidth == CONFIG_BOOLEAN_YES || (do_bandwidth == CONFIG_BOOLEAN_AUTO && (system_rbytes || system_tbytes))) {
+    if(do_bandwidth == CONFIG_BOOLEAN_YES || (do_bandwidth == CONFIG_BOOLEAN_AUTO &&
+                                              (system_rbytes || system_tbytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_bandwidth = CONFIG_BOOLEAN_YES;
         static RRDSET *st_system_net = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;

--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -932,7 +932,8 @@ int do_proc_net_dev(int update_every, usec_t dt) {
     }
 
     if(do_bandwidth == CONFIG_BOOLEAN_YES || (do_bandwidth == CONFIG_BOOLEAN_AUTO &&
-                                              (system_rbytes || system_tbytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                              (system_rbytes || system_tbytes ||
+                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_bandwidth = CONFIG_BOOLEAN_YES;
         static RRDSET *st_system_net = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;

--- a/collectors/proc.plugin/proc_net_netstat.c
+++ b/collectors/proc.plugin/proc_net_netstat.c
@@ -262,7 +262,10 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_bandwidth == CONFIG_BOOLEAN_YES || (do_bandwidth == CONFIG_BOOLEAN_AUTO && (ipext_InOctets || ipext_OutOctets))) {
+            if(do_bandwidth == CONFIG_BOOLEAN_YES || (do_bandwidth == CONFIG_BOOLEAN_AUTO &&
+                                                      (ipext_InOctets ||
+                                                       ipext_OutOctets ||
+                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_bandwidth = CONFIG_BOOLEAN_YES;
                 static RRDSET *st_system_ip = NULL;
                 static RRDDIM *rd_in = NULL, *rd_out = NULL;
@@ -297,7 +300,10 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_inerrors == CONFIG_BOOLEAN_YES || (do_inerrors == CONFIG_BOOLEAN_AUTO && (ipext_InNoRoutes || ipext_InTruncatedPkts))) {
+            if(do_inerrors == CONFIG_BOOLEAN_YES || (do_inerrors == CONFIG_BOOLEAN_AUTO &&
+                                                     (ipext_InNoRoutes ||
+                                                      ipext_InTruncatedPkts ||
+                                                      netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_inerrors = CONFIG_BOOLEAN_YES;
                 static RRDSET *st_ip_inerrors = NULL;
                 static RRDDIM *rd_noroutes = NULL, *rd_truncated = NULL, *rd_checksum = NULL;
@@ -336,7 +342,10 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_mcast == CONFIG_BOOLEAN_YES || (do_mcast == CONFIG_BOOLEAN_AUTO && (ipext_InMcastOctets || ipext_OutMcastOctets))) {
+            if(do_mcast == CONFIG_BOOLEAN_YES || (do_mcast == CONFIG_BOOLEAN_AUTO &&
+                                                  (ipext_InMcastOctets ||
+                                                   ipext_OutMcastOctets ||
+                                                   netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_mcast = CONFIG_BOOLEAN_YES;
                 static RRDSET *st_ip_mcast = NULL;
                 static RRDDIM *rd_in = NULL, *rd_out = NULL;
@@ -373,7 +382,10 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_bcast == CONFIG_BOOLEAN_YES || (do_bcast == CONFIG_BOOLEAN_AUTO && (ipext_InBcastOctets || ipext_OutBcastOctets))) {
+            if(do_bcast == CONFIG_BOOLEAN_YES || (do_bcast == CONFIG_BOOLEAN_AUTO &&
+                                                  (ipext_InBcastOctets ||
+                                                   ipext_OutBcastOctets ||
+                                                   netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_bcast = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_ip_bcast = NULL;
@@ -411,7 +423,10 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_mcast_p == CONFIG_BOOLEAN_YES || (do_mcast_p == CONFIG_BOOLEAN_AUTO && (ipext_InMcastPkts || ipext_OutMcastPkts))) {
+            if(do_mcast_p == CONFIG_BOOLEAN_YES || (do_mcast_p == CONFIG_BOOLEAN_AUTO &&
+                                                    (ipext_InMcastPkts ||
+                                                     ipext_OutMcastPkts ||
+                                                     netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_mcast_p = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_ip_mcastpkts = NULL;
@@ -448,7 +463,10 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_bcast_p == CONFIG_BOOLEAN_YES || (do_bcast_p == CONFIG_BOOLEAN_AUTO && (ipext_InBcastPkts || ipext_OutBcastPkts))) {
+            if(do_bcast_p == CONFIG_BOOLEAN_YES || (do_bcast_p == CONFIG_BOOLEAN_AUTO &&
+                                                    (ipext_InBcastPkts ||
+                                                     ipext_OutBcastPkts ||
+                                                     netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_bcast_p = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_ip_bcastpkts = NULL;
@@ -486,7 +504,12 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_ecn == CONFIG_BOOLEAN_YES || (do_ecn == CONFIG_BOOLEAN_AUTO && (ipext_InCEPkts || ipext_InECT0Pkts || ipext_InECT1Pkts || ipext_InNoECTPkts))) {
+            if(do_ecn == CONFIG_BOOLEAN_YES || (do_ecn == CONFIG_BOOLEAN_AUTO &&
+                                                (ipext_InCEPkts ||
+                                                 ipext_InECT0Pkts ||
+                                                 ipext_InECT1Pkts ||
+                                                 ipext_InNoECTPkts ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ecn = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_ecnpkts = NULL;
@@ -538,7 +561,9 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcpext_memory == CONFIG_BOOLEAN_YES || (do_tcpext_memory == CONFIG_BOOLEAN_AUTO && (tcpext_TCPMemoryPressures))) {
+            if(do_tcpext_memory == CONFIG_BOOLEAN_YES || (do_tcpext_memory == CONFIG_BOOLEAN_AUTO &&
+                                                          (tcpext_TCPMemoryPressures ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_memory = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_tcpmemorypressures = NULL;
@@ -572,7 +597,14 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcpext_connaborts == CONFIG_BOOLEAN_YES || (do_tcpext_connaborts == CONFIG_BOOLEAN_AUTO && (tcpext_TCPAbortOnData || tcpext_TCPAbortOnClose || tcpext_TCPAbortOnMemory || tcpext_TCPAbortOnTimeout || tcpext_TCPAbortOnLinger || tcpext_TCPAbortFailed))) {
+            if(do_tcpext_connaborts == CONFIG_BOOLEAN_YES || (do_tcpext_connaborts == CONFIG_BOOLEAN_AUTO &&
+                                                              (tcpext_TCPAbortOnData ||
+                                                               tcpext_TCPAbortOnClose ||
+                                                               tcpext_TCPAbortOnMemory ||
+                                                               tcpext_TCPAbortOnTimeout ||
+                                                               tcpext_TCPAbortOnLinger ||
+                                                               tcpext_TCPAbortFailed ||
+                                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_connaborts = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_tcpconnaborts = NULL;
@@ -616,7 +648,12 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcpext_reorder == CONFIG_BOOLEAN_YES || (do_tcpext_reorder == CONFIG_BOOLEAN_AUTO && (tcpext_TCPRenoReorder || tcpext_TCPFACKReorder || tcpext_TCPSACKReorder || tcpext_TCPTSReorder))) {
+            if(do_tcpext_reorder == CONFIG_BOOLEAN_YES || (do_tcpext_reorder == CONFIG_BOOLEAN_AUTO &&
+                                                           (tcpext_TCPRenoReorder ||
+                                                            tcpext_TCPFACKReorder ||
+                                                            tcpext_TCPSACKReorder ||
+                                                            tcpext_TCPTSReorder ||
+                                                            netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_reorder = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_tcpreorders = NULL;
@@ -656,7 +693,11 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcpext_ofo == CONFIG_BOOLEAN_YES || (do_tcpext_ofo == CONFIG_BOOLEAN_AUTO && (tcpext_TCPOFOQueue || tcpext_TCPOFODrop || tcpext_TCPOFOMerge))) {
+            if(do_tcpext_ofo == CONFIG_BOOLEAN_YES || (do_tcpext_ofo == CONFIG_BOOLEAN_AUTO &&
+                                                       (tcpext_TCPOFOQueue ||
+                                                        tcpext_TCPOFODrop ||
+                                                        tcpext_TCPOFOMerge ||
+                                                        netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_ofo = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_ip_tcpofo = NULL;
@@ -697,7 +738,11 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcpext_syscookies == CONFIG_BOOLEAN_YES || (do_tcpext_syscookies == CONFIG_BOOLEAN_AUTO && (tcpext_SyncookiesSent || tcpext_SyncookiesRecv || tcpext_SyncookiesFailed))) {
+            if(do_tcpext_syscookies == CONFIG_BOOLEAN_YES || (do_tcpext_syscookies == CONFIG_BOOLEAN_AUTO &&
+                                                              (tcpext_SyncookiesSent ||
+                                                               tcpext_SyncookiesRecv ||
+                                                               tcpext_SyncookiesFailed ||
+                                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_syscookies = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_syncookies = NULL;
@@ -736,7 +781,10 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcpext_syn_queue == CONFIG_BOOLEAN_YES || (do_tcpext_syn_queue == CONFIG_BOOLEAN_AUTO && (tcpext_TCPReqQFullDrop || tcpext_TCPReqQFullDoCookies))) {
+            if(do_tcpext_syn_queue == CONFIG_BOOLEAN_YES || (do_tcpext_syn_queue == CONFIG_BOOLEAN_AUTO &&
+                                                             (tcpext_TCPReqQFullDrop ||
+                                                              tcpext_TCPReqQFullDoCookies ||
+                                                              netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_syn_queue = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_syn_queue = NULL;
@@ -775,7 +823,10 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcpext_accept_queue == CONFIG_BOOLEAN_YES || (do_tcpext_accept_queue == CONFIG_BOOLEAN_AUTO && (tcpext_ListenOverflows || tcpext_ListenDrops))) {
+            if(do_tcpext_accept_queue == CONFIG_BOOLEAN_YES || (do_tcpext_accept_queue == CONFIG_BOOLEAN_AUTO &&
+                                                                (tcpext_ListenOverflows ||
+                                                                 tcpext_ListenDrops ||
+                                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcpext_accept_queue = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_accept_queue = NULL;

--- a/collectors/proc.plugin/proc_net_sctp_snmp.c
+++ b/collectors/proc.plugin/proc_net_sctp_snmp.c
@@ -124,7 +124,8 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_associations == CONFIG_BOOLEAN_YES || (do_associations == CONFIG_BOOLEAN_AUTO && SctpCurrEstab)) {
+    if(do_associations == CONFIG_BOOLEAN_YES || (do_associations == CONFIG_BOOLEAN_AUTO &&
+                                                 (SctpCurrEstab || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_associations = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_established = NULL;
@@ -155,7 +156,12 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_transitions == CONFIG_BOOLEAN_YES || (do_transitions == CONFIG_BOOLEAN_AUTO && (SctpActiveEstabs || SctpPassiveEstabs || SctpAborteds || SctpShutdowns))) {
+    if(do_transitions == CONFIG_BOOLEAN_YES || (do_transitions == CONFIG_BOOLEAN_AUTO &&
+                                                (SctpActiveEstabs ||
+                                                 SctpPassiveEstabs ||
+                                                 SctpAborteds ||
+                                                 SctpShutdowns ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_transitions = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_active = NULL,
@@ -195,7 +201,10 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_packets == CONFIG_BOOLEAN_YES || (do_packets == CONFIG_BOOLEAN_AUTO && (SctpInSCTPPacks || SctpOutSCTPPacks))) {
+    if(do_packets == CONFIG_BOOLEAN_YES || (do_packets == CONFIG_BOOLEAN_AUTO &&
+                                            (SctpInSCTPPacks ||
+                                             SctpOutSCTPPacks ||
+                                             netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_packets = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_received = NULL,
@@ -230,7 +239,10 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_packet_errors == CONFIG_BOOLEAN_YES || (do_packet_errors == CONFIG_BOOLEAN_AUTO && (SctpOutOfBlues || SctpChecksumErrors))) {
+    if(do_packet_errors == CONFIG_BOOLEAN_YES || (do_packet_errors == CONFIG_BOOLEAN_AUTO &&
+                                                  (SctpOutOfBlues ||
+                                                   SctpChecksumErrors ||
+                                                   netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_packet_errors = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_invalid = NULL,
@@ -265,7 +277,10 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_fragmentation == CONFIG_BOOLEAN_YES || (do_fragmentation == CONFIG_BOOLEAN_AUTO && (SctpFragUsrMsgs || SctpReasmUsrMsgs))) {
+    if(do_fragmentation == CONFIG_BOOLEAN_YES || (do_fragmentation == CONFIG_BOOLEAN_AUTO &&
+                                                  (SctpFragUsrMsgs ||
+                                                   SctpReasmUsrMsgs ||
+                                                   netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_fragmentation = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -300,8 +315,14 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_chunk_types == CONFIG_BOOLEAN_YES || (do_chunk_types == CONFIG_BOOLEAN_AUTO
-        && (SctpInCtrlChunks || SctpInOrderChunks || SctpInUnorderChunks || SctpOutCtrlChunks || SctpOutOrderChunks || SctpOutUnorderChunks))) {
+    if(do_chunk_types == CONFIG_BOOLEAN_YES || (do_chunk_types == CONFIG_BOOLEAN_AUTO &&
+                                                (SctpInCtrlChunks ||
+                                                 SctpInOrderChunks ||
+                                                 SctpInUnorderChunks ||
+                                                 SctpOutCtrlChunks ||
+                                                 SctpOutOrderChunks ||
+                                                 SctpOutUnorderChunks ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_chunk_types = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM

--- a/collectors/proc.plugin/proc_net_snmp.c
+++ b/collectors/proc.plugin/proc_net_snmp.c
@@ -704,7 +704,8 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // see http://net-snmp.sourceforge.net/docs/mibs/tcp.html
             if(do_tcp_sockets == CONFIG_BOOLEAN_YES || (do_tcp_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                        (snmp_root.tcp_CurrEstab || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                        (snmp_root.tcp_CurrEstab ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcp_sockets = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;

--- a/collectors/proc.plugin/proc_net_snmp.c
+++ b/collectors/proc.plugin/proc_net_snmp.c
@@ -258,7 +258,12 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_ip_packets == CONFIG_BOOLEAN_YES || (do_ip_packets == CONFIG_BOOLEAN_AUTO && (snmp_root.ip_OutRequests || snmp_root.ip_InReceives || snmp_root.ip_ForwDatagrams || snmp_root.ip_InDelivers))) {
+            if(do_ip_packets == CONFIG_BOOLEAN_YES || (do_ip_packets == CONFIG_BOOLEAN_AUTO &&
+                                                       (snmp_root.ip_OutRequests ||
+                                                        snmp_root.ip_InReceives ||
+                                                        snmp_root.ip_ForwDatagrams ||
+                                                        snmp_root.ip_InDelivers ||
+                                                        netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip_packets = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -299,7 +304,11 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_ip_fragsout == CONFIG_BOOLEAN_YES || (do_ip_fragsout == CONFIG_BOOLEAN_AUTO && (snmp_root.ip_FragOKs || snmp_root.ip_FragFails || snmp_root.ip_FragCreates))) {
+            if(do_ip_fragsout == CONFIG_BOOLEAN_YES || (do_ip_fragsout == CONFIG_BOOLEAN_AUTO &&
+                                                        (snmp_root.ip_FragOKs ||
+                                                         snmp_root.ip_FragFails ||
+                                                         snmp_root.ip_FragCreates ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip_fragsout = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -338,7 +347,11 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_ip_fragsin == CONFIG_BOOLEAN_YES || (do_ip_fragsin == CONFIG_BOOLEAN_AUTO && (snmp_root.ip_ReasmOKs || snmp_root.ip_ReasmFails || snmp_root.ip_ReasmReqds))) {
+            if(do_ip_fragsin == CONFIG_BOOLEAN_YES || (do_ip_fragsin == CONFIG_BOOLEAN_AUTO &&
+                                                       (snmp_root.ip_ReasmOKs ||
+                                                        snmp_root.ip_ReasmFails ||
+                                                        snmp_root.ip_ReasmReqds ||
+                                                        netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip_fragsin = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -377,7 +390,14 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_ip_errors == CONFIG_BOOLEAN_YES || (do_ip_errors == CONFIG_BOOLEAN_AUTO && (snmp_root.ip_InDiscards || snmp_root.ip_OutDiscards || snmp_root.ip_InHdrErrors || snmp_root.ip_InAddrErrors || snmp_root.ip_InUnknownProtos || snmp_root.ip_OutNoRoutes))) {
+            if(do_ip_errors == CONFIG_BOOLEAN_YES || (do_ip_errors == CONFIG_BOOLEAN_AUTO &&
+                                                      (snmp_root.ip_InDiscards ||
+                                                       snmp_root.ip_OutDiscards ||
+                                                       snmp_root.ip_InHdrErrors ||
+                                                       snmp_root.ip_InAddrErrors ||
+                                                       snmp_root.ip_InUnknownProtos ||
+                                                       snmp_root.ip_OutNoRoutes ||
+                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_ip_errors = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -447,7 +467,13 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_icmp_packets == CONFIG_BOOLEAN_YES || (do_icmp_packets == CONFIG_BOOLEAN_AUTO && (snmp_root.icmp_InMsgs || snmp_root.icmp_OutMsgs || snmp_root.icmp_InErrors || snmp_root.icmp_OutErrors || snmp_root.icmp_InCsumErrors))) {
+            if(do_icmp_packets == CONFIG_BOOLEAN_YES || (do_icmp_packets == CONFIG_BOOLEAN_AUTO &&
+                                                         (snmp_root.icmp_InMsgs ||
+                                                          snmp_root.icmp_OutMsgs ||
+                                                          snmp_root.icmp_InErrors ||
+                                                          snmp_root.icmp_OutErrors ||
+                                                          snmp_root.icmp_InCsumErrors ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmp_packets = CONFIG_BOOLEAN_YES;
 
                 {
@@ -540,28 +566,28 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_icmpmsg == CONFIG_BOOLEAN_YES || (do_icmpmsg == CONFIG_BOOLEAN_AUTO && (
-                    snmp_root.icmpmsg_InEchoReps
-                    || snmp_root.icmpmsg_OutEchoReps
-                    || snmp_root.icmpmsg_InDestUnreachs
-                    || snmp_root.icmpmsg_OutDestUnreachs
-                    || snmp_root.icmpmsg_InRedirects
-                    || snmp_root.icmpmsg_OutRedirects
-                    || snmp_root.icmpmsg_InEchos
-                    || snmp_root.icmpmsg_OutEchos
-                    || snmp_root.icmpmsg_InRouterAdvert
-                    || snmp_root.icmpmsg_OutRouterAdvert
-                    || snmp_root.icmpmsg_InRouterSelect
-                    || snmp_root.icmpmsg_OutRouterSelect
-                    || snmp_root.icmpmsg_InTimeExcds
-                    || snmp_root.icmpmsg_OutTimeExcds
-                    || snmp_root.icmpmsg_InParmProbs
-                    || snmp_root.icmpmsg_OutParmProbs
-                    || snmp_root.icmpmsg_InTimestamps
-                    || snmp_root.icmpmsg_OutTimestamps
-                    || snmp_root.icmpmsg_InTimestampReps
-                    || snmp_root.icmpmsg_OutTimestampReps
-                    ))) {
+            if(do_icmpmsg == CONFIG_BOOLEAN_YES || (do_icmpmsg == CONFIG_BOOLEAN_AUTO &&
+                                                    (snmp_root.icmpmsg_InEchoReps ||
+                                                     snmp_root.icmpmsg_OutEchoReps ||
+                                                     snmp_root.icmpmsg_InDestUnreachs ||
+                                                     snmp_root.icmpmsg_OutDestUnreachs ||
+                                                     snmp_root.icmpmsg_InRedirects ||
+                                                     snmp_root.icmpmsg_OutRedirects ||
+                                                     snmp_root.icmpmsg_InEchos ||
+                                                     snmp_root.icmpmsg_OutEchos ||
+                                                     snmp_root.icmpmsg_InRouterAdvert ||
+                                                     snmp_root.icmpmsg_OutRouterAdvert ||
+                                                     snmp_root.icmpmsg_InRouterSelect ||
+                                                     snmp_root.icmpmsg_OutRouterSelect ||
+                                                     snmp_root.icmpmsg_InTimeExcds ||
+                                                     snmp_root.icmpmsg_OutTimeExcds ||
+                                                     snmp_root.icmpmsg_InParmProbs ||
+                                                     snmp_root.icmpmsg_OutParmProbs ||
+                                                     snmp_root.icmpmsg_InTimestamps ||
+                                                     snmp_root.icmpmsg_OutTimestamps ||
+                                                     snmp_root.icmpmsg_InTimestampReps ||
+                                                     snmp_root.icmpmsg_OutTimestampReps ||
+                                                     netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_icmpmsg = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st                  = NULL;
@@ -677,7 +703,8 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
             // --------------------------------------------------------------------
 
             // see http://net-snmp.sourceforge.net/docs/mibs/tcp.html
-            if(do_tcp_sockets == CONFIG_BOOLEAN_YES || (do_tcp_sockets == CONFIG_BOOLEAN_AUTO && snmp_root.tcp_CurrEstab)) {
+            if(do_tcp_sockets == CONFIG_BOOLEAN_YES || (do_tcp_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                        (snmp_root.tcp_CurrEstab || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcp_sockets = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -709,7 +736,10 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcp_packets == CONFIG_BOOLEAN_YES || (do_tcp_packets == CONFIG_BOOLEAN_AUTO && (snmp_root.tcp_InSegs || snmp_root.tcp_OutSegs))) {
+            if(do_tcp_packets == CONFIG_BOOLEAN_YES || (do_tcp_packets == CONFIG_BOOLEAN_AUTO &&
+                                                        (snmp_root.tcp_InSegs ||
+                                                         snmp_root.tcp_OutSegs ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcp_packets = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -744,7 +774,11 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcp_errors == CONFIG_BOOLEAN_YES || (do_tcp_errors == CONFIG_BOOLEAN_AUTO && (snmp_root.tcp_InErrs || snmp_root.tcp_InCsumErrors || snmp_root.tcp_RetransSegs))) {
+            if(do_tcp_errors == CONFIG_BOOLEAN_YES || (do_tcp_errors == CONFIG_BOOLEAN_AUTO &&
+                                                       (snmp_root.tcp_InErrs ||
+                                                        snmp_root.tcp_InCsumErrors ||
+                                                        snmp_root.tcp_RetransSegs ||
+                                                        netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcp_errors = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -783,7 +817,10 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcp_opens == CONFIG_BOOLEAN_YES || (do_tcp_opens == CONFIG_BOOLEAN_AUTO && (snmp_root.tcp_ActiveOpens || snmp_root.tcp_PassiveOpens))) {
+            if(do_tcp_opens == CONFIG_BOOLEAN_YES || (do_tcp_opens == CONFIG_BOOLEAN_AUTO &&
+                                                      (snmp_root.tcp_ActiveOpens ||
+                                                       snmp_root.tcp_PassiveOpens ||
+                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcp_opens = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -819,7 +856,11 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_tcp_handshake == CONFIG_BOOLEAN_YES || (do_tcp_handshake == CONFIG_BOOLEAN_AUTO && (snmp_root.tcp_EstabResets || snmp_root.tcp_OutRsts || snmp_root.tcp_AttemptFails))) {
+            if(do_tcp_handshake == CONFIG_BOOLEAN_YES || (do_tcp_handshake == CONFIG_BOOLEAN_AUTO &&
+                                                          (snmp_root.tcp_EstabResets ||
+                                                           snmp_root.tcp_OutRsts ||
+                                                           snmp_root.tcp_AttemptFails ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_tcp_handshake = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -882,7 +923,10 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
             // --------------------------------------------------------------------
 
             // see http://net-snmp.sourceforge.net/docs/mibs/udp.html
-            if(do_udp_packets == CONFIG_BOOLEAN_YES || (do_udp_packets == CONFIG_BOOLEAN_AUTO && (snmp_root.udp_InDatagrams || snmp_root.udp_OutDatagrams))) {
+            if(do_udp_packets == CONFIG_BOOLEAN_YES || (do_udp_packets == CONFIG_BOOLEAN_AUTO &&
+                                                        (snmp_root.udp_InDatagrams ||
+                                                         snmp_root.udp_OutDatagrams ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_udp_packets = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -917,14 +961,14 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_udp_errors == CONFIG_BOOLEAN_YES || (do_udp_errors == CONFIG_BOOLEAN_AUTO && (
-                    snmp_root.udp_InErrors
-                    || snmp_root.udp_NoPorts
-                    || snmp_root.udp_RcvbufErrors
-                    || snmp_root.udp_SndbufErrors
-                    || snmp_root.udp_InCsumErrors
-                    || snmp_root.udp_IgnoredMulti
-                    ))) {
+            if(do_udp_errors == CONFIG_BOOLEAN_YES || (do_udp_errors == CONFIG_BOOLEAN_AUTO &&
+                                                     (snmp_root.udp_InErrors ||
+                                                      snmp_root.udp_NoPorts ||
+                                                      snmp_root.udp_RcvbufErrors ||
+                                                      snmp_root.udp_SndbufErrors ||
+                                                      snmp_root.udp_InCsumErrors ||
+                                                      snmp_root.udp_IgnoredMulti ||
+                                                      netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_udp_errors = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st = NULL;
@@ -992,16 +1036,16 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
 
             // --------------------------------------------------------------------
 
-            if(do_udplite_packets == CONFIG_BOOLEAN_YES || (do_udplite_packets == CONFIG_BOOLEAN_AUTO && (
-                    snmp_root.udplite_InDatagrams
-                    || snmp_root.udplite_OutDatagrams
-                    || snmp_root.udplite_NoPorts
-                    || snmp_root.udplite_InErrors
-                    || snmp_root.udplite_InCsumErrors
-                    || snmp_root.udplite_RcvbufErrors
-                    || snmp_root.udplite_SndbufErrors
-                    || snmp_root.udplite_IgnoredMulti
-                    ))) {
+            if(do_udplite_packets == CONFIG_BOOLEAN_YES || (do_udplite_packets == CONFIG_BOOLEAN_AUTO &&
+                                                            (snmp_root.udplite_InDatagrams ||
+                                                             snmp_root.udplite_OutDatagrams ||
+                                                             snmp_root.udplite_NoPorts ||
+                                                             snmp_root.udplite_InErrors ||
+                                                             snmp_root.udplite_InCsumErrors ||
+                                                             snmp_root.udplite_RcvbufErrors ||
+                                                             snmp_root.udplite_SndbufErrors ||
+                                                             snmp_root.udplite_IgnoredMulti ||
+                                                             netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
                 do_udplite_packets = CONFIG_BOOLEAN_YES;
 
                 {

--- a/collectors/proc.plugin/proc_net_snmp6.c
+++ b/collectors/proc.plugin/proc_net_snmp6.c
@@ -277,7 +277,10 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_bandwidth == CONFIG_BOOLEAN_YES || (do_bandwidth == CONFIG_BOOLEAN_AUTO && (Ip6InOctets || Ip6OutOctets))) {
+    if(do_bandwidth == CONFIG_BOOLEAN_YES || (do_bandwidth == CONFIG_BOOLEAN_AUTO &&
+                                              (Ip6InOctets ||
+                                               Ip6OutOctets ||
+                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_bandwidth = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_received = NULL,
@@ -311,7 +314,12 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_ip_packets == CONFIG_BOOLEAN_YES || (do_ip_packets == CONFIG_BOOLEAN_AUTO && (Ip6InReceives || Ip6OutRequests || Ip6InDelivers || Ip6OutForwDatagrams))) {
+    if(do_ip_packets == CONFIG_BOOLEAN_YES || (do_ip_packets == CONFIG_BOOLEAN_AUTO &&
+                                               (Ip6InReceives ||
+                                                Ip6OutRequests ||
+                                                Ip6InDelivers ||
+                                                Ip6OutForwDatagrams ||
+                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_ip_packets = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_received = NULL,
@@ -351,7 +359,11 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_ip_fragsout == CONFIG_BOOLEAN_YES || (do_ip_fragsout == CONFIG_BOOLEAN_AUTO && (Ip6FragOKs || Ip6FragFails || Ip6FragCreates))) {
+    if(do_ip_fragsout == CONFIG_BOOLEAN_YES || (do_ip_fragsout == CONFIG_BOOLEAN_AUTO &&
+                                                (Ip6FragOKs ||
+                                                 Ip6FragFails ||
+                                                 Ip6FragCreates ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_ip_fragsout = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_ok = NULL,
@@ -389,13 +401,12 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_ip_fragsin == CONFIG_BOOLEAN_YES || (do_ip_fragsin == CONFIG_BOOLEAN_AUTO
-        && (
-            Ip6ReasmOKs
-            || Ip6ReasmFails
-            || Ip6ReasmTimeout
-            || Ip6ReasmReqds
-            ))) {
+    if(do_ip_fragsin == CONFIG_BOOLEAN_YES || (do_ip_fragsin == CONFIG_BOOLEAN_AUTO &&
+                                               (Ip6ReasmOKs ||
+                                                Ip6ReasmFails ||
+                                                Ip6ReasmTimeout ||
+                                                Ip6ReasmReqds  ||
+                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_ip_fragsin = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -436,17 +447,16 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_ip_errors == CONFIG_BOOLEAN_YES || (do_ip_errors == CONFIG_BOOLEAN_AUTO
-        && (
-            Ip6InDiscards
-            || Ip6OutDiscards
-            || Ip6InHdrErrors
-            || Ip6InAddrErrors
-            || Ip6InUnknownProtos
-            || Ip6InTooBigErrors
-            || Ip6InTruncatedPkts
-            || Ip6InNoRoutes
-        ))) {
+    if(do_ip_errors == CONFIG_BOOLEAN_YES || (do_ip_errors == CONFIG_BOOLEAN_AUTO &&
+                                              (Ip6InDiscards ||
+                                               Ip6OutDiscards ||
+                                               Ip6InHdrErrors ||
+                                               Ip6InAddrErrors ||
+                                               Ip6InUnknownProtos ||
+                                               Ip6InTooBigErrors ||
+                                               Ip6InTruncatedPkts ||
+                                               Ip6InNoRoutes ||
+                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_ip_errors = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_InDiscards      = NULL,
@@ -502,7 +512,10 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_udp_packets == CONFIG_BOOLEAN_YES || (do_udp_packets == CONFIG_BOOLEAN_AUTO && (Udp6InDatagrams || Udp6OutDatagrams))) {
+    if(do_udp_packets == CONFIG_BOOLEAN_YES || (do_udp_packets == CONFIG_BOOLEAN_AUTO &&
+                                                (Udp6InDatagrams ||
+                                                 Udp6OutDatagrams ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udp_packets = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_received = NULL,
@@ -536,15 +549,14 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_udp_errors == CONFIG_BOOLEAN_YES || (do_udp_errors == CONFIG_BOOLEAN_AUTO
-        && (
-            Udp6InErrors
-            || Udp6NoPorts
-            || Udp6RcvbufErrors
-            || Udp6SndbufErrors
-            || Udp6InCsumErrors
-            || Udp6IgnoredMulti
-        ))) {
+    if(do_udp_errors == CONFIG_BOOLEAN_YES || (do_udp_errors == CONFIG_BOOLEAN_AUTO &&
+                                               (Udp6InErrors ||
+                                                Udp6NoPorts ||
+                                                Udp6RcvbufErrors ||
+                                                Udp6SndbufErrors ||
+                                                Udp6InCsumErrors ||
+                                                Udp6IgnoredMulti ||
+                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udp_errors = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_RcvbufErrors = NULL,
@@ -591,7 +603,10 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_udplite_packets == CONFIG_BOOLEAN_YES || (do_udplite_packets == CONFIG_BOOLEAN_AUTO && (UdpLite6InDatagrams || UdpLite6OutDatagrams))) {
+    if(do_udplite_packets == CONFIG_BOOLEAN_YES || (do_udplite_packets == CONFIG_BOOLEAN_AUTO &&
+                                                    (UdpLite6InDatagrams ||
+                                                     UdpLite6OutDatagrams ||
+                                                     netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udplite_packets = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_received = NULL,
@@ -625,15 +640,14 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_udplite_errors == CONFIG_BOOLEAN_YES || (do_udplite_errors == CONFIG_BOOLEAN_AUTO
-        && (
-            UdpLite6InErrors
-            || UdpLite6NoPorts
-            || UdpLite6RcvbufErrors
-            || UdpLite6SndbufErrors
-            || Udp6InCsumErrors
-            || UdpLite6InCsumErrors
-        ))) {
+    if(do_udplite_errors == CONFIG_BOOLEAN_YES || (do_udplite_errors == CONFIG_BOOLEAN_AUTO &&
+                                                   (UdpLite6InErrors ||
+                                                    UdpLite6NoPorts ||
+                                                    UdpLite6RcvbufErrors ||
+                                                    UdpLite6SndbufErrors ||
+                                                    Udp6InCsumErrors ||
+                                                    UdpLite6InCsumErrors ||
+                                                    netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udplite_errors = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_RcvbufErrors = NULL,
@@ -677,7 +691,10 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_mcast == CONFIG_BOOLEAN_YES || (do_mcast == CONFIG_BOOLEAN_AUTO && (Ip6OutMcastOctets || Ip6InMcastOctets))) {
+    if(do_mcast == CONFIG_BOOLEAN_YES || (do_mcast == CONFIG_BOOLEAN_AUTO &&
+                                          (Ip6OutMcastOctets ||
+                                           Ip6InMcastOctets ||
+                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_mcast = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_Ip6InMcastOctets  = NULL,
@@ -712,7 +729,10 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_bcast == CONFIG_BOOLEAN_YES || (do_bcast == CONFIG_BOOLEAN_AUTO && (Ip6OutBcastOctets || Ip6InBcastOctets))) {
+    if(do_bcast == CONFIG_BOOLEAN_YES || (do_bcast == CONFIG_BOOLEAN_AUTO &&
+                                          (Ip6OutBcastOctets ||
+                                           Ip6InBcastOctets ||
+                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_bcast = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_Ip6InBcastOctets  = NULL,
@@ -747,7 +767,10 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_mcast_p == CONFIG_BOOLEAN_YES || (do_mcast_p == CONFIG_BOOLEAN_AUTO && (Ip6OutMcastPkts || Ip6InMcastPkts))) {
+    if(do_mcast_p == CONFIG_BOOLEAN_YES || (do_mcast_p == CONFIG_BOOLEAN_AUTO &&
+                                            (Ip6OutMcastPkts ||
+                                             Ip6InMcastPkts ||
+                                             netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_mcast_p = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_Ip6InMcastPkts  = NULL,
@@ -782,7 +805,10 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_icmp == CONFIG_BOOLEAN_YES || (do_icmp == CONFIG_BOOLEAN_AUTO && (Icmp6InMsgs || Icmp6OutMsgs))) {
+    if(do_icmp == CONFIG_BOOLEAN_YES || (do_icmp == CONFIG_BOOLEAN_AUTO &&
+                                         (Icmp6InMsgs ||
+                                          Icmp6OutMsgs ||
+                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_icmp = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_Icmp6InMsgs  = NULL,
@@ -816,7 +842,10 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_icmp_redir == CONFIG_BOOLEAN_YES || (do_icmp_redir == CONFIG_BOOLEAN_AUTO && (Icmp6InRedirects || Icmp6OutRedirects))) {
+    if(do_icmp_redir == CONFIG_BOOLEAN_YES || (do_icmp_redir == CONFIG_BOOLEAN_AUTO &&
+                                               (Icmp6InRedirects ||
+                                                Icmp6OutRedirects ||
+                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_icmp_redir = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_Icmp6InRedirects  = NULL,
@@ -850,20 +879,19 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_icmp_errors == CONFIG_BOOLEAN_YES || (do_icmp_errors == CONFIG_BOOLEAN_AUTO
-        && (
-            Icmp6InErrors
-            || Icmp6OutErrors
-            || Icmp6InCsumErrors
-            || Icmp6InDestUnreachs
-            || Icmp6InPktTooBigs
-            || Icmp6InTimeExcds
-            || Icmp6InParmProblems
-            || Icmp6OutDestUnreachs
-            || Icmp6OutPktTooBigs
-            || Icmp6OutTimeExcds
-            || Icmp6OutParmProblems
-        ))) {
+    if(do_icmp_errors == CONFIG_BOOLEAN_YES || (do_icmp_errors == CONFIG_BOOLEAN_AUTO &&
+                                                (Icmp6InErrors ||
+                                                 Icmp6OutErrors ||
+                                                 Icmp6InCsumErrors ||
+                                                 Icmp6InDestUnreachs ||
+                                                 Icmp6InPktTooBigs ||
+                                                 Icmp6InTimeExcds ||
+                                                 Icmp6InParmProblems ||
+                                                 Icmp6OutDestUnreachs ||
+                                                 Icmp6OutPktTooBigs ||
+                                                 Icmp6OutTimeExcds ||
+                                                 Icmp6OutParmProblems ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_icmp_errors = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_InErrors        = NULL,
@@ -924,13 +952,12 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_icmp_echos == CONFIG_BOOLEAN_YES || (do_icmp_echos == CONFIG_BOOLEAN_AUTO
-        && (
-            Icmp6InEchos
-            || Icmp6OutEchos
-            || Icmp6InEchoReplies
-            || Icmp6OutEchoReplies
-        ))) {
+    if(do_icmp_echos == CONFIG_BOOLEAN_YES || (do_icmp_echos == CONFIG_BOOLEAN_AUTO &&
+                                               (Icmp6InEchos ||
+                                                Icmp6OutEchos ||
+                                                Icmp6InEchoReplies ||
+                                                Icmp6OutEchoReplies ||
+                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_icmp_echos = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_InEchos        = NULL,
@@ -970,15 +997,14 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_icmp_groupmemb == CONFIG_BOOLEAN_YES || (do_icmp_groupmemb == CONFIG_BOOLEAN_AUTO
-        && (
-            Icmp6InGroupMembQueries
-            || Icmp6OutGroupMembQueries
-            || Icmp6InGroupMembResponses
-            || Icmp6OutGroupMembResponses
-            || Icmp6InGroupMembReductions
-            || Icmp6OutGroupMembReductions
-        ))) {
+    if(do_icmp_groupmemb == CONFIG_BOOLEAN_YES || (do_icmp_groupmemb == CONFIG_BOOLEAN_AUTO &&
+                                                   (Icmp6InGroupMembQueries ||
+                                                    Icmp6OutGroupMembQueries ||
+                                                    Icmp6InGroupMembResponses ||
+                                                    Icmp6OutGroupMembResponses ||
+                                                    Icmp6InGroupMembReductions ||
+                                                    Icmp6OutGroupMembReductions ||
+                                                    netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_icmp_groupmemb = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_InQueries     = NULL,
@@ -1023,13 +1049,12 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_icmp_router == CONFIG_BOOLEAN_YES || (do_icmp_router == CONFIG_BOOLEAN_AUTO
-        && (
-            Icmp6InRouterSolicits
-            || Icmp6OutRouterSolicits
-            || Icmp6InRouterAdvertisements
-            || Icmp6OutRouterAdvertisements
-        ))) {
+    if(do_icmp_router == CONFIG_BOOLEAN_YES || (do_icmp_router == CONFIG_BOOLEAN_AUTO &&
+                                                (Icmp6InRouterSolicits ||
+                                                 Icmp6OutRouterSolicits ||
+                                                 Icmp6InRouterAdvertisements ||
+                                                 Icmp6OutRouterAdvertisements ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_icmp_router = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_InSolicits        = NULL,
@@ -1069,13 +1094,12 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_icmp_neighbor == CONFIG_BOOLEAN_YES || (do_icmp_neighbor == CONFIG_BOOLEAN_AUTO
-        && (
-            Icmp6InNeighborSolicits
-            || Icmp6OutNeighborSolicits
-            || Icmp6InNeighborAdvertisements
-            || Icmp6OutNeighborAdvertisements
-        ))) {
+    if(do_icmp_neighbor == CONFIG_BOOLEAN_YES || (do_icmp_neighbor == CONFIG_BOOLEAN_AUTO &&
+                                                  (Icmp6InNeighborSolicits ||
+                                                   Icmp6OutNeighborSolicits ||
+                                                   Icmp6InNeighborAdvertisements ||
+                                                   Icmp6OutNeighborAdvertisements ||
+                                                   netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_icmp_neighbor = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_InSolicits        = NULL,
@@ -1115,7 +1139,10 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_icmp_mldv2 == CONFIG_BOOLEAN_YES || (do_icmp_mldv2 == CONFIG_BOOLEAN_AUTO && (Icmp6InMLDv2Reports || Icmp6OutMLDv2Reports))) {
+    if(do_icmp_mldv2 == CONFIG_BOOLEAN_YES || (do_icmp_mldv2 == CONFIG_BOOLEAN_AUTO &&
+                                               (Icmp6InMLDv2Reports ||
+                                                Icmp6OutMLDv2Reports ||
+                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_icmp_mldv2 = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_InMLDv2Reports  = NULL,
@@ -1149,19 +1176,18 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_icmp_types == CONFIG_BOOLEAN_YES || (do_icmp_types == CONFIG_BOOLEAN_AUTO
-        && (
-            Icmp6InType1
-            || Icmp6InType128
-            || Icmp6InType129
-            || Icmp6InType136
-            || Icmp6OutType1
-            || Icmp6OutType128
-            || Icmp6OutType129
-            || Icmp6OutType133
-            || Icmp6OutType135
-            || Icmp6OutType143
-        ))) {
+    if(do_icmp_types == CONFIG_BOOLEAN_YES || (do_icmp_types == CONFIG_BOOLEAN_AUTO &&
+                                               (Icmp6InType1 ||
+                                                Icmp6InType128 ||
+                                                Icmp6InType129 ||
+                                                Icmp6InType136 ||
+                                                Icmp6OutType1 ||
+                                                Icmp6OutType128 ||
+                                                Icmp6OutType129 ||
+                                                Icmp6OutType133 ||
+                                                Icmp6OutType135 ||
+                                                Icmp6OutType143 ||
+                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_icmp_types = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_InType1    = NULL,
@@ -1219,13 +1245,12 @@ int do_proc_net_snmp6(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_ect == CONFIG_BOOLEAN_YES || (do_ect == CONFIG_BOOLEAN_AUTO
-        && (
-            Ip6InNoECTPkts
-            || Ip6InECT1Pkts
-            || Ip6InECT0Pkts
-            || Ip6InCEPkts
-        ))) {
+    if(do_ect == CONFIG_BOOLEAN_YES || (do_ect == CONFIG_BOOLEAN_AUTO &&
+                                        (Ip6InNoECTPkts ||
+                                         Ip6InECT1Pkts ||
+                                         Ip6InECT0Pkts ||
+                                         Ip6InCEPkts ||
+                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_ect = CONFIG_BOOLEAN_YES;
         static RRDSET *st = NULL;
         static RRDDIM *rd_InNoECTPkts = NULL,

--- a/collectors/proc.plugin/proc_net_sockstat.c
+++ b/collectors/proc.plugin/proc_net_sockstat.c
@@ -219,7 +219,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_sockets == CONFIG_BOOLEAN_YES || (do_sockets == CONFIG_BOOLEAN_AUTO &&
-                                            (sockstat_root.sockets_used || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                            (sockstat_root.sockets_used ||
+                                             netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -331,7 +332,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_udp_sockets == CONFIG_BOOLEAN_YES || (do_udp_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                (sockstat_root.udp_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                (sockstat_root.udp_inuse ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udp_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -364,7 +366,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_udp_mem == CONFIG_BOOLEAN_YES || (do_udp_mem == CONFIG_BOOLEAN_AUTO &&
-                                            (sockstat_root.udp_mem || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                            (sockstat_root.udp_mem ||
+                                             netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udp_mem = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -397,7 +400,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_udplite_sockets == CONFIG_BOOLEAN_YES || (do_udplite_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                    (sockstat_root.udplite_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                    (sockstat_root.udplite_inuse ||
+                                                     netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udplite_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -430,7 +434,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_raw_sockets == CONFIG_BOOLEAN_YES || (do_raw_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                (sockstat_root.raw_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                (sockstat_root.raw_inuse ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_raw_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -463,7 +468,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_frag_sockets == CONFIG_BOOLEAN_YES || (do_frag_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                 (sockstat_root.frag_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                 (sockstat_root.frag_inuse ||
+                                                  netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_frag_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -496,7 +502,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_frag_mem == CONFIG_BOOLEAN_YES || (do_frag_mem == CONFIG_BOOLEAN_AUTO &&
-                                             (sockstat_root.frag_memory || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                             (sockstat_root.frag_memory ||
+                                              netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_frag_mem = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;

--- a/collectors/proc.plugin/proc_net_sockstat.c
+++ b/collectors/proc.plugin/proc_net_sockstat.c
@@ -218,7 +218,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_sockets == CONFIG_BOOLEAN_YES || (do_sockets == CONFIG_BOOLEAN_AUTO && sockstat_root.sockets_used)) {
+    if(do_sockets == CONFIG_BOOLEAN_YES || (do_sockets == CONFIG_BOOLEAN_AUTO &&
+                                            (sockstat_root.sockets_used || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -250,7 +251,12 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_tcp_sockets == CONFIG_BOOLEAN_YES || (do_tcp_sockets == CONFIG_BOOLEAN_AUTO && (sockstat_root.tcp_inuse || sockstat_root.tcp_orphan || sockstat_root.tcp_tw || sockstat_root.tcp_alloc))) {
+    if(do_tcp_sockets == CONFIG_BOOLEAN_YES || (do_tcp_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                (sockstat_root.tcp_inuse ||
+                                                 sockstat_root.tcp_orphan ||
+                                                 sockstat_root.tcp_tw ||
+                                                 sockstat_root.tcp_alloc ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_tcp_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -291,7 +297,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_tcp_mem == CONFIG_BOOLEAN_YES || (do_tcp_mem == CONFIG_BOOLEAN_AUTO && sockstat_root.tcp_mem)) {
+    if(do_tcp_mem == CONFIG_BOOLEAN_YES || (do_tcp_mem == CONFIG_BOOLEAN_AUTO &&
+                                            (sockstat_root.tcp_mem || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_tcp_mem = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -323,7 +330,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_udp_sockets == CONFIG_BOOLEAN_YES || (do_udp_sockets == CONFIG_BOOLEAN_AUTO && sockstat_root.udp_inuse)) {
+    if(do_udp_sockets == CONFIG_BOOLEAN_YES || (do_udp_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                (sockstat_root.udp_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udp_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -355,7 +363,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_udp_mem == CONFIG_BOOLEAN_YES || (do_udp_mem == CONFIG_BOOLEAN_AUTO && sockstat_root.udp_mem)) {
+    if(do_udp_mem == CONFIG_BOOLEAN_YES || (do_udp_mem == CONFIG_BOOLEAN_AUTO &&
+                                            (sockstat_root.udp_mem || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udp_mem = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -387,7 +396,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_udplite_sockets == CONFIG_BOOLEAN_YES || (do_udplite_sockets == CONFIG_BOOLEAN_AUTO && sockstat_root.udplite_inuse)) {
+    if(do_udplite_sockets == CONFIG_BOOLEAN_YES || (do_udplite_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                    (sockstat_root.udplite_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udplite_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -419,7 +429,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_raw_sockets == CONFIG_BOOLEAN_YES || (do_raw_sockets == CONFIG_BOOLEAN_AUTO && sockstat_root.raw_inuse)) {
+    if(do_raw_sockets == CONFIG_BOOLEAN_YES || (do_raw_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                (sockstat_root.raw_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_raw_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -451,7 +462,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_frag_sockets == CONFIG_BOOLEAN_YES || (do_frag_sockets == CONFIG_BOOLEAN_AUTO && sockstat_root.frag_inuse)) {
+    if(do_frag_sockets == CONFIG_BOOLEAN_YES || (do_frag_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                 (sockstat_root.frag_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_frag_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -483,7 +495,8 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_frag_mem == CONFIG_BOOLEAN_YES || (do_frag_mem == CONFIG_BOOLEAN_AUTO && sockstat_root.frag_memory)) {
+    if(do_frag_mem == CONFIG_BOOLEAN_YES || (do_frag_mem == CONFIG_BOOLEAN_AUTO &&
+                                             (sockstat_root.frag_memory || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_frag_mem = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;

--- a/collectors/proc.plugin/proc_net_sockstat6.c
+++ b/collectors/proc.plugin/proc_net_sockstat6.c
@@ -112,7 +112,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_tcp_sockets == CONFIG_BOOLEAN_YES || (do_tcp_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                (sockstat6_root.tcp6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                (sockstat6_root.tcp6_inuse ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_tcp_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -145,7 +146,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_udp_sockets == CONFIG_BOOLEAN_YES || (do_udp_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                (sockstat6_root.udp6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                (sockstat6_root.udp6_inuse ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udp_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -178,7 +180,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_udplite_sockets == CONFIG_BOOLEAN_YES || (do_udplite_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                    (sockstat6_root.udplite6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                    (sockstat6_root.udplite6_inuse ||
+                                                     netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udplite_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -211,7 +214,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_raw_sockets == CONFIG_BOOLEAN_YES || (do_raw_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                (sockstat6_root.raw6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                (sockstat6_root.raw6_inuse ||
+                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_raw_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -244,7 +248,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
     // ------------------------------------------------------------------------
 
     if(do_frag_sockets == CONFIG_BOOLEAN_YES || (do_frag_sockets == CONFIG_BOOLEAN_AUTO &&
-                                                 (sockstat6_root.frag6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                                 (sockstat6_root.frag6_inuse ||
+                                                  netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_frag_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;

--- a/collectors/proc.plugin/proc_net_sockstat6.c
+++ b/collectors/proc.plugin/proc_net_sockstat6.c
@@ -111,7 +111,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_tcp_sockets == CONFIG_BOOLEAN_YES || (do_tcp_sockets == CONFIG_BOOLEAN_AUTO && (sockstat6_root.tcp6_inuse))) {
+    if(do_tcp_sockets == CONFIG_BOOLEAN_YES || (do_tcp_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                (sockstat6_root.tcp6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_tcp_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -143,7 +144,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_udp_sockets == CONFIG_BOOLEAN_YES || (do_udp_sockets == CONFIG_BOOLEAN_AUTO && sockstat6_root.udp6_inuse)) {
+    if(do_udp_sockets == CONFIG_BOOLEAN_YES || (do_udp_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                (sockstat6_root.udp6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udp_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -175,7 +177,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_udplite_sockets == CONFIG_BOOLEAN_YES || (do_udplite_sockets == CONFIG_BOOLEAN_AUTO && sockstat6_root.udplite6_inuse)) {
+    if(do_udplite_sockets == CONFIG_BOOLEAN_YES || (do_udplite_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                    (sockstat6_root.udplite6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_udplite_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -207,7 +210,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_raw_sockets == CONFIG_BOOLEAN_YES || (do_raw_sockets == CONFIG_BOOLEAN_AUTO && sockstat6_root.raw6_inuse)) {
+    if(do_raw_sockets == CONFIG_BOOLEAN_YES || (do_raw_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                (sockstat6_root.raw6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_raw_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -239,7 +243,8 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
 
     // ------------------------------------------------------------------------
 
-    if(do_frag_sockets == CONFIG_BOOLEAN_YES || (do_frag_sockets == CONFIG_BOOLEAN_AUTO && sockstat6_root.frag6_inuse)) {
+    if(do_frag_sockets == CONFIG_BOOLEAN_YES || (do_frag_sockets == CONFIG_BOOLEAN_AUTO &&
+                                                 (sockstat6_root.frag6_inuse || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_frag_sockets = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;

--- a/collectors/proc.plugin/proc_net_stat_synproxy.c
+++ b/collectors/proc.plugin/proc_net_stat_synproxy.c
@@ -59,7 +59,8 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if((do_entries == CONFIG_BOOLEAN_AUTO && events) || do_entries == CONFIG_BOOLEAN_YES) {
+    if(do_entries == CONFIG_BOOLEAN_YES || (do_entries == CONFIG_BOOLEAN_AUTO &&
+                                            (events || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_entries = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -89,7 +90,8 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if((do_syns == CONFIG_BOOLEAN_AUTO && events) || do_syns == CONFIG_BOOLEAN_YES) {
+    if(do_syns == CONFIG_BOOLEAN_YES || (do_syns == CONFIG_BOOLEAN_AUTO &&
+                                         (events || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_syns = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -119,7 +121,8 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if((do_reopened == CONFIG_BOOLEAN_AUTO && events) || do_reopened == CONFIG_BOOLEAN_YES) {
+    if(do_reopened == CONFIG_BOOLEAN_YES || (do_reopened == CONFIG_BOOLEAN_AUTO &&
+                                             (events || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_reopened = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
@@ -149,7 +152,8 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if((do_cookies == CONFIG_BOOLEAN_AUTO && events) || do_cookies == CONFIG_BOOLEAN_YES) {
+    if(do_cookies == CONFIG_BOOLEAN_YES || (do_cookies == CONFIG_BOOLEAN_AUTO &&
+                                            (events || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_cookies = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;

--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -124,6 +124,8 @@ int do_proc_spl_kstat_zfs_arcstats(int update_every, usec_t dt) {
         dirname = config_get("plugin:proc:" ZFS_PROC_ARCSTATS, "directory to monitor", filename);
 
         show_zero_charts = config_get_boolean_ondemand("plugin:proc:" ZFS_PROC_ARCSTATS, "show zero charts", CONFIG_BOOLEAN_NO);
+        if(show_zero_charts == CONFIG_BOOLEAN_AUTO && netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)
+            show_zero_charts = CONFIG_BOOLEAN_YES;
         if(unlikely(show_zero_charts == CONFIG_BOOLEAN_YES))
             do_zfs_stats = 1;
     }

--- a/collectors/proc.plugin/proc_vmstat.c
+++ b/collectors/proc.plugin/proc_vmstat.c
@@ -43,7 +43,8 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         arl_expect(arl_base, "pswpin", &pswpin);
         arl_expect(arl_base, "pswpout", &pswpout);
 
-        if(do_numa == CONFIG_BOOLEAN_YES || (do_numa == CONFIG_BOOLEAN_AUTO && get_numa_node_count() >= 2)) {
+        if(do_numa == CONFIG_BOOLEAN_YES || (do_numa == CONFIG_BOOLEAN_AUTO &&
+                                             (get_numa_node_count() >= 2 || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             arl_expect(arl_base, "numa_foreign", &numa_foreign);
             arl_expect(arl_base, "numa_hint_faults_local", &numa_hint_faults_local);
             arl_expect(arl_base, "numa_hint_faults", &numa_hint_faults);
@@ -91,7 +92,8 @@ int do_proc_vmstat(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(pswpin || pswpout || do_swapio == CONFIG_BOOLEAN_YES) {
+    if(do_swapio == CONFIG_BOOLEAN_YES || (do_swapio == CONFIG_BOOLEAN_AUTO &&
+                                           (pswpin || pswpout || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_swapio = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_swapio = NULL;

--- a/collectors/proc.plugin/proc_vmstat.c
+++ b/collectors/proc.plugin/proc_vmstat.c
@@ -44,7 +44,8 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         arl_expect(arl_base, "pswpout", &pswpout);
 
         if(do_numa == CONFIG_BOOLEAN_YES || (do_numa == CONFIG_BOOLEAN_AUTO &&
-                                             (get_numa_node_count() >= 2 || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                             (get_numa_node_count() >= 2 ||
+                                              netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             arl_expect(arl_base, "numa_foreign", &numa_foreign);
             arl_expect(arl_base, "numa_hint_faults_local", &numa_hint_faults_local);
             arl_expect(arl_base, "numa_hint_faults", &numa_hint_faults);
@@ -93,7 +94,8 @@ int do_proc_vmstat(int update_every, usec_t dt) {
     // --------------------------------------------------------------------
 
     if(do_swapio == CONFIG_BOOLEAN_YES || (do_swapio == CONFIG_BOOLEAN_AUTO &&
-                                           (pswpin || pswpout || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+                                           (pswpin || pswpout ||
+                                            netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_swapio = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_swapio = NULL;

--- a/collectors/proc.plugin/sys_devices_system_edac_mc.c
+++ b/collectors/proc.plugin/sys_devices_system_edac_mc.c
@@ -128,7 +128,8 @@ int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_ce == CONFIG_BOOLEAN_YES || (do_ce == CONFIG_BOOLEAN_AUTO && ce_sum > 0)) {
+    if(do_ce == CONFIG_BOOLEAN_YES || (do_ce == CONFIG_BOOLEAN_AUTO &&
+                                       (ce_sum > 0 || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_ce = CONFIG_BOOLEAN_YES;
 
         static RRDSET *ce_st = NULL;
@@ -166,7 +167,8 @@ int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(do_ue == CONFIG_BOOLEAN_YES || (do_ue == CONFIG_BOOLEAN_AUTO && ue_sum > 0)) {
+    if(do_ue == CONFIG_BOOLEAN_YES || (do_ue == CONFIG_BOOLEAN_AUTO &&
+                                       (ue_sum > 0 || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         do_ue = CONFIG_BOOLEAN_YES;
 
         static RRDSET *ue_st = NULL;

--- a/collectors/proc.plugin/sys_devices_system_node.c
+++ b/collectors/proc.plugin/sys_devices_system_node.c
@@ -83,7 +83,8 @@ int do_proc_sys_devices_system_node(int update_every, usec_t dt) {
         hash_numa_miss      = simple_hash("numa_miss");
     }
 
-    if(do_numastat == CONFIG_BOOLEAN_YES || (do_numastat == CONFIG_BOOLEAN_AUTO && numa_node_count >= 2)) {
+    if(do_numastat == CONFIG_BOOLEAN_YES || (do_numastat == CONFIG_BOOLEAN_AUTO &&
+                                             (numa_node_count >= 2 || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         for(m = numa_root; m; m = m->next) {
             if(m->numastat_filename) {
 

--- a/collectors/proc.plugin/sys_fs_btrfs.c
+++ b/collectors/proc.plugin/sys_fs_btrfs.c
@@ -542,7 +542,9 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
         // --------------------------------------------------------------------
         // allocation/disks
 
-        if(do_allocation_disks == CONFIG_BOOLEAN_YES || (do_allocation_disks == CONFIG_BOOLEAN_AUTO && node->all_disks_total && node->allocation_data_disk_total)) {
+        if(do_allocation_disks == CONFIG_BOOLEAN_YES || (do_allocation_disks == CONFIG_BOOLEAN_AUTO &&
+                                                         ((node->all_disks_total && node->allocation_data_disk_total) ||
+                                                          netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             do_allocation_disks = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!node->st_allocation_disks)) {
@@ -598,7 +600,9 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
         // --------------------------------------------------------------------
         // allocation/data
 
-        if(do_allocation_data == CONFIG_BOOLEAN_YES || (do_allocation_data == CONFIG_BOOLEAN_AUTO && node->allocation_data_total_bytes)) {
+        if(do_allocation_data == CONFIG_BOOLEAN_YES || (do_allocation_data == CONFIG_BOOLEAN_AUTO &&
+                                                        (node->allocation_data_total_bytes ||
+                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             do_allocation_data = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!node->st_allocation_data)) {
@@ -639,7 +643,9 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
         // --------------------------------------------------------------------
         // allocation/metadata
 
-        if(do_allocation_metadata == CONFIG_BOOLEAN_YES || (do_allocation_metadata == CONFIG_BOOLEAN_AUTO && node->allocation_metadata_total_bytes)) {
+        if(do_allocation_metadata == CONFIG_BOOLEAN_YES || (do_allocation_metadata == CONFIG_BOOLEAN_AUTO &&
+                                                            (node->allocation_metadata_total_bytes ||
+                                                             netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             do_allocation_metadata = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!node->st_allocation_metadata)) {
@@ -682,7 +688,9 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
         // --------------------------------------------------------------------
         // allocation/system
 
-        if(do_allocation_system == CONFIG_BOOLEAN_YES || (do_allocation_system == CONFIG_BOOLEAN_AUTO && node->allocation_system_total_bytes)) {
+        if(do_allocation_system == CONFIG_BOOLEAN_YES || (do_allocation_system == CONFIG_BOOLEAN_AUTO &&
+                                                          (node->allocation_system_total_bytes ||
+                                                           netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             do_allocation_system = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!node->st_allocation_system)) {

--- a/collectors/proc.plugin/sys_kernel_mm_ksm.c
+++ b/collectors/proc.plugin/sys_kernel_mm_ksm.c
@@ -89,7 +89,7 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
     offered = pages_sharing + pages_shared + pages_unshared + pages_volatile;
     saved = pages_sharing;
 
-    if(unlikely(!offered /*|| !pages_to_scan*/)) return 0;
+    if(unlikely(!offered /*|| !pages_to_scan*/ && netdata_zero_metrics_enabled == CONFIG_BOOLEAN_NO)) return 0;
 
     // --------------------------------------------------------------------
 
@@ -192,7 +192,7 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
         else
             rrdset_next(st_mem_ksm_ratios);
 
-        rrddim_set_by_pointer(st_mem_ksm_ratios, rd_savings, (saved * 1000000) / offered);
+        rrddim_set_by_pointer(st_mem_ksm_ratios, rd_savings, offered ? (saved * 1000000) / offered : 0);
 
         rrdset_done(st_mem_ksm_ratios);
     }

--- a/collectors/tc.plugin/README.md
+++ b/collectors/tc.plugin/README.md
@@ -191,7 +191,7 @@ Add the following configuration option in `/etc/netdata.conf`:
 Finally, create `/etc/netdata/tc-qos-helper.conf` with this content:
 ```tc_show="class"```
 
-Please note, that by default Netdata will enable monitoring metrics only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a chart instead of `auto` to enable it permanently.
+Please note, that by default Netdata will enable monitoring metrics only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a chart instead of `auto` to enable it permanently. You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero metrics for all internal Netdata plugins.
 
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Ftc.plugin%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)]()

--- a/collectors/tc.plugin/plugin_tc.c
+++ b/collectors/tc.plugin/plugin_tc.c
@@ -382,7 +382,9 @@ static inline void tc_device_commit(struct tc_device *d) {
     // --------------------------------------------------------------------
     // bytes
 
-    if(d->enabled_bytes == CONFIG_BOOLEAN_YES || (d->enabled_bytes == CONFIG_BOOLEAN_AUTO && bytes_sum)) {
+    if(d->enabled_bytes == CONFIG_BOOLEAN_YES || (d->enabled_bytes == CONFIG_BOOLEAN_AUTO &&
+                                                  (bytes_sum ||
+                                                   netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         d->enabled_bytes = CONFIG_BOOLEAN_YES;
 
         if(unlikely(!d->st_bytes))
@@ -425,7 +427,9 @@ static inline void tc_device_commit(struct tc_device *d) {
     // --------------------------------------------------------------------
     // packets
 
-    if(d->enabled_packets == CONFIG_BOOLEAN_YES || (d->enabled_packets == CONFIG_BOOLEAN_AUTO && packets_sum)) {
+    if(d->enabled_packets == CONFIG_BOOLEAN_YES || (d->enabled_packets == CONFIG_BOOLEAN_AUTO &&
+                                                    (packets_sum ||
+                                                     netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         d->enabled_packets = CONFIG_BOOLEAN_YES;
 
         if(unlikely(!d->st_packets)) {
@@ -478,7 +482,9 @@ static inline void tc_device_commit(struct tc_device *d) {
     // --------------------------------------------------------------------
     // dropped
 
-    if(d->enabled_dropped == CONFIG_BOOLEAN_YES || (d->enabled_dropped == CONFIG_BOOLEAN_AUTO && dropped_sum)) {
+    if(d->enabled_dropped == CONFIG_BOOLEAN_YES || (d->enabled_dropped == CONFIG_BOOLEAN_AUTO &&
+                                                    (dropped_sum ||
+                                                     netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         d->enabled_dropped = CONFIG_BOOLEAN_YES;
 
         if(unlikely(!d->st_dropped)) {
@@ -531,7 +537,9 @@ static inline void tc_device_commit(struct tc_device *d) {
     // --------------------------------------------------------------------
     // tokens
 
-    if(d->enabled_tokens == CONFIG_BOOLEAN_YES || (d->enabled_tokens == CONFIG_BOOLEAN_AUTO && tokens_sum)) {
+    if(d->enabled_tokens == CONFIG_BOOLEAN_YES || (d->enabled_tokens == CONFIG_BOOLEAN_AUTO &&
+                                                   (tokens_sum ||
+                                                    netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         d->enabled_tokens = CONFIG_BOOLEAN_YES;
 
         if(unlikely(!d->st_tokens)) {
@@ -585,7 +593,9 @@ static inline void tc_device_commit(struct tc_device *d) {
     // --------------------------------------------------------------------
     // ctokens
 
-    if(d->enabled_ctokens == CONFIG_BOOLEAN_YES || (d->enabled_ctokens == CONFIG_BOOLEAN_AUTO && ctokens_sum)) {
+    if(d->enabled_ctokens == CONFIG_BOOLEAN_YES || (d->enabled_ctokens == CONFIG_BOOLEAN_AUTO &&
+                                                    (ctokens_sum ||
+                                                     netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         d->enabled_ctokens = CONFIG_BOOLEAN_YES;
 
         if(unlikely(!d->st_ctokens)) {

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -78,6 +78,7 @@ extern char *netdata_configured_varlib_dir;
 extern char *netdata_configured_home_dir;
 extern char *netdata_configured_host_prefix;
 extern char *netdata_configured_timezone;
+extern int netdata_zero_metrics_enabled;
 extern int netdata_anonymous_statistics_enabled;
 
 int netdata_ready;

--- a/daemon/config/README.md
+++ b/daemon/config/README.md
@@ -74,6 +74,7 @@ gap when lost iterations above | `1` |
 cleanup orphan hosts after seconds | `3600` |  How long to wait until automatically removing from the DB a remote netdata host (slave) that is no longer sending data.
 delete obsolete charts files | `yes` |  See [monitoring ephemeral containers](../../collectors/cgroups.plugin/#monitoring-ephemeral-containers), also affects the deletion of files for obsolete dimensions
 delete orphan hosts files | `yes` |  Set to `no` to disable non-responsive host removal.
+enable zero metrics | `no` |  Set to `yes` to show charts when all their metrics are zero.
 
 ### [web] section options
 
@@ -128,7 +129,7 @@ The configuration options for plugins appear in sections following the pattern `
 
 Most internal plugins will provide additional options. Check [Internal Plugins](../../collectors/) for more information.
 
-Please note, that by default Netdata will enable monitoring metrics for disks, memory, and network only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Use `yes` instead of `auto` in plugin configuration sections to enable these charts permanently.
+Please note, that by default Netdata will enable monitoring metrics for disks, memory, and network only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Use `yes` instead of `auto` in plugin configuration sections to enable these charts permanently. You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero metrics for all internal Netdata plugins.
 
 #### External plugins
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -2,6 +2,7 @@
 
 #include "common.h"
 
+int netdata_zero_metrics_enabled;
 int netdata_anonymous_statistics_enabled;
 
 struct config netdata_config = {
@@ -1214,6 +1215,8 @@ int main(int argc, char **argv) {
 
     web_server_config_options();
 
+    netdata_zero_metrics_enabled = config_get_boolean(CONFIG_SECTION_GLOBAL, "enable zero metrics", CONFIG_BOOLEAN_NO);
+
     for (i = 0; static_threads[i].name != NULL ; i++) {
         struct netdata_static_thread *st = &static_threads[i];
 
@@ -1227,7 +1230,7 @@ int main(int argc, char **argv) {
 
     info("netdata initialization completed. Enjoy real-time performance monitoring!");
     netdata_ready = 1;
-  
+
     send_statistics("START", "-",  "-");
 
     // ------------------------------------------------------------------------

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1215,7 +1215,7 @@ int main(int argc, char **argv) {
 
     web_server_config_options();
 
-    netdata_zero_metrics_enabled = config_get_boolean(CONFIG_SECTION_GLOBAL, "enable zero metrics", CONFIG_BOOLEAN_NO);
+    netdata_zero_metrics_enabled = config_get_boolean_ondemand(CONFIG_SECTION_GLOBAL, "enable zero metrics", CONFIG_BOOLEAN_NO);
 
     for (i = 0; static_threads[i].name != NULL ; i++) {
         struct netdata_static_thread *st = &static_threads[i];

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -59,7 +59,7 @@ Entire plugins can be turned off from the [netdata.conf [plugins]](../daemon/con
 
 ##### Show charts with zero metrics
 
-By default, Netdata will enable monitoring metrics for disks, memory, and network only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Use `yes` instead of `auto` in plugin configuration sections to enable these charts permanently.
+By default, Netdata will enable monitoring metrics for disks, memory, and network only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Use `yes` instead of `auto` in plugin configuration sections to enable these charts permanently. You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero metrics for all internal Netdata plugins.
 
 ### Modify alarms and notifications
 


### PR DESCRIPTION
##### Summary
If all metrics are zero in a chart, it is not displayed by default. A global configuration option will be added to allow users to see charts with all zero metrics if desired. 

Closes #6315

##### Component Name
proc plugin
diskspace plugin
cgroups plugin
freebsd plugin
macos plugin
tc plugin