### PR TITLE
python.d/retroshare: add readme

### DIFF
--- a/collectors/python.d.plugin/retroshare/README.md
+++ b/collectors/python.d.plugin/retroshare/README.md
@@ -1,3 +1,33 @@
 # retroshare
 
+[RetroShare](https://retroshare.cc/) is a free and open-source peer-to-peer communication and file sharing app based on a friend-to-friend network.
+
+This module will monitor one or more `RetroShare` applications, depending on your configuration.
+
+## Charts
+
+This module produces the following charts:
+
+-   Bandwidth in `kilobits/s`
+-   Peers in `peers`
+-   DHT in `peers`
+
+
+## Configuration
+
+Here is an example for 2 servers:
+
+```yaml
+localhost:
+  url      : 'http://localhost:9090'
+  user     : "user"
+  password : "pass"
+
+remote:
+  url      : 'http://203.0.113.1:9090'
+  user     : "user"
+  password : "pass"
+```
+---
+
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fretroshare%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

[Formatting python.d modules code](https://github.com/netdata/netdata/pull/7832) i noticed that `restroshare` module readme file is empty. This PR fixes it.

##### Component Name

[`/collectors/python.d.plugin/retroshare`](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/retroshare)

##### Additional Information

