### PR TITLE
Fix remark warnings for Daemon README

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -2,12 +2,10 @@
 
 ## Starting netdata
 
--   You can start Netdata by executing it with `/usr/sbin/netdata` (the
-    installer will also start it).
+-   You can start Netdata by executing it with `/usr/sbin/netdata` (the installer will also start it).
 
--   You can stop Netdata by killing it with `killall netdata`. You can stop and
-    start Netdata at any point. Netdata saves on exit its round robbin database
-    to `/var/cache/netdata` so that it will continue from where it stopped the
+-   You can stop Netdata by killing it with `killall netdata`. You can stop and start Netdata at any point. Netdata
+    saves on exit its round robbin database to `/var/cache/netdata` so that it will continue from where it stopped the
     last time.
 
 Access to the web site, for all graphs, is by default on port `19999`, so go to:
@@ -48,9 +46,8 @@ systemctl start netdata
 
 #### init.d
 
-In the system directory you can find `netdata-lsb`. Copy it to the proper place
-according to your distribution documentation. For Ubuntu, this can be done via
-running the following commands as root.
+In the system directory you can find `netdata-lsb`. Copy it to the proper place according to your distribution
+documentation. For Ubuntu, this can be done via running the following commands as root.
 
 ```sh
 # copy the Netdata startup file to /etc/init.d
@@ -70,9 +67,8 @@ place according to your distribution documentation.
 
 #### CentOS / Red Hat Enterprise Linux
 
-For older versions of RHEL/CentOS that don't have systemd, an init script is
-included in the system directory. This can be installed by running the following
-commands as root.
+For older versions of RHEL/CentOS that don't have systemd, an init script is included in the system directory. This can
+be installed by running the following commands as root.
 
 ```sh
 # copy the Netdata startup file to /etc/init.d
@@ -197,10 +193,9 @@ Netdata uses 3 log files:
 2.  `access.log`
 3.  `debug.log`
 
-Any of them can be disabled by setting it to `/dev/null` or `none` in
-`netdata.conf`. By default `error.log` and `access.log` are enabled. `debug.log`
-is only enabled if debugging/tracing is also enabled (Netdata needs to be
-compiled with debugging enabled).
+Any of them can be disabled by setting it to `/dev/null` or `none` in `netdata.conf`. By default `error.log` and
+`access.log` are enabled. `debug.log` is only enabled if debugging/tracing is also enabled (Netdata needs to be compiled
+with debugging enabled).
 
 Log files are stored in `/var/log/netdata/` by default.
 
@@ -212,8 +207,7 @@ run by `netdata`.
 So if any process, in the Netdata process tree, writes anything to its standard error,
 it will appear in `error.log`.
 
-For most Netdata programs (including standard external plugins shipped by
-netdata), the following lines may appear:
+For most Netdata programs (including standard external plugins shipped by netdata), the following lines may appear:
 
 | tag     | description                                                                                                               |
 |:-:|:----------|
@@ -221,8 +215,8 @@ netdata), the following lines may appear:
 | `ERROR` | Something that might disable a part of netdata.<br/>The log line includes `errno` (if it is not zero).                    |
 | `FATAL` | Something prevented a program from running.<br/>The log line includes `errno` (if it is not zero) and the program exited. |
 
-So, when auto-detection of data collection fail, `ERROR` lines are logged and
-the relevant modules are disabled, but the program continues to run.
+So, when auto-detection of data collection fail, `ERROR` lines are logged and the relevant modules are disabled, but the
+program continues to run.
 
 When a Netdata program cannot run at all, a `FATAL` line is logged.
 
@@ -242,8 +236,8 @@ where:
 -   `PERCENT_COMPRESSION` is the percentage of traffic saved due to compression.
 -   `PREP_TIME` is the time in milliseconds needed to prepared the response.
 -   `SENT_TIME` is the time in milliseconds needed to sent the response to the client.
--   `TOTAL_TIME` is the total time the request was inside Netdata (from the
-    first byte of the request to the last byte of the response).
+-   `TOTAL_TIME` is the total time the request was inside Netdata (from the first byte of the request to the last byte
+    of the response).
 -   `ACTION` can be `filecopy`, `options` (used in CORS), `data` (API call).
 
 ### debug.log
