### PR TITLE
fix spigotmc plugin bugs

### DIFF
--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -52,7 +52,7 @@ _TPS_REGEX = re.compile(
     re.X
 )
 _LIST_REGEX = re.compile(
-    r'(\d+)',  # Current user count.
+    r'[^§](\d+)(?:.*?(?=/).*?[^§](\d+))?',  # Current user count.
     re.X
 )
 
@@ -140,7 +140,13 @@ class Service(SimpleService):
                 raw = self.console.command(COMMAND_ONLINE)
                 match = _LIST_REGEX.search(raw)
             if match:
-                data['users'] = int(match.group(1))
+                users = int(match.group(1))
+                hidden_users = match.group(2)
+                if hidden_users:
+                    hidden_users = int(hidden_users)
+                else:
+                    hidden_users = 0
+                data['users'] = users + hidden_users
             else:
                 if not raw:
                     self.error("'{0}' and '{1}' commands returned no value, make sure you set correct password".format(

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -85,6 +85,7 @@ class Service(SimpleService):
         self.console.connect(self.host, self.port, self.password)
 
     def reconnect(self):
+        self.error('try reconnect.')
         try:
             try:
                 self.console.disconnect()
@@ -99,7 +100,7 @@ class Service(SimpleService):
         return True
 
     def is_alive(self):
-        if not any(
+        if any(
             [
                 not self.alive,
                 self.console.socket.getsockopt(socket.IPPROTO_TCP, socket.TCP_INFO, 0) != 1

--- a/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
+++ b/collectors/python.d.plugin/spigotmc/spigotmc.chart.py
@@ -52,6 +52,12 @@ _TPS_REGEX = re.compile(
     re.X
 )
 _LIST_REGEX = re.compile(
+    # Examples:
+    # There are 4 of a max 50 players online: player1, player2, player3, player4
+    # §6There are §c4§6 out of maximum §c50§6 players online.
+    # §6There are §c3§6/§c1§6 out of maximum §c50§6 players online.
+    # §6当前有 §c4§6 个玩家在线,最大在线人数为 §c50§6 个玩家.
+    # §c4§6 人のプレイヤーが接続中です。最大接続可能人数\:§c 50
     r'[^§](\d+)(?:.*?(?=/).*?[^§](\d+))?',  # Current user count.
     re.X
 )


### PR DESCRIPTION
##### Summary
* Fix spigotmc plugin can't reconnect.
    * Prior to this, the connection will continue to try to reconnect when it is normal.
    * After the connection is interrupted, it will not try to reconnect.
* Improve the compatibility of spigotmc plugin player count check
    * Previously, the color output would give the wrong result.
    * And does not support counting the number of invisible players.

##### Component Name
collectors/python.d.plugin/spigotmc/

##### Additional Information
For the new regular, you can test with the following code:

```python3
import re
r = re.compile(r'[^§](\d+)(?:.*?(?=/).*?[^§](\d+))?', re.X)

m = r.search('§6当前有 §c2§6 个玩家在线,最大在线人数为 §c50§6 个玩家.')
(m.group(1), m.group(2))

m = r.search('§6There are §c2§6/§c1§6 out of maximum §c50§6 players online.')
(m.group(1), m.group(2))

m = r.search('§6There are §c2§6 / §c1§6 out of maximum §c50§6 players online.')
(m.group(1), m.group(2))

m = r.search('当前有 2 个玩家在线,最大在线人数为 50 个玩家.')
(m.group(1), m.group(2))

m = r.search('There are 2/1 out of maximum 50 players online.')
(m.group(1), m.group(2))

m = r.search('There are 2 / 1 out of maximum 50 players online.')
(m.group(1), m.group(2))
```

The result should look similar to the following:

```
Cat73@Cat73s-MacBook-Air ~/D/c/g/netdata> python3
Python 3.7.4 (default, Jul  9 2019, 18:13:23) 
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> r = re.compile(r'[^§](\d+)(?:.*?(?=/).*?[^§](\d+))?', re.X)
>>> 
>>> m = r.search('§6当前有 §c2§6 个玩家在线,最大在线人数为 §c50§6 个玩家.')
>>> (m.group(1), m.group(2))
('2', None)
>>> 
>>> m = r.search('§6There are §c2§6/§c1§6 out of maximum §c50§6 players online.')
>>> (m.group(1), m.group(2))
('2', '1')
>>> 
>>> m = r.search('§6There are §c2§6 / §c1§6 out of maximum §c50§6 players online.')
>>> (m.group(1), m.group(2))
('2', '1')
>>> 
>>> m = r.search('当前有 2 个玩家在线,最大在线人数为 50 个玩家.')
>>> (m.group(1), m.group(2))
('2', None)
>>> 
>>> m = r.search('There are 2/1 out of maximum 50 players online.')
>>> (m.group(1), m.group(2))
('2', '1')
>>> 
>>> m = r.search('There are 2 / 1 out of maximum 50 players online.')
>>> (m.group(1), m.group(2))
('2', '1')
>>> 
```
