### PR TITLE
elasticsearch: collect metrics from _cat/indices

### DIFF
--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -1,6 +1,6 @@
 # elasticsearch
 
-This module monitors Elasticsearch performance and health metrics.
+This module monitors `Elasticsearch` performance and health metrics.
 
 It produces:
 
@@ -51,19 +51,28 @@ It produces:
     -   Store statistics
     -   Indices and shards statistics
 
+9.  **Indices** charts (per index statistics):
+
+    -   Docs count
+    -   Store size
+    -   Num of replicas
+    -   Health status
+
 ## configuration
 
 Sample:
 
 ```yaml
 local:
-  host               : 'ipaddress'    # Elasticsearch server ip address or hostname
-  port               : 'port'         # Port on which elasticsearch listens
-  cluster_health     :  True/False    # Calls to cluster health elasticsearch API. Enabled by default.
-  cluster_stats      :  True/False    # Calls to cluster stats elasticsearch API. Enabled by default.
+  host               : 'ipaddress'    # Elasticsearch server ip address or hostname.
+  port               : 'port'         # Port on which elasticsearch listens.
+  node_status        :  yes/no        # Get metrics from "/_nodes/_local/stats". Enabled by default.
+  cluster_health     :  yes/no        # Get metrics from "/_cluster/health". Enabled by default.
+  cluster_stats      :  yes/no        # Get metrics from "'/_cluster/stats". Enabled by default.
+  indices_stats      :  yes/no        # Get metrics from "/_cat/indices". Enabled by default.
 ```
 
-If no configuration is given, module will fail to run.
+If no configuration is given, module will try to connect to `http://127.0.0.1:9200`.
 
 ---
 

--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -1,6 +1,6 @@
 # elasticsearch
 
