### PR TITLE
Skip unit testing during CI when it's not needed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,9 +154,11 @@ jobs:
 
       name: Unit Testing
       script:
-        - fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it --enable-plugin-nfacct --enable-plugin-freeipmi --disable-lto
-        - $HOME/netdata/usr/sbin/netdata -W unittest
+        - .travis/run-unit-tests.sh
       env: CFLAGS='-O1 -DNETDATA_INTERNAL_CHECKS=1 -DNETDATA_VERIFY_LOCKS=1'
+      # We need a full deep clone for the checks done by the unit testing script to work.
+      git:
+        depth: false
       after_failure: post_message "TRAVIS_MESSAGE" "Unit testing failed"
 
     - name: Build/Install for ubuntu 18.04 (not containerized)

--- a/.travis/README.md
+++ b/.travis/README.md
@@ -63,7 +63,7 @@ that our product meets certain epxectations. At the current stage, we are focusi
 like installing in different distributions, running the full lifecycle of install-run-update-install and so on.
 We are still working on enriching this with more and more use cases, to get us closer to achieving full stability of our software.
 Briefly we currently evaluate the following activities:
-- Basic software unit testing
+- Basic software unit testing (only run when changes happen that require it)
 - Non containerized build and install on ubuntu 14.04
 - Non containerized build and install on ubuntu 18.04
 - Running the full Netdata lifecycle (install, update, uninstall) on ubuntu 18.04

--- a/.travis/run-unit-tests.sh
+++ b/.travis/run-unit-tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Unit-testing script
+#
+# This script does the following:
+#   1. Check whether any files were modified that would necessitate unit testing (using the `TRAVIS_COMMIT_RANGE` environment variable).
+#   2. If there are no changed files that require unit testing, exit successfully.
+#   3. Otherwise, run all the unit tests.
+#
+# We do things this way because our unit testing takes a rather long
+# time (average 18-19 minutes as of the original creation of this script),
+# so skipping it when we don't actually need it can significantly speed
+# up the CI process.
+#
+# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author: Austin S. Hemmelgarn <austin@netdata.cloud>
+#
+# shellcheck disable=SC2230
+
+install_netdata() {
+    echo "Installing Netdata"
+    fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it --enable-plugin-nfacct --enable-plugin-freeipmi --disable-lto
+}
+
+c_unit_tests() {
+    echo "Running C code unit tests"
+    $HOME/netdata/usr/sbin/netdata -W unittest
+}
+
+run_c_unit_tests=
+
+if [ -z ${TRAVIS_COMMIT_RANGE} ] ; then
+    # Travis gave us no commit range, so just run all the unit tests.
+    # Per the docs, this is the case when a new branch is pushed for the first time.
+    run_c_unit_tests=1
+else
+    COMMIT1="$(echo ${TRAVIS_COMMIT_RANGE} | cut -f 1 -d '.')"
+    COMMIT2="$(echo ${TRAVIS_COMMIT_RANGE} | cut -f 4 -d '.')"
+
+    if [ "$(git cat-file -t ${COMMIT1} 2>/dev/null)" = commit -a "$(git cat-file -t ${COMMIT2} 2>/dev/null)" = commit ] ; then
+        changed_paths="$(git diff --numstat ${COMMIT1}..${COMMIT2} --  | cut -f 3)"
+
+        # Check for changes that would require the C code to be re-tested
+        if (echo ${changed_paths} | grep -qE "daemon/unit_test|database") ; then
+            run_c_unit_tests=1
+        fi
+    else
+        # We couldn't find at least one of the changesets, so this build
+        # was probably triggered by a history rewrite. Since we can't
+        # figure out what chnaged, we need to just run all the tests anyway.
+        echo "Cannot determine which commits we are testing, running all unit tests."
+        run_c_unit_tests=1
+    fi
+fi
+
+if [ -z ${run_c_unit_tests} ] ; then
+    # No tests to run, log this and exit with success
+    echo "Commit range ${TRAVIS_COMMIT_RANGE} appears to make no changes that require unit tests, skipping unit testing."
+    exit 0
+else
+    install_netdata || exit 1
+
+    if [ -n ${run_c_unit_tests} ] ; then
+        c_unit_tests || exit 1
+    fi
+fi

