### PR TITLE
unbound: fix init

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -80,6 +80,9 @@ class SocketService(SimpleService):
         if self.tls:
             try:
                 self.debug('Encapsulating socket with TLS')
+                self.debug('Using keyfile: {0}, certfile: {1}, cert_reqs: {2}, ssl_version: {3}'.format(
+                    self.key, self.cert, ssl.CERT_NONE, ssl.PROTOCOL_TLS
+                ))
                 self._sock = ssl.wrap_socket(self._sock,
                                              keyfile=self.key,
                                              certfile=self.cert,

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -16,9 +16,9 @@ else:
 
 if _TLS_SUPPORT:
     try:
-        from ssl import PROTOCOL_TLS
-    except ImportError:
-        from ssl import PROTOCOL_SSLv23 as PROTOCOL_TLS
+        PROTOCOL_TLS = ssl.PROTOCOL_TLS
+    except AttributeError:
+        PROTOCOL_TLS = ssl.PROTOCOL_SSLv23
 
 from bases.FrameworkServices.SimpleService import SimpleService
 

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -87,8 +87,8 @@ class SocketService(SimpleService):
                                              cert_reqs=ssl.CERT_NONE,
                                              ssl_version=ssl.PROTOCOL_TLS,
                                              )
-            except (socket.error, ssl.SSLError) as error:
-                self.error('failed to wrap socket : {0}'.format(error))
+            except (socket.error, ssl.SSLError, IOError, OSError) as error:
+                self.error('failed to wrap socket : {0}'.format(repr(error)))
                 self._disconnect()
                 self.__socket_config = None
                 return False
@@ -167,7 +167,8 @@ class SocketService(SimpleService):
                         if self._connect2socket(res):
                             break
 
-        except Exception:
+        except Exception as error:
+            self.error('unhandled exception during connect : {0}'.format(repr(error)))
             self._sock = None
             self.__socket_config = None
 

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -14,6 +14,12 @@ except ImportError:
 else:
     _TLS_SUPPORT = True
 
+if _TLS_SUPPORT:
+    try:
+        from ssl import PROTOCOL_TLS
+    except ImportError:
+        from ssl import PROTOCOL_SSLv23 as PROTOCOL_TLS
+
 from bases.FrameworkServices.SimpleService import SimpleService
 
 
@@ -81,14 +87,14 @@ class SocketService(SimpleService):
             try:
                 self.debug('Encapsulating socket with TLS')
                 self.debug('Using keyfile: {0}, certfile: {1}, cert_reqs: {2}, ssl_version: {3}'.format(
-                    self.key, self.cert, ssl.CERT_NONE, ssl.PROTOCOL_TLS
+                    self.key, self.cert, ssl.CERT_NONE, PROTOCOL_TLS
                 ))
                 self._sock = ssl.wrap_socket(self._sock,
                                              keyfile=self.key,
                                              certfile=self.cert,
                                              server_side=False,
                                              cert_reqs=ssl.CERT_NONE,
-                                             ssl_version=ssl.PROTOCOL_TLS,
+                                             ssl_version=PROTOCOL_TLS,
                                              )
             except (socket.error, ssl.SSLError, IOError, OSError) as error:
                 self.error('failed to wrap socket : {0}'.format(repr(error)))

--- a/collectors/python.d.plugin/unbound/unbound.chart.py
+++ b/collectors/python.d.plugin/unbound/unbound.chart.py
@@ -103,7 +103,6 @@ PER_THREAD_CHARTS = {
     }
 }
 
