### PR TITLE
fix_irc_notification: Remove line break from message

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1628,7 +1628,7 @@ send_irc() {
 		*) color="#777777" ;;
 		esac
 
-    SNDMESSAGE="${MESSAGE//$'\n'/", "}"
+		SNDMESSAGE="${MESSAGE//$'\n'/", "}"
 		for CHANNEL in ${CHANNELS}; do
 			error=0
 			send_alarm=$(echo -e "USER ${NICKNAME} guest ${REALNAME} ${SERVERNAME}\\nNICK ${NICKNAME}\\nJOIN ${CHANNEL}\\nPRIVMSG ${CHANNEL} :${SNDMESSAGE}\\nQUIT\\n" \  | nc "${NETWORK}" 6667)

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1628,9 +1628,10 @@ send_irc() {
 		*) color="#777777" ;;
 		esac
 
+    SNDMESSAGE="${MESSAGE//$'\n'/", "}"
 		for CHANNEL in ${CHANNELS}; do
 			error=0
-			send_alarm=$(echo -e "USER ${NICKNAME} guest ${REALNAME} ${SERVERNAME}\\nNICK ${NICKNAME}\\nJOIN ${CHANNEL}\\nPRIVMSG ${CHANNEL} :${MESSAGE}\\nQUIT\\n" \  | nc "${NETWORK}" 6667)
+			send_alarm=$(echo -e "USER ${NICKNAME} guest ${REALNAME} ${SERVERNAME}\\nNICK ${NICKNAME}\\nJOIN ${CHANNEL}\\nPRIVMSG ${CHANNEL} :${SNDMESSAGE}\\nQUIT\\n" \  | nc "${NETWORK}" 6667)
 			reply_codes=$(echo "${send_alarm}" | cut -d ' ' -f 2 | grep -o '[0-9]*')
 			for code in ${reply_codes}; do
 				if [ "${code}" -ge 400 ] && [ "${code}" -le 599 ]; then


### PR DESCRIPTION
##### Summary
Fixes #7233 

When Netdata is sending messages to IRC channels, the messages are generating the error 421, because our default message is not according RFC1459(https://tools.ietf.org/html/rfc1459#section-2.3.1 ), this PR replaces the line break with commas to fix the problem.
##### Component Name
Alarms
##### Additional Information
I used the server ircd-hybrid to develop, because I wanted to have messages from both sides, but it is possible to do a simpler test, this PR must avoid the error.log to have error messages 421 when we send an alarm.
