### PR TITLE
vcsa collector: charts descritpion and alarms

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -84,6 +84,7 @@ dist_healthconfig_DATA = \
     health.d/tcp_resets.conf \
     health.d/udp_errors.conf \
     health.d/varnish.conf \
+    health.d/vcsa.conf \
     health.d/vsphere.conf \
     health.d/web_log.conf \
     health.d/wmi.conf \

--- a/health/health.d/vcsa.conf
+++ b/health/health.d/vcsa.conf
@@ -12,26 +12,33 @@ template: vcsa_last_collected_secs
     info: number of seconds since the last successful data collection
       to: sysadmin
 
-# vCenter Server Appliance components health status:
+# Overall system health:
+#  - 0: all components are healthy.
+#  - 1: one or more components might become overloaded soon.
+#  - 2: one or more components in the appliance might be degraded.
+#  - 3: one or more components might be in an unusable status and the appliance might become unresponsive soon.
+#  - 4: no health data is available.
+
+template: vcsa_system_health
+      on: vcsa.system_health
+  lookup: max -10s unaligned of system
+   units: status
+   every: 10s
+    warn: ($this == 1) || ($this == 2)
+    crit: $this == 3
+   delay: down 1m multiplier 1.5 max 1h
+    info: overall system health status
+      to: sysadmin
+
+# Components health:
 #  - 0: healthy.
 #  - 1: healthy, but may have some problems.
 #  - 2: degraded, and may have serious problems.
 #  - 3: unavailable, or will stop functioning soon.
 #  - 4: no health data is available.
 
-template: vcsa_system_health
-      on: vcsa.health
-  lookup: max -10s unaligned of system
-   units: status
-   every: 10s
-    warn: $this == 1
-    crit: ($this == 2) || ($this == 3)
-   delay: down 1m multiplier 1.5 max 1h
-    info: overall system health status
-      to: sysadmin
-
 template: vcsa_swap_health
-      on: vcsa.health
+      on: vcsa.components_health
   lookup: max -10s unaligned of swap
    units: status
    every: 10s
@@ -42,7 +49,7 @@ template: vcsa_swap_health
       to: sysadmin
 
 template: vcsa_storage_health
-      on: vcsa.health
+      on: vcsa.components_health
   lookup: max -10s unaligned of storage
    units: status
    every: 10s
@@ -53,7 +60,7 @@ template: vcsa_storage_health
       to: sysadmin
 
 template: vcsa_mem_health
-      on: vcsa.health
+      on: vcsa.components_health
   lookup: max -10s unaligned of mem
    units: status
    every: 10s
@@ -64,7 +71,7 @@ template: vcsa_mem_health
       to: sysadmin
 
 template: vcsa_load_health
-      on: vcsa.health
+      on: vcsa.components_health
   lookup: max -10s unaligned of load
    units: status
    every: 10s
@@ -75,7 +82,7 @@ template: vcsa_load_health
       to: sysadmin
 
 template: vcsa_database_storage_health
-      on: vcsa.health
+      on: vcsa.components_health
   lookup: max -10s unaligned of database_storage
    units: status
    every: 10s
@@ -86,8 +93,8 @@ template: vcsa_database_storage_health
       to: sysadmin
 
 template: vcsa_applmgmt_health
-      on: vcsa.health
-  lookup: max -10s unaligned of appl_mgmt
+      on: vcsa.components_health
+  lookup: max -10s unaligned of applmgmt
    units: status
    every: 10s
     warn: $this == 1
@@ -97,15 +104,14 @@ template: vcsa_applmgmt_health
       to: sysadmin
 
 
-# vCenter Server Appliance software packages health status:
+# Software updates health:
 #  - 0: no updates available.
-#  - 1: ??? (no such status in vmware docs).
 #  - 2: non-security updates are available.
 #  - 3: security updates are available.
 #  - 4: an error retrieving information on software updates.
 
-template: vcsa_software_packages_health
-      on: vcsa.health
+template: vcsa_software_updates_health
+      on: vcsa.software_updates_health
   lookup: max -10s unaligned of software_packages
    units: status
    every: 10s

