### PR TITLE
Update handling of shutdown of the Netdata agent on update and uninstall.

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -424,7 +424,7 @@ install_netdata_service() {
 pidisnetdata() {
 	if [ -d /proc/self ]; then
 		[ -z "$1" -o ! -f "/proc/$1/stat" ] && return 1
-		[ "$(cat "/proc/$1/stat" | cut -d '(' -f 2 | cut -d ')' -f 1)" = "netdata" ] && return 0
+		[ "$(cut -d '(' -f 2 "/proc/$1/stat" | cut -d ')' -f 1)" = "netdata" ] && return 0
 		return 1
 	fi
 	return 0

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -437,17 +437,27 @@ stop_netdata_on_pid() {
 
 	printf >&2 "Stopping netdata on pid %s ..." "${pid}"
 	while [ -n "$pid" ] && [ ${ret} -eq 0 ]; do
-		if [ ${count} -gt 45 ]; then
+		if [ ${count} -gt 24 ]; then
 			echo >&2 "Cannot stop the running netdata on pid ${pid}."
 			return 1
 		fi
 
 		count=$((count + 1))
 
-		run kill "${pid}" 2>/dev/null
-		ret=$?
+		pidisnetdata "${pid}" || ret=1
+		if [ ${ret} -eq 1 ] ; then
+			break
+		fi
 
-		test ${ret} -eq 0 && printf >&2 "." && sleep 2
+		if [ ${count} -lt 12 ] ; then
+			run kill "${pid}" 2>/dev/null
+			ret=$?
+		else
+			run kill -9 "${pid}" 2>/dev/null
+			ret=$?
+		fi
+
+		test ${ret} -eq 0 && printf >&2 "." && sleep 5
 
 	done
 

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -490,6 +490,12 @@ netdata_pids() {
 
 stop_all_netdata() {
 	local p
+
+	if [ -n $(netdata_pids) -a -n "$(builtin type -P netdatacli)" ] ; then
+		netdatacli shutdown-agent
+		sleep 20
+	fi
+
 	for p in $(netdata_pids); do
 		# shellcheck disable=SC2086
 		stop_netdata_on_pid ${p}

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -258,22 +258,98 @@ rm_dir() {
 	fi
 }
 
+safe_pidof() {
+	local pidof_cmd="$(command -v pidof 2>/dev/null)"
+	if [ -n "${pidof_cmd}" ]; then
+		${pidof_cmd} "${@}"
+		return $?
+	else
+		ps -acxo pid,comm |
+			sed "s/^ *//g" |
+			grep netdata |
+			cut -d ' ' -f 1
+		return $?
+	fi
+}
+
+pidisnetdata() {
+	if [ -d /proc/self ]; then
+		[ -z "$1" -o ! -f "/proc/$1/stat" ] && return 1
+		[ "$(cat "/proc/$1/stat" | cut -d '(' -f 2 | cut -d ')' -f 1)" = "netdata" ] && return 0
+		return 1
+	fi
+	return 0
+}
+
+stop_netdata_on_pid() {
+	local pid="${1}" ret=0 count=0
+
+	pidisnetdata "${pid}" || return 0
+
+	printf >&2 "Stopping netdata on pid %s ..." "${pid}"
+	while [ -n "$pid" ] && [ ${ret} -eq 0 ]; do
+		if [ ${count} -gt 24 ]; then
+			echo >&2 "Cannot stop the running netdata on pid ${pid}."
+			return 1
+		fi
+
+		count=$((count + 1))
+
+		pidisnetdata "${pid}" || ret=1
+		if [ ${ret} -eq 1 ] ; then
+			break
+		fi
+
+		if [ ${count} -lt 12 ] ; then
+			run kill "${pid}" 2>/dev/null
+			ret=$?
+		else
+			run kill -9 "${pid}" 2>/dev/null
+			ret=$?
+		fi
+
+		test ${ret} -eq 0 && printf >&2 "." && sleep 5
+
+	done
+
+	echo >&2
+	if [ ${ret} -eq 0 ]; then
+		echo >&2 "SORRY! CANNOT STOP netdata ON PID ${pid} !"
+		return 1
+	fi
+
+	echo >&2 "netdata on pid ${pid} stopped."
+	return 0
+}
+
 netdata_pids() {
 	local p myns ns
+
 	myns="$(readlink /proc/self/ns/pid 2>/dev/null)"
+
 	for p in \
 		$(cat /var/run/netdata.pid 2>/dev/null) \
 		$(cat /var/run/netdata/netdata.pid 2>/dev/null) \
-		$(pidof netdata 2>/dev/null); do
-
+		$(safe_pidof netdata 2>/dev/null); do
 		ns="$(readlink "/proc/${p}/ns/pid" 2>/dev/null)"
-		#shellcheck disable=SC2002
+
 		if [ -z "${myns}" ] || [ -z "${ns}" ] || [ "${myns}" = "${ns}" ]; then
-			name="$(cat "/proc/${p}/stat" 2>/dev/null | cut -d '(' -f 2 | cut -d ')' -f 1)"
-			if [ "${name}" = "netdata" ]; then
-				echo "${p}"
-			fi
+			pidisnetdata "${p}" && echo "${p}"
 		fi
+	done
+}
+
+stop_all_netdata() {
+	local p
+
+	if [ -n $(netdata_pids) -a -n "$(builtin type -P netdatacli)" ] ; then
+		netdatacli shutdown-agent
+		sleep 20
+	fi
+
+	for p in $(netdata_pids); do
+		# shellcheck disable=SC2086
+		stop_netdata_on_pid ${p}
 	done
 }
 
@@ -284,20 +360,7 @@ source "${ENVIRONMENT_FILE}" || exit 1
 
 #### STOP NETDATA
 echo >&2 "Stopping a possibly running netdata..."
-for p in $(netdata_pids); do
-	i=0
-	while kill "${p}" 2>/dev/null; do
-		if [ "$i" -gt 30 ]; then
-			echo >&2 "Forcefully stopping netdata with pid ${p}"
-			run kill -9 "${p}"
-			run sleep 2
-			break
-		fi
-		sleep 1
-		i=$((i + 1))
-	done
-done
-sleep 2
+stop_all_netdata
 
 #### REMOVE NETDATA FILES
 rm_file /etc/logrotate.d/netdata

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -275,7 +275,7 @@ safe_pidof() {
 pidisnetdata() {
 	if [ -d /proc/self ]; then
 		[ -z "$1" -o ! -f "/proc/$1/stat" ] && return 1
-		[ "$(cat "/proc/$1/stat" | cut -d '(' -f 2 | cut -d ')' -f 1)" = "netdata" ] && return 0
+		[ "$(cut -d '(' -f 2 "/proc/$1/stat" | cut -d ')' -f 1)" = "netdata" ] && return 0
 		return 1
 	fi
 	return 0


### PR DESCRIPTION
##### Summary

This improves the logic in the update and uninstall scripts used for kickstart installations so that they more reliably stop the Netdata agent process. This will help mitigate the impact of bugs in the shutdown code for the agent itself.

##### Component Name

area/packaging

##### Additional Information

Fixes: #7585 
Fixes: #7248 
Fixes: #7320

---

The new logic is intended to work like so:

1. If we can find `netdatacil` in `$PATH` and there appears to be an agent running, use that to try and shutdown the agent, then wait for 20 seconds before proceeding.
2. For each live Netdata PID, spend up to 60 seconds trying to stop it with SIGTERM, and then up to another 60 seconds trying with SIGKILL if SIGTERM fails.

This can technically still leave a live agent process running, though it is very unlikely. I plan to update the installer and updater code in a future PR to log an error and not start Netdata if they see what appears to be a live agent still running.

---

As of right now this appears to work based on running the following tests on Linux (in Docker containers):

* Make a clean install of an older version of Netdata (specifically a nightly from 2019-12-19), then update using this code, followed by uninstalling using this code.
* Same as above, but with `netdatacli` manually removed from `$PATH`.
* Same as the above, but with GDB used to manipulate the signal mask so that the agent was ignoring SIGTERM.

---

I've now run equivalent tests to the above on FreeBSD as well as on more Linux distributions, and am reasonably confident that this works correctly.