### PR TITLE
Update SYN cookie alarm to be less aggressive.

### DIFF
--- a/health/health.d/tcp_listen.conf
+++ b/health/health.d/tcp_listen.conf
@@ -71,12 +71,12 @@
       on: ip.tcp_syn_queue
       os: linux
    hosts: *
-  lookup: sum -60s unaligned absolute of TCPReqQFullDoCookies
+  lookup: average -60s unaligned absolute of TCPReqQFullDoCookies
    units: cookies
    every: 10s
-    warn: $this > 0
-    crit: $this > (($status == $CRITICAL) ? (0) : (60))
-   delay: up 0 down 5m multiplier 1.5 max 1h
+    warn: $this > 1
+    crit: $this > (($status == $CRITICAL) ? (0) : (5))
+   delay: up 5 down 5m multiplier 1.5 max 1h
     info: the number of times the TCP SYN queue of the kernel was full and sent SYN cookies, during the last minute
       to: sysadmin
 

--- a/health/health.d/tcp_listen.conf
+++ b/health/health.d/tcp_listen.conf
@@ -58,12 +58,12 @@
       on: ip.tcp_syn_queue
       os: linux
    hosts: *
-  lookup: sum -60s unaligned absolute of TCPReqQFullDrop
+  lookup: average -60s unaligned absolute of TCPReqQFullDrop
    units: drops
    every: 10s
-    warn: $this > 0
-    crit: $this > (($status == $CRITICAL) ? (0) : (60))
-   delay: up 0 down 5m multiplier 1.5 max 1h
+    warn: $this > 1
+    crit: $this > (($status == $CRITICAL) ? (0) : (5))
+   delay: up 10 down 5m multiplier 1.5 max 1h
     info: the number of times the TCP SYN queue of the kernel was full and dropped packets, during the last minute
       to: sysadmin
 
@@ -76,7 +76,7 @@
    every: 10s
     warn: $this > 1
     crit: $this > (($status == $CRITICAL) ? (0) : (5))
-   delay: up 5 down 5m multiplier 1.5 max 1h
+   delay: up 10 down 5m multiplier 1.5 max 1h
     info: the number of times the TCP SYN queue of the kernel was full and sent SYN cookies, during the last minute
       to: sysadmin
 


### PR DESCRIPTION
Based on discussion from #6998

This should make the alarms much less noisy in cases where SYN cookies aren't being used with a particularly high frequency.