### PR TITLE
web_log: treat 401 Unauthorized requests as successful

### DIFF
--- a/collectors/python.d.plugin/web_log/web_log.chart.py
+++ b/collectors/python.d.plugin/web_log/web_log.chart.py
@@ -867,7 +867,7 @@ class Web:
         :return:
         """
         code_class = code[0]
-        if code_class == '2' or code == '304' or code_class == '1':
+        if code_class == '2' or code == '304' or code_class == '1' or code == '401':
             self.data['successful_requests'] += 1
         elif code_class == '3':
             self.data['redirects'] += 1

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1822,7 +1822,7 @@ netdataDashboard.context = {
     // web_log
 
     'web_log.response_statuses': {
-        info: 'Web server responses by type. <code>success</code> includes <b>1xx</b>, <b>2xx</b> and <b>304</b>, <code>error</code> includes <b>5xx</b>, <code>redirect</code> includes <b>3xx</b> except <b>304</b>, <code>bad</code> includes <b>4xx</b>, <code>other</code> are all the other responses.',
+        info: 'Web server responses by type. <code>success</code> includes <b>1xx</b>, <b>2xx</b>, <b>304</b> and <b>401</b>, <code>error</code> includes <b>5xx</b>, <code>redirect</code> includes <b>3xx</b> except <b>304</b>, <code>bad</code> includes <b>4xx</b> except <b>401</b>, <code>other</code> are all the other responses.',
         mainheads: [
             function (os, id) {
                 void(os);


### PR DESCRIPTION
The web_log chart module currently treats requests with a 401 status code as bad requests. However, the 401 answers just say that the incoming request wasn't authorized properly and are often followed by a request with the correct authorization.

We're using Kerberos based authentication on our internal pages, and for this authentication method, _every_ request needs to be sent in two steps:
* Client sends an unauthenticated request
* Server replies 401 with WWW-Authenticate:Negoatiate <token>
* Client sends request again with Authorization: Negotiate <much-more-data>
* Server replies 200

The token sent in the first request will be different for every request, thus it is required to send two requests - and there will be (if all authentication tries are successful) around 50% requests with a 401 code.

To show more correct data in netdata (and avoid false alarms), I'd suggest to include the 401 code in the successful_requests bin (instead of bad_requests).