### PR TITLE
python.d logger: do not unicode decode if it is already unicode

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/collection.py
+++ b/collectors/python.d.plugin/python_modules/bases/collection.py
@@ -95,6 +95,8 @@ def unicode_str(arg):
     :return: <str>
     """
     try:
+        if isinstance(arg, unicode):
+            return arg
         return unicode(arg, errors='ignore')
     except NameError:
         return str(arg)


### PR DESCRIPTION
### Summary

Fixes: #7613

##### Component Name
`/collectors/python.d.plugin/python_modules`

##### Additional Information

