### PR TITLE
Fix missing streaming when slave has SSL activated.

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -258,17 +258,17 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
 #ifdef ENABLE_HTTPS
         int normalread = 1;
         if(netdata_srv_ctx) {
-            if(host->ssl.conn && !host->ssl.flags) {
+            if(host->stream_ssl.conn && !host->stream_ssl.flags) {
                 if(!bytesleft) {
                     r = line;
                     readfrom = tmpbuffer;
-                    bytesleft = pluginsd_update_buffer(readfrom, host->ssl.conn);
+                    bytesleft = pluginsd_update_buffer(readfrom, host->stream_ssl.conn);
                     if(bytesleft <= 0) {
                         break;
                     }
                 }
 
-                readfrom =  pluginsd_get_from_buffer(line, &bytesleft, readfrom, host->ssl.conn, tmpbuffer);
+                readfrom =  pluginsd_get_from_buffer(line, &bytesleft, readfrom, host->stream_ssl.conn, tmpbuffer);
                 if(!readfrom) {
                     r = NULL;
                 }

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -739,6 +739,7 @@ struct rrdhost {
 
 #ifdef ENABLE_HTTPS
     struct netdata_ssl ssl;                         //Structure used to encrypt the connection
+    struct netdata_ssl stream_ssl;                         //Structure used to encrypt the stream
 #endif
 
     struct rrdhost *next;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -150,6 +150,8 @@ RRDHOST *rrdhost_create(const char *hostname,
 #ifdef ENABLE_HTTPS
     host->ssl.conn = NULL;
     host->ssl.flags = NETDATA_SSL_START;
+    host->stream_ssl.conn = NULL;
+    host->stream_ssl.flags = NETDATA_SSL_START;
 #endif
 
     netdata_mutex_init(&host->rrdpush_sender_buffer_mutex);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -1079,8 +1079,8 @@ static int rrdpush_receive(int fd
 
     info("STREAM %s [receive from [%s]:%s]: initializing communication...", host->hostname, client_ip, client_port);
 #ifdef ENABLE_HTTPS
-    host->ssl.conn = ssl->conn;
-    host->ssl.flags = ssl->flags;
+    host->stream_ssl.conn = ssl->conn;
+    host->stream_ssl.flags = ssl->flags;
     if(send_timeout(ssl,fd, START_STREAMING_PROMPT, strlen(START_STREAMING_PROMPT), 0, 60) != strlen(START_STREAMING_PROMPT)) {
 #else
     if(send_timeout(fd, START_STREAMING_PROMPT, strlen(START_STREAMING_PROMPT), 0, 60) != strlen(START_STREAMING_PROMPT)) {


### PR DESCRIPTION
##### Summary
Fixes #7291 

Our user detected that when the slaves has SSL certificate enabled and it was connecting to a master with SSL, some of the metrics were not being sent, this PR fixes this problem.
##### Component Name
Stream
##### Additional Information

