### PR TITLE
Add alarm variables to the response of chart and data (#6054)

### DIFF
--- a/database/rrdvar.c
+++ b/database/rrdvar.c
@@ -260,9 +260,9 @@ static int single_custom_variable2json(void *entry, void *data) {
             buffer_sprintf(helper->buf, "%s\n\t\t\t\t\"%s\": null", helper->counter?",":"", rv->name);
         else
             buffer_sprintf(helper->buf, "%s\n\t\t\t\t\"%s\": %0.5" LONG_DOUBLE_MODIFIER, helper->counter?",":"", rv->name, (LONG_DOUBLE)value);
-    }
 
-    helper->counter++;
+        helper->counter++;
+    }
 
     return 0;
 }

--- a/health/health.h
+++ b/health/health.h
@@ -62,6 +62,7 @@ extern void health_alarms2json(RRDHOST *host, BUFFER *wb, int all);
 extern void health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after);
 
 void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *buf);
+void health_api_v1_chart_custom_variables2json(RRDSET *st, BUFFER *buf);
 
 extern int health_alarm_log_open(RRDHOST *host);
 extern void health_alarm_log_close(RRDHOST *host);

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -182,9 +182,11 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
 
     rrdr_buffer_print_format(wb, format);
 
-    buffer_sprintf(wb, "%s,\n"
+    buffer_sprintf(wb, "%s,\n   %schart_variables%s: ", kq, kq, kq);
+    health_api_v1_chart_custom_variables2json(r->st, wb);
+
+    buffer_sprintf(wb, ",\n"
                        "   %sresult%s: "
-                   , sq
                    , kq, kq
     );
 

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -187,9 +187,9 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
         health_api_v1_chart_custom_variables2json(r->st, wb);
     }
 
-    buffer_sprintf(wb, ",\n"
+    buffer_sprintf(wb, "%s,\n"
                        "   %sresult%s: "
-                   , kq, kq
+                   , sq, kq, kq
     );
 
     if(string_value) buffer_strcat(wb, sq);

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -183,14 +183,13 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
     rrdr_buffer_print_format(wb, format);
 
     if((options & RRDR_OPTION_CUSTOM_VARS) && (options & RRDR_OPTION_JSON_WRAP)) {
-        buffer_sprintf(wb, "%s,\n   %schart_variables%s: ", kq, kq, kq);
+        buffer_sprintf(wb, "%s,\n   %schart_variables%s: ", sq, kq, kq);
         health_api_v1_chart_custom_variables2json(r->st, wb);
     }
+    else
+        buffer_sprintf(wb, "%s", sq);
 
-    buffer_sprintf(wb, "%s,\n"
-                       "   %sresult%s: "
-                   , sq, kq, kq
-    );
+    buffer_sprintf(wb, ",\n   %sresult%s: ", kq, kq);
 
     if(string_value) buffer_strcat(wb, sq);
     //info("JSONWRAPPER(): %s: END", r->st->id);

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -182,8 +182,10 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
 
     rrdr_buffer_print_format(wb, format);
 
-    buffer_sprintf(wb, "%s,\n   %schart_variables%s: ", kq, kq, kq);
-    health_api_v1_chart_custom_variables2json(r->st, wb);
+    if((options & RRDR_OPTION_CUSTOM_VARS) && (options & RRDR_OPTION_JSON_WRAP)) {
+        buffer_sprintf(wb, "%s,\n   %schart_variables%s: ", kq, kq, kq);
+        health_api_v1_chart_custom_variables2json(r->st, wb);
+    }
 
     buffer_sprintf(wb, ",\n"
                        "   %sresult%s: "

--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -105,9 +105,10 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
 
         alarms++;
     }
-    buffer_sprintf(wb, "\n\t\t\t}");
 
-    buffer_sprintf(wb, "\n\t\t}");
+    buffer_sprintf(wb,
+            "\n\t\t\t}\n\t\t}"
+    );
 
     rrdset_unlock(st);
 }

--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -73,7 +73,10 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
     if(dimensions_count) *dimensions_count += dimensions;
     if(memory_used) *memory_used += memory;
 
-    buffer_strcat(wb, "\n\t\t\t},\n\t\t\t\"green\": ");
+    buffer_sprintf(wb, "\n\t\t\t},\n\t\t\t\"chart_variables\": ");
+    health_api_v1_chart_custom_variables2json(st, wb);
+
+    buffer_strcat(wb, ",\n\t\t\t\"green\": ");
     buffer_rrd_value(wb, st->green);
     buffer_strcat(wb, ",\n\t\t\t\"red\": ");
     buffer_rrd_value(wb, st->red);
@@ -102,10 +105,9 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
 
         alarms++;
     }
+    buffer_sprintf(wb, "\n\t\t\t}");
 
-    buffer_sprintf(wb,
-            "\n\t\t\t}\n\t\t}"
-    );
+    buffer_sprintf(wb, "\n\t\t}");
 
     rrdset_unlock(st);
 }

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -243,7 +243,8 @@
                 "percentage",
                 "unaligned",
                 "match-ids",
-                "match-names"
+                "match-names",
+                "showcustomvars"
               ],
               "collectionFormat": "pipes"
             },

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -975,6 +975,14 @@
             }
           }
         },
