### PR TITLE
netdata/packaging: Split CUPS plugin to separate package (RPM)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ stages:
 
     # Build RPM packages under special conditions
   - name: Package centos, fedora and opensuse
-    if: type != cron AND type != pull_request AND branch = split-cups
+    if: type != cron AND type != pull_request AND branch = master
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - export PACKAGING_USER="netdata" # Standard package cloud account
   - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export DEPLOY_REPO="netdata-edge"; fi;
   - export PACKAGE_CLOUD_RETENTION_DAYS=30
-  - if [ "${TRAVIS_REPO_SLUG}" = "paulkatsoulakis/netdata" ]; then export DEPLOY_REPO="netdata-devel";  fi;
+  - if [ ! "${TRAVIS_REPO_SLUG}" = "netdata/netdata" ]; then export DEPLOY_REPO="netdata-devel";  fi;
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,11 @@ install:
   - export LATEST_RELEASE_DATE="$(git log -1 --format=%aD "${LATEST_RELEASE_VERSION}" | cat)"
   - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export BUILD_VERSION="$(cat packaging/version | cut -d'-' -f1,2 | sed -e 's/-/./g').latest"; fi;
   - export DEPLOY_REPO="netdata"  # Default production packaging repository
+  - export PACKAGING_USER="netdata" # Standard package cloud account
   - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export DEPLOY_REPO="netdata-edge"; fi;
   - export PACKAGING_USER="$(echo ${TRAVIS_REPO_SLUG} | cut -d'/' -f1)"
   - export PACKAGE_CLOUD_RETENTION_DAYS=30
+  - if [ "${TRAVIS_REPO_SLUG}" = "paulkatsoulakis/netdata" ]; then export DEPLOY_REPO="netdata-devel";  fi;
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ install:
   - export LATEST_RELEASE_DATE="$(git log -1 --format=%aD "${LATEST_RELEASE_VERSION}" | cat)"
   - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export BUILD_VERSION="$(cat packaging/version | cut -d'-' -f1,2 | sed -e 's/-/./g').latest"; fi;
   - export DEPLOY_REPO="netdata"  # Default production packaging repository
-  - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export DEPLOY_REPO="netdata-edge"; fi;
   - export PACKAGING_USER="netdata" # Standard package cloud account
+  - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export DEPLOY_REPO="netdata-edge"; fi;
   - export PACKAGE_CLOUD_RETENTION_DAYS=30
   - if [ "${TRAVIS_REPO_SLUG}" = "paulkatsoulakis/netdata" ]; then export DEPLOY_REPO="netdata-devel";  fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,8 @@ install:
   - export LATEST_RELEASE_DATE="$(git log -1 --format=%aD "${LATEST_RELEASE_VERSION}" | cat)"
   - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export BUILD_VERSION="$(cat packaging/version | cut -d'-' -f1,2 | sed -e 's/-/./g').latest"; fi;
   - export DEPLOY_REPO="netdata"  # Default production packaging repository
-  - export PACKAGING_USER="netdata" # Standard package cloud account
   - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export DEPLOY_REPO="netdata-edge"; fi;
-  - export PACKAGING_USER="$(echo ${TRAVIS_REPO_SLUG} | cut -d'/' -f1)"
+  - export PACKAGING_USER="netdata" # Standard package cloud account
   - export PACKAGE_CLOUD_RETENTION_DAYS=30
   - if [ "${TRAVIS_REPO_SLUG}" = "paulkatsoulakis/netdata" ]; then export DEPLOY_REPO="netdata-devel";  fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ stages:
 
     # Build RPM packages under special conditions
   - name: Package centos, fedora and opensuse
-    if: type != cron AND type != pull_request AND branch = master
+    if: type != cron AND type != pull_request AND branch = split-cups
 
 
 

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -103,7 +103,6 @@ def install_common_dependendencies(container):
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "freeipmi-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups-devel"])
-        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "snappy-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-c-devel"])
@@ -123,7 +122,6 @@ def install_common_dependendencies(container):
     else:
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "gcc-c++"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups-devel"])
-        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "freeipmi-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "snappy-devel"])

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -103,6 +103,7 @@ def install_common_dependendencies(container):
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "freeipmi-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups-devel"])
+        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "snappy-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-c-devel"])
@@ -122,6 +123,7 @@ def install_common_dependendencies(container):
     else:
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "gcc-c++"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups-devel"])
+        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "cups"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "freeipmi-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "json-c-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "snappy-devel"])

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 %global contentdir %{_datadir}/netdata
+%global version @PACKAGE_VERSION@
 
 #TODO: Temporary fix for the build-id error during go.d plugin set up
 %global _missing_build_ids_terminate_build 0
@@ -82,7 +83,7 @@ fi \
 
 Summary:	Real-time performance monitoring, done right!
 Name:		netdata
-Version:	@PACKAGE_VERSION@
+Version:	%{version}
 Release:	1%{?dist}
 License:	GPLv3+
 Group:		Applications/System
@@ -489,7 +490,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 Summary: The Common Unix Printing System plugin for netdata
 Group: Applications/System
 Requires: cups
-Requires: netdata
+Requires: netdata = %{version}
 
 %description plugin-cups
  This is the Common Unix Printing System plugin for the netdata daemon.

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -277,6 +277,10 @@ install -m 4750 -p apps.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.
 install -m 4750 -p perf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/perf.plugin"
 
 # ###########################################################
