### PR TITLE
Improve system-info.sh to better handle certain cases when gathering info on the system's disk capacity.

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -342,7 +342,7 @@ else
                            (echo "${dev_major_whitelist}" | grep -q ":$(cut -f 1 -d ':' "${disk}/dev"):") && \
                            grep -qv 1 "${disk}/removable"
                         then
-                            size="$(cat "${disk}/size")"
+                            size="$(($(cat "${disk}/size") * 512))"
                             DISK_SIZE="$((DISK_SIZE + size))"
                         fi
                 done

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -326,9 +326,9 @@ else
                 # The ':' surrounding each number are important for matching.
                 dev_major_whitelist=':3:8:9:21:22:28:31:33:34:44:45:47:48:49:50:51:52:53:54:55:56:57:65:66:67:68:69:70:71:72:73:74:75:76:77:78:79:88:89:90:91:93:94:96:98:101:104:105:106:107:108:109:110:111:112:114:116:128:129:130:131:132:134:135:136:137:138:139:140:141:142:143:153:160:161:179:180:202:256:257:'
 
-                if [ "${VIRTUALIZATION}" != "unknown" ] ; then
-                    # We're running virtualized, add the local range of device major numbers so that we catch paravirtualized block devices.
-                    dev_major_whitelist="${dev_major_whitelist}240:241:242:243:244:245:246:247:248:249:250:251:252:253:254:"
+                if grep -qE ' vbd$' /proc/devices ; then
+                    # VirtIO Block devices are in use, add their device major number to the list of ones we check.
+                    dev_major_whitelist="${dev_major_whitelist}:$(grep -E 'vbd$' /proc/devices | cut -f 1 -d ' ' | sed -e 's/^[[:space:]]*//'):"
                 fi
 
                 DISK_DETECTION="sysfs"

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -121,9 +121,9 @@ else
                         if [ "${ID}" = "unknown" ]; then CONTAINER_ID="${DISTRIB_CODENAME}"; fi
                 fi
                 if [ -n "$(command -v lsb_release 2>/dev/null)" ]; then
-                        if [ "${OS_DETECTION}" = "unknown" ]; then 
+                        if [ "${OS_DETECTION}" = "unknown" ]; then
                                 CONTAINER_OS_DETECTION="lsb_release"
-                        else 
+                        else
                                 CONTAINER_OS_DETECTION="Mixed"
                         fi
                         if [ "${NAME}" = "unknown" ]; then CONTAINER_NAME="$(lsb_release -is 2>/dev/null)"; fi

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -332,7 +332,7 @@ else
 
                 for name in ${device_names} ; do
                         if grep -qE " ${name}\$" /proc/devices ; then
-                                dev_major_whitelist="${dev_major_whitelist}:$(grep -E "${name}\$" /proc/devices | cut -f 1 -d ' ' | sed -e 's/^[[:space:]]*//' | tr '\n' ':'):"
+                                dev_major_whitelist="${dev_major_whitelist}:$(grep -E "${name}\$" /proc/devices | sed -e 's/^[[:space:]]*//' | cut -f 1 -d ' ' | tr '\n' ':'):"
                         fi
                 done
 

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -308,7 +308,7 @@ if [ "${KERNEL_NAME}" = "Darwin" ]; then
         fi
 
         DISK_DETECTION="df"
-        DISK_SIZE=$(($(/bin/df -k -t ${types} | tail -n +1 | sed -r 's/\/dev\/disk([[:digit:]]*)s[[:digit:]]*/\/dev\/disk\1/g' | sort -u -k '1,2n,4n' | awk '{print $2}' | tr '\n' '+' | head -c -1) * 1024))
+        DISK_SIZE=$(($(/bin/df -k -t ${types} | tail -n +1 | sed -E 's/\/dev\/disk([[:digit:]]*)s[[:digit:]]*/\/dev\/disk\1/g' | sort -u -k '1,2n,4n' | awk '{print $2}' | tr '\n' '+' | head -c -1) * 1024))
 elif [ "${KERNEL_NAME}" = FreeBSD ] ; then
         types='ufs'
 

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -308,8 +308,7 @@ if [ "${KERNEL_NAME}" = "Darwin" ]; then
         fi
 
         DISK_DETECTION="df"
-        total="$(/bin/df -k -t ${types} | tail -n +1 | sed -r 's/\/dev\/disk([[:digit:]]*)s[[:digit:]]*/\/dev\/disk\1/g' | sort -u -k '1,2n,4n' | awk '{s+=$2} END {print s}')"
-        DISK_SIZE="$((total * 1024))"
+        DISK_SIZE=$(($(/bin/df -k -t ${types} | tail -n +1 | sed -r 's/\/dev\/disk([[:digit:]]*)s[[:digit:]]*/\/dev\/disk\1/g' | sort -u -k '1,2n,4n' | awk '{print $2}' | tr '\n' '+' | head -c -1) * 1024))
 elif [ "${KERNEL_NAME}" = FreeBSD ] ; then
         types='ufs'
 

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -308,7 +308,7 @@ if [ "${KERNEL_NAME}" = "Darwin" ]; then
         fi
 
         DISK_DETECTION="df"
