### PR TITLE
Remove Dollar sign from Bash code in documentation and fix remark-lint warnings

### DIFF
--- a/collectors/charts.d.plugin/apache/README.md
+++ b/collectors/charts.d.plugin/apache/README.md
@@ -26,7 +26,7 @@ It has been tested with apache 2.2 and apache 2.4. The latter also provides conn
 Apache 2.2 response:
 
 ```sh
-$ curl "http://127.0.0.1/server-status?auto"
+curl "http://127.0.0.1/server-status?auto"
 Total Accesses: 80057
 Total kBytes: 223017
 CPULoad: .018287
@@ -42,7 +42,7 @@ Scoreboard: _________________________......................................._W__
 Apache 2.4 response:
 
 ```sh
-$ curl "http://127.0.0.1/server-status?auto"
+curl "http://127.0.0.1/server-status?auto"
 127.0.0.1
 ServerVersion: Apache/2.4.18 (Unix)
 ServerMPM: event

--- a/docs/Running-behind-haproxy.md
+++ b/docs/Running-behind-haproxy.md
@@ -1,16 +1,21 @@
 # Netdata via HAProxy
 
-> HAProxy is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications. It is particularly suited for very high traffic web sites and powers quite a number of the world's most visited ones.
+> HAProxy is a free, very fast and reliable solution offering high availability, load balancing, 
+> and proxying for TCP and HTTP-based applications. It is particularly suited for very high traffic web sites 
+> and powers quite a number of the world's most visited ones.
 
-If Netdata is running on a host running HAProxy, rather than connecting to Netdata from a port number, a domain name can be pointed at HAProxy, and HAProxy can redirect connections to the Netdata port. This can make it possible to connect to Netdata at <https://example.com> or <https://example.com/netdata/>, which is a much nicer experience then <http://example.com:19999>.
+If Netdata is running on a host running HAProxy, rather than connecting to Netdata from a port number, a domain name 
+can be pointed at HAProxy, and HAProxy can redirect connections to the Netdata port. This can make it possible to 
+connect to Netdata at <https://example.com> or <https://example.com/netdata/>, which is a much nicer experience then <http://example.com:19999>.
 
