### PR TITLE
Add docs generator directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,8 @@ python.d/python-modules-installer.sh
 # documentation generated files
 docs/generator/src
 docs/generator/build
+docs/generator/doc
+docs/generator/localization
 docs/generator/mkdocs.yml
 
 .environment.sh


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

When building the docs, and the build fails due to some reason (like broken links), all the files created by the `buildhtml.sh` script in the `docs/generator/doc` folder start getting tracked by Git, in addition to the `doc/generator/localization/` folder. I then I have to unstage everything and `rm -rf` the localization folder to have a clean slate to work from when committing my actual work.

These two additions should streamline the process of building docs locally without losing information, as those directories are always cleaned up during a successful build.

##### Component Name

.gitignore
docs

##### Additional Information

