### PR TITLE
monit: overwrite __eq__, __ne__ in child classes (lgtm warnings)

### DIFF
--- a/collectors/python.d.plugin/monit/monit.chart.py
+++ b/collectors/python.d.plugin/monit/monit.chart.py
@@ -4,11 +4,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import xml.etree.ElementTree as ET
-
 from collections import namedtuple
 
 from bases.FrameworkServices.UrlService import UrlService
-
 
 MonitType = namedtuple('MonitType', ('index', 'name'))
 
@@ -122,7 +120,7 @@ CHARTS = {
 
 
 class BaseMonitService(object):
-    def __init__(self, typ, name,  status, monitor):
+    def __init__(self, typ, name, status, monitor):
         self.type = typ
         self.name = name
         self.status = status
@@ -153,7 +151,7 @@ class BaseMonitService(object):
 
 
 class ProcessMonitService(BaseMonitService):
-    def __init__(self, typ, name,  status, monitor):
+    def __init__(self, typ, name, status, monitor):
         super(ProcessMonitService, self).__init__(typ, name, status, monitor)
         self.uptime = None
         self.threads = None
@@ -192,7 +190,7 @@ class ProcessMonitService(BaseMonitService):
 
 
 class HostMonitService(BaseMonitService):
-    def __init__(self, typ, name,  status, monitor):
+    def __init__(self, typ, name, status, monitor):
         super(HostMonitService, self).__init__(typ, name, status, monitor)
         self.latency = None
 
@@ -210,7 +208,7 @@ class HostMonitService(BaseMonitService):
 
     def data(self):
         base_data = super(HostMonitService, self).data()
-        latency = float(self.latency) * 1000000 if self.latency  else None
+        latency = float(self.latency) * 1000000 if self.latency else None
         data = {self.latency_key(): latency}
         data.update(base_data)
 

--- a/collectors/python.d.plugin/monit/monit.chart.py
+++ b/collectors/python.d.plugin/monit/monit.chart.py
@@ -165,6 +165,9 @@ class ProcessMonitService(BaseMonitService):
     def __ne__(self, other):
         return super(ProcessMonitService, self).__ne__(other)
 
+    def __hash__(self):
+        return super(ProcessMonitService, self).__hash__()
+
     def uptime_key(self):
         return 'process_uptime_{0}'.format(self.name)
 
@@ -198,6 +201,9 @@ class HostMonitService(BaseMonitService):
 
     def __ne__(self, other):
         return super(HostMonitService, self).__ne__(other)
+
+    def __hash__(self):
+        return super(HostMonitService, self).__hash__()
 
     def latency_key(self):
         return 'host_latency_{0}'.format(self.name)

--- a/collectors/python.d.plugin/monit/monit.chart.py
+++ b/collectors/python.d.plugin/monit/monit.chart.py
@@ -159,6 +159,12 @@ class ProcessMonitService(BaseMonitService):
         self.threads = None
         self.children = None
 
+    def __eq__(self, other):
+        return super(ProcessMonitService, self).__eq__(other)
+
+    def __ne__(self, other):
+        return super(ProcessMonitService, self).__ne__(other)
+
     def uptime_key(self):
         return 'process_uptime_{0}'.format(self.name)
 
@@ -186,6 +192,12 @@ class HostMonitService(BaseMonitService):
     def __init__(self, typ, name,  status, monitor):
         super(HostMonitService, self).__init__(typ, name, status, monitor)
         self.latency = None
+
+    def __eq__(self, other):
+        return super(HostMonitService, self).__eq__(other)
+
+    def __ne__(self, other):
+        return super(HostMonitService, self).__ne__(other)
 
     def latency_key(self):
         return 'host_latency_{0}'.format(self.name)


### PR DESCRIPTION
##### Summary

Fixes lgtm warning from #7385

Rule is
> https://lgtm.com/rules/9990086/

It is a recomendation, in our specific case we could ignore it because it is more false positive then not, but in general it sounds good and there is no reason to no apply it imo.

##### Component Name

[/collectors/python.d.plugin/monit](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/monit)

##### Additional Information

