### PR TITLE
Set standard name to non-libnetdata threads (libuv, pthread)

### DIFF
--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -1007,6 +1007,8 @@ int do_proc_stat(int update_every, usec_t dt) {
                     error("Cannot create wake_cpu_thread");
                 else if(unlikely(pthread_join(thread, NULL)))
                     error("Cannot join wake_cpu_thread");
+                if(thread)
+                    pthread_setname_np(thread, "PLUGIN[cpuidle]");
                 cpu_states_updated = 1;
             }
         }

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -556,6 +556,7 @@ void commands_init(void)
     /* wait for worker thread to initialize */
     wait_for_completion(&completion);
     destroy_completion(&completion);
+    uv_thread_set_name(thread, "DAEMON_COMMAND");
 
     if (command_thread_error) {
         error = uv_thread_join(&thread);

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -556,7 +556,7 @@ void commands_init(void)
     /* wait for worker thread to initialize */
     wait_for_completion(&completion);
     destroy_completion(&completion);
-    uv_thread_set_name(thread, "DAEMON_COMMAND");
+    uv_thread_set_name_np(thread, "DAEMON_COMMAND");
 
     if (command_thread_error) {
         error = uv_thread_join(&thread);

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -791,7 +791,7 @@ int rrdeng_init(struct rrdengine_instance **ctxp, char *dbfiles_path, unsigned p
     /* wait for worker thread to initialize */
     wait_for_completion(&ctx->rrdengine_completion);
     destroy_completion(&ctx->rrdengine_completion);
-    uv_thread_set_name(ctx->worker_config.thread, "DBENGINE");
+    uv_thread_set_name_np(ctx->worker_config.thread, "DBENGINE");
     if (ctx->worker_config.error) {
         goto error_after_rrdeng_worker;
     }

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -791,6 +791,7 @@ int rrdeng_init(struct rrdengine_instance **ctxp, char *dbfiles_path, unsigned p
     /* wait for worker thread to initialize */
     wait_for_completion(&ctx->rrdengine_completion);
     destroy_completion(&ctx->rrdengine_completion);
+    uv_thread_set_name(ctx->worker_config.thread, "DBENGINE");
     if (ctx->worker_config.error) {
         goto error_after_rrdeng_worker;
     }

--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -65,9 +65,9 @@ int init_connectors(struct engine *engine)
 
             // dispatch the instance worker thread
             uv_thread_create(&instance->thread, connector->worker, instance);
-            char threadname[32];
-            snprintfz(threadname, 31, "EXPORTING-%zu", instance->index);
-            uv_thread_set_name(instance->thread, threadname);
+            char threadname[NETDATA_THREAD_NAME_MAX+1];
+            snprintfz(threadname, NETDATA_THREAD_NAME_MAX, "EXPORTING-%zu", instance->index);
+            uv_thread_set_name_np(instance->thread, threadname);
         }
     }
 

--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -65,6 +65,9 @@ int init_connectors(struct engine *engine)
 
             // dispatch the instance worker thread
             uv_thread_create(&instance->thread, connector->worker, instance);
+            char threadname[32];
+            snprintfz(threadname, 31, "EXPORTING-%zu", instance->index);
+            uv_thread_set_name(instance->thread, threadname);
         }
     }
 

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -109,14 +109,13 @@ static void thread_cleanup(void *ptr) {
     netdata_thread = NULL;
 }
 
