### PR TITLE
Docker socket doesn't have to be writeable to resolve container names

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -60,7 +60,7 @@ If you don't want to use the apps.plugin functionality, you can remove the mount
 
 ### Docker container names resolution
 
-If you want to have your container names resolved by netdata, make netdata user be part of the group that owns the socket.
+If you want to have your container names resolved by Netdata, make the `netdata` user be part of the group that owns the socket.
    To achieve that just add environment variable `PGID=[GROUP NUMBER]` to the Netdata container,
    where `[GROUP NUMBER]` is practically the group id of the group assigned to the docker socket, on your host.
    This group number can be found by running the following (if socket group ownership is docker):

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -61,7 +61,7 @@ If you don't want to use the apps.plugin functionality, you can remove the mount
 ### Docker container names resolution
 
 If you want to have your container names resolved by netdata, make netdata user be part of the group that owns the socket.
-   To achieve that just add environment variable `PGID=[GROUP NUMBER]` to the netdata container,
+   To achieve that just add environment variable `PGID=[GROUP NUMBER]` to the Netdata container,
    where `[GROUP NUMBER]` is practically the group id of the group assigned to the docker socket, on your host.
    This group number can be found by running the following (if socket group ownership is docker):
    ```bash

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -60,28 +60,13 @@ If you don't want to use the apps.plugin functionality, you can remove the mount
 
 ### Docker container names resolution
 
-If you want to have your container names resolved by netdata, you need to do two things:
-1) Make netdata user be part of the group that owns the socket.
+If you want to have your container names resolved by netdata, make netdata user be part of the group that owns the socket.
    To achieve that just add environment variable `PGID=[GROUP NUMBER]` to the netdata container,
    where `[GROUP NUMBER]` is practically the group id of the group assigned to the docker socket, on your host.
    This group number can be found by running the following (if socket group ownership is docker):
    ```bash
    grep docker /etc/group | cut -d ':' -f 3
    ```
-
-2) Change docker socket access level to read/write like so:
-   from
-   ```
-   /var/run/docker.sock:/var/run/docker.sock:ro
-   ```
-
-   change to
-   ```
-   /var/run/docker.sock:/var/run/docker.sock:rw
-   ```
-
-**Important Note**: You should seriously consider the necessity of activating this option,
-as it grants to the netdata user access to the privileged socket connection of docker service
 
 ### Pass command line options to Netdata 
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Documentation tells users to bind docker socket writeable, although it doesn't seem necessary for docker container name resolution. 

##### Component Name
Gitbook

##### Additional Information
Other users reporting success with this method can be found in this [issue thread](https://github.com/netdata/netdata/issues/3972#issuecomment-419721436)

