### PR TITLE
Add an environment variable check to Travis configuration to allow disabling nightlies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,16 +47,16 @@ stages:
   - name: Build process
   - name: Artifacts validation
   - name: Artifacts validation on bare OS, stable to current lifecycle checks
-    if: branch = master AND (type = pull_request OR type = cron)
+    if: branch = master AND (type = pull_request OR (type = cron AND env(RUN_NIGHTLY) = yes))
 
     # Nightly operations
   - name: Nightly operations
-    if: branch = master AND type = cron
+    if: branch = master AND type = cron AND env(RUN_NIGHTLY) = yes
 
   - name: Nightly release
-    if: branch = master AND type = cron
+    if: branch = master AND type = cron AND env(RUN_NIGHTLY) = yes
   - name: Trigger deb and rpm package build (nightly release)
-    if: branch = master AND type = cron
+    if: branch = master AND type = cron AND env(RUN_NIGHTLY) = yes
 
     # Scheduled releases
   - name: Support activities on main branch


### PR DESCRIPTION
##### Summary

This allows us to control whether nightly builds run based on the presence or absence of an environment variable, instead of requiring us to remove and then re-add a scheduled build job. The primary advantage to using this approach is that nightlies will run at the same time each day, instead of moving to whenever they happen to be re-enabled.

The variable in question is named `RUN_NIGHTLY`, and must be defined with a value of 'yes' for nightly builds to run.

When this is merged, I will open a PR to update the release process documentation to reflect this change.

##### Component Name

area/ci

##### Additional Information

When an environment variable is not present, Travis will expand it to an empty string just like POSIX sh does, thus ensuring the check will fail if the environment variable is not defined.