### PR TITLE
rethinkdb collector new driver support

### DIFF
--- a/collectors/python.d.plugin/rethinkdbs/rethinkdbs.chart.py
+++ b/collectors/python.d.plugin/rethinkdbs/rethinkdbs.chart.py
@@ -9,8 +9,6 @@ try:
 except ImportError:
     HAS_RETHINKDB = False
 
-from distutils.version import StrictVersion
-
 from bases.FrameworkServices.SimpleService import SimpleService
 
 ORDER = [

--- a/collectors/python.d.plugin/rethinkdbs/rethinkdbs.chart.py
+++ b/collectors/python.d.plugin/rethinkdbs/rethinkdbs.chart.py
@@ -3,8 +3,6 @@
 # Author: Ilya Mashchenko (ilyam8)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import re
-
 try:
     import rethinkdb as rdb
     HAS_RETHINKDB = True


### PR DESCRIPTION
##### Summary

Fixes: #6429

There are some breaking changes in rethinkdb python driver
https://pypi.org/project/rethinkdb/2.4.0/

Before 2.4.0

```python
import rethinkdb

connection = rethinkdb.connect(db='test')
```

After 2.4.0

```python
from rethinkdb import RethinkDB

r = RethinkDB()
connection = r.connect(db='test')
```

The driver still can be used as a drop in replacement.


##### Component Name
[/collectors/python.d.plugin/rethinkdbs](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/rethinkdbs
)


##### Additional Information

The fix:
 - check if rethinkdb lib has `RethinkDB` attribute (class,was added in 2.4.0)
 - use appropriate object based on check


Tests:
 - [tested](https://github.com/netdata/netdata/issues/6429#issuecomment-510532874) by @sloaizav