### PR TITLE
Fix typo in health_alarm_notify.conf

### DIFF
--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -640,7 +640,7 @@ SEND_SYSLOG="NO"
 # configuration to change that needs to happen in the syslog daemon
 # configuration, not here.
 
-# This controls which facility is used by defalt for logging.  Defaults
+# This controls which facility is used by default for logging.  Defaults
 # to local6.
 SYSLOG_FACILITY=''
 


### PR DESCRIPTION
##### Summary
Typo fix

##### Component Name
health_alarm_notify.conf
