### PR TITLE
Fix notification report

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -435,7 +435,6 @@ filter_recipient_by_criticality() {
 		if [ -f "${NETDATA_CACHE_DIR}/alarm-notify/${method}/${r}/${alarm_id}" ]; then
 			# we do not remove the file, so that he will get future notifications of this alarm
 			debug "SEVERITY FILTERING for ${x} VIA ${method}: ALLOW: recipient has been notified for this alarm in the past (will still receive next status change)"
-			return 0
 		fi
 		;;
 
@@ -444,7 +443,6 @@ filter_recipient_by_criticality() {
 			# remove the file, so that he will only receive notifications for CRITICAL states for this alarm
 			rm "${NETDATA_CACHE_DIR}/alarm-notify/${method}/${r}/${alarm_id}"
 			debug "SEVERITY FILTERING for ${x} VIA ${method}: ALLOW: recipient has been notified for this alarm (will only receive CRITICAL notifications from now on)"
-			return 0
 		fi
 		;;
 	esac


### PR DESCRIPTION
##### Summary
Fixes #7756 

According with our `health_alarm_notify.conf ` when we append `|critical` to notification, Netdata will  send only `critical` events for the users, but sometimes this was not happening when the `ROLE` was set to `root`. This PR fixes this problem.
##### Component Name
Health ( Alarm notify)
##### Additional Information
I used Slack to replicate the error, my configuration was:

```
SEND_SLACK="YES"
SLACK_WEBHOOK_URL="https://hooks.slack.com/services/X/Y/Z"
DEFAULT_RECIPIENT_SLACK="myalarms|critical"
```

And I used the following alarm:

```
 alarm: fix_or
    on: example.random
lookup: average -3s at 0 every 3
 units: %
 every: 1s
  warn: $this > 20
  crit: $this > 120 
```

When we use the master branch I received `warning` and 'critical` events on Slack, but with this PR I began to receive only `critical.