### PR TITLE
Adds reviewdog/shellcheck to CI via Github Actions on changed shell scripts in PRs

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,16 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  shellcheck:
+    name: runner / shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
+          path: "."
+          pattern: "*.sh*"
+          exclude: "./.git/*"


### PR DESCRIPTION
##### Summary

Fixes #7793 by introducing `shellcheck` checks against changed shell scripts `*.sh*` in PR(s) via [reviewdog](https://github.com/reviewdog) which has support for quite a few Github Actions we can utilise.

##### Component Name

area/ci

##### Additional Information

Due to security limitations of Github Actions it is not possible to use the IHMO nicer `github-pr-review` reporter on our triangular forking model. See [this section](https://github.com/reviewdog/reviewdog/blob/9abb5e45a11e4e3826a7ccc5cba82d21cef465c8/README.md#graceful-degradation-for-pull-requests-from-forked-repositories) in the reviewdog README.