### PR TITLE
address lgtm alerts

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -1,8 +1,5 @@
 // Source: https://github.com/codacy/codacy-remark-lint/raw/master/.remarkrc.js
 
-const fs = require("fs");
-const path = require("path");
-
 exports.settings = {
   gfm: true,
   commonmark: true,
@@ -18,13 +15,6 @@ exports.settings = {
   listItemIndent: 'tab',
   incrementListMarker: true
 };
-
-const personalDictionaryPath = path.join(__dirname, ".dictionary");
-const personalDictionary = fs.existsSync(personalDictionaryPath)
-  ? {
-      personal: fs.readFileSync(personalDictionaryPath, "utf8")
-    }
-  : {};
 
 const remarkPresetLintMarkdownStyleGuide = {
   plugins: require("remark-preset-lint-markdown-style-guide").plugins.filter(

--- a/web/gui/dash-example.html
+++ b/web/gui/dash-example.html
@@ -692,7 +692,7 @@ class PickNSort {
 
 			for (var i = 0; i < aProps.length; i++) {
 				var propName = aProps[i];
-				var aa = a[propName]
+				var aa = a[propName];
 				var aaProps = Object.keys(aa);
 				var bb = b[propName];
 				var bbProps = Object.keys(bb);

--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -1818,7 +1818,7 @@ function renderPage(menus, data) {
 
     if (!isMemoryModeDbEngine) {
         sidebar += '<br />&nbsp;<br />Get more history by ' +
-          '<a href="https://docs.netdata.cloud/docs/configuration-guide/#increase-the-metrics-retention-period" target=_blank>configuring Netdata\'s <strong>history</strong></a> or using the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine.</a>'
+          '<a href="https://docs.netdata.cloud/docs/configuration-guide/#increase-the-metrics-retention-period" target=_blank>configuring Netdata\'s <strong>history</strong></a> or using the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine.</a>';
     }
 
     sidebar += '<br/>&nbsp;<br/><strong>netdata</strong><br/>' + data.version.toString() + '</small></li>';
@@ -4956,7 +4956,8 @@ function handleSignInMessage(e) {
 
     netdataRegistryCallback(registryAgents);
     if (e.data.redirectURI && !window.location.href.includes(e.data.redirectURI)) {
-        window.location.replace(e.data.redirectURI);
+        // lgtm false-positive - redirectURI does not come from user input, but from iframe callback
+        window.location.replace(e.data.redirectURI); // lgtm[js/client-side-unvalidated-url-redirection]
     }
 }
 
@@ -5183,5 +5184,5 @@ if (document.readyState === "complete") {
         if (document.readyState === "complete") {
             initializeApp();
         }
-    })
+    });
 }


### PR DESCRIPTION
##### Summary

Fixes javascript lgtm warning from #7385

1 error silenced: https://lgtm.com/rules/1979240340/
because it's a false-positive - LGTM thinks that redirect is caused by user input (sees the `event` property), but actually it only comes from iframe.

The rest is just lint (semicolons added) and unused code removal

##### Component Name

web