+        "chart_variables": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "$ref": "#/definitions/chart_variables"
+            }
+          }
+        },
         "green": {
           "type": "number",
           "description": "Chart health green threshold"
@@ -1011,13 +1019,8 @@
         "chart_variables": {
           "type": "object",
           "properties": {
-            "varname1": {
-              "type": "number",
-              "format": "float"
-            },
-            "varname2": {
-              "type": "number",
-              "format": "float"
+            "key": {
+              "$ref": "#/definitions/chart_variables"
             }
           }
         },
@@ -1046,6 +1049,19 @@
               "format": "float"
             }
           }
+        }
+      }
+    },
+    "chart_variables": {
+      "type": "object",
+      "properties": {
+        "varname1": {
+          "type": "number",
+          "format": "float"
+        },
+        "varname2": {
+          "type": "number",
+          "format": "float"
         }
       }
     },
@@ -1144,6 +1160,14 @@
         "format": {
           "type": "string",
           "description": "The format of the result returned."
+        },
+        "chart_variables": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "$ref": "#/definitions/chart_variables"
+            }
+          }
         },
         "result": {
           "description": "The result requested, in the format requested."

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -654,6 +654,11 @@ definitions:
         properties:
           key:
             $ref: '#/definitions/dimension'
+      chart_variables:
+        type: object
+        properties:
+          key:
+            $ref: '#/definitions/chart_variables'
       green:
         type: number
         description: 'Chart health green threshold'
@@ -681,12 +686,8 @@ definitions:
       chart_variables:
         type: object
         properties:
-          varname1:
-            type: number
-            format: float
-          varname2:
-            type: number
-            format: float
+          key:
+            $ref: '#/definitions/chart_variables'
       family_variables:
         type: object
         properties:
@@ -705,6 +706,15 @@ definitions:
           varname2:
             type: number
             format: float
+  chart_variables:
+    type: object
+    properties:
+      varname1:
+        type: number
+        format: float
+      varname2:
+        type: number
+        format: float
   dimension:
     type: object
     properties:
@@ -776,6 +786,11 @@ definitions:
       format:
         type: string
         description: 'The format of the result returned.'
+      chart_variables:
+        type: object
+        properties:
+          key:
+            $ref: '#/definitions/chart_variables'
       result:
         description: 'The result requested, in the format requested.'
   alarms:

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -163,7 +163,7 @@ paths:
           type: array
           items:
             type: string
-            enum: [ 'nonzero', 'flip', 'jsonwrap', 'min2max', 'seconds', 'milliseconds', 'abs', 'absolute', 'absolute-sum', 'null2zero', 'objectrows', 'google_json', 'percentage', 'unaligned', 'match-ids', 'match-names' ]
+            enum: [ 'nonzero', 'flip', 'jsonwrap', 'min2max', 'seconds', 'milliseconds', 'abs', 'absolute', 'absolute-sum', 'null2zero', 'objectrows', 'google_json', 'percentage', 'unaligned', 'match-ids', 'match-names', 'showcustomvars' ]
             collectionFormat: pipes
           default: [seconds, jsonwrap]
           allowEmptyValue: false

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -22,6 +22,7 @@ typedef enum rrdr_options {
     RRDR_OPTION_DISPLAY_ABS  = 0x00002000, // for badges, display the absolute value, but calculate colors with sign
     RRDR_OPTION_MATCH_IDS    = 0x00004000, // when filtering dimensions, match only IDs
     RRDR_OPTION_MATCH_NAMES  = 0x00008000, // when filtering dimensions, match only names
+    RRDR_OPTION_CUSTOM_VARS  = 0x00010000, // when wraping response in a JSON, return custom variables in response
 } RRDR_OPTIONS;
 
 typedef enum rrdr_value_flag {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -32,6 +32,7 @@ static struct {
         , {"match-ids"       , 0    , RRDR_OPTION_MATCH_IDS}
         , {"match_names"     , 0    , RRDR_OPTION_MATCH_NAMES}
         , {"match-names"     , 0    , RRDR_OPTION_MATCH_NAMES}
+        , {"showcustomvars"  , 0    , RRDR_OPTION_CUSTOM_VARS}
         , {                  NULL, 0, 0}
 };
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Implements feature #6054 

Now requests like 

http://localhost:19999/api/v1/chart?chart=example.random
http://localhost:19999/api/v1/data?chart=example.random&options=jsonwrap&options=showcustomvars

- return chart variables in their responses. Chart variables include only those with options set to RRDVAR_OPTION_CUSTOM_CHART_VAR
- for /api/v1/data requests chart variables are returned when parameter options=jsonwrap and options=showcustomvars

##### Component Name
[/database](https://github.com/netdata/netdata/tree/master/database/)
[/web/api/formatters](https://github.com/netdata/netdata/tree/master/web/api/formatters)

##### Additional Information
To test functionality the collectors/python.d.plugin/example chart has been configured to have the following variables:

```python
CHARTS = {
    'random': {
        'options': [None, 'A random number', 'random number', 'random', 'random', 'line'],
        'lines': [
            ['random1']
        ],
        'variables': [
            ['var_1', 999],
            ['var_2', 999],
            ['var_3', 999],
            ['var_4', 'abc']
        ]
    }
}
```
After that responses for requests 
```bash
curl http://localhost:19999/api/v1/data?chart=example.random&options=jsonwrap&options=showcustomvars
curl http://localhost:19999/api/v1/chart?chart=example.random
```
compared with response from request 

```bash
curl http://localhost:19999/api/v1/alarm_variables?chart=example.random
```

Expected: /api/v1/chart and /api/v1/data requests should contain same custom chart variables with same values as in /api/v1/alarm_variables
