### PR TITLE
apps.plugin: add process group for git-related processes

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -305,3 +305,5 @@ node: node*
 factorio: factorio
 
 p4: p4*
+
+git: gitea gitlab-runner

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -306,4 +306,4 @@ factorio: factorio
 
 p4: p4*
 
-git: gitea gitlab-runner
+git-services: gitea gitlab-runner


### PR DESCRIPTION
##### Summary

Add git/software forge related processes to [apps_groups.conf](https://github.com/netdata/netdata/blob/master/collectors/apps.plugin/apps_groups.conf):
 - Gitea self-hosted Git service https://gitea.io/en-us/
 - Gitlab continuous integration runner https://docs.gitlab.com/runner/

##### Component Name

[/collectors/apps.plugin](https://github.com/netdata/netdata/tree/master/collectors/apps.plugin)

##### Additional Information

Default configuration change. Group called 'git' for lack of a better name.
