### PR TITLE
netdata-installer.sh follow-up based on #7060 review

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1051,7 +1051,7 @@ echo >&2 "Uninstall script copied to: ${TPUT_RED}${TPUT_BOLD}${NETDATA_PREFIX}/u
 echo >&2
 
 # -----------------------------------------------------------------------------
-progress "Install (but not enable) netdata updater tool"
+progress "Installing (but not enabling) the netdata updater tool"
 cleanup_old_netdata_updater || run_failed "Cannot cleanup old netdata updater tool."
 install_netdata_updater || run_failed "Cannot install netdata updater tool."
 

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -728,7 +728,7 @@ safe_sha256sum() {
 	fi
 }
 
-get_crondir() {
+_get_crondir() {
 	if [ -d /etc/cron.daily ]; then
 		echo /etc/cron.daily
 	elif [ -d /etc/periodic/daily ]; then
@@ -741,7 +741,7 @@ get_crondir() {
 	return 0
 }
 
-check_crondir_permissions() {
+_check_crondir_permissions() {
 	if [ "${UID}" -ne "0" ]; then
 		# We cant touch cron if we are not running as root
 		echo >&2 "You need to run the installer as root for auto-updating via cron"
@@ -775,8 +775,8 @@ cleanup_old_netdata_updater() {
 		rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh
 	fi
 
-	crondir="$(get_crondir)" || return 1
-	check_crondir_permissions "${crondir}" || return 1
+	crondir="$(_get_crondir)" || return 1
+	_check_crondir_permissions "${crondir}" || return 1
 
 	if [ -f "${crondir}/netdata-updater.sh" ]; then
 		echo >&2 "Removing incorrect netdata-updater filename in cron"
@@ -787,8 +787,8 @@ cleanup_old_netdata_updater() {
 }
 
 enable_netdata_updater() {
-	crondir="$(get_crondir)" || return 1
-	check_crondir_permissions "${crondir}" || return 1
+	crondir="$(_get_crondir)" || return 1
+	_check_crondir_permissions "${crondir}" || return 1
 
 	echo >&2 "Adding to cron"
 
@@ -805,8 +805,8 @@ enable_netdata_updater() {
 }
 
 disable_netdata_updater() {
-	crondir="$(get_crondir)" || return 1
-	check_crondir_permissions "${crondir}" || return 1
+	crondir="$(_get_crondir)" || return 1
+	_check_crondir_permissions "${crondir}" || return 1
 
 	echo >&2 "You chose *NOT* to enable auto-update, removing any links to the updater from cron (it may have happened if you are reinstalling)"
 	echo >&2


### PR DESCRIPTION
##### Summary
- netdata-installer.sh: Improve message about updater installation
- packaging/installer/functions.sh: get_crondir fails if crondir is not found
- packaging/installer/functions.sh: mark get_crondir and check_crondir_permissions functions as private

##### Component Name
netdata-installer.sh

##### Additional Information
Some follow-up corrections to netdata-installer.sh based on review comments in #7060