### PR TITLE
netdata/packaging: we didnt fix changelog handling, fixes and nits now

### DIFF
--- a/.travis/package_management/trigger_deb_lxc_build.py
+++ b/.travis/package_management/trigger_deb_lxc_build.py
@@ -57,8 +57,13 @@ print("Checking version consistency")
 since_version = os.environ["LATEST_RELEASE_VERSION"]
 if str(since_version).replace('v', '') == str(new_version) and str(new_version).count('.') == 2:
     s = since_version.split('.')
-    prev = str(int(s[1]) - 1)
-    since_version = s[0] + '.' + prev + s[2]
+    if int(s[2]) > 0:
+        patch_prev = str(int(s[2]) - 1)
+        since_version = s[0] + '.' + s[1] + '.'  + patch_prev
+    else:
+        prev = str(int(s[1]) - 1)
+        since_version = s[0] + '.' + prev + '.' + s[2]
+
     print("We seem to be building a new stable release, reduce by one since_version option. New since_version:%s" % since_version)
 
 print("Fixing changelog tags")


### PR DESCRIPTION

##### Summary
1) We missed a dot when reconstructing since_version
2) When we are on a patch release, just step back to fetch history from the previous patch release (or last minor release, respectively)

##### Component Name
netdata/packaging

##### Additional Information
N/A