### PR TITLE
Fixes Source0 URL in RPM spec

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -87,7 +87,7 @@ Version:	%{version}
 Release:	1%{?dist}
 License:	GPLv3+
 Group:		Applications/System
-Source0:	https://github.com/netdata/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
+Source0:	https://github.com/netdata/%{name}/releases/download/v%{version}/%{name}-v%{version}.tar.gz
 URL:		http://my-netdata.io
 
 # #####################################################################


### PR DESCRIPTION
##### Summary

Fixes the `Source0` URL in the `netdata.spec.in` RPM spec file.

Adds the missing `v` prefix to the version strings.

Fixes #7141 

##### Component Name

area/packaging

##### Additional Information

