### PR TITLE
/collectors/python.d/varnish: collect smf metrics

### DIFF
--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -1,80 +1,41 @@
 # varnish
 
-Module uses the `varnishstat` command to provide varnish cache statistics.
+This module will monitor `Varnish Cache` performance metrics.
 
-It produces:
+It uses the `varnishstat` command to provide varnish cache statistics.
 
-1.  **Connections Statistics** in connections/s
+## Requirements
 
-    -   accepted
-    -   dropped
+-   `netdata` user must be a member of `varnish` group 
 
-2.  **Client Requests** in requests/s
+## Charts
 
-    -   received
+It produces following charts:
 
-3.  **All History Hit Rate Ratio** in percent
+-   Connections Statistics in `connections/s`
+-   Client Requests in `requests/s`
+-   All History Hit Rate Ratio in `percent`
+-   Current Poll Hit Rate Ratio in `percent`
+-   Expired Objects in `expired/s`
+-   Least Recently Used Nuked Objects in `nuked/s`
+-   Number Of Threads In All Pools in `pools`
+-   Threads Statistics in `threads/s`
+-   Current Queue Length in `requests`
+-   Backend Connections Statistics in `connections/s`
+-   Requests To The Backend in `requests/s`
+-   ESI Statistics in `problems/s`
+-   Memory Usage in `MiB`
+-   Uptime in `seconds`
 
-    -   hit
-    -   miss
-    -   hitpass
+For every backend (VBE):
 
-4.  **Current Poll Hit Rate Ratio** in percent
+-   Backend Response Statistics in `kilobits/s`
 
-    -   hit
-    -   miss
-    -   hitpass
+For every disk (SMF):
 
-5.  **Expired Objects** in expired/s
+-   Disk Usage in `KiB` 
 
-    -   objects
-
-6.  **Least Recently Used Nuked Objects** in nuked/s
-
-    -   objects
-
-7.  **Number Of Threads In All Pools** in threads
-
-    -   threads
-
-8.  **Threads Statistics** in threads/s
-
-    -   created
-    -   failed
-    -   limited
-
-9.  **Current Queue Length** in requests
-
-    -   in queue
-
-10. **Backend Connections Statistics** in connections/s
-
-    -   successful
-    -   unhealthy
-    -   reused
-    -   closed
-    -   resycled
-    -   failed
-
-11. **Requests To The Backend** in requests/s
-
-    -   received
-
-12. **ESI Statistics** in problems/s
-
-    -   errors
-    -   warnings
-
-13. **Memory Usage** in MB
-
-    -   free
-    -   allocated
-
-14. **Uptime** in seconds
-
-    -   uptime
-
-## configuration
+## Configuration
 
 Only one parameter is supported:
 
@@ -82,7 +43,7 @@ Only one parameter is supported:
 instance_name: 'name'
 ```
 
-The name of the varnishd instance to get logs from. If not specified, the host name is used.
+The name of the `varnishd` instance to get logs from. If not specified, the host name is used.
 
 ---
 

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -6,7 +6,7 @@ It uses the `varnishstat` command to provide varnish cache statistics.
 
 ## Requirements
 
--   `netdata` user must be a member of `varnish` group 
+-   `netdata` user must be a member of the `varnish` group 
 
 ## Charts
 

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -2,7 +2,7 @@
 
 This module will monitor [`Varnish Cache`](https://varnish-cache.org/) performance metrics.
 
-It uses the `varnishstat` command to provide varnish cache statistics.
+It uses the `varnishstat` command to provide Varnish Cache statistics.
 
 ## Requirements
 

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -10,7 +10,7 @@ It uses the `varnishstat` command to provide Varnish Cache statistics.
 
 ## Charts
 
-It produces following charts:
+This module produces the following charts:
 
 -   Connections Statistics in `connections/s`
 -   Client Requests in `requests/s`

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -1,6 +1,6 @@
 # varnish
 
-This module will monitor `Varnish Cache` performance metrics.
+This module will monitor [`Varnish Cache`](https://varnish-cache.org/) performance metrics.
 
 It uses the `varnishstat` command to provide varnish cache statistics.
 


### PR DESCRIPTION
#### Summary

Fixes: #7872

This PR adds [SMF metrics](https://varnish-cache.org/docs/trunk/reference/varnish-counters.html#smf-file-stevedore-counters) (cache on disk) collection to the `varnish` python module.

All available stats:

```
SMF.ssdStorage.c_req                      47686         0.51 Allocator requests
SMF.ssdStorage.c_fail                         0         0.00 Allocator failures
SMF.ssdStorage.c_bytes                668102656      7186.06 Bytes allocated
SMF.ssdStorage.c_freed                140980224      1516.37 Bytes freed
SMF.ssdStorage.g_alloc                    39753          .   Allocations outstanding
SMF.ssdStorage.g_bytes                527122432          .   Bytes outstanding
SMF.ssdStorage.g_space              53159968768          .   Bytes available
SMF.ssdStorage.g_smf                      40130          .   N struct smf
SMF.ssdStorage.g_smf_frag                   311          .   N small free smf
SMF.ssdStorage.g_smf_large                   66          .   N large free smf
```

Collected metrics:

- g_space
- g_bytes

##### Component Name

[/collectors/python.d.plugin/varnish](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/varnish)

##### Additional Information

@ibantxo could you test it?

to do it

- download `varnish.chart.py`

> `wget https://raw.githubusercontent.com/ilyam8/netdata/varnish_disk_usage/collectors/python.d.plugin/varnish/varnish.chart.py`

- move it to the `/python.d/` directoty with all other `*.chart.py`

___

Tested by:
- @ibantxo https://github.com/netdata/netdata/pull/7926#issuecomment-580602860
- me https://github.com/netdata/netdata/pull/7926#issuecomment-580638075
