### PR TITLE
netdata/packaging: Do not deliver edit-config as part of the distribution tarball

### DIFF
--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -18,7 +18,6 @@ include $(top_srcdir)/build/subst.inc
 SUFFIXES = .in
 
 dist_config_SCRIPTS = \
-    edit-config \
     $(NULL)
 
 nodist_noinst_DATA = \


### PR DESCRIPTION
##### Summary
As part of #6165, we faced an issue with mac OS installation where edit-config file was havint the wrong variables setup.
After deep investigation on the way Formulae was building netdata, we realized that generated edit-config was delivered
together with the generated edit-conf, thus resulting on not re-creating it with the right variables.

So the fix here is to not deliver edit-config with the distribution tarball, so that it gets generated as it should

##### Component Name
netdata/packaging

##### Additional Information
Fixes #6165 