### PR TITLE
make coverity-scan.sh usable by hand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,8 +77,7 @@ packaging/makeself/tmp/
 # coverity
 cov-int/
 netdata-coverity-analysis.tgz
-.coverity-token
-.coverity-build
+.coverity-scan.conf
 
 .cproject/
 .idea/

--- a/coverity-install.sh
+++ b/coverity-install.sh
@@ -5,38 +5,4 @@
 #
 # Author: Pavlos Emm. Katsoulakis (paul@netdata.cloud)
 
-token="${COVERITY_SCAN_TOKEN}"
-([ -z "${token}" ] && [ -f .coverity-token ]) && token="$(<.coverity-token)"
-if [ -z "${token}" ]; then
-	echo >&2 "Save the coverity token to .coverity-token or export it as COVERITY_SCAN_TOKEN."
-	exit 1
-fi
-
-covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
-([ -z "${covbuild}" ] && [ -f .coverity-build ]) && covbuild="$(<.coverity-build)"
-if [ ! -z "${covbuild}" ]; then
-	echo >&2 "Coverity already installed, nothing to do!"
-	exit 0
-fi
-
-echo >&2 "Installing coverity..."
-WORKDIR="/opt/coverity-source"
-mkdir -p "${WORKDIR}"
-
-curl -SL --data "token=${token}&project=${REPOSITORY}" https://scan.coverity.com/download/linux64 > "${WORKDIR}/coverity_tool.tar.gz"
-if [ -f "${WORKDIR}/coverity_tool.tar.gz" ]; then
-	tar -x -C "${WORKDIR}" -f "${WORKDIR}/coverity_tool.tar.gz"
-	sudo mv "${WORKDIR}/cov-analysis-linux64-2017.07" /opt/coverity
-	export PATH=${PATH}:/opt/coverity/bin/
-else
-	echo "Failed to download coverity tool tarball!"
-fi
-
-# Validate the installation
-covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
-if [ -z "$covbuild" ]; then
-	echo "Failed to install coverity!"
-	exit 1
-else
-	echo >&2 "Coverity scan installed!"
-fi
+exec ./coverity-scan.sh install "${@}"

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -26,6 +26,12 @@
 # COVERITY_SUBMIT_DEBUG=1
 #
 # All these variables can also be exported before running this script.
+#
+# If the first parameter of this script is "install",
+# coverity build tools will be downloaded and installed in /opt/coverity
+
+# the version of coverity to use
+COVERITY_BUILD_VERSION="cov-analysis-linux64-2019.03"
 
 source packaging/installer/functions.sh || exit 1
 
@@ -39,86 +45,123 @@ fi
 
 repo="${REPOSITORY}"
 if [ -z "${repo}" ]; then
-	echo >&2 "export variable REPOSITORY or set it in .coverity-scan.conf"
-	exit 1
+	fatal "export variable REPOSITORY or set it in .coverity-scan.conf"
 fi
 repo="${repo//\//%2F}"
 
 email="${COVERITY_SCAN_SUBMIT_MAIL}"
 if [ -z "${email}" ]; then
-	echo >&2 "export variable COVERITY_SCAN_SUBMIT_MAIL or set it in .coverity-scan.conf"
-	exit 1
+	fatal "export variable COVERITY_SCAN_SUBMIT_MAIL or set it in .coverity-scan.conf"
 fi
 
 token="${COVERITY_SCAN_TOKEN}"
 if [ -z "${token}" ]; then
-	echo >&2 "export variable COVERITY_SCAN_TOKEN or set it in .coverity-scan.conf"
-	exit 1
+	fatal "export variable COVERITY_SCAN_TOKEN or set it in .coverity-scan.conf"
 fi
 
