### PR TITLE
[libnetdata/thread] Set thread name from tag

### DIFF
--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -112,27 +112,25 @@ static void thread_cleanup(void *ptr) {
 static void thread_set_name(NETDATA_THREAD *nt) {
 
     if (nt->tag) {
-        char *threadname = strdupz(nt->tag);
         int ret = 0;
 
-        if (threadname) {
-            // Name is limited to 16 chars
-            threadname[15] = 0;
+        // Name is limited to 16 chars
+        char threadname[16];
+        strncpyz(threadname, nt->tag, 15);
+
 #if defined(__FreeBSD__)
-            pthread_set_name_np(pthread_self(), threadname);
+        pthread_set_name_np(pthread_self(), threadname);
 #elif defined(__APPLE__)
-            ret = pthread_setname_np(threadname);
+        ret = pthread_setname_np(threadname);
 #else
-            ret = pthread_setname_np(pthread_self(), threadname);
+        ret = pthread_setname_np(pthread_self(), threadname);
 #endif
 
-            if (ret != 0)
-                error("cannot set pthread name of %d to %s. ErrCode: %d", gettid(), threadname, ret);
-            else
-                info("set name of thread %d to %s", gettid(), threadname);
+        if (ret != 0)
+            error("cannot set pthread name of %d to %s. ErrCode: %d", gettid(), threadname, ret);
+        else
+            info("set name of thread %d to %s", gettid(), threadname);
 
-            free(threadname);
-        }
     }
 }
 

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -109,7 +109,7 @@ static void thread_cleanup(void *ptr) {
     netdata_thread = NULL;
 }
 
-static void *thread_set_name(NETDATA_THREAD *nt) {
+static void thread_set_name(NETDATA_THREAD *nt) {
 
     if (nt->tag) {
         char *threadname = strdupz(nt->tag);

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -119,7 +119,7 @@ static void thread_set_name(NETDATA_THREAD *nt) {
             // Name is limited to 16 chars
             threadname[15] = 0;
 #if defined(__FreeBSD__)
-            ret = pthread_set_name_np(pthread_self(), threadname);
+            pthread_set_name_np(pthread_self(), threadname);
 #elif defined(__APPLE__)
             ret = pthread_setname_np(threadname);
 #else

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -142,6 +142,13 @@ int netdata_thread_create(netdata_thread_t *thread, const char *tag, NETDATA_THR
         error("failed to create new thread for %s. pthread_create() failed with code %d", tag, ret);
 
     else {
+#if defined(__gnu_linux__)
+        if (tag)
+            pthread_setname_np(*thread, tag);
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+        if (tag)
+            pthread_set_name_np(*thread, tag);
+#endif
         if (!(options & NETDATA_THREAD_OPTION_JOINABLE)) {
             int ret2 = pthread_detach(*thread);
             if (ret2 != 0)


### PR DESCRIPTION
When calling netdata_thread_create, you can provide a tag to identify
the thread in the error message
This patch uses this tag to rename the thread if supported by the
pthread distribution to allow better identification of the thread.

This have helped identify the bug #6741

Sample output:

```
ps -L -o tid,pid,comm,args -p $(pgrep netdata)
  TID   PID COMMAND         COMMAND
 5123  5123 netdata         ./netdata -D
 5133  5123 PLUGIN[proc]    ./netdata -D
 5134  5123 netdata         ./netdata -D
 5135  5123 PLUGIN[cgroups] ./netdata -D
 5136  5123 netdata         ./netdata -D
 5137  5123 STATSD          ./netdata -D
 5138  5123 BACKENDS        ./netdata -D
 5139  5123 netdata         ./netdata -D
 5140  5123 PLUGINSD        ./netdata -D
 5141  5123 netdata         ./netdata -D
 5142  5123 HEALTH          ./netdata -D
 5143  5123 netdata         ./netdata -D
 5145  5123 netdata         ./netdata -D
 5146  5123 PLUGINSD        ./netdata -D
 5147  5123 PLUGINSD[apps]  ./netdata -D
 5148  5123 netdata         ./netdata -D
 5150  5123 netdata         ./netdata -D
 5151  5123 STATSD          ./netdata -D
```

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

