### PR TITLE
Safer container names

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -53,18 +53,26 @@ function docker_get_name_classic() {
 }
 
 function docker_get_name_api() {
-	local id="${1}"
-	if [ ! -S "${DOCKER_HOST}" ]; then
-		warning "Can't find ${DOCKER_HOST}"
+	local path="/containers/${1}/json"
+	if [ -z "${DOCKER_HOST}" ]; then
+		warning "No DOCKER_HOST is set"
 		return 1
 	fi
 	if ! command -v jq >/dev/null 2>&1; then
 		warning "Can't find jq command line tool. jq is required for netdata to retrieve docker container name using ${DOCKER_HOST} API, falling back to docker ps"
 		return 1
 	fi
-
-	info "Running API command: /containers/${id}/json"
-	JSON=$(echo -e "GET /containers/${id}/json HTTP/1.0\\r\\n" | nc -U "${DOCKER_HOST}" | grep '^{.*')
+    if [ -S "${DOCKER_HOST}" ]; then
+        info "Running API command: curl --unix-socket ${DOCKER_HOST} http://localhost${path}"
+        JSON=$(curl --unix-socket ${DOCKER_HOST} http://localhost${path})
+    elif [ "${DOCKER_HOST}" == "/var/run/docker.sock" ]; then
+        warning "Docker socket was not found at ${DOCKER_HOST}"
+        return 1
+    else
+        info "Running API command: curl ${DOCKER_HOST}${path}"
+        JSON=$(curl ${DOCKER_HOST}${path})
+    fi
+    info "Got docker result: ${JSON}"
 	NAME=$(echo "$JSON" | jq -r .Name,.Config.Hostname | grep -v null | head -n1 | sed 's|^/||')
 	return 0
 }

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -62,17 +62,17 @@ function docker_get_name_api() {
 		warning "Can't find jq command line tool. jq is required for netdata to retrieve docker container name using ${DOCKER_HOST} API, falling back to docker ps"
 		return 1
 	fi
-    if [ -S "${DOCKER_HOST}" ]; then
-        info "Running API command: curl --unix-socket ${DOCKER_HOST} http://localhost${path}"
-        JSON=$(curl --unix-socket ${DOCKER_HOST} http://localhost${path})
-    elif [ "${DOCKER_HOST}" == "/var/run/docker.sock" ]; then
-        warning "Docker socket was not found at ${DOCKER_HOST}"
-        return 1
-    else
-        info "Running API command: curl ${DOCKER_HOST}${path}"
-        JSON=$(curl ${DOCKER_HOST}${path})
-    fi
-    info "Got docker result: ${JSON}"
+	if [ -S "${DOCKER_HOST}" ]; then
+		info "Running API command: curl --unix-socket ${DOCKER_HOST} http://localhost${path}"
+		JSON=$(curl --unix-socket "${DOCKER_HOST}" "http://localhost${path}")
+	elif [ "${DOCKER_HOST}" == "/var/run/docker.sock" ]; then
+		warning "Docker socket was not found at ${DOCKER_HOST}"
+		return 1
+	else
+		info "Running API command: curl ${DOCKER_HOST}${path}"
+		JSON=$(curl "${DOCKER_HOST}${path}")
+	fi
+	info "Got docker result: ${JSON}"
 	NAME=$(echo "$JSON" | jq -r .Name,.Config.Hostname | grep -v null | head -n1 | sed 's|^/||')
 	return 0
 }

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -64,15 +64,14 @@ function docker_get_name_api() {
 	fi
 	if [ -S "${DOCKER_HOST}" ]; then
 		info "Running API command: curl --unix-socket ${DOCKER_HOST} http://localhost${path}"
-		JSON=$(curl --unix-socket "${DOCKER_HOST}" "http://localhost${path}")
+		JSON=$(curl -sS --unix-socket "${DOCKER_HOST}" "http://localhost${path}")
 	elif [ "${DOCKER_HOST}" == "/var/run/docker.sock" ]; then
 		warning "Docker socket was not found at ${DOCKER_HOST}"
 		return 1
 	else
 		info "Running API command: curl ${DOCKER_HOST}${path}"
-		JSON=$(curl "${DOCKER_HOST}${path}")
+		JSON=$(curl -sS "${DOCKER_HOST}${path}")
 	fi
-	info "Got docker result: ${JSON}"
 	NAME=$(echo "$JSON" | jq -r .Name,.Config.Hostname | grep -v null | head -n1 | sed 's|^/||')
 	return 0
 }

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -62,7 +62,7 @@ ENV DOCKER_GRP netdata
 ENV DOCKER_USR netdata
 RUN \
     # provide judy installation to base image
-    apk add make alpine-sdk && \
+    apk add make alpine-sdk shadow && \
     cd /judy-${JUDY_VER} && make install && cd / && \
     # Clean the source stuff once judy is installed
     rm -rf /judy-${JUDY_VER} && apk del make alpine-sdk && \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -58,6 +58,8 @@ COPY --from=builder /app /
 # Configure system
 ARG NETDATA_UID=201
 ARG NETDATA_GID=201
+ENV DOCKER_GRP netdata
+ENV DOCKER_USR netdata
 RUN \
     # provide judy installation to base image
     apk add make alpine-sdk && \
@@ -69,8 +71,8 @@ RUN \
     chmod 4755 /usr/local/bin/fping && \
     mkdir -p /var/log/netdata && \
     # Add netdata user
-    addgroup -g ${NETDATA_GID} -S netdata && \
-    adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G netdata netdata && \
+    addgroup -g ${NETDATA_GID} -S "${DOCKER_GRP}" && \
+    adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}" && \
     # Apply the permissions as described in
     # https://github.com/netdata/netdata/wiki/netdata-security#netdata-directories
     chown -R root:netdata /etc/netdata && \

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -57,27 +57,7 @@ There are a few options for resolving container names within netdata. Some metho
 
 #### Docker Socket Proxy (Safest Option)
 
-Deploy a Docker socket proxy, such as [tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy/blob/master/README.md), so that it resticts connections to read only access to the CONTAINERS endpoint.
-
-A simple example is shown in the compose snippet below:
-
-```yaml
-version: '3'
-services:
-  netdata:
-    image: netdata/netdata
-    # ... rest of your config ...
-    ports:
-      - 19999:19999
-    environment:
-      - DOCKER_HOST=proxy:2375
-  proxy:
-    image: tecnativa/docker-socket-proxy
-    volumes:
-     - /var/run/docker.sock:/var/run/docker.sock:ro
-    environment:
-      - CONTAINERS=1
-```
+Deploy a Docker socket proxy that accepts will filter out requests using something like haproxy so that it resticts connections to read only access to the CONTAINERS endpoint.
 
 The reason it's safer to expose the socket to the proxy is because netdata has a TCP port exposed outside the Docker network. Access to the proxy container is limited to only within the network.
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -57,7 +57,7 @@ There are a few options for resolving container names within netdata. Some metho
 
 #### Docker Socket Proxy (Safest Option)
 
-Deploy a Docker socket proxy that accepts will filter out requests using something like haproxy so that it resticts connections to read only access to the CONTAINERS endpoint.
+Deploy a Docker socket proxy that accepts will filter out requests using something like HAProxy so that it restricts connections to read-only access to the CONTAINERS endpoint.
 
 The reason it's safer to expose the socket to the proxy is because netdata has a TCP port exposed outside the Docker network. Access to the proxy container is limited to only within the network.
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -26,7 +26,6 @@ docker run -d --name=netdata \
   -p 19999:19999 \
   -v /proc:/host/proc:ro \
   -v /sys:/host/sys:ro \
-  -v /var/run/docker.sock:/var/run/docker.sock:ro \
   --cap-add SYS_PTRACE \
   --security-opt apparmor=unconfined \
   netdata/netdata
@@ -57,7 +56,7 @@ There are a few options for resolving container names within netdata. Some metho
 
 #### Docker Socket Proxy (Safest Option)
 
-Deploy a Docker socket proxy that accepts will filter out requests using something like HAProxy so that it restricts connections to read-only access to the CONTAINERS endpoint.
+Deploy a Docker socket proxy that accepts and filter out requests using something like [HAProxy](https://docs.netdata.cloud/docs/running-behind-haproxy/) so that it restricts connections to read-only access to the CONTAINERS endpoint.
 
 The reason it's safer to expose the socket to the proxy is because netdata has a TCP port exposed outside the Docker network. Access to the proxy container is limited to only within the network.
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -61,6 +61,22 @@ Deploy a Docker socket proxy that accepts will filter out requests using somethi
 
 The reason it's safer to expose the socket to the proxy is because netdata has a TCP port exposed outside the Docker network. Access to the proxy container is limited to only within the network.
 
+#### Giving group access to Docker Socket (Less safe)
+
+**Important Note**: You should seriously consider the necessity of activating this option,
+as it grants to the netdata user access to the privileged socket connection of docker service and therefore your whole machine.
+
+If you want to have your container names resolved by Netdata, make the `netdata` user be part of the group that owns the socket.
+
+To achieve that just add environment variable `PGID=[GROUP NUMBER]` to the Netdata container, 
+where `[GROUP NUMBER]` is practically the group id of the group assigned to the docker socket, on your host.
+
+This group number can be found by running the following (if socket group ownership is docker):
+
+```bash
+grep docker /etc/group | cut -d ':' -f 3
+```
+
 #### Running as root (Unsafe)
 
 **Important Note**: You should seriously consider the necessity of activating this option,

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -13,6 +13,13 @@ if [ ${RESCRAMBLE+x} ]; then
 	apk upgrade --update-cache --available
 fi
 
+if [ -n "${PGID}" ]; then
+    echo "Creating docker group ${PGID}"
+    addgroup -g "${PGID}" "docker" || echo >&2 "Could not add group docker with ID ${PGID}, its already there probably"
+    echo "Assign netdata user to docker group ${PGID}"
+    usermod -a -G ${PGID} ${DOCKER_USR} || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
+fi
+
 exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_PORT}" "$@"
 
 echo "Netdata entrypoint script, completed!"

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -9,30 +9,9 @@ set -e
 
 echo "Netdata entrypoint script starting"
 if [ ${RESCRAMBLE+x} ]; then
-    echo "Reinstalling all packages to get the latest Polymorphic Linux scramble"
-    apk upgrade --update-cache --available
+	echo "Reinstalling all packages to get the latest Polymorphic Linux scramble"
+	apk upgrade --update-cache --available
 fi
-
-create_group_and_assign_to_user() {
-	local local_DOCKER_GROUP="$1"
-	local local_DOCKER_GID="$2"
-	local local_DOCKER_USR="$3"
-
-	echo >&2 "Adding group with ID ${local_DOCKER_GID} and name '${local_DOCKER_GROUP}'"
-	addgroup -g "${local_DOCKER_GID}" "${local_DOCKER_GROUP}" || echo >&2 "Could not add group ${local_DOCKER_GROUP} with ID ${local_DOCKER_GID}, its already there probably"
-
-	echo >&2 "Adding user '${local_DOCKER_USR}' to group '${local_DOCKER_GROUP}/${local_DOCKER_GID}'"
-	sed -i "s/:${local_DOCKER_GID}:$/:${local_DOCKER_GID}:${local_DOCKER_USR}/g" /etc/group
-
-	# Make sure we use the right docker group
-	GRP_TO_ASSIGN="$(grep ":x:${local_DOCKER_GID}:" /etc/group | cut -d':' -f1)"
-	if [ -z "${GRP_TO_ASSIGN}" ]; then
-		echo >&2 "Could not find group ID ${local_DOCKER_GID} in /etc/group. Check your logs and report it if this is an unrecovereable error"
-	else
-		echo >&2 "Group creation and assignment completed, netdata was assigned to group ${GRP_TO_ASSIGN}/${local_DOCKER_GID}"
-		echo "${GRP_TO_ASSIGN}"
-	fi
-}
 
 exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_PORT}" "$@"
 

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -34,18 +34,6 @@ create_group_and_assign_to_user() {
 	fi
 }
 
