### PR TITLE
Fix CPU charts in apps plugin on FreeBSD

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -2569,7 +2569,7 @@ static int collect_data_for_all_processes(void) {
 
     size_t new_procbase_size;
 
-    int mib[3] = { CTL_KERN, KERN_PROC, KERN_PROC_ALL };
+    int mib[3] = { CTL_KERN, KERN_PROC, KERN_PROC_PROC };
     if (unlikely(sysctl(mib, 3, NULL, &new_procbase_size, NULL, 0))) {
         error("sysctl error: Can't get processes data size");
         return 0;


### PR DESCRIPTION
##### Summary
CPU charts in apps plugin showed less CPU usage than it was in fact.

Fixes #7087

Relevant: #5038, #3245, #4037

##### Component Name
apps plugin