### PR TITLE
Documentation navigation fix

### DIFF
--- a/docs/generator/custom/css/netdata.css
+++ b/docs/generator/custom/css/netdata.css
@@ -6,6 +6,12 @@
     font-size: .75rem
 }
 
+/* Underline text */
+
+.md-typeset a:not(.nav-button):not(.md-icon):not(.headerlink) {
+    border-bottom: 1px solid #272b30;
+}
+
 /*  Custom styling for the new documentation homepage.
     In particular, the three buttons for install/getting started/configuration. */
 
@@ -36,9 +42,13 @@
     text-align: center;
 }
 
-/* Hide the label at the top of the navigation menu. Does nothing. */
-.md-nav__title {
-    display: none;
+/* Hide the label at the top of the navigation menu. Does nothing. 
+   Well, it does do something on mobile, and this media query makes
+   sure it's hidden only on screens wide enough to not use the mobile sidebar. */
+@media only screen and (min-width:76.25em) {
+    .md-nav--primary .md-nav__title {
+        display: none;
+    }
 }
 
 /* Change the language selector dropdown to match new color. */
@@ -57,4 +67,9 @@
 /* Make sure inline code in tables doesn't break. */
 .md-typeset__table code {
     word-break: normal;
+}
+
+/* Bold the first item on the docs sidebar: Netdata Documentation */
+.md-nav--primary > .md-nav__list > .md-nav__item:first-of-type {
+    font-weight: 700;
 }


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

I realized that in a previous PR for styling fixes for the docs that when I used CSS to hide `md-nav__title` in left-hand navigation menu, it also inadvertently hid various essential items in the mobile navigation. With `md-nav__title` set to `display: none`, you can't navigate up a level in the navigation.

In this PR, the element I want hidden is only done on wide screens when the mobile nav is not active.

**Current**:

*Top level*
![Screenshot_2019-07-24 Netdata Documentation - Netdata Documentation](https://user-images.githubusercontent.com/1153921/61809023-5c5f8c00-adf1-11e9-9647-8b1232d33334.png)

*One level deep*
![Screenshot_2019-07-24 Netdata Documentation - Netdata Documentation(1)](https://user-images.githubusercontent.com/1153921/61809043-64b7c700-adf1-11e9-8b9e-4ed313ad56b7.png)

**Restored in this PR**:

*Top level*
![image](https://user-images.githubusercontent.com/1153921/61808588-8e242300-adf0-11e9-938f-744804f58953.png)

*One level deep*
![Screenshot_2019-07-24 Install netdata with Docker - Netdata Documentation(1)](https://user-images.githubusercontent.com/1153921/61809142-9761bf80-adf1-11e9-84a9-9846212b4851.png)

##### Component Name

docs

##### Additional Information

I also added an underline to links in the body of docs to make them stand out a bit better, per @cakrit's comment.
