### PR TITLE
Accept <> around links in markdown

### DIFF
--- a/collectors/python.d.plugin/riakkv/README.md
+++ b/collectors/python.d.plugin/riakkv/README.md
@@ -4,8 +4,7 @@ Monitors one or more Riak KV servers.
 
 **Requirements:**
 
-* An accessible `/stats` endpoint. See [the Riak KV configuration reference]
-  documentation](https://docs.riak.com/riak/kv/2.2.3/configuring/reference/#client-interfaces)
+* An accessible `/stats` endpoint. See [the Riak KV configuration reference documentation](<https://docs.riak.com/riak/kv/2.2.3/configuring/reference/#client-interfaces>)
   for how to enable this.
 
 The following charts are included, which are mostly derived from the metrics

--- a/docs/generator/checklinks.sh
+++ b/docs/generator/checklinks.sh
@@ -227,7 +227,7 @@ checklinks () {
 	while read -r l ; do
 		for word in $l ; do
 			if [[ $word =~ .*\]\(([^\(\) ]*)\).* ]] ; then
-				lnk="${BASH_REMATCH[1]}"
+				lnk=$(echo "${BASH_REMATCH[1]}" | tr -d '<>')
 				if [ -z "$lnk" ] ; then continue ; fi
 				dbg "-$lnk"
 				case "$lnk" in


### PR DESCRIPTION
##### Summary
Accept syntax of markdown links that encapsulates links inside '<>'. 

##### Component Name
docs generator

##### Additional Information
Strips the '<>' from the link before applying the logic.

