### PR TITLE
Auto Assign PRs to their Authors

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,1 @@
+addAssignees: author

--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -1,0 +1,10 @@
+name: 'Auto Assign'
+on: pull_request
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.0.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -1,10 +1,16 @@
-name: 'Auto Assign'
-on: pull_request
+---
+# Handles Assigning PR(s) to theit Author.
+name: Pull Request Auto Assign
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
 
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v1.0.1
+        if: github.repository == 'netdata/netdata'
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
##### Summary

Fixes a minor annoyance with the ZenHub UI and Github PRs where by default the Assignee of the PR is "unassigned". IHMO its better that this is the Author of the PR so its more clearly visible in "card form" :)

##### Component Name

area/ci

##### Additional Information

