### PR TITLE
Add alarm status counter api call

### DIFF
--- a/health/health.h
+++ b/health/health.h
@@ -58,6 +58,7 @@ extern void *health_main(void *ptr);
 extern void health_reload(void);
 
 extern int health_variable_lookup(const char *variable, uint32_t hash, RRDCALC *rc, calculated_number *result);
+extern void health_agregate_alarms(RRDHOST *host, BUFFER *wb, uint32_t hash_context, char* context);
 extern void health_alarms2json(RRDHOST *host, BUFFER *wb, int all);
 extern void health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after);
 

--- a/health/health.h
+++ b/health/health.h
@@ -58,7 +58,7 @@ extern void *health_main(void *ptr);
 extern void health_reload(void);
 
 extern int health_variable_lookup(const char *variable, uint32_t hash, RRDCALC *rc, calculated_number *result);
-extern void health_agregate_alarms(RRDHOST *host, BUFFER *wb, uint32_t hash_context, char* context);
+extern void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* context, RRDCALC_STATUS status);
 extern void health_alarms2json(RRDHOST *host, BUFFER *wb, int all);
 extern void health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after);
 

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -231,15 +231,9 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
 //
 //}
 
-#define CHECK(x) { if(!(x)) { error("CHECK(%s)", #x); return; } }
-
 void health_agregate_alarms(RRDHOST *host, BUFFER *wb, uint32_t hash_context, char* context) {
     int status = RRDCALC_STATUS_REMOVED;
     RRDCALC *rc;
-
-    CHECK(host);
-    CHECK(wb);
-    CHECK(context);
 
     rrdhost_rdlock(host);
     for(rc = host->alarms; rc ; rc = rc->next) {

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -240,7 +240,7 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
     rrdhost_rdlock(host);
 
     if (contexts) {
-        p = buffer_tostring(contexts);
+        p = (char*)buffer_tostring(contexts);
         while(p && *p && (tok = mystrsep(&p, ", |"))) {
             if(!*tok) continue;
 
@@ -248,7 +248,8 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
                 if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
                     continue;
                 if(unlikely(rc->rrdset && rc->rrdset->hash_context == simple_hash(tok)
-                            && !strcmp(rc->rrdset->context, tok) && rc->status == status))
+                            && !strcmp(rc->rrdset->context, tok)
+                            && ((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status)))
                     numberOfAlarms++;
             }
         }
@@ -258,7 +259,7 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
             if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
                 continue;
 
-            if(unlikely(rc->status == status))
+            if(unlikely((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status))
                 numberOfAlarms++;
         }
     }

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -245,7 +245,7 @@ void health_agregate_alarms(RRDHOST *host, BUFFER *wb, uint32_t hash_context, ch
             status = rc->status;
     }
 
-    buffer_sprintf(wb, "\t{%s:'%s'}", context, rrdcalc_status2string(status));
+    buffer_sprintf(wb, "\t{\"context\": \"%s\", \"status\":\"%s\"}", context, rrdcalc_status2string(status));
     rrdhost_unlock(host);
 }
 

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -660,7 +660,7 @@
     "/alarm_count": {
       "get": {
         "summary": "Get an overall status of the chart",
-        "description": "Check multiple charts with the same context and aggregate their health statistics into one metric/status. The alarm_count endpoint returns the status with the maximum severity for all charts families in the given context. \n\nThe lowest severity for the chart status is REMOVED and the highest is CRITICAL. For example, cpu.cpu context groups as many charts as many cpu cores exists on the system, i.e. cpu.cpu0, cpu.cpu1 etc.  If at least one core is 100% utilized then alarm_count endpoint will return CRITICAL status.\n",
+        "description": "Checks multiple charts with the same context and counts number of alarms with given status.",
         "parameters": [
           {
             "in": "query",
@@ -674,17 +674,35 @@
               "collectionFormat": "pipes"
             },
             "default": [
-              "cpu.cpu"
+              "system.cpu"
             ]
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "description": "Specify alarm status to count",
+            "required": false,
+            "allowEmptyValue": true,
+            "type": "string",
+            "enum": [
+              "REMOVED",
+              "UNDEFINED",
+              "UNINITIALIZED",
+              "CLEAR",
+              "RAISED",
+              "WARNING",
+              "CRITICAL"
+            ],
+            "default": "RAISED"
           }
         ],
         "responses": {
           "200": {
-            "description": "An object containing a list of contexts and their max severity alarms",
+            "description": "An object containing a count of alarms with given status for given contexts",
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/alarm_count_entry"
+                "type": "number"
               }
             }
           },
@@ -1390,17 +1408,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "alarm_count_entry": {
-      "type": "object",
-      "properties": {
-        "context": {
-          "type": "string"
-        },
-        "status": {
-          "type": "string"
         }
       }
     },

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -657,6 +657,43 @@
         }
       }
     },