--- a/.travis/run-unit-tests.sh
+++ b/.travis/run-unit-tests.sh
@@ -56,11 +56,11 @@ else
             run_c_unit_tests=1
         fi
     else
-        # This is a PR build, assume it's targeting `master` and look
-        # at everything from that to HEAD.
+        # This is a PR build, look at all commits from the target branch
+        # to HEAD.
         echo "Checking commits:"
-        git log --format=oneline --abbrev-commit master..HEAD
-        changed_paths="$(git diff --name-only master..HEAD --)"
+        git log --format=oneline --abbrev-commit ${TRAVIS_BRANCH}..HEAD
+        changed_paths="$(git diff --name-only ${TRAVIS_BRANCH}..HEAD --)"
     fi
 
     if [ -n "${changed_paths}" ] ; then

--- a/.travis/run-unit-tests.sh
+++ b/.travis/run-unit-tests.sh
@@ -45,6 +45,8 @@ else
 
         if [ "$(git cat-file -t ${COMMIT1} 2>/dev/null)" = commit -a "$(git cat-file -t ${COMMIT2} 2>/dev/null)" = commit ] ; then
             # Examine the exact set of commits passed by Travis.
+            echo "Checking commits:"
+            git log --format=oneline --abbrev-commit ${COMMIT1}..${COMMIT2}
             changed_paths="$(git diff --name-only ${COMMIT1}..${COMMIT2} --)"
         else
             # We couldn't find at least one of the changesets, so this build
@@ -56,6 +58,8 @@ else
     else
         # This is a PR build, assume it's targeting `master` and look
         # at everything from that to HEAD.
+        echo "Checking commits:"
+        git log --format=oneline --abbrev-commit master..HEAD
         changed_paths="$(git diff --name-only master..HEAD --)"
     fi
 


### PR DESCRIPTION
##### Summary

Our current unit testing takes almost 20 minutes on average during the CI process, which is almost twice as long as any other step, and it's only going to get longer as we get better test coverage.

This commit slightly alters how we handle unit testing during CI so that only those unit tests which are actually needed get run.

This is achieved by using the `$TRAVIS_COMMIT_RANGE` environment variable provided by Travis to determine which commits we're actually testing, and then using that information to query Git for what files actually changed.

As of right now, the only unit testing we're doing is in the dbengine code, so we check to see if any of 
those files or the C unit testing files are modified by the PR and only runs the unit tests for those if they were modified. The checks are a bit more wide-ranging than they probably need to be so that we make sure to avoid any false negatives.

For the cases where we don't actually need to run unit tests, this provides a net speedup of about 14-16 minutes (it would be a bit better, but we need a full deep clone of the repo for this to work reliably, so the clone step is taking a bit longer than it was previously).

##### Component Name

area/ci

##### Additional Information

Internally this follows these rules to determine whether to run unit tests or not:

1. If Travis supplied no commit information (which means that this is the first push of a new branch), run all the unit tests.
2. If we can't identify the first or last commit of the range, run all the tests. This happens when a branch is force pushed causing a history rewrite.
3. Otherwise, query `git` to produce a list of all files changed by the range of commits we're testing. If any files changed that are either unit tested or handle the running of the unit tests, run the appropriate unit tests.
4. Otherwise, skip the unit tests.

Sample build for rule 2 above: https://travis-ci.org/Ferroin/netdata/builds/626224019
Sample build for rule 3 above: https://travis-ci.org/Ferroin/netdata/builds/626233338
Sample build for rule 4 above: https://travis-ci.org/Ferroin/netdata/builds/626206692

This produces a net speedup of builds that don't actually need unit testing of roughly 15-16 minutes.

Long-term, I'm planning on updating rules 1 and 2 above to just look at the entirety of the branch (unless it's the master branch) to determine whether to run tests instead of just always running them under those conditions.