### PR TITLE
netdata/packaging: Move tarball checksum information into lib dir of netdata

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -985,8 +985,13 @@ fi
 
 # -----------------------------------------------------------------------------
 progress "Copy uninstaller"
-sed "s|ENVIRONMENT_FILE=\"/etc/netdata/.environment\"|ENVIRONMENT_FILE=\"${NETDATA_PREFIX}/etc/netdata/.environment\"|" packaging/installer/netdata-uninstaller.sh > ${NETDATA_PREFIX}/usr/libexec/netdata-uninstaller.sh
-chmod 750 ${NETDATA_PREFIX}/usr/libexec/netdata-uninstaller.sh
+if [ -f "${NETDATA_PREFIX}"/usr/libexec/netdata-uninstaller.sh ]; then
+	echo >&2 "Removing uninstaller from old location"
+	rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-uninstaller.sh;
+fi
+
+sed "s|ENVIRONMENT_FILE=\"/etc/netdata/.environment\"|ENVIRONMENT_FILE=\"${NETDATA_PREFIX}/etc/netdata/.environment\"|" packaging/installer/netdata-uninstaller.sh > ${NETDATA_PREFIX}/usr/libexec/netdata/netdata-uninstaller.sh
+chmod 750 ${NETDATA_PREFIX}/usr/libexec/netdata/netdata-uninstaller.sh
 
 # -----------------------------------------------------------------------------
 progress "Basic netdata instructions"
@@ -1007,19 +1012,24 @@ To start netdata run:
   ${TPUT_YELLOW}${TPUT_BOLD}${NETDATA_START_CMD}${TPUT_RESET}
 
 END
-echo >&2 "Uninstall script copied to: ${TPUT_RED}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata-uninstaller.sh${TPUT_RESET}"
+echo >&2 "Uninstall script copied to: ${TPUT_RED}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata/netdata-uninstaller.sh${TPUT_RESET}"
 echo >&2
 
 progress "Install netdata updater tool"
 
-if [ -f "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" ]; then
-	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh" || exit 1
-else
-	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh" || exit 1
+if [ -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh ]; then
+	echo >&2 "Removing updater from previous location"
+	rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh
 fi
 
-chmod 0755 ${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh
-echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh${TPUT_RESET}"
+if [ -f "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" ]; then
+	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
+else
+	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
+fi
+
+chmod 0755 ${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh
+echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh${TPUT_RESET}"
 echo >&2
 
 # Figure out the cron directory for the distro
@@ -1043,7 +1053,7 @@ else
 		echo >&2 "Adding to cron"
 
 		rm -f "${crondir}/netdata-updater"
-		ln -sf "${NETDATA_PREFIX}/usr/libexec/netdata-updater.sh" "${crondir}/netdata-updater"
+		ln -sf "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" "${crondir}/netdata-updater"
 
 		echo >&2 "Auto-updating has been enabled. Updater script linked to: ${TPUT_RED}${TPUT_BOLD}${crondir}/netdata-update${TPUT_RESET}"
 		echo >&2

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1062,7 +1062,10 @@ else
 	fi
 fi
 
+progress "Wrap up environment set up"
+
 # Save environment variables
+echo >&2 "Preparing .environment file"
 cat <<EOF > "${NETDATA_USER_CONFIG_DIR}/.environment"
 # Created by installer
 PATH="${PATH}"
@@ -1075,10 +1078,13 @@ NETDATA_GROUP="${NETDATA_GROUP}"
 REINSTALL_COMMAND="${REINSTALL_COMMAND}"
 RELEASE_CHANNEL="${RELEASE_CHANNEL}"
 IS_NETDATA_STATIC_BINARY="${IS_NETDATA_STATIC_BINARY}"
-# This value is meant to be populated by autoupdater (if enabled)
-NETDATA_TARBALL_CHECKSUM="new_installation"
+NETDATA_LIB_DIR="${NETDATA_LIB_DIR}"
 EOF
 
+echo >&2 "Setting netdata.tarball.checksum to 'new_installation'"
+cat <<EOF > "${NETDATA_LIB_DIR}/netdata.tarball.checksum"
+new_installation
+EOF
 
 # -----------------------------------------------------------------------------
 echo >&2

--- a/packaging/installer/UNINSTALL.md
+++ b/packaging/installer/UNINSTALL.md
@@ -16,7 +16,7 @@ NETDATA_ADDED_TO_GROUPS="<additional groups>"  # Additional groups for a user ru
 ```
 3. Run `netdata-uninstaller.sh` as follows
 ```
-${NETDATA_PREFIX}/usr/libexec/netdata-uninstaller.sh --yes --env <environment_file>
+${NETDATA_PREFIX}/usr/libexec/netdata/netdata-uninstaller.sh --yes --env <environment_file>
 ```
 
 Note: Existing installations may still need to download the file if it's not present.


### PR DESCRIPTION
##### Summary
1) Introduce NETDATA_LIB_DIR within environment file, we are going to need to refer to it
2) move NETDATA_TARBALL_CHECKSUM to /netdata.tarball.checksum
3) Make sure you support transitional period, which means load and remove the variable from the old location then move it to the new one

##### Component Name
netdata/packaging/installer

##### Additional Information

Fixes #6550