### PR TITLE
minor - check for curl to not get wrong error message

### DIFF
--- a/tests/stress.sh
+++ b/tests/stress.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+if ! hash curl 2>/dev/null
+then
+	1>&2 echo "'curl' not found on system. Please install 'curl'."
+	exit 1
+fi
+
 # set the host to connect to
 if [ ! -z "$1" ]
 then


### PR DESCRIPTION
##### Summary
Very small change -> Check for `curl` presence in system.
Before if `curl` is not installed you will get error message (and start investigating what is wrong with netdata):
```bash
using netdata server at: http://127.0.0.1:19999
Cannot download charts from server: http://127.0.0.1:19999
```
even if netdata running and responding well.
##### Component Name
tests/stress.sh


