### PR TITLE
Skip issues from release changelog

### DIFF
--- a/.travis/generate_changelog_for_release.sh
+++ b/.travis/generate_changelog_for_release.sh
@@ -30,7 +30,8 @@ docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest
 	--user "${ORGANIZATION}" \
 	--project "${PROJECT}" \
 	--token "${GITHUB_TOKEN}" \
-	--since-tag "v1.13.0" \
+	--since-tag "v1.10.0" \
+	--no-issues \
 	--unreleased-label "**Next release**" \
 	--exclude-labels "stale,duplicate,question,invalid,wontfix,discussion,no changelog" \
 	--no-compare-link ${OPTS}


### PR DESCRIPTION
##### Summary
Make release changelog same as nightly changelog, skipping the issues. 

##### Component Name
CI/CD

##### Additional Information
Changelog generation takes too long and errors during releases, because the issues shouldn't be added (too many requests to github). 
