### PR TITLE
Fix a warning in prometheus remote write backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ find_library(HAVE_KINESIS aws-cpp-sdk-kinesis)
 # -----------------------------------------------------------------------------
 # Detect libprotobuf
 
-pkg_check_modules(PROTOBUF protobuf)
+pkg_check_modules(PROTOBUF protobuf>=3.1)
 # later we use:
 # ${PROTOBUF_LIBRARIES}
 # ${PROTOBUF_CFLAGS_OTHER}

--- a/backends/prometheus/remote_write/remote_write.cc
+++ b/backends/prometheus/remote_write/remote_write.cc
@@ -98,7 +98,7 @@ void add_metric(const char *name, const char *chart, const char *family, const c
 }
 
 size_t get_write_request_size(){
-    size_t size = (size_t)snappy::MaxCompressedLength(write_request->ByteSize());
+    size_t size = (size_t)snappy::MaxCompressedLength(write_request->ByteSizeLong());
 
     return (size < INT_MAX)?size:0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -932,7 +932,7 @@ AM_CONDITIONAL([ENABLE_BACKEND_KINESIS], [test "${enable_backend_kinesis}" = "ye
 
 PKG_CHECK_MODULES(
     [PROTOBUF],
-    [protobuf >= 3],
+    [protobuf >= 3.1],
     [have_libprotobuf=yes],
     [have_libprotobuf=no]
 )


### PR DESCRIPTION
##### Summary
`ByteSize()` is deprecated. `ByteSizeLong()` should be used instead.

##### Component Name
backends