### PR TITLE
Pass -Wl,-dead_strip,-bind_at_load on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,7 +222,7 @@ freebsd*)
 darwin*)
     build_target=macos
     build_target_id=3
-    LDFLAGS="${LDFLAGS} -framework CoreFoundation -framework IOKit"
+    LDFLAGS="${LDFLAGS} -framework CoreFoundation -framework IOKit -Wl,-dead_strip,-bind_at_load"
     ;;
 *)
     build_target=linux


### PR DESCRIPTION
### Summary
Pass -Wl,-dead_strip,-bind_at_load on macOS to make binary slightly lighter.

##### Component Name
Autotools

##### Additional Information
From `man ld`:
```
-dead_strip
                 Remove functions and data that are unreachable by the entry point or exported symbols.
```
```
-bind_at_load
                 Sets a bit in the mach header of the resulting binary which tells dyld to bind all symbols when the binary is loaded,
                 rather than lazily.
```
Before:
```
% wc -c netdatacli 
   19156 netdatacli

% otool -l netdatacli
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 16384
    rebase_size 8
       bind_off 16392
      bind_size 88
  weak_bind_off 0
 weak_bind_size 0
  lazy_bind_off 16480
 lazy_bind_size 336
     export_off 16816
    export_size 48
```
After:
```
% wc -c netdatacli
   19076 netdatacli

% otool -l netdatacli
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 16384
    rebase_size 8
       bind_off 16392
      bind_size 344
  weak_bind_off 0
 weak_bind_size 0
  lazy_bind_off 0
 lazy_bind_size 0
     export_off 16736
    export_size 48
```