### PR TITLE
samba: properly check if it is allowed to run smbstatus with sudo

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/ExecutableService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/ExecutableService.py
@@ -22,12 +22,14 @@ class ExecutableService(SimpleService):
         Get raw data from executed command
         :return: <list>
         """
+        command = command or self.command
+        self.debug("Executing command '{0}'".format(' '.join(command)))
         try:
-            p = Popen(command if command else self.command, stdout=PIPE, stderr=PIPE)
+            p = Popen(command, stdout=PIPE, stderr=PIPE)
         except Exception as error:
-            self.error('Executing command {command} resulted in error: {error}'.format(command=command or self.command,
-                                                                                       error=error))
+            self.error('Executing command {0} resulted in error: {1}'.format(command, error))
             return None
+
         data = list()
         std = p.stderr if stderr else p.stdout
         for line in std:

--- a/collectors/python.d.plugin/samba/samba.chart.py
+++ b/collectors/python.d.plugin/samba/samba.chart.py
@@ -21,7 +21,6 @@ import re
 from bases.collection import find_binary
 from bases.FrameworkServices.ExecutableService import ExecutableService
 
-
 disabled_by_default = True
 
 update_every = 5
@@ -96,6 +95,9 @@ CHARTS = {
     }
 }
 
+SUDO = 'sudo'
+SMBSTATUS = 'smbstatus'
+
 
 class Service(ExecutableService):
     def __init__(self, configuration=None, name=None):
@@ -105,20 +107,24 @@ class Service(ExecutableService):
         self.rgx_smb2 = re.compile(r'(smb2_[^:]+|syscall_.*file_bytes):\s+(\d+)')
 
     def check(self):
-        sudo_binary, smbstatus_binary = find_binary('sudo'), find_binary('smbstatus')
-
-        if not (sudo_binary and smbstatus_binary):
-            self.error("Can\'t locate 'sudo' or 'smbstatus' binary")
+        sudo_binary = find_binary(SUDO)
+        if not sudo_binary:
+            self.error("can't locate '{0}' binary".format(SUDO))
             return False
 
-        self.command = [sudo_binary, '-v']
-        err = self._get_raw_data(stderr=True)
-        if err:
-            self.error(''.join(err))
+        smbstatus_binary = find_binary(SMBSTATUS)
+        if not smbstatus_binary:
+            self.error("can't locate '{0}' binary".format(SMBSTATUS))
+            return False
+
+        command = [sudo_binary, '-n', '-l', smbstatus_binary, '-P']
+        smbstatus = '{0} -P'.format(smbstatus_binary)
+        allowed = self._get_raw_data(command=command)
+        if not allowed or allowed[0].strip() != smbstatus:
+            self.error("not allowed to run sudo for command '{0}'".format(smbstatus))
             return False
 
         self.command = ' '.join([sudo_binary, '-n', smbstatus_binary, '-P'])
-
         return ExecutableService.check(self)
 
     def _get_data(self):

--- a/collectors/python.d.plugin/samba/samba.chart.py
+++ b/collectors/python.d.plugin/samba/samba.chart.py
@@ -120,7 +120,7 @@ class Service(ExecutableService):
         command = [sudo_binary, '-n', '-l', smbstatus_binary, '-P']
         smbstatus = '{0} -P'.format(smbstatus_binary)
         allowed = self._get_raw_data(command=command)
-        if not (allowed and allowed[0].strip() != smbstatus):
+        if not (allowed and allowed[0].strip() == smbstatus):
             self.error("not allowed to run sudo for command '{0}'".format(smbstatus))
             return False
 

--- a/collectors/python.d.plugin/samba/samba.chart.py
+++ b/collectors/python.d.plugin/samba/samba.chart.py
@@ -120,7 +120,7 @@ class Service(ExecutableService):
         command = [sudo_binary, '-n', '-l', smbstatus_binary, '-P']
         smbstatus = '{0} -P'.format(smbstatus_binary)
         allowed = self._get_raw_data(command=command)
-        if not allowed or allowed[0].strip() != smbstatus:
+        if not (allowed and allowed[0].strip() != smbstatus):
             self.error("not allowed to run sudo for command '{0}'".format(smbstatus))
             return False
 


### PR DESCRIPTION
### Summary

Fixes: #7651

We want to be sure we are allowed to run command with sudo before executing it.

Old approach:
 - `sudo -v`

Is not good, see https://github.com/netdata/netdata/issues/7651#issuecomment-570163063

After this PR:
 - execute `sudo -n -l COMMAND`, read output, compare output with `COMMAND`


##### Component Name

[`/collectors/python.d.plugin/samba`](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/samba)

##### Additional Information

@camjesus2 could you test it?

- `git clone https://github.com/ilyam8/netdata --branch=samba_check_fix netdata_samba_fix`
- `cd netdata_samba_fix`
- install netdata
- check the dashboard