### PR TITLE
redis: populate `keys_redis` chart in runtime

### DIFF
--- a/collectors/python.d.plugin/redis/redis.chart.py
+++ b/collectors/python.d.plugin/redis/redis.chart.py
@@ -209,6 +209,9 @@ class Service(SocketService):
                 if k.startswith('db') and k not in self.keyspace_dbs:
                     self.keyspace_dbs.add(k)
                     self.charts['keys_redis'].add_dimension([k, None, 'absolute'])
+            for db in self.keyspace_dbs:
+                if db not in data:
+                    data[db] = 0
 
         return data
 


### PR DESCRIPTION
##### Summary
Fixes: #7635

Following stats appear in the redis `INFO` output only if there are some keys in the database.

```console
# Keyspace
db0:keys=2,expires=0,avg_ttl=0
```

We need to check this stats on every iteration. If there is new db we add dimension to the `keys_redis` chart.

##### Component Name

`/collectors/python.d.plugin/redis`

##### Additional Information

i tested the PR, it works (tests: set key via `redis-cli` in runtime, remove key, etc.). 