-This module monitors `Elasticsearch` performance and health metrics.
+This module monitors [`Elasticsearch`](https://www.elastic.co/products/elasticsearch) performance and health metrics.
 
 It produces:
 

--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -1,6 +1,6 @@
 # elasticsearch
 
-This module monitors [`Elasticsearch`](https://www.elastic.co/products/elasticsearch) performance and health metrics.
+This module monitors [Elasticsearch](https://www.elastic.co/products/elasticsearch) performance and health metrics.
 
 It produces:
 

--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -51,7 +51,7 @@ It produces:
     -   Store statistics
     -   Indices and shards statistics
 
-9.  **Indices** charts (per index statistics):
+9.  **Indices** charts (per index statistics, disabled by default):
 
     -   Docs count
     -   Store size
@@ -69,7 +69,7 @@ local:
   node_status        :  yes/no        # Get metrics from "/_nodes/_local/stats". Enabled by default.
   cluster_health     :  yes/no        # Get metrics from "/_cluster/health". Enabled by default.
   cluster_stats      :  yes/no        # Get metrics from "'/_cluster/stats". Enabled by default.
-  indices_stats      :  yes/no        # Get metrics from "/_cat/indices". Enabled by default.
+  indices_stats      :  yes/no        # Get metrics from "/_cat/indices". Disabled by default.
 ```
 
 If no configuration is given, module will try to connect to `http://127.0.0.1:9200`.

--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
@@ -487,7 +487,7 @@ CHARTS = {
         ]
     },
     'index_docs_count': {
-        'options': [None, 'Docs Count', 'num', 'indices', 'elastic.index_docs_count', 'line'],
+        'options': [None, 'Docs Count', 'count', 'indices', 'elastic.index_docs', 'line'],
         'lines': []
     },
     'index_store_size': {
@@ -495,7 +495,7 @@ CHARTS = {
         'lines': []
     },
     'index_replica': {
-        'options': [None, 'Replica', 'num', 'indices', 'elastic.index_replica', 'line'],
+        'options': [None, 'Replica', 'count', 'indices', 'elastic.index_replica', 'line'],
         'lines': []
     },
     'index_health': {

--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
@@ -576,7 +576,7 @@ class Service(UrlService):
             METHODS(
                 get_data=self._get_indices,
                 url=self.url + '/_cat/indices',
-                run=self.configuration.get('indices_stats', True),
+                run=self.configuration.get('indices_stats', False),
             ),
         ]
         return UrlService.check(self)

--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
@@ -168,6 +168,10 @@ ORDER = [
     'cluster_stats_store',
     'cluster_stats_indices',
     'cluster_stats_shards_total',
+    'index_docs_count',
+    'index_store_size',
+    'index_replica',
+    'index_health',
 ]
 
 CHARTS = {
@@ -483,8 +487,45 @@ CHARTS = {
         'lines': [
             ['http_current_open', 'opened', 'absolute', 1, 1]
         ]
-    }
+    },
+    'index_docs_count': {
+        'options': [None, 'Docs Count', 'num', 'indices', 'elastic.index_docs_count', 'line'],
+        'lines': []
+    },
+    'index_store_size': {
+        'options': [None, 'Store Size', 'bytes', 'indices', 'elastic.index_store_size', 'line'],
+        'lines': []
+    },
+    'index_replica': {
+        'options': [None, 'Replica', 'num', 'indices', 'elastic.index_replica', 'line'],
+        'lines': []
+    },
+    'index_health': {
+        'options': [None, 'Health', 'num', 'indices', 'elastic.index_health', 'line'],
+        'lines': []
+    },
 }
+
+
+def convert_index_health(health):
+    if health == 'green':
+        return 0
+    elif health == 'yellow':
+        return 1
+    elif health == 'read':
+        return 2
+    return -1
+
+
+def get_survive_any(method):
+    def w(*args):
+        try:
+            method(*args)
+        except Exception as error:
+            self, queue, url = args[0], args[1], args[2]
+            self.error("error during '{0}' : {1}".format(url, error))
+            queue.put(dict())
+    return w
 
 
 class Service(UrlService):
@@ -501,34 +542,41 @@ class Service(UrlService):
         )
         self.latency = dict()
         self.methods = list()
+        self.collected_indices = set()
 
     def check(self):
-        if not all([self.host,
-                    self.port,
-                    isinstance(self.host, str),
-                    isinstance(self.port, (str, int))]):
+        if not self.host:
             self.error('Host is not defined in the module configuration file')
             return False
 
-        # Hostname -> ip address
         try:
             self.host = gethostbyname(self.host)
         except gaierror as error:
-            self.error(str(error))
+            self.error(repr(error))
             return False
 
-        # Create URL for every Elasticsearch API
-        self.methods = [METHODS(get_data=self._get_node_stats,
-                                url=self.url + '/_nodes/_local/stats',
-                                run=self.configuration.get('node_stats', True)),
-                        METHODS(get_data=self._get_cluster_health,
-                                url=self.url + '/_cluster/health',
-                                run=self.configuration.get('cluster_health', True)),
-                        METHODS(get_data=self._get_cluster_stats,
-                                url=self.url + '/_cluster/stats',
-                                run=self.configuration.get('cluster_stats', True))]
-
-        # Remove disabled API calls from 'avail methods'
+        self.methods = [
+            METHODS(
+                get_data=self._get_node_stats,
+                url=self.url + '/_nodes/_local/stats',
+                run=self.configuration.get('node_stats', True),
+            ),
+            METHODS(
+                get_data=self._get_cluster_health,
+                url=self.url + '/_cluster/health',
+                run=self.configuration.get('cluster_health', True)
+            ),
+            METHODS(
+                get_data=self._get_cluster_stats,
+                url=self.url + '/_cluster/stats',
+                run=self.configuration.get('cluster_stats', True),
+            ),
+            METHODS(
+                get_data=self._get_indices,
+                url=self.url + '/_cat/indices',
+                run=self.configuration.get('indices_stats', True),
+            ),
+        ]
         return UrlService.check(self)
 
     def _get_data(self):
@@ -541,6 +589,7 @@ class Service(UrlService):
                 continue
             th = threading.Thread(target=method.get_data,
                                   args=(queue, method.url))
+            th.daemon = True
             th.start()
             threads.append(th)
 
@@ -550,88 +599,119 @@ class Service(UrlService):
 
         return result or None
 
+    def add_index_to_charts(self, idx_name):
+        for name in ('index_docs_count', 'index_store_size', 'index_replica', 'index_health'):
+            chart = self.charts[name]
+            dim = ['{0}_{1}'.format(idx_name, name), idx_name]
+            chart.add_dimension(dim)
+
+    @get_survive_any
+    def _get_indices(self, queue, url):
+        # [
+        #     {
+        #         "pri.store.size": "650b",
+        #         "health": "yellow",
+        #         "status": "open",
+        #         "index": "twitter",
+        #         "pri": "5",
+        #         "rep": "1",
+        #         "docs.count": "10",
+        #         "docs.deleted": "3",
+        #         "store.size": "650b"
+        #     }
+        # ]
+        raw_data = self._get_raw_data(url)
+        if not raw_data:
+            return queue.put(dict())
+
+        indices = self.json_parse(raw_data)
+        if not indices:
+            return queue.put(dict())
+
+        charts_initialized = len(self.charts) != 0
+        data = dict()
+        for idx in indices:
+            try:
+                name = idx['index']
+                v = {
+                    '{0}_index_docs_count'.format(name): idx['docs.count'],
+                    '{0}_index_store_size'.format(name): idx['store.size'][:-1],
+                    '{0}_index_replica'.format(name): idx['rep'],
+                    '{0}_index_health'.format(name): convert_index_health(idx['health']),
+                }
+            except KeyError as error:
+                self.debug("error on parsing index : {0}".format(repr(error)))
+                continue
+
+            data.update(v)
+            if name not in self.collected_indices and charts_initialized:
+                self.collected_indices.add(name)
+                self.add_index_to_charts(name)
+
+        return queue.put(data)
+
+    @get_survive_any
     def _get_cluster_health(self, queue, url):
-        """
-        Format data received from http request
-        :return: dict
-        """
-
-        raw_data = self._get_raw_data(url)
-
-        if not raw_data:
+        raw = self._get_raw_data(url)
+        if not raw:
             return queue.put(dict())
 
-        data = self.json_reply(raw_data)
-
-        if not data:
+        parsed = self.json_parse(raw)
+        if not parsed:
             return queue.put(dict())
 
-        to_netdata = fetch_data_(raw_data=data,
-                                 metrics=HEALTH_STATS)
+        data = fetch_data(raw_data=parsed, metrics=HEALTH_STATS)
 
-        to_netdata.update({'status_green': 0, 'status_red': 0, 'status_yellow': 0,
+        data.update({'status_green': 0, 'status_red': 0, 'status_yellow': 0,
                            'status_foo1': 0, 'status_foo2': 0, 'status_foo3': 0})
-        current_status = 'status_' + data['status']
-        to_netdata[current_status] = 1
+        current_status = 'status_' + parsed['status']
+        data[current_status] = 1
 
-        return queue.put(to_netdata)
+        return queue.put(data)
 
+    @get_survive_any
     def _get_cluster_stats(self, queue, url):
-        """
-        Format data received from http request
-        :return: dict
-        """
-
-        raw_data = self._get_raw_data(url)
-
-        if not raw_data:
+        raw = self._get_raw_data(url)
+        if not raw:
             return queue.put(dict())
 
-        data = self.json_reply(raw_data)
-
-        if not data:
+        parsed = self.json_parse(raw)
+        if not parsed:
             return queue.put(dict())
 
-        to_netdata = fetch_data_(raw_data=data,
-                                 metrics=CLUSTER_STATS)
+        data = fetch_data(raw_data=parsed, metrics=CLUSTER_STATS)
 
-        return queue.put(to_netdata)
+        return queue.put(data)
 
+    @get_survive_any
     def _get_node_stats(self, queue, url):
-        """
-        Format data received from http request
-        :return: dict
-        """
-
-        raw_data = self._get_raw_data(url)
-
-        if not raw_data:
+        raw = self._get_raw_data(url)
+        if not raw:
             return queue.put(dict())
 
-        data = self.json_reply(raw_data)
-
-        if not data:
+        parsed = self.json_parse(raw)
+        if not parsed:
             return queue.put(dict())
 
-        node = list(data['nodes'].keys())[0]
-        to_netdata = fetch_data_(raw_data=data['nodes'][node],
-                                 metrics=NODE_STATS)
+        node = list(parsed['nodes'].keys())[0]
+        data = fetch_data(raw_data=parsed['nodes'][node], metrics=NODE_STATS)
 
         # Search, index, flush, fetch performance latency
         for key in LATENCY:
             try:
-                to_netdata[key] = self.find_avg(total=to_netdata[LATENCY[key]['total']],
-                                                spent_time=to_netdata[LATENCY[key]['spent_time']],
-                                                key=key)
+                data[key] = self.find_avg(
+                    total=data[LATENCY[key]['total']],
+                    spent_time=data[LATENCY[key]['spent_time']],
+                    key=key)
             except KeyError:
                 continue
-        if 'process_open_file_descriptors' in to_netdata and 'process_max_file_descriptors' in to_netdata:
-            to_netdata['file_descriptors_used'] = round(float(to_netdata['process_open_file_descriptors'])
-                                                        / to_netdata['process_max_file_descriptors'] * 1000)
+        if 'process_open_file_descriptors' in data and 'process_max_file_descriptors' in data:
+            data['file_descriptors_used'] = round(float(data['process_open_file_descriptors'])
+                                                        / data['process_max_file_descriptors'] * 1000)
 
-        return queue.put(to_netdata)
+        return queue.put(data)
 
-    def json_reply(self, reply):
+    def json_parse(self, reply):
         try:
             return json.loads(reply)
         except ValueError as err:
@@ -640,8 +720,7 @@ class Service(UrlService):
 
     def find_avg(self, total, spent_time, key):
         if key not in self.latency:
-            self.latency[key] = dict(total=total,
-                                     spent_time=spent_time)
+            self.latency[key] = dict(total=total, spent_time=spent_time)
             return 0
         if self.latency[key]['total'] != total:
             latency = float(spent_time - self.latency[key]['spent_time'])\
@@ -653,7 +732,7 @@ class Service(UrlService):
         return 0
 
 
-def fetch_data_(raw_data, metrics):
+def fetch_data(raw_data, metrics):
     data = dict()
     for metric in metrics:
         value = raw_data
@@ -661,7 +740,7 @@ def fetch_data_(raw_data, metrics):
         try:
             for m in metrics_list:
                 value = value[m]
-        except KeyError:
+        except (KeyError, TypeError):
             continue
         data['_'.join(metrics_list)] = value
     return data

--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
@@ -502,7 +502,7 @@ CHARTS = {
         'lines': []
     },
     'index_health': {
-        'options': [None, 'Health', 'num', 'indices', 'elastic.index_health', 'line'],
+        'options': [None, 'Health', 'status', 'indices', 'elastic.index_health', 'line'],
         'lines': []
     },
 }

--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
@@ -575,7 +575,7 @@ class Service(UrlService):
             ),
             METHODS(
                 get_data=self._get_indices,
-                url=self.url + '/_cat/indices',
+                url=self.url + '/_cat/indices?format=json',
                 run=self.configuration.get('indices_stats', False),
             ),
         ]

