### PR TITLE
Add a missing parameter to the allmetrics endpoint in Swagger Editor

### DIFF
--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -562,6 +562,20 @@
             }
           },
           {
+            "name": "variables",
+            "in": "query",
+            "description": "When enabled, netdata will expose various system configuration metrics.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "yes",
+                "no"
+              ],
+              "default": "no"
+            }
+          },
+          {
             "name": "help",
             "in": "query",
             "description": "Enable or disable HELP lines in prometheus output.",

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -481,6 +481,17 @@ paths:
               - prometheus_all_hosts
               - json
             default: shell
+        - name: variables
+          in: query
+          description: When enabled, netdata will expose various system
+            configuration metrics.
+          required: false
+          schema:
+            type: string
+            enum:
+              - yes
+              - no
+            default: no
         - name: help
           in: query
           description: Enable or disable HELP lines in prometheus output.


### PR DESCRIPTION
##### Summary
The [`variables`](https://docs.netdata.cloud/backends/prometheus/#netdata-host-variables) parameter in the `/api/v1/allmetrics` call was missing from the API documentation in the Swagger Editor.

##### Component Name
web API