### PR TITLE
netdata/packaging: override control file for debian/buster

### DIFF
--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -87,6 +87,9 @@ if str(os.environ["BUILD_STRING"]).count("debian/jessie") == 1:
 if str(os.environ["BUILD_STRING"]).count("ubuntu/trusty") == 1:
     common.run_command_in_host(['sudo', 'rm', 'contrib/debian/control'])
     common.run_command_in_host(['sudo', 'cp', 'contrib/debian/control.trusty', 'contrib/debian/control'])
+if str(os.environ["BUILD_STRING"]).count("debian/buster") == 1:
+    common.run_command_in_host(['sudo', 'rm', 'contrib/debian/control'])
+    common.run_command_in_host(['sudo', 'cp', 'contrib/debian/control.buster', 'contrib/debian/control'])
 
 common.prepare_version_source(dest_archive, friendly_version, tag=tag)
 

--- a/contrib/debian/control.buster
+++ b/contrib/debian/control.buster
@@ -1,0 +1,58 @@
+Source: netdata
+Build-Depends: debhelper (>= 9),
+               dh-autoreconf,
+               dh-systemd (>= 1.5),
+               dpkg-dev (>= 1.13.19),
+               zlib1g-dev,
+               uuid-dev,
+               libuv1-dev,
+               liblz4-dev,
+               libjudy-dev,
+               libssl-dev,
+               libmnl-dev,
+               libjson-c-dev,
+               libcups2-dev,
+               libipmimonitoring-dev,
+               libnetfilter-acct-dev,
+               libsnappy-dev,
+               libprotobuf-dev,
+               libprotoc-dev,
+               autogen,
+               autoconf,
+               automake,
+               pkg-config,
+               curl,
+               gcc,
+               g++
+Section: net
+Priority: optional
+Maintainer: Netdata Builder <bot@netdata.cloud>
+Standards-Version: 3.9.6
+Homepage: https://netdata.cloud
+
+Package: netdata
+Architecture: any
+Depends: adduser,
+         libcap2-bin (>= 1:2.0),
+         lsb-base (>= 3.1-23.2),
+         zlib1g,
+         libuuid1,
+         libuv1,
+         liblz4-1,
+         libjudydebian1,
+         openssl,
+         libmnl0,
+         libjson-c3,
+         cups,
+         freeipmi,
+         libnetfilter-acct1,
+         libprotobuf-c1,
+         libsnappy1v5,
+         libprotoc17,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: real-time charts for system monitoring
+ Netdata is a daemon that collects data in realtime (per second)
+ and presents a web site to view and analyze them. The presentation
+ is also real-time and full of interactive charts that precisely
+ render all collected values.


### PR DESCRIPTION
##### Summary
On debian/buster, there is a different library available for protoc runtime

##### Component Name
netdata/packaging

##### Additional Information
Fixes #6774
