### PR TITLE
proc.plugin: add pressure stall information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,7 @@ set(PROC_PLUGIN_FILES
         collectors/proc.plugin/proc_vmstat.c
         collectors/proc.plugin/proc_uptime.c
         collectors/proc.plugin/proc_pressure.c
+        collectors/proc.plugin/proc_pressure.h
         collectors/proc.plugin/sys_kernel_mm_ksm.c
         collectors/proc.plugin/sys_block_zram.c
         collectors/proc.plugin/sys_devices_system_edac_mc.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ set(PROC_PLUGIN_FILES
         collectors/proc.plugin/proc_sys_kernel_random_entropy_avail.c
         collectors/proc.plugin/proc_vmstat.c
         collectors/proc.plugin/proc_uptime.c
+        collectors/proc.plugin/proc_pressure.c
         collectors/proc.plugin/sys_kernel_mm_ksm.c
         collectors/proc.plugin/sys_block_zram.c
         collectors/proc.plugin/sys_devices_system_edac_mc.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -265,34 +265,34 @@ PROC_PLUGIN_FILES = \
     collectors/proc.plugin/proc_pagetypeinfo.c \
     collectors/proc.plugin/proc_pressure.c \
     collectors/proc.plugin/proc_pressure.h \
-	collectors/proc.plugin/proc_net_dev.c \
-	collectors/proc.plugin/proc_net_ip_vs_stats.c \
-	collectors/proc.plugin/proc_net_netstat.c \
-	collectors/proc.plugin/proc_net_rpc_nfs.c \
-	collectors/proc.plugin/proc_net_rpc_nfsd.c \
-	collectors/proc.plugin/proc_net_snmp.c \
-	collectors/proc.plugin/proc_net_snmp6.c \
-	collectors/proc.plugin/proc_net_sctp_snmp.c \
-	collectors/proc.plugin/proc_net_sockstat.c \
-	collectors/proc.plugin/proc_net_sockstat6.c \
-	collectors/proc.plugin/proc_net_softnet_stat.c \
-	collectors/proc.plugin/proc_net_stat_conntrack.c \
-	collectors/proc.plugin/proc_net_stat_synproxy.c \
-	collectors/proc.plugin/proc_self_mountinfo.c \
-	collectors/proc.plugin/proc_self_mountinfo.h \
-	collectors/proc.plugin/zfs_common.c \
-	collectors/proc.plugin/zfs_common.h \
-	collectors/proc.plugin/proc_spl_kstat_zfs.c \
-	collectors/proc.plugin/proc_stat.c \
-	collectors/proc.plugin/proc_sys_kernel_random_entropy_avail.c \
-	collectors/proc.plugin/proc_vmstat.c \
-	collectors/proc.plugin/proc_uptime.c \
-	collectors/proc.plugin/sys_kernel_mm_ksm.c \
-	collectors/proc.plugin/sys_block_zram.c \
-	collectors/proc.plugin/sys_devices_system_edac_mc.c \
-	collectors/proc.plugin/sys_devices_system_node.c \
-	collectors/proc.plugin/sys_fs_btrfs.c \
-	collectors/proc.plugin/sys_class_power_supply.c \
+    collectors/proc.plugin/proc_net_dev.c \
+    collectors/proc.plugin/proc_net_ip_vs_stats.c \
+    collectors/proc.plugin/proc_net_netstat.c \
+    collectors/proc.plugin/proc_net_rpc_nfs.c \
+    collectors/proc.plugin/proc_net_rpc_nfsd.c \
+    collectors/proc.plugin/proc_net_snmp.c \
+    collectors/proc.plugin/proc_net_snmp6.c \
+    collectors/proc.plugin/proc_net_sctp_snmp.c \
+    collectors/proc.plugin/proc_net_sockstat.c \
+    collectors/proc.plugin/proc_net_sockstat6.c \
+    collectors/proc.plugin/proc_net_softnet_stat.c \
+    collectors/proc.plugin/proc_net_stat_conntrack.c \
+    collectors/proc.plugin/proc_net_stat_synproxy.c \
+    collectors/proc.plugin/proc_self_mountinfo.c \
+    collectors/proc.plugin/proc_self_mountinfo.h \
+    collectors/proc.plugin/zfs_common.c \
+    collectors/proc.plugin/zfs_common.h \
+    collectors/proc.plugin/proc_spl_kstat_zfs.c \
+    collectors/proc.plugin/proc_stat.c \
+    collectors/proc.plugin/proc_sys_kernel_random_entropy_avail.c \
+    collectors/proc.plugin/proc_vmstat.c \
+    collectors/proc.plugin/proc_uptime.c \
+    collectors/proc.plugin/sys_kernel_mm_ksm.c \
+    collectors/proc.plugin/sys_block_zram.c \
+    collectors/proc.plugin/sys_devices_system_edac_mc.c \
+    collectors/proc.plugin/sys_devices_system_node.c \
+    collectors/proc.plugin/sys_fs_btrfs.c \
+    collectors/proc.plugin/sys_class_power_supply.c \
     $(NULL)
 
 TC_PLUGIN_FILES = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -264,6 +264,7 @@ PROC_PLUGIN_FILES = \
     collectors/proc.plugin/proc_meminfo.c \
     collectors/proc.plugin/proc_pagetypeinfo.c \
     collectors/proc.plugin/proc_pressure.c \
+    collectors/proc.plugin/proc_pressure.h \
 	collectors/proc.plugin/proc_net_dev.c \
 	collectors/proc.plugin/proc_net_ip_vs_stats.c \
 	collectors/proc.plugin/proc_net_netstat.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -263,34 +263,35 @@ PROC_PLUGIN_FILES = \
     collectors/proc.plugin/proc_loadavg.c \
     collectors/proc.plugin/proc_meminfo.c \
     collectors/proc.plugin/proc_pagetypeinfo.c \
-    collectors/proc.plugin/proc_net_dev.c \
-    collectors/proc.plugin/proc_net_ip_vs_stats.c \
-    collectors/proc.plugin/proc_net_netstat.c \
-    collectors/proc.plugin/proc_net_rpc_nfs.c \
-    collectors/proc.plugin/proc_net_rpc_nfsd.c \
-    collectors/proc.plugin/proc_net_snmp.c \
-    collectors/proc.plugin/proc_net_snmp6.c \
-    collectors/proc.plugin/proc_net_sctp_snmp.c \
-    collectors/proc.plugin/proc_net_sockstat.c \
-    collectors/proc.plugin/proc_net_sockstat6.c \
-    collectors/proc.plugin/proc_net_softnet_stat.c \
-    collectors/proc.plugin/proc_net_stat_conntrack.c \
-    collectors/proc.plugin/proc_net_stat_synproxy.c \
-    collectors/proc.plugin/proc_self_mountinfo.c \
-    collectors/proc.plugin/proc_self_mountinfo.h \
-    collectors/proc.plugin/zfs_common.c \
-    collectors/proc.plugin/zfs_common.h \
-    collectors/proc.plugin/proc_spl_kstat_zfs.c \
-    collectors/proc.plugin/proc_stat.c \
-    collectors/proc.plugin/proc_sys_kernel_random_entropy_avail.c \
-    collectors/proc.plugin/proc_vmstat.c \
-    collectors/proc.plugin/proc_uptime.c \
-    collectors/proc.plugin/sys_kernel_mm_ksm.c \
-    collectors/proc.plugin/sys_block_zram.c \
-    collectors/proc.plugin/sys_devices_system_edac_mc.c \
-    collectors/proc.plugin/sys_devices_system_node.c \
-    collectors/proc.plugin/sys_fs_btrfs.c \
-    collectors/proc.plugin/sys_class_power_supply.c \
+    collectors/proc.plugin/proc_pressure.c \
+	collectors/proc.plugin/proc_net_dev.c \
+	collectors/proc.plugin/proc_net_ip_vs_stats.c \
+	collectors/proc.plugin/proc_net_netstat.c \
+	collectors/proc.plugin/proc_net_rpc_nfs.c \
+	collectors/proc.plugin/proc_net_rpc_nfsd.c \
+	collectors/proc.plugin/proc_net_snmp.c \
+	collectors/proc.plugin/proc_net_snmp6.c \
+	collectors/proc.plugin/proc_net_sctp_snmp.c \
+	collectors/proc.plugin/proc_net_sockstat.c \
+	collectors/proc.plugin/proc_net_sockstat6.c \
+	collectors/proc.plugin/proc_net_softnet_stat.c \
+	collectors/proc.plugin/proc_net_stat_conntrack.c \
+	collectors/proc.plugin/proc_net_stat_synproxy.c \
+	collectors/proc.plugin/proc_self_mountinfo.c \
+	collectors/proc.plugin/proc_self_mountinfo.h \
+	collectors/proc.plugin/zfs_common.c \
+	collectors/proc.plugin/zfs_common.h \
+	collectors/proc.plugin/proc_spl_kstat_zfs.c \
+	collectors/proc.plugin/proc_stat.c \
+	collectors/proc.plugin/proc_sys_kernel_random_entropy_avail.c \
+	collectors/proc.plugin/proc_vmstat.c \
+	collectors/proc.plugin/proc_uptime.c \
+	collectors/proc.plugin/sys_kernel_mm_ksm.c \
+	collectors/proc.plugin/sys_block_zram.c \
+	collectors/proc.plugin/sys_devices_system_edac_mc.c \
+	collectors/proc.plugin/sys_devices_system_node.c \
+	collectors/proc.plugin/sys_fs_btrfs.c \
+	collectors/proc.plugin/sys_class_power_supply.c \
     $(NULL)
 
 TC_PLUGIN_FILES = \

--- a/collectors/all.h
+++ b/collectors/all.h
@@ -36,6 +36,7 @@
 #define NETDATA_CHART_PRIO_SYSTEM_RAM                  200
 #define NETDATA_CHART_PRIO_SYSTEM_SWAP                 201
 #define NETDATA_CHART_PRIO_SYSTEM_SWAPIO               250
+#define NETDATA_CHART_PRIO_SYSTEM_PRESSURE             400
 #define NETDATA_CHART_PRIO_SYSTEM_NET                  500
 #define NETDATA_CHART_PRIO_SYSTEM_IPV4                 500 // freebsd only
 #define NETDATA_CHART_PRIO_SYSTEM_IP                   501

--- a/collectors/all.h
+++ b/collectors/all.h
@@ -36,7 +36,6 @@
 #define NETDATA_CHART_PRIO_SYSTEM_RAM                  200
 #define NETDATA_CHART_PRIO_SYSTEM_SWAP                 201
 #define NETDATA_CHART_PRIO_SYSTEM_SWAPIO               250
-#define NETDATA_CHART_PRIO_SYSTEM_PRESSURE             400
 #define NETDATA_CHART_PRIO_SYSTEM_NET                  500
 #define NETDATA_CHART_PRIO_SYSTEM_IPV4                 500 // freebsd only
 #define NETDATA_CHART_PRIO_SYSTEM_IP                   501

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -501,8 +501,6 @@ struct cgroup {
     RRDSET *st_queued_ops;
     RRDSET *st_merged_ops;
 
-    // pressure charts are inside `struct pressure' due to complexity
-
     // per cgroup chart variables
     char *filename_cpuset_cpus;
     unsigned long long cpuset_cpus;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -23,6 +23,11 @@ static int cgroup_enable_blkio_throttle_io = CONFIG_BOOLEAN_AUTO;
 static int cgroup_enable_blkio_throttle_ops = CONFIG_BOOLEAN_AUTO;
 static int cgroup_enable_blkio_merged_ops = CONFIG_BOOLEAN_AUTO;
 static int cgroup_enable_blkio_queued_ops = CONFIG_BOOLEAN_AUTO;
+static int cgroup_enable_pressure_cpu = CONFIG_BOOLEAN_AUTO;
+static int cgroup_enable_pressure_io_some = CONFIG_BOOLEAN_AUTO;
+static int cgroup_enable_pressure_io_full = CONFIG_BOOLEAN_AUTO;
+static int cgroup_enable_pressure_memory_some = CONFIG_BOOLEAN_AUTO;
+static int cgroup_enable_pressure_memory_full = CONFIG_BOOLEAN_AUTO;
 
 static int cgroup_enable_systemd_services = CONFIG_BOOLEAN_YES;
 static int cgroup_enable_systemd_services_detailed_memory = CONFIG_BOOLEAN_NO;
@@ -105,6 +110,12 @@ void read_cgroup_plugin_configuration() {
     cgroup_enable_blkio_queued_ops = config_get_boolean_ondemand("plugin:cgroups", "enable blkio queued operations", cgroup_enable_blkio_queued_ops);
     cgroup_enable_blkio_merged_ops = config_get_boolean_ondemand("plugin:cgroups", "enable blkio merged operations", cgroup_enable_blkio_merged_ops);
 
+    cgroup_enable_pressure_cpu = config_get_boolean_ondemand("plugin:cgroups", "enable cpu pressure", cgroup_enable_pressure_cpu);
+    cgroup_enable_pressure_io_some = config_get_boolean_ondemand("plugin:cgroups", "enable io some pressure", cgroup_enable_pressure_io_some);
+    cgroup_enable_pressure_io_full = config_get_boolean_ondemand("plugin:cgroups", "enable io full pressure", cgroup_enable_pressure_io_full);
+    cgroup_enable_pressure_memory_some = config_get_boolean_ondemand("plugin:cgroups", "enable memory pressure", cgroup_enable_pressure_memory_some);
+    cgroup_enable_pressure_memory_full = config_get_boolean_ondemand("plugin:cgroups", "enable memory pressure", cgroup_enable_pressure_memory_full);
+
     cgroup_recheck_zero_blkio_every_iterations = (int)config_get_number("plugin:cgroups", "recheck zero blkio every iterations", cgroup_recheck_zero_blkio_every_iterations);
     cgroup_recheck_zero_mem_failcnt_every_iterations = (int)config_get_number("plugin:cgroups", "recheck zero memory failcnt every iterations", cgroup_recheck_zero_mem_failcnt_every_iterations);
     cgroup_recheck_zero_mem_detailed_every_iterations = (int)config_get_number("plugin:cgroups", "recheck zero detailed memory every iterations", cgroup_recheck_zero_mem_detailed_every_iterations);
@@ -116,6 +127,13 @@ void read_cgroup_plugin_configuration() {
     char filename[FILENAME_MAX + 1], *s;
     struct mountinfo *mi, *root = mountinfo_read(0);
     if(!cgroup_use_unified_cgroups) {
+        // cgroup v1 does not have pressure metrics
+        cgroup_enable_pressure_cpu =
+        cgroup_enable_pressure_io_some =
+        cgroup_enable_pressure_io_full =
+        cgroup_enable_pressure_memory_some =
+        cgroup_enable_pressure_memory_full = CONFIG_BOOLEAN_NO;
+
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuacct");
         if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "cpuacct");
         if(!mi) {
@@ -461,6 +479,10 @@ struct cgroup {
 
     struct cgroup_network_interface *interfaces;
 
+    struct pressure cpu_pressure;
+    struct pressure io_pressure;
+    struct pressure memory_pressure;
+
     // per cgroup charts
     RRDSET *st_cpu;
     RRDSET *st_cpu_limit;
@@ -478,6 +500,8 @@ struct cgroup {
     RRDSET *st_throttle_serviced_ops;
     RRDSET *st_queued_ops;
     RRDSET *st_merged_ops;
+
+    // pressure charts are inside `struct pressure' due to complexity
 
     // per cgroup chart variables
     char *filename_cpuset_cpus;
@@ -798,6 +822,54 @@ static inline void cgroup2_read_blkio(struct blkio *io, unsigned int word_offset
         }
 }
 
+static inline void cgroup2_read_pressure(struct pressure *res) {
+    static procfile *ff = NULL;
+
+    if (likely(res->filename)) {
+        ff = procfile_reopen(ff, res->filename, " =", PROCFILE_FLAG_DEFAULT);
+        if (unlikely(!ff)) {
+            res->updated = 0;
+            cgroups_check = 1;
+            return;
+        }
+
+        ff = procfile_readall(ff);
+        if (unlikely(!ff)) {
+            res->updated = 0;
+            cgroups_check = 1;
+            return;
+        }
+
+        size_t lines = procfile_lines(ff);
+        if (lines < 1) {
+            error("CGROUP: file '%s' should have 1+ lines.", res->filename);
+            res->updated = 0;
+            return;
+        }
+
+        res->some.value10 = strtod(procfile_lineword(ff, 0, 2), NULL);
+        res->some.value60 = strtod(procfile_lineword(ff, 0, 4), NULL);
+        res->some.value300 = strtod(procfile_lineword(ff, 0, 6), NULL);
+
+        if (lines > 2) {
+            res->full.value10 = strtod(procfile_lineword(ff, 1, 2), NULL);
+            res->full.value60 = strtod(procfile_lineword(ff, 1, 4), NULL);
+            res->full.value300 = strtod(procfile_lineword(ff, 1, 6), NULL);
+        }
+
+        res->updated = 1;
+
+        if (unlikely(res->some.enabled == CONFIG_BOOLEAN_AUTO)) {
+            res->some.enabled = CONFIG_BOOLEAN_YES;
+            if (lines > 2) {
+                res->full.enabled = CONFIG_BOOLEAN_YES;
+            } else {
+                res->full.enabled = CONFIG_BOOLEAN_NO;
+            }
+        }
+    }
+}
+
 static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unified) {
     static procfile *ff = NULL;
 
@@ -946,6 +1018,9 @@ static inline void cgroup_read(struct cgroup *cg) {
         cgroup2_read_blkio(&cg->io_service_bytes, 0);
         cgroup2_read_blkio(&cg->io_serviced, 4);
         cgroup2_read_cpuacct_stat(&cg->cpuacct_stat);
+        cgroup2_read_pressure(&cg->cpu_pressure);
+        cgroup2_read_pressure(&cg->io_pressure);
+        cgroup2_read_pressure(&cg->memory_pressure);
         cgroup_read_memory(&cg->memory, 1);
     }
 }
@@ -1236,6 +1311,12 @@ static inline struct cgroup *cgroup_add(const char *id) {
     return cg;
 }
 
+static inline void free_pressure(struct pressure *res) {
+    if (res->some.st)   rrdset_is_obsolete(res->some.st);
+    if (res->full.st)   rrdset_is_obsolete(res->full.st);
+    freez(res->filename);
+}
+
 static inline void cgroup_free(struct cgroup *cg) {
     debug(D_CGROUP, "Removing cgroup '%s' with chart id '%s' (was %s and %s)", cg->id, cg->chart_id, (cg->enabled)?"enabled":"disabled", (cg->available)?"available":"not available");
 
@@ -1283,6 +1364,10 @@ static inline void cgroup_free(struct cgroup *cg) {
 
     freez(cg->io_merged.filename);
     freez(cg->io_queued.filename);
+
+    free_pressure(&cg->cpu_pressure);
+    free_pressure(&cg->io_pressure);
+    free_pressure(&cg->memory_pressure);
 
     freez(cg->id);
     freez(cg->chart_id);
@@ -1747,6 +1832,42 @@ static inline void find_all_cgroups() {
                 }
                 else
                     debug(D_CGROUP, "memory.swap file for cgroup '%s': '%s' does not exist.", cg->id, filename);
+            }
+
+            if (unlikely(cgroup_enable_pressure_cpu && !cg->cpu_pressure.filename)) {
+                snprintfz(filename, FILENAME_MAX, "%s%s/cpu.pressure", cgroup_unified_base, cg->id);
+                if (likely(stat(filename, &buf) != -1)) {
+                    cg->cpu_pressure.filename = strdupz(filename);
+                    cg->cpu_pressure.some.enabled = cgroup_enable_pressure_cpu;
+                    cg->cpu_pressure.full.enabled = CONFIG_BOOLEAN_NO;
+                    debug(D_CGROUP, "cpu.pressure filename for cgroup '%s': '%s'", cg->id, cg->cpu_pressure.filename);
+                } else {
+                    debug(D_CGROUP, "cpu.pressure file for cgroup '%s': '%s' does not exist", cg->id, filename);
+                }
+            }
+
+            if (unlikely((cgroup_enable_pressure_io_some || cgroup_enable_pressure_io_full) && !cg->io_pressure.filename)) {
+                snprintfz(filename, FILENAME_MAX, "%s%s/io.pressure", cgroup_unified_base, cg->id);
+                if (likely(stat(filename, &buf) != -1)) {
+                    cg->io_pressure.filename = strdupz(filename);
+                    cg->io_pressure.some.enabled = cgroup_enable_pressure_io_some;
+                    cg->io_pressure.full.enabled = cgroup_enable_pressure_io_full;
+                    debug(D_CGROUP, "io.pressure filename for cgroup '%s': '%s'", cg->id, cg->io_pressure.filename);
+                } else {
+                    debug(D_CGROUP, "io.pressure file for cgroup '%s': '%s' does not exist", cg->id, filename);
+                }
+            }
+
+            if (unlikely((cgroup_enable_pressure_memory_some || cgroup_enable_pressure_memory_full) && !cg->memory_pressure.filename)) {
+                snprintfz(filename, FILENAME_MAX, "%s%s/memory.pressure", cgroup_unified_base, cg->id);
+                if (likely(stat(filename, &buf) != -1)) {
+                    cg->memory_pressure.filename = strdupz(filename);
+                    cg->memory_pressure.some.enabled = cgroup_enable_pressure_memory_some;
+                    cg->memory_pressure.full.enabled = cgroup_enable_pressure_memory_full;
+                    debug(D_CGROUP, "memory.pressure filename for cgroup '%s': '%s'", cg->id, cg->memory_pressure.filename);
+                } else {
+                    debug(D_CGROUP, "memory.pressure file for cgroup '%s': '%s' does not exist", cg->id, filename);
+                }
             }
         }
     }
@@ -3363,6 +3484,156 @@ void update_cgroup_charts(int update_every) {
             rrddim_set(cg->st_merged_ops, "read", cg->io_merged.Read);
             rrddim_set(cg->st_merged_ops, "write", cg->io_merged.Write);
             rrdset_done(cg->st_merged_ops);
+        }
+
+        if (cg->options & CGROUP_OPTIONS_IS_UNIFIED) {
+            struct pressure *res = &cg->cpu_pressure;
+            if (likely(res->updated && res->some.enabled)) {
+                if (unlikely(!res->some.st)) {
+                    RRDSET *chart;
+                    snprintfz(title, CHART_TITLE_MAX, "CPU pressure for cgroup %s", cg->chart_title);
+
+                    chart = res->some.st = rrdset_create_localhost(
+                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        , "cpu_pressure"
+                        , NULL
+                        , "cpu"
+                        , "cgroup.cpu_pressure"
+                        , title
+                        , "percentage"
+                        , PLUGIN_CGROUPS_NAME
+                        , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
+                        , cgroup_containers_chart_priority + 2200
+                        , update_every,
+                        RRDSET_TYPE_LINE);
+
+                    res->some.rd10 = rrddim_add(chart, "some 10", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->some.rd60 = rrddim_add(chart, "some 60", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->some.rd300 = rrddim_add(chart, "some 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                } else {
+                    rrdset_next(res->some.st);
+                }
+
+                update_pressure_chart(&res->some);
+            }
+
+            res = &cg->memory_pressure;
+            if (likely(res->updated && res->some.enabled)) {
+                if (unlikely(!res->some.st)) {
+                    RRDSET *chart;
+                    snprintfz(title, CHART_TITLE_MAX, "Memory pressure for cgroup %s", cg->chart_title);
+
+                    chart = res->some.st = rrdset_create_localhost(
+                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        , "mem_pressure"
+                        , NULL
+                        , "mem"
+                        , "cgroup.memory_pressure"
+                        , title
+                        , "percentage"
+                        , PLUGIN_CGROUPS_NAME
+                        , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
+                        , cgroup_containers_chart_priority + 2300
+                        , update_every,
+                        RRDSET_TYPE_LINE);
+
+                    res->some.rd10 = rrddim_add(chart, "some 10", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->some.rd60 = rrddim_add(chart, "some 60", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->some.rd300 = rrddim_add(chart, "some 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                } else {
+                    rrdset_next(res->some.st);
+                }
+
+                update_pressure_chart(&res->some);
+            }
+
+            if (likely(res->updated && res->full.enabled)) {
+                if (unlikely(!res->full.st)) {
+                    RRDSET *chart;
+                    snprintfz(title, CHART_TITLE_MAX, "Memory full pressure for cgroup %s", cg->chart_title);
+
+                    chart = res->full.st = rrdset_create_localhost(
+                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        , "mem_full_pressure"
+                        , NULL
+                        , "mem"
+                        , "cgroup.memory_full_pressure"
+                        , title
+                        , "percentage"
+                        , PLUGIN_CGROUPS_NAME
+                        , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
+                        , cgroup_containers_chart_priority + 2350
+                        , update_every,
+                        RRDSET_TYPE_LINE);
+
+                    res->full.rd10 = rrddim_add(chart, "full 10", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->full.rd60 = rrddim_add(chart, "full 60", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->full.rd300 = rrddim_add(chart, "full 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                } else {
+                    rrdset_next(res->full.st);
+                }
+
+                update_pressure_chart(&res->full);
+            }
+
+            res = &cg->io_pressure;
+            if (likely(res->updated && res->some.enabled)) {
+                if (unlikely(!res->some.st)) {
+                    RRDSET *chart;
+                    snprintfz(title, CHART_TITLE_MAX, "I/O pressure for cgroup %s", cg->chart_title);
+
+                    chart = res->some.st = rrdset_create_localhost(
+                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        , "io_pressure"
+                        , NULL
+                        , "disk"
+                        , "cgroup.io_pressure"
+                        , title
+                        , "percentage"
+                        , PLUGIN_CGROUPS_NAME
+                        , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
+                        , cgroup_containers_chart_priority + 2400
+                        , update_every,
+                        RRDSET_TYPE_LINE);
+
+                    res->some.rd10 = rrddim_add(chart, "some 10", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->some.rd60 = rrddim_add(chart, "some 60", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->some.rd300 = rrddim_add(chart, "some 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                } else {
+                    rrdset_next(res->some.st);
+                }
+
+                update_pressure_chart(&res->some);
+            }
+
+            if (likely(res->updated && res->full.enabled)) {
+                if (unlikely(!res->full.st)) {
+                    RRDSET *chart;
+                    snprintfz(title, CHART_TITLE_MAX, "I/O full pressure for cgroup %s", cg->chart_title);
+
+                    chart = res->full.st = rrdset_create_localhost(
+                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        , "io_full_pressure"
+                        , NULL
+                        , "disk"
+                        , "cgroup.io_full_pressure"
+                        , title
+                        , "percentage"
+                        , PLUGIN_CGROUPS_NAME
+                        , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
+                        , cgroup_containers_chart_priority + 2450
+                        , update_every,
+                        RRDSET_TYPE_LINE);
+
+                    res->full.rd10 = rrddim_add(chart, "full 10", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->full.rd60 = rrddim_add(chart, "full 60", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                    res->full.rd300 = rrddim_add(chart, "full 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+                } else {
+                    rrdset_next(res->full.st);
+                }
+
+                update_pressure_chart(&res->full);
+            }
         }
     }
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -113,8 +113,8 @@ void read_cgroup_plugin_configuration() {
     cgroup_enable_pressure_cpu = config_get_boolean_ondemand("plugin:cgroups", "enable cpu pressure", cgroup_enable_pressure_cpu);
     cgroup_enable_pressure_io_some = config_get_boolean_ondemand("plugin:cgroups", "enable io some pressure", cgroup_enable_pressure_io_some);
     cgroup_enable_pressure_io_full = config_get_boolean_ondemand("plugin:cgroups", "enable io full pressure", cgroup_enable_pressure_io_full);
-    cgroup_enable_pressure_memory_some = config_get_boolean_ondemand("plugin:cgroups", "enable memory pressure", cgroup_enable_pressure_memory_some);
-    cgroup_enable_pressure_memory_full = config_get_boolean_ondemand("plugin:cgroups", "enable memory pressure", cgroup_enable_pressure_memory_full);
+    cgroup_enable_pressure_memory_some = config_get_boolean_ondemand("plugin:cgroups", "enable memory some pressure", cgroup_enable_pressure_memory_some);
+    cgroup_enable_pressure_memory_full = config_get_boolean_ondemand("plugin:cgroups", "enable memory full pressure", cgroup_enable_pressure_memory_full);
 
     cgroup_recheck_zero_blkio_every_iterations = (int)config_get_number("plugin:cgroups", "recheck zero blkio every iterations", cgroup_recheck_zero_blkio_every_iterations);
     cgroup_recheck_zero_mem_failcnt_every_iterations = (int)config_get_number("plugin:cgroups", "recheck zero memory failcnt every iterations", cgroup_recheck_zero_mem_failcnt_every_iterations);

--- a/collectors/proc.plugin/README.md
+++ b/collectors/proc.plugin/README.md
@@ -18,6 +18,7 @@
 -   `/proc/interrupts` (total and per core hardware interrupts)
 -   `/proc/softirqs` (total and per core software interrupts)
 -   `/proc/loadavg` (system load and total processes running)
+-   `/proc/pressure/{cpu,memory,io}` (pressure stall information)
 -   `/proc/sys/kernel/random/entropy_avail` (random numbers pool availability - used in cryptography)
 -   `/sys/class/power_supply` (power supply properties)
 -   `ipc` (IPC semaphores and message queues)

--- a/collectors/proc.plugin/plugin_proc.c
+++ b/collectors/proc.plugin/plugin_proc.c
@@ -21,6 +21,9 @@ static struct proc_module {
         { .name = "/proc/loadavg", .dim = "loadavg", .func = do_proc_loadavg },
         { .name = "/proc/sys/kernel/random/entropy_avail", .dim = "entropy", .func = do_proc_sys_kernel_random_entropy_avail },
 
+        // pressure metrics
+        { .name = "/proc/pressure", .dim = "pressure", .func = do_proc_pressure },
+
         // CPU metrics
         { .name = "/proc/interrupts", .dim = "interrupts", .func = do_proc_interrupts },
         { .name = "/proc/softirqs", .dim = "softirqs", .func = do_proc_softirqs },

--- a/collectors/proc.plugin/plugin_proc.h
+++ b/collectors/proc.plugin/plugin_proc.h
@@ -40,6 +40,7 @@ extern int do_proc_net_rpc_nfsd(int update_every, usec_t dt);
 extern int do_proc_sys_kernel_random_entropy_avail(int update_every, usec_t dt);
 extern int do_proc_interrupts(int update_every, usec_t dt);
 extern int do_proc_softirqs(int update_every, usec_t dt);
+extern int do_proc_pressure(int update_every, usec_t dt);
 extern int do_sys_kernel_mm_ksm(int update_every, usec_t dt);
 extern int do_sys_block_zram(int update_every, usec_t dt);
 extern int do_proc_loadavg(int update_every, usec_t dt);

--- a/collectors/proc.plugin/plugin_proc.h
+++ b/collectors/proc.plugin/plugin_proc.h
@@ -67,6 +67,7 @@ extern void netdev_rename_device_add(const char *host_device, const char *contai
 extern void netdev_rename_device_del(const char *host_device);
 
 #include "proc_self_mountinfo.h"
+#include "proc_pressure.h"
 #include "zfs_common.h"
 
 #else // (TARGET_OS == OS_LINUX)

--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -4,50 +4,31 @@
 
 #define PLUGIN_PROC_MODULE_PRESSURE_NAME "/proc/pressure"
 #define CONFIG_SECTION_PLUGIN_PROC_PRESSURE "plugin:" PLUGIN_PROC_CONFIG_NAME ":" PLUGIN_PROC_MODULE_PRESSURE_NAME
-#define NUM_RESOURCES 3
 
 // linux calculates this every 2 seconds, see kernel/sched/psi.c PSI_FREQ
 #define MIN_PRESSURE_UPDATE_EVERY 2
 
 
-struct pressure_chart {
-    int enabled;
+static struct pressure resources[PRESSURE_NUM_RESOURCES] = {
+        { .family = "cpu",
+          .some = { .id = "cpu", .title = "CPU Pressure" },
+        },
 
-    const char *id;
-    const char *title;
-    RRDSET *st;
-    RRDDIM *rd10;
-    RRDDIM *rd60;
-    RRDDIM *rd300;
+        { .family = "memory",
+          .some = { .id = "memory", .title = "Memory Pressure" },
+          .full = { .id = "memory_full", .title = "Memory Full Pressure" },
+        },
+
+        { .family = "io",
+          .some = { .id = "io", .title = "I/O Pressure" },
+          .full = { .id = "io_full", .title = "I/O Full Pressure" },
+        },
 };
 
-static struct {
-    const char *family;
-    procfile *pf;
-    struct {
-        struct pressure_chart some;
-        struct pressure_chart full;
-    } charts;
-} resources[NUM_RESOURCES] = {
-        { .family = "cpu", .charts = {
-                .some = { .id = "cpu", .title = "CPU Pressure" },
-        }},
-
-        { .family = "memory", .charts = {
-                .some = { .id = "memory", .title = "Memory Pressure" },
-                .full = { .id = "memory_full", .title = "Memory Full Pressure" },
-        }},
-
-        { .family = "io", .charts = {
-                .some = { .id = "io", .title = "I/O Pressure" },
-                .full = { .id = "io_full", .title = "I/O Full Pressure" },
-        }},
-};
-
-void update_pressure_chart(struct pressure_chart *chart, double value10, double value60, double value300) {
-    rrddim_set_by_pointer(chart->st, chart->rd10, (collected_number) (value10 * 100));
-    rrddim_set_by_pointer(chart->st, chart->rd60, (collected_number) (value60 * 100));
-    rrddim_set_by_pointer(chart->st, chart->rd300, (collected_number) (value300 * 100));
+void update_pressure_chart(struct pressure_chart *chart) {
+    rrddim_set_by_pointer(chart->st, chart->rd10, (collected_number)(chart->value10 * 100));
+    rrddim_set_by_pointer(chart->st, chart->rd60, (collected_number) (chart->value60 * 100));
+    rrddim_set_by_pointer(chart->st, chart->rd300, (collected_number) (chart->value300 * 100));
 
     rrdset_done(chart->st);
 }
@@ -57,6 +38,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
     int i;
 
     static usec_t next_pressure_dt = 0;
+    static procfile *pf[PRESSURE_NUM_RESOURCES];
 
     update_every = (update_every < MIN_PRESSURE_UPDATE_EVERY) ? MIN_PRESSURE_UPDATE_EVERY : update_every;
 
@@ -67,9 +49,9 @@ int do_proc_pressure(int update_every, usec_t dt) {
         return 0;
     }
 
-    for (i = 0; i < NUM_RESOURCES; i++) {
-        procfile *ff = resources[i].pf;
-        int do_some = resources[i].charts.some.enabled, do_full = resources[i].charts.full.enabled;
+    for (i = 0; i < PRESSURE_NUM_RESOURCES; i++) {
+        procfile *ff = pf[i];
+        int do_some = resources[i].some.enabled, do_full = resources[i].full.enabled;
 
         if (unlikely(!ff)) {
             char filename[FILENAME_MAX + 1];
@@ -88,11 +70,11 @@ int do_proc_pressure(int update_every, usec_t dt) {
 
             snprintfz(config_key, CONFIG_MAX_NAME, "enable %s some pressure", resources[i].family);
             do_some = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, config_key, CONFIG_BOOLEAN_YES);
-            resources[i].charts.some.enabled = do_some;
-            if (resources[i].charts.full.id) {
+            resources[i].some.enabled = do_some;
+            if (resources[i].full.id) {
                 snprintfz(config_key, CONFIG_MAX_NAME, "enable %s full pressure", resources[i].family);
                 do_full = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, config_key, CONFIG_BOOLEAN_YES);
-                resources[i].charts.full.enabled = do_full;
+                resources[i].full.enabled = do_full;
             }
 
             ff = procfile_open(pressure_filename, " =", PROCFILE_FLAG_DEFAULT);
@@ -104,7 +86,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
         }
 
         ff = procfile_readall(ff);
-        resources[i].pf = ff;
+        pf[i] = ff;
         if (unlikely(!ff)) {
             continue;
         }
@@ -118,7 +100,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
 
         struct pressure_chart *chart;
         if (do_some) {
-            chart = &resources[i].charts.some;
+            chart = &resources[i].some;
             if (unlikely(!chart->st)) {
                 chart->st = rrdset_create_localhost(
                         "pressure"
@@ -141,14 +123,14 @@ int do_proc_pressure(int update_every, usec_t dt) {
                 rrdset_next(chart->st);
             }
 
-            double some10 = strtod(procfile_lineword(ff, 0, 2), NULL);
-            double some60 = strtod(procfile_lineword(ff, 0, 4), NULL);
-            double some300 = strtod(procfile_lineword(ff, 0, 6), NULL);
-            update_pressure_chart(chart, some10, some60, some300);
+            chart->value10 = strtod(procfile_lineword(ff, 0, 2), NULL);
+            chart->value60 = strtod(procfile_lineword(ff, 0, 4), NULL);
+            chart->value300 = strtod(procfile_lineword(ff, 0, 6), NULL);
+            update_pressure_chart(chart);
         }
 
         if (do_full && lines > 2) {
-            chart = &resources[i].charts.full;
+            chart = &resources[i].full;
             if (unlikely(!chart->st)) {
                 chart->st = rrdset_create_localhost(
                         "pressure"
@@ -171,14 +153,14 @@ int do_proc_pressure(int update_every, usec_t dt) {
                 rrdset_next(chart->st);
             }
 
-            double full10 = strtod(procfile_lineword(ff, 1, 2), NULL);
-            double full60 = strtod(procfile_lineword(ff, 1, 4), NULL);
-            double full300 = strtod(procfile_lineword(ff, 1, 6), NULL);
-            update_pressure_chart(&resources[i].charts.full, full10, full60, full300);
+            chart->value10 = strtod(procfile_lineword(ff, 1, 2), NULL);
+            chart->value60 = strtod(procfile_lineword(ff, 1, 4), NULL);
+            chart->value300 = strtod(procfile_lineword(ff, 1, 6), NULL);
+            update_pressure_chart(chart);
         }
     }
 
-    if (NUM_RESOURCES == fail_count) {
+    if (PRESSURE_NUM_RESOURCES == fail_count) {
         return 1;
     }
 

--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -174,7 +174,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
             double full10 = strtod(procfile_lineword(ff, 1, 2), NULL);
             double full60 = strtod(procfile_lineword(ff, 1, 4), NULL);
             double full300 = strtod(procfile_lineword(ff, 1, 6), NULL);
-            update_pressure_chart(&resources[i].charts.some, full10, full60, full300);
+            update_pressure_chart(&resources[i].charts.full, full10, full60, full300);
         }
     }
 

--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "plugin_proc.h"
+
+#define PLUGIN_PROC_MODULE_PRESSURE_NAME "/proc/pressure"
+#define CONFIG_SECTION_PLUGIN_PROC_PRESSURE "plugin:" PLUGIN_PROC_CONFIG_NAME ":" PLUGIN_PROC_MODULE_PRESSURE_NAME
+#define NUM_RESOURCES 3
+
+// linux calculates this every 2 seconds, see kernel/sched/psi.c PSI_FREQ
+#define MIN_PRESSURE_UPDATE_EVERY 2
+
+struct pressure_chart {
+    int enabled;
+
+    const char *id;
+    const char *title;
+    RRDSET *st;
+    RRDDIM *rd10;
+    RRDDIM *rd60;
+    RRDDIM *rd300;
+};
+
+static struct {
+    const char *family;
+    procfile *pf;
+    struct {
+        struct pressure_chart some;
+        struct pressure_chart full;
+    } charts;
+} resources[NUM_RESOURCES] = {
+        { .family = "cpu", .charts = {
+                .some = { .id = "cpu", .title = "CPU Pressure" },
+        }},
+
+        { .family = "memory", .charts = {
+                .some = { .id = "memory", .title = "Memory Pressure" },
+                .full = { .id = "memory_full", .title = "Memory Full Pressure" },
+        }},
+
+        { .family = "io", .charts = {
+                .some = { .id = "io", .title = "I/O Pressure" },
+                .full = { .id = "io_full", .title = "I/O Full Pressure" },
+        }},
+};
+
+void
+chart_pressure_information(struct pressure_chart *chart, int priority, double value10, double value60, double value300,
+                           int update_every, const char *family) {
+    if (unlikely(!chart->st)) {
+        chart->st = rrdset_create_localhost(
+                "pressure"
+                , chart->id
+                , NULL
+                , family
+                , NULL
+                , chart->title
+                , "percentage"
+                , PLUGIN_PROC_NAME
+                , PLUGIN_PROC_MODULE_PRESSURE_NAME
+                , NETDATA_CHART_PRIO_SYSTEM_PRESSURE + priority
+                , update_every
+                , RRDSET_TYPE_LINE
+        );
+        chart->rd10 = rrddim_add(chart->st, "some 10", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+        chart->rd60 = rrddim_add(chart->st, "some 60", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+        chart->rd300 = rrddim_add(chart->st, "some 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+    } else {
+        rrdset_next(chart->st);
+    }
+
+    rrddim_set_by_pointer(chart->st, chart->rd10, (collected_number) (value10 * 100));
+    rrddim_set_by_pointer(chart->st, chart->rd60, (collected_number) (value60 * 100));
+    rrddim_set_by_pointer(chart->st, chart->rd300, (collected_number) (value300 * 100));
+
+    rrdset_done(chart->st);
+}
+
+int do_proc_pressure(int update_every, usec_t dt) {
+    int fail_count = 0;
+    int i;
+
+    static usec_t next_pressure_dt = 0;
+
+    update_every = (update_every < MIN_PRESSURE_UPDATE_EVERY) ? MIN_PRESSURE_UPDATE_EVERY : update_every;
+
+    if (next_pressure_dt <= dt) {
+        next_pressure_dt = update_every * USEC_PER_SEC;
+    } else {
+        next_pressure_dt -= dt;
+        return 0;
+    }
+
+    for (i = 0; i < NUM_RESOURCES; i++) {
+        procfile *ff = resources[i].pf;
+        int do_some = resources[i].charts.some.enabled, do_full = resources[i].charts.full.enabled;
+
+        if (unlikely(!ff)) {
+            char filename[FILENAME_MAX + 1];
+            char config_key[CONFIG_MAX_NAME + 1];
+            char *pressure_filename;
+
+            snprintfz(filename
+                      , FILENAME_MAX
+                      , "%s%s/%s"
+                      , netdata_configured_host_prefix
+                      , PLUGIN_PROC_MODULE_PRESSURE_NAME
+                      , resources[i].family);
+
+            snprintfz(config_key, CONFIG_MAX_NAME, "path to %s pressure", resources[i].family);
+            pressure_filename = config_get(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, config_key, filename);
+
+            snprintfz(config_key, CONFIG_MAX_NAME, "enable %s some pressure", resources[i].family);
+            do_some = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, config_key, CONFIG_BOOLEAN_YES);
+            resources[i].charts.some.enabled = do_some;
+            if (resources[i].charts.full.id) {
+                snprintfz(config_key, CONFIG_MAX_NAME, "enable %s full pressure", resources[i].family);
+                do_full = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, config_key, CONFIG_BOOLEAN_YES);
+                resources[i].charts.full.enabled = do_full;
+            }
+
+            ff = procfile_open(pressure_filename, " =", PROCFILE_FLAG_DEFAULT);
+            if (unlikely(!ff)) {
+                error("Cannot read pressure information from %s.", pressure_filename);
+                fail_count++;
+                continue;
+            }
+        }
+
+        ff = procfile_readall(ff);
+        resources[i].pf = ff;
+        if (unlikely(!ff)) {
+            continue;
+        }
+
+        size_t lines = procfile_lines(ff);
+        if (unlikely(lines < 1)) {
+            error("%s has no lines.", procfile_filename(ff));
+            fail_count++;
+            continue;
+        }
+
+        if (do_some) {
+            double some10 = strtod(procfile_lineword(ff, 0, 2), NULL);
+            double some60 = strtod(procfile_lineword(ff, 0, 4), NULL);
+            double some300 = strtod(procfile_lineword(ff, 0, 6), NULL);
+
+            chart_pressure_information(&resources[i].charts.some
+                                       , NETDATA_CHART_PRIO_SYSTEM_PRESSURE + 2 * i
+                                       , some10
+                                       , some60
+                                       , some300
+                                       , update_every
+                                       , resources[i].family);
+
+        }
+
+        if (do_full && lines > 2) {
+            double full10 = -1., full60 = -1., full300 = -1.;
+            full10 = strtod(procfile_lineword(ff, 1, 2), NULL);
+            full60 = strtod(procfile_lineword(ff, 1, 4), NULL);
+            full300 = strtod(procfile_lineword(ff, 1, 6), NULL);
+            chart_pressure_information(&resources[i].charts.full
+                                       , NETDATA_CHART_PRIO_SYSTEM_PRESSURE + 2 * i + 1
+                                       , full10
+                                       , full60
+                                       , full300
+                                       , update_every
+                                       , resources[i].family);
+        }
+    }
+
+    if (NUM_RESOURCES == fail_count) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/collectors/proc.plugin/proc_pressure.h
+++ b/collectors/proc.plugin/proc_pressure.h
@@ -8,7 +8,6 @@
 struct pressure {
     int updated;
     char *filename;
-    const char *family;
 
     struct pressure_chart {
         int enabled;

--- a/collectors/proc.plugin/proc_pressure.h
+++ b/collectors/proc.plugin/proc_pressure.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_PROC_PRESSURE_H
+#define NETDATA_PROC_PRESSURE_H
+
+#define PRESSURE_NUM_RESOURCES 3
+
+struct pressure {
+    int updated;
+    char *filename;
+    const char *family;
+
+    struct pressure_chart {
+        int enabled;
+
+        const char *id;
+        const char *title;
+
+        double value10;
+        double value60;
+        double value300;
+
+        RRDSET *st;
+        RRDDIM *rd10;
+        RRDDIM *rd60;
+        RRDDIM *rd300;
+    } some, full;
+};
+
+extern void update_pressure_chart(struct pressure_chart *chart);
+
+#endif //NETDATA_PROC_PRESSURE_H

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -25,7 +25,7 @@ netdataDashboard.menu = {
             'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on a given resource.<br>' +
             'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on a given resource simultaneously. ' +
             'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing.<br>' +
-            'The ratios (in %) are tracked as recent trends over 10, 60 and 300 second windows.'
+            'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
     },
 
     'services': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -17,6 +17,17 @@ netdataDashboard.menu = {
         info: 'Overview of the key system metrics.'
     },
 
+    'pressure': {
+        title: 'Pressure',
+        icon: '<i class="fas fa-fire"></i>',
+        info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html">Pressure Stall Information</a> ' +
+            'identifies and quantifies the disruptions caused by resource contentions.<br>' +
+            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on a given resource.<br>' +
+            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on a given resource simultaneously. ' +
+            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing.<br>' +
+            'The ratios (in %) are tracked as recent trends over 10, 60 and 300 second windows.'
+    },
+
     'services': {
         title: 'systemd Services',
         icon: '<i class="fas fa-cogs"></i>',

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -17,17 +17,6 @@ netdataDashboard.menu = {
         info: 'Overview of the key system metrics.'
     },
 
-    'pressure': {
-        title: 'Pressure',
-        icon: '<i class="fas fa-fire"></i>',
-        info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html">Pressure Stall Information</a> ' +
-            'identifies and quantifies the disruptions caused by resource contentions.<br>' +
-            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on a given resource.<br>' +
-            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on a given resource simultaneously. ' +
-            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing.<br>' +
-            'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
-    },
-
     'services': {
         title: 'systemd Services',
         icon: '<i class="fas fa-cogs"></i>',
@@ -727,6 +716,32 @@ netdataDashboard.context = {
     'system.load': {
         info: 'Current system load, i.e. the number of processes using CPU or waiting for system resources (usually CPU and disk). The 3 metrics refer to 1, 5 and 15 minute averages. The system calculates this once every 5 seconds. For more information check <a href="https://en.wikipedia.org/wiki/Load_(computing)" target="_blank">this wikipedia article</a>',
         height: 0.7
+    },
+
+    'system.cpu_pressure': {
+        info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html">Pressure Stall Information</a> ' +
+            'identifies and quantifies the disruptions caused by resource contentions. ' +
+            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on a given resource. ' +
+            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. ' +
+            'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+
+    'system.memory_some_pressure': {
+        info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html">Pressure Stall Information</a> ' +
+            'identifies and quantifies the disruptions caused by resource contentions. ' +
+            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on a given resource. ' +
+            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on a given resource simultaneously. ' +
+            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. ' +
+            'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+
+    'system.io_some_pressure': {
+        info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html">Pressure Stall Information</a> ' +
+            'identifies and quantifies the disruptions caused by resource contentions. ' +
+            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on a given resource. ' +
+            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on a given resource simultaneously. ' +
+            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. ' +
+            'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
     },
 
     'system.io': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -721,16 +721,15 @@ netdataDashboard.context = {
     'system.cpu_pressure': {
         info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html">Pressure Stall Information</a> ' +
             'identifies and quantifies the disruptions caused by resource contentions. ' +
-            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on a given resource. ' +
-            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. ' +
+            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on CPU. ' +
             'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
     },
 
     'system.memory_some_pressure': {
         info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html">Pressure Stall Information</a> ' +
             'identifies and quantifies the disruptions caused by resource contentions. ' +
-            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on a given resource. ' +
-            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on a given resource simultaneously. ' +
+            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on memory. ' +
+            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on memory simultaneously. ' +
             'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. ' +
             'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
     },
@@ -738,8 +737,8 @@ netdataDashboard.context = {
     'system.io_some_pressure': {
         info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html">Pressure Stall Information</a> ' +
             'identifies and quantifies the disruptions caused by resource contentions. ' +
-            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on a given resource. ' +
-            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on a given resource simultaneously. ' +
+            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on I/O. ' +
+            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on I/O simultaneously. ' +
             'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. ' +
             'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
     },


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Add [PSI](https://www.kernel.org/doc/html/latest/accounting/psi.html) monitoring to proc.plugin. Fixes #5901.

##### Component Name
collectors/proc.plugin

##### Additional Information
This is WIP because:
- [x] Explanation text on the dashboard is currently missing
- [ ] CGroup2 PSI monitoring is currently missing

Things I'd like to make sure before continuing:
- [x] Currently, it resides under "System", and has 5 graphs. Does it deserve its own section?
- [x] Is there a better way to arrange them?
- [ ] The "total" fields are not graphed. Do we need them?
- [x] Do we need a switch for each graph (like in proc_loadavg)?
- [x] The `procfile_lines` returns 2 for `/proc/pressure/cpu`, which should only have 1 line, for example:
    ```
    % python                   
    Python 3.7.4 (default, Oct  4 2019, 06:57:26) 
    [GCC 9.2.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> open('/proc/pressure/cpu', 'rb').read()
    b'some avg10=3.22 avg60=4.15 avg300=4.07 total=11747246754\n'
    ```
    Is this intended or is it a bug? Currently, I'm using `lines > 2` to workaround this behavior. What would be a better way to handle this?

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/529520/67707460-c53f3d00-f9ba-11e9-9857-5030e844a9ba.png)

</details>
