### PR TITLE
Ownership and permissions of /etc/netdata

### DIFF
--- a/collectors/Makefile.am
+++ b/collectors/Makefile.am
@@ -27,6 +27,18 @@ SUBDIRS = \
     tc.plugin \
     $(NULL)
 
+usercustompluginsconfigdir=$(configdir)/custom-plugins.d
+usergoconfigdir=$(configdir)/go.d
+
+# Explicitly install directories to avoid permission issues due to umask
+install-exec-local:
+	$(INSTALL) -d $(DESTDIR)$(usercustompluginsconfigdir)
+	$(INSTALL) -d $(DESTDIR)$(usergoconfigdir)
+
+uninstall-local:
+	-rmdir $(DESTDIR)$(usercustompluginsconfigdir)
+	-rmdir $(DESTDIR)$(usergoconfigdir)
+
 dist_noinst_DATA = \
     README.md \
     $(NULL)

--- a/collectors/Makefile.am
+++ b/collectors/Makefile.am
@@ -35,10 +35,6 @@ install-exec-local:
 	$(INSTALL) -d $(DESTDIR)$(usercustompluginsconfigdir)
 	$(INSTALL) -d $(DESTDIR)$(usergoconfigdir)
 
-uninstall-local:
-	-rmdir $(DESTDIR)$(usercustompluginsconfigdir)
-	-rmdir $(DESTDIR)$(usergoconfigdir)
-
 dist_noinst_DATA = \
     README.md \
     $(NULL)

--- a/collectors/charts.d.plugin/Makefile.am
+++ b/collectors/charts.d.plugin/Makefile.am
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
-
 CLEANFILES = \
     charts.d.plugin \
     $(NULL)

--- a/collectors/charts.d.plugin/Makefile.am
+++ b/collectors/charts.d.plugin/Makefile.am
@@ -34,6 +34,10 @@ dist_userchartsconfig_DATA = \
     .keep \
     $(NULL)
 
+# Explicitly install directories to avoid permission issues due to umask
+install-exec-local:
+	$(INSTALL) -d $(DESTDIR)$(userchartsconfigdir)
+
 chartsconfigdir=$(libconfigdir)/charts.d
 dist_chartsconfig_DATA = \
     $(NULL)

--- a/collectors/charts.d.plugin/Makefile.am
+++ b/collectors/charts.d.plugin/Makefile.am
@@ -1,38 +1,39 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+
 CLEANFILES = \
-	charts.d.plugin \
-	$(NULL)
+    charts.d.plugin \
+    $(NULL)
 
 include $(top_srcdir)/build/subst.inc
 SUFFIXES = .in
 
 dist_libconfig_DATA = \
-	charts.d.conf \
-	$(NULL)
+    charts.d.conf \
+    $(NULL)
 
 dist_plugins_SCRIPTS = \
-	charts.d.dryrun-helper.sh \
-	charts.d.plugin \
-	loopsleepms.sh.inc \
-	$(NULL)
+    charts.d.dryrun-helper.sh \
+    charts.d.plugin \
+    loopsleepms.sh.inc \
+    $(NULL)
 
 dist_noinst_DATA = \
-	charts.d.plugin.in \
-	README.md \
-	$(NULL)
+    charts.d.plugin.in \
+    README.md \
+    $(NULL)
 
 dist_charts_SCRIPTS = \
-	$(NULL)
+    $(NULL)
 
 dist_charts_DATA = \
-	$(NULL)
+    $(NULL)
 
 userchartsconfigdir=$(configdir)/charts.d
 dist_userchartsconfig_DATA = \
