### PR TITLE
Collector slabinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ xenstat.plugin
 perf.plugin
 !perf.plugin/
 
+slabinfo.plugin
+!slabinfo.plugin/
+
 cgroup-network
 !cgroup-network/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,6 +728,7 @@ IF(LINUX)
     SET(ENABLE_PLUGIN_CGROUP_NETWORK True)
     SET(ENABLE_PLUGIN_APPS True)
     SET(ENABLE_PLUGIN_PERF True)
+    SET(ENABLE_PLUGIN_SLABINFO True)
 
 ELSEIF(FREEBSD)
     add_executable(netdata config.h ${NETDATA_FILES} ${FREEBSD_PLUGIN_FILES})
@@ -737,6 +738,7 @@ ELSEIF(FREEBSD)
     SET(ENABLE_PLUGIN_CGROUP_NETWORK False)
     SET(ENABLE_PLUGIN_APPS True)
     SET(ENABLE_PLUGIN_PERF False)
+    SET(ENABLE_PLUGIN_SLABINFO False)
 
 ELSEIF(MACOS)
     add_executable(netdata config.h ${NETDATA_FILES} ${MACOS_PLUGIN_FILES})
@@ -746,6 +748,7 @@ ELSEIF(MACOS)
     SET(ENABLE_PLUGIN_CGROUP_NETWORK False)
     SET(ENABLE_PLUGIN_APPS False)
     SET(ENABLE_PLUGIN_PERF False)
+    SET(ENABLE_PLUGIN_SLABINFO False)
 
 ENDIF()
 
@@ -840,6 +843,20 @@ IF(ENABLE_PLUGIN_PERF)
     target_compile_options(perf.plugin PUBLIC ${NETDATA_COMMON_CFLAGS})
 ELSE()
     message(STATUS "perf.plugin: disabled")
+ENDIF()
+
+
+# -----------------------------------------------------------------------------
+# slabinfo.plugin
+
+IF(ENABLE_PLUGIN_SLABINFO)
+    message(STATUS "slabinfo.plugin: enabled")
+    add_executable(slabinfo.plugin config.h ${SLABINFO_PLUGIN_FILES})
+    target_link_libraries (slabinfo.plugin libnetdata ${NETDATA_COMMON_LIBRARIES})
+    target_include_directories(slabinfo.plugin PUBLIC ${NETDATA_COMMON_INCLUDE_DIRS})
+    target_compile_options(slabinfo.plugin PUBLIC ${NETDATA_COMMON_CFLAGS})
+ELSE()
+    message(STATUS "slabinfo.plugin: disabled")
 ENDIF()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,10 @@ set(PERF_PLUGIN_FILES
         collectors/perf.plugin/perf_plugin.c
         )
 