--- a/health/health.d/vcsa.conf
+++ b/health/health.d/vcsa.conf
@@ -1,0 +1,116 @@
+
+# make sure vcsa is running and responding
+
+template: vcsa_last_collected_secs
+      on: vcsa.health
+    calc: $now - $last_collected_t
+   units: seconds ago
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: sysadmin
+
+# vCenter Server Appliance components health status:
+#  - 0: healthy.
+#  - 1: healthy, but may have some problems.
+#  - 2: degraded, and may have serious problems.
+#  - 3: unavailable, or will stop functioning soon.
+#  - 4: no health data is available.
+
+template: vcsa_system_health
+      on: vcsa.health
+  lookup: max -10s unaligned of system
+   units: status
+   every: 10s
+    warn: $this == 1
+    crit: ($this == 2) || ($this == 3)
+   delay: down 1m multiplier 1.5 max 1h
+    info: overall system health status
+      to: sysadmin
+
+template: vcsa_swap_health
+      on: vcsa.health
+  lookup: max -10s unaligned of swap
+   units: status
+   every: 10s
+    warn: $this == 1
+    crit: ($this == 2) || ($this == 3)
+   delay: down 1m multiplier 1.5 max 1h
+    info: swap health status
+      to: sysadmin
+
+template: vcsa_storage_health
+      on: vcsa.health
+  lookup: max -10s unaligned of storage
+   units: status
+   every: 10s
+    warn: $this == 1
+    crit: ($this == 2) || ($this == 3)
+   delay: down 1m multiplier 1.5 max 1h
+    info: storage health status
+      to: sysadmin
+
+template: vcsa_mem_health
+      on: vcsa.health
+  lookup: max -10s unaligned of mem
+   units: status
+   every: 10s
+    warn: $this == 1
+    crit: ($this == 2) || ($this == 3)
+   delay: down 1m multiplier 1.5 max 1h
+    info: mem health status
+      to: sysadmin
+
+template: vcsa_load_health
+      on: vcsa.health
+  lookup: max -10s unaligned of load
+   units: status
+   every: 10s
+    warn: $this == 1
+    crit: ($this == 2) || ($this == 3)
+   delay: down 1m multiplier 1.5 max 1h
+    info: load health status
+      to: sysadmin
+
+template: vcsa_database_storage_health
+      on: vcsa.health
+  lookup: max -10s unaligned of database_storage
+   units: status
+   every: 10s
+    warn: $this == 1
+    crit: ($this == 2) || ($this == 3)
+   delay: down 1m multiplier 1.5 max 1h
+    info: database storage health status
+      to: sysadmin
+
+template: vcsa_applmgmt_health
+      on: vcsa.health
+  lookup: max -10s unaligned of appl_mgmt
+   units: status
+   every: 10s
+    warn: $this == 1
+    crit: ($this == 2) || ($this == 3)
+   delay: down 1m multiplier 1.5 max 1h
+    info: appl mgmt health status
+      to: sysadmin
+
+
+# vCenter Server Appliance software packages health status:
+#  - 0: no updates available.
+#  - 1: ??? (no such status in vmware docs).
+#  - 2: non-security updates are available.
+#  - 3: security updates are available.
+#  - 4: an error retrieving information on software updates.
+
+template: vcsa_software_packages_health
+      on: vcsa.health
+  lookup: max -10s unaligned of software_packages
+   units: status
+   every: 10s
+    warn: $this == 4
+    crit: $this == 3
+   delay: down 1m multiplier 1.5 max 1h
+    info: software packages health status
+      to: sysadmin

--- a/health/health.d/vcsa.conf
+++ b/health/health.d/vcsa.conf
@@ -2,7 +2,7 @@
 # make sure vcsa is running and responding
 
 template: vcsa_last_collected_secs
