### PR TITLE
health_doc_name: Clarify the rules to create an alarm name

### DIFF
--- a/health/QUICKSTART.md
+++ b/health/QUICKSTART.md
@@ -87,10 +87,10 @@ lookup: average -1m percentage of used
 
 Let's look into each of the lines to see how they create a working health entity.
 
--   `alarm`: The name for your new entity. The name needs to follow the requirements:
+-   `alarm`: The name for your new entity. The name needs to follow these requirements:
      - Any alphabet letter or number.
-     - Symbols `.` and `_`.
-     - Cannot be `dimension name`, `chart name`, `family name` or `chart variable names`. 
+     - The symbols `.` and `_`.
+     - Cannot be `chart name`, `dimension name`, `family name`, or `chart variable names`.  
 -   `on`: Which chart the entity listens to.
 -   `lookup`: Which metrics the alarm monitors, the duration of time to monitor, and how to process the metrics into a
     usable format.

--- a/health/QUICKSTART.md
+++ b/health/QUICKSTART.md
@@ -87,7 +87,10 @@ lookup: average -1m percentage of used
 
 Let's look into each of the lines to see how they create a working health entity.
 
--   `alarm`: The name for your new entity. The name can be anything, but the only symbols allowed are `.` and `_`.
+-   `alarm`: The name for your new entity. The name needs to follow the requirements:
+     - Any alphabet letter or number.
+     - Symbols `.` and `_`.
+     - Cannot be `dimension name`, `chart name`, `family name` or `chart variable names`. 
 -   `on`: Which chart the entity listens to.
 -   `lookup`: Which metrics the alarm monitors, the duration of time to monitor, and how to process the metrics into a
     usable format.

--- a/health/QUICKSTART.md
+++ b/health/QUICKSTART.md
@@ -88,9 +88,9 @@ lookup: average -1m percentage of used
 Let's look into each of the lines to see how they create a working health entity.
 
 -   `alarm`: The name for your new entity. The name needs to follow these requirements:
-     - Any alphabet letter or number.
-     - The symbols `.` and `_`.
-     - Cannot be `chart name`, `dimension name`, `family name`, or `chart variable names`.  
+     -   Any alphabet letter or number.
+     -   The symbols `.` and `_`.
+     -   Cannot be `chart name`, `dimension name`, `family name`, or `chart variable names`.  
 -   `on`: Which chart the entity listens to.
 -   `lookup`: Which metrics the alarm monitors, the duration of time to monitor, and how to process the metrics into a
     usable format.

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -88,7 +88,8 @@ alarm: NAME
 template: NAME
 ```
 
-`NAME` can be anything, with `.` (period) and `_` (underscore) as the only allowed symbols.
+`NAME` can be any alpha character, with `.` (period) and `_` (underscore) as the only allowed symbols, but the names 
+cannot be `chart name`, `dimension name`, `family name`, or `chart variables names`.
 
 #### Alarm line `on`
 


### PR DESCRIPTION
##### Summary
Fixes #7910 

This PR clarifies the allowed names for `alarm` and `templates`
##### Component Name
Heath
##### Additional Information

