### PR TITLE
HTTP response message

### DIFF
--- a/web/api/exporters/allmetrics.c
+++ b/web/api/exporters/allmetrics.c
@@ -75,12 +75,12 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
         case ALLMETRICS_JSON:
             w->response.data->contenttype = CT_APPLICATION_JSON;
             rrd_stats_api_v1_charts_allmetrics_json(host, w->response.data);
-            return 200;
+            return HTTP_RESP_OK;
 
         case ALLMETRICS_SHELL:
             w->response.data->contenttype = CT_TEXT_PLAIN;
             rrd_stats_api_v1_charts_allmetrics_shell(host, w->response.data);
-            return 200;
+            return HTTP_RESP_OK;
 
         case ALLMETRICS_PROMETHEUS:
             w->response.data->contenttype = CT_PROMETHEUS;
@@ -92,7 +92,7 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
                     , prometheus_backend_options
                     , prometheus_output_options
             );
-            return 200;
+            return HTTP_RESP_OK;
 
         case ALLMETRICS_PROMETHEUS_ALL_HOSTS:
             w->response.data->contenttype = CT_PROMETHEUS;
@@ -104,11 +104,11 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
                     , prometheus_backend_options
                     , prometheus_output_options
             );
-            return 200;
+            return HTTP_RESP_OK;
 
         default:
             w->response.data->contenttype = CT_TEXT_PLAIN;
             buffer_strcat(w->response.data, "Which format? '" ALLMETRICS_FORMAT_SHELL "', '" ALLMETRICS_FORMAT_PROMETHEUS "', '" ALLMETRICS_FORMAT_PROMETHEUS_ALL_HOSTS "' and '" ALLMETRICS_FORMAT_JSON "' are currently supported.");
-            return 400;
+            return HTTP_RESP_BAD_REQUEST;
     }
 }

--- a/web/api/exporters/allmetrics.h
+++ b/web/api/exporters/allmetrics.h
@@ -5,6 +5,7 @@
 
 #include "web/api/formatters/rrd2json.h"
 #include "shell/allmetrics_shell.h"
