### PR TITLE
Remove unnessecary `echo` call in updater.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -142,7 +142,6 @@ update() {
 			do_not_start="--dont-start-it"
 		fi
 
-		echo "${REINSTALL_OPTIONS}"
 		info "Re-installing netdata..."
 		eval "./netdata-installer.sh ${REINSTALL_OPTIONS} --dont-wait ${do_not_start}" >&3 2>&3 || fatal "FAILED TO COMPILE/INSTALL NETDATA"
 


### PR DESCRIPTION
##### Summary

This was left over from testing, and I forgot to remove it before merging the changes needed to make the updater work for static installs.

##### Component Name

area/packaging

##### Additional Information

Fixes: #7779 