### PR TITLE
netdata/installer: Fix error running kickstart as a non-privileged user

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -45,7 +45,7 @@ $ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 Verify the integrity of the script with this:
 
 ``` bash
-[ "d7982e4a80794e4d4d8f48d50ce3a38b" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "b6d16c171ccad073b86327246151d875" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 *It should print `OK, VALID` if the script is the one we ship.*
 
@@ -101,7 +101,7 @@ $ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh)
 Verify the integrity of the script with this:
 
 ```bash
-[ "d3c20a89a87d178dbf5cf6a4ce4b9568" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "4415e8c13e529a795abb953a9be14ad5" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -45,7 +45,7 @@ $ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 Verify the integrity of the script with this:
 
 ``` bash
-[ "8a2b054081a108dff915994ce77f2f2d" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "d7982e4a80794e4d4d8f48d50ce3a38b" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 *It should print `OK, VALID` if the script is the one we ship.*
 
@@ -101,7 +101,7 @@ $ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh)
 Verify the integrity of the script with this:
 
 ```bash
-[ "8779d8717ccaa8dac18d599502eef591" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "d3c20a89a87d178dbf5cf6a4ce4b9568" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -207,7 +207,7 @@ run ${sudo} sh "${TMPDIR}/netdata-latest.gz.run" ${opts} ${inner_opts}
 #shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
 	run ${sudo} rm "${TMPDIR}/netdata-latest.gz.run"
-	if [ ! "${TMPDIR}" == "/tmp" ] && [ ! "${TMPDIR}" == "/" ] && [ -d "${TMPDIR}" ]; then
+	if [ ! "${TMPDIR}" = "/tmp" ] && [ ! "${TMPDIR}" = "/" ] && [ -d "${TMPDIR}" ]; then
 		run ${sudo} rm -rf "${TMPDIR}"
 	fi
 else

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -189,7 +189,7 @@ done
 
 # ---------------------------------------------------------------------------------------------------------------------
 TMPDIR=$(create_tmp_directory)
-cd "${TMPDIR}" || :
+cd "${TMPDIR}" || TMPDIR="/tmp"
 
 set_tarball_urls "${RELEASE_CHANNEL}"
 progress "Downloading static netdata binary: ${NETDATA_TARBALL_URL}"
@@ -202,12 +202,14 @@ fi
 
 # ---------------------------------------------------------------------------------------------------------------------
 progress "Installing netdata"
-
 run ${sudo} sh "${TMPDIR}/netdata-latest.gz.run" ${opts} ${inner_opts}
 
 #shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
-	rm "${TMPDIR}/netdata-latest.gz.run"
+	run ${sudo} rm "${TMPDIR}/netdata-latest.gz.run"
+	if [ ! "${TMPDIR}" == "/tmp" ] && [ ! "${TMPDIR}" == "/" ] && [ -d "${TMPDIR}" ]; then
+		run ${sudo} rm -rf "${TMPDIR}"
+	fi
 else
 	echo >&2 "NOTE: did not remove: ${TMPDIR}/netdata-latest.gz.run"
 fi

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -189,7 +189,7 @@ done
 
 # ---------------------------------------------------------------------------------------------------------------------
 TMPDIR=$(create_tmp_directory)
-cd "${TMPDIR}" || (export TMPDIR="/tmp" && cd "${TMPDIR}")
+cd "${TMPDIR}"
 
 set_tarball_urls "${RELEASE_CHANNEL}"
 progress "Downloading static netdata binary: ${NETDATA_TARBALL_URL}"
@@ -207,7 +207,7 @@ run ${sudo} sh "${TMPDIR}/netdata-latest.gz.run" ${opts} ${inner_opts}
 #shellcheck disable=SC2181
 if [ $? -eq 0 ]; then
 	run ${sudo} rm "${TMPDIR}/netdata-latest.gz.run"
-	if [ ! "${TMPDIR}" = "/tmp" ] && [ ! "${TMPDIR}" = "/" ] && [ -d "${TMPDIR}" ]; then
+	if [ ! "${TMPDIR}" = "/" ] && [ -d "${TMPDIR}" ]; then
 		run ${sudo} rm -rf "${TMPDIR}"
 	fi
 else

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -189,7 +189,7 @@ done
 
 # ---------------------------------------------------------------------------------------------------------------------
 TMPDIR=$(create_tmp_directory)
-cd "${TMPDIR}" || TMPDIR="/tmp"
+cd "${TMPDIR}" || (export TMPDIR="/tmp" && cd "${TMPDIR}")
 
 set_tarball_urls "${RELEASE_CHANNEL}"
 progress "Downloading static netdata binary: ${NETDATA_TARBALL_URL}"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -328,7 +328,7 @@ cd netdata-* || fatal "Cannot cd to netdata source tree"
 if [ -x netdata-installer.sh ]; then
 	progress "Installing netdata..."
 	run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS} "${@}" || fatal "netdata-installer.sh exited with error"
-	if [ -n "${TMPDIR}" ] && [ -d "${TMPDIR}" ] && [ ! "${TMPDIR}" == "/tmp" ] && [ ! "${TMPDIR}" == "/" ]; then
+	if [ -n "${TMPDIR}" ] && [ -d "${TMPDIR}" ] && [ ! "${TMPDIR}" = "/tmp" ] && [ ! "${TMPDIR}" = "/" ]; then
 		run ${sudo} rm -rf "${TMPDIR}" >/dev/null 2>&1
 	fi
 else

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -304,7 +304,7 @@ if [ "${INTERACTIVE}" = "0" ]; then
 fi
 
 TMPDIR=$(create_tmp_directory)
-cd "${TMPDIR}" || (export TMPDIR="/tmp" && cd "${TMPDIR}")
+cd "${TMPDIR}"
 
 dependencies
 
@@ -328,7 +328,7 @@ cd netdata-* || fatal "Cannot cd to netdata source tree"
 if [ -x netdata-installer.sh ]; then
 	progress "Installing netdata..."
 	run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS} "${@}" || fatal "netdata-installer.sh exited with error"
