### PR TITLE
[collector/proc.plugin] Add /proc/pagetypeinfo parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,6 +414,7 @@ set(PROC_PLUGIN_FILES
         collectors/proc.plugin/proc_softirqs.c
         collectors/proc.plugin/proc_loadavg.c
         collectors/proc.plugin/proc_meminfo.c
+        collectors/proc.plugin/proc_pagetypeinfo.c
         collectors/proc.plugin/proc_net_dev.c
         collectors/proc.plugin/proc_net_ip_vs_stats.c
         collectors/proc.plugin/proc_net_netstat.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -261,6 +261,7 @@ PROC_PLUGIN_FILES = \
 	collectors/proc.plugin/proc_softirqs.c \
 	collectors/proc.plugin/proc_loadavg.c \
 	collectors/proc.plugin/proc_meminfo.c \
+	collectors/proc.plugin/proc_pagetypeinfo.c \
 	collectors/proc.plugin/proc_net_dev.c \
 	collectors/proc.plugin/proc_net_ip_vs_stats.c \
 	collectors/proc.plugin/proc_net_netstat.c \

--- a/collectors/all.h
+++ b/collectors/all.h
@@ -35,7 +35,6 @@
 #define NETDATA_CHART_PRIO_SYSTEM_PGPGIO               151
 #define NETDATA_CHART_PRIO_SYSTEM_RAM                  200
 #define NETDATA_CHART_PRIO_SYSTEM_SWAP                 201
-#define NETDATA_CHART_PRIO_SYSTEM_MEMFRAG              220
 #define NETDATA_CHART_PRIO_SYSTEM_SWAPIO               250
 #define NETDATA_CHART_PRIO_SYSTEM_NET                  500
 #define NETDATA_CHART_PRIO_SYSTEM_IPV4                 500 // freebsd only

--- a/collectors/all.h
+++ b/collectors/all.h
@@ -35,6 +35,7 @@
 #define NETDATA_CHART_PRIO_SYSTEM_PGPGIO               151
 #define NETDATA_CHART_PRIO_SYSTEM_RAM                  200
 #define NETDATA_CHART_PRIO_SYSTEM_SWAP                 201
+#define NETDATA_CHART_PRIO_SYSTEM_MEMFRAG              220
 #define NETDATA_CHART_PRIO_SYSTEM_SWAPIO               250
 #define NETDATA_CHART_PRIO_SYSTEM_NET                  500
 #define NETDATA_CHART_PRIO_SYSTEM_IPV4                 500 // freebsd only
@@ -90,6 +91,7 @@
 #define NETDATA_CHART_PRIO_MEM_KSM_RATIOS             1302
 #define NETDATA_CHART_PRIO_MEM_NUMA                   1400
 #define NETDATA_CHART_PRIO_MEM_NUMA_NODES             1410
+#define NETDATA_CHART_PRIO_MEM_PAGEFRAG               1450
 #define NETDATA_CHART_PRIO_MEM_HW                     1500
 #define NETDATA_CHART_PRIO_MEM_HW_ECC_CE              1550
 #define NETDATA_CHART_PRIO_MEM_HW_ECC_UE              1560

--- a/collectors/proc.plugin/plugin_proc.c
+++ b/collectors/proc.plugin/plugin_proc.c
@@ -32,7 +32,7 @@ static struct proc_module {
         { .name = "/sys/block/zram", .dim = "zram", .func = do_sys_block_zram },
         { .name = "/sys/devices/system/edac/mc", .dim = "ecc", .func = do_proc_sys_devices_system_edac_mc },
         { .name = "/sys/devices/system/node", .dim = "numa", .func = do_proc_sys_devices_system_node },
-        { .name = "/proc/pagetypeinfo", .dim = "meminfo", .func = do_proc_pagetypeinfo },
+        { .name = "/proc/pagetypeinfo", .dim = "pagetypeinfo", .func = do_proc_pagetypeinfo },
 
         // network metrics
         { .name = "/proc/net/dev", .dim = "netdev", .func = do_proc_net_dev },

--- a/collectors/proc.plugin/plugin_proc.c
+++ b/collectors/proc.plugin/plugin_proc.c
@@ -32,6 +32,7 @@ static struct proc_module {
         { .name = "/sys/block/zram", .dim = "zram", .func = do_sys_block_zram },
         { .name = "/sys/devices/system/edac/mc", .dim = "ecc", .func = do_proc_sys_devices_system_edac_mc },
         { .name = "/sys/devices/system/node", .dim = "numa", .func = do_proc_sys_devices_system_node },
+        { .name = "/proc/pagetypeinfo", .dim = "meminfo", .func = do_proc_pagetypeinfo },
 
         // network metrics
         { .name = "/proc/net/dev", .dim = "netdev", .func = do_proc_net_dev },

--- a/collectors/proc.plugin/plugin_proc.h
+++ b/collectors/proc.plugin/plugin_proc.h
@@ -55,6 +55,7 @@ extern int do_proc_net_sockstat6(int update_every, usec_t dt);
 extern int do_proc_net_sctp_snmp(int update_every, usec_t dt);
 extern int do_ipc(int update_every, usec_t dt);
 extern int do_sys_class_power_supply(int update_every, usec_t dt);
+extern int do_proc_pagetypeinfo(int update_every, usec_t dt);
 extern int get_numa_node_count(void);
 
 // metrics that need to be shared among data collectors

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -292,7 +292,6 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
             systemorders[o].size += pagelines[p].free_pages_size[o];
         }
 
-        assert(p < pagelines_cnt);
         p++;
     }
 

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -181,7 +181,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
             pgl->node = nodenum;
             pgl->type = typename;
             pgl->zone = zonename;
-            for (o = 0; o < MAX_PAGETYPE_ORDER; o++)
+            for (o = 0; o < pageorders_cnt; o++)
                 pgl->free_pages_size[o] = str2uint64_t(procfile_lineword(ff, l, o+6)) * 1 << o;
 
             p++;
@@ -205,7 +205,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
                 , update_every
                 , RRDSET_TYPE_STACKED
             );
