### PR TITLE
Adds a Dockerfile.docs for more easily and reproducibly building/rebuilding docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,6 +39,7 @@ web/gui/ @jacekkolasa @cosmix
 # Ownership by filetype (overwrites ownership by directory)
 *.md @cosmix @joelhans
 *.am @cosmix @Ferroin @knatsakis @ncmans @prologic
+Dockerfile.* @Ferroin @knatsakis @ncmans @prologic @cosmix
 
 # Ownership of specific files
 .gitignore @cosmix @Ferroin @knatsakis @ncmans @prologic
@@ -49,6 +50,7 @@ web/gui/ @jacekkolasa @cosmix
 .csslintrc @cosmix @Ferroin @knatsakis @ncmans @prologic
 .codeclimate.yml @cosmix @Ferroin @knatsakis @ncmans @prologic
 .codacy.yml @cosmix @Ferroin @knatsakis @ncmans @prologic
+Dockerfile @Ferroin @knatsakis @ncmans @prologic @cosmix
 netdata.spec.in @cosmix @Ferroin @knatsakis @ncmans @prologic
 netdata-installer.sh @cosmix @Ferroin @knatsakis @ncmans @prologic
 netlify.toml @cosmix

--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,0 +1,26 @@
+ARG PYVER=3.8
+
+FROM python:${PYVER}-alpine
+
+WORKDIR /netdata
+
+# These scripts use Bash(ism) so install Bash
+# TODO: Maybe rewrite the link checker in something more sane
+RUN apk add --no-cache -U bash
+
+# The scripts also clone the netdata/netdata repo using git
+# TODO: Maybe also optionally support bind-mounted sources
+RUN apk add --no-cache -U git
+
+# The scripts also use GNU find options
+RUN apk add --no-cache -U findutils
+
+# Copy and Install build dependencies first to cache them so we don't have to
+# do this every single time we want to rebuild the docs. The cache is busted
+# when/if the SHA of the requirements.txt is changed.
+COPY docs/generator /netdata/docs/generator
+RUN pip install -r /netdata/docs/generator/requirements.txt
+
+COPY . .
+
+CMD ["/netdata/docs/generator/buildhtml.sh"]

--- a/docs/contributing/contributing-documentation.md
+++ b/docs/contributing/contributing-documentation.md
@@ -131,10 +131,21 @@ reason.
 Building the documentation periodically gives you a glimpse into the final product, and is generally required if you're
 making changes to the table of contents.
 
-!!! attention "" We have only tested the build process on Linux. Initial tests on OS X have been unsuccessful. Windows
-    is fully untested at this point, but we would love to know if it works there as well!
+We have a [netdata/docs Docker Image](https://hub.docker.com/r/netdata/os-test) available on the Docker Hub
+that greatly simplifies building the documentation on any [Docker](https://www.docker.com) supported platform.
 
-To build the documentation, you need `python`/`pip`, `mkdocs`, and `mkdocs-material` installed on your machine.
+To build the docs using this image via Docker simply run the following commands in your shell:
+
+```bash
+cd /path/to/netdata
+docker run -i -t -v $PWD:/netdata netdata/docs
+```
+
+----
+
+if you are using a GNU/Linux based system for developing / contribiting to our documentation, you may build the
+docs with the provided Shell scripts in `./docs/generator/buildhtml.sh`. This requires GNU Bash and findutils
+as well as Python/pip and some Python packages `mkdocs` and `mkdocs-material` installed in your environment.
 
 Follow the [Python installation instructions](https://www.python.org/downloads/) for your machine.
 


### PR DESCRIPTION
This is part of a larger body of work related to CI/CD in general where we have decided to use [Docker](https://www.docker.com) to facilitate easier packaging, builds and reproducibility. This PR introduces a new `Dockerfile` specifically for building our documentation.

The intention is to publish this image to our [NetData Docker Hub Org](https://hub.docker.com/netdata) so other maintainers/contributors can also more easily and quickly get going on contributing to our docs.