### PR TITLE
Convert recursion timings to miliseconds.

### DIFF
--- a/collectors/python.d.plugin/unbound/unbound.chart.py
+++ b/collectors/python.d.plugin/unbound/unbound.chart.py
@@ -32,10 +32,10 @@ CHARTS = {
         ]
     },
     'recursion': {
-        'options': [None, 'Recursion Timings', 'seconds', 'Unbound', 'unbound.recursion', 'line'],
+        'options': [None, 'Recursion Timings', 'miliseconds', 'Unbound', 'unbound.recursion', 'line'],
         'lines': [
-            ['recursive_avg', 'average', 'absolute', 1, PRECISION],
-            ['recursive_med', 'median', 'absolute', 1, PRECISION]
+            ['recursive_avg', 'average', 'absolute', 1, 1],
+            ['recursive_med', 'median', 'absolute', 1, 1]
         ]
     },
     'reqlist': {
@@ -83,11 +83,11 @@ PER_THREAD_CHARTS = {
         ]
     },
     '_recursion': {
-        'options': [None, '{longname} Recursion Timings', 'seconds', 'Recursive Timings',
+        'options': [None, '{longname} Recursion Timings', 'miliseconds', 'Recursive Timings',
                     'unbound.threads.recursion', 'line'],
         'lines': [
-            ['{shortname}_recursive_avg', 'average', 'absolute', 1, PRECISION],
-            ['{shortname}_recursive_med', 'median', 'absolute', 1, PRECISION]
+            ['{shortname}_recursive_avg', 'average', 'absolute', 1, 1],
+            ['{shortname}_recursive_med', 'median', 'absolute', 1, 1]
         ]
     },
     '_reqlist': {
@@ -117,6 +117,7 @@ STAT_MAP = {
     'total.requestlist.exceeded': ('reqlist_exceeded', 1),
     'total.requestlist.current.all': ('reqlist_current', 1),
     'total.requestlist.current.user': ('reqlist_user', 1),
+    # Unbound reports recursion timings as fractional seconds, but we want to show them as miliseconds.
     'total.recursion.time.avg': ('recursive_avg', PRECISION),
     'total.recursion.time.median': ('recursive_med', PRECISION),
     'msg.cache.count': ('cache_message', 1),
@@ -141,6 +142,7 @@ PER_THREAD_STAT_MAP = {
     '{shortname}.requestlist.exceeded': ('{shortname}_reqlist_exceeded', 1),
     '{shortname}.requestlist.current.all': ('{shortname}_reqlist_current', 1),
     '{shortname}.requestlist.current.user': ('{shortname}_reqlist_user', 1),
+    # Unbound reports recursion timings as fractional seconds, but we want to show them as miliseconds.
     '{shortname}.recursion.time.avg': ('{shortname}_recursive_avg', PRECISION),
     '{shortname}.recursion.time.median': ('{shortname}_recursive_med', PRECISION)
 }

--- a/collectors/python.d.plugin/unbound/unbound.chart.py
+++ b/collectors/python.d.plugin/unbound/unbound.chart.py
@@ -32,7 +32,7 @@ CHARTS = {
         ]
     },
     'recursion': {
-        'options': [None, 'Recursion Timings', 'miliseconds', 'Unbound', 'unbound.recursion', 'line'],
+        'options': [None, 'Recursion Timings', 'milliseconds', 'Unbound', 'unbound.recursion', 'line'],
         'lines': [
             ['recursive_avg', 'average', 'absolute', 1, 1],
             ['recursive_med', 'median', 'absolute', 1, 1]
@@ -83,7 +83,7 @@ PER_THREAD_CHARTS = {
         ]
     },
     '_recursion': {
-        'options': [None, '{longname} Recursion Timings', 'miliseconds', 'Recursive Timings',
+        'options': [None, '{longname} Recursion Timings', 'milliseconds', 'Recursive Timings',
                     'unbound.threads.recursion', 'line'],
         'lines': [
             ['{shortname}_recursive_avg', 'average', 'absolute', 1, 1],
@@ -117,7 +117,7 @@ STAT_MAP = {
     'total.requestlist.exceeded': ('reqlist_exceeded', 1),
     'total.requestlist.current.all': ('reqlist_current', 1),
     'total.requestlist.current.user': ('reqlist_user', 1),
-    # Unbound reports recursion timings as fractional seconds, but we want to show them as miliseconds.
+    # Unbound reports recursion timings as fractional seconds, but we want to show them as milliseconds.
     'total.recursion.time.avg': ('recursive_avg', PRECISION),
     'total.recursion.time.median': ('recursive_med', PRECISION),
     'msg.cache.count': ('cache_message', 1),
@@ -142,7 +142,7 @@ PER_THREAD_STAT_MAP = {
     '{shortname}.requestlist.exceeded': ('{shortname}_reqlist_exceeded', 1),
     '{shortname}.requestlist.current.all': ('{shortname}_reqlist_current', 1),
     '{shortname}.requestlist.current.user': ('{shortname}_reqlist_user', 1),
-    # Unbound reports recursion timings as fractional seconds, but we want to show them as miliseconds.
+    # Unbound reports recursion timings as fractional seconds, but we want to show them as milliseconds.
     '{shortname}.recursion.time.avg': ('{shortname}_recursive_avg', PRECISION),
     '{shortname}.recursion.time.median': ('{shortname}_recursive_med', PRECISION)
 }


### PR DESCRIPTION
##### Summary
This avoids them being mangled to the point of being useless when the
locale settings are configured to convert seconds to times.

These were originally implemented as seconds because that's how Unound
itself reports them.

##### Component Name

collectors/python.d/unbound

##### Additional Information

Fixes #7120 

Shows no issues in testing, though the switch-over doesn't drop old data or convert it properly (that's probably a bug elsewhere though, and I don't feel it should block this PR).