### PR TITLE
Fix to docker-compose+Caddy installation

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -162,7 +162,7 @@ services:
       - 443:443
     volumes:
       - /opt/Caddyfile:/etc/Caddyfile
-      - caddy:/root/.caddy
+      - $HOME/.caddy:/root/.caddy
     environment:
       ACME_AGREE: 'true'
   netdata:


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fixes #7075 

I tested this new line for the `docker-compose.yml` file on a VPS and it works fine.

I bet the old line works in _some_ cases, but hard-coding the location of the SSL files seems safer to me overall and should work in more cases so the location of the SSL files isn't dependent on where the user puts `docker-compose.yml` file.

##### Component Name

docs

##### Additional Information

