### PR TITLE
Fix crash in malloc

### DIFF
--- a/tests/urls/request.sh.in
+++ b/tests/urls/request.sh.in
@@ -212,7 +212,7 @@ netdata_create_directory $OUTEDIR
 netdata_create_directory $OUTOPTDIR
 netdata_create_directory $ERRDIR
 
-wget --execute="robots = off" --mirror --convert-links --no-parent http://127.0.0.1:19999
+wget --no-check-certificate --execute="robots = off" --mirror --convert-links --no-parent $MURL
 TEST=$?
 if [ $TEST -ne "0" ] ; then
     echo "Cannot connect to Netdata"
@@ -232,9 +232,9 @@ netdata_download_various_with_options $MURL "api/v1/info" "info"
 netdata_download_various $MURL "api/v1/info?this%20could%20not%20be%20here" "err_info"
 
 netdata_print_header "Getting all the netdata charts"
-CHARTS=$( netdata_download_charts "http://127.0.0.1:19999" "api/v1/charts" )
-WCHARTS=$( netdata_download_charts "http://127.0.0.1:19999" "api/v1/charts?this%20could%20not%20be%20here" )
-WCHARTS2=$( netdata_download_charts "http://127.0.0.1:19999" "api/v1/charts%3fthis%20could%20not%20be%20here" )
+CHARTS=$( netdata_download_charts "$MURL9" "api/v1/charts" )
+WCHARTS=$( netdata_download_charts "$MURL9" "api/v1/charts?this%20could%20not%20be%20here" )
+WCHARTS2=$( netdata_download_charts "$MURL9" "api/v1/charts%3fthis%20could%20not%20be%20here" )
 
 if [ ${#CHARTS[@]} -ne ${#WCHARTS[@]} ]; then
     echo "The number of charts does not match with division not encoded.";
@@ -294,8 +294,6 @@ for I in $CHARTS ; do
     netdata_download_chart $MURL "api/v1/data?chart" "$I" "data"
     break;
 done
-
-#http://arch-esxi:19999/api/v1/(*@&$!$%%5E)!$*%&)!$*%%5E*!%5E%!%5E$%!%5E%(!*%5E*%5E%(*@&$%5E%(!%5E#*&!^#$*&!^%)@($%^)!*&^(!*&^#$&#$)!$%^)!$*%&)#$!^#*$^!(*#^#)!%^!)$*%&!(*&$!^#$*&^!*#^$!*^)%(!*&$%)(!&#$!^*#&$^!*^%)!$%)!(&#$!^#*&^$
 
 WHITE='\033[0;37m'
 echo -e "${WHITE}ALL the URLS got 200 as answer!"

--- a/tests/urls/request.sh.in
+++ b/tests/urls/request.sh.in
@@ -232,9 +232,9 @@ netdata_download_various_with_options $MURL "api/v1/info" "info"
 netdata_download_various $MURL "api/v1/info?this%20could%20not%20be%20here" "err_info"
 
 netdata_print_header "Getting all the netdata charts"
-CHARTS=$( netdata_download_charts "$MURL9" "api/v1/charts" )
-WCHARTS=$( netdata_download_charts "$MURL9" "api/v1/charts?this%20could%20not%20be%20here" )
-WCHARTS2=$( netdata_download_charts "$MURL9" "api/v1/charts%3fthis%20could%20not%20be%20here" )
+CHARTS=$( netdata_download_charts "$MURL" "api/v1/charts" )
+WCHARTS=$( netdata_download_charts "$MURL" "api/v1/charts?this%20could%20not%20be%20here" )
+WCHARTS2=$( netdata_download_charts "$MURL" "api/v1/charts%3fthis%20could%20not%20be%20here" )
 
 if [ ${#CHARTS[@]} -ne ${#WCHARTS[@]} ]; then
     echo "The number of charts does not match with division not encoded.";

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1041,7 +1041,7 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 } else {
                     web_client_split_path_query(w, encoded_url);
 
-                    if (w->separator) {
+                    if (w->separator && w->url_search_path) {
                         *w->url_search_path = 0x00;
                     }
 
@@ -1064,7 +1064,7 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 // copy the URL - we are going to overwrite parts of it
                 // TODO -- ideally we we should avoid copying buffers around
                 strncpyz(w->last_url, w->decoded_url, NETDATA_WEB_REQUEST_URL_SIZE);
-                if (w->separator) {
+                if (w->separator && w->url_search_path) {
                     *w->url_search_path = 0x00;
                 }
 #ifdef ENABLE_HTTPS

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -929,7 +929,6 @@ void web_client_split_path_query(struct web_client *w, char *s) {
 
     w->separator = 0x00;
     w->url_path_length = strlen(s);
-    w->url_search_path = NULL;
 }
 
 /**
@@ -1035,6 +1034,8 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 // a valid complete HTTP request found
 
                 *ue = '\0';
+                //This is to avoid crash in line
+                w->url_search_path = NULL;
                 if(w->mode != WEB_CLIENT_MODE_NORMAL) {
                     if(!url_decode_r(w->decoded_url, encoded_url, NETDATA_WEB_REQUEST_URL_SIZE + 1))
                         return HTTP_VALIDATION_MALFORMED_URL;

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1042,14 +1042,14 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 } else {
                     web_client_split_path_query(w, encoded_url);
 
-                    if (w->separator && w->url_search_path) {
+                    if (w->url_search_path && w->separator) {
                         *w->url_search_path = 0x00;
                     }
 
                     if(!url_decode_r(w->decoded_url, encoded_url, NETDATA_WEB_REQUEST_URL_SIZE + 1))
                         return HTTP_VALIDATION_MALFORMED_URL;
 
-                    if (w->separator) {
+                    if (w->url_search_path && w->separator) {
                         *w->url_search_path = w->separator;
 
                         char *from = (encoded_url + w->url_path_length);
@@ -1065,7 +1065,7 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 // copy the URL - we are going to overwrite parts of it
                 // TODO -- ideally we we should avoid copying buffers around
                 strncpyz(w->last_url, w->decoded_url, NETDATA_WEB_REQUEST_URL_SIZE);
-                if (w->separator && w->url_search_path) {
+                if (w->url_search_path && w->separator) {
                     *w->url_search_path = 0x00;
                 }
 #ifdef ENABLE_HTTPS


### PR DESCRIPTION
##### Summary
The netdata has a random error to allocate memory in some requests according with outputs  we were receiving from our demo server.

After to check the valgrind output, it was possible to verify that the malloc error could happen steps before due a set of values in an address NULL. This pull request fixes this checking the existence of a valid address before to set the value.
##### Component Name
web/ url parser
##### Additional Information
It fixes #6582 
