### PR TITLE
Check valid label inside kubernet and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ system/netdata-freebsd
 system/edit-config
 
 daemon/anonymous-statistics.sh
+daemon/get-kubernetes-labels.sh
 
 health/notifications/alarm-notify.sh
 collectors/cgroups.plugin/cgroup-name.sh

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -781,7 +781,9 @@ struct label *load_kubernetes_labels()
                 while (*eos && *eos != '\n') eos++;
                 if (*eos == '\n') *eos = '\0';
                 if (strlen(value)>1) {
-                    l = add_label_to_list(l, name, value, LABEL_SOURCE_KUBERNETES);
+                    if (is_valid_label_key(name)){
+                        l = add_label_to_list(l, name, value, LABEL_SOURCE_KUBERNETES);
+                    }
                 } else {
                     info("%s returned: '%s'", label_script, name);
                 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -757,7 +757,7 @@ struct label *load_config_labels()
 {
     int status = config_load(NULL, 1, CONFIG_SECTION_HOST_LABEL);
     if(!status) {
-        char *filename = filename = CONFIG_DIR "/" CONFIG_FILENAME;
+        char *filename = CONFIG_DIR "/" CONFIG_FILENAME;
         error("LABEL: Cannot reload the configuration file '%s', using labels in memory", filename);
     }
 


### PR DESCRIPTION
##### Summary
Fixes #7460
For I do not do two PRs for kubernets, considering that both are small, I am also bring a change inside `rrdhost.c` that check whether a label is valid before to add it to the link list.
##### Component Name
Database
##### Additional Information

