### PR TITLE
netdata/packaging: work around redhat complaining on build-id binary

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -387,7 +387,7 @@ install_go() {
 	return 0
 }
 install_go
-install -m 0750 -p go.d.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/go.d.plugin"
+install -m 0640 -p go.d.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/go.d.plugin"
 
 %pre
 


### PR DESCRIPTION
##### Summary
This is to work around the build failure for rhel 6/7 over the go.d binary installation
We basically fool the process by removing the executable permission at install time.
This way end result will remain the same but build won't fail since the system won't try to do anything with the binary


It has been manually tested on a build system.
End result binary has the execute permission after this

```
[builder@netdata-builder03 ~]$ rpm -qp --dump rpmbuild/RPMS/x86_64/netdata-v1.17.0-1.el7.x86_64.rpm|grep go.d.plugin
/usr/libexec/netdata/plugins.d/go.d.plugin 31586073 1565126182 53b7fe7f36927881ed94c42b2f4bef26d3358a48d1a981ca5a77663000db2390 0100755 netdata netdata 0 0 0 X
```

`--dump` option provides the following items on the output seen above `#path size mtime digest mode owner group isconfig isdoc rdev symlink`

##### Component Name
netdata/packaging/rpm

##### Additional Information
N/A
