### PR TITLE
Labels to alarms

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -605,10 +605,9 @@ void rrdcalc_unlink_and_free(RRDHOST *host, RRDCALC *rc) {
     rrdcalc_free(rc);
 }
 
-void rrdcalc_labels_unlink_alarm_from_host(RRDHOST *host) {
-    netdata_rwlock_rdlock(&host->labels_rwlock);
+static void rrdcalc_labels_unlink_alarm_loop(RRDHOST *host, RRDCALC *alarms) {
     RRDCALC *rc, *clean = NULL;
-    for (rc = host->alarms; rc; rc = rc->next) {
+    for (rc = alarms; rc; rc = rc->next) {
         if (!rc->labels) {
             continue;
         }
@@ -651,6 +650,15 @@ void rrdcalc_labels_unlink_alarm_from_host(RRDHOST *host) {
               clean->labels);
         rrdcalc_unlink_and_free(host, clean);
     }
+
+
+}
+
+void rrdcalc_labels_unlink_alarm_from_host(RRDHOST *host) {
+    netdata_rwlock_rdlock(&host->labels_rwlock);
+
+    rrdcalc_labels_unlink_alarm_loop(host, host->alarms);
+    rrdcalc_labels_unlink_alarm_loop(host, host->alarms_with_foreach);
 
     netdata_rwlock_unlock(&host->labels_rwlock);
 }

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -615,7 +615,7 @@ void rrdcalc_labels_unlink() {
 
         if (host->labels) {
             rrdhost_wrlock(host);
-            netdata_rwlock_wrlock(&host->labels_rwlock);
+            netdata_rwlock_rdlock(&host->labels_rwlock);
 
             RRDCALC *rc, *clean = NULL;
             for (rc = host->alarms; rc; rc = rc->next) {

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -559,6 +559,8 @@ void rrdcalc_free(RRDCALC *rc) {
     freez(rc->units);
     freez(rc->info);
     simple_pattern_free(rc->spdim);
+    freez(rc->labels);
+    simple_pattern_free(rc->splabels);
     freez(rc);
 }
 

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -612,12 +612,16 @@ static void rrdcalc_labels_unlink_alarm_loop(RRDHOST *host, RRDCALC *alarms) {
             continue;
         }
 
+        debug("Going to test labels for alarm '%s'", rc->name);
         if (clean) {
-            error("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
+            info("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
                   clean->name,
                   host->hostname,
                   clean->labels);
-            rrdcalc_unlink_and_free(host, clean);
+            debug("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
+                 clean->name,
+                 host->hostname,
+                 rrdcalc_unlink_and_free(host, clean);
             clean = NULL;
         }
 
@@ -644,7 +648,7 @@ static void rrdcalc_labels_unlink_alarm_loop(RRDHOST *host, RRDCALC *alarms) {
     }
 
     if (clean) {
-        error("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
+        info("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
               clean->name,
               host->hostname,
               clean->labels);

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -612,16 +612,11 @@ static void rrdcalc_labels_unlink_alarm_loop(RRDHOST *host, RRDCALC *alarms) {
             continue;
         }
 
-        debug("Going to test labels for alarm '%s'", rc->name);
         if (clean) {
             info("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
                   clean->name,
                   host->hostname,
                   clean->labels);
-            debug("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
-                 clean->name,
-                 host->hostname,
-                 rrdcalc_unlink_and_free(host, clean);
             clean = NULL;
         }
 

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -91,6 +91,11 @@ struct rrdcalc {
     uint32_t crit_repeat_every; // interval between repeating critical notifications
 
     // ------------------------------------------------------------------------
+    // Labels settings
+    char *labels;                   // the label read from an alarm file
+    SIMPLE_PATTERN *splabels;       // the simple pattern of labels
+
+    // ------------------------------------------------------------------------
     // runtime information
 
     RRDCALC_STATUS old_status; // the old status of the alarm

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -162,6 +162,8 @@ extern void rrdcalc_add_to_host(RRDHOST *host, RRDCALC *rc);
 extern void dimension_remove_pipe_comma(char *str);
 extern char *alarm_name_with_dim(char *name, size_t namelen, const char *dim, size_t dimlen);
 
+extern void rrdcalc_labels_unlink();
+
 static inline int rrdcalc_isrepeating(RRDCALC *rc) {
     if (unlikely(rc->warn_repeat_every > 0 || rc->crit_repeat_every > 0)) {
         return 1;

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -163,6 +163,7 @@ extern void dimension_remove_pipe_comma(char *str);
 extern char *alarm_name_with_dim(char *name, size_t namelen, const char *dim, size_t dimlen);
 
 extern void rrdcalc_labels_unlink();
+extern void rrdcalc_labels_unlink_alarm_from_host(RRDHOST *host);
 
 static inline int rrdcalc_isrepeating(RRDCALC *rc) {
     if (unlikely(rc->warn_repeat_every > 0 || rc->crit_repeat_every > 0)) {

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -56,7 +56,9 @@ inline void rrdcalctemplate_free(RRDCALCTEMPLATE *rt) {
     freez(rt->info);
     freez(rt->dimensions);
     freez(rt->foreachdim);
+    freez(rt->labels);
     simple_pattern_free(rt->spdim);
+    simple_pattern_free(rt->splabels);
     freez(rt);
 }
 

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -9,7 +9,7 @@ static int rrdcalctemplate_has_label(RRDCALCTEMPLATE *rt,  RRDHOST *host) {
     errno = 0;
     struct label *move = host->labels;
     if(move && rt->labels) {
-        netdata_rwlock_wrlock(&host->labels_rwlock);
+        netdata_rwlock_rdlock(&host->labels_rwlock);
         while(move) {
             if (simple_pattern_matches(rt->splabels, move->key)) {
                 break;

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -14,14 +14,15 @@ static int rrdcalctemplate_has_label(RRDCALCTEMPLATE *rt,  RRDHOST *host) {
     size_t len = strlen(rt->labels)+1;
     char *cmp = mallocz(len);
     if(!cmp)
-        return 0;
+        return 1;
 
     int ret;
-    if(move && rt->labels) {
+    if(move) {
         netdata_rwlock_rdlock(&host->labels_rwlock);
         while(move) {
             snprintfz(cmp, len, "%s=%s", move->key, move->value);
-            if (simple_pattern_matches(rt->splabels, move->key) || simple_pattern_matches(rt->splabels, cmp)) {
+            if (simple_pattern_matches(rt->splabels, move->key) ||
+                simple_pattern_matches(rt->splabels, cmp)) {
                 break;
             }
             move = move->next;
@@ -42,8 +43,7 @@ static int rrdcalctemplate_has_label(RRDCALCTEMPLATE *rt,  RRDHOST *host) {
         ret =1;
     }
 
-    if(cmp)
-        freez(cmp);
+    freez(cmp);
 
     return ret;
 }

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -9,18 +9,19 @@ static int rrdcalctemplate_has_label(RRDCALCTEMPLATE *rt,  RRDHOST *host) {
     errno = 0;
     struct label *move = host->labels;
     if(move && rt->labels) {
-        netdata_rwlock_wrlock(&localhost->labels_rwlock);
+        netdata_rwlock_wrlock(&host->labels_rwlock);
         while(move) {
             if (simple_pattern_matches(rt->splabels, move->key)) {
                 break;
             }
             move = move->next;
         }
-        netdata_rwlock_unlock(&localhost->labels_rwlock);
+        netdata_rwlock_unlock(&host->labels_rwlock);
 
         if(!move) {
-            error("Health template '%s' cannot be applied, because this host does not have the label(s) '%s'",
+            error("Health template '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
                    rt->name,
+                   host->hostname,
                    rt->labels
             );
             return 0;

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -5,7 +5,7 @@
 
 // ----------------------------------------------------------------------------
 
-int rrdcalctemplate_has_label(RRDCALCTEMPLATE *rt,  RRDHOST *host) {
+static int rrdcalctemplate_has_label(RRDCALCTEMPLATE *rt,  RRDHOST *host) {
     errno = 0;
     struct label *move = host->labels;
     if(move && rt->labels) {

--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -59,6 +59,11 @@ struct rrdcalctemplate {
     uint32_t crit_repeat_every; // interval between repeating critical notifications
 
     // ------------------------------------------------------------------------
+    // Labels settings
+    char *labels;                   // the label read from an alarm file
+    SIMPLE_PATTERN *splabels;       // the simple pattern of labels
+
+    // ------------------------------------------------------------------------
     // expressions related to the alarm
 
     EVAL_EXPRESSION *calculation;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -930,6 +930,8 @@ void reload_host_labels()
         old_labels = old_labels->next;
         freez(current);
     }
+
+    health_reload();
 }
 
 // ----------------------------------------------------------------------------

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -405,12 +405,14 @@ inside a room that were installed in a specific time, I can write the following 
 label: room = workstation AND installed = 201705
 ```
 
-It also possible to use [simple patterns](../libnetdata/simple_pattern/)  with labels. Continuing with our example, case
-I decided to create an alarm that will be applied to all hosts installed in the last decade, I can set label like:
+The `label` is a space-separate list that accepts simple patterns, for example, case I decided to create an alarm 
+that will be applied to all hosts installed in the last decade, I can set label like:
 
 ```yaml
 label: installed = 201*
 ```
+
+See our [simple patterns docs](../libnetdata/simple_pattern/) for more examples.
 
 ## Expressions
 

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -373,18 +373,43 @@ good idea to tell Netdata to not clear the notification, by using the `no-clear-
 
 #### Alarm line `label`
 
-Defines the list of labels expected on host, for example, case I want apply an alarm only on Netdata slave, I can specify
-this using the label `_is_master`
+Defines the list of labels expected on host, for example, let us suppose that `netdata.conf` is configured with the
+following labels:
 
 ```yaml
-label: _is_master = false
+[host labels]
+    installed = 20191211
+    room = server
 ```
- 
-This option accepts [Netdata simple patterns](../libnetdata/simple_pattern/), so, case you wanna apply an alarm to either
-a master or a slave, you can write:
+
+but, we also have for the workstations the following `netdata.conf`
 
 ```yaml
-label: _is_master = *
+[host labels]
+    installed = 201705
+    room = workstation
+```
+
+I have defined inside `netdata.conf` labels to classify hosts and now we can apply alarms for them using labels, for example,
+case I add the following line inside alarms:
+
+```yaml
+label: room = server
+```
+
+this will apply alarms only on hosts that have `room = server`. 
+It is also possible to combine labels to apply alarm, for example, case I want to raise a specific alarm only for hosts
+inside a room that were installed in a specific time, I can write the following label condition:
+
+```yaml
+label: room = workstation AND installed = 201705
+```
+
+It also possible to use [simple patterns](../libnetdata/simple_pattern/)  with labels. Continuing with our example, case
+I decided to create an alarm that will be applied to all hosts installed in the last decade, I can set label like:
+
+```yaml
+label: installed = 201*
 ```
 
 ## Expressions

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -68,6 +68,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`delay`](#alarm-line-delay)                        | no              | Optional hysteresis settings to prevent floods of notifications.                      |
 | [`repeat`](#alarm-line-repeat)                      | no              | The interval for sending notifications when an alarm is in WARNING or CRITICAL mode.  |
 | [`option`](#alarm-line-option)                      | no              | Add an option to not clear alarms.                                                    |
+| [`label`](#alarm-line-label)                        | no              | List of labels present on a host.                                                     |
 
 The `alarm` or `template` line must be the first line of any entity.
 
@@ -369,6 +370,22 @@ cleared. As time passes, the newest window moves into the older, so the average 
 increasing. Eventually, the comparison will find the averages in the two time-frames close enough to clear the alarm.
 However, the issue was not resolved, it's just a matter of the newer data "polluting" the old. For such alarms, it's a
 good idea to tell Netdata to not clear the notification, by using the `no-clear-notification` option.
+
+#### Alarm line `label`
+
+Defines the list of labels expected on host, for example, case I want apply an alarm only on Netdata slave, I can specify
+this using the label `_is_master`
+
+```yaml
+label: _is_master = false
+```
+ 
+This option accepts [Netdata simple patterns](../libnetdata/simple_pattern/), so, case you wanna apply an alarm to either
+a master or a slave, you can write:
+
+```yaml
+label: _is_master = *
+```
 
 ## Expressions
 

--- a/health/health.c
+++ b/health/health.c
@@ -577,6 +577,8 @@ void *health_main(void *ptr) {
     time_t now                = now_realtime_sec();
     time_t hibernation_delay  = config_get_number(CONFIG_SECTION_HEALTH, "postpone alarms during hibernation for seconds", 60);
 
+    rrdcalc_labels_unlink();
+
     unsigned int loop = 0;
     while(!netdata_exit) {
         loop++;

--- a/health/health.c
+++ b/health/health.c
@@ -167,6 +167,8 @@ void health_reload_host(RRDHOST *host) {
     }
 
     rrdhost_unlock(host);
+
+    rrdcalc_labels_unlink();
 }
 
 /**

--- a/health/health.c
+++ b/health/health.c
@@ -152,6 +152,9 @@ void health_reload_host(RRDHOST *host) {
     rrdhost_wrlock(host);
     health_readdir(host, user_path, stock_path, NULL);
 
+    //Discard alarms with labels that do not apply to host
+    rrdcalc_labels_unlink_alarm_from_host(host);
+
     // link the loaded alarms to their charts
     RRDDIM *rd;
     rrdset_foreach_write(st, host) {
@@ -167,8 +170,6 @@ void health_reload_host(RRDHOST *host) {
     }
 
     rrdhost_unlock(host);
-
-    rrdcalc_labels_unlink();
 }
 
 /**

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -24,6 +24,7 @@
 #define HEALTH_DELAY_KEY "delay"
 #define HEALTH_OPTIONS_KEY "options"
 #define HEALTH_REPEAT_KEY "repeat"
+#define HEALTH_LABEL_KEY "label"
 
 static inline int rrdcalc_add_alarm_from_config(RRDHOST *host, RRDCALC *rc) {
     if(!rc->chart) {
@@ -497,7 +498,8 @@ static int health_readfile(const char *filename, void *data) {
             hash_recipient = 0,
             hash_delay = 0,
             hash_options = 0,
-            hash_repeat = 0;
+            hash_repeat = 0,
+            hash_label = 0;
 
     char buffer[HEALTH_CONF_MAX_LINE + 1];
 
@@ -522,6 +524,7 @@ static int health_readfile(const char *filename, void *data) {
         hash_delay = simple_uhash(HEALTH_DELAY_KEY);
         hash_options = simple_uhash(HEALTH_OPTIONS_KEY);
         hash_repeat = simple_uhash(HEALTH_REPEAT_KEY);
+        hash_label = simple_uhash(HEALTH_LABEL_KEY);
     }
 
     FILE *fp = fopen(filename, "r");
@@ -795,6 +798,19 @@ static int health_readfile(const char *filename, void *data) {
                                     &rc->warn_repeat_every,
                                     &rc->crit_repeat_every);
             }
+            else if(hash == hash_label && !strcasecmp(key, HEALTH_LABEL_KEY)) {
+                if(rc->labels) {
+                    if(strcmp(rc->labels, value) != 0)
+                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'.",
+                              line, filename, rc->name, key, value, value);
+
+                    freez(rc->labels);
+                    simple_pattern_free(rc->splabels);
+                }
+
+                rc->labels = strdupz(value);
+                rc->splabels = simple_pattern_create(rc->labels, NULL, SIMPLE_PATTERN_EXACT);
+            }
             else {
                 error("Health configuration at line %zu of file '%s' for alarm '%s' has unknown key '%s'.",
                         line, filename, rc->name, key);
@@ -926,6 +942,19 @@ static int health_readfile(const char *filename, void *data) {
                 health_parse_repeat(line, filename, value,
                                     &rt->warn_repeat_every,
                                     &rt->crit_repeat_every);
+            }
+            else if(hash == hash_label && !strcasecmp(key, HEALTH_LABEL_KEY)) {
+                if(rt->labels) {
+                    if(strcmp(rt->labels, value) != 0)
+                        error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                              line, filename, rt->name, key, rt->labels, value, value);
+
+                    freez(rt->labels);
+                    simple_pattern_free(rt->splabels);
+                }
+
+                rt->labels = strdupz(value);
+                rt->splabels = simple_pattern_create(rt->labels, NULL, SIMPLE_PATTERN_EXACT);
             }
             else {
                 error("Health configuration at line %zu of file '%s' for template '%s' has unknown key '%s'.",

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -808,7 +808,7 @@ static int health_readfile(const char *filename, void *data) {
                     simple_pattern_free(rc->splabels);
                 }
 
-                rc->labels = strdupz(value);
+                rc->labels = simple_pattern_trim_around_equal(value);
                 rc->splabels = simple_pattern_create(rc->labels, NULL, SIMPLE_PATTERN_EXACT);
             }
             else {
@@ -953,7 +953,7 @@ static int health_readfile(const char *filename, void *data) {
                     simple_pattern_free(rt->splabels);
                 }
 
-                rt->labels = strdupz(value);
+                rt->labels = simple_pattern_trim_around_equal(value);
                 rt->splabels = simple_pattern_create(rt->labels, NULL, SIMPLE_PATTERN_EXACT);
             }
             else {

--- a/libnetdata/simple_pattern/simple_pattern.c
+++ b/libnetdata/simple_pattern/simple_pattern.c
@@ -331,3 +331,26 @@ extern int simple_pattern_is_potential_name(SIMPLE_PATTERN *p)
     }
     return (alpha || wildcards) && !colon;
 }
+
+char *simple_pattern_trim_around_equal(char *src) {
+    char *store = mallocz(strlen(src) +1);
+    if(!store)
+        return NULL;
+
+    char *dst = store;
+    while (*src) {
+        if (*src == '=') {
+            if (*(dst -1) == ' ')
+                dst--;
+
+            *dst++ = *src++;
+            if (*src == ' ')
+                src++;
+        }
+
+        *dst++ = *src++;
+    }
+    *dst = 0x00;
+
+    return store;
+}

--- a/libnetdata/simple_pattern/simple_pattern.h
+++ b/libnetdata/simple_pattern/simple_pattern.h
@@ -33,4 +33,7 @@ extern void simple_pattern_free(SIMPLE_PATTERN *list);
 extern void simple_pattern_dump(uint64_t debug_type, SIMPLE_PATTERN *p) ;
 extern int simple_pattern_is_potential_name(SIMPLE_PATTERN *p) ;
 
+//Auxiliary function to create a pattern
+char *simple_pattern_trim_around_equal(char *src);
+
 #endif //NETDATA_SIMPLE_PATTERN_H


### PR DESCRIPTION
##### Summary
Closes #7369 

This PR brings the labels feature to alarms.
##### Component Name
Health
##### Additional Information
While I was developing, I used the following alarm

```
 alarm: dev_dim_template_user
    on: system.cpu
    os: linux
lookup: sum -3s at 0 every 3 percentage of user
 units: %
 every: 1s
  warn: $this > 1
  crit: $this > 4
 label: label1 = 123 
```

and I changed `netdata.conf` to 

```
[host labels]
        label1 = 123
        label2 =456
        label3= 789
```

I executed the following tests:

1 - I run netdata to confirm I had alarms.
2 - change `label1 = 123 ` to invalid value `label1 = 123456`, I cannot have alarms
3 - Use only the label name  inside `label:`, for example, `label1` I will have alarms again.
4 - Use simple patterns with `label:`, for example `label*` instead `label1`
5 - Change the previous lookup line for one with `foreach`:
`lookup: sum -3s at 0 every 3 percentage foreach system,user,nice`
I must have alarms again
6 - Change `alarm:` to `template:` I also need to have alarms.
