### PR TITLE
netdata/packaging: Make spec file more consistent with version dependencies, plus some documentation nits

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -193,7 +193,7 @@ Requires: freeipmi
 
 # CUPS plugin dependencies
 %if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7
-BuildRequires: cups-devel
+BuildRequires: cups-devel >= 1.7
 %endif
 # end - cups plugin dependencies
 
@@ -503,7 +503,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %package plugin-cups
 Summary: The Common Unix Printing System plugin for netdata
 Group: Applications/System
-Requires: cups
+Requires: cups >= 1.7
 Requires: netdata = %{version}
 
 %description plugin-cups

--- a/packaging/DISTRIBUTIONS.md
+++ b/packaging/DISTRIBUTIONS.md
@@ -199,7 +199,7 @@ This is Netdata's TLS capability that incorporates encryption on the web server 
 
 -   **Flags/instructions to enable**: None
 -   **Flags to disable from source**: --disable-plugin-cups
--   **What packages required for auto-detect?**: `cups-devel`
+-   **What packages required for auto-detect?**: `cups-devel >= 1.7`
 
 #### FPING
 


### PR DESCRIPTION

##### Summary
Sice we have identified that we missed a critical CUPS version dependency, we need to update our spec file so that we guarantee we always depend on the right versions of CUPS.
This way we ensure we won't bump into build problems in the future.

Also, take note of the CUPs version required in the distributions table

##### Component Name
netdata/packaging
netdata/docs

##### Additional Information
N/A
