### PR TITLE
changed naming for redirect_uri param

### DIFF
--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -4897,8 +4897,8 @@ function handleSignInMessage(e) {
     cloudToken = e.data.token;
 
     netdataRegistryCallback(registryAgents);
-    if (e.data.redirectUri) {
-        window.location.replace(e.data.redirectUri);
+    if (e.data.redirectURI) {
+        window.location.replace(e.data.redirectURI);
     }
 }
 

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -708,7 +708,7 @@ function openAuthenticatedUrl(url) {
     if (isSignedIn()) {
         window.open(url);
     } else {
-        window.open(`${NETDATA.registry.cloudBaseURL}/account/sign-in-agent?id=${NETDATA.registry.machine_guid}&name=${encodeURIComponent(NETDATA.registry.hostname)}&origin=${encodeURIComponent(window.location.origin + "/")}&redirectUrl=${encodeURIComponent(window.location.origin + "/" + url)}`);
+        window.open(`${NETDATA.registry.cloudBaseURL}/account/sign-in-agent?id=${NETDATA.registry.machine_guid}&name=${encodeURIComponent(NETDATA.registry.hostname)}&origin=${encodeURIComponent(window.location.origin + "/")}&redirect_uri=${encodeURIComponent(window.location.origin + "/" + url)}`);
     }
 }
 
@@ -4897,8 +4897,8 @@ function handleSignInMessage(e) {
     cloudToken = e.data.token;
 
     netdataRegistryCallback(registryAgents);
-    if (e.data.redirectUrl) {
-        window.location.replace(e.data.redirectUrl);
+    if (e.data.redirectUri) {
+        window.location.replace(e.data.redirectUri);
     }
 }
 


### PR DESCRIPTION
A change requested by the cloud team, since they're using snake_case for query string params and want to use more generic `uri` (instead of `url`)

This param was introduced recently to fix this issue: https://github.com/netdata/netdata/issues/6542
This PR needs also corresponding change in the [Cloud](https://github.com/netdata/cloud/pull/1237), and if only 1 change will be applied, there will be no breaking error because of this, but the minor issue described in #6542 will be happening again, until both Agent and Cloud will be updated.

redirectUrl > redirect_uri in query params for cloud sign-in call
redirectUrl > redirectUri in response object from iframe's window.parent.postMessage
