### PR TITLE
smartd_log: change ATTR5 chart algorithm to absolute

### DIFF
--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -265,7 +265,7 @@ CHARTS = {
                     'line'],
         'lines': [],
         'attrs': [ATTR5],
-        'algo': INCREMENTAL,
+        'algo': ABSOLUTE,
     },
     'reserved_block_count': {
         'options': [None, 'Reserved Block Count', 'percentage', 'wear', 'smartd_log.reserved_block_count', 'line'],


### PR DESCRIPTION
### Summary

Fixes: #7383

##### Component Name
[/collectors/python.d.plugin/smartd_log](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/smartd_log)

##### Additional Information

[Reallocated Sectors Count](https://www.stellarinfo.com/blog/how-to-fix-reallocated-sector-count-warning/)

> the reallocated sector—also known as bad sector or bad block—is an area on the disk that is no longer safe to store data. When a system can’t read, write, or verify data stored at a particular sector, it marks the sector bad and reallocates or remaps the stored data to a reserved area (spare area) on the hard drive. The reserved area is set aside by the disk for normal operation of the drive and to prevent immediate data loss due to bad sectors.

> There is no ‘fix’ for reallocated sector count warning other than cloning the affected drive with a new one. Bad sectors—whether it’s a soft bad sector or hard—can’t be repaired. However, a drive with the reallocated sector count warning doesn’t mean that the drive will not work. You can continue using the drive as long as it runs but at your own risk.

