### PR TITLE
netdata/packaging: Align libdir in all configure commands

### DIFF
--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -147,7 +147,7 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     run_command_in_host(['autoreconf', '-ivf'])
 
     print(".4 Run configure")
-    run_command_in_host(['./configure', '--prefix=/usr', '--sysconfdir=/etc', '--localstatedir=/var', '--libexecdir=/usr/libexec', '--with-math', '--with-zlib', '--with-user=netdata'])
+    run_command_in_host(['./configure', '--prefix=/usr', '--sysconfdir=/etc', '--localstatedir=/var', '--libdir=/usr/lib', '--libexecdir=/usr/libexec', '--with-math', '--with-zlib', '--with-user=netdata'])
 
     print(".5 Run make dist")
     run_command_in_host(['make', 'dist'])

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -18,7 +18,7 @@ TOP = $(CURDIR)/debian/netdata
 
 override_dh_auto_configure:
 	autoreconf -ivf
-	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --localstatedir=/var \
+	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib \
 	--libexecdir=/usr/libexec --with-user=netdata --with-math --with-zlib --with-webdir=/var/lib/netdata/www
 
 debian/%.postinst: debian/%.postinst.in

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -400,6 +400,7 @@ run ./configure \
 	--sysconfdir="${NETDATA_PREFIX}/etc" \
 	--localstatedir="${NETDATA_PREFIX}/var" \
 	--libexecdir="${NETDATA_PREFIX}/usr/libexec" \
+	--libdir="${NETDATA_PREFIX}/usr/lib" \
 	--with-zlib \
 	--with-math \
 	--with-user=netdata \

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -11,6 +11,7 @@
 %define _sysconfdir /etc
 %define _localstatedir /var
 %define _libexecdir /usr/libexec
+%define _libdir /usr/lib
 
 #
 # Conditional build:
@@ -235,6 +236,7 @@ autoreconf -ivf
 	--sysconfdir="%{_sysconfdir}" \
 	--localstatedir="%{_localstatedir}" \
 	--libexecdir="%{_libexecdir}" \
+        --libdir="%{_libdir}" \
 	--with-zlib \
 	--with-math \
 	--with-user=netdata \


### PR DESCRIPTION
##### Summary
As part of #6666 we had to go through the configure process across all distributions channels and evaluate the behaviour of our end to end build systems.

It seems that we are in need to align libdir option in our configure command, so that we can guarantee consistent layout of our installation across all distributions.

##### Component Name
netdata/packaging

##### Additional Information
None