### PR TITLE
mongodb collector: take password from both pass and password field

### DIFF
--- a/collectors/python.d.plugin/mongodb/mongodb.chart.py
+++ b/collectors/python.d.plugin/mongodb/mongodb.chart.py
@@ -426,7 +426,7 @@ class Service(SimpleService):
         self.definitions = deepcopy(CHARTS)
         self.authdb = self.configuration.get('authdb', 'admin')
         self.user = self.configuration.get('user')
-        self.password = self.configuration.get('pass')
+        self.password = self.configuration.get('pass', self.configuration.get('password'))
         self.host = self.configuration.get('host', '127.0.0.1')
         self.port = self.configuration.get('port', 27017)
         self.timeout = self.configuration.get('timeout', 100)


### PR DESCRIPTION
##### Summary
The docs say to use "password", the code worked with "pass". To keep backwards compatibility both ways I suggest to look for both keys, with preference for "pass" since that is the current behavior.

##### Component Name
python.d mongodb

##### Additional Information
Right now using user+password logged an error message "no users authenticated", which wasn't really helpful. Working on the error handling there might be helpful :)
