### PR TITLE
add support for memcachier

### DIFF
--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -67,6 +67,7 @@ include litespeed/Makefile.inc
 include logind/Makefile.inc
 include megacli/Makefile.inc
 include memcached/Makefile.inc
+include memcachier/Makefile.inc
 include mongodb/Makefile.inc
 include monit/Makefile.inc
 include mysql/Makefile.inc

--- a/collectors/python.d.plugin/memcachier/Makefile.inc
+++ b/collectors/python.d.plugin/memcachier/Makefile.inc
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_python_DATA       += memcachier/memcachier.chart.py
+dist_pythonconfig_DATA += memcachier/memcachier.conf
+
+# do not install these files, but include them in the distribution
+dist_noinst_DATA       += memcachier/README.md memcachier/Makefile.inc

--- a/collectors/python.d.plugin/memcachier/README.md
+++ b/collectors/python.d.plugin/memcachier/README.md
@@ -1,0 +1,24 @@
+# memcachier
+
+Memcachier monitoring module. Data is retrieved using the [analytics API](https://www.memcachier.com/documentation/analytics-api).
+Based on the [Memcached plugin](../memcached).
+
+This plugin expects to receive only one cache_id and only one cache_server per job instance.
+
+If you're having issues, running the plugin in [debug mode](../#how-to-debug-a-python-module) will show the results from each request.
+
+## Configuration
+
+It is necessary to provide a valid user/pass parameter in the configuration file before using this plugin.
+Due to this restriction, the plugin is deactivated by default.
+
+Sample:
+
+```
+instance1:
+  name: 'testing'
+  user: '012DEF'
+  pass: '32D1G175000000000000000000000000'
+```
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fmemcachier%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/memcachier/memcachier.chart.py
+++ b/collectors/python.d.plugin/memcachier/memcachier.chart.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+# Description: memcachier netdata python.d module
+# Author: José Canal (joseliber)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+
+from bases.FrameworkServices.UrlService import UrlService
+
+
+ORDER = [
+    'cache',
+    'net',
+    'connections',
+    'items',
+    'evicted',
+    'expired',
+    'get',
+    'get_rate',
+    'set_rate',
+    'flush_rate',
+    'delete_rate',
+    'cas',
+    'delete',
+    'increment',
+    'decrement',
+    'touch',
+    'touch_rate',
+]
+
+CHARTS = {
+    'cache': {
+        'options': [None, 'Cache Size', 'MiB', 'cache', 'memcachier.cache', 'stacked'],
+        'lines': [
+            ['avail', 'available', 'absolute', 1, 1 << 20],
+            ['used', 'used', 'absolute', 1, 1 << 20]
+        ]
+    },
+    'net': {
+        'options': [None, 'Network', 'kilobits/s', 'network', 'memcachier.net', 'area'],
+        'lines': [
+            ['bytes_read', 'in', 'incremental', 8, 1000],
+            ['bytes_written', 'out', 'incremental', -8, 1000],
+        ]
+    },
+    'connections': {
+        'options': [None, 'Connections', 'connections/s', 'connections', 'memcachier.connections', 'line'],
+        'lines': [
+            ['curr_connections', 'current', 'incremental'],
+            ['total_connections', 'total', 'incremental']
+        ]
+    },
+    'items': {
+        'options': [None, 'Items', 'items', 'items', 'memcachier.items', 'line'],
+        'lines': [
+            ['curr_items', 'current', 'absolute'],
+            ['total_items', 'total', 'absolute']
+        ]
+    },
+    'evicted': {
+        'options': [None, 'Items', 'items', 'items', 'memcachier.evicted', 'line'],
+        'lines': [
+            ['evictions', 'evicted', 'absolute']
+        ]
+    },
+    'expired': {
+        'options': [None, 'Items', 'items', 'items', 'memcachier.expired', 'line'],
+        'lines': [
+            ['expired', 'expired', 'absolute']
+        ]
+    },
+    'get': {
+        'options': [None, 'Requests', 'requests', 'get ops', 'memcachier.get', 'stacked'],
+        'lines': [
+            ['get_hits', 'hits', 'percent-of-absolute-row'],
+            ['get_misses', 'misses', 'percent-of-absolute-row']
+        ]
+    },
+    'get_rate': {
+        'options': [None, 'Rate', 'requests/s', 'get ops', 'memcachier.get_rate', 'line'],
+        'lines': [
+            ['cmd_get', 'rate', 'incremental']
+        ]
+    },
+    'set_rate': {
+        'options': [None, 'Rate', 'requests/s', 'set ops', 'memcachier.set_rate', 'line'],
+        'lines': [
+            ['cmd_set', 'rate', 'incremental']
+        ]
+    },
+    'flush_rate': {
+        'options': [None, 'Rate', 'requests/s', 'flush ops', 'memcachier.flush_rate', 'line'],
+        'lines': [
+            ['cmd_flush', 'rate', 'incremental']
+        ]
+    },
+    'delete_rate': {
+        'options': [None, 'Rate', 'requests/s', 'delete ops', 'memcachier.delete_rate', 'line'],
+        'lines': [
+            ['cmd_delete', 'rate', 'incremental']
+        ]
+    },
+    'delete': {
+        'options': [None, 'Requests', 'requests', 'delete ops', 'memcachier.delete', 'stacked'],
+        'lines': [
+            ['delete_hits', 'hits', 'percent-of-absolute-row'],
+            ['delete_misses', 'misses', 'percent-of-absolute-row'],
+        ]
+    },
+    'cas': {
+        'options': [None, 'Requests', 'requests', 'check and set ops', 'memcachier.cas', 'stacked'],
+        'lines': [
+            ['cas_hits', 'hits', 'percent-of-absolute-row'],
+            ['cas_misses', 'misses', 'percent-of-absolute-row'],
+            ['cas_badval', 'bad value', 'percent-of-absolute-row']
+        ]
+    },
+    'increment': {
+        'options': [None, 'Requests', 'requests', 'increment ops', 'memcachier.increment', 'stacked'],
+        'lines': [
+            ['incr_hits', 'hits', 'percent-of-absolute-row'],
+            ['incr_misses', 'misses', 'percent-of-absolute-row']
+        ]
+    },
+    'decrement': {
+        'options': [None, 'Requests', 'requests', 'decrement ops', 'memcachier.decrement', 'stacked'],
+        'lines': [
+            ['decr_hits', 'hits', 'percent-of-absolute-row'],
+            ['decr_misses', 'misses', 'percent-of-absolute-row']
+        ]
+    },
+    'touch': {
+        'options': [None, 'Requests', 'requests', 'touch ops', 'memcachier.touch', 'stacked'],
+        'lines': [
+            ['touch_hits', 'hits', 'percent-of-absolute-row'],
+            ['touch_misses', 'misses', 'percent-of-absolute-row']
+        ]
+    },
+    'touch_rate': {
+        'options': [None, 'Rate', 'requests/s', 'touch ops', 'memcachier.touch_rate', 'line'],
+        'lines': [
+            ['cmd_touch', 'rate', 'incremental']
+        ]
+    }
+}
+
+
+class Service(UrlService):
+    def __init__(self, configuration=None, name=None):
+        UrlService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.url = 'https://analytics.memcachier.com/api/v1/login'
+        self.user = self.configuration.get('user')
+        self.password = self.configuration.get('pass')
+
+    def _get_data(self):
+        """
+        Get data from API
+        :return: dict
+        """
+        response = self._get_raw_data()
+        if response is None:
+            return None
+
+        metrics = json.loads(response)
+
+        # check if we have more than one server in the results
+        if len(metrics) > 1:
+            self.error('This plugin only works with one cache_server per job.')
+            self.debug('Request result: {r}'.format(r=metrics))
+            return None
+
+        data = list(metrics.values())[0]
+
+        # custom calculations
+        try:
+            data['avail'] = int(data['limit_maxbytes']) - int(data['bytes'])
+            data['used'] = int(data['bytes'])
+        except (KeyError, ValueError, TypeError):
+            pass
+
+        return data
+
+    def check(self):
+        """
+        Create manager, get cache_id and update url
+        :return: boolean
+        """
+        self._manager = self._build_manager()
+        data = self._get_raw_data()
+
+        if data is None:
+            return False
+
+        # we need to guarantee that only one cache_id is passed forward
+        data = json.loads(data)
+        if len(data) == 1 and type(data['cache_id']) == int:
+            self.url = 'https://analytics.memcachier.com/api/v1/{id}/stats'.format(id=data['cache_id'])
+            return True
+
+        self.error('This plugin only works with one cache_id per job.')
+        self.debug('Request result: {r}'.format(r=data))
+        return False

--- a/collectors/python.d.plugin/memcachier/memcachier.conf
+++ b/collectors/python.d.plugin/memcachier/memcachier.conf
@@ -1,0 +1,70 @@
+# netdata python.d.plugin configuration for memcachier
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# penalty indicates whether to apply penalty to update_every in case of failures.
+# Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
+# penalty: yes
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, memcachier requires the following:
+#
+#     user: '012DEF'
+#     pass: '32D1G175000000000000000000000000'
+#
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+# It is not possible to provide auto-detection jobs with this plugin
+# because a valid user/pass must be sent to the memcachier API call.

--- a/collectors/python.d.plugin/python.d.conf
+++ b/collectors/python.d.plugin/python.d.conf
@@ -65,6 +65,9 @@ gunicorn_log: no
 logind: no
 # megacli: yes
 # memcached: yes
+
+# memcachier needs to be configured before activation
+memcachier: no
 # mongodb: yes
 # monit: yes
 # mysql: yes


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Add support for Memcachier service stats via [analytics API](https://www.memcachier.com/documentation/analytics-api)

Fixes: #7147

Work based on Memcached collector.

##### Component Name
collectors/python.d/memcachier

##### Additional Information
Collector is disabled by default since it needs to be configured with user/pass
before activation.

From personal experience, I've restricted the cache_id and cache_server to only 1 result per job. I've searched through the Memcachier documentation and did tests with multiple caches per user to confirm this behavior. This is explained in the README as well.

I've purposefully left out the following metrics:
    "auth_cmds": 0,
    "auth_errors": 0,

Since auth_cmds will increase with each stats request made by netdata (1/s currently).