### PR TITLE
netdata/installer: fix static64 installer always overwriting configuration

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -10,6 +10,13 @@ umask 002
 renice 19 $$ >/dev/null 2>/dev/null
 
 # -----------------------------------------------------------------------------
+if [ -d /opt/netdata/etc/netdata.old ]; then
+	progress "Found old etc/netdata directory, reinstating this"
+	mv -f /opt/netdata/etc/netdata /opt/netdata/etc/netdata.new
+	mv -f /opt/netdata/etc/netdata.old /opt/netdata/etc/netdata
+	progress "Trigger stock config clean up"
+	rm -f /opt/netdata/etc/netdata/.installer-cleanup-of-stock-configs-done
+fi
 
 STARTIT=1
 
@@ -215,11 +222,6 @@ fi
 
 
 # -----------------------------------------------------------------------------
-if [ -d /opt/netdata/etc/netdata.old ]; then
-	progress "Found old etc/netdata directory, reinstating this"
-	mv -f /opt/netdata/etc/netdata /opt/netdata/etc/netdata.new
-	mv -f /opt/netdata/etc/netdata.old /opt/netdata/etc/netdata
-fi
 
 if [ ${STARTIT} -eq 0 ]; then
     create_netdata_conf "/opt/netdata/etc/netdata/netdata.conf"

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -215,6 +215,11 @@ fi
 
 
 # -----------------------------------------------------------------------------
+if [ -d /opt/netdata/etc/netdata.old ]; then
+	progress "Found old etc/netdata directory, reinstating this"
+	mv -f /opt/netdata/etc/netdata /opt/netdata/etc/netdata.new
+	mv -f /opt/netdata/etc/netdata.old /opt/netdata/etc/netdata
+fi
 
 if [ ${STARTIT} -eq 0 ]; then
     create_netdata_conf "/opt/netdata/etc/netdata/netdata.conf"

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -12,7 +12,7 @@ renice 19 $$ >/dev/null 2>/dev/null
 # -----------------------------------------------------------------------------
 if [ -d /opt/netdata/etc/netdata.old ]; then
 	progress "Found old etc/netdata directory, reinstating this"
-	[ -f /opt/netdata/etc/netdata.new ] && rm -rf /opt/netdata/etc/netdata.new
+	[ -d /opt/netdata/etc/netdata.new ] && rm -rf /opt/netdata/etc/netdata.new
 	mv -f /opt/netdata/etc/netdata /opt/netdata/etc/netdata.new
 	mv -f /opt/netdata/etc/netdata.old /opt/netdata/etc/netdata
 

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -12,8 +12,10 @@ renice 19 $$ >/dev/null 2>/dev/null
 # -----------------------------------------------------------------------------
 if [ -d /opt/netdata/etc/netdata.old ]; then
 	progress "Found old etc/netdata directory, reinstating this"
+	[ -f /opt/netdata/etc/netdata.new ] && rm -rf /opt/netdata/etc/netdata.new
 	mv -f /opt/netdata/etc/netdata /opt/netdata/etc/netdata.new
 	mv -f /opt/netdata/etc/netdata.old /opt/netdata/etc/netdata
+
 	progress "Trigger stock config clean up"
 	rm -f /opt/netdata/etc/netdata/.installer-cleanup-of-stock-configs-done
 fi

--- a/packaging/makeself/makeself-header.sh
+++ b/packaging/makeself/makeself-header.sh
@@ -438,6 +438,7 @@ if test x"\$nox11" = xn; then
     fi
 fi
 
+[ -d "\$targetdir/etc/netdata.old" ] && echo "Moving existing old directory" && mv "\$targetdir/etc/netdata.old" "\$targetdir/etc/netdata.old.$$"
 [ -d \$targetdir/etc/netdata ] && echo "Backing up existing directory" && cp -r \$targetdir/etc/netdata "\$targetdir/etc/netdata.old"
 
 if test x"\$targetdir" = x.; then

--- a/packaging/makeself/makeself-header.sh
+++ b/packaging/makeself/makeself-header.sh
@@ -438,6 +438,8 @@ if test x"\$nox11" = xn; then
     fi
 fi
 
+[ -d \$targetdir/etc/netdata ] && echo "Backing up existing directory" && cp -r \$targetdir/etc/netdata "\$targetdir/etc/netdata.old"
+
 if test x"\$targetdir" = x.; then
     tmpdir="."
 else


### PR DESCRIPTION

##### Summary
As per the #6692 issue, it has been identified that a BUG exists on the static installation regarding the preservation of existing configuration files when the installer runs for the second time.

After investigating the scenarios, it seems that the static installer was always re-creating the folder structure, thus resulting into always having a clean installation of netdata regardless of any customisations a user may have done in the config folder.

With this PR we attempt to mitigate the issue by touching two places:
1) Initial entry point script of makeself, to trigger the back-up of the configuration folder if it already exists

2) Adjust the install or update scriptlet and make it reinstate the existing folder and also trigger stock config files clean up (if the files weren't modified)


##### Component Name
netdata/installer

##### Additional Information
Fixes #6692 