### PR TITLE
web api: include family into allmetrics json response

### DIFF
--- a/web/api/exporters/shell/allmetrics_shell.c
+++ b/web/api/exporters/shell/allmetrics_shell.c
@@ -108,6 +108,7 @@ void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, BUFFER *wb) {
             buffer_sprintf(wb, "%s\n"
                                "\t\"%s\": {\n"
                                "\t\t\"name\":\"%s\",\n"
+                               "\t\t\"family\":\"%s\",\n"
                                "\t\t\"context\":\"%s\",\n"
                                "\t\t\"units\":\"%s\",\n"
                                "\t\t\"last_updated\": %ld,\n"
@@ -115,6 +116,7 @@ void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, BUFFER *wb) {
                            , chart_counter?",":""
                            , st->id
                            , st->name
+                           , st->family
                            , st->context
                            , st->units
                            , rrdset_last_entry_t(st)


### PR DESCRIPTION
##### Summary

This PR adds family to `allmetrics?format=json` response.

Sometimes we encode meaningful things in family.
Example: vsphere collector [vm charts family](https://github.com/netdata/go.d.plugin/blob/master/modules/vsphere/charts.go#L154)
 - virtual machine name
 - host name

The main problem is lack of labels of course. But still i dont see any reason to not include family in json allmetrics response .

rel issue: https://github.com/netdata/go.d.plugin/issues/274

##### Component Name

[/web/api/exporters](https://github.com/netdata/netdata/tree/master/web/api/exporters/shell)

##### Additional Information

