### PR TITLE
Increase minimum release for changelog

### DIFF
--- a/.travis/generate_changelog_for_release.sh
+++ b/.travis/generate_changelog_for_release.sh
@@ -30,7 +30,7 @@ docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest
 	--user "${ORGANIZATION}" \
 	--project "${PROJECT}" \
 	--token "${GITHUB_TOKEN}" \
-	--since-tag "v1.10.0" \
+	--since-tag "v1.13.0" \
 	--unreleased-label "**Next release**" \
 	--exclude-labels "stale,duplicate,question,invalid,wontfix,discussion,no changelog" \
 	--no-compare-link ${OPTS}


### PR DESCRIPTION
##### Summary
Travis build for release fails while generating changelog, due to the number of issues. Increased the minimum tag taken into consideration.

##### Component Name
CI/CD


