### PR TITLE
Update alarm-notify.sh to enable IRC notifications

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -29,6 +29,7 @@
 #  - hipchat notifications by @ktsaou #1561
 #  - fleep notifications by @Ferroin
 #  - prowlapp.com notifications by @Ferroin
+#  - irc notifications by @ktsaou
 #  - custom notifications by @ktsaou
 #  - syslog messages by @Ferroin
 #  - Microsoft Team notification by @tioumen
@@ -164,6 +165,7 @@ custom
 msteam
 kavenegar
 prowl
+irc
 awssns
 rocketchat
 sms

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -29,7 +29,7 @@
 #  - hipchat notifications by @ktsaou #1561
 #  - fleep notifications by @Ferroin
 #  - prowlapp.com notifications by @Ferroin
-#  - irc notifications by @ktsaou
+#  - irc notifications by @manosf
 #  - custom notifications by @ktsaou
 #  - syslog messages by @Ferroin
 #  - Microsoft Team notification by @tioumen


### PR DESCRIPTION
##### Summary
This fixes IRC notifications not working (being ignored even when configured).
Added IRC as method and updated author name.
##### Component Name
`alarm-notify.sh`
##### Additional Information
There's still some bugs using IRC notifications but adding it to the method list at least enables the notification method and sends alerts as expected.
Basically, `/usr/lib/netdata/plugins.d/alarm-notify.sh` throws error code 421 for IRC, which is false, as the alert is seen on IRC with these changes when configured in `health_alarm_notify.conf`.

Error 421 = `ERR_UNKNOWNCOMMAND | "<command> :Unknown command"`
@ktsaou @manosf Is there was a way for `alarm-notify.sh` to print the entire command that IRC is trying with the variables? As `bash -x` does not and: https://github.com/netdata/netdata/blob/5d82cb5a2407fd2d983fcbcd81ecc2ca41dd0f53/health/notifications/alarm-notify.sh.in#L1620 works fine when substituted in Bash.

Also, it might be prudent to tell the user which version of netcat (`nc`) is expected between `gnu-netcat` and `openbsd-netcat`.