### PR TITLE
Markdown syntax fixes for MDX parser

### DIFF
--- a/collectors/node.d.plugin/snmp/README.md
+++ b/collectors/node.d.plugin/snmp/README.md
@@ -356,8 +356,7 @@ This switch has a very slow SNMP processors. To respond, it needs about 8 second
                 }
             }
         }
-    }
-    ]
+    }],
 }
 ```
 

--- a/collectors/node.d.plugin/snmp/README.md
+++ b/collectors/node.d.plugin/snmp/README.md
@@ -96,8 +96,8 @@ In this example:
 
 <details markdown="1"><summary><b>Caution: Counter64 metrics do not support `offset` (issue #5028).</b></summary>
 The SNMP plugin supports Counter64 metrics with the only limitation that the `offset` parameter should not be defined. Due to the way Javascript handles large numbers and the fact that the offset is applied to metrics inside the plugin, the offset will be ignored silently.
-</details> 
-<br>
+</details>
+
 If you need to define many charts using incremental OIDs, you can use something like this:
 
 ```json

--- a/collectors/python.d.plugin/dnsdist/README.md
+++ b/collectors/python.d.plugin/dnsdist/README.md
@@ -1,8 +1,8 @@
 # dnsdist
 
-Module monitor dnsdist performance and health metrics.
+This module monitors dnsdist performance and health metrics.
 
-Following charts are drawn:
+The module draws the following charts:
 
 1.  **Response latency**
 
@@ -45,7 +45,7 @@ Following charts are drawn:
     -   servfail-responses
     -   trunc-failures
 
-## configuration
+## Configuration
 
 ```yaml
 localhost:
@@ -56,7 +56,5 @@ localhost:
   header:
     X-API-Key: 'dnsdist-api-key'
 ```
-
----
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fdnsdist%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -106,7 +106,7 @@ The page on [Netdata performance](Performance.md) has an excellent guide on how 
 
 ##### Change when Netdata saves metrics to disk
 
-[netdata.conf \[global\]](../daemon/config/#global-section-options) : `memory mode`</details>
+[netdata.conf \[global\]](../daemon/config/#global-section-options) : `memory mode`
 
 ##### Prevent Netdata from getting immediately killed when my server runs out of memory
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

A revised and simplified PR compared to #6746, which I'm going to close in favor of this one.

The Gatsby build (Learn site) errors out due to Markdown syntax errors on these pages. Mostly some stray Markdown syntax that `mkdocs` is silently ignoring but should be fixed regardless.

##### Component Name

docs

##### Additional Information

