### PR TITLE
netdata/ci: Force last good version of git-semver, they broke it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 install:
   - sudo apt-get install -y libcap2-bin zlib1g-dev uuid-dev fakeroot libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev gnupg python-pip
   - sudo apt install -y --only-upgrade docker-ce
-  - sudo pip install git-semver
+  - sudo pip install git-semver==0.2.4 # 11/Sep/2019: git-semver tip was broken, so we had to force last good run of it
   - docker info
   - source tests/installer/slack.sh
   - export NOTIF_CHANNEL="automation-beta"


### PR DESCRIPTION

##### Summary
We noticed that builds were breaking at the execution of `git semver`, during changelog generation.
When we debugged the process on travis, we realised that version 0.3.1 (latest available from travis) is broken.
We fall back to the last good version that we found on travis build history until they fix it (or forever, if the version doesn't become deprecated)

##### Component Name
netdata/ci

##### Additional Information
N/A