### PR TITLE
python.d.plugin: UrlService bytes decode, logger unicode encoding fix

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -152,7 +152,7 @@ class UrlService(SimpleService):
         )
         if isinstance(response.data, str):
             return response.status, response.data
-        return response.status, response.data.decode()
+        return response.status, response.data.decode(errors='ignore')
 
     def check(self):
         """

--- a/collectors/python.d.plugin/python_modules/bases/collection.py
+++ b/collectors/python.d.plugin/python_modules/bases/collection.py
@@ -95,6 +95,6 @@ def unicode_str(arg):
     :return: <str>
     """
     try:
-        return unicode(arg)
+        return unicode(arg, errors='ignore')
     except NameError:
         return str(arg)


### PR DESCRIPTION
##### Summary

fixes: https://github.com/netdata/netdata/issues/3656#issuecomment-567931801

##### Component Name

`/collectors/python.d.plugin/python_modules`


##### Additional Information

I tested, with the changes `httpcheck` module works with `https://google.ru` URL in both py2 and py3.

