### PR TITLE
add possibility to change badge text font color

### DIFF
--- a/web/api/badges/README.md
+++ b/web/api/badges/README.md
@@ -192,6 +192,14 @@ These are options dedicated to badges:
 
     The supported operators are `<`, `>`, `<=`, `>=`, `=` (or `:`) and `!=` (or `<>`).
 
+-   `text_color_lbl=RGB` or `text_color_lbl=RRGGBB`
+
+    Specifies hexadecimal color *(like in HTML but without `#` prepended)* for the font of left/label side of the badge. If not given or given with empty value default color will be used.
+
+-   `text_color_val=RGB` or `text_color_val=RRGGBB`
+
+    Specifies hexadecimal color *(like in HTML but without `#` prepended)* for the font of right/value side of the badge. If not given or given with empty value default color will be used.
+
 -   `precision=NUMBER`
 
     The number of decimal digits of the value. By default Netdata will add:

--- a/web/api/badges/README.md
+++ b/web/api/badges/README.md
@@ -180,7 +180,21 @@ These are options dedicated to badges:
 
 -   `label_color=COLOR`
 
-    The color of the label (the left part). You can use any HTML color, include `#NNN` and `#NNNNNN`. The following colors are defined in Netdata (and you can use them by name): `green`, `brightgreen`, `yellow`, `yellowgreen`, `orange`, `red`, `blue`, `grey`, `gray`, `lightgrey`, `lightgray`. These are taken from <https://github.com/badges/shields> so they are compatible with standard badges.
+    The color of the label (the left part). You can use any HTML color in `RGB` or `RRGGBB` hex notation (without `#` character in beginning). Additionally you can use one of the following predefined colors (and you can use them by their name):
+    
+    - `green`
+    - `brightgreen`
+    - `yellow`
+    - `yellowgreen`
+    - `orange`
+    - `red`
+    - `blue`
+    - `grey`
+    - `gray`
+    - `lightgrey`
+    - `lightgray`
+    
+    These are taken from <https://github.com/badges/shields> so they are compatible with standard badges.
 
 -   `value_color=COLOR:null|COLOR<VALUE|COLOR>VALUE|COLOR>=VALUE|COLOR<=VALUE|...`
 
@@ -192,13 +206,15 @@ These are options dedicated to badges:
 
     The supported operators are `<`, `>`, `<=`, `>=`, `=` (or `:`) and `!=` (or `<>`).
 
--   `text_color_lbl=RGB` or `text_color_lbl=RRGGBB`
+    For each color you can use same syntax for `label_color` parameter (predefined color by name or custom color in `RGB` or `RRGGBB` hex notation).
 
-    Specifies hexadecimal color *(like in HTML but without `#` prepended)* for the font of left/label side of the badge. If not given or given with empty value default color will be used.
+-   `text_color_lbl=RGB` or `text_color_lbl=RRGGBB` or `text_color_lbl=color_by_name`
 
--   `text_color_val=RGB` or `text_color_val=RRGGBB`
+    Specifies font color for the font of left/label side of the badge. Syntax is the same as for `label_color` parameter. If not given or given with empty value default color will be used.
 
-    Specifies hexadecimal color *(like in HTML but without `#` prepended)* for the font of right/value side of the badge. If not given or given with empty value default color will be used.
+-   `text_color_val=RGB` or `text_color_val=RRGGBB` or `text_color_lbl=color_by_name`
+
+    Specifies font color for the font of right/value side of the badge. Syntax is the same as for `label_color` parameter. If not given or given with empty value default color will be used.
 
 -   `precision=NUMBER`
 

--- a/web/api/badges/README.md
+++ b/web/api/badges/README.md
@@ -202,7 +202,7 @@ These are options dedicated to badges:
 
     Example: `value_color=grey:null|green<10|yellow<100|orange<1000|blue<10000|red`
 
-    The above will set `grey` if no value exists (not collected within the `gap when lost iterations above` in `netdata.conf` for the chart), `green` if the value is less than 10, `yellow` if the value is less than 100, etc up to `red` which will be used if no other conditions match.
+    The above will set `grey` if no value exists (not collected within the `gap when lost iterations above` in `netdata.conf` for the chart), `green` if the value is less than 10, `yellow` if the value is less than 100, etc up to `red` which will be used if no other conditions match. Currently only integers are suported as values.
 
     The supported operators are `<`, `>`, `<=`, `>=`, `=` (or `:`) and `!=` (or `<>`).
 

