### PR TITLE
Adds ReviewDog CI checks for Golang

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,6 +1,17 @@
 name: reviewdog
 on: [pull_request]
 jobs:
+  golangci-lint:
+    name: runner / golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
+
   shellcheck:
     name: runner / shellcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### Summary

Similar to #7795 adds CI check for Golang source code in Pull Requests
(_changed only_).

##### Component Name

area/ci

##### Additional Information

We will remove a lot of the Travis CI checks that do the same thing once we're
happy enough with the way reviewdog CI checks against changed files
in PR(s) work.