### PR TITLE
nvidia-smi: not loop mode

### DIFF
--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -16,6 +16,8 @@ This module monitors the `nvidia-smi` cli tool.
 
 -   Make sure `netdata` user can execute `/usr/bin/nvidia-smi` or wherever your binary is.
 
+-   If `nvidia-smi` process [is not killed after netdata restart](https://github.com/netdata/netdata/issues/7143) you need to off `loop_mode`.
+
 -   `poll_seconds` is how often in seconds the tool is polled for as an integer.
 
 It produces:
@@ -36,7 +38,8 @@ It produces:
 Sample:
 
 ```yaml
-poll_seconds: 1
+loop_mode    : yes
+poll_seconds : 1
 ```
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fnvidia_smi%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -7,11 +7,10 @@ import subprocess
 import threading
 import xml.etree.ElementTree as et
 
-from bases.collection import find_binary
 from bases.FrameworkServices.SimpleService import SimpleService
+from bases.collection import find_binary
 
 disabled_by_default = True
-
 
 NVIDIA_SMI = 'nvidia-smi'
 
@@ -76,7 +75,8 @@ def gpu_charts(gpu):
             ]
         },
         ENCODER_UTIL: {
-            'options': [None, 'Encoder/Decoder Utilization', 'percentage', fam, 'nvidia_smi.encoder_utilization', 'line'],
+            'options': [None, 'Encoder/Decoder Utilization', 'percentage', fam, 'nvidia_smi.encoder_utilization',
+                        'line'],
             'lines': [
                 ['encoder_util', 'encoder'],
                 ['decoder_util', 'decoder'],
@@ -212,6 +212,7 @@ def handle_attr_error(method):
             return method(*args, **kwargs)
         except AttributeError:
             return None
+
     return on_call
 
 
@@ -221,6 +222,7 @@ def handle_value_error(method):
             return method(*args, **kwargs)
         except ValueError:
             return None
+
     return on_call
 
 
@@ -342,22 +344,29 @@ class Service(SimpleService):
         super(Service, self).__init__(configuration=configuration, name=name)
         self.order = list()
         self.definitions = dict()
+        self.loop_mode = configuration.get('loop_mode', True)
         poll = int(configuration.get('poll_seconds', 1))
         self.poller = NvidiaSMIPoller(poll)
 
-    def get_data(self):
-        # if not self.poller.is_started():
-        #     self.poller.start()
-        #
-        # if not self.poller.is_alive():
-        #     self.debug('poller is off')
-        #     return None
-        #
-        # last_data = self.poller.data()
-        # if not last_data:
-        #     return None
+    def get_data_loop_mode(self):
+        if not self.poller.is_started():
+            self.poller.start()
 
-        last_data = self.poller.run_once()
+        if not self.poller.is_alive():
+            self.debug('poller is off')
+            return None
+
+        return self.poller.data()
+
+    def get_data_simple_mode(self):
+        return self.poller.run_once()
+
+    def get_data(self):
+        if self.loop_mode:
+            last_data = self.get_data_loop_mode()
+        else:
+            last_data = self.get_data_simple_mode()
+
         if not last_data:
             return None
 

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -358,14 +358,14 @@ class Service(SimpleService):
 
         return self.poller.data()
 
-    def get_data_simple_mode(self):
+    def get_data_normal_mode(self):
         return self.poller.run_once()
 
     def get_data(self):
         if self.loop_mode:
             last_data = self.get_data_loop_mode()
         else:
-            last_data = self.get_data_simple_mode()
+            last_data = self.get_data_normal_mode()
 
         if not last_data:
             return None

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -346,14 +346,18 @@ class Service(SimpleService):
         self.poller = NvidiaSMIPoller(poll)
 
     def get_data(self):
-        if not self.poller.is_started():
-            self.poller.start()
+        # if not self.poller.is_started():
+        #     self.poller.start()
+        #
+        # if not self.poller.is_alive():
+        #     self.debug('poller is off')
+        #     return None
+        #
+        # last_data = self.poller.data()
+        # if not last_data:
+        #     return None
 
-        if not self.poller.is_alive():
-            self.debug('poller is off')
-            return None
-
-        last_data = self.poller.data()
+        last_data = self.poller.run_once()
         if not last_data:
             return None
 

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.conf
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.conf
@@ -61,6 +61,7 @@
 #
 # Additionally to the above, example also supports the following:
 #
-# poll_seconds: SECONDS       # default is 1. Sets the frequency of seconds the nvidia-smi tool is polled.
+# loop_mode: yes/no           # default is yes. If set to yes `nvidia-smi` is executed in a separate thread using `-l` option.
+# poll_seconds: SECONDS       # default is 1. Sets the frequency of seconds the nvidia-smi tool is polled in loop mode.
 #
 # ----------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

Fixes: #7143 

nvidia_smi module executes `nvidia-smi` program in the loop mode

```
-l SEC, --loop=SEC
       Continuously report query data at the specified interval, rather than the default of just once.  The application will sleep in-between queries.  Note that on Linux ECC error or XID error events will print out during the sleep period if the -x flag was  not  specified.   Pressing
       Ctrl+C at any time will abort the loop, which will otherwise run indefinitely.  If no argument is specified for the -l form a default interval of 5 seconds is used.
```

This PR makes it configurable and allows to execute the program in normal mode.

##### Component Name

[/collectors/python.d.plugin/nvidia_smi](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/nvidia_smi)

##### Additional Information

I tested it on my linux pc with Nvidia card.
