### PR TITLE
Netdata-installer warning removed

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -249,7 +249,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
 #ifdef ENABLE_HTTPS
     int bytesleft = 0;
     char tmpbuffer[PLUGINSD_LINE_MAX];
-    char *readfrom;
+    char *readfrom=NULL;
 #endif
     char *r = NULL;
     while(!ferror(fp)) {

--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -249,7 +249,7 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
 #ifdef ENABLE_HTTPS
     int bytesleft = 0;
     char tmpbuffer[PLUGINSD_LINE_MAX];
-    char *readfrom=NULL;
+    char *readfrom = NULL;
 #endif
     char *r = NULL;
     while(!ferror(fp)) {


### PR DESCRIPTION
##### Summary
Today when I compiled Netdata using netdata-installer.sh, I notice that there was the following warning:

`
collectors/plugins.d/plugins_d.c: In function 'pluginsd_process':
collectors/plugins.d/plugins_d.c:271:29: warning: 'readfrom' may be used uninitialized in this function [-Wmaybe-uninitialized]
  271 |                 readfrom =  pluginsd_get_from_buffer(line, &bytesleft, readfrom, host->ssl.conn, tmpbuffer);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
`

I am creating this PR to remove the warning from the compilation process.
##### Component Name
Collectors
##### Additional Information

