### PR TITLE
Fix the formatting of the trailer line in the Debian changelog template.

### DIFF
--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -2,5 +2,5 @@ netdata (PREVIOUS_PACKAGE_VERSION) unstable; urgency=medium
 
   * Initial Release
 
--- Netdata Builder <bot@netdata.cloud>  PREVIOUS_PACKAGE_DATE
+ -- Netdata Builder <bot@netdata.cloud>  PREVIOUS_PACKAGE_DATE
 


### PR DESCRIPTION
##### Summary

As per the [Debian Policy Manual, section 4, sub-section 4](https://www.debian.org/doc/debian-policy/ch-source.html#s-dpkgchangelog), the trailer line containing the maintainer information and the date in the changelog file must have a single space preceding the two dashes that mark the start of the line.

This fixes warnings in the package build process, as well as enabling the builds to work with older more pedantic versions of dpkg-buildpackage.

##### Component Name

area/packaging

##### Additional Information

This is required for successful builds on Ubuntu 18.04 and 16.04 with the new package builder images added by https://github.com/netdata/helper-images/pull/32