### PR TITLE
Finalize kubernetes labels

### DIFF
--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -14,12 +14,5 @@ if [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}"
 		exit 1
 	fi
 else
-	# Following is only for testing and will be removed
-	echo "app:netdata
-controller-revision-hash:64966d4b74
-pod-template-generation:4
-release:netdata
-role:slave
-a line to display as info"
 	exit 0
 fi


### PR DESCRIPTION
##### Summary
Fixes #7411 
- Add check for script exit code and handle it appropriately (logging, freeing)
- Fix length check for label value 
- Add log message when a label is ignored due to invalid name
- Remove test return values for the script
- Convert "Attempting to" msg from info to debug 