-	if [ -n "${TMPDIR}" ] && [ -d "${TMPDIR}" ] && [ ! "${TMPDIR}" = "/tmp" ] && [ ! "${TMPDIR}" = "/" ]; then
+	if [ -d "${TMPDIR}" ] && [ ! "${TMPDIR}" = "/" ]; then
 		run ${sudo} rm -rf "${TMPDIR}" >/dev/null 2>&1
 	fi
 else

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -304,7 +304,7 @@ if [ "${INTERACTIVE}" = "0" ]; then
 fi
 
 TMPDIR=$(create_tmp_directory)
-cd ${TMPDIR} || :
+cd ${TMPDIR} || TMPDIR="/tmp"
 
 dependencies
 
@@ -328,7 +328,9 @@ cd netdata-* || fatal "Cannot cd to netdata source tree"
 if [ -x netdata-installer.sh ]; then
 	progress "Installing netdata..."
 	run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS} "${@}" || fatal "netdata-installer.sh exited with error"
-	rm -rf "${TMPDIR}" >/dev/null 2>&1
+	if [ -n "${TMPDIR}" ] && [ -d "${TMPDIR}" ] && [ ! "${TMPDIR}" == "/tmp" ] && [ ! "${TMPDIR}" == "/" ]; then
+		run ${sudo} rm -rf "${TMPDIR}" >/dev/null 2>&1
+	fi
 else
 	fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${TMPDIR}"
 fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -304,7 +304,7 @@ if [ "${INTERACTIVE}" = "0" ]; then
 fi
 
 TMPDIR=$(create_tmp_directory)
-cd ${TMPDIR} || TMPDIR="/tmp"
+cd "${TMPDIR}" || (export TMPDIR="/tmp" && cd "${TMPDIR}")
 
 dependencies
 


### PR DESCRIPTION
##### Summary
One of our users reported an issue occurring with our kickstart installer, when it is executed with a non-privileged user.
Our kickstart has the capability to selectively run commands with sudo where needed, when the user executing kickstart is not root.

During the end of the execution, we had a set of commands that were not executed with sudo and were masked to hide the failure, thus only resulting on a non-zero exit code of the script execution when user is not root.

This PR mitigates this problem and helps cleaning up after installation properly.

Fixes:
1) Make sure we always have a proper TMPDIR variable
2) Make sure we use sudo variable on the deletions 
3) Guard deletions for the cases we shouldn't be deleting anything (for example when /tmp is the TMPDIR)

##### Component Name
netdata/installer

##### Additional Information
Fixes #6633 
