### PR TITLE
.travis.yml: Remove 'sudo: true' as it is now deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: true
 language: c
 services:
   - docker


### PR DESCRIPTION
##### Summary
Remove 'sudo: true' from .travis.yml because it has been deprecated

##### Component Name
.travis.yml

##### Additional Information
According to the following blog post, the 'sudo: true/false' setting in .travis.yml has been deprecated:
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Some more information can be found here as well:
https://changelog.travis-ci.com/linux-builds-run-on-vms-by-default-77106

Also a test build with all stages and jobs can be found here:
https://travis-ci.org/knatsakis/netdata/builds/569643721 (There are some failures, but they are not related to the sudo change as far as I can tell).