### PR TITLE
[collector/slabinfo] Fix pagesize not defined in non-x86 arches

### DIFF
--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -10,10 +10,6 @@
 #define CHART_FAMILY "slab"
 #define CHART_PRIO 3000
 
-// As we're talking about kernel-pagesize, there's no hugepage.
-// So it's reliable to use it as an arch constant
-#define SLAB_PAGE_SIZE PAGE_SIZE
-
 // #define slabdebug(...) if (debug) { fprintf(stderr, __VA_ARGS__); }
 #define slabdebug(args...) if (debug) { \
     fprintf(stderr, "slabinfo.plugin DEBUG (%04d@%-10.10s:%-15.15s)::", __LINE__, __FILE__, __FUNCTION__); \


### PR DESCRIPTION
##### Summary
Makes pagesize dynamic at startup instead of fixed at compile time

Some arches does not export PAGE_SIZE in `<sys/user.h>`.
ARM (raspberry pi) provides `/usr/include/arm-linux-gnueabihf/sys/user.h` which does not provide it.
 
Changed `#define` to `static long` fetched from POSIX `sysconf(_SC_PAGESIZE)` (defined in `<unistd.h>`) [manpage](http://man7.org/linux/man-pages/man3/sysconf.3.html)

##### Component Name
collectors/slabinfo.plugin

##### Additional Information
Fixes #6896 : Fail to build on raspberry pi