### PR TITLE
mysql: add cluster_status alarm

### DIFF
--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -132,3 +132,15 @@ template: mysql_galera_cluster_state
    delay: up 30s down 5m multiplier 1.5 max 1h
     info: node state (0: undefined, 1: joining, 2: donor/desynced, 3: joined, 4: synced)
       to: dba
+
+
+# galera node status
+
+template: mysql_galera_cluster_status
+      on: mysql.galera_cluster_status
+    calc: $wsrep_cluster_status
+   every: 10s
+    crit: $mysql_galera_cluster_state != nan AND $this != 0
+   delay: up 30s down 5m multiplier 1.5 max 1h
+    info: node and cluster status (-1: unknown, 0: primary/quorum present, 1: non-primary/quorum lost, 2: disconnected)
+      to: dba


### PR DESCRIPTION
##### Summary

galera cluster status alarm suggested by @ekexcello in https://github.com/netdata/netdata/pull/6962#issuecomment-537002612

Added as a separate PR because the alarm is false positive until #6980 is fixed.

Should be merged after #6984

##### Component Name

[health/health.d/mysql.conf](https://github.com/netdata/netdata/blob/master/health/health.d/mysql.conf)

##### Additional Information