@@ -252,8 +246,8 @@ See [debugging](#debugging).
 
 ## OOM Score
 
-Netdata runs with `OOMScore = 1000`. This means Netdata will be the first to be
-killed when your server runs out of memory.
+Netdata runs with `OOMScore = 1000`. This means Netdata will be the first to be killed when your server runs out of
+memory.
 
 You can set Netdata OOMScore in `netdata.conf`, like this:
 
@@ -271,11 +265,9 @@ Netdata logs its OOM score when it starts:
 
 ### OOM score and systemd
 
-Netdata will not be able to lower its OOM Score below zero, when it is started
-as the `netdata` user (systemd case).
+Netdata will not be able to lower its OOM Score below zero, when it is started as the `netdata` user (systemd case).
 
-To allow Netdata control its OOM Score in such cases, you will need to edit
-`netdata.service` and set:
+To allow Netdata control its OOM Score in such cases, you will need to edit `netdata.service` and set:
 
 ```sh
 [Service]
@@ -288,8 +280,7 @@ OOMScoreAdjust=-1000
 
 Run `systemctl daemon-reload` to reload these changes.
 
-The above, sets and OOMScore for Netdata to `-1000`, so that Netdata can
-increase it via `netdata.conf`.
+The above, sets and OOMScore for Netdata to `-1000`, so that Netdata can increase it via `netdata.conf`.
 
 If you want to control it entirely via systemd, you can set in `netdata.conf`:
 
@@ -298,14 +289,12 @@ If you want to control it entirely via systemd, you can set in `netdata.conf`:
     OOM score = keep
 ```
 
-Using the above, whatever OOM Score you have set at `netdata.service` will be
-maintained by netdata.
+Using the above, whatever OOM Score you have set at `netdata.service` will be maintained by netdata.
 
 ## Netdata process scheduling policy
 
-By default Netdata runs with the `idle` process scheduling policy, so that it
-uses CPU resources, only when there is idle CPU to spare. On very busy servers
-(or weak servers), this can lead to gaps on the charts.
+By default Netdata runs with the `idle` process scheduling policy, so that it uses CPU resources, only when there is
+idle CPU to spare. On very busy servers (or weak servers), this can lead to gaps on the charts.
 
 You can set Netdata scheduling policy in `netdata.conf`, like this:
 
@@ -350,8 +339,8 @@ When the policy is set to `other`, `nice`, or `batch`, the following will appear
 
 ## scheduling settings and systemd
 
-Netdata will not be able to set its scheduling policy and priority to more
-important values when it is started as the `netdata` user (systemd case).
+Netdata will not be able to set its scheduling policy and priority to more important values when it is started as the
+`netdata` user (systemd case).
 
 You can set these settings at `/etc/systemd/system/netdata.service`:
 
@@ -387,8 +376,8 @@ will be maintained by netdata.
 
 ### Example 1: Netdata with nice -1 on non-systemd systems
 
-On a system that is not based on systemd, to make Netdata run with nice level -1
-(a little bit higher to the default for all programs), edit `netdata.conf` and set:
+On a system that is not based on systemd, to make Netdata run with nice level -1 (a little bit higher to the default for
+all programs), edit `netdata.conf` and set:
 
 ```conf
 [global]
@@ -404,8 +393,8 @@ sudo service netdata restart
 
 #### Example 2: Netdata with nice -1 on systemd systems
 
-On a system that is based on systemd, to make Netdata run with nice level -1 (a
-little bit higher to the default for all programs), edit `netdata.conf` and set:
+On a system that is based on systemd, to make Netdata run with nice level -1 (a little bit higher to the default for all
+programs), edit `netdata.conf` and set:
 
 ```conf
 [global]
@@ -429,12 +418,11 @@ sudo systemctl restart netdata
 
 ## Virtual memory
 
-You may notice that netdata's virtual memory size, as reported by `ps` or
-`/proc/pid/status` (or even netdata's applications virtual memory chart) is
-unrealistically high.
+You may notice that netdata's virtual memory size, as reported by `ps` or `/proc/pid/status` (or even netdata's
+applications virtual memory chart) is unrealistically high.
 
-For example, it may be reported to be 150+MB, even if the resident memory size
-is just 25MB. Similar values may be reported for Netdata plugins too.
+For example, it may be reported to be 150+MB, even if the resident memory size is just 25MB. Similar values may be
+reported for Netdata plugins too.
 
 Check this for example: A Netdata installation with default settings on Ubuntu
 16.04LTS. The top chart is **real memory used**, while the bottom one is
@@ -444,14 +432,12 @@ Check this for example: A Netdata installation with default settings on Ubuntu
 
 ### Why does this happen?
 
-The system memory allocator allocates virtual memory arenas, per thread running.
-On Linux systems this defaults to 16MB per thread on 64 bit machines. So, if you
-get the difference between real and virtual memory and divide it by 16MB you
+The system memory allocator allocates virtual memory arenas, per thread running. On Linux systems this defaults to 16MB
+per thread on 64 bit machines. So, if you get the difference between real and virtual memory and divide it by 16MB you
 will roughly get the number of threads running.
 
-The system does this for speed. Having a separate memory arena for each thread,
-allows the threads to run in parallel in multi-core systems, without any locks
-between them.
+The system does this for speed. Having a separate memory arena for each thread, allows the threads to run in parallel in
+multi-core systems, without any locks between them.
 
 This behaviour is system specific. For example, the chart above when running
 Netdata on Alpine Linux (that uses **musl** instead of **glibc**) is this:
@@ -460,11 +446,11 @@ Netdata on Alpine Linux (that uses **musl** instead of **glibc**) is this:
 
 ### Can we do anything to lower it?
 
-Since Netdata already uses minimal memory allocations while it runs (i.e. it adapts its memory on start, 
-so that while repeatedly collects data it does not do memory allocations), 
-it already instructs the system memory allocator to minimize the memory arenas for each thread. 
-We have also added [2 configuration options](https://github.com/netdata/netdata/blob/5645b1ee35248d94e6931b64a8688f7f0d865ec6/src/main.c#L410-L418)
-to allow you tweak these settings: `glibc malloc arena max for plugins` and `glibc malloc arena max for netdata`.
+Since Netdata already uses minimal memory allocations while it runs (i.e. it adapts its memory on start, so that while
+repeatedly collects data it does not do memory allocations), it already instructs the system memory allocator to
+minimize the memory arenas for each thread. We have also added [2 configuration
+options](https://github.com/netdata/netdata/blob/5645b1ee35248d94e6931b64a8688f7f0d865ec6/src/main.c#L410-L418) to allow
+you tweak these settings: `glibc malloc arena max for plugins` and `glibc malloc arena max for netdata`.
 
 However, even if we instructed the memory allocator to use just one arena, it
 seems it allocates an arena per thread.
@@ -476,12 +462,10 @@ same to the glibc memory allocator in this aspect.
 
 No, it is not.
 
-Linux reserves real memory (physical RAM) in pages (on x86 machines pages are
-4KB each). So even if the system memory allocator is allocating huge amounts of
-virtual memory, only the 4KB pages that are actually used are reserving physical
-RAM. The **real memory** chart on Netdata application section, shows the amount
-of physical memory these pages occupy(it accounts the whole pages, even if parts
-of them are actually used).
+Linux reserves real memory (physical RAM) in pages (on x86 machines pages are 4KB each). So even if the system memory
+allocator is allocating huge amounts of virtual memory, only the 4KB pages that are actually used are reserving physical
+RAM. The **real memory** chart on Netdata application section, shows the amount of physical memory these pages occupy(it
+accounts the whole pages, even if parts of them are actually used).
 
 ## Debugging
 
@@ -489,19 +473,17 @@ When you compile Netdata with debugging:
 
 1.  compiler optimizations for your CPU are disabled (Netdata will run somewhat slower)
 
-2.  a lot of code is added all over netdata, to log debug messages to
-    `/var/log/netdata/debug.log`. However, nothing is printed by default.
-    Netdata allows you to select which sections of Netdata you want to trace.
-    Tracing is activated via the config option `debug flags`. It accepts a hex
-    number, to enable or disable specific sections. You can find the options
-    supported at [log.h](../libnetdata/log/log.h). They are the `D_*` defines.
-    The value `0xffffffffffffffff` will enable all possible debug flags.
+2.  a lot of code is added all over netdata, to log debug messages to `/var/log/netdata/debug.log`. However, nothing is
+    printed by default. Netdata allows you to select which sections of Netdata you want to trace. Tracing is activated
+    via the config option `debug flags`. It accepts a hex number, to enable or disable specific sections. You can find
+    the options supported at [log.h](../libnetdata/log/log.h). They are the `D_*` defines. The value
+    `0xffffffffffffffff` will enable all possible debug flags.
 
-Once Netdata is compiled with debugging and tracing is enabled for a few
-sections, the file `/var/log/netdata/debug.log` will contain the messages.
+Once Netdata is compiled with debugging and tracing is enabled for a few sections, the file `/var/log/netdata/debug.log`
+will contain the messages.
 
-> Do not forget to disable tracing (`debug flags = 0`) when you are done
-> tracing. The file `debug.log` can grow too fast.
+> Do not forget to disable tracing (`debug flags = 0`) when you are done tracing. The file `debug.log` can grow too
+> fast.
 
 ### compiling Netdata with debugging
 
@@ -515,18 +497,17 @@ cd /usr/src/netdata.git
 CFLAGS="-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1" ./netdata-installer.sh
 ```
 
-The above will compile and install Netdata with debugging info embedded. You can
-now use `debug flags` to set the section(s) you need to trace.
+The above will compile and install Netdata with debugging info embedded. You can now use `debug flags` to set the
+section(s) you need to trace.
 
 ### debugging crashes
 
-We have made the most to make Netdata crash free. If however, Netdata crashes on
-your system, it would be very helpful to provide stack traces of the crash.
-Without them, is will be almost impossible to find the issue (the code base is
+We have made the most to make Netdata crash free. If however, Netdata crashes on your system, it would be very helpful
+to provide stack traces of the crash. Without them, is will be almost impossible to find the issue (the code base is
 quite large to find such an issue by just objerving it).
 
-To provide stack traces, **you need to have Netdata compiled with debugging**.
-There is no need to enable any tracing (`debug flags`).
+To provide stack traces, **you need to have Netdata compiled with debugging**. There is no need to enable any tracing
+(`debug flags`).
 
 Then you need to be in one of the following 2 cases:
 
@@ -534,8 +515,8 @@ Then you need to be in one of the following 2 cases:
 
 2.  you can reproduce the crash
 
-If you are not on these cases, you need to find a way to be (i.e. if your system
-does not produce core dumps, check your distro documentation to enable them).
+If you are not on these cases, you need to find a way to be (i.e. if your system does not produce core dumps, check your
+distro documentation to enable them).
 
 ### Netdata crashes and you have a core dump
 
@@ -549,8 +530,7 @@ gdb $(which netdata) /path/to/core/dump
 
 ### you can reproduce a Netdata crash on your system
 
-> you need to have Netdata compiled with debugging info for this to work (check
-> above)
+> you need to have Netdata compiled with debugging info for this to work (check above)
 
 Install the package `valgrind` and run:
 
@@ -558,8 +538,7 @@ Install the package `valgrind` and run:
 valgrind $(which netdata) -D
 ```
 
-Netdata will start and it will be a lot slower. Now reproduce the crash and
-`valgrind` will dump on your console the stack trace. Open a new github issue
-and post the output.
+Netdata will start and it will be a lot slower. Now reproduce the crash and `valgrind` will dump on your console the
+stack trace. Open a new github issue and post the output.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdaemon%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -10,7 +10,7 @@
 
 Access to the web site, for all graphs, is by default on port `19999`, so go to:
 
-```
+```sh
 http://127.0.0.1:19999/
 ```
 
@@ -45,7 +45,9 @@ systemctl start netdata
 
 #### init.d
 
-In the system directory you can find `netdata-lsb`. Copy it to the proper place according to your distribution documentation. For Ubuntu, this can be done via running the following commands as root.
+In the system directory you can find `netdata-lsb`. 
+Copy it to the proper place according to your distribution documentation. 
+For Ubuntu, this can be done via running the following commands as root.
 
 ```sh
 # copy the Netdata startup file to /etc/init.d
@@ -60,11 +62,13 @@ update-rc.d netdata defaults
 
 #### openrc (gentoo)
 
-In the `system` directory you can find `netdata-openrc`. Copy it to the proper place according to your distribution documentation.
+In the `system` directory you can find `netdata-openrc`. 
+Copy it to the proper place according to your distribution documentation.
 
 #### CentOS / Red Hat Enterprise Linux
 
-For older versions of RHEL/CentOS that don't have systemd, an init script is included in the system directory. This can be installed by running the following commands as root.
+For older versions of RHEL/CentOS that don't have systemd, an init script is included in the system directory. 
+This can be installed by running the following commands as root.
 
 ```sh
 # copy the Netdata startup file to /etc/init.d
@@ -99,7 +103,7 @@ The program will print the supported command line parameters.
 
 The command line options of the Netdata 1.10.0 version are the following:
 
-```
+```sh
  ^
  |.-.   .-.   .-.   .-.   .  netdata                                         
  |   '-'   '-'   '-'   '-'   real-time performance monitoring, done right!   
@@ -194,7 +198,7 @@ debugging/tracing is also enabled (Netdata needs to be compiled with debugging e
 
 Log files are stored in `/var/log/netdata/` by default.
 
-#### error.log
+### error.log
 
 The `error.log` is the `stderr` of the `netdata` daemon and all external plugins run by netdata.
 
@@ -204,18 +208,18 @@ it will appear in `error.log`.
 For most Netdata programs (including standard external plugins shipped by netdata), the
 following lines may appear:
 
-| tag|description|
+| tag     | description                                                                                                               |
 |:-:|:----------|
-| `INFO`|Something important the user should know.|
-| `ERROR`|Something that might disable a part of netdata.<br/>The log line includes `errno` (if it is not zero).|
-| `FATAL`|Something prevented a program from running.<br/>The log line includes `errno` (if it is not zero) and the program exited.|
+| `INFO`  | Something important the user should know.                                                                                 |
+| `ERROR` | Something that might disable a part of netdata.<br/>The log line includes `errno` (if it is not zero).                    |
+| `FATAL` | Something prevented a program from running.<br/>The log line includes `errno` (if it is not zero) and the program exited. |
 
 So, when auto-detection of data collection fail, `ERROR` lines are logged and the relevant modules
 are disabled, but the program continues to run.
 
 When a Netdata program cannot run at all, a `FATAL` line is logged.
 
-#### access.log
+### access.log
 
 The `access.log` logs web requests. The format is:
 
@@ -231,10 +235,11 @@ where:
 -   `PERCENT_COMPRESSION` is the percentage of traffic saved due to compression.
 -   `PREP_TIME` is the time in milliseconds needed to prepared the response.
 -   `SENT_TIME` is the time in milliseconds needed to sent the response to the client.
--   `TOTAL_TIME` is the total time the request was inside Netdata (from the first byte of the request to the last byte of the response).
+-   `TOTAL_TIME` is the total time the request was inside Netdata 
+(from the first byte of the request to the last byte of the response).
 -   `ACTION` can be `filecopy`, `options` (used in CORS), `data` (API call).
 
-#### debug.log
+### debug.log
 
 See [debugging](#debugging).
 
@@ -245,7 +250,7 @@ server runs out of memory.
 
 You can set Netdata OOMScore in `netdata.conf`, like this:
 
-```
+```conf
 [global]
     OOM score = 1000
 ```
@@ -257,7 +262,7 @@ Netdata logs its OOM score when it starts:
 2017-10-15 03:47:31: netdata INFO : Adjusted my Out-Of-Memory (OOM) score from 0 to 1000.
 ```
 
-#### OOM score and systemd
+### OOM score and systemd
 
 Netdata will not be able to lower its OOM Score below zero, when it is started as the `netdata`
 user (systemd case).
@@ -265,7 +270,7 @@ user (systemd case).
 To allow Netdata control its OOM Score in such cases, you will need to edit
 `netdata.service` and set:
 
-```
+```sh
 [Service]
 # The minimum Netdata Out-Of-Memory (OOM) score.
 # Netdata (via [global].OOM score in netdata.conf) can only increase the value set here.
@@ -281,7 +286,7 @@ The above, sets and OOMScore for Netdata to `-1000`, so that Netdata can increas
 
 If you want to control it entirely via systemd, you can set in `netdata.conf`:
 
-```
+```conf
 [global]
     OOM score = keep
 ```
@@ -290,25 +295,27 @@ Using the above, whatever OOM Score you have set at `netdata.service` will be ma
 
 ## Netdata process scheduling policy
 
-By default Netdata runs with the `idle` process scheduling policy, so that it uses CPU resources, only when there is idle CPU to spare. On very busy servers (or weak servers), this can lead to gaps on the charts.
+By default Netdata runs with the `idle` process scheduling policy, 
+so that it uses CPU resources, only when there is idle CPU to spare. 
+On very busy servers (or weak servers), this can lead to gaps on the charts.
 
 You can set Netdata scheduling policy in `netdata.conf`, like this:
 
-```
+```conf
 [global]
   process scheduling policy = idle
 ```
 
 You can use the following:
 
-| policy|description|
+| policy                    | description |                                                                                                                 
 |:----:|:----------|
-| `idle`|use CPU only when there is spare - this is lower than nice 19 - it is the default for Netdata and it is so low that Netdata will run in "slow motion" under extreme system load, resulting in short (1-2 seconds) gaps at the charts.|
-| `other`<br/>or<br/>`nice`|this is the default policy for all processes under Linux. It provides dynamic priorities based on the `nice` level of each process. Check below for setting this `nice` level for netdata.|
-| `batch`|This policy is similar to `other` in that it schedules the thread according to its dynamic priority (based on the `nice` value).  The difference is that this policy will cause the scheduler to always assume that the thread is CPU-intensive.  Consequently, the scheduler will  apply a small scheduling penalty with respect to wake-up behavior, so that this thread is mildly disfavored in scheduling decisions.|
-| `fifo`|`fifo` can be used only with static priorities higher than 0, which means that when a `fifo` threads becomes runnable, it will always  immediately  preempt  any  currently running  `other`, `batch`, or `idle` thread.  `fifo` is a simple scheduling algorithm without time slicing.|
-| `rr`|a simple enhancement of `fifo`.  Everything described above for `fifo` also applies to `rr`, except that each thread is allowed to run only for a  maximum time quantum.|
-| `keep`<br/>or<br/>`none`|do not set scheduling policy, priority or nice level - i.e. keep running with whatever it is set already (e.g. by systemd).|
+| `idle`                    | use CPU only when there is spare - this is lower than nice 19 - it is the default for Netdata and it is so low that Netdata will run in "slow motion" under extreme system load, resulting in short (1-2 seconds) gaps at the charts. | 
+| `other`<br/>or<br/>`nice` | this is the default policy for all processes under Linux. It provides dynamic priorities based on the `nice` level of each process. Check below for setting this `nice` level for netdata. |
+| `batch`                   | This policy is similar to `other` in that it schedules the thread according to its dynamic priority (based on the `nice` value).  The difference is that this policy will cause the scheduler to always assume that the thread is CPU-intensive.  Consequently, the scheduler will  apply a small scheduling penalty with respect to wake-up behavior, so that this thread is mildly disfavored in scheduling decisions. |
+| `fifo`                    | `fifo` can be used only with static priorities higher than 0, which means that when a `fifo` threads becomes runnable, it will always  immediately  preempt  any  currently running  `other`, `batch`, or `idle` thread.  `fifo` is a simple scheduling algorithm without time slicing. |
+| `rr`                      | a simple enhancement of `fifo`.  Everything described above for `fifo` also applies to `rr`, except that each thread is allowed to run only for a  maximum time quantum. |
+| `keep`<br/>or<br/>`none`  | do not set scheduling policy, priority or nice level - i.e. keep running with whatever it is set already (e.g. by systemd). |
 
 For more information see `man sched`.
 
@@ -316,7 +323,7 @@ For more information see `man sched`.
 
 Once the policy is set to one of `rr` or `fifo`, the following will appear:
 
-```
+```conf
 [global]
     process scheduling priority = 0
 ```
@@ -327,18 +334,19 @@ These priorities are usually from 0 to 99. Higher numbers make the process more 
 
 When the policy is set to `other`, `nice`, or `batch`, the following will appear:
 
-```
+```conf
 [global]
     process nice level = 19
 ```
 
 ## scheduling settings and systemd
 
-Netdata will not be able to set its scheduling policy and priority to more important values when it is started as the `netdata` user (systemd case).
+Netdata will not be able to set its scheduling policy and priority to more important values 
+when it is started as the `netdata` user (systemd case).
 
 You can set these settings at `/etc/systemd/system/netdata.service`:
 
-```
+```sh
 [Service]
 # By default Netdata switches to scheduling policy idle, which makes it use CPU, only
 # when there is spare available.
@@ -359,18 +367,19 @@ Run `systemctl daemon-reload` to reload these changes.
 
 Now, tell Netdata to keep these settings, as set by systemd, by editing `netdata.conf` and setting:
 
-```
+```conf
 [global]
     process scheduling policy = keep
 ```
 
 Using the above, whatever scheduling settings you have set at `netdata.service` will be maintained by netdata.
 
-#### Example 1: Netdata with nice -1 on non-systemd systems
+### Example 1: Netdata with nice -1 on non-systemd systems
 
-On a system that is not based on systemd, to make Netdata run with nice level -1 (a little bit higher to the default for all programs), edit `netdata.conf` and set:
+On a system that is not based on systemd, to make Netdata run with nice level -1 
+(a little bit higher to the default for all programs), edit `netdata.conf` and set:
 
-```
+```conf
 [global]
   process scheduling policy = other
   process nice level = -1
@@ -384,16 +393,17 @@ sudo service netdata restart
 
 #### Example 2: Netdata with nice -1 on systemd systems
 
-On a system that is based on systemd, to make Netdata run with nice level -1 (a little bit higher to the default for all programs), edit `netdata.conf` and set:
+On a system that is based on systemd, to make Netdata run with nice level -1 
+(a little bit higher to the default for all programs), edit `netdata.conf` and set:
 
-```
+```conf
 [global]
   process scheduling policy = keep
 ```
 
 edit /etc/systemd/system/netdata.service and set:
 
-```
+```sh
 [Service]
 CPUSchedulingPolicy=other
 Nice=-1
@@ -408,15 +418,18 @@ sudo systemctl restart netdata
 
 ## Virtual memory
 
-You may notice that netdata's virtual memory size, as reported by `ps` or `/proc/pid/status` (or even netdata's applications virtual memory chart) is unrealistically high.
+You may notice that netdata's virtual memory size, as reported by `ps` or `/proc/pid/status` 
+(or even netdata's applications virtual memory chart) is unrealistically high.
 
-For example, it may be reported to be 150+MB, even if the resident memory size is just 25MB. Similar values may be reported for Netdata plugins too.
+For example, it may be reported to be 150+MB, even if the resident memory size is just 25MB. 
+Similar values may be reported for Netdata plugins too.
 
-Check this for example: A Netdata installation with default settings on Ubuntu 16.04LTS. The top chart is **real memory used**, while the bottom one is **virtual memory**:
+Check this for example: A Netdata installation with default settings on Ubuntu 16.04LTS. 
+The top chart is **real memory used**, while the bottom one is **virtual memory**:
 
 ![image](https://cloud.githubusercontent.com/assets/2662304/19013772/5eb7173e-87e3-11e6-8f2b-a2ccfeb06faf.png)
 
-**Why does this happen?**
+### Why does this happen?
 
 The system memory allocator allocates virtual memory arenas, per thread running.
 On Linux systems this defaults to 16MB per thread on 64 bit machines. So, if you get the
@@ -426,20 +439,25 @@ number of threads running.
 The system does this for speed. Having a separate memory arena for each thread, allows the
 threads to run in parallel in multi-core systems, without any locks between them.
 
-This behaviour is system specific. For example, the chart above when running Netdata on Alpine Linux (that uses **musl** instead of **glibc**) is this:
+This behaviour is system specific. For example, the chart above when running Netdata on Alpine Linux 
+(that uses **musl** instead of **glibc**) is this:
 
 ![image](https://cloud.githubusercontent.com/assets/2662304/19013807/7cf5878e-87e4-11e6-9651-082e68701eab.png)
 
-**Can we do anything to lower it?**
+### Can we do anything to lower it?
 
-Since Netdata already uses minimal memory allocations while it runs (i.e. it adapts its memory on start, so that while repeatedly collects data it does not do memory allocations), it already instructs the system memory allocator to minimize the memory arenas for each thread. We have also added [2 configuration options](https://github.com/netdata/netdata/blob/5645b1ee35248d94e6931b64a8688f7f0d865ec6/src/main.c#L410-L418)
+Since Netdata already uses minimal memory allocations while it runs (i.e. it adapts its memory on start, 
+so that while repeatedly collects data it does not do memory allocations), 
+it already instructs the system memory allocator to minimize the memory arenas for each thread. 
+We have also added [2 configuration options](https://github.com/netdata/netdata/blob/5645b1ee35248d94e6931b64a8688f7f0d865ec6/src/main.c#L410-L418)
 to allow you tweak these settings: `glibc malloc arena max for plugins` and `glibc malloc arena max for netdata`.
 
 However, even if we instructed the memory allocator to use just one arena, it seems it allocates an arena per thread.
 
-Netdata also supports `jemalloc` and `tcmalloc`, however both behave exactly the same to the glibc memory allocator in this aspect.
+Netdata also supports `jemalloc` and `tcmalloc`, 
+however both behave exactly the same to the glibc memory allocator in this aspect.
 
-**Is this a problem?**
+### Is this a problem?
 
 No, it is not.
 
@@ -455,13 +473,20 @@ When you compile Netdata with debugging:
 
 1.  compiler optimizations for your CPU are disabled (Netdata will run somewhat slower)
 
-2.  a lot of code is added all over netdata, to log debug messages to `/var/log/netdata/debug.log`. However, nothing is printed by default. Netdata allows you to select which sections of Netdata you want to trace. Tracing is activated via the config option `debug flags`. It accepts a hex number, to enable or disable specific sections. You can find the options supported at [log.h](../libnetdata/log/log.h). They are the `D_*` defines. The value `0xffffffffffffffff` will enable all possible debug flags.
+2.  a lot of code is added all over netdata, to log debug messages to `/var/log/netdata/debug.log`. 
+  However, nothing is printed by default. Netdata allows you to select which sections of Netdata you want to trace. 
+  Tracing is activated via the config option `debug flags`. 
+  It accepts a hex number, to enable or disable specific sections. 
+  You can find the options supported at [log.h](../libnetdata/log/log.h). 
+  They are the `D_*` defines. The value `0xffffffffffffffff` will enable all possible debug flags.
 
-Once Netdata is compiled with debugging and tracing is enabled for a few sections, the file `/var/log/netdata/debug.log` will contain the messages.
+Once Netdata is compiled with debugging and tracing is enabled for a few sections, 
+the file `/var/log/netdata/debug.log` will contain the messages.
 
-> Do not forget to disable tracing (`debug flags = 0`) when you are done tracing. The file `debug.log` can grow too fast.
+> Do not forget to disable tracing (`debug flags = 0`) when you are done tracing. 
+>The file `debug.log` can grow too fast.
 
-#### compiling Netdata with debugging
+### compiling Netdata with debugging
 
 To compile Netdata with debugging, use this:
 
@@ -473,11 +498,15 @@ cd /usr/src/netdata.git
 CFLAGS="-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1" ./netdata-installer.sh
 ```
 
-The above will compile and install Netdata with debugging info embedded. You can now use `debug flags` to set the section(s) you need to trace.
+The above will compile and install Netdata with debugging info embedded. 
+You can now use `debug flags` to set the section(s) you need to trace.
 
-#### debugging crashes
+### debugging crashes
 
-We have made the most to make Netdata crash free. If however, Netdata crashes on your system, it would be very helpful to provide stack traces of the crash. Without them, is will be almost impossible to find the issue (the code base is quite large to find such an issue by just objerving it).
+We have made the most to make Netdata crash free. 
+If however, Netdata crashes on your system, it would be very helpful to provide stack traces of the crash. 
+Without them, is will be almost impossible to find the issue 
+(the code base is quite large to find such an issue by just objerving it).
 
 To provide stack traces, **you need to have Netdata compiled with debugging**. There is no need to enable any tracing (`debug flags`).
 
@@ -487,9 +516,10 @@ Then you need to be in one of the following 2 cases:
 
 2.  you can reproduce the crash
 
-If you are not on these cases, you need to find a way to be (i.e. if your system does not produce core dumps, check your distro documentation to enable them).
+If you are not on these cases, you need to find a way to be 
+(i.e. if your system does not produce core dumps, check your distro documentation to enable them).
 
-#### Netdata crashes and you have a core dump
+### Netdata crashes and you have a core dump
 
 > you need to have Netdata compiled with debugging info for this to work (check above)
 
@@ -499,7 +529,7 @@ Run the following command and post the output on a github issue.
 gdb $(which netdata) /path/to/core/dump
 ```
 
-#### you can reproduce a Netdata crash on your system
+### you can reproduce a Netdata crash on your system
 
 > you need to have Netdata compiled with debugging info for this to work (check above)
 
@@ -509,6 +539,8 @@ Install the package `valgrind` and run:
 valgrind $(which netdata) -D
 ```
 
-Netdata will start and it will be a lot slower. Now reproduce the crash and `valgrind` will dump on your console the stack trace. Open a new github issue and post the output.
+Netdata will start and it will be a lot slower. 
+Now reproduce the crash and `valgrind` will dump on your console the stack trace. 
+Open a new github issue and post the output.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdaemon%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -2,11 +2,13 @@
 
 ## Starting netdata
 
--   You can start Netdata by executing it with `/usr/sbin/netdata` (the installer will also start it).
+-   You can start Netdata by executing it with `/usr/sbin/netdata` (the
+    installer will also start it).
 
--   You can stop Netdata by killing it with `killall netdata`.
-      You can stop and start Netdata at any point. Netdata saves on exit its round robbin
-      database to `/var/cache/netdata` so that it will continue from where it stopped the last time.
+-   You can stop Netdata by killing it with `killall netdata`. You can stop and
+    start Netdata at any point. Netdata saves on exit its round robbin database
+    to `/var/cache/netdata` so that it will continue from where it stopped the
+    last time.
 
 Access to the web site, for all graphs, is by default on port `19999`, so go to:
 
@@ -18,7 +20,8 @@ You can get the running config file at any time, by accessing `http://127.0.0.1:
 
 ### Starting Netdata at boot
 
-In the `system` directory you can find scripts and configurations for the various distros.
+In the `system` directory you can find scripts and configurations for the
+various distros.
 
 #### systemd
 
@@ -45,9 +48,9 @@ systemctl start netdata
 
 #### init.d
 
-In the system directory you can find `netdata-lsb`. 
-Copy it to the proper place according to your distribution documentation. 
-For Ubuntu, this can be done via running the following commands as root.
+In the system directory you can find `netdata-lsb`. Copy it to the proper place
+according to your distribution documentation. For Ubuntu, this can be done via
+running the following commands as root.
 
 ```sh
 # copy the Netdata startup file to /etc/init.d
@@ -62,13 +65,14 @@ update-rc.d netdata defaults
 
 #### openrc (gentoo)
 
-In the `system` directory you can find `netdata-openrc`. 
-Copy it to the proper place according to your distribution documentation.
+In the `system` directory you can find `netdata-openrc`. Copy it to the proper
+place according to your distribution documentation.
 
 #### CentOS / Red Hat Enterprise Linux
 
-For older versions of RHEL/CentOS that don't have systemd, an init script is included in the system directory. 
-This can be installed by running the following commands as root.
+For older versions of RHEL/CentOS that don't have systemd, an init script is
+included in the system directory. This can be installed by running the following
+commands as root.
 
 ```sh
 # copy the Netdata startup file to /etc/init.d
@@ -81,7 +85,8 @@ chmod +x /etc/init.d/netdata
 chkconfig --add netdata
 ```
 
-_There have been some recent work on the init script, see PR <https://github.com/netdata/netdata/pull/403>_
+_There have been some recent work on the init script, see PR
+<https://github.com/netdata/netdata/pull/403>_
 
 #### other systems
 
@@ -192,21 +197,23 @@ Netdata uses 3 log files:
 2.  `access.log`
 3.  `debug.log`
 
-Any of them can be disabled by setting it to `/dev/null` or `none` in `netdata.conf`.
-By default `error.log` and `access.log` are enabled. `debug.log` is only enabled if
-debugging/tracing is also enabled (Netdata needs to be compiled with debugging enabled).
+Any of them can be disabled by setting it to `/dev/null` or `none` in
+`netdata.conf`. By default `error.log` and `access.log` are enabled. `debug.log`
+is only enabled if debugging/tracing is also enabled (Netdata needs to be
+compiled with debugging enabled).
 
 Log files are stored in `/var/log/netdata/` by default.
 
 ### error.log
 
-The `error.log` is the `stderr` of the `netdata` daemon and all external plugins run by netdata.
+The `error.log` is the `stderr` of the `netdata` daemon and all external plugins
+run by `netdata`.
 
 So if any process, in the Netdata process tree, writes anything to its standard error,
 it will appear in `error.log`.
 
-For most Netdata programs (including standard external plugins shipped by netdata), the
-following lines may appear:
+For most Netdata programs (including standard external plugins shipped by
+netdata), the following lines may appear:
 
 | tag     | description                                                                                                               |
 |:-:|:----------|
@@ -214,8 +221,8 @@ following lines may appear:
 | `ERROR` | Something that might disable a part of netdata.<br/>The log line includes `errno` (if it is not zero).                    |
 | `FATAL` | Something prevented a program from running.<br/>The log line includes `errno` (if it is not zero) and the program exited. |
 
-So, when auto-detection of data collection fail, `ERROR` lines are logged and the relevant modules
-are disabled, but the program continues to run.
+So, when auto-detection of data collection fail, `ERROR` lines are logged and
+the relevant modules are disabled, but the program continues to run.
 
 When a Netdata program cannot run at all, a `FATAL` line is logged.
 
@@ -235,8 +242,8 @@ where:
 -   `PERCENT_COMPRESSION` is the percentage of traffic saved due to compression.
 -   `PREP_TIME` is the time in milliseconds needed to prepared the response.
 -   `SENT_TIME` is the time in milliseconds needed to sent the response to the client.
--   `TOTAL_TIME` is the total time the request was inside Netdata 
-(from the first byte of the request to the last byte of the response).
+-   `TOTAL_TIME` is the total time the request was inside Netdata (from the
+    first byte of the request to the last byte of the response).
 -   `ACTION` can be `filecopy`, `options` (used in CORS), `data` (API call).
 
 ### debug.log
@@ -245,8 +252,8 @@ See [debugging](#debugging).
 
 ## OOM Score
 
-Netdata runs with `OOMScore = 1000`. This means Netdata will be the first to be killed when your
-server runs out of memory.
+Netdata runs with `OOMScore = 1000`. This means Netdata will be the first to be
+killed when your server runs out of memory.
 
 You can set Netdata OOMScore in `netdata.conf`, like this:
 
@@ -264,8 +271,8 @@ Netdata logs its OOM score when it starts:
 
 ### OOM score and systemd
 
-Netdata will not be able to lower its OOM Score below zero, when it is started as the `netdata`
-user (systemd case).
+Netdata will not be able to lower its OOM Score below zero, when it is started
+as the `netdata` user (systemd case).
 
 To allow Netdata control its OOM Score in such cases, you will need to edit
 `netdata.service` and set:
@@ -281,8 +288,8 @@ OOMScoreAdjust=-1000
 
 Run `systemctl daemon-reload` to reload these changes.
 
-The above, sets and OOMScore for Netdata to `-1000`, so that Netdata can increase it via
-`netdata.conf`.
+The above, sets and OOMScore for Netdata to `-1000`, so that Netdata can
+increase it via `netdata.conf`.
 
 If you want to control it entirely via systemd, you can set in `netdata.conf`:
 
@@ -291,13 +298,14 @@ If you want to control it entirely via systemd, you can set in `netdata.conf`:
     OOM score = keep
 ```
 
-Using the above, whatever OOM Score you have set at `netdata.service` will be maintained by netdata.
+Using the above, whatever OOM Score you have set at `netdata.service` will be
+maintained by netdata.
 
 ## Netdata process scheduling policy
 
-By default Netdata runs with the `idle` process scheduling policy, 
-so that it uses CPU resources, only when there is idle CPU to spare. 
-On very busy servers (or weak servers), this can lead to gaps on the charts.
+By default Netdata runs with the `idle` process scheduling policy, so that it
+uses CPU resources, only when there is idle CPU to spare. On very busy servers
+(or weak servers), this can lead to gaps on the charts.
 
 You can set Netdata scheduling policy in `netdata.conf`, like this:
 
@@ -328,7 +336,8 @@ Once the policy is set to one of `rr` or `fifo`, the following will appear:
     process scheduling priority = 0
 ```
 
-These priorities are usually from 0 to 99. Higher numbers make the process more important.
+These priorities are usually from 0 to 99. Higher numbers make the process more
+important.
 
 ### nice level for policies `other` or `batch`
 
@@ -341,8 +350,8 @@ When the policy is set to `other`, `nice`, or `batch`, the following will appear
 
 ## scheduling settings and systemd
 
-Netdata will not be able to set its scheduling policy and priority to more important values 
-when it is started as the `netdata` user (systemd case).
+Netdata will not be able to set its scheduling policy and priority to more
+important values when it is started as the `netdata` user (systemd case).
 
 You can set these settings at `/etc/systemd/system/netdata.service`:
 
@@ -365,18 +374,20 @@ You can set these settings at `/etc/systemd/system/netdata.service`:
 
 Run `systemctl daemon-reload` to reload these changes.
 
-Now, tell Netdata to keep these settings, as set by systemd, by editing `netdata.conf` and setting:
+Now, tell Netdata to keep these settings, as set by systemd, by editing
+`netdata.conf` and setting:
 
 ```conf
 [global]
     process scheduling policy = keep
 ```
 
-Using the above, whatever scheduling settings you have set at `netdata.service` will be maintained by netdata.
+Using the above, whatever scheduling settings you have set at `netdata.service`
+will be maintained by netdata.
 
 ### Example 1: Netdata with nice -1 on non-systemd systems
 
-On a system that is not based on systemd, to make Netdata run with nice level -1 
+On a system that is not based on systemd, to make Netdata run with nice level -1
 (a little bit higher to the default for all programs), edit `netdata.conf` and set:
 
 ```conf
@@ -393,8 +404,8 @@ sudo service netdata restart
 
 #### Example 2: Netdata with nice -1 on systemd systems
 
-On a system that is based on systemd, to make Netdata run with nice level -1 
-(a little bit higher to the default for all programs), edit `netdata.conf` and set:
+On a system that is based on systemd, to make Netdata run with nice level -1 (a
+little bit higher to the default for all programs), edit `netdata.conf` and set:
 
 ```conf
 [global]
@@ -418,29 +429,32 @@ sudo systemctl restart netdata
 
 ## Virtual memory
 
-You may notice that netdata's virtual memory size, as reported by `ps` or `/proc/pid/status` 
-(or even netdata's applications virtual memory chart) is unrealistically high.
+You may notice that netdata's virtual memory size, as reported by `ps` or
+`/proc/pid/status` (or even netdata's applications virtual memory chart) is
+unrealistically high.
 
-For example, it may be reported to be 150+MB, even if the resident memory size is just 25MB. 
-Similar values may be reported for Netdata plugins too.
+For example, it may be reported to be 150+MB, even if the resident memory size
+is just 25MB. Similar values may be reported for Netdata plugins too.
 
-Check this for example: A Netdata installation with default settings on Ubuntu 16.04LTS. 
-The top chart is **real memory used**, while the bottom one is **virtual memory**:
+Check this for example: A Netdata installation with default settings on Ubuntu
+16.04LTS. The top chart is **real memory used**, while the bottom one is
+**virtual memory**:
 
 ![image](https://cloud.githubusercontent.com/assets/2662304/19013772/5eb7173e-87e3-11e6-8f2b-a2ccfeb06faf.png)
 
 ### Why does this happen?
 
 The system memory allocator allocates virtual memory arenas, per thread running.
-On Linux systems this defaults to 16MB per thread on 64 bit machines. So, if you get the
-difference between real and virtual memory and divide it by 16MB you will roughly get the
-number of threads running.
+On Linux systems this defaults to 16MB per thread on 64 bit machines. So, if you
+get the difference between real and virtual memory and divide it by 16MB you
+will roughly get the number of threads running.
 
-The system does this for speed. Having a separate memory arena for each thread, allows the
-threads to run in parallel in multi-core systems, without any locks between them.
+The system does this for speed. Having a separate memory arena for each thread,
+allows the threads to run in parallel in multi-core systems, without any locks
+between them.
 
-This behaviour is system specific. For example, the chart above when running Netdata on Alpine Linux 
-(that uses **musl** instead of **glibc**) is this:
+This behaviour is system specific. For example, the chart above when running
+Netdata on Alpine Linux (that uses **musl** instead of **glibc**) is this:
 
 ![image](https://cloud.githubusercontent.com/assets/2662304/19013807/7cf5878e-87e4-11e6-9651-082e68701eab.png)
 
@@ -452,20 +466,22 @@ it already instructs the system memory allocator to minimize the memory arenas f
 We have also added [2 configuration options](https://github.com/netdata/netdata/blob/5645b1ee35248d94e6931b64a8688f7f0d865ec6/src/main.c#L410-L418)
 to allow you tweak these settings: `glibc malloc arena max for plugins` and `glibc malloc arena max for netdata`.
 
-However, even if we instructed the memory allocator to use just one arena, it seems it allocates an arena per thread.
+However, even if we instructed the memory allocator to use just one arena, it
+seems it allocates an arena per thread.
 
-Netdata also supports `jemalloc` and `tcmalloc`, 
-however both behave exactly the same to the glibc memory allocator in this aspect.
+Netdata also supports `jemalloc` and `tcmalloc`, however both behave exactly the
+same to the glibc memory allocator in this aspect.
 
 ### Is this a problem?
 
 No, it is not.
 
-Linux reserves real memory (physical RAM) in pages (on x86 machines pages are 4KB each).
-So even if the system memory allocator is allocating huge amounts of virtual memory,
-only the 4KB pages that are actually used are reserving physical RAM. The **real memory** chart
-on Netdata application section, shows the amount of physical memory these pages occupy(it
-accounts the whole pages, even if parts of them are actually used).
+Linux reserves real memory (physical RAM) in pages (on x86 machines pages are
+4KB each). So even if the system memory allocator is allocating huge amounts of
+virtual memory, only the 4KB pages that are actually used are reserving physical
+RAM. The **real memory** chart on Netdata application section, shows the amount
+of physical memory these pages occupy(it accounts the whole pages, even if parts
+of them are actually used).
 
 ## Debugging
 
@@ -473,18 +489,19 @@ When you compile Netdata with debugging:
 
 1.  compiler optimizations for your CPU are disabled (Netdata will run somewhat slower)
 
-2.  a lot of code is added all over netdata, to log debug messages to `/var/log/netdata/debug.log`. 
-  However, nothing is printed by default. Netdata allows you to select which sections of Netdata you want to trace. 
-  Tracing is activated via the config option `debug flags`. 
-  It accepts a hex number, to enable or disable specific sections. 
-  You can find the options supported at [log.h](../libnetdata/log/log.h). 
-  They are the `D_*` defines. The value `0xffffffffffffffff` will enable all possible debug flags.
+2.  a lot of code is added all over netdata, to log debug messages to
+    `/var/log/netdata/debug.log`. However, nothing is printed by default.
+    Netdata allows you to select which sections of Netdata you want to trace.
+    Tracing is activated via the config option `debug flags`. It accepts a hex
+    number, to enable or disable specific sections. You can find the options
+    supported at [log.h](../libnetdata/log/log.h). They are the `D_*` defines.
+    The value `0xffffffffffffffff` will enable all possible debug flags.
 
-Once Netdata is compiled with debugging and tracing is enabled for a few sections, 
-the file `/var/log/netdata/debug.log` will contain the messages.
+Once Netdata is compiled with debugging and tracing is enabled for a few
+sections, the file `/var/log/netdata/debug.log` will contain the messages.
 
-> Do not forget to disable tracing (`debug flags = 0`) when you are done tracing. 
->The file `debug.log` can grow too fast.
+> Do not forget to disable tracing (`debug flags = 0`) when you are done
+> tracing. The file `debug.log` can grow too fast.
 
 ### compiling Netdata with debugging
 
@@ -498,17 +515,18 @@ cd /usr/src/netdata.git
 CFLAGS="-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1" ./netdata-installer.sh
 ```
 
-The above will compile and install Netdata with debugging info embedded. 
-You can now use `debug flags` to set the section(s) you need to trace.
+The above will compile and install Netdata with debugging info embedded. You can
+now use `debug flags` to set the section(s) you need to trace.
 
 ### debugging crashes
 
-We have made the most to make Netdata crash free. 
-If however, Netdata crashes on your system, it would be very helpful to provide stack traces of the crash. 
-Without them, is will be almost impossible to find the issue 
-(the code base is quite large to find such an issue by just objerving it).
+We have made the most to make Netdata crash free. If however, Netdata crashes on
+your system, it would be very helpful to provide stack traces of the crash.
+Without them, is will be almost impossible to find the issue (the code base is
+quite large to find such an issue by just objerving it).
 
-To provide stack traces, **you need to have Netdata compiled with debugging**. There is no need to enable any tracing (`debug flags`).
+To provide stack traces, **you need to have Netdata compiled with debugging**.
+There is no need to enable any tracing (`debug flags`).
 
 Then you need to be in one of the following 2 cases:
 
@@ -516,8 +534,8 @@ Then you need to be in one of the following 2 cases:
 
 2.  you can reproduce the crash
 
-If you are not on these cases, you need to find a way to be 
-(i.e. if your system does not produce core dumps, check your distro documentation to enable them).
+If you are not on these cases, you need to find a way to be (i.e. if your system
+does not produce core dumps, check your distro documentation to enable them).
 
 ### Netdata crashes and you have a core dump
 
@@ -531,7 +549,8 @@ gdb $(which netdata) /path/to/core/dump
 
 ### you can reproduce a Netdata crash on your system
 
-> you need to have Netdata compiled with debugging info for this to work (check above)
+> you need to have Netdata compiled with debugging info for this to work (check
+> above)
 
 Install the package `valgrind` and run:
 
@@ -539,8 +558,8 @@ Install the package `valgrind` and run:
 valgrind $(which netdata) -D
 ```
 
-Netdata will start and it will be a lot slower. 
-Now reproduce the crash and `valgrind` will dump on your console the stack trace. 
-Open a new github issue and post the output.
+Netdata will start and it will be a lot slower. Now reproduce the crash and
+`valgrind` will dump on your console the stack trace. Open a new github issue
+and post the output.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdaemon%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
This PR fixes remark lint warnings for the README Daemon.

Related: #5941

##### Component Name
Docs
##### Additional Information
Fixing this warning `[table-pipe-alignment] Misaligned table fence` causes the table not to render on GitHub and MkDocs. That's why I am leaving it as is.