### PR TITLE
Add Fedora 31 CI integrations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -421,6 +421,14 @@ jobs:
         - PACKAGE_TYPE="rpm" REPO_TOOL="yum"
         - ALLOW_SOFT_FAILURE_HERE=true
 
+    - name: "Build & Publish RPM package for Fedora 31"
+      <<: *RPM_TEMPLATE
+      if: commit_message =~ /\[Package (amd64|arm64) RPM( Fedora)?\]/
+      env:
+        - BUILDER_NAME="builder" BUILD_DISTRO="fedora" BUILD_RELEASE="31" BUILD_STRING="fedora/31"
+        - PACKAGE_TYPE="rpm" REPO_TOOL="dnf"
+        - ALLOW_SOFT_FAILURE_HERE=true
+
     - name: "Build & Publish RPM package for Fedora 30"
       <<: *RPM_TEMPLATE
       if: commit_message =~ /\[Package (amd64|arm64) RPM( Fedora)?\]/

--- a/.travis.yml
+++ b/.travis.yml
@@ -244,9 +244,9 @@ jobs:
       script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "fedora:30" tests/updater_checks.sh
       after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Fedora 30"
 
-#    - name: Run netdata lifecycle, on Fedora 31 (Containerized)
-#      script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "fedora:31" tests/updater_checks.sh
-#      after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Fedora 31"
+    - name: Run netdata lifecycle, on Fedora 31 (Containerized)
+      script: docker run -it -v "${PWD}:/netdata:rw" -w /netdata "fedora:31" tests/updater_checks.sh
+      after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Fedora 31"
 
 
 


### PR DESCRIPTION
##### Summary

Fedora 31 has been out for roughly 2.5 months (release date was 2019-10-29). It's about time we add package generation and publishing for it to CI.

##### Component Name

area/packaging

##### Additional Information

Sample build results: https://travis-ci.org/Ferroin/netdata/jobs/624623473?utm_medium=notification&utm_source=email

I've not rigorously tested that the generated RPM works perfectly, but it appears to install correctly, and it looks like it runs, collects data, and serves the Web UI correctly. However, it would be good to have som additional testing of this before merging. Note that I've only tested the amd64 package (I don't have an arm64 system I can test against).