### PR TITLE
Fix spelling of Prometheus (#7673)

### DIFF
--- a/backends/backends.c
+++ b/backends/backends.c
@@ -439,7 +439,7 @@ BACKEND_TYPE backend_select_type(const char *type) {
         return BACKEND_TYPE_JSON;
     }
     else if (!strcmp(type, "prometheus_remote_write")) {
-        return  BACKEND_TYPE_PROMETEUS;
+        return  BACKEND_TYPE_PROMETHEUS;
     }
     else if (!strcmp(type, "kinesis") || !strcmp(type, "kinesis:plaintext")) {
         return BACKEND_TYPE_KINESIS;
@@ -557,7 +557,7 @@ void *backends_main(void *ptr) {
             backend_set_opentsdb_http_variables(&default_port,&backend_response_checker,&backend_request_formatter);
             break;
         }
-        case BACKEND_TYPE_PROMETEUS: {
+        case BACKEND_TYPE_PROMETHEUS: {
 #if ENABLE_PROMETHEUS_REMOTE_WRITE
             do_prometheus_remote_write = 1;
 

--- a/backends/backends.h
+++ b/backends/backends.h
@@ -21,7 +21,7 @@ typedef enum backend_types {
     BACKEND_TYPE_OPENTSDB_USING_TELNET,     // Send data to OpenTSDB using telnet API
     BACKEND_TYPE_OPENTSDB_USING_HTTP,       // Send data to OpenTSDB using HTTP API
     BACKEND_TYPE_JSON,                      // Stores the data using JSON.
-    BACKEND_TYPE_PROMETEUS,                 // The user selected to use Prometheus backend
+    BACKEND_TYPE_PROMETHEUS,                // The user selected to use Prometheus backend
     BACKEND_TYPE_KINESIS,                   // Send message to AWS Kinesis
     BACKEND_TYPE_MONGODB,                   // Send data to MongoDB collection
     BACKEND_TYPE_NUM                        // Number of backend types

--- a/configure.ac
+++ b/configure.ac
@@ -999,7 +999,7 @@ test "${enable_backend_prometheus_remote_write}" = "yes" -a "${have_CXX_compiler
     AC_MSG_ERROR([C++ compiler required but not found. try installing g++])
 
 AC_MSG_CHECKING([if prometheus remote write backend should be enabled])
-if test "${enable_backend_prometeus_remote_write}" != "no" -a "${have_libprotobuf}" = "yes" -a "${have_libsnappy}" = "yes" \
+if test "${enable_backend_prometheus_remote_write}" != "no" -a "${have_libprotobuf}" = "yes" -a "${have_libsnappy}" = "yes" \
                                                            -a "${have_protoc}" = "yes" -a "${have_CXX_compiler}" = "yes"; then
     enable_backend_prometheus_remote_write="yes"
     AC_DEFINE([ENABLE_PROMETHEUS_REMOTE_WRITE], [1], [Prometheus remote write API usability])

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -150,7 +150,7 @@ BACKEND_TYPE exporting_select_type(const char *type)
     } else if (!strcmp(type, "json") || !strcmp(type, "json:plaintext")) {
         return BACKEND_TYPE_JSON;
     } else if (!strcmp(type, "prometheus_remote_write")) {
-        return BACKEND_TYPE_PROMETEUS;
+        return BACKEND_TYPE_PROMETHEUS;
     } else if (!strcmp(type, "kinesis") || !strcmp(type, "kinesis:plaintext")) {
         return BACKEND_TYPE_KINESIS;
     } else if (!strcmp(type, "mongodb") || !strcmp(type, "mongodb:plaintext"))


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
"Prometheus" was spelled wrong. The misspelling in configure.ac caused #7673
##### Component Name
Prometheus
##### Additional Information

