### PR TITLE
Make the docker image to run as arbitrary user

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -74,13 +74,21 @@ RUN \
     addgroup -g ${NETDATA_GID} -S "${DOCKER_GRP}" && \
     adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}" && \
     # Apply the permissions as described in
-    # https://github.com/netdata/netdata/wiki/netdata-security#netdata-directories
-    chown -R root:netdata /etc/netdata && \
-    chown -R netdata:netdata /var/cache/netdata /var/lib/netdata /usr/share/netdata && \
-    chown -R root:netdata /usr/lib/netdata && \
-    chown -R root:netdata /usr/libexec/netdata/ && \
-    chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network /usr/libexec/netdata/plugins.d/apps.plugin && \
-    chmod 0750 /var/lib/netdata /var/cache/netdata && \
+    # https://docs.netdata.cloud/docs/netdata-security/#netdata-directories, but own everything by root group due to https://github.com/netdata/netdata/pull/6543
+    chown -R root:root \
+        /etc/netdata \
+        /usr/share/netdata \
+        /usr/libexec/netdata && \
+    chown -R netdata:root \
+        /usr/lib/netdata \
+        /var/cache/netdata \
+        /var/lib/netdata \
+        /var/log/netdata && \
+    chmod 0755 /usr/libexec/netdata/plugins.d/*.plugin && \
+    chmod 4755 /usr/libexec/netdata/plugins.d/cgroup-network /usr/libexec/netdata/plugins.d/apps.plugin && \
+    # Group write permissions due to: https://github.com/netdata/netdata/pull/6543chmod 0770 -R /var/lib/netdata /var/cache/netdata && \
+    find /var/lib/netdata /var/cache/netdata -type d -exec chmod 0770 {} \; && \
+    find /var/lib/netdata /var/cache/netdata -type f -exec chmod 0660 {} \; && \
     # Link log files to stdout
     ln -sf /dev/stdout /var/log/netdata/access.log && \
     ln -sf /dev/stdout /var/log/netdata/debug.log && \

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -20,6 +20,6 @@ if [ -n "${PGID}" ]; then
     usermod -a -G ${PGID} ${DOCKER_USR} || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
 fi
 
-exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_PORT}" "$@"
+exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_PORT}" -W set web "web files group" root -W set web "web files owner" root "$@"
 
 echo "Netdata entrypoint script, completed!"


### PR DESCRIPTION
##### Summary
In container runtime with arbitrary user (e.g. [Openshift](https://docs.openshift.com/container-platform/3.3/creating_images/guidelines.html#openshift-container-platform-specific-guidelines)) there are permission problems when trying to start. These changes will make the image runnable as any arbitrary user, as long as this user belongs to root group.

##### Component Name
Docker image

##### Additional Information

This is necessary in Kubernetes/Openshift environments with much restricted Security contexts. In Openshift, images run as a very high user id (e.g. 94000334) and group 0. Without the changes in this PR, we would need to extend and maintain a custom image with just the permission changes.

I'm aware of https://docs.netdata.cloud/docs/netdata-security/#netdata-directories, but maybe in Docker environment this might need a review.

What do you think?

I should also mention that I haven't tested with any additional Docker socket mounts.
