### PR TITLE
smartd_log: use `del_dimension` instead of `hide_dimension` to delete inactive disks

### DIFF
--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -750,5 +750,4 @@ class Service(SimpleService):
             if not chart_id or chart_id not in self.charts:
                 continue
 
-            # TODO: can't delete dimension
-            self.charts[chart_id].hide_dimension('{0}_{1}'.format(disk.name, attr.name))
+            self.charts[chart_id].del_dimension('{0}_{1}'.format(disk.name, attr.name))


### PR DESCRIPTION
##### Summary

`smartd_log` does `cleanup` every 60 seconds, during cleanup it removes inactive disks (last update time > 30min) from the list of monitored disks and from charts.

Module uses [`hide_dimension`](https://github.com/netdata/netdata/blob/2f7962c9e154dcce1684f2275387c9b6ac4d0b4c/collectors/python.d.plugin/python_modules/bases/charts.py#L214-L220) function. The function doesn actually obsolete dimension.

This PR changes `hide_dimension` to [`del_dimension`](https://github.com/netdata/netdata/blob/2f7962c9e154dcce1684f2275387c9b6ac4d0b4c/collectors/python.d.plugin/python_modules/bases/charts.py#L203-L212). `del_dimension` sets dim `obsolete` flag.


##### Component Name
[collectors/python.d.plugin/smartd_log](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/smartd_log)

##### Additional Information
Tests:
  - i tested it, works w/o problem

