### PR TITLE
Do not crash when logging UTF-8 data in Python 2

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SocketService.py
@@ -247,7 +247,7 @@ class SocketService(SimpleService):
             if self._check_raw_data(data):
                 break
 
-        self.debug('final response: {0}'.format(data))
+        self.debug(u'final response: {0}'.format(data))
         return data
 
     def _get_raw_data(self, raw=False, request=None):

--- a/collectors/python.d.plugin/python_modules/bases/collection.py
+++ b/collectors/python.d.plugin/python_modules/bases/collection.py
@@ -82,3 +82,19 @@ def read_last_line(f):
                 break
         result = opened.readline()
     return result.decode()
+
+
+def unicode_str(arg):
+    """Return the argument as a unicode string.
+
+    The `unicode` function has been removed from Python3 and `str` takes its
+    place. This function is a helper which will try using Python 2's `unicode`
+    and if it doesn't exist, assume we're using Python 3 and use `str`.
+
+    :param arg:
+    :return: <str>
+    """
+    try:
+        return unicode(arg)
+    except NameError:
+        return str(arg)

--- a/collectors/python.d.plugin/python_modules/bases/loggers.py
+++ b/collectors/python.d.plugin/python_modules/bases/loggers.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     from time import time
 
-from bases.collection import on_try_except_finally
+from bases.collection import on_try_except_finally, unicode_str
 
 
 LOGGING_LEVELS = {'CRITICAL': 50,
@@ -121,23 +121,23 @@ class BaseLogger(object):
             self.logger.setLevel(LOGGING_LEVELS[level])
 
     def debug(self, *msg, **kwargs):
-        self.logger.debug(' '.join(map(str, msg)), **kwargs)
+        self.logger.debug(' '.join(map(unicode_str, msg)), **kwargs)
 
     def info(self, *msg, **kwargs):
-        self.logger.info(' '.join(map(str, msg)), **kwargs)
+        self.logger.info(' '.join(map(unicode_str, msg)), **kwargs)
 
     def warning(self, *msg, **kwargs):
-        self.logger.warning(' '.join(map(str, msg)), **kwargs)
+        self.logger.warning(' '.join(map(unicode_str, msg)), **kwargs)
 
     def error(self, *msg, **kwargs):
-        self.logger.error(' '.join(map(str, msg)), **kwargs)
+        self.logger.error(' '.join(map(unicode_str, msg)), **kwargs)
 
     def alert(self, *msg,  **kwargs):
-        self.logger.critical(' '.join(map(str, msg)), **kwargs)
+        self.logger.critical(' '.join(map(unicode_str, msg)), **kwargs)
 
     @on_try_except_finally(on_finally=(exit, 1))
     def fatal(self, *msg, **kwargs):
-        self.logger.critical(' '.join(map(str, msg)), **kwargs)
+        self.logger.critical(' '.join(map(unicode_str, msg)), **kwargs)
 
 
 class PythonDLogger(object):


### PR DESCRIPTION
### Summary

There is an issue with logging UTF-8 characters when Netdata is run under Python 2. I've explained it in detail here: https://github.com/netdata/netdata/issues/7190#issuecomment-557563779.

Effectively, the response from ntp can sometimes contain UTF-8 characters and this would cause the ntp plugin to crash. This is because the message is put through the `str` function and this isn't expecting UTF-8 characters in Python 2. However, the debugging should be able to handle UTF-8 strings. Using the `unicode` function fixes this issue, but this function has been removed in Python 3 because UTF-8 is the default and `str` is sufficient. Therefore, I've added a helper which will try `unicode` and if it doesn't exist, fall back to `str`.

An alternative would be to use [future](https://pypi.org/project/future/) and import `future.builtins.str` which will mimic Python 3's `str` function. I didn't proceed with this as it adds a dependency to netdata.

Fixes #7190 

### Component Name

Logging for python plugins

### Additional Information

I couldn't see any unit testing for the code I've changed. If I've just missed it, let me know and I'll add tests for what I've done.

To replicate the issue: 
* Spin up a Centos 7 VM and install netdata
* Install ntpd
* Point ntp at a non-existent ntp server e.g.
```
[root@localhost ~]# cat /etc/ntp.conf
restrict default ignore
restrict 127.0.0.1
restrict -6 ::1  # In case IPv6 is enabled

restrict 10.1.2.3 nomodify notrap
server 10.1.2.3 iburst
```
* Check it's at stratum 16 with `ntpq`:
```
[root@localhost ~]# ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 10.1.2.3        .INIT.          16 u    -   64    0    0.000    0.000   0.000
```
* Run the ntp module:
```
sudo -u netdata python /usr/libexec/netdata/plugins.d/python.d.plugin ntpd debug trace
```

### Testing

#### Before changes

Python 2.7.5 on CentOS 7:

The plugin crashes:
```
[root@localhost ~]# sudo -u netdata python /usr/libexec/netdata/plugins.d/python.d.plugin ntpd debug trace
2019-11-27 16:08:14: python.d INFO: plugin[main] : using python v2
2019-11-27 16:08:14: python.d DEBUG: plugin[main] : looking for 'python.d.conf' in ['/usr/local/etc/netdata', '/usr/local/lib/netdata/conf.d']
2019-11-27 16:08:14: python.d WARNING: plugin[main] : 'python.d.conf' was not found, using defaults
2019-11-27 16:08:14: python.d DEBUG: plugin[main] : looking for 'pythond-jobs-statuses.json' in /usr/local/var/lib/netdata
2019-11-27 16:08:14: python.d WARNING: plugin[main] : 'pythond-jobs-statuses.json' was not found
2019-11-27 16:08:14: python.d DEBUG: plugin[main] : [ntpd] looking for 'ntpd.conf' in ['/usr/local/etc/netdata/python.d', '/usr/local/lib/netdata/conf.d/python.d']
2019-11-27 16:08:14: python.d WARNING: plugin[main] : [ntpd] 'ntpd.conf' was not found
2019-11-27 16:08:14: python.d INFO: plugin[main] : [ntpd] built 1 job(s) configs
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : No unix socket specified. Trying TCP/IP socket.
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : No host specified. Using: "localhost"
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : No port specified. Using: "ntp"
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : No TLS preference specified, not using TLS.
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : No request specified. Using: ""
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : Creating socket to "::1", port 123
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : connecting socket to "::1", port 123
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : set socket connect timeout to: 2.0
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : connected to "::1", port 123
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : set socket write timeout to: 2.0
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : sending request:
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : receiving response
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : set socket read timeout to: 2.0
2019-11-27 16:08:14: python.d DEBUG: ntpd[ntpd] : received data
2019-11-27 16:08:14: python.d WARNING: plugin[main] : ntpd[ntpd] : unhandled exception on check : UnicodeEncodeError('ascii', u'\u0582\x00\x01\x11\x00\x00\x00\x00\x01{version="ntpd 4.2.6p5@1.2349-o Thu Aug  8 11:47:59 UTC 2019 (1)",\r\nprocessor="x86_64", system="Linux/3.10.0-862.11.6.el7.x86_64", leap=3,\r\nstratum=16, precision=-25, rootdelay=0.000, rootdisp=65.085, refid=INIT,\r\nreftime=0x00000000.00000000, clock=0xe1891dee.53663024, peer=0, tc=3,\r\nmintc=3, offset=0.000, frequency=0.000, sys_jitter=0.000,\r\nclk_jitter=0.000, clk_wander=0.000\r\n\x00', 0, 1, 'ordinal not in range(128)'), skipping the job
2019-11-27 16:08:14: python.d INFO: plugin[main] : no jobs to serve
2019-11-27 16:08:14: python.d INFO: plugin[main] : exiting from main...
```

Python 3.6.8 on CentOS 7:

The plugin is fine:
```
[root@localhost ~]# sudo -u netdata python3 /usr/libexec/netdata/plugins.d/python.d.plugin ntpd debug trace
2019-11-27 16:08:52: python.d INFO: plugin[main] : using python v3
2019-11-27 16:08:52: python.d DEBUG: plugin[main] : looking for 'python.d.conf' in ['/usr/local/etc/netdata', '/usr/local/lib/netdata/conf.d']
2019-11-27 16:08:52: python.d WARNING: plugin[main] : 'python.d.conf' was not found, using defaults
2019-11-27 16:08:52: python.d DEBUG: plugin[main] : looking for 'pythond-jobs-statuses.json' in /usr/local/var/lib/netdata
2019-11-27 16:08:52: python.d WARNING: plugin[main] : 'pythond-jobs-statuses.json' was not found
2019-11-27 16:08:52: python.d DEBUG: plugin[main] : [ntpd] looking for 'ntpd.conf' in ['/usr/local/etc/netdata/python.d', '/usr/local/lib/netdata/conf.d/python.d']
2019-11-27 16:08:52: python.d WARNING: plugin[main] : [ntpd] 'ntpd.conf' was not found
2019-11-27 16:08:52: python.d INFO: plugin[main] : [ntpd] built 1 job(s) configs
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : No unix socket specified. Trying TCP/IP socket.
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : No host specified. Using: "localhost"
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : No port specified. Using: "ntp"
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : No TLS preference specified, not using TLS.
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : No request specified. Using: ""
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : Creating socket to "::1", port 123
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : connecting socket to "::1", port 123
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : set socket connect timeout to: 2.0
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : connected to "::1", port 123
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : set socket write timeout to: 2.0
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : sending request: b'\x16\x02\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00'
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : receiving response
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : set socket read timeout to: 2.0
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : received data
2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : final response: ւ{version="ntpd 4.2.6p5@1.2349-o Thu Aug  8 11:47:59 UTC 2019 (1)",
processor="x86_64", system="Linux/3.10.0-862.11.6.el7.x86_64", leap=3,
stratum=16, precision=-25, rootdelay=0.000, rootdisp=65.655, refid=INIT,
reftime=0x00000000.00000000, clock=0xe1891e14.90b1d1ae, peer=0, tc=3,
mintc=3, offset=0.000, frequency=0.000, sys_jitter=0.000,
clk_jitter=0.000, clk_wander=0.000

2019-11-27 16:08:52: python.d DEBUG: ntpd[ntpd] : closing socket
2019-11-27 16:08:52: python.d INFO: plugin[main] : ntpd[ntpd] : check success
...
BEGIN ntpd.sys_stratum 0
SET 'stratum' = 16000000
END
...

```

#### After Changes

Python 2.7.5 on CentOS 7:

The plugin no longer crashes:
```
[root@localhost ~]# sudo -u netdata python /usr/libexec/netdata/plugins.d/python.d.plugin ntpd debug trace
2019-11-27 16:10:38: python.d INFO: plugin[main] : using python v2
2019-11-27 16:10:38: python.d DEBUG: plugin[main] : looking for 'python.d.conf' in ['/usr/local/etc/netdata', '/usr/local/lib/netdata/conf.d']
2019-11-27 16:10:38: python.d WARNING: plugin[main] : 'python.d.conf' was not found, using defaults
2019-11-27 16:10:38: python.d DEBUG: plugin[main] : looking for 'pythond-jobs-statuses.json' in /usr/local/var/lib/netdata
2019-11-27 16:10:38: python.d WARNING: plugin[main] : 'pythond-jobs-statuses.json' was not found
2019-11-27 16:10:38: python.d DEBUG: plugin[main] : [ntpd] looking for 'ntpd.conf' in ['/usr/local/etc/netdata/python.d', '/usr/local/lib/netdata/conf.d/python.d']
2019-11-27 16:10:38: python.d WARNING: plugin[main] : [ntpd] 'ntpd.conf' was not found
2019-11-27 16:10:38: python.d INFO: plugin[main] : [ntpd] built 1 job(s) configs
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : No unix socket specified. Trying TCP/IP socket.
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : No host specified. Using: "localhost"
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : No port specified. Using: "ntp"
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : No TLS preference specified, not using TLS.
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : No request specified. Using: ""
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : Creating socket to "::1", port 123
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : connecting socket to "::1", port 123
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : set socket connect timeout to: 2.0
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : connected to "::1", port 123
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : set socket write timeout to: 2.0
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : sending request:
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : receiving response
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : set socket read timeout to: 2.0
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : received data
2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : final response: ւ{version="ntpd 4.2.6p5@1.2349-o Thu Aug  8 11:47:59 UTC 2019 (1)",
processor="x86_64", system="Linux/3.10.0-862.11.6.el7.x86_64", leap=3,
stratum=16, precision=-25, rootdelay=0.000, rootdisp=67.245, refid=INIT,
reftime=0x00000000.00000000, clock=0xe1891e7e.a0557cbd, peer=0, tc=3,
mintc=3, offset=0.000, frequency=0.000, sys_jitter=0.000,
clk_jitter=0.000, clk_wander=0.000

2019-11-27 16:10:38: python.d DEBUG: ntpd[ntpd] : closing socket
2019-11-27 16:10:38: python.d INFO: plugin[main] : ntpd[ntpd] : check success
...
BEGIN ntpd.sys_stratum 0
SET 'stratum' = 16000000
END
...
```

Python 3.6.8 on CentOS 7:

The plugin works the same as before:
```
[root@localhost ~]# sudo -u netdata python3 /usr/libexec/netdata/plugins.d/python.d.plugin ntpd debug trace
2019-11-27 16:11:39: python.d INFO: plugin[main] : using python v3
2019-11-27 16:11:39: python.d DEBUG: plugin[main] : looking for 'python.d.conf' in ['/usr/local/etc/netdata', '/usr/local/lib/netdata/conf.d']
2019-11-27 16:11:39: python.d WARNING: plugin[main] : 'python.d.conf' was not found, using defaults
2019-11-27 16:11:39: python.d DEBUG: plugin[main] : looking for 'pythond-jobs-statuses.json' in /usr/local/var/lib/netdata
2019-11-27 16:11:39: python.d WARNING: plugin[main] : 'pythond-jobs-statuses.json' was not found
2019-11-27 16:11:39: python.d DEBUG: plugin[main] : [ntpd] looking for 'ntpd.conf' in ['/usr/local/etc/netdata/python.d', '/usr/local/lib/netdata/conf.d/python.d']
2019-11-27 16:11:39: python.d WARNING: plugin[main] : [ntpd] 'ntpd.conf' was not found
2019-11-27 16:11:39: python.d INFO: plugin[main] : [ntpd] built 1 job(s) configs
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : No unix socket specified. Trying TCP/IP socket.
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : No host specified. Using: "localhost"
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : No port specified. Using: "ntp"
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : No TLS preference specified, not using TLS.
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : No request specified. Using: ""
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : Creating socket to "::1", port 123
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : connecting socket to "::1", port 123
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : set socket connect timeout to: 2.0
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : connected to "::1", port 123
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : set socket write timeout to: 2.0
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : sending request: b'\x16\x02\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00'
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : receiving response
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : set socket read timeout to: 2.0
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : received data
2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : final response: ւ{version="ntpd 4.2.6p5@1.2349-o Thu Aug  8 11:47:59 UTC 2019 (1)",
processor="x86_64", system="Linux/3.10.0-862.11.6.el7.x86_64", leap=3,
stratum=16, precision=-25, rootdelay=0.000, rootdisp=68.175, refid=INIT,
reftime=0x00000000.00000000, clock=0xe1891ebb.bd7981c8, peer=0, tc=3,
mintc=3, offset=0.000, frequency=0.000, sys_jitter=0.000,
clk_jitter=0.000, clk_wander=0.000

2019-11-27 16:11:39: python.d DEBUG: ntpd[ntpd] : closing socket
2019-11-27 16:11:39: python.d INFO: plugin[main] : ntpd[ntpd] : check success
...
BEGIN ntpd.sys_stratum 0
SET 'stratum' = 16000000
END
...
```
