### PR TITLE
netdata/packaging: fix changelog generation failing the build

### DIFF
--- a/.travis/package_management/trigger_deb_lxc_build.py
+++ b/.travis/package_management/trigger_deb_lxc_build.py
@@ -53,18 +53,26 @@ unpacked_netdata = netdata_tarball.replace(".tar.gz", "")
 print("Extracting tarball %s" % netdata_tarball)
 common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "tar", "xf", netdata_tarball, "-C", build_path])
 
+print("Checking version consistency")
+since_version = os.environ["LATEST_RELEASE_VERSION"]
+if str(since_version).replace('v', '') == str(new_version) and str(new_version).count('.') == 2:
+    s = since_version.split('.')
+    prev = str(int(s[1]) - 1)
+    since_version = s[0] + '.' + prev + s[2]
+    print("We seem to be building a new stable release, reduce by one since_version option. New since_version:%s" % since_version)
+
 print("Fixing changelog tags")
 changelog_in_host = "contrib/debian/changelog"
-common.run_command_in_host(['sed', '-i', 's/PREVIOUS_PACKAGE_VERSION/%s-1/g' % os.environ["LATEST_RELEASE_VERSION"].replace("v", ""), changelog_in_host])
+common.run_command_in_host(['sed', '-i', 's/PREVIOUS_PACKAGE_VERSION/%s-1/g' % since_version.replace("v", ""), changelog_in_host])
 common.run_command_in_host(['sed', '-i', 's/PREVIOUS_PACKAGE_DATE/%s/g' % os.environ["LATEST_RELEASE_DATE"], changelog_in_host])
 
 print("Executing gbp dch command..")
-common.run_command_in_host(['gbp', 'dch', '--release', '--ignore-branch', '--spawn-editor=snapshot', '--since=%s' % os.environ["LATEST_RELEASE_VERSION"], '--new-version=%s' % new_version])
+common.run_command_in_host(['gbp', 'dch', '--release', '--ignore-branch', '--spawn-editor=snapshot', '--since=%s' % since_version, '--new-version=%s' % new_version])
 
 print("Copying over changelog to the destination machine")
 common.run_command_in_host(['sudo', 'cp', 'debian/changelog', "%s/%s/netdata-%s/contrib/debian/" % (os.environ['LXC_CONTAINER_ROOT'], build_path, new_version)])
 
-print("Running debian build script since %s" % os.environ["LATEST_RELEASE_VERSION"])
+print("Running debian build script since %s" % since_version)
 common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "%s/build.sh" % build_path, unpacked_netdata, new_version])
 
 print("Listing contents on build path")


### PR DESCRIPTION

##### Summary
We bumped into an error that caused debian/jessie package generation to fail.
When building stable release, we don't properly detect the change from previous stable to this one.
So the changelog generation fails and only on some distros causes the process to fail.

With this change we attempt to detect this peculiarity and just try fo decrease latest release version, to properly fetch the full changes

##### Component Name
netdata/packaging

##### Additional Information
References #6774 