### PR TITLE
proc_pressure: increment fail_count on read fail

### DIFF
--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -97,6 +97,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
         ff = procfile_readall(ff);
         resource_info[i].pf = ff;
         if (unlikely(!ff)) {
+            fail_count++;
             continue;
         }
 


### PR DESCRIPTION
##### Summary
Also increment `fail_count` if read fails.

##### Component Name
proc.plugin > proc_pressure

##### Additional Information
This is an improvement to the behavior seen in #7531.