### PR TITLE
Fix crash on FreeBSD due to do_dev_cpu_temperature stack corruption

### DIFF
--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -470,7 +470,7 @@ int do_dev_cpu_temperature(int update_every, usec_t dt) {
         pcpu_temperature = reallocz(pcpu_temperature, sizeof(int) * number_of_cpus);
         mib = reallocz(mib, sizeof(int) * number_of_cpus * 4);
         if (unlikely(number_of_cpus > old_number_of_cpus))
-            memset(&mib[old_number_of_cpus * 4], 0, sizeof(RRDDIM) * (number_of_cpus - old_number_of_cpus));
+            memset(&mib[old_number_of_cpus * 4], 0, 4 * (number_of_cpus - old_number_of_cpus));
     }
     for (i = 0; i < number_of_cpus; i++) {
         if (unlikely(!(mib[i * 4])))


### PR DESCRIPTION
##### Summary

fixes #7010

Fix for the issue #7010. I am not 100% sure if it is valid, but i made it in accordance with other plugins in the freebsd collector code. Please review. For me it fix crashe and valgrind report.

##### Component Name

FreeBSD plugin

##### Additional Information
See #7010 and [valgrind report](https://github.com/netdata/netdata/issues/7010#issuecomment-539354446)
