### PR TITLE
Control introduction of new languages in docs translation

### DIFF
--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -91,7 +91,7 @@ prep_html() {
 
 }
 
-for d in "en" $(find ${LOC_DIR} -mindepth 1 -maxdepth 1 -name .git -prune -o -type d -printf '%f ') ; do
+for d in "en" "zh" "pt" ; do
 	echo "Preparing source for $d"
 	cp -r ${SRC_DIR} ${DOCS_DIR}
 	if [ "${d}" != "en" ] ; then


### PR DESCRIPTION
##### Summary
Explicitly specify which translations to include in the docs localization options.
We need that in order to run a proper test of a new language, before we show the option for it. 
Previously, we automatically added any new languages present in the netdata/localization project, without ensuring that:
- An option for the language appears on the language selection menu
- The links in the new language are valid (`checklinks.sh` script)

##### Component Name
docs

##### Additional Information
Pre-requisite to add support for the Korean translations in https://github.com/netdata/localization/pull/25
