### PR TITLE
.travis.yml: Add timestamps to output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - env: ALLOW_SOFT_FAILURE_HERE=true
 
 before_install:
-  - exec > >(ts -s %H:%M:%.S) 2>&1
+  - exec > >(ts -s '%H:%M:%.S ') 2>&1
   - source .travis/utils.sh
 
 # Install dependencies for all, once

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: c
 services:
   - docker
 
-
+addons:
+  apt:
+    packages: ['moreutils']
 
 # This is a hook to help us introduce "soft" errors on our process
 matrix:
@@ -11,6 +13,7 @@ matrix:
     - env: ALLOW_SOFT_FAILURE_HERE=true
 
 before_install:
+  - exec > >(ts -s %.T)
   - source .travis/utils.sh
 
 # Install dependencies for all, once

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - env: ALLOW_SOFT_FAILURE_HERE=true
 
 before_install:
-  - exec > >(ts -s %H:%M:%.S)
+  - exec > >(ts -s %H:%M:%.S) 2>&1
   - source .travis/utils.sh
 
 # Install dependencies for all, once

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - env: ALLOW_SOFT_FAILURE_HERE=true
 
 before_install:
-  - exec > >(ts -s %.T)
+  - exec > >(ts -s %H:%M:%.S)
   - source .travis/utils.sh
 
 # Install dependencies for all, once


### PR DESCRIPTION
##### Summary
Add timestamps to travis output. These timestamps can be invaluable in helping with debugging timing issues.

##### Component Name
.travis.yml

##### Additional Information
[Test build](https://travis-ci.org/knatsakis/netdata/builds/605954639) with timestamped output of various build stages
