### PR TITLE
Better system OS detection for RHEL6 and Mac OS X

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -22,8 +22,8 @@ if [ "${KERNEL_NAME}" = "Darwin" ]; then
 	OIFS="$IFS"
 	IFS=$'\n'
 	set $(sw_vers) > /dev/null
-	NAME=$(echo $1 | tr "\n" ' ' | sed 's/ProductName:[ ]*//')
-	VERSION=$(echo $2 | tr "\n" ' ' | sed 's/ProductVersion:[ ]*//')
+	NAME=$(echo $1 | tr "\n\t" '  ' | sed -e 's/ProductName:[ ]*//' -e 's/[ ]*$//')
+	VERSION=$(echo $2 | tr "\n\t" '  ' | sed -e 's/ProductVersion:[ ]*//' -e 's/[ ]*$//')
 	ID="mac"
 	ID_LIKE="mac"
 	OS_DETECTION="sw_vers"

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -44,7 +44,8 @@ else
 			if [ "${NAME}" = "unknown" ]; then NAME="${DISTRIB_ID}"; fi
 			if [ "${VERSION}" = "unknown" ]; then VERSION="${DISTRIB_RELEASE}"; fi
 			if [ "${ID}" = "unknown" ]; then ID="${DISTRIB_CODENAME}"; fi
-		elif [ -n "$(command -v lsb_release 2>/dev/null)" ]; then
+		fi
+		if [ -n "$(command -v lsb_release 2>/dev/null)" ]; then
 			if [ "${OS_DETECTION}" = "unknown" ]; then OS_DETECTION="lsb_release"; else OS_DETECTION="Mixed"; fi
 			if [ "${NAME}" = "unknown" ]; then NAME="$(lsb_release -is 2>/dev/null)"; fi
 			if [ "${VERSION}" = "unknown" ]; then VERSION="$(lsb_release -rs 2>/dev/null)"; fi


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Better system OS detection for RHEL6 and Mac OS X

Fixes: #6608

##### Component Name

system-info.sh

##### Additional Information

RHEL6 has `/etc/lsb-release` file that contains something like:

```
LSB_VERSION=base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch
```

so only output from `lsb_release` command contains something useful:

For Mac OS X i made some trimming for strings so they don't contain additional white chars anymore.

