### PR TITLE
Fixes a bug in DO_NOT_TRACK expression

### DIFF
--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -18,7 +18,7 @@ ACTION_DATA=$(echo "${ACTION_DATA}" | tr '"' "'")
 # -------------------------------------------------------------------------------------------------
 # check opt-out
 
-if [ -f "@configdir_POST@/.opt-out-from-anonymous-statistics" ] || [ ! "$DO_NOT_TRACK" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
+if [ -f "@configdir_POST@/.opt-out-from-anonymous-statistics" ] || [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
   exit 0
 fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -887,7 +887,7 @@ install_go
 # -----------------------------------------------------------------------------
 progress "Telemetry configuration"
 
-if [ ! "$DO_NOT_TRACK" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
+if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
   NETDATA_DISABLE_TELEMETRY=1
 fi
 

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -7,7 +7,7 @@
 # Author  : Pavlos Emm. Katsoulakis <paul@netdata.cloud>
 set -e
 
-if [ ! "$DO_NOT_TRACK" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
+if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
   touch /etc/netdata/.opt-out-from-anonymous-statistics
 fi
 

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -231,7 +231,7 @@ while [ -n "${1}" ]; do
   fi
 done
 
-if [ ! "$DO_NOT_TRACK" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
+if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
   NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS:+${NETDATA_INSTALLER_OPTIONS} }--disable-telemtry"
 fi
 

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -68,7 +68,7 @@ To use `md5sum` to verify the intregity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "788cfe179615158331877a577c140486" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "33ecd20452f569c1d9972bcefdf04692" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -57,7 +57,7 @@ while [ "${1}" ]; do
   shift 1
 done
 
-if [ ! "$DO_NOT_TRACK" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
+if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
   REINSTALL_OPTIONS="${REINSTALL_OPTIONS} --disable-telemtry"
 fi
 


### PR DESCRIPTION
Fixes #7921

##### Summary

As per title. How embarassing 🤦‍♂️

##### Component Name

area/packaging

##### Additional Information

None

##### Test Plan

Before:

```sh
$ DO_NOT_TRACK=; if [ ! "$DO_NOT_TRACK" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then echo "foo"; fi
-bash: [: : integer expression expected
```

After:

```sh
$ DO_NOT_TRACK=; if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then echo "foo"; fi

```