### PR TITLE
netdata/packaging: Refine devel packaging pipeline, update .travis/README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,12 @@ install:
   - export LATEST_RELEASE_DATE="$(git log -1 --format=%aD "${LATEST_RELEASE_VERSION}" | cat)"
   - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export BUILD_VERSION="$(cat packaging/version | cut -d'-' -f1,2 | sed -e 's/-/./g').latest"; fi;
   - export DEPLOY_REPO="netdata"  # Default production packaging repository
-  - export PACKAGING_USER="netdata" # Standard package cloud account
   - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export DEPLOY_REPO="netdata-edge"; fi;
-  - export PACKAGE_CLOUD_RETENTION_DAYS=30
   - if [ ! "${TRAVIS_REPO_SLUG}" = "netdata/netdata" ]; then export DEPLOY_REPO="netdata-devel";  fi;
+  - export PKG_DEPLOYMENT_GIT_REPO="master" # By default, we expect to publish from master branch
+  - if [ "${DEPLOY_REPO}" = "netdata-devel" -a "${TRAVIS_EVENT_TYPE}" = "push" ]; the export PKG_DEPLOYMENT_GIT_REPO="${TRAVIS_BRANCH}"; fi; # If netdata-devel and is not PR or api call, allow publishing from whatever that branch is
+  - export PACKAGING_USER="netdata" # Standard package cloud account
+  - export PACKAGE_CLOUD_RETENTION_DAYS=30
   # These are release-related artifacts and have to be evaluated before we start doing conditional checks inside stages
   - source ".travis/tagger.sh"
   - export GIT_TAG="$(git tag --points-at)"
@@ -303,7 +305,7 @@ jobs:
             on:
               # Only deploy on ${USER}/netdata, master branch, when build-area directory is created
               repo: ${TRAVIS_REPO_SLUG}
-              branch: "master"
+              branch: "${PKG_DEPLOYMENT_GIT_REPO}"
               condition: -d "${PACKAGES_DIRECTORY}"
         after_deploy:
           - if [ -n "${BUILDER_NAME}" ]; then rm -rf /home/${BUILDER_NAME}/* && echo "Cleared /home/${BUILDER_NAME} directory" || echo "Failed to clean /home/${BUILDER_NAME} directory"; fi;
@@ -409,7 +411,7 @@ jobs:
             on:
               # Only deploy on ${USER}/netdata, master branch, when packages directory is created
               repo: ${TRAVIS_REPO_SLUG}
-              branch: "master"
+              branch: "${PKG_DEPLOYMENT_GIT_REPO}"
               condition: -d "${PACKAGES_DIRECTORY}"
         after_deploy:
           - if [ -n "${BUILDER_NAME}" ]; then rm -rf /home/${BUILDER_NAME}/* && echo "Cleared /home/${BUILDER_NAME} directory" || echo "Failed to clean /home/${BUILDER_NAME} directory"; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - if [[ "${TRAVIS_COMMIT_MESSAGE}" = *"[Build latest]"* ]]; then export DEPLOY_REPO="netdata-edge"; fi;
   - if [ ! "${TRAVIS_REPO_SLUG}" = "netdata/netdata" ]; then export DEPLOY_REPO="netdata-devel";  fi;
   - export PKG_DEPLOYMENT_GIT_REPO="master" # By default, we expect to publish from master branch
-  - if [ "${DEPLOY_REPO}" = "netdata-devel" -a "${TRAVIS_EVENT_TYPE}" = "push" ]; the export PKG_DEPLOYMENT_GIT_REPO="${TRAVIS_BRANCH}"; fi; # If netdata-devel and is not PR or api call, allow publishing from whatever that branch is
+  - if [ "${DEPLOY_REPO}" = "netdata-devel" -a "${TRAVIS_EVENT_TYPE}" = "push" ]; then export PKG_DEPLOYMENT_GIT_REPO="${TRAVIS_BRANCH}"; fi; # If netdata-devel and is not PR or api call, allow publishing from whatever that branch is
   - export PACKAGING_USER="netdata" # Standard package cloud account
   - export PACKAGE_CLOUD_RETENTION_DAYS=30
   # These are release-related artifacts and have to be evaluated before we start doing conditional checks inside stages

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -52,7 +52,7 @@ override_dh_install: debian/netdata.postinst
 	mkdir -p $(TOP)/etc/netdata/health.d
 	mkdir -p $(TOP)/etc/netdata/python.d
 	mkdir -p $(TOP)/etc/netdata/charts.d
-	mkdir -p $(TOP)/etc/netdata/cystonm-plugins.d
+	mkdir -p $(TOP)/etc/netdata/custom-plugins.d
 	mkdir -p $(TOP)/etc/netdata/go.d
 	mkdir -p $(TOP)/etc/netdata/ssl
 	mkdir -p $(TOP)/etc/netdata/node.d


### PR DESCRIPTION
##### Summary
This PR is about updating our .travis/README. to become more up to date with the latest developments.

It also includes a change in our pipelines, so that binary package publishing to `netdata/netdata-devel` becomes easier for the developer.

I have modified a guard condition on the deployment provider for package cloud, so that when the repository is NOT `netdata/netdata` and the trigger is basically a commit push, then the guard would simple be set to the branch name. With this change if a developer has issued a packaging trigger on a branch on his own git repository, the pipeline will attempt to publish the package to netdata-devel after building it, provided that the developer's Travis CI is properly linked to his forked repository.

**Note**: @knatsakis i will need your help on bringing this on your own repo, then push it to your own forked remote and verify it works because i have removed all set ups from my accounts. I will be available for any questions or any walkthroughs you might need on this.

@joelhans As usual i will need your valuable input on the readme changes. I am open to discuss overall the structure of this document since i went in update it, so anything you see except the actual changes feel free to propose.

##### Component Name
netdata/packaging

##### Additional Information
**Note**: I have pushed in this PR a minor typo i found when troubleshooting a packaging issue.
It's the most recent commit seen.