### PR TITLE
.travis.yml: packaging/docker/check_login.sh can cause the build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -505,10 +505,11 @@ jobs:
           - echo "Last commit:" && git log -1
           - echo "GIT Describe:" && git describe
           - echo "packaging/version:" && cat packaging/version
-          - packaging/docker/check_login.sh
-          - echo "Switching to latest master branch, to pick up tagging if any" && git checkout master && git pull
-          - packaging/docker/build.sh
-          - packaging/docker/publish.sh
+          - >-
+            packaging/docker/check_login.sh
+            && echo "Switching to latest master branch, to pick up tagging if any" && git checkout master && git pull
+            && packaging/docker/build.sh
+            && packaging/docker/publish.sh
         after_failure: post_message "TRAVIS_MESSAGE" "<!here> Docker image publishing failed"
 
       name: Build & Publish docker image for i386
@@ -589,9 +590,10 @@ jobs:
           - echo "GIT Describe:" && git describe
           - echo "packaging/version:" && cat packaging/version
           - docker info
-          - packaging/docker/check_login.sh
-          - packaging/docker/build.sh
-          - packaging/docker/publish.sh
+          - >-
+            packaging/docker/check_login.sh
+            && packaging/docker/build.sh
+            && packaging/docker/publish.sh
         after_failure: post_message "TRAVIS_MESSAGE" "<!here> Nightly docker image publish failed"
 
       name: Build & Publish docker image for i386


### PR DESCRIPTION
##### Summary
Change .travis.yml so that the script packaging/docker/check_login.sh can cause the build to fail promptly (Publish for release & Nightly release stages).

##### Component Name
.travis.yml

##### Additional Information
I believe that packaging/docker/check_login.sh was meant to cancel the release build if the credentials are wrong. But currently the build keeps running even if check_login.sh fails.

With the current .travis.yml, this is in accordance with the [documented](https://docs.travis-ci.com/user/job-lifecycle#customizing-the-build-phase) behaviour:

> When one of the build commands returns a non-zero exit code, the Travis CI build **runs the subsequent commands as well**, and accumulates the build result.

This PR makes the check_login.sh failure to fail the build promptly.

You can find before and after test builds here:
https://travis-ci.org/knatsakis/netdata/jobs/571436083#L455
https://travis-ci.org/knatsakis/netdata/jobs/571436087#L406
and here:
https://travis-ci.org/knatsakis/netdata/jobs/571508994
https://travis-ci.org/knatsakis/netdata/jobs/571508998