### PR TITLE
Fix problems with names when alarm is created

### DIFF
--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -160,7 +160,7 @@ void rrdcalc_link_to_rrddim(RRDDIM *rd, RRDSET *st, RRDHOST *host) {
     RRDCALC *rrdc;
     for (rrdc = host->alarms_with_foreach; rrdc ; rrdc = rrdc->next) {
         if (simple_pattern_matches(rrdc->spdim, rd->id) || simple_pattern_matches(rrdc->spdim, rd->name)) {
-            if (!strcmp(rrdc->chart, st->name)) {
+            if (rrdc->hash_chart == st->hash_name || !strcmp(rrdc->chart, st->name) || !strcmp(rrdc->chart, st->id)) {
                 char *usename = alarm_name_with_dim(rrdc->name, strlen(rrdc->name), rd->name, strlen(rd->name));
                 if (usename) {
                     if(rrdcalc_exists(host, st->name, usename, 0, 0)){


### PR DESCRIPTION
##### Summary
Fixes #7058 

Netdata has yet problems with dashes and  underscores and this was creating problems with the new features like template for all dimension. The bug reported from our users were happening because Netdata uses the chart id to create charts from template (`database/rrdcalctemplate.c` function `rrdcalctemplate_link_matching_test`)  instead the chart name and name and id sometimes are not matching, the same problem does not happen when we created the alarm using `alarm`, because in this case the user must type write the name that he is seeing on his screen and Netdata uses this information to set the chart( `health/health_config.c` function `health_readfile` ).

##### Component Name
Health
##### Additional Information

