### PR TITLE
netdata/packaging: fix kickstart-static64 argument parsing

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -109,7 +109,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "5c432e78d5f40403e8b7c00b1a19a7ca" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "c529e4eb7ce201845cef605d450f8380" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -188,10 +188,13 @@ RELEASE_CHANNEL="nightly"
 while [ -n "${1}" ]; do
 	if [ "${1}" = "--dont-wait" ] || [ "${1}" = "--non-interactive" ] || [ "${1}" = "--accept" ]; then
 		opts="${opts} --accept"
+		shift 1
 	elif [ "${1}" = "--dont-start-it" ]; then
 		inner_opts="${inner_opts} ${1}"
+		shift 1
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
+		shift 1
 	elif [ "${1}" = "--local-files" ]; then
 		shift 1
 		if [ -z "${1}" ]; then


### PR DESCRIPTION
##### Summary
We missed the argument parsing fix on static installer. It's a bug that was caught and fixed on kickstart.sh, but slipped through on kickstart-static64.sh

##### Component Name
netdata/packaging

##### Additional Information
Fixes #6891