### PR TITLE
Fix PR labeling GitHub Action.

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/labeler@v2
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ secrets.NETDATABOT_TOKEN }}"


### PR DESCRIPTION
##### Summary

This updates the access token in the labeler action to use permissions of the netdatabot account instead of using the generic access token provided by GitHub.

This allows the labeling to work correctly even for forks owned by people who do not have write access to the repo.

##### Component Name

area/ci