--- a/web/api/badges/README.md
+++ b/web/api/badges/README.md
@@ -178,52 +178,62 @@ These are options dedicated to badges:
 
     Divide the value with this number. The default is `1`.
 
--   Color Customisation Prameters Overview
+-   Color customization parameters
 
-    Following parameters specify collors of each individual part of the badge. Each parameter is documented in detail below.
+    The following parameters specify colors of each individual part of the badge. Each parameter is documented in detail
+    below.
 
-    | Area of Badge | Backgroud Color Parameter | Text Color Parameter |
-    | ---: | :---: | :---: |
-    | Label (left) part | `label_color` | `text_color_lbl` |
-    | Value (right) part | `value_color` | `text_color_val` |
+    | Area of badge      | Backgroud color parameter | Text color parameter |
+    | ---:               | :-----------------------: | :------------------: |
+    | Label (left) part  | `label_color`             | `text_color_lbl`     |
+    | Value (right) part | `value_color`             | `text_color_val`     |
 
--   `label_color=COLOR`
+    -   `label_color=COLOR`
 
-    The color of the label (the left part). You can use any HTML color in `RGB` or `RRGGBB` hex notation (without `#` character in beginning). Additionally you can use one of the following predefined colors (and you can use them by their name):
+        The color of the label (the left part). You can use any HTML color in `RGB` or `RRGGBB` hex notation (without
+        the `#` character at the beginning). Additionally, you can use one of the following predefined colors (and you
+        can use them by their name):
     
-    - `green`
-    - `brightgreen`
-    - `yellow`
-    - `yellowgreen`
-    - `orange`
-    - `red`
-    - `blue`
-    - `grey`
-    - `gray`
-    - `lightgrey`
-    - `lightgray`
+        -   `green`
+        -   `brightgreen`
+        -   `yellow`
+        -   `yellowgreen`
+        -   `orange`
+        -   `red`
+        -   `blue`
+        -   `grey`
+        -   `gray`
+        -   `lightgrey`
+        -   `lightgray`
     
-    These are taken from <https://github.com/badges/shields> so they are compatible with standard badges.
+        These colors are taken from <https://github.com/badges/shields>, which makes them compatible with standard
+        badges.
 
--   `value_color=COLOR:null|COLOR<VALUE|COLOR>VALUE|COLOR>=VALUE|COLOR<=VALUE|...`
+    -   `value_color=COLOR:null|COLOR<VALUE|COLOR>VALUE|COLOR>=VALUE|COLOR<=VALUE|...`
 
-    You can add a pipe delimited list of conditions to pick the color. The first matching (left to right) will be used.
+        You can add a pipe delimited list of conditions to pick the value color. The first matching (left to right) will
+        be used.
 
-    Example: `value_color=grey:null|green<10|yellow<100|orange<1000|blue<10000|red`
+        Example: `value_color=grey:null|green<10|yellow<100|orange<1000|blue<10000|red`
 
-    The above will set `grey` if no value exists (not collected within the `gap when lost iterations above` in `netdata.conf` for the chart), `green` if the value is less than 10, `yellow` if the value is less than 100, etc up to `red` which will be used if no other conditions match. Currently only integers are suported as values.
+        The above will set `grey` if no value exists (not collected within the `gap when lost iterations above` in
+        `netdata.conf` for the chart), `green` if the value is less than 10, `yellow` if the value is less than 100, and
+        so on. Netdata will use `red` if no other conditions match. Only integers are suported as values.
 
-    The supported operators are `<`, `>`, `<=`, `>=`, `=` (or `:`) and `!=` (or `<>`).
+        The supported operators are `<`, `>`, `<=`, `>=`, `=` (or `:`), and `!=` (or `<>`).
 
-    For each color you can use same syntax for `label_color` parameter (predefined color by name or custom color in `RGB` or `RRGGBB` hex notation).
+        You can also use the same syntax as the `label_color` parameter to define each of these colors. You can
+        reference a predefined color by name or `RGB`/`RRGGBB` hex notation.
 
--   `text_color_lbl=RGB` or `text_color_lbl=RRGGBB` or `text_color_lbl=color_by_name`
+    -   `text_color_lbl=RGB` or `text_color_lbl=RRGGBB` or `text_color_lbl=color_by_name`
 
