### PR TITLE
netdata/packaging: separately identify dependency resolution for HTTPS and DB engine

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -384,8 +384,11 @@ test "${enable_dbengine}" = "yes" -a -z "${LZ4_LIBS}" && \
 test "${enable_dbengine}" = "yes" -a -z "${JUDY_LIBS}" && \
     AC_MSG_ERROR([libJudy required but not found. Try installing 'libjudy-dev' or 'Judy-devel'.])
 
-test "${enable_dbengine}" = "yes" -o "${enable_https}" = "yes" -a -z "${SSL_LIBS}" && \
-    AC_MSG_ERROR([OpenSSL required but not found. Try installing 'libssl-dev' or 'openssl-devel'.])
+test "${enable_https}" = "yes" -a -z "${SSL_LIBS}" && \
+    AC_MSG_ERROR([OpenSSL required for HTTPS but not found. Try installing 'libssl-dev' or 'openssl-devel'.])
+
+test "${enable_dbengine}" = "yes" -a -z "${SSL_LIBS}" && \
+    AC_MSG_ERROR([OpenSSL required for DBENGINE but not found. Try installing 'libssl-dev' or 'openssl-devel'.])
 
 AC_MSG_CHECKING([if netdata dbengine should be used])
 if test "${enable_dbengine}" != "no" -a "${UV_LIBS}" -a "${LZ4_LIBS}" -a "${JUDY_LIBS}" -a "${SSL_LIBS}"; then


### PR DESCRIPTION

##### Summary
As part of the gentoo overlay creation, we bumped into an interesting compilation problem on SSL.
During investigation i realised that the and/or condition mix that checks for SSL libs when dbengine or https is enabled, didn't work as expected.

Beats me why we didn't notice this earlier, it could be because on packaging we rely on auto-detection and probably this is not raised then.

##### Component Name
netdata/packaging
netdata/https
netdata/dbengine

##### Additional Information
Fixes #6669 
