### PR TITLE
Add k8s labels and other label-related additions

### DIFF
--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -13,9 +13,11 @@ dist_noinst_DATA = \
     README.md \
     config/README.md \
     anonymous-statistics.sh.in \
+    get-kubernetes-labels.sh.in \
     $(NULL)
 
 dist_plugins_SCRIPTS = \
     anonymous-statistics.sh \
     system-info.sh \
+    get-kubernetes-labels.sh \
     $(NULL)

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -96,6 +96,8 @@ static cmd_status_t cmd_help_execute(char *args, char **message)
              "    Show this help menu.\n"
              "reload-health\n"
              "    Reload health configuration.\n"
+             "reload-labels\n"
+             "    Reload all labels.\n"
              "save-database\n"
              "    Save internal DB to disk for memory mode save.\n"
              "reopen-logs\n"
@@ -177,7 +179,14 @@ static cmd_status_t cmd_reload_labels_execute(char *args, char **message)
     (void)message;
     info("COMMAND: reloading host labels.");
     reload_host_labels();
-
+    struct label *l=localhost->labels;
+    BUFFER *wb = buffer_create(10);
+    while (l != NULL) {
+        buffer_sprintf(wb,"Label [source id=%s]: \"%s\" -> \"%s\"\n", translate_label_source(l->label_source), l->key, l->value);
+        l = l->next;
+    }
+    (*message)=strdupz(buffer_tostring(wb));
+    buffer_free(wb);
     return CMD_STATUS_SUCCESS;
 }
 

--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Checks if netdata is running in a kubernetes pod and fetches that pod's labels
+
+if [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}" ] && [ -n "${MY_POD_NAMESPACE}" ] && [ -n "${MY_POD_NAME}" ]; then
+	if command -v jq >/dev/null 2>&1; then
+			KUBE_TOKEN="$(</var/run/secrets/kubernetes.io/serviceaccount/token)"
+		URL="https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/$MY_POD_NAMESPACE/pods/$MY_POD_NAME"
+		curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" "$URL" |
+		jq -r '.metadata.labels' | grep ':' | tr -d '," '
+		exit 0
+	else
+		echo "jq command not available. Please install jq to get host labels for kubernetes pods."
+		exit 1
+	fi
+else
+	# Following is only for testing and will be removed
+	echo "app:netdata
+controller-revision-hash:64966d4b74
+pod-template-generation:4
+release:netdata
+role:slave
+a line to display as info"
+	exit 0
+fi

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1267,19 +1267,8 @@ int main(int argc, char **argv) {
 
     error_log_limit_reset();
 
-    // ------------------------------------------------------------------------
-    // load the host-level labels
-    /*
-       Temporary test-vector for #7408.
-       Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
-
-    netdata_rwlock_wrlock(&localhost->labels_rwlock);
-    struct label *l = create_label("HostLabel1","Höst Låbel",LABEL_SOURCE_AUTO);
-    l->next = create_label("Label2","xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",LABEL_SOURCE_ENVIRONMENT);
-    localhost->labels = l;
-    netdata_rwlock_unlock(&localhost->labels_rwlock);
-    */
-
+    // Load host labels
+    reload_host_labels();
 
     // ------------------------------------------------------------------------
     // spawn the threads

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -150,10 +150,10 @@ typedef enum rrddim_flags {
 
 typedef enum label_source {
     LABEL_SOURCE_AUTO             = 0,
-    LABEL_SOURCE_NETDATA_CONF     = (1 << 0),
-    LABEL_SOURCE_DOCKER           = (1 << 1),
-    LABEL_SOURCE_ENVIRONMENT      = (1 << 2),
-    LABEL_SOURCE_KUBERNETES       = (1 << 3)
+    LABEL_SOURCE_NETDATA_CONF     = 1,
+    LABEL_SOURCE_DOCKER           = 2,
+    LABEL_SOURCE_ENVIRONMENT      = 3,
+    LABEL_SOURCE_KUBERNETES       = 4
 } LABEL_SOURCE;
 
 struct label {
@@ -163,6 +163,7 @@ struct label {
     struct label *next;
 };
 
+char *translate_label_source(LABEL_SOURCE l);
 struct label *create_label(char *key, char *value, LABEL_SOURCE label_source);
 struct label *add_label_to_list(struct label *l, char *key, char *value, LABEL_SOURCE label_source);
 void reload_host_labels();

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -764,21 +764,6 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, char *url) {
     (void)url;
     if (!netdata_ready) return HTTP_RESP_BACKEND_FETCH_FAILED;
-
-    /* Temporary test-vector for #7408
-       Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
-    netdata_rwlock_rdlock(&localhost->labels_rwlock);
-    struct label *l = localhost->labels;
-    while (l != NULL) {
-        error("Label [source id=%u]: \"%s\" -> \"%s\"", l->label_source, l->key, l->value);
-        l = l->next;
-    }
-    netdata_rwlock_unlock(&localhost->labels_rwlock);
-    */
-
-
-
-
     BUFFER *wb = w->response.data;
     buffer_flush(wb);
     wb->contenttype = CT_APPLICATION_JSON;


### PR DESCRIPTION
##### Summary
- Get labels from the kubernetes pod (all of #7411). Note that **there are test return values** in  ` daemon/get-kubernetes-labels.sh.in`, so we can all test the process, regardless of whether we run in k8s. 
- Execute reload_labels at startup
- Log labels in reload_labels
- Output labels when reloading from the command CLI
- Add info to commandcli help
- Fix enums
- enum to text translation for the log messages

There is one improvement I'd like to make, get back and process the exit code of the executable, so I can present an ERROR message when it exits with 1. Right now, I only output lines not matching the pattern, if the error message for jq contained a ':' in it, it would be considered a label. 

If you don't see anything seriously wrong I suggest you merge and I can add more fixes in a new PR, many of the changes will help everyone debug their code better. 