-	.keep \
-	$(NULL)
+    .keep \
+    $(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:
@@ -40,7 +41,7 @@ install-exec-local:
 
 chartsconfigdir=$(libconfigdir)/charts.d
 dist_chartsconfig_DATA = \
-	$(NULL)
+    $(NULL)
 
 include ap/Makefile.inc
 include apache/Makefile.inc

--- a/collectors/charts.d.plugin/Makefile.am
+++ b/collectors/charts.d.plugin/Makefile.am
@@ -2,37 +2,37 @@
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 CLEANFILES = \
-    charts.d.plugin \
-    $(NULL)
+	charts.d.plugin \
+	$(NULL)
 
 include $(top_srcdir)/build/subst.inc
 SUFFIXES = .in
 
 dist_libconfig_DATA = \
-    charts.d.conf \
-    $(NULL)
+	charts.d.conf \
+	$(NULL)
 
 dist_plugins_SCRIPTS = \
-    charts.d.dryrun-helper.sh \
-    charts.d.plugin \
-    loopsleepms.sh.inc \
-    $(NULL)
+	charts.d.dryrun-helper.sh \
+	charts.d.plugin \
+	loopsleepms.sh.inc \
+	$(NULL)
 
 dist_noinst_DATA = \
-    charts.d.plugin.in \
-    README.md \
-    $(NULL)
+	charts.d.plugin.in \
+	README.md \
+	$(NULL)
 
 dist_charts_SCRIPTS = \
-    $(NULL)
+	$(NULL)
 
 dist_charts_DATA = \
-    $(NULL)
+	$(NULL)
 
 userchartsconfigdir=$(configdir)/charts.d
 dist_userchartsconfig_DATA = \
-    .keep \
-    $(NULL)
+	.keep \
+	$(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:
@@ -40,7 +40,7 @@ install-exec-local:
 
 chartsconfigdir=$(libconfigdir)/charts.d
 dist_chartsconfig_DATA = \
-    $(NULL)
+	$(NULL)
 
 include ap/Makefile.inc
 include apache/Makefile.inc

--- a/collectors/node.d.plugin/Makefile.am
+++ b/collectors/node.d.plugin/Makefile.am
@@ -26,6 +26,10 @@ dist_usernodeconfig_DATA = \
     .keep \
     $(NULL)
 
+# Explicitly install directories to avoid permission issues due to umask
+install-exec-local:
+	$(INSTALL) -d $(DESTDIR)$(usernodeconfigdir)
+
 nodeconfigdir=$(libconfigdir)/node.d
 dist_nodeconfig_DATA = \
     $(NULL)

--- a/collectors/node.d.plugin/Makefile.am
+++ b/collectors/node.d.plugin/Makefile.am
@@ -9,8 +9,8 @@ include $(top_srcdir)/build/subst.inc
 SUFFIXES = .in
 
 dist_libconfig_DATA = \
-	node.d.conf \
-	$(NULL)
+    node.d.conf \
+    $(NULL)
 
 dist_plugins_SCRIPTS = \
     node.d.plugin \
@@ -23,8 +23,8 @@ dist_noinst_DATA = \
 
 usernodeconfigdir=$(configdir)/node.d
 dist_usernodeconfig_DATA = \
-	.keep \
-	$(NULL)
+    .keep \
+    $(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:
@@ -32,7 +32,7 @@ install-exec-local:
 
 nodeconfigdir=$(libconfigdir)/node.d
 dist_nodeconfig_DATA = \
-	$(NULL)
+    $(NULL)
 
 dist_node_DATA = \
     $(NULL)

--- a/collectors/node.d.plugin/Makefile.am
+++ b/collectors/node.d.plugin/Makefile.am
@@ -9,8 +9,8 @@ include $(top_srcdir)/build/subst.inc
 SUFFIXES = .in
 
 dist_libconfig_DATA = \
-    node.d.conf \
-    $(NULL)
+	node.d.conf \
+	$(NULL)
 
 dist_plugins_SCRIPTS = \
     node.d.plugin \
@@ -23,8 +23,8 @@ dist_noinst_DATA = \
 
 usernodeconfigdir=$(configdir)/node.d
 dist_usernodeconfig_DATA = \
-    .keep \
-    $(NULL)
+	.keep \
+	$(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:
@@ -32,7 +32,7 @@ install-exec-local:
 
 nodeconfigdir=$(libconfigdir)/node.d
 dist_nodeconfig_DATA = \
-    $(NULL)
+	$(NULL)
 
 dist_node_DATA = \
     $(NULL)

--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -32,6 +32,10 @@ dist_userpythonconfig_DATA = \
     .keep \
     $(NULL)
 
+# Explicitly install directories to avoid permission issues due to umask
+install-exec-local:
+	$(INSTALL) -d $(DESTDIR)$(userpythonconfigdir)
+
 pythonconfigdir=$(libconfigdir)/python.d
 dist_pythonconfig_DATA = \
     $(NULL)

--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -2,35 +2,35 @@
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 CLEANFILES = \
-	python.d.plugin \
-	$(NULL)
+    python.d.plugin \
+    $(NULL)
 
 include $(top_srcdir)/build/subst.inc
 SUFFIXES = .in
 
 dist_libconfig_DATA = \
-	python.d.conf \
-	$(NULL)
+    python.d.conf \
+    $(NULL)
 
 dist_plugins_SCRIPTS = \
-	python.d.plugin \
-	$(NULL)
+    python.d.plugin \
+    $(NULL)
 
 dist_noinst_DATA = \
-	python.d.plugin.in \
-	README.md \
-	$(NULL)
+    python.d.plugin.in \
+    README.md \
+    $(NULL)
 
 dist_python_SCRIPTS = \
-	$(NULL)
+    $(NULL)
 
 dist_python_DATA = \
-	$(NULL)
+    $(NULL)
 
 userpythonconfigdir=$(configdir)/python.d
 dist_userpythonconfig_DATA = \
-	.keep \
-	$(NULL)
+    .keep \
+    $(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:
@@ -38,7 +38,7 @@ install-exec-local:
 
 pythonconfigdir=$(libconfigdir)/python.d
 dist_pythonconfig_DATA = \
-	$(NULL)
+    $(NULL)
 
 include adaptec_raid/Makefile.inc
 include am2320/Makefile.inc
@@ -111,141 +111,141 @@ include web_log/Makefile.inc
 
 pythonmodulesdir=$(pythondir)/python_modules
 dist_pythonmodules_DATA = \
-	python_modules/__init__.py \
-	$(NULL)
+    python_modules/__init__.py \
+    $(NULL)
 
 basesdir=$(pythonmodulesdir)/bases
 dist_bases_DATA = \
-	python_modules/bases/__init__.py \
-	python_modules/bases/charts.py \
-	python_modules/bases/collection.py \
-	python_modules/bases/loaders.py \
-	python_modules/bases/loggers.py \
-	$(NULL)
+    python_modules/bases/__init__.py \
+    python_modules/bases/charts.py \
+    python_modules/bases/collection.py \
+    python_modules/bases/loaders.py \
+    python_modules/bases/loggers.py \
+    $(NULL)
 
 bases_framework_servicesdir=$(basesdir)/FrameworkServices
 dist_bases_framework_services_DATA = \
-	python_modules/bases/FrameworkServices/__init__.py \
-	python_modules/bases/FrameworkServices/ExecutableService.py \
-	python_modules/bases/FrameworkServices/LogService.py \
-	python_modules/bases/FrameworkServices/MySQLService.py \
-	python_modules/bases/FrameworkServices/SimpleService.py \
-	python_modules/bases/FrameworkServices/SocketService.py \
-	python_modules/bases/FrameworkServices/UrlService.py \
-	$(NULL)
+    python_modules/bases/FrameworkServices/__init__.py \
+    python_modules/bases/FrameworkServices/ExecutableService.py \
+    python_modules/bases/FrameworkServices/LogService.py \
+    python_modules/bases/FrameworkServices/MySQLService.py \
+    python_modules/bases/FrameworkServices/SimpleService.py \
+    python_modules/bases/FrameworkServices/SocketService.py \
+    python_modules/bases/FrameworkServices/UrlService.py \
+    $(NULL)
 
 third_partydir=$(pythonmodulesdir)/third_party
 dist_third_party_DATA = \
-	python_modules/third_party/__init__.py \
-	python_modules/third_party/ordereddict.py \
-	python_modules/third_party/lm_sensors.py \
-	python_modules/third_party/mcrcon.py \
-	python_modules/third_party/boinc_client.py \
-	python_modules/third_party/monotonic.py \
-	$(NULL)
+    python_modules/third_party/__init__.py \
+    python_modules/third_party/ordereddict.py \
+    python_modules/third_party/lm_sensors.py \
+    python_modules/third_party/mcrcon.py \
+    python_modules/third_party/boinc_client.py \
+    python_modules/third_party/monotonic.py \
+    $(NULL)
 
 pythonyaml2dir=$(pythonmodulesdir)/pyyaml2
 dist_pythonyaml2_DATA = \
-	python_modules/pyyaml2/__init__.py \
-	python_modules/pyyaml2/composer.py \
-	python_modules/pyyaml2/constructor.py \
-	python_modules/pyyaml2/cyaml.py \
-	python_modules/pyyaml2/dumper.py \
-	python_modules/pyyaml2/emitter.py \
-	python_modules/pyyaml2/error.py \
-	python_modules/pyyaml2/events.py \
-	python_modules/pyyaml2/loader.py \
-	python_modules/pyyaml2/nodes.py \
-	python_modules/pyyaml2/parser.py \
-	python_modules/pyyaml2/reader.py \
-	python_modules/pyyaml2/representer.py \
-	python_modules/pyyaml2/resolver.py \
-	python_modules/pyyaml2/scanner.py \
-	python_modules/pyyaml2/serializer.py \
-	python_modules/pyyaml2/tokens.py \
-	$(NULL)
+    python_modules/pyyaml2/__init__.py \
+    python_modules/pyyaml2/composer.py \
+    python_modules/pyyaml2/constructor.py \
+    python_modules/pyyaml2/cyaml.py \
+    python_modules/pyyaml2/dumper.py \
+    python_modules/pyyaml2/emitter.py \
+    python_modules/pyyaml2/error.py \
+    python_modules/pyyaml2/events.py \
+    python_modules/pyyaml2/loader.py \
+    python_modules/pyyaml2/nodes.py \
+    python_modules/pyyaml2/parser.py \
+    python_modules/pyyaml2/reader.py \
+    python_modules/pyyaml2/representer.py \
+    python_modules/pyyaml2/resolver.py \
+    python_modules/pyyaml2/scanner.py \
+    python_modules/pyyaml2/serializer.py \
+    python_modules/pyyaml2/tokens.py \
+    $(NULL)
 
 pythonyaml3dir=$(pythonmodulesdir)/pyyaml3
 dist_pythonyaml3_DATA = \
-	python_modules/pyyaml3/__init__.py \
-	python_modules/pyyaml3/composer.py \
-	python_modules/pyyaml3/constructor.py \
-	python_modules/pyyaml3/cyaml.py \
-	python_modules/pyyaml3/dumper.py \
-	python_modules/pyyaml3/emitter.py \
-	python_modules/pyyaml3/error.py \
-	python_modules/pyyaml3/events.py \
-	python_modules/pyyaml3/loader.py \
-	python_modules/pyyaml3/nodes.py \
-	python_modules/pyyaml3/parser.py \
-	python_modules/pyyaml3/reader.py \
-	python_modules/pyyaml3/representer.py \
-	python_modules/pyyaml3/resolver.py \
-	python_modules/pyyaml3/scanner.py \
-	python_modules/pyyaml3/serializer.py \
-	python_modules/pyyaml3/tokens.py \
-	$(NULL)
+    python_modules/pyyaml3/__init__.py \
+    python_modules/pyyaml3/composer.py \
+    python_modules/pyyaml3/constructor.py \
+    python_modules/pyyaml3/cyaml.py \
+    python_modules/pyyaml3/dumper.py \
+    python_modules/pyyaml3/emitter.py \
+    python_modules/pyyaml3/error.py \
+    python_modules/pyyaml3/events.py \
+    python_modules/pyyaml3/loader.py \
+    python_modules/pyyaml3/nodes.py \
+    python_modules/pyyaml3/parser.py \
+    python_modules/pyyaml3/reader.py \
+    python_modules/pyyaml3/representer.py \
+    python_modules/pyyaml3/resolver.py \
+    python_modules/pyyaml3/scanner.py \
+    python_modules/pyyaml3/serializer.py \
+    python_modules/pyyaml3/tokens.py \
+    $(NULL)
 
 python_urllib3dir=$(pythonmodulesdir)/urllib3
 dist_python_urllib3_DATA = \
-	python_modules/urllib3/__init__.py \
-	python_modules/urllib3/_collections.py \
-	python_modules/urllib3/connection.py \
-	python_modules/urllib3/connectionpool.py \
-	python_modules/urllib3/exceptions.py \
-	python_modules/urllib3/fields.py \
-	python_modules/urllib3/filepost.py \
-	python_modules/urllib3/response.py \
-	python_modules/urllib3/poolmanager.py \
-	python_modules/urllib3/request.py \
-	$(NULL)
+    python_modules/urllib3/__init__.py \
+    python_modules/urllib3/_collections.py \
+    python_modules/urllib3/connection.py \
+    python_modules/urllib3/connectionpool.py \
+    python_modules/urllib3/exceptions.py \
+    python_modules/urllib3/fields.py \
+    python_modules/urllib3/filepost.py \
+    python_modules/urllib3/response.py \
+    python_modules/urllib3/poolmanager.py \
+    python_modules/urllib3/request.py \
+    $(NULL)
 
 python_urllib3_utildir=$(python_urllib3dir)/util
 dist_python_urllib3_util_DATA = \
-	python_modules/urllib3/util/__init__.py \
-	python_modules/urllib3/util/connection.py \
-	python_modules/urllib3/util/request.py \
-	python_modules/urllib3/util/response.py \
-	python_modules/urllib3/util/retry.py \
-	python_modules/urllib3/util/selectors.py \
-	python_modules/urllib3/util/ssl_.py \
-	python_modules/urllib3/util/timeout.py \
-	python_modules/urllib3/util/url.py \
-	python_modules/urllib3/util/wait.py \
-	$(NULL)
+    python_modules/urllib3/util/__init__.py \
+    python_modules/urllib3/util/connection.py \
+    python_modules/urllib3/util/request.py \
+    python_modules/urllib3/util/response.py \
+    python_modules/urllib3/util/retry.py \
+    python_modules/urllib3/util/selectors.py \
+    python_modules/urllib3/util/ssl_.py \
+    python_modules/urllib3/util/timeout.py \
+    python_modules/urllib3/util/url.py \
+    python_modules/urllib3/util/wait.py \
+    $(NULL)
 
 python_urllib3_packagesdir=$(python_urllib3dir)/packages
 dist_python_urllib3_packages_DATA = \
-	python_modules/urllib3/packages/__init__.py \
-	python_modules/urllib3/packages/ordered_dict.py \
-	python_modules/urllib3/packages/six.py \
-	$(NULL)
+    python_modules/urllib3/packages/__init__.py \
+    python_modules/urllib3/packages/ordered_dict.py \
+    python_modules/urllib3/packages/six.py \
+    $(NULL)
 
 python_urllib3_backportsdir=$(python_urllib3_packagesdir)/backports
 dist_python_urllib3_backports_DATA = \
-	python_modules/urllib3/packages/backports/__init__.py \
-	python_modules/urllib3/packages/backports/makefile.py \
-	$(NULL)
+    python_modules/urllib3/packages/backports/__init__.py \
+    python_modules/urllib3/packages/backports/makefile.py \
+    $(NULL)
 
 python_urllib3_ssl_match_hostnamedir=$(python_urllib3_packagesdir)/ssl_match_hostname
 dist_python_urllib3_ssl_match_hostname_DATA = \
-	python_modules/urllib3/packages/ssl_match_hostname/__init__.py \
-	python_modules/urllib3/packages/ssl_match_hostname/_implementation.py \
-	$(NULL)
+    python_modules/urllib3/packages/ssl_match_hostname/__init__.py \
+    python_modules/urllib3/packages/ssl_match_hostname/_implementation.py \
+    $(NULL)
 
 python_urllib3_contribdir=$(python_urllib3dir)/contrib
 dist_python_urllib3_contrib_DATA = \
-	python_modules/urllib3/contrib/__init__.py \
-	python_modules/urllib3/contrib/appengine.py \
-	python_modules/urllib3/contrib/ntlmpool.py \
-	python_modules/urllib3/contrib/pyopenssl.py \
-	python_modules/urllib3/contrib/securetransport.py \
-	python_modules/urllib3/contrib/socks.py \
-	$(NULL)
+    python_modules/urllib3/contrib/__init__.py \
+    python_modules/urllib3/contrib/appengine.py \
+    python_modules/urllib3/contrib/ntlmpool.py \
+    python_modules/urllib3/contrib/pyopenssl.py \
+    python_modules/urllib3/contrib/securetransport.py \
+    python_modules/urllib3/contrib/socks.py \
+    $(NULL)
 
 python_urllib3_securetransportdir=$(python_urllib3_contribdir)/_securetransport
 dist_python_urllib3_securetransport_DATA = \
-	python_modules/urllib3/contrib/_securetransport/__init__.py \
-	python_modules/urllib3/contrib/_securetransport/bindings.py \
-	python_modules/urllib3/contrib/_securetransport/low_level.py \
-	$(NULL)
+    python_modules/urllib3/contrib/_securetransport/__init__.py \
+    python_modules/urllib3/contrib/_securetransport/bindings.py \
+    python_modules/urllib3/contrib/_securetransport/low_level.py \
+    $(NULL)

--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -2,35 +2,35 @@
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 CLEANFILES = \
-    python.d.plugin \
-    $(NULL)
+	python.d.plugin \
+	$(NULL)
 
 include $(top_srcdir)/build/subst.inc
 SUFFIXES = .in
 
 dist_libconfig_DATA = \
-    python.d.conf \
-    $(NULL)
+	python.d.conf \
+	$(NULL)
 
 dist_plugins_SCRIPTS = \
-    python.d.plugin \
-    $(NULL)
+	python.d.plugin \
+	$(NULL)
 
 dist_noinst_DATA = \
-    python.d.plugin.in \
-    README.md \
-    $(NULL)
+	python.d.plugin.in \
+	README.md \
+	$(NULL)
 
 dist_python_SCRIPTS = \
-    $(NULL)
+	$(NULL)
 
 dist_python_DATA = \
-    $(NULL)
+	$(NULL)
 
 userpythonconfigdir=$(configdir)/python.d
 dist_userpythonconfig_DATA = \
-    .keep \
-    $(NULL)
+	.keep \
+	$(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:
@@ -38,7 +38,7 @@ install-exec-local:
 
 pythonconfigdir=$(libconfigdir)/python.d
 dist_pythonconfig_DATA = \
-    $(NULL)
+	$(NULL)
 
 include adaptec_raid/Makefile.inc
 include am2320/Makefile.inc
@@ -111,141 +111,141 @@ include web_log/Makefile.inc
 
 pythonmodulesdir=$(pythondir)/python_modules
 dist_pythonmodules_DATA = \
-    python_modules/__init__.py \
-    $(NULL)
+	python_modules/__init__.py \
+	$(NULL)
 
 basesdir=$(pythonmodulesdir)/bases
 dist_bases_DATA = \
-    python_modules/bases/__init__.py \
-    python_modules/bases/charts.py \
-    python_modules/bases/collection.py \
-    python_modules/bases/loaders.py \
-    python_modules/bases/loggers.py \
-    $(NULL)
+	python_modules/bases/__init__.py \
+	python_modules/bases/charts.py \
+	python_modules/bases/collection.py \
+	python_modules/bases/loaders.py \
+	python_modules/bases/loggers.py \
+	$(NULL)
 
 bases_framework_servicesdir=$(basesdir)/FrameworkServices
 dist_bases_framework_services_DATA = \
-    python_modules/bases/FrameworkServices/__init__.py \
-    python_modules/bases/FrameworkServices/ExecutableService.py \
-    python_modules/bases/FrameworkServices/LogService.py \
-    python_modules/bases/FrameworkServices/MySQLService.py \
-    python_modules/bases/FrameworkServices/SimpleService.py \
-    python_modules/bases/FrameworkServices/SocketService.py \
-    python_modules/bases/FrameworkServices/UrlService.py \
-    $(NULL)
+	python_modules/bases/FrameworkServices/__init__.py \
+	python_modules/bases/FrameworkServices/ExecutableService.py \
+	python_modules/bases/FrameworkServices/LogService.py \
+	python_modules/bases/FrameworkServices/MySQLService.py \
+	python_modules/bases/FrameworkServices/SimpleService.py \
+	python_modules/bases/FrameworkServices/SocketService.py \
+	python_modules/bases/FrameworkServices/UrlService.py \
+	$(NULL)
 
 third_partydir=$(pythonmodulesdir)/third_party
 dist_third_party_DATA = \
-    python_modules/third_party/__init__.py \
-    python_modules/third_party/ordereddict.py \
-    python_modules/third_party/lm_sensors.py \
-    python_modules/third_party/mcrcon.py \
-    python_modules/third_party/boinc_client.py \
-    python_modules/third_party/monotonic.py \
-    $(NULL)
+	python_modules/third_party/__init__.py \
+	python_modules/third_party/ordereddict.py \
+	python_modules/third_party/lm_sensors.py \
+	python_modules/third_party/mcrcon.py \
+	python_modules/third_party/boinc_client.py \
+	python_modules/third_party/monotonic.py \
+	$(NULL)
 
 pythonyaml2dir=$(pythonmodulesdir)/pyyaml2
 dist_pythonyaml2_DATA = \
-    python_modules/pyyaml2/__init__.py \
-    python_modules/pyyaml2/composer.py \
-    python_modules/pyyaml2/constructor.py \
-    python_modules/pyyaml2/cyaml.py \
-    python_modules/pyyaml2/dumper.py \
-    python_modules/pyyaml2/emitter.py \
-    python_modules/pyyaml2/error.py \
-    python_modules/pyyaml2/events.py \
-    python_modules/pyyaml2/loader.py \
-    python_modules/pyyaml2/nodes.py \
-    python_modules/pyyaml2/parser.py \
-    python_modules/pyyaml2/reader.py \
-    python_modules/pyyaml2/representer.py \
-    python_modules/pyyaml2/resolver.py \
-    python_modules/pyyaml2/scanner.py \
-    python_modules/pyyaml2/serializer.py \
-    python_modules/pyyaml2/tokens.py \
-    $(NULL)
+	python_modules/pyyaml2/__init__.py \
+	python_modules/pyyaml2/composer.py \
+	python_modules/pyyaml2/constructor.py \
+	python_modules/pyyaml2/cyaml.py \
+	python_modules/pyyaml2/dumper.py \
+	python_modules/pyyaml2/emitter.py \
+	python_modules/pyyaml2/error.py \
+	python_modules/pyyaml2/events.py \
+	python_modules/pyyaml2/loader.py \
+	python_modules/pyyaml2/nodes.py \
+	python_modules/pyyaml2/parser.py \
+	python_modules/pyyaml2/reader.py \
+	python_modules/pyyaml2/representer.py \
+	python_modules/pyyaml2/resolver.py \
+	python_modules/pyyaml2/scanner.py \
+	python_modules/pyyaml2/serializer.py \
+	python_modules/pyyaml2/tokens.py \
+	$(NULL)
 
 pythonyaml3dir=$(pythonmodulesdir)/pyyaml3
 dist_pythonyaml3_DATA = \
-    python_modules/pyyaml3/__init__.py \
-    python_modules/pyyaml3/composer.py \
-    python_modules/pyyaml3/constructor.py \
-    python_modules/pyyaml3/cyaml.py \
-    python_modules/pyyaml3/dumper.py \
-    python_modules/pyyaml3/emitter.py \
-    python_modules/pyyaml3/error.py \
-    python_modules/pyyaml3/events.py \
-    python_modules/pyyaml3/loader.py \
-    python_modules/pyyaml3/nodes.py \
-    python_modules/pyyaml3/parser.py \
-    python_modules/pyyaml3/reader.py \
-    python_modules/pyyaml3/representer.py \
-    python_modules/pyyaml3/resolver.py \
-    python_modules/pyyaml3/scanner.py \
-    python_modules/pyyaml3/serializer.py \
-    python_modules/pyyaml3/tokens.py \
-    $(NULL)
+	python_modules/pyyaml3/__init__.py \
+	python_modules/pyyaml3/composer.py \
+	python_modules/pyyaml3/constructor.py \
+	python_modules/pyyaml3/cyaml.py \
+	python_modules/pyyaml3/dumper.py \
+	python_modules/pyyaml3/emitter.py \
+	python_modules/pyyaml3/error.py \
+	python_modules/pyyaml3/events.py \
+	python_modules/pyyaml3/loader.py \
+	python_modules/pyyaml3/nodes.py \
+	python_modules/pyyaml3/parser.py \
+	python_modules/pyyaml3/reader.py \
+	python_modules/pyyaml3/representer.py \
+	python_modules/pyyaml3/resolver.py \
+	python_modules/pyyaml3/scanner.py \
+	python_modules/pyyaml3/serializer.py \
+	python_modules/pyyaml3/tokens.py \
+	$(NULL)
 
 python_urllib3dir=$(pythonmodulesdir)/urllib3
 dist_python_urllib3_DATA = \
-    python_modules/urllib3/__init__.py \
-    python_modules/urllib3/_collections.py \
-    python_modules/urllib3/connection.py \
-    python_modules/urllib3/connectionpool.py \
-    python_modules/urllib3/exceptions.py \
-    python_modules/urllib3/fields.py \
-    python_modules/urllib3/filepost.py \
-    python_modules/urllib3/response.py \
-    python_modules/urllib3/poolmanager.py \
-    python_modules/urllib3/request.py \
-    $(NULL)
+	python_modules/urllib3/__init__.py \
+	python_modules/urllib3/_collections.py \
+	python_modules/urllib3/connection.py \
+	python_modules/urllib3/connectionpool.py \
+	python_modules/urllib3/exceptions.py \
+	python_modules/urllib3/fields.py \
+	python_modules/urllib3/filepost.py \
+	python_modules/urllib3/response.py \
+	python_modules/urllib3/poolmanager.py \
+	python_modules/urllib3/request.py \
+	$(NULL)
 
 python_urllib3_utildir=$(python_urllib3dir)/util
 dist_python_urllib3_util_DATA = \
-    python_modules/urllib3/util/__init__.py \
-    python_modules/urllib3/util/connection.py \
-    python_modules/urllib3/util/request.py \
-    python_modules/urllib3/util/response.py \
-    python_modules/urllib3/util/retry.py \
-    python_modules/urllib3/util/selectors.py \
-    python_modules/urllib3/util/ssl_.py \
-    python_modules/urllib3/util/timeout.py \
-    python_modules/urllib3/util/url.py \
-    python_modules/urllib3/util/wait.py \
-    $(NULL)
+	python_modules/urllib3/util/__init__.py \
+	python_modules/urllib3/util/connection.py \
+	python_modules/urllib3/util/request.py \
+	python_modules/urllib3/util/response.py \
+	python_modules/urllib3/util/retry.py \
+	python_modules/urllib3/util/selectors.py \
+	python_modules/urllib3/util/ssl_.py \
+	python_modules/urllib3/util/timeout.py \
+	python_modules/urllib3/util/url.py \
+	python_modules/urllib3/util/wait.py \
+	$(NULL)
 
 python_urllib3_packagesdir=$(python_urllib3dir)/packages
 dist_python_urllib3_packages_DATA = \
-    python_modules/urllib3/packages/__init__.py \
-    python_modules/urllib3/packages/ordered_dict.py \
-    python_modules/urllib3/packages/six.py \
-    $(NULL)
+	python_modules/urllib3/packages/__init__.py \
+	python_modules/urllib3/packages/ordered_dict.py \
+	python_modules/urllib3/packages/six.py \
+	$(NULL)
 
 python_urllib3_backportsdir=$(python_urllib3_packagesdir)/backports
 dist_python_urllib3_backports_DATA = \
-    python_modules/urllib3/packages/backports/__init__.py \
-    python_modules/urllib3/packages/backports/makefile.py \
-    $(NULL)
+	python_modules/urllib3/packages/backports/__init__.py \
+	python_modules/urllib3/packages/backports/makefile.py \
+	$(NULL)
 
 python_urllib3_ssl_match_hostnamedir=$(python_urllib3_packagesdir)/ssl_match_hostname
 dist_python_urllib3_ssl_match_hostname_DATA = \
-    python_modules/urllib3/packages/ssl_match_hostname/__init__.py \
-    python_modules/urllib3/packages/ssl_match_hostname/_implementation.py \
-    $(NULL)
+	python_modules/urllib3/packages/ssl_match_hostname/__init__.py \
+	python_modules/urllib3/packages/ssl_match_hostname/_implementation.py \
+	$(NULL)
 
 python_urllib3_contribdir=$(python_urllib3dir)/contrib
 dist_python_urllib3_contrib_DATA = \
-    python_modules/urllib3/contrib/__init__.py \
-    python_modules/urllib3/contrib/appengine.py \
-    python_modules/urllib3/contrib/ntlmpool.py \
-    python_modules/urllib3/contrib/pyopenssl.py \
-    python_modules/urllib3/contrib/securetransport.py \
-    python_modules/urllib3/contrib/socks.py \
-    $(NULL)
+	python_modules/urllib3/contrib/__init__.py \
+	python_modules/urllib3/contrib/appengine.py \
+	python_modules/urllib3/contrib/ntlmpool.py \
+	python_modules/urllib3/contrib/pyopenssl.py \
+	python_modules/urllib3/contrib/securetransport.py \
+	python_modules/urllib3/contrib/socks.py \
+	$(NULL)
 
 python_urllib3_securetransportdir=$(python_urllib3_contribdir)/_securetransport
 dist_python_urllib3_securetransport_DATA = \
-    python_modules/urllib3/contrib/_securetransport/__init__.py \
-    python_modules/urllib3/contrib/_securetransport/bindings.py \
-    python_modules/urllib3/contrib/_securetransport/low_level.py \
-    $(NULL)
+	python_modules/urllib3/contrib/_securetransport/__init__.py \
+	python_modules/urllib3/contrib/_securetransport/bindings.py \
+	python_modules/urllib3/contrib/_securetransport/low_level.py \
+	$(NULL)

--- a/collectors/statsd.plugin/Makefile.am
+++ b/collectors/statsd.plugin/Makefile.am
@@ -16,3 +16,7 @@ userstatsdconfigdir=$(configdir)/statsd.d
 dist_userstatsdconfig_DATA = \
     .keep \
     $(NULL)
+
+# Explicitly install directories to avoid permission issues due to umask
+install-exec-local:
+	$(INSTALL) -d $(DESTDIR)$(userstatsdconfigdir)

--- a/collectors/statsd.plugin/Makefile.am
+++ b/collectors/statsd.plugin/Makefile.am
@@ -9,13 +9,13 @@ dist_noinst_DATA = \
 
 statsdconfigdir=$(libconfigdir)/statsd.d
 dist_statsdconfig_DATA = \
-    example.conf \
-    $(NULL)
+	example.conf \
+	$(NULL)
 
 userstatsdconfigdir=$(configdir)/statsd.d
 dist_userstatsdconfig_DATA = \
-    .keep \
-    $(NULL)
+	.keep \
+	$(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:

--- a/collectors/statsd.plugin/Makefile.am
+++ b/collectors/statsd.plugin/Makefile.am
@@ -9,13 +9,13 @@ dist_noinst_DATA = \
 
 statsdconfigdir=$(libconfigdir)/statsd.d
 dist_statsdconfig_DATA = \
-	example.conf \
-	$(NULL)
+    example.conf \
+    $(NULL)
 
 userstatsdconfigdir=$(configdir)/statsd.d
 dist_userstatsdconfig_DATA = \
-	.keep \
-	$(NULL)
+    .keep \
+    $(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -28,10 +28,6 @@ debian/%.postinst: debian/%.postinst.in
 override_dh_install: debian/netdata.postinst
 	dh_install
 
-	# Remove unneeded .keep files
-	#
-	find "$(TOP)" -name .keep -exec rm '{}' ';'
-
 	# Set the CUPS plugin install rule
 	#
 	mkdir -p $(TOP)-plugin-cups/usr/libexec/netdata/plugins.d
@@ -42,22 +38,7 @@ override_dh_install: debian/netdata.postinst
 	#
 	cp -rp $(TEMPTOP)/usr $(TOP)/usr
 	cp -rp $(TEMPTOP)/var $(TOP)/var
-	#cp -rp $(TEMPTOP)/etc $(TOP)/etc
-
-	# Copy sample netdata.conf
-	cp -p $(CURDIR)/system/edit-config $(TOP)/etc/netdata/
-
-	# Create placeholder dirs in netdata configuration directory
-	#
-	mkdir -p $(TOP)/etc/netdata/health.d
-	mkdir -p $(TOP)/etc/netdata/python.d
-	mkdir -p $(TOP)/etc/netdata/charts.d
-	mkdir -p $(TOP)/etc/netdata/cystonm-plugins.d
-	mkdir -p $(TOP)/etc/netdata/go.d
-	mkdir -p $(TOP)/etc/netdata/ssl
-	mkdir -p $(TOP)/etc/netdata/node.d
-	mkdir -p $(TOP)/etc/netdata/statsd.d
-
+	cp -rp $(TEMPTOP)/etc $(TOP)/etc
 
 	# Move files that local user shouldn't be editing to /usr/share/netdata
 	#
@@ -109,10 +90,6 @@ override_dh_fixperms:
 	chmod 0754 $(TOP)/usr/libexec/netdata/plugins.d/perf.plugin
 	chmod 0754 $(TOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin
 	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/go.d.plugin
-
-	# Support script for configuration file management
-	#
-	chmod 0750 $(TOP)/etc/netdata/edit-config
 
 	# CUPS plugin package
 	chmod 0750 $(TOP)-plugin-cups/usr/libexec/netdata/plugins.d/cups.plugin

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -36,9 +36,9 @@ override_dh_install: debian/netdata.postinst
 
 	# Set the rest of the software in the main package
 	#
-	cp -rp $(TEMPTOP)/usr $(TOP)/usr
-	cp -rp $(TEMPTOP)/var $(TOP)/var
-	cp -rp $(TEMPTOP)/etc $(TOP)/etc
+	cp -rp $(TEMPTOP)/usr $(TOP)
+	cp -rp $(TEMPTOP)/var $(TOP)
+	cp -rp $(TEMPTOP)/etc $(TOP)
 
 	# Move files that local user shouldn't be editing to /usr/share/netdata
 	#

--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -19,6 +19,10 @@ dist_userhealthconfig_DATA = \
     .keep \
     $(NULL)
 
+# Explicitly install directories to avoid permission issues due to umask
+install-exec-local:
+	$(INSTALL) -d $(DESTDIR)$(userhealthconfigdir)
+
 healthconfigdir=$(libconfigdir)/health.d
 dist_healthconfig_DATA = \
     health.d/adaptec_raid.conf \

--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -4,8 +4,8 @@ AUTOMAKE_OPTIONS = subdir-objects
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 SUBDIRS = \
-	notifications \
-	$(NULL)
+    notifications \
+    $(NULL)
 
 CLEANFILES = \
     $(NULL)
@@ -16,8 +16,8 @@ dist_noinst_DATA = \
 
 userhealthconfigdir=$(configdir)/health.d
 dist_userhealthconfig_DATA = \
-	.keep \
-	$(NULL)
+    .keep \
+    $(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:
@@ -25,78 +25,78 @@ install-exec-local:
 
 healthconfigdir=$(libconfigdir)/health.d
 dist_healthconfig_DATA = \
-	health.d/adaptec_raid.conf \
-	health.d/am2320.conf \
-	health.d/apache.conf \
-	health.d/apcupsd.conf \
-	health.d/backend.conf \
-	health.d/bcache.conf \
-	health.d/beanstalkd.conf \
-	health.d/bind_rndc.conf \
-	health.d/boinc.conf \
-	health.d/btrfs.conf \
-	health.d/ceph.conf \
-	health.d/cgroups.conf \
-	health.d/cpu.conf \
-	health.d/couchdb.conf \
-	health.d/disks.conf \
-	health.d/dnsmasq_dhcp.conf \
-	health.d/dockerd.conf \
-	health.d/elasticsearch.conf \
-	health.d/entropy.conf \
-	health.d/fping.conf \
-	health.d/ioping.conf \
-	health.d/fronius.conf \
-	health.d/gearman.conf \
-	health.d/haproxy.conf \
-	health.d/hdfs.conf \
-	health.d/httpcheck.conf \
-	health.d/ipc.conf \
-	health.d/ipfs.conf \
-	health.d/ipmi.conf \
-	health.d/isc_dhcpd.conf \
-	health.d/kubelet.conf \
-	health.d/lighttpd.conf \
-	health.d/linux_power_supply.conf \
-	health.d/load.conf \
-	health.d/mdstat.conf \
-	health.d/megacli.conf \
-	health.d/memcached.conf \
-	health.d/memory.conf \
-	health.d/mongodb.conf \
-	health.d/mysql.conf \
-	health.d/named.conf \
-	health.d/net.conf \
-	health.d/netfilter.conf \
-	health.d/nginx.conf \
-	health.d/nginx_plus.conf \
-	health.d/pihole.conf \
-	health.d/phpfpm.conf \
-	health.d/portcheck.conf \
-	health.d/postgres.conf \
-	health.d/processes.conf \
-	health.d/qos.conf \
-	health.d/ram.conf \
-	health.d/redis.conf \
-	health.d/retroshare.conf \
-	health.d/riakkv.conf \
-	health.d/softnet.conf \
-	health.d/squid.conf \
-	health.d/stiebeleltron.conf \
-	health.d/swap.conf \
-	health.d/tcp_conn.conf \
-	health.d/tcp_listen.conf \
-	health.d/tcp_mem.conf \
-	health.d/tcp_orphans.conf \
-	health.d/tcp_resets.conf \
-	health.d/udp_errors.conf \
-	health.d/varnish.conf \
-	health.d/vcsa.conf \
-	health.d/vsphere.conf \
-	health.d/web_log.conf \
-	health.d/wmi.conf \
-	health.d/x509check.conf \
-	health.d/zfs.conf \
-	health.d/zookeeper.conf \
-	health.d/dbengine.conf \
-	$(NULL)
+    health.d/adaptec_raid.conf \
+    health.d/am2320.conf \
+    health.d/apache.conf \
+    health.d/apcupsd.conf \
+    health.d/backend.conf \
+    health.d/bcache.conf \
+    health.d/beanstalkd.conf \
+    health.d/bind_rndc.conf \
+    health.d/boinc.conf \
+    health.d/btrfs.conf \
+    health.d/ceph.conf \
+    health.d/cgroups.conf \
+    health.d/cpu.conf \
+    health.d/couchdb.conf \
+    health.d/disks.conf \
+    health.d/dnsmasq_dhcp.conf \
+    health.d/dockerd.conf \
+    health.d/elasticsearch.conf \
+    health.d/entropy.conf \
+    health.d/fping.conf \
+    health.d/ioping.conf \
+    health.d/fronius.conf \
+    health.d/gearman.conf \
+    health.d/haproxy.conf \
+    health.d/hdfs.conf \
+    health.d/httpcheck.conf \
+    health.d/ipc.conf \
+    health.d/ipfs.conf \
+    health.d/ipmi.conf \
+    health.d/isc_dhcpd.conf \
+    health.d/kubelet.conf \
+    health.d/lighttpd.conf \
+    health.d/linux_power_supply.conf \
+    health.d/load.conf \
+    health.d/mdstat.conf \
+    health.d/megacli.conf \
+    health.d/memcached.conf \
+    health.d/memory.conf \
+    health.d/mongodb.conf \
+    health.d/mysql.conf \
+    health.d/named.conf \
+    health.d/net.conf \
+    health.d/netfilter.conf \
+    health.d/nginx.conf \
+    health.d/nginx_plus.conf \
+    health.d/pihole.conf \
+    health.d/phpfpm.conf \
+    health.d/portcheck.conf \
+    health.d/postgres.conf \
+    health.d/processes.conf \
+    health.d/qos.conf \
+    health.d/ram.conf \
+    health.d/redis.conf \
+    health.d/retroshare.conf \
+    health.d/riakkv.conf \
+    health.d/softnet.conf \
+    health.d/squid.conf \
+    health.d/stiebeleltron.conf \
+    health.d/swap.conf \
+    health.d/tcp_conn.conf \
+    health.d/tcp_listen.conf \
+    health.d/tcp_mem.conf \
+    health.d/tcp_orphans.conf \
+    health.d/tcp_resets.conf \
+    health.d/udp_errors.conf \
+    health.d/varnish.conf \
+    health.d/vcsa.conf \
+    health.d/vsphere.conf \
+    health.d/web_log.conf \
+    health.d/wmi.conf \
+    health.d/x509check.conf \
+    health.d/zfs.conf \
+    health.d/zookeeper.conf \
+    health.d/dbengine.conf \
+    $(NULL)

--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -4,8 +4,8 @@ AUTOMAKE_OPTIONS = subdir-objects
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 SUBDIRS = \
-    notifications \
-    $(NULL)
+	notifications \
+	$(NULL)
 
 CLEANFILES = \
     $(NULL)
@@ -16,8 +16,8 @@ dist_noinst_DATA = \
 
 userhealthconfigdir=$(configdir)/health.d
 dist_userhealthconfig_DATA = \
-    .keep \
-    $(NULL)
+	.keep \
+	$(NULL)
 
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:
@@ -25,78 +25,78 @@ install-exec-local:
 
 healthconfigdir=$(libconfigdir)/health.d
 dist_healthconfig_DATA = \
-    health.d/adaptec_raid.conf \
-    health.d/am2320.conf \
-    health.d/apache.conf \
-    health.d/apcupsd.conf \
-    health.d/backend.conf \
-    health.d/bcache.conf \
-    health.d/beanstalkd.conf \
-    health.d/bind_rndc.conf \
-    health.d/boinc.conf \
-    health.d/btrfs.conf \
-    health.d/ceph.conf \
-    health.d/cgroups.conf \
-    health.d/cpu.conf \
-    health.d/couchdb.conf \
-    health.d/disks.conf \
-    health.d/dnsmasq_dhcp.conf \
-    health.d/dockerd.conf \
-    health.d/elasticsearch.conf \
-    health.d/entropy.conf \
-    health.d/fping.conf \
-    health.d/ioping.conf \
-    health.d/fronius.conf \
-    health.d/gearman.conf \
-    health.d/haproxy.conf \
-    health.d/hdfs.conf \
-    health.d/httpcheck.conf \
-    health.d/ipc.conf \
-    health.d/ipfs.conf \
-    health.d/ipmi.conf \
-    health.d/isc_dhcpd.conf \
-    health.d/kubelet.conf \
-    health.d/lighttpd.conf \
-    health.d/linux_power_supply.conf \
-    health.d/load.conf \
-    health.d/mdstat.conf \
-    health.d/megacli.conf \
-    health.d/memcached.conf \
-    health.d/memory.conf \
-    health.d/mongodb.conf \
-    health.d/mysql.conf \
-    health.d/named.conf \
-    health.d/net.conf \
-    health.d/netfilter.conf \
-    health.d/nginx.conf \
-    health.d/nginx_plus.conf \
-    health.d/pihole.conf \
-    health.d/phpfpm.conf \
-    health.d/portcheck.conf \
-    health.d/postgres.conf \
-    health.d/processes.conf \
-    health.d/qos.conf \
-    health.d/ram.conf \
-    health.d/redis.conf \
-    health.d/retroshare.conf \
-    health.d/riakkv.conf \
-    health.d/softnet.conf \
-    health.d/squid.conf \
-    health.d/stiebeleltron.conf \
-    health.d/swap.conf \
-    health.d/tcp_conn.conf \
-    health.d/tcp_listen.conf \
-    health.d/tcp_mem.conf \
-    health.d/tcp_orphans.conf \
-    health.d/tcp_resets.conf \
-    health.d/udp_errors.conf \
-    health.d/varnish.conf \
-    health.d/vcsa.conf \
-    health.d/vsphere.conf \
-    health.d/web_log.conf \
-    health.d/wmi.conf \
-    health.d/x509check.conf \
-    health.d/zfs.conf \
-    health.d/zookeeper.conf \
-    health.d/dbengine.conf \
-    $(NULL)
+	health.d/adaptec_raid.conf \
+	health.d/am2320.conf \
+	health.d/apache.conf \
+	health.d/apcupsd.conf \
+	health.d/backend.conf \
+	health.d/bcache.conf \
+	health.d/beanstalkd.conf \
+	health.d/bind_rndc.conf \
+	health.d/boinc.conf \
+	health.d/btrfs.conf \
+	health.d/ceph.conf \
+	health.d/cgroups.conf \
+	health.d/cpu.conf \
+	health.d/couchdb.conf \
+	health.d/disks.conf \
+	health.d/dnsmasq_dhcp.conf \
+	health.d/dockerd.conf \
+	health.d/elasticsearch.conf \
+	health.d/entropy.conf \
+	health.d/fping.conf \
+	health.d/ioping.conf \
+	health.d/fronius.conf \
+	health.d/gearman.conf \
+	health.d/haproxy.conf \
+	health.d/hdfs.conf \
+	health.d/httpcheck.conf \
+	health.d/ipc.conf \
+	health.d/ipfs.conf \
+	health.d/ipmi.conf \
+	health.d/isc_dhcpd.conf \
+	health.d/kubelet.conf \
+	health.d/lighttpd.conf \
+	health.d/linux_power_supply.conf \
+	health.d/load.conf \
+	health.d/mdstat.conf \
+	health.d/megacli.conf \
+	health.d/memcached.conf \
+	health.d/memory.conf \
+	health.d/mongodb.conf \
+	health.d/mysql.conf \
+	health.d/named.conf \
+	health.d/net.conf \
+	health.d/netfilter.conf \
+	health.d/nginx.conf \
+	health.d/nginx_plus.conf \
+	health.d/pihole.conf \
+	health.d/phpfpm.conf \
+	health.d/portcheck.conf \
+	health.d/postgres.conf \
+	health.d/processes.conf \
+	health.d/qos.conf \
+	health.d/ram.conf \
+	health.d/redis.conf \
+	health.d/retroshare.conf \
+	health.d/riakkv.conf \
+	health.d/softnet.conf \
+	health.d/squid.conf \
+	health.d/stiebeleltron.conf \
+	health.d/swap.conf \
+	health.d/tcp_conn.conf \
+	health.d/tcp_listen.conf \
+	health.d/tcp_mem.conf \
+	health.d/tcp_orphans.conf \
+	health.d/tcp_resets.conf \
+	health.d/udp_errors.conf \
+	health.d/varnish.conf \
+	health.d/vcsa.conf \
+	health.d/vsphere.conf \
+	health.d/web_log.conf \
+	health.d/wmi.conf \
+	health.d/x509check.conf \
+	health.d/zfs.conf \
+	health.d/zookeeper.conf \
+	health.d/dbengine.conf \
+	$(NULL)

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -649,19 +649,6 @@ if [ ! -d "${NETDATA_RUN_DIR}" ]; then
 	run mkdir -p "${NETDATA_RUN_DIR}" || exit 1
 fi
 
-# --- conf dir ----
-
-for x in "python.d" "charts.d" "node.d" "health.d" "statsd.d" "go.d" "custom-plugins.d" "ssl"; do
-	if [ ! -d "${NETDATA_USER_CONFIG_DIR}/${x}" ]; then
-		echo >&2 "Creating directory '${NETDATA_USER_CONFIG_DIR}/${x}'"
-		run mkdir -p "${NETDATA_USER_CONFIG_DIR}/${x}" || exit 1
-	fi
-done
-run chown -R "${ROOT_USER}:${NETDATA_GROUP}" "${NETDATA_USER_CONFIG_DIR}"
-run find "${NETDATA_USER_CONFIG_DIR}" -type f -exec chmod 0640 {} \;
-run find "${NETDATA_USER_CONFIG_DIR}" -type d -exec chmod 0755 {} \;
-run chmod 755 "${NETDATA_USER_CONFIG_DIR}/edit-config"
-
 # --- stock conf dir ----
 
 [ ! -d "${NETDATA_STOCK_CONFIG_DIR}" ] && mkdir -p "${NETDATA_STOCK_CONFIG_DIR}"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -590,7 +590,7 @@ if [ "${UID}" = "0" ]; then
 	ROOT_USER="root"
 else
 	NETDATA_USER="${USER}"
-	ROOT_USER="${NETDATA_USER}"
+	ROOT_USER="${USER}"
 fi
 NETDATA_GROUP="$(id -g -n "${NETDATA_USER}")"
 [ -z "${NETDATA_GROUP}" ] && NETDATA_GROUP="${NETDATA_USER}"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -907,10 +907,7 @@ else
 	run_ok "netdata started!"
 	create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf" "http://localhost:${NETDATA_PORT}/netdata.conf"
 fi
-if [ "${UID}" -eq 0 ]; then
-	run chown "${NETDATA_USER}" "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
-fi
-run chmod 0664 "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
+run chmod 0644 "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
 
 if [ "$(uname)" = "Linux" ]; then
 	# -------------------------------------------------------------------------

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1070,6 +1070,7 @@ RELEASE_CHANNEL="${RELEASE_CHANNEL}"
 IS_NETDATA_STATIC_BINARY="${IS_NETDATA_STATIC_BINARY}"
 NETDATA_LIB_DIR="${NETDATA_LIB_DIR}"
 EOF
+run chmod 0644 "${NETDATA_USER_CONFIG_DIR}/.environment"
 
 echo >&2 "Setting netdata.tarball.checksum to 'new_installation'"
 cat <<EOF > "${NETDATA_LIB_DIR}/netdata.tarball.checksum"

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -256,7 +256,7 @@ autoreconf -ivf
 rm -rf "${RPM_BUILD_ROOT}"
 %{__make} %{?_smp_mflags} DESTDIR="${RPM_BUILD_ROOT}" install
 
-find "${RPM_BUILD_ROOT}" -name .keep -delete
+find "${RPM_BUILD_ROOT}%{_localstatedir}" -name .keep -delete -print
 
 install -m 644 -p system/netdata.conf "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}"
 
@@ -290,9 +290,6 @@ install -m 4750 -p slabinfo.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plug
 # ###########################################################
 # Install registry directory
 install -m 755 -d "${RPM_BUILD_ROOT}%{_localstatedir}/lib/%{name}/registry"
-install -m 755 -d "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/custom-plugins.d"
-install -m 755 -d "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/go.d"
-install -m 755 -d "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/ssl"
 
 # ###########################################################
 # Install netdata service
@@ -423,12 +420,12 @@ rm -rf "${RPM_BUILD_ROOT}"
 
 %files
 %doc README.md
-%defattr(-,root,netdata)
+%{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/netdata.conf
 
-%dir %{_sysconfdir}/%{name}
+%defattr(-,root,netdata)
 %dir %{_libdir}/%{name}
 
-%config(noreplace) %{_sysconfdir}/%{name}/*.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 
 %{_libdir}/%{name}
@@ -436,7 +433,6 @@ rm -rf "${RPM_BUILD_ROOT}"
 %defattr(0755,netdata,netdata,0755)
 %{_libexecdir}/%{name}
 %{_sbindir}/%{name}
-%{_sysconfdir}/%{name}/edit-config
 
 %defattr(4750,root,netdata,0750)
 
@@ -466,15 +462,6 @@ rm -rf "${RPM_BUILD_ROOT}"
 %dir %{_datadir}/%{name}
 
 %defattr(0750,netdata,netdata,0755)
-
-%dir %{_sysconfdir}/%{name}/health.d
-%dir %{_sysconfdir}/%{name}/python.d
-%dir %{_sysconfdir}/%{name}/charts.d
-%dir %{_sysconfdir}/%{name}/custom-plugins.d
-%dir %{_sysconfdir}/%{name}/go.d
-%dir %{_sysconfdir}/%{name}/ssl
-%dir %{_sysconfdir}/%{name}/node.d
-%dir %{_sysconfdir}/%{name}/statsd.d
 %{_libdir}/%{name}/conf.d/
 
 %if %{with systemd}
@@ -515,6 +502,8 @@ Use this plugin to enable metrics collection from cupsd, the daemon running when
 %endif
 
 %changelog
+* Mon Nov 04 2019 Konstantinos Natsakis <konstantinos.natsakis@gmail.com> 0.0.0-10
+- Fix /etc/netdata permissions
 * Mon Sep 23 2019 Konstantinos Natsakis <konstantinos.natsakis@gmail.com> 0.0.0-9
 - Do not build CUPS plugin subpackage on CentOS 6 and CentOS 7
 * Tue Aug 20 2019 Pavlos Emm. Katsoulakis <paul@netdat.acloud> - 0.0.0-8

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -259,5 +259,4 @@ else
         netdata_banner "is installed now!"
     fi
 fi
-run chown "${NETDATA_USER}:${NETDATA_GROUP}" "/opt/netdata/etc/netdata/netdata.conf"
-run chmod 0664 "/opt/netdata/etc/netdata/netdata.conf"
+run chmod 0644 "/opt/netdata/etc/netdata/netdata.conf"

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -246,17 +246,17 @@ fi
 # -----------------------------------------------------------------------------
 
 if [ ${STARTIT} -eq 0 ]; then
-    create_netdata_conf "/opt/netdata/etc/netdata/netdata.conf"
+    create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
     netdata_banner "is installed now!"
 else
     progress "starting netdata"
 
-    if ! restart_netdata "/opt/netdata/bin/netdata"; then
-        create_netdata_conf "/opt/netdata/etc/netdata/netdata.conf"
+    if ! restart_netdata "${NETDATA_PREFIX}/bin/netdata"; then
+        create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
         netdata_banner "is installed and running now!"
     else
-        create_netdata_conf "/opt/netdata/etc/netdata/netdata.conf" "http://localhost:19999/netdata.conf"
+        create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf" "http://localhost:19999/netdata.conf"
         netdata_banner "is installed now!"
     fi
 fi
-run chmod 0644 "/opt/netdata/etc/netdata/netdata.conf"
+run chmod 0644 "${NETDATA_PREFIX}/etc/netdata/netdata.conf"

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -244,19 +244,18 @@ fi
 
 
 # -----------------------------------------------------------------------------
-
 if [ ${STARTIT} -eq 0 ]; then
-    create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
-    netdata_banner "is installed now!"
+	create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
+	netdata_banner "is installed now!"
 else
-    progress "starting netdata"
+	progress "starting netdata"
 
-    if ! restart_netdata "${NETDATA_PREFIX}/bin/netdata"; then
-        create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
-        netdata_banner "is installed and running now!"
-    else
-        create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf" "http://localhost:19999/netdata.conf"
-        netdata_banner "is installed now!"
-    fi
+	if ! restart_netdata "${NETDATA_PREFIX}/bin/netdata"; then
+		create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
+		netdata_banner "is installed and running now!"
+	else
+		create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf" "http://localhost:19999/netdata.conf"
+		netdata_banner "is installed now!"
+	fi
 fi
 run chmod 0644 "${NETDATA_PREFIX}/etc/netdata/netdata.conf"

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -201,19 +201,6 @@ fi
 
 
 # -----------------------------------------------------------------------------
-
-progress "create user config directories"
-
-for x in "python.d" "charts.d" "node.d" "health.d" "statsd.d" "custom-plugins.d" "ssl"
-do
-    if [ ! -d "etc/netdata/${x}" ]
-        then
-        run mkdir -p "etc/netdata/${x}" || exit 1
-    fi
-done
-
-
-# -----------------------------------------------------------------------------
 progress "fix permissions"
 
 run chmod g+rx,o+rx /opt

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -20,6 +20,10 @@ dist_config_SCRIPTS = \
     edit-config \
     $(NULL)
 
+# Explicitly install directories to avoid permission issues due to umask
+install-exec-local:
+	$(INSTALL) -d $(DESTDIR)$(configdir)
+
 nodist_noinst_DATA = \
     netdata-openrc \
     netdata.logrotate \

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -1,4 +1,3 @@
-#
 # Copyright (C) 2015 Alon Bar-Lev <alon.barlev@gmail.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -1,3 +1,4 @@
+#
 # Copyright (C) 2015 Alon Bar-Lev <alon.barlev@gmail.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/web/Makefile.am
+++ b/web/Makefile.am
@@ -9,6 +9,15 @@ SUBDIRS = \
     server \
     $(NULL)
 
+usersslconfigdir=$(configdir)/ssl
+
+# Explicitly install directories to avoid permission issues due to umask
+install-exec-local:
+	$(INSTALL) -d $(DESTDIR)$(usersslconfigdir)
+
+uninstall-local:
+	-rmdir $(DESTDIR)$(usersslconfigdir)
+
 dist_noinst_DATA = \
     README.md \
     gui/confluence/README.md \

--- a/web/Makefile.am
+++ b/web/Makefile.am
@@ -4,10 +4,10 @@ AUTOMAKE_OPTIONS = subdir-objects
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 SUBDIRS = \
-	api \
-	gui \
-	server \
-	$(NULL)
+    api \
+    gui \
+    server \
+    $(NULL)
 
 usersslconfigdir=$(configdir)/ssl
 

--- a/web/Makefile.am
+++ b/web/Makefile.am
@@ -15,9 +15,6 @@ usersslconfigdir=$(configdir)/ssl
 install-exec-local:
 	$(INSTALL) -d $(DESTDIR)$(usersslconfigdir)
 
-uninstall-local:
-	-rmdir $(DESTDIR)$(usersslconfigdir)
-
 dist_noinst_DATA = \
     README.md \
     gui/confluence/README.md \

--- a/web/Makefile.am
+++ b/web/Makefile.am
@@ -4,10 +4,10 @@ AUTOMAKE_OPTIONS = subdir-objects
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 SUBDIRS = \
-    api \
-    gui \
-    server \
-    $(NULL)
+	api \
+	gui \
+	server \
+	$(NULL)
 
 usersslconfigdir=$(configdir)/ssl
 


### PR DESCRIPTION
#### Summary
Improve ownership and permissions of /etc/netdata based on suggestions in #6619 
This PR should address points 1-4 of #6619 

##### Component Name
netdata-installer.sh (kickstart.sh installations)
install-or-update.sh (kickstart-static64.sh installations)
debian/rules (.deb packages)
netdata.spec.in (.rpm packages)

##### Additional Information
The following use cases have been tested:
- clean kickstart.sh installation (uses root)
- upgrade with kickstart.sh (uses root)
- clean netdata-installer.sh as knatsakis (uses non-root user)
- clean kickstart-static64.sh installation (uses root)
- ./configure && make && make install installation (used root)
- .deb package installation
- .rpm package installation

The most significant change is on the ownership/permissions of /etc/netdata/netdata.conf that change to root:root 0644. This means that our users will not be able to `sudo -u netdata /etc/netdata/edit-config`, but this should be ok since our documentation states that our users should `sudo /etc/netdata/edit-config` (use root) anyway.

Please try to come up with uses cases that this change breaks when reviewing this PR.