### PR TITLE
Force the repo name to be lowercase in the tag for docker builds.

### DIFF
--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -60,7 +60,7 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 # Build images using multi-arch Dockerfile.
 for ARCH in ${ARCHS[@]}; do
-     TAG="${REPOSITORY}:${VERSION}-${ARCH}"
+     TAG="${REPOSITORY,,}:${VERSION}-${ARCH}"
      echo "Building tag ${TAG}.."
      eval docker build --no-cache \
           --build-arg ARCH="${ARCH}" \


### PR DESCRIPTION
##### Summary

Docker, for reasons I cannot fathom, insists on all image tags not having any uppercase letters. This has not been an issue thus far as everyone who is doing automated CI builds of Netdata has a lowercase username on GitHub, as well as their forked repo having a lowercase name. I, however, don't meet that first criteria (my username starts with a capital letter), meaning that when I try to run CI builds on my fork of the repo, I get failures on the docker build step that look like this: https://travis-ci.org/Ferroin/netdata/jobs/624140530.

This updates the script used for the docker builds to force the repository name to lowercase on expansion as part of the tag (utilizing Bash 4's `${foo,,}` expansion syntax), preventing this from being an issue.

##### Component Name

areas/ci
areas/packaging

##### Additional Information

Strictly speaking, this should have zero visible impact to end users. It will, however, let me avoid having to change my GitHub username (and deal with all the fallout from that) just to get the CI build working on my fork of the repo, and prevent this from being an issue for anybody else who may want to run CI builds on their fork.