### PR TITLE
UrlService: allow to skip tls_verify for http scheme

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -102,8 +102,7 @@ class UrlService(SimpleService):
         if tls_ca_file:
             params['ca_certs'] = tls_ca_file
         try:
-            url = header_kw.get('url') or self.url
-            if url.startswith('https') and not self.tls_verify and not tls_ca_file:
+            if self.tls_verify is False and not tls_ca_file:
                 params['ca_certs'] = None
                 return manager(assert_hostname=False, cert_reqs='CERT_NONE', **params)
             return manager(**params)

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -180,6 +180,7 @@ class UrlService(SimpleService):
 
 
 def skip_tls_verify(is_https, tls_verify, tls_ca_file):
+    # default 'tls_verify' value is None
     # logic is:
     #   - never skip if there is 'tls_ca_file' file
     #   - skip by default for https

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -180,6 +180,10 @@ class UrlService(SimpleService):
 
 
 def skip_tls_verify(is_https, tls_verify, tls_ca_file):
+    # logic is:
+    #   - never skip if there is 'tls_ca_file' file
+    #   - skip by default for https
+    #   - do not skip by default for http
     if tls_ca_file:
         return False
     if is_https and not tls_verify:


### PR DESCRIPTION
##### Summary

Fixes: #7222

Do not check scheme applying `tls_verify` option.

##### Component Name

[/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py)

##### Additional Information

