### PR TITLE
Fix a memory leak

### DIFF
--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -1300,6 +1300,9 @@ inline void poll_close_fd(POLLINFO *pi) {
     freez(pi->client_port);
     pi->client_port = NULL;
 
+    freez(pi->client_host);
+    pi->client_host = NULL;
+
     pi->next = p->first_free;
     p->first_free = pi;
 


### PR DESCRIPTION
##### Summary
When Netdata was run under valgrind, it reported memory leaks on exit.

Fixes #6944

##### Component Name
libnetdata/socket