### PR TITLE
[health] Dispatch some alarms into health.log instead of debug

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -399,6 +399,9 @@ static void log_init(void) {
     snprintfz(filename, FILENAME_MAX, "%s/access.log", netdata_configured_log_dir);
     stdaccess_filename = config_get(CONFIG_SECTION_LOGS, "access", filename);
 
+    snprintfz(filename, FILENAME_MAX, "%s/health.log", netdata_configured_log_dir);
+    healthlog_filename = config_get(CONFIG_SECTION_GLOBAL, "health log", filename);
+
     char deffacility[8];
     snprintfz(deffacility,7,"%s","daemon");
     facility_log = config_get(CONFIG_SECTION_LOGS, "facility",  deffacility);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -400,7 +400,7 @@ static void log_init(void) {
     stdaccess_filename = config_get(CONFIG_SECTION_LOGS, "access", filename);
 
     snprintfz(filename, FILENAME_MAX, "%s/health.log", netdata_configured_log_dir);
-    healthlog_filename = config_get(CONFIG_SECTION_GLOBAL, "health log", filename);
+    healthlog_filename = config_get(CONFIG_SECTION_LOGS, "health", filename);
 
     char deffacility[8];
     snprintfz(deffacility,7,"%s","daemon");

--- a/health/health.c
+++ b/health/health.c
@@ -403,7 +403,8 @@ static inline void health_alarm_wait_for_execution(ALARM_ENTRY *ae) {
         return;
 
     spawn_wait_cmd(ae->exec_spawn_serial, &ae->exec_code, &ae->exec_run_timestamp);
-    debug(D_HEALTH, "done executing command - returned with code %d", ae->exec_code);
+    health_alarm_log_dispatch((ae->exec_code == 0) ? HEALTH_ENTRY_FLAG_EXEC_RUN : HEALTH_ENTRY_FLAG_EXEC_FAILED,
+        "done executing command '%"PRIu64"' - returned with code %d at %"PRId64, ae->exec_spawn_serial, ae->exec_code, ae->exec_run_timestamp);
     ae->flags &= ~HEALTH_ENTRY_FLAG_EXEC_IN_PROGRESS;
 
     if(ae->exec_code != 0)

--- a/health/health.c
+++ b/health/health.c
@@ -387,6 +387,8 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
     debug(D_HEALTH, "executing command '%s'", command_to_run);
     ae->flags |= HEALTH_ENTRY_FLAG_EXEC_IN_PROGRESS;
     ae->exec_spawn_serial = spawn_enq_cmd(command_to_run);
+    health_alarm_log_dispatch(HEALTH_ENTRY_FLAG_EXEC_RUN, "Queued command '%s' as id '%"PRIu64"'",
+        command_to_run, ae->exec_spawn_serial);
     enqueue_alarm_notify_in_progress(ae);
 
     freez(edit_command);
@@ -414,12 +416,14 @@ static inline void health_alarm_wait_for_execution(ALARM_ENTRY *ae) {
 }
 
 static inline void health_process_notifications(RRDHOST *host, ALARM_ENTRY *ae) {
-    debug(D_HEALTH, "Health alarm '%s.%s' = " NETDATA_DOUBLE_FORMAT_AUTO " - changed status from %s to %s",
-         ae->chart?ae->chart:"NOCHART", ae->name,
-         ae->new_value,
-         rrdcalc_status2string(ae->old_status),
-         rrdcalc_status2string(ae->new_status)
-    );
+    if(likely(ae->new_status >= RRDCALC_STATUS_CLEAR && ae->old_status >= RRDCALC_STATUS_CLEAR)) {
+        health_alarm_log_dispatch(HEALTH_ENTRY_FLAG_UPDATED, "Health alarm '%s.%s' = " NETDATA_DOUBLE_FORMAT_AUTO " - changed status from %s to %s",
+            ae->chart?ae->chart:"NOCHART", ae->name,
+            ae->new_value,
+            rrdcalc_status2string(ae->old_status),
+            rrdcalc_status2string(ae->new_status)
+        );
+    }
 
     health_alarm_execute(host, ae);
 }

--- a/health/health.h
+++ b/health/health.h
@@ -6,6 +6,14 @@
 #include "daemon/common.h"
 
 extern unsigned int default_health_enabled;
+extern unsigned int health_alarm_log_flags;
+
+#define health_alarm_log_dispatch(flag, args...) do { \
+    if ((flag & health_alarm_log_flags) > 0) { \
+        log_health(args); \
+    } else { \
+        debug(D_HEALTH, args); \
+    } } while(0)
 
 #define HEALTH_ENTRY_FLAG_PROCESSED             0x00000001
 #define HEALTH_ENTRY_FLAG_UPDATED               0x00000002
@@ -17,6 +25,7 @@ extern unsigned int default_health_enabled;
 
 #define HEALTH_ENTRY_FLAG_SAVED                 0x10000000
 #define HEALTH_ENTRY_FLAG_ACLK_QUEUED           0x20000000
+#define HEALTH_ENTRY_FLAG_SKIPPED               0x40000000
 #define HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION 0x80000000
 
 #ifndef HEALTH_LISTEN_PORT

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -886,3 +886,24 @@ void log_access( const char *fmt, ... ) {
             netdata_mutex_unlock(&access_mutex);
     }
 }
+
+void log_health( const char *fmt, ... ) {
+    va_list args;
+
+    if(health_log_syslog) {
+        va_start( args, fmt );
+        vsyslog(LOG_INFO,  fmt, args );
+        va_end( args );
+    }
+
+    if(healthlog) {
+        char date[LOG_DATE_LENGTH];
+        log_date(date, LOG_DATE_LENGTH);
+        fprintf(healthlog, "%s: ", date);
+
+        va_start( args, fmt );
+        vfprintf( healthlog, fmt, args );
+        va_end( args );
+        fputc('\n', healthlog);
+    }
+}

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -570,7 +570,7 @@ void reopen_all_log_files() {
         stdaccess = open_log_file(stdaccess_fd, stdaccess, stdaccess_filename, &access_log_syslog, 1, &stdaccess_fd);
 
     if(healthlog_filename)
-        healthlog = open_log_file(healthlog_fd, healthlog, healthlog_filename, &health_log_syslog, 1, &heathlog_fd);
+        healthlog = open_log_file(healthlog_fd, healthlog, healthlog_filename, &health_log_syslog, 1, &healthlog_fd);
 }
 
 void open_all_log_files() {

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -905,6 +905,9 @@ void log_health( const char *fmt, ... ) {
     }
 
     if(healthlog) {
+        static netdata_mutex_t health_mutex = NETDATA_MUTEX_INITIALIZER;
+        netdata_mutex_lock(&health_mutex);
+
         char date[LOG_DATE_LENGTH];
         log_date(date, LOG_DATE_LENGTH);
         fprintf(healthlog, "%s: ", date);
@@ -913,5 +916,7 @@ void log_health( const char *fmt, ... ) {
         vfprintf( healthlog, fmt, args );
         va_end( args );
         fputc('\n', healthlog);
+
+        netdata_mutex_unlock(&health_mutex);
     }
 }

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -9,13 +9,17 @@ const char *program_name = "";
 uint64_t debug_flags = 0;
 
 int access_log_syslog = 1;
+int health_log_syslog = 1;
 int error_log_syslog = 1;
 int output_log_syslog = 1;  // debug log
 
 int stdaccess_fd = -1;
 FILE *stdaccess = NULL;
+int healthlog_fd = -1;
+FILE *healthlog = NULL;
 
 const char *stdaccess_filename = NULL;
+const char *healthlog_filename = NULL;
 const char *stderr_filename = NULL;
 const char *stdout_filename = NULL;
 const char *facility_log = NULL;
@@ -563,7 +567,10 @@ void reopen_all_log_files() {
         open_log_file(STDERR_FILENO, stderr, stderr_filename, &error_log_syslog, 0, NULL);
 
     if(stdaccess_filename)
-         stdaccess = open_log_file(stdaccess_fd, stdaccess, stdaccess_filename, &access_log_syslog, 1, &stdaccess_fd);
+        stdaccess = open_log_file(stdaccess_fd, stdaccess, stdaccess_filename, &access_log_syslog, 1, &stdaccess_fd);
+
+    if(healthlog_filename)
+        healthlog = open_log_file(healthlog_fd, healthlog, healthlog_filename, &health_log_syslog, 1, &heathlog_fd);
 }
 
 void open_all_log_files() {
@@ -573,6 +580,7 @@ void open_all_log_files() {
     open_log_file(STDOUT_FILENO, stdout, stdout_filename, &output_log_syslog, 0, NULL);
     open_log_file(STDERR_FILENO, stderr, stderr_filename, &error_log_syslog, 0, NULL);
     stdaccess = open_log_file(stdaccess_fd, stdaccess, stdaccess_filename, &access_log_syslog, 1, &stdaccess_fd);
+    healthlog = open_log_file(healthlog_fd, healthlog, healthlog_filename, &health_log_syslog, 1, &healthlog_fd);
 }
 
 // ----------------------------------------------------------------------------

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -55,8 +55,11 @@ extern const char *program_name;
 
 extern int stdaccess_fd;
 extern FILE *stdaccess;
+extern int healthlog_fd;
+extern FILE *healthlog;
 
 extern const char *stdaccess_filename;
+extern const char *healthlog_filename;
 extern const char *stderr_filename;
 extern const char *stdout_filename;
 extern const char *facility_log;
@@ -100,6 +103,7 @@ extern void info_int( const char *file, const char *function, const unsigned lon
 extern void error_int( const char *prefix, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(5, 6);
 extern void fatal_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) NORETURN PRINTFLIKE(4, 5);
 extern void log_access( const char *fmt, ... ) PRINTFLIKE(1, 2);
+extern void log_health( const char *fmt, ... ) PRINTFLIKE(1, 2);
 
 # ifdef __cplusplus
 }


### PR DESCRIPTION
##### Summary

Fixes: #6822
Goal: to provide more detail on the "alarm script" execution (#6822)

This script can be used to send simple notification (features provided
by default), but can also be used to notify more complex systems.
When netdata registers an alarm but the upstream alerting system doesn't
receive the alarm/clear, it's complicated to pinpoint where the alert
was dropped.

Issues where this would be useful:
 - The health thread popen() the alerting script. If it is somehow stall,
the health thread is stopped too. Adding execution time log with the
notification to have some trace of slow script.
 - Alerts can be inhibited by the 'delay' health configuration, assuming
user don't want to be flooded by notifications. Many bug tickets were
due to this feature silently discarding notifications (like #3326 #3489
 #3590 #2952 and more). Here we can have a log while not being in debug
 - When the script fails but we are not aware of it, so we have the
 return code and special path for exit != 0

New configuration options in `[health]` section to control logging. By default, all are off, thus is the same state as currently (debug).
```
[health]
	# log alarm exec = no
	# log alarm exec errors = no
	# log alarm silenced = no
	# log alarm skipped = no
	# log alarm clear = no
```

More logs lines should be added to cover the different paths where alerts come from (like repeating alerts, transcient, etc..)

##### Component Name
health + libnetdata/logs

##### Additional Information

Sample output (with all options = yes):

```
[ Startup ]
2019-12-18 15:28:57: Health not sending notification for alarm 'net_packets.wlp4s0.10s_received_packets_storm' status CLEAR (it has no-clear-notification enabled)
2019-12-18 15:28:57: Health not sending notification for alarm 'net_packets.wwp0s20f0u6.10s_received_packets_storm' status CLEAR (it has no-clear-notification enabled)
2019-12-18 15:28:57: Health not sending notification for alarm 'net_packets.virbr0.10s_received_packets_storm' status CLEAR (it has no-clear-notification enabled)
2019-12-18 15:28:57: Health not sending notification for alarm 'ipv4.tcphandshake.10s_ipv4_tcp_resets_received' status CLEAR (it has no-clear-notification enabled)
2019-12-18 15:28:57: Health not sending notification for alarm 'ipv4.tcphandshake.10s_ipv4_tcp_resets_sent' status CLEAR (it has no-clear-notification enabled)
[ Filling /tmp with dd if=/dev/urandom of=/tmp/coin bs=1M count=15k ]
2019-12-18 15:30:57: executing command 'exec /usr/libexec/netdata/plugins.d/alarm-notify.sh 'sysadmin' 'munin' '1572513246' '1572509068' '43' '1576679457' 'out_of_disk_space_time' 'disk_space._tmp' '/tmp' 'CRITICAL' 'CLEAR' '0' 'nan' '68@/usr/lib/netdata/conf.d/health.d/disks.conf' '120' '0' 'hours' 'estimated time the disk will run out of space, if the system continues to add data with the rate of the last hour' '0h' 'undefined' '$this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))' '[ $this = 0.0370937 ] [ $this = 0.0370937 ] [ $status = 1 ] [ $CRITICAL = 4 ] ' '1' '1''
2019-12-18 15:30:57: done executing command in 0.437300 s - returned with code 1
2019-12-18 15:31:57: executing command 'exec /usr/libexec/netdata/plugins.d/alarm-notify.sh 'sysadmin' 'munin' '1572513245' '1572509066' '38' '1576679457' 'disk_space_usage' 'disk_space._tmp' '/tmp' 'WARNING' 'CLEAR' '96' '45' '12@/usr/lib/netdata/conf.d/health.d/disks.conf' '120' '0' '%' 'current disk space usage' '96.4%' '44.9%' '$this > (($status >= $WARNING ) ? (80) : (90))' '[ $this = 96.4439625 ] [ $status = 3 ] [ $WARNING = 3 ] ' '1' '1''
2019-12-18 15:31:57: done executing command in 0.625700 s - returned with code 1
[ Emptying /tmp/coin ]
[ Filling again with dd if=/dev/urandom of=/tmp/coin bs=1M count=15k ]
2019-12-18 15:34:57: Health not sending again notification for alarm 'disk_space._tmp.out_of_disk_space_time' status CRITICAL
```