-            for (o = 0; o < MAX_PAGETYPE_ORDER; o++) {
+            for (o = 0; o < pageorder_cnt; o++) {
                 char id[3+1];
                 snprintfz(id, 3, "%lu", o);
 

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -101,7 +101,13 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
     }
 
     if(unlikely(!ff)) {
-        ff = procfile_open(PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME, " \t,", PROCFILE_FLAG_DEFAULT);
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME);
+        ff = procfile_open(config_get(CONFIG_SECTION_PLUGIN_PROC_PAGETYPEINFO, "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
+
+        if(unlikely(!ff)) {
+            ff = procfile_open(PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME, " \t,", PROCFILE_FLAG_DEFAULT);
+        }
     }
     if(unlikely(!ff))
         return 1;

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -206,7 +206,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
         // Init the RRD graphs
 
         // Per-Order: sum of all node, zone, type Grouped by order
-        if (do_global == CONFIG_BOOLEAN_YES) {
+        if (do_global != CONFIG_BOOLEAN_NO) {
             st_order = rrdset_create_localhost(
                 "mem"
                 , "pagetype_global"

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -236,9 +236,9 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
                 || (do_detail == CONFIG_BOOLEAN_AUTO && pageline_total_count(pgl) == 0))
                 continue;
 
-            // "pagetype" + NUMA-NodeId + ZoneName + TypeName
-            char setid[8+1+2+1+MAX_ZONETYPE_NAME+1+MAX_PAGETYPE_NAME+1];
-            snprintfz(setid, 4+2+1+MAX_ZONETYPE_NAME+1+MAX_PAGETYPE_NAME, "pagetype_%d_%s_%s", pgl->node, pgl->zone, pgl->type);
+            // "pagetype Node" + NUMA-NodeId + ZoneName + TypeName
+            char setid[13+1+2+1+MAX_ZONETYPE_NAME+1+MAX_PAGETYPE_NAME+1];
+            snprintfz(setid, 13+1+2+1+MAX_ZONETYPE_NAME+1+MAX_PAGETYPE_NAME, "pagetype_Node%d_%s_%s", pgl->node, pgl->zone, pgl->type);
 
             // Skip explicitely refused charts
             if (simple_pattern_matches(filter_types, setid))

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -208,7 +208,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
                 , "B"
                 , PLUGIN_PROC_NAME
                 , PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME
-                , NETDATA_CHART_PRIO_SYSTEM_MEMFRAG
+                , NETDATA_CHART_PRIO_MEM_PAGEFRAG
                 , update_every
                 , RRDSET_TYPE_STACKED
             );
@@ -259,7 +259,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
                     , "B"
                     , PLUGIN_PROC_NAME
                     , PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME
-                    , NETDATA_CHART_PRIO_MEM_PAGEFRAG + p
+                    , NETDATA_CHART_PRIO_MEM_PAGEFRAG + 1 + p
                     , update_every
                     , RRDSET_TYPE_STACKED
             );

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "plugin_proc.h"
+
+// For PAGE_SIZE
+#include <sys/user.h>
+
+
+#define PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME "/proc/pagetypeinfo"
+#define CONFIG_SECTION_PLUGIN_PROC_PAGETYPEINFO "plugin:" PLUGIN_PROC_CONFIG_NAME ":" PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME
+
+// Zone struct is pglist_data, in include/linux/mmzone.h
+// MAX_NR_ZONES is from __MAX_NR_ZONE, which is the last value of the enum.
+#define MAX_PAGETYPE_ORDER 11
+
+// Names are in mm/page_alloc.c :: migratetype_names. Max size = 10.
+#define MAX_ZONETYPE_NAME 16
+#define MAX_PAGETYPE_NAME 16
+
+// Defined in include/linux/mmzone.h as __MAX_NR_ZONE (last enum of zone_type)
+#define MAX_ZONETYPE  6
+// Defined in include/linux/mmzone.h as MIGRATE_TYPES (last enum of migratetype)
+#define MAX_PAGETYPE  7
+
+// Defined as 2^CONFIG_cnt_nodes_SHIFT. We'll use 16 for now (8 max * 2 as margin):
+// - Up to 4 Intel Xeon, each with SNC (x2) = 8 cnt_nodes.
+// - Up to 2 AMD  EPYC, each with 4 CPUs = 8 cnt_nodes.
+#define MAX_NUMA_cnt_nodes 16
+
+//
+// /proc/pagetypeinfo is declared in mm/vmstat.c :: init_mm_internals
+//
+struct pageline {
+	int node;
+	char *zone;
+	char *type;
+	uint64_t free_pages[MAX_PAGETYPE_ORDER];
+};
+
+struct nodezone {
+	int node;
+	char *zone;
+	struct pageline* lines[MAX_PAGETYPE];
+};
+
+struct systemorder {
+	uint64_t count;
+	RRDDIM *rd;
+};
+
+
+
+static inline uint64_t pageline_total_size(struct pageline *p) {
+	uint64_t sum = 0;
+	for (int o=0; o<MAX_PAGETYPE_ORDER; o++)
+		sum += p->free_pages[o] * (o+1) * PAGE_SIZE;
+	return sum;
+}
+
+static inline uint64_t pageline_total_count(struct pageline *p) {
+	uint64_t sum = 0;
+	for (int o=0; o<MAX_PAGETYPE_ORDER; o++)
+		sum += p->free_pages[0];
+	return sum;
+}
+
+
+
+int do_proc_pagetypeinfo(int update_every, usec_t dt) {
+	(void)dt;
+
+	static int cnt_nodes = -1, cnt_zones = -1, cnt_pagetypes = -1, cnt_pageorders = -1, linemax = -1;
+
+	static struct systemorder systemorders[MAX_PAGETYPE_ORDER] = {};
+	static struct pageline** pagelines = NULL;
+	static size_t pagelines_cnt = -1;
+
+	static procfile *ff = NULL;
+
+	static RRDSET *st_order = NULL;
+	//static RRDSET **st_nodezone = NULL;
+	static RRDSET **st_nodezonetype = NULL;
+
+	size_t l, o, p;
+	struct pageline *pgl;
+
+	if(unlikely(!ff)) {
+		ff = procfile_open(PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME, " \t,", PROCFILE_FLAG_DEFAULT);
+	}
+	if(unlikely(!ff))
+		return 1;
+
+	ff = procfile_readall(ff);
+	if(unlikely(!ff))
+		return 0; // we return 0, so that we will retry to open it next time
+
+	// --------------------------------------------------------------------
+	// Init: find how many cnt_nodes, Zones and Types
+	if(unlikely(cnt_nodes == -1)) {
+		size_t nodelast = -1, tmpint = -1;
+
+		size_t lines = procfile_lines(ff);
+		if(unlikely(!lines)) {
+			error("PLUGIN: PROC_PAGETYPEINFO: Cannot read %s, zero lines reported.", PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME);
+			return 1;
+		}
+
+		// 4th line is the "Free pages count...". Just substract the 8 words.
+		cnt_pageorders = procfile_linewords(ff, 3) - 8;
+		cnt_nodes = 0;
+		pagelines_cnt = 0;
+
+		for (l=4; l < lines; l++) {
+			// first empty line is the end of the "Free pages" block
+			if (strncmp(procfile_lineword(ff, l, 0), "Node", 4) != 0) {
+				linemax = l;
+				break;
+			}
+
+			// Count the number of numa cnt_nodes
+			if( (tmpint = strtoul(procfile_lineword(ff, l, 0), NULL, 16) ) && tmpint != nodelast ) {
+				cnt_nodes++;
+				nodelast = tmpint;
+			}
+
+			// Unmovable is always the first in the enum. The first line higher than 4
+			if (strncmp(procfile_lineword(ff, l, 6), "Unmovable", 10) == 0 && l >4) {
+				if (cnt_pagetypes == -1)
+					cnt_pagetypes = l - 4;
+			}
+
+			pagelines_cnt++;
+		}
+
+		debug(0x1, "Init: cnt_nodes=%d types=%d orders=%d linemax=%d",
+			cnt_nodes, cnt_pagetypes, cnt_pageorders, linemax );
+
+		// Init pagelines
+		if (!pagelines) {
+			pagelines = callocz(pagelines_cnt, sizeof(struct pageline));
+			if (!pagelines) {
+				error("PLUGIN: PROC_PAGETYPEINFO: Cannot allocate %lu B for pageline", linemax * sizeof(struct pageline));
+				return 1;
+			}
+		}
+
+		// Init the RRD graphs
+
+		// Per-Order: sum of all node, zone, type Grouped by order
+		st_order = rrdset_create_localhost(
+			"mem"
+			, "pagetype_orders"
+			, NULL
+			, "pagetype"
+			, NULL
+			, "System orders available"
+			, "MB"
+			, PLUGIN_PROC_NAME
+			, PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME
+			, NETDATA_CHART_PRIO_SYSTEM_MEMFRAG
+			, update_every
+			, RRDSET_TYPE_STACKED
+		);
+		for (o = 0; o < MAX_PAGETYPE_ORDER; o++) {
+			char id[3+1];
+			snprintfz(id, 3, "%lu", o);
+			char name[20+1];
+			snprintfz(name, 16,"Order %lu (%luMB)", o, (1 << o) * PAGE_SIZE);
+			systemorders[o].rd = rrddim_add(st_order, id, name, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+			rrddim_set_by_pointer(st_order, systemorders[o].rd, systemorders[o].count);
+		}
+
+		// Per Numa-Node & Zone
+		// TODO
+
+		// Per-Numa Node & Zone & Type (full detail). Only if sum(line) > 0
+		st_nodezonetype = callocz(cnt_zones, sizeof(RRDSET*));
+		for (p = 0; p < pagelines_cnt; p++) {
+			pgl = pagelines[p];
+
+			// Skip empty pagelines
+			if (pageline_total_count(pgl) == 0)
+				continue;
+
+
+			char id[MAX_ZONETYPE_NAME+1];
+			snprintfz(id, MAX_ZONETYPE_NAME, "node%d_%s_%s", pgl->node, pgl->zone, pgl->type);
+
+			st_nodezonetype[p] = rrdset_create_localhost(
+					"mem"
+					, id
+					, NULL
+					, "pagetype"
+					, NULL
+					, "Page Size Distribution"
+					, "pages size"
+					, PLUGIN_PROC_NAME
+					, PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME
+					, NETDATA_CHART_PRIO_MEM_PAGEFRAG
+					, update_every
+					, RRDSET_TYPE_STACKED
+			);
+
+			for (o = 0; o < MAX_PAGETYPE_ORDER; o++) {
+				char id[3+1];
+				snprintfz(id, 3, "%lu", o);
+				char name[20+1];
+				snprintfz(name, 20,"Order %lu (%luMB)", o, (1 << o) * PAGE_SIZE);
+				RRDDIM *rd = rrddim_add(st_nodezonetype[p], id, name, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+				rrddim_set_by_pointer(st_order, rd, pgl->free_pages[o]);
+			}
+		}
+	}
+
+	if(unlikely(!cnt_nodes)) {
+		error("PLUGIN: PROC_PAGETPEINFO: Cannot find the number of CPUs in %s", PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME);
+		return 1;
+	}
+
+	// --------------------------------------------------------------------
+	// Update pagelines
+
+	// Process each line
+	for (p = 0; p < pagelines_cnt; p++) {
+		l = p+4;
+
+		int words = procfile_linewords(ff, l);
+		if (words < 6+cnt_pageorders) {
+			error("Unable to read line %lu, only %d words found instead of %d", l, words, 6 + cnt_pageorders);
+			break;
+		}
+
+		for (o = 0; o < MAX_PAGETYPE_ORDER; o++) {
+			// Reset counter
+			if (p == 0)
+				systemorders[o].count = 0;
+
+			// Update orders of the current line
+			pagelines[p]->free_pages[o] = str2uint64_t(procfile_lineword(ff, l, o+6));
+
+			// Update sum by order
+			systemorders[o].count += pagelines[p]->free_pages[o];
+		}
+	}
+
+	// --------------------------------------------------------------------
+	// update RRD values
+
+	// Global system per order
+	rrdset_next(st_order);
+	for (o = 0; o < MAX_PAGETYPE_ORDER; o++) {
+		rrddim_set_by_pointer(st_order, systemorders[o].rd, systemorders[o].count);
+	}
+	rrdset_done(st_order);
+
+
+	// Per Node-Zone-Type
+
+	return 0;
+}

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -134,6 +134,10 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
 
             pagelines_cnt++;
         }
+        if (pagelines_cnt == 0) {
+            error("PLUGIN: PROC_PAGETYPEINFO: Unable to parse any valid line in %s", ff_path);
+            return 1;
+        }
 
         // 4th line is the "Free pages count per migrate type at order". Just substract these 8 words.
         pageorders_cnt = procfile_linewords(ff, 3);
@@ -185,11 +189,6 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
                 pgl->free_pages_size[o] = str2uint64_t(procfile_lineword(ff, l, o+6)) * 1 << o;
 
             p++;
-        }
-
-        if (p == 0) {
-            error("PLUGIN: PROC_PAGETYPEINFO: Unable to parse any valid line in %s", ff_path);
-            return 1;
         }
 
         // Init the RRD graphs

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -270,11 +270,6 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
         }
     }
 
