### PR TITLE
Buffer overflow

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -791,7 +791,7 @@ static inline char *http_header_parse(struct web_client *w, char *s, int parse_u
         w->auth_bearer_token = strdupz(v);
     }
     else if(hash == hash_host && !strcasecmp(s, "Host")){
-        strncpyz(w->host, v, (ve-v<sizeof(w->host)-1?ve-v:sizeof(w->host)-1));
+        strncpyz(w->host, v, ((size_t)(ve - v) < sizeof(w->host)-1 ? (size_t)(ve - v) : sizeof(w->host)-1));
     }
 #ifdef NETDATA_WITH_ZLIB
     else if(hash == hash_accept_encoding && !strcasecmp(s, "Accept-Encoding")) {

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -791,7 +791,7 @@ static inline char *http_header_parse(struct web_client *w, char *s, int parse_u
         w->auth_bearer_token = strdupz(v);
     }
     else if(hash == hash_host && !strcasecmp(s, "Host")){
-        strncpyz(w->host, v, (ve - v));
+        strncpyz(w->host, v, (ve-v<sizeof(w->host)-1?ve-v:sizeof(w->host)-1));
     }
 #ifdef NETDATA_WITH_ZLIB
     else if(hash == hash_accept_encoding && !strcasecmp(s, "Accept-Encoding")) {


### PR DESCRIPTION
##### Summary

The host field in the web_client is to store the value of the Host HTTP header,
but it is an arbitrary size and there are no length checks. I could not see an
easy way to exploit it but this checks it will not overflow the buffer.

##### Component Name
daemon / web_server

##### Additional Information
Splitting out from PR#6796.
