### PR TITLE
Fixes netdata group deletion on linux for uninstall script

### DIFF
--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -161,7 +161,7 @@ portable_del_group() {
 		if grep -q "${groupname}" /etc/group; then
 		  run groupdel -f "${groupname}" && return 0
 		else
-		  echo >&2 "Group ${groupname} already remove in a previous step."
+		  echo >&2 "Group ${groupname} already removed in a previous step."
 		  run_ok
 		fi
 	fi

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -158,7 +158,12 @@ portable_del_group() {
 
 	# Linux
 	if command -v groupdel 1>/dev/null 2>&1; then
-		run groupdel -f "${groupname}" && return 0
+		if grep -q "${groupname}" /etc/group; then
+		  run groupdel -f "${groupname}" && return 0
+		else
+		  echo >&2 "Group ${groupname} already remove in a previous step."
+		  run_ok
+		fi
 	fi
 
 	# mac OS


### PR DESCRIPTION
##### Summary
For the uninstall script, the command used to delete de netdata user in linux (userdel -f "${username}") deletes the group as well because of the -f option, so the netdata group deletion step fails.

This pull request adds a conditional to only delete the netdata group if it still exists, otherwise just print a message and mark step as OK.

##### Component Name

Uninstall script.

##### Additional Information
From userdel man page:
```
       -f, --force
           This option forces the removal of the user account, even if the user is still logged in. It also forces userdel to remove the user's home directory and mail spool, even if another user uses the
           same home directory or if the mail spool is not owned by the specified user. If USERGROUPS_ENAB is defined to yes in /etc/login.defs and if a group exists with the same name as the deleted user,
           then this group will be removed, even if it is still the primary group of another user.

           Note: This option is dangerous and may leave your system in an inconsistent state.
```


