### PR TITLE
Filter out lxc cgroups which are not useful

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -251,6 +251,9 @@ void read_cgroup_plugin_configuration() {
                     " !/libvirt "
                     " !/lxc "
                     " !/lxc/*/* "                          //  #1397 #2649
+                    " !/lxc.monitor "
+                    " !/lxc.pivot "
+                    " !/lxc.payload "
                     " !/machine "
                     " !/qemu "
                     " !/system "
@@ -270,6 +273,8 @@ void read_cgroup_plugin_configuration() {
                     " !/user "
                     " !/user.slice "
                     " !/lxc/*/* "                          //  #2161 #2649
+                    " !/lxc.monitor "
+                    " !/lxc.payload/*/* "
                     " * "
             ), NULL, SIMPLE_PATTERN_EXACT);
 


### PR DESCRIPTION
##### Summary
Since LXC 3.1.0 there are new directories in lxc hierarchy - `lxc.monitor`, `lxc.payload`, and `lxc.pivot` instead of `lxc`. We need to filter out unuseful directories and containers.

Fixes #6481

##### Component Name
cgroups plugin