### PR TITLE
Fix configure.ac allowing deprecated LZ4 library call

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -283,7 +283,7 @@ OPTIONAL_UV_LIBS="${UV_LIBS}"
 
 AC_CHECK_LIB(
     [lz4],
-    [LZ4_decompress_safe],
+    [LZ4_compress_default],
     [LZ4_LIBS="-llz4"]
 )
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->
Fix configure.ac allowing deprecated LZ4 library call.  Fixes #6580

Previously it was possible for older versions of LZ4 libraries to succesfully pass the ./configure phase of the build process even though they shouldn't.

By requiring the most recent API call of LZ4 that is being used by netdata, which is LZ4_compress_default(), we eliminate the risk of a false positive LZ4 flag in the ./configure phase of the build.

As a result, any system with a deprecated LZ4 library will build netdata without LZ4 support (and subsequently without dbengine support).