### PR TITLE
Fix segmentation fault in FreeBSD when statsd is disabled

### DIFF
--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -2222,7 +2222,7 @@ void *statsd_main(void *ptr) {
     // ----------------------------------------------------------------------------------------------------------------
     // statsd setup
 
-    if(!statsd.enabled) return NULL;
+    if(!statsd.enabled) goto cleanup;
 
     statsd_listen_sockets_setup();
     if(!statsd.sockets.opened) {


### PR DESCRIPTION
##### Summary
Netdata was crashing on FreeBSD when statsd was disabled due to the 
peculiarities of `pthread_cleanup_push` behavior in FreeBSD.

Fixes #7064

##### Component Name
statsd plugin