### PR TITLE
container-engines: add balena* to apps_group.conf

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -174,7 +174,7 @@ heapster: heapster
 # -----------------------------------------------------------------------------
 # containers & virtual machines
 
-containers: lxc* docker*
+containers: lxc* docker* balena*
 VMs: vbox* VBox* qemu*
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Matthew McGinn <mamcgi@gmail.com>

##### Summary
balenaEngine is a moby-based container engine often used in IoT: https://github.com/balena-os/balena-engine/

##### Component Name
apps_groups.conf

##### Additional Information

