### PR TITLE
[WIP] Fix counter reset detection

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -628,95 +628,9 @@ struct test test5 = {
 };
 
 // --------------------------------------------------------------------------------------------------------------------
-// test5b - 16 bit overflows
+// test5b - 64 bit overflows
 
 struct feed_values test5b_feed[] = {
-        { 0,       0x000000000000FFFFULL / 3 * 0 },
-        { 1000000, 0x000000000000FFFFULL / 3 * 1 },
-        { 1000000, 0x000000000000FFFFULL / 3 * 2 },
-        { 1000000, 0x000000000000FFFFULL / 3 * 0 },
-        { 1000000, 0x000000000000FFFFULL / 3 * 1 },
-        { 1000000, 0x000000000000FFFFULL / 3 * 2 },
-        { 1000000, 0x000000000000FFFFULL / 3 * 0 },
-        { 1000000, 0x000000000000FFFFULL / 3 * 1 },
-        { 1000000, 0x000000000000FFFFULL / 3 * 2 },
-        { 1000000, 0x000000000000FFFFULL / 3 * 0 },
-};
-
-calculated_number test5b_results[] = {
-        0x000000000000FFFFULL / 3,
-        0x000000000000FFFFULL / 3,
-        0x000000000000FFFFULL / 3,
-        0x000000000000FFFFULL / 3,
-        0x000000000000FFFFULL / 3,
-        0x000000000000FFFFULL / 3,
-        0x000000000000FFFFULL / 3,
-        0x000000000000FFFFULL / 3,
-        0x000000000000FFFFULL / 3,
-};
-
-struct test test5b = {
-        "test5b",            // name
-        "test 16-bit incremental values overflow",
-        1,                  // update_every
-        1,                  // multiplier
-        1,                  // divisor
-        RRD_ALGORITHM_INCREMENTAL, // algorithm
-        10,                 // feed entries
-        9,                  // result entries
-        test5b_feed,        // feed
-        test5b_results,     // results
-        NULL,               // feed2
-        NULL                // results2
-};
-
-// --------------------------------------------------------------------------------------------------------------------
-// test5c - 8 bit overflows
-
-struct feed_values test5c_feed[] = {
-        { 0,       0x00000000000000FFULL / 3 * 0 },
-        { 1000000, 0x00000000000000FFULL / 3 * 1 },
-        { 1000000, 0x00000000000000FFULL / 3 * 2 },
-        { 1000000, 0x00000000000000FFULL / 3 * 0 },
-        { 1000000, 0x00000000000000FFULL / 3 * 1 },
-        { 1000000, 0x00000000000000FFULL / 3 * 2 },
-        { 1000000, 0x00000000000000FFULL / 3 * 0 },
-        { 1000000, 0x00000000000000FFULL / 3 * 1 },
-        { 1000000, 0x00000000000000FFULL / 3 * 2 },
-        { 1000000, 0x00000000000000FFULL / 3 * 0 },
-};
-
-calculated_number test5c_results[] = {
-        0x00000000000000FFULL / 3,
-        0x00000000000000FFULL / 3,
-        0x00000000000000FFULL / 3,
-        0x00000000000000FFULL / 3,
-        0x00000000000000FFULL / 3,
-        0x00000000000000FFULL / 3,
-        0x00000000000000FFULL / 3,
-        0x00000000000000FFULL / 3,
-        0x00000000000000FFULL / 3,
-};
-
-struct test test5c = {
-        "test5c",            // name
-        "test 8-bit incremental values overflow",
-        1,                  // update_every
-        1,                  // multiplier
-        1,                  // divisor
-        RRD_ALGORITHM_INCREMENTAL, // algorithm
-        10,                 // feed entries
-        9,                  // result entries
-        test5c_feed,        // feed
-        test5c_results,     // results
-        NULL,               // feed2
-        NULL                // results2
-};
-
-// --------------------------------------------------------------------------------------------------------------------
-// test5d - 64 bit overflows
-
-struct feed_values test5d_feed[] = {
         { 0,       0xFFFFFFFFFFFFFFFFULL / 3 * 0 },
         { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 1 },
         { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 2 },
@@ -729,7 +643,7 @@ struct feed_values test5d_feed[] = {
         { 1000000, 0xFFFFFFFFFFFFFFFFULL / 3 * 0 },
 };
 
-calculated_number test5d_results[] = {
+calculated_number test5b_results[] = {
         0xFFFFFFFFFFFFFFFFULL / 3,
         0xFFFFFFFFFFFFFFFFULL / 3,
         0xFFFFFFFFFFFFFFFFULL / 3,
@@ -741,8 +655,8 @@ calculated_number test5d_results[] = {
         0xFFFFFFFFFFFFFFFFULL / 3,
 };
 
-struct test test5d = {
-        "test5d",            // name
+struct test test5b = {
+        "test5b",            // name
         "test 64-bit incremental values overflow",
         1,                  // update_every
         1,                  // multiplier
@@ -750,8 +664,8 @@ struct test test5d = {
         RRD_ALGORITHM_INCREMENTAL, // algorithm
         10,                 // feed entries
         9,                  // result entries
-        test5d_feed,        // feed
-        test5d_results,     // results
+        test5b_feed,        // feed
+        test5b_results,     // results
         NULL,               // feed2
         NULL                // results2
 };
@@ -1415,12 +1329,6 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(run_test(&test5b))
-        return 1;
-
-    if(run_test(&test5c))
-        return 1;
-
-    if(run_test(&test5d))
         return 1;
 
     if(run_test(&test6))

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1463,10 +1463,10 @@ void rrdset_done(RRDSET *st) {
                     uint64_t max = (uint64_t)rd->collected_value_max;
                     uint64_t cap = 0;
 
-                         if(max > 0x00000000FFFFFFFFULL) cap = 0xFFFFFFFFFFFFFFFFULL;
-                    else if(max > 0x000000000000FFFFULL) cap = 0x00000000FFFFFFFFULL;
-                    else if(max > 0x00000000000000FFULL) cap = 0x000000000000FFFFULL;
-                    else                                 cap = 0x00000000000000FFULL;
+                    if (max > 0x00000000FFFFFFFFULL)
+                        cap = 0xFFFFFFFFFFFFFFFFULL;
+                    else
+                        cap = 0x00000000FFFFFFFFULL;
 
                     uint64_t delta = cap - last + new;
 

--- a/libnetdata/storage_number/storage_number.h
+++ b/libnetdata/storage_number/storage_number.h
@@ -87,4 +87,8 @@ int print_calculated_number(char *str, calculated_number value);
 #define ACCURACY_LOSS_ACCEPTED_PERCENT 0.0001
 #define accuracy_loss(t1, t2) (((t1) == (t2) || (t1) == 0.0 || (t2) == 0.0) ? 0.0 : (100.0 - (((t1) > (t2)) ? ((t2) * 100.0 / (t1) ) : ((t1) * 100.0 / (t2)))))
 
+// Maximum acceptable rate of increase for counters. With a rate of 10% netdata can safely detect overflows with a
+// period of at least every other 10 samples.
+#define MAX_INCREMENTAL_PERCENT_RATE 10
+
 #endif /* NETDATA_STORAGE_NUMBER_H */


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #4962
Fixes #5297
Fixes #7217

##### Component Name
daemon
database
##### Additional Information

This is the first step to fix some of the problems discussed in #7049 .

It is theoretically impossible to always be 100% sure about things such as hardware counters that overflow. As a result it is theoretically impossible to both solve the counter reset and the counter overflow prroblem.

This implementation attempts to solve both issues by mostly erring on the safe side as if it was a counter reset.

8-bit and 16-bit or any arbitrary precision counters are not supported as it would be too much effort.

We attempt to identify most of the wrap-arounds without creating too many false negatives for counter resets.