### PR TITLE
Make MongoDB backend multithreaded

### DIFF
--- a/backends/backends.c
+++ b/backends/backends.c
@@ -267,7 +267,7 @@ static struct objects_to_clean {
 #ifdef ENABLE_HTTPS
     struct netdata_ssl *opentsdb_ssl;
 #endif
-} objects_to_clean;
+};
 
 static void backends_main_cleanup(void *objects_to_clean) {
     struct objects_to_clean *objects = (struct objects_to_clean *)objects_to_clean;
@@ -543,6 +543,8 @@ BACKEND_TYPE backend_select_type(const char *type) {
  * @return It always return NULL.
  */
 void *backends_main(void *ptr) {
+    struct objects_to_clean objects_to_clean;
+
     netdata_thread_cleanup_push(backends_main_cleanup, (void *)&objects_to_clean);
 
     int default_port = 0;
@@ -1328,7 +1330,9 @@ void *backends_main(void *ptr) {
         // ------------------------------------------------------------------------
         // update the monitoring charts
 
+#if HAVE_MONGOC
 update_charts:
+#endif
         if(likely(chart_ops->counter_done)) rrdset_next(chart_ops);
         rrddim_set(chart_ops, "read",         chart_receptions);
         rrddim_set(chart_ops, "write",        chart_transmission_successes);

--- a/backends/backends.c
+++ b/backends/backends.c
@@ -517,16 +517,16 @@ BACKEND_TYPE backend_select_type(const char *type) {
     else if(!strcmp(type, "opentsdb:http") || !strcmp(type, "opentsdb:https")) {
         return BACKEND_TYPE_OPENTSDB_USING_HTTP;
     }
-    else if (!strcmp(type, "json") || !strcmp(type, "json:plaintext")) {
+    else if(!strcmp(type, "json") || !strcmp(type, "json:plaintext")) {
         return BACKEND_TYPE_JSON;
     }
-    else if (!strcmp(type, "prometheus_remote_write")) {
+    else if(!strcmp(type, "prometheus_remote_write")) {
         return  BACKEND_TYPE_PROMETEUS;
     }
-    else if (!strcmp(type, "kinesis") || !strcmp(type, "kinesis:plaintext")) {
+    else if(!strcmp(type, "kinesis") || !strcmp(type, "kinesis:plaintext")) {
         return BACKEND_TYPE_KINESIS;
     }
-    else if (!strcmp(type, "mongodb") || !strcmp(type, "mongodb:plaintext")) {
+    else if(!strcmp(type, "mongodb") || !strcmp(type, "mongodb:plaintext")) {
         return BACKEND_TYPE_MONGODB;
     }
 

--- a/backends/backends.c
+++ b/backends/backends.c
@@ -866,9 +866,9 @@ void *backends_main(void *ptr) {
 #if HAVE_MONGOC
         int mongodb_thread_index = MONGODB_THREAD_INDEX_UNDEFINED;
 
-        chart_buffered_metrics = 0;
-
         if(do_mongodb) {
+            chart_buffered_metrics = 0;
+
             for(int i = 0; i < MONGODB_THREADS_NUMBER; i++) {
                 if(mongodb_threads[i].busy == 0) {
                     mongodb_thread_index = i;
@@ -880,10 +880,11 @@ void *backends_main(void *ptr) {
                 b = default_buffer;
             else
                 b = mongodb_threads[mongodb_thread_index].buffer;
-        }
-#else
-        b = default_buffer;
+        } else
 #endif
+        {
+            b = default_buffer;
+        }
 
         rrd_rdlock();
         RRDHOST *host;

--- a/backends/backends.c
+++ b/backends/backends.c
@@ -603,8 +603,7 @@ void *backends_main(void *ptr) {
 
             mongodb_threads = callocz(MONGODB_THREADS_NUMBER, sizeof(struct mongodb_thread));
 
-            int i;
-            for(i = 0; i < MONGODB_THREADS_NUMBER; i++) {
+            for(int i = 0; i < MONGODB_THREADS_NUMBER; i++) {
                 netdata_mutex_init(&mongodb_threads[i].mutex);
                 mongodb_threads[i].buffer = buffer_create(1);
             }
@@ -1284,6 +1283,12 @@ cleanup:
         freez(mongodb_uri);
         freez(mongodb_database);
         freez(mongodb_collection);
+
+        for(int i = 0; i < MONGODB_THREADS_NUMBER; i++) {
+            if(mongodb_threads[i].busy)
+                netdata_thread_cancel(mongodb_threads[i].thread);
+            buffer_free(mongodb_threads[i].buffer);
+        }
         freez(mongodb_threads);
     }
 #endif

--- a/backends/backends.c
+++ b/backends/backends.c
@@ -294,29 +294,7 @@ static void backends_objects_cleanup(void *objects_to_clean) {
         freez(*objects->mongodb_database);
         freez(*objects->mongodb_collection);
 
-        // clean up mongodb threads
         for(int i = 0; i < MONGODB_THREADS_NUMBER; i++) {
-            if((*objects->mongodb_threads)[i].busy) {
-                netdata_mutex_lock(&(*objects->mongodb_threads)[i].mutex);
-                if(!(*objects->mongodb_threads)[i].finished) {
-info("BACKEND: cancelled = %zu", (*objects->mongodb_threads)[i].thread);
-                    netdata_thread_cancel((*objects->mongodb_threads)[i].thread);
-                }
-                netdata_mutex_unlock(&(*objects->mongodb_threads)[i].mutex);
-            }
-        }
-        for(int i = 0; i < MONGODB_THREADS_NUMBER; i++) {
-            if((*objects->mongodb_threads)[i].busy) {
-                netdata_mutex_lock(&(*objects->mongodb_threads)[i].mutex);
-                for(int j = 0; j < 10 && !(*objects->mongodb_threads)[i].finished; j++) {
-                    netdata_mutex_unlock(&(*objects->mongodb_threads)[i].mutex);
-info("BACKEND: locked = %zu", (*objects->mongodb_threads)[i].thread);
-                    sleep_usec(100);
-                    netdata_mutex_lock(&(*objects->mongodb_threads)[i].mutex);
-                }
-                netdata_mutex_unlock(&(*objects->mongodb_threads)[i].mutex);
-            }
-info("BACKEND: lock finished = %zu", (*objects->mongodb_threads)[i].thread);
             buffer_free((*objects->mongodb_threads)[i].buffer);
         }
 info("BACKEND: free threads");
@@ -324,7 +302,7 @@ info("BACKEND: free threads");
 
 info("BACKEND: mongodb_cleanup");
         mongodb_cleanup();
-info("BACKEND: END");
+info("BACKEND: End of cleanup");
     }
 #endif
 

--- a/backends/backends.c
+++ b/backends/backends.c
@@ -294,19 +294,37 @@ static void backends_objects_cleanup(void *objects_to_clean) {
         freez(*objects->mongodb_database);
         freez(*objects->mongodb_collection);
 
+        // clean up mongodb threads
         for(int i = 0; i < MONGODB_THREADS_NUMBER; i++) {
             if((*objects->mongodb_threads)[i].busy) {
                 netdata_mutex_lock(&(*objects->mongodb_threads)[i].mutex);
-                if(!(*objects->mongodb_threads)[i].finished)
+                if(!(*objects->mongodb_threads)[i].finished) {
+info("BACKEND: cancelled = %zu", (*objects->mongodb_threads)[i].thread);
                     netdata_thread_cancel((*objects->mongodb_threads)[i].thread);
+                }
                 netdata_mutex_unlock(&(*objects->mongodb_threads)[i].mutex);
             }
+        }
+        for(int i = 0; i < MONGODB_THREADS_NUMBER; i++) {
+            if((*objects->mongodb_threads)[i].busy) {
+                netdata_mutex_lock(&(*objects->mongodb_threads)[i].mutex);
+                for(int j = 0; j < 10 && !(*objects->mongodb_threads)[i].finished; j++) {
+                    netdata_mutex_unlock(&(*objects->mongodb_threads)[i].mutex);
+info("BACKEND: locked = %zu", (*objects->mongodb_threads)[i].thread);
+                    sleep_usec(100);
+                    netdata_mutex_lock(&(*objects->mongodb_threads)[i].mutex);
+                }
+                netdata_mutex_unlock(&(*objects->mongodb_threads)[i].mutex);
+            }
+info("BACKEND: lock finished = %zu", (*objects->mongodb_threads)[i].thread);
             buffer_free((*objects->mongodb_threads)[i].buffer);
         }
-sleep(1);
+info("BACKEND: free threads");
         freez(*objects->mongodb_threads);
 
+info("BACKEND: mongodb_cleanup");
         mongodb_cleanup();
+info("BACKEND: END");
     }
 #endif
 
@@ -1095,6 +1113,7 @@ void *backends_main(void *ptr) {
                   buffer = %zu", mongodb_uri, mongodb_database, mongodb_collection, buffer_len);
 
             if(!netdata_thread_create(&mongodb_threads[i].thread, "BACKENDS[mongodb]", NETDATA_THREAD_OPTION_DONT_LOG, mongodb_insert, (void *)&mongodb_threads[i])) {
+info("BACKEND: start thread %zu", mongodb_threads[i].thread);
                 mongodb_threads[i].busy = 1;
             }
             else {

--- a/backends/backends.c
+++ b/backends/backends.c
@@ -491,7 +491,7 @@ void *backends_main(void *ptr) {
     struct mongodb_thread *mongodb_threads = NULL;
 
     // set the default socket timeout in ms
-    int32_t mongodb_default_socket_timeout = (int32_t)(global_backend_update_every < 60)?(global_backend_update_every * 10 * MSEC_PER_SEC):600 * MSEC_PER_SEC;
+    int32_t mongodb_default_socket_timeout = (int32_t)(global_backend_update_every < 30)?(global_backend_update_every * 10 * MSEC_PER_SEC):300 * MSEC_PER_SEC;
 
 #endif
 

--- a/backends/mongodb/README.md
+++ b/backends/mongodb/README.md
@@ -25,7 +25,7 @@ database = your_database_name
 collection = your_collection_name
 ```
 
-The default socket timeout depends on the backend update interval. The timeout is 500 ms shorter than the interval (but not less than 1000 ms). You can alter the timeout using the `sockettimeoutms` MongoDB URI option.
+The default socket timeout depends on the backend update interval. The timeout is 10 times longer than the interval (but not more than 5 minutes). You can alter the timeout using the `sockettimeoutms` MongoDB URI option.
 
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fbackends%2Fmongodb%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)]()

--- a/backends/mongodb/mongodb.c
+++ b/backends/mongodb/mongodb.c
@@ -74,14 +74,16 @@ struct objects_to_clean {
 static void mongodb_insert_cleanup(void *objects_to_clean) {
     struct objects_to_clean *objects = (struct objects_to_clean *)objects_to_clean;
 
+info("free bson = %p, documens = %zu", *objects->insert, *objects->n_documents);
     free_bson(*objects->insert, *objects->n_documents);
     mongoc_collection_destroy(*objects->collection);
+info("push client = %p", *objects->client);
     mongoc_client_pool_push(mongodb_client_pool, *objects->client);
 
     buffer_flush((*objects->thread_data)->buffer);
 
     netdata_mutex_lock(&(*objects->thread_data)->mutex);
-info("BACKEND: finished = %zu", (*objects->thread_data)->thread);
+info("MONGODB: finished = %zu", (*objects->thread_data)->thread);
     (*objects->thread_data)->finished = 1;
     netdata_mutex_unlock(&(*objects->thread_data)->mutex);
 }
@@ -107,6 +109,7 @@ void *mongodb_insert(void *mongodb_thread) {
 
 
     client = mongoc_client_pool_pop(mongodb_client_pool);
+info("pop client = %p", client);
     if(unlikely(!client)) {
         error("BACKEND: failed to create a new client");
         thread_data->error = 1;
@@ -156,9 +159,9 @@ cleanup:
 void mongodb_cleanup() {
 // info("MONFODB: pool destroy");
 //     mongoc_client_pool_destroy(mongodb_client_pool);
-info("MONFODB: cleanup");
+info("MONGODB: cleanup");
     mongoc_cleanup();
-info("MONFODB: end of cleanup");
+info("MONGODB: end of cleanup");
 
     return;
 }

--- a/backends/mongodb/mongodb.c
+++ b/backends/mongodb/mongodb.c
@@ -43,7 +43,7 @@ int mongodb_init(const char *uri_string,
     mongoc_client_pool_set_error_api(mongodb_client_pool, MONGOC_ERROR_API_VERSION_2);
 
     const char *appname = mongoc_uri_get_option_as_utf8(uri, MONGOC_URI_APPNAME, "netdata");
-    if(!mongoc_client_pool_set_appname(mongodb_client_pool, appname)) {
+    if(unlikely(!mongoc_client_pool_set_appname(mongodb_client_pool, appname))) {
         error("BACKEND: failed to set client appname");
     };
 

--- a/backends/mongodb/mongodb.c
+++ b/backends/mongodb/mongodb.c
@@ -81,6 +81,7 @@ static void mongodb_insert_cleanup(void *objects_to_clean) {
     buffer_flush((*objects->thread_data)->buffer);
 
     netdata_mutex_lock(&(*objects->thread_data)->mutex);
+info("BACKEND: finished = %zu", (*objects->thread_data)->thread);
     (*objects->thread_data)->finished = 1;
     netdata_mutex_unlock(&(*objects->thread_data)->mutex);
 }
@@ -153,8 +154,11 @@ cleanup:
 }
 
 void mongodb_cleanup() {
-    mongoc_client_pool_destroy(mongodb_client_pool);
+// info("MONFODB: pool destroy");
+//     mongoc_client_pool_destroy(mongodb_client_pool);
+info("MONFODB: cleanup");
     mongoc_cleanup();
+info("MONFODB: end of cleanup");
 
     return;
 }

--- a/backends/mongodb/mongodb.h
+++ b/backends/mongodb/mongodb.h
@@ -5,7 +5,7 @@
 
 #include "backends/backends.h"
 
-#define MONGODB_THREADS_NUMBER 3
+#define MONGODB_THREADS_NUMBER 10
 #define MONGODB_THREAD_INDEX_UNDEFINED -1
 
 struct mongodb_thread {

--- a/backends/mongodb/mongodb.h
+++ b/backends/mongodb/mongodb.h
@@ -5,9 +5,22 @@
 
 #include "backends/backends.h"
 
+struct mongodb_thread {
+    netdata_thread_t thread;
+    netdata_mutex_t mutex;
+
+    BUFFER *buffer;
+    size_t n_bytes;
+    size_t n_metrics;
+
+    int busy;
+    int finished;
+    int error;
+};
+
 extern int mongodb_init(const char *uri_string, const char *database_string, const char *collection_string, const int32_t socket_timeout);
 
-extern int mongodb_insert(char *data, size_t n_metrics);
+extern void *mongodb_insert(void *mongodb_thread);
 
 extern void mongodb_cleanup();
 

--- a/backends/mongodb/mongodb.h
+++ b/backends/mongodb/mongodb.h
@@ -5,6 +5,9 @@
 
 #include "backends/backends.h"
 
+#define MONGODB_THREADS_NUMBER 3
+#define MONGODB_THREAD_INDEX_UNDEFINED -1
+
 struct mongodb_thread {
     netdata_thread_t thread;
     netdata_mutex_t mutex;


### PR DESCRIPTION
##### Summary
- Detach blocking operations into separate threads.
- Clean up dynamic objects using cleanup handlers on Netdata exit.

Closes #6599

##### Component Name
backends