### PR TITLE
Fine tune clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,7 @@ AlignConsecutiveDeclarations: false
 #AlignEscapedNewlines: Left # Unknown to clang-format-4.0
 AlignOperands: true
 AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
@@ -26,8 +26,8 @@ AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: false
-BinPackArguments: true
-BinPackParameters: true
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
   AfterClass: false
   AfterControlStatement: false
@@ -58,7 +58,7 @@ CommentPragmas: '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
-Cpp11BracedListStyle: false
+Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: false


### PR DESCRIPTION
##### Summary
During the last meetup, we vote for a new `.clang-format` configuration. As far as we didn't try to see how actually code is looking for every parameter, there were some misunderstandings.

I propose some subtle changes to the format. The most important are `BinPackArguments` and `BinPackParameters`. It's very difficult to read code when there are multiple rows with multiple parameters in a row like in the following example:
```
buffer_sprintf(
    b, "%s.%s.%s.%s%s%s " COLLECTED_NUMBER_FORMAT " %llu\n", prefix, hostname, chart_name, dimension_name,
    (host->tags) ? ";" : "", (host->tags) ? host->tags : "", rd->last_collected_value,
    (unsigned long long)rd->last_collected_time.tv_sec);
```

Start of the discussion https://github.com/netdata/netdata/pull/7149#discussion_r341551942