### PR TITLE
mongodb: change `password` to `pass` in the module config

### DIFF
--- a/collectors/python.d.plugin/mongodb/mongodb.conf
+++ b/collectors/python.d.plugin/mongodb/mongodb.conf
@@ -84,9 +84,9 @@ local:
     port : 27017
 
 # authsample:
-#     name : 'secure'
-#     host : 'mongodb.example.com'
-#     port : 27017
+#     name   : 'secure'
+#     host   : 'mongodb.example.com'
+#     port   : 27017
 #     authdb : 'admin'
-#     user : 'monitor'
-#     password : 'supersecret'
+#     user   : 'monitor'
+#     pass   : 'supersecret'


### PR DESCRIPTION
##### Summary
Fixes: #6512

There is a wrong keyword in the `authsample` job in the module configuration file

https://github.com/netdata/netdata/blob/fb49bb93a9195bf09bcf2e58f5fde7af428d5ad1/collectors/python.d.plugin/mongodb/mongodb.conf#L86-L92 

Correct keyword is `pass`.

 - config file
https://github.com/netdata/netdata/blob/aaf31295c35f790ebb3880b3f94cd787213ab98b/collectors/python.d.plugin/mongodb/mongodb.conf#L69-L72

 - code
https://github.com/netdata/netdata/blob/fb49bb93a9195bf09bcf2e58f5fde7af428d5ad1/collectors/python.d.plugin/mongodb/mongodb.chart.py#L422-L429

 - [readme](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/mongodb#configuration)





##### Component Name

[collectors/python.d.plugin/mongodb](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/mongodb)

##### Additional Information

