### PR TITLE
.travis.yml: Increase timeout for docker image builds to 20 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -493,10 +493,10 @@ jobs:
           - echo "Last commit:" && git log -1
           - echo "GIT Describe:" && git describe
           - echo "packaging/version:" && cat packaging/version
-          - >-
-            packaging/docker/check_login.sh
+          - docker info
+          - packaging/docker/check_login.sh
             && echo "Switching to latest master branch, to pick up tagging if any" && git checkout master && git pull
-            && packaging/docker/build.sh
+            && travis_wait 20 packaging/docker/build.sh
             && packaging/docker/publish.sh
         after_failure: post_message "TRAVIS_MESSAGE" "<!here> Docker image publishing failed"
 
@@ -592,9 +592,8 @@ jobs:
           - echo "GIT Describe:" && git describe
           - echo "packaging/version:" && cat packaging/version
           - docker info
-          - >-
-            packaging/docker/check_login.sh
-            && packaging/docker/build.sh
+          - packaging/docker/check_login.sh
+            && travis_wait 20 packaging/docker/build.sh
             && packaging/docker/publish.sh
         after_failure: post_message "TRAVIS_MESSAGE" "<!here> Nightly docker image publish failed"
 


### PR DESCRIPTION
##### Summary
Increase the timeout for docker image builds to 20 minutes

##### Component Name
.travis.yml

##### Additional Information
Fixes #7213 