-      on: vcsa.health
+      on: vcsa.system_health
     calc: $now - $last_collected_t
    units: seconds ago
    every: 10s

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -2591,21 +2591,33 @@ netdataDashboard.context = {
 
     // ------------------------------------------------------------------------
     // VCSA
-    'vcsa.health': {
+    'vcsa.system_health': {
         info:
-         '<code>system</code> represents overall health of the system.<br>' +
-         'All except <code>softwarepackages</code>:<br>' +
-         '<code>-1</code>: unknown; ' +
-         '<code>0</code>: healthy; ' +
-         '<code>1</code>: healthy, but may have some problems; ' +
-         '<code>2</code>: degraded, and may have serious problems; ' +
-         '<code>3</code>: unavailable, or will stop functioning soon; ' +
-         '<code>4</code>: no health data is available;<br>' +
-         '<code>softwarepackages</code> represents information on available software updates available in the remote vSphere Update Manager repository:<br>' +
-         '<code>-1</code>: unknown; ' +
-         '<code>0</code>: no updates available; ' +
-         '<code>2</code>: non-security updates are available; ' +
-         '<code>3</code>: security updates are available; ' +
-         '<code>4</code>: an error retrieving information on software updates;'
-    },
+            '<code>-1</code>: unknown; ' +
+            '<code>0</code>: all components are healthy; ' +
+            '<code>1</code>: one or more components might become overloaded soon; ' +
+            '<code>2</code>: one or more components in the appliance might be degraded; ' +
+            '<code>3</code>: one or more components might be in an unusable status and the appliance might become unresponsive soon; ' +
+            '<code>4</code>: no health data is available.'
+            },
+
+    'vcsa.components_health': {
+        info:
+            '<code>-1</code>: unknown; ' +
+            '<code>0</code>: healthy; ' +
+            '<code>1</code>: healthy, but may have some problems; ' +
+            '<code>2</code>: degraded, and may have serious problems; ' +
+            '<code>3</code>: unavailable, or will stop functioning soon; ' +
+            '<code>4</code>: no health data is available.'
+            },
+
+    'vcsa.software_updates_health': {
+        info:
+            '<code>softwarepackages</code> represents information on available software updates available in the remote vSphere Update Manager repository:<br>' +
+            '<code>-1</code>: unknown; ' +
+            '<code>0</code>: no updates available; ' +
+            '<code>2</code>: non-security updates are available; ' +
+            '<code>3</code>: security updates are available; ' +
+            '<code>4</code>: an error retrieving information on software updates.'
+            }
 };

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -492,6 +492,12 @@ netdataDashboard.menu = {
         title: 'vSphere',
         icon: '<i class="fas fa-server"></i>',
         info: 'Performance statistics for ESXI hosts and virtual machines. Data collected from <a href="https://www.vmware.com/products/vcenter-server.html">VMware vCenter Server</a> using <code><a href="https://github.com/vmware/govmomi"> govmomi</a></code>  library.'
+    },
+
+    'vcsa': {
+        title: 'VCSA',
+        icon: '<i class="fas fa-server"></i>',
+        info: 'vCenter Server Appliance health statistics. Data collected from <a href="https://vmware.github.io/vsphere-automation-sdk-rest/vsphere/index.html#SVC_com.vmware.appliance.health">Health API</a>.'
     }
 };
 
@@ -2581,5 +2587,25 @@ netdataDashboard.context = {
 
     'vsphere.overall_status': {
         info: '<code>0</code> is unknown, <code>1</code> is OK, <code>2</code> is might have a problem, <code>3</code> is definitely has a problem.'
-    }
+    },
+
+    // ------------------------------------------------------------------------
+    // VCSA
+    'vcsa.health': {
+        info:
+         '<code>system</code> represents overall health of the system.<br>' +
+         'All except <code>softwarepackages</code>:<br>' +
+         '<code>-1</code>: unknown; ' +
+         '<code>0</code>: healthy; ' +
+         '<code>1</code>: healthy, but may have some problems; ' +
+         '<code>2</code>: degraded, and may have serious problems; ' +
+         '<code>3</code>: unavailable, or will stop functioning soon; ' +
+         '<code>4</code>: no health data is available;<br>' +
+         '<code>softwarepackages</code> represents information on available software updates available in the remote vSphere Update Manager repository:<br>' +
+         '<code>-1</code>: unknown; ' +
+         '<code>0</code>: no updates available; ' +
+         '<code>2</code>: non-security updates are available; ' +
+         '<code>3</code>: security updates are available; ' +
+         '<code>4</code>: an error retrieving information on software updates;'
+    },
 };

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -2613,7 +2613,7 @@ netdataDashboard.context = {
 
     'vcsa.software_updates_health': {
         info:
-            '<code>softwarepackages</code> represents information on available software updates available in the remote vSphere Update Manager repository:<br>' +
+            '<code>softwarepackages</code> represents information on available software updates available in the remote vSphere Update Manager repository.<br>' +
             '<code>-1</code>: unknown; ' +
             '<code>0</code>: no updates available; ' +
             '<code>2</code>: non-security updates are available; ' +


### PR DESCRIPTION
##### Summary
This PR adds:
- [X] collector/charts descriptions
- [X] alarms 

From [documentation](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcsa.doc/GUID-52AF3379-8D78-437F-96EF-25D1A1100BEE.html):

```
 The vCenter Server Appliance API offers health status indicators for several key components of the appliance:
 - green  The component is healthy.
 - yellow The component is healthy, but may have some problems.
 - orange The component is degraded, and may have serious problems.
 - red The component is unavailable, or will stop functioning soon.
 - gray No health data is available.
```

Alarms added for following components:
  - applmgmt
  - databasestorage
  - load
  - mem
  - softwarepackages
  - storage
  - swap
  - system

##### Component Name
[/web/gui](https://github.com/netdata/netdata/tree/master/web/gui)
[health/health.d](https://github.com/netdata/netdata/tree/master/health/health.d)

##### Additional Information

Ref: https://github.com/netdata/go.d.plugin/pull/260