### PR TITLE
Permit x-auth-token in Access-Control-Allow-Headers

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1212,7 +1212,7 @@ static inline void web_client_send_http_header(struct web_client *w) {
     if(w->mode == WEB_CLIENT_MODE_OPTIONS) {
         buffer_strcat(w->response.header_output,
                 "Access-Control-Allow-Methods: GET, OPTIONS\r\n"
-                        "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control\r\n"
+                        "Access-Control-Allow-Headers: accept, x-requested-with, origin, content-type, cookie, pragma, cache-control, x-auth-token\r\n"
                         "Access-Control-Max-Age: 1209600\r\n" // 86400 * 14
         );
     }


### PR DESCRIPTION
#### Summary
Fixes #6893

##### Component Name
web

##### Additional Information
Ajax requests were being blocked with `Request header field x-auth-token is not allowed by Access-Control-Allow-Headers in preflight response.` 