### PR TITLE
netdata/packaging: Notify us when CHANGELOG.md gets too old

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -557,7 +557,9 @@ jobs:
     # This is generating the changelog for nightly release and publish it
   - name: Generate nightly changelog
     before_script: post_message "TRAVIS_MESSAGE" "Starting changelog generation for nightlies" "${NOTIF_CHANNEL}"
-    script: ".travis/nightlies.sh"
+    script:
+    - ".travis/nightlies.sh"
+    - ".travis/check_changelog_last_modification.sh"
     after_failure: post_message "TRAVIS_MESSAGE" "<!here> Nightly changelog generation failed"
     git:
       depth: false

--- a/.travis/check_changelog_last_modification.sh
+++ b/.travis/check_changelog_last_modification.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+LAST_MODIFICATION="$(git log -1 --pretty="format:%at" CHANGELOG.md)"
+CURRENT_TIME="$(date +"%s")"
+TWO_DAYS_IN_SECONDS=172800
+
+DIFF=$((CURRENT_TIME - LAST_MODIFICATION))
+
+echo "Checking CHANGELOG.md last modification time on GIT.."
+echo "CHANGELOG.md timestamp: ${LAST_MODIFICATION}"
+echo "Current timestamp: ${CURRENT_TIME}"
+echo "Diff: ${DIFF}"
+
+if [ ${DIFF} -gt ${TWO_DAYS_IN_SECONDS} ]; then
+	echo "CHANGELOG.md is more than two days old!"
+	post_message "TRAVIS_MESSAGE" "Hi <!here>, CHANGELOG.md was found more than two days old (Diff: ${DIFF} seconds)" "${NOTIF_CHANNEL}"
+else
+	echo "CHANGELOG.md is less than two days old, fine"
+fi


### PR DESCRIPTION
##### Summary
Throw a notification when changelog generation gets too old.
It is a soft error, but we do want to know about it

##### Component Name
netdata/ci

##### Additional Information
None