-    Specifies font color for the font of left/label side of the badge. Syntax is the same as for `label_color` parameter. If not given or given with empty value default color will be used.
+        This value specifies the font color for the font of left/label side of the badge. The syntax is the same as the
+        `label_color` parameter. If not given, or given with an empty value, Netdata will use the default color.
 
--   `text_color_val=RGB` or `text_color_val=RRGGBB` or `text_color_lbl=color_by_name`
+    -   `text_color_val=RGB` or `text_color_val=RRGGBB` or `text_color_lbl=color_by_name`
 
-    Specifies font color for the font of right/value side of the badge. Syntax is the same as for `label_color` parameter. If not given or given with empty value default color will be used.
+        This value specifies the font color for the font of right/value side of the badge. The syntax is the same as the
+        `label_color` parameter. If not given, or given with an empty value, Netdata will use the default color.
 
 -   `precision=NUMBER`
 

--- a/web/api/badges/README.md
+++ b/web/api/badges/README.md
@@ -178,6 +178,15 @@ These are options dedicated to badges:
 
     Divide the value with this number. The default is `1`.
 
+-   Color Customisation Prameters Overview
+
+    Following parameters specify collors of each individual part of the badge. Each parameter is documented in detail below.
+
+    | Area of Badge | Backgroud Color Parameter | Text Color Parameter |
+    | ---: | :---: | :---: |
+    | Label (left) part | `label_color` | `text_color_lbl` |
+    | Value (right) part | `value_color` | `text_color_val` |
+
 -   `label_color=COLOR`
 
     The color of the label (the left part). You can use any HTML color in `RGB` or `RRGGBB` hex notation (without `#` character in beginning). Additionally you can use one of the following predefined colors (and you can use them by their name):

--- a/web/api/badges/web_buffer_svg.h
+++ b/web/api/badges/web_buffer_svg.h
@@ -6,7 +6,7 @@
 #include "libnetdata/libnetdata.h"
 #include "web/server/web_client.h"
 
