### PR TITLE
exact path to netdata.conf in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ netdata-coverity-analysis.tgz
 .settings/
 README
 TODO.md
-system/netdata.conf
 TODO.txt
 
 web/gui/chart-info/

--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,7 @@ netdata-coverity-analysis.tgz
 .settings/
 README
 TODO.md
-netdata.conf
+system/netdata.conf
 TODO.txt
 
 web/gui/chart-info/


### PR DESCRIPTION
Signed-off-by: Katharina Drexel <katharina.drexel@bfh.ch>



##### Summary

adding system/netdata.conf in the .gitignore file instead of netdata.conf

##### Component Name

.gitignore

##### Additional Information

When building a netdata debian package there are config files under debian/local. Excluding only "netdata.conf" in .gitignore is a nuisance because elementary config files will be missing and the package won't build. Full paths will prevent build errors.