### PR TITLE
Set ownership correctly for plugins in netdata-installer.sh

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -731,6 +731,7 @@ if [ "${UID}" -eq 0 ]; then
   run chown -R "root:${admin_group}" "${NETDATA_PREFIX}/usr/libexec/netdata"
   run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type d -exec chmod 0755 {} \;
   run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -exec chmod 0644 {} \;
+  run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -a -name \*.plugin -exec chown :${NETDATA_GROUP} {} \;
   run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -a -name \*.plugin -exec chmod 0750 {} \;
   run find "${NETDATA_PREFIX}/usr/libexec/netdata" -type f -a -name \*.sh -exec chmod 0755 {} \;
 


### PR DESCRIPTION
##### Summary

This fixes an issue in plugin ownership introduced by #7632.

##### Component Name

area/packaging

##### Additional Information

Fixes: #7922