### PR TITLE
zookeeper and hdfs: alarms and dashboard_info

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -44,6 +44,7 @@ dist_healthconfig_DATA = \
     health.d/fronius.conf \
     health.d/gearman.conf \
     health.d/haproxy.conf \
+    health.d/hdfs.conf \
     health.d/httpcheck.conf \
     health.d/ipc.conf \
     health.d/ipfs.conf \

--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -91,5 +91,6 @@ dist_healthconfig_DATA = \
     health.d/wmi.conf \
     health.d/x509check.conf \
     health.d/zfs.conf \
+    health.d/zookeeper.conf \
     health.d/dbengine.conf \
     $(NULL)

--- a/health/health.d/hdfs.conf
+++ b/health/health.d/hdfs.conf
@@ -71,5 +71,5 @@ template: hdfs_num_failed_volumes
    every: 10s
     warn: $this > 0
    delay: down 15m multiplier 1.5 max 1h
-    info: dead data nodes
+    info: failed volumes
       to: sysadmin

--- a/health/health.d/hdfs.conf
+++ b/health/health.d/hdfs.conf
@@ -1,0 +1,75 @@
+
+# make sure hdfs is running
+
+template: hdfs_last_collected_secs
+      on: hdfs.heap_memory
+    calc: $now - $last_collected_t
+   units: seconds ago
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: webmaster
+
+
+# Common
+
+template: hdfs_capacity_usage
+      on: hdfs.capacity
+    calc: ($used) * 100 / ($used + $remaining)
+   units: %
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? (70) : (80))
+    crit: $this > (($status == $CRITICAL) ? (80) : (98))
+   delay: down 15m multiplier 1.5 max 1h
+    info: used capacity
+      to: sysadmin
+
+
+# NameNode
+
+template: hdfs_missing_blocks
+      on: hdfs.blocks
+    calc: $missing
+   units: missing blocks
+   every: 10s
+    warn: $this > 0
+   delay: down 15m multiplier 1.5 max 1h
+    info: missing blocks
+      to: sysadmin
+
+
+template: hdfs_stale_nodes
+      on: hdfs.data_nodes
+    calc: $stale
+   units: dead nodes
+   every: 10s
+    warn: $this > 0
+   delay: down 15m multiplier 1.5 max 1h
+    info: stale data nodes
+      to: sysadmin
+
+
+template: hdfs_dead_nodes
+      on: hdfs.data_nodes
+    calc: $dead
+   units: dead nodes
+   every: 10s
+    crit: $this > 0
+   delay: down 15m multiplier 1.5 max 1h
+    info: dead data nodes
+      to: sysadmin
+
+
+# DataNode
+
+template: hdfs_num_failed_volumes
+      on: hdfs.num_failed_volumes
+    calc: $fsds_num_failed_volumes
+   units: failed volumes
+   every: 10s
+    warn: $this > 0
+   delay: down 15m multiplier 1.5 max 1h
+    info: dead data nodes
+      to: sysadmin

--- a/health/health.d/zookeeper.conf
+++ b/health/health.d/zookeeper.conf
@@ -1,5 +1,5 @@
 
-# make sure apache is running
+# make sure zookeeper is running
 
 template: zookeeper_last_collected_secs
       on: zookeeper.requests

--- a/health/health.d/zookeeper.conf
+++ b/health/health.d/zookeeper.conf
@@ -1,0 +1,14 @@
+
+# make sure apache is running
+
+template: zookeeper_last_collected_secs
+      on: zookeeper.requests
+    calc: $now - $last_collected_t
+   units: seconds ago
+   every: 10s
+    warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+    crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+   delay: down 5m multiplier 1.5 max 1h
+    info: number of seconds since the last successful data collection
+      to: webmaster
+

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -504,6 +504,12 @@ netdataDashboard.menu = {
         title: 'VCSA',
         icon: '<i class="fas fa-server"></i>',
         info: 'vCenter Server Appliance health statistics. Data collected from <a href="https://vmware.github.io/vsphere-automation-sdk-rest/vsphere/index.html#SVC_com.vmware.appliance.health">Health API</a>.'
+    },
+
+    'zookeeper': {
+        title: 'Zookeeper',
+        icon: '<i class="fas fa-database"></i>',
+        info: 'Provides health statistics for <b><a href="https://zookeeper.apache.org/">Zookeeper</a></b> server. Data collected through the command port using <code><a href="https://zookeeper.apache.org/doc/r3.4.13/zookeeperAdmin.html#sc_zkCommands">mntr</a></code> command.'
     }
 };
 
