### PR TITLE
Cleanup of packages installation doc

### DIFF
--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -8,9 +8,8 @@ For certain Linux distributions (see our [distribution matrix](../../DISTRIBUTIO
 architectures), these packages integrate tightly with your system's package manager, making them easier to maintain,
 update, and uninstall.
 
-We currently use [packagecloud](https://packagecloud.io/netdata/) to supply repositories and packages.
-
-We provide two separate repositories, one for nightly releases and another for stable releases.
+We currently use [packagecloud](https://packagecloud.io/netdata/) to supply repositories and packages. We provide two
+separate repositories, one for nightly releases, and another for stable releases.
 
 -   Nightly releases: [netdata/netdata-edge](https://packagecloud.io/netdata/netdata-edge)
 -   Stable releases: [netdata/netdata](https://packagecloud.io/netdata/netdata)
@@ -20,26 +19,46 @@ differences between the two.
 
 ## Quickstart
 
-packagecloud offers two helper installation scripts for `.deb` and `.rpm` distributions. Use one of the two scripts
-below to install Netdata get _automatic nightly updates_ via your package manager.
+packagecloud offers helper installation scripts to add their repositories to your package manager. Jump to your
+distribution and use the commands to install Netdata get _automatic nightly updates_ via your distribution's package
+manager. You can also manually add the repositories on [`.deb`
+systems](https://packagecloud.io/netdata/netdata-edge/install#manual-deb) or [`.rpm`
+systems](https://packagecloud.io/netdata/netdata-edge/install#manual-rpm).
 
-For `.deb` systems (Ubuntu, Debian)
+-   [Ubuntu and Debian (`.deb`)](#ubuntu-and-debian-deb)
+-   [Fedora (`.rpm`)](#fedora-rpm)
+
+### Ubuntu and Debian (`.deb`)
+
+Use the helper script to add the packagecloud repository, then use `apt` to install Netdata.
 
 ```bash
 curl -s https://packagecloud.io/install/repositories/netdata/netdata-edge/script.deb.sh | sudo bash
-```
-
-For `.rpm` systems (Fedora, CentOS, RHEL, OpenSuSE)
-
-```bash
-curl -s https://packagecloud.io/install/repositories/netdata/netdata-edge/script.rpm.sh | sudo bash
+sudo apt-get update
+sudo apt-get install netdata
 ```
 
 Skip ahead to the [What's next?](#whats-next) section to find links to helpful post-installation guides.
 
-If you prefer to add the packagecloud repositories to your package manager's repository list manually, see the
-instructions for [`.deb` systems](https://packagecloud.io/netdata/netdata-edge/install#manual-deb) or [`.rpm`
-systems](https://packagecloud.io/netdata/netdata-edge/install#manual-rpm).
+### Fedora (`.rpm`)
+
+Use the helper script to add the packagecloud repository, then use `dnf` to install Netdata.
+
+For `.rpm` systems using YUM (Fedora, CentOS, RHEL, OpenSuSE):
+
+```bash
+curl -s https://packagecloud.io/install/repositories/netdata/netdata-edge/script.rpm.sh | sudo bash
+sudo dnf update
+sudo dnf install netdata
+```
+
+Skip ahead to the [What's next?](#whats-next) section to find links to helpful post-installation guides.
+
+### Other operating systems
+
+While RHEL, CentOS, and Open SuSE all support `.rpm` packages, full support via these packages is still a
+work-in-progress. See our [distribution matrix](../../DISTRIBUTIONS.md) to understand whether you can install Netdata
+via `.rpm` packages, and then use your package manager to add the packagecloud repository and install Netdata.
 
 ## Using caching proxies with packagecloud repositories
 

--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -58,7 +58,7 @@ Skip ahead to the [What's next?](#whats-next) section to find links to helpful p
 
 While RHEL, CentOS, and Open SuSE all support `.rpm` packages, full support via these packages is still a
 work-in-progress. See our [distribution matrix](../../DISTRIBUTIONS.md) to understand whether you can install Netdata
-via `.rpm` packages, and then use your package manager to add the packagecloud repository and install Netdata.
+via these `.rpm` packages, and then use your package manager to add the packagecloud repository and install Netdata.
 
 ## Using caching proxies with packagecloud repositories
 

--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -2,46 +2,59 @@
 
 ![](https://raw.githubusercontent.com/netdata/netdata/master/web/gui/images/packaging-beta-tag.svg?sanitize=true)
 
-We provide our own flavour of binary packages for the most common operating systems that comply with .RPM and .DEB
-packaging formats.
+This page covers detailed instructions on using `.deb` or `.rpm` packages to install Netdata. 
 
-We have currently released packages following the .RPM format with version
-[1.16.0](https://github.com/netdata/netdata/releases/tag/v1.16.0). We have planned to release packages following the
-.DEB format with version [1.17.0](https://github.com/netdata/netdata/releases/tag/v1.17.0). Early adopters may
-experiment with our .DEB formatted packages using our nightly releases. Our current packaging infrastructure provider is
-[Package Cloud](https://packagecloud.io).
+For certain Linux distributions (see our [distribution matrix](../../DISTRIBUTIONS.md) for supported versions and
+architectures), these packages integrate tightly with your system's package manager, making them easier to maintain,
+update, and uninstall.
 
-Netdata is committed to support installation of our solution to all operating systems. This is a constant battle for
-Netdata, as we strive to automate and make things easier for our users. For the operating system support matrix, please
-visit our [distributions](../../DISTRIBUTIONS.md) support page.
+We currently use [packagecloud](https://packagecloud.io/netdata/) to supply repositories and packages.
 
-We provide two separate repositories, one for our stable releases and one for our nightly releases.
+We provide two separate repositories, one for nightly releases and another for stable releases.
 
-1.  Stable releases: Our stable production releases are hosted in
-    [netdata/netdata](https://packagecloud.io/netdata/netdata) repository of package cloud
-2.  Nightly releases: Our latest releases are hosted in
-    [netdata/netdata-edge](https://packagecloud.io/netdata/netdata-edge) repository of package cloud
+-   Nightly releases: [netdata/netdata-edge](https://packagecloud.io/netdata/netdata-edge)
+-   Stable releases: [netdata/netdata](https://packagecloud.io/netdata/netdata)
 
-Visit the repository pages and follow the quick set-up instructions to get started.
+Read our notice about [nightly vs. stable releases](../README.md#nightly-vs-stable-releases) to understand the
+differences between the two.
 
-## Using caching proxies with PackageCloud repositories
+## Quickstart
 
-PackageCloud only provides HTTPS access to repositories they host, which
-means in turn that Netdata's package repositories are only accessible
-via HTTPS. This is known to cause issues with some setups that use a
-caching proxy for package downloads.
+packagecloud offers two helper installation scripts for `.deb` and `.rpm` distributions. Use one of the two scripts
+below to install Netdata get _automatic nightly updates_ via your package manager.
+
+For `.deb` systems (Ubuntu, Debian)
+
+```bash
+curl -s https://packagecloud.io/install/repositories/netdata/netdata-edge/script.deb.sh | sudo bash
+```
+
+For `.rpm` systems (Fedora, CentOS, RHEL, OpenSuSE)
+
+```bash
+curl -s https://packagecloud.io/install/repositories/netdata/netdata-edge/script.rpm.sh | sudo bash
+```
+
+Skip ahead to the [What's next?](#whats-next) section to find links to helpful post-installation guides.
+
+If you prefer to add the packagecloud repositories to your package manager's repository list manually, see the
+instructions for [`.deb` systems](https://packagecloud.io/netdata/netdata-edge/install#manual-deb) or [`.rpm`
+systems](https://packagecloud.io/netdata/netdata-edge/install#manual-rpm).
+
+## Using caching proxies with packagecloud repositories
+
+packagecloud only provides HTTPS access to repositories they host, which means in turn that Netdata's package
+repositories are only accessible via HTTPS. This is known to cause issues with some setups that use a caching proxy for
+package downloads.
 
 If you are using such a setup, there are a couple of ways you can work around this:
 
-* Configure your proxy to automatically pass through HTTPS connections
-  without caching them. This is the simplest solution, but means that
-  downloads of Netdata pacakges will not be cached.
-* Mirror the respository locally on your proxy system, and use that mirror
-  when installing on other systems. This requires more setup and more disk
-  space on the caching host, but it lets you cache the packages locally.
-* Some specific caching proxies may have alternative configuration
-  options to deal with these issues. You can find such options in their
-  documentation.
+-   Configure your proxy to automatically pass through HTTPS connections without caching them. This is the simplest
+    solution, but means that downloads of Netdata pacakges will not be cached.
+-   Mirror the respository locally on your proxy system, and use that mirror when installing on other systems. This
+    requires more setup and more disk space on the caching host, but it lets you cache the packages locally.
+-   Some specific caching proxies may have alternative configuration options to deal with these issues. You can find
+    such options in their documentation.
 
 ## What's next?
 

--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -49,9 +49,9 @@ package downloads.
 
 If you are using such a setup, there are a couple of ways you can work around this:
 
--   Configure your proxy to automatically pass through HTTPS connections without caching them. This is the simplest
-    solution, but means that downloads of Netdata pacakges will not be cached.
--   Mirror the respository locally on your proxy system, and use that mirror when installing on other systems. This
+-   Configure your proxy to pass through HTTPS connections without caching them automatically. This is the simplest
+    solution, but means that downloads of Netdata packages will not be cached.
+-   Mirror the repository locally on your proxy system, and use that mirror when installing on other systems. This
     requires more setup and more disk space on the caching host, but it lets you cache the packages locally.
 -   Some specific caching proxies may have alternative configuration options to deal with these issues. You can find
     such options in their documentation.


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Given that the SRE/packaging team wants to promote our .deb/.rpm packages more, I felt like the `packaging/installer/methods/packages.md` page was lacking. It just pushed people to packagecloud for them to figure out how to use their scripts to enable the repo, and had no details about how to actually install Netdata after enabling the repo.

I stuck with explicit directions for just Ubuntu/Debian/Fedora, as those are the only 3 that are fully supported across versions, and work with their most recent versions.

I'm going to move away from cleaning up other installation pages until I have a more concrete conversation with @prologic about creating separate pages for each OS! :wink: What we decide to do there would define how many of these other pages are structured, and the content they feature.

##### Component Name

docs
packaging/

##### Additional Information