+set(SLABINFO_PLUGIN_FILES
+        collectors/slabinfo.plugin/slabinfo.c
+        )
+
 set(PROC_PLUGIN_FILES
         collectors/proc.plugin/ipc.c
         collectors/proc.plugin/plugin_proc.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -236,6 +236,11 @@ NFACCT_PLUGIN_FILES = \
     $(LIBNETDATA_FILES) \
     $(NULL)
 
+SLABINFO_PLUGIN_FILES = \
+	collectors/slabinfo.plugin/slabinfo.c \
+	$(LIBNETDATA_FILES)
+	$(NULL)
+
 XENSTAT_PLUGIN_FILES = \
     collectors/xenstat.plugin/xenstat_plugin.c \
     $(LIBNETDATA_FILES) \
@@ -596,6 +601,14 @@ if ENABLE_PLUGIN_PERF
     plugins_PROGRAMS += perf.plugin
     perf_plugin_SOURCES = $(PERF_PLUGIN_FILES)
     perf_plugin_LDADD = \
+        $(NETDATA_COMMON_LIBS) \
+        $(NULL)
+endif
+
+if ENABLE_PLUGIN_SLABINFO
+    plugins_PROGRAMS += slabinfo.plugin
+    slabinfo_plugin_SOURCES = $(SLABINFO_PLUGIN_FILES)
+    slabinfo_plugin_LDADD = \
         $(NETDATA_COMMON_LIBS) \
         $(NULL)
 endif

--- a/collectors/Makefile.am
+++ b/collectors/Makefile.am
@@ -22,6 +22,7 @@ SUBDIRS = \
     node.d.plugin \
     proc.plugin \
     python.d.plugin \
+    slabinfo.plugin \
     statsd.plugin \
     tc.plugin \
    	$(NULL)

--- a/collectors/README.md
+++ b/collectors/README.md
@@ -42,6 +42,7 @@ To minimize the number of processes spawn for data collection, Netdata also supp
 |[plugins.d](plugins.d/)|`C`|any|internal|-|implements the **external plugins** API and serves external plugins|
 |[proc.plugin](proc.plugin/)|`C`|linux|internal|yes|collects resource usage and performance data on Linux systems|
 |[python.d.plugin](python.d.plugin/)|`python` v2+|any|external|yes|a **plugin orchestrator** for data collection modules written in `python` v2 or v3 (both are supported).|
+|[slabinfo.plugin](slabinfo.plugin/)|`C`|linux|external|-|collects kernel SLAB details on Linux systems|
 |[statsd.plugin](statsd.plugin/)|`C`|any|internal|-|implements a high performance **statsd** server for Netdata|
 |[tc.plugin](tc.plugin/)|`C`|linux|internal|-|collects traffic QoS metrics (`tc`) of Linux network interfaces|
 

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -85,6 +85,7 @@ tc-qos-helper: *tc-qos-helper.sh*
 fping: fping
 ioping: ioping
 go.d.plugin: *go.d.plugin*
+slabinfo.plugin: slabinfo.plugin
 
 # -----------------------------------------------------------------------------
 # authentication/authorization related servers

--- a/collectors/plugins.d/README.md
+++ b/collectors/plugins.d/README.md
@@ -18,6 +18,7 @@ from external processes, thus allowing Netdata to use **external plugins**.
 |[perf.plugin](../perf.plugin/)|`C`|linux|collects CPU performance metrics using performance monitoring units (PMU).|
 |[node.d.plugin](../node.d.plugin/)|`node.js`|all|a **plugin orchestrator** for data collection modules written in `node.js`.|
 |[python.d.plugin](../python.d.plugin/)|`python`|all|a **plugin orchestrator** for data collection modules written in `python` v2 or v3 (both are supported).|
+|[slabinfo.plugin](../slabinfo.plugin/)|`C`|linux|collects kernel internal cache objects (SLAB) metrics.|
 
 Plugin orchestrators may also be described as **modular plugins**. They are modular since they accept custom made modules to be included. Writing modules for these plugins is easier than accessing the native Netdata API directly. You will find modules already available for each orchestrator under the directory of the particular modular plugin (e.g. under python.d.plugin for the python orchestrator).
 Each of these modular plugins has each own methods for defining modules. Please check the examples and their documentation.

--- a/collectors/slabinfo.plugin/Makefile.am
+++ b/collectors/slabinfo.plugin/Makefile.am
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+AUTOMAKE_OPTIONS = subdir-objects
+MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+
+include $(top_srcdir)/build/subst.inc
+SUFFIXES = .in
+
+dist_noinst_DATA = \
+	README.md \
+	$(NULL)

--- a/collectors/slabinfo.plugin/Makefile.am
+++ b/collectors/slabinfo.plugin/Makefile.am
@@ -2,10 +2,13 @@
 
 AUTOMAKE_OPTIONS = subdir-objects
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+CLEANFILES = \
+    slabinfo.plugin \
+    $(NULL)
 
 include $(top_srcdir)/build/subst.inc
 SUFFIXES = .in
 
 dist_noinst_DATA = \
-	README.md \
-	$(NULL)
+    README.md \
+    $(NULL)

--- a/collectors/slabinfo.plugin/README.md
+++ b/collectors/slabinfo.plugin/README.md
@@ -7,12 +7,9 @@ Each internal structure (process, file descriptor, inode...) is stored within a 
 
 ## configuring Netdata for slabinfo
 
-There is currently no configuration needed, aside to have the `slabinfo.plugin` plugin being able to read 
-`/proc/slabinfo`. As this procfile is only readable by root, (mode `0400` in the kernel source), we need to grant the 
-slabinfo.plugin this access, either by:
--  with Setuid root: `chown root: slabinfo.plugin && chmod u+s slabinfo.plugin`
--  with capability dac_override: `setcap cap_dac_override+ep slabinfo.plugin`
+There is currently no configuration needed.
 
+As `/proc/slabinfo` is only readable by root, this plugin needs to be setuid root.
 
 ## For what use
 

--- a/collectors/slabinfo.plugin/README.md
+++ b/collectors/slabinfo.plugin/README.md
@@ -7,9 +7,9 @@ Each internal structure (process, file descriptor, inode...) is stored within a 
 
 ## configuring Netdata for slabinfo
 
-There is currently no configuration needed, aside to have the `slabinfo.plugin` plugin being able to read `/proc/slabinfo`.
-
-This can be done either by:
+There is currently no configuration needed, aside to have the `slabinfo.plugin` plugin being able to read 
+`/proc/slabinfo`. As this procfile is only readable by root, (mode `0400` in the kernel source), we need to grant the 
+slabinfo.plugin this access, either by:
 -  with Setuid root: `chown root: slabinfo.plugin && chmod u+s slabinfo.plugin`
 -  with capability dac_override: `setcap cap_dac_override+ep slabinfo.plugin`
 

--- a/collectors/slabinfo.plugin/README.md
+++ b/collectors/slabinfo.plugin/README.md
@@ -1,0 +1,25 @@
+# slabinfo.plugin
+
+SLAB is a cache mechanism used by the Kernel to avoid fragmentation.
+
+Each internal structure (process, file descriptor, inode...) is stored within a SLAB.
+
+
+## configuring Netdata for slabinfo
+
+There is currently no configuration needed, aside to have the `slabinfo.plugin` plugin being able to read `/proc/slabinfo`.
+
+This can be done either by:
+-  with Setuid root: `chown root: slabinfo.plugin && chmod u+s slabinfo.plugin`
+-  with capability dac_override: `setcap cap_dac_override+ep slabinfo.plugin`
+
+
+## For what use
+
+This slabinfo details allows to have clues on actions done on your system.
+In the following screenshot, you can clearly see a `find` done on a ext4 filesystem (the number of `ext4_inode_cache` & `dentry` are rising fast), and a few seconds later, an admin issued a `echo 3 > /proc/sys/vm/drop_cached` as their count dropped.
+
+![netdata_slabinfo](https://user-images.githubusercontent.com/9157986/64433811-7f06e500-d0bf-11e9-8e1e-087497e61033.png)
+
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fslabinfo.plugin%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/slabinfo.plugin/README.md
+++ b/collectors/slabinfo.plugin/README.md
@@ -9,7 +9,7 @@ Each internal structure (process, file descriptor, inode...) is stored within a 
 
 There is currently no configuration needed.
 
-As `/proc/slabinfo` is only readable by root, this plugin needs to be setuid root.
+As `/proc/slabinfo` is only readable by root, this plugin is setuid root.
 
 ## For what use
 

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// For CentOS 6 support
+#include <stdint.h>
 // For PAGE_SIZE
 #include <sys/user.h>
 

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -272,7 +272,6 @@ unsigned int do_slab_stats(int update_every) {
 				, update_every
 				, PLUGIN_SLABINFO_NAME
 			);
-			debug(D_PLUGIN_SLABINFO, " ok 2");
 			for (s = sactive; s; s = s->next) {
 				printf("DIMENSION %s '' absolute 1 1\n", s->name);
 			}

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -19,7 +19,7 @@
 
 // #define slabdebug(...) if (debug) { fprintf(stderr, __VA_ARGS__); }
 #define slabdebug(args...) if (debug) { \
-    fprintf(stderr, "slabinfo.plugin DEBUG (%04lu@%-10.10s:%-15.15s)::", __LINE__, __FILE__, __FUNCTION__); \
+    fprintf(stderr, "slabinfo.plugin DEBUG (%04d@%-10.10s:%-15.15s)::", __LINE__, __FILE__, __FUNCTION__); \
     fprintf(stderr, ##args); \
     fprintf(stderr, "\n"); }
 

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -212,10 +212,10 @@ struct slabinfo *read_file_slabinfo() {
 		//uint32_t lossperslab = memperslab - s->obj_per_slab * s->obj_size;
 
 		// Total usage = slabs * pages per slab * page size
-		s->mem_usage = s->data_num_slabs * memperslab;
+		s->mem_usage = (uint64_t)s->data_num_slabs * (uint64_t)memperslab;
 
 		// Wasted memory (filling): slabs allocated but not filled: sum total slab - sum total objects
-		s->mem_waste = s->mem_usage - s->active_objs * s->obj_size;
+		s->mem_waste = s->mem_usage - (uint64_t)(s->active_objs * s->obj_size);
 		//if (s->data_num_slabs > 1)
 		//	s->mem_waste += s->data_num_slabs * lossperslab;
 

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -366,11 +366,10 @@ int main(int argc, char **argv) {
 	error_log_syslog = 0;
 
 	int update_every = 1;
-	int n = 0;
 
 	// Very simple options: only 1 for the time being
 	if (argc == 2) {
-		n = (int) str2l(argv[1]);
+		int n = (int) str2l(argv[1]);
 		if (n > 0) {
 			if (n >= UPDATE_EVERY_MAX) {
 				error("Invalid interval value: %s", argv[1]);

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -388,11 +388,10 @@ int main(int argc, char **argv) {
 		}
 		else {
 			fprintf(stderr,
+				"netdata slabinfo.plugin %s\n"
+				"This program is a data collector plugin for netdata.\n"
 				"\n"
-				" netdata slabinfo.plugin %s\n"
-				" This program is a data collector plugin for netdata.\n"
-				"\n"
-				" Available command line options:\n"
+				"Available command line options:\n"
 				"\n"
 				"  COLLECTION_FREQUENCY    data collection frequency in seconds\n"
 				"                          minimum: %d\n"
@@ -400,6 +399,7 @@ int main(int argc, char **argv) {
 				"  debug                   enable verbose output\n"
 				"                          default: disabled\n"
 				"\n",
+				program_version,
 				update_every
 			);
 			exit(1);

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -363,7 +363,28 @@ int main(int argc, char **argv) {
 	program_version = "0.1";
 	error_log_syslog = 0;
 
-	do_stats(1, 0);
+	int update_every = 1;
+	int n = 0;
+
+	// Very simple options: only 1 for the time being
+	if (argc == 2) {
+		n = (int) str2l(argv[1]);
+		if (n > 0) {
+			if (n >= UPDATE_EVERY_MAX) {
+				error("Invalid interval value: %s", argv[1]);
+				exit(1);
+			}
+
+			update_every = n;
+		}
+		else {
+			error("Invalid interval value: %s", argv[1]);
+			exit(1);
+		}
+	}
+
+	// Call the main function. Time drift to be added
+	do_slab_stats(update_every, 0);
 
 	return 0;
 }

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -252,7 +252,7 @@ unsigned int do_stats(int update_every, usec_t dt) {
 			// Memory Usage
 			printf("CHART %s.%s '' 'Memory Usage' 'B' '%s' '' line %d %d %s\n"
 				, CHART_TYPE
-				, "memory"
+				, "slabmemory"
 				, CHART_FAMILY
 				, CHART_PRIO
 				, update_every
@@ -265,7 +265,7 @@ unsigned int do_stats(int update_every, usec_t dt) {
 			// Slab active usage (filling)
 			printf("CHART %s.%s '' 'Object Filling' '%%' '%s' '' line %d %d %s\n"
 				, CHART_TYPE
-				, "filling"
+				, "slabfilling"
 				, CHART_FAMILY
 				, CHART_PRIO + 1
 				, update_every
@@ -279,7 +279,7 @@ unsigned int do_stats(int update_every, usec_t dt) {
 			// Memory waste
 			printf("CHART %s.%s '' 'Memory waste' 'B' '%s' '' line %d %d %s\n"
 				, CHART_TYPE
-				, "waste"
+				, "slabwaste"
 				, CHART_FAMILY
 				, CHART_PRIO + 2
 				, update_every
@@ -296,7 +296,7 @@ unsigned int do_stats(int update_every, usec_t dt) {
 		//
 		printf("BEGIN %s.%s\n"
 			, CHART_TYPE
-			, "memory"
+			, "slabmemory"
 		);
 		for (s = sactive; s; s = s->next) {
 			printf("SET %s = %lu\n"
@@ -311,7 +311,7 @@ unsigned int do_stats(int update_every, usec_t dt) {
 		//
 		printf("BEGIN %s.%s\n"
 			, CHART_TYPE
-			, "filling"
+			, "slabfilling"
 		);
 		for (s = sactive; s; s = s->next) {
 			printf("SET %s = %lu\n"
@@ -326,7 +326,7 @@ unsigned int do_stats(int update_every, usec_t dt) {
 		//
 		printf("BEGIN %s.%s\n"
 			, CHART_TYPE
-			, "waste"
+			, "slabwaste"
 		);
 		for (s = sactive; s; s = s->next) {
 			printf("SET %s = %lu\n"

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -189,10 +189,10 @@ struct slabinfo *read_file_slabinfo() {
     // Iterate on all lines to populate / update the slabinfo struct
     size_t lines = procfile_lines(ff), l;
 
-    slabdebug("   Read %lu lines from procfile", lines);
+    slabdebug("   Read %lu lines from procfile", (unsigned long)lines);
     for(l = 2; l < lines; l++) {
         if (unlikely(procfile_linewords(ff, l) < 14)) {
-            slabdebug("    Line %lu has only %lu words, skipping", l, procfile_linewords(ff,l));
+            slabdebug("    Line %lu has only %lu words, skipping", (unsigned long)l, procfile_linewords(ff,l));
             continue;
         }
 

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -19,23 +19,23 @@
 
 // #define slabdebug(...) if (debug) { fprintf(stderr, __VA_ARGS__); }
 #define slabdebug(args...) if (debug) { \
-	fprintf(stderr, "slabinfo.plugin DEBUG (%04lu@%-10.10s:%-15.15s)::", __LINE__, __FILE__, __FUNCTION__); \
-	fprintf(stderr, ##args); \
-	fprintf(stderr, "\n"); }
+    fprintf(stderr, "slabinfo.plugin DEBUG (%04lu@%-10.10s:%-15.15s)::", __LINE__, __FILE__, __FUNCTION__); \
+    fprintf(stderr, ##args); \
+    fprintf(stderr, "\n"); }
 
 
 // ----------------------------------------------------------------------------
 
 // callback required by fatal()
 void netdata_cleanup_and_exit(int ret) {
-	exit(ret);
+    exit(ret);
 }
 
 void send_statistics(const char *action, const char *action_result, const char *action_data) {
-	(void) action;
-	(void) action_result;
-	(void) action_data;
-	return;
+    (void) action;
+    (void) action_result;
+    (void) action_data;
+    return;
 }
 
 // callbacks required by popen()
@@ -45,11 +45,11 @@ void signals_reset(void) {};
 
 // callback required by eval()
 int health_variable_lookup(const char *variable, uint32_t hash, struct rrdcalc *rc, calculated_number *result) {
-	(void)variable;
-	(void)hash;
-	(void)rc;
-	(void)result;
-	return 0;
+    (void)variable;
+    (void)hash;
+    (void)rc;
+    (void)result;
+    return 0;
 };
 
 // required by get_system_cpus()
@@ -89,266 +89,266 @@ int debug = 0;
 // - Using uint64 everywhere, as types fits and allows to use standard helpers
 
 struct slabinfo {
-	// procfile fields
-	const char *name;
-	uint64_t active_objs;
-	uint64_t num_objs;
-	uint64_t obj_size;
-	uint64_t obj_per_slab;
-	uint64_t pages_per_slab;
-	uint64_t tune_limit;
-	uint64_t tune_batchcnt;
-	uint64_t tune_shared_factor;
-	uint64_t data_active_slabs;
-	uint64_t data_num_slabs;
-	uint64_t data_shared_avail;
+    // procfile fields
+    const char *name;
+    uint64_t active_objs;
+    uint64_t num_objs;
+    uint64_t obj_size;
+    uint64_t obj_per_slab;
+    uint64_t pages_per_slab;
+    uint64_t tune_limit;
+    uint64_t tune_batchcnt;
+    uint64_t tune_shared_factor;
+    uint64_t data_active_slabs;
+    uint64_t data_num_slabs;
+    uint64_t data_shared_avail;
 
-	// Calculated fields
-	uint64_t mem_usage;
-	uint64_t mem_waste;
-	uint8_t  obj_filling;
+    // Calculated fields
+    uint64_t mem_usage;
+    uint64_t mem_waste;
+    uint8_t  obj_filling;
 
-	uint32_t hash;
-	struct slabinfo *next;
+    uint32_t hash;
+    struct slabinfo *next;
 } *slabinfo_root = NULL, *slabinfo_next = NULL, *slabinfo_last_used = NULL;
 
 // The code is very inspired from "proc_net_dev.c" and "perf_plugin.c"
 
 // Get the existing object, or create a new one
 static struct slabinfo *get_slabstruct(const char *name) {
-	struct slabinfo *s;
+    struct slabinfo *s;
 
-	slabdebug("--> Requested slabstruct %s", name);
+    slabdebug("--> Requested slabstruct %s", name);
 
-	uint32_t hash = simple_hash(name);
+    uint32_t hash = simple_hash(name);
 
-	// Search it, from the next to the end
-	for (s = slabinfo_next; s; s = s->next) {
-		if ((hash = s->hash) && !strcmp(name, s->name)) {
-			slabdebug("<-- Found existing slabstruct after %s", slabinfo_last_used->name);
-			// Prepare the next run
-			slabinfo_next = s->next;
-			slabinfo_last_used = s;
-			return s;
-		}
-	}
+    // Search it, from the next to the end
+    for (s = slabinfo_next; s; s = s->next) {
+        if ((hash = s->hash) && !strcmp(name, s->name)) {
+            slabdebug("<-- Found existing slabstruct after %s", slabinfo_last_used->name);
+            // Prepare the next run
+            slabinfo_next = s->next;
+            slabinfo_last_used = s;
+            return s;
+        }
+    }
 
-	// Search it from the begining to the last position we used
-	for (s = slabinfo_root; s != slabinfo_last_used; s = s->next) {
-		if (hash == s->hash && !strcmp(name, s->name)) {
-			slabdebug("<-- Found existing slabstruct after root %s", slabinfo_root->name);
-			slabinfo_next = s->next;
-			slabinfo_last_used = s;
-			return s;
-		}
-	}
+    // Search it from the begining to the last position we used
+    for (s = slabinfo_root; s != slabinfo_last_used; s = s->next) {
+        if (hash == s->hash && !strcmp(name, s->name)) {
+            slabdebug("<-- Found existing slabstruct after root %s", slabinfo_root->name);
+            slabinfo_next = s->next;
+            slabinfo_last_used = s;
+            return s;
+        }
+    }
 
-	// Create a new one
-	s = callocz(1, sizeof(struct slabinfo));
-	s->name = strdupz(name);
-	s->hash = hash;
+    // Create a new one
+    s = callocz(1, sizeof(struct slabinfo));
+    s->name = strdupz(name);
+    s->hash = hash;
 
-	// Add it to the current postion
-	if (slabinfo_root) {
-		slabdebug("<-- Creating new slabstruct after %s", slabinfo_last_used->name);
-		s->next = slabinfo_last_used->next;
-		slabinfo_last_used->next = s;
-		slabinfo_last_used = s;
-	}
-	else {
-		slabdebug("<-- Creating new slabstruct as root");
-		slabinfo_root = slabinfo_last_used = s;
-	}
+    // Add it to the current postion
+    if (slabinfo_root) {
+        slabdebug("<-- Creating new slabstruct after %s", slabinfo_last_used->name);
+        s->next = slabinfo_last_used->next;
+        slabinfo_last_used->next = s;
+        slabinfo_last_used = s;
+    }
+    else {
+        slabdebug("<-- Creating new slabstruct as root");
+        slabinfo_root = slabinfo_last_used = s;
+    }
 
-	return s;
+    return s;
 }
 
 
 // Read a full pass of slabinfo to update the structs
 struct slabinfo *read_file_slabinfo() {
 
-	slabdebug("-> Reading procfile %s", PLUGIN_SLABINFO_PROCFILE);
+    slabdebug("-> Reading procfile %s", PLUGIN_SLABINFO_PROCFILE);
 
-	static procfile *ff = NULL;
+    static procfile *ff = NULL;
 
-	if(unlikely(!ff)) {
-		ff = procfile_reopen(ff, PLUGIN_SLABINFO_PROCFILE, " ,:" , PROCFILE_FLAG_DEFAULT);
-		if(unlikely(!ff)) {
-			error("<- Cannot open file '%s", PLUGIN_SLABINFO_PROCFILE);
-			exit(1);
-		}
-	}
+    if(unlikely(!ff)) {
+        ff = procfile_reopen(ff, PLUGIN_SLABINFO_PROCFILE, " ,:" , PROCFILE_FLAG_DEFAULT);
+        if(unlikely(!ff)) {
+            error("<- Cannot open file '%s", PLUGIN_SLABINFO_PROCFILE);
+            exit(1);
+        }
+    }
 
-	ff = procfile_readall(ff);
-	if(unlikely(!ff)) {
-		error("<- Cannot read file '%s'", PLUGIN_SLABINFO_PROCFILE);
-		exit(0);
-	}
-
-
-	// Iterate on all lines to populate / update the slabinfo struct
-	size_t lines = procfile_lines(ff), l;
-
-	slabdebug("   Read %lu lines from procfile", lines);
-	for(l = 2; l < lines; l++) {
-		if (unlikely(procfile_linewords(ff, l) < 14)) {
-			slabdebug("    Line %lu has only %lu words, skipping", l, procfile_linewords(ff,l));
-			continue;
-		}
-
-		char *name = procfile_lineword(ff, l, 0);
-		struct slabinfo *s = get_slabstruct(name);
-
-		s->active_objs    = str2uint64_t(procfile_lineword(ff, l, 1));
-		s->num_objs       = str2uint64_t(procfile_lineword(ff, l, 2));
-		s->obj_size       = str2uint64_t(procfile_lineword(ff, l, 3));
-		s->obj_per_slab   = str2uint64_t(procfile_lineword(ff, l, 4));
-		s->pages_per_slab = str2uint64_t(procfile_lineword(ff, l, 5));
-
-		s->tune_limit     = str2uint64_t(procfile_lineword(ff, l, 7));
-		s->tune_batchcnt  = str2uint64_t(procfile_lineword(ff, l, 8));
-		s->tune_shared_factor = str2uint64_t(procfile_lineword(ff, l, 9));
-
-		s->data_active_slabs = str2uint64_t(procfile_lineword(ff, l, 11));
-		s->data_num_slabs    = str2uint64_t(procfile_lineword(ff, l, 12));
-		s->data_shared_avail = str2uint64_t(procfile_lineword(ff, l, 13));
-
-		uint32_t memperslab = s->pages_per_slab * SLAB_PAGE_SIZE;
-		// Internal fragmentation: loss per slab, due to objects not being a multiple of pagesize
-		//uint32_t lossperslab = memperslab - s->obj_per_slab * s->obj_size;
-
-		// Total usage = slabs * pages per slab * page size
-		s->mem_usage = (uint64_t)(s->data_num_slabs * memperslab);
-
-		// Wasted memory (filling): slabs allocated but not filled: sum total slab - sum total objects
-		s->mem_waste = s->mem_usage - (uint64_t)(s->active_objs * s->obj_size);
-		//if (s->data_num_slabs > 1)
-		//	s->mem_waste += s->data_num_slabs * lossperslab;
+    ff = procfile_readall(ff);
+    if(unlikely(!ff)) {
+        error("<- Cannot read file '%s'", PLUGIN_SLABINFO_PROCFILE);
+        exit(0);
+    }
 
 
-		// Slab filling efficiency
-		if (s->num_objs > 0)
-			s->obj_filling = 100 * s->active_objs / s->num_objs;
-		else
-			s->obj_filling = 0;
+    // Iterate on all lines to populate / update the slabinfo struct
+    size_t lines = procfile_lines(ff), l;
 
-		slabdebug("    Updated slab %s: %lu %lu %lu %lu %lu / %lu %lu %lu / %lu %lu %lu / %lu %lu %hhu",
-			name, s->active_objs, s->num_objs, s->obj_size, s->obj_per_slab, s->pages_per_slab,
-			s->tune_limit, s->tune_batchcnt, s->tune_shared_factor,
-			s->data_active_slabs, s->data_num_slabs, s->data_shared_avail,
-			s->mem_usage, s->mem_waste, s->obj_filling);
-	}
+    slabdebug("   Read %lu lines from procfile", lines);
+    for(l = 2; l < lines; l++) {
+        if (unlikely(procfile_linewords(ff, l) < 14)) {
+            slabdebug("    Line %lu has only %lu words, skipping", l, procfile_linewords(ff,l));
+            continue;
+        }
 
-	return slabinfo_root;
+        char *name = procfile_lineword(ff, l, 0);
+        struct slabinfo *s = get_slabstruct(name);
+
+        s->active_objs    = str2uint64_t(procfile_lineword(ff, l, 1));
+        s->num_objs       = str2uint64_t(procfile_lineword(ff, l, 2));
+        s->obj_size       = str2uint64_t(procfile_lineword(ff, l, 3));
+        s->obj_per_slab   = str2uint64_t(procfile_lineword(ff, l, 4));
+        s->pages_per_slab = str2uint64_t(procfile_lineword(ff, l, 5));
+
+        s->tune_limit     = str2uint64_t(procfile_lineword(ff, l, 7));
+        s->tune_batchcnt  = str2uint64_t(procfile_lineword(ff, l, 8));
+        s->tune_shared_factor = str2uint64_t(procfile_lineword(ff, l, 9));
+
+        s->data_active_slabs = str2uint64_t(procfile_lineword(ff, l, 11));
+        s->data_num_slabs    = str2uint64_t(procfile_lineword(ff, l, 12));
+        s->data_shared_avail = str2uint64_t(procfile_lineword(ff, l, 13));
+
+        uint32_t memperslab = s->pages_per_slab * SLAB_PAGE_SIZE;
+        // Internal fragmentation: loss per slab, due to objects not being a multiple of pagesize
+        //uint32_t lossperslab = memperslab - s->obj_per_slab * s->obj_size;
+
+        // Total usage = slabs * pages per slab * page size
+        s->mem_usage = (uint64_t)(s->data_num_slabs * memperslab);
+
+        // Wasted memory (filling): slabs allocated but not filled: sum total slab - sum total objects
+        s->mem_waste = s->mem_usage - (uint64_t)(s->active_objs * s->obj_size);
+        //if (s->data_num_slabs > 1)
+        //    s->mem_waste += s->data_num_slabs * lossperslab;
+
+
+        // Slab filling efficiency
+        if (s->num_objs > 0)
+            s->obj_filling = 100 * s->active_objs / s->num_objs;
+        else
+            s->obj_filling = 0;
+
+        slabdebug("    Updated slab %s: %lu %lu %lu %lu %lu / %lu %lu %lu / %lu %lu %lu / %lu %lu %hhu",
+            name, s->active_objs, s->num_objs, s->obj_size, s->obj_per_slab, s->pages_per_slab,
+            s->tune_limit, s->tune_batchcnt, s->tune_shared_factor,
+            s->data_active_slabs, s->data_num_slabs, s->data_shared_avail,
+            s->mem_usage, s->mem_waste, s->obj_filling);
+    }
+
+    return slabinfo_root;
 }
 
 
 
 unsigned int do_slab_stats(int update_every) {
 
-	static unsigned int loops = 0;
-	struct slabinfo *sactive = NULL, *s = NULL;
+    static unsigned int loops = 0;
+    struct slabinfo *sactive = NULL, *s = NULL;
 
-	// Main processing loop
-	while (running) {
+    // Main processing loop
+    while (running) {
 
-		sactive = read_file_slabinfo();
+        sactive = read_file_slabinfo();
 
-		// Init Charts
-		if (unlikely(loops == 0)) {
-			// Memory Usage
-			printf("CHART %s.%s '' 'Memory Usage' 'B' '%s' '' line %d %d %s\n"
-				, CHART_TYPE
-				, "slabmemory"
-				, CHART_FAMILY
-				, CHART_PRIO
-				, update_every
-				, PLUGIN_SLABINFO_NAME
-			);
-			for (s = sactive; s; s = s->next) {
-				printf("DIMENSION %s '' absolute 1 1\n", s->name);
-			}
+        // Init Charts
+        if (unlikely(loops == 0)) {
+            // Memory Usage
+            printf("CHART %s.%s '' 'Memory Usage' 'B' '%s' '' line %d %d %s\n"
+                , CHART_TYPE
+                , "slabmemory"
+                , CHART_FAMILY
+                , CHART_PRIO
+                , update_every
+                , PLUGIN_SLABINFO_NAME
+            );
+            for (s = sactive; s; s = s->next) {
+                printf("DIMENSION %s '' absolute 1 1\n", s->name);
+            }
 
-			// Slab active usage (filling)
-			printf("CHART %s.%s '' 'Object Filling' '%%' '%s' '' line %d %d %s\n"
-				, CHART_TYPE
-				, "slabfilling"
-				, CHART_FAMILY
-				, CHART_PRIO + 1
-				, update_every
-				, PLUGIN_SLABINFO_NAME
-			);
-			for (s = sactive; s; s = s->next) {
-				printf("DIMENSION %s '' absolute 1 1\n", s->name);
-			}
+            // Slab active usage (filling)
+            printf("CHART %s.%s '' 'Object Filling' '%%' '%s' '' line %d %d %s\n"
+                , CHART_TYPE
+                , "slabfilling"
+                , CHART_FAMILY
+                , CHART_PRIO + 1
+                , update_every
+                , PLUGIN_SLABINFO_NAME
+            );
+            for (s = sactive; s; s = s->next) {
+                printf("DIMENSION %s '' absolute 1 1\n", s->name);
+            }
 
-			// Memory waste
-			printf("CHART %s.%s '' 'Memory waste' 'B' '%s' '' line %d %d %s\n"
-				, CHART_TYPE
-				, "slabwaste"
-				, CHART_FAMILY
-				, CHART_PRIO + 2
-				, update_every
-				, PLUGIN_SLABINFO_NAME
-			);
-			for (s = sactive; s; s = s->next) {
-				printf("DIMENSION %s '' absolute 1 1\n", s->name);
-			}
-		}
-
-
-		//
-		// Memory usage
-		//
-		printf("BEGIN %s.%s\n"
-			, CHART_TYPE
-			, "slabmemory"
-		);
-		for (s = sactive; s; s = s->next) {
-			printf("SET %s = %lu\n"
-				, s->name
-				, s->mem_usage
-			);
-		}
-		printf("END\n");
-
-		//
-		// Slab active usage
-		//
-		printf("BEGIN %s.%s\n"
-			, CHART_TYPE
-			, "slabfilling"
-		);
-		for (s = sactive; s; s = s->next) {
-			printf("SET %s = %u\n"
-				, s->name
-				, s->obj_filling
-			);
-		}
-		printf("END\n");
-
-		//
-		// Memory waste
-		//
-		printf("BEGIN %s.%s\n"
-			, CHART_TYPE
-			, "slabwaste"
-		);
-		for (s = sactive; s; s = s->next) {
-			printf("SET %s = %lu\n"
-				, s->name
-				, s->mem_waste
-			);
-		}
-		printf("END\n");
+            // Memory waste
+            printf("CHART %s.%s '' 'Memory waste' 'B' '%s' '' line %d %d %s\n"
+                , CHART_TYPE
+                , "slabwaste"
+                , CHART_FAMILY
+                , CHART_PRIO + 2
+                , update_every
+                , PLUGIN_SLABINFO_NAME
+            );
+            for (s = sactive; s; s = s->next) {
+                printf("DIMENSION %s '' absolute 1 1\n", s->name);
+            }
+        }
 
 
-		loops++;
+        //
+        // Memory usage
+        //
+        printf("BEGIN %s.%s\n"
+            , CHART_TYPE
+            , "slabmemory"
+        );
+        for (s = sactive; s; s = s->next) {
+            printf("SET %s = %lu\n"
+                , s->name
+                , s->mem_usage
+            );
+        }
+        printf("END\n");
 
-		sleep(update_every);
-	}
+        //
+        // Slab active usage
+        //
+        printf("BEGIN %s.%s\n"
+            , CHART_TYPE
+            , "slabfilling"
+        );
+        for (s = sactive; s; s = s->next) {
+            printf("SET %s = %u\n"
+                , s->name
+                , s->obj_filling
+            );
+        }
+        printf("END\n");
 
-	return loops;
+        //
+        // Memory waste
+        //
+        printf("BEGIN %s.%s\n"
+            , CHART_TYPE
+            , "slabwaste"
+        );
+        for (s = sactive; s; s = s->next) {
+            printf("SET %s = %lu\n"
+                , s->name
+                , s->mem_waste
+            );
+        }
+        printf("END\n");
+
+
+        loops++;
+
+        sleep(update_every);
+    }
+
+    return loops;
 }
 
 
@@ -358,62 +358,62 @@ unsigned int do_slab_stats(int update_every) {
 // main
 
 void usage(void) {
-	fprintf(stderr, "%s\n", program_name);
-	exit(1);
+    fprintf(stderr, "%s\n", program_name);
+    exit(1);
 }
 
 int main(int argc, char **argv) {
 
-	program_name = argv[0];
-	program_version = "0.1";
-	error_log_syslog = 0;
+    program_name = argv[0];
+    program_version = "0.1";
+    error_log_syslog = 0;
 
-	int update_every = 1, i, n, freq = 0;
+    int update_every = 1, i, n, freq = 0;
 
-	for (i = 1; i < argc; i++) {
-		// Frequency parsing
-		if(isdigit(*argv[i]) && !freq) {
-			n = (int) str2l(argv[i]);
-			if (n > 0) {
-				if (n >= UPDATE_EVERY_MAX) {
-					error("Invalid interval value: %s", argv[i]);
-					exit(1);
-				}
-				freq = n;
-			}
-		}
-		else if (strcmp("debug", argv[i]) == 0) {
-			debug = 1;
-			continue;
-		}
-		else {
-			fprintf(stderr,
-				"netdata slabinfo.plugin %s\n"
-				"This program is a data collector plugin for netdata.\n"
-				"\n"
-				"Available command line options:\n"
-				"\n"
-				"  COLLECTION_FREQUENCY    data collection frequency in seconds\n"
-				"                          minimum: %d\n"
-				"\n"
-				"  debug                   enable verbose output\n"
-				"                          default: disabled\n"
-				"\n",
-				program_version,
-				update_every
-			);
-			exit(1);
-		}
-	}
+    for (i = 1; i < argc; i++) {
+        // Frequency parsing
+        if(isdigit(*argv[i]) && !freq) {
+            n = (int) str2l(argv[i]);
+            if (n > 0) {
+                if (n >= UPDATE_EVERY_MAX) {
+                    error("Invalid interval value: %s", argv[i]);
+                    exit(1);
+                }
+                freq = n;
+            }
+        }
+        else if (strcmp("debug", argv[i]) == 0) {
+            debug = 1;
+            continue;
+        }
+        else {
+            fprintf(stderr,
+                "netdata slabinfo.plugin %s\n"
+                "This program is a data collector plugin for netdata.\n"
+                "\n"
+                "Available command line options:\n"
+                "\n"
+                "  COLLECTION_FREQUENCY    data collection frequency in seconds\n"
+                "                          minimum: %d\n"
+                "\n"
+                "  debug                   enable verbose output\n"
+                "                          default: disabled\n"
+                "\n",
+                program_version,
+                update_every
+            );
+            exit(1);
+        }
+    }
 
-	if(freq >= update_every)
-		update_every = freq;
-	else if(freq)
-		error("update frequency %d seconds is too small for slabinfo. Using %d.", freq, update_every);
+    if(freq >= update_every)
+        update_every = freq;
+    else if(freq)
+        error("update frequency %d seconds is too small for slabinfo. Using %d.", freq, update_every);
 
 
-	// Call the main function. Time drift to be added
-	do_slab_stats(update_every);
+    // Call the main function. Time drift to be added
+    do_slab_stats(update_every);
 
-	return 0;
+    return 0;
 }

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -26,7 +26,7 @@ void netdata_cleanup_and_exit(int ret) {
 	exit(ret);
 }
 
-void send_statistics( const char *action, const char *action_result, const char *action_data) {
+void send_statistics(const char *action, const char *action_result, const char *action_data) {
 	(void) action;
 	(void) action_result;
 	(void) action_data;
@@ -57,23 +57,23 @@ int running = 1;
 
 // Slabinfo format :
 // format 2.1 Was provided by 57ed3eda977a215f054102b460ab0eb5d8d112e6 (2.6.24-rc6) as:
-// seq_puts(m, "# name			<active_objs> <num_objs> <objsize> <objperslab> <pagesperslab>");
+// seq_puts(m, "# name  <active_objs> <num_objs> <objsize> <objperslab> <pagesperslab>");
 // seq_puts(m, " : tunables <limit> <batchcount> <sharedfactor>");
 // seq_puts(m, " : slabdata <active_slabs> <num_slabs> <sharedavail>");
 //
 // With max values:
 // seq_printf(m, "%-17s %6lu %6lu %6u %4u %4d",
-//	cache_name(s), sinfo.active_objs, sinfo.num_objs, s->size, sinfo.objects_per_slab, (1 << sinfo.cache_order));
+//   cache_name(s), sinfo.active_objs, sinfo.num_objs, s->size, sinfo.objects_per_slab, (1 << sinfo.cache_order));
 // seq_printf(m, " : tunables %4u %4u %4u",
-//	sinfo.limit, sinfo.batchcount, sinfo.shared);
+//   sinfo.limit, sinfo.batchcount, sinfo.shared);
 // seq_printf(m, " : slabdata %6lu %6lu %6lu",
-//	sinfo.active_slabs, sinfo.num_slabs, sinfo.shared_avail);
+//   sinfo.active_slabs, sinfo.num_slabs, sinfo.shared_avail);
 //
 // If CONFIG_DEBUG_SLAB is set, it will also add columns from slabinfo_show_stats (for SLAB only):
 // seq_printf(m, " : globalstat %7lu %6lu %5lu %4lu %4lu %4lu %4lu %4lu %4lu",
-//	  allocs, high, grown, reaped, errors, max_freeable, node_allocs, node_frees, overflows);
+//   allocs, high, grown, reaped, errors, max_freeable, node_allocs, node_frees, overflows);
 // seq_printf(m, " : cpustat %6lu %6lu %6lu %6lu",
-//	   allochit, allocmiss, freehit, freemiss);
+//   allochit, allocmiss, freehit, freemiss);
 //
 // Implementation choices:
 // - Iterates through a linked list of kmem_cache.
@@ -244,7 +244,7 @@ unsigned int do_slab_stats(int update_every) {
 	struct slabinfo *sactive = NULL, *s = NULL;
 
 	// Main processing loop
-	while ( running ) {
+	while (running) {
 
 		sactive = read_file_slabinfo();
 

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include <fcntl.h>
+// For PAGE_SIZE
 #include <sys/user.h>
+
 #include "libnetdata/libnetdata.h"
 #include "daemon/common.h"
 
@@ -208,7 +209,7 @@ struct slabinfo *read_file_slabinfo() {
 
 		uint32_t memperslab = s->pages_per_slab * SLAB_PAGE_SIZE;
 		// Internal fragmentation: loss per slab, due to objects not being a multiple of pagesize
-		uint32_t lossperslab = memperslab - s->obj_per_slab * s->obj_size;
+		//uint32_t lossperslab = memperslab - s->obj_per_slab * s->obj_size;
 
 		// Total usage = slabs * pages per slab * page size
 		s->mem_usage = s->data_num_slabs * memperslab;
@@ -237,7 +238,7 @@ struct slabinfo *read_file_slabinfo() {
 
 
 
-unsigned int do_stats(int update_every, usec_t dt) {
+unsigned int do_slab_stats(int update_every, usec_t dt) {
 
 	static unsigned int loops = 0;
 	struct slabinfo *sactive = NULL, *s = NULL;
@@ -314,7 +315,7 @@ unsigned int do_stats(int update_every, usec_t dt) {
 			, "slabfilling"
 		);
 		for (s = sactive; s; s = s->next) {
-			printf("SET %s = %lu\n"
+			printf("SET %s = %u\n"
 				, s->name
 				, s->obj_filling
 			);
@@ -357,7 +358,6 @@ void usage(void) {
 }
 
 int main(int argc, char **argv) {
-	pid_t pid = 0;
 
 	program_name = argv[0];
 	program_version = "0.1";

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// For CentOS 6 support
-#include <stdint.h>
-// For PAGE_SIZE
-#include <sys/user.h>
-
 #include "libnetdata/libnetdata.h"
 #include "daemon/common.h"
+
+// For PAGE_SIZE
+#include <sys/user.h>
 
 #define PLUGIN_SLABINFO_NAME "slabinfo.plugin"
 #define PLUGIN_SLABINFO_PROCFILE "/proc/slabinfo"

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <fcntl.h>
+#include <sys/user.h>
+#include "libnetdata/libnetdata.h"
+#include "daemon/common.h"
+
+#define PLUGIN_SLABINFO_NAME "slabinfo.plugin"
+#define PLUGIN_SLABINFO_PROCFILE "/proc/slabinfo"
+
+#define D_PLUGIN_SLABINFO 0x0000000200000000
+
+#define CHART_TYPE "mem"
+#define CHART_FAMILY "slab"
+#define CHART_PRIO 3000
+
+// As we're talking about kernel-pagesize, there's no hugepage.
+// So it's reliable to use it as an arch constant
+#define SLAB_PAGE_SIZE PAGE_SIZE
+
+// ----------------------------------------------------------------------------
+
+// callback required by fatal()
+void netdata_cleanup_and_exit(int ret) {
+	exit(ret);
+}
+
+void send_statistics( const char *action, const char *action_result, const char *action_data) {
+	(void) action;
+	(void) action_result;
+	(void) action_data;
+	return;
+}
+
+// callbacks required by popen()
+void signals_block(void) {};
+void signals_unblock(void) {};
+void signals_reset(void) {};
+
+// callback required by eval()
+int health_variable_lookup(const char *variable, uint32_t hash, struct rrdcalc *rc, calculated_number *result) {
+	(void)variable;
+	(void)hash;
+	(void)rc;
+	(void)result;
+	return 0;
+};
+
+// required by get_system_cpus()
+char *netdata_configured_host_prefix = "";
+
+
+int running = 1;
+
+// ----------------------------------------------------------------------------
+
+// Slabinfo format :
+// format 2.1 Was provided by 57ed3eda977a215f054102b460ab0eb5d8d112e6 (2.6.24-rc6) as:
+// seq_puts(m, "# name			<active_objs> <num_objs> <objsize> <objperslab> <pagesperslab>");
+// seq_puts(m, " : tunables <limit> <batchcount> <sharedfactor>");
+// seq_puts(m, " : slabdata <active_slabs> <num_slabs> <sharedavail>");
+//
+// With max values:
+// seq_printf(m, "%-17s %6lu %6lu %6u %4u %4d",
+//	cache_name(s), sinfo.active_objs, sinfo.num_objs, s->size, sinfo.objects_per_slab, (1 << sinfo.cache_order));
+// seq_printf(m, " : tunables %4u %4u %4u",
+//	sinfo.limit, sinfo.batchcount, sinfo.shared);
+// seq_printf(m, " : slabdata %6lu %6lu %6lu",
+//	sinfo.active_slabs, sinfo.num_slabs, sinfo.shared_avail);
+//
+// If CONFIG_DEBUG_SLAB is set, it will also add columns from slabinfo_show_stats (for SLAB only):
+// seq_printf(m, " : globalstat %7lu %6lu %5lu %4lu %4lu %4lu %4lu %4lu %4lu",
+//	  allocs, high, grown, reaped, errors, max_freeable, node_allocs, node_frees, overflows);
+// seq_printf(m, " : cpustat %6lu %6lu %6lu %6lu",
+//	   allochit, allocmiss, freehit, freemiss);
+//
+// Implementation choices:
+// - Iterates through a linked list of kmem_cache.
+// - Name is a char* from struct kmem_cache (mm/slab.h).
+// - Using 32chars for max name (max found is 24, with following cmd)
+//     grep -roP 'kmem_cache_create\(".+"'| awk '{split($0,a,"\""); print a[2],length(a[2]); }' | sort -k2 -n
+// - Using uint32 everywhere, as types fits and allows to use standard helpers
+
+struct slabinfo {
+	// procfile fields
+	const char *name;
+	uint32_t active_objs;
+	uint32_t num_objs;
+	uint32_t obj_size;
+	uint32_t obj_per_slab;
+	uint32_t pages_per_slab;
+	uint32_t tune_limit;
+	uint32_t tune_batchcnt;
+	uint32_t tune_shared_factor;
+	uint32_t data_active_slabs;
+	uint32_t data_num_slabs;
+	uint32_t data_shared_avail;
+
+	// Calculated fields
+	uint64_t mem_usage;
+	uint64_t mem_waste;
+	uint32_t obj_filling;
+
+	uint32_t hash;
+	struct slabinfo *next;
+} *slabinfo_root = NULL, *slabinfo_next = NULL, *slabinfo_last_used = NULL;
+
+// The code is very inspired from "proc_net_dev.c" and "perf_plugin.c"
+
+// Get the existing object, or create a new one
+static struct slabinfo *get_slabstruct(const char *name) {
+	struct slabinfo *s;
+
+	debug(D_PLUGIN_SLABINFO, "--> Requested slabstruct %s", name);
+
+	uint32_t hash = simple_hash(name);
+
+	// Search it, from the next to the end
+	for (s = slabinfo_next; s; s = s->next) {
+		if (hash = s->hash && !strcmp(name, s->name)) {
+			debug(D_PLUGIN_SLABINFO, "<-- Found existing slabstruct after %s", slabinfo_last_used->name);
+			// Prepare the next run
+			slabinfo_next = s->next;
+			slabinfo_last_used = s;
+			return s;
+		}
+	}
+
+	// Search it from the begining to the last position we used
+	for (s = slabinfo_root; s != slabinfo_last_used; s = s->next) {
+		if (hash == s->hash && !strcmp(name, s->name)) {
+			debug(D_PLUGIN_SLABINFO, "<-- Found existing slabstruct after root %s", slabinfo_root->name);
+			slabinfo_next = s->next;
+			slabinfo_last_used = s;
+			return s;
+		}
+	}
+
+	// Create a new one
+	s = callocz(1, sizeof(struct slabinfo));
+	s->name = strdupz(name);
+	s->hash = hash;
+
+	// Add it to the current postion
+	if (slabinfo_root) {
+		debug(D_PLUGIN_SLABINFO, "<-- Creating new slabstruct after %s", slabinfo_last_used->name);
+		s->next = slabinfo_last_used->next;
+		slabinfo_last_used->next = s;
+		slabinfo_last_used = s;
+	}
+	else {
+		debug(D_PLUGIN_SLABINFO, "<-- Creating new slabstruct as root");
+		slabinfo_root = slabinfo_last_used = s;
+	}
+
+	return s;
+}
+
+
+// Read a full pass of slabinfo to update the structs
+struct slabinfo *read_file_slabinfo() {
+
+	debug(D_PLUGIN_SLABINFO, "-> Reading procfile %s", PLUGIN_SLABINFO_PROCFILE);
+
+	static procfile *ff = NULL;
+
+	if(unlikely(!ff)) {
+		ff = procfile_reopen(ff, PLUGIN_SLABINFO_PROCFILE, " ,:" , PROCFILE_FLAG_DEFAULT);
+		if(unlikely(!ff)) {
+			error("<- Cannot open file '%s", PLUGIN_SLABINFO_PROCFILE);
+			exit(1);
+		}
+	}
+
+	ff = procfile_readall(ff);
+	if(unlikely(!ff)) {
+		error("<- Cannot read file '%s'", PLUGIN_SLABINFO_PROCFILE);
+		exit(0);
+	}
+
+
+	// Iterate on all lines to populate / update the slabinfo struct
+	size_t lines = procfile_lines(ff), l;
+
+	debug(D_PLUGIN_SLABINFO, "   Read %d lines from procfile", lines);
+	for(l = 2; l < lines; l++) {
+		if (unlikely(procfile_linewords(ff, l) < 14)) {
+			debug(D_PLUGIN_SLABINFO, "    Line %d has only %d words, skipping", l, procfile_linewords(ff,l));
+			continue;
+		}
+
+		char *name = procfile_lineword(ff, l, 0);
+		struct slabinfo *s = get_slabstruct(name);
+
+		s->active_objs    = str2uint32_t(procfile_lineword(ff, l, 1));
+		s->num_objs       = str2uint32_t(procfile_lineword(ff, l, 2));
+		s->obj_size       = str2uint32_t(procfile_lineword(ff, l, 3));
+		s->obj_per_slab   = str2uint32_t(procfile_lineword(ff, l, 4));
+		s->pages_per_slab = str2uint32_t(procfile_lineword(ff, l, 5));
+
+		s->tune_limit     = str2uint32_t(procfile_lineword(ff, l, 7));
+		s->tune_batchcnt  = str2uint32_t(procfile_lineword(ff, l, 8));
+		s->tune_shared_factor = str2uint32_t(procfile_lineword(ff, l, 9));
+
+		s->data_active_slabs = str2uint32_t(procfile_lineword(ff, l, 11));
+		s->data_num_slabs    = str2uint32_t(procfile_lineword(ff, l, 12));
+		s->data_shared_avail = str2uint32_t(procfile_lineword(ff, l, 13));
+
+		uint32_t memperslab = s->pages_per_slab * SLAB_PAGE_SIZE;
+		// Internal fragmentation: loss per slab, due to objects not being a multiple of pagesize
+		uint32_t lossperslab = memperslab - s->obj_per_slab * s->obj_size;
+
+		// Total usage = slabs * pages per slab * page size
+		s->mem_usage = s->data_num_slabs * memperslab;
+
+		// Wasted memory (filling): slabs allocated but not filled: sum total slab - sum total objects
+		s->mem_waste = s->mem_usage - s->active_objs * s->obj_size;
+		//if (s->data_num_slabs > 1)
+		//	s->mem_waste += s->data_num_slabs * lossperslab;
+
+
+		// Slab filling efficiency
+		if (s->num_objs > 0)
+			s->obj_filling = 100 * s->active_objs / s->num_objs;
+		else
+			s->obj_filling = 0;
+
+		debug(D_PLUGIN_SLABINFO, "    Updated slab %s: %lu %lu %lu %lu %lu / %lu %lu %lu / %lu %lu %lu / %lu %lu %lu",
+			name, s->active_objs, s->num_objs, s->obj_size, s->obj_per_slab, s->pages_per_slab,
+			s->tune_limit, s->tune_batchcnt, s->tune_shared_factor,
+			s->data_active_slabs, s->data_num_slabs, s->data_shared_avail,
+			s->mem_usage, s->mem_waste, s->obj_filling);
+	}
+
+	return slabinfo_root;
+}
+
+
+
+unsigned int do_stats(int update_every, usec_t dt) {
+
+	static unsigned int loops = 0;
+	struct slabinfo *sactive = NULL, *s = NULL;
+
+	// Main processing loop
+	while ( running ) {
+
+		sactive = read_file_slabinfo();
+
+		// Init Charts
+		if (unlikely(loops == 0)) {
+			// Memory Usage
+			printf("CHART %s.%s '' 'Memory Usage' 'B' '%s' '' line %d %d %s\n"
+				, CHART_TYPE
+				, "memory"
+				, CHART_FAMILY
+				, CHART_PRIO
+				, update_every
+				, PLUGIN_SLABINFO_NAME
+			);
+			for (s = sactive; s; s = s->next) {
+				printf("DIMENSION %s '' absolute 1 1\n", s->name);
+			}
+
+			// Slab active usage (filling)
+			printf("CHART %s.%s '' 'Object Filling' '%%' '%s' '' line %d %d %s\n"
+				, CHART_TYPE
+				, "filling"
+				, CHART_FAMILY
+				, CHART_PRIO + 1
+				, update_every
+				, PLUGIN_SLABINFO_NAME
+			);
+			debug(D_PLUGIN_SLABINFO, " ok 2");
+			for (s = sactive; s; s = s->next) {
+				printf("DIMENSION %s '' absolute 1 1\n", s->name);
+			}
+
+			// Memory waste
+			printf("CHART %s.%s '' 'Memory waste' 'B' '%s' '' line %d %d %s\n"
+				, CHART_TYPE
+				, "waste"
+				, CHART_FAMILY
+				, CHART_PRIO + 2
+				, update_every
+				, PLUGIN_SLABINFO_NAME
+			);
+			for (s = sactive; s; s = s->next) {
+				printf("DIMENSION %s '' absolute 1 1\n", s->name);
+			}
+		}
+
+
+		//
+		// Memory usage
+		//
+		printf("BEGIN %s.%s\n"
+			, CHART_TYPE
+			, "memory"
+		);
+		for (s = sactive; s; s = s->next) {
+			printf("SET %s = %lu\n"
+				, s->name
+				, s->mem_usage
+			);
+		}
+		printf("END\n");
+
+		//
+		// Slab active usage
+		//
+		printf("BEGIN %s.%s\n"
+			, CHART_TYPE
+			, "filling"
+		);
+		for (s = sactive; s; s = s->next) {
+			printf("SET %s = %lu\n"
+				, s->name
+				, s->obj_filling
+			);
+		}
+		printf("END\n");
+
+		//
+		// Memory waste
+		//
+		printf("BEGIN %s.%s\n"
+			, CHART_TYPE
+			, "waste"
+		);
+		for (s = sactive; s; s = s->next) {
+			printf("SET %s = %lu\n"
+				, s->name
+				, s->mem_waste
+			);
+		}
+		printf("END\n");
+
+
+		loops++;
+
+		sleep(update_every);
+	}
+
+	return loops;
+}
+
+
+
+
+// ----------------------------------------------------------------------------
+// main
+
+void usage(void) {
+	fprintf(stderr, "%s\n", program_name);
+	exit(1);
+}
+
+int main(int argc, char **argv) {
+	pid_t pid = 0;
+
+	program_name = argv[0];
+	program_version = "0.1";
+	error_log_syslog = 0;
+
+	do_stats(1, 0);
+
+	return 0;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -1160,6 +1160,7 @@ AC_CONFIG_FILES([
     collectors/plugins.d/Makefile
     collectors/proc.plugin/Makefile
     collectors/python.d.plugin/Makefile
+    collectors/slabinfo.plugin/Makefile
     collectors/statsd.plugin/Makefile
     collectors/tc.plugin/Makefile
     collectors/xenstat.plugin/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -774,6 +774,19 @@ AM_CONDITIONAL([ENABLE_PLUGIN_PERF], [test "${enable_plugin_perf}" = "yes"])
 
 
 # -----------------------------------------------------------------------------
+# slabinfo.plugin
+
+AC_MSG_CHECKING([if slabinfo.plugin should be enabled])
+if test "${build_target}" == "linux"; then
+    enable_plugin_slabinfo="yes"
+else
+    enable_plugin_slabinfo="no"
+fi
+AC_MSG_RESULT([${enable_plugin_slabinfo}])
+AM_CONDITIONAL([ENABLE_PLUGIN_SLABINFO], [test "${enable_plugin_slabinfo}" = "yes"])
+
+
+# -----------------------------------------------------------------------------
 # AWS Kinesis backend - libaws-cpp-sdk-kinesis, libaws-cpp-sdk-core, libssl, libcrypto, libcurl
 
 PKG_CHECK_MODULES(

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -107,6 +107,7 @@ override_dh_fixperms:
 	chmod 0754 $(TOP)/usr/libexec/netdata/plugins.d/apps.plugin
 	chmod 0754 $(TOP)/usr/libexec/netdata/plugins.d/freeipmi.plugin
 	chmod 0754 $(TOP)/usr/libexec/netdata/plugins.d/perf.plugin
+	chmod 0754 $(TOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin
 	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/go.d.plugin
 
 	# Support script for configuration file management

--- a/docs/Add-more-charts-to-netdata.md
+++ b/docs/Add-more-charts-to-netdata.md
@@ -70,6 +70,7 @@ To control which plugins Netdata run, edit `netdata.conf` and check the `[plugin
 	# apps = yes
 	# xenstat = yes
 	# perf = no
+	# slabinfo = no
 ```
 
 The default for all plugins is the option `enable running new plugins`. So, setting this to `no` will disable all the plugins, except the ones specifically enabled.
@@ -96,7 +97,7 @@ sudo su -s /bin/bash netdata
 ```
 
 Similarly, you can use `charts.d.plugin` for BASH plugins and `node.d.plugin` for node.js plugins.
-Other plugins (like `apps.plugin`, `freeipmi.plugin`, `fping.plugin`, `ioping.plugin`, `nfacct.plugin`, `xenstat.plugin`, `perf.plugin`) use the native Netdata plugin API and can be run directly.
+Other plugins (like `apps.plugin`, `freeipmi.plugin`, `fping.plugin`, `ioping.plugin`, `nfacct.plugin`, `xenstat.plugin`, `perf.plugin`, `slabinfo.plugin`) use the native Netdata plugin API and can be run directly.
 
 If you need to configure a Netdata plugin or module, all user supplied configuration is kept at `/etc/netdata` while the stock versions of all files is at `/usr/lib/netdata/conf.d`.
 To copy a stock file and edit it, run `/etc/netdata/edit-config`. Running this command without an argument, will list the available stock files.
@@ -126,6 +127,7 @@ This is a map of the all supported configuration options:
 | `proc.plugin`<br/>(internal plugin for monitoring Linux system resources)|`C`|`netdata.conf` section `[plugin:proc]`|one section for each module `[plugin:proc:MODULE]`. Each module may provide additional sections in the form of `[plugin:proc:MODULE:SUBSECTION]`.|
 | `python.d.plugin`<br/>(external plugin orchestrator for running python modules)|`python`<br/>v2 or v3<br/>both are supported|`python.d.conf`|a file for each module in `/etc/netdata/python.d/`.|
 | `statsd.plugin`<br/>(internal plugin for collecting statsd metrics)|`C`|`netdata.conf` section `[statsd]`|Synthetic statsd charts can be configured with files in `/etc/netdata/statsd.d/`.|
+| `slabinfo.plugin`<br/>(external plugin for monitoring Kernel SLAB cache on Linux)|`C`|`netdata.conf` section `[plugin:slabinfo]`|N/A|
 | `tc.plugin`<br/>(internal plugin for collecting Linux traffic QoS)|`C`|`netdata.conf` section `[plugin:tc]`|The plugin runs an external helper called `tc-qos-helper.sh` to interface with the `tc` command. This helper supports a few additional options using `tc-qos-helper.conf`.|
 
 ## writing data collection modules
@@ -316,6 +318,7 @@ These are all the data collection plugins currently available.
 | cpu_apps|BASH<br/>Shell Script|Collects the CPU utilization of select apps.<br/><br/>DEPRECATED IN FAVOR OF `apps.plugin`. It is still supplied only as an example module to shell scripting plugins.<br/> <br/>Netdata plugin: [charts.d.plugin](../collectors/charts.d.plugin#chartsdplugin)<br/>plugin module: [cpu_apps.chart.sh](../collectors/charts.d.plugin/cpu_apps)<br/>configuration file: [charts.d/cpu_apps.conf](../collectors/charts.d.plugin/cpu_apps)|
 | load_average|BASH<br/>Shell Script|Collects the current system load average.<br/><br/>DEPRECATED IN FAVOR OF THE NETDATA INTERNAL ONE. It is still supplied only as an example module to shell scripting plugins.<br/> <br/>Netdata plugin: [charts.d.plugin](../collectors/charts.d.plugin#chartsdplugin)<br/>plugin module: [load_average.chart.sh](../collectors/charts.d.plugin/load_average)<br/>configuration file: [charts.d/load_average.conf](../collectors/charts.d.plugin/load_average)|
 | mem_apps|BASH<br/>Shell Script|Collects the memory footprint of select applications.<br/><br/>DEPRECATED IN FAVOR OF `apps.plugin`. It is still supplied only as an example module to shell scripting plugins.<br/> <br/>Netdata plugin: [charts.d.plugin](../collectors/charts.d.plugin#chartsdplugin)<br/>plugin module: [mem_apps.chart.sh](../collectors/charts.d.plugin/mem_apps)<br/>configuration file: [charts.d/mem_apps.conf](../collectors/charts.d.plugin/mem_apps)|
+| slabinfo|C|`slabinfo.plugin` collects Kernel SLAB cache metrics on Linux .<br/> <br/>[Documentation of `slabinfo.plugin`](../collectors/slabinfo.plugin/).<br/> <br/>Netdata plugin: [`slabinfo_plugin.c`](../collectors/slabinfo.plugin)|
 
 ---
 

--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -250,6 +250,7 @@ navpart 3 collectors/freeipmi.plugin
 navpart 3 collectors/nfacct.plugin
 navpart 3 collectors/xenstat.plugin
 navpart 3 collectors/perf.plugin
+navpart 3 collectors/slabinfo.plugin
 
 
 echo -ne "    - 'docs/Third-Party-Plugins.md'

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -752,6 +752,11 @@ if [ "${UID}" -eq 0 ]; then
 		run chmod 4750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin"
 	fi
 
+	if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/slabinfo.plugin" ]; then
+		run chown root:${NETDATA_GROUP} "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/slabinfo.plugin"
+		run chmod 4750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/slabinfo.plugin"
+	fi
+
 	if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ioping" ]; then
 		run chown root:${NETDATA_GROUP} "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ioping"
 		run chmod 4750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ioping"

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -279,6 +279,9 @@ install -m 4750 -p perf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.
 # Install cups.plugin
 install -m 0750 -p cups.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/cups.plugin"
 
+# ###########################################################
+# Install slabinfo.plugin
+install -m 4750 -p slabinfo.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/slabinfo.plugin"
 
 # ###########################################################
 # Install registry directory
@@ -451,6 +454,8 @@ rm -rf "${RPM_BUILD_ROOT}"
 # perf plugin
 %caps(cap_setuid=ep) %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/perf.plugin
 
+# perf plugin
+%caps(cap_setuid=ep) %attr(4550,root,netdata) %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
 
 # freeipmi files
 %caps(cap_setuid=ep) %attr(4550,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin


### PR DESCRIPTION
#### Summary

Provide new collector parsing `/proc/slabinfo` to provide details on kernel slab structures.

Asked by issue #13 (very happy for the oldest issue in backlog) 

##### Component Name

collectors/slabinfo.plugin

##### Additional Information

This slabinfo details allows to have clues on actions done on your system.
In the following screenshot, you can clearly see a `find` done on a ext4 filesystem (the number of `ext4_inode_cache` & `dentry` are rising fast), and a few seconds later, an admin issued a `echo 3 > /proc/sys/vm/drop_cached` as their count dropped.

![netdata_slabinfo](https://user-images.githubusercontent.com/9157986/64433811-7f06e500-d0bf-11e9-8e1e-087497e61033.png)
