### PR TITLE
Disable slabinfo plugin by default

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -779,6 +779,9 @@ void *pluginsd_main(void *ptr) {
     int scan_frequency = (int) config_get_number(CONFIG_SECTION_PLUGINS, "check for new plugins every", 60);
     if(scan_frequency < 1) scan_frequency = 1;
 
+    // disable some plugins by default
+    config_get_boolean(CONFIG_SECTION_PLUGINS, "slabinfo", CONFIG_BOOLEAN_NO);
+
     // store the errno for each plugins directory
     // so that we don't log broken directories on each loop
     int directory_errors[PLUGINSD_MAX_DIRECTORIES] =  { 0 };

--- a/collectors/slabinfo.plugin/README.md
+++ b/collectors/slabinfo.plugin/README.md
@@ -7,7 +7,9 @@ Each internal structure (process, file descriptor, inode...) is stored within a 
 
 ## configuring Netdata for slabinfo
 
-There is currently no configuration needed.
+The plugin is disabled by default because it collects and displays a huge amount of metrics.
+
+There is currently no configuration needed for the plugin itself.
 
 As `/proc/slabinfo` is only readable by root, this plugin is setuid root.
 

--- a/collectors/slabinfo.plugin/README.md
+++ b/collectors/slabinfo.plugin/README.md
@@ -4,10 +4,10 @@ SLAB is a cache mechanism used by the Kernel to avoid fragmentation.
 
 Each internal structure (process, file descriptor, inode...) is stored within a SLAB.
 
-
 ## configuring Netdata for slabinfo
 
 The plugin is disabled by default because it collects and displays a huge amount of metrics.
+To enable it set `slabinfo = yes` in the `plugins` section of the `netdata.conf` configuration file.
 
 There is currently no configuration needed for the plugin itself.
 


### PR DESCRIPTION
##### Summary
There are a lot of metrics in slabinfo charts. Hundreds or even thousands (depends on host). Thus, we are disabling the slabinfo charts by default.

Fixes #7053

##### Component Name
slabinfo plugin