### PR TITLE
netdata/ci: fix package generation flow, during release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -520,15 +520,8 @@ jobs:
         - echo "packaging/version:" && cat packaging/version
         - echo "Generating release artifacts" && .travis/create_artifacts.sh  # Could/should be a common storage to put this and share between jobs
         - .travis/draft_release.sh
+        - echo "Triggering package generation for release" && .travis/trigger_package_generation.sh
       after_failure: post_message "TRAVIS_MESSAGE" "<!here> Draft release submission failed"
-
-    - name: Trigger .RPM and .DEB package generation
-      before_script: post_message "TRAVIS_MESSAGE" "Starting RPM and DEB package generation for release" "${NOTIF_CHANNEL}"
-      script:
-        - .travis/trigger_package_generation.sh
-      after_failure: post_message "TRAVIS_MESSAGE" "<!here> Stable release package generation produced errors" "${NOTIF_CHANNEL}"
-      git:
-        depth: false
 
 
 
@@ -566,6 +559,8 @@ jobs:
       script:
         - DEPLOY_REPO="netdata-edge" .travis/package_management/old_package_purging.sh
         - DEPLOY_REPO="netdata-devel" .travis/package_management/old_package_purging.sh
+
+
 
     # This is the nightly execution step
     #


### PR DESCRIPTION

##### Summary
Because tasks within a stage run in parallel, this messes up our workflow for the release.
We rely on the set of commits in place to take decisions, so packaging must be triggered once draft release is complete.

To achieve that, we remove the separate step and make package generation a job within the draft release generation

##### Component Name
netdata/ci

##### Additional Information
Fix for the release process