### PR TITLE
python.d: fix log warnings in start_job

### DIFF
--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -588,16 +588,16 @@ class Plugin:
                 try:
                     job.init()
                 except Exception as error:
-                    self.log.warning("{0}[{1}] : unhandled exception on init : {2}, skipping the job",
-                                     job.module_name, job.real_name, repr(error))
+                    self.log.warning("{0}[{1}] : unhandled exception on init : {2}, skipping the job".format(
+                                     job.module_name, job.real_name, repr(error)))
                     job.status = JOB_STATUS_DROPPED
                     continue
 
             try:
                 ok = job.check()
             except Exception as error:
-                self.log.warning("{0}[{1}] : unhandled exception on check : {2}, skipping the job",
-                                 job.module_name, job.real_name, repr(error))
+                self.log.warning("{0}[{1}] : unhandled exception on check : {2}, skipping the job".format(
+                                 job.module_name, job.real_name, repr(error)))
                 job.status = JOB_STATUS_DROPPED
                 continue
             if not ok:
@@ -609,8 +609,8 @@ class Plugin:
             try:
                 job.create()
             except Exception as error:
-                self.log.error("{0}[{1}] : unhandled exception on create : {2}, skipping the job",
-                               job.module_name, job.real_name, repr(error))
+                self.log.warning("{0}[{1}] : unhandled exception on create : {2}, skipping the job".format(
+                               job.module_name, job.real_name, repr(error)))
                 job.status = JOB_STATUS_DROPPED
                 continue
 


### PR DESCRIPTION
##### Summary

ssia

> 2019-09-23 17:17:15: python.d WARNING: plugin[main] : {0}[{1}] : unhandled exception on check : {2}, skipping the job web_log nginx_log UnicodeEncodeError('ascii', u'/opt/\xfc.log', 5, 6, 'ordinal not in range(128)')

> plugin[main] : {0}[{1}]

##### Component Name

[collectors/python.d.plugin/python.d.plugin](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/python.d.plugin.in)

##### Additional Information

