### PR TITLE
rabbitmq: fix handle_disabled_disk_monitoring

### DIFF
--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -291,5 +291,5 @@ def handle_disabled_disk_monitoring(node_stats):
     # https://github.com/netdata/netdata/issues/7218
     # can be "disk_free": "disk_free_monitoring_disabled"
     v = node_stats.get('disk_free')
-    if v and isinstance(v, str):
+    if v and not isinstance(v, int):
         del node_stats['disk_free']


### PR DESCRIPTION
##### Summary

Fixes: #7218

`handle_disabled_disk_monitoring` uses `isinstance(obj, str)` to check if disk_free value is string, it doesnt work in py2, because value is unicode.

##### Component Name

[/collectors/python.d.plugin/rabbitmq](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/rabbitmq/)

##### Additional Information

