### PR TITLE
Fix libuv IPC pipe cleanup problem

### DIFF
--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -540,6 +540,7 @@ error_after_pipe_bind:
 error_after_pipe_init:
     uv_close((uv_handle_t *)&async, NULL);
 error_after_async_init:
+    uv_run(loop, UV_RUN_DEFAULT);
     assert(0 == uv_loop_close(loop));
 error_after_loop_init:
     freez(loop);
@@ -587,7 +588,7 @@ void commands_init(void)
     return;
 
 after_error:
-    error("Failed to initialize command server.");
+    error("Failed to initialize command server. The netdata cli tool will be unable to send commands.");
 }
 
 void commands_exit(void)

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -526,7 +526,7 @@ static void command_thread(void *arg)
     info("Shutting down command event loop.");
     uv_close((uv_handle_t *)&async, NULL);
     uv_close((uv_handle_t*)&server_pipe, NULL);
-    uv_run(loop, UV_RUN_DEFAULT);
+    uv_run(loop, UV_RUN_DEFAULT); /* flush all libuv handles */
 
     info("Shutting down command loop complete.");
     assert(0 == uv_loop_close(loop));
@@ -540,7 +540,7 @@ error_after_pipe_bind:
 error_after_pipe_init:
     uv_close((uv_handle_t *)&async, NULL);
 error_after_async_init:
-    uv_run(loop, UV_RUN_DEFAULT);
+    uv_run(loop, UV_RUN_DEFAULT); /* flush all libuv handles */
     assert(0 == uv_loop_close(loop));
 error_after_loop_init:
     freez(loop);

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -376,6 +376,7 @@ if [ -n "${NETDATA_PREFIX}" ] && [ -d "${NETDATA_PREFIX}" ]; then
 else
 	rm_file "/usr/sbin/netdata"
 	rm_file "/usr/sbin/netdatacli"
+	rm_file "/tmp/netdata-ipc"
 	rm_file "/usr/sbin/netdata-claim.sh"
 	rm_dir "/usr/share/netdata"
 	rm_dir "/usr/libexec/netdata"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

Fixes #7734 

When netdata fails to delete any pre-existing unix domain sockets due to permission or other reasons it should gracefully disable the command server. Moreover, the uninstaller should help clean up given sufficient permission.