### PR TITLE
Remove of unecessary NULL web server

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1065,9 +1065,6 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 // copy the URL - we are going to overwrite parts of it
                 // TODO -- ideally we we should avoid copying buffers around
                 strncpyz(w->last_url, w->decoded_url, NETDATA_WEB_REQUEST_URL_SIZE);
-                if (w->url_search_path && w->separator) {
-                    *w->url_search_path = 0x00;
-                }
 #ifdef ENABLE_HTTPS
                 if ( (!web_client_check_unix(w)) && (netdata_srv_ctx) ) {
                     if ((w->ssl.conn) && ((w->ssl.flags & NETDATA_SSL_NO_HANDSHAKE) && (web_client_is_using_ssl_force(w) || web_client_is_using_ssl_default(w)) && (w->mode != WEB_CLIENT_MODE_STREAM))  ) {


### PR DESCRIPTION
##### Summary
With the recent changes on URL parsing, we caused an issue in the registry. Requests were not being logged, so the counters remained the same. The reason was that we modified the request buffer and the daemon couldn't access the cookie required to store the info.

After @cosmix review, I notice that there was a code that is not necessary on Netdata. I executed tests with the stress.sh and urls/request.sh scripts, this last I used  during 4 hours with cron calling it each hour.

@paulkatsoulakis is it possible we test this specific PR in a computer where the registry is with wrong count? I am not sure yet that this can fix the problem discovered.

##### Component Name
web server

##### Additional Information

A proper buffer is shown below
```
v1.16.0 w->response.data->buffer = "GET /api/v1/registry?action=access&machine=7e972e74-19a7-11e9-9c78-b808cfc55d7d&name=chris-msi&url=http%3A%2F%2Flocalhost%3A19999%2F&_=1566248089729 HTTP/1.1\r\nHost: 192.168.178.227:19999\r\nConnection: keep-alive\r\nPragma: no-cache\r\nAccept: */*\r\nCache-Control: no-cache, no-store\r\nOrigin: http://localhost:19999\r\nUser-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36\r\nReferer: http://localhost:19999/\r\nAccept-Encoding: gzip, deflate\r\nAccept-Language: en-US,en;q=0.9,el;q=0.8\r\nCookie: netdata_registry_id=give-me-back-this-cookie-now--please\r\n\r\n"
```

The cookie the registry is looking for is "netdata_registry_id=give-me-back-this-cookie-now--please\r\n\r\n"

In tests, we saw a MUCH shorter w->response.data->buffer in the latest version, which was traced to adding a null to modify it.

Original PR was #6247