### PR TITLE
Allow hostnames in Access Control Lists

### DIFF
--- a/docs/netdata-security.md
+++ b/docs/netdata-security.md
@@ -86,6 +86,41 @@ In Netdata v1.9+ there is also access list support, like this:
 	allow connections from = localhost 10.* 192.168.*
 ```
 
+#### Fine-grainined access control
+
+The access list support allows filtering of all incoming connections, by specific IP addresses, ranges
+or validated DNS lookups. Only connections that match an entry on the list will be allowed:
+
+```
+[web]
+	allow connections from = localhost 192.168.* 1.2.3.4 homeip.net
+```
+
+Connections from the IP addresses are allowed if the connection IP matches one of the patterns given.
+The alias localhost is alway checked against 127.0.0.1, any other symbolic names need to resolve in
+both directions using DNS. In the above example the IP address of `homeip.net` must reverse DNS resolve
+to the incoming IP address and a DNS lookup on `homeip.net` must return the incoming IP address as
+one of the resolved addresses.
+
+More specific control of what each incoming connection can do can be specified through the access control
+list settings:
+
+```
+[web]
+	allow connections from = 160.1.*
+	allow badges from = 160.1.1.2
+	allow streaming from = 160.1.2.*
+	allow management from = control.subnet.ip
+	allow netdata.conf from = updates.subnet.ip
+	allow dashboard from = frontend.subnet.ip
+```
+
+In this example only connections from `160.1.x.x` are allowed, only the specific IP address `160.1.1.2`
+can access badges, only IP addresses in the smaller range `160.1.2.x` can stream data. The three
+hostnames shown can access specific features, this assumes that DNS is setup to resolve these names
+to IP addresses within the `160.1.x.x` range and that reverse DNS is setup for these hosts.
+
+
 #### Use an authenticating web server in proxy mode
 
 Use one web server to provide authentication in front of **all your Netdata servers**. So, you will be accessing all your Netdata with URLs like `http://{HOST}/netdata/{NETDATA_HOSTNAME}/` and authentication will be shared among all of them (you will sign-in once for all your servers). Instructions are provided on how to set the proxy configuration to have Netdata run behind [nginx](Running-behind-nginx.md), [Apache](Running-behind-apache.md), [lighthttpd](Running-behind-lighttpd.md#netdata-via-lighttpd-v14x) and [Caddy](Running-behind-caddy.md#netdata-via-caddy).

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -1018,20 +1018,20 @@ extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t
         struct sockaddr_storage sadr;
         socklen_t addrlen = sizeof(sadr);
         int err = getpeername(fd, (struct sockaddr*)&sadr, &addrlen);
-        if (err!=0 ||
+        if (err != 0 ||
             (err = getnameinfo((struct sockaddr *)&sadr, addrlen, client_host, (socklen_t)hostsize,
                               NULL, 0, NI_NAMEREQD)) != 0) {
             error("Incoming connection on '%s' does not match a numeric pattern, "
                   "and host could not be resolved (err=%s)", client_ip, gai_strerror(err));
-            if (hostsize>=8)
+            if (hostsize >= 8)
                 strcpy(client_host,"UNKNOWN");
             return 0;
         }
         struct addrinfo *addr_infos = NULL;
-        if (getaddrinfo(client_host, NULL, NULL, &addr_infos)!=0) {
+        if (getaddrinfo(client_host, NULL, NULL, &addr_infos) !=0 ) {
             error("LISTENER: cannot validate hostname '%s' from '%s' by resolving it",
                   client_host, client_ip);
-            if (hostsize>=8)
+            if (hostsize >= 8)
                 strcpy(client_host,"UNKNOWN");
             return 0;
         }
@@ -1058,7 +1058,7 @@ extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t
         }
         if (!validated) {
             error("LISTENER: Cannot validate '%s' as ip of '%s', not listed in DNS", client_ip, client_host);
-            if (hostsize>=8)
+            if (hostsize >= 8)
                 strcpy(client_host,"UNKNOWN");
         }
         if (addr_infos!=NULL)

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -1114,8 +1114,7 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
         }
         if(!connection_allowed(&sadr, addrlen, client_ip, ipsize, access_list)) {
             errno = 0;
-            debug(D_LISTENER, "Permission denied for client '%s', port '%s'", client_ip, client_port);
-            error("DENIED ACCESS to client '%s'", client_ip);
+            error("Permission denied for client '%s', port '%s'", client_ip, client_port);
             close(nfd);
             nfd = -1;
             errno = EPERM;

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -1095,8 +1095,8 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
             }
 
             // Allow patterns to match against either the resolved hostname or the numeric ip address.
