### PR TITLE
Remove `-f` option from `groupdel` in uninstaller.

### DIFF
--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -159,7 +159,7 @@ portable_del_group() {
 	# Linux
 	if command -v groupdel 1>/dev/null 2>&1; then
 		if grep -q "${groupname}" /etc/group; then
-		  run groupdel -f "${groupname}" && return 0
+		  run groupdel "${groupname}" && return 0
 		else
 		  echo >&2 "Group ${groupname} already removed in a previous step."
 		  run_ok


### PR DESCRIPTION
##### Summary

The `-f` option forces removal of a group even if it is the primary group for a user. We should not be using this option for three reasons:

* It's not universally supported. Gentoo, for example, does not provide a version of `groupdel` with this option.
* We shouldn't need it. Short of unusual user configurations, the `netdata` user should be the only one who has a primary group of `netdata`, and we remove the `netdata` user before trying to remove `netdata` group.
* In the unlikely event that the above point is not the case on a given system, removing the `netdata` group will actually break things.

##### Component Name

area/packaging

##### Additional Information

Fixes: #6348 