### PR TITLE
Fixes install on FreeBSD systems with non GNU sed (do't use -i)

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -782,7 +782,7 @@ install_netdata_updater() {
         cat "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" >"${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || return 1
     fi
 
-    sed -e "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" -i "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || return 1
+    sed -i -e "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || return 1
 
     chmod 0755 ${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh
     echo >&2 "Update script is located at ${TPUT_GREEN}${TPUT_BOLD}${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh${TPUT_RESET}"
@@ -846,5 +846,5 @@ disable_netdata_updater() {
 }
 
 set_netdata_updater_channel() {
-    sed -e "s/^RELEASE_CHANNEL=.*/RELEASE_CHANNEL=\"${RELEASE_CHANNEL}\"/" -i "${NETDATA_USER_CONFIG_DIR}/.environment"
+    sed -i -e "s/^RELEASE_CHANNEL=.*/RELEASE_CHANNEL=\"${RELEASE_CHANNEL}\"/" "${NETDATA_USER_CONFIG_DIR}/.environment"
 }


### PR DESCRIPTION
##### Summary

Fixes support for isntalling NetData Agent (_from source_) by fixing our
invocations of `sed -e ... -i`. Specifically the version of `sed` on BSD
systems don't handle parsing command-line arguments the same way as GNU Sed
and so `sed -e ... -i <file>` gets interpreted incorrectly.

Be sure to use the form `sed -i -e ... file` :D

TODO: Write/Create a CI linter to protect outselves from this in future?

Fixes #7788

##### Component Name

area/packaging

##### Additional Information

I've confirmed the correct behaviour of both BSD and GNU `sed` and to be
consistent and portable we should use the form `sed -i -e ... file` and *not*
`sed -e ... -i file`.