### PR TITLE
netdata/installer: Add support for offline installs using kickstart or kickstart-static64

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -807,9 +807,19 @@ install_go() {
 		tmp=$(mktemp -d /tmp/netdata-go-XXXXXX)
 		GO_PACKAGE_BASENAME="go.d.plugin-${GO_PACKAGE_VERSION}.${OS}-${ARCH}.tar.gz"
 
-		download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/${GO_PACKAGE_BASENAME}" "${tmp}/${GO_PACKAGE_BASENAME}"
+		if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" ]; then
+			download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/${GO_PACKAGE_BASENAME}" "${tmp}/${GO_PACKAGE_BASENAME}"
+		else
+			progress "Using provided go.d tarball ${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}"
+			run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" "${tmp}/${GO_PACKAGE_BASENAME}"
+		fi
 
-		download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/config.tar.gz" "${tmp}/config.tar.gz"
+		if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}" ]; then
+			download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/config.tar.gz" "${tmp}/config.tar.gz"
+		else
+			progress "Using provided config file for go.d ${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}"
+			run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}" "${tmp}/config.tar.gz"
+		fi
 
 		if [ ! -f "${tmp}/${GO_PACKAGE_BASENAME}" ] || [ ! -f "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/${GO_PACKAGE_BASENAME}" ]; then
 			run_failed "go.d plugin download failed, go.d plugin will not be available"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -811,14 +811,14 @@ install_go() {
 			download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/${GO_PACKAGE_BASENAME}" "${tmp}/${GO_PACKAGE_BASENAME}"
 		else
 			progress "Using provided go.d tarball ${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}"
-			run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" "${tmp}/${GO_PACKAGE_BASENAME}"
+			run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" "${tmp}/${GO_PACKAGE_BASENAME}"
 		fi
 
 		if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}" ]; then
 			download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/config.tar.gz" "${tmp}/config.tar.gz"
 		else
 			progress "Using provided config file for go.d ${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}"
-			run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}" "${tmp}/config.tar.gz"
+			run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}" "${tmp}/config.tar.gz"
 		fi
 
 		if [ ! -f "${tmp}/${GO_PACKAGE_BASENAME}" ] || [ ! -f "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/${GO_PACKAGE_BASENAME}" ]; then

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -530,6 +530,12 @@ download the required files manually.
 ```bash
 cd /tmp
 
+# Since you won't be having an active internet connection on the destination, you will need to manually get the kickstart script itself
+# Download kickstart.sh or kickstart-static64.sh, depending the installation you have chosen to run
+curl -s https://my-netdata.io/kickstart.sh > kickstart.sh
+or
+curl -s https://my-netdata.io/kickstart-static64.sh > kickstart-static64.sh
+
 # Netdata tarball
 curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*tar.gz" | cut -d '"' -f 4 | wget -qi -
 
@@ -559,10 +565,10 @@ the location and names of the files you just downloaded.
 
 ```bash
 # kickstart.sh
