### PR TITLE
update grep to be more specific

### DIFF
--- a/docs/high-performance-netdata.md
+++ b/docs/high-performance-netdata.md
@@ -126,7 +126,7 @@ You can check limits with following commands:
 
 ```sh
 cat /proc/$(ps aux | grep "nginx: master process" | grep -v grep | awk '{print $2}')/limits | grep "Max open files"
-cat /proc/$(ps aux | grep "netdata.pid" | head -n1 | grep -v grep | awk '{print $2}')/limits | grep "Max open files"
+cat /proc/$(ps aux | grep "\/netdata " | head -n1 | grep -v grep | awk '{print $2}')/limits | grep "Max open files"
 ```
 
 View of the files:

--- a/docs/high-performance-netdata.md
+++ b/docs/high-performance-netdata.md
@@ -126,7 +126,7 @@ You can check limits with following commands:
 
 ```sh
 cat /proc/$(ps aux | grep "nginx: master process" | grep -v grep | awk '{print $2}')/limits | grep "Max open files"
-cat /proc/$(ps aux | grep "netdata" | head -n1 | grep -v grep | awk '{print $2}')/limits | grep "Max open files"
+cat /proc/$(ps aux | grep "netdata.pid" | head -n1 | grep -v grep | awk '{print $2}')/limits | grep "Max open files"
 ```
 
 View of the files:

--- a/docs/high-performance-netdata.md
+++ b/docs/high-performance-netdata.md
@@ -126,7 +126,7 @@ You can check limits with following commands:
 
 ```sh
 cat /proc/$(ps aux | grep "nginx: master process" | grep -v grep | awk '{print $2}')/limits | grep "Max open files"
-cat /proc/$(ps aux | grep "\/netdata " | head -n1 | grep -v grep | awk '{print $2}')/limits | grep "Max open files"
+cat /proc/$(ps aux | grep "\/[n]etdata " | head -n1 | grep -v grep | awk '{print $2}')/limits | grep "Max open files"
 ```
 
 View of the files:


### PR DESCRIPTION
when grepping for openfiles the netdata example is not exact enough and will return results from too many processes, just adding `.pid` to the grep _should_ pick up the correct process.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Additional Information

