### PR TITLE
Remove warning from Coverity

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -584,21 +584,19 @@ void rrdcalc_unlink_and_free(RRDHOST *host, RRDCALC *rc) {
             error("Cannot unlink alarm '%s.%s' from host '%s': not found", rc->chart?rc->chart:"NOCHART", rc->name, host->hostname);
     }
 
-    if (rc) {
-        RRDCALC *rdcmp = (RRDCALC *) avl_search_lock(&(host)->alarms_idx_health_log, (avl *)rc);
-        if (rdcmp) {
-            rdcmp = (RRDCALC *) avl_remove_lock(&(host)->alarms_idx_health_log, (avl *)rc);
-            if (!rdcmp) {
-                error("Cannot remove the health alarm index from health_log");
-            }
+    RRDCALC *rdcmp = (RRDCALC *) avl_search_lock(&(host)->alarms_idx_health_log, (avl *)rc);
+    if (rdcmp) {
+        rdcmp = (RRDCALC *) avl_remove_lock(&(host)->alarms_idx_health_log, (avl *)rc);
+        if (!rdcmp) {
+            error("Cannot remove the health alarm index from health_log");
         }
+    }
 
-        rdcmp = (RRDCALC *) avl_search_lock(&(host)->alarms_idx_name, (avl *)rc);
-        if (rdcmp) {
-            rdcmp = (RRDCALC *) avl_remove_lock(&(host)->alarms_idx_name, (avl *)rc);
-            if (!rdcmp) {
-                error("Cannot remove the health alarm index from idx_name");
-            }
+    rdcmp = (RRDCALC *) avl_search_lock(&(host)->alarms_idx_name, (avl *)rc);
+    if (rdcmp) {
+        rdcmp = (RRDCALC *) avl_remove_lock(&(host)->alarms_idx_name, (avl *)rc);
+        if (!rdcmp) {
+            error("Cannot remove the health alarm index from idx_name");
         }
     }
 

--- a/libnetdata/eval/eval.c
+++ b/libnetdata/eval/eval.c
@@ -1077,7 +1077,6 @@ int expression_evaluate(EVAL_EXPRESSION *expression) {
         // although there is an unknown variable
         // the expression was evaluated successfully
         expression->error = EVAL_ERROR_OK;
-        expression->result = NAN;
     }
 
     if(expression->error != EVAL_ERROR_OK) {

--- a/libnetdata/eval/eval.c
+++ b/libnetdata/eval/eval.c
@@ -1077,6 +1077,7 @@ int expression_evaluate(EVAL_EXPRESSION *expression) {
         // although there is an unknown variable
         // the expression was evaluated successfully
         expression->error = EVAL_ERROR_OK;
+        expression->result = NAN;
     }
 
     if(expression->error != EVAL_ERROR_OK) {


### PR DESCRIPTION
##### Summary
Coverity reported us that on CID 348642 that we have an unnecessary check on our code, this PR is moving up the code inside ```if``` to remove the issue reported.
##### Component Name
Database
Health
##### Additional Information

