### PR TITLE
General fixes to the installer.

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -332,7 +332,7 @@ install_non_systemd_init() {
 
 NETDATA_START_CMD="netdata"
 NETDATA_STOP_CMD="killall netdata"
-NETDATA_INSTALLER_START_CMD="${NETDATA_START_CMD}"
+NETDATA_INSTALLER_START_CMD=""
 NETDATA_INSTALLER_STOP_CMD="${NETDATA_STOP_CMD}"
 
 install_netdata_service() {
@@ -512,6 +512,10 @@ restart_netdata() {
 	local started=0
 
 	progress "Restarting netdata instance"
+
+	if [ -z "${NETDATA_INSTALLER_START_CMD}" ] ; then
+		NETDATA_INSTALLER_START_CMD="${netdata}"
+	fi
 
 	if [ "${UID}" -eq 0 ]; then
 		echo >&2

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -631,7 +631,7 @@ portable_add_user() {
 	echo >&2 "Adding ${username} user account with home ${homedir} ..."
 
 	# shellcheck disable=SC2230
-	local nologin="$(command -v nologin >/dev/null 2>&1 || echo '/bin/false')"
+	local nologin="$(command -v nologin || echo '/bin/false')"
 
 	# Linux
 	if command -v useradd 1>/dev/null 2>&1; then


### PR DESCRIPTION
##### Summary

This includes a couple of simple quality of life fixes for the installer. It ensures that we try to start netdata from the location it was installed to, as well as making the detection of where the `nologin` command is work correctly.

##### Component Name

area/packaging

##### Additional Information

Fixes: #7692 
Fixes: #7687

@thiagoftsm 