### PR TITLE
Docs: Remove text about nightly version

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -93,12 +93,8 @@ $ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh)
     To learn more about the pros and cons of using *nightly* vs. *stable* releases, see our [notice about the two options](README.md#nightly-vs-stable-releases).
 
     If your system does not have `bash` installed, open the `More information and advanced uses of the kickstart-static64.sh script` dropdown for instructions to run the installer without `bash`.
-
-**Nightly releases can be unstable!** If you have concerns about running nightly versions of Netdata, for example in a production system, you can append `--stable-channel` to the above command (`bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --stable-channel`) to ensure Netdata only updates on new major releases.
-
-**Do not use `sudo` for the static binary installer**—it will escalate privileges itself if needed. If the target system does not have `bash` installed, see below for instructions to run it without `bash`)*
-
-**This script installs Netdata at `/opt/netdata`**.
+    
+    This script installs Netdata at `/opt/netdata`.
 
 <details markdown="1"><summary>Click here for more information and advanced use of this command.</summary>
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

When I deployed the new text about nightly vs. stable versions of Netdata, I failed to remove the old text from the 64-bit static binary section of the installation page. I've replaced that with the new boilerplate about nightly vs. stable releases and a link to the section that explains it more.

##### Component Name

docs

##### Additional Information

