### PR TITLE
netdata/packaging: Adopt netdata-updater to run properly for static64 installations.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -199,6 +199,7 @@ NETDATA_PREFIX=
 LIBS_ARE_HERE=0
 NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS-}"
 RELEASE_CHANNEL="nightly"
+IS_NETDATA_STATIC_BINARY="no"
 while [ -n "${1}" ]; do
 	case "${1}" in
 		"--zlib-is-really-here") LIBS_ARE_HERE=1;;
@@ -207,6 +208,7 @@ while [ -n "${1}" ]; do
 		"--dont-wait") DONOTWAIT=1;;
 		"--auto-update"|"-u") AUTOUPDATE=1;;
 		"--stable-channel") RELEASE_CHANNEL="stable";;
+		"--static") IS_NETDATA_STATIC_BINARY="yes";;
 		"--enable-plugin-freeipmi")  NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-freeipmi/} --enable-plugin-freeipmi";;
 		"--disable-plugin-freeipmi") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-plugin-freeipmi/} --disable-plugin-freeipmi";;
 		"--enable-plugin-nfacct") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-nfacct/} --enable-plugin-nfacct";;
@@ -1073,6 +1075,7 @@ INSTALL_UID="${UID}"
 NETDATA_GROUP="${NETDATA_GROUP}"
 REINSTALL_COMMAND="${REINSTALL_COMMAND}"
 RELEASE_CHANNEL="${RELEASE_CHANNEL}"
+IS_NETDATA_STATIC_BINARY="${IS_NETDATA_STATIC_BINARY}"
 # This value is meant to be populated by autoupdater (if enabled)
 NETDATA_TARBALL_CHECKSUM="new_installation"
 EOF

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -199,7 +199,7 @@ NETDATA_PREFIX=
 LIBS_ARE_HERE=0
 NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS-}"
 RELEASE_CHANNEL="nightly"
-IS_NETDATA_STATIC_BINARY="no"
+IS_NETDATA_STATIC_BINARY="${IS_NETDATA_STATIC_BINARY:-"no"}"
 while [ -n "${1}" ]; do
 	case "${1}" in
 		"--zlib-is-really-here") LIBS_ARE_HERE=1;;
@@ -208,7 +208,6 @@ while [ -n "${1}" ]; do
 		"--dont-wait") DONOTWAIT=1;;
 		"--auto-update"|"-u") AUTOUPDATE=1;;
 		"--stable-channel") RELEASE_CHANNEL="stable";;
-		"--static") IS_NETDATA_STATIC_BINARY="yes";;
 		"--enable-plugin-freeipmi")  NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-freeipmi/} --enable-plugin-freeipmi";;
 		"--disable-plugin-freeipmi") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-plugin-freeipmi/} --disable-plugin-freeipmi";;
 		"--enable-plugin-nfacct") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-nfacct/} --enable-plugin-nfacct";;

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -179,7 +179,12 @@ fi
 set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
 
 if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
-	TMPDIR=$(create_tmp_directory)
+	TMPDIR="$(create_tmp_directory)"
+	PREVDIR="$(pwd)"
+
+	echo >&2 "Entering ${TMPDIR}"
+	cd "${TMPDIR}"
+
 	download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
 	download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.gz.run"
 	if ! grep netdata-latest.gz.run "${TMPDIR}/sha256sum.txt" | safe_sha256sum -c - >/dev/null 2>&1; then
@@ -195,6 +200,8 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
 	else
 		echo >&2 "NOTE: did not remove: ${TMPDIR}/netdata-latest.gz.run"
 	fi
+	echo >&2 "Switching back to ${PREVDIR}"
+	cd "${PREVDIR}"
 else
 	# the installer updates this script - so we run and exit in a single line
 	update && exit 0

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -196,9 +196,9 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
 
 	#shellcheck disable=SC2181
 	if [ $? -eq 0 ]; then
-		rm "${TMPDIR}/netdata-latest.gz.run"
+		rm -r "${TMPDIR}"
 	else
-		echo >&2 "NOTE: did not remove: ${TMPDIR}/netdata-latest.gz.run"
+		echo >&2 "NOTE: did not remove: ${TMPDIR}"
 	fi
 	echo >&2 "Switching back to ${PREVDIR}"
 	cd "${PREVDIR}"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -73,10 +73,15 @@ download() {
 }
 
 set_tarball_urls() {
+	local extension="tar.gz"
 
 	if [ ! -z "${NETDATA_LOCAL_TARBAL_OVERRIDE}" ]; then
 		info "Not fetching remote tarballs, local override was given"
 		return
+	fi
+
+	if [ "$2" == "yes" ]; then
+		extension="gz.run"
 	fi
 
 	if [ "$1" = "stable" ]; then
@@ -84,10 +89,10 @@ set_tarball_urls() {
 		# Simple version
 		# latest="$(curl -sSL https://api.github.com/repos/netdata/netdata/releases/latest | grep tag_name | cut -d'"' -f4)"
 		latest="$(download "https://api.github.com/repos/netdata/netdata/releases/latest" /dev/stdout | grep tag_name | cut -d'"' -f4)"
-		export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.tar.gz"
+		export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.${extension}"
 		export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
 	else
-		export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.tar.gz"
+		export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.${extension}"
 		export NETDATA_TARBALL_CHECKSUM_URL="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
 	fi
 }
@@ -171,7 +176,27 @@ else
 	exec 3>"${logfile}"
 fi
 
-set_tarball_urls "${RELEASE_CHANNEL}"
+set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
 
-# the installer updates this script - so we run and exit in a single line
-update && exit 0
+if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
+	TMPDIR=$(create_tmp_directory)
+	download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
+	download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.gz.run"
+	if ! grep netdata-latest.gz.run "${TMPDIR}/sha256sum.txt" | safe_sha256sum -c - >/dev/null 2>&1; then
+		fatal "Static binary checksum validation failed. Stopping netdata installation and leaving binary in ${TMPDIR}"
+	fi
+
+	# Do not pass any options other than the accept, for now
+	sh "${TMPDIR}/netdata-latest.gz.run" --accept
+
+	#shellcheck disable=SC2181
+	if [ $? -eq 0 ]; then
+		rm "${TMPDIR}/netdata-latest.gz.run"
+	else
+		echo >&2 "NOTE: did not remove: ${TMPDIR}/netdata-latest.gz.run"
+	fi
+else
+	# the installer updates this script - so we run and exit in a single line
+	update && exit 0
+fi
+

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -13,10 +13,13 @@ else
 #    export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness"
 fi
 
+# We export this to 'yes', installer sets this to .environment.
+# The updater consumes this one, so that it can tell whether it should update a static install or a non-static one
+export IS_NETDATA_STATIC_BINARY="yes"
+
 run ./netdata-installer.sh --install "${NETDATA_INSTALL_PARENT}" \
     --dont-wait \
     --dont-start-it \
-    --static \
     ${NULL}
 
 if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -16,6 +16,7 @@ fi
 run ./netdata-installer.sh --install "${NETDATA_INSTALL_PARENT}" \
     --dont-wait \
     --dont-start-it \
+    --static \
     ${NULL}
 
 if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]


### PR DESCRIPTION
##### Summary
Since we already ship netdata-updater.sh with our static64 installer, all that is left is to make sure that the updater can handle the proper update of a static installation with the latest version.

This change introduces the necessary artifacts that gets us there.
In simple words, the updater becomes aware of the installation type (static or not) and then with minor adjustments we just execute a different type of install process.

#### Component Name
netdata/packaging/installer

##### Additional Information
Fixes #4122 