### PR TITLE
Second part of fix for #7040

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -109,7 +109,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "8a0c82abd3a7a70bf1c3e6360b06ada7" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "8ad43ff960bf6f2487233682909f7a87" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -109,7 +109,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "7c3471506f548968edbbf8d085fbea65" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "8a0c82abd3a7a70bf1c3e6360b06ada7" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*
@@ -127,7 +127,6 @@ Example using all the above parameters:
 ```sh
 bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait --dont-start-it --no-updates --stable-channel --local-files /tmp/my-selfdownloaded-tarball.tar.gz /tmp/checksums.txt
 ```
-Note: `--stable-channel` and `--local-files` overlap, if you use the tarball override the stable channel option is not effective
 
 If your shell fails to handle the above one liner, do this:
 

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -198,7 +198,7 @@ while [ -n "${1}" ]; do
 		shift 1
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
-		NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS:+${NETDATA_INSTALLER_OPTIONS} }--stable-channel"
+		NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS:+${NETDATA_INSTALLER_OPTIONS} }${1}"
 		shift 1
 	elif [ "${1}" = "--local-files" ]; then
 		shift 1

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -198,6 +198,7 @@ while [ -n "${1}" ]; do
 		shift 1
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
+		NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS:+${NETDATA_INSTALLER_OPTIONS} }--stable-channel"
 		shift 1
 	elif [ "${1}" = "--local-files" ]; then
 		shift 1


### PR DESCRIPTION
##### Summary
This should complete the fix for #7040 (kickstart-static64.sh only). It modifies kickstart-static64.sh in order to pass the --stable-channel option to netdata-latest.gz.run

##### Component Name
packaging/installer/kickstart-static64.sh

##### Additional Information
Please do not merge this, before #7082 gets merged **and released**

After merging and deploying this, the kickstart-static64.sh script at https://my-netdata.io/ must be updated