### PR TITLE
7040 enable stable channel option

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -822,5 +822,5 @@ disable_netdata_updater() {
 }
 
 set_netdata_updater_channel() {
-	sed -e "s/^RELEASE_CHANNEL=.*/RELEASE_CHANNEL=${RELEASE_CHANNEL}/" -i "${NETDATA_USER_CONFIG_DIR}/.environment"
+	sed -e "s/^RELEASE_CHANNEL=.*/RELEASE_CHANNEL=\"${RELEASE_CHANNEL}\"/" -i "${NETDATA_USER_CONFIG_DIR}/.environment"
 }

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -820,3 +820,7 @@ disable_netdata_updater() {
 
 	return 0
 }
+
+set_netdata_updater_channel() {
+	sed -e "s/^RELEASE_CHANNEL=.*/RELEASE_CHANNEL=${RELEASE_CHANNEL}/" -i "${NETDATA_USER_CONFIG_DIR}/.environment"
+}

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -25,11 +25,13 @@ fi
 
 STARTIT=1
 AUTOUPDATE=0
+RELEASE_CHANNEL="nightly"
 
 while [ "${1}" ]; do
 	case "${1}" in
 		"--dont-start-it") STARTIT=0;;
 		"--auto-update"|"-u") AUTOUPDATE=1;;
+		"--stable-channel") RELEASE_CHANNEL="stable";;
 		*) echo >&2 "Unknown option '${1}'. Ignoring it.";;
 	esac
 	shift 1
@@ -137,6 +139,9 @@ install_netdata_logrotate || run_failed "Cannot install logrotate file for netda
 progress "Install netdata at system init"
 
 install_netdata_service || run_failed "Cannot install netdata init service."
+
+
+set_netdata_updater_channel || run_failed "Cannot set netdata updater tool release channel to '${RELEASE_CHANNEL}'"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
Partial fix for #7040 
- install-or-update.sh now accepts the --stable-channel option and updates the environment file

##### Component Name
packaging/makeself/install-or-update.sh

##### Additional Information
Another PR will be needed, in order to update kickstart-static64.sh and pass the --stable-channel options when needed
