### PR TITLE
Stop docs icon from linking to streaming page instead of docs root

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -48,6 +48,7 @@ navpart() {
 }
 
 echo -e 'site_name: Netdata Documentation
+site_url: https://docs.netdata.cloud
 repo_url: https://github.com/netdata/netdata
 repo_name: GitHub
 edit_uri: blob/master


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

The little book icon on the top-left of the documentation, left of `Netdata Documentation`, links to `docs.netdata.cloud/streaming` instead of the docs root for some very, very strange and silly reason. I found this out quite randomly just a few moments ago.

I added a `site_url` to the mkdocs config to make sure it links to `docs.netdata.cloud` and stops sending our poor users over to the streaming page.

##### Component Name

docs

##### Additional Information

I guess this will [break](https://github.com/mkdocs/mkdocs/issues/1414) the `mkdocs serve` feature, but I never could figure that out anyway. :man_shrugging: 