### PR TITLE
mysql: collect galera cluster metrics

### DIFF
--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -241,12 +241,12 @@ It will produce following charts (if data is available):
     -   sql
     -   io
 
-42. **Replicated Writesets** in writesets/s
+42. **Galera Replicated Writesets** in writesets/s
 
     -   rx
     -   tx
 
-43. **Replicated Bytes** in KiB/s
+43. **Galera Replicated Bytes** in KiB/s
 
     -   rx
     -   tx
@@ -256,16 +256,48 @@ It will produce following charts (if data is available):
     -   rx
     -   tx
 
-45. **Replication Conflicts** in transactions
+45. **Galera Replication Conflicts** in transactions
 
     -   bf aborts
     -   cert fails
 
-46. **Flow Control** in ms
+46. **Galera Flow Control** in ms
 
     -   paused
 
-47. **Users CPU time** in percentage
+47. **Galera Cluster Status** in status
+
+    -   status
+
+48. **Galera Cluster State** in state
+
+    -   state
+
+49. **Galera Number of Nodes in the Cluster** in num
+
+    -   nodes
+
+50. **Galera Total Weight of the Current Members in the Cluster** in weight
+
+    -   weight
+
+51. **Galera Whether the Node is Connected to the Cluster** in boolean
+
+    -   connected
+
+52. **Galera Whether the Node is Ready to Accept Queries** in boolean
+
+    -   ready
+
+53. **Galera Open Transactions** in num
+
+    -   open transactions
+
+54. **Galera Total Number of WSRep (applier/rollbacker) Threads** in num
+
+    -   threads
+
+55. **Users CPU time** in percentage
 
     -   users
 

--- a/collectors/python.d.plugin/mysql/mysql.chart.py
+++ b/collectors/python.d.plugin/mysql/mysql.chart.py
@@ -744,7 +744,7 @@ class WSRepDataConverter:
     def convert(self, key, value):
         if key == 'wsrep_connected':
             return self.convert_connected(value)
-        if key == 'wsrep_ready':
+        elif key == 'wsrep_ready':
             return self.convert_ready(value)
         elif key == 'wsrep_cluster_status':
             return self.convert_cluster_status(value)

