### PR TITLE
fix(freeipmi): Update frequency config check

### DIFF
--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1790,7 +1790,7 @@ int main (int argc, char **argv) {
 
     errno = 0;
 
-    if(freq > netdata_update_every)
+    if(freq >= netdata_update_every)
         netdata_update_every = freq;
 
     else if(freq)


### PR DESCRIPTION
##### Summary
Fix the update frequency check for freeipmi which was warning that 5 was too frequent an it was setting it to 5.

##### Component Name
collectors/freeipmi