### PR TITLE
Suggest using /var/run/netdata for the unix socket

### DIFF
--- a/docs/Running-behind-nginx.md
+++ b/docs/Running-behind-nginx.md
@@ -205,7 +205,7 @@ You can also use a unix domain socket. This will also provide a faster route bet
 
 ```
 [web]
-    bind to = unix:/tmp/netdata.sock
+    bind to = unix:/run/netdata/netdata.sock
 ```
 
 *note: Netdata v1.8+ support unix domain sockets*
@@ -214,7 +214,7 @@ At the Nginx side, use something like this to use the same unix domain socket:
 
 ```conf
 upstream backend {
-    server unix:/tmp/netdata.sock;
+    server unix:/run/netdata/netdata.sock;
     keepalive 64;
 }
 ```

--- a/docs/Running-behind-nginx.md
+++ b/docs/Running-behind-nginx.md
@@ -205,7 +205,7 @@ You can also use a unix domain socket. This will also provide a faster route bet
 
 ```
 [web]
-    bind to = unix:/run/netdata/netdata.sock
+    bind to = unix:/var/run/netdata/netdata.sock
 ```
 
 *note: Netdata v1.8+ support unix domain sockets*
@@ -214,7 +214,7 @@ At the Nginx side, use something like this to use the same unix domain socket:
 
 ```conf
 upstream backend {
-    server unix:/run/netdata/netdata.sock;
+    server unix:/var/run/netdata/netdata.sock;
     keepalive 64;
 }
 ```


### PR DESCRIPTION
##### Summary

Additional fix to #3342
(in another location in docs)

##### Component Name

docs

##### Additional Information

Don't use /tmp for unix sockets.