### PR TITLE
/var/lib/netdata/registry was being left behind after purge

### DIFF
--- a/contrib/debian/netdata.postrm
+++ b/contrib/debian/netdata.postrm
@@ -15,6 +15,10 @@ case "$1" in
 			dpkg-statoverride --remove /var/lib/netdata/www
 		fi
 
+		if dpkg-statoverride --list | grep -qw /var/lib/netdata/registry; then
+			dpkg-statoverride --remove /var/lib/netdata/registry
+		fi
+
 		if dpkg-statoverride --list | grep -qw /var/lib/netdata; then
 			dpkg-statoverride --remove /var/lib/netdata
 		fi


### PR DESCRIPTION
### Summary
When removing/purging the Debian package
```
root netdata 775 /var/lib/netdata/registry
```
was being left behind in the `/var/lib/dpkg/statoverride` file. This causes subsequent installations to fail with:
```
dpkg: unrecoverable fatal error, aborting:
 unknown group 'netdata' in statoverride file
```

##### Component Name
packaging/debian

##### Additional Information
e.g.:
```
$ sudo apt-get purge netdata
...
$ sudo grep netdata /var/lib/dpkg/statoverride
root netdata 775 /var/lib/netdata/registry
$ sudo dpkg -i netdata_1.17.1_amd64.deb
dpkg: unrecoverable fatal error, aborting:
 unknown group 'netdata' in statoverride file
```
