### PR TITLE
Docs: Change build process to allow apostrophes in headers

### DIFF
--- a/docs/generator/checklinks.sh
+++ b/docs/generator/checklinks.sh
@@ -55,7 +55,7 @@ testinternal () {
 	ilnk=${3}
 	header=${ilnk//-/}
 	dbg "   - Searching for \"$header\" in $ifile"
-	tr -d '[],_.:? `'< "$ifile" | sed 's/-//g' | grep -i "^\\#*$header\$" >/dev/null
+	tr -d '[],_.:? `'< "$ifile" | sed -e 's/-//g' -e "s/'//g" | grep -i "^\\#*$header\$" >/dev/null
 	if [ $? -eq 0 ] ; then
 		dbg "   - $ilnk found in $ifile"
 		return 0


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

In migrating over my big tutorial over to the existing docs site I noticed that the current `checklink.sh` script doesn't very much like when a header has an apostrophe in it.

For example, the following anchor link and heading don't work together:

```
[this is an anchor link to the heading below](#lets-try-this-test)

## Let's try this test
```

This tweak to the line cuts out apostrophes, the same way it cuts dashes, from the checking logic so the script can properly verify that the heading exists.

##### Component Name

docs

##### Additional Information
