### PR TITLE
Fix unit tests for the exporting engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -969,6 +969,7 @@ if(BUILD_TESTING)
         -Wl,--wrap=notify_workers
         -Wl,--wrap=send_internal_metrics
         -Wl,--wrap=now_realtime_sec
+        -Wl,--wrap=uv_thread_set_name_np
         -Wl,--wrap=uv_thread_create
         -Wl,--wrap=uv_mutex_lock
         -Wl,--wrap=uv_mutex_unlock

--- a/Makefile.am
+++ b/Makefile.am
@@ -790,6 +790,7 @@ if ENABLE_UNITTESTS
         -Wl,--wrap=notify_workers \
         -Wl,--wrap=send_internal_metrics \
         -Wl,--wrap=now_realtime_sec \
+        -Wl,--wrap=uv_thread_set_name_np \
         -Wl,--wrap=uv_thread_create \
         -Wl,--wrap=uv_mutex_lock \
         -Wl,--wrap=uv_mutex_unlock \

--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -14,7 +14,6 @@
 int init_connectors(struct engine *engine)
 {
     engine->now = now_realtime_sec();
-
     for (struct connector *connector = engine->connector_root; connector; connector = connector->next) {
         switch (connector->config.type) {
             case BACKEND_TYPE_GRAPHITE:

--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -14,6 +14,7 @@
 int init_connectors(struct engine *engine)
 {
     engine->now = now_realtime_sec();
+
     for (struct connector *connector = engine->connector_root; connector; connector = connector->next) {
         switch (connector->config.type) {
             case BACKEND_TYPE_GRAPHITE:

--- a/exporting/tests/netdata_doubles.c
+++ b/exporting/tests/netdata_doubles.c
@@ -17,6 +17,14 @@ time_t __wrap_now_realtime_sec(void)
     return mock_type(time_t);
 }
 
+void __wrap_uv_thread_set_name_np(uv_thread_t ut, const char* name)
+{
+    (void)ut;
+    (void)name;
+
+    function_called();
+}
+
 void __wrap_info_int(const char *file, const char *function, const unsigned long line, const char *fmt, ...)
 {
     (void)file;

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -25,6 +25,8 @@ void init_connectors_in_tests(struct engine *engine)
     expect_value(__wrap_uv_thread_create, worker, simple_connector_worker);
     expect_value(__wrap_uv_thread_create, arg, engine->connector_root->instance_root);
 
+    expect_function_call(__wrap_uv_thread_set_name_np);
+
     assert_int_equal(__real_init_connectors(engine), 0);
 
     assert_int_equal(engine->now, 2);


### PR DESCRIPTION
##### Summary
#7584 broke unit tests for the exporting engine. We should wrap `uv_thread_set_name_np` to make the tests work again. 

##### Component Name
exporting engine