### PR TITLE
Partial fix for #7039

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1050,63 +1050,13 @@ END
 echo >&2 "Uninstall script copied to: ${TPUT_RED}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata/netdata-uninstaller.sh${TPUT_RESET}"
 echo >&2
 
+# -----------------------------------------------------------------------------
 progress "Install netdata updater tool"
 
-if [ -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh ]; then
-	echo >&2 "Removing updater from previous location"
-	rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh
-fi
+install_or_remove_netdata_updater || run_failed "Cannot install netdata updater tool."
 
-if [ -f "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" ]; then
-	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
-else
-	sed "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
-fi
 
-chmod 0755 ${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh
-echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh${TPUT_RESET}"
-echo >&2
-
-# Figure out the cron directory for the distro
-crondir=
-[ -d "/etc/periodic/daily" ] && crondir="/etc/periodic/daily"
-[ -d "/etc/cron.daily" ] && crondir="/etc/cron.daily"
-
-if [ -z "${crondir}" ]; then
-	echo >&2 "Cannot figure out the cron directory to handle netdata-updater.sh activation/deactivation"
-elif [ "${UID}" -ne "0" ]; then
-	# We cant touch cron if we are not running as root
-	echo >&2 "You need to run the installer as root for auto-updating via cron."
-else
-	progress "Check if we must enable/disable the netdata updater"
-	if [ "${AUTOUPDATE}" = "1" ]; then
-		if [ -f "${crondir}/netdata-updater.sh" ]; then
-			progress "Removing incorrect netdata-updater filename in cron"
-			rm -f "${crondir}/netdata-updater.sh"
-		fi
-
-		echo >&2 "Adding to cron"
-
-		rm -f "${crondir}/netdata-updater"
-		ln -sf "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" "${crondir}/netdata-updater"
-
-		echo >&2 "Auto-updating has been enabled. Updater script linked to: ${TPUT_RED}${TPUT_BOLD}${crondir}/netdata-update${TPUT_RESET}"
-		echo >&2
-		echo >&2 "${TPUT_DIM}${TPUT_BOLD}netdata-updater.sh${TPUT_RESET}${TPUT_DIM} works from cron. It will trigger an email from cron"
-		echo >&2 "only if it fails (it should not print anything when it can update netdata).${TPUT_RESET}"
-	else
-		echo >&2 "You chose *NOT* to enable auto-update, removing any links to the updater from cron (it may have happened if you are reinstalling)"
-		echo >&2
-
-		if [ -f "${crondir}/netdata-updater" ]; then
-			echo >&2 "Removing cron reference: ${crondir}/netdata-updater"
-			rm -f "${crondir}/netdata-updater"
-		else
-			echo >&2 "Did not find any cron entries to remove"
-		fi
-	fi
-fi
-
+# -----------------------------------------------------------------------------
 progress "Wrap up environment set up"
 
 # Save environment variables

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1051,15 +1051,15 @@ echo >&2 "Uninstall script copied to: ${TPUT_RED}${TPUT_BOLD}${NETDATA_PREFIX}/u
 echo >&2
 
 # -----------------------------------------------------------------------------
-progress "Install netdata updater tool"
+progress "Install (but not enable) netdata updater tool"
 cleanup_old_netdata_updater || run_failed "Cannot cleanup old netdata updater tool."
 install_netdata_updater || run_failed "Cannot install netdata updater tool."
 
-progress "Check if we must enable/disable the netdata updater"
+progress "Check if we must enable/disable the netdata updater tool"
 if [ "${AUTOUPDATE}" = "1" ]; then
-	enable_netdata_updater || run_failed "Cannot enable netdata updater tool."
+	enable_netdata_updater || run_failed "Cannot enable netdata updater tool"
 else
-	disable_netdata_updater || run_failed "Cannot disable netdata updater tool."
+	disable_netdata_updater || run_failed "Cannot disable netdata updater tool"
 fi
 
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1052,8 +1052,15 @@ echo >&2
 
 # -----------------------------------------------------------------------------
 progress "Install netdata updater tool"
+cleanup_old_netdata_updater || run_failed "Cannot cleanup old netdata updater tool."
+install_netdata_updater || run_failed "Cannot install netdata updater tool."
 
-install_or_remove_netdata_updater || run_failed "Cannot install netdata updater tool."
+progress "Check if we must enable/disable the netdata updater"
+if [ "${AUTOUPDATE}" = "1" ]; then
+	enable_netdata_updater || run_failed "Cannot enable netdata updater tool."
+else
+	disable_netdata_updater || run_failed "Cannot disable netdata updater tool."
+fi
 
 
 # -----------------------------------------------------------------------------

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -727,3 +727,64 @@ safe_sha256sum() {
 		fatal "I could not find a suitable checksum binary to use"
 	fi
 }
+
+install_or_remove_netdata_updater() {
+	if [ -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh ]; then
+		echo >&2 "Removing updater from previous location"
+		rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh
+	fi
+
+	if [ "${INSTALLER_DIR}" ] && [ -f "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" ]; then
+		cat "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
+	fi
+
+	if [ "${NETDATA_SOURCE_DIR}" ] && [ -f "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" ]; then
+		cat "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
+	fi
+
+	sed -e "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" -i "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
+
+	chmod 0755 ${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh
+	echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh${TPUT_RESET}"
+	echo >&2
+
+	# Figure out the cron directory for the distro
+	crondir=
+	[ -d "/etc/periodic/daily" ] && crondir="/etc/periodic/daily"
+	[ -d "/etc/cron.daily" ] && crondir="/etc/cron.daily"
+
+	if [ -z "${crondir}" ]; then
+		echo >&2 "Cannot figure out the cron directory to handle netdata-updater.sh activation/deactivation"
+	elif [ "${UID}" -ne "0" ]; then
+		# We cant touch cron if we are not running as root
+		echo >&2 "You need to run the installer as root for auto-updating via cron."
+	else
+		progress "Check if we must enable/disable the netdata updater"
+		if [ "${AUTOUPDATE}" = "1" ]; then
+			if [ -f "${crondir}/netdata-updater.sh" ]; then
+				progress "Removing incorrect netdata-updater filename in cron"
+				rm -f "${crondir}/netdata-updater.sh"
+			fi
+
+			echo >&2 "Adding to cron"
+
+			rm -f "${crondir}/netdata-updater"
+			ln -sf "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" "${crondir}/netdata-updater"
+
+			echo >&2 "Auto-updating has been enabled. Updater script linked to: ${TPUT_RED}${TPUT_BOLD}${crondir}/netdata-update${TPUT_RESET}"
+			echo >&2
+			echo >&2 "${TPUT_DIM}${TPUT_BOLD}netdata-updater.sh${TPUT_RESET}${TPUT_DIM} works from cron. It will trigger an email from cron"
+			echo >&2 "only if it fails (it should not print anything when it can update netdata).${TPUT_RESET}"
+		else
+			echo >&2 "You chose *NOT* to enable auto-update, removing any links to the updater from cron (it may have happened if you are reinstalling)"
+			echo >&2
+
+			if [ -f "${crondir}/netdata-updater" ]; then
+				echo >&2 "Removing cron reference: ${crondir}/netdata-updater"
+				rm -f "${crondir}/netdata-updater"
+			else
+				echo >&2 "Did not find any cron entries to remove"
+			fi
+		fi
+	fi
+}

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -742,7 +742,7 @@ check_crondir_permissions() {
 		return 1
 	elif [ "${UID}" -ne "0" ]; then
 		# We cant touch cron if we are not running as root
-		echo >&2 "You need to run the installer as root for auto-updating via cron."
+		echo >&2 "You need to run the installer as root for auto-updating via cron"
 		return 1
 	fi
 
@@ -769,7 +769,7 @@ install_netdata_updater() {
 
 cleanup_old_netdata_updater() {
 	if [ -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh ]; then
-		echo >&2 "Removing updater from previous location"
+		echo >&2 "Removing updater from deprecated location"
 		rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh
 	fi
 
@@ -777,7 +777,7 @@ cleanup_old_netdata_updater() {
 	check_crondir_permissions "${crondir}" || return 1
 
 	if [ -f "${crondir}/netdata-updater.sh" ]; then
-		progress "Removing incorrect netdata-updater filename in cron"
+		echo >&2 "Removing incorrect netdata-updater filename in cron"
 		rm -f "${crondir}/netdata-updater.sh"
 	fi
 
@@ -797,6 +797,7 @@ enable_netdata_updater() {
 	echo >&2
 	echo >&2 "${TPUT_DIM}${TPUT_BOLD}netdata-updater.sh${TPUT_RESET}${TPUT_DIM} works from cron. It will trigger an email from cron"
 	echo >&2 "only if it fails (it should not print anything when it can update netdata).${TPUT_RESET}"
+	echo >&2
 
 	return 0
 }
@@ -810,9 +811,11 @@ disable_netdata_updater() {
 
 	if [ -f "${crondir}/netdata-updater" ]; then
 		echo >&2 "Removing cron reference: ${crondir}/netdata-updater"
+		echo >&2
 		rm -f "${crondir}/netdata-updater"
 	else
 		echo >&2 "Did not find any cron entries to remove"
+		echo >&2
 	fi
 
 	return 0

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -728,63 +728,92 @@ safe_sha256sum() {
 	fi
 }
 
-install_or_remove_netdata_updater() {
-	if [ -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh ]; then
-		echo >&2 "Removing updater from previous location"
-		rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh
+get_crondir() {
+	crondir=
+	[ -d "/etc/periodic/daily" ] && crondir="/etc/periodic/daily"
+	[ -d "/etc/cron.daily" ] && crondir="/etc/cron.daily"
+
+	echo "${crondir}"
+}
+
+check_crondir_permissions() {
+	if [ -z "${1}" ]; then
+		echo >&2 "Cannot figure out the cron directory to handle netdata-updater.sh activation/deactivation"
+		return 1
+	elif [ "${UID}" -ne "0" ]; then
+		# We cant touch cron if we are not running as root
+		echo >&2 "You need to run the installer as root for auto-updating via cron."
+		return 1
 	fi
 
+	return 0
+}
+
+install_netdata_updater() {
 	if [ "${INSTALLER_DIR}" ] && [ -f "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" ]; then
-		cat "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
+		cat "${INSTALLER_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || return 1
 	fi
 
 	if [ "${NETDATA_SOURCE_DIR}" ] && [ -f "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" ]; then
-		cat "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
+		cat "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || return 1
 	fi
 
-	sed -e "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" -i "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || exit 1
+	sed -e "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" -i "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || return 1
 
 	chmod 0755 ${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh
 	echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh${TPUT_RESET}"
 	echo >&2
 
-	# Figure out the cron directory for the distro
-	crondir=
-	[ -d "/etc/periodic/daily" ] && crondir="/etc/periodic/daily"
-	[ -d "/etc/cron.daily" ] && crondir="/etc/cron.daily"
+	return 0
+}
 
-	if [ -z "${crondir}" ]; then
-		echo >&2 "Cannot figure out the cron directory to handle netdata-updater.sh activation/deactivation"
-	elif [ "${UID}" -ne "0" ]; then
-		# We cant touch cron if we are not running as root
-		echo >&2 "You need to run the installer as root for auto-updating via cron."
-	else
-		progress "Check if we must enable/disable the netdata updater"
-		if [ "${AUTOUPDATE}" = "1" ]; then
-			if [ -f "${crondir}/netdata-updater.sh" ]; then
-				progress "Removing incorrect netdata-updater filename in cron"
-				rm -f "${crondir}/netdata-updater.sh"
-			fi
-
-			echo >&2 "Adding to cron"
-
-			rm -f "${crondir}/netdata-updater"
-			ln -sf "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" "${crondir}/netdata-updater"
-
-			echo >&2 "Auto-updating has been enabled. Updater script linked to: ${TPUT_RED}${TPUT_BOLD}${crondir}/netdata-update${TPUT_RESET}"
-			echo >&2
-			echo >&2 "${TPUT_DIM}${TPUT_BOLD}netdata-updater.sh${TPUT_RESET}${TPUT_DIM} works from cron. It will trigger an email from cron"
-			echo >&2 "only if it fails (it should not print anything when it can update netdata).${TPUT_RESET}"
-		else
-			echo >&2 "You chose *NOT* to enable auto-update, removing any links to the updater from cron (it may have happened if you are reinstalling)"
-			echo >&2
-
-			if [ -f "${crondir}/netdata-updater" ]; then
-				echo >&2 "Removing cron reference: ${crondir}/netdata-updater"
-				rm -f "${crondir}/netdata-updater"
-			else
-				echo >&2 "Did not find any cron entries to remove"
-			fi
-		fi
+cleanup_old_netdata_updater() {
+	if [ -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh ]; then
+		echo >&2 "Removing updater from previous location"
+		rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh
 	fi
+
+	crondir="$(get_crondir)"
+	check_crondir_permissions "${crondir}" || return 1
+
+	if [ -f "${crondir}/netdata-updater.sh" ]; then
+		progress "Removing incorrect netdata-updater filename in cron"
+		rm -f "${crondir}/netdata-updater.sh"
+	fi
+
+	return 0
+}
+
+enable_netdata_updater() {
+	crondir="$(get_crondir)"
+	check_crondir_permissions "${crondir}" || return 1
+
+	echo >&2 "Adding to cron"
+
+	rm -f "${crondir}/netdata-updater"
+	ln -sf "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" "${crondir}/netdata-updater"
+
+	echo >&2 "Auto-updating has been enabled. Updater script linked to: ${TPUT_RED}${TPUT_BOLD}${crondir}/netdata-update${TPUT_RESET}"
+	echo >&2
+	echo >&2 "${TPUT_DIM}${TPUT_BOLD}netdata-updater.sh${TPUT_RESET}${TPUT_DIM} works from cron. It will trigger an email from cron"
+	echo >&2 "only if it fails (it should not print anything when it can update netdata).${TPUT_RESET}"
+
+	return 0
+}
+
+disable_netdata_updater() {
+	crondir="$(get_crondir)"
+	check_crondir_permissions "${crondir}" || return 1
+
+	echo >&2 "You chose *NOT* to enable auto-update, removing any links to the updater from cron (it may have happened if you are reinstalling)"
+	echo >&2
+
+	if [ -f "${crondir}/netdata-updater" ]; then
+		echo >&2 "Removing cron reference: ${crondir}/netdata-updater"
+		rm -f "${crondir}/netdata-updater"
+	else
+		echo >&2 "Did not find any cron entries to remove"
+	fi
+
+	return 0
 }

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -141,8 +141,15 @@ install_netdata_service || run_failed "Cannot install netdata init service."
 
 # -----------------------------------------------------------------------------
 progress "Install netdata updater tool"
+cleanup_old_netdata_updater || run_failed "Cannot cleanup old netdata updater tool."
+install_netdata_updater || run_failed "Cannot install netdata updater tool."
 
-install_or_remove_netdata_updater || run_failed "Cannot install netdata updater tool."
+progress "Check if we must enable/disable the netdata updater"
+if [ "${AUTOUPDATE}" = "1" ]; then
+	enable_netdata_updater || run_failed "Cannot enable netdata updater tool."
+else
+	disable_netdata_updater || run_failed "Cannot disable netdata updater tool."
+fi
 
 
 # -----------------------------------------------------------------------------

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -9,6 +9,10 @@ umask 002
 # Be nice on production environments
 renice 19 $$ >/dev/null 2>/dev/null
 
+AUTOUPDATE=0
+NETDATA_PREFIX="/opt/netdata"
+NETDATA_USER_CONFIG_DIR="${NETDATA_PREFIX}/etc/netdata"
+
 # -----------------------------------------------------------------------------
 if [ -d /opt/netdata/etc/netdata.old ]; then
 	progress "Found old etc/netdata directory, reinstating this"
@@ -22,15 +26,13 @@ fi
 
 STARTIT=1
 
-while [ ! -z "${1}" ]
-do
-    if [ "${1}" = "--dont-start-it" ]
-    then
-        STARTIT=0
-    else
-        echo >&2 "Unknown option '${1}'. Ignoring it."
-    fi
-    shift
+while [ "${1}" ]; do
+	case "${1}" in
+		"--dont-start-it") STARTIT=0;;
+		"--auto-update"|"-u") AUTOUPDATE=1;;
+		*) echo >&2 "Unknown option '${1}'. Ignoring it.";;
+	esac
+	shift 1
 done
 
 deleted_stock_configs=0
@@ -135,6 +137,12 @@ install_netdata_logrotate || run_failed "Cannot install logrotate file for netda
 progress "Install netdata at system init"
 
 install_netdata_service || run_failed "Cannot install netdata init service."
+
+
+# -----------------------------------------------------------------------------
+progress "Install netdata updater tool"
+
+install_or_remove_netdata_updater || run_failed "Cannot install netdata updater tool."
 
 
 # -----------------------------------------------------------------------------

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -140,15 +140,15 @@ install_netdata_service || run_failed "Cannot install netdata init service."
 
 
 # -----------------------------------------------------------------------------
-progress "Install netdata updater tool"
+progress "Install (but not enable) netdata updater tool"
 cleanup_old_netdata_updater || run_failed "Cannot cleanup old netdata updater tool."
 install_netdata_updater || run_failed "Cannot install netdata updater tool."
 
-progress "Check if we must enable/disable the netdata updater"
+progress "Check if we must enable/disable the netdata updater tool"
 if [ "${AUTOUPDATE}" = "1" ]; then
-	enable_netdata_updater || run_failed "Cannot enable netdata updater tool."
+	enable_netdata_updater || run_failed "Cannot enable netdata updater tool"
 else
-	disable_netdata_updater || run_failed "Cannot disable netdata updater tool."
+	disable_netdata_updater || run_failed "Cannot disable netdata updater tool"
 fi
 
 

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -9,7 +9,6 @@ umask 002
 # Be nice on production environments
 renice 19 $$ >/dev/null 2>/dev/null
 
-AUTOUPDATE=0
 NETDATA_PREFIX="/opt/netdata"
 NETDATA_USER_CONFIG_DIR="${NETDATA_PREFIX}/etc/netdata"
 
@@ -25,6 +24,7 @@ if [ -d /opt/netdata/etc/netdata.old ]; then
 fi
 
 STARTIT=1
+AUTOUPDATE=0
 
 while [ "${1}" ]; do
 	case "${1}" in


### PR DESCRIPTION
##### Summary
Partial fix for #7039

- Moved updater installation code from netdata-installer.sh to packaging/installer/functions.sh
- packaging/makeself/install-or-update.sh uses above code to install
netdata updater

##### Component Name
packaging/makeself/install-or-update.sh

##### Additional Information
Another PR will be needed, in order to update kickstart-static64.sh and enable the netdata installer by default