### PR TITLE
BuildRequires protobuf-devel >= 3

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -193,7 +193,7 @@ Requires: cups
 
 # Prometheus remote write dependencies
 BuildRequires: snappy-devel
-BuildRequires: protobuf-devel
+BuildRequires: protobuf-devel >= 3
 %if 0%{?suse_version}
 BuildRequires: libprotobuf-c-devel
 %else
@@ -207,7 +207,7 @@ Requires: libprotobuf15
 %else
 Requires: snappy
 Requires: protobuf-c
-Requires: protobuf
+Requires: protobuf >= 3
 %endif
 # end - prometheus remote write dependencies
 


### PR DESCRIPTION
The version of protobuf-devel that is required at build time must be >=3
because version 2 can't handle the proto files created for version 3.

##### Summary
The spec file doesn't build with protobuf-devel 2. Enforcing version >= 3 as a BuildRequires will make it more obvious.

##### Component Name

##### Additional Information

