### PR TITLE
Add Korean translation to docs

### DIFF
--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -91,7 +91,7 @@ prep_html() {
 
 }
 
-for d in "en" "zh" "pt" ; do
+for d in "en" "kr" "zh" "pt" ; do
 	echo "Preparing source for $d"
 	cp -r ${SRC_DIR} ${DOCS_DIR}
 	if [ "${d}" != "en" ] ; then

--- a/docs/generator/custom/themes/material/partials/header.html
+++ b/docs/generator/custom/themes/material/partials/header.html
@@ -93,6 +93,7 @@
           <option href="#" value='en'>English</option>
           <option href="#" value='zh'>中文</option>
           <option href="#" value='pt'>Portugues-Brasil</option>
+          <option href="#" value='kr'>한국어</option>
         </select>
       </div>
 


### PR DESCRIPTION
##### Summary
Thanks to @wonsangki we have some docs translated to Korean in https://github.com/netdata/localization/pull/25
This PR adds those pages to docs.netdata.cloud

##### Component Name
docs

##### Additional Information
Verified locally that we have no broken links, the translation itself will need to be checked.