-extern void buffer_svg(BUFFER *wb, const char *label, calculated_number value, const char *units, const char *label_color, const char *value_color, int precision, int scale, uint32_t options, int fixed_width_lbl, int fixed_width_val);
+extern void buffer_svg(BUFFER *wb, const char *label, calculated_number value, const char *units, const char *label_color, const char *value_color, int precision, int scale, uint32_t options, int fixed_width_lbl, int fixed_width_val, const char* text_color_lbl, const char* text_color_val);
 extern char *format_value_and_unit(char *value_string, size_t value_string_len, calculated_number value, const char *units, int precision);
 
 extern int web_client_api_request_v1_badge(struct rrdhost *host, struct web_client *w, char *url);

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -491,6 +491,28 @@
             }
           },
           {
+            "name": "text_color_lbl",
+            "in": "query",
+            "description": "Font color for label part of the badge. Given as HTML hexadecimal color without `#` character. Formats allowed `RGB` or `RRGGBB`. If no value given default color will be used.",
+            "required": false,
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "format": "^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
+            }
+          },
+          {
+            "name": "text_color_val",
+            "in": "query",
+            "description": "Font color for value part of the badge. Given as HTML hexadecimal color without `#` character. Formats allowed `RGB` or `RRGGBB`. If no value given default color will be used.",
+            "required": false,
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "format": "^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
+            }
+          },
+          {
             "name": "multiply",
             "in": "query",
             "description": "Multiply the value with this number for rendering it at the image (integer value required).",

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -338,7 +338,7 @@
     },
     "/badge.svg": {
       "get": {
-        "summary": "Generate a SVG image for a chart (or dimension)",
+        "summary": "Generate a badge in form of SVG image for a chart (or dimension)",
         "description": "Successful responses are SVG images.",
         "parameters": [
           {
@@ -471,18 +471,38 @@
           {
             "name": "label_color",
             "in": "query",
-            "description": "A color to be used for the background of the label.",
+            "description": "A color to be used for the background of the label side(left side) of the badge. One of predefined colors or specific color in hex `RGB` or `RRGGBB` format (without preceding `#` character). If value wrong or not given default color will be used.",
             "required": false,
             "allowEmptyValue": true,
             "schema": {
-              "type": "string",
-              "format": "any text"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum" : [
+                    "green",
+                    "brightgreen",
+                    "yellow",
+                    "yellowgreen",
+                    "orange",
+                    "red",
+                    "blue",
+                    "grey",
+                    "gray",
+                    "lightgrey",
+                    "lightgray"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "format": "^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
+                }
+              ]
             }
           },
           {
             "name": "value_color",
             "in": "query",
-            "description": "A color to be used for the background of the label. You can set multiple using a pipe with a condition each, like this: colorvalue|color:null The following operators are supported: >, <, >=, <=, =, :null (to check if no value exists).",
+            "description": "A color to be used for the background of the value *(right)* part of badge. You can set multiple using a pipe with a condition each, like this: colorvalue|color:null The following operators are supported: >, <, >=, <=, =, :null (to check if no value exists). Each color can be specified in same manner as for `label_color` parameter.",
             "required": false,
             "allowEmptyValue": true,
             "schema": {
@@ -493,23 +513,63 @@
           {
             "name": "text_color_lbl",
             "in": "query",
-            "description": "Font color for label part of the badge. Given as HTML hexadecimal color without `#` character. Formats allowed `RGB` or `RRGGBB`. If no value given default color will be used.",
+            "description": "Font color for label *(left)* part of the badge. One of predefined colors or as HTML hexadecimal color without preceeding `#` character. Formats allowed `RGB` or `RRGGBB`. If no or wrong value given default color will be used.",
             "required": false,
             "allowEmptyValue": true,
             "schema": {
-              "type": "string",
-              "format": "^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum" : [
+                    "green",
+                    "brightgreen",
+                    "yellow",
+                    "yellowgreen",
+                    "orange",
+                    "red",
+                    "blue",
+                    "grey",
+                    "gray",
+                    "lightgrey",
+                    "lightgray"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "format": "^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
+                }
+              ]
             }
           },
           {
             "name": "text_color_val",
             "in": "query",
-            "description": "Font color for value part of the badge. Given as HTML hexadecimal color without `#` character. Formats allowed `RGB` or `RRGGBB`. If no value given default color will be used.",
+            "description": "Font color for value *(right)* part of the badge. One of predefined colors or as HTML hexadecimal color without preceeding `#` character. Formats allowed `RGB` or `RRGGBB`. If no or wrong value given default color will be used.",
             "required": false,
             "allowEmptyValue": true,
             "schema": {
-              "type": "string",
-              "format": "^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum" : [
+                    "green",
+                    "brightgreen",
+                    "yellow",
+                    "yellowgreen",
+                    "orange",
+                    "red",
+                    "blue",
+                    "grey",
+                    "gray",
+                    "lightgrey",
+                    "lightgray"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "format": "^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$"
+                }
+              ]
             }
           },
           {

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -502,7 +502,7 @@
           {
             "name": "value_color",
             "in": "query",
-            "description": "A color to be used for the background of the value *(right)* part of badge. You can set multiple using a pipe with a condition each, like this: colorvalue|color:null The following operators are supported: >, <, >=, <=, =, :null (to check if no value exists). Each color can be specified in same manner as for `label_color` parameter.",
+            "description": "A color to be used for the background of the value *(right)* part of badge. You can set multiple using a pipe with a condition each, like this: `color<value|color:null` The following operators are supported: >, <, >=, <=, =, :null (to check if no value exists). Each color can be specified in same manner as for `label_color` parameter. Currently only integers are suported as values.",
             "required": false,
             "allowEmptyValue": true,
             "schema": {

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -427,6 +427,22 @@ paths:
           schema:
             type: string
             format: any text
+        - name: text_color_lbl
+          in: query
+          description: Font color for label part of the badge. Given as HTML hexadecimal color without `#` character. Formats allowed `RGB` or `RRGGBB`. If no value given default color will be used.
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
+            format: '^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$'
+        - name: text_color_val
+          in: query
+          description: Font color for value part of the badge. Given as HTML hexadecimal color without `#` character. Formats allowed `RGB` or `RRGGBB`. If no value given default color will be used.
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
+            format": '^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$'
         - name: multiply
           in: query
           description: Multiply the value with this number for rendering it at the image

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -434,8 +434,9 @@ paths:
           in: query
           description: "A color to be used for the background of the value *(right)* part of badge. You can set
             multiple using a pipe with a condition each, like this:
-            colorvalue|color:null The following operators are
-            supported: >, <, >=, <=, =, :null (to check if no value exists). Each color can be specified in same manner as for `label_color` parameter."
+            `color<value|color:null` The following operators are
+            supported: >, <, >=, <=, =, :null (to check if no value exists). Each color can be specified in same manner as for `label_color` parameter.
+            Currently only integers are suported as values."
           required: false
           allowEmptyValue: true
           schema:

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -291,7 +291,7 @@ paths:
             memory.
   /badge.svg:
     get:
-      summary: Generate a SVG image for a chart (or dimension)
+      summary: Generate a badge in form of SVG image for a chart (or dimension)
       description: Successful responses are SVG images.
       parameters:
         - name: chart
@@ -410,18 +410,32 @@ paths:
             format: any text
         - name: label_color
           in: query
-          description: A color to be used for the background of the label.
+          description: A color to be used for the background of the label side(left side) of the badge. One of predefined colors or specific color in hex `RGB` or `RRGGBB` format (without preceding `#` character). If value wrong or not given default color will be used.
           required: false
           allowEmptyValue: true
           schema:
-            type: string
-            format: any text
+            oneOf:
+              - type: string
+                enum:
+                  - green
+                  - brightgreen
+                  - yellow
+                  - yellowgreen
+                  - orange
+                  - red
+                  - blue
+                  - grey
+                  - gray
+                  - lightgrey
+                  - lightgray
+              - type: string
+                format: ^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
         - name: value_color
           in: query
-          description: "A color to be used for the background of the label. You can set
+          description: "A color to be used for the background of the value *(right)* part of badge. You can set
             multiple using a pipe with a condition each, like this:
             colorvalue|color:null The following operators are
-            supported: >, <, >=, <=, =, :null (to check if no value exists)."
+            supported: >, <, >=, <=, =, :null (to check if no value exists). Each color can be specified in same manner as for `label_color` parameter."
           required: false
           allowEmptyValue: true
           schema:
@@ -429,20 +443,48 @@ paths:
             format: any text
         - name: text_color_lbl
           in: query
-          description: Font color for label part of the badge. Given as HTML hexadecimal color without `#` character. Formats allowed `RGB` or `RRGGBB`. If no value given default color will be used.
+          description: Font color for label *(left)* part of the badge. One of predefined colors or as HTML hexadecimal color without preceeding `#` character. Formats allowed `RGB` or `RRGGBB`. If no or wrong value given default color will be used.
           required: false
           allowEmptyValue: true
           schema:
-            type: string
-            format: '^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$'
+           oneOf:
+              - type: string
+                enum:
+                  - green
+                  - brightgreen
+                  - yellow
+                  - yellowgreen
+                  - orange
+                  - red
+                  - blue
+                  - grey
+                  - gray
+                  - lightgrey
+                  - lightgray
+              - type: string
+                format: ^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
         - name: text_color_val
           in: query
-          description: Font color for value part of the badge. Given as HTML hexadecimal color without `#` character. Formats allowed `RGB` or `RRGGBB`. If no value given default color will be used.
+          description: Font color for value *(right)* part of the badge. One of predefined colors or as HTML hexadecimal color without preceeding `#` character. Formats allowed `RGB` or `RRGGBB`. If no or wrong value given default color will be used.
           required: false
           allowEmptyValue: true
           schema:
-            type: string
-            format": '^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$'
+           oneOf:
+              - type: string
+                enum:
+                  - green
+                  - brightgreen
+                  - yellow
+                  - yellowgreen
+                  - orange
+                  - red
+                  - blue
+                  - grey
+                  - gray
+                  - lightgrey
+                  - lightgray
+              - type: string
+                format: ^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
         - name: multiply
           in: query
           description: Multiply the value with this number for rendering it at the image


### PR DESCRIPTION
##### Summary
Fixes #7791 - request of user to be able to specify color of the text in badge

__Additionally__
Fixes problem where the custom color given to `label_color` was ignored using both `#RRGGBB` and `RRGGBB` syntax (in contrast with specification in documentation which allows this).
Unifies all `/color/` values with same syntax. 2 options:
- one of predefined colors
- custom color specified as hex in `RGB` or `RRGGBB` format *(without preceeding `#` char)*

##### Component Name
agent `api/v1/badge.svg` and related documetation

##### Additional Information
color can be specified with HEX value as in HTML without `#` character in the beggining. Either in `RGB` or `RRGGBB` format

