### PR TITLE
netdata/installer: do not enable netdata, if it was previously disabled

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -380,10 +380,17 @@ install_netdata_service() {
 			fi
 
 			if [ "${SYSTEMD_DIRECTORY}x" != "x" ]; then
+				ENABLE_NETDATA_IF_PREVIOUSLY_ENABLED="run systemctl enable netdata"
+				IS_NETDATA_ENABLED=`systemctl is-enabled netdata 2> /dev/null || echo "Netdata not there"`
+				if [ "${IS_NETDATA_ENABLED}" == "disabled" ]; then
+					echo >&2 "Netdata was there and disabled, make sure we don't re-enable it ourselves"
+					ENABLE_NETDATA_IF_PREVIOUSLY_ENABLED="echo"
+				fi
+
 				echo >&2 "Installing systemd service..."
 				run cp system/netdata.service "${SYSTEMD_DIRECTORY}/netdata.service" &&
 					run systemctl daemon-reload &&
-					run systemctl enable netdata &&
+					${ENABLE_NETDATA_IF_PREVIOUSLY_ENABLED} &&
 					return 0
 			else
 				echo >&2 "no systemd directory; cannot install netdata.service"

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -381,7 +381,7 @@ install_netdata_service() {
 
 			if [ "${SYSTEMD_DIRECTORY}x" != "x" ]; then
 				ENABLE_NETDATA_IF_PREVIOUSLY_ENABLED="run systemctl enable netdata"
-				IS_NETDATA_ENABLED=`systemctl is-enabled netdata 2> /dev/null || echo "Netdata not there"`
+				IS_NETDATA_ENABLED="$(systemctl is-enabled netdata 2> /dev/null || echo "Netdata not there")"
 				if [ "${IS_NETDATA_ENABLED}" == "disabled" ]; then
 					echo >&2 "Netdata was there and disabled, make sure we don't re-enable it ourselves"
 					ENABLE_NETDATA_IF_PREVIOUSLY_ENABLED="true"

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -384,7 +384,7 @@ install_netdata_service() {
 				IS_NETDATA_ENABLED=`systemctl is-enabled netdata 2> /dev/null || echo "Netdata not there"`
 				if [ "${IS_NETDATA_ENABLED}" == "disabled" ]; then
 					echo >&2 "Netdata was there and disabled, make sure we don't re-enable it ourselves"
-					ENABLE_NETDATA_IF_PREVIOUSLY_ENABLED="echo"
+					ENABLE_NETDATA_IF_PREVIOUSLY_ENABLED="true"
 				fi
 
 				echo >&2 "Installing systemd service..."


### PR DESCRIPTION
##### Summary
Fixes #6601 
Basically we do not want to enable netdata, if it was previously disabled

##### Component Name
netdata/installer

##### Additional Information
None
