### PR TITLE
silencers_info: Change error to info

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -70,7 +70,7 @@ void health_silencers_init(void) {
         }
         fclose(fd);
     } else {
-        error("Cannot open the file %s",silencers_filename);
+        info("Cannot open the file %s, so Netdata will work with the default health configuration.",silencers_filename);
     }
 }
 


### PR DESCRIPTION
#### Summary
Fixes #7477 

As it was correctly pointer for our user, the error message that Netdata is giving is not properly an error, because nobody used the API so the file is not present. The correct would be to give an information about what Netdata will do.
##### Component Name
Health
##### Additional Information

