### PR TITLE
Clean up host labels in API responses

### DIFF
--- a/database/rrdvar.c
+++ b/database/rrdvar.c
@@ -296,10 +296,7 @@ void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *buf) {
     helper.counter = 0;
     avl_traverse_lock(&st->rrdfamily->rrdvar_root_index, single_variable2json, (void *)&helper);
 
-    buffer_sprintf(buf, "\n\t},\n\t\"host\": \"%s\",", host->hostname);
-    buffer_strcat(buf, "\n\t\"labels\": {\n");
-    host_labels2json(st->rrdhost, buf, 2);
-    buffer_strcat(buf, "\t},\n\t\"host_variables\": {");
+    buffer_sprintf(buf, "\n\t},\n\t\"host\": \"%s\",\n\t\"host_variables\": {", host->hostname);
     helper.counter = 0;
     avl_traverse_lock(&host->rrdvar_root_index, single_variable2json, (void *)&helper);
 

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -304,12 +304,8 @@ void health_alarms2json(RRDHOST *host, BUFFER *wb, int all) {
 //    for(rt = host->templates; rt ; rt = rt->next)
 //        health_rrdcalctemplate2json_nolock(wb, rt);
 
-    buffer_strcat(wb, "\n\t},");
+    buffer_strcat(wb, "\n\t}\n}\n");
     rrdhost_unlock(host);
-
-    buffer_strcat(wb, "\n\t\"labels\": {\n");
-    host_labels2json(host, wb, 2);
-    buffer_strcat(wb, "\t}\n}\n");
 }
 
 

--- a/web/api/formatters/charts2json.c
+++ b/web/api/formatters/charts2json.c
@@ -56,6 +56,7 @@ void charts2json(RRDHOST *host, BUFFER *wb) {
                        ",\n\t\"history\": %ld"
                        ",\n\t\"memory_mode\": \"%s\""
                        ",\n\t\"custom_info\": \"%s\""
+                       ",\n\t\"charts\": {"
                    , host->hostname
                    , host->program_version
                    , get_release_channel()
@@ -66,12 +67,6 @@ void charts2json(RRDHOST *host, BUFFER *wb) {
                    , rrd_memory_mode_name(host->rrd_memory_mode)
                    , custom_dashboard_info_js_filename
     );
-
-    buffer_strcat(wb, ",\n\t\"labels\": {\n");
-    host_labels2json(host, wb, 2);
-    buffer_strcat(wb, "\t}");
-
-    buffer_strcat(wb, ",\n\t\"charts\": {");
 
     c = 0;
     rrdhost_rdlock(host);

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -26,35 +26,16 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                        "   %sapi%s: 1,\n"
                        "   %sid%s: %s%s%s,\n"
                        "   %sname%s: %s%s%s,\n"
-                   , kq, kq
-                   , kq, kq, sq, r->st->id, sq
-                   , kq, kq, sq, r->st->name, sq);
-
-    RRDHOST *host = r->st->rrdhost;
-    buffer_sprintf(wb, "   %slabels%s: {\n", kq, kq);
-
-    int count = 0;
-    netdata_rwlock_rdlock(&host->labels_rwlock);
-    for (struct label *label = host->labels; label; label = label->next) {
-        if(count > 0) buffer_strcat(wb, ",\n");
-
-        char value[CONFIG_MAX_VALUE * 2 + 1];
-        escape_json_string(value, label->value, CONFIG_MAX_VALUE * 2);
-        buffer_sprintf(wb, "      %s%s%s: %s%s%s", kq, label->key, kq, sq, value, sq);
-
-        count++;
-    }
-    netdata_rwlock_unlock(&host->labels_rwlock);
-
-    buffer_strcat(wb, "\n   },\n");
-
-    buffer_sprintf(wb, "   %sview_update_every%s: %d,\n"
+                       "   %sview_update_every%s: %d,\n"
                        "   %supdate_every%s: %d,\n"
                        "   %sfirst_entry%s: %u,\n"
                        "   %slast_entry%s: %u,\n"
                        "   %sbefore%s: %u,\n"
                        "   %safter%s: %u,\n"
                        "   %sdimension_names%s: ["
+                   , kq, kq
+                   , kq, kq, sq, r->st->id, sq
+                   , kq, kq, sq, r->st->name, sq
                    , kq, kq, r->update_every
                    , kq, kq, r->st->update_every
                    , kq, kq, (uint32_t)rrdset_first_entry_t(r->st)

--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -73,11 +73,7 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
     if(dimensions_count) *dimensions_count += dimensions;
     if(memory_used) *memory_used += memory;
 
-    buffer_strcat(wb, "\n\t\t\t},\n\t\t\t\"labels\": {\n");
-    host_labels2json(st->rrdhost, wb, 4);
-    buffer_strcat(wb, "\t\t\t}");
-
-    buffer_sprintf(wb, ",\n\t\t\t\"chart_variables\": ");
+    buffer_sprintf(wb, "\n\t\t\t},\n\t\t\t\"chart_variables\": ");
     health_api_v1_chart_custom_variables2json(st, wb);
 
     buffer_strcat(wb, ",\n\t\t\t\"green\": ");

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -1079,17 +1079,6 @@
             "type": "number",
             "description": "The default update frequency of the netdata server. All charts have an update frequency equal or bigger than this."
           },
-          "labels": {
-            "type": "object",
-            "description": "List of host labels.",
-            "properties": {
-              "app": {
-                "type": "string",
-                "description": "Host label.",
-                "example": "netdata"
-              }
-            }
-          },
           "charts": {
             "type": "object",
             "description": "An object containing all the chart objects available at the netdata server. This is used as an indexed array. The key of each chart object is the id of the chart.",
@@ -1192,17 +1181,6 @@
               }
             }
           },
