### PR TITLE
Resolve all Kubernetes container names

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -86,7 +86,7 @@ function k8s_get_name() {
 	if command -v jq >/dev/null 2>&1; then
 		NAME="$(
 		curl -sSk -H "Authorization: Bearer $KUBE_TOKEN"  "https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/pods" |
-		jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_\(.status.containerStatuses[0].name) \(.status.containerStatuses[0].containerID)"' |
+		jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_" + (.status.containerStatuses[]? | "\(.name) \(.containerID)")' |
 		grep "$id" |
 		cut -d' ' -f1
 		)"


### PR DESCRIPTION
##### Summary
Fixes #6878 
All containers in a kubernetes pod were not being resolved, as there was a hard-limit on the first item in `containerStatuses[]`
Thanks to @majodev for the catch and the fix

##### Component Name
collectors/cgroup-name.sh


