### PR TITLE
Get user and group names from files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ To try Netdata in a docker container, run this:
 ```
 docker run -d --name=netdata \
   -p 19999:19999 \
+  -v /etc:/host/etc:ro \
   -v /proc:/host/proc:ro \
   -v /sys:/host/sys:ro \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ To try Netdata in a docker container, run this:
 ```
 docker run -d --name=netdata \
   -p 19999:19999 \
-  -v /etc:/host/etc:ro \
+  -v /etc/passwd:/host/etc/passwd:ro \
+  -v /etc/group:/host/etc/group:ro \
   -v /proc:/host/proc:ro \
   -v /sys:/host/sys:ro \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -500,39 +500,88 @@ static int
         all_files_size = 0;
 
 // ----------------------------------------------------------------------------
-// /host/etc/passwd and /host/etc/group should be read when Netdata is inside
-// a container
+// read users and groups from files
 
-struct user_id {
+struct user_or_group_id {
     avl avl;
 
-    uid_t id;
+    union {
+        uid_t uid;
+        gid_t gid;
+    } id;
+
     char *name;
 
     int updated;
 
-    struct user_id * next;
+    struct user_or_group_id * next;
+};
+
+enum user_or_group_id_type {
+    USER_ID,
+    GROUP_ID
+};
+
+struct user_or_group_ids{
+    enum user_or_group_id_type type;
+
+    avl_tree index;
+    struct user_or_group_id *root;
+
+    char filename[FILENAME_MAX + 1];
 };
 
 int user_id_compare(void* a, void* b) {
-    if(((struct user_id *)a)->id < ((struct user_id *)b)->id)
+    if(((struct user_or_group_id *)a)->id.uid < ((struct user_or_group_id *)b)->id.uid)
         return -1;
-    else if(((struct user_id *)a)->id > ((struct user_id *)b)->id)
+
+    else if(((struct user_or_group_id *)a)->id.uid > ((struct user_or_group_id *)b)->id.uid)
         return 1;
+
     else
         return 0;
 }
 
-avl_tree all_user_id_index = {
+struct user_or_group_ids all_user_ids = {
+    .type = USER_ID,
+
+    .index = {
         NULL,
         user_id_compare
+    },
+
+    .root = NULL,
+
+    .filename = "",
 };
 
-struct user_id *all_user_id_root = NULL;
+int group_id_compare(void* a, void* b) {
+    if(((struct user_or_group_id *)a)->id.gid < ((struct user_or_group_id *)b)->id.gid)
+        return -1;
+
+    else if(((struct user_or_group_id *)a)->id.gid > ((struct user_or_group_id *)b)->id.gid)
+        return 1;
+
+    else
+        return 0;
+}
+
+struct user_or_group_ids all_group_ids = {
+    .type = GROUP_ID,
+
+    .index = {
+        NULL,
+        group_id_compare
+    },
+
+    .root = NULL,
+
+    .filename = "",
+};
 
 int file_changed(const struct stat *statbuf, struct timespec *last_modification_time) {
-    if(statbuf->st_mtim.tv_sec == last_modification_time->tv_sec &&
-       statbuf->st_mtim.tv_nsec == last_modification_time->tv_nsec) return 0;
+    if(likely(statbuf->st_mtim.tv_sec == last_modification_time->tv_sec &&
+       statbuf->st_mtim.tv_nsec == last_modification_time->tv_nsec)) return 0;
 
     last_modification_time->tv_sec = statbuf->st_mtim.tv_sec;
     last_modification_time->tv_nsec = statbuf->st_mtim.tv_nsec;
@@ -540,101 +589,91 @@ int file_changed(const struct stat *statbuf, struct timespec *last_modification_
     return 1;
 }
 
-int read_user_ids() {
-    static struct timespec last_modification_time;
-    char filename[FILENAME_MAX + 1];
-
-    // snprintfz(filename, FILENAME_MAX, "%s/etc/passwd", netdata_configured_host_prefix);
-    snprintfz(filename, FILENAME_MAX, "/home/vlad/passwd");
-
-    debug_log("passwd file: '%s'", filename);
-
+int read_user_or_group_ids(struct user_or_group_ids *ids, struct timespec *last_modification_time) {
     struct stat statbuf;
-    if(stat(filename, &statbuf))
+    if(unlikely(stat(ids->filename, &statbuf)))
         return 1;
     else
-        if(!file_changed(&statbuf, &last_modification_time)) return 0;
+        if(likely(!file_changed(&statbuf, last_modification_time))) return 0;
 
-    // ----------------------------------------
-
-    info("READ FILE");
-
-    procfile *ff = procfile_open(filename, " :\t", PROCFILE_FLAG_DEFAULT);
-    if(!ff) return 1;
+    procfile *ff = procfile_open(ids->filename, " :\t", PROCFILE_FLAG_DEFAULT);
+    if(unlikely(!ff)) return 1;
 
     ff = procfile_readall(ff);
-    if(!ff) return 1;
+    if(unlikely(!ff)) return 1;
 
     size_t line, lines = procfile_lines(ff);
 
     for(line = 0; line < lines ;line++) {
         size_t words = procfile_linewords(ff, line);
-        if(words < 3) continue;
+        if(unlikely(words < 3)) continue;
 
         char *name = procfile_lineword(ff, line, 0);
-        if(!name || !*name) continue;
+        if(unlikely(!name || !*name)) continue;
 
-        char *uid = procfile_lineword(ff, line, 2);
-        if(!uid || !*uid) continue;
+        char *id_string = procfile_lineword(ff, line, 2);
+        if(unlikely(!id_string || !*id_string)) continue;
 
 
-        struct user_id *user_id = callocz(1, sizeof(struct user_id));
-        user_id->id = (uid_t)str2ull(uid);
-        user_id->name = strdupz(name);
-        user_id->updated = 1;
+        struct user_or_group_id *user_or_group_id = callocz(1, sizeof(struct user_or_group_id));
 
-        struct user_id *existing_user_id = NULL;
+        if(ids->type == USER_ID)
+            user_or_group_id->id.uid = (uid_t)str2ull(id_string);
+        else
+            user_or_group_id->id.gid = (uid_t)str2ull(id_string);
 
-        if(all_user_id_index.root)
-            existing_user_id = (struct user_id *)avl_search(&all_user_id_index, (avl *) user_id);
+        user_or_group_id->name = strdupz(name);
+        user_or_group_id->updated = 1;
 
-        if(existing_user_id) {
+        struct user_or_group_id *existing_user_id = NULL;
+
+        if(likely(ids->root))
+            existing_user_id = (struct user_or_group_id *)avl_search(&ids->index, (avl *) user_or_group_id);
+
+        if(unlikely(existing_user_id)) {
             freez(existing_user_id->name);
-            existing_user_id->name = user_id->name;
+            existing_user_id->name = user_or_group_id->name;
             existing_user_id->updated = 1;
-            freez(user_id);
+            freez(user_or_group_id);
         }
         else {
-            info("INSERT id = %u, name = %s", user_id->id, user_id->name);
-            if(avl_insert(&all_user_id_index, (avl *) user_id) != (void *) user_id) {
-                error("INTERNAL ERROR: duplicate indexing of user id during realloc");
+            if(unlikely(avl_insert(&ids->index, (avl *) user_or_group_id) != (void *) user_or_group_id)) {
+                error("INTERNAL ERROR: duplicate indexing of id during realloc");
             };
 
-            user_id->next = all_user_id_root;
-            all_user_id_root = user_id;
+            user_or_group_id->next = ids->root;
+            ids->root = user_or_group_id;
         }
     }
 
     procfile_close(ff);
 
-    struct user_id *user_id = all_user_id_root, *prev_user_id = NULL;
+    // remove unused ids
+    struct user_or_group_id *user_or_group_id = ids->root, *prev_user_id = NULL;
 
-    while(user_id) {
-        if(!user_id->updated) {
-            info("REMOVE id = %u, name = %s", user_id->id, user_id->name);
-            if((struct user_id *)avl_remove(&all_user_id_index, (avl *) user_id) != user_id)
-                error("INTERNAL ERROR: removal of unused user id from index, removed a different user id");
-
-            if(prev_user_id)
-                prev_user_id->next = user_id->next;
-            else
-                all_user_id_root = user_id->next;
-
-            freez(user_id->name);
-            freez(user_id);
+    while(user_or_group_id) {
+        if(unlikely(!user_or_group_id->updated)) {
+            if(unlikely((struct user_or_group_id *)avl_remove(&ids->index, (avl *) user_or_group_id) != user_or_group_id))
+                error("INTERNAL ERROR: removal of unused id from index, removed a different id");
 
             if(prev_user_id)
-                user_id = prev_user_id->next;
+                prev_user_id->next = user_or_group_id->next;
             else
-                user_id = all_user_id_root;
+                ids->root = user_or_group_id->next;
+
+            freez(user_or_group_id->name);
+            freez(user_or_group_id);
+
+            if(prev_user_id)
+                user_or_group_id = prev_user_id->next;
+            else
+                user_or_group_id = ids->root;
         }
         else {
-            user_id->updated = 0;
+            user_or_group_id->updated = 0;
 
-            info("id = %u, name = %s", user_id->id, user_id->name);
-
-            prev_user_id = user_id;
-            user_id = user_id->next;
+            prev_user_id = user_or_group_id;
+            user_or_group_id = user_or_group_id->next;
         }
     }
 
@@ -658,18 +697,19 @@ static struct target *get_users_target(uid_t uid) {
     snprintfz(w->id, MAX_NAME, "%u", uid);
     w->idhash = simple_hash(w->id);
 
-    struct user_id tmp_user_id, *user_id = NULL;
-    tmp_user_id.id = uid;
+    struct user_or_group_id user_id_to_find, *user_or_group_id = NULL;
+    user_id_to_find.id.uid = uid;
 
-    if(all_user_id_index.root)
-            user_id = (struct user_id *)avl_search(&all_user_id_index, (avl *) &tmp_user_id);
+    static struct timespec last_passwd_modification_time;
+    int ret = read_user_or_group_ids(&all_user_ids, &last_passwd_modification_time);
 
-    if(user_id && user_id->name && *user_id->name) {
-        info("Copy name from passwd");
-        snprintfz(w->name, MAX_NAME, "%s", user_id->name);
+    if(likely(!ret && all_user_ids.index.root))
+            user_or_group_id = (struct user_or_group_id *)avl_search(&all_user_ids.index, (avl *) &user_id_to_find);
+
+    if(likely(user_or_group_id && user_or_group_id->name && *user_or_group_id->name)) {
+        snprintfz(w->name, MAX_NAME, "%s", user_or_group_id->name);
     }
     else {
-        info("Copy name from getpwuid");
         struct passwd *pw = getpwuid(uid);
         if(!pw || !pw->pw_name || !*pw->pw_name)
             snprintfz(w->name, MAX_NAME, "%u", uid);
@@ -703,11 +743,25 @@ struct target *get_groups_target(gid_t gid)
     snprintfz(w->id, MAX_NAME, "%u", gid);
     w->idhash = simple_hash(w->id);
 
-    struct group *gr = getgrgid(gid);
-    if(!gr || !gr->gr_name || !*gr->gr_name)
-        snprintfz(w->name, MAX_NAME, "%u", gid);
-    else
-        snprintfz(w->name, MAX_NAME, "%s", gr->gr_name);
+    struct user_or_group_id group_id_to_find, *group_id = NULL;
+    group_id_to_find.id.gid = gid;
+
+    static struct timespec last_group_modification_time;
+    int ret = read_user_or_group_ids(&all_group_ids, &last_group_modification_time);
+
+    if(likely(!ret && all_group_ids.index.root))
+            group_id = (struct user_or_group_id *)avl_search(&all_group_ids.index, (avl *) &group_id_to_find);
+
+    if(likely(group_id && group_id->name && *group_id->name)) {
+        snprintfz(w->name, MAX_NAME, "%s", group_id->name);
+    }
+    else {
+        struct group *gr = getgrgid(gid);
+        if(!gr || !gr->gr_name || !*gr->gr_name)
+            snprintfz(w->name, MAX_NAME, "%u", gid);
+        else
+            snprintfz(w->name, MAX_NAME, "%s", gr->gr_name);
+    }
 
     netdata_fix_chart_name(w->name);
 
@@ -3981,6 +4035,12 @@ int main(int argc, char **argv) {
 
     info("started on pid %d", getpid());
 
+    snprintfz(all_user_ids.filename, FILENAME_MAX, "%s/etc/passwd", netdata_configured_host_prefix);
+    debug_log("passwd file: '%s'", all_user_ids.filename);
+
+    snprintfz(all_group_ids.filename, FILENAME_MAX, "%s/etc/group", netdata_configured_host_prefix);
+    debug_log("group file: '%s'", all_group_ids.filename);
+
 #if (ALL_PIDS_ARE_READ_INSTANTLY == 0)
     all_pids_sortlist = callocz(sizeof(pid_t), (size_t)pid_max);
 #endif
@@ -4002,8 +4062,6 @@ int main(int argc, char **argv) {
 #else
         usec_t dt = heartbeat_next(&hb, step);
 #endif
-
-        read_user_ids();
 
         if(!collect_data_for_all_processes()) {
             error("Cannot collect /proc data for running processes. Disabling apps.plugin...");

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -700,13 +700,15 @@ static struct target *get_users_target(uid_t uid) {
     struct user_or_group_id user_id_to_find, *user_or_group_id = NULL;
     user_id_to_find.id.uid = uid;
 
-    static struct timespec last_passwd_modification_time;
-    int ret = read_user_or_group_ids(&all_user_ids, &last_passwd_modification_time);
+    if(*netdata_configured_host_prefix) {
+        static struct timespec last_passwd_modification_time;
+        int ret = read_user_or_group_ids(&all_user_ids, &last_passwd_modification_time);
 
-    if(likely(!ret && all_user_ids.index.root))
-            user_or_group_id = (struct user_or_group_id *)avl_search(&all_user_ids.index, (avl *) &user_id_to_find);
+        if(likely(!ret && all_user_ids.index.root))
+                user_or_group_id = (struct user_or_group_id *)avl_search(&all_user_ids.index, (avl *) &user_id_to_find);
+    }
 
-    if(likely(user_or_group_id && user_or_group_id->name && *user_or_group_id->name)) {
+    if(user_or_group_id && user_or_group_id->name && *user_or_group_id->name) {
         snprintfz(w->name, MAX_NAME, "%s", user_or_group_id->name);
     }
     else {
@@ -746,13 +748,15 @@ struct target *get_groups_target(gid_t gid)
     struct user_or_group_id group_id_to_find, *group_id = NULL;
     group_id_to_find.id.gid = gid;
 
-    static struct timespec last_group_modification_time;
-    int ret = read_user_or_group_ids(&all_group_ids, &last_group_modification_time);
+    if(*netdata_configured_host_prefix) {
+        static struct timespec last_group_modification_time;
+        int ret = read_user_or_group_ids(&all_group_ids, &last_group_modification_time);
 
-    if(likely(!ret && all_group_ids.index.root))
-            group_id = (struct user_or_group_id *)avl_search(&all_group_ids.index, (avl *) &group_id_to_find);
+        if(likely(!ret && all_group_ids.index.root))
+                group_id = (struct user_or_group_id *)avl_search(&all_group_ids.index, (avl *) &group_id_to_find);
+    }
 
-    if(likely(group_id && group_id->name && *group_id->name)) {
+    if(group_id && group_id->name && *group_id->name) {
         snprintfz(w->name, MAX_NAME, "%s", group_id->name);
     }
     else {

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -24,7 +24,8 @@ This is good for an internal network or to quickly analyse a host.
 ```bash
 docker run -d --name=netdata \
   -p 19999:19999 \
-  -v /etc:/host/etc:ro \
+  -v /etc/passwd:/host/etc/passwd:ro \
+  -v /etc/group:/host/etc/group:ro \
   -v /proc:/host/proc:ro \
   -v /sys:/host/sys:ro \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -48,11 +49,14 @@ services:
     security_opt:
       - apparmor:unconfined
     volumes:
-      - /etc:/host/etc:ro
+      - /etc/passwd:/host/etc/passwd:ro
+      - /etc/group:/host/etc/group:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
 ```
+
+If you don't want to use the apps.plugin functionality, you can remove the mounts of `/etc/passwd` and `/etc/group` (they are used to get proper user and group names for the monitored host) to get slightly better security.
 
 ### Docker container names resolution
 
@@ -134,7 +138,8 @@ services:
     security_opt:
       - apparmor:unconfined
     volumes:
-      - /etc:/host/etc:ro
+      - /etc/passwd:/host/etc/passwd:ro
+      - /etc/group:/host/etc/group:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -24,6 +24,7 @@ This is good for an internal network or to quickly analyse a host.
 ```bash
 docker run -d --name=netdata \
   -p 19999:19999 \
+  -v /etc:/host/etc:ro \
   -v /proc:/host/proc:ro \
   -v /sys:/host/sys:ro \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -47,6 +48,7 @@ services:
     security_opt:
       - apparmor:unconfined
     volumes:
+      - /etc:/host/etc:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -132,6 +134,7 @@ services:
     security_opt:
       - apparmor:unconfined
     volumes:
+      - /etc:/host/etc:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
##### Summary
When Netdata runs inside a container, it can't display correct names for "User" and "User Groups" sections. That is because Netdata uses `getpwuid()` and `getgrgid()` functions, which get local user and group names, while we want to monitor processes outside the container.

We will read `/etc/passwd` and `/etc/group` files and fall back to `getpwuid()` and `getgrgid()` only if the files can't be read. To read the host files from the container the `/etc` folder should be mounted with the `-v /etc:/host/etc:ro` option.

Fixes #5585

##### Component Name
apps plugin