### PR TITLE
Make auto-updates work on kickstart-static64 installs.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -93,16 +93,12 @@ printf 'LDFLAGS="%s" ' "${LDFLAGS}" >>netdata-installer.log
 printf "%q " "${PROGRAM}" "${@}" >>netdata-installer.log
 printf "\\n" >>netdata-installer.log
 
-REINSTALL_COMMAND="$(
-	printf "%q " "${PROGRAM}" "${@}"
+REINSTALL_OPTIONS="$(
+	printf "%s" "${*}"
 	printf "\\n"
 )"
 # remove options that shown not be inherited by netdata-updater.sh
-REINSTALL_COMMAND="${REINSTALL_COMMAND// --dont-wait/}"
-REINSTALL_COMMAND="${REINSTALL_COMMAND// --dont-start-it/}"
-if [ "${REINSTALL_COMMAND:0:1}" != "." ] && [ "${REINSTALL_COMMAND:0:1}" != "/" ] && [ -f "./${PROGRAM}" ]; then
-	REINSTALL_COMMAND="./${REINSTALL_COMMAND}"
-fi
+REINSTALL_OPTIONS="$(echo "${REINSTALL_OPTIONS}" | sed 's/--dont-wait//g' - | sed 's/--dont-start-it//g' -)"
 
 banner_nonroot_install() {
 	cat <<NONROOTNOPREFIX
@@ -1099,7 +1095,7 @@ NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS}"
 NETDATA_ADDED_TO_GROUPS="${NETDATA_ADDED_TO_GROUPS}"
 INSTALL_UID="${UID}"
 NETDATA_GROUP="${NETDATA_GROUP}"
-REINSTALL_COMMAND="${REINSTALL_COMMAND}"
+REINSTALL_OPTIONS="${REINSTALL_OPTIONS}"
 RELEASE_CHANNEL="${RELEASE_CHANNEL}"
 IS_NETDATA_STATIC_BINARY="${IS_NETDATA_STATIC_BINARY}"
 NETDATA_LIB_DIR="${NETDATA_LIB_DIR}"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -98,7 +98,7 @@ REINSTALL_OPTIONS="$(
 	printf "\\n"
 )"
 # remove options that shown not be inherited by netdata-updater.sh