@@ -2625,5 +2631,17 @@ netdataDashboard.context = {
             '<code>2</code>: non-security updates are available; ' +
             '<code>3</code>: security updates are available; ' +
             '<code>4</code>: an error retrieving information on software updates.'
+            },
+
+    // ------------------------------------------------------------------------
+    // Zookeeper
+
+    'zookeeper.server_state': {
+        info:
+            '<code>0</code>: unknown; ' +
+            '<code>1</code>: leader; ' +
+            '<code>2</code>: follower; ' +
+            '<code>3</code>: observer; ' +
+            '<code>4</code>: standalone.'
             }
 };

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -510,6 +510,12 @@ netdataDashboard.menu = {
         title: 'Zookeeper',
         icon: '<i class="fas fa-database"></i>',
         info: 'Provides health statistics for <b><a href="https://zookeeper.apache.org/">Zookeeper</a></b> server. Data collected through the command port using <code><a href="https://zookeeper.apache.org/doc/r3.4.13/zookeeperAdmin.html#sc_zkCommands">mntr</a></code> command.'
+    },
+
+    'hdfs': {
+        title: 'HDFS',
+        icon: '<i class="fas fa-folder-open"></i>',
+        info: 'Provides <b><a href="https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html">Hadoop Distributed File System</a></b> performance statistics. Module collects metrics over <code>Java Management Extensions</code> through the web interface of an <code>HDFS</code> daemon.'
     }
 };
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -2644,10 +2644,10 @@ netdataDashboard.context = {
 
     'zookeeper.server_state': {
         info:
-            '<code>0</code>: unknown; ' +
-            '<code>1</code>: leader; ' +
-            '<code>2</code>: follower; ' +
-            '<code>3</code>: observer; ' +
+            '<code>0</code>: unknown, ' +
+            '<code>1</code>: leader, ' +
+            '<code>2</code>: follower, ' +
+            '<code>3</code>: observer, ' +
             '<code>4</code>: standalone.'
             }
 };

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -509,13 +509,13 @@ netdataDashboard.menu = {
     'zookeeper': {
         title: 'Zookeeper',
         icon: '<i class="fas fa-database"></i>',
-        info: 'Provides health statistics for <b><a href="https://zookeeper.apache.org/">Zookeeper</a></b> server. Data collected through the command port using <code><a href="https://zookeeper.apache.org/doc/r3.4.13/zookeeperAdmin.html#sc_zkCommands">mntr</a></code> command.'
+        info: 'Provides health statistics for <b><a href="https://zookeeper.apache.org/">Zookeeper</a></b> server. Data collected through the command port using <code><a href="https://zookeeper.apache.org/doc/r3.5.5/zookeeperAdmin.html#sc_zkCommands">mntr</a></code> command.'
     },
 
     'hdfs': {
         title: 'HDFS',
         icon: '<i class="fas fa-folder-open"></i>',
-        info: 'Provides <b><a href="https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html">Hadoop Distributed File System</a></b> performance statistics. Module collects metrics over <code>Java Management Extensions</code> through the web interface of an <code>HDFS</code> daemon.'
+        info: 'Provides <b><a href="https://hadoop.apache.org/docs/r3.2.0/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html">Hadoop Distributed File System</a></b> performance statistics. Module collects metrics over <code>Java Management Extensions</code> through the web interface of an <code>HDFS</code> daemon.'
     }
 };
 


### PR DESCRIPTION
##### Summary

This PR adds:
- [X] `zookeeper` alarms
- [X] `hdfs` alarms
- [X] `zookeeper` module description/icon
- [X] `hdfs` module description/icon

`zookeeper` alarms:
 - availability

`hdfs` name node alarms:
 - availability
 - capacity usage
 - missing blocks
 - stale nodes
 - dead nodes

`hdfs` data node alarms:
 - availability
 - capacity usage
 - failed volumes

##### Component Name
[/web/gui](https://github.com/netdata/netdata/tree/master/web/gui)
[health/health.d](https://github.com/netdata/netdata/tree/master/health/health.d)

##### Additional Information

 - i tested the PR installing it, it works - i see all info/alarms on the dashboard.

cc: @killerwhile
