### PR TITLE
netdata/packaging: remove fedora/28, is no longer available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -442,14 +442,6 @@ jobs:
         - PACKAGE_TYPE="rpm" REPO_TOOL="dnf"
         - ALLOW_SOFT_FAILURE_HERE=true
 
-    - name: "Build & Publish RPM package for Fedora 28"
-      <<: *RPM_TEMPLATE
-      if: commit_message =~ /\[Package (amd64|arm64) RPM( Fedora)?\]/
-      env:
-        - BUILDER_NAME="builder" BUILD_DISTRO="fedora" BUILD_RELEASE="28" BUILD_STRING="fedora/28"
-        - PACKAGE_TYPE="rpm" REPO_TOOL="dnf"
-        - ALLOW_SOFT_FAILURE_HERE=true
-
     - name: "Build & Publish RPM package for OpenSuSE 15.1"
       <<: *RPM_TEMPLATE
       if: commit_message =~ /\[Package (amd64|arm64) RPM( openSuSE)?\]/


### PR DESCRIPTION

##### Summary
Fedora/28 is no longer on the list of supported software (https://fedoraproject.org/wiki/Releases)
Removing it's generation from our packaging

##### Component Name
netdata/packaging

##### Additional Information

N/A