--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
@@ -402,9 +402,6 @@ CHARTS = {
         'lines': [
             ['status_green', 'green', 'absolute'],
             ['status_red', 'red', 'absolute'],
-            ['status_foo1', None, 'absolute'],
-            ['status_foo2', None, 'absolute'],
-            ['status_foo3', None, 'absolute'],
             ['status_yellow', 'yellow', 'absolute']
         ]
     },
@@ -688,9 +685,6 @@ class Service(UrlService):
             'status_green': 0,
             'status_red': 0,
             'status_yellow': 0,
-            'status_foo1': 0,
-            'status_foo2': 0,
-            'status_foo3': 0,
         }
         data.update(dummy)
         current_status = 'status_' + parsed['status']

--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.conf
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.conf
@@ -61,11 +61,12 @@
 #
 # Additionally to the above, elasticsearch plugin also supports the following:
 #
-#     host: 'ipaddress'                # Server ip address or hostname.
-#     port: 'port'                     # Port on which elasticsearch  listen.
-#     scheme: 'scheme'                 # URL scheme. Default is 'http'.
-#     cluster_health: False/True       # Calls to cluster health elasticsearch API. Enabled by default.
-#     cluster_stats: False/True        # Calls to cluster stats elasticsearch API. Enabled by default.
+#  host               : 'ipaddress'    # Elasticsearch server ip address or hostname.
+#  port               : 'port'         # Port on which elasticsearch listens.
+#  node_status        :  yes/no        # Get metrics from "/_nodes/_local/stats". Enabled by default.
+#  cluster_health     :  yes/no        # Get metrics from "/_cluster/health". Enabled by default.
+#  cluster_stats      :  yes/no        # Get metrics from "'/_cluster/stats". Enabled by default.
+#  indices_stats      :  yes/no        # Get metrics from "/_cat/indices". Enabled by default.
 #
 #
 # if the URL is password protected, the following are supported:

--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.conf
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.conf
@@ -66,7 +66,7 @@
 #  node_status        :  yes/no        # Get metrics from "/_nodes/_local/stats". Enabled by default.
 #  cluster_health     :  yes/no        # Get metrics from "/_cluster/health". Enabled by default.
 #  cluster_stats      :  yes/no        # Get metrics from "'/_cluster/stats". Enabled by default.
-#  indices_stats      :  yes/no        # Get metrics from "/_cat/indices". Enabled by default.
+#  indices_stats      :  yes/no        # Get metrics from "/_cat/indices". Disabled by default.
 #
 #
 # if the URL is password protected, the following are supported:


### PR DESCRIPTION
##### Summary

Fixes: #6541

This PR adds per index metrics:
 - docs count
 - store size
 - number of replicas
 - health status

Modules gathers these metrics from `_cat/indices` endpoint. Per index metrics is optional and disabled by default.

##### Component Name

[`/collectors/python.d.plugin/elasticsearch`](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py)

##### Additional Information

