### PR TITLE
kickstart-static64.sh passes --auto-update to netdata-latest.gz.run

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -109,7 +109,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "c529e4eb7ce201845cef605d450f8380" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "20260e22a79b2c53bcf6bf9e8baf907c" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*
@@ -596,7 +596,11 @@ By default, Netdata's installation scripts enable automatic updates for both nig
 If you would prefer to manually update your Netdata agent, you can disable automatic updates by using the `--no-updates` option when you install or update Netdata using the [one-line installation script](#one-line-installation).
 
 ```bash
+# kickstart.sh
 bash <(curl -Ss https://my-netdata.io/kickstart.sh) --no-updates
+
+# kickstart-static64.sh
+bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --no-updates
 ```
 
 With automatic updates disabled, you can choose exactly when and how you [update Netdata](UPDATE.md).

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -109,7 +109,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "20260e22a79b2c53bcf6bf9e8baf907c" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "7c3471506f548968edbbf8d085fbea65" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/UPDATE.md
+++ b/packaging/installer/UPDATE.md
@@ -29,10 +29,14 @@ Keep in mind, Netdata may now have new features, or certain old features may now
 
 ### Manual update to get the latest nightly build
 
-The `kickstart.sh` one-liner will do a one-time update to the latest nightly build, if executed as follows:
+The `kickstart.sh` and `kickstart-static64.sh` one-liners will do a one-time update to the latest nightly build, if executed as follows:
 
 ```sh
+# kickstart.sh
 bash <(curl -Ss https://my-netdata.io/kickstart.sh) --no-updates
+
+# kickstart-static64.sh
+bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --no-updates
 ```
 
 ### Auto-update
@@ -42,11 +46,11 @@ _Please, consider the risks of running an auto-update. Something can always go w
 Calling the `netdata-installer.sh` with the `--auto-update` or `-u` option will create the `netdata-updater` script under 
 either  `/etc/cron.daily/`, or `/etc/periodic/daily/`. Whenever the `netdata-updater` is executed, it checks if a newer nightly build is available and then handles the download, installation and Netdata restart.  
 
-Note that after Jan 2019, the `kickstart.sh` one-liner `bash <(curl -Ss https://my-netdata.io/kickstart.sh)` calls the `netdata-installer.sh` with the auto-update option. So if you just run the one-liner without options once, your Netdata will be kept auto-updated.
+Note that after Jan 2019, the `kickstart.sh` one-liner `bash <(curl -Ss https://my-netdata.io/kickstart.sh)` calls the `netdata-installer.sh` with the auto-update option. So if you just run the one-liner without options once, your Netdata will be kept auto-updated. The same applies to the `kickstart-static64.sh` one-liner since Oct 2019.
 
 ## You downloaded a binary package
 
-If you installed it from a binary package, the best way is to **obtain a newer copy** from the source you got it in the first place. This includes the static binary installation via `kickstart-base64.sh`, which would need to be executed again.
+If you installed it from a binary package, the best way is to **obtain a newer copy** from the source you got it in the first place.
 
 If a newer version of Netdata is not available from the source you got it, we suggest to uninstall the version you have and follow the [installation](README.md) instructions for installing a fresh version of Netdata.
 

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -183,14 +183,18 @@ fi
 
 # ---------------------------------------------------------------------------------------------------------------------
 opts=
-inner_opts=
+NETDATA_INSTALLER_OPTIONS=
+NETDATA_UPDATES="--auto-update"
 RELEASE_CHANNEL="nightly"
 while [ -n "${1}" ]; do
 	if [ "${1}" = "--dont-wait" ] || [ "${1}" = "--non-interactive" ] || [ "${1}" = "--accept" ]; then
 		opts="${opts} --accept"
 		shift 1
 	elif [ "${1}" = "--dont-start-it" ]; then
-		inner_opts="${inner_opts} ${1}"
+		NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} ${1}"
+		shift 1
+	elif [ "${1}" = "--no-updates" ]; then
+		NETDATA_UPDATES=
 		shift 1
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
@@ -214,7 +218,6 @@ while [ -n "${1}" ]; do
 		exit 1
 	fi
 done
-[ -n "${inner_opts}" ] && inner_opts="-- ${inner_opts}"
 
 # ---------------------------------------------------------------------------------------------------------------------
 TMPDIR=$(create_tmp_directory)
@@ -238,7 +241,7 @@ fi
 
 # ---------------------------------------------------------------------------------------------------------------------
 progress "Installing netdata"
-run ${sudo} sh "${TMPDIR}/netdata-latest.gz.run" ${opts} ${inner_opts}
+run ${sudo} sh "${TMPDIR}/netdata-latest.gz.run" ${opts} -- ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS}
 
 #shellcheck disable=SC2181
 if [ $? -eq 0 ]; then

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -183,7 +183,7 @@ fi
 
 # ---------------------------------------------------------------------------------------------------------------------
 opts=
-NETDATA_INSTALLER_OPTIONS=
+NETDATA_INSTALLER_OPTIONS=""
 NETDATA_UPDATES="--auto-update"
 RELEASE_CHANNEL="nightly"
 while [ -n "${1}" ]; do
@@ -191,10 +191,10 @@ while [ -n "${1}" ]; do
 		opts="${opts} --accept"
 		shift 1
 	elif [ "${1}" = "--dont-start-it" ]; then
-		NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} ${1}"
+		NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS:+${NETDATA_INSTALLER_OPTIONS} }${1}"
 		shift 1
 	elif [ "${1}" = "--no-updates" ]; then
-		NETDATA_UPDATES=
+		NETDATA_UPDATES=""
 		shift 1
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"


### PR DESCRIPTION
##### Summary
This should complete the fix for #7039. It modifies kickstart-static64.sh in order to pass the --auto-update option to netdata-latest.gz.run

##### Component Name
packaging/installer/kickstart-static64.sh

##### Additional Information
Please do not merge this, before #7060 gets merged **and released**

After merging and deploying this, the kickstart scripts at https://my-netdata.io/ must be updated
