### PR TITLE
Netdata/packaging: Add documentation for binary packages, plus draft table for distributions support

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -138,6 +138,7 @@ echo -ne "    - 'docs/Demo-Sites.md'
     - 'packaging/installer/README.md'
     - 'packaging/docker/README.md'
     - 'packaging/installer/UPDATE.md'
+    - 'packaging/DISTRIBUTIONS.md'
     - 'packaging/installer/UNINSTALL.md'
 - 'docs/GettingStarted.md'
 - Running Netdata:

--- a/packaging/DISTRIBUTIONS.md
+++ b/packaging/DISTRIBUTIONS.md
@@ -8,31 +8,31 @@ Kindly note that the following table is a work in progress. We have concluded on
 that we currently supporting and we are working on documenting our current state so that our users
 have complete visibility over the range of support
 
-Distribution | Family| Code health | Installer support | Kickstart support | Binary packaging support | Integrity testing (CI) | Functionality testing (CI) | Community support
-:------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :--------------------
-14.04.6 LTS (Trusty Tahr) | Ubuntu |  |  |  |  |  |  | 
-16.04.6 LTS (Xenial Xerus) | Ubuntu |  |  |  |  |  |  | 
-18.04.2 LTS (Bionic Beaver) | Ubuntu |  |  |  |  |  |  | 
-19.04 (Disco Dingo) Latest | Ubuntu |  |  |  |  |  |  | 
-Debian 7 (Wheezy) | Debian |  |  |  |  |  |  | 
-Debian 8 (Jessie) | Debian |  |  |  |  |  |  | 
-Debian 9 (Stretch) | Debian |  |  |  |  |  |  | 
-Debian 10 (Buster) | Debian |  |  |  |  |  |  | 
-Versions 6.* | RHEL |  |  |  |  |  |  | 
-Versions 7.* | RHEL |  |  |  |  |  |  | 
-Versions 8.* | RHEL |  |  |  |  |  |  | 
-Fedora 28 | Fedora |  |  |  |  |  |  | 
-Fedora 29 | Fedora |  |  |  |  |  |  | 
-Fedora 30 | Fedora |  |  |  |  |  |  | 
-Fedora 31 | Fedora |  |  |  |  |  |  | 
-CentOS 6.* | Cent OS | |  |  |  |  |  |  | 
-CentOS 7.* | Cent OS | |  |  |  |  |  |  | 
-CentOS 8.* | Cent OS | |  |  |  |  |  |  | 
-Open SuSE Leap 15.0 | Open SuSE |  |  |  |  |  |  | 
-Open SuSE Leap 15.1 | Open SuSE |  |  |  |  |  |  | 
-Open SuSE Tumbleweed (latest) | Open SuSE |  |  |  |  |  |  | 
-SuSE Enterprise Linux Server 11 | SLES |  |  |  |  |  |  | 
-SuSE Enterprise Linux Server 12 | SLES |  |  |  |  |  |  | 
-SuSE Enterprise Linux Server 15 | SLES |  |  |  |  |  |  | 
-Arch Linux (latest) | Arch |  |  |  |  |  |  | 
-All other linux | Other | |  |  |  |  |  | 
+Distribution | Family | Architecture | Code health | Installer support | Kickstart support | Binary packaging support | Integrity testing (CI) | Functionality testing (CI) | Community support
+:------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :--------------------
+14.04.6 LTS (Trusty Tahr) | Ubuntu |  |  |  |  |  |  | | 
+16.04.6 LTS (Xenial Xerus) | Ubuntu |  |  |  |  |  |  | | 
+18.04.2 LTS (Bionic Beaver) | Ubuntu |  |  |  |  |  |  | | 
+19.04 (Disco Dingo) Latest | Ubuntu |  |  |  |  |  |  | | 
+Debian 7 (Wheezy) | Debian |  |  |  |  |  |  | | 
+Debian 8 (Jessie) | Debian |  |  |  |  |  |  | | 
+Debian 9 (Stretch) | Debian |  |  |  |  |  |  | | 
+Debian 10 (Buster) | Debian |  |  |  |  |  |  | | 
+Versions 6.* | RHEL |  |  |  |  |  |  | | 
+Versions 7.* | RHEL |  |  |  |  |  |  | | 
+Versions 8.* | RHEL |  |  |  |  |  |  | | 
+Fedora 28 | Fedora |  |  |  |  |  |  | | 
+Fedora 29 | Fedora |  |  |  |  |  |  | | 
+Fedora 30 | Fedora |  |  |  |  |  |  | | 
+Fedora 31 | Fedora |  |  |  |  |  |  | | 
+CentOS 6.* | Cent OS | |  |  |  |  |  |  | | 
+CentOS 7.* | Cent OS | |  |  |  |  |  |  | | 
+CentOS 8.* | Cent OS | |  |  |  |  |  |  | | 
+Open SuSE Leap 15.0 | Open SuSE |  |  |  |  |  |  | | 
+Open SuSE Leap 15.1 | Open SuSE |  |  |  |  |  |  | | 
+Open SuSE Tumbleweed (latest) | Open SuSE |  |  |  |  |  |  | | 
+SuSE Enterprise Linux Server 11 | SLES |  |  |  |  |  |  | | 
+SuSE Enterprise Linux Server 12 | SLES |  |  |  |  |  |  | | 
+SuSE Enterprise Linux Server 15 | SLES |  |  |  |  |  |  | | 
+Arch Linux (latest) | Arch |  |  |  |  |  |  | | 
+All other linux | Other | |  |  |  |  |  | | 

