### PR TITLE
Fix remark lint for Contrib 

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -11,20 +11,20 @@ To build Netdata for a Debian Jessie system, the debian directory
 has to be available in the root of the Netdata source. The easiest
 way to do this is with a symlink:
 
-```
+```sh
 ~/netdata$ ln -s contrib/debian
 ```
 
 Then build the debian package:
 
-```
+```sh
 ~/netdata$ dpkg-buildpackage -us -uc -rfakeroot
 ```
 
 This should give a package that can be installed in the parent
 directory, which you can install manually with dpkg.
 
-```
+```sh
 ~/netdata$ ls ../*.deb
 ../netdata_1.0.0_amd64.deb
 ~/netdata$ sudo dpkg -i ../netdata_1.0.0_amd64.deb

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -12,22 +12,22 @@ has to be available in the root of the Netdata source. The easiest
 way to do this is with a symlink:
 
 ```sh
-~/netdata$ ln -s contrib/debian
+ln -s contrib/debian
 ```
 
 Then build the debian package:
 
 ```sh
-~/netdata$ dpkg-buildpackage -us -uc -rfakeroot
+dpkg-buildpackage -us -uc -rfakeroot
 ```
 
 This should give a package that can be installed in the parent
 directory, which you can install manually with dpkg.
 
 ```sh
-~/netdata$ ls ../*.deb
+ls ../*.deb
 ../netdata_1.0.0_amd64.deb
-~/netdata$ sudo dpkg -i ../netdata_1.0.0_amd64.deb
+sudo dpkg -i ../netdata_1.0.0_amd64.deb
 ```
 
 ### Building for a Debian system without systemd


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR fixes remark lint warnings for the README files in the Contrib directory.

Related: #5941

##### Component Name
Docs
##### Additional Information
`~/netdata$` was removed to avoid it being copied to clipboard. 