### PR TITLE
[libnetdata/threads] Change log level on error

### DIFF
--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -148,7 +148,7 @@ void uv_thread_set_name_np(uv_thread_t ut, const char* name) {
 #endif
 
     if (ret)
-        error("cannot set libuv thread name to %s. Err: %d", threadname, ret);
+        info("cannot set libuv thread name to %s. Err: %d", threadname, ret);
 }
 
 static void *thread_start(void *ptr) {


### PR DESCRIPTION
##### Summary
Reduce log for `uv_thread_set_name_np` from `error` to `info`.

Thread renaming is not a requirement, but ease bug reporting. On bug #7644 for an unknown reason, libuv could not rename its threads on CentOS6. So the logs showed an error log that was reported.

##### Component Name
- libnetdata/threads/thread.c

##### Additional Information
