### PR TITLE
Adds missing dep for Alpine based installations

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -460,7 +460,7 @@ Execute these commands to install Netdata in Alpine Linux 3.x:
 
 ```sh
 # install required packages
-apk add alpine-sdk bash curl zlib-dev util-linux-dev libmnl-dev gcc make git autoconf automake pkgconfig python logrotate
+apk add alpine-sdk bash curl libuv-dev zlib-dev util-linux-dev libmnl-dev gcc make git autoconf automake pkgconfig python logrotate
 
 # if you plan to run node.js Netdata plugins
 apk add nodejs


### PR DESCRIPTION
##### Summary

Noticed this while doing somethiing else. Our docs for Alpine were _slightly_
off and were missing our hard dependency `libuv-dev`.

##### Component Name

area/docs

##### Additional Information

```sh
checking for uv_fs_scandir_next in -luv... no
configure: error: libuv required but not found. Try installing 'libuv1-dev' or 'libuv-devel'.
 FAILED
```