### PR TITLE
netdata/packaging: fix ubuntu/xenial runtime dependencies

### DIFF
--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -87,6 +87,9 @@ if str(os.environ["BUILD_STRING"]).count("debian/jessie") == 1:
 if str(os.environ["BUILD_STRING"]).count("ubuntu/trusty") == 1:
     common.run_command_in_host(['sudo', 'rm', 'contrib/debian/control'])
     common.run_command_in_host(['sudo', 'cp', 'contrib/debian/control.trusty', 'contrib/debian/control'])
+if str(os.environ["BUILD_STRING"]).count("ubuntu/xenial") == 1:
+    common.run_command_in_host(['sudo', 'rm', 'contrib/debian/control'])
+    common.run_command_in_host(['sudo', 'cp', 'contrib/debian/control.xenial', 'contrib/debian/control'])
 if str(os.environ["BUILD_STRING"]).count("debian/buster") == 1:
     common.run_command_in_host(['sudo', 'rm', 'contrib/debian/control'])
     common.run_command_in_host(['sudo', 'cp', 'contrib/debian/control.buster', 'contrib/debian/control'])

--- a/contrib/debian/control.xenial
+++ b/contrib/debian/control.xenial
@@ -1,0 +1,58 @@
+Source: netdata
+Build-Depends: debhelper (>= 9),
+               dh-autoreconf,
+               dh-systemd (>= 1.5),
+               dpkg-dev (>= 1.13.19),
+               zlib1g-dev,
+               uuid-dev,
+               libuv1-dev,
+               liblz4-dev,
+               libjudy-dev,
+               libssl-dev,
+               libmnl-dev,
+               libjson-c-dev,
+               libcups2-dev,
+               libipmimonitoring-dev,
+               libnetfilter-acct-dev,
+               libsnappy-dev,
+               libprotobuf-dev,
+               libprotoc-dev,
+               autogen,
+               autoconf,
+               automake,
+               pkg-config,
+               curl,
+               gcc,
+               g++
+Section: net
+Priority: optional
+Maintainer: Netdata Builder <bot@netdata.cloud>
+Standards-Version: 3.9.6
+Homepage: https://netdata.cloud
+
+Package: netdata
+Architecture: any
+Depends: adduser,
+         libcap2-bin (>= 1:2.0),
+         lsb-base (>= 3.1-23.2),
+         zlib1g,
+         libuuid1,
+         libuv1,
+         liblz4-1,
+         libjudydebian1,
+         openssl,
+         libmnl0,
+         libjson-c2,
+         cups,
+         freeipmi,
+         libnetfilter-acct1,
+         libprotobuf-c1,
+         libsnappy1v5,
+         libprotoc9v5,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: real-time charts for system monitoring
+ Netdata is a daemon that collects data in realtime (per second)
+ and presents a web site to view and analyze them. The presentation
+ is also real-time and full of interactive charts that precisely
+ render all collected values.


### PR DESCRIPTION
##### Summary
Yet another distribution with runtime version issues

libjson-c3 -> libjson-c2
libprotoc10 -> libprotoc9v5

```
root@af0192542851:/netdata# apt-get install libprotoc9v5 libjson-c2
Reading package lists... Done
Building dependency tree       
Reading state information... Done
libjson-c2 is already the newest version (0.11-4ubuntu2).
libprotoc9v5 is already the newest version (2.6.1-1.3).
0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
root@af0192542851:/netdata# cat /etc/os-release 
NAME="Ubuntu"
VERSION="16.04.6 LTS (Xenial Xerus)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 16.04.6 LTS"
VERSION_ID="16.04"
HOME_URL="http://www.ubuntu.com/"
SUPPORT_URL="http://help.ubuntu.com/"
BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
VERSION_CODENAME=xenial
UBUNTU_CODENAME=xenial
root@af0192542851:/netdata# 
```
##### Component Name
netdata/packaging

##### Additional Information
Fixes #6824 
