### PR TITLE
Fixes shellcheck in CI for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,8 +98,10 @@ jobs:
       # Do code quality, syntax checking and other pre-build activities
     - stage: Code quality, linting, syntax, code style
 
-      name: Run shellchecking on BASH
-      script: shellcheck --format=gcc $(find . -name '*.sh.in' -not -iwholename '*.git*')
+      name: Run shellchecking on Shell Scripts
+      script:
+        - shellcheck --format=gcc $(find . -name '*.sh.in' -not -iwholename '*.git*')
+        - shellcheck --format=gcc $(find . -name '*.sh' -not -iwholename '*.git*')
 
       # Check if any of the C code deviates from our coding style
     - name: Check coding style
@@ -148,6 +150,10 @@ jobs:
       after_script: rm -rf /tmp/netdata-makedist-test
       after_failure: post_message "TRAVIS_MESSAGE" "'make dist' failed"
 
+
+    - name: Re-check Shell Scripts (after build) with shellcheck
+      script:
+        - shellcheck --format=gcc $(find . -name '*.sh' -not -iwholename '*.git*')
 
 
     - stage: Artifacts validation


### PR DESCRIPTION
##### Summary

Fixes running `shellcheck` in PR(s) in CI confirmed in #7488 and #7787 and found by @thiagoftsm 

This _may_ not be 100% correct here; but the rationale is:

- Check all `*.sh` and `*.sh.in` shell scripts.
- Check all `*.sh` shell scripts against after the build process.

The scripts in `*.sh.in` are templated; so we check them twice.

##### Component Name

area/ci

##### Additional Information

