### PR TITLE
Fix issue with HTML docs generation

### DIFF
--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -93,7 +93,7 @@ for d in "en" $(find ${LOC_DIR} -mindepth 1 -maxdepth 1 -name .git -prune -o -ty
 		cp -r ${LOC_DIR}/${d}/* ${DOCS_DIR}/
 	fi
 	prep_html $d
-	rm -rf ${DOCS_DIR}/*
+	rm -rf ${DOCS_DIR}
 done
 
 # Remove cloned projects and temp directories

--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -88,9 +88,9 @@ prep_html() {
 
 for d in "en" $(find ${LOC_DIR} -mindepth 1 -maxdepth 1 -name .git -prune -o -type d -printf '%f ') ; do
 	echo "Preparing source for $d"
-	cp -r ${SRC_DIR} ${DOCS_DIR}/
+	cp -r ${SRC_DIR} ${DOCS_DIR}
 	if [ "${d}" != "en" ] ; then
-		cp -r ${LOC_DIR}/${d}/* ${DOCS_DIR}/
+		cp -a ${LOC_DIR}/${d}/* ${DOCS_DIR}/
 	fi
 	prep_html $d
 	rm -rf ${DOCS_DIR}

--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -39,7 +39,6 @@ find ${SRC_DIR} -name "*.md" -print0 | xargs -0 sed -i -e 's/\[!\[analytics.*UA-
 declare -a EXCLUDE_LIST=(
 	"HISTORICAL_CHANGELOG.md"
 	"contrib/sles11/README.md"
-	"packaging/maintainers/README.md"
 )
 
 for f in "${EXCLUDE_LIST[@]}"; do
@@ -56,7 +55,6 @@ MKDOCS_CONFIG_FILE="${GENERATOR_DIR}/mkdocs.yml"
 MKDOCS_DIR="doc"
 DOCS_DIR=${GENERATOR_DIR}/${MKDOCS_DIR}
 rm -rf ${DOCS_DIR}
-mkdir ${DOCS_DIR}
 
 prep_html() {
 	lang="${1}"
@@ -90,9 +88,9 @@ prep_html() {
 
 for d in "en" $(find ${LOC_DIR} -mindepth 1 -maxdepth 1 -name .git -prune -o -type d -printf '%f ') ; do
 	echo "Preparing source for $d"
-	cp -a ${SRC_DIR}/* ${DOCS_DIR}/
+	cp -r ${SRC_DIR} ${DOCS_DIR}/
 	if [ "${d}" != "en" ] ; then
-		cp -a ${LOC_DIR}/${d}/* ${DOCS_DIR}/
+		cp -r ${LOC_DIR}/${d}/* ${DOCS_DIR}/
 	fi
 	prep_html $d
 	rm -rf ${DOCS_DIR}/*

--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -253,9 +253,10 @@ navpart 2 web/api/badges "" "" 2
 navpart 2 web/api/health "" "" 2
 navpart 2 web/api/queries "" "Queries" 2
 
-echo -ne "- Hacking Netdata:
+echo -ne "- Additional Info:
     - CODE_OF_CONDUCT.md
     - CONTRIBUTORS.md
+    - packaging/maintainers/README.md
 "
 navpart 2 packaging/makeself "" "" 4
 navpart 2 libnetdata "" "libnetdata" 4

--- a/docs/generator/checklinks.sh
+++ b/docs/generator/checklinks.sh
@@ -5,6 +5,8 @@
 # Validates and tries to fix all links that will cause issues either in the repo, or in the html site
 
 GENERATOR_DIR="docs/generator"
+MKDOCS_DIR="doc"
+DOCS_DIR=${GENERATOR_DIR}/${MKDOCS_DIR}
 
 dbg () {
 	if [ "$VERBOSE" -eq 1 ] ; then printf "%s\\n" "${1}" ; fi
@@ -186,25 +188,27 @@ ck_netdata_relative () {
 			fi
 			;;
 		* )
-			if [ -f "$fpath/$rlnk" ] ; then
-				dbg "-- # (path/someotherfile) $rlnk"
-				if [ "$fpath" = "." ] ; then
-					s="https://github.com/netdata/netdata/tree/master/$rlnk"
-				else
-					s="https://github.com/netdata/netdata/tree/master/$fpath/$rlnk"
+			if [ -d "$fpath/$rlnk" ] ; then
+				dbg "-- # (path) -> htmldoc (path/)"
+				testf "$f" "$fpath/$rlnk/README.md"
+				if [ $? -eq 0 ] ; then
+					s="$rlnk/"
+					if [ "$fname" != "README.md" ] ; then s="../$s"; fi
 				fi
 			else
-				if [ -d "$fpath/$rlnk" ] ; then
-					dbg "-- # (path) -> htmldoc (path/)"
-					testf "$f" "$fpath/$rlnk/README.md"
-					if [ $? -eq 0 ] ; then
-						s="$rlnk/"
-						if [ "$fname" != "README.md" ] ; then s="../$s"; fi
+				cd - >/dev/null
+				if [ -f "$fpath/$rlnk" ] ; then
+					dbg "-- # (path/someotherfile) $rlnk"
+					if [ "$fpath" = "." ] ; then
+						s="https://github.com/netdata/netdata/tree/master/$rlnk"
+					else
+						s="https://github.com/netdata/netdata/tree/master/$fpath/$rlnk"
 					fi
 				else
 					echo "-- ERROR: $f - $rlnk is neither a file or a directory. Giving up!"
 					EXITCODE=1
 				fi
+				cd $DOCS_DIR >/dev/null
 			fi
 			;;
 		esac
@@ -212,7 +216,7 @@ ck_netdata_relative () {
 		if [[ ! -z $s ]] ; then
 			srch=$(echo "$rlnk" | sed 's/\//\\\//g')
 			rplc=$(echo "$s" | sed 's/\//\\\//g')
-			fix "sed -i 's/($srch)/($rplc)/g' $GENERATOR_DIR/doc/$f"
+			fix "sed -i 's/($srch)/($rplc)/g' $f"
 		fi
 }
 
@@ -314,9 +318,11 @@ if [ -z "${file}" ] ; then
 		printhelp
 		exit 1
 	fi
+	cd ${DOCS_DIR}
 	for f in $(find . -type d \( -path ./${GENERATOR_DIR} -o -path ./node_modules \) -prune -o -name "*.md" -print); do
 		checklinks "$f"
 	done
+	cd -
 else
 	if [ $RECURSIVE -eq 1 ] ; then 
 		printhelp


### PR DESCRIPTION
##### Summary
PR #6428 brought up a bug with the html build process and specifically with `checklinks.sh`. 
This PR addresses the issues will enable that PR to be tested and merged.

##### Component Name
docs/generator

##### Additional Information
`checklinks.sh` assumed it would be executed from the root directory and need to validate the links in the file immediately under the root directory. However, that was incorrect, as the actual source files for the HTML generation were under `docs/generator/doc`. Therefore:
 - Files excluded from the population of the `docs/generator/doc` directory were not properly checked. 
 - Any modification/renaming of files confused checklinks.sh
 - We had two cases of broken links in documents that were not caught, because of the previous reasons.

