### PR TITLE
redirect after clicking Nodes > SignIn

### DIFF
--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -704,11 +704,11 @@ function restrictMyNetdataMenu() {
     </div>`);
 }
 
-function openAuthenticatedUrl(url) {  
+function openAuthenticatedUrl(url) {
     if (isSignedIn()) {
         window.open(url);
     } else {
-        window.open(`${NETDATA.registry.cloudBaseURL}/account/sign-in-agent?id=${NETDATA.registry.machine_guid}&name=${encodeURIComponent(NETDATA.registry.hostname)}&origin=${encodeURIComponent(window.location.origin + "/")}`);
+        window.open(`${NETDATA.registry.cloudBaseURL}/account/sign-in-agent?id=${NETDATA.registry.machine_guid}&name=${encodeURIComponent(NETDATA.registry.hostname)}&origin=${encodeURIComponent(window.location.origin + "/")}&redirectUrl=${encodeURIComponent(window.location.origin + "/" + url)}`);
     }
 }
 
@@ -4897,6 +4897,9 @@ function handleSignInMessage(e) {
     cloudToken = e.data.token;
 
     netdataRegistryCallback(registryAgents);
+    if (e.data.redirectUrl) {
+        window.location.replace(e.data.redirectUrl);
+    }
 }
 
 function handleSignOutMessage(e) {


### PR DESCRIPTION
##### Summary
After logging via clicking `Nodes`, user should be redirected to `console.html`. Because it was hard to detect it in the `message` that cloud generates, i decided to add a separate param to the cloud window url. This param is passed through and (after sign in) returns to `handleSignInMessage`

##### Component Name
main.js (Dashboard)

Fixes #6542 

