### PR TITLE
Close kubernetes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ system/netdata-freebsd
 system/edit-config
 
 daemon/anonymous-statistics.sh
+daemon/get-kubernetes-labels.sh
 
 health/notifications/alarm-notify.sh
 collectors/cgroups.plugin/cgroup-name.sh

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -13,9 +13,11 @@ dist_noinst_DATA = \
     README.md \
     config/README.md \
     anonymous-statistics.sh.in \
+    get-kubernetes-labels.sh.in \
     $(NULL)
 
 dist_plugins_SCRIPTS = \
     anonymous-statistics.sh \
     system-info.sh \
+    get-kubernetes-labels.sh \
     $(NULL)

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -96,6 +96,8 @@ static cmd_status_t cmd_help_execute(char *args, char **message)
              "    Show this help menu.\n"
              "reload-health\n"
              "    Reload health configuration.\n"
+             "reload-labels\n"
+             "    Reload all labels.\n"
              "save-database\n"
              "    Save internal DB to disk for memory mode save.\n"
              "reopen-logs\n"
@@ -177,7 +179,14 @@ static cmd_status_t cmd_reload_labels_execute(char *args, char **message)
     (void)message;
     info("COMMAND: reloading host labels.");
     reload_host_labels();
-
+    struct label *l=localhost->labels;
+    BUFFER *wb = buffer_create(10);
+    while (l != NULL) {
+        buffer_sprintf(wb,"Label [source id=%s]: \"%s\" -> \"%s\"\n", translate_label_source(l->label_source), l->key, l->value);
+        l = l->next;
+    }
+    (*message)=strdupz(buffer_tostring(wb));
+    buffer_free(wb);
     return CMD_STATUS_SUCCESS;
 }
 

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -37,7 +37,6 @@ static cmd_status_t cmd_save_database_execute(char *args, char **message);
 static cmd_status_t cmd_reopen_logs_execute(char *args, char **message);
 static cmd_status_t cmd_exit_execute(char *args, char **message);
 static cmd_status_t cmd_fatal_execute(char *args, char **message);
-static cmd_status_t cmd_reload_labels_execute(char *args, char **message);
 
 static command_info_t command_info_array[] = {
         {"help", cmd_help_execute, CMD_TYPE_HIGH_PRIORITY},                  // show help menu
@@ -46,7 +45,6 @@ static command_info_t command_info_array[] = {
         {"reopen-logs", cmd_reopen_logs_execute, CMD_TYPE_ORTHOGONAL},       // Close and reopen log files
         {"shutdown-agent", cmd_exit_execute, CMD_TYPE_EXCLUSIVE},            // exit cleanly
         {"fatal-agent", cmd_fatal_execute, CMD_TYPE_HIGH_PRIORITY},          // exit with fatal error
-        {"reload-labels", cmd_reload_labels_execute, CMD_TYPE_ORTHOGONAL},   // reload the labels
 };
 
 /* Mutexes for commands of type CMD_TYPE_ORTHOGONAL */
@@ -167,16 +165,6 @@ static cmd_status_t cmd_fatal_execute(char *args, char **message)
     (void)message;
 
     fatal("COMMAND: netdata now exits.");
-
-    return CMD_STATUS_SUCCESS;
-}
-
-static cmd_status_t cmd_reload_labels_execute(char *args, char **message)
-{
-    (void)args;
-    (void)message;
-    info("COMMAND: reloading host labels.");
-    reload_host_labels();
 
     return CMD_STATUS_SUCCESS;
 }

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -37,6 +37,7 @@ static cmd_status_t cmd_save_database_execute(char *args, char **message);
 static cmd_status_t cmd_reopen_logs_execute(char *args, char **message);
 static cmd_status_t cmd_exit_execute(char *args, char **message);
 static cmd_status_t cmd_fatal_execute(char *args, char **message);
+static cmd_status_t cmd_reload_labels_execute(char *args, char **message);
 
 static command_info_t command_info_array[] = {
         {"help", cmd_help_execute, CMD_TYPE_HIGH_PRIORITY},                  // show help menu
@@ -45,6 +46,7 @@ static command_info_t command_info_array[] = {
         {"reopen-logs", cmd_reopen_logs_execute, CMD_TYPE_ORTHOGONAL},       // Close and reopen log files
         {"shutdown-agent", cmd_exit_execute, CMD_TYPE_EXCLUSIVE},            // exit cleanly
         {"fatal-agent", cmd_fatal_execute, CMD_TYPE_HIGH_PRIORITY},          // exit with fatal error
+        {"reload-labels", cmd_reload_labels_execute, CMD_TYPE_ORTHOGONAL},   // reload the labels
 };
 
 /* Mutexes for commands of type CMD_TYPE_ORTHOGONAL */
@@ -165,6 +167,16 @@ static cmd_status_t cmd_fatal_execute(char *args, char **message)
     (void)message;
 
     fatal("COMMAND: netdata now exits.");
+
+    return CMD_STATUS_SUCCESS;
+}
+
+static cmd_status_t cmd_reload_labels_execute(char *args, char **message)
+{
+    (void)args;
+    (void)message;
+    info("COMMAND: reloading host labels.");
+    reload_host_labels();
 
     return CMD_STATUS_SUCCESS;
 }

--- a/daemon/commands.h
+++ b/daemon/commands.h
@@ -19,6 +19,7 @@ typedef enum cmd {
     CMD_REOPEN_LOGS,
     CMD_EXIT,
     CMD_FATAL,
+    CMD_RELOAD_LABELS,
     CMD_TOTAL_COMMANDS
 } cmd_t;
 

--- a/daemon/commands.h
+++ b/daemon/commands.h
@@ -19,7 +19,6 @@ typedef enum cmd {
     CMD_REOPEN_LOGS,
     CMD_EXIT,
     CMD_FATAL,
-    CMD_RELOAD_LABELS,
     CMD_TOTAL_COMMANDS
 } cmd_t;
 

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -8,7 +8,7 @@
 // ----------------------------------------------------------------------------
 // shortcuts for the default netdata configuration
 
-#define config_load(filename, overwrite_used) appconfig_load(&netdata_config, filename, overwrite_used)
+#define config_load(filename, overwrite_used, section) appconfig_load(&netdata_config, filename, overwrite_used, section)
 #define config_get(section, name, default_value) appconfig_get(&netdata_config, section, name, default_value)
 #define config_get_number(section, name, value) appconfig_get_number(&netdata_config, section, name, value)
 #define config_get_float(section, name, value) appconfig_get_float(&netdata_config, section, name, value)

--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Checks if netdata is running in a kubernetes pod and fetches that pod's labels
+
+if [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}" ] && [ -n "${MY_POD_NAMESPACE}" ] && [ -n "${MY_POD_NAME}" ]; then
+	if command -v jq >/dev/null 2>&1; then
+			KUBE_TOKEN="$(</var/run/secrets/kubernetes.io/serviceaccount/token)"
+		URL="https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/$MY_POD_NAMESPACE/pods/$MY_POD_NAME"
+		curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" "$URL" |
+		jq -r '.metadata.labels' | grep ':' | tr -d '," '
+		exit 0
+	else
+		echo "jq command not available. Please install jq to get host labels for kubernetes pods."
+		exit 1
+	fi
+else
+	# Following is only for testing and will be removed
+	echo "app:netdata
+controller-revision-hash:64966d4b74
+pod-template-generation:4
+release:netdata
+role:slave
+a line to display as info"
+	exit 0
+fi