-export PATH=${PATH}:/opt/coverity/bin/
-covbuild="${COVERITY_BUILD_PATH}"
-[ -z "${covbuild}" ] && covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
-if [ -z "${covbuild}" ]; then
-	echo >&2 "Cannot find 'cov-build' binary in \$PATH. Export variable COVERITY_BUILD_PATH or set it in .coverity-scan.conf"
-	exit 1
-elif [ ! -x "${covbuild}" ]; then
-	echo >&2 "The command ${covbuild} is not executable. Export variable COVERITY_BUILD_PATH or set it in .coverity-scan.conf"
-	exit 1
-fi
-
-version="$(grep "^#define PACKAGE_VERSION" config.h | cut -d '"' -f 2)"
-echo >&2 "Working on netdata version: ${version}"
-
-echo >&2 "Cleaning up old builds..."
-run make clean || echo >&2 "Nothing to clean"
-
-[ -d "cov-int" ] && rm -rf "cov-int"
-
-[ -f netdata-coverity-analysis.tgz ] && run rm netdata-coverity-analysis.tgz
-
-run autoreconf -ivf
-run ./configure --disable-lto \
-	--enable-https \
-	--enable-jsonc \
-	--enable-plugin-nfacct \
-	--enable-plugin-freeipmi \
-	--enable-plugin-cups \
-	--enable-backend-prometheus-remote-write \
-	${NULL}
-
-# TODO: enable these plugins too
-#	--enable-plugin-xenstat \
-#	--enable-backend-kinesis \
-#	--enable-backend-mongodb \
-
-run "${covbuild}" --dir cov-int make -j${cpus} || exit 1
-
-echo >&2 "Compressing data..."
-run tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
-
+# only print the output of a command
+# when debugging is enabled
+# used to hide the token when debugging is not enabled
 debugrun() {
-	# hide the token when DEBUG is not 1
-
-	if [ "${COVERITY_SUBMIT_DEBUG}" = "1" ]
-	then
-		run "${@}"
-		return $?
-	else
-		"${@}"
-		return $?
-	fi
+  if [ "${COVERITY_SUBMIT_DEBUG}" = "1" ]
+  then
+    run "${@}"
+    return $?
+  else
+    "${@}"
+    return $?
+  fi
 }
 