+    "/alarm_count": {
+      "get": {
+        "summary": "Get an overall status of the chart",
+        "description": "Check multiple charts with the same context and aggregate their health statistics into one metric/status. The alarm_count endpoint returns the status with the maximum severity for all charts families in the given context. \n\nThe lowest severity for the chart status is REMOVED and the highest is CRITICAL. For example, cpu.cpu context groups as many charts as many cpu cores exists on the system, i.e. cpu.cpu0, cpu.cpu1 etc.  If at least one core is 100% utilized then alarm_count endpoint will return CRITICAL status.\n",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "context",
+            "description": "Specify context which should be checked",
+            "required": false,
+            "allowEmptyValue": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "collectionFormat": "pipes"
+            },
+            "default": [
+              "cpu.cpu"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An object containing a list of contexts and their max severity alarms",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/alarm_count_entry"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error. This usually means the server is out of memory."
+          }
+        }
+      }
+    },
     "/manage/health": {
       "get": {
         "summary": "Accesses the health management API to control health checks and notifications at runtime.",
@@ -1353,6 +1390,17 @@
               }
             }
           }
+        }
+      }
+    },
+    "alarm_count_entry": {
+      "type": "object",
+      "properties": {
+        "context": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
         }
       }
     },

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -430,6 +430,33 @@ paths:
             type: array
             items:
               $ref: '#/definitions/alarm_log_entry'
+  /alarm_count:
+    get:
+      summary: 'Get an overall status of the chart'
+      description: |
+        Check multiple charts with the same context and aggregate their health statistics into one metric/status. The alarm_count endpoint returns the status with the maximum severity for all charts families in the given context. 
+        
+        The lowest severity for the chart status is REMOVED and the highest is CRITICAL. For example, cpu.cpu context groups as many charts as many cpu cores exists on the system, i.e. cpu.cpu0, cpu.cpu1 etc.  If at least one core is 100% utilized then alarm_count endpoint will return CRITICAL status.
+      parameters:
+        - in: query
+          name: context
+          description: "Specify context which should be checked"
+          required: false
+          allowEmptyValue: true
+          type: array
+          items:
+            type: string
+            collectionFormat: pipes
+          default: ['cpu.cpu']
+      responses:
+        '200':
+          description: 'An object containing a list of contexts and their max severity alarms'
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/alarm_count_entry'
+        '500':
+          description: 'Internal server error. This usually means the server is out of memory.'
   /manage/health:
     get:
       summary: 'Accesses the health management API to control health checks and notifications at runtime.'
@@ -921,6 +948,13 @@ definitions:
                 format: nullable
               value: 
                 type: number
+  alarm_count_entry:
+    type: object
+    properties:
+      context:
+        type: string
+      status:
+        type: string
   alarm_log_entry:
     type: object
     properties: 

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -433,10 +433,7 @@ paths:
   /alarm_count:
     get:
       summary: 'Get an overall status of the chart'
-      description: |
-        Check multiple charts with the same context and aggregate their health statistics into one metric/status. The alarm_count endpoint returns the status with the maximum severity for all charts families in the given context. 
-        
-        The lowest severity for the chart status is REMOVED and the highest is CRITICAL. For example, cpu.cpu context groups as many charts as many cpu cores exists on the system, i.e. cpu.cpu0, cpu.cpu1 etc.  If at least one core is 100% utilized then alarm_count endpoint will return CRITICAL status.
+      description: "Checks multiple charts with the same context and counts number of alarms with given status."
       parameters:
         - in: query
           name: context
@@ -447,14 +444,22 @@ paths:
           items:
             type: string
             collectionFormat: pipes
-          default: ['cpu.cpu']
+          default: ['system.cpu']
+        - in: query
+          name: status
+          description: "Specify alarm status to count"
+          required: false
+          allowEmptyValue: true
+          type: string
+          enum: ['REMOVED', 'UNDEFINED', 'UNINITIALIZED', 'CLEAR', 'RAISED', 'WARNING', 'CRITICAL']
+          default: 'RAISED'
       responses:
         '200':
-          description: 'An object containing a list of contexts and their max severity alarms'
+          description: 'An object containing a count of alarms with given status for given contexts'
           schema:
             type: array
-            items:
-              $ref: '#/definitions/alarm_count_entry'
+            items: 
+              type: number
         '500':
           description: 'Internal server error. This usually means the server is out of memory.'
   /manage/health:
@@ -948,13 +953,6 @@ definitions:
                 format: nullable
               value: 
                 type: number
-  alarm_count_entry:
-    type: object
-    properties:
-      context:
-        type: string
-      status:
-        type: string
   alarm_log_entry:
     type: object
     properties: 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -213,7 +213,7 @@ inline int web_client_api_request_v1_alarms(RRDHOST *host, struct web_client *w,
     return 200;
 }
 
