### PR TITLE
sensors: check fix

### DIFF
--- a/collectors/python.d.plugin/sensors/sensors.chart.py
+++ b/collectors/python.d.plugin/sensors/sensors.chart.py
@@ -162,4 +162,4 @@ class Service(SimpleService):
 
         self.create_definitions()
 
-        return True
+        return bool(self.get_data())


### PR DESCRIPTION
##### Summary

Currently `sensors` module does only `sensors.init()` in `check` and returns `True` if there is no error. 

https://github.com/netdata/netdata/blob/7953472f1190b96c46ce3180c935bdcc9b5d2717/collectors/python.d.plugin/sensors/sensors.chart.py#L156-L165

It is not enough to be sure module can get some data.
Solution is to invoke `get_data` at the end of the `check` and see if it returns any data.

##### Component Name
[/collectors/python.d.plugin/sensors](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/sensors)

##### Additional Information

