### PR TITLE
Cleanup packaging/makeself/build-x86_64-static.sh to use /bin/sh and remove use of sudo

### DIFF
--- a/packaging/makeself/build-x86_64-static.sh
+++ b/packaging/makeself/build-x86_64-static.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
+
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 . $(dirname "$0")/../installer/functions.sh || exit 1
@@ -7,36 +8,34 @@ set -e
 
 DOCKER_CONTAINER_NAME="netdata-package-x86_64-static-alpine37"
 
-if ! sudo docker inspect "${DOCKER_CONTAINER_NAME}" >/dev/null 2>&1
-then
+if ! docker inspect "${DOCKER_CONTAINER_NAME}" >/dev/null 2>&1; then
     # To run interactively:
-    #   sudo docker run -it netdata-package-x86_64-static /bin/sh
+    #   docker run -it netdata-package-x86_64-static /bin/sh
     # (add -v host-dir:guest-dir:rw arguments to mount volumes)
     #
     # To remove images in order to re-create:
-    #   sudo docker rm -v $(sudo docker ps -a -q -f status=exited)
-    #   sudo docker rmi netdata-package-x86_64-static
+    #   docker rm -v $(sudo docker ps -a -q -f status=exited)
+    #   docker rmi netdata-package-x86_64-static
     #
     # This command maps the current directory to
     #   /usr/src/netdata.git
     # inside the container and runs the script install-alpine-packages.sh
     # (also inside the container)
     #
-    run sudo docker run -v $(pwd):/usr/src/netdata.git:rw alpine:3.7 \
+    run docker run -v $(pwd):/usr/src/netdata.git:rw alpine:3.7 \
         /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh
 
     # save the changes made permanently
-    id=$(sudo docker ps -l -q)
-    run sudo docker commit ${id} "${DOCKER_CONTAINER_NAME}"
+    id=$(docker ps -l -q)
+    run docker commit ${id} "${DOCKER_CONTAINER_NAME}"
 fi
 
 # Run the build script inside the container
-run sudo docker run -a stdin -a stdout -a stderr -i -t -v \
+run docker run -a stdin -a stdout -a stderr -i -t -v \
     $(pwd):/usr/src/netdata.git:rw \
     "${DOCKER_CONTAINER_NAME}" \
     /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
 
-if [ "${USER}" ]
-    then
-    sudo chown -R "${USER}" .
+if [ "${USER}" ]; then
+    chown -R "${USER}" .
 fi


### PR DESCRIPTION
##### Summary

This is just a little PR to cleanup and remove the use of `sudo` of the script used to build/rebuild the self-extracting tarballs we use in the `kickstart-static64.sh` installer.

Couple of things here:

- Use POSIX Sh here `#!/bin/sh` as we're not really using any Bash(isms) anyway and its a simple script
- Remove the use of `sudo`; mostly used in `sudo docker ...` which is not necessary as typically you would have read/write permissions to the Docker daemon UNIX socket on your system (_if you don't; you should!_)
  - One less thing run as root

##### Component Name

Packaging

##### Additional Information

On first run (_wasn't able to repro again_) `tar` complains it cannot find `bash-4.18.4/ChangeLog` despite it actually being available on the file system when this script is executed.