### PR TITLE
Change the log level for chart updates

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -150,7 +150,7 @@ int rrdset_set_name(RRDSET *st, const char *name) {
     rrdset_strncpyz_name(b, n, CONFIG_MAX_VALUE);
 
     if(rrdset_index_find_name(host, b, 0)) {
-        error("RRDSET: chart name '%s' on host '%s' already exists.", b, host->hostname);
+        info("RRDSET: chart name '%s' on host '%s' already exists.", b, host->hostname);
         return 0;
     }
 


### PR DESCRIPTION
##### Summary
As far as the `CHART` command of the Netdata API can be used to redefine chart names in the database, it is a valid operation, so it should not be reported as an error.

Fixes #6819

##### Component Name
Netdata database