+# Install cups.plugin
+install -m 0750 -p cups.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/cups.plugin"
+
+# ###########################################################
 # Install registry directory
 install -m 755 -d "${RPM_BUILD_ROOT}%{_localstatedir}/lib/%{name}/registry"
 install -m 755 -d "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/custom-plugins.d"
@@ -482,6 +486,17 @@ rm -rf "${RPM_BUILD_ROOT}"
 %attr(0755,netdata,root) %dir %{_localstatedir}/log/%{name}
 %attr(0770,netdata,netdata) %dir %{_localstatedir}/lib/%{name}
 %attr(0770,netdata,netdata) %dir %{_localstatedir}/lib/%{name}/registry
+
+%package plugin-cups
+Summary: The Common Unix Printing System plugin for netdata
+Group: Applications/System
+
+%description plugin-cups
+ This is the Common Unix Printing System plugin for the netdata daemon.
+Use this plugin to enable metrics collection from cupsd, the daemon running when CUPS is enabled on the system
+
+%files plugin-cups
+%attr(4550,root,netdata) %{_libexecdir}/%{name}/plugins.d/cups.plugin
 
 
 %changelog

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -193,7 +193,6 @@ Requires: freeipmi
 
 # CUPS plugin dependencies
 BuildRequires: cups-devel
-BuildRequires: cups
 # end - cups plugin dependencies
 
 # Prometheus remote write dependencies

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -193,6 +193,7 @@ Requires: freeipmi
 
 # CUPS plugin dependencies
 BuildRequires: cups-devel
+BuildRequires: cups
 # end - cups plugin dependencies
 
 # Prometheus remote write dependencies

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -192,7 +192,6 @@ Requires: freeipmi
 
 # CUPS plugin dependencies
 BuildRequires: cups-devel
-Requires: cups
 # end - cups plugin dependencies
 
 # Prometheus remote write dependencies
@@ -489,6 +488,8 @@ rm -rf "${RPM_BUILD_ROOT}"
 %package plugin-cups
 Summary: The Common Unix Printing System plugin for netdata
 Group: Applications/System
+Requires: cups
+Requires: netdata
 
 %description plugin-cups
  This is the Common Unix Printing System plugin for the netdata daemon.

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -501,7 +501,7 @@ Requires: netdata = %{version}
 Use this plugin to enable metrics collection from cupsd, the daemon running when CUPS is enabled on the system
 
 %files plugin-cups
-%attr(4550,root,netdata) %{_libexecdir}/%{name}/plugins.d/cups.plugin
+%attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cups.plugin
 
 %changelog
 * Tue Aug 20 2019 Pavlos Emm. Katsoulakis <paul@netdat.acloud> - 0.0.0-8

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -276,10 +276,6 @@ install -m 4750 -p apps.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.
 install -m 4750 -p perf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/perf.plugin"
 
 # ###########################################################
-# Install cups.plugin
-install -m 0750 -p cups.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/cups.plugin"
-
-# ###########################################################
 # Install registry directory
 install -m 755 -d "${RPM_BUILD_ROOT}%{_localstatedir}/lib/%{name}/registry"
 install -m 755 -d "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/custom-plugins.d"
@@ -499,8 +495,9 @@ Use this plugin to enable metrics collection from cupsd, the daemon running when
 %files plugin-cups
 %attr(4550,root,netdata) %{_libexecdir}/%{name}/plugins.d/cups.plugin
 
-
 %changelog
+* Tue Aug 20 2019 Pavlos Emm. Katsoulakis <paul@netdat.acloud> - 0.0.0-8
+- Split CUPS functionality on separate package
 * Fri Jun 28 2019 Pavlos Emm. Katsoulakis <paul@netdata.cloud> - 0.0.0-7
 - Raise the path overrides to the spec file level, not just the configure.
 - Adjust tighter permissions on some folders, based on what we did on our installer

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -276,6 +276,11 @@ install -m 4750 -p apps.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.
 install -m 4750 -p perf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/perf.plugin"
 
 # ###########################################################
+# Install cups.plugin
+install -m 0750 -p cups.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/cups.plugin"
+
+
+# ###########################################################
 # Install registry directory
 install -m 755 -d "${RPM_BUILD_ROOT}%{_localstatedir}/lib/%{name}/registry"
 install -m 755 -d "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/custom-plugins.d"
@@ -481,6 +486,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 %attr(0755,netdata,root) %dir %{_localstatedir}/log/%{name}
 %attr(0770,netdata,netdata) %dir %{_localstatedir}/lib/%{name}
 %attr(0770,netdata,netdata) %dir %{_localstatedir}/lib/%{name}/registry
+
+# CUPS belongs to a different sub package
+%exclude %{_libexecdir}/%{name}/plugins.d/cups.plugin
 
 %package plugin-cups
 Summary: The Common Unix Printing System plugin for netdata

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 %global contentdir %{_datadir}/netdata
 
-
 #TODO: Temporary fix for the build-id error during go.d plugin set up
 %global _missing_build_ids_terminate_build 0
 


### PR DESCRIPTION

##### Summary
As per the #6662 report, the time has come to consider separating all plugins that are easy to split on separate packages. 

This is the first plugin from a series of plugins that can be separated.
Once we fine grain the results of this PR we will mass-change the rest of the plugins following the same templated way given here.

Note: won't be touching .DEB sub-packaging yet as i need more context to get through

##### Component Name
netdata/packaging

##### Additional Information
Fixes #6662