### PR TITLE
database: include limits.h before using LONG_MAX

### DIFF
--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -65,6 +65,7 @@
 #include <getopt.h>
 #include <grp.h>
 #include <pwd.h>
+#include <limits.h>
 #include <locale.h>
 #include <net/if.h>
 #include <poll.h>


### PR DESCRIPTION
##### Summary
Include limits.h before using LONG_MAX. This fixes build with musl standard C library.

##### Component Name
database

##### Additional Information