-echo >&2 "Sending analysis for version ${version} ..."
-COVERITY_SUBMIT_RESULT=$(debugrun curl --progress-bar \
-  --form token="${token}" \
-  --form email=${email} \
-  --form file=@netdata-coverity-analysis.tgz \
-  --form version="${version}" \
-  --form description="netdata, monitor everything, in real-time." \
-  https://scan.coverity.com/builds?project=${repo})
+scanit() {
+  export PATH="${PATH}:/opt/${COVERITY_BUILD_VERSION}/bin/"
+  covbuild="${COVERITY_BUILD_PATH}"
+  [ -z "${covbuild}" ] && covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
+  if [ -z "${covbuild}" ]; then
+    fatal "Cannot find 'cov-build' binary in \$PATH. Export variable COVERITY_BUILD_PATH or set it in .coverity-scan.conf"
+  elif [ ! -x "${covbuild}" ]; then
+    fatal "The command '${covbuild}' is not executable. Export variable COVERITY_BUILD_PATH or set it in .coverity-scan.conf"
+  fi
 
-echo ${COVERITY_SUBMIT_RESULT} | grep -q -e 'Build successfully submitted' || echo >&2 "scan results were not pushed to coverity. Message was: ${COVERITY_SUBMIT_RESULT}"
+  version="$(grep "^#define PACKAGE_VERSION" config.h | cut -d '"' -f 2)"
+  progress "Working on netdata version: ${version}"
 
-echo >&2 "Coverity scan mechanism completed"
+  progress "Cleaning up old builds..."
+  run make clean || echo >&2 "Nothing to clean"
+
+  [ -d "cov-int" ] && rm -rf "cov-int"
+
+  [ -f netdata-coverity-analysis.tgz ] && run rm netdata-coverity-analysis.tgz
+
+  progress "Configuring netdata source..."
+  run autoreconf -ivf
+  run ./configure --disable-lto \
+    --enable-https \
+    --enable-jsonc \
+    --enable-plugin-nfacct \
+    --enable-plugin-freeipmi \
+    --enable-plugin-cups \
+    --enable-backend-prometheus-remote-write \
+    ${NULL}
+
+  # TODO: enable these plugins too
+  #	--enable-plugin-xenstat \
+  #	--enable-backend-kinesis \
+  #	--enable-backend-mongodb \
+
+  progress "Analyzing netdata..."
+  run "${covbuild}" --dir cov-int make -j${cpus} || exit 1
+
+  echo >&2 "Compressing analysis..."
+  run tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
+
+  echo >&2 "Sending analysis to coverity for netdata version ${version} ..."
+  COVERITY_SUBMIT_RESULT=$(debugrun curl --progress-bar \
+    --form token="${token}" \
+    --form email=${email} \
+    --form file=@netdata-coverity-analysis.tgz \
+    --form version="${version}" \
+    --form description="netdata, monitor everything, in real-time." \
+    https://scan.coverity.com/builds?project=${repo})
+
+  echo ${COVERITY_SUBMIT_RESULT} | grep -q -e 'Build successfully submitted' || echo >&2 "scan results were not pushed to coverity. Message was: ${COVERITY_SUBMIT_RESULT}"
+
+  progress "Coverity scan completed"
+}
+
+installit() {
+  progress "Downloading coverity..."
+  cd /tmp || exit 1
+
+  [ -f "${COVERITY_BUILD_VERSION}.tar.gz" ] && run rm -f "${COVERITY_BUILD_VERSION}.tar.gz"
+  debugrun curl --remote-name --remote-header-name --show-error --location --data "token=${token}&project=${repo}" https://scan.coverity.com/download/linux64
+
+  if [ -f "${COVERITY_BUILD_VERSION}.tar.gz" ]; then
+    progress "Installing coverity..."
+    cd /opt || exit 1
+    run sudo tar -z -x -f  "/tmp/${COVERITY_BUILD_VERSION}.tar.gz" || exit 1
+    rm "/tmp/${COVERITY_BUILD_VERSION}.tar.gz"
+    export PATH=${PATH}:/opt/${COVERITY_BUILD_VERSION}/bin/
+  else
+    fatal "Failed to download coverity tool tarball!"
+  fi
+
+  # Validate the installation
+  covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
+  if [ -z "$covbuild" ]; then
+    fatal "Failed to install coverity."
+  fi
+
+  progress "Coverity scan tools are installed."
+  return 0
+}
+
+if [ "${1}" = "install" ]
+then
+  shift 1
+  installit "${@}"
+  exit $?
+else
+  scanit "${@}"
+  exit $?
+fi

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -1,34 +1,59 @@
 #!/usr/bin/env bash
 # Coverity scan script
 #
-# To run this script you need to provide API token. This can be done either by:
-#  - Putting token in ".coverity-token" file
-#  - Assigning token value to COVERITY_SCAN_TOKEN environment variable
-#
 # Copyright: SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Author  : Costa Tsaousis (costa@netdata.cloud)
 # Author  : Pawel Krupa (paulfantom)
 # Author  : Pavlos Emm. Katsoulakis (paul@netdata.cloud)
 
-cpus=$(grep -c ^processor </proc/cpuinfo)
+# To run manually, save configuration to .coverity-scan.conf like this:
+#
+# REPOSITORY="netdata/netdata"
+# COVERITY_SCAN_SUBMIT_MAIL="you@example.com"
+# COVERITY_SCAN_TOKEN="TOKEN taken from Coverity site"
+# COVERITY_BUILD_PATH="/opt/cov-analysis-linux64-2019.03/bin/cov-build"
+# DEBUG=1
+#
+# All these variables can also be exported before running this script.
+
+source packaging/installer/functions.sh || exit 1
+
+cpus=$(find_processors)
 [ -z "${cpus}" ] && cpus=1
 
+if [ -f ".coverity-scan.conf" ]
+then
+	source ".coverity-scan.conf" || exit 1
+fi
+
+repo="${REPOSITORY}"
+if [ -z "${repo}" ]; then
+	echo >&2 "export variable REPOSITORY or set it in .coverity-scan.conf"
+	exit 1
+fi
+repo="${repo//\//%2F}"
+
+email="${COVERITY_SCAN_SUBMIT_MAIL}"
+if [ -z "${email}" ]; then
+	echo >&2 "export variable COVERITY_SCAN_SUBMIT_MAIL or set it in .coverity-scan.conf"
+	exit 1
+fi
+
 token="${COVERITY_SCAN_TOKEN}"
-([ -z "${token}" ] && [ -f .coverity-token ]) && token="$(<.coverity-token)"
 if [ -z "${token}" ]; then
-	echo >&2 "Save the coverity token to .coverity-token or export it as COVERITY_SCAN_TOKEN."
+	echo >&2 "export variable COVERITY_SCAN_TOKEN or set it in .coverity-scan.conf"
 	exit 1
 fi
 
 export PATH=${PATH}:/opt/coverity/bin/
-covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
-([ -z "${covbuild}" ] && [ -f .coverity-build ]) && covbuild="$(<.coverity-build)"
+covbuild="${COVERITY_BUILD_PATH}"
+[ -z "${covbuild}" ] && covbuild="$(which cov-build 2>/dev/null || command -v cov-build 2>/dev/null)"
 if [ -z "${covbuild}" ]; then
-	echo >&2 "Cannot find 'cov-build' binary in \$PATH."
+	echo >&2 "Cannot find 'cov-build' binary in \$PATH. Export variable COVERITY_BUILD_PATH or set it in .coverity-scan.conf"
 	exit 1
 elif [ ! -x "${covbuild}" ]; then
-	echo >&2 "The command ${covbuild} is not executable. Save command the full filename of cov-build in .coverity-build"
+	echo >&2 "The command ${covbuild} is not executable. Export variable COVERITY_BUILD_PATH or set it in .coverity-scan.conf"
 	exit 1
 fi
 
@@ -36,26 +61,53 @@ version="$(grep "^#define PACKAGE_VERSION" config.h | cut -d '"' -f 2)"
 echo >&2 "Working on netdata version: ${version}"
 
 echo >&2 "Cleaning up old builds..."
-make clean || echo >&2 "Nothing to clean"
+run make clean || echo >&2 "Nothing to clean"
 
 [ -d "cov-int" ] && rm -rf "cov-int"
 
-[ -f netdata-coverity-analysis.tgz ] && rm netdata-coverity-analysis.tgz
+[ -f netdata-coverity-analysis.tgz ] && run rm netdata-coverity-analysis.tgz
 
-autoreconf -ivf
-./configure --enable-plugin-nfacct --enable-plugin-freeipmi
-"${covbuild}" --dir cov-int make -j${cpus} || exit 1
+run autoreconf -ivf
+run ./configure --disable-lto \
+	--enable-https \
+	--enable-jsonc \
+	--enable-plugin-nfacct \
+	--enable-plugin-freeipmi \
+	--enable-plugin-cups \
+	--enable-backend-prometheus-remote-write \
+	${NULL}
+
+# TODO: enable these plugins too
+#	--enable-plugin-xenstat \
+#	--enable-backend-kinesis \
+#	--enable-backend-mongodb \
+
+run "${covbuild}" --dir cov-int make -j${cpus} || exit 1
 
 echo >&2 "Compressing data..."
-tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
+run tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
+
+debugrun() {
+	# hide the token when DEBUG is not 1
+
+	if [ "${DEBUG}" = "1" ]
+	then
+		run "${@}"
+		return $?
+	else
+		"${@}"
+		return $?
+	fi
+}
 
 echo >&2 "Sending analysis for version ${version} ..."
-COVERITY_SUBMIT_RESULT=$(curl --progress-bar --form token="${token}" \
-  --form email=${COVERITY_SCAN_SUBMIT_MAIL} \
+COVERITY_SUBMIT_RESULT=$(debugrun curl --progress-bar \
+  --form token="${token}" \
+  --form email=${email} \
   --form file=@netdata-coverity-analysis.tgz \
   --form version="${version}" \
-  --form description="netdata, real-time performance monitoring, done right." \
-  https://scan.coverity.com/builds?project=${REPOSITORY})
+  --form description="netdata, monitor everything, in real-time." \
+  https://scan.coverity.com/builds?project=${repo})
 
 echo ${COVERITY_SUBMIT_RESULT} | grep -q -e 'Build successfully submitted' || echo >&2 "scan results were not pushed to coverity. Message was: ${COVERITY_SUBMIT_RESULT}"
 

--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -9,11 +9,21 @@
 
 # To run manually, save configuration to .coverity-scan.conf like this:
 #
+# the repository to report to coverity - devs can set here their own fork
 # REPOSITORY="netdata/netdata"
+#
+# the email of the developer, as given to coverity
 # COVERITY_SCAN_SUBMIT_MAIL="you@example.com"
+#
+# the token given by coverity to the developer
 # COVERITY_SCAN_TOKEN="TOKEN taken from Coverity site"
+#
+# the absolute path of the cov-build - optional
 # COVERITY_BUILD_PATH="/opt/cov-analysis-linux64-2019.03/bin/cov-build"
-# DEBUG=1
+#
+# when set, the script will print on screen the curl command that submits the build to coverity
+# this includes the token, so the default is not to print it.
+# COVERITY_SUBMIT_DEBUG=1
 #
 # All these variables can also be exported before running this script.
 
@@ -90,7 +100,7 @@ run tar czvf netdata-coverity-analysis.tgz cov-int || exit 1
 debugrun() {
 	# hide the token when DEBUG is not 1
 
-	if [ "${DEBUG}" = "1" ]
+	if [ "${COVERITY_SUBMIT_DEBUG}" = "1" ]
 	then
 		run "${@}"
 		return $?


### PR DESCRIPTION
`./coverity-scan.sh` should be easily usable by hand.

Prior to this PR, developers should remember to export certain variables (`REPOSITORY` and `COVERITY_SCAN_SUBMIT_MAIL`). They were given to option to configure `COVERITY_SCAN_TOKEN` and configure the path of the `cov-build` by configuring separate files for each of them. So, a developer was not able to just configure its environment and then just run the script every time it is needed.

This PR allows devs to create the file `.coverity-scan.conf` with the following information:

```sh
# the repository to report to coverity - devs can set here their own fork
REPOSITORY="netdata/netdata"

# the email of the developer, as given to coverity
COVERITY_SCAN_SUBMIT_MAIL="you@example.com"

# the token given by coverity to the developer
COVERITY_SCAN_TOKEN="TOKEN taken from Coverity site"

# the absolute path of the cov-build - optional
COVERITY_BUILD_PATH="/opt/cov-analysis-linux64-2019.03/bin/cov-build"

# when set, the script will print on screen the curl command that submits the build to coverity
# this includes the token, so the default is not to print it.
COVERITY_SUBMIT_DEBUG=1
```

The script is also updated to configure netdata with the following:

```

	--enable-https \
	--enable-jsonc \
	--enable-plugin-nfacct \
	--enable-plugin-freeipmi \
	--enable-plugin-cups \
	--enable-backend-prometheus-remote-write \

```

Ideally, the script should build all the features of netdata, including:

```

	--enable-plugin-xenstat \
	--enable-backend-kinesis \
	--enable-backend-mongodb \

```

@paulkatsoulakis I don't know if we should enable these on travis.

Also:

- `coverity-install.sh` is not needed any more. Run `./coverity-scan.sh install` to install coverity build tools. @paulkatsoulakis please update travis and then simply remove `coverity-install.sh` from the repo (the update version of this script just calls `./coverity-scan.sh install`.
- the installation will fail if the downloaded version is not the expected one
- the scan will fail if the expected version of coverity is not installed
- the installer `functions.sh` is used to simplify the script and beautify the output