-REINSTALL_OPTIONS="$(echo "${REINSTALL_OPTIONS}" | sed 's/--dont-wait//g' - | sed 's/--dont-start-it//g' -)"
+REINSTALL_OPTIONS="$(echo "${REINSTALL_OPTIONS}" | sed 's/--dont-wait//g' | sed 's/--dont-start-it//g')"
 
 banner_nonroot_install() {
 	cat <<NONROOTNOPREFIX

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -116,7 +116,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "23e0f38dfb9d517be16393c3ed1f88bd" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "38b810272e9741ccb4827804484c043d" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -153,6 +153,7 @@ sh /tmp/kickstart-static64.sh
 -   The static binary files are kept in repo [binary-packages](https://github.com/netdata/binary-packages). You can download any of the `.run` files, and run it. These files are self-extracting shell scripts built with [makeself](https://github.com/megastep/makeself).
 -   The target system does **not** need to have bash installed.
 -   The same files can be used for updates too.
+-   If the `--local-files` option was not specified, installs `netdata-updater.sh` to `cron.daily`, so your Netdata installation will be updated daily (you will get a message from cron only if the update fails).
 -   For QA purposes, this installation method lets us know if it succeed or failed.
 
 </details>

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -116,7 +116,7 @@ This script installs Netdata at `/opt/netdata`.
 Verify the integrity of the script with this:
 
 ```bash
-[ "38b810272e9741ccb4827804484c043d" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "9e0901736a8ed5ebcc84bc1c2c7b5db9" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 *It should print `OK, VALID` if the script is the one we ship.*

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -207,6 +207,7 @@ while [ -n "${1}" ]; do
 		NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS:+${NETDATA_INSTALLER_OPTIONS} }${1}"
 		shift 1
 	elif [ "${1}" = "--local-files" ]; then
+		NETDATA_UPDATES="" # Disable autoupdates if using pre-downloaded files.
 		shift 1
 		if [ -z "${1}" ]; then
 			fatal "Option --local-files requires extra information. The desired tarball full filename is needed"

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -197,6 +197,8 @@ while [ -n "${1}" ]; do
 	elif [ "${1}" = "--no-updates" ]; then
 		NETDATA_UPDATES=""
 		shift 1
+	elif [ "${1}" = "--auto-update" ]; then
+		true # This is the default behaviour, so ignore it.
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
 		NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS:+${NETDATA_INSTALLER_OPTIONS} }${1}"

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -199,6 +199,7 @@ while [ -n "${1}" ]; do
 		shift 1
 	elif [ "${1}" = "--auto-update" ]; then
 		true # This is the default behaviour, so ignore it.
+		shift 1
 	elif [ "${1}" = "--stable-channel" ]; then
 		RELEASE_CHANNEL="stable"
 		NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS:+${NETDATA_INSTALLER_OPTIONS} }${1}"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -8,7 +8,7 @@
 #  - CFLAGS
 #  - LDFLAGS
 #  - NETDATA_CONFIGURE_OPTIONS
-#  - REINSTALL_COMMAND
+#  - REINSTALL_OPTIONS
 #  - NETDATA_TARBALL_URL
 #  - NETDATA_TARBALL_CHECKSUM_URL
 #  - NETDATA_TARBALL_CHECKSUM
@@ -141,8 +141,9 @@ update() {
 			do_not_start="--dont-start-it"
 		fi
 
+		echo "${REINSTALL_OPTIONS}"
 		info "Re-installing netdata..."
-		eval "${REINSTALL_COMMAND} --dont-wait ${do_not_start}" >&3 2>&3 || fatal "FAILED TO COMPILE/INSTALL NETDATA"
+		eval "./netdata-installer.sh ${REINSTALL_OPTIONS} --dont-wait ${do_not_start}" >&3 2>&3 || fatal "FAILED TO COMPILE/INSTALL NETDATA"
 
 		# We no longer store checksum info here. but leave this so that we clean up all environment files upon next update.
 		sed -i '/NETDATA_TARBALL/d' "${ENVIRONMENT_FILE}"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -7,6 +7,7 @@
 #  - PATH
 #  - CFLAGS
 #  - LDFLAGS
+#  - IS_NETDATA_STATIC_BINARY
 #  - NETDATA_CONFIGURE_OPTIONS
 #  - REINSTALL_OPTIONS
 #  - NETDATA_TARBALL_URL
@@ -202,7 +203,7 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
 	fi
 
 	# Do not pass any options other than the accept, for now
-	sh "${TMPDIR}/netdata-latest.gz.run" --accept
+	sh "${TMPDIR}/netdata-latest.gz.run" --accept ${REINSTALL_OPTIONS}
 
 	#shellcheck disable=SC2181
 	if [ $? -eq 0 ]; then

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -25,15 +25,31 @@ fi
 
 STARTIT=1
 AUTOUPDATE=0
+REINSTALL_OPTIONS=""
 RELEASE_CHANNEL="nightly" # check .travis/create_artifacts.sh before modifying
 
 while [ "${1}" ]; do
 	case "${1}" in
-		"--dont-start-it") STARTIT=0;;
-		"--auto-update"|"-u") AUTOUPDATE=1;;
-		"--stable-channel") RELEASE_CHANNEL="stable";;
-		"--nightly-channel") RELEASE_CHANNEL="nightly";;
-		"--disable-telemetry") DISABLE_TELEMETRY=1;;
+		"--dont-start-it")
+			STARTIT=0
+			REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1}"
+			;;
+		"--auto-update"|"-u")
+			AUTOUPDATE=1
+			REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1}"
+			;;
+		"--stable-channel")
+			RELEASE_CHANNEL="stable"
+			REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1}"
+			;;
+		"--nightly-channel")
+			RELEASE_CHANNEL="nightly"
+			REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1}"
+			;;
+		"--disable-telemetry")
+			DISABLE_TELEMETRY=1
+			REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1}"
+			;;
 
 		*) echo >&2 "Unknown option '${1}'. Ignoring it.";;
 	esac
@@ -241,6 +257,11 @@ then
     run chmod 4750 bin/fping
 fi
 
+# -----------------------------------------------------------------------------
+
+echo "Save install options"
+grep -qv 'IS_NETDATA_STATIC_BINARY="yes"' "${NETDATA_PREFIX}/etc/netdata/.environment" || echo IS_NETDATA_STATIC_BINARY=\"yes\" >> "${NETDATA_PREFIX}/etc/netdata/.environment"
+sed -i "s/REINSTALL_OPTIONS=\".*\"/REINSTALL_OPTIONS=\"${REINSTALL_OPTIONS}\"/" "${NETDATA_PREFIX}/etc/netdata/.environment"
 
 # -----------------------------------------------------------------------------
 if [ ${STARTIT} -eq 0 ]; then


### PR DESCRIPTION
##### Summary

This PR makes auto-updating work correctly for installations done using the `kickstart-static64.sh` installer.

It consists of two logical parts:

1. Update handling of the `.environment` file to store only the options to be used for reinstallation instead of the full command. We currently only have two possible 'commands', and they are trivially differentiated based on whether the install is with `kickstart.sh` or `kickstart-static64.sh`, so we don't really need to store the command that was used.
2. Actually enable the currently dead code in `netdata-updater.sh` that handles the case of static installs, and adds some extra support code to make it work correctly.

##### Component Name

area/packaging

##### Additional Information

Fixes: #7197 
Fixes: #7198 

Minimally tested so far (passes CI lifecycle checks without issue), will mark ready for review once more rigorous testing is finished.