-static void thread_set_name(NETDATA_THREAD *nt) {
+static void thread_set_name_np(NETDATA_THREAD *nt) {
 
     if (nt->tag) {
         int ret = 0;
 
-        // Name is limited to 16 chars
-        char threadname[16];
-        strncpyz(threadname, nt->tag, 15);
+        char threadname[NETDATA_THREAD_NAME_MAX+1];
+        strncpyz(threadname, nt->tag, NETDATA_THREAD_NAME_MAX);
 
 #if defined(__FreeBSD__)
         pthread_set_name_np(pthread_self(), threadname);
@@ -134,15 +133,14 @@ static void thread_set_name(NETDATA_THREAD *nt) {
     }
 }
 
-void uv_thread_set_name(uv_thread_t ut, const char* name) {
-    int ret=0;
+void uv_thread_set_name_np(uv_thread_t ut, const char* name) {
+    int ret = 0;
 
-    // Name is limited to 16 chars
-    char threadname[16];
-    strncpyz(threadname, name, 15);
+    char threadname[NETDATA_THREAD_NAME_MAX+1];
+    strncpyz(threadname, name, NETDATA_THREAD_NAME_MAX);
 
 #if defined(__FreeBSD__)
-    ret = pthread_set_name_np(ut, threadname);
+    pthread_set_name_np(ut, threadname);
 #elif defined(__APPLE__)
     // Apple can only set its own name
 #else
@@ -165,7 +163,7 @@ static void *thread_start(void *ptr) {
     if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
         error("cannot set pthread cancel state to ENABLE.");
 
-    thread_set_name(ptr);
+    thread_set_name_np(ptr);
 
     void *ret = NULL;
     pthread_cleanup_push(thread_cleanup, ptr);

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -134,6 +134,25 @@ static void thread_set_name(NETDATA_THREAD *nt) {
     }
 }
 
+void uv_thread_set_name(uv_thread_t ut, const char* name) {
+    int ret=0;
+
+    // Name is limited to 16 chars
+    char threadname[16];
+    strncpyz(threadname, name, 15);
+
+#if defined(__FreeBSD__)
+    ret = pthread_set_name_np(ut, threadname);
+#elif defined(__APPLE__)
+    // Apple can only set its own name
+#else
+    ret = pthread_setname_np(ut, threadname);
+#endif
+
+    if (ret)
+        error("cannot set libuv thread name to %s. Err: %d", threadname, ret);
+}
+
 static void *thread_start(void *ptr) {
     netdata_thread = (NETDATA_THREAD *)ptr;
 

--- a/libnetdata/threads/threads.h
+++ b/libnetdata/threads/threads.h
@@ -31,6 +31,8 @@ extern int netdata_thread_cancel(netdata_thread_t thread);
 extern int netdata_thread_join(netdata_thread_t thread, void **retval);
 extern int netdata_thread_detach(pthread_t thread);
 
+extern void uv_thread_set_name(uv_thread_t ut, const char* name);
+
 #define netdata_thread_self pthread_self
 #define netdata_thread_testcancel pthread_testcancel
 

--- a/libnetdata/threads/threads.h
+++ b/libnetdata/threads/threads.h
@@ -31,7 +31,8 @@ extern int netdata_thread_cancel(netdata_thread_t thread);
 extern int netdata_thread_join(netdata_thread_t thread, void **retval);
 extern int netdata_thread_detach(pthread_t thread);
 
-extern void uv_thread_set_name(uv_thread_t ut, const char* name);
+#define NETDATA_THREAD_NAME_MAX 15
+extern void uv_thread_set_name_np(uv_thread_t ut, const char* name);
 
 #define netdata_thread_self pthread_self
 #define netdata_thread_testcancel pthread_testcancel


### PR DESCRIPTION
##### Summary
Using the same logic as libnetdata' `thead_set_name()`, we should set the name of the other threads.

Implementing `uv_thread_set_name` within libnetdata for libuv threads

Came from issue #7531 / [comment #566285792](https://github.com/netdata/netdata/issues/7531#issuecomment-566285792) 

##### Component Name
- libnetdata/threads/
- exporting
- database/engine
- daemon/command
- collector/proc.plugin/proc_stat

##### Additional Information

Generated output: 

```
 1886  1886 17848 netdata         ./netdata -D
 1886  1896 17848 DBENGINE        ./netdata -D
 1886  1897 17848 PLUGIN[proc]    ./netdata -D
 1886  1898 17848 PLUGIN[diskspac ./netdata -D
 1886  1899 17848 PLUGIN[cgroups] ./netdata -D
 1886  1900 17848 PLUGIN[tc]      ./netdata -D
 1886  1901 17848 PLUGIN[idlejitt ./netdata -D
 1886  1902 17848 STATSD          ./netdata -D
 1886  1905 17848 WEB_SERVER[stat ./netdata -D
 1886  1906 17848 PLUGINSD        ./netdata -D
 1886  1907 17848 HEALTH          ./netdata -D
 1886  1908 17848 DAEMON_COMMAND  ./netdata -D
 1886  1911 17848 PLUGINSD[slabin ./netdata -D
 1886  1912 17848 PLUGINSD[python ./netdata -D
 1886  1913 17848 PLUGINSD[pcm]   ./netdata -D
 1886  1914 17848 WEB_SERVER[stat ./netdata -D
 1886  1916 17848 WEB_SERVER[stat ./netdata -D
 1886  1917 17848 PLUGINSD[apps]  ./netdata -D
 1886  1919 17848 WEB_SERVER[stat ./netdata -D
 1886  1920 17848 WEB_SERVER[stat ./netdata -D
 1886  1921 17848 PLUGINSD[go.d]  ./netdata -D
 1886  1930 17848 WEB_SERVER[stat ./netdata -D
 1886  1933 17848 STATSD_COLLECTO ./netdata -D
 1886  2405 17848 DBENGINE        ./netdata -D
 1886  2406 17848 DBENGINE        ./netdata -D
 1886  2407 17848 DBENGINE        ./netdata -D
 1886  2409 17848 DBENGINE        ./netdata -D
```