-          "labels": {
-            "type": "object",
-            "description": "List of host labels.",
-            "properties": {
-              "app": {
-                "type": "string",
-                "description": "Host label.",
-                "example": "netdata"
-              }
-            }
-          },
           "chart_variables": {
             "type": "object",
             "additionalProperties": {
@@ -1243,17 +1221,6 @@
           "host": {
             "type": "string",
             "description": "The host containing the chart."
-          },
-          "labels": {
-            "type": "object",
-            "description": "List of host labels.",
-            "properties": {
-              "app": {
-                "type": "string",
-                "description": "Host label.",
-                "example": "netdata"
-              }
-            }
           },
           "chart_variables": {
             "type": "object",
@@ -1320,17 +1287,6 @@
           "name": {
             "type": "string",
             "description": "The name of the chart."
-          },
-          "labels": {
-            "type": "object",
-            "description": "List of host labels.",
-            "properties": {
-              "app": {
-                "type": "string",
-                "description": "Host label.",
-                "example": "netdata"
-              }
-            }
           },
           "update_every": {
             "type": "number",
@@ -1737,17 +1693,6 @@
                     "type": "number"
                   }
                 }
-              }
-            }
-          },
-          "labels": {
-            "type": "object",
-            "description": "List of host labels.",
-            "properties": {
-              "app": {
-                "type": "string",
-                "description": "Host label.",
-                "example": "netdata"
               }
             }
           }

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -878,14 +878,6 @@ components:
           type: number
           description: The default update frequency of the netdata server. All charts have
             an update frequency equal or bigger than this.
-        labels:
-          type: object
-          description: List of host labels.
-          properties:
-            app:
-              type: string
-              description: Host label.
-              example: netdata
         charts:
           type: object
           description: An object containing all the chart objects available at the netdata
@@ -979,14 +971,6 @@ components:
               name:
                 type: string
                 description: The name of the dimension
-        labels:
-          type: object
-          description: List of host labels.
-          properties:
-            app:
-              type: string
-              description: Host label.
-              example: netdata
         chart_variables:
           type: object
           additionalProperties:
@@ -1018,14 +1002,6 @@ components:
         host:
           type: string
           description: The host containing the chart.
-        labels:
-          type: object
-          description: List of host labels.
-          properties:
-            app:
-              type: string
-              description: Host label.
-              example: netdata
         chart_variables:
           type: object
           additionalProperties:
@@ -1073,14 +1049,6 @@ components:
         name:
           type: string
           description: The name of the chart.
-        labels:
-          type: object
-          description: List of host labels.
-          properties:
-            app:
-              type: string
-              description: Host label.
-              example: netdata
         update_every:
           type: number
           description: The update frequency of this chart, in seconds. One value every this
@@ -1373,14 +1341,6 @@ components:
                   format: nullable
                 value:
                   type: number
-        labels:
-          type: object
-          description: List of host labels.
-          properties:
-            app:
-              type: string
-              description: Host label.
-              example: netdata
     alarm_log_entry:
       type: object
       properties:

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -822,7 +822,7 @@ inline int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
     buffer_sprintf(wb, "\t\"container\": \"%s\",\n", (host->system_info->container) ? host->system_info->container : "");
     buffer_sprintf(wb, "\t\"container_detection\": \"%s\",\n", (host->system_info->container_detection) ? host->system_info->container_detection : "");
 
-    buffer_strcat(wb, "\t\"labels\": {\n");
+    buffer_strcat(wb, "\t\"host_labels\": {\n");
     host_labels2json(host, wb, 2);
     buffer_strcat(wb, "\t},\n");
 


### PR DESCRIPTION
##### Summary
Host labels were deleted from
- [x] `api/v1/charts`
- [x] `api/v1/chart`
- [x] `api/v1/data`
- [x] `api/v1/alarm_variables`
- [x] `api/v1/alarms`

Fixes #7615

##### Component Name
web