-        DISK_SIZE=$(($(/bin/df -k -t ${types} | tail -n +1 | sed -E 's/\/dev\/disk([[:digit:]]*)s[[:digit:]]*/\/dev\/disk\1/g' | sort -u -k '1,2n,4n' | awk '{print $2}' | tr '\n' '+' | head -c -1) * 1024))
+        DISK_SIZE=$(($(/bin/df -k -t ${types} | tail -n +2 | sed -E 's/\/dev\/disk([[:digit:]]*)s[[:digit:]]*/\/dev\/disk\1/g' | sort -k 1 | awk -F ' ' '{s=$NF;for(i=NF-1;i>=1;i--)s=s FS $i;print s}' | uniq -f 9 | awk '{print $8}' | tr '\n' '+' | rev | cut -f 2- -d '+' | rev) * 1024))
 elif [ "${KERNEL_NAME}" = FreeBSD ] ; then
         types='ufs'
 

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -321,7 +321,7 @@ elif [ "${KERNEL_NAME}" = FreeBSD ] ; then
         total="$(df -t ${types} -c -k | tail -n 1 | awk '{print $2}')"
         DISK_SIZE="$((total * 1024))"
 else
-        if [ -d /sys/block ] ; then
+        if [ -d /sys/block ] && [ -r /proc/devices ] ; then
                 dev_major_whitelist=''
 
                 # This is a list of device names used for block storage devices.

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -349,12 +349,11 @@ else
                 done
         elif df --version 2>/dev/null | grep -qF "GNU coreutils" ; then
                 DISK_DETECTION="df"
-                DISK_SIZE="$(df -x tmpfs -x devtmpfs -x squashfs -l --total -B1 --output=size | tail -n 1 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+                DISK_SIZE=$(($(df -x tmpfs -x devtmpfs -x squashfs -l -B1 --output=source,size | tail -n +2 | sort -u -k 1 | awk '{print $2}' | tr '\n' '+' | head -c -1)))
         else
                 DISK_DETECTION="df"
                 include_fs_types="ext*|btrfs|xfs|jfs|reiser*|zfs"
-                total="$(df -T -P | grep "${include_fs_types}" | awk '{s+=$3} END {print s}')"
-                DISK_SIZE="$((total * 1024))"
+                DISK_SIZE=$(($(df -T -P | tail -n +2 | sort -u -k 1 | grep "${include_fs_types}" | awk '{print $3}' | tr '\n' '+' | head -c -1) * 1024))
         fi
 fi
 

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -307,7 +307,7 @@ if [ "${KERNEL_NAME}" = "Darwin" ]; then
         fi
 
         DISK_DETECTION="df"
-        total="$(/bin/df -k -t ${types} | tail -n +1 | awk '{s+=$2} END {print s}')"
+        total="$(/bin/df -k -t ${types} | tail -n +1 | sed -r 's/\/dev\/disk([[:digit:]]*)s[[:digit:]]*/\/dev\/disk\1/g' | sort -u -k '1,2n,4n' | awk '{s+=$2} END {print s}')"
         DISK_SIZE="$((total * 1024))"
 elif [ "${KERNEL_NAME}" = FreeBSD ] ; then
         types='ufs'

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -326,10 +326,14 @@ else
                 # The ':' surrounding each number are important for matching.
                 dev_major_whitelist=':3:8:9:21:22:28:31:33:34:44:45:47:48:49:50:51:52:53:54:55:56:57:65:66:67:68:69:70:71:72:73:74:75:76:77:78:79:88:89:90:91:93:94:96:98:101:104:105:106:107:108:109:110:111:112:114:116:128:129:130:131:132:134:135:136:137:138:139:140:141:142:143:153:160:161:179:180:202:256:257:'
 
-                if grep -qE ' vbd$' /proc/devices ; then
-                    # VirtIO Block devices are in use, add their device major number to the list of ones we check.
-                    dev_major_whitelist="${dev_major_whitelist}:$(grep -E 'vbd$' /proc/devices | cut -f 1 -d ' ' | sed -e 's/^[[:space:]]*//'):"
-                fi
+                # These device types use dynamic device majors, so we have to hunt for them in `/proc/devices`
+                dynamic_device_names='vbd nvme'
+
+                for name in ${dynamic_device_names} ; do
+                        if grep -qE " ${name}\$" /proc/devices ; then
+                                dev_major_whitelist="${dev_major_whitelist}:$(grep -E "${name}\$" /proc/devices | cut -f 1 -d ' ' | sed -e 's/^[[:space:]]*//'):"
+                        fi
+                done
 
                 DISK_DETECTION="sysfs"
                 DISK_SIZE="0"


### PR DESCRIPTION
##### Summary

This contains the following overall changes:

* We now properly count APFS instances only once instead of once per mount point (note that I'm avoiding the term 'volume' here because APFS uses it like a logical volume manager and not a filesystem).
* On Linux, we now look up device major numbers in `/proc/devices` instead of hard coding them, This simplifies handling of device types which use dynamically assigned device major numbers, as well as making the code more robust and easier to update in the future. We still need to do device number matching for reliability reasons.
* We now also look at NVMe devices (we were ignoring them previously).
* We now handle BTRFS on Linux in a manner similar to APFS on macOS, except we're able to use simpler deduplication logic because BTRFS behaves like a filesystem instead of a volume manager.
* We now avoid using `awk` to do math, which means we will always print actual integers instead of values in scientific notation.

##### Component Name

area/daemon

##### Additional Information

Tested minimally on a number of Linux systems, virtual and otherwise. I can't test the macOS part myself.

Fixes: #7895

Fixes for handling of DM multipath on Linux and GEOM on FreeBSD will be handled as separate PR's since they're more complicated and require further research on my part.