### PR TITLE
Limit 'support activities on main branch' to main repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ stages:
 
     # Scheduled releases
   - name: Support activities on main branch
-    if: branch = master AND type != pull_request AND type != cron
+    if: branch = master AND type != pull_request AND type != cron AND repo = netdata/netdata
 
     # We don't run on release candidates
   - name: Publish for release


### PR DESCRIPTION
##### Summary

This adds a check to prevent the 'Support activities on main branch' stage from running on forked repos. In such repos, it will automatically fail without special effort from the user, requiring them to carry local patches on their master branch.

Without this, CI builds of the 'master' branch will fail for users who do not go through the effort of setting up the custom patches to disable this stage in their repo.

##### Component Name

area/ci

##### Additional Information

Sample build on a forked repo that demonstrates the issue this is fixing: https://travis-ci.org/Ferroin/netdata/builds/624598589
Sample build on the same repo with this commit on the master branch: https://travis-ci.org/Ferroin/netdata/builds/625732675

I can't really test that this won't break the stage on the master branch of the main repo, but I've validated the modified conditional using the procedure [outlined in the Travis CI docs](https://docs.travis-ci.com/user/conditions-testing).