-    if(unlikely(!pagelines_cnt)) {
-        error("PLUGIN: PROC_PAGETPEINFO: Cannot find the number of NUMA Nodes in %s", PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME);
-        return 1;
-    }
-
     // --------------------------------------------------------------------
     // Update pagelines
 

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -225,7 +225,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
             // Skip invalid, refused or empty pagelines if not explicitely requested
             if (!pgl
                 || do_detail == CONFIG_BOOLEAN_NO
-                || (do_detail == CONFIG_BOOLEAN_AUTO && pageline_total_count(pgl) == 0))
+                || (do_detail == CONFIG_BOOLEAN_AUTO && pageline_total_count(pgl) == 0 && netdata_zero_metrics_enabled != CONFIG_BOOLEAN_YES))
                 continue;
 
             // "pagetype Node" + NUMA-NodeId + ZoneName + TypeName

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -210,7 +210,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
                 , update_every
                 , RRDSET_TYPE_STACKED
             );
-            for (o = 0; o < pageorder_cnt; o++) {
+            for (o = 0; o < pageorders_cnt; o++) {
                 char id[3+1];
                 snprintfz(id, 3, "%lu", o);
 

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -52,15 +52,15 @@ struct systemorder {
 
 
 static inline uint64_t pageline_total_size(struct pageline *p) {
-	uint64_t sum = 0;
-	for (int o=0; o<MAX_PAGETYPE_ORDER; o++)
+	uint64_t sum = 0, o;
+	for (o=0; o<MAX_PAGETYPE_ORDER; o++)
 		sum += p->free_pages[o] * (o+1) * PAGE_SIZE;
 	return sum;
 }
 
 static inline uint64_t pageline_total_count(struct pageline *p) {
-	uint64_t sum = 0;
-	for (int o=0; o<MAX_PAGETYPE_ORDER; o++)
+	uint64_t sum = 0, o;
+	for (o=0; o<MAX_PAGETYPE_ORDER; o++)
 		sum += p->free_pages[0];
 	return sum;
 }

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -187,6 +187,11 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
             p++;
         }
 
+        if (p == 0) {
+            error("PLUGIN: PROC_PAGETYPEINFO: Unable to parse any valid line in %s", ff_path);
+            return 1;
+        }
+
         // Init the RRD graphs
 
         // Per-Order: sum of all node, zone, type Grouped by order

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -21,10 +21,6 @@
 // Defined in include/linux/mmzone.h as MIGRATE_TYPES (last enum of migratetype)
 #define MAX_PAGETYPE  7
 
-// Defined as 2^CONFIG_cnt_nodes_SHIFT. We'll use 16 for now (8 max * 2 as margin):
-// - Up to 4 Intel Xeon, each with SNC (x2) = 8 cnt_nodes.
-// - Up to 2 AMD  EPYC, each with 4 CPUs = 8 cnt_nodes.
-#define MAX_NUMA_cnt_nodes 16
 
 //
 // /proc/pagetypeinfo is declared in mm/vmstat.c :: init_mm_internals
@@ -284,7 +280,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
     }
 
     if(unlikely(!cnt_nodes)) {
-        error("PLUGIN: PROC_PAGETPEINFO: Cannot find the number of CPUs in %s", PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME);
+        error("PLUGIN: PROC_PAGETPEINFO: Cannot find the number of NUMA Nodes in %s", PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME);
         return 1;
     }
 
@@ -336,10 +332,8 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
     if (do_detail) {
         for (p = 0; p < pagelines_cnt; p++) {
             // Skip empty graphs
-            if (!st_nodezonetype[p]) {
-                error("Skipping line %lu", p);
+            if (!st_nodezonetype[p])
                 continue;
-            }
 
             rrdset_next(st_nodezonetype[p]);
             for (o = 0; o < MAX_PAGETYPE_ORDER; o++)


### PR DESCRIPTION
##### Summary

### Provides parsing of /proc/pagetypeinfo to provide fragmentation of free memory pages.

The buddyallocator is the system memory allocator: the whole memory space is split
 in **physical pages** (whose size is determined by the CPU Architecture & MMU). These physical pages are grouped into "page groups" of 2^10 (order 10) physical pages. (also numa node & zones).

When the kernel or an application requests some memory, the buddyallocator provides a page that matches closest the request. 
If an application requests 100KB, the buddy allocator will try to find a page of 128KB (order 7: 2^7).
If there is no such order available, it will find a page frm a superior order, and split it in 2 * 128K page. If no super page is available, it will try to reclaim memory from buffer / cache (reclaimable).

In x86, this translates to:  
- each physical page is 4KB,
- minimal size (order 0) of a pagegroup = 4KB
- maximal size (order 10) or a pagegroup = 4MB
- Zone DMA = 24bits: 0 => 16MB
- Zone DMA32 = 32bits: 16MB => 4GB
- Zone Normal = 4GB and up

pagetypeinfo show statistics of free memory available from the buddy allocator.
The sum of all buddyallocator pages must be equal the "Free Memory" from `/proc/meminfo`

##### Component Name

This addition is done in `collectors/proc.plugin`.

##### Additional Information
Closes #6802 

Ideas about configuration items and default values are welcome.