### PR TITLE
Added ability to get pod name from cgroup with kubectl in bare metal deployment

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -96,11 +96,14 @@ function k8s_get_name() {
 			cut -d' ' -f1
 			)"
 		elif ps -C kubelet >/dev/null 2>&1 && command -v kubectl >/dev/null 2>&1; then
-			if kubectl get pod --all-namespaces >/dev/null 2>&1; then
-				NAME="$(kubectl get pod --all-namespaces --output='json' | \
+			if [[ -z ${KUBE_CONFIG+x} ]]; then
+				KUBE_CONFIG="/etc/kubernetes/admin.conf"
+			fi
+			if kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces >/dev/null 2>&1; then
+				NAME="$(kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces --output='json' | \
 				jq -r '.items[] | select(.metadata.uid == "'$id'") | .metadata.name')"
 			else
-				warning "kubectl cannot get pod list, check for configuration file in $HOME/.kube/config"
+				warning "kubectl cannot get pod list, check for configuration file in $KUBE_CONFIG, or set this path to env \$KUBE_CONFIG"
 			fi
 		fi
 	else

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -100,6 +100,7 @@ function k8s_get_name() {
 				KUBE_CONFIG="/etc/kubernetes/admin.conf"
 			fi
 			if kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces >/dev/null 2>&1; then
+				#shellcheck disable=SC2086
 				NAME="$(kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces --output='json' | \
 				jq -r '.items[] | select(.metadata.uid == "'$id'") | .metadata.name')"
 			else

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -77,19 +77,32 @@ function docker_get_name_api() {
 }
 
 function k8s_get_name() {
-	# Take the last part of the delimited path identifier (expecting either _ or / as a delimiter).
-	local id="${1##*_}"
-	if [ "${id}" == "${1}" ]; then
-		id="${1##*/}"
+	if [[ "${1}" =~ ^kube.*_pod.*$ ]]; then
+		local id="${1##*_pod}"
+	else
+		# Take the last part of the delimited path identifier (expecting either _ or / as a delimiter).
+		local id="${1##*_}"
+		if [ "${id}" == "${1}" ]; then
+			id="${1##*/}"
+		fi
 	fi
-	KUBE_TOKEN="$(</var/run/secrets/kubernetes.io/serviceaccount/token)"
 	if command -v jq >/dev/null 2>&1; then
-		NAME="$(
-		curl -sSk -H "Authorization: Bearer $KUBE_TOKEN"  "https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/pods" |
-		jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_" + (.status.containerStatuses[]? | "\(.name) \(.containerID)")' |
-		grep "$id" |
-		cut -d' ' -f1
-		)"
+		if [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}" ]; then
+			KUBE_TOKEN="$(</var/run/secrets/kubernetes.io/serviceaccount/token)"
+			NAME="$(
+			curl -sSk -H "Authorization: Bearer $KUBE_TOKEN"  "https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/pods" |
+			jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_\(.status.containerStatuses[0].name) \(.status.containerStatuses[0].containerID)"' |
+			grep "$id" |
+			cut -d' ' -f1
+			)"
+		elif ps -C kubelet >/dev/null 2>&1 && command -v kubectl >/dev/null 2>&1; then
+			if kubectl get pod --all-namespaces >/dev/null 2>&1; then
+				NAME="$(kubectl get pod --all-namespaces --output='json' | \
+				jq -r '.items[] | select(.metadata.uid == "'$id'") | .metadata.name')"
+			else
+				warning "kubectl cannot get pod list, check for configuration file in $HOME/.kube/config"
+			fi
+		fi
 	else
 		warning "jq command not available, k8s_get_name() cannot execute. Please install jq should you wish for k8s to be fully functional"
 	fi
@@ -158,12 +171,10 @@ for CONFIG in "${NETDATA_USER_CONFIG_DIR}/cgroups-names.conf" "${NETDATA_STOCK_C
 	fi
 done
 
-if [ -z "${NAME}" ] && [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}" ] && [[ ${CGROUP} =~ ^.*kubepods.* ]]; then
-	k8s_get_name "${CGROUP}"
-fi
-
 if [ -z "${NAME}" ]; then
-	if [[ ${CGROUP} =~ ^.*docker[-_/\.][a-fA-F0-9]+[-_\.]?.*$ ]]; then
+	if [[ ${CGROUP} =~ ^.*kubepods.* ]]; then
+		k8s_get_name "${CGROUP}"
+	elif [[ ${CGROUP} =~ ^.*docker[-_/\.][a-fA-F0-9]+[-_\.]?.*$ ]]; then
 		# docker containers
 		#shellcheck disable=SC1117
 		DOCKERID="$(echo "${CGROUP}" | sed "s|^.*docker[-_/]\([a-fA-F0-9]\+\)[-_\.]\?.*$|\1|")"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
In those cases when kubernetes and netdata are manually installed on bare metal, the`cgroup-name.sh` script cannot get the names of the containers due to empty variables:
* `$KUBERNETES_SERVICE_HOST`
* `$KUBERNETES_PORT_443_TCP_PORT`

Also missing file `/var/run/secrets/kubernetes.io/serviceaccount/token`

My edits add an alternative opportunity to get the name of the container if no variables are set and `kubelet` is running on the system and `kubectl` binary is available.

By default, `/etc/kubernetes/admin.conf` is used to access kubectl, if an error occurs during execution, an entry will be added to the log with the warning level, but if you specify the path in the variable `$KUBE_CONFIG`, then it will be used your custom config.

For example, you can use systemd daemon:
```
[Service]
Environment=KUBE_CONFIG=/etc/netdata/kubernetes.conf
```

##### Component Name
`collectors/cgroups.plugin/cgroup-name.sh.in`

##### Additional Information

![before/after](https://i.imgur.com/zPQGegK.png)