--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -14,12 +14,5 @@ if [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}"
 		exit 1
 	fi
 else
-	# Following is only for testing and will be removed
-	echo "app:netdata
-controller-revision-hash:64966d4b74
-pod-template-generation:4
-release:netdata
-role:slave
-a line to display as info"
 	exit 0
 fi

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1274,8 +1274,8 @@ int main(int argc, char **argv) {
        Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
 
     netdata_rwlock_wrlock(&localhost->labels_rwlock);
-    struct label *l = create_label("HostLabel1","Höst Låbel");
-    l->next = create_label("Label2","xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    struct label *l = create_label("HostLabel1","Höst Låbel",LABEL_SOURCE_AUTO);
+    l->next = create_label("Label2","xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",LABEL_SOURCE_ENVIRONMENT);
     localhost->labels = l;
     netdata_rwlock_unlock(&localhost->labels_rwlock);
     */

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1268,6 +1268,20 @@ int main(int argc, char **argv) {
     error_log_limit_reset();
 
     // ------------------------------------------------------------------------
+    // load the host-level labels
+    /*
+       Temporary test-vector for #7408.
+       Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
+
+    netdata_rwlock_wrlock(&localhost->labels_rwlock);
+    struct label *l = create_label("HostLabel1","Höst Låbel");
+    l->next = create_label("Label2","xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    localhost->labels = l;
+    netdata_rwlock_unlock(&localhost->labels_rwlock);
+    */
+
+
+    // ------------------------------------------------------------------------
     // spawn the threads
 
     web_server_config_options();

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -700,20 +700,20 @@ static int load_netdata_conf(char *filename, char overwrite_used) {
     int ret = 0;
 
     if(filename && *filename) {
-        ret = config_load(filename, overwrite_used);
+        ret = config_load(filename, overwrite_used, NULL);
         if(!ret)
             error("CONFIG: cannot load config file '%s'.", filename);
     }
     else {
         filename = strdupz_path_subpath(netdata_configured_user_config_dir, "netdata.conf");
 
-        ret = config_load(filename, overwrite_used);
+        ret = config_load(filename, overwrite_used, NULL);
         if(!ret) {
             info("CONFIG: cannot load user config '%s'. Will try the stock version.", filename);
             freez(filename);
 
             filename = strdupz_path_subpath(netdata_configured_stock_config_dir, "netdata.conf");
-            ret = config_load(filename, overwrite_used);
+            ret = config_load(filename, overwrite_used, NULL);
             if(!ret)
                 info("CONFIG: cannot load stock config '%s'. Running with internal defaults.", filename);
         }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1267,19 +1267,8 @@ int main(int argc, char **argv) {
 
     error_log_limit_reset();
 
-    // ------------------------------------------------------------------------
-    // load the host-level labels
-    /*
-       Temporary test-vector for #7408.
-       Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
-
-    netdata_rwlock_wrlock(&localhost->labels_rwlock);
-    struct label *l = create_label("HostLabel1","Höst Låbel",LABEL_SOURCE_AUTO);
-    l->next = create_label("Label2","xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",LABEL_SOURCE_ENVIRONMENT);
-    localhost->labels = l;
-    netdata_rwlock_unlock(&localhost->labels_rwlock);
-    */
-
+    // Load host labels
+    reload_host_labels();
 
     // ------------------------------------------------------------------------
     // spawn the threads

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -150,10 +150,10 @@ typedef enum rrddim_flags {
 
 typedef enum label_source {
     LABEL_SOURCE_AUTO             = 0,
-    LABEL_SOURCE_NETDATA_CONF     = (1 << 0),
-    LABEL_SOURCE_DOCKER           = (1 << 1),
-    LABEL_SOURCE_ENVIRONMENT      = (1 << 2),
-    LABEL_SOURCE_KUBERNETES       = (1 << 3)
+    LABEL_SOURCE_NETDATA_CONF     = 1,
+    LABEL_SOURCE_DOCKER           = 2,
+    LABEL_SOURCE_ENVIRONMENT      = 3,
+    LABEL_SOURCE_KUBERNETES       = 4
 } LABEL_SOURCE;
 
 struct label {
@@ -163,6 +163,7 @@ struct label {
     struct label *next;
 };
 
+char *translate_label_source(LABEL_SOURCE l);
 struct label *create_label(char *key, char *value, LABEL_SOURCE label_source);
 struct label *add_label_to_list(struct label *l, char *key, char *value, LABEL_SOURCE label_source);
 void reload_host_labels();

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -148,12 +148,21 @@ typedef enum rrddim_flags {
 #define rrddim_flag_clear(rd, flag) (rd)->flags &= ~(flag)
 #endif
 
+typedef enum label_source {
+    LABEL_SOURCE_AUTO             = 0,
+    LABEL_SOURCE_NETDATA_CONF     = (1 << 0),
+    LABEL_SOURCE_DOCKER           = (1 << 1),
+    LABEL_SOURCE_ENVIRONMENT      = (1 << 2),
+    LABEL_SOURCE_KUBERNETES       = (1 << 3)
+} LABEL_SOURCE;
+
 struct label {
     char *key, *value;
+    LABEL_SOURCE label_source;
     struct label *next;
 };
 
-struct label *create_label(char *key, char *value);
+struct label *create_label(char *key, char *value, LABEL_SOURCE label_source);
 
 // ----------------------------------------------------------------------------
 // RRD DIMENSION - this is a metric

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -148,6 +148,12 @@ typedef enum rrddim_flags {
 #define rrddim_flag_clear(rd, flag) (rd)->flags &= ~(flag)
 #endif
 
+struct label {
+    char *key, *value;
+    struct label *next;
+};
+
+struct label *create_label(char *key, char *value);
 
 // ----------------------------------------------------------------------------
 // RRD DIMENSION - this is a metric
@@ -723,6 +729,11 @@ struct rrdhost {
     // locks
 
     netdata_rwlock_t rrdhost_rwlock;                // lock for this RRDHOST (protects rrdset_root linked list)
+
+    // ------------------------------------------------------------------------
+    // Support for host-level labels
+    struct label *labels;
+    netdata_rwlock_t labels_rwlock;         // lock for the label list
 
     // ------------------------------------------------------------------------
     // indexes

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -164,7 +164,6 @@ struct label {
 };
 
 struct label *create_label(char *key, char *value, LABEL_SOURCE label_source);
-struct label *add_label_to_list(struct label *l, char *key, char *value, LABEL_SOURCE label_source);
 
 // ----------------------------------------------------------------------------
 // RRD DIMENSION - this is a metric

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -164,6 +164,7 @@ struct label {
 };
 
 struct label *create_label(char *key, char *value, LABEL_SOURCE label_source);
+struct label *add_label_to_list(struct label *l, char *key, char *value, LABEL_SOURCE label_source);
 
 // ----------------------------------------------------------------------------
 // RRD DIMENSION - this is a metric

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -158,6 +158,7 @@ typedef enum label_source {
 
 struct label {
     char *key, *value;
+    uint32_t key_hash;
     LABEL_SOURCE label_source;
     struct label *next;
 };

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -164,6 +164,8 @@ struct label {
 };
 
 struct label *create_label(char *key, char *value, LABEL_SOURCE label_source);
+struct label *add_label_to_list(struct label *l, char *key, char *value, LABEL_SOURCE label_source);
+void reload_host_labels();
 
 // ----------------------------------------------------------------------------
 // RRD DIMENSION - this is a metric

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -91,6 +91,11 @@ struct rrdcalc {
     uint32_t crit_repeat_every; // interval between repeating critical notifications
 
     // ------------------------------------------------------------------------
+    // Labels settings
+    char *labels;                   // the label read from an alarm file
+    SIMPLE_PATTERN *splabels;       // the simple pattern of labels
+
+    // ------------------------------------------------------------------------
     // runtime information
 
     RRDCALC_STATUS old_status; // the old status of the alarm
@@ -156,6 +161,9 @@ extern RRDCALC *rrdcalc_create_from_rrdcalc(RRDCALC *rc, RRDHOST *host, const ch
 extern void rrdcalc_add_to_host(RRDHOST *host, RRDCALC *rc);
 extern void dimension_remove_pipe_comma(char *str);
 extern char *alarm_name_with_dim(char *name, size_t namelen, const char *dim, size_t dimlen);
+
+extern void rrdcalc_labels_unlink();
+extern void rrdcalc_labels_unlink_alarm_from_host(RRDHOST *host);
 
 static inline int rrdcalc_isrepeating(RRDCALC *rc) {
     if (unlikely(rc->warn_repeat_every > 0 || rc->crit_repeat_every > 0)) {

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -4,6 +4,50 @@
 #include "rrd.h"
 
 // ----------------------------------------------------------------------------
+
+static int rrdcalctemplate_has_label(RRDCALCTEMPLATE *rt,  RRDHOST *host) {
+    if(!rt->labels)
+        return 1;
+
+    errno = 0;
+    struct label *move = host->labels;
+    size_t len = strlen(rt->labels)+1;
+    char *cmp = mallocz(len);
+    if(!cmp)
+        return 1;
+
+    int ret;
+    if(move) {
+        netdata_rwlock_rdlock(&host->labels_rwlock);
+        while(move) {
+            snprintfz(cmp, len, "%s=%s", move->key, move->value);
+            if (simple_pattern_matches(rt->splabels, move->key) ||
+                simple_pattern_matches(rt->splabels, cmp)) {
+                break;
+            }
+            move = move->next;
+        }
+        netdata_rwlock_unlock(&host->labels_rwlock);
+
+        if(!move) {
+            error("Health template '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
+                   rt->name,
+                   host->hostname,
+                   rt->labels
+            );
+            ret = 0;
+        } else {
+            ret = 1;
+        }
+    } else {
+        ret =1;
+    }
+
+    freez(cmp);
+
+    return ret;
+}
+
 // RRDCALCTEMPLATE management
 /**
  * RRDCALC TEMPLATE LINK MATCHING
@@ -14,13 +58,18 @@
 void rrdcalctemplate_link_matching_test(RRDCALCTEMPLATE *rt, RRDSET *st, RRDHOST *host ) {
     if(rt->hash_context == st->hash_context && !strcmp(rt->context, st->context)
        && (!rt->family_pattern || simple_pattern_matches(rt->family_pattern, st->family))) {
-        RRDCALC *rc = rrdcalc_create_from_template(host, rt, st->id);
-        if(unlikely(!rc))
-            info("Health tried to create alarm from template '%s' on chart '%s' of host '%s', but it failed", rt->name, st->id, host->hostname);
+        if (rrdcalctemplate_has_label(rt, host)) {
+            RRDCALC *rc = rrdcalc_create_from_template(host, rt, st->id);
+            if (unlikely(!rc))
+                info("Health tried to create alarm from template '%s' on chart '%s' of host '%s', but it failed",
+                     rt->name, st->id, host->hostname);
 #ifdef NETDATA_INTERNAL_CHECKS
-        else if(rc->rrdset != st && !rc->foreachdim) //When we have a template with foreadhdim, the child will be added to the index late
-            error("Health alarm '%s.%s' should be linked to chart '%s', but it is not", rc->chart?rc->chart:"NOCHART", rc->name, st->id);
+            else if (rc->rrdset != st &&
+                     !rc->foreachdim) //When we have a template with foreadhdim, the child will be added to the index late
+                error("Health alarm '%s.%s' should be linked to chart '%s', but it is not",
+                      rc->chart ? rc->chart : "NOCHART", rc->name, st->id);
 #endif
+        }
     }
 }
 
@@ -56,7 +105,9 @@ inline void rrdcalctemplate_free(RRDCALCTEMPLATE *rt) {
     freez(rt->info);
     freez(rt->dimensions);
     freez(rt->foreachdim);
+    freez(rt->labels);
     simple_pattern_free(rt->spdim);
+    simple_pattern_free(rt->splabels);
     freez(rt);
 }
 

--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -59,6 +59,11 @@ struct rrdcalctemplate {
     uint32_t crit_repeat_every; // interval between repeating critical notifications
 
     // ------------------------------------------------------------------------
+    // Labels settings
+    char *labels;                   // the label read from an alarm file
+    SIMPLE_PATTERN *splabels;       // the simple pattern of labels
+
+    // ------------------------------------------------------------------------
     // expressions related to the alarm
 
     EVAL_EXPRESSION *calculation;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -763,9 +763,9 @@ struct label *add_label_to_list(struct label *l, char *key, char *value, LABEL_S
     return lab;
 }
 
-int list_contains(struct label *head, struct label *check)
+int label_list_contains(struct label *head, struct label *check)
 {
-    while (head!=NULL)
+    while (head != NULL)
     {
         if (head->key_hash == check->key_hash && !strcmp(head->key, check->key))
             return 1;
@@ -784,7 +784,7 @@ struct label *merge_label_lists(struct label *lo_pri, struct label *hi_pri)
     {
         struct label *current = lo_pri;
         lo_pri = lo_pri->next;
-        if (!list_contains(result, current)) {
+        if (!label_list_contains(result, current)) {
             current->next = result;
             result = current;
         }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -709,31 +709,16 @@ void rrdhost_save_charts(RRDHOST *host) {
 
 struct label *load_auto_labels()
 {
-    // TESTING ONLY DELETE AFTER REVIEW
-    struct label *l = add_label_to_list(NULL, "_os_name", "Linux for the win", LABEL_SOURCE_AUTO);
-    l = add_label_to_list(l, "_os_version", "All the versions", LABEL_SOURCE_AUTO);
-    l = add_label_to_list(l, "_kernel_version", "The absolute latest", LABEL_SOURCE_AUTO);
-    return l;
     return NULL;
 }
 
 struct label *load_config_labels()
 {
-    // TESTING ONLY DELETE AFTER REVIEW
-    struct label *l = add_label_to_list(NULL, "_os_name", "Darwin overwrites everything", LABEL_SOURCE_NETDATA_CONF);
-    l = add_label_to_list(l, "alpha", "Alpha value from config", LABEL_SOURCE_NETDATA_CONF);
-    l = add_label_to_list(l, "somethingUnique", "Unique value from config", LABEL_SOURCE_NETDATA_CONF);
-    return l;
     return NULL;
 }
 
 struct label *load_kubernetes_labels()
 {
-    // TESTING ONLY DELETE AFTER REVIEW
-    struct label *l = add_label_to_list(NULL, "alpha", "Alpha value from k8s", LABEL_SOURCE_KUBERNETES);
-    l = add_label_to_list(l, "beta", "Beta value from k8s", LABEL_SOURCE_KUBERNETES);
-    l = add_label_to_list(l, "_os_version", "os version from k8s", LABEL_SOURCE_KUBERNETES);
-    return l;
     return NULL;
 }
 
@@ -754,66 +739,6 @@ struct label *create_label(char *key, char *value, LABEL_SOURCE label_source)
         result->key_hash = simple_hash(result->key);
     }
     return result;
-}
-
-struct label *add_label_to_list(struct label *l, char *key, char *value, LABEL_SOURCE label_source)
-{
-    struct label *lab = create_label(key, value, label_source);
-    lab->next = l;
-    return lab;
-}
-
-int list_contains(struct label *head, struct label *check)
-{
-    while (head!=NULL)
-    {
-        if (head->key_hash == check->key_hash && !strcmp(head->key, check->key))
-            return 1;
-        head = head->next;
-    }
-    return 0;
-}
-
-/* Create a list with entries from both lists.
-   If any entry in the low priority list is masked by an entry in the high priorty list then delete it.
-*/
-struct label *merge_label_lists(struct label *lo_pri, struct label *hi_pri)
-{
-    struct label *result = hi_pri;
-    while (lo_pri != NULL)
-    {
-        struct label *current = lo_pri;
-        lo_pri = lo_pri->next;
-        if (!list_contains(result, current)) {
-            current->next = result;
-            result = current;
-        }
-        else
-            freez(current);
-    }
-    return result;
-}
-
-void reload_host_labels()
-{
-    struct label *from_auto = load_auto_labels();
-    struct label *from_k8s = load_kubernetes_labels();
-    struct label *from_config = load_auto_labels();
-
-    struct label *new_labels = merge_label_lists(from_auto, from_k8s);
-    new_labels = merge_label_lists(new_labels, from_config);
-
-    netdata_rwlock_wrlock(&localhost->labels_rwlock);
-    struct label *old_labels = localhost->labels;
-    localhost->labels = new_labels;
-    netdata_rwlock_unlock(&localhost->labels_rwlock);
-
-    while (old_labels != NULL)
-    {
-        struct label *current = old_labels;
-        old_labels = old_labels->next;
-        freez(current);
-    }
 }
 
 // ----------------------------------------------------------------------------

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -930,6 +930,8 @@ void reload_host_labels()
         old_labels = old_labels->next;
         freez(current);
     }
+
+    health_reload();
 }
 
 // ----------------------------------------------------------------------------

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -709,16 +709,31 @@ void rrdhost_save_charts(RRDHOST *host) {
 
 struct label *load_auto_labels()
 {
+    // TESTING ONLY DELETE AFTER REVIEW
+    struct label *l = add_label_to_list(NULL, "_os_name", "Linux for the win", LABEL_SOURCE_AUTO);
+    l = add_label_to_list(l, "_os_version", "All the versions", LABEL_SOURCE_AUTO);
+    l = add_label_to_list(l, "_kernel_version", "The absolute latest", LABEL_SOURCE_AUTO);
+    return l;
     return NULL;
 }
 
 struct label *load_config_labels()
 {
+    // TESTING ONLY DELETE AFTER REVIEW
+    struct label *l = add_label_to_list(NULL, "_os_name", "Darwin overwrites everything", LABEL_SOURCE_NETDATA_CONF);
+    l = add_label_to_list(l, "alpha", "Alpha value from config", LABEL_SOURCE_NETDATA_CONF);
+    l = add_label_to_list(l, "somethingUnique", "Unique value from config", LABEL_SOURCE_NETDATA_CONF);
+    return l;
     return NULL;
 }
 
 struct label *load_kubernetes_labels()
 {
+    // TESTING ONLY DELETE AFTER REVIEW
+    struct label *l = add_label_to_list(NULL, "alpha", "Alpha value from k8s", LABEL_SOURCE_KUBERNETES);
+    l = add_label_to_list(l, "beta", "Beta value from k8s", LABEL_SOURCE_KUBERNETES);
+    l = add_label_to_list(l, "_os_version", "os version from k8s", LABEL_SOURCE_KUBERNETES);
+    return l;
     return NULL;
 }
 
@@ -739,6 +754,66 @@ struct label *create_label(char *key, char *value, LABEL_SOURCE label_source)
         result->key_hash = simple_hash(result->key);
     }
     return result;
+}
+
+struct label *add_label_to_list(struct label *l, char *key, char *value, LABEL_SOURCE label_source)
+{
+    struct label *lab = create_label(key, value, label_source);
+    lab->next = l;
+    return lab;
+}
+
+int list_contains(struct label *head, struct label *check)
+{
+    while (head!=NULL)
+    {
+        if (head->key_hash == check->key_hash && !strcmp(head->key, check->key))
+            return 1;
+        head = head->next;
+    }
+    return 0;
+}
+
+/* Create a list with entries from both lists.
+   If any entry in the low priority list is masked by an entry in the high priorty list then delete it.
+*/
+struct label *merge_label_lists(struct label *lo_pri, struct label *hi_pri)
+{
+    struct label *result = hi_pri;
+    while (lo_pri != NULL)
+    {
+        struct label *current = lo_pri;
+        lo_pri = lo_pri->next;
+        if (!list_contains(result, current)) {
+            current->next = result;
+            result = current;
+        }
+        else
+            freez(current);
+    }
+    return result;
+}
+
+void reload_host_labels()
+{
+    struct label *from_auto = load_auto_labels();
+    struct label *from_k8s = load_kubernetes_labels();
+    struct label *from_config = load_auto_labels();
+
+    struct label *new_labels = merge_label_lists(from_auto, from_k8s);
+    new_labels = merge_label_lists(new_labels, from_config);
+
+    netdata_rwlock_wrlock(&localhost->labels_rwlock);
+    struct label *old_labels = localhost->labels;
+    localhost->labels = new_labels;
+    netdata_rwlock_unlock(&localhost->labels_rwlock);
+
+    while (old_labels != NULL)
+    {
+        struct label *current = old_labels;
+        old_labels = old_labels->next;
+        freez(current);
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -707,14 +707,31 @@ void rrdhost_save_charts(RRDHOST *host) {
     rrdhost_unlock(host);
 }
 
+static int is_valid_label_key(char *key) {
+    while(*key) {
+        if(!(isdigit(*key) || isalpha(*key) || *key == '.' || *key == '_' || *key == '-'))
+            return 0;
+
+        key++;
+    }
+
+    return 1;
+}
+
 char *translate_label_source(LABEL_SOURCE l) {
     switch (l) {
-        case LABEL_SOURCE_AUTO: return "AUTO";
-        case LABEL_SOURCE_NETDATA_CONF: return "NETDATA.CONF";
-        case LABEL_SOURCE_DOCKER : return "DOCKER";
-        case LABEL_SOURCE_ENVIRONMENT  : return "ENVIRONMENT";
-        case LABEL_SOURCE_KUBERNETES : return "KUBERNETES";
-        default: return "Invalid label source";
+        case LABEL_SOURCE_AUTO:
+            return "AUTO";
+        case LABEL_SOURCE_NETDATA_CONF:
+            return "NETDATA.CONF";
+        case LABEL_SOURCE_DOCKER :
+            return "DOCKER";
+        case LABEL_SOURCE_ENVIRONMENT  :
+            return "ENVIRONMENT";
+        case LABEL_SOURCE_KUBERNETES :
+            return "KUBERNETES";
+        default:
+            return "Invalid label source";
     }
 }
 
@@ -730,12 +747,9 @@ struct label *load_auto_labels()
 
 struct label *load_config_labels()
 {
-    /* TESTING ONLY DELETE AFTER REVIEW
-    struct label *l = add_label_to_list(NULL, "_os_name", "Darwin overwrites everything", LABEL_SOURCE_NETDATA_CONF);
-    l = add_label_to_list(l, "alpha", "Alpha value from config", LABEL_SOURCE_NETDATA_CONF);
-    l = add_label_to_list(l, "somethingUnique", "Unique value from config", LABEL_SOURCE_NETDATA_CONF);
-    return l; */
-    return NULL;
+    struct label *ret = NULL;
+//add_label_to_list
+    return ret;
 }
 
 struct label *load_kubernetes_labels()

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -707,7 +707,7 @@ void rrdhost_save_charts(RRDHOST *host) {
     rrdhost_unlock(host);
 }
 
-struct label *create_label(char *key, char *value)
+struct label *create_label(char *key, char *value, LABEL_SOURCE label_source)
 {
     size_t key_len = strlen(key), value_len = strlen(value);
     size_t n = key_len + 1 + value_len + 1 + sizeof(struct label);
@@ -720,6 +720,7 @@ struct label *create_label(char *key, char *value)
         c += key_len + 1;
         strcpy(c, value);
         result->value = c;
+        result->label_source = label_source;
     }
     return result;
 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -757,7 +757,7 @@ struct label *load_config_labels()
 {
     int status = config_load(NULL, 1, CONFIG_SECTION_HOST_LABEL);
     if(!status) {
-        char *filename = filename = CONFIG_DIR "/" CONFIG_FILENAME;
+        char *filename = CONFIG_DIR "/" CONFIG_FILENAME;
         error("LABEL: Cannot reload the configuration file '%s', using labels in memory", filename);
     }
 
@@ -810,7 +810,9 @@ struct label *load_kubernetes_labels()
                 while (*eos && *eos != '\n') eos++;
                 if (*eos == '\n') *eos = '\0';
                 if (strlen(value)>1) {
-                    l = add_label_to_list(l, name, value, LABEL_SOURCE_KUBERNETES);
+                    if (is_valid_label_key(name)){
+                        l = add_label_to_list(l, name, value, LABEL_SOURCE_KUBERNETES);
+                    }
                 } else {
                     info("%s returned: '%s'", label_script, name);
                 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -708,6 +708,14 @@ void rrdhost_save_charts(RRDHOST *host) {
 }
 
 static int is_valid_label_key(char *key) {
+    //Prometheus exporter
+    if(!strcmp(key, "chart") || !strcmp(key, "family")  || !strcmp(key, "dimension"))
+        return 0;
+
+    //Netdata and Prometheus  internal
+    if (*key == '_')
+        return 0;
+
     while(*key) {
         if(!(isdigit(*key) || isalpha(*key) || *key == '.' || *key == '_' || *key == '-'))
             return 0;
@@ -747,9 +755,30 @@ struct label *load_auto_labels()
 
 struct label *load_config_labels()
 {
-    struct label *ret = NULL;
-//add_label_to_list
-    return ret;
+    int status = config_load(NULL, 1, CONFIG_SECTION_HOST_LABEL);
+    if(!status) {
+        char *filename = filename = CONFIG_DIR "/" CONFIG_FILENAME;
+        error("LABEL: Cannot reload the configuration file '%s', using labels in memory", filename);
+    }
+
+    struct label *l = NULL;
+    struct section *co = appconfig_get_section(&netdata_config, CONFIG_SECTION_HOST_LABEL);
+    if(co) {
+        config_section_wrlock(co);
+        struct config_option *cv;
+        for(cv = co->values; cv ; cv = cv->next) {
+            char *name = cv->name;
+            if(is_valid_label_key(name) && strcmp(name, "from environment") && strcmp(name, "from kubernetes pods") ) {
+                l = add_label_to_list(l, name, cv->value, LABEL_SOURCE_NETDATA_CONF);
+            } else {
+                error("LABELS: It was not possible to create the label '%s' because it contains invalid character(s) or values."
+                       , name);
+            }
+        }
+        config_section_unlock(co);
+    }
+
+    return l;
 }
 
 struct label *load_kubernetes_labels()
@@ -864,17 +893,6 @@ void reload_host_labels()
     struct label *old_labels = localhost->labels;
     localhost->labels = new_labels;
     netdata_rwlock_unlock(&localhost->labels_rwlock);
-
-/*  This should not be done without holding the reader lock.
-    The clitool will output this information when you reload.
-    DELETE THIS COMMENT?
-
-    struct label *l=localhost->labels;
-    while (l != NULL) {
-        info("Label [source=%s]: \"%s\" -> \"%s\"", translate_label_source(l->label_source), l->key, l->value);
-        l = l->next;
-    }
-*/
 
     while (old_labels != NULL)
     {

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -710,12 +710,11 @@ void rrdhost_save_charts(RRDHOST *host) {
 char *translate_label_source(LABEL_SOURCE l) {
     switch (l) {
         case LABEL_SOURCE_AUTO: return "AUTO";
-            break;
         case LABEL_SOURCE_NETDATA_CONF: return "NETDATA.CONF";
         case LABEL_SOURCE_DOCKER : return "DOCKER";
         case LABEL_SOURCE_ENVIRONMENT  : return "ENVIRONMENT";
         case LABEL_SOURCE_KUBERNETES : return "KUBERNETES";
-        default: return "";
+        default: return "Invalid label source";
     }
 }
 
@@ -741,12 +740,6 @@ struct label *load_config_labels()
 
 struct label *load_kubernetes_labels()
 {
-    /* TESTING ONLY DELETE AFTER REVIEW
-    struct label *l = add_label_to_list(NULL, "alpha", "Alpha value from k8s", LABEL_SOURCE_KUBERNETES);
-    l = add_label_to_list(l, "beta", "Beta value from k8s", LABEL_SOURCE_KUBERNETES);
-    l = add_label_to_list(l, "_os_version", "os version from k8s", LABEL_SOURCE_KUBERNETES);
-    return l; */
-
     struct label *l=NULL;
     char *label_script = mallocz(sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("get-kubernetes-labels.sh") + 2));
     sprintf(label_script, "%s/%s", netdata_configured_primary_plugins_dir, "get-kubernetes-labels.sh");
@@ -858,19 +851,23 @@ void reload_host_labels()
     localhost->labels = new_labels;
     netdata_rwlock_unlock(&localhost->labels_rwlock);
 
+/*  This should not be done without holding the reader lock.
+    The clitool will output this information when you reload.
+    DELETE THIS COMMENT?
+
     struct label *l=localhost->labels;
     while (l != NULL) {
         info("Label [source=%s]: \"%s\" -> \"%s\"", translate_label_source(l->label_source), l->key, l->value);
         l = l->next;
     }
+*/
+
     while (old_labels != NULL)
     {
         struct label *current = old_labels;
         old_labels = old_labels->next;
         freez(current);
     }
-
-
 }
 
 // ----------------------------------------------------------------------------

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -745,12 +745,40 @@ char *translate_label_source(LABEL_SOURCE l) {
 
 struct label *load_auto_labels()
 {
-    /* TESTING ONLY DELETE AFTER REVIEW
-    struct label *l = add_label_to_list(NULL, "_os_name", "Linux for the win", LABEL_SOURCE_AUTO);
-    l = add_label_to_list(l, "_os_version", "All the versions", LABEL_SOURCE_AUTO);
-    l = add_label_to_list(l, "_kernel_version", "The absolute latest", LABEL_SOURCE_AUTO);
-    return l; */
-    return NULL;
+    struct label *label_list = NULL;
+
+    if (localhost->system_info->os_name)
+        label_list =
+            add_label_to_list(label_list, "_os_name", localhost->system_info->os_name, LABEL_SOURCE_AUTO);
+
+    if (localhost->system_info->os_version)
+        label_list =
+            add_label_to_list(label_list, "_os_version", localhost->system_info->os_version, LABEL_SOURCE_AUTO);
+
+    if (localhost->system_info->kernel_version)
+        label_list =
+            add_label_to_list(label_list, "_kernel_version", localhost->system_info->kernel_version, LABEL_SOURCE_AUTO);
+
+    if (localhost->system_info->architecture)
+        label_list =
+            add_label_to_list(label_list, "_architecture", localhost->system_info->architecture, LABEL_SOURCE_AUTO);
+
+    if (localhost->system_info->virtualization)
+        label_list =
+            add_label_to_list(label_list, "_virtualization", localhost->system_info->virtualization, LABEL_SOURCE_AUTO);
+
+    if (localhost->system_info->virt_detection)
+        label_list =
+            add_label_to_list(label_list, "_container", localhost->system_info->virt_detection, LABEL_SOURCE_AUTO);
+
+    label_list = add_label_to_list(
+        label_list, "_is_master", (localhost->next || configured_as_master()) ? "true" : "false", LABEL_SOURCE_AUTO);
+
+    if (localhost->rrdpush_send_destination)
+        label_list =
+            add_label_to_list(label_list, "_streams_to", localhost->rrdpush_send_destination, LABEL_SOURCE_AUTO);
+
+    return label_list;
 }
 
 struct label *load_config_labels()

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -709,16 +709,31 @@ void rrdhost_save_charts(RRDHOST *host) {
 
 struct label *load_auto_labels()
 {
+    /* TESTING ONLY DELETE AFTER REVIEW
+    struct label *l = add_label_to_list(NULL, "_os_name", "Linux for the win", LABEL_SOURCE_AUTO);
+    l = add_label_to_list(l, "_os_version", "All the versions", LABEL_SOURCE_AUTO);
+    l = add_label_to_list(l, "_kernel_version", "The absolute latest", LABEL_SOURCE_AUTO);
+    return l; */
     return NULL;
 }
 
 struct label *load_config_labels()
 {
+    /* TESTING ONLY DELETE AFTER REVIEW
+    struct label *l = add_label_to_list(NULL, "_os_name", "Darwin overwrites everything", LABEL_SOURCE_NETDATA_CONF);
+    l = add_label_to_list(l, "alpha", "Alpha value from config", LABEL_SOURCE_NETDATA_CONF);
+    l = add_label_to_list(l, "somethingUnique", "Unique value from config", LABEL_SOURCE_NETDATA_CONF);
+    return l; */
     return NULL;
 }
 
 struct label *load_kubernetes_labels()
 {
+    /* TESTING ONLY DELETE AFTER REVIEW
+    struct label *l = add_label_to_list(NULL, "alpha", "Alpha value from k8s", LABEL_SOURCE_KUBERNETES);
+    l = add_label_to_list(l, "beta", "Beta value from k8s", LABEL_SOURCE_KUBERNETES);
+    l = add_label_to_list(l, "_os_version", "os version from k8s", LABEL_SOURCE_KUBERNETES);
+    return l; */
     return NULL;
 }
 
@@ -726,7 +741,7 @@ struct label *create_label(char *key, char *value, LABEL_SOURCE label_source)
 {
     size_t key_len = strlen(key), value_len = strlen(value);
     size_t n = sizeof(struct label) + key_len + 1 + value_len + 1;
-    struct label *result = callocz(n,1);
+    struct label *result = callocz(1,n);
     if (result != NULL) {
         char *c = (char *)result;
         c += sizeof(struct label);
@@ -739,6 +754,66 @@ struct label *create_label(char *key, char *value, LABEL_SOURCE label_source)
         result->key_hash = simple_hash(result->key);
     }
     return result;
+}
+
+struct label *add_label_to_list(struct label *l, char *key, char *value, LABEL_SOURCE label_source)
+{
+    struct label *lab = create_label(key, value, label_source);
+    lab->next = l;
+    return lab;
+}
+
+int list_contains(struct label *head, struct label *check)
+{
+    while (head!=NULL)
+    {
+        if (head->key_hash == check->key_hash && !strcmp(head->key, check->key))
+            return 1;
+        head = head->next;
+    }
+    return 0;
+}
+
+/* Create a list with entries from both lists.
+   If any entry in the low priority list is masked by an entry in the high priorty list then delete it.
+*/
+struct label *merge_label_lists(struct label *lo_pri, struct label *hi_pri)
+{
+    struct label *result = hi_pri;
+    while (lo_pri != NULL)
+    {
+        struct label *current = lo_pri;
+        lo_pri = lo_pri->next;
+        if (!list_contains(result, current)) {
+            current->next = result;
+            result = current;
+        }
+        else
+            freez(current);
+    }
+    return result;
+}
+
+void reload_host_labels()
+{
+    struct label *from_auto = load_auto_labels();
+    struct label *from_k8s = load_kubernetes_labels();
+    struct label *from_config = load_config_labels();
+
+    struct label *new_labels = merge_label_lists(from_auto, from_k8s);
+    new_labels = merge_label_lists(new_labels, from_config);
+
+    netdata_rwlock_wrlock(&localhost->labels_rwlock);
+    struct label *old_labels = localhost->labels;
+    localhost->labels = new_labels;
+    netdata_rwlock_unlock(&localhost->labels_rwlock);
+
+    while (old_labels != NULL)
+    {
+        struct label *current = old_labels;
+        old_labels = old_labels->next;
+        freez(current);
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -707,6 +707,23 @@ void rrdhost_save_charts(RRDHOST *host) {
     rrdhost_unlock(host);
 }
 
+struct label *create_label(char *key, char *value)
+{
+    size_t key_len = strlen(key), value_len = strlen(value);
+    size_t n = key_len + 1 + value_len + 1 + sizeof(struct label);
+    struct label *result = callocz(n,1);
+    if (result != NULL) {
+        char *c = (char *)result;
+        c += sizeof(struct label);
+        strcpy(c, key);
+        result->key = c;
+        c += key_len + 1;
+        strcpy(c, value);
+        result->value = c;
+    }
+    return result;
+}
+
 // ----------------------------------------------------------------------------
 // RRDHOST - delete host files
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -707,10 +707,25 @@ void rrdhost_save_charts(RRDHOST *host) {
     rrdhost_unlock(host);
 }
 
+struct label *load_auto_labels()
+{
+    return NULL;
+}
+
+struct label *load_config_labels()
+{
+    return NULL;
+}
+
+struct label *load_kubernetes_labels()
+{
+    return NULL;
+}
+
 struct label *create_label(char *key, char *value, LABEL_SOURCE label_source)
 {
     size_t key_len = strlen(key), value_len = strlen(value);
-    size_t n = key_len + 1 + value_len + 1 + sizeof(struct label);
+    size_t n = sizeof(struct label) + key_len + 1 + value_len + 1;
     struct label *result = callocz(n,1);
     if (result != NULL) {
         char *c = (char *)result;
@@ -721,6 +736,7 @@ struct label *create_label(char *key, char *value, LABEL_SOURCE label_source)
         strcpy(c, value);
         result->value = c;
         result->label_source = label_source;
+        result->key_hash = simple_hash(result->key);
     }
     return result;
 }

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -68,6 +68,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`delay`](#alarm-line-delay)                        | no              | Optional hysteresis settings to prevent floods of notifications.                      |
 | [`repeat`](#alarm-line-repeat)                      | no              | The interval for sending notifications when an alarm is in WARNING or CRITICAL mode.  |
 | [`option`](#alarm-line-option)                      | no              | Add an option to not clear alarms.                                                    |
+| [`label`](#alarm-line-label)                        | no              | List of labels present on a host.                                                     |
 
 The `alarm` or `template` line must be the first line of any entity.
 
@@ -369,6 +370,49 @@ cleared. As time passes, the newest window moves into the older, so the average 
 increasing. Eventually, the comparison will find the averages in the two time-frames close enough to clear the alarm.
 However, the issue was not resolved, it's just a matter of the newer data "polluting" the old. For such alarms, it's a
 good idea to tell Netdata to not clear the notification, by using the `no-clear-notification` option.
+
+#### Alarm line `label`
+
+Defines the list of labels expected on host, for example, let us suppose that `netdata.conf` is configured with the
+following labels:
+
+```yaml
+[host labels]
+    installed = 20191211
+    room = server
+```
+
+but, we also have for the workstations the following `netdata.conf`
+
+```yaml
+[host labels]
+    installed = 201705
+    room = workstation
+```
+
+I have defined inside `netdata.conf` labels to classify hosts and now we can apply alarms for them using labels, for example,
+case I add the following line inside alarms:
+
+```yaml
+label: room = server
+```
+
+this will apply alarms only on hosts that have `room = server`. 
+It is also possible to combine labels to apply alarm, for example, case I want to raise a specific alarm only for hosts
+inside a room that were installed in a specific time, I can write the following label condition:
+
+```yaml
+label: room = workstation AND installed = 201705
+```
+
+The `label` is a space-separate list that accepts simple patterns, for example, case I decided to create an alarm 
+that will be applied to all hosts installed in the last decade, I can set label like:
+
+```yaml
+label: installed = 201*
+```
+
+See our [simple patterns docs](../libnetdata/simple_pattern/) for more examples.
 
 ## Expressions
 

--- a/health/health.c
+++ b/health/health.c
@@ -152,6 +152,9 @@ void health_reload_host(RRDHOST *host) {
     rrdhost_wrlock(host);
     health_readdir(host, user_path, stock_path, NULL);
 
+    //Discard alarms with labels that do not apply to host
+    rrdcalc_labels_unlink_alarm_from_host(host);
+
     // link the loaded alarms to their charts
     RRDDIM *rd;
     rrdset_foreach_write(st, host) {
@@ -576,6 +579,8 @@ void *health_main(void *ptr) {
 
     time_t now                = now_realtime_sec();
     time_t hibernation_delay  = config_get_number(CONFIG_SECTION_HEALTH, "postpone alarms during hibernation for seconds", 60);
+
+    rrdcalc_labels_unlink();
 
     unsigned int loop = 0;
     while(!netdata_exit) {

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -12,15 +12,14 @@
 #define CONFIG_VALUE_CHANGED 0x04 // has been changed from the loaded value or the internal default value
 #define CONFIG_VALUE_CHECKED 0x08 // has been checked if the value is different from the default
 
-
 // ----------------------------------------------------------------------------
 // locking
 
-static inline void appconfig_wrlock(struct config *root) {
+inline void appconfig_wrlock(struct config *root) {
     netdata_mutex_lock(&root->mutex);
 }
 
-static inline void appconfig_unlock(struct config *root) {
+inline void appconfig_unlock(struct config *root) {
     netdata_mutex_unlock(&root->mutex);
 }
 

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -91,6 +91,7 @@
 #define CONFIG_SECTION_HEALTH   "health"
 #define CONFIG_SECTION_BACKEND  "backend"
 #define CONFIG_SECTION_STREAM   "stream"
+#define CONFIG_SECTION_HOST_LABEL   "host labels"
 
 // these are used to limit the configuration names and values lengths
 // they are not enforced by config.c functions (they will strdup() all strings, no matter of their length)
@@ -112,7 +113,7 @@ struct config {
 #define CONFIG_BOOLEAN_AUTO 2       // enabled if it has useful info when enabled
 #endif
 
-extern int appconfig_load(struct config *root, char *filename, int overwrite_used);
+extern int appconfig_load(struct config *root, char *filename, int overwrite_used, const char *section_name);
 
 extern char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
 extern long long appconfig_get_number(struct config *root, const char *section, const char *name, long long value);

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -98,6 +98,36 @@
 #define CONFIG_MAX_NAME 1024
 #define CONFIG_MAX_VALUE 2048
 
+struct config_option {
+    avl avl;                // the index entry of this entry - this has to be first!
+
+    uint8_t flags;
+    uint32_t hash;          // a simple hash to speed up searching
+    // we first compare hashes, and only if the hashes are equal we do string comparisons
+
+    char *name;
+    char *value;
+
+    struct config_option *next; // config->mutex protects just this
+};
+
+struct section {
+    avl avl;                // the index entry of this section - this has to be first!
+
+    uint32_t hash;          // a simple hash to speed up searching
+    // we first compare hashes, and only if the hashes are equal we do string comparisons
+
+    char *name;
+
+    struct section *next;    // gloabl config_mutex protects just this
+
+    struct config_option *values;
+    avl_tree_lock values_index;
+
+    netdata_mutex_t mutex;  // this locks only the writers, to ensure atomic updates
+    // readers are protected using the rwlock in avl_tree_lock
+};
+
 struct config {
     struct section *sections;
     netdata_mutex_t mutex;
@@ -114,6 +144,8 @@ struct config {
 #endif
 
 extern int appconfig_load(struct config *root, char *filename, int overwrite_used, const char *section_name);
+extern void config_section_wrlock(struct section *co);
+extern void config_section_unlock(struct section *co);
 
 extern char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
 extern long long appconfig_get_number(struct config *root, const char *section, const char *name, long long value);
@@ -136,5 +168,7 @@ extern void appconfig_generate(struct config *root, BUFFER *wb, int only_changed
 extern int appconfig_section_compare(void *a, void *b);
 
 extern int config_parse_duration(const char* string, int* result);
+
+extern struct section *appconfig_get_section(struct config *root, const char *name);
 
 #endif /* NETDATA_CONFIG_H */

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -103,7 +103,7 @@ struct config_option {
 
     uint8_t flags;
     uint32_t hash;          // a simple hash to speed up searching
-    // we first compare hashes, and only if the hashes are equal we do string comparisons
+                            // we first compare hashes, and only if the hashes are equal we do string comparisons
 
     char *name;
     char *value;
@@ -115,7 +115,7 @@ struct section {
     avl avl;                // the index entry of this section - this has to be first!
 
     uint32_t hash;          // a simple hash to speed up searching
-    // we first compare hashes, and only if the hashes are equal we do string comparisons
+                            // we first compare hashes, and only if the hashes are equal we do string comparisons
 
     char *name;
 
@@ -125,7 +125,7 @@ struct section {
     avl_tree_lock values_index;
 
     netdata_mutex_t mutex;  // this locks only the writers, to ensure atomic updates
-    // readers are protected using the rwlock in avl_tree_lock
+                            // readers are protected using the rwlock in avl_tree_lock
 };
 
 struct config {
@@ -170,5 +170,8 @@ extern int appconfig_section_compare(void *a, void *b);
 extern int config_parse_duration(const char* string, int* result);
 
 extern struct section *appconfig_get_section(struct config *root, const char *name);
+
+extern void appconfig_wrlock(struct config *root);
+extern void appconfig_unlock(struct config *root);
 
 #endif /* NETDATA_CONFIG_H */

--- a/libnetdata/simple_pattern/simple_pattern.c
+++ b/libnetdata/simple_pattern/simple_pattern.c
@@ -331,3 +331,26 @@ extern int simple_pattern_is_potential_name(SIMPLE_PATTERN *p)
     }
     return (alpha || wildcards) && !colon;
 }
+
+char *simple_pattern_trim_around_equal(char *src) {
+    char *store = mallocz(strlen(src) +1);
+    if(!store)
+        return NULL;
+
+    char *dst = store;
+    while (*src) {
+        if (*src == '=') {
+            if (*(dst -1) == ' ')
+                dst--;
+
+            *dst++ = *src++;
+            if (*src == ' ')
+                src++;
+        }
+
+        *dst++ = *src++;
+    }
+    *dst = 0x00;
+
+    return store;
+}

--- a/libnetdata/simple_pattern/simple_pattern.h
+++ b/libnetdata/simple_pattern/simple_pattern.h
@@ -33,4 +33,7 @@ extern void simple_pattern_free(SIMPLE_PATTERN *list);
 extern void simple_pattern_dump(uint64_t debug_type, SIMPLE_PATTERN *p) ;
 extern int simple_pattern_is_potential_name(SIMPLE_PATTERN *p) ;
 
+//Auxiliary function to create a pattern
+char *simple_pattern_trim_around_equal(char *src);
+
 #endif //NETDATA_SIMPLE_PATTERN_H

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -57,12 +57,12 @@ char *netdata_ssl_ca_file = NULL;
 static void load_stream_conf() {
     errno = 0;
     char *filename = strdupz_path_subpath(netdata_configured_user_config_dir, "stream.conf");
-    if(!appconfig_load(&stream_config, filename, 0)) {
+    if(!appconfig_load(&stream_config, filename, 0, NULL)) {
         info("CONFIG: cannot load user config '%s'. Will try stock config.", filename);
         freez(filename);
 
         filename = strdupz_path_subpath(netdata_configured_stock_config_dir, "stream.conf");
-        if(!appconfig_load(&stream_config, filename, 0))
+        if(!appconfig_load(&stream_config, filename, 0, NULL))
             info("CONFIG: cannot load stock config '%s'. Running with internal defaults.", filename);
     }
     freez(filename);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -151,6 +151,25 @@ static inline int should_send_chart_matching(RRDSET *st) {
     return(rrdset_flag_check(st, RRDSET_FLAG_UPSTREAM_SEND));
 }
 
+int configured_as_master() {
+    struct section *section = NULL;
+    int is_master = 0;
+
+    appconfig_wrlock(&stream_config);
+    for (section = stream_config.sections; section; section = section->next) {
+        uuid_t uuid;
+
+        if (uuid_parse(section->name, uuid) != -1 &&
+            appconfig_get_boolean(&stream_config, section->name, "enabled", 0)) {
+            is_master = 1;
+            break;
+        }
+    }
+    appconfig_unlock(&stream_config);
+
+    return is_master;
+}
+
 // checks if the current chart definition has been sent
 static inline int need_to_send_chart_definition(RRDSET *st) {
     rrdset_check_rdlock(st);

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -13,6 +13,7 @@ extern char *default_rrdpush_send_charts_matching;
 extern unsigned int remote_clock_resync_iterations;
 
 extern int rrdpush_init();
+extern int configured_as_master();
 extern void rrdset_done_push(RRDSET *st);
 extern void rrdset_push_chart_definition_now(RRDSET *st);
 extern void *rrdpush_sender_thread(void *ptr);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -775,7 +775,7 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
         l = l->next;
     }
 
-    netdata_rwlock_rdlock(&localhost->labels_rwlock);
+    netdata_rwlock_unlock(&localhost->labels_rwlock);
     */
 
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -764,21 +764,6 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, char *url) {
     (void)url;
     if (!netdata_ready) return HTTP_RESP_BACKEND_FETCH_FAILED;
-
-    /* Temporary test-vector for #7408
-       Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
-    netdata_rwlock_rdlock(&localhost->labels_rwlock);
-    struct label *l = localhost->labels;
-    while (l != NULL) {
-        error("Label [source id=%u]: \"%s\" -> \"%s\"", l->label_source, l->key, l->value);
-        l = l->next;
-    }
-    netdata_rwlock_unlock(&localhost->labels_rwlock);
-    */
-
-
-
-
     BUFFER *wb = w->response.data;
     buffer_flush(wb);
     wb->contenttype = CT_APPLICATION_JSON;

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -767,16 +767,15 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
 
     /* Temporary test-vector for #7408
        Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
-
     netdata_rwlock_rdlock(&localhost->labels_rwlock);
     struct label *l = localhost->labels;
     while (l != NULL) {
         error("Label [source id=%u]: \"%s\" -> \"%s\"", l->label_source, l->key, l->value);
         l = l->next;
     }
-
     netdata_rwlock_unlock(&localhost->labels_rwlock);
     */
+
 
 
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -767,7 +767,7 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
 
     /* Temporary test-vector for #7408
        Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
-
+    */
     netdata_rwlock_rdlock(&localhost->labels_rwlock);
     struct label *l = localhost->labels;
     while (l != NULL) {
@@ -776,7 +776,6 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
     }
 
     netdata_rwlock_unlock(&localhost->labels_rwlock);
-    */
 
 
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -771,7 +771,7 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
     netdata_rwlock_rdlock(&localhost->labels_rwlock);
     struct label *l = localhost->labels;
     while (l != NULL) {
-        error("Label: \"%s\" -> \"%s\"", l->key, l->value);
+        error("Label [source id=%u]: \"%s\" -> \"%s\"", l->label_source, l->key, l->value);
         l = l->next;
     }
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -767,7 +767,7 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
 
     /* Temporary test-vector for #7408
        Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
-    */
+
     netdata_rwlock_rdlock(&localhost->labels_rwlock);
     struct label *l = localhost->labels;
     while (l != NULL) {
@@ -776,6 +776,7 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
     }
 
     netdata_rwlock_unlock(&localhost->labels_rwlock);
+    */
 
 
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -765,6 +765,21 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
     (void)url;
     if (!netdata_ready) return HTTP_RESP_BACKEND_FETCH_FAILED;
 
+    /* Temporary test-vector for #7408
+       Leave the code commented out to support easy testing until #7410 is complete (and then delete it).
+
+    netdata_rwlock_rdlock(&localhost->labels_rwlock);
+    struct label *l = localhost->labels;
+    while (l != NULL) {
+        error("Label: \"%s\" -> \"%s\"", l->key, l->value);
+        l = l->next;
+    }
+
+    netdata_rwlock_rdlock(&localhost->labels_rwlock);
+    */
+
+
+
     BUFFER *wb = w->response.data;
     buffer_flush(wb);
     wb->contenttype = CT_APPLICATION_JSON;


### PR DESCRIPTION
##### Summary
Fixes #7411 
- Add check for script exit code and handle it appropriately (logging, freeing)
- Fix length check for label value 
- Add log message when a label is ignored due to invalid name
- Remove test return values for the script
- Convert "Attempting to" msg from info to debug 
