### PR TITLE
litespeed: add support for different .rtreport format

### DIFF
--- a/collectors/python.d.plugin/litespeed/litespeed.chart.py
+++ b/collectors/python.d.plugin/litespeed/litespeed.chart.py
@@ -178,7 +178,7 @@ class Service(SimpleService):
 
 def parse_file(data, lines):
     for line in lines:
-        if not line.startswith(('BPS_IN:', 'MAXCONN:', 'REQ_RATE []:')):
+        if not line.startswith(('BPS_IN:', 'MAXCONN:', 'PLAINCONN:', 'REQ_RATE []:')):
             continue
         m = dict(RE.findall(line))
         for v in T:


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Add support for different .rtreport format

Some .rtreport files do not contain `MAXCONN` and `MAXSSL_CONN` variables, but simply list the in use connections.

This PR adds support for this by looking for lines starting with `PLAINCONN:` as well.

##### Component Name

python.d litespeed

##### Additional Information

I'm ops @ LiteSpeed Technologies