### PR TITLE
Inject archived backports repository on Debian Jessie for CI package builds.

### DIFF
--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -80,7 +80,11 @@ def prepare_repo(container):
             run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "epel-release"])
 
     elif str(os.environ["REPO_TOOL"]).count("apt-get") == 1:
-        run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
+        if str(os.environ["BUILD_STRING"]).count("debian/jessie") == 1:
+            run_command(container, ["bash", "-c", "echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list"])
+            run_command(container, [os.environ["REPO_TOOL"], "update", "-y", '-o', 'Acquire::Check-Valid-Until=false'])
+        else
+            run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
     else:
         run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
 

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -83,7 +83,7 @@ def prepare_repo(container):
         if str(os.environ["BUILD_STRING"]).count("debian/jessie") == 1:
             run_command(container, ["bash", "-c", "echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list"])
             run_command(container, [os.environ["REPO_TOOL"], "update", "-y", '-o', 'Acquire::Check-Valid-Until=false'])
-        else
+        else:
             run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])
     else:
         run_command(container, [os.environ["REPO_TOOL"], "update", "-y"])

--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -50,7 +50,11 @@ common.run_command(container, ["useradd", "-m", os.environ['BUILDER_NAME']])
 print("2. Preparing repo on LXC container")
 common.prepare_repo(container)
 
-print("2.1 Install .DEB build support packages")
+print("2.1 Add extra repositories")
+if str(os.environ["BUILD_STRING"]).count("debian/jessie") == 1:
+    common.run_command(container, ["bash", "-c", "echo \"deb http://archive.debian.org/debian/ jessie-backports main contrib non-free\" > /etc/apt/sources.list.d/99-archived.list"])
+
+print("2.2 Install .DEB build support packages")
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "dpkg-dev"])
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libdistro-info-perl"])
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "dh-make"])
@@ -58,7 +62,7 @@ common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "dh-sys
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "dh-autoreconf"])
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "git-buildpackage"])
 
-print("2.2 Add more dependencies")
+print("2.3 Add more dependencies")
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libnetfilter-acct-dev"])
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libcups2-dev"])
 

--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -52,7 +52,7 @@ common.prepare_repo(container)
 
 if str(os.environ["BUILD_STRING"]).count("debian/jessie") == 1:
     print("2.0 Add extra repositories")
-    common.run_command(container, ["bash", "-c", "echo \"deb http://archive.debian.org/debian/ jessie-backports main contrib non-free\" >> /etc/apt/sources.list"])
+    common.run_command(container, ["bash", "-c", "echo \"deb http://archive.debian.org/debian/ jessie-backports main contrib non-free\" >> /etc/apt/sources.list.d/99-archived.list"])
     common.run_command(container, [os.environ["REPO_TOOL"], "update"])
 
 print("2.1 Install .DEB build support packages")

--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -50,11 +50,6 @@ common.run_command(container, ["useradd", "-m", os.environ['BUILDER_NAME']])
 print("2. Preparing repo on LXC container")
 common.prepare_repo(container)
 
-if str(os.environ["BUILD_STRING"]).count("debian/jessie") == 1:
-    print("2.0 Add extra repositories")
-    common.run_command(container, ["bash", "-c", "echo \"deb http://archive.debian.org/debian/ jessie-backports main contrib non-free\" >> /etc/apt/sources.list.d/99-archived.list"])
-    common.run_command(container, [os.environ["REPO_TOOL"], "update"])
-
 print("2.1 Install .DEB build support packages")
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "dpkg-dev"])
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libdistro-info-perl"])

--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -50,11 +50,12 @@ common.run_command(container, ["useradd", "-m", os.environ['BUILDER_NAME']])
 print("2. Preparing repo on LXC container")
 common.prepare_repo(container)
 
-print("2.1 Add extra repositories")
 if str(os.environ["BUILD_STRING"]).count("debian/jessie") == 1:
-    common.run_command(container, ["bash", "-c", "echo \"deb http://archive.debian.org/debian/ jessie-backports main contrib non-free\" > /etc/apt/sources.list.d/99-archived.list"])
+    print("2.0 Add extra repositories")
+    common.run_command(container, ["bash", "-c", "echo \"deb http://archive.debian.org/debian/ jessie-backports main contrib non-free\" >> /etc/apt/sources.list"])
+    common.run_command(container, [os.environ["REPO_TOOL"], "update"])
 
-print("2.2 Install .DEB build support packages")
+print("2.1 Install .DEB build support packages")
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "dpkg-dev"])
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libdistro-info-perl"])
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "dh-make"])
@@ -62,7 +63,7 @@ common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "dh-sys
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "dh-autoreconf"])
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "git-buildpackage"])
 
-print("2.3 Add more dependencies")
+print("2.2 Add more dependencies")
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libnetfilter-acct-dev"])
 common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libcups2-dev"])
 


### PR DESCRIPTION
#### Summary

Debian Jessie only ever had libuv1 as a backport, not part of the base
release. This means that we need the backports repository on Jessie for
the build to work, which has been archived.

This updates the environment prep script for building Debian packages
for Jessie to inject a file into `/etc/apt/sources.list.d` to add in the
archived repository so that everything works correctly.

##### Component Name

areas/ci

##### Additional Information

Fixes: #7492 

This is realistically a quick hack calling out to a shell to inject a file using the `echo` builtin and shell redirection. I am not exactly an expert at Travis, and did not see any better approach from a quick look at the docs either, but I may have missed something that would allow this to be much cleaner.