### PR TITLE
Add user information to MySQL Python module documentation

### DIFF
--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -14,7 +14,7 @@ create user 'netdata'@'localhost';
 grant usage on *.* to 'netdata'@'localhost';
 flush privileges;
 ```
-The `netdata` user will have the ability to connect to the MySQL server on the localhost without a password. 
+The `netdata` user will have the ability to connect to the MySQL server on `localhost` without a password. 
 It will only be able to gather MySQL statistics without being able to alter or affect MySQL operations in any way. 
 
 This module will produce following charts (if data is available):

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -374,7 +374,7 @@ If no configuration is given, the module will attempt to connect to MySQL server
 `/var/run/mysqld/mysqld.sock` without password and with username `root`.
 
 `userstats` graph works only if you enable the plugin in MariaDB server and set proper MySQL privileges (SUPER or
-PROCESS). For more detail please check [MariaDB User Statistics
+PROCESS). For more details, please check the [MariaDB User Statistics
 page](https://mariadb.com/kb/en/library/user-statistics/)
 
 ---

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -5,8 +5,19 @@ Module monitors one or more mysql servers
 **Requirements:**
 
 -   python library [MySQLdb](https://github.com/PyMySQL/mysqlclient-python) (faster) or [PyMySQL](https://github.com/PyMySQL/PyMySQL) (slower)
+-   `netdata` local user to connect to the MySQL server. 
 
-It will produce following charts (if data is available):
+To create the `netdata` user, execute the following:
+
+```sh
+create user 'netdata'@'localhost';
+grant usage on *.* to 'netdata'@'localhost';
+flush privileges;
+```
+The `netdata` user will have the ability to connect to the MySQL server on the localhost without a password. 
+It will only be able to gather MySQL statistics without being able to alter or affect MySQL operations in any way. 
+
+This module will produce following charts (if data is available):
 
 1.  **Bandwidth** in kilobits/s
 
@@ -331,7 +342,8 @@ You can provide, per server, the following:
 
     -   key: the path name of the client private key file.
     -   cert: the path name of the client public key certificate file.
-    -   ca: the path name of the Certificate Authority (CA) certificate file. This option, if used, must specify the same certificate used by the server.
+    -   ca: the path name of the Certificate Authority (CA) certificate file. This option, if used, must specify the
+        same certificate used by the server.
     -   capath: the path name of the directory that contains trusted SSL CA certificate files.
     -   cipher: the list of permitted ciphers for SSL encryption.
 
@@ -358,9 +370,12 @@ remote:
   port     : 9000
 ```
 
-If no configuration is given, module will attempt to connect to mysql server via unix socket at `/var/run/mysqld/mysqld.sock` without password and with username `root`
+If no configuration is given, module will attempt to connect to mysql server via unix socket at
+`/var/run/mysqld/mysqld.sock` without password and with username `root`.
 
-`userstats` graph works only if you enable such plugin in MariaDB server and set proper mysql priviliges (SUPER or PROCESS). For more detail please check [MariaDB User Statistics page](https://mariadb.com/kb/en/library/user-statistics/)
+`userstats` graph works only if you enable such plugin in MariaDB server and set proper mysql priviliges (SUPER or
+PROCESS). For more detail please check [MariaDB User Statistics
+page](https://mariadb.com/kb/en/library/user-statistics/)
 
 ---
 

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -373,7 +373,7 @@ remote:
 If no configuration is given, the module will attempt to connect to MySQL server via a unix socket at
 `/var/run/mysqld/mysqld.sock` without password and with username `root`.
 
-`userstats` graph works only if you enable such plugin in MariaDB server and set proper mysql priviliges (SUPER or
+`userstats` graph works only if you enable the plugin in MariaDB server and set proper MySQL privileges (SUPER or
 PROCESS). For more detail please check [MariaDB User Statistics
 page](https://mariadb.com/kb/en/library/user-statistics/)
 

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -370,7 +370,7 @@ remote:
   port     : 9000
 ```
 
-If no configuration is given, module will attempt to connect to mysql server via unix socket at
+If no configuration is given, the module will attempt to connect to MySQL server via a unix socket at
 `/var/run/mysqld/mysqld.sock` without password and with username `root`.
 
 `userstats` graph works only if you enable such plugin in MariaDB server and set proper mysql priviliges (SUPER or

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -7,7 +7,7 @@ Module monitors one or more mysql servers
 -   python library [MySQLdb](https://github.com/PyMySQL/mysqlclient-python) (faster) or [PyMySQL](https://github.com/PyMySQL/PyMySQL) (slower)
 -   `netdata` local user to connect to the MySQL server. 
 
-To create the `netdata` user, execute the following:
+To create the `netdata` user, execute the following in the MySQL shell:
 
 ```sh
 create user 'netdata'@'localhost';


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Related to: #7126 

It is not stated in the documentation that `netdata` MySQL user has to be created for the MySQL charts to show on the dashboard. 

##### Component Name
docs
##### Additional Information

