### PR TITLE
Add command-line option descriptions for apps.plugin

### DIFF
--- a/collectors/apps.plugin/README.md
+++ b/collectors/apps.plugin/README.md
@@ -137,6 +137,13 @@ ones at the top. Processes not matched by any row, will inherit it from their pa
 The order also controls the order of the dimensions on the generated charts (although applications started
 after apps.plugin is started, will be appended to the existing list of dimensions the `netdata` daemon maintains).
 
+There are a few command line options you can pass to `apps.plugin`. The list of available options can be acquired with the `--help` flag. The options can be set in the `netdata.conf` file. For example, to disable user and user group charts you should set
+
+```
+[plugin:apps]
+  command options = without-users without-groups
+```
+
 ## Permissions
 
 `apps.plugin` requires additional privileges to collect all the information it needs.

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3855,6 +3855,10 @@ static void parse_args(int argc, char **argv)
                     " without-files     enable / disable reporting files, sockets, pipes\n"
                     "                   (default is enabled)\n"
                     "\n"
+                    " without-users     disable reporting per user charts\n"
+                    "\n"
+                    " without-groups    disable reporting per user group charts\n"
+                    "\n"
 #ifndef __FreeBSD__
                     " fds-cache-secs N  cache the files of processed for N seconds\n"
                     "                   caching is adaptive per file (when a file\n"


### PR DESCRIPTION
##### Summary
Update the documentation in order to make clear that additional command-line options are available for apps plugin.

Fixes #6708

##### Component Name
documentation