### PR TITLE
feat(reaper): Add process reaper support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -129,5 +129,6 @@ This is the list of contributors that have signed this agreement:
 |@skrzyp1|Jerzy S.||
 |@akwan|Alan Kwan||
 |@underhood|Timotej Šiškovič||
+|@stevenh|Steven Hartland|steven.hartland@multiplay.co.uk|
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2FCONTRIBUTORS&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -647,7 +647,7 @@ static void pluginsd_worker_thread_cleanup(void *arg) {
         if (cd->pid) {
             siginfo_t info;
             info("killing child process pid %d", cd->pid);
-            if (killpid(cd->pid, SIGTERM) != -1) {
+            if (killpid(cd->pid) != -1) {
                 info("waiting for child process pid %d to exit...", cd->pid);
                 waitid(P_PID, (id_t) cd->pid, &info, WEXITED);
             }
@@ -738,7 +738,7 @@ void *pluginsd_worker_thread(void *arg) {
         info("connected to '%s' running on pid %d", cd->fullfilename, cd->pid);
         count = pluginsd_process(localhost, cd, fp, 0);
         error("'%s' (pid %d) disconnected after %zu successful data collections (ENDs).", cd->fullfilename, cd->pid, count);
-        killpid(cd->pid, SIGTERM);
+        killpid(cd->pid);
 
         int worker_ret_code = mypclose(fp, cd->pid);
 

--- a/collectors/tc.plugin/plugin_tc.c
+++ b/collectors/tc.plugin/plugin_tc.c
@@ -851,12 +851,11 @@ static void tc_main_cleanup(void *ptr) {
 
     if(tc_child_pid) {
         info("TC: killing with SIGTERM tc-qos-helper process %d", tc_child_pid);
-        if(killpid(tc_child_pid, SIGTERM) != -1) {
+        if(killpid(tc_child_pid) != -1) {
             siginfo_t info;
 
             info("TC: waiting for tc plugin child process pid %d to exit...", tc_child_pid);
             waitid(P_PID, (id_t) tc_child_pid, &info, WEXITED);
-            // info("TC: finished tc plugin child process pid %d.", tc_child_pid);
         }
 
         tc_child_pid = 0;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -146,44 +146,26 @@ void web_server_config_options(void) {
 }
 
 
-int killpid(pid_t pid, int signal)
-{
-    int ret = -1;
+// killpid kills pid with SIGTERM.
+int killpid(pid_t pid) {
+    int ret;
     debug(D_EXIT, "Request to kill pid %d", pid);
 
     errno = 0;
-    if(kill(pid, 0) == -1) {
+    ret = kill(pid, SIGTERM);
+    if (ret == -1) {
         switch(errno) {
             case ESRCH:
-                error("Request to kill pid %d, but it is not running.", pid);
-                break;
+                // We wanted the process to exit so just let the caller handle.
+                return ret;
 
             case EPERM:
-                error("Request to kill pid %d, but I do not have enough permissions.", pid);
+                error("Cannot kill pid %d, but I do not have enough permissions.", pid);
                 break;
 
             default:
-                error("Request to kill pid %d, but I received an error.", pid);
+                error("Cannot kill pid %d, but I received an error.", pid);
                 break;
-        }
-    }
-    else {
-        errno = 0;
-        ret = kill(pid, signal);
-        if(ret == -1) {
-            switch(errno) {
-                case ESRCH:
-                    error("Cannot kill pid %d, but it is not running.", pid);
-                    break;
-
-                case EPERM:
-                    error("Cannot kill pid %d, but I do not have enough permissions.", pid);
-                    break;
-
-                default:
-                    error("Cannot kill pid %d, but I received an error.", pid);
-                    break;
-            }
         }
     }
 

--- a/daemon/main.h
+++ b/daemon/main.h
@@ -41,7 +41,7 @@ struct netdata_static_thread {
 };
 
 extern void cancel_main_threads(void);
-extern int killpid(pid_t pid, int signal);
+extern int killpid(pid_t pid);
 extern void netdata_cleanup_and_exit(int ret) NORETURN;
 extern void send_statistics(const char *action, const char *action_result, const char *action_data);
 

--- a/daemon/signals.c
+++ b/daemon/signals.c
@@ -132,12 +132,12 @@ static void reap_child(pid_t pid) {
     siginfo_t i;
 
     errno = 0;
-    info("SIGNAL: Reaping pid: %d...", pid);
+    debug("SIGNAL: Reaping pid: %d...", pid);
     if (waitid(P_PID, (id_t)pid, &i, WEXITED|WNOHANG) == -1) {
         if (errno != ECHILD)
             error("SIGNAL: Failed to wait for: %d", pid);
         else
-            info("SIGNAL: Already reaped: %d", pid);
+            debug("SIGNAL: Already reaped: %d", pid);
         return;
     } else if (i.si_pid == 0) {
         // Process didn't exit, this shouldn't happen.
@@ -146,25 +146,25 @@ static void reap_child(pid_t pid) {
 
     switch (i.si_code) {
     case CLD_EXITED:
-        info("SIGNAL: Child %d exited: %d", pid, i.si_status);
+        debug("SIGNAL: Child %d exited: %d", pid, i.si_status);
         break;
     case CLD_KILLED:
-        info("SIGNAL: Child %d killed by signal: %d", pid, i.si_status);
+        debug("SIGNAL: Child %d killed by signal: %d", pid, i.si_status);
         break;
     case CLD_DUMPED:
-        info("SIGNAL: Child %d dumped core by signal: %d", pid, i.si_status);
+        debug("SIGNAL: Child %d dumped core by signal: %d", pid, i.si_status);
         break;
     case CLD_STOPPED:
-        info("SIGNAL: Child %d stopped by signal: %d", pid, i.si_status);
+        debug("SIGNAL: Child %d stopped by signal: %d", pid, i.si_status);
         break;
     case CLD_TRAPPED:
-        info("SIGNAL: Child %d trapped by signal: %d", pid, i.si_status);
+        debug("SIGNAL: Child %d trapped by signal: %d", pid, i.si_status);
         break;
     case CLD_CONTINUED:
-        info("SIGNAL: Child %d continued by signal: %d", pid, i.si_status);
+        debug("SIGNAL: Child %d continued by signal: %d", pid, i.si_status);
         break;
     default:
-        error("SIGNAL: Child %d gave us a SIGCHLD with code %d and status %d.", pid, i.si_code, i.si_status);
+        debug("SIGNAL: Child %d gave us a SIGCHLD with code %d and status %d.", pid, i.si_code, i.si_status);
     }
 }
 
@@ -250,7 +250,7 @@ void signals_handle(void) {
                                 fatal("SIGNAL: Received %s. netdata now exits.", name);
 
                             case NETDATA_SIGNAL_CHILD:
-                                info("SIGNAL: Received %s. Reaping...", name);
+                                debug("SIGNAL: Received %s. Reaping...", name);
                                 reap_children();
                                 break;
 

--- a/daemon/signals.c
+++ b/daemon/signals.c
@@ -132,12 +132,12 @@ static void reap_child(pid_t pid) {
     siginfo_t i;
 
     errno = 0;
-    debug("SIGNAL: Reaping pid: %d...", pid);
+    debug(D_CHILDS, "SIGNAL: Reaping pid: %d...", pid);
     if (waitid(P_PID, (id_t)pid, &i, WEXITED|WNOHANG) == -1) {
         if (errno != ECHILD)
             error("SIGNAL: Failed to wait for: %d", pid);
         else
-            debug("SIGNAL: Already reaped: %d", pid);
+            debug(D_CHILDS, "SIGNAL: Already reaped: %d", pid);
         return;
     } else if (i.si_pid == 0) {
         // Process didn't exit, this shouldn't happen.
@@ -146,25 +146,25 @@ static void reap_child(pid_t pid) {
 
     switch (i.si_code) {
     case CLD_EXITED:
-        debug("SIGNAL: Child %d exited: %d", pid, i.si_status);
+        debug(D_CHILDS, "SIGNAL: Child %d exited: %d", pid, i.si_status);
         break;
     case CLD_KILLED:
-        debug("SIGNAL: Child %d killed by signal: %d", pid, i.si_status);
+        debug(D_CHILDS, "SIGNAL: Child %d killed by signal: %d", pid, i.si_status);
         break;
     case CLD_DUMPED:
-        debug("SIGNAL: Child %d dumped core by signal: %d", pid, i.si_status);
+        debug(D_CHILDS, "SIGNAL: Child %d dumped core by signal: %d", pid, i.si_status);
         break;
     case CLD_STOPPED:
-        debug("SIGNAL: Child %d stopped by signal: %d", pid, i.si_status);
+        debug(D_CHILDS, "SIGNAL: Child %d stopped by signal: %d", pid, i.si_status);
         break;
     case CLD_TRAPPED:
-        debug("SIGNAL: Child %d trapped by signal: %d", pid, i.si_status);
+        debug(D_CHILDS, "SIGNAL: Child %d trapped by signal: %d", pid, i.si_status);
         break;
     case CLD_CONTINUED:
-        debug("SIGNAL: Child %d continued by signal: %d", pid, i.si_status);
+        debug(D_CHILDS, "SIGNAL: Child %d continued by signal: %d", pid, i.si_status);
         break;
     default:
-        debug("SIGNAL: Child %d gave us a SIGCHLD with code %d and status %d.", pid, i.si_code, i.si_status);
+        debug(D_CHILDS, "SIGNAL: Child %d gave us a SIGCHLD with code %d and status %d.", pid, i.si_code, i.si_status);
     }
 }
 
@@ -250,7 +250,7 @@ void signals_handle(void) {
                                 fatal("SIGNAL: Received %s. netdata now exits.", name);
 
                             case NETDATA_SIGNAL_CHILD:
-                                debug("SIGNAL: Received %s. Reaping...", name);
+                                debug(D_CHILDS, "SIGNAL: Received %s. Reaping...", name);
                                 reap_children();
                                 break;
 

--- a/libnetdata/popen/popen.h
+++ b/libnetdata/popen/popen.h
@@ -11,6 +11,9 @@
 extern FILE *mypopen(const char *command, volatile pid_t *pidptr);
 extern FILE *mypopene(const char *command, volatile pid_t *pidptr, char **env);
 extern int mypclose(FILE *fp, pid_t pid);
+extern void myp_init(void);
+extern void myp_free(void);
+extern int myp_reap(pid_t pid);
 
 extern void signals_unblock(void);
 extern void signals_reset(void);


### PR DESCRIPTION
##### Summary
Add a child process reaper to the main netdata app if running as init (pid = 1).

This prevents zombie processes when a child is re-parented to netdata when its running in a container.

Also:
* Few style cleanups to match surrounding code.

Fixes: #6033

##### Component Name
netdata binary

##### Additional Information
This re-purposes old commented out code in `popen.c`, which already implemented part of the required process tracking.

Without this on a standard netdata docker install we saw at least one zombie `timeout` process straight after the container was started.