-To proxy requests from [HAProxy](https://github.com/haproxy/haproxy) to Netdata, the following configuration can be used:
+To proxy requests from [HAProxy](https://github.com/haproxy/haproxy) to Netdata, 
+the following configuration can be used:
 
 ## Default Configuration
 
 For all examples, set the mode to `http`
 
-```
+```conf
 defaults
     mode    http
 ```
@@ -23,7 +28,7 @@ A simple example where the base URL, say <http://example.com>, is used with no s
 
 Create a frontend to recieve the request.
 
-```
+```conf
 frontend http_frontend
     ## HTTP ipv4 and ipv6 on all ips ##
     bind :::80 v4v6
@@ -35,7 +40,7 @@ frontend http_frontend
 
 Create the Netdata backend which will send requests to port `19999`.
 
-```
+```conf
 backend netdata_backend
     option       forwardfor
     server       netdata_local     127.0.0.1:19999
@@ -54,7 +59,7 @@ A example where the base URL is used with a subpath `/netdata/`:
 
 To use a subpath, create an ACL, which will set a variable based on the subpath.
 
-```
+```conf
 frontend http_frontend
     ## HTTP ipv4 and ipv6 on all ips ##
     bind :::80 v4v6
@@ -77,7 +82,7 @@ frontend http_frontend
 
 Same as simple example, expept remove `/netdata/` with regex.
 
-```
+```conf
 backend netdata_backend
     option      forwardfor
     server      netdata_local     127.0.0.1:19999
@@ -92,13 +97,14 @@ backend netdata_backend
 
 ## Using TLS communication
 
-TLS can be used by adding port `443` and a cert to the frontend. This example will only use Netdata if host matches example.com (replace with your domain).
+TLS can be used by adding port `443` and a cert to the frontend. 
+This example will only use Netdata if host matches example.com (replace with your domain).
 
 ### Frontend
 
 This frontend uses a certificate list.
 
-```
+```conf
 frontend https_frontend
     ## HTTP ##
     bind :::80 v4v6
@@ -123,14 +129,15 @@ In the cert list file place a mapping from a certificate file to the domain used
 
 `/etc/letsencrypt/certslist.txt`:
 
-```
+```txt
 example.com /etc/letsencrypt/live/example.com/example.com.pem
 ```
 
-The file `/etc/letsencrypt/live/example.com/example.com.pem` should contain the key and certificate (in that order) concatenated into a `.pem` file.:
+The file `/etc/letsencrypt/live/example.com/example.com.pem` should contain the key and 
+certificate (in that order) concatenated into a `.pem` file.:
 
-```
-$ cat /etc/letsencrypt/live/example.com/fullchain.pem \
+```sh
+cat /etc/letsencrypt/live/example.com/fullchain.pem \
     /etc/letsencrypt/live/example.com/privkey.pem > \
     /etc/letsencrypt/live/example.com/example.com.pem
 ```
@@ -139,7 +146,7 @@ $ cat /etc/letsencrypt/live/example.com/fullchain.pem \
 
 Same as simple, except set protocol `https`.
 
-```
+```conf
 backend netdata_backend
     option forwardfor
     server      netdata_local     127.0.0.1:19999
@@ -155,7 +162,7 @@ backend netdata_backend
 
 To use basic HTTP Authentication, create a authentication list:
 
-```
+```conf
 # HTTP Auth
 userlist basic-auth-list
   group is-admin
@@ -165,20 +172,20 @@ userlist basic-auth-list
 
 You can create a hashed password using the `mkpassword` utility.
 
-```
-$ printf "passwordhere" | mkpasswd --stdin --method=sha-256
+```sh
+ printf "passwordhere" | mkpasswd --stdin --method=sha-256
 $5$l7Gk0VPIpKO$f5iEcxvjfdF11khw.utzSKqP7W.0oq8wX9nJwPLwzy1
 ```
 
 Replace `passwordhere` with hash:
 
-```
+```conf
 user admin password $5$l7Gk0VPIpKO$f5iEcxvjfdF11khw.utzSKqP7W.0oq8wX9nJwPLwzy1 groups is-admin
 ```
 
 Now add at the top of the backend:
 
-```
+```conf
 acl devops-auth http_auth_group(basic-auth-list) is-admin
 http-request auth realm netdata_local unless devops-auth
 ```
@@ -187,7 +194,7 @@ http-request auth realm netdata_local unless devops-auth
 
 Full example configuration with HTTP auth over TLS with subpath:
 
-```
+```conf
 global
     maxconn     20000
 

--- a/docs/contributing/contributing-documentation.md
+++ b/docs/contributing/contributing-documentation.md
@@ -1,12 +1,19 @@
 # Contributing to documentation
 
-We welcome contributions to Netdata's already extensive documentation, which we host at [docs.netdata.cloud](https://docs.netdata.cloud/) and store inside of the [main repository](https://github.com/netdata/netdata) on GitHub.
+We welcome contributions to Netdata's already extensive documentation, 
+which we host at [docs.netdata.cloud](https://docs.netdata.cloud/) 
+and store inside of the [main repository](https://github.com/netdata/netdata) on GitHub.
 
-Like all contributing to all other aspects of Netdata, we ask that anyone who wants to help with documentation read and abide by the [Contributor Convenant Code of Conduct](https://docs.netdata.cloud/code_of_conduct/) and follow the instructions outlined in our [Contributing document](../../CONTRIBUTING.md).
+Like all contributing to all other aspects of Netdata, we ask that anyone who wants to help with documentation 
+read and abide by the [Contributor Convenant Code of Conduct](https://docs.netdata.cloud/code_of_conduct/) 
+and follow the instructions outlined in our [Contributing document](../../CONTRIBUTING.md).
 
-We also ask you to read our [documentation style guide](style-guide.md), which, while not complete, will give you some guidance on how we write and organize our documentation.
+We also ask you to read our [documentation style guide](style-guide.md), which, while not complete, 
+will give you some guidance on how we write and organize our documentation.
 
-All our documentation uses the Markdown syntax. If you're not familiar with how it works, please read the [Markdown introduction post](https://daringfireball.net/projects/markdown/) by its creator, followed by [Mastering Markdown](https://guides.github.com/features/mastering-markdown/) guide from GitHub.
+All our documentation uses the Markdown syntax. If you're not familiar with how it works, 
+please read the [Markdown introduction post](https://daringfireball.net/projects/markdown/) by its creator, 
+followed by [Mastering Markdown](https://guides.github.com/features/mastering-markdown/) guide from GitHub.
 
 ## How contributing to the documentation works
 
@@ -15,11 +22,17 @@ There are two ways to contribute to Netdata's documentation:
 1.  Edit documentation [directly in GitHub](#edit-documentation-directly-on-gitHub).
 2.  Download the repository and [edit documentation locally](#edit-documentation-locally).
 
-Editing in GitHub is a simpler process and is perfect for quick edits to a single document, such as fixing a typo or clarifying a confusing sentence.
+Editing in GitHub is a simpler process and is perfect for quick edits to a single document, 
+such as fixing a typo or clarifying a confusing sentence.
 
-Editing locally is more complex, as you need to download the Netdata repository and build the documentation using `mkdocs`, but allows you to better organize complex projects. By building documentation locally, you can preview your work using a local web server before you submit your PR.
+Editing locally is more complex, as you need to download the Netdata repository 
+and build the documentation using `mkdocs`, but allows you to better organize complex projects. 
+By building documentation locally, you can preview your work using a local web server before you submit your PR.
 
-In both cases, you'll finish by submitting a pull request (PR). Once you submit your PR, GitHub will initiate a number of jobs, including a Netlify preview. You can use this preview to view the documentation site with your changes applied, which might help you catch any lingering issues.
+In both cases, you'll finish by submitting a pull request (PR). 
+Once you submit your PR, GitHub will initiate a number of jobs, including a Netlify preview. 
+You can use this preview to view the documentation site with your changes applied, 
+which might help you catch any lingering issues.
 
 To continue, follow one of the paths below:
 
@@ -28,32 +41,46 @@ To continue, follow one of the paths below:
 
 ## Edit documentation directly on GitHub
 
-Start editing documentation on GitHub by clicking the small pencil icon on any page on Netdata's [documentation site](https://docs.netdata.cloud/). You can find them at the top of every page.
+Start editing documentation on GitHub by clicking the small pencil icon on any page on Netdata's [documentation site](https://docs.netdata.cloud/). 
+You can find them at the top of every page.
 
-Clicking on this icon will take you to the associated page in the `netdata/netdata` repository. Then click the small pencil icon on any documentation file (those ending in the `.md` [Markdown] extension) in the `netdata/netdata` repository.
+Clicking on this icon will take you to the associated page in the `netdata/netdata` repository. 
+Then click the small pencil icon on any documentation file (those ending in the `.md` [Markdown] extension) in the `netdata/netdata` repository.
 
 ![A screenshot of editing a Markdown file directly in the Netdata repository](https://user-images.githubusercontent.com/1153921/59637188-10426d00-910a-11e9-99f2-ec564d6fb7d5.png)
 
-If you know where a file resides in the Netdata repository already, you can skip the step of beginning on the documentation site and go directly to GitHub.
+If you know where a file resides in the Netdata repository already, 
+you can skip the step of beginning on the documentation site and go directly to GitHub.
 
-Once you've clicked the pencil icon on GitHub, you'll see a full Markdown version of the file. Make changes as you see fit. You can use the `Preview changes` button to ensure your Markdown syntax is working properly.
+Once you've clicked the pencil icon on GitHub, you'll see a full Markdown version of the file. 
+Make changes as you see fit. 
+You can use the `Preview changes` button to ensure your Markdown syntax is working properly.
 
-Under the `Propose file change` header, write in a descriptive title for your requested change. Beneath that, add a concise descrition of what you've changed and why you think it's important. Then, click the `Propose file change` button. 
+Under the `Propose file change` header, write in a descriptive title for your requested change. 
+Beneath that, add a concise descrition of what you've changed and why you think it's important. Then, click the `Propose file change` button. 
 
-After you've hit that button, jump down to our instructions on [pull requests and cleanup](#pull-requests-and-final-steps) for your next steps. 
+After you've hit that button, 
+jump down to our instructions on [pull requests and cleanup](#pull-requests-and-final-steps) for your next steps. 
 
 !!! note
-    This process will create a branch directly on the `netdata/netdata` repository, which then requires manual cleanup. If you're going to make significant documentation contributions, or contribute often, we recommend the local editing process just below.
+    This process will create a branch directly on the `netdata/netdata` repository, which then requires manual cleanup. 
+    If you're going to make significant documentation contributions, or contribute often, 
+    we recommend the local editing process just below.
 
 ## Edit documentation locally
 
-Editing documentation locally is the preferred method for complex changes, PRs that span across multiple documents, or those that change the styling or underlying functionality of the documentation.
+Editing documentation locally is the preferred method for complex changes, PRs that span across multiple documents, 
+or those that change the styling or underlying functionality of the documentation.
 
-Here is the workflow for editing documentation locally. First, create a fork of the Netdata repository, if you don't have one already. Visit the [Netdata repository](https://github.com/netdata/netdata) and click on the `Fork` button in the upper-right corner of the window.
+Here is the workflow for editing documentation locally. First, create a fork of the Netdata repository, 
+if you don't have one already. Visit the [Netdata repository](https://github.com/netdata/netdata) 
+and click on the `Fork` button in the upper-right corner of the window.
 
 ![Screenshot of forking the Netdata repository](https://user-images.githubusercontent.com/1153921/59873572-25f5a380-9351-11e9-92a4-a681fe4a2ed9.png)
 
-GitHub will ask you where you want to clone the repository, and once finished you'll end up at the index of your forked Netdata repository. Clone your fork to your local machine:
+GitHub will ask you where you want to clone the repository, 
+and once finished you'll end up at the index of your forked Netdata repository. 
+Clone your fork to your local machine:
 
 ```bash
 git clone https://github.com/YOUR-GITHUB-USERNAME/netdata.git
@@ -63,40 +90,57 @@ You can now jump into the directory and explore Netdata's structure for yourself
 
 ### Understanding the structure of Netdata's documentation
 
-All of Netdata's documentation is stored within the repository itself, as close as possible to the code it corresponds to. Many sub-folders contain a `README.md` file, which is then used to populate the documentation about that feature/component of Netdata.
+All of Netdata's documentation is stored within the repository itself, as close as possible to the code it 
+corresponds to. Many sub-folders contain a `README.md` file, 
+which is then used to populate the documentation about that feature/component of Netdata.
 
-For example, the file at `packaging/installer/README.md` becomes `https://docs.netdata.cloud/packaging/installer/` and is our installation documentation. By co-locating it with quick-start installtion code, we ensure documentation is always tightly knit with the functions it describes.
+For example, the file at `packaging/installer/README.md` becomes `https://docs.netdata.cloud/packaging/installer/` 
+and is our installation documentation. By co-locating it with quick-start installtion code, 
+we ensure documentation is always tightly knit with the functions it describes.
 
-You might find other `.md` files within these directories. The `packaging/installer/` folder also contains `UPDATE.md` and `UNINSTALL.md`, which become `https://docs.netdata.cloud/packaging/installer/update/` and `https://docs.netdata.cloud/packaging/installer/uninstall/`, respectively.
+You might find other `.md` files within these directories. The `packaging/installer/` folder also contains `UPDATE.md` 
+and `UNINSTALL.md`, which become `https://docs.netdata.cloud/packaging/installer/update/` 
+and `https://docs.netdata.cloud/packaging/installer/uninstall/`, respectively.
 
-If the documentation you're working on has a direct correlation to some component of Netdata, place it into the correct folder and either name it `README.md` for generic documentation, or with another name for very specific instructions.
+If the documentation you're working on has a direct correlation to some component of Netdata, place it into the correct 
+folder and either name it `README.md` for generic documentation, or with another name for very specific instructions.
 
 #### The `docs` folder
 
-At the root of the Netdata repository is a `docs/` folder. Inside this folder we place documentation that does not have a direct relationship to a specific component of Netdata. It's where we house our [getting started guide](../GettingStarted.md), guides on [running Netdata behind Nginx](../Running-behind-nginx.md), and more.
+At the root of the Netdata repository is a `docs/` folder. Inside this folder we place documentation that does not 
+have a direct relationship to a specific component of Netdata. It's where we house our [getting started guide](../GettingStarted.md), 
+guides on [running Netdata behind Nginx](../Running-behind-nginx.md), and more.
 
-If the documentation you're working on doesn't have a direct relaionship to a component of Netdata, it can be placed in this `docs/` folder.
+If the documentation you're working on doesn't have a direct relaionship to a component of Netdata, 
+it can be placed in this `docs/` folder.
 
 ### Make your edits
 
-Now that you're set up and understand where to find or create your `.md` file, you can now begin to make your edits. Just use your favorite editor and keep in mind our [style guide](style-guide.md) as you work.
+Now that you're set up and understand where to find or create your `.md` file, you can now begin to make your edits. 
+Just use your favorite editor and keep in mind our [style guide](style-guide.md) as you work.
 
-If you add a new file to the documentation, you may need to modify the `buildyaml.sh` file to ensure it's added to the site's navigation. This is true for any file added to the `docs/` folder.
+If you add a new file to the documentation, you may need to modify the `buildyaml.sh` file to ensure 
+it's added to the site's navigation. This is true for any file added to the `docs/` folder.
 
-Be sure to periodically add/commit your edits so that you don't lose your work! We use version control software for a reason.
+Be sure to periodically add/commit your edits so that you don't lose your work! 
+We use version control software for a reason.
 
 ### Build the documentation
 
-Building the documentation periodically gives you a glimpse into the final product, and is generally required if you're making changes to the table of contents.
+Building the documentation periodically gives you a glimpse into the final product, and is generally required 
+if you're making changes to the table of contents.
 
 !!! attention ""
-    We have only tested the build process on Linux. Initial tests on OS X have been unsuccessful. Windows is fully untested at this point, but we would love to know if it works there as well!
+    We have only tested the build process on Linux. Initial tests on OS X have been unsuccessful. 
+    Windows is fully untested at this point, but we would love to know if it works there as well!
 
 To build the documentation, you need `python`/`pip`, `mkdocs`, and `mkdocs-material` installed on your machine.
 
 Follow the [Python installation instructions](https://www.python.org/downloads/) for your machine.
 
-Use `pip`, which was installed alongside Python, to install `mkdocs` and `mkdocs-material`. Your operating system might force you to use `pip2` or `pip3` instead, dependin on which version of Python you have installed.
+Use `pip`, which was installed alongside Python, to install `mkdocs` and `mkdocs-material`. 
+Your operating system might force you to use `pip2` or `pip3` instead, 
+dependin on which version of Python you have installed.
 
 ```bash
 pip install mkdocs mkdocs-material
@@ -105,7 +149,8 @@ pip install mkdocs mkdocs-material
 ??? note "Troubleshooting"
     If you're having trouble with the installation of Python, `mkdocs`, or `mkdocs-material`, try looking into the `mkdocs` [installation instructions](https://squidfunk.github.io/mkdocs-material/getting-started/#installation).
 
-When `pip` is finished installing, navigate to the root directory of the Netdata repository and run the documentation generator script.
+When `pip` is finished installing, navigate to the root directory of the Netdata repository 
+and run the documentation generator script.
 
 ```bash
 sh docs/generator/buildhtml.sh
@@ -115,7 +160,8 @@ This process will take some time. Once finished, the built documentation site wi
 
 ### Run a local web server to test documentation
 
-The best way to view the documentation site you just built is to run a simple web server from the `docs/generator/build/` directory. So, navigate there and run a Python-based web server:
+The best way to view the documentation site you just built is to run a simple web server from the `docs/generator/build/` directory. 
+So, navigate there and run a Python-based web server:
 
 ```sh
 cd docs/generator/build/
@@ -124,13 +170,18 @@ python3 -m http.server 20000
 
 Feel free to replace the port number you want this web server to listen on (port `20000` in this case [only one higher than the agent!]).
 
-Open your web browser and navigate to `http://localhost:20000`. If you replaced the port earlier, change it here as well. You can now navigate through the documentation as you would on the live site!
+Open your web browser and navigate to `http://localhost:20000`. 
+If you replaced the port earlier, change it here as well. 
+You can now navigate through the documentation as you would on the live site!
 
 ## Pull requests and final steps
 
-When you're finished with your changes, add and commit them to your fork of the Netdata repository. Head over to GitHub to create your pull request (PR).
+When you're finished with your changes, add and commit them to your fork of the Netdata repository. 
+Head over to GitHub to create your pull request (PR).
 
-Once we receive your pull request (PR), we'll take time to read through it and assess it for correctness, conciseness, and overall quality. We may point to specific sections and ask for additional information or other fixes.
+Once we receive your pull request (PR), we'll take time to read through it and assess it for correctness, conciseness, 
+and overall quality. 
+We may point to specific sections and ask for additional information or other fixes.
 
 ## What's next
 

--- a/docs/contributing/contributing-documentation.md
+++ b/docs/contributing/contributing-documentation.md
@@ -117,9 +117,9 @@ This process will take some time. Once finished, the built documentation site wi
 
 The best way to view the documentation site you just built is to run a simple web server from the `docs/generator/build/` directory. So, navigate there and run a Python-based web server:
 
-```
-$ cd docs/generator/build/
-$ python3 -m http.server 20000
+```sh
+cd docs/generator/build/
+python3 -m http.server 20000
 ```
 
 Feel free to replace the port number you want this web server to listen on (port `20000` in this case [only one higher than the agent!]).

--- a/docs/contributing/contributing-documentation.md
+++ b/docs/contributing/contributing-documentation.md
@@ -56,7 +56,7 @@ Here is the workflow for editing documentation locally. First, create a fork of 
 GitHub will ask you where you want to clone the repository, and once finished you'll end up at the index of your forked Netdata repository. Clone your fork to your local machine:
 
 ```bash
-$ git clone https://github.com/YOUR-GITHUB-USERNAME/netdata.git
+git clone https://github.com/YOUR-GITHUB-USERNAME/netdata.git
 ```
 
 You can now jump into the directory and explore Netdata's structure for yourself.
@@ -99,7 +99,7 @@ Follow the [Python installation instructions](https://www.python.org/downloads/)
 Use `pip`, which was installed alongside Python, to install `mkdocs` and `mkdocs-material`. Your operating system might force you to use `pip2` or `pip3` instead, dependin on which version of Python you have installed.
 
 ```bash
-$ pip install mkdocs mkdocs-material
+pip install mkdocs mkdocs-material
 ```
 
 ??? note "Troubleshooting"
@@ -108,7 +108,7 @@ $ pip install mkdocs mkdocs-material
 When `pip` is finished installing, navigate to the root directory of the Netdata repository and run the documentation generator script.
 
 ```bash
-$ sh docs/generator/buildhtml.sh
+sh docs/generator/buildhtml.sh
 ```
 
 This process will take some time. Once finished, the built documentation site will be located at `docs/generator/build/`.

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -33,7 +33,7 @@ This method is **fully automatic on all Linux distributions**. FreeBSD and MacOS
 To install Netdata from source, and keep it up to date with our **nightly releases** automatically, run the following:
 
 ```bash
-$ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
+bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 ```
 
 !!! note
@@ -72,7 +72,7 @@ The `kickstart.sh` script passes all its parameters to `netdata-installer.sh`, s
 Example using all the above parameters:
 
 ```bash
-$ bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-files /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt /tmp/manually.downloaded.go.d.binary.tar.gz /tmp/manually.downloaded.go.d.config.tar.gz
+bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-files /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt /tmp/manually.downloaded.go.d.binary.tar.gz /tmp/manually.downloaded.go.d.config.tar.gz
 ```
 Note: `--stable-channel` and `--local-files` overlap, if you use the tarball override the stable channel option is not effective
 </details>
@@ -90,7 +90,7 @@ You can install a pre-compiled static binary of Netdata on any Intel/AMD 64bit L
 To install Netdata from a binary package on any Linux distro and any kernel version on **Intel/AMD 64bit** systems, and keep it up to date with our **nightly releases** automatically, run the following:
 
 ```bash
-$ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh)
+bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh)
 ```
 
 !!! note

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -125,7 +125,7 @@ The `kickstart-static64.sh` script passes all its parameters to `netdata-install
 Example using all the above parameters:
 
 ```sh
-$ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-files /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt
+bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-files /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt
 ```
 Note: `--stable-channel` and `--local-files` overlap, if you use the tarball override the stable channel option is not effective
 
@@ -472,9 +472,9 @@ When Netdata is first installed, it will run as *root*. This may or may not be a
 3.  Change ownership of the following directories, as defined in [Netdata Security](../../docs/netdata-security.md#security-design):
 
 ```sh
-$ chown -R root:netdata /opt/netdata/usr/share/netdata
-$ chown -R netdata:netdata /opt/netdata/var/lib/netdata /opt/netdata/var/cache/netdata
-$ chown -R netdata:root /opt/netdata/var/log/netdata
+chown -R root:netdata /opt/netdata/usr/share/netdata
+chown -R netdata:netdata /opt/netdata/var/lib/netdata /opt/netdata/var/cache/netdata
+chown -R netdata:root /opt/netdata/var/log/netdata
 ```
 
 Additionally, as of 2018/06/24, the Netdata installer doesn't recognize DSM as an operating system, so no init script is installed. You'll have to do this manually:

--- a/packaging/installer/UNINSTALL.md
+++ b/packaging/installer/UNINSTALL.md
@@ -1,8 +1,14 @@
 # Uninstalling Netdata
 
-Our self-contained uninstaller is able to remove Netdata installations created with shell installer. It doesn't need any other Netdata repository files to be run. All it needs is an .environment file, which is created during installation (with shell installer) and put in ${NETDATA_USER_CONFIG_DIR}/.environment (by default /etc/netdata/.environment). That file contains some parameters which are passed to our installer and which are needed during uninstallation process. Mainly two parameters are needed:
+Our self-contained uninstaller is able to remove Netdata installations created with shell installer. 
+It doesn't need any other Netdata repository files to be run. 
+All it needs is an `.environment` file, which is created during installation (with shell installer) 
+and put in `${NETDATA_USER_CONFIG_DIR}/.environment` (by default `/etc/netdata/.environment`). 
+That file contains some parameters which are passed to our installer 
+and which are needed during uninstallation process. 
+Mainly two parameters are needed:
 
-```
+```sh
 NETDATA_PREFIX
 NETDATA_ADDED_TO_GROUPS
 ```
@@ -10,16 +16,16 @@ NETDATA_ADDED_TO_GROUPS
 A workflow for uninstallation looks like this:
 
 1.  Find your `.environment` file, which is usually `/etc/netdata/.environment` in a default installation.
-2.  If you cannot find that file and would like to uninstall Netdata, then create new file with following content:
+2.  If you cannot find that file and would like to uninstall Netdata, then create a new file with the following content:
 
-```
+```sh
 NETDATA_PREFIX="<installation prefix>"   # put what you used as a parameter to shell installed `--install` flag. Otherwise it should be empty
 NETDATA_ADDED_TO_GROUPS="<additional groups>"  # Additional groups for a user running the Netdata process
 ```
 
 3.  Run `netdata-uninstaller.sh` as follows
 
-```
+```sh
 ${NETDATA_PREFIX}/usr/libexec/netdata/netdata-uninstaller.sh --yes --env <environment_file>
 ```
 
@@ -34,6 +40,7 @@ chmod +x ./netdata-uninstaller.sh
 
 The default `environment_file` is `/etc/netdata/.environment`. 
 
-Note: This uninstallation method assumes previous installation with `netdata-installer.sh` or the kickstart script. Currently using it when Netdata was installed by a package manager can work or cause unexpected results.
+Note: This uninstallation method assumes previous installation with `netdata-installer.sh` or the kickstart script. 
+Currently using it when Netdata was installed by a package manager can work or cause unexpected results.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Finstaller%2FUNINSTALL&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/web/api/formatters/json/README.md
+++ b/web/api/formatters/json/README.md
@@ -103,7 +103,7 @@ callback({
 > Using `format=datatable` and `options=`
 
 ```bash
-$ curl -Ss 'https://registry.my-netdata.io/api/v1/data?chart=nginx_local.connections&after=-3600&points=6&group=average&formdatatable&options='
+curl -Ss 'https://registry.my-netdata.io/api/v1/data?chart=nginx_local.connections&after=-3600&points=6&group=average&formdatatable&options='
 {
  "cols":
  [

--- a/web/server/README.md
+++ b/web/server/README.md
@@ -79,14 +79,14 @@ Both files must be readable by the `netdata` user. If either of these files do n
 For test purposes, you can generate self-signed certificates with the following command:
 
 ```bash
-$ openssl req -newkey rsa:2048 -nodes -sha512 -x509 -days 365 -keyout key.pem -out cert.pem
+openssl req -newkey rsa:2048 -nodes -sha512 -x509 -days 365 -keyout key.pem -out cert.pem
 ```
 
 !!! note
     If you use 4096 bits for your key and the certificate, Netdata will need more CPU to process the communication. `rsa4096` can be up to 4 times slower than `rsa2048`, so we recommend using 2048 bits. You can verify the difference by running:
 
 ```sh
-$ openssl speed rsa2048 rsa4096
+openssl speed rsa2048 rsa4096
 ```
 
 #### TLS/SSL enforcement
@@ -98,11 +98,11 @@ When the certificates are defined and unless any other options are provided, a N
 
 To change this behavior, you need to modify the `bind to` setting in the `[web]` section of `netdata.conf`. At the end of each port definition, you can append `^SSL=force` or `^SSL=optional`. What happens with these settings differs, depending on whether the port is used for HTTP/S requests, or for streaming.
 
-|SSL setting|HTTP requests|HTTPS requests|Unencrypted Streams|Encrypted Streams|
+| SSL setting | HTTP requests|HTTPS requests|Unencrypted Streams|Encrypted Streams|
 |:---------:|:-----------:|:------------:|:-----------------:|:----------------|
-|none|Redirected to HTTPS|Accepted|Accepted|Accepted|
-|`force`|Redirected to HTTPS|Accepted|Denied|Accepted|
-|`optional`|Accepted|Accepted|Accepted|Accepted|
+| none | Redirected to HTTPS|Accepted|Accepted|Accepted|
+| `force`| Redirected to HTTPS|Accepted|Denied|Accepted|
+| `optional`| Accepted|Accepted|Accepted|Accepted|
 
 Example:
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

In the [one-line installation](https://docs.netdata.cloud/packaging/installer/#one-line-installation), click "copy to clipboard" button. 

Pasting it on any terminal (or anywhere else) to begin the installation of Netdata:

Below is what gets pasted. 
```sh
$ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
```
This is the output:

```
$: command not found
```

Installation code, of course, works perfectly without the `$` being copied. 

This works as expected:

```
bash <(curl -Ss https://my-netdata.io/kickstart.sh)
```

Another way to tackle this would be to prevent the starting `$` in bash or shell code from getting copied on MkDocs when that button is clicked. 

However, there are already other bash/shell codes that do not have the dollar signs starting them. 

I resolved some remark-lint warnings in the HAProxy and Uninstall docs. 


##### Component Name
Docs
##### Additional Information

