### PR TITLE
- Retrieve current affinity of the process and make sure not to

### DIFF
--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -993,6 +993,13 @@ int do_proc_stat(int update_every, usec_t dt) {
         for(core = 0; core < schedstat_cores_found; core++) {
             if(unlikely(!(cpuidle_charts[core].active_time - cpuidle_charts[core].last_active_time))) {
                 pthread_t thread;
+                cpu_set_t global_cpu_set;
+
+                sched_getaffinity(getpid(), sizeof(cpu_set_t), &global_cpu_set);
+
+                if (unlikely(!CPU_ISSET(core, &global_cpu_set))) {
+                    continue;
+                }
 
                 if(unlikely(pthread_create(&thread, NULL, wake_cpu_thread, (void *)&core)))
                     error("Cannot create wake_cpu_thread");

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -995,11 +995,13 @@ int do_proc_stat(int update_every, usec_t dt) {
                 pthread_t thread;
                 cpu_set_t global_cpu_set;
 
-                sched_getaffinity(getpid(), sizeof(cpu_set_t), &global_cpu_set);
-
-                if (unlikely(!CPU_ISSET(core, &global_cpu_set))) {
-                    continue;
+                if (likely(!pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &global_cpu_set))) {
+                    if (unlikely(!CPU_ISSET(core, &global_cpu_set))) {
+                        continue;
+                    }
                 }
+                else
+                    error("Cannot read current process affinity");
 
                 if(unlikely(pthread_create(&thread, NULL, wake_cpu_thread, (void *)&core)))
                     error("Cannot create wake_cpu_thread");


### PR DESCRIPTION
  start an idle thread (wake_cpu_thread) if the core is not  in
  the allowed cpu set.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #6741
Prevent isolated CPUs from being used by the idle thread 

This is done by reading the current affinity of the process and making sure
that the excluded cores do not spawn an idle thread (`wake_cpu_thread`) 

##### Component Name

##### Additional Information