-DOCKER_USR="netdata"
-DOCKER_SOCKET="/var/run/docker.sock"
-DOCKER_GROUP="docker"
-
-if [ -S "${DOCKER_SOCKET}" ] && [ -n "${PGID}" ]; then
-	GRP=$(create_group_and_assign_to_user "${DOCKER_GROUP}" "${PGID}" "${DOCKER_USR}")
-	if [ -n "${GRP}" ]; then
-		echo "Adjusting ownership of mapped docker socket '${DOCKER_SOCKET}' to root:${GRP}"
-		chown "root:${GRP}" "${DOCKER_SOCKET}" || echo "Failed to change ownership on docker socket, container name resolution might not work"
-	fi
-fi
-
 exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_PORT}" "$@"
 
 echo "Netdata entrypoint script, completed!"


### PR DESCRIPTION
##### Summary

The current method of getting Docker container names is risky and non-standard. This is documented in #5680 and #6293. This new diff will allow a safer method of querying as well as allow the user of a proxy between the docker socket (as described on #5680).

There is one issue I encountered when testing. For some reason, when I run the application configured to access `/var/run/docker.sock`, I'm seeing `curl: (7) Couldn't connect to server`. However, if I run the plugin directly via `docker exec`, it works perfectly. Eg: `/usr/libexec/netdata/plugins.d/cgroup-name.sh docker_a1c9bbf558a66841ba5b9b465ee3d6e9f6369cab6423e2fd8fb2a931e0adc407`

I'm not sure if there is some other complication due to how the script is being executed, but any pointers on where to go to resolve that would be appreciated.

I did confirm that it's not a bug introduced by my diff as I get the same issue using `nc`.

##### Component Name

##### Additional Information

This branch actually contains two diffs, one to make testing easier and the other to actually implement the change. I'm happy to revert the testing one or force remove it, but thought it might be handy for others.
Fixes #5680 
Fixes #6293 