-inline int web_client_api_request_v1_alarm_counts(RRDHOST *host, struct web_client *w, char *url) {
+inline int web_client_api_request_v1_alarm_count(RRDHOST *host, struct web_client *w, char *url) {
     int i = 0;
 
     buffer_flush(w->response.data);
@@ -227,7 +227,7 @@ inline int web_client_api_request_v1_alarm_counts(RRDHOST *host, struct web_clie
         if(!name || !*name) continue;
         if(!value || !*value) continue;
 
-        debug(D_WEB_CLIENT, "%llu: API v1 alarm_counts query param '%s' with value '%s'", w->id, name, value);
+        debug(D_WEB_CLIENT, "%llu: API v1 alarm_count query param '%s' with value '%s'", w->id, name, value);
 
         if(likely(i))
             buffer_strcat(w->response.data, ",\n");
@@ -811,7 +811,7 @@ static struct api_command {
         { "alarms",          0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarms          },
         { "alarm_log",       0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_log       },
         { "alarm_variables", 0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_variables },
-        { "alarm_counts",    0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_counts    },
+        { "alarm_count",     0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_count     },
         { "allmetrics",      0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_allmetrics      },
         { "manage/health",   0, WEB_CLIENT_ACL_MGMT,      web_client_api_request_v1_mgmt_health     },
         // terminator

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -236,8 +236,8 @@ inline int web_client_api_request_v1_alarm_count(RRDHOST *host, struct web_clien
             if (!strcmp("CRITICAL", value)) status = RRDCALC_STATUS_CRITICAL;
             else if (!strcmp("WARNING", value)) status = RRDCALC_STATUS_WARNING;
             else if (!strcmp("UNINITIALIZED", value)) status = RRDCALC_STATUS_UNINITIALIZED;
-            else if (!strcmp("REMOVED", value)) status = RRDCALC_STATUS_REMOVED;
             else if (!strcmp("UNDEFINED", value)) status = RRDCALC_STATUS_UNDEFINED;
+            else if (!strcmp("REMOVED", value)) status = RRDCALC_STATUS_REMOVED;
             else if (!strcmp("CLEAR", value)) status = RRDCALC_STATUS_CLEAR;
         }
         else if(!strcmp(name, "context") || !strcmp(name, "ctx")) {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -213,14 +213,8 @@ inline int web_client_api_request_v1_alarms(RRDHOST *host, struct web_client *w,
     return 200;
 }
 
-#define CHECK_HTTP400(x) { if(!(x)) { error("CHECK_HTTP400(%s)", #x); return 400; } }
-
 inline int web_client_api_request_v1_alarm_counts(RRDHOST *host, struct web_client *w, char *url) {
     int i = 0;
-
-    CHECK_HTTP400(host);
-    CHECK_HTTP400(w);
-    CHECK_HTTP400(url);
 
     buffer_flush(w->response.data);
     buffer_sprintf(w->response.data, "{\n");

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -218,7 +218,7 @@ inline int web_client_api_request_v1_alarm_count(RRDHOST *host, struct web_clien
     BUFFER *contexts = NULL;
 
     buffer_flush(w->response.data);
-    buffer_sprintf(w->response.data, "[\n");
+    buffer_sprintf(w->response.data, "[");
 
     while(url) {
         char *value = mystrsep(&url, "&");
@@ -249,7 +249,7 @@ inline int web_client_api_request_v1_alarm_count(RRDHOST *host, struct web_clien
 
     health_aggregate_alarms(host, w->response.data, contexts, status);
 
-    buffer_sprintf(w->response.data, "\n]\n");
+    buffer_sprintf(w->response.data, "]\n");
     w->response.data->contenttype = CT_APPLICATION_JSON;
     buffer_no_cacheable(w->response.data);
 

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -16,6 +16,7 @@ extern int web_client_api_request_v1_alarms(RRDHOST *host, struct web_client *w,
 extern int web_client_api_request_v1_alarm_log(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_single_chart(RRDHOST *host, struct web_client *w, char *url, void callback(RRDSET *st, BUFFER *buf));
 extern int web_client_api_request_v1_alarm_variables(RRDHOST *host, struct web_client *w, char *url);
+extern int web_client_api_request_v1_alarm_counts(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_v1_charts(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_v1_chart(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, char *url);

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -16,7 +16,7 @@ extern int web_client_api_request_v1_alarms(RRDHOST *host, struct web_client *w,
 extern int web_client_api_request_v1_alarm_log(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_single_chart(RRDHOST *host, struct web_client *w, char *url, void callback(RRDSET *st, BUFFER *buf));
 extern int web_client_api_request_v1_alarm_variables(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_alarm_counts(RRDHOST *host, struct web_client *w, char *url);
+extern int web_client_api_request_v1_alarm_count(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_v1_charts(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_v1_chart(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, char *url);


### PR DESCRIPTION
##### Summary
This is implementation of a prerequisite for the requested feature #6536 (Generate an overall status badge/chart for the health of category)

##### Component Name
web/api/
health/

##### Additional Information
Command line used for testing and response format:

curl "http://localhost:19999/api/v1/alarm_count?context=system.cpu,system.ram&status=clear"
[4]
curl "http://localhost:19999/api/v1/alarm_count?context=system.cpu,system.ram&status=undefined"
[1]
curl "http://localhost:19999/api/v1/alarm_count?status=critical"
[0]
curl "http://localhost:19999/api/v1/alarm_count"
[0]
