### PR TITLE
Adjust alarm labels

### DIFF
--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -394,21 +394,21 @@ By defining labels inside of `netdata.conf`, you can now apply labels to alarms.
 line to any alarms you'd like to apply to hosts that have the label `room = server`.
 
 ```yaml
-host lables: room = server
+host labels: room = server
 ```
 
 You can also combine labels when applying them to alarms. For example, if you want to raise a specific alarm only for hosts 
 inside a room that were installed at a specific time, you can write the following label line:
 
 ```yaml
-host lables: room = workstation AND installed = 201705
+host labels: room = workstation AND installed = 201705
 ```
 
 The `label` is a space-separated list that accepts simple patterns. For example, you can create an alarm 
 that will be applied to all hosts installed in the last decade with the following line:
 
 ```yaml
-host lables: installed = 201*
+host labels: installed = 201*
 ```
 
 See our [simple patterns docs](../libnetdata/simple_pattern/) for more examples.

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -68,7 +68,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`delay`](#alarm-line-delay)                        | no              | Optional hysteresis settings to prevent floods of notifications.                      |
 | [`repeat`](#alarm-line-repeat)                      | no              | The interval for sending notifications when an alarm is in WARNING or CRITICAL mode.  |
 | [`option`](#alarm-line-option)                      | no              | Add an option to not clear alarms.                                                    |
-| [`host labels`](#alarm-line-host-label)                   | no              | List of labels present on a host.                                                     |
+| [`host labels`](#alarm-line-host-label)             | no              | List of labels present on a host.                                                     |
 
 The `alarm` or `template` line must be the first line of any entity.
 

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -68,7 +68,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`delay`](#alarm-line-delay)                        | no              | Optional hysteresis settings to prevent floods of notifications.                      |
 | [`repeat`](#alarm-line-repeat)                      | no              | The interval for sending notifications when an alarm is in WARNING or CRITICAL mode.  |
 | [`option`](#alarm-line-option)                      | no              | Add an option to not clear alarms.                                                    |
-| [`label`](#alarm-line-label)                        | no              | List of labels present on a host.                                                     |
+| [`host labels`](#alarm-line-host-label)                   | no              | List of labels present on a host.                                                     |
 
 The `alarm` or `template` line must be the first line of any entity.
 
@@ -371,9 +371,9 @@ increasing. Eventually, the comparison will find the averages in the two time-fr
 However, the issue was not resolved, it's just a matter of the newer data "polluting" the old. For such alarms, it's a
 good idea to tell Netdata to not clear the notification, by using the `no-clear-notification` option.
 
-#### Alarm line `label`
+#### Alarm line `host labels`
 
-Defines the list of labels expected on a host. For example, let's suppose that `netdata.conf` is configured with the
+Defines the list of labels present on a host. For example, let's suppose that `netdata.conf` is configured with the
 following labels:
 
 ```yaml
@@ -394,21 +394,21 @@ By defining labels inside of `netdata.conf`, you can now apply labels to alarms.
 line to any alarms you'd like to apply to hosts that have the label `room = server`.
 
 ```yaml
-label: room = server
+host lables: room = server
 ```
 
 You can also combine labels when applying them to alarms. For example, if you want to raise a specific alarm only for hosts 
 inside a room that were installed at a specific time, you can write the following label line:
 
 ```yaml
-label: room = workstation AND installed = 201705
+host lables: room = workstation AND installed = 201705
 ```
 
 The `label` is a space-separated list that accepts simple patterns. For example, you can create an alarm 
 that will be applied to all hosts installed in the last decade with the following line:
 
 ```yaml
-label: installed = 201*
+host lables: installed = 201*
 ```
 
 See our [simple patterns docs](../libnetdata/simple_pattern/) for more examples.

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -68,7 +68,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`delay`](#alarm-line-delay)                        | no              | Optional hysteresis settings to prevent floods of notifications.                      |
 | [`repeat`](#alarm-line-repeat)                      | no              | The interval for sending notifications when an alarm is in WARNING or CRITICAL mode.  |
 | [`option`](#alarm-line-option)                      | no              | Add an option to not clear alarms.                                                    |
-| [`host labels`](#alarm-line-label)                   | no              | List of labels present on a host.                                                     |
+| [`host labels`](#alarm-line-host-labels)            | no              | List of labels present on a host.                                                     |
 
 The `alarm` or `template` line must be the first line of any entity.
 

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -68,7 +68,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`delay`](#alarm-line-delay)                        | no              | Optional hysteresis settings to prevent floods of notifications.                      |
 | [`repeat`](#alarm-line-repeat)                      | no              | The interval for sending notifications when an alarm is in WARNING or CRITICAL mode.  |
 | [`option`](#alarm-line-option)                      | no              | Add an option to not clear alarms.                                                    |
-| [`host labels`](#alarm-line-host)                   | no              | List of labels present on a host.                                                     |
+| [`host labels`](#alarm-line-label)                   | no              | List of labels present on a host.                                                     |
 
 The `alarm` or `template` line must be the first line of any entity.
 

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -397,13 +397,6 @@ line to any alarms you'd like to apply to hosts that have the label `room = serv
 host labels: room = server
 ```
 
-You can also combine labels when applying them to alarms. For example, if you want to raise a specific alarm only for hosts 
-inside a room that were installed at a specific time, you can write the following label line:
-
-```yaml
-host labels: room = workstation AND installed = 201705
-```
-
 The `label` is a space-separated list that accepts simple patterns. For example, you can create an alarm 
 that will be applied to all hosts installed in the last decade with the following line:
 

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -397,7 +397,7 @@ line to any alarms you'd like to apply to hosts that have the label `room = serv
 host labels: room = server
 ```
 
-The `label` is a space-separated list that accepts simple patterns. For example, you can create an alarm 
+The `host labels` is a space-separated list that accepts simple patterns. For example, you can create an alarm 
 that will be applied to all hosts installed in the last decade with the following line:
 
 ```yaml

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -68,7 +68,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`delay`](#alarm-line-delay)                        | no              | Optional hysteresis settings to prevent floods of notifications.                      |
 | [`repeat`](#alarm-line-repeat)                      | no              | The interval for sending notifications when an alarm is in WARNING or CRITICAL mode.  |
 | [`option`](#alarm-line-option)                      | no              | Add an option to not clear alarms.                                                    |
-| [`host labels`](#alarm-line-host-label)             | no              | List of labels present on a host.                                                     |
+| [`host labels`](#alarm-line-host)                   | no              | List of labels present on a host.                                                     |
 
 The `alarm` or `template` line must be the first line of any entity.
 

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -24,7 +24,7 @@
 #define HEALTH_DELAY_KEY "delay"
 #define HEALTH_OPTIONS_KEY "options"
 #define HEALTH_REPEAT_KEY "repeat"
-#define HEALTH_LABEL_KEY "label"
+#define HEALTH_HOST_LABEL_KEY "host labels"
 
 static inline int rrdcalc_add_alarm_from_config(RRDHOST *host, RRDCALC *rc) {
     if(!rc->chart) {
@@ -499,7 +499,7 @@ static int health_readfile(const char *filename, void *data) {
             hash_delay = 0,
             hash_options = 0,
             hash_repeat = 0,
-            hash_label = 0;
+            hash_host_label = 0;
 
     char buffer[HEALTH_CONF_MAX_LINE + 1];
 
@@ -524,7 +524,7 @@ static int health_readfile(const char *filename, void *data) {
         hash_delay = simple_uhash(HEALTH_DELAY_KEY);
         hash_options = simple_uhash(HEALTH_OPTIONS_KEY);
         hash_repeat = simple_uhash(HEALTH_REPEAT_KEY);
-        hash_label = simple_uhash(HEALTH_LABEL_KEY);
+        hash_host_label = simple_uhash(HEALTH_HOST_LABEL_KEY);
     }
 
     FILE *fp = fopen(filename, "r");
@@ -798,7 +798,7 @@ static int health_readfile(const char *filename, void *data) {
                                     &rc->warn_repeat_every,
                                     &rc->crit_repeat_every);
             }
-            else if(hash == hash_label && !strcasecmp(key, HEALTH_LABEL_KEY)) {
+            else if(hash == hash_host_label && !strcasecmp(key, HEALTH_HOST_LABEL_KEY)) {
                 if(rc->labels) {
                     if(strcmp(rc->labels, value) != 0)
                         error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'.",
@@ -943,7 +943,7 @@ static int health_readfile(const char *filename, void *data) {
                                     &rt->warn_repeat_every,
                                     &rt->crit_repeat_every);
             }
-            else if(hash == hash_label && !strcasecmp(key, HEALTH_LABEL_KEY)) {
+            else if(hash == hash_host_label && !strcasecmp(key, HEALTH_HOST_LABEL_KEY)) {
                 if(rt->labels) {
                     if(strcmp(rt->labels, value) != 0)
                         error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",


### PR DESCRIPTION
##### Summary
Fixes #7599 

This PR brings the necessary changes for Netdata to have `host labels` instead `label` parsed on alarms.
##### Component Name
Health
##### Additional Information
During the development, I created few labels inside my netdata.conf in the new setion `[host labels]`, after this I ran `cp tests/template_dimension/system_cpu.conf.unique_alarm /etc/netdata/health.d/system_cpu.conf` and I inserted the labels for each alarm, the labels were defined following these steps:

- All alarms with the same label defined using `host labels:`
- Different labels for each alarm, here I also used valid labels.
- Change the labels to invalid values inside the alarm, but I kept one with correct values.
