### PR TITLE
Improve changelog generation and add it back to the pipeline

### DIFF
--- a/.travis/generate_changelog_and_tag_release.sh
+++ b/.travis/generate_changelog_and_tag_release.sh
@@ -55,9 +55,9 @@ echo "---- UPDATE VERSION FILE ----"
 echo "$GIT_TAG" >packaging/version
 git add packaging/version
 
-#echo "---- GENERATE CHANGELOG -----"
-#./.travis/generate_changelog_for_release.sh
-#git add CHANGELOG.md
+echo "---- GENERATE CHANGELOG -----"
+./.travis/generate_changelog_for_release.sh
+git add CHANGELOG.md
 
 echo "---- COMMIT AND PUSH CHANGES ----"
 git commit -m "[ci skip] release $GIT_TAG" --author "${GIT_USER} <${GIT_MAIL}>"

--- a/.travis/generate_changelog_for_nightlies.sh
+++ b/.travis/generate_changelog_for_nightlies.sh
@@ -51,7 +51,8 @@ docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest
 	--unreleased-label "**Next release**" \
 	--no-issues \
 	--exclude-labels "stale,duplicate,question,invalid,wontfix,discussion,no changelog" \
-	--no-compare-link ${OPTS}
+	--max-issues 500 \
+	--bug-labels IGNOREBUGS
 
 echo "Changelog created! Adding packaging/version(${NEW_VERSION}) and CHANGELOG.md to the repository"
 echo "${NEW_VERSION}" > packaging/version

--- a/.travis/generate_changelog_for_release.sh
+++ b/.travis/generate_changelog_for_release.sh
@@ -25,7 +25,7 @@ fi
 echo "--- Creating changelog ---"
 git checkout master
 git pull
-#docker run -it --rm -v "$(pwd)":/usr/local/src/your-app ferrarimarco/github-changelog-generator:1.14.3 \
+
 docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest \
 	--user "${ORGANIZATION}" \
 	--project "${PROJECT}" \
@@ -34,4 +34,5 @@ docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest
 	--no-issues \
 	--unreleased-label "**Next release**" \
 	--exclude-labels "stale,duplicate,question,invalid,wontfix,discussion,no changelog" \
-	--no-compare-link ${OPTS}
+        --max-issues 500 \
+        --bug-labels IGNOREBUGS


### PR DESCRIPTION
#### Summary
Preparation for #6899 
Make changelog generation faster and ensure it won't crash. Put it back to the pipeline. 

##### Component Name
CI/CD

##### Additional Information
- Added correct max-issues specification. Note that the number of issues affects the number of displayed PRs. There's no way to ensure that all the PRs in a tag will be displayed, but with a limit of 500 we know that the most recent releases will be complete.
- Let the CHANGELOG show links to diffs
- Put an invalid Bug tag, to ensure that fixed bugs are not listed (the result with the defaults was incorrect)
- Enable running the changelog generation again


