### PR TITLE
Fix installer permissions for Netdata service and `/usr/libexec/netdata`.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -588,9 +588,11 @@ config_option() {
 if [ "${UID}" = "0" ]; then
 	NETDATA_USER="$(config_option "global" "run as user" "netdata")"
 	ROOT_USER="root"
+	ROOT_GROUP="root"
 else
 	NETDATA_USER="${USER}"
 	ROOT_USER="${USER}"
+	ROOT_GROUP="${USER}"
 fi
 NETDATA_GROUP="$(id -g -n "${NETDATA_USER}")"
 [ -z "${NETDATA_GROUP}" ] && NETDATA_GROUP="${NETDATA_USER}"
@@ -700,7 +702,7 @@ if [ "${UID}" -eq 0 ]; then
 	test -z "${admin_group}" && admin_group="${NETDATA_GROUP}"
 
 	run chown "${NETDATA_USER}:${admin_group}" "${NETDATA_LOG_DIR}"
-	run chown -R "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata"
+	run chown -R "${ROOT_USER}:${ROOT_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata"
 	run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type d -exec chmod 0755 {} \;
 	run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -exec chmod 0644 {} \;
 	run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -a -name \*.plugin -exec chmod 0750 {} \;

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -431,8 +431,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_libdir}/%{name}
 
 %defattr(0755,netdata,netdata,0755)
-%{_libexecdir}/%{name}
 %{_sbindir}/%{name}
+
+%attr(0755,root,root) %{_libexecdir}/%{name}
 
 %defattr(0755,root,root,0755)
 %{_sbindir}/netdatacli

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -468,9 +468,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_libdir}/%{name}/conf.d/
 
 %if %{with systemd}
-%{_unitdir}/netdata.service
+%attr(0644,root,root) %%{_unitdir}/netdata.service
 %else
-%{_sysconfdir}/rc.d/init.d/netdata
+%attr(0755,root,root) %{_sysconfdir}/rc.d/init.d/netdata
 %endif
 
 # Enforce 0644 for files and 0755 for directories


### PR DESCRIPTION
##### Summary

This corrects permissions and ownership for the `/usr/libexec/netdata` directory and the Netdata init script and systemd service files.

The current DEB packages already use the correct permissions for both, so they are not touched by this PR.

##### Component Name

area/packaging

##### Additional Information

Relevant to: #6619 
Fixes: #7300 #7298 

Installer script tested in Docker containers for Debian, Ubuntu, Fedora, and OpenSUSE.

RPM package tested through a manual build and installation on Fedora and OpenSUSE.

I had initially been planning on just fixing all the ownership/permissions issues in one big PR, but it's taking me longer than I expected to sort things out with the installer script, so I'm opening a PR with what I have working right now,