### PR TITLE
Clarify editing health config files in health quickstart

### DIFF
--- a/health/QUICKSTART.md
+++ b/health/QUICKSTART.md
@@ -28,6 +28,9 @@ cd /etc/netdata/ # Replace with your Netdata configuration directory, if not /et
 ```
 
 > You may need to use `sudo` or another method of elevating your privileges: `sudo ./edit-config health.d/cpu.conf`.
+>
+> You can also use the `$EDITOR` environment variable to use your preferred terminal editor with `edit-config`. See 
+> [this page](../docs/step-by-step/step-04.md#use-edit-config-to-open-netdataconf) for details.
 
 Each health configuration file contains one or more health entities, which always begin with an `alarm:` or `template:`
 line. You can edit these entities based on your needs. To make any changes live, be sure to [reload your health

--- a/health/QUICKSTART.md
+++ b/health/QUICKSTART.md
@@ -8,18 +8,40 @@ To learn about more advanced health configurations, visit the [health reference 
 
 ## What's in this getting started guide
 
--   [Locate health configuration files](#locate-health-configuration-files)
--   [Edit existing health configuration files](#edit-existing-health-configuration-files)
+-   [Edit health configuration files](#edit-health-configuration-files)
+-   [Reference Netdata's stock health configuration files](#reference-netdatas-stock-health-configuration-files)
 -   [Write a new health entity](#write-a-new-health-entity)
 -   [Reload health configuration](#reload-health-configuration)
 
-## Locate health configuration files
+## Edit health configuration files
 
-By default, Netdata will put health configuration files in `/usr/lib/netdata/conf.d/health.d`.
+You should use `edit-config` to edit Netdata's health configuration files. `edit-config` will open your system's default
+terminal editor for you to make your changes. Once you've saved and closed the editor, `edit-config` will copy your
+edited file into `/etc/netdata/health.d/`, which will override the stock file in `/usr/lib/netdata/conf.d/health.d/` and
+ensure your customizations are persistent between updates.
 
-However, you can double-check the location of these files by navigating to `http://HOST:19999/netdata.conf` in your
-browser and looking for the `stock health configuration directory` option. The value here will show the correct path for
-your installation.
+For example, to edit the `cpu.conf` health configuration file, you would run:
+
+```bash
+cd /etc/netdata/ # Replace with your Netdata configuration directory, if not /etc/netdata/
+./edit-config health.d/cpu.conf
+```
+
+> You may need to use `sudo` or another method of elevating your privileges: `sudo ./edit-config health.d/cpu.conf`.
+
+Each health configuration file contains one or more health entities, which always begin with an `alarm:` or `template:`
+line. You can edit these entities based on your needs. To make any changes live, be sure to [reload your health
+configuration](#reload-health-configuration).
+
+## Reference Netdata's stock health configuration files
+
+While you should always [use `edit-config`](#edit-health-configuration-files), you might also want to view the stock
+health configuration files Netdata ships with. Stock files can be useful as reference material, or to determine which
+file you should edit with `edit-config`.
+
+By default, Netdata will put health configuration files in `/usr/lib/netdata/conf.d/health.d`.  However, you can
+double-check the location of these files by navigating to `http://HOST:19999/netdata.conf` in your browser and looking
+for the `stock health configuration directory` option. The value here will show the correct path for your installation.
 
 ```conf
 [health]
@@ -27,7 +49,7 @@ your installation.
  # stock health configuration directory = /usr/lib/netdata/conf.d/health.d
 ```
 
-Navigate to the health configuration directory to see all the available files.
+Navigate to the health configuration directory to see all the available files and open them for reading.
 
 ```bash
 cd /usr/lib/netdata/conf.d/health.d/
@@ -38,26 +60,8 @@ apache.conf fronius.conf mysql.conf swap.conf
 ...
 ```
 
-## Edit existing health configuration files
-
-You should use `edit-config` to edit Netdata's health configuration files.
-
-For example, to edit the `cpu.conf` health configuration file, you would run:
-
-```bash
-cd /etc/netdata/ # Replace with your Netdata configuration directory, if not /etc/netdata/
-./edit-config health.d/cpu.conf
-```
-
-> You may need to use `sudo` or another method of elevating your privileges.
-
-`edit-config` will open a text editor for you to make your changes. Once you've saved and closed the editor,
-`edit-config` will copy your edited file into `/etc/netdata/health.d/`, and it will now override the default in
-`/usr/lib/netdata/conf.d/health.d/`.
-
-Each health configuration file contains one or more health entities, which always begin with an `alarm:` or `template:`
-line. You can edit these entities based on your needs. To make any changes live, be sure to [reload your health
-configuration](#reload-health-configuration).
+> ⚠️ If you edit configuration files in your stock health configuration directory, Netdata will overwrite them during
+> any updates. Please use `edit-config` as described in the [section above](#edit-health-configuration-files).
 
 ## Write a new health entity
 

--- a/health/tutorials/stop-notifications-alarms.md
+++ b/health/tutorials/stop-notifications-alarms.md
@@ -28,8 +28,8 @@ In the `source` row, you see that this chart is getting its configuration from
 `4@/usr/lib/netdata/conf.d/health.d/cpu.conf`. The relevant part of begins at `health.d`: `health.d/cpu.conf`. That's
 the file you need to edit if you want to silence this alarm.
 
-For more information about locating health configuration files on your system, see the [health
-quickstart](../QUICKSTART.md#locate-health-configuration-files).
+For more information about editing or referencing health configuration files on your system, see the [health
+quickstart](../QUICKSTART.md#edit-health-configuration-files).
 
 ## Edit the file to enable silencing
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fixes #7855 

I've moved the section about editing to the top, and tried to emphasize in multiple places that users should not edit files in `/usr/lib/netdata/conf.d`, as they're only for reference.

@manos-saratsis Let me know if this helps clarify your questions! I figure this issue is done when the doc addresses your specific concerns.

##### Component Name

docs

##### Additional Information

