### PR TITLE
Correct read length of silencers file

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -51,7 +51,7 @@ void health_silencers_init(void) {
         off_t length = (off_t) ftell(fd);
         fseek(fd, 0 , SEEK_SET);
 
-        if (length && length < HEALTH_SILENCERS_MAX_FILE_LEN) {
+        if (length > 0 && length < HEALTH_SILENCERS_MAX_FILE_LEN) {
             char *str = mallocz((length+1)* sizeof(char));
             if(str) {
                 size_t copied;


### PR DESCRIPTION
##### Summary
Fix potential issue reported by coverity, length should be > 1 to proceed with processing of the file read.

##### Component Name
health

##### Additional Information

```
** CID 349499:  Error handling issues  (NEGATIVE_RETURNS)
/health/health.c: 58 in health_silencers_init()


________________________________________________________________________________________________________
*** CID 349499:  Error handling issues  (NEGATIVE_RETURNS)
/health/health.c: 58 in health_silencers_init()
52             fseek(fd, 0 , SEEK_SET);
53     
54             if (length && length < HEALTH_SILENCERS_MAX_FILE_LEN) {
55                 char *str = mallocz((length+1)* sizeof(char));
56                 if(str) {
57                     size_t copied;
>>>     CID 349499:  Error handling issues  (NEGATIVE_RETURNS)
>>>     "length" is passed to a parameter that cannot be negative.
58                     copied = fread(str, sizeof(char), length, fd);
59                     if (copied == (length* sizeof(char))) {
60                         str[length] = 0x00;
61                         json_parse(str, NULL, health_silencers_json_read_callback);
62                         info("Parsed health silencers file %s", silencers_filename);
63                     } else {
```