### PR TITLE
rabbitmq: handle "disk_free": "disk_free_monitoring_disabled"

### DIFF
--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -231,6 +231,7 @@ class Service(UrlService):
 
         data = loads(raw)
         stats = fetch_data(raw_data=data, metrics=NODE_STATS)
+        handle_disabled_disk_monitoring(stats)
         self.debug("number of metrics: {0}".format(len(stats)))
         return stats
 
@@ -284,3 +285,11 @@ def fetch_data(raw_data, metrics):
         data['_'.join(metrics_list)] = value
 
     return data
+
+
+def handle_disabled_disk_monitoring(node_stats):
+    # https://github.com/netdata/netdata/issues/7218
+    # can be "disk_free": "disk_free_monitoring_disabled"
+    v = node_stats.get('disk_free')
+    if v and isinstance(v, str):
+        del node_stats['disk_free']


### PR DESCRIPTION
##### Summary
Fixes: #7218

`/api/nodes` endpoint returns `disk_free_monitoring_disabled` as a value for `disk_free` and `disk_free_limit` if rabbitmq failes to get this data.

rel: 
> https://stackoverflow.com/questions/43460638/can-rabbitmq-disk-free-monitoring-be-enabled?rq=1

##### Component Name

[/collectors/python.d.plugin/rabbitmq](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/rabbitmq)

##### Additional Information

