### PR TITLE
dont redirect when redirectURI is the same

### DIFF
--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -4955,7 +4955,7 @@ function handleSignInMessage(e) {
     cloudToken = e.data.token;
 
     netdataRegistryCallback(registryAgents);
-    if (e.data.redirectURI) {
+    if (e.data.redirectURI && !window.location.href.includes(e.data.redirectURI)) {
         window.location.replace(e.data.redirectURI);
     }
 }


### PR DESCRIPTION
##### Summary
somehow we get redirectURI from the cloud on every sign-in, which causes redirect loop. I think something has changed on the Cloud side, but i don't have time to check it now.
This change prevents constant loop, and redirects only when it's needed