### PR TITLE
Styling improvements to documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Read documentation on https://docs.netdata.cloud
+
+Welcome to the Netdata documentation! While you can read Netdata documentation here, or throughout the Netdata repository, our intention is that these pages are read on [docs.netdata.cloud](https://docs.netdata.cloud). 
+
+Links between documentation pages will work fine here, but the formatting may not be perfect, as our documentation site uses a few extra Markdown features that GitHub doesn't support natively. Other things might be missing or look less than perfect.
+
+Now get out there and build an exceptional infrastructure.

--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -101,7 +101,9 @@ markdown_extensions:
  - pymdownx.caret
  - pymdownx.critic
  - pymdownx.details
- - pymdownx.highlight
+ - pymdownx.highlight:
+    pygments_style: manni
+    noclasses: true
  - pymdownx.inlinehilite
  - pymdownx.magiclink
  - pymdownx.mark

--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -67,6 +67,9 @@ extra:
       link: "https://www.facebook.com/linuxnetdata/"
 theme:
     name: "material"
+    palette:
+      primary: "blue grey"
+      accent: "light green"
     custom_dir: custom/themes/material
     favicon: custom/img/favicon.ico
     language: '${language}'

--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -88,7 +88,6 @@ markdown_extensions:
  - footnotes
  - tables
  - admonition
- - codehilite
  - meta
  - sane_lists
  - smarty
@@ -102,6 +101,7 @@ markdown_extensions:
  - pymdownx.caret
  - pymdownx.critic
  - pymdownx.details
+ - pymdownx.highlight
  - pymdownx.inlinehilite
  - pymdownx.magiclink
  - pymdownx.mark

--- a/docs/generator/custom/css/netdata.css
+++ b/docs/generator/custom/css/netdata.css
@@ -5,3 +5,26 @@
 .md-typeset {
     font-size: .75rem
 }
+
+/* Hide the label at the top of the navigation menu. Does nothing. */
+.md-nav__title {
+    display: none;
+}
+
+/* Change the language selector dropdown to match new color. */
+.md-header-nav select#sel {
+    background-color: rgba(0,0,0,.26) !important;
+    padding: 3px;
+    margin-left: 5px;
+    margin-right: 20px;
+}
+
+/* Add some whitespace to the bottom of each doc. */
+.md-content {
+    margin-bottom: 6rem;
+}
+
+/* Make sure inline code in tables doesn't break. */
+.md-typeset__table code {
+    word-break: normal;
+}


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

I've been trying to improve the look and feel of the docs here and there in all my different WIP branches and decided it was finally time to put them all together.

- Move away from the `highlight` plugin and to the `pymdownx.highlight` plugin, as the latter is better supported and doesn't do weird things with inline code blocks.
- Add some padding to the bottom of each page.
- Change the colors to grey and green to better match our new site (it's not perfect but it's way closer than the blue).
- Add a `docs/README.md` file to direct people toward the docs site.
- A few CSS tweaks to make things look nicer.

##### Component Name

docs

##### Additional Information

