### PR TITLE
Test shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,8 +98,10 @@ jobs:
       # Do code quality, syntax checking and other pre-build activities
     - stage: Code quality, linting, syntax, code style
 
-      name: Run shellchecking on BASH
-      script: shellcheck --format=gcc $(find . -name '*.sh.in' -not -iwholename '*.git*')
+      name: Run shellchecking on Shell Scripts
+      script:
+        - shellcheck --format=gcc $(find . -name '*.sh.in' -not -iwholename '*.git*')
+        - shellcheck --format=gcc $(find . -name '*.sh' -not -iwholename '*.git*')
 
       # Check if any of the C code deviates from our coding style
     - name: Check coding style
@@ -148,6 +150,10 @@ jobs:
       after_script: rm -rf /tmp/netdata-makedist-test
       after_failure: post_message "TRAVIS_MESSAGE" "'make dist' failed"
 
+
+    - name: Re-check Shell Scriopts (after build) with shellcheck
+      script:
+        - shellcheck --format=gcc $(find . -name '*.sh' -not -iwholename '*.git*')
 
 
     - stage: Artifacts validation

--- a/rubbish-shell-scriopt.sh
+++ b/rubbish-shell-scriopt.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# XXX: Confirming we don't do `shellcheck` on shell scripts (Re: #7770)
+
+if [ -z x"FOO' == ]; then
+  echo "..."
+fi


### PR DESCRIPTION
This should fail CI with:

_somewhere_

```sh
$ shellcheck rubbish-shell-scriopt.sh

In rubbish-shell-scriopt.sh line 5:
if [ -z x"FOO' == ]; then
   ^-- SC1009: The mentioned syntax error was in this test expression.
        ^-- SC1019: Expected this to be an argument to the unary condition.


In rubbish-shell-scriopt.sh line 6:
  echo "..."
           ^-- SC1073: Couldn't parse this double quoted string. Fix to allow more checks.


In rubbish-shell-scriopt.sh line 8:

^-- SC1072: Expected end of double quoted string. Fix any mentioned problems and try again.

For more information:
  https://www.shellcheck.net/wiki/SC1019 -- Expected this to be an argument t...
  https://www.shellcheck.net/wiki/SC1072 -- Expected end of double quoted str...
  https://www.shellcheck.net/wiki/SC1073 -- Couldn't parse this double quoted...
```