### PR TITLE
megacli: search binary and sudo check fix

### DIFF
--- a/collectors/python.d.plugin/megacli/megacli.chart.py
+++ b/collectors/python.d.plugin/megacli/megacli.chart.py
@@ -164,7 +164,7 @@ class Megacli:
     def __init__(self):
         self.s = find_binary('sudo')
         self.m = find_binary('megacli') or find_binary('MegaCli')  # Binary on FreeBSD is MegaCli
-        self.sudo_check = [self.s, '-n', '-v']
+        self.sudo_check = [self.s, '-n', '-l']
         self.disk_info = [self.s, '-n', self.m, '-LDPDInfo', '-aAll', '-NoLog']
         self.battery_info = [self.s, '-n', self.m, '-AdpBbuCmd', '-a0', '-NoLog']
 

--- a/collectors/python.d.plugin/megacli/megacli.chart.py
+++ b/collectors/python.d.plugin/megacli/megacli.chart.py
@@ -163,7 +163,7 @@ class Battery:
 class Megacli:
     def __init__(self):
         self.s = find_binary('sudo')
-        self.m = find_binary('megacli')
+        self.m = find_binary('megacli') or find_binary('MegaCli')  # Binary on FreeBSD is MegaCli
         self.sudo_check = [self.s, '-n', '-v']
         self.disk_info = [self.s, '-n', self.m, '-LDPDInfo', '-aAll', '-NoLog']
         self.battery_info = [self.s, '-n', self.m, '-AdpBbuCmd', '-a0', '-NoLog']


### PR DESCRIPTION
##### Summary

fixes: #7107

 - search for `MegaCli` binary (FreeBSD)
 - use `sudo -n -l` instead of `sudo -n -v` for sudo check

##### Component Name

[/collectors/python.d.plugin/megacli](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/megacli)

##### Additional Information

