### PR TITLE
Handle disconnected sockets in unbound collector.

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -4,6 +4,7 @@
 # Author: Ilya Mashchenko (ilyam8)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import errno
 import socket
 
 try:
@@ -181,7 +182,8 @@ class SocketService(SimpleService):
                 self._sock.shutdown(2)  # 0 - read, 1 - write, 2 - all
                 self._sock.close()
             except Exception as error:
-                self.error(error)
+                if not (hasattr(error, 'errno') and error.errno == errno.ENOTCONN):
+                    self.error(error)
             self._sock = None
 
     def _send(self, request=None):

--- a/collectors/python.d.plugin/unbound/unbound.chart.py
+++ b/collectors/python.d.plugin/unbound/unbound.chart.py
@@ -5,7 +5,6 @@
 
 import os
 import sys
-import errno
 
 from copy import deepcopy
 
@@ -264,18 +263,6 @@ class Service(SocketService):
                 self.perthread = False
             self.request = tmp
         return result
-
-    def _disconnect(self):
-        # Custom _disconnect method to work around the issue reported in #6434
-        if self._sock is not None:
-            try:
-                self.debug('closing socket')
-                self._sock.shutdown(2)  # 0 - read, 1 - write, 2 - all
-                self._sock.close()
-            except Exception as error:
-                if not (hasattr(error, 'errno') and error.errno == errno.ENOTCONN):
-                    self.error(error)
-            self._sock = None
 
     @staticmethod
     def _check_raw_data(data):

--- a/collectors/python.d.plugin/unbound/unbound.chart.py
+++ b/collectors/python.d.plugin/unbound/unbound.chart.py
@@ -255,7 +255,7 @@ class Service(SocketService):
             raw = self._get_raw_data()
             if raw is None:
                 result = False
-                self.warning('Recieved no data from socket.')
+                self.warning('Received no data from socket.')
             else:
                 for line in raw.splitlines():
                     if line.startswith('threads'):
@@ -278,10 +278,13 @@ class Service(SocketService):
         raw = self._get_raw_data()
         data = dict()
         tmp = dict()
-        for line in raw.splitlines():
-            stat = line.split('=')
-            tmp[stat[0]] = stat[1]
-        for item in self.statmap:
-            if item in tmp:
-                data[self.statmap[item][0]] = float(tmp[item]) * self.statmap[item][1]
+        if raw is not None:
+            for line in raw.splitlines():
+                stat = line.split('=')
+                tmp[stat[0]] = stat[1]
+            for item in self.statmap:
+                if item in tmp:
+                    data[self.statmap[item][0]] = float(tmp[item]) * self.statmap[item][1]
+        else:
+            self.warning('Received no data from socket.')
         return data

--- a/collectors/python.d.plugin/unbound/unbound.chart.py
+++ b/collectors/python.d.plugin/unbound/unbound.chart.py
@@ -253,15 +253,19 @@ class Service(SocketService):
             else:
                 self.request = b'UBCT1 status\n'
             raw = self._get_raw_data()
-            for line in raw.splitlines():
-                if line.startswith('threads'):
-                    self.threads = int(line.split()[1])
-                    self._generate_perthread_charts()
-                    break
-            if self.threads is None:
-                self.info('Unable to auto-detect thread counts, disabling per-thread stats.')
-                self.perthread = False
-            self.request = tmp
+            if raw is None:
+                result = False
+                self.warning('Recieved no data from socket.')
+            else:
+                for line in raw.splitlines():
+                    if line.startswith('threads'):
+                        self.threads = int(line.split()[1])
+                        self._generate_perthread_charts()
+                        break
+                if self.threads is None:
+                    self.info('Unable to auto-detect thread counts, disabling per-thread stats.')
+                    self.perthread = False
+                self.request = tmp
         return result
 
     @staticmethod

--- a/collectors/python.d.plugin/unbound/unbound.chart.py
+++ b/collectors/python.d.plugin/unbound/unbound.chart.py
@@ -273,11 +273,8 @@ class Service(SocketService):
                 self._sock.shutdown(2)  # 0 - read, 1 - write, 2 - all
                 self._sock.close()
             except Exception as error:
-                if ('errno' in error) and (error.errno == errno.ENOTCONN):
-                    pass
-                else:
+                if not ('errno' in error and error.errno == errno.ENOTCONN):
                     self.error(error)
-                self.error(error)
             self._sock = None
 
     @staticmethod

--- a/collectors/python.d.plugin/unbound/unbound.chart.py
+++ b/collectors/python.d.plugin/unbound/unbound.chart.py
@@ -273,7 +273,7 @@ class Service(SocketService):
                 self._sock.shutdown(2)  # 0 - read, 1 - write, 2 - all
                 self._sock.close()
             except Exception as error:
-                if not ('errno' in error and error.errno == errno.ENOTCONN):
+                if not (hasattr(error, 'errno') and error.errno == errno.ENOTCONN):
                     self.error(error)
             self._sock = None
 


### PR DESCRIPTION
#### Summary
This adds an explicit check for the case of a socket that's already
disconnected and skips logging an error message.  The conditionn
technically is an error, but it's one that we can recover from trivially
by just doing nothing in this case (we were trying to disconnect the
scoket anyway, so if it's already disconnected, we don't need to change
anything).

This uses Python's `errno` module so that we can detect this situation
in a system-agnostic manner.

##### Component Name
collectors/python.d

##### Additional Information

Fixes #6434

-----

@ilyam8 I'm of the opinion that this check should probably just go into the `SocketService` base class instead of being an as-needed thing in specific modules.  I honestly can't think of any case where a socket being disconnected as reported in #6434 would be an actual error in the disconnect method (it just means the socket is already in the state we want it to be in).

@Duffyx Could you check and see if this change stops the error logs getting flooded with the message you were seeing?  As mentioned in the issue itself, I wasn't able to reproduce this locally, so I'm going to need some help to make sure it works.