### PR TITLE
Updating the Travis pipeline (issue 7189)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,10 @@ jobs:
       name: Run shellchecking on BASH
       script: shellcheck --format=gcc $(find . -name '*.sh.in' -not -iwholename '*.git*')
 
+      # Check if any of the C code deviates from our coding style
+    - name: Check coding style
+      script: find . -type f -name '*.[ch]' | while read filename; do echo -ne "$filename: "; diff <(clang-format -style=file $filename) $filename | wc -l; done
+
       # This falls under same stage defined earlier
     - name: Run checksum checks on kickstart files
       script: ./tests/installer/checksums.sh
@@ -120,7 +124,7 @@ jobs:
 
       name: Standard netdata build
       script: fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it --enable-plugin-nfacct --enable-plugin-freeipmi --disable-lto
-      env: CFLAGS='-O1 -DNETDATA_INTERNAL_CHECKS=1 -DNETDATA_VERIFY_LOCKS=1'
+      env: CFLAGS="-O1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1"
       after_failure: post_message "TRAVIS_MESSAGE" "<!here> standard netdata build is failing (Still dont know which one, will improve soon)"
 
     - name: Docker container build process (alpine installation)

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ jobs:
 
       name: Standard netdata build
       script: fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it --enable-plugin-nfacct --enable-plugin-freeipmi --disable-lto
-      env: CFLAGS="-O1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1"
+      env: CFLAGS='-O1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1'
       after_failure: post_message "TRAVIS_MESSAGE" "<!here> standard netdata build is failing (Still dont know which one, will improve soon)"
 
     - name: Docker container build process (alpine installation)

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ jobs:
 
       # Check if any of the C code deviates from our coding style
     - name: Check coding style
-      script: find . -type f -name '*.[ch]' | while read filename; do echo -ne "$filename: "; diff <(clang-format -style=file $filename) $filename | wc -l; done
+      script: .travis/clangformat.sh
 
       # This falls under same stage defined earlier
     - name: Run checksum checks on kickstart files
@@ -124,7 +124,7 @@ jobs:
 
       name: Standard netdata build
       script: fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it --enable-plugin-nfacct --enable-plugin-freeipmi --disable-lto
-      env: CFLAGS='-O1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1'
+      env: CFLAGS="-O1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1"
       after_failure: post_message "TRAVIS_MESSAGE" "<!here> standard netdata build is failing (Still dont know which one, will improve soon)"
 
     - name: Docker container build process (alpine installation)

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 # Install dependencies for all, once
 #
 install:
-  - sudo apt-get install -y libcap2-bin zlib1g-dev uuid-dev fakeroot libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev gnupg python-pip
+  - sudo apt-get install -y libuv1-dev liblz4-dev libjudy-dev libcap2-bin zlib1g-dev uuid-dev fakeroot libipmimonitoring-dev libmnl-dev libnetfilter-acct-dev gnupg python-pip
   - sudo apt install -y --only-upgrade docker-ce
   - sudo pip install git-semver==0.2.4 # 11/Sep/2019: git-semver tip was broken, so we had to force last good run of it
   - docker info

--- a/.travis/clangformat.sh
+++ b/.travis/clangformat.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 find . -type f -name '*.[ch]' | while read filename; do echo -ne "$filename: "; diff <(clang-format -style=file $filename) $filename | wc -l; done

--- a/.travis/clangformat.sh
+++ b/.travis/clangformat.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find . -type f -name '*.[ch]' | while read filename; do echo -ne "$filename: "; diff <(clang-format -style=file $filename) $filename | wc -l; done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,36 @@ We expect most contributions to be for new data collection plugins. You can read
 
 Of course we appreciate contributions for any other part of the NetData agent, including the [daemon](daemon), [backends for long term archiving](backends/), innovative ways of using the [REST API](web/api) to create cool [Custom Dashboards](web/gui/custom/) or to include NetData charts in other applications, similarly to what can be done with [Confluence](web/gui/confluence/).
 
