### PR TITLE
netdata/packaging: Ensure that we do not mess with CI tooling, when building stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ stages:
 
     # Build DEB packages under special conditions
   - name: Package ubuntu/* and debian/*
-    if: type != cron AND type != pull_request AND branch = fix-workflow-for-changelog
+    if: type != cron AND type != pull_request AND branch = master
 
     # Build RPM packages under special conditions
   - name: Package centos, fedora and opensuse

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ stages:
 
     # Build DEB packages under special conditions
   - name: Package ubuntu/* and debian/*
-    if: type != cron AND type != pull_request AND branch = master
+    if: type != cron AND type != pull_request AND branch = fix-workflow-for-changelog
 
     # Build RPM packages under special conditions
   - name: Package centos, fedora and opensuse

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -134,8 +134,8 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     tar_file = os.environ['LXC_CONTAINER_ROOT'] + dest_archive
 
     print(".0 Copy repo to prepare it for tarball generation")
-    run_command_in_host(['cp', '-r', '.', 'netdata-source'])
-    run_command_in_host(['cd', 'netdata-source'])
+    run_command_in_host(['cp', '-r', '.', '/tmp/netdata-source/'])
+    run_command_in_host(['cd', '/tmp/netdata-source'])
 
     if tag is not None:
         print(".1 Checking out tag %s" % tag)
@@ -164,8 +164,8 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
         run_command_in_host(['sudo', 'chmod', '777', tar_file])
 
         print(".8 Returning to original directory, removing temp");
-        run_command_in_host(['cd', '..'])
-        run_command_in_host(['rm', '-r', 'netdata-source'])
+        run_command_in_host(['cd', '-'])
+        run_command_in_host(['rm', '-r', '/tmp/netdata-source'])
 
     else:
         print("I could not find (%s) on the disk, stopping the build. Kindly check the logs and try again" % 'netdata-%s.tar.gz' % pkg_friendly_version)

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -53,10 +53,10 @@ def run_command(container, command):
     if command_result != 0:
         raise Exception("Command failed with exit code %d" % command_result)
 
-def run_command_in_host(cmd):
-    print("Issue command in host: %s" % str(cmd))
+def run_command_in_host(cmd, cwd=None):
+    print("Issue command in host: %s, cwd:%s" % (str(cmd), str(cwd)))
 
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
     o, e = proc.communicate()
     print('Output: ' + o.decode('ascii'))
     print('Error: '  + e.decode('ascii'))
@@ -134,37 +134,36 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     tar_file = os.environ['LXC_CONTAINER_ROOT'] + dest_archive
 
     print(".0 Copy repo to prepare it for tarball generation")
-    run_command_in_host(['cp', '-r', '.', '/tmp/netdata-source/'])
-    run_command_in_host(['cd', '/tmp/netdata-source'])
+    tmp_src = '/tmp/netdata-source/'
+    run_command_in_host(['cp', '-r', '.', tmp_src])
 
     if tag is not None:
         print(".1 Checking out tag %s" % tag)
-        run_command_in_host(['git', 'fetch', '--all'])
+        run_command_in_host(['git', 'fetch', '--all'], tmp_src)
 
         # TODO: Keep in mind that tricky 'v' there, needs to be removed once we clear our versioning scheme
-        run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version])
+        run_command_in_host(['git', 'checkout', 'v%s' % pkg_friendly_version], tmp_src)
 
     print(".2 Tagging the code with version: %s" % pkg_friendly_version)
-    run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]])
+    run_command_in_host(['git', 'tag', '-a', pkg_friendly_version, '-m', 'Tagging while packaging on %s' % os.environ["CONTAINER_NAME"]], tmp_src)
 
     print(".3 Run autoreconf -ivf")
-    run_command_in_host(['autoreconf', '-ivf'])
+    run_command_in_host(['autoreconf', '-ivf'], tmp_src)
 
     print(".4 Run configure")
-    run_command_in_host(['./configure', '--prefix=/usr', '--sysconfdir=/etc', '--localstatedir=/var', '--libdir=/usr/lib', '--libexecdir=/usr/libexec', '--with-math', '--with-zlib', '--with-user=netdata'])
+    run_command_in_host(['./configure', '--prefix=/usr', '--sysconfdir=/etc', '--localstatedir=/var', '--libdir=/usr/lib', '--libexecdir=/usr/libexec', '--with-math', '--with-zlib', '--with-user=netdata'], tmp_src)
 
     print(".5 Run make dist")
-    run_command_in_host(['make', 'dist'])
+    run_command_in_host(['make', 'dist'], tmp_src)
 
     print(".6 Copy generated tarbal to desired path")
     if os.path.exists('netdata-%s.tar.gz' % pkg_friendly_version):
-        run_command_in_host(['sudo', 'cp', 'netdata-%s.tar.gz' % pkg_friendly_version, tar_file])
+        run_command_in_host(['sudo', 'cp', 'netdata-%s.tar.gz' % pkg_friendly_version, tar_file], tmp_src)
 
         print(".7 Fixing permissions on tarball")
-        run_command_in_host(['sudo', 'chmod', '777', tar_file])
+        run_command_in_host(['sudo', 'chmod', '777', tar_file], tmp_src)
 
         print(".8 Returning to original directory, removing temp");
-        run_command_in_host(['cd', '-'])
         run_command_in_host(['rm', '-r', '/tmp/netdata-source'])
 
     else:

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -7,6 +7,7 @@
 import lxc
 import subprocess
 import os
+import sys
 
 def fetch_version(orig_build_version):
     tag = None
@@ -157,15 +158,17 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     run_command_in_host(['make', 'dist'], tmp_src)
 
     print(".6 Copy generated tarbal to desired path")
+    generated_tarball = '%snetdata-%s.tar.gz' % (tmp_src, pkg_friendly_version)
+
     if os.path.exists('netdata-%s.tar.gz' % pkg_friendly_version):
-        run_command_in_host(['sudo', 'cp', '%snetdata-%s.tar.gz' % (tmp_src, pkg_friendly_version), tar_file], tmp_src)
+        run_command_in_host(['sudo', 'cp', generated_tarball, tar_file])
 
         print(".7 Fixing permissions on tarball")
-        run_command_in_host(['sudo', 'chmod', '777', tar_file], tmp_src)
+        run_command_in_host(['sudo', 'chmod', '777', tar_file])
 
         print(".8 Returning to original directory, removing temp");
-        run_command_in_host(['rm', '-r', '/tmp/netdata-source'])
+        run_command_in_host(['rm', '-r', tmp_src])
 
     else:
-        print("I could not find (%s) on the disk, stopping the build. Kindly check the logs and try again" % 'netdata-%s.tar.gz' % pkg_friendly_version)
+        print("I could not find (%s) on the disk, stopping the build. Kindly check the logs and try again" % generated_tarball)
         sys.exit(1)

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -133,6 +133,10 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     print(".0 Preparing local implementation tarball for version %s" % pkg_friendly_version)
     tar_file = os.environ['LXC_CONTAINER_ROOT'] + dest_archive
 
+    print(".0 Copy repo to prepare it for tarball generation")
+    run_command_in_host(['cp', '-r', '.', 'netdata-source'])
+    run_command_in_host(['cd', 'netdata-source'])
+
     if tag is not None:
         print(".1 Checking out tag %s" % tag)
         run_command_in_host(['git', 'fetch', '--all'])
@@ -158,6 +162,11 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
 
         print(".7 Fixing permissions on tarball")
         run_command_in_host(['sudo', 'chmod', '777', tar_file])
+
+        print(".8 Returning to original directory, removing temp");
+        run_command_in_host(['cd', '..'])
+        run_command_in_host(['rm', '-r', 'netdata-source'])
+
     else:
         print("I could not find (%s) on the disk, stopping the build. Kindly check the logs and try again" % 'netdata-%s.tar.gz' % pkg_friendly_version)
         sys.exit(1)

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -8,6 +8,8 @@ import lxc
 import subprocess
 import os
 import sys
+import tempfile
+import shutil
 
 def fetch_version(orig_build_version):
     tag = None
@@ -135,7 +137,7 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     tar_file = os.environ['LXC_CONTAINER_ROOT'] + dest_archive
 
     print(".0 Copy repo to prepare it for tarball generation")
-    tmp_src = '/tmp/netdata-source/'
+    tmp_src = tempfile.mkdtemp(prefix='netdata-source-')
     run_command_in_host(['cp', '-r', '.', tmp_src])
 
     if tag is not None:
@@ -167,8 +169,7 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
         run_command_in_host(['sudo', 'chmod', '777', tar_file])
 
         print(".8 Returning to original directory, removing temp");
-        run_command_in_host(['rm', '-r', tmp_src])
-
+        shutil.rmtree(tmp_src)
     else:
         print("I could not find (%s) on the disk, stopping the build. Kindly check the logs and try again" % generated_tarball)
         sys.exit(1)

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -158,7 +158,7 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
 
     print(".6 Copy generated tarbal to desired path")
     if os.path.exists('netdata-%s.tar.gz' % pkg_friendly_version):
-        run_command_in_host(['sudo', 'cp', 'netdata-%s.tar.gz' % pkg_friendly_version, tar_file], tmp_src)
+        run_command_in_host(['sudo', 'cp', '%snetdata-%s.tar.gz' % (tmp_src, pkg_friendly_version), tar_file], tmp_src)
 
         print(".7 Fixing permissions on tarball")
         run_command_in_host(['sudo', 'chmod', '777', tar_file], tmp_src)

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -160,7 +160,7 @@ def prepare_version_source(dest_archive, pkg_friendly_version, tag=None):
     print(".6 Copy generated tarbal to desired path")
     generated_tarball = '%snetdata-%s.tar.gz' % (tmp_src, pkg_friendly_version)
 
-    if os.path.exists('netdata-%s.tar.gz' % pkg_friendly_version):
+    if os.path.exists(generated_tarball):
         run_command_in_host(['sudo', 'cp', generated_tarball, tar_file])
 
         print(".7 Fixing permissions on tarball")


### PR DESCRIPTION

##### Summary
When we built binary package tooling, we had to perform some git operations in order to create tarballs of the source code to push on the build machines for package generation.

What happened now is that when we built stable, we checkout to the latest patch or release version. This is resulting into switching the whole repository there, which in turn results into messing up the CI tooling code because we basically go back in history when half of the code has been executed.

With this change, we take the repository on a temporary directory and build the required tarballs there, so that we don't mess with CI scripts along the way.
So now we can have CI implementation from the tip of master, to build the stable version of binary packages

##### Component Name
netdata/packaging

##### Additional Information
N/A