-bash &lt;(curl -Ss https://my-netdata.io/kickstart.sh) --local-files /tmp/netdata.tar.gz /tmp/checksums.txt /tmp/go.d.binary.tar.gz /tmp/go.d.config.tar.gz
+bash kickstart.sh --local-files /tmp/netdata.tar.gz /tmp/checksums.txt /tmp/go.d.binary.tar.gz /tmp/go.d.config.tar.gz
 
 # kickstart-static64.sh
-bash &lt;(curl -Ss https://my-netdata.io/kickstart-static64.sh) --local-files /tmp/netdata.tar.gz /tmp/checksums.txt
+bash kickstart-static64.sh --local-files /tmp/netdata.tar.gz /tmp/checksums.txt
 ```
 
 Now that you're finished with your offline installation, you can move on to our

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -514,7 +514,7 @@ a few extra steps to make it work.
 
 By default, the `kickstart.sh` and `kickstart-static64.sh` download Netdata
 assets, like the precompiled binary and a few dependencies, using the system's
-internet connect, but you can also supply these files from the local filesystem.
+internet connection, but you can also supply these files from the local filesystem.
 
 First, download the required files. If you're using `kickstart.sh`, you need the
 Netdata tarball, the checksums, the go.d plugin binary, and the go.d plugin
@@ -545,14 +545,14 @@ curl -s https://api.github.com/repos/netdata/go.d.plugin/releases/latest | grep 
 ```
 
 Move these files to the `/tmp` directory on the offline system in whichever way
-your organization allows.
+your defined policy allows (if any).
 
 Now you can run either the `kickstart.sh` or `kickstart-static64.sh` scripts
 using the `--local-tarball-override` option. This option requires you to specify
 the location and names of the files you just downloaded. 
 
 !!! note When using `--local-tarball-override`, the `kickstart.sh` or
-    `kickstart-64.sh` scripts won't download any Netdata assets from the
+    `kickstart-static64.sh` scripts won't download any Netdata assets from the
     internet. But, you may still need a connection to install dependencies using
     your system's package manager. The scripts will warn you if your system
     doesn't have all the dependencies.

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -48,7 +48,7 @@ To learn more about the pros and cons of using *nightly* vs. *stable* releases, 
 Verify the integrity of the script with this:
 
 ```bash
-[ "b6d16c171ccad073b86327246151d875" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "6e54dd18a482dc8271b4ec245b986d3f" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 _It should print `OK, VALID` if the script is the one we ship._
@@ -108,7 +108,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "4415e8c13e529a795abb953a9be14ad5" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "97a7696d59f8c91d0db8f9bca2e8c594" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -48,7 +48,7 @@ To learn more about the pros and cons of using *nightly* vs. *stable* releases, 
 Verify the integrity of the script with this:
 
 ```bash
-[ "dc844b0f55d86afcb6c9405c76330371" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "735e9966a4cf0187863e06a5282b34a7" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 _It should print `OK, VALID` if the script is the one we ship._

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -109,7 +109,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "97a7696d59f8c91d0db8f9bca2e8c594" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "8a9f864ddcb70b7dc01d4e5bf4550a81" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -109,7 +109,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "722e0164ccdf98316b3ce5f563ffc2bf" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "5c432e78d5f40403e8b7c00b1a19a7ca" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -67,13 +67,14 @@ The `kickstart.sh` script passes all its parameters to `netdata-installer.sh`, s
 -   `--dont-start-it`: Prevent the installer from starting Netdata automatically.
 -   `--stable-channel`: Automatically update only on the release of new major versions.
 -   `--no-updates`: Prevent automatic updates of any kind.
+-   `--local-tarball-override`: Useful for offline installations. Pass two file paths, one of the tarball and one of the checksum file to force kickstart run the process using those files.
 
 Example using all the above parameters:
 
 ```bash
-$ bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait --dont-start-it --no-updates --stable-channel
+$ bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-tarball-override /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt
 ```
-
+Note: `--stable-channel` and `--local-tarball-override` overlap, if you use the tarball override the stable channel option is not effective
 </details>
 
 Once Netdata is installed, see [Getting Started](../../docs/GettingStarted.md).

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -48,7 +48,7 @@ To learn more about the pros and cons of using *nightly* vs. *stable* releases, 
 Verify the integrity of the script with this:
 
 ```bash
-[ "dc439c58bfc41de23b14b86d71c79a31" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "dc844b0f55d86afcb6c9405c76330371" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 _It should print `OK, VALID` if the script is the one we ship._

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -48,7 +48,7 @@ To learn more about the pros and cons of using *nightly* vs. *stable* releases, 
 Verify the integrity of the script with this:
 
 ```bash
-[ "6e54dd18a482dc8271b4ec245b986d3f" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "574456abacd54a625b44275fda43c507" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 _It should print `OK, VALID` if the script is the one we ship._
@@ -67,12 +67,12 @@ The `kickstart.sh` script passes all its parameters to `netdata-installer.sh`, s
 -   `--dont-start-it`: Prevent the installer from starting Netdata automatically.
 -   `--stable-channel`: Automatically update only on the release of new major versions.
 -   `--no-updates`: Prevent automatic updates of any kind.
--   `--local-tarball-override`: Useful for offline installations. Pass two file paths, one of the tarball and one of the checksum file to force kickstart run the process using those files.
+-   `--local-tarball-override`: Useful for offline installations. Pass four file paths: the netdata tarball, the checksum file, the go.d plugin tarball and the go.d plugin config tarball to force kickstart run the process using those files.
 
 Example using all the above parameters:
 
 ```bash
-$ bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-tarball-override /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt
+$ bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-tarball-override /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt /tmp/manually.downloaded.go.d.binary.tar.gz /tmp/manually.downloaded.go.d.config.tar.gz
 ```
 Note: `--stable-channel` and `--local-tarball-override` overlap, if you use the tarball override the stable channel option is not effective
 </details>

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -120,12 +120,14 @@ The `kickstart-static64.sh` script passes all its parameters to `netdata-install
 -   `--dont-start-it`: Prevent the installer from starting Netdata automatically.
 -   `--stable-channel`: Automatically update only on the release of new major versions.
 -   `--no-updates`: Prevent automatic updates of any kind.
+-   `--local-tarball-override`: Useful for offline installations. Pass two file paths, one of the tarball and one of the checksum file to force kickstart run the process using those files.
 
 Example using all the above parameters:
 
 ```sh
-$ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait --dont-start-it --no-updates --stable-channel
+$ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-tarball-override /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt
 ```
+Note: `--stable-channel` and `--local-tarball-override` overlap, if you use the tarball override the stable channel option is not effective
 
 If your shell fails to handle the above one liner, do this:
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -507,6 +507,68 @@ The Netdata team maintains two releases of the Netdata agent: **nightly** and **
 -   Protect yourself from the rare instance when major bugs slip through our testing and negatively affect a Netdata installation
 -   Retain more control over the Netdata version you use
 
+## Offline installations
+
+You can install Netdata on systems without internet access, but you need to take
+a few extra steps to make it work.
+
+By default, the `kickstart.sh` and `kickstart-static64.sh` download Netdata
+assets, like the precompiled binary and a few dependencies, using the system's
+internet connect, but you can also supply these files from the local filesystem.
+
+First, download the required files. If you're using `kickstart.sh`, you need the
+Netdata tarball, the checksums, the go.d plugin binary, and the go.d plugin
+configuration. If you're using `kickstart-static64.sh`, you need only the
+Netdata tarball and checksums.
+
+Download the files you need to a system of yours that's connected to the
+internet. You can use the commands below, or visit the [latest Netdata release
+page](https://github.com/netdata/netdata/releases/latest) and [latest go.d
+plugin release page](https://github.com/netdata/go.d.plugin/releases) to
+download the required files manually.
+
+```bash
+cd /tmp
+
+# Netdata tarball
+curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*tar.gz" | cut -d '"' -f 4 | wget -qi -
+
+# Netdata checksums
+curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*txt" | cut -d '"' -f 4 | wget -qi -
+
+# go.d plugin (for linux-amd64 systems)
+# For binaries for other OS types and architectures, visit the go.d releases 
+# page: https://github.com/netdata/go.d.plugin/releases/latest
+curl -s https://api.github.com/repos/netdata/go.d.plugin/releases/latest | grep "browser_download_url.*linux-amd64.tar.gz" | cut -d '"' -f 4 | wget -qi -
+
+# go.d configuration 
+curl -s https://api.github.com/repos/netdata/go.d.plugin/releases/latest | grep "browser_download_url.*config.tar.gz" | cut -d '"' -f 4 | wget -qi -
+```
+
+Move these files to the `/tmp` directory on the offline system in whichever way
+your organization allows.
+
+Now you can run either the `kickstart.sh` or `kickstart-static64.sh` scripts
+using the `--local-tarball-override` option. This option requires you to specify
+the location and names of the files you just downloaded. 
+
+!!! note When using `--local-tarball-override`, the `kickstart.sh` or
+    `kickstart-64.sh` scripts won't download any Netdata assets from the
+    internet. But, you may still need a connection to install dependencies using
+    your system's package manager. The scripts will warn you if your system
+    doesn't have all the dependencies.
+
+```bash
+# kickstart.sh
+bash &lt;(curl -Ss https://my-netdata.io/kickstart.sh) --local-tarball-override /tmp/netdata.tar.gz /tmp/checksums.txt /tmp/go.d.binary.tar.gz /tmp/go.d.config.tar.gz
+
+# kickstart-static64.sh
+bash &lt;(curl -Ss https://my-netdata.io/kickstart-static64.sh) --local-tarball-override /tmp/netdata.tar.gz /tmp/checksums.txt
+```
+
+Now that you're finished with your offline installation, you can move on to our
+[getting started guide](../../docs/GettingStarted.md)!
+
 ## Automatic updates
 
 By default, Netdata's installation scripts enable automatic updates for both nightly and stable release channels.

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -67,7 +67,7 @@ The `kickstart.sh` script passes all its parameters to `netdata-installer.sh`, s
 -   `--dont-start-it`: Prevent the installer from starting Netdata automatically.
 -   `--stable-channel`: Automatically update only on the release of new major versions.
 -   `--no-updates`: Prevent automatic updates of any kind.
--   `--local-tarball-override`: Useful for offline installations. Pass four file paths: the netdata tarball, the checksum file, the go.d plugin tarball and the go.d plugin config tarball to force kickstart run the process using those files.
+-   `--local-tarball-override`: Used for offline installations. Pass four file paths: the Netdata tarball, the checksum file, the go.d plugin tarball, and the go.d plugin config tarball, to force kickstart run the process using those files.
 
 Example using all the above parameters:
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -542,6 +542,9 @@ curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "bro
 # Netdata checksums
 curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*txt" | cut -d '"' -f 4 | wget -qi -
 
+# Netdata dependency handling script
+curl -s https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh | wget -qi -
+
 # go.d plugin 
 # For binaries for OS types and architectures not listed on [go.d releases](https://github.com/netdata/go.d.plugin/releases/latest), kindly open a github issue and we will do our best to serve your request
 export OS=$(uname -s | tr '[:upper:]' '[:lower:]') ARCH=$(uname -m | sed -e 's/i386/386/g' -e 's/i686/386/g' -e 's/x86_64/amd64/g' -e 's/aarch64/arm64/g' -e 's/armv64/arm64/g' -e 's/armv6l/arm/g' -e 's/armv7l/arm/g' -e 's/armv5tel/arm/g') && curl -s https://api.github.com/repos/netdata/go.d.plugin/releases/latest | grep "browser_download_url.*${OS}-${ARCH}.tar.gz" | cut -d '"' -f 4 | wget -qi -
@@ -565,7 +568,7 @@ the location and names of the files you just downloaded.
 
 ```bash
 # kickstart.sh
-bash kickstart.sh --local-files /tmp/netdata.tar.gz /tmp/checksums.txt /tmp/go.d.binary.tar.gz /tmp/go.d.config.tar.gz
+bash kickstart.sh --local-files /tmp/netdata-version-number-here.tar.gz /tmp/sha256sums.txt /tmp/go.d-binary-filename.tar.gz /tmp/config.tar.gz /tmp/install-required-packages.sh
 
 # kickstart-static64.sh
 bash kickstart-static64.sh --local-files /tmp/netdata.tar.gz /tmp/checksums.txt

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -120,7 +120,7 @@ The `kickstart-static64.sh` script passes all its parameters to `netdata-install
 -   `--dont-start-it`: Prevent the installer from starting Netdata automatically.
 -   `--stable-channel`: Automatically update only on the release of new major versions.
 -   `--no-updates`: Prevent automatic updates of any kind.
--   `--local-tarball-override`: Useful for offline installations. Pass two file paths, one of the tarball and one of the checksum file to force kickstart run the process using those files.
+-   `--local-tarball-override`: Used for offline installations. Pass two file paths, one for the tarball and one fir the checksum file, to force kickstart run the process using those files.
 
 Example using all the above parameters:
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -536,10 +536,9 @@ curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "bro
 # Netdata checksums
 curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*txt" | cut -d '"' -f 4 | wget -qi -
 
-# go.d plugin (for linux-amd64 systems)
-# For binaries for other OS types and architectures, visit the go.d releases 
-# page: https://github.com/netdata/go.d.plugin/releases/latest
-curl -s https://api.github.com/repos/netdata/go.d.plugin/releases/latest | grep "browser_download_url.*linux-amd64.tar.gz" | cut -d '"' -f 4 | wget -qi -
+# go.d plugin 
+# For binaries for OS types and architectures not listed on [go.d releases](https://github.com/netdata/go.d.plugin/releases/latest), kindly open a github issue and we will do our best to serve your request
+export OS=$(uname -s | tr '[:upper:]' '[:lower:]') ARCH=$(uname -m | sed -e 's/i386/386/g' -e 's/i686/386/g' -e 's/x86_64/amd64/g' -e 's/aarch64/arm64/g' -e 's/armv64/arm64/g' -e 's/armv6l/arm/g' -e 's/armv7l/arm/g' -e 's/armv5tel/arm/g') && curl -s https://api.github.com/repos/netdata/go.d.plugin/releases/latest | grep "browser_download_url.*${OS}-${ARCH}.tar.gz" | cut -d '"' -f 4 | wget -qi -
 
 # go.d configuration 
 curl -s https://api.github.com/repos/netdata/go.d.plugin/releases/latest | grep "browser_download_url.*config.tar.gz" | cut -d '"' -f 4 | wget -qi -

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -48,7 +48,7 @@ To learn more about the pros and cons of using *nightly* vs. *stable* releases, 
 Verify the integrity of the script with this:
 
 ```bash
-[ "574456abacd54a625b44275fda43c507" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "dc439c58bfc41de23b14b86d71c79a31" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 _It should print `OK, VALID` if the script is the one we ship._
@@ -67,14 +67,14 @@ The `kickstart.sh` script passes all its parameters to `netdata-installer.sh`, s
 -   `--dont-start-it`: Prevent the installer from starting Netdata automatically.
 -   `--stable-channel`: Automatically update only on the release of new major versions.
 -   `--no-updates`: Prevent automatic updates of any kind.
--   `--local-tarball-override`: Used for offline installations. Pass four file paths: the Netdata tarball, the checksum file, the go.d plugin tarball, and the go.d plugin config tarball, to force kickstart run the process using those files.
+-   `--local-files`: Used for offline installations. Pass four file paths: the Netdata tarball, the checksum file, the go.d plugin tarball, and the go.d plugin config tarball, to force kickstart run the process using those files.
 
 Example using all the above parameters:
 
 ```bash
-$ bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-tarball-override /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt /tmp/manually.downloaded.go.d.binary.tar.gz /tmp/manually.downloaded.go.d.config.tar.gz
+$ bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-files /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt /tmp/manually.downloaded.go.d.binary.tar.gz /tmp/manually.downloaded.go.d.config.tar.gz
 ```
-Note: `--stable-channel` and `--local-tarball-override` overlap, if you use the tarball override the stable channel option is not effective
+Note: `--stable-channel` and `--local-files` overlap, if you use the tarball override the stable channel option is not effective
 </details>
 
 Once Netdata is installed, see [Getting Started](../../docs/GettingStarted.md).
@@ -109,7 +109,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "8a9f864ddcb70b7dc01d4e5bf4550a81" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "722e0164ccdf98316b3ce5f563ffc2bf" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*
@@ -120,14 +120,14 @@ The `kickstart-static64.sh` script passes all its parameters to `netdata-install
 -   `--dont-start-it`: Prevent the installer from starting Netdata automatically.
 -   `--stable-channel`: Automatically update only on the release of new major versions.
 -   `--no-updates`: Prevent automatic updates of any kind.
--   `--local-tarball-override`: Used for offline installations. Pass two file paths, one for the tarball and one fir the checksum file, to force kickstart run the process using those files.
+-   `--local-files`: Used for offline installations. Pass two file paths, one for the tarball and one fir the checksum file, to force kickstart run the process using those files.
 
 Example using all the above parameters:
 
 ```sh
-$ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-tarball-override /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt
+$ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-files /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt
 ```
-Note: `--stable-channel` and `--local-tarball-override` overlap, if you use the tarball override the stable channel option is not effective
+Note: `--stable-channel` and `--local-files` overlap, if you use the tarball override the stable channel option is not effective
 
 If your shell fails to handle the above one liner, do this:
 
@@ -548,10 +548,10 @@ Move these files to the `/tmp` directory on the offline system in whichever way
 your defined policy allows (if any).
 
 Now you can run either the `kickstart.sh` or `kickstart-static64.sh` scripts
-using the `--local-tarball-override` option. This option requires you to specify
+using the `--local-files` option. This option requires you to specify
 the location and names of the files you just downloaded. 
 
-!!! note When using `--local-tarball-override`, the `kickstart.sh` or
+!!! note When using `--local-files`, the `kickstart.sh` or
     `kickstart-static64.sh` scripts won't download any Netdata assets from the
     internet. But, you may still need a connection to install dependencies using
     your system's package manager. The scripts will warn you if your system
@@ -559,10 +559,10 @@ the location and names of the files you just downloaded.
 
 ```bash
 # kickstart.sh
-bash &lt;(curl -Ss https://my-netdata.io/kickstart.sh) --local-tarball-override /tmp/netdata.tar.gz /tmp/checksums.txt /tmp/go.d.binary.tar.gz /tmp/go.d.config.tar.gz
+bash &lt;(curl -Ss https://my-netdata.io/kickstart.sh) --local-files /tmp/netdata.tar.gz /tmp/checksums.txt /tmp/go.d.binary.tar.gz /tmp/go.d.config.tar.gz
 
 # kickstart-static64.sh
-bash &lt;(curl -Ss https://my-netdata.io/kickstart-static64.sh) --local-tarball-override /tmp/netdata.tar.gz /tmp/checksums.txt
+bash &lt;(curl -Ss https://my-netdata.io/kickstart-static64.sh) --local-files /tmp/netdata.tar.gz /tmp/checksums.txt
 ```
 
 Now that you're finished with your offline installation, you can move on to our

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -8,7 +8,7 @@
 #  --non-interactive        do not wait for input
 #  --dont-start-it          do not start netdata after install
 #  --stable-channel         Use the stable release channel, rather than the nightly to fetch sources
-#  --local-tarball-override Use a manually provided tarball for the installation
+#  --local-files Use a manually provided tarball for the installation
 #
 # ---------------------------------------------------------------------------------------------------------------------
 # library functions copied from packaging/installer/functions.sh
@@ -192,16 +192,16 @@ while [ -n "${1}" ]; do
 		inner_opts="${inner_opts} ${1}"
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
-	elif [ "${1}" = "--local-tarball-override" ]; then
+	elif [ "${1}" = "--local-files" ]; then
 		shift 1
 		if [ -z "${1}" ]; then
-			fatal "Option --local-tarball-override requires extra information. The desired tarball full filename is needed"
+			fatal "Option --local-files requires extra information. The desired tarball full filename is needed"
 		fi
 
 		NETDATA_LOCAL_TARBALL_OVERRIDE="${1}"
 		shift 1
 		if [ -z "${1}" ]; then
-			fatal "Option --local-tarball-override requires a pair of the tarball source and the checksum file"
+			fatal "Option --local-files requires a pair of the tarball source and the checksum file"
 		fi
 
 		NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM="${1}"

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -225,8 +225,8 @@ if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE}" ]; then
 	download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.gz.run"
 else
 	progress "Installation sources were given as input, running installation using \"${NETDATA_LOCAL_TARBALL_OVERRIDE}\""
-	run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE}" "${TMPDIR}/netdata-latest.gz.run"
-	run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM}" "${TMPDIR}/sha256sum.txt"
+	run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE}" "${TMPDIR}/netdata-latest.gz.run"
+	run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM}" "${TMPDIR}/sha256sum.txt"
 fi
 
 if ! grep netdata-latest.gz.run "${TMPDIR}/sha256sum.txt" | safe_sha256sum -c - >/dev/null 2>&1; then

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -210,7 +210,6 @@ while [ -n "${1}" ]; do
 		echo >&2 "Unknown option '${1}'"
 		exit 1
 	fi
-	shift
 done
 [ -n "${inner_opts}" ] && inner_opts="-- ${inner_opts}"
 

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env sh
+#
 # SPDX-License-Identifier: GPL-3.0-or-later
 # shellcheck disable=SC1117,SC2039,SC2059,SC2086
-
+#
+#  Options to run
+#  --dont-wait              do not wait for input
+#  --non-interactive        do not wait for input
+#  --dont-start-it          do not start netdata after install
+#  --stable-channel         Use the stable release channel, rather than the nightly to fetch sources
+#  --local-tarball-override Use a manually provided tarball for the installation
+#
 # ---------------------------------------------------------------------------------------------------------------------
 # library functions copied from packaging/installer/functions.sh
 
@@ -127,6 +135,11 @@ download() {
 }
 
 set_tarball_urls() {
+	if [ -n "${NETDATA_LOCAL_TARBALL_OVERRIDE}" ]; then
+		progress "Not fetching remote tarballs, local override was given"
+		return
+	fi
+
 	if [ "$1" = "stable" ]; then
 		local latest
 		# Simple version
@@ -179,6 +192,20 @@ while [ -n "${1}" ]; do
 		inner_opts="${inner_opts} ${1}"
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
+	elif [ "${1}" = "--local-tarball-override" ]; then
+		shift 1
+		if [ -z "${1}" ]; then
+			fatal "Option --local-tarball-override requires extra information. The desired tarball full filename is needed"
+		fi
+
+		NETDATA_LOCAL_TARBALL_OVERRIDE="${1}"
+		shift 1
+		if [ -z "${1}" ]; then
+			fatal "Option --local-tarball-override requires a pair of the tarball source and the checksum file"
+		fi
+
+		NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM="${1}"
+		shift 1
 	else
 		echo >&2 "Unknown option '${1}'"
 		exit 1
@@ -191,11 +218,18 @@ done
 TMPDIR=$(create_tmp_directory)
 cd "${TMPDIR}"
 
-set_tarball_urls "${RELEASE_CHANNEL}"
-progress "Downloading static netdata binary: ${NETDATA_TARBALL_URL}"
+if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE}" ]; then
+	set_tarball_urls "${RELEASE_CHANNEL}"
+	progress "Downloading static netdata binary: ${NETDATA_TARBALL_URL}"
 
-download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
-download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.gz.run"
+	download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
+	download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.gz.run"
+else
+	progress "Installation sources were given as input, running installation using \"${NETDATA_LOCAL_TARBALL_OVERRIDE}\""
+	run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE}" "${TMPDIR}/netdata-latest.gz.run"
+	run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM}" "${TMPDIR}/sha256sum.txt"
+fi
+
 if ! grep netdata-latest.gz.run "${TMPDIR}/sha256sum.txt" | safe_sha256sum -c - >/dev/null 2>&1; then
 	fatal "Static binary checksum validation failed. Stopping netdata installation and leaving binary in ${TMPDIR}"
 fi

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -207,7 +207,7 @@ while [ -n "${1}" ]; do
 		NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM="${1}"
 		shift 1
 	else
-		echo >&2 "Unknown option '${1}'"
+		echo >&2 "Unknown option '${1}' or invalid number of arguments. Please check the README for the available arguments of ${0} and try again"
 		exit 1
 	fi
 done

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -302,17 +302,31 @@ while [ -n "${1}" ]; do
 	elif [ "${1}" == "--local-tarball-override" ]; then
 		shift 1
 		if [ -z "${1}" ]; then
-			fatal "Option --local-tarball-override requires extra information. The desired tarball full filename is needed"
+			fatal "Missing netdata: Option --local-tarball-override requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
 		fi
 
-		NETDATA_LOCAL_TARBALL_OVERRIDE="${1}"
+		export NETDATA_LOCAL_TARBALL_OVERRIDE="${1}"
 		shift 1
 
 		if [ -z "${1}" ]; then
-			fatal "Option --local-tarball-override requires extra information. The desired tarball and the checksum file"
+			fatal "Missing checksum file: Option --local-tarball-override requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
 		fi
 
-		NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM="${1}"
+		export NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM="${1}"
+		shift 1
+
+		if [ -z "${1}" ]; then
+			fatal "Missing go.d tarball: Option --local-tarball-override requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+		fi
+
+		export NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN="${1}"
+		shift 1
+
+		if [ -z "${1}" ]; then
+			fatal "Missing go.d config tarball: Option --local-tarball-override requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+		fi
+
+		export NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG="${1}"
 		shift 1
 	else
 		break

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -222,8 +222,17 @@ dependencies() {
 		if ! detect_bash4 "${bash}"; then
 			warning "Cannot detect packages to be installed in this system, without BASH v4+."
 		else
-			progress "Downloading script to detect required packages..."
-			download "${PACKAGES_SCRIPT}" "${TMPDIR}/install-required-packages.sh"
+			progress "Fetching script to detect required packages..."
+			if [ -n "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" ]; then
+				if [ -f "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" ]; then
+					run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" "${TMPDIR}/install-required-packages.sh"
+				else
+					fatal "Invalid given dependency file, please check your --local-files parameter options and try again"
+				fi
+			else
+				download "${PACKAGES_SCRIPT}" "${TMPDIR}/install-required-packages.sh"
+			fi
+
 			if [ ! -s "${TMPDIR}/install-required-packages.sh" ]; then
 				warning "Downloaded dependency installation script is empty."
 			else
@@ -299,34 +308,41 @@ while [ -n "${1}" ]; do
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
 		shift 1
-	elif [ "${1}" == "--local-files" ]; then
+	elif [ "${1}" = "--local-files" ]; then
 		shift 1
 		if [ -z "${1}" ]; then
-			fatal "Missing netdata: Option --local-files requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+			fatal "Missing netdata: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
 		fi
 
 		export NETDATA_LOCAL_TARBALL_OVERRIDE="${1}"
 		shift 1
 
 		if [ -z "${1}" ]; then
-			fatal "Missing checksum file: Option --local-files requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+			fatal "Missing checksum file: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
 		fi
 
 		export NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM="${1}"
 		shift 1
 
 		if [ -z "${1}" ]; then
-			fatal "Missing go.d tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+			fatal "Missing go.d tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
 		fi
 
 		export NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN="${1}"
 		shift 1
 
 		if [ -z "${1}" ]; then
-			fatal "Missing go.d config tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+			fatal "Missing go.d config tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
 		fi
 
 		export NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG="${1}"
+		shift 1
+
+		if [ -z "${1}" ]; then
+			fatal "Missing dependencies management scriptlet: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
+		fi
+
+		export NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT="${1}"
 		shift 1
 	else
 		break

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -225,7 +225,7 @@ dependencies() {
 			progress "Fetching script to detect required packages..."
 			if [ -n "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" ]; then
 				if [ -f "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" ]; then
-					run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" "${TMPDIR}/install-required-packages.sh"
+					run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" "${TMPDIR}/install-required-packages.sh"
 				else
 					fatal "Invalid given dependency file, please check your --local-files parameter options and try again"
 				fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -13,7 +13,7 @@
 #  --dont-wait                do not prompt for user input
 #  --non-interactive          do not prompt for user input
 #  --no-updates               do not install script for daily updates
-#  --local-tarball-override   set the full path of the desired tarball to run install with
+#  --local-files   set the full path of the desired tarball to run install with
 #
 # This script will:
 #
@@ -299,31 +299,31 @@ while [ -n "${1}" ]; do
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
 		shift 1
-	elif [ "${1}" == "--local-tarball-override" ]; then
+	elif [ "${1}" == "--local-files" ]; then
 		shift 1
 		if [ -z "${1}" ]; then
-			fatal "Missing netdata: Option --local-tarball-override requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+			fatal "Missing netdata: Option --local-files requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
 		fi
 
 		export NETDATA_LOCAL_TARBALL_OVERRIDE="${1}"
 		shift 1
 
 		if [ -z "${1}" ]; then
-			fatal "Missing checksum file: Option --local-tarball-override requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+			fatal "Missing checksum file: Option --local-files requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
 		fi
 
 		export NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM="${1}"
 		shift 1
 
 		if [ -z "${1}" ]; then
-			fatal "Missing go.d tarball: Option --local-tarball-override requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+			fatal "Missing go.d tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
 		fi
 
 		export NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN="${1}"
 		shift 1
 
 		if [ -z "${1}" ]; then
-			fatal "Missing go.d config tarball: Option --local-tarball-override requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
+			fatal "Missing go.d config tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksumi, the go.d plugin tarball and the go.d plugin config tarball, in this particular order"
 		fi
 
 		export NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG="${1}"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -353,8 +353,8 @@ if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE}" ]; then
 	download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.tar.gz"
 else
 	progress "Installation sources were given as input, running installation using \"${NETDATA_LOCAL_TARBALL_OVERRIDE}\""
-	run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM}" "${TMPDIR}/sha256sum.txt"
-	run mv "${NETDATA_LOCAL_TARBALL_OVERRIDE}" "${TMPDIR}/netdata-latest.tar.gz"
+	run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM}" "${TMPDIR}/sha256sum.txt"
+	run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE}" "${TMPDIR}/netdata-latest.tar.gz"
 fi
 
 if ! grep netdata-latest.tar.gz "${TMPDIR}/sha256sum.txt" | safe_sha256sum -c - >/dev/null 2>&1; then


### PR DESCRIPTION
##### Summary
We introduce the option `--local-files` to allow our users to manually define the source and the checksum file for the kickstart to use in the installation process.
This option is useful for cases that users do not want to run kickstart with an internet connection

Note: we still require internet though for the dependency management

##### Component Name
netdata/installer/kickstart
netdata/installer/kickstart-static64

##### Additional Information
Fixes #6684 
