### PR TITLE
History tips

### DIFF
--- a/web/gui/dashboard.css
+++ b/web/gui/dashboard.css
@@ -746,10 +746,12 @@ body {
     margin-right: 25px;
     direction: rtl;
     overflow: hidden;
+    pointer-events: none;
 }
 
 .dygraph__history-tip-content {
     display: inline-block;
     white-space: nowrap;
     direction: ltr;
+    pointer-events: auto;
 }

--- a/web/gui/dashboard.css
+++ b/web/gui/dashboard.css
@@ -737,3 +737,19 @@ body {
 .ps-container:hover > .ps-scrollbar-y-rail:hover > .ps-scrollbar-y {
     background-color: #999; /* scrollbar color on hover */
 }
+
+.dygraph__history-tip {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    display: none; /* overriden in js */
+    margin-right: 25px;
+    direction: rtl;
+    overflow: hidden;
+}
+
+.dygraph__history-tip-content {
+    display: inline-block;
+    white-space: nowrap;
+    direction: ltr;
+}

--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -2281,8 +2281,28 @@ NETDATA.dygraphChartCreate = function (state, data) {
             NETDATA.globalSelectionSync.stop();
         },
         underlayCallback: function (canvas, area, g) {
-
             // the chart is about to be drawn
+
+            // update history_tip_element
+            if (state.tmp.dygraph_history_tip_element) {
+                const xHookRightSide = g.toDomXCoord(state.netdata_first);
+                if (xHookRightSide > area.x) {
+                    state.tmp.dygraph_history_tip_element_displayed = true;
+                    // group the styles for possible better performance
+                    state.tmp.dygraph_history_tip_element.setAttribute(
+                      'style',
+                      `display: block; left: ${area.x}px; right: calc(100% - ${xHookRightSide}px);`
+                    )
+                } else {
+                    if (state.tmp.dygraph_history_tip_element_displayed) {
+                        // additional check just for performance
+                        // don't update the DOM when it's not needed
+                        state.tmp.dygraph_history_tip_element.style.display = 'none';
+                        state.tmp.dygraph_history_tip_element_displayed = false;
+                    }
+                }
+            }
+
             // this function renders global highlighted time-frame
 
             if (NETDATA.globalChartUnderlay.isActive()) {
@@ -2750,6 +2770,21 @@ NETDATA.dygraphChartCreate = function (state, data) {
 
     state.tmp.dygraph_instance = new Dygraph(state.element_chart,
         data.result.data, state.tmp.dygraph_options);
+
+
+    state.tmp.dygraph_history_tip_element = document.createElement('div');
+    state.tmp.dygraph_history_tip_element.innerHTML = `
+        <span class="dygraph__history-tip-content">
+          Want to extend your history of real-time metrics?
+          <br />
+           <a href="https://docs.netdata.cloud/daemon/config/#global-section-options" target=_blank>
+             Configure Netdata's <b>history</b></a>
+           or use the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine</a>.
+        </span>
+    `;
+    state.tmp.dygraph_history_tip_element.className = 'dygraph__history-tip';
+    state.element_chart.appendChild(state.tmp.dygraph_history_tip_element);
+
 
     state.tmp.dygraph_force_zoom = false;
     state.tmp.dygraph_user_action = false;

--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -2777,7 +2777,7 @@ NETDATA.dygraphChartCreate = function (state, data) {
         <span class="dygraph__history-tip-content">
           Want to extend your history of real-time metrics?
           <br />
-           <a href="https://docs.netdata.cloud/daemon/config/#global-section-options" target=_blank>
+           <a href="https://docs.netdata.cloud/docs/configuration-guide/#increase-the-metrics-retention-period" target=_blank>
              Configure Netdata's <b>history</b></a>
            or use the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine</a>.
         </span>

--- a/web/gui/dashboard.slate.css
+++ b/web/gui/dashboard.slate.css
@@ -764,10 +764,12 @@ code {
     margin-right: 25px;
     direction: rtl;
     overflow: hidden;
+    pointer-events: none;
 }
 
 .dygraph__history-tip-content {
     display: inline-block;
     white-space: nowrap;
     direction: ltr;
+    pointer-events: auto;
 }

--- a/web/gui/dashboard.slate.css
+++ b/web/gui/dashboard.slate.css
@@ -755,3 +755,19 @@ code {
 .ps-container:hover > .ps-scrollbar-y-rail:hover > .ps-scrollbar-y {
     background-color: #999; /* scrollbar color on hover */
 }
+
+.dygraph__history-tip {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    display: none; /* overriden in js */
+    margin-right: 25px;
+    direction: rtl;
+    overflow: hidden;
+}
+
+.dygraph__history-tip-content {
+    display: inline-block;
+    white-space: nowrap;
+    direction: ltr;
+}

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -1788,16 +1788,19 @@ function renderPage(menus, data) {
 
     sidebar += '<li class="" style="padding-top:15px;"><a href="https://github.com/netdata/netdata/blob/master/docs/Add-more-charts-to-netdata.md#add-more-charts-to-netdata" target="_blank"><i class="fas fa-plus"></i> add more charts</a></li>';
     sidebar += '<li class=""><a href="https://github.com/netdata/netdata/tree/master/health#Health-monitoring" target="_blank"><i class="fas fa-plus"></i> add more alarms</a></li>';
-    sidebar += '<li class="" style="margin:20px;color:#666;"><small>netdata on <b>' +
-      data.hostname.toString() + '</b>, collects every ' +
-      ((data.update_every === 1) ? 'second' : data.update_every.toString() + ' seconds') +
-      ' <b>' + data.dimensions_count.toLocaleString() + '</b> metrics, presented as <b>' +
-      data.charts_count.toLocaleString() + '</b> charts and monitored by <b>' +
-      data.alarms_count.toLocaleString() + '</b> alarms, using ' +
-      Math.round(data.rrd_memory_bytes / 1024 / 1024).toLocaleString() + ' MB of memory for ' +
-      NETDATA.seconds4human(data.update_every * data.history, { space: '&nbsp;' }) +
-      ' of real-time history.<br/>&nbsp;<br/><b>netdata</b><br/>' +
-      data.version.toString() + '</small></li>';
+    sidebar += '<li class="" style="margin:20px;color:#666;"><small>Every ' +
+      ((data.update_every === 1) ? 'second' : data.update_every.toString() + ' seconds') + ', ' +
+      'Netdata collects <b>' + data.dimensions_count.toLocaleString() + '</b> metrics, presents them in <b>' +
+      data.charts_count.toLocaleString() + '</b> charts and monitors them with <b>' +
+      data.alarms_count.toLocaleString() + '</b> alarms. Netdata is using ' +
+      Math.round(data.rrd_memory_bytes / 1024 / 1024).toLocaleString() + ' MB of memory on <b>' +
+      data.hostname.toString() + '</b> for ' +
+      NETDATA.seconds4human(data.update_every * data.history, {
+        minute: 'minute', minutes: 'minutes', second: 'second', seconds: 'seconds', space: '&nbsp;',
+      }) +
+      ' of real-time history.<br />&nbsp;<br />' + 'Get more history by ' +
+      '<a href="https://docs.netdata.cloud/daemon/config/#global-section-options" target=_blank>configuring Netdata\'s <b>history</b></a> or using the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine.</a>' +
+      '<br/>&nbsp;<br/><b>netdata</b><br/>' + data.version.toString() + '</small></li>';
     sidebar += '</ul>';
     div.innerHTML = html;
     document.getElementById('sidebar').innerHTML = sidebar;

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -1788,7 +1788,16 @@ function renderPage(menus, data) {
 
     sidebar += '<li class="" style="padding-top:15px;"><a href="https://github.com/netdata/netdata/blob/master/docs/Add-more-charts-to-netdata.md#add-more-charts-to-netdata" target="_blank"><i class="fas fa-plus"></i> add more charts</a></li>';
     sidebar += '<li class=""><a href="https://github.com/netdata/netdata/tree/master/health#Health-monitoring" target="_blank"><i class="fas fa-plus"></i> add more alarms</a></li>';
-    sidebar += '<li class="" style="margin:20px;color:#666;"><small>netdata on <b>' + data.hostname.toString() + '</b>, collects every ' + ((data.update_every === 1) ? 'second' : data.update_every.toString() + ' seconds') + ' <b>' + data.dimensions_count.toLocaleString() + '</b> metrics, presented as <b>' + data.charts_count.toLocaleString() + '</b> charts and monitored by <b>' + data.alarms_count.toLocaleString() + '</b> alarms, using ' + Math.round(data.rrd_memory_bytes / 1024 / 1024).toLocaleString() + ' MB of memory for ' + NETDATA.seconds4human(data.update_every * data.history, { space: '&nbsp;' }) + ' of real-time history.<br/>&nbsp;<br/><b>netdata</b><br/>' + data.version.toString() + '</small></li>';
+    sidebar += '<li class="" style="margin:20px;color:#666;"><small>netdata on <b>' +
+      data.hostname.toString() + '</b>, collects every ' +
+      ((data.update_every === 1) ? 'second' : data.update_every.toString() + ' seconds') +
+      ' <b>' + data.dimensions_count.toLocaleString() + '</b> metrics, presented as <b>' +
+      data.charts_count.toLocaleString() + '</b> charts and monitored by <b>' +
+      data.alarms_count.toLocaleString() + '</b> alarms, using ' +
+      Math.round(data.rrd_memory_bytes / 1024 / 1024).toLocaleString() + ' MB of memory for ' +
+      NETDATA.seconds4human(data.update_every * data.history, { space: '&nbsp;' }) +
+      ' of real-time history.<br/>&nbsp;<br/><b>netdata</b><br/>' +
+      data.version.toString() + '</small></li>';
     sidebar += '</ul>';
     div.innerHTML = html;
     document.getElementById('sidebar').innerHTML = sidebar;

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -1799,7 +1799,7 @@ function renderPage(menus, data) {
         minute: 'minute', minutes: 'minutes', second: 'second', seconds: 'seconds', space: '&nbsp;',
       }) +
       ' of real-time history.<br />&nbsp;<br />' + 'Get more history by ' +
-      '<a href="https://docs.netdata.cloud/daemon/config/#global-section-options" target=_blank>configuring Netdata\'s <b>history</b></a> or using the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine.</a>' +
+      '<a href="https://docs.netdata.cloud/docs/configuration-guide/#increase-the-metrics-retention-period" target=_blank>configuring Netdata\'s <b>history</b></a> or using the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine.</a>' +
       '<br/>&nbsp;<br/><b>netdata</b><br/>' + data.version.toString() + '</small></li>';
     sidebar += '</ul>';
     div.innerHTML = html;

--- a/web/gui/src/dashboard.js/charting/dygraph.js
+++ b/web/gui/src/dashboard.js/charting/dygraph.js
@@ -979,7 +979,7 @@ NETDATA.dygraphChartCreate = function (state, data) {
         <span class="dygraph__history-tip-content">
           Want to extend your history of real-time metrics?
           <br />
-           <a href="https://docs.netdata.cloud/daemon/config/#global-section-options" target=_blank>
+           <a href="https://docs.netdata.cloud/docs/configuration-guide/#increase-the-metrics-retention-period" target=_blank>
              Configure Netdata's <b>history</b></a>
            or use the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine</a>.
         </span>

--- a/web/gui/src/dashboard.js/charting/dygraph.js
+++ b/web/gui/src/dashboard.js/charting/dygraph.js
@@ -483,8 +483,28 @@ NETDATA.dygraphChartCreate = function (state, data) {
             NETDATA.globalSelectionSync.stop();
         },
         underlayCallback: function (canvas, area, g) {
-
             // the chart is about to be drawn
+
+            // update history_tip_element
+            if (state.tmp.dygraph_history_tip_element) {
+                const xHookRightSide = g.toDomXCoord(state.netdata_first);
+                if (xHookRightSide > area.x) {
+                    state.tmp.dygraph_history_tip_element_displayed = true;
+                    // group the styles for possible better performance
+                    state.tmp.dygraph_history_tip_element.setAttribute(
+                      'style',
+                      `display: block; left: ${area.x}px; right: calc(100% - ${xHookRightSide}px);`
+                    )
+                } else {
+                    if (state.tmp.dygraph_history_tip_element_displayed) {
+                        // additional check just for performance
+                        // don't update the DOM when it's not needed
+                        state.tmp.dygraph_history_tip_element.style.display = 'none';
+                        state.tmp.dygraph_history_tip_element_displayed = false;
+                    }
+                }
+            }
+
             // this function renders global highlighted time-frame
 
             if (NETDATA.globalChartUnderlay.isActive()) {
@@ -952,6 +972,21 @@ NETDATA.dygraphChartCreate = function (state, data) {
 
     state.tmp.dygraph_instance = new Dygraph(state.element_chart,
         data.result.data, state.tmp.dygraph_options);
+
+
+    state.tmp.dygraph_history_tip_element = document.createElement('div');
+    state.tmp.dygraph_history_tip_element.innerHTML = `
+        <span class="dygraph__history-tip-content">
+          Want to extend your history of real-time metrics?
+          <br />
+           <a href="https://docs.netdata.cloud/daemon/config/#global-section-options" target=_blank>
+             Configure Netdata's <b>history</b></a>
+           or use the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine</a>.
+        </span>
+    `;
+    state.tmp.dygraph_history_tip_element.className = 'dygraph__history-tip';
+    state.element_chart.appendChild(state.tmp.dygraph_history_tip_element);
+
 
     state.tmp.dygraph_force_zoom = false;
     state.tmp.dygraph_user_action = false;


### PR DESCRIPTION
Fixes #6587 

##### Summary
Changed the note in sidebar - grammatical fixes and added history tip with links
![image](https://user-images.githubusercontent.com/5786722/63524302-72ea2780-c504-11e9-9453-608262eb3ff6.png)

Also added "sticky" note on the left side of Dygraph Plot
![image](https://user-images.githubusercontent.com/5786722/63524374-957c4080-c504-11e9-9da4-c5dee48d8d15.png)

here's how it looks when it's clipped:
![image](https://user-images.githubusercontent.com/5786722/63524427-ac229780-c504-11e9-8f99-977ebcdd43fa.png)

I haven't used any special styling for text formatting. The text if centered vertically, and it's 25 pxs on the left from first point in the chart, there is no additional background for that block. Please let me know if you need some more styling tweaks.

I saw that `history` in description here: https://github.com/netdata/netdata/issues/6587#issuecomment-522661131 was formatted as `code`, @joelhans is it ok if i use **bold** instead? There's bold in other places in dashboard.

The "sticky note" is added manually, i was experimenting with issues provided by Dygraph, but they were not a good match: Annotations (but i was unable to force them to render 2 links) and Hairlines plugin (but it was too heavy and was adding draggability to all notes).

##### Component Name
Dashboard