--- a/collectors/python.d.plugin/mysql/mysql.chart.py
+++ b/collectors/python.d.plugin/mysql/mysql.chart.py
@@ -628,7 +628,7 @@ CHARTS = {
     'galera_cluster_size': {
         'options': [None, 'Number of Nodes in the Cluster', 'num', 'galera', 'mysql.galera_cluster_size', 'line'],
         'lines': [
-            ['wsrep_cluster_size', 'size', 'absolute'],
+            ['wsrep_cluster_size', 'nodes', 'absolute'],
         ]
     },
     'galera_cluster_weight': {

--- a/collectors/python.d.plugin/mysql/mysql.chart.py
+++ b/collectors/python.d.plugin/mysql/mysql.chart.py
@@ -117,6 +117,14 @@ GLOBAL_STATS = [
     'Connection_errors_peer_address',
     'Connection_errors_select',
     'Connection_errors_tcpwrap',
+    'Com_delete',
+    'Com_insert',
+    'Com_select',
+    'Com_update',
+    'Com_replace'
+]
+
+GALERA_STATS = [
     'wsrep_local_recv_queue',
     'wsrep_local_send_queue',
     'wsrep_received',
@@ -126,11 +134,15 @@ GLOBAL_STATS = [
     'wsrep_local_bf_aborts',
     'wsrep_local_cert_failures',
     'wsrep_flow_control_paused_ns',
-    'Com_delete',
-    'Com_insert',
-    'Com_select',
-    'Com_update',
-    'Com_replace'
+    'wsrep_cluster_weight',
+    'wsrep_cluster_size',
+    'wsrep_cluster_status',
+    'wsrep_local_state_comment',
+    'wsrep_open_transactions',
+    'wsrep_connected',
+    'wsrep_local_index',
+    'wsrep_ready',
+    'wsrep_thread_count'
 ]
 
 
@@ -216,7 +228,15 @@ ORDER = [
     'galera_queue',
     'galera_conflicts',
     'galera_flow_control',
-    'userstats_cpu'
+    'galera_cluster_status',
+    'galera_cluster_state',
+    'galera_cluster_size',
+    'galera_cluster_weight',
+    'galera_connected',
+    'galera_ready',
+    'galera_open_transactions',
+    'galera_thread_count',
+    'userstats_cpu',
 ]
 
 CHARTS = {
@@ -594,6 +614,59 @@ CHARTS = {
             ['wsrep_flow_control_paused_ns', 'paused', 'incremental', 1, 1000000],
         ]
     },
+    'galera_cluster_status': {
+        'options': [None, 'Cluster Component Status', 'status', 'galera', 'mysql.galera_cluster_status', 'line'],
+        'lines': [
+            ['wsrep_cluster_status', 'status', 'absolute'],
+        ]
+    },
+    'galera_cluster_state': {
+        'options': [None, 'Cluster Component State', 'state', 'galera', 'mysql.galera_cluster_state', 'line'],
+        'lines': [
+            ['wsrep_local_state_comment', 'state', 'absolute'],
+        ]
+    },
+    'galera_cluster_size': {
+        'options': [None, 'Number of Nodes in the Cluster', 'num', 'galera', 'mysql.galera_cluster_size', 'line'],
+        'lines': [
+            ['wsrep_cluster_size', 'size', 'absolute'],
+        ]
+    },
+    'galera_cluster_weight': {
+        'options': [None, 'The Total Weight of the Current Members in the Cluster', 'weight', 'galera',
+                    'mysql.galera_cluster_weight', 'line'],
+        'lines': [
+            ['wsrep_cluster_weight', 'weight', 'absolute'],
+        ]
+    },
+    'galera_connected': {
+        'options': [None, 'Whether the Node is Connected to the Cluster', 'boolean', 'galera',
+                    'mysql.galera_connected', 'line'],
+        'lines': [
+            ['wsrep_connected', 'connected', 'absolute'],
+        ]
+    },
+    'galera_ready': {
+        'options': [None, 'Whether the Node is Ready to Accept Queries', 'boolean', 'galera',
+                    'mysql.galera_ready', 'line'],
+        'lines': [
+            ['wsrep_ready', 'ready', 'absolute'],
+        ]
+    },
+    'galera_open_transactions': {
+        'options': [None, 'The Number of Locally Running Registered Inside the WSRep Provider Transactions', 'num',
+                    'galera', 'mysql.galera_open_transactions', 'line'],
+        'lines': [
+            ['wsrep_open_transactions', 'open transactions', 'absolute'],
+        ]
+    },
+    'galera_thread_count': {
+        'options': [None, 'Total Number of WSRep (applier/rollbacker) Threads', 'num', 'galera',
+                    'mysql.galera_thread_count', 'line'],
+        'lines': [
+            ['wsrep_thread_count', 'threads', 'absolute'],
+        ]
+    },
     'userstats_cpu': {
         'options': [None, 'Users CPU time', 'percentage', 'userstats', 'mysql.userstats_cpu', 'stacked'],
         'lines': []
@@ -663,6 +736,65 @@ def userstats_chart_template(name):
 DEFAULT_REPL_CHANNEL = ''
 
 
+# Write Set REPlication
+# https://galeracluster.com/library/documentation/galera-status-variables.html
+# https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html
+class WSRepDataConverter:
+    unknown_value = -1
+
+    def convert(self, key, value):
+        if key == 'wsrep_connected':
+            return self.convert_connected(value)
+        if key == 'wsrep_ready':
+            return self.convert_ready(value)
+        elif key == 'wsrep_cluster_status':
+            return self.convert_cluster_status(value)
+        elif key == 'wsrep_local_state_comment':
+            return self.convert_local_state_comment(value)
+        return value
+
+    def convert_connected(self, value):
+        # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_connected
+        if value == 'OFF':
+            return 0
+        if value == 'ON':
+            return 1
+        return self.unknown_value
+
+    def convert_ready(self, value):
+        # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_ready
+        if value == 'OFF':
+            return 0
+        if value == 'ON':
+            return 1
+        return self.unknown_value
+
+    def convert_local_state_comment(self, value):
+        # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_local_state_comment
+        if value == 'Joining':
+            return 1
+        elif value == 'Donor' or value == 'Desynced':
+            return 2
+        elif value == 'Joined':
+            return 3
+        elif value == 'Synced':
+            return 4
+        return self.unknown_value
+
+    def convert_cluster_status(self, value):
+        # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_cluster_status
+        if value == 'Primary':
+            return 1
+        elif value == 'Non-Primary':
+            return 2
+        elif value == 'Disconnected':
+            return 3
+        return self.unknown_value
+
+
+wsrep_converter = WSRepDataConverter()
+
+
 class Service(MySQLService):
     def __init__(self, configuration=None, name=None):
         MySQLService.__init__(self, configuration=configuration, name=name)
@@ -686,12 +818,9 @@ class Service(MySQLService):
         data = dict()
 
         if 'global_status' in raw_data:
-            global_status = dict(raw_data['global_status'][0])
-            for key in GLOBAL_STATS:
-                if key in global_status:
-                    data[key] = global_status[key]
-            if 'Threads_created' in data and 'Connections' in data:
-                data['Thread_cache_misses'] = round(int(data['Threads_created']) / float(data['Connections']) * 10000)
+            global_status = self.get_global_status(raw_data['global_status'])
+            if global_status:
+                data.update(global_status)
 
         if 'slave_status' in raw_data:
             status = self.get_slave_status(raw_data['slave_status'])
@@ -711,6 +840,54 @@ class Service(MySQLService):
                     data[key] = variables[key]
 
         return data or None
+
+    @staticmethod
+    def convert_wsrep(key, value):
+        return wsrep_converter.convert(key, value)
+
+    def get_global_status(self, raw_global_status):
+        """
+        MariaDB [(none)]> show global status;
+        +--------------------------------------------------------------+-----------------------------------------------+
+        | Variable_name                                                | Value                                         |
+        +--------------------------------------------------------------+-----------------------------------------------+
+        | Aborted_clients                                              | 5                                             |
+        | Aborted_connects                                             | 20                                            |
+        | Access_denied_errors                                         | 22                                            |
+        | Acl_column_grants                                            | 0                                             |
+        | Acl_database_grants                                          | 0                                             |
+        | Acl_function_grants                                          | 0                                             |
+        ...
+        ...
+        | wsrep_ready                                                  | OFF                                           |
+        | wsrep_rollbacker_thread_count                                | 0                                             |
+        | wsrep_thread_count                                           | 0                                             |
+        +--------------------------------------------------------------+-----------------------------------------------+
+        """
+
+        rows = raw_global_status[0]
+        if not rows:
+            return
+
+        global_status = dict(rows)
+        data = dict()
+
+        for key in GLOBAL_STATS:
+            if key not in global_status:
+                continue
+            value = global_status[key]
+            data[key] = value
+
+        for key in GALERA_STATS:
+            if key not in global_status:
+                continue
+            value = global_status[key]
+            value = self.convert_wsrep(key, value)
+            data[key] = value
+
+        if 'Threads_created' in data and 'Connections' in data:
+            data['Thread_cache_misses'] = round(int(data['Threads_created']) / float(data['Connections']) * 10000)
+        return data
 
     def get_slave_status(self, slave_status_data):
         rows, description = slave_status_data[0], slave_status_data[1]
@@ -742,41 +919,6 @@ class Service(MySQLService):
         self.add_new_charts(slave_status_chart_template, name)
 
     def get_userstats(self, raw_data):
-        # raw_data['user_statistics'] contains the following data structure:
-        #   (
-        #       (
-        #           ('netdata', 42L, 0L, 1264L, 3.111252999999968, 2.968510299999994, 110267L, 19741424L, 0L, 0L, 1265L, 0L,
-        #           0L, 0L, 3L, 0L, 1301L, 0L, 0L, 7633L, 0L, 83L, 44L, 0L, 0L),
-        #           ('root', 60L, 0L, 184L, 0.22856499999999966, 0.1601419999999998, 11605L, 1516513L, 0L, 9L, 220L, 0L, 2L, 1L,
-        #           6L, 4L,127L, 0L, 0L, 45L, 0L, 45L, 0L, 0L, 0L)
-        #        ),
-        #    (
-        #        ('User', 253, 9, 128, 128, 0, 0),
-        #        ('Total_connections', 3, 2, 11, 11, 0, 0),
-        #        ('Concurrent_connections', 3, 1, 11, 11, 0, 0),
-        #        ('Connected_time', 3, 4, 11, 11, 0, 0),
-        #        ('Busy_time', 5, 21, 21, 21, 31, 0),
-        #        ('Cpu_time', 5, 18, 21, 21, 31, 0),
-        #        ('Bytes_received', 8, 6, 21, 21, 0, 0),
-        #        ('Bytes_sent', 8, 8, 21, 21, 0, 0),
-        #        ('Binlog_bytes_written', 8, 1, 21, 21, 0, 0),
-        #        ('Rows_read', 8, 1, 21, 21, 0, 0),
-        #        ('Rows_sent', 8, 4, 21, 21, 0, 0),
-        #        ('Rows_deleted', 8, 1, 21, 21, 0, 0),
-        #        ('Rows_inserted', 8, 1, 21, 21, 0, 0),
-        #        ('Rows_updated', 8, 1, 21, 21, 0, 0),
-        #        ('Select_commands', 8, 1, 21, 21, 0, 0),
-        #        ('Update_commands', 8, 1, 21, 21, 0, 0),
-        #        ('Other_commands', 8, 4, 21, 21, 0, 0),
-        #        ('Commit_transactions', 8, 1, 21, 21, 0, 0),
-        #        ('Rollback_transactions', 8, 1, 21, 21, 0, 0),
-        #        ('Denied_connections', 8, 4, 21, 21, 0, 0),
-        #        ('Lost_connections', 8, 1, 21, 21, 0, 0),
-        #        ('Access_denied', 8, 2, 21, 21, 0, 0),
-        #        ('Empty_queries', 8, 2, 21, 21, 0, 0),
-        #        ('Total_ssl_connections', 8, 1, 21, 21, 0, 0),
-        #        ('Max_statement_time_exceeded', 8, 1, 21, 21, 0, 0)),
-        #   )
         data = dict()
         userstats_vars = [e[0] for e in raw_data['user_statistics'][1]]
         for i, _ in enumerate(raw_data['user_statistics'][0]):

--- a/collectors/python.d.plugin/mysql/mysql.chart.py
+++ b/collectors/python.d.plugin/mysql/mysql.chart.py
@@ -653,8 +653,7 @@ CHARTS = {
         ]
     },
     'galera_open_transactions': {
-        'options': [None, 'The Number of Locally Running Registered Inside the WSRep Provider Transactions', 'num',
-                    'galera', 'mysql.galera_open_transactions', 'line'],
+        'options': [None, 'Open Transactions', 'num', 'galera', 'mysql.galera_open_transactions', 'line'],
         'lines': [
             ['wsrep_open_transactions', 'open transactions', 'absolute'],
         ]
@@ -771,23 +770,23 @@ class WSRepDataConverter:
     def convert_local_state_comment(self, value):
         # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_local_state_comment
         if value == 'Joining':
-            return 1
+            return 0
         elif value == 'Donor' or value == 'Desynced':
-            return 2
+            return 1
         elif value == 'Joined':
-            return 3
+            return 2
         elif value == 'Synced':
-            return 4
+            return 3
         return self.unknown_value
 
     def convert_cluster_status(self, value):
         # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_cluster_status
         if value == 'Primary':
-            return 1
+            return 0
         elif value == 'Non-Primary':
-            return 2
+            return 1
         elif value == 'Disconnected':
-            return 3
+            return 2
         return self.unknown_value
 
 

--- a/collectors/python.d.plugin/mysql/mysql.chart.py
+++ b/collectors/python.d.plugin/mysql/mysql.chart.py
@@ -140,7 +140,6 @@ GALERA_STATS = [
     'wsrep_local_state_comment',
     'wsrep_open_transactions',
     'wsrep_connected',
-    'wsrep_local_index',
     'wsrep_ready',
     'wsrep_thread_count'
 ]
@@ -846,25 +845,23 @@ class Service(MySQLService):
         return wsrep_converter.convert(key, value)
 
     def get_global_status(self, raw_global_status):
-        """
-        MariaDB [(none)]> show global status;
-        +--------------------------------------------------------------+-----------------------------------------------+
-        | Variable_name                                                | Value                                         |
-        +--------------------------------------------------------------+-----------------------------------------------+
-        | Aborted_clients                                              | 5                                             |
-        | Aborted_connects                                             | 20                                            |
-        | Access_denied_errors                                         | 22                                            |
-        | Acl_column_grants                                            | 0                                             |
-        | Acl_database_grants                                          | 0                                             |
-        | Acl_function_grants                                          | 0                                             |
-        ...
-        ...
-        | wsrep_ready                                                  | OFF                                           |
-        | wsrep_rollbacker_thread_count                                | 0                                             |
-        | wsrep_thread_count                                           | 0                                             |
-        +--------------------------------------------------------------+-----------------------------------------------+
-        """
-
+        # (
+        #     (
+        #         ('Aborted_clients', '18'),
+        #         ('Aborted_connects', '33'),
+        #         ('Access_denied_errors', '80'),
+        #         ('Acl_column_grants', '0'),
+        #         ('Acl_database_grants', '0'),
+        #         ('Acl_function_grants', '0'),
+        #         ('wsrep_ready', 'OFF'),
+        #         ('wsrep_rollbacker_thread_count', '0'),
+        #         ('wsrep_thread_count', '0')
+        #     ),
+        #     (
+        #         ('Variable_name', 253, 60, 64, 64, 0, 0),
+        #         ('Value', 253, 48, 2048, 2048, 0, 0),
+        #     )
+        # )
         rows = raw_global_status[0]
         if not rows:
             return
@@ -919,6 +916,39 @@ class Service(MySQLService):
         self.add_new_charts(slave_status_chart_template, name)
 
     def get_userstats(self, raw_data):
+        # (
+        #     (
+        #         ('netdata', 1L, 0L, 60L, 0.15842499999999984, 0.15767439999999996, 5206L, 963957L, 0L, 0L,
+        #          61L, 0L, 0L, 0L, 0L, 0L, 62L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L),
+        #     ),
+        #     (
+        #         ('User', 253, 7, 128, 128, 0, 0),
+        #         ('Total_connections', 3, 2, 11, 11, 0, 0),
+        #         ('Concurrent_connections', 3, 1, 11, 11, 0, 0),
+        #         ('Connected_time', 3, 2, 11, 11, 0, 0),
+        #         ('Busy_time', 5, 20, 21, 21, 31, 0),
+        #         ('Cpu_time', 5, 20, 21, 21, 31, 0),
+        #         ('Bytes_received', 8, 4, 21, 21, 0, 0),
+        #         ('Bytes_sent', 8, 6, 21, 21, 0, 0),
+        #         ('Binlog_bytes_written', 8, 1, 21, 21, 0, 0),
+        #         ('Rows_read', 8, 1, 21, 21, 0, 0),
+        #         ('Rows_sent', 8, 2, 21, 21, 0, 0),
+        #         ('Rows_deleted', 8, 1, 21, 21, 0, 0),
+        #         ('Rows_inserted', 8, 1, 21, 21, 0, 0),
+        #         ('Rows_updated', 8, 1, 21, 21, 0, 0),
+        #         ('Select_commands', 8, 2, 21, 21, 0, 0),
+        #         ('Update_commands', 8, 1, 21, 21, 0, 0),
+        #         ('Other_commands', 8, 2, 21, 21, 0, 0),
+        #         ('Commit_transactions', 8, 1, 21, 21, 0, 0),
+        #         ('Rollback_transactions', 8, 1, 21, 21, 0, 0),
+        #         ('Denied_connections', 8, 1, 21, 21, 0, 0),
+        #         ('Lost_connections', 8, 1, 21, 21, 0, 0),
+        #         ('Access_denied', 8, 1, 21, 21, 0, 0),
+        #         ('Empty_queries', 8, 2, 21, 21, 0, 0),
+        #         ('Total_ssl_connections', 8, 1, 21, 21, 0, 0),
+        #         ('Max_statement_time_exceeded', 8, 1, 21, 21, 0, 0)
+        #     )
+        # )
         data = dict()
         userstats_vars = [e[0] for e in raw_data['user_statistics'][1]]
         for i, _ in enumerate(raw_data['user_statistics'][0]):

--- a/collectors/python.d.plugin/mysql/mysql.chart.py
+++ b/collectors/python.d.plugin/mysql/mysql.chart.py
@@ -765,30 +765,6 @@ class WSRepDataConverter:
             return 1
         return self.unknown_value
 
-    def convert_local_state_comment(self, value):
-        # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_local_state_comment
-        # https://github.com/codership/wsrep-API/blob/eab2d5d5a31672c0b7d116ef1629ff18392fd7d0/wsrep_api.h
-        # typedef enum wsrep_member_status {
-        #     WSREP_MEMBER_UNDEFINED, //!< undefined state
-        #     WSREP_MEMBER_JOINER,    //!< incomplete state, requested state transfer
-        #     WSREP_MEMBER_DONOR,     //!< complete state, donates state transfer
-        #     WSREP_MEMBER_JOINED,    //!< complete state
-        #     WSREP_MEMBER_SYNCED,    //!< complete state, synchronized with group
-        #     WSREP_MEMBER_ERROR,     //!< this and above is provider-specific error code
-        #     WSREP_MEMBER_MAX
-        # } wsrep_member_status_t;
-        if value == 'Undefined':
-            return 0
-        elif value == 'Joining':
-            return 1
-        elif value == 'Donor/Desynced':
-            return 2
-        elif value == 'Joined':
-            return 3
-        elif value == 'Synced':
-            return 4
-        return self.unknown_value
-
     def convert_cluster_status(self, value):
         # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_cluster_status
         # https://github.com/codership/wsrep-API/blob/eab2d5d5a31672c0b7d116ef1629ff18392fd7d0/wsrep_api.h
@@ -798,11 +774,12 @@ class WSRepDataConverter:
         #     WSREP_VIEW_DISCONNECTED, //!< not connected to group, retrying.
         #     WSREP_VIEW_MAX
         # } wsrep_view_status_t;
-        if value == 'Primary':
+        value = value.lower()
+        if value == 'primary':
             return 0
-        elif value == 'Non-Primary' or value == 'non-Primary':
+        elif value == 'non-primary':
             return 1
-        elif value == 'Disconnected':
+        elif value == 'disconnected':
             return 2
         return self.unknown_value
 

--- a/collectors/python.d.plugin/mysql/mysql.chart.py
+++ b/collectors/python.d.plugin/mysql/mysql.chart.py
@@ -771,7 +771,7 @@ class WSRepDataConverter:
         # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_local_state_comment
         if value == 'Joining':
             return 0
-        elif value == 'Donor' or value == 'Desynced':
+        elif value == 'Donor/Desynced':
             return 1
         elif value == 'Joined':
             return 2
@@ -783,7 +783,7 @@ class WSRepDataConverter:
         # https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html#wsrep_cluster_status
         if value == 'Primary':
             return 0
-        elif value == 'Non-Primary':
+        elif value == 'Non-Primary' or value == 'non-Primary':
             return 1
         elif value == 'Disconnected':
             return 2

--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -105,7 +105,7 @@ template: mysql_replication_lag
 template: mysql_galera_cluster_size_max_2m
       on: mysql.galera_cluster_size
   lookup: max -2m absolute
-   units: size
+   units: nodes
    every: 10s
     info: max cluster size 2 minute
       to: dba
@@ -113,7 +113,7 @@ template: mysql_galera_cluster_size_max_2m
 template: mysql_galera_cluster_size
       on: mysql.galera_cluster_size
     calc: $nodes
-   units: size
+   units: nodes
    every: 10s
     warn: $this > $mysql_galera_cluster_size_max_2m
     crit: $this < $mysql_galera_cluster_size_max_2m

--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -120,3 +120,13 @@ template: mysql_galera_cluster_size
    delay: up 20s down 5m multiplier 1.5 max 1h
     info: cluster size has changed
       to: dba
+
+template: mysql_galera_cluster_state
+      on: mysql.galera_cluster_state
+    calc: $state
+   every: 10s
+    warn: $this < 4
+    crit: $this < 2
+   delay: up 30s down 5m down 5m multiplier 1.5 max 1h
+    info: node state (0: undefined, 1: joining, 2: donor/desynced, 3: joined, 4: synced)
+      to: dba

--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -121,12 +121,14 @@ template: mysql_galera_cluster_size
     info: cluster size has changed
       to: dba
 
+# galera node state
+
 template: mysql_galera_cluster_state
       on: mysql.galera_cluster_state
     calc: $state
    every: 10s
     warn: $this < 4
     crit: $this < 2
-   delay: up 30s down 5m down 5m multiplier 1.5 max 1h
+   delay: up 30s down 5m multiplier 1.5 max 1h
     info: node state (0: undefined, 1: joining, 2: donor/desynced, 3: joined, 4: synced)
       to: dba

--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -98,3 +98,24 @@ template: mysql_replication_lag
     info: the number of seconds mysql replication is behind this master
       to: dba
 
+
+# -----------------------------------------------------------------------------
+# galera cluster size
+
+template: mysql_galera_cluster_size_max_2m
+      on: mysql.galera_cluster_size
+  lookup: max -2m absolute
+   units: size
+   every: 10s
+    info: max cluster size 2 minute
+      to: dba
+
+template: mysql_galera_cluster_size
+      on: mysql.galera_cluster_size
+    calc: $size
+   units: size
+   every: 10s
+    crit: $this < $mysql_galera_cluster_size_max_2m
+   delay: down 5m multiplier 1.5 max 1h
+    info: cluster size has been decreases
+      to: dba

--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -112,10 +112,11 @@ template: mysql_galera_cluster_size_max_2m
 
 template: mysql_galera_cluster_size
       on: mysql.galera_cluster_size
-    calc: $size
+    calc: $nodes
    units: size
    every: 10s
+    warn: $this > $mysql_galera_cluster_size_max_2m
     crit: $this < $mysql_galera_cluster_size_max_2m
-   delay: down 5m multiplier 1.5 max 1h
-    info: cluster size has been decreases
+   delay: up 20s down 5m multiplier 1.5 max 1h
+    info: cluster size has changed
       to: dba

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1260,6 +1260,39 @@ netdataDashboard.context = {
         info: 'A deadlock happens when two or more transactions mutually hold and request for locks, creating a cycle of dependencies. For more information about <a href="https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks-handling.html" target="_blank">how to minimize and handle deadlocks</a>.'
     },
 
+    'mysql.galera_cluster_status': {
+        info:
+            '<code>-1</code>: unknown, ' +
+            '<code>0</code>: primary (primary group configuration, quorum present), ' +
+            '<code>1</code>: non-primary (non-primary group configuration, quorum lost), ' +
+            '<code>2</code>: disconnected(not connected to group, retrying).'
+    },
+
+    'mysql.galera_cluster_state': {
+        info:
+            '<code>-1</code>: unknown, ' +
+            '<code>0</code>: joining, ' +
+            '<code>1</code>: donor or desynced, ' +
+            '<code>2</code>: joined, ' +
+            '<code>3</code>: synced.'
+    },
+
+    'mysql.galera_cluster_weight': {
+        info: 'The value is counted as a sum of <code>pc.weight</code> of the nodes in the current Primary Component.'
+    },
+
+    'mysql.galera_connected': {
+        info: '<code>0</code> means that the node has not yet connected to any of the cluster components. ' +
+            'This may be due to misconfiguration.'
+    },
+
+    'mysql.open_transactions': {
+        info: 'The number of locally running transactions which have been registered inside the wsrep provider. ' +
+            'This means transactions which have made operations which have caused write set population to happen. ' +
+            'Transactions which are read only are not counted.'
+    },
+
+
     // ------------------------------------------------------------------------
     // POSTGRESQL
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1270,11 +1270,11 @@ netdataDashboard.context = {
 
     'mysql.galera_cluster_state': {
         info:
-            '<code>-1</code>: unknown, ' +
-            '<code>0</code>: joining, ' +
-            '<code>1</code>: donor or desynced, ' +
-            '<code>2</code>: joined, ' +
-            '<code>3</code>: synced.'
+            '<code>0</code>: undefined, ' +
+            '<code>1</code>: joining, ' +
+            '<code>2</code>: donor/desynced, ' +
+            '<code>3</code>: joined, ' +
+            '<code>4</code>: synced.'
     },
 
     'mysql.galera_cluster_weight': {


### PR DESCRIPTION
##### Summary

Fixes: #6934

Info sources:
 - https://mariadb.com/kb/en/library/galera-cluster-status-variables
 - https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-status-index.html


This PR adds:
   - [X] cluster charts 
   - [x] new charts description (dashboard_info)
   - [x] alarms

New collected metrics:
 - `wsrep_cluster_weight`
 - `wsrep_cluster_size`
 - `wsrep_cluster_status`
 - `wsrep_local_state`
 - `wsrep_open_transactions`
 - `wsrep_connected`
 - `wsrep_ready`
 - `wsrep_thread_count`

##### Component Name

[`/collectors/python.d.plugin/mysql`](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/mysql)

##### Additional Information

cc: @ekexcello
