### PR TITLE
Fix PR labeling.

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,16 +2,14 @@
 # Handles labelling of PR's.
 name: Pull Request Labeler
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronized
-      - reopened
-      - ready_for_review
+  schedule:
+    - cron: '*/5 * * * *'
 jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v2
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: paulfantom/periodic-labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository
+          LABEL_MAPPING_FILE: .github/labeler.yml


### PR DESCRIPTION
##### Summary

Due to how GitHub Actions operate, PR's originating from forks who's owners do not have write access to the repo do not get labeled by the official labeler action.

This switches to using [paulfantom/periodic-labeler](https://github.com/marketplace/actions/periodic-labeler) instead of the official labeler action, which sidesteps this issue by instead checking all open PR's every 5 minutes and applying labels through the regular API.

##### Component Name

area/ci

##### Additional Information

Longer term, I intend to look into properly resolving this issue so that we can just use the official labeler action, but for now I'm just trying to get things working ASAP.