--- a/packaging/DISTRIBUTIONS.md
+++ b/packaging/DISTRIBUTIONS.md
@@ -1,0 +1,34 @@
+# Netdata distribution support matrix
+![](https://raw.githubusercontent.com/netdata/netdata/master/web/gui/images/packaging-beta-tag.svg?sanitize=true)
+
+In the following table we provide the list of officially supported operating systems.
+We detail the Distributions, flavours and the way of support Netdata is currently capable to provide.
+
+Distribution | Family| Code healthy | Installer support | Kickstart support | Binary packaging support | Integrity testing (CI) | Functionality testing (CI) | Community support
+:------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :--------------------
+14.04.6 LTS (Trusty Tahr) | Ubuntu |  |  |  |  |  |  | 
+16.04.6 LTS (Xenial Xerus) | Ubuntu |  |  |  |  |  |  | 
+18.04.2 LTS (Bionic Beaver) | Ubuntu |  |  |  |  |  |  | 
+19.04 (Disco Dingo) Latest | Ubuntu |  |  |  |  |  |  | 
+Debian 7 (Wheezy) | Debian |  |  |  |  |  |  | 
+Debian 8 (Jessie) | Debian |  |  |  |  |  |  | 
+Debian 9 (Stretch) | Debian |  |  |  |  |  |  | 
+Debian 10 (Buster) **Not released | Debian |  |  |  |  |  |  | 
+Versions 6.* | RHEL |  |  |  |  |  |  | 
+Versions 7.* | RHEL |  |  |  |  |  |  | 
+Versions 8.* | RHEL |  |  |  |  |  |  | 
+Fedora 28 | Fedora |  |  |  |  |  |  | 
+Fedora 29 | Fedora |  |  |  |  |  |  | 
+Fedora 30 | Fedora |  |  |  |  |  |  | 
+Fedora 31 | Fedora |  |  |  |  |  |  | 
+CentOS 6.* | Cent OS | |  |  |  |  |  |  | 
+CentOS 7.* | Cent OS | |  |  |  |  |  |  | 
+CentOS 8.* | Cent OS | |  |  |  |  |  |  | 
+Open SuSE Leap 15.0 | Open SuSE |  |  |  |  |  |  | 
+Open SuSE Leap 15.1 | Open SuSE |  |  |  |  |  |  | 
+Open SuSE Tumbleweed (latest) | Open SuSE |  |  |  |  |  |  | 
+SuSE Enterprise Linux Server 11 | SLES |  |  |  |  |  |  | 
+SuSE Enterprise Linux Server 12 | SLES |  |  |  |  |  |  | 
+SuSE Enterprise Linux Server 15 | SLES |  |  |  |  |  |  | 
+Arch Linux (latest) | Arch |  |  |  |  |  |  | 
+All other linux | Other | |  |  |  |  |  | 

--- a/packaging/DISTRIBUTIONS.md
+++ b/packaging/DISTRIBUTIONS.md
@@ -2,9 +2,13 @@
 ![](https://raw.githubusercontent.com/netdata/netdata/master/web/gui/images/packaging-beta-tag.svg?sanitize=true)
 
 In the following table we provide the list of officially supported operating systems.
-We detail the Distributions, flavours and the way of support Netdata is currently capable to provide.
+We detail the Distributions, flavours and the level of support Netdata is currently capable to provide.
 
-Distribution | Family| Code healthy | Installer support | Kickstart support | Binary packaging support | Integrity testing (CI) | Functionality testing (CI) | Community support
+Kindly note that the following table is a work in progress. We have concluded on the list of distributions
+that we currently supporting and we are working on documenting our current state so that our users
+have complete visibility over the range of support
+
+Distribution | Family| Code health | Installer support | Kickstart support | Binary packaging support | Integrity testing (CI) | Functionality testing (CI) | Community support
 :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :--------------------
 14.04.6 LTS (Trusty Tahr) | Ubuntu |  |  |  |  |  |  | 
 16.04.6 LTS (Xenial Xerus) | Ubuntu |  |  |  |  |  |  | 

--- a/packaging/DISTRIBUTIONS.md
+++ b/packaging/DISTRIBUTIONS.md
@@ -1,12 +1,11 @@
 # Netdata distribution support matrix
 ![](https://raw.githubusercontent.com/netdata/netdata/master/web/gui/images/packaging-beta-tag.svg?sanitize=true)
 
-In the following table we provide the list of officially supported operating systems.
-We detail the Distributions, flavours and the level of support Netdata is currently capable to provide.
+In the following table we've listed Netdata's official supported operating systems. We detail the distributions, flavors, and the level of support Netdata is currently capable to provide.
 
-Kindly note that the following table is a work in progress. We have concluded on the list of distributions
+The following table is a work in progress. We have concluded on the list of distributions
 that we currently supporting and we are working on documenting our current state so that our users
-have complete visibility over the range of support
+have complete visibility over the range of support.
 
 Distribution | Family | Architecture | Code health | Installer support | Kickstart support | Binary packaging support | Integrity testing (CI) | Functionality testing (CI) | Community support
 :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :--------------------

--- a/packaging/DISTRIBUTIONS.md
+++ b/packaging/DISTRIBUTIONS.md
@@ -17,7 +17,7 @@ Distribution | Family| Code health | Installer support | Kickstart support | Bin
 Debian 7 (Wheezy) | Debian |  |  |  |  |  |  | 
 Debian 8 (Jessie) | Debian |  |  |  |  |  |  | 
 Debian 9 (Stretch) | Debian |  |  |  |  |  |  | 
-Debian 10 (Buster) **Not released | Debian |  |  |  |  |  |  | 
+Debian 10 (Buster) | Debian |  |  |  |  |  |  | 
 Versions 6.* | RHEL |  |  |  |  |  |  | 
 Versions 7.* | RHEL |  |  |  |  |  |  | 
 Versions 8.* | RHEL |  |  |  |  |  |  | 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -393,6 +393,9 @@ The installer will also install a startup plist to start Netdata when your Mac b
 
 Netdata is proud to present it's own flavour of binary packages for the most common operating systems that comply with .RPM and .DEB packaging formats.
 We have currently released .RPM versions with version [1.16.0](https://github.com/netdata/netdata/releases/tag/v1.16.0). We are planning to release packages following the .DEB format on one of the following releases. Our current packaging infrastructure provider is [Package Cloud](https://packagecloud.io).
+Netdata is committed to support installation of our solution to all operating systems.
+This is a constant battle for Netdata, as we strive to automate and make things easier for our users.
+For the operating system support matrix, please visit our [distributions](../DISTRIBUTIONS.md) support page.
 
 We provide two separate repositories, one for our stable releases and one for our nightly releases.
 1. Stable releases

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -205,16 +205,16 @@ This is how to do it by hand:
 
 ```sh
 # Debian / Ubuntu
-apt-get install zlib1g-dev uuid-dev libuv1-dev liblz4-dev libjudy-dev libssl-dev libmnl-dev gcc make git autoconf autoconf-archive autogen automake pkg-config curl
+apt-get install zlib1g-dev uuid-dev libuv1-dev liblz4-dev libjudy-dev libssl-dev libmnl-dev gcc make git autoconf autoconf-archive autogen automake pkg-config curl python
 
 # Fedora
-dnf install zlib-devel libuuid-devel libuv-devel lz4-devel Judy-devel openssl-devel libmnl-devel gcc make git autoconf autoconf-archive autogen automake pkgconfig curl findutils
+dnf install zlib-devel libuuid-devel libuv-devel lz4-devel Judy-devel openssl-devel libmnl-devel gcc make git autoconf autoconf-archive autogen automake pkgconfig curl findutils python
 
 # CentOS / Red Hat Enterprise Linux
 yum install autoconf automake curl gcc git libmnl-devel libuuid-devel openssl-devel libuv-devel lz4-devel Judy-devel make nc pkgconfig python zlib-devel
 
 # openSUSE
-zypper install zlib-devel libuuid-devel libuv-devel liblz4-devel judy-devel libopenssl-devel libmnl-devel gcc make git autoconf autoconf-archive autogen automake pkgconfig curl findutils
+zypper install zlib-devel libuuid-devel libuv-devel liblz4-devel judy-devel libopenssl-devel libmnl-devel gcc make git autoconf autoconf-archive autogen automake pkgconfig curl findutils python
 
 ```
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -297,21 +297,17 @@ To apply the changes you made, you have to restart Netdata.
 ![](https://raw.githubusercontent.com/netdata/netdata/master/web/gui/images/packaging-beta-tag.svg?sanitize=true)
 
 We provide our own flavour of binary packages for the most common operating systems that comply with .RPM and .DEB packaging formats.
+
 We have currently released .RPM versions with version [1.16.0](https://github.com/netdata/netdata/releases/tag/v1.16.0). We are planning to release packages following the .DEB format on one of the following releases. Our current packaging infrastructure provider is [Package Cloud](https://packagecloud.io).
-Netdata is committed to support installation of our solution to all operating systems.
-This is a constant battle for Netdata, as we strive to automate and make things easier for our users.
-For the operating system support matrix, please visit our [distributions](../DISTRIBUTIONS.md) support page.
+
+Netdata is committed to support installation of our solution to all operating systems. This is a constant battle for Netdata, as we strive to automate and make things easier for our users. For the operating system support matrix, please visit our [distributions](../DISTRIBUTIONS.md) support page. 
 
 We provide two separate repositories, one for our stable releases and one for our nightly releases.
-1. Stable releases
 
-   Our stable production releases are hosted in [netdata/netdata](https://packagecloud.io/netdata/netdata) repository of package cloud
+1. Stable releases: Our stable production releases are hosted in [netdata/netdata](https://packagecloud.io/netdata/netdata) repository of package cloud
+2. Nightly releases: Our latest releases are hosted in [netdata/netdata-edge](https://packagecloud.io/netdata/netdata-edge) repository of package cloud
 
-2. Nightly releases
-
-   Our latest releases are hosted in [netdata/netdata-edge](https://packagecloud.io/netdata/netdata-edge) repository of package cloud
-
-Visit the repository pages and follow the instructions for the quick repository set up
+Visit the repository pages and follow the quick set-up instructions to get started.
 
 ---
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -6,7 +6,6 @@ The best way to install Netdata is directly from source. Our **automatic install
 
 !!! warning
     You can find Netdata packages distributed by third parties. In many cases, these packages are either too old or broken. So, the suggested ways to install Netdata are the ones in this page.
-    **We are currently working to provide our binary packages for all Linux distros.** Stay tuned...
 
 1. [Automatic one line installation](#one-line-installation), easy installation from source, **this is the default**
 2. [Install pre-built static binary on any 64bit Linux](#linux-64bit-pre-built-static-binary)
@@ -17,6 +16,7 @@ The best way to install Netdata is directly from source. Our **automatic install
 7. [Enable on FreeNAS Corral](#freenas)
 8. [Install on macOS (OS X)](#macos)
 9. [Install on a Kubernetes cluster](https://github.com/netdata/helmchart#netdata-helm-chart-for-kubernetes-deployments)
+10. [Install using binary packages](#binary-packages)
 
 See also the list of Netdata [package maintainers](../maintainers) for ASUSTOR NAS, OpenWRT, ReadyNAS, etc.
 
@@ -387,6 +387,23 @@ sudo ./netdata-installer.sh --install /usr/local
 ```
 
 The installer will also install a startup plist to start Netdata when your Mac boots.
+
+##### Binary Packages
+![](https://raw.githubusercontent.com/netdata/netdata/master/web/gui/images/packaging-beta-tag.svg?sanitize=true)
+
+Netdata is proud to present it's own flavour of binary packages for the most common operating systems that comply with .RPM and .DEB packaging formats.
+We have currently released .RPM versions with version [1.16.0](https://github.com/netdata/netdata/releases/tag/v1.16.0). We are planning to release packages following the .DEB format on one of the following releases. Our current packaging infrastructure provider is [Package Cloud](https://packagecloud.io).
+
+We provide two separate repositories, one for our stable releases and one for our nightly releases.
+1. Stable releases
+
+   Our stable production releases are hosted in [netdata/netdata](https://packagecloud.io/netdata/netdata) repository of package cloud
+
+2. Nightly releases
+
+   Our latest releases are hosted in [netdata/netdata-edge](https://packagecloud.io/netdata/netdata-edge) repository of package cloud
+
+Visit the repository pages and follow the instructions for the quick repository set up
 
 ##### Alpine 3.x
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -296,7 +296,7 @@ To apply the changes you made, you have to restart Netdata.
 ### Binary Packages
 ![](https://raw.githubusercontent.com/netdata/netdata/master/web/gui/images/packaging-beta-tag.svg?sanitize=true)
 
-Netdata is proud to present it's own flavour of binary packages for the most common operating systems that comply with .RPM and .DEB packaging formats.
+We provide our own flavour of binary packages for the most common operating systems that comply with .RPM and .DEB packaging formats.
 We have currently released .RPM versions with version [1.16.0](https://github.com/netdata/netdata/releases/tag/v1.16.0). We are planning to release packages following the .DEB format on one of the following releases. Our current packaging infrastructure provider is [Package Cloud](https://packagecloud.io).
 Netdata is committed to support installation of our solution to all operating systems.
 This is a constant battle for Netdata, as we strive to automate and make things easier for our users.

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -293,6 +293,28 @@ To apply the changes you made, you have to restart Netdata.
 
 ---
 
+### Binary Packages
+![](https://raw.githubusercontent.com/netdata/netdata/master/web/gui/images/packaging-beta-tag.svg?sanitize=true)
+
+Netdata is proud to present it's own flavour of binary packages for the most common operating systems that comply with .RPM and .DEB packaging formats.
+We have currently released .RPM versions with version [1.16.0](https://github.com/netdata/netdata/releases/tag/v1.16.0). We are planning to release packages following the .DEB format on one of the following releases. Our current packaging infrastructure provider is [Package Cloud](https://packagecloud.io).
+Netdata is committed to support installation of our solution to all operating systems.
+This is a constant battle for Netdata, as we strive to automate and make things easier for our users.
+For the operating system support matrix, please visit our [distributions](../DISTRIBUTIONS.md) support page.
+
+We provide two separate repositories, one for our stable releases and one for our nightly releases.
+1. Stable releases
+
+   Our stable production releases are hosted in [netdata/netdata](https://packagecloud.io/netdata/netdata) repository of package cloud
+
+2. Nightly releases
+
+   Our latest releases are hosted in [netdata/netdata-edge](https://packagecloud.io/netdata/netdata-edge) repository of package cloud
+
+Visit the repository pages and follow the instructions for the quick repository set up
+
+---
+
 ## Other Systems
 
 
@@ -387,26 +409,6 @@ sudo ./netdata-installer.sh --install /usr/local
 ```
 
 The installer will also install a startup plist to start Netdata when your Mac boots.
-
-##### Binary Packages
-![](https://raw.githubusercontent.com/netdata/netdata/master/web/gui/images/packaging-beta-tag.svg?sanitize=true)
-
-Netdata is proud to present it's own flavour of binary packages for the most common operating systems that comply with .RPM and .DEB packaging formats.
-We have currently released .RPM versions with version [1.16.0](https://github.com/netdata/netdata/releases/tag/v1.16.0). We are planning to release packages following the .DEB format on one of the following releases. Our current packaging infrastructure provider is [Package Cloud](https://packagecloud.io).
-Netdata is committed to support installation of our solution to all operating systems.
-This is a constant battle for Netdata, as we strive to automate and make things easier for our users.
-For the operating system support matrix, please visit our [distributions](../DISTRIBUTIONS.md) support page.
-
-We provide two separate repositories, one for our stable releases and one for our nightly releases.
-1. Stable releases
-
-   Our stable production releases are hosted in [netdata/netdata](https://packagecloud.io/netdata/netdata) repository of package cloud
-
-2. Nightly releases
-
-   Our latest releases are hosted in [netdata/netdata-edge](https://packagecloud.io/netdata/netdata-edge) repository of package cloud
-
-Visit the repository pages and follow the instructions for the quick repository set up
 
 ##### Alpine 3.x
 


### PR DESCRIPTION
##### Summary
Here's the first version of the packaging documentation.

Note: also added one small nit on the package dependencies that require python and we only mention it on one distribution set

##### Component Name
netdata/packaging
Documentation

##### Additional Information
