### PR TITLE
rabbitmq: collect vhosts msg metrics from `/api/vhosts`

### DIFF
--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -1,6 +1,6 @@
 # rabbitmq
 
-Module monitor rabbitmq performance and health metrics.
+Module monitor [`RabbitMQ`](https://www.rabbitmq.com/) performance and health metrics.
 
 Following charts are drawn:
 
@@ -47,6 +47,20 @@ Following charts are drawn:
 9.  **Disk Space**
 
     -   free disk space in gigabytes
+
+
+Per Vhost charts:
+
+1.  **Vhost Messages**
+
+    -   ack
+    -   confirm
+    -   deliver
+    -   get
+    -   get_no_ack
+    -   publish
+    -   redeliver
+    -   return_unroutable
 
 ## configuration
 

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -1,6 +1,6 @@
 # rabbitmq
 
-Module monitor [`RabbitMQ`](https://www.rabbitmq.com/) performance and health metrics.
+This module monitors [RabbitMQ](https://www.rabbitmq.com/) performance and health metrics.
 
 Following charts are drawn:
 

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -139,7 +139,7 @@ def vhost_chart_template(name):
     charts = {
         order[0]: {
             'options': [
-                None, 'Vhost "{0}" Messages'.format(name), 'msg/s', family, 'rabbitmq.vhost_messages', 'stacked'],
+                None, 'Vhost "{0}" Messages'.format(name), 'messages/s', family, 'rabbitmq.vhost_messages', 'stacked'],
             'lines': [
                 ['vhost_{0}_message_stats_ack'.format(name), 'ack', 'incremental'],
                 ['vhost_{0}_message_stats_confirm'.format(name), 'confirm', 'incremental'],

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -134,7 +134,7 @@ def vhost_chart_template(name):
     order = [
         'vhost_{0}_message_stats'.format(name),
     ]
-    family = name
+    family = 'vhost {0}'.format(name)
 
     charts = {
         order[0]: {

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -123,14 +123,7 @@ CHARTS = {
 }
 
 
-def normalize_vhost_name(name):
-    if name.startswith('/') and len(name) > 1:
-        return name[1:]
-    return name
-
-
 def vhost_chart_template(name):
-    name = normalize_vhost_name(name)
     order = [
         'vhost_{0}_message_stats'.format(name),
     ]
@@ -164,7 +157,7 @@ class VhostStatsBuilder:
         self.stats = raw_stats
 
     def name(self):
-        return normalize_vhost_name(self.stats['name'])
+        return self.stats['name']
 
     def has_msg_stats(self):
         return bool(self.stats.get('message_stats'))

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -9,6 +9,7 @@ from bases.FrameworkServices.UrlService import UrlService
 
 API_NODE = 'api/nodes'
 API_OVERVIEW = 'api/overview'
+API_VHOSTS = 'api/vhosts'
 
 NODE_STATS = [
     'fd_used',
@@ -31,6 +32,17 @@ OVERVIEW_STATS = [
     'message_stats.redeliver',
     'message_stats.deliver',
     'message_stats.publish'
+]
+
+VHOST_MESSAGE_STATS = [
+    'message_stats.ack',
+    'message_stats.confirm',
+    'message_stats.deliver',
+    'message_stats.get',
+    'message_stats.get_no_ack',
+    'message_stats.publish',
+    'message_stats.redeliver',
+    'message_stats.return_unroutable',
 ]
 
 ORDER = [
@@ -111,6 +123,49 @@ CHARTS = {
 }
 
 
+def vhost_chart_template(name):
+    order = [
+        'vhost_{0}_message_stats'.format(name),
+    ]
+
+    charts = {
+        order[0]: {
+            'options': [
+                None, 'Vhost "{0}" Messages'.format(name), 'msg/s', "vhosts", 'rabbitmq.vhost_messages', 'stacked'],
+            'lines': [
+                ['vhost_{0}_message_stats_ack'.format(name), 'ack', 'incremental'],
+                ['vhost_{0}_message_stats_confirm'.format(name), 'confirm', 'incremental'],
+                ['vhost_{0}_message_stats_deliver'.format(name), 'deliver', 'incremental'],
+                ['vhost_{0}_message_stats_get'.format(name), 'get', 'incremental'],
+                ['vhost_{0}_message_stats_get_no_ack'.format(name), 'get_no_ack', 'incremental'],
+                ['vhost_{0}_message_stats_publish'.format(name), 'publish', 'incremental'],
+                ['vhost_{0}_message_stats_redeliver'.format(name), 'redeliver', 'incremental'],
+                ['vhost_{0}_message_stats_return_unroutable'.format(name), 'return_unroutable', 'incremental'],
+            ]
+        },
+    }
+
+    return order, charts
+
+
+class VhostStatsBuilder:
+    def __init__(self):
+        self.stats = None
+
+    def set(self, raw_stats):
+        self.stats = raw_stats
+
+    def name(self):
+        return self.stats['name']
+
+    def has_msg_stats(self):
+        return bool(self.stats.get('message_stats'))
+
+    def msg_stats(self):
+        stats = fetch_data(raw_data=self.stats, metrics=VHOST_MESSAGE_STATS)
+        return dict(('vhost_{0}_{1}'.format(self.name(), k), v) for k, v in stats.items())
+
+
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
@@ -122,19 +177,25 @@ class Service(UrlService):
             configuration.get('port', 15672),
         )
         self.node_name = str()
+        self.vhost = VhostStatsBuilder()
+        self.collected_vhosts = set()
 
     def _get_data(self):
         data = dict()
 
         stats = self.get_overview_stats()
-
         if not stats:
             return None
 
         data.update(stats)
 
         stats = self.get_nodes_stats()
+        if not stats:
+            return None
 
+        data.update(stats)
+
+        stats = self.get_vhosts_stats()
         if not stats:
             return None
 
@@ -144,41 +205,67 @@ class Service(UrlService):
 
     def get_overview_stats(self):
         url = '{0}/{1}'.format(self.url, API_OVERVIEW)
-
         raw = self._get_raw_data(url)
-
         if not raw:
             return None
 
         data = loads(raw)
-
         self.node_name = data['node']
-
         return fetch_data(raw_data=data, metrics=OVERVIEW_STATS)
 
     def get_nodes_stats(self):
         url = '{0}/{1}/{2}'.format(self.url, API_NODE, self.node_name)
-
         raw = self._get_raw_data(url)
-
         if not raw:
             return None
 
         data = loads(raw)
-
         return fetch_data(raw_data=data, metrics=NODE_STATS)
+
+    def get_vhosts_stats(self):
+        url = '{0}/{1}'.format(self.url, API_VHOSTS)
+        raw = self._get_raw_data(url)
+        if not raw:
+            return None
+
+        data = dict()
+        vhosts = loads(raw)
+        charts_initialized = len(self.charts) > 0
+
+        for vhost in vhosts:
+            self.vhost.set(vhost)
+            if not self.vhost.has_msg_stats():
+                continue
+
+            if charts_initialized and self.vhost.name() not in self.collected_vhosts:
+                self.collected_vhosts.add(self.vhost.name())
+                self.add_vhost_charts(self.vhost.name())
+
+            data.update(self.vhost.msg_stats())
+
+        return data
+
+    def add_vhost_charts(self, vhost_name):
+        order, charts = vhost_chart_template(vhost_name)
+
+        for chart_name in order:
+            params = [chart_name] + charts[chart_name]['options']
+            dimensions = charts[chart_name]['lines']
+
+            new_chart = self.charts.add_chart(params)
+            for dimension in dimensions:
+                new_chart.add_dimension(dimension)
 
 
 def fetch_data(raw_data, metrics):
     data = dict()
-
     for metric in metrics:
         value = raw_data
         metrics_list = metric.split('.')
         try:
             for m in metrics_list:
                 value = value[m]
-        except KeyError:
+        except (KeyError, TypeError):
             continue
         data['_'.join(metrics_list)] = value
 


### PR DESCRIPTION
##### Summary

Fixes: #6686

This PR adds per vhost message stats metrics.

Message stats:
  -  ack
  -  confirm
  -  deliver
  -  get
  -  get_no_ack
  -  publish
  -  redeliver
  -  return_unroutable

Modules gathers these metrics from `/api/vhosts` endpoint.

##### Component Name

[`/collectors/python.d.plugin/rabbitmq`](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/elasticsearch/rabbitmq.chart.py)

##### Additional Information

