### PR TITLE
Update Netdata RPM spec file to package netdatacli.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -433,7 +433,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 %defattr(0755,netdata,netdata,0755)
 %{_libexecdir}/%{name}
 %{_sbindir}/%{name}
-%{_sbindir}/%{name}cli
+
+%defattr(0755,root,root,0755)
+%{_sbindir}/netdatacli
 
 %defattr(4750,root,netdata,0750)
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -433,6 +433,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %defattr(0755,netdata,netdata,0755)
 %{_libexecdir}/%{name}
 %{_sbindir}/%{name}
+%{_sbindir}/%{name}cli
 
 %defattr(4750,root,netdata,0750)
 


### PR DESCRIPTION
##### Summary

This adds the `netdatacli` binary to the RPM spec file for Netdata, fixing the current RPM package build failures.

##### Component Name

area/packaging

##### Additional Information

Sample successful build with this change: https://travis-ci.org/Ferroin/netdata/jobs/624291381