### PR TITLE
Limit PR labeler runs to the main repo.

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: paulfantom/periodic-labeler@master
+        if: github.repository == 'netdata/netdata'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
##### Summary

This limits runs of the PR labeler to the main repo only, which should cut down on noise people get from GitHub.

##### Component Name

area/ci

##### Additional Information

Tested on personal fork that this prevents the labeler from actually trying to do anything, as well as verifying that it does indeed match repos correctly.