+If you are working on the C source code please be aware that we have a standard build configuration that we use. This
+is meant to keep the source tree clean and free of warnings. When you are preparing to work on the code:
+```
+CFLAGS="-O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1" ./netdata-installer.sh --disable-lto --dont-wait
+```
+
+Typically we will enable LTO during production builds. The reasons for configuring it this way are:
+
+| CFLAG / argument | Reasoning |
+| ---------------- | --------- |
+| `-O1` | This makes the debugger easier to use as it disables optimisations that break the relationship between the source and the state of the debugger |
+| `-ggdb` | Enable debugging symbols in gdb format (this also works with clang / llbdb) |
+| `-Wall -Wextra -Wformat-signedness` | Really, definitely, absolutely all the warnings |
+| `-DNETDATA_INTERNAL_CHECKS=1` | This enables the debug.log and turns on the macro that outputs to it |
+| `-D_FORTIFY_SOURCE=2` | Enable buffer-overflow checks on string-processing functions |
+| `-DNETDATA_VERIFY_LOCKS=1` | Enable extra checks and debug |
+| `--disable-lto ` | We enable LTO for production builds, but disable it during development are it can hide errors about missing symbols that have been pruned. |
+
+Before submitting a PR we run through this checklist:
+
+* Compilation warnings
+* valgrind
+* ./netdata-installer.sh
+* make dist
+* `packaging/makeself/build-x86_64-static.sh`
+* `clang-format -style=file`
+
+Please be aware that the linting pass at the end is currently messy as we are transitioning between code styles
+across most of our code-base, but we prefer new contributions that match the linting style.
+
 ### Contributions Ground Rules
 
 #### Code of Conduct and CLA

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -921,8 +921,8 @@ int main(int argc, char **argv) {
                     {
                         char* stacksize_string = "stacksize=";
                         char* debug_flags_string = "debug_flags=";
-                        char* createdataset_string = "createdataset=";
-                        char* stresstest_string = "stresstest=";
+                        //char* createdataset_string = "createdataset="; Unused?
+                        //char* stresstest_string = "stresstest=";  Unused?
 
                         if(strcmp(optarg, "unittest") == 0) {
                             if(unit_test_buffer()) return 1;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -921,8 +921,10 @@ int main(int argc, char **argv) {
                     {
                         char* stacksize_string = "stacksize=";
                         char* debug_flags_string = "debug_flags=";
-                        //char* createdataset_string = "createdataset="; Unused?
-                        //char* stresstest_string = "stresstest=";  Unused?
+#ifdef ENABLE_DBENGINE
+                        char* createdataset_string = "createdataset=";
+                        char* stresstest_string = "stresstest=";
+#endif
 
                         if(strcmp(optarg, "unittest") == 0) {
                             if(unit_test_buffer()) return 1;

--- a/libnetdata/simple_pattern/simple_pattern.c
+++ b/libnetdata/simple_pattern/simple_pattern.c
@@ -273,7 +273,7 @@ extern void simple_pattern_dump(uint64_t debug_type, SIMPLE_PATTERN *p)
         debug(debug_type,"dump_pattern(NULL)");
         return;
     }
-    debug(debug_type,"dump_pattern(%p) child=%p next=%p mode=%d match=%s", root, root->child, root->next, root->mode,
+    debug(debug_type,"dump_pattern(%p) child=%p next=%p mode=%u match=%s", root, root->child, root->next, root->mode,
           root->match);
     if(root->child!=NULL)
         simple_pattern_dump(debug_type, (SIMPLE_PATTERN*)root->child);


### PR DESCRIPTION
##### Summary
Fixes #7189 

The current build doesn't match our conventions during development on the team. We have a different build configuration in Travis to the one that we should use to keep the code warning free. There is no indication on how the code matches our coding style.

* Added a linting pass. This is non-blocking but will output a measure of how much each .c and .h file deviates from our current `.clang-format`.

* Changed the standard built to include all of the warning that we are using in dev.

##### Component Name

##### Additional Information

