### PR TITLE
.travis.yml: Prevent nightly jobs from timing out (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ matrix:
   allow_failures:
     - env: ALLOW_SOFT_FAILURE_HERE=true
 
-
+before_install:
+  - source .travis/utils.sh
 
 # Install dependencies for all, once
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -496,7 +496,7 @@ jobs:
           - echo "packaging/version:" && cat packaging/version
           - packaging/docker/check_login.sh
             && echo "Switching to latest master branch, to pick up tagging if any" && git checkout master && git pull
-            && travis_wait 20 packaging/docker/build.sh
+            && tick packaging/docker/build.sh
             && packaging/docker/publish.sh
         after_failure: post_message "TRAVIS_MESSAGE" "<!here> Docker image publishing failed"
 
@@ -592,7 +592,7 @@ jobs:
           - echo "GIT Describe:" && git describe
           - echo "packaging/version:" && cat packaging/version
           - packaging/docker/check_login.sh
-            && travis_wait 20 packaging/docker/build.sh
+            && tick packaging/docker/build.sh
             && packaging/docker/publish.sh
         after_failure: post_message "TRAVIS_MESSAGE" "<!here> Nightly docker image publish failed"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -494,7 +494,6 @@ jobs:
           - echo "Last commit:" && git log -1
           - echo "GIT Describe:" && git describe
           - echo "packaging/version:" && cat packaging/version
-          - docker info
           - packaging/docker/check_login.sh
             && echo "Switching to latest master branch, to pick up tagging if any" && git checkout master && git pull
             && travis_wait 20 packaging/docker/build.sh
@@ -592,7 +591,6 @@ jobs:
           - echo "Last commit:" && git log -1
           - echo "GIT Describe:" && git describe
           - echo "packaging/version:" && cat packaging/version
-          - docker info
           - packaging/docker/check_login.sh
             && travis_wait 20 packaging/docker/build.sh
             && packaging/docker/publish.sh

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Prevent travis from timing out after 10 minutes of no output
+tick() {
+	(while true; do sleep 300; echo; done) &
+	local PID=$!
+	disown
+
+	"$@"
+	local RET=$?
+
+	kill $PID
+	return $RET
+}
+
+retry() {
+	local tries=$1
+	shift
+
+	local i=0
+	while [ "$i" -lt "$tries" ]; do
+		"$@" && return 0
+		sleep $((2**((i++))))
+	done
+
+	return 1
+}


### PR DESCRIPTION
#### Summary
Prevent nightlies from timing out (again). Using a different approach this time because the first attempt was not good enough.

##### Component Name
.travis.yml

##### Additional Information
[Test build output](https://travis-ci.org/knatsakis/netdata/jobs/605792730)
