### PR TITLE
Restore support for protobuf 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ find_library(HAVE_KINESIS aws-cpp-sdk-kinesis)
 # -----------------------------------------------------------------------------
 # Detect libprotobuf
 
-pkg_check_modules(PROTOBUF protobuf>=3.1)
+pkg_check_modules(PROTOBUF protobuf>=3)
 # later we use:
 # ${PROTOBUF_LIBRARIES}
 # ${PROTOBUF_CFLAGS_OTHER}

--- a/backends/prometheus/remote_write/remote_write.cc
+++ b/backends/prometheus/remote_write/remote_write.cc
@@ -98,7 +98,11 @@ void add_metric(const char *name, const char *chart, const char *family, const c
 }
 
 size_t get_write_request_size(){
+#if GOOGLE_PROTOBUF_VERSION < 3001000
+    size_t size = (size_t)snappy::MaxCompressedLength(write_request->ByteSize());
+#else
     size_t size = (size_t)snappy::MaxCompressedLength(write_request->ByteSizeLong());
+#endif
 
     return (size < INT_MAX)?size:0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -932,7 +932,7 @@ AM_CONDITIONAL([ENABLE_BACKEND_KINESIS], [test "${enable_backend_kinesis}" = "ye
 
 PKG_CHECK_MODULES(
     [PROTOBUF],
-    [protobuf >= 3.1],
+    [protobuf >= 3],
     [have_libprotobuf=yes],
     [have_libprotobuf=no]
 )


### PR DESCRIPTION
##### Summary
After #7609, where the protobuf version was restricted to 3.1 and newer, Coverity scan fails because only protobuf 3.0.0 is available for the build. Therefore, we are bringing back support for the old version.

Fixes #7679

##### Component Name
backends