### PR TITLE
Fix sizeof inside callocz

### DIFF
--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -222,7 +222,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
 
 
         // Per-Numa Node & Zone & Type (full detail). Only if sum(line) > 0
-        st_nodezonetype = callocz(pagelines_cnt, sizeof(RRDSET));
+        st_nodezonetype = callocz(pagelines_cnt, sizeof(RRDSET *));
         for (p = 0; p < pagelines_cnt; p++) {
             pgl = &pagelines[p];
 


### PR DESCRIPTION
##### Summary
Fixes #7160 

Coverity reported us that the callocz was allocating to a pointer to pointer a simple vector, this was using more memory than necessary and thanks this we did not have any bug reported, this PR fixes this problem
##### Component Name
Collectors
##### Additional Information