+#include "web/server/web_client.h"
 
 extern int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client *w, char *url);
 

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -72,7 +72,7 @@ int rrdset2value_api_v1(
     RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions);
     if(!r) {
         if(value_is_null) *value_is_null = 1;
-        return 500;
+        return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
 
     if(rrdr_rows(r) == 0) {
@@ -82,7 +82,7 @@ int rrdset2value_api_v1(
         if(db_before) *db_before = 0;
         if(value_is_null) *value_is_null = 1;
 
-        return 400;
+        return HTTP_RESP_BAD_REQUEST;
     }
 
     if(wb) {
@@ -99,7 +99,7 @@ int rrdset2value_api_v1(
     *n = rrdr2value(r, i, options, value_is_null);
 
     rrdr_free(r);
-    return 200;
+    return HTTP_RESP_OK;
 }
 
 int rrdset2anything_api_v1(
@@ -120,7 +120,7 @@ int rrdset2anything_api_v1(
     RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions?buffer_tostring(dimensions):NULL);
     if(!r) {
         buffer_strcat(wb, "Cannot generate output with these parameters on this chart.");
-        return 500;
+        return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
 
     if(r->result_options & RRDR_RESULT_OPTION_RELATIVE)
@@ -294,5 +294,5 @@ int rrdset2anything_api_v1(
     }
 
     rrdr_free(r);
-    return 200;
+    return HTTP_RESP_OK;
 }

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -16,6 +16,8 @@
 #include "web/api/formatters/charts2json.h"
 #include "web/api/formatters/json_wrapper.h"
 
+#include "web/server/web_client.h"
+
 #define HOSTNAME_MAX 1024
 
 #define API_RELATIVE_TIME_MAX (3 * 365 * 86400)

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -209,7 +209,7 @@ inline int web_client_api_request_v1_alarms(RRDHOST *host, struct web_client *w,
     w->response.data->contenttype = CT_APPLICATION_JSON;
     health_alarms2json(host, w->response.data, all);
     buffer_no_cacheable(w->response.data);
-    return 200;
+    return HTTP_RESP_OK;
 }
 
 inline int web_client_api_request_v1_alarm_log(RRDHOST *host, struct web_client *w, char *url) {
@@ -229,11 +229,11 @@ inline int web_client_api_request_v1_alarm_log(RRDHOST *host, struct web_client 
     buffer_flush(w->response.data);
     w->response.data->contenttype = CT_APPLICATION_JSON;
     health_alarm_log2json(host, w->response.data, after);
-    return 200;
+    return HTTP_RESP_OK;
 }
 
 inline int web_client_api_request_single_chart(RRDHOST *host, struct web_client *w, char *url, void callback(RRDSET *st, BUFFER *buf)) {
-    int ret = 400;
+    int ret = HTTP_RESP_BAD_REQUEST;
     char *chart = NULL;
 
     buffer_flush(w->response.data);
@@ -266,14 +266,14 @@ inline int web_client_api_request_single_chart(RRDHOST *host, struct web_client 
     if(!st) {
         buffer_strcat(w->response.data, "Chart is not found: ");
         buffer_strcat_htmlescape(w->response.data, chart);
-        ret = 404;
+        ret = HTTP_RESP_NOT_FOUND;
         goto cleanup;
     }
 
     w->response.data->contenttype = CT_APPLICATION_JSON;
     st->last_accessed_time = now_realtime_sec();
     callback(st, w->response.data);
-    return 200;
+    return HTTP_RESP_OK;
 
     cleanup:
     return ret;
@@ -289,7 +289,7 @@ inline int web_client_api_request_v1_charts(RRDHOST *host, struct web_client *w,
     buffer_flush(w->response.data);
     w->response.data->contenttype = CT_APPLICATION_JSON;
     charts2json(host, w->response.data);
-    return 200;
+    return HTTP_RESP_OK;
 }
 
 inline int web_client_api_request_v1_chart(RRDHOST *host, struct web_client *w, char *url) {
@@ -309,7 +309,7 @@ void fix_google_param(char *s) {
 inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, char *url) {
     debug(D_WEB_CLIENT, "%llu: API v1 data with URL '%s'", w->id, url);
 
-    int ret = 400;
+    int ret = HTTP_RESP_BAD_REQUEST;
     BUFFER *dimensions = NULL;
 
     buffer_flush(w->response.data);
@@ -422,7 +422,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     if(!st) {
         buffer_strcat(w->response.data, "Chart is not found: ");
         buffer_strcat_htmlescape(w->response.data, chart);
-        ret = 404;
+        ret = HTTP_RESP_NOT_FOUND;
         goto cleanup;
     }
     st->last_accessed_time = now_realtime_sec();
@@ -609,7 +609,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
     if(unlikely(respect_web_browser_do_not_track_policy && web_client_has_donottrack(w))) {
         buffer_flush(w->response.data);
         buffer_sprintf(w->response.data, "Your web browser is sending 'DNT: 1' (Do Not Track). The registry requires persistent cookies on your browser to work.");
-        return 400;
+        return HTTP_RESP_BAD_REQUEST;
     }
 
     if(unlikely(action == 'H')) {
@@ -629,7 +629,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
                 error("Invalid registry request - access requires these parameters: machine ('%s'), url ('%s'), name ('%s')", machine_guid ? machine_guid : "UNSET", machine_url ? machine_url : "UNSET", url_name ? url_name : "UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Access request.");
-                return 400;
+                return HTTP_RESP_BAD_REQUEST;
             }
 
             web_client_enable_tracking_required(w);
@@ -640,7 +640,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
                 error("Invalid registry request - delete requires these parameters: machine ('%s'), url ('%s'), delete_url ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", delete_url?delete_url:"UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Delete request.");
-                return 400;
+                return HTTP_RESP_BAD_REQUEST;
             }
 
             web_client_enable_tracking_required(w);
@@ -651,7 +651,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
                 error("Invalid registry request - search requires these parameters: machine ('%s'), url ('%s'), for ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", search_machine_guid?search_machine_guid:"UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Search request.");
-                return 400;
+                return HTTP_RESP_BAD_REQUEST;
             }
 
             web_client_enable_tracking_required(w);
@@ -662,7 +662,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
                 error("Invalid registry request - switching identity requires these parameters: machine ('%s'), url ('%s'), to ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", to_person_guid?to_person_guid:"UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Switch request.");
-                return 400;
+                return HTTP_RESP_BAD_REQUEST;
             }
 
             web_client_enable_tracking_required(w);
@@ -674,7 +674,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
         default:
             buffer_flush(w->response.data);
             buffer_strcat(w->response.data, "Invalid registry request - you need to set an action: hello, access, delete, search");
-            return 400;
+            return HTTP_RESP_BAD_REQUEST;
     }
 }
 
@@ -718,7 +718,7 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 
 inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, char *url) {
     (void)url;
-    if (!netdata_ready) return 503;
+    if (!netdata_ready) return HTTP_RESP_BACKEND_FETCH_FAILED;
 
     BUFFER *wb = w->response.data;
     buffer_flush(wb);
@@ -756,7 +756,7 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
 
     buffer_strcat(wb, "}");
     buffer_no_cacheable(wb);
-    return 200;
+    return HTTP_RESP_OK;
 }
 
 static struct api_command {
@@ -814,11 +814,11 @@ inline int web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *
         buffer_flush(w->response.data);
         buffer_strcat(w->response.data, "Unsupported v1 API command: ");
         buffer_strcat_htmlescape(w->response.data, url);
-        return 404;
+        return HTTP_RESP_NOT_FOUND;
     }
     else {
         buffer_flush(w->response.data);
         buffer_sprintf(w->response.data, "Which API v1 command?");
-        return 400;
+        return HTTP_RESP_BAD_REQUEST;
     }
 }

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -25,6 +25,8 @@ extern int web_enable_gzip,
 #define HTTP_RESP_NOT_FOUND     404
 #define HTTP_RESP_PRECOND_FAIL  412
 
+// HTTP_CODES 5XX Server Errors
+#define HTTP_RESP_INTERNAL_SERVER_ERROR 500
 
 extern int respect_web_browser_do_not_track_policy;
 extern char *web_x_frame_options;

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -27,6 +27,7 @@ extern int web_enable_gzip,
 
 // HTTP_CODES 5XX Server Errors
 #define HTTP_RESP_INTERNAL_SERVER_ERROR 500
+#define HTTP_RESP_BACKEND_FETCH_FAILED 503
 
 extern int respect_web_browser_do_not_track_policy;
 extern char *web_x_frame_options;


### PR DESCRIPTION
##### Summary
When we merged an PR in the last sprint, Netdata has a new pattern for the file web_client.c, every time it returned an HTTP error, it did not have explicit the error number, the codes was changed for the error name, but this was not carry for all the Netdata web files. This PR fixes this creating again one unique pattern to give the error.
##### Component Name
Web
##### Additional Information
Fixes #6559
