### PR TITLE
python sensors collector: sensor chips filtering fix

### DIFF
--- a/collectors/python.d.plugin/sensors/sensors.chart.py
+++ b/collectors/python.d.plugin/sensors/sensors.chart.py
@@ -92,7 +92,7 @@ class Service(SimpleService):
         SimpleService.__init__(self, configuration=configuration, name=name)
         self.order = list()
         self.definitions = dict()
-        self.chips = list()
+        self.chips = configuration.get('chips')
 
     def get_data(self):
         data = dict()


### PR DESCRIPTION
 ### Summary
Fixes: #6462

List of allowed chip names is not gathered from the module configuration file in `init()`.

https://github.com/netdata/netdata/blob/b548214e35454cd1a4f36cd3fa39703b2c270e50/collectors/python.d.plugin/sensors/sensors.conf#L48-L55

##### Component Name
[collectors/python.d.plugin/sensors](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/sensors/sensors.chart.py)

##### Additional Information

The fix:
 - get list of allowed chip names in `init()`

Tests:
 - i tested the fix, it works