-
 # This maps the Unbound stat names to our names and precision requiremnets.
 STAT_MAP = {
     'total.num.queries_ip_ratelimited': ('ratelimit', 1),
@@ -207,31 +206,7 @@ class Service(SocketService):
             self.debug('Using certificate: {0}'.format(self.cert))
 
     def _auto_config(self):
-        if self.ubconf and is_readable(self.ubconf):
-            self.debug('Unbound config: {0}'.format(self.ubconf))
-            conf = dict()
-
-            try:
-                conf = load_config(self.ubconf)
-            except Exception as error:
-                self.error("error on loading '{0}' : {1}".format(self.ubconf, error))
-
-            if self.ext is None:
-                if 'extended-statistics' in conf['server']:
-                    self.ext = conf['server']['extended-statistics']
-
-            if 'remote-control' in conf and isinstance(conf['remote-control'], dict):
-                if conf['remote-control'].get('control-use-cert', False):
-                    self.key = self.key or conf['remote-control'].get('control-key-file')
-                    self.cert = self.cert or conf['remote-control'].get('control-cert-file')
-                    self.port = self.port or conf['remote-control'].get('control-port')
-                else:
-                    ci = conf['remote-control'].get('control-interface', "")
-                    is_socket = "/" in ci
-                    if is_socket:
-                        self.unix_socket = ci
-        else:
-            self.debug('Unbound configuration not found.')
+        self.load_unbound_config()
 
         if not self.key:
             self.key = '/etc/unbound/unbound_control.key'
@@ -239,6 +214,38 @@ class Service(SocketService):
             self.cert = '/etc/unbound/unbound_control.pem'
         if not self.port:
             self.port = 8953
+
+    def load_unbound_config(self):
+        if not (self.ubconf and is_readable(self.ubconf)):
+            self.debug('Unbound configuration not found.')
+            return
+
+        self.debug('Loading Unbound config: {0}'.format(self.ubconf))
+
+        try:
+            conf = load_config(self.ubconf)
+        except Exception as error:
+            self.error("error on loading '{0}' : {1}".format(self.ubconf, error))
+            return
+
+        srv = conf.get('server')
+        if self.ext is None:
+            if srv and 'extended-statistics' in srv:
+                self.ext = srv['extended-statistics']
+
+        rc = conf.get('remote-control')
+        if not (rc and isinstance(rc, dict)):
+            return
+
+        if rc.get('control-use-cert', False):
+            self.key = self.key or rc.get('control-key-file')
+            self.cert = self.cert or rc.get('control-cert-file')
+            self.port = self.port or rc.get('control-port')
+        else:
+            ci = rc.get('control-interface', str())
+            is_socket = '/' in ci
+            if is_socket:
+                self.unix_socket = ci
 
     def _generate_perthread_charts(self):
         tmporder = list()
@@ -250,10 +257,11 @@ class Service(SocketService):
         self.order.extend(sorted(tmporder))
 
     def check(self):
-        if self.key and not is_readable(self.key):
+        if not is_readable(self.key):
             self.error("ssl key '{0}' is not readable".format(self.key))
             return False
-        if self.cert and not is_readable(self.cert):
+
+        if not is_readable(self.cert):
             self.error("ssl certificate '{0}' is not readable".format(self.certificate))
             return False
 
@@ -286,12 +294,6 @@ class Service(SocketService):
                 self.request = tmp
         return result
 
-    @staticmethod
-    def _check_raw_data(data):
-        # The server will close the connection when it's done sending
-        # data, so just keep looping until that happens.
-        return False
-
     def _get_data(self):
         raw = self._get_raw_data()
         data = dict()
@@ -306,3 +308,9 @@ class Service(SocketService):
         else:
             self.warning('Received no data from socket.')
         return data
+
+    @staticmethod
+    def _check_raw_data(data):
+        # The server will close the connection when it's done sending
+        # data, so just keep looping until that happens.
+        return False

--- a/collectors/python.d.plugin/unbound/unbound.chart.py
+++ b/collectors/python.d.plugin/unbound/unbound.chart.py
@@ -147,6 +147,10 @@ PER_THREAD_STAT_MAP = {
 }
 
 
+def is_readable(name):
+    return os.access(name, os.R_OK)
+
+
 # Used to actually generate per-thread charts.
 def _get_perthread_info(thread):
     sname = 'thread{0}'.format(thread)
@@ -203,7 +207,7 @@ class Service(SocketService):
             self.debug('Using certificate: {0}'.format(self.cert))
 
     def _auto_config(self):
-        if self.ubconf and os.access(self.ubconf, os.R_OK):
+        if self.ubconf and is_readable(self.ubconf):
             self.debug('Unbound config: {0}'.format(self.ubconf))
             conf = dict()
             try:
@@ -239,6 +243,13 @@ class Service(SocketService):
         self.order.extend(sorted(tmporder))
 
     def check(self):
+        if self.key and not is_readable(self.key):
+            self.error("ssl key '{0}' is not readable".format(self.key))
+            return False
+        if self.cert and not is_readable(self.cert):
+            self.error("ssl certificate '{0}' is not readable".format(self.certificate))
+            return False
+
         # Check if authentication is working.
         self._connect()
         result = bool(self._sock)


### PR DESCRIPTION
##### Summary

fixes: #7111

This PR:
 - fixes `ssl.PROTOCOL_TLS` import (added in py 2.7.13, it deprecates `ssl.PROTOCOL_SSLv23`)
 - fixes unhandled `IOError`, `OSError` exceptions in `SocketService._connect2socket` method during `ssl.wrap_socket` (it happens if ssl key or cert is not exists/readable)
 - adds two checks to the unbound module check method: check if ssl key is readable, check if ssl cert is readable
 - moves load unbound config logic to a sep method

##### Component Name

[/collectors/python.d.plugin/unbound/unbound](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/unbound)

##### Additional Information

