### PR TITLE
Fixed broken left navbar links in translated docs

### DIFF
--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -24,11 +24,6 @@ echo "Copying files"
 rm -rf ${SRC_DIR}
 find . -type d \( -path ./${GENERATOR_DIR} -o -path ./node_modules \) -prune -o -name "*.md" -print | cpio -pd ${SRC_DIR}
 
-# Move main README.md file to what-is-netdata.md
-# echo "Replacing docs homepage"
-# mv ./${SRC_DIR}/README.md ./${SRC_DIR}/what-is-netdata.md
-# mv ./${SRC_DIR}/DOCUMENTATION.md ./${SRC_DIR}/README.md
-
 # Copy Netdata html resources
 cp -a ./${GENERATOR_DIR}/custom ./${SRC_DIR}/
 
@@ -64,7 +59,7 @@ prep_html() {
 	lang="${1}"
 	echo "Creating ${lang} mkdocs.yaml"
 
-	if [ "${lang}" = "en" ] ; then
+	if [ "${lang}" == "en" ] ; then
 		SITE_DIR="build"
 	else
 		SITE_DIR="build/${lang}"
@@ -89,9 +84,10 @@ prep_html() {
 		find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
 	fi
 
-	# Replace index.html with DOCUMENTATION/index.html
+	# Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
 	echo "Replacing index.html with DOCUMENTATION/index.html"
-	cat ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
+	sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
+
 }
 
 for d in "en" $(find ${LOC_DIR} -mindepth 1 -maxdepth 1 -name .git -prune -o -type d -printf '%f ') ; do


### PR DESCRIPTION
##### Summary
Links in Mandarin docs home page would lead back to the English site after PR #6428 

##### Component Name
docs

##### Additional Information
The PR to add a new docs homepage included a difficult to avoid hack during the docs html generation process, that involved copying an index.html from a subdirectory to the root of the tree. The links for the left navbar are relative, so they all contained '../'. This worked fine for the English docs site, since we were already at the root directory and there was no upper directory to go. But for the `/zh/index.html` , it had the effect of sending us back to the English site. 

Replaced the copy with a sed to fix it. Also modified an `=` to a `==` in an `if` condition. 
