### PR TITLE
Add netdata-claim.sh to the RPM spec file.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -436,6 +436,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 
 %defattr(0755,root,root,0755)
 %{_sbindir}/netdatacli
+%{_sbindir}/netdata-claim.sh
 
 %defattr(4750,root,netdata,0750)
 


### PR DESCRIPTION
##### Summary

The newly added `netdata-claim.sh` script was not added to the RPM spec file, which was causing the RPM build to fail due to the presence of an 'installed but unpackaged' file.

This adds the script to the specfile, which fixes the build process.

##### Component Name

area/packaging