### PR TITLE
mysql: do not remove `slave_status` from queries in module

### DIFF
--- a/collectors/python.d.plugin/mysql/mysql.chart.py
+++ b/collectors/python.d.plugin/mysql/mysql.chart.py
@@ -695,9 +695,8 @@ class Service(MySQLService):
 
         if 'slave_status' in raw_data:
             status = self.get_slave_status(raw_data['slave_status'])
-            data.update(status)
-        else:
-            self.queries.pop('slave_status')
+            if status:
+                data.update(status)
 
         if 'user_statistics' in raw_data:
             if raw_data['user_statistics'][0]:


### PR DESCRIPTION
##### Summary

Fixes: #6616

bug was added in #6597

MySQLService removes query itself in  case of error

https://github.com/netdata/netdata/blob/66d6498ed4fa433fdd397da5ef1470312e539bd6/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py#L144-L151

##### Component Name

[/collectors/python.d.plugin/mysql](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/mysql)

##### Additional Information

