### PR TITLE
contrib/debian: Fix typo in Description

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -61,4 +61,4 @@ Package: netdata-plugin-cups
 Architecture: any
 Depends: cups,
          netdata (>= ${source:Version})
-Description: The Common Unix Printing System plugin for metrics collection from cupds
+Description: The Common Unix Printing System plugin for metrics collection from cupsd

--- a/contrib/debian/control.buster
+++ b/contrib/debian/control.buster
@@ -61,4 +61,4 @@ Package: netdata-plugin-cups
 Architecture: any
 Depends: cups,
          netdata (>= ${source:Version})
-Description: The Common Unix Printing System plugin for metrics collection from cupds
+Description: The Common Unix Printing System plugin for metrics collection from cupsd

--- a/contrib/debian/control.jessie
+++ b/contrib/debian/control.jessie
@@ -59,4 +59,4 @@ Package: netdata-plugin-cups
 Architecture: any
 Depends: cups,
          netdata (>= ${source:Version})
-Description: The Common Unix Printing System plugin for metrics collection from cupds
+Description: The Common Unix Printing System plugin for metrics collection from cupsd

--- a/contrib/debian/control.trusty
+++ b/contrib/debian/control.trusty
@@ -59,4 +59,4 @@ Package: netdata-plugin-cups
 Architecture: any
 Depends: cups,
          netdata (>= ${source:Version})
-Description: The Common Unix Printing System plugin for metrics collection from cupds
+Description: The Common Unix Printing System plugin for metrics collection from cupsd

--- a/contrib/debian/control.wheezy
+++ b/contrib/debian/control.wheezy
@@ -28,4 +28,4 @@ Package: netdata-plugin-cups
 Architecture: any
 Depends: cups,
          netdata (>= ${source:Version})
-Description: The Common Unix Printing System plugin for metrics collection from cupds
+Description: The Common Unix Printing System plugin for metrics collection from cupsd

--- a/contrib/debian/control.xenial
+++ b/contrib/debian/control.xenial
@@ -61,4 +61,4 @@ Package: netdata-plugin-cups
 Architecture: any
 Depends: cups,
          netdata (>= ${source:Version})
-Description: The Common Unix Printing System plugin for metrics collection from cupds
+Description: The Common Unix Printing System plugin for metrics collection from cupsd


### PR DESCRIPTION
##### Component Name

`contrib/debian/control*`