### PR TITLE
Merge the matrix and jobs keys in Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ addons:
   apt:
     packages: ['moreutils']
 
-# This is a hook to help us introduce "soft" errors on our process
-matrix:
-  allow_failures:
-    - env: ALLOW_SOFT_FAILURE_HERE=true
-
 before_install:
   - exec > >(ts -s '%H:%M:%.S ') 2>&1
   - source .travis/utils.sh
@@ -96,6 +91,9 @@ stages:
 # Define stage implementation details
 #
 jobs:
+  # This is a hook to help us introduce "soft" errors on our process
+  allow_failures:
+    - env: ALLOW_SOFT_FAILURE_HERE=true
   include:
       # Do code quality, syntax checking and other pre-build activities
     - stage: Code quality, linting, syntax, code style


### PR DESCRIPTION
##### Summary

The `matrix` key is officially deprecated and gets auto-merged with the `jobs` key during config parsing.

If this auto-merging occurs, then the config will fail config validation, which will in turn cause odd failues during the build because of how Travis handles config validation (namely, it falls back to a default config for the detected language).

This change allows us to enable the Config Validation feature in Travis, which will in turn cause the build to fail very quickly if the configuration is invalid in some way.

##### Component Name

area/ci

##### Additional Information

Successful test build with this change: https://travis-ci.org/Ferroin/netdata/builds/625727800

This is based on discussion with @knatsakis in Slack when I ran into issues setting up Travis for my fork and discovered that the main repo does not have config validation enabled in Travis.