-            if(unlikely(!simple_pattern_matches(access_list, client_ip) && 
-                        (client_host[0]==0 || !simple_pattern_matches(access_list, client_host)))) {
+            if(!simple_pattern_matches(access_list, client_ip) &&
+               (client_host[0]==0 || !simple_pattern_matches(access_list, client_host))) {
                 errno = 0;
                 debug(D_LISTENER, "Permission denied for client '%s' (%s), port '%s'", 
                       client_ip, client_host, client_port);

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -1001,68 +1001,80 @@ int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags) {
  *                        Numeric patterns are checked against the IP address first, only if they
  *                        do not match is the hostname resolved (reverse-DNS) and checked. If the
  *                        hostname matches then we perform forward DNS resolution to check the IP
- *                        is really associated with the DNS record.
+ *                        is really associated with the DNS record. This call is repeatable: the
+ *                        web server may check more refined matches against the connection. Will
+ *                        update the client_host if uninitialized - ensure the hostsize is the number
+ *                        of *writable* bytes (i.e. be aware of the strdup used to compact the pollinfo).
  */
-int connection_allowed(struct sockaddr_storage *sadr, socklen_t addrlen, char *client_ip, size_t ipsize, 
-                       SIMPLE_PATTERN *access_list) {
-    char client_host[NI_MAXHOST];
-    client_host[NI_MAXHOST-1] = 0;
-    if(!access_list)
+extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsize, SIMPLE_PATTERN *access_list) {
+    if (!access_list)
         return 1;
-    if(simple_pattern_matches(access_list, client_ip))
+    if (simple_pattern_matches(access_list, client_ip))
         return 1;
-    if(getnameinfo((struct sockaddr *)sadr, addrlen, client_host, (socklen_t)ipsize, 
-                   NULL, 0, NI_NAMEREQD) != 0) {
-        error("Incoming connection on '%s' does not match a numeric pattern, "
-              "and host could not be resolved", client_ip);
-        return 0;
+    // If the host is uninitialized then 
+    if (client_host[0]==0)
+    {
+        struct sockaddr_storage sadr;
+        socklen_t addrlen = sizeof(sadr);
+        if (getsockname(fd, (struct sockaddr*)&sadr, &addrlen)!=0 ||
+            getnameinfo((struct sockaddr *)&sadr, addrlen, client_host, (socklen_t)hostsize,
+                        NULL, 0, NI_NAMEREQD) != 0) {
+            error("Incoming connection on '%s' does not match a numeric pattern, "
+                  "and host could not be resolved", client_ip);
+            if (hostsize>=8)
+                strcpy(client_host,"UNKNOWN");
+            return 0;
+        }
+        struct addrinfo *addr_infos = NULL;
+        if (getaddrinfo(client_host, NULL, NULL, &addr_infos)!=0) {
+            error("LISTENER: cannot validate hostname '%s' from '%s' by resolving it",
+                  client_host, client_ip);
+            if (hostsize>=8)
+                strcpy(client_host,"UNKNOWN");
+            return 0;
+        }
+        struct addrinfo *scan = addr_infos;
+        int    validated = 0;
+        while (scan) {
+            char address[INET6_ADDRSTRLEN];
+            address[0] = 0;
+            switch (scan->ai_addr->sa_family) {
+                case AF_INET:
+                    inet_ntop(AF_INET, &((struct sockaddr_in*)(scan->ai_addr))->sin_addr, address, INET6_ADDRSTRLEN);
+                    break;
+                case AF_INET6:
+                    inet_ntop(AF_INET6, &((struct sockaddr_in6*)(scan->ai_addr))->sin6_addr, address, INET6_ADDRSTRLEN);
+                    break;
+            }
+            debug(D_LISTENER, "Incoming ip %s rev-resolved onto %s, validating against forward-resolution %s",
+                  client_ip, client_host, address);
+            if (!strcmp(client_ip, address)) {
+                validated = 1;
+                break;
+            }
+            scan = scan->ai_next;
+        }
+        if (!validated) {
+            error("LISTENER: Cannot validate '%s' as ip of '%s', not listed in DNS", client_ip, client_host);
+            if (hostsize>=8)
+                strcpy(client_host,"UNKNOWN");
+        }
+        if (addr_infos!=NULL)
+            freeaddrinfo(addr_infos);
     }
-    if( !simple_pattern_matches(access_list, client_host)) {
+    if (!simple_pattern_matches(access_list, client_host)) {
         error("Incoming connection on '%s' (%s) does not match allowed pattern",
               client_ip, client_host);
         return 0;
     }
-    struct addrinfo *addr_infos = NULL;
-    if(getaddrinfo(client_host, NULL, NULL, &addr_infos)!=0) {
-        error("LISTENER: cannot validate hostname '%s' from '%s' by resolving it",
-              client_host, client_ip);
-        return 0;
-    }
-    struct addrinfo *scan = addr_infos;
-    int    validated = 0;
-    while(scan) {
-        char address[INET6_ADDRSTRLEN];
-        address[0] = 0;
-        switch(scan->ai_addr->sa_family) {
-            case AF_INET:
-                inet_ntop(AF_INET, &((struct sockaddr_in*)(scan->ai_addr))->sin_addr,
-                          address, INET6_ADDRSTRLEN);
-                break;
-            case AF_INET6:
-                inet_ntop(AF_INET6, &((struct sockaddr_in6*)(scan->ai_addr))->sin6_addr,
-                          address, INET6_ADDRSTRLEN);
-                break;
-        }
-        debug(D_LISTENER, "Incoming ip %s rev-resolved onto %s, validating against forward-resolution %s",
-              client_ip, client_host, address);
-        if(!strcmp(client_ip, address)) {
-            validated = 1;
-            break;
-        }
-        scan = scan->ai_next;
-    }
-    if(!validated)
-        error("LISTENER: Cannot validate '%s' as ip of '%s', not listed in DNS", client_ip, client_host);
-    if(addr_infos!=NULL)
-        freeaddrinfo(addr_infos);
-    return validated;
+    return 1;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
 // accept_socket() - accept a socket and store client IP and port
 
 int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize, 
-                  SIMPLE_PATTERN *access_list) {
+                  char *client_host, size_t hostsize, SIMPLE_PATTERN *access_list) {
     struct sockaddr_storage sadr;
     socklen_t addrlen = sizeof(sadr);
 
@@ -1112,7 +1124,7 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
                 debug(D_LISTENER, "New UNKNOWN web client from %s port %s on socket %d.", client_ip, client_port, fd);
                 break;
         }
-        if(!connection_allowed(&sadr, addrlen, client_ip, ipsize, access_list)) {
+        if(!connection_allowed(fd, client_ip, client_host, hostsize, access_list)) {
             errno = 0;
             error("Permission denied for client '%s', port '%s'", client_ip, client_port);
             close(nfd);
@@ -1143,6 +1155,7 @@ inline POLLINFO *poll_add_fd(POLLJOB *p
                              , uint32_t flags
                              , const char *client_ip
                              , const char *client_port
+                             , const char *client_host
                              , void *(*add_callback)(POLLINFO * /*pi*/, short int * /*events*/, void * /*data*/)
                              , void  (*del_callback)(POLLINFO * /*pi*/)
                              , int   (*rcv_callback)(POLLINFO * /*pi*/, short int * /*events*/)
@@ -1182,6 +1195,7 @@ inline POLLINFO *poll_add_fd(POLLJOB *p
 
             p->inf[i].client_ip = NULL;
             p->inf[i].client_port = NULL;
+            p->inf[i].client_host = NULL;
             p->inf[i].del_callback = p->del_callback;
             p->inf[i].rcv_callback = p->rcv_callback;
             p->inf[i].snd_callback = p->snd_callback;
@@ -1212,8 +1226,9 @@ inline POLLINFO *poll_add_fd(POLLJOB *p
     pi->port_acl = port_acl;
     pi->flags = flags;
     pi->next = NULL;
-    pi->client_ip = strdupz(client_ip);
+    pi->client_ip   = strdupz(client_ip);
     pi->client_port = strdupz(client_port);
+    pi->client_host = strdupz(client_host);
 
     pi->del_callback = del_callback;
     pi->rcv_callback = rcv_callback;
@@ -1415,13 +1430,16 @@ static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, sho
 
                     int nfd;
                     do {
-                        char client_ip[NI_MAXHOST + 1];
-                        char client_port[NI_MAXSERV + 1];
-                        client_ip[0] = 0x00;
-                        client_port[0] = 0x00;
+                        char client_ip[INET6_ADDRSTRLEN];
+                        char client_port[NI_MAXSERV];
+                        char client_host[NI_MAXHOST];
+                        client_host[0] = 0;
+                        client_ip[0]   = 0;
+                        client_port[0] = 0;
 
                         debug(D_POLLFD, "POLLFD: LISTENER: calling accept4() slot %zu (fd %d)", i, fd);
-                        nfd = accept_socket(fd, SOCK_NONBLOCK, client_ip, NI_MAXHOST + 1, client_port, NI_MAXSERV + 1, p->access_list);
+                        nfd = accept_socket(fd, SOCK_NONBLOCK, client_ip, INET6_ADDRSTRLEN, client_port, NI_MAXSERV, 
+                                            client_host, NI_MAXHOST, p->access_list);
                         if (unlikely(nfd < 0)) {
                             // accept failed
 
@@ -1446,6 +1464,7 @@ static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, sho
                                         , POLLINFO_FLAG_CLIENT_SOCKET
                                         , client_ip
                                         , client_port
+                                        , client_host
                                         , p->add_callback
                                         , p->del_callback
                                         , p->rcv_callback
@@ -1588,6 +1607,7 @@ void poll_events(LISTEN_SOCKETS *sockets
                                    , sockets->fds_acl_flags[i]
                                    , POLLINFO_FLAG_SERVER_SOCKET
                                    , (sockets->fds_names[i])?sockets->fds_names[i]:"UNKNOWN"
+                                   , ""
                                    , ""
                                    , p.add_callback
                                    , p.del_callback

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -1012,7 +1012,7 @@ extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t
         return 1;
     if (simple_pattern_matches(access_list, client_ip))
         return 1;
-    // If the host is uninitialized then 
+    // If the hostname is unresolved (and needed) then attempt the DNS lookups.
     if (client_host[0]==0)
     {
         struct sockaddr_storage sadr;
@@ -1075,7 +1075,7 @@ extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t
 // --------------------------------------------------------------------------------------------------------------------
 // accept_socket() - accept a socket and store client IP and port
 
-int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize, 
+int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize,
                   char *client_host, size_t hostsize, SIMPLE_PATTERN *access_list) {
     struct sockaddr_storage sadr;
     socklen_t addrlen = sizeof(sadr);
@@ -1440,7 +1440,7 @@ static void poll_events_process(POLLJOB *p, POLLINFO *pi, struct pollfd *pf, sho
                         client_port[0] = 0;
 
                         debug(D_POLLFD, "POLLFD: LISTENER: calling accept4() slot %zu (fd %d)", i, fd);
-                        nfd = accept_socket(fd, SOCK_NONBLOCK, client_ip, INET6_ADDRSTRLEN, client_port, NI_MAXSERV, 
+                        nfd = accept_socket(fd, SOCK_NONBLOCK, client_ip, INET6_ADDRSTRLEN, client_port, NI_MAXSERV,
                                             client_host, NI_MAXHOST, p->access_list);
                         if (unlikely(nfd < 0)) {
                             // accept failed

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -1065,7 +1065,7 @@ extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t
             freeaddrinfo(addr_infos);
     }
     if (!simple_pattern_matches(access_list, client_host)) {
-        info("Incoming connection on '%s' (%s) does not match allowed pattern for %s",
+        debug(D_LISTENER, "Incoming connection on '%s' (%s) does not match allowed pattern for %s",
               client_ip, client_host, patname);
         return 0;
     }

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -1005,7 +1005,7 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
 
     int nfd = accept4(fd, (struct sockaddr *)&sadr, &addrlen, flags);
     if (likely(nfd >= 0)) {
-        if (getnameinfo((struct sockaddr *)&sadr, addrlen, client_ip, (socklen_t)ipsize, client_port, (socklen_t)portsize, NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
+        if (getnameinfo((struct sockaddr *)&sadr, addrlen, client_ip, (socklen_t)ipsize, client_port, (socklen_t)portsize, NI_NUMERICSERV) != 0) {
             error("LISTENER: cannot getnameinfo() on received client connection.");
             strncpyz(client_ip, "UNKNOWN", ipsize - 1);
             strncpyz(client_port, "UNKNOWN", portsize - 1);

--- a/libnetdata/socket/socket.h
+++ b/libnetdata/socket/socket.h
@@ -72,7 +72,8 @@ extern int sock_setreuse_port(int fd, int reuse);
 extern int sock_enlarge_in(int fd);
 extern int sock_enlarge_out(int fd);
 
-extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsize, SIMPLE_PATTERN *access_list);
+extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsize, 
+                              SIMPLE_PATTERN *access_list, const char *patname);
 extern int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize, 
                          char *client_host, size_t hostsize, SIMPLE_PATTERN *access_list);
 

--- a/libnetdata/socket/socket.h
+++ b/libnetdata/socket/socket.h
@@ -72,9 +72,9 @@ extern int sock_setreuse_port(int fd, int reuse);
 extern int sock_enlarge_in(int fd);
 extern int sock_enlarge_out(int fd);
 
-extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsize, 
+extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsize,
                               SIMPLE_PATTERN *access_list, const char *patname);
-extern int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize, 
+extern int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize,
                          char *client_host, size_t hostsize, SIMPLE_PATTERN *access_list);
 
 #ifndef HAVE_ACCEPT4

--- a/libnetdata/socket/socket.h
+++ b/libnetdata/socket/socket.h
@@ -72,7 +72,9 @@ extern int sock_setreuse_port(int fd, int reuse);
 extern int sock_enlarge_in(int fd);
 extern int sock_enlarge_out(int fd);
 
-extern int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize, SIMPLE_PATTERN *access_list);
+extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsize, SIMPLE_PATTERN *access_list);
+extern int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize, 
+                         char *client_host, size_t hostsize, SIMPLE_PATTERN *access_list);
 
 #ifndef HAVE_ACCEPT4
 extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags);
@@ -104,9 +106,9 @@ typedef struct pollinfo {
     int fd;                 // the file descriptor
     int socktype;           // the client socket type
     WEB_CLIENT_ACL port_acl; // the access lists permitted on this web server port (it's -1 for client sockets)
-    char *client_ip;        // the connected client IP
-    char *client_port;      // the connected client port
-    char client_host[NI_MAXHOST];
+    char *client_ip;         // Max INET6_ADDRSTRLEN bytes
+    char *client_port;       // Max NI_MAXSERV bytes
+    char *client_host;       // Max NI_MAXHOST bytes
 
     time_t connected_t;     // the time the socket connected
     time_t last_received_t; // the time the socket last received data
@@ -174,6 +176,7 @@ extern POLLINFO *poll_add_fd(POLLJOB *p
                              , uint32_t flags
                              , const char *client_ip
                              , const char *client_port
+                             , const char *client_host
                              , void *(*add_callback)(POLLINFO *pi, short int *events, void *data)
                              , void  (*del_callback)(POLLINFO *pi)
                              , int   (*rcv_callback)(POLLINFO *pi, short int *events)

--- a/libnetdata/socket/socket.h
+++ b/libnetdata/socket/socket.h
@@ -106,6 +106,7 @@ typedef struct pollinfo {
     WEB_CLIENT_ACL port_acl; // the access lists permitted on this web server port (it's -1 for client sockets)
     char *client_ip;        // the connected client IP
     char *client_port;      // the connected client port
+    char client_host[NI_MAXHOST];
 
     time_t connected_t;     // the time the socket connected
     time_t last_received_t; // the time the socket last received data

--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -19,7 +19,7 @@ static struct web_client *web_client_create_on_fd(POLLINFO *pi) {
 
     strncpyz(w->client_ip,   pi->client_ip,   sizeof(w->client_ip) - 1);
     strncpyz(w->client_port, pi->client_port, sizeof(w->client_port) - 1);
-    strncpyz(w->client_host, pi->host,        sizeof(w->client_host) - 1);
+    strncpyz(w->client_host, pi->client_host, sizeof(w->client_host) - 1);
 
     if(unlikely(!*w->client_ip))   strcpy(w->client_ip,   "-");
     if(unlikely(!*w->client_port)) strcpy(w->client_port, "-");
@@ -271,6 +271,7 @@ static int web_server_rcv_callback(POLLINFO *pi, short int *events) {
                         , 0
                         , POLLINFO_FLAG_CLIENT_SOCKET
                         , "FILENAME"
+                        , ""
                         , ""
                         , web_server_file_add_callback
                         , web_server_file_del_callback

--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -7,23 +7,26 @@ int web_client_timeout = DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS;
 int web_client_first_request_timeout = DEFAULT_TIMEOUT_TO_RECEIVE_FIRST_WEB_REQUEST;
 long web_client_streaming_rate_t = 0L;
 
-// ----------------------------------------------------------------------------
-// high level web clients connection management
-
-static struct web_client *web_client_create_on_fd(int fd, const char *client_ip, const char *client_port, int port_acl) {
+/*
+ * --------------------------------------------------------------------------------------------------------------------
+ * Build web_client state from the pollinfo that describes an accepted connection.
+ */
+static struct web_client *web_client_create_on_fd(POLLINFO *pi) {
     struct web_client *w;
 
     w = web_client_get_from_cache_or_allocate();
-    w->ifd = w->ofd = fd;
+    w->ifd = w->ofd = pi->fd;
 
-    strncpyz(w->client_ip, client_ip, sizeof(w->client_ip) - 1);
-    strncpyz(w->client_port, client_port, sizeof(w->client_port) - 1);
+    strncpyz(w->client_ip,   pi->client_ip,   sizeof(w->client_ip) - 1);
+    strncpyz(w->client_port, pi->client_port, sizeof(w->client_port) - 1);
+    strncpyz(w->client_host, pi->host,        sizeof(w->client_host) - 1);
 
     if(unlikely(!*w->client_ip))   strcpy(w->client_ip,   "-");
     if(unlikely(!*w->client_port)) strcpy(w->client_port, "-");
-	w->port_acl = port_acl;
+	w->port_acl = pi->port_acl;
 
     web_client_initialize_connection(w);
+    w->pollinfo_slot = pi->slot;
     return(w);
 }
 
@@ -138,7 +141,7 @@ static int web_server_file_write_callback(POLLINFO *pi, short int *events) {
 // web server clients
 
 static void *web_server_add_callback(POLLINFO *pi, short int *events, void *data) {
-    (void)data;
+    (void)data;         // Supress warning on unused argument
 
     worker_private->connected++;
 
@@ -149,10 +152,9 @@ static void *web_server_add_callback(POLLINFO *pi, short int *events, void *data
     *events = POLLIN;
 
     debug(D_WEB_CLIENT_ACCESS, "LISTENER on %d: new connection.", pi->fd);
-    struct web_client *w = web_client_create_on_fd(pi->fd, pi->client_ip, pi->client_port, pi->port_acl);
-    w->pollinfo_slot = pi->slot;
+    struct web_client *w = web_client_create_on_fd(pi);
 
-    if ( !strncmp(pi->client_port,"UNIX",4)){
+    if (!strncmp(pi->client_port, "UNIX", 4)) {
         web_client_set_unix(w);
     } else {
         web_client_set_tcp(w);

--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -76,7 +76,7 @@ static void *web_server_file_add_callback(POLLINFO *pi, short int *events, void 
     return w;
 }
 
-static void web_werver_file_del_callback(POLLINFO *pi) {
+static void web_server_file_del_callback(POLLINFO *pi) {
     struct web_client *w = (struct web_client *)pi->data;
     debug(D_WEB_CLIENT, "%llu: RELEASE FILE READ ON FD %d", w->id, pi->fd);
 
@@ -271,7 +271,7 @@ static int web_server_rcv_callback(POLLINFO *pi, short int *events) {
                         , "FILENAME"
                         , ""
                         , web_server_file_add_callback
-                        , web_werver_file_del_callback
+                        , web_server_file_del_callback
                         , web_server_file_read_callback
                         , web_server_file_write_callback
                         , (void *) w

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1147,8 +1147,8 @@ static inline void web_client_send_http_header(struct web_client *w) {
     char headerbegin[8328];
     if (w->response.code == HTTP_RESP_MOVED_PERM) {
         memcpy(headerbegin,"\r\nLocation: https://",20);
-        size_t headerlength = strlen(w->host);
-        memcpy(&headerbegin[20],w->host,headerlength);
+        size_t headerlength = strlen(w->server_host);
+        memcpy(&headerbegin[20],w->server_host,headerlength);
         headerlength += 20;
         size_t tmp = strlen(w->last_url);
         memcpy(&headerbegin[headerlength],w->last_url,tmp);

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -791,7 +791,7 @@ static inline char *http_header_parse(struct web_client *w, char *s, int parse_u
         w->auth_bearer_token = strdupz(v);
     }
     else if(hash == hash_host && !strcasecmp(s, "Host")){
-        strncpyz(w->host, v, ((size_t)(ve - v) < sizeof(w->host)-1 ? (size_t)(ve - v) : sizeof(w->host)-1));
+        strncpyz(w->server_host, v, ((size_t)(ve - v) < sizeof(w->server_host)-1 ? (size_t)(ve - v) : sizeof(w->server_host)-1));
     }
 #ifdef NETDATA_WITH_ZLIB
     else if(hash == hash_accept_encoding && !strcasecmp(s, "Accept-Encoding")) {

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -160,7 +160,8 @@ struct web_client {
     char decoded_url[NETDATA_WEB_REQUEST_URL_SIZE + 1];  // we decode the URL in this buffer
     char decoded_query_string[NETDATA_WEB_REQUEST_URL_SIZE + 1];  // we decode the Query String in this buffer
     char last_url[NETDATA_WEB_REQUEST_URL_SIZE+1];       // we keep a copy of the decoded URL here
-    char host[256];
+    char server_host[NI_MAXHOST];
+    char client_host[NI_MAXHOST];
     size_t url_path_length;
     char separator; // This value can be either '?' or 'f'
     char *url_search_path; //A pointer to the search path sent by the client

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -154,14 +154,14 @@ struct web_client {
     int ifd;
     int ofd;
 
-    char client_ip[NI_MAXHOST+1];
-    char client_port[NI_MAXSERV+1];
+    char client_ip[INET6_ADDRSTRLEN];   // Defined buffer sizes include null-terminators
+    char client_port[NI_MAXSERV];
+    char server_host[NI_MAXHOST];
+    char client_host[NI_MAXHOST];
 
     char decoded_url[NETDATA_WEB_REQUEST_URL_SIZE + 1];  // we decode the URL in this buffer
     char decoded_query_string[NETDATA_WEB_REQUEST_URL_SIZE + 1];  // we decode the Query String in this buffer
     char last_url[NETDATA_WEB_REQUEST_URL_SIZE+1];       // we keep a copy of the decoded URL here
-    char server_host[NI_MAXHOST];
-    char client_host[NI_MAXHOST];
     size_t url_path_length;
     char separator; // This value can be either '?' or 'f'
     char *url_search_path; //A pointer to the search path sent by the client

--- a/web/server/web_server.c
+++ b/web/server/web_server.c
@@ -87,27 +87,33 @@ void web_client_update_acl_matches(struct web_client *w) {
     w->acl = WEB_CLIENT_ACL_NONE;
 
     if (!web_allow_dashboard_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_dashboard_from))
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+                           web_allow_dashboard_from, "dashboard"))
         w->acl |= WEB_CLIENT_ACL_DASHBOARD;
 
     if (!web_allow_registry_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_registry_from))
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+                           web_allow_registry_from, "registry"))
         w->acl |= WEB_CLIENT_ACL_REGISTRY;
 
     if (!web_allow_badges_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_badges_from))
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+                           web_allow_badges_from, "badges"))
         w->acl |= WEB_CLIENT_ACL_BADGE;
 
     if (!web_allow_mgmt_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_mgmt_from))
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+                           web_allow_mgmt_from, "management"))
         w->acl |= WEB_CLIENT_ACL_MGMT;
 
     if (!web_allow_streaming_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_streaming_from))
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+                           web_allow_streaming_from, "streaming"))
         w->acl |= WEB_CLIENT_ACL_STREAMING;
 
     if (!web_allow_netdataconf_from ||
-       connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_netdataconf_from))
+       connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+                          web_allow_netdataconf_from, "netdata.conf"))
         w->acl |= WEB_CLIENT_ACL_NETDATACONF;
 
     w->acl &= w->port_acl;

--- a/web/server/web_server.c
+++ b/web/server/web_server.c
@@ -87,32 +87,32 @@ void web_client_update_acl_matches(struct web_client *w) {
     w->acl = WEB_CLIENT_ACL_NONE;
 
     if (!web_allow_dashboard_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host),
                            web_allow_dashboard_from, "dashboard"))
         w->acl |= WEB_CLIENT_ACL_DASHBOARD;
 
     if (!web_allow_registry_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host),
                            web_allow_registry_from, "registry"))
         w->acl |= WEB_CLIENT_ACL_REGISTRY;
 
     if (!web_allow_badges_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host),
                            web_allow_badges_from, "badges"))
         w->acl |= WEB_CLIENT_ACL_BADGE;
 
     if (!web_allow_mgmt_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host),
                            web_allow_mgmt_from, "management"))
         w->acl |= WEB_CLIENT_ACL_MGMT;
 
     if (!web_allow_streaming_from ||
-        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host),
                            web_allow_streaming_from, "streaming"))
         w->acl |= WEB_CLIENT_ACL_STREAMING;
 
     if (!web_allow_netdataconf_from ||
-       connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), 
+       connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host),
                           web_allow_netdataconf_from, "netdata.conf"))
         w->acl |= WEB_CLIENT_ACL_NETDATACONF;
 

--- a/web/server/web_server.c
+++ b/web/server/web_server.c
@@ -86,22 +86,28 @@ SIMPLE_PATTERN *web_allow_netdataconf_from = NULL;
 void web_client_update_acl_matches(struct web_client *w) {
     w->acl = WEB_CLIENT_ACL_NONE;
 
-    if(!web_allow_dashboard_from || simple_pattern_matches(web_allow_dashboard_from, w->client_ip))
+    if (!web_allow_dashboard_from ||
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_dashboard_from))
         w->acl |= WEB_CLIENT_ACL_DASHBOARD;
 
-    if(!web_allow_registry_from || simple_pattern_matches(web_allow_registry_from, w->client_ip))
+    if (!web_allow_registry_from ||
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_registry_from))
         w->acl |= WEB_CLIENT_ACL_REGISTRY;
 
-    if(!web_allow_badges_from || simple_pattern_matches(web_allow_badges_from, w->client_ip))
+    if (!web_allow_badges_from ||
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_badges_from))
         w->acl |= WEB_CLIENT_ACL_BADGE;
 
-    if(!web_allow_mgmt_from || simple_pattern_matches(web_allow_mgmt_from, w->client_ip))
+    if (!web_allow_mgmt_from ||
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_mgmt_from))
         w->acl |= WEB_CLIENT_ACL_MGMT;
 
-    if(!web_allow_streaming_from || simple_pattern_matches(web_allow_streaming_from, w->client_ip))
+    if (!web_allow_streaming_from ||
+        connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_streaming_from))
         w->acl |= WEB_CLIENT_ACL_STREAMING;
 
-    if(!web_allow_netdataconf_from || simple_pattern_matches(web_allow_netdataconf_from, w->client_ip))
+    if (!web_allow_netdataconf_from ||
+       connection_allowed(w->ifd, w->client_ip, w->client_host, sizeof(w->client_host), web_allow_netdataconf_from))
         w->acl |= WEB_CLIENT_ACL_NETDATACONF;
 
     w->acl &= w->port_acl;


### PR DESCRIPTION
##### Summary
The Access Control List (ACL) configuration parameters can now use hostnames with simple patterns. Incoming connections are resolved using reverse DNS to obtain the hostname. Where a hostname is resolved, forward DNS resolution is performed to check the IP address is really associated with the hostname. If the checks pass then the patterns supplied are checked. Any patterns supplied for numeric ip addresses are also checked.

##### Component Name
daemon

##### Additional Information
Fixes #6438
