### PR TITLE
install go.d.plugin only if there is new version

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -887,9 +887,9 @@ should_install_go() {
 
   govercomp "$latest_version" "$actual_version"
   case $? in
-  1) return 0 ;; # >
-  3) return 0 ;; # error
-  *) return 1 ;; # =,<
+  0) return 1 ;; # =
+  2) return 1 ;; # <
+  *) return 0 ;; # >, error
   esac
 }
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -817,7 +817,7 @@ govercomp() {
   # - go.d.plugin, version: v0.14.1-dirty
   # - go.d.plugin, version: v0.14.1-1-g4c5f98c
   # - go.d.plugin, version: v0.14.1-1-g4c5f98c-dirty
-  #
+
   # we need to compare only MAJOR.MINOR.PATCH part
   local ver1 ver2
   ver1=$(echo "$1" | grep -E -o "[0-9]+\.[0-9]+\.[0-9]+")
@@ -832,19 +832,10 @@ govercomp() {
   fi
 
   local i
-  for ((i = ${#ver1[@]}; i < ${#ver2[@]}; i++)); do
-    ver1[i]=0
-  done
-
-  for ((i = ${#ver2[@]}; i < ${#ver1[@]}; i++)); do
-    ver2[i]=0
-  done
-
   for ((i = 0; i < ${#ver1[@]}; i++)); do
     if ((10#${ver1[i]} > 10#${ver2[i]})); then
       return 1
-    fi
-    if ((10#${ver1[i]} < 10#${ver2[i]})); then
+    elif ((10#${ver1[i]} < 10#${ver2[i]})); then
       return 2
     fi
   done

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -802,26 +802,36 @@ fi
 
 # -----------------------------------------------------------------------------
 
-# govercomp compares two versions. This function exit codes:
+# govercomp compares go.d.plugin versions. Exit codes:
 # 0 - version1 == version2
 # 1 - version1 > version2
 # 2 - version2 > version1
 # 3 - error
-# Expected version format: dot separated numbers.
 govercomp() {
-  if [[ "$1" == "$2" ]]; then
-    return 0
-  fi
+  # version in file:
+  # - v0.14.0
+  #
+  # 'go.d.plugin -v' output variants:
+  # - go.d.plugin, version: unknown
+  # - go.d.plugin, version: v0.14.1
+  # - go.d.plugin, version: v0.14.1-dirty
+  # - go.d.plugin, version: v0.14.1-1-g4c5f98c
+  # - go.d.plugin, version: v0.14.1-1-g4c5f98c-dirty
+  #
+  # we need to compare only MAJOR.MINOR.PATCH part
+  local ver1 ver2
+  ver1=$(echo "$1" | grep -E -o "[0-9]+\.[0-9]+\.[0-9]+")
+  ver2=$(echo "$2" | grep -E -o "[0-9]+\.[0-9]+\.[0-9]+")
 
   local IFS=.
-  local i ver1 ver2
-  read -ra ver1 <<<"$1"
-  read -ra ver2 <<<"$2"
+  read -ra ver1 <<<"$ver1"
+  read -ra ver2 <<<"$ver2"
 
   if [[ ${#ver1[@]} -eq 0 ]] || [[ ${#ver2[@]} -eq 0 ]]; then
     return 3
   fi
 
+  local i
   for ((i = ${#ver1[@]}; i < ${#ver2[@]}; i++)); do
     ver1[i]=0
   done
@@ -843,49 +853,13 @@ govercomp() {
 }
 
 should_install_go() {
-  # 'go.d.plugin -v' output variants:
-  # - go.d.plugin, version: unknown
-  # - go.d.plugin, version: v0.14.1
-  # - go.d.plugin, version: v0.14.1-dirty
-  # - go.d.plugin, version: v0.14.1-1-g4c5f98c
-  # - go.d.plugin, version: v0.14.1-1-g4c5f98c-dirty
-  #
-  # we download if:
-  # - error during determining latest/actual version and parsing
-  # - actual version < latest version
-  #
-  # we dont if:
-  # - actual version = latest version
-  # - actual version > latest version
-  #
-  # we need to compare only MAJOR.MINOR.PATCH part
+  local version_in_file
+  local binary_version
 
-  local latest_version
-  local binary
-  local binary_output
-  local actual_version
+  version_in_file="$(cat packaging/go.d.version 2>/dev/null)"
+  binary_version=$(${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin -v 2>/dev/null)
 
-  latest_version="$(grep -E -o "[0-9]+\.[0-9]+\.[0-9]+" packaging/go.d.version 2>/dev/null)"
-  if [[ ! $latest_version ]]; then
-    return 0
-  fi
-
-  binary="${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
-  if [[ ! -f $binary ]] || [[ ! -x $binary ]]; then
-    return 0
-  fi
-
-  binary_output=$($binary -v 2>/dev/null)
-  if [[ ! $binary_output ]]; then
-    return 0
-  fi
-
-  actual_version=$(echo "$binary_output" | grep -E -o "[0-9]+\.[0-9]+\.[0-9]+")
-  if [[ ! $actual_version ]]; then
-    return 0
-  fi
-
-  govercomp "$latest_version" "$actual_version"
+  govercomp "$version_in_file" "$binary_version"
   case $? in
   0) return 1 ;; # =
   2) return 1 ;; # <

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -853,6 +853,10 @@ govercomp() {
 }
 
 should_install_go() {
+  if [[ -n "${NETDATA_DISABLE_GO+x}" ]]; then
+    return 1
+  fi
+
   local version_in_file
   local binary_version
 
@@ -885,73 +889,72 @@ install_go() {
     'armv5tel::arm'
   )
 
-  if [ -z "${NETDATA_DISABLE_GO+x}" ]; then
-    progress "Install go.d.plugin"
-    ARCH=$(uname -m)
-    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+  progress "Install go.d.plugin"
+  ARCH=$(uname -m)
+  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-    for index in "${ARCH_MAP[@]}"; do
-      KEY="${index%%::*}"
-      VALUE="${index##*::}"
-      if [ "$KEY" = "$ARCH" ]; then
-        ARCH="${VALUE}"
-        break
-      fi
-    done
-    tmp=$(mktemp -d /tmp/netdata-go-XXXXXX)
-    GO_PACKAGE_BASENAME="go.d.plugin-${GO_PACKAGE_VERSION}.${OS}-${ARCH}.tar.gz"
-
-    if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" ]; then
-      download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/${GO_PACKAGE_BASENAME}" "${tmp}/${GO_PACKAGE_BASENAME}"
-    else
-      progress "Using provided go.d tarball ${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}"
-      run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" "${tmp}/${GO_PACKAGE_BASENAME}"
+  for index in "${ARCH_MAP[@]}"; do
+    KEY="${index%%::*}"
+    VALUE="${index##*::}"
+    if [ "$KEY" = "$ARCH" ]; then
+      ARCH="${VALUE}"
+      break
     fi
+  done
+  tmp=$(mktemp -d /tmp/netdata-go-XXXXXX)
+  GO_PACKAGE_BASENAME="go.d.plugin-${GO_PACKAGE_VERSION}.${OS}-${ARCH}.tar.gz"
 
-    if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}" ]; then
-      download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/config.tar.gz" "${tmp}/config.tar.gz"
-    else
-      progress "Using provided config file for go.d ${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}"
-      run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}" "${tmp}/config.tar.gz"
-    fi
-
-    if [ ! -f "${tmp}/${GO_PACKAGE_BASENAME}" ] || [ ! -f "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/${GO_PACKAGE_BASENAME}" ]; then
-      run_failed "go.d plugin download failed, go.d plugin will not be available"
-      echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
-      echo >&2
-      return 0
-    fi
-
-    grep "${GO_PACKAGE_BASENAME}\$" "${INSTALLER_DIR}/packaging/go.d.checksums" > "${tmp}/sha256sums.txt" 2> /dev/null
-    grep "config.tar.gz" "${INSTALLER_DIR}/packaging/go.d.checksums" >> "${tmp}/sha256sums.txt" 2> /dev/null
-
-    # Checksum validation
-    if ! (cd "${tmp}" && safe_sha256sum -c "sha256sums.txt"); then
-
-      echo >&2 "go.d plugin checksum validation failure."
-      echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
-      echo >&2
-
-      run_failed "go.d.plugin package files checksum validation failed."
-      return 0
-    fi
-
-    # Install new files
-    run rm -rf "${NETDATA_STOCK_CONFIG_DIR}/go.d"
-    run rm -rf "${NETDATA_STOCK_CONFIG_DIR}/go.d.conf"
-    run tar -xf "${tmp}/config.tar.gz" -C "${NETDATA_STOCK_CONFIG_DIR}/"
-    run chown -R "${ROOT_USER}:${ROOT_GROUP}" "${NETDATA_STOCK_CONFIG_DIR}"
-
-    run tar xf "${tmp}/${GO_PACKAGE_BASENAME}"
-    run mv "${GO_PACKAGE_BASENAME/\.tar\.gz/}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
-    if [ "${UID}" -eq 0 ]; then
-      run chown "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
-    fi
-    run chmod 0750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
-    rm -rf "${tmp}"
+  if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" ]; then
+    download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/${GO_PACKAGE_BASENAME}" "${tmp}/${GO_PACKAGE_BASENAME}"
+  else
+    progress "Using provided go.d tarball ${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}"
+    run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" "${tmp}/${GO_PACKAGE_BASENAME}"
   fi
+
+  if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}" ]; then
+    download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/config.tar.gz" "${tmp}/config.tar.gz"
+  else
+    progress "Using provided config file for go.d ${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}"
+    run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG}" "${tmp}/config.tar.gz"
+  fi
+
+  if [ ! -f "${tmp}/${GO_PACKAGE_BASENAME}" ] || [ ! -f "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/${GO_PACKAGE_BASENAME}" ]; then
+    run_failed "go.d plugin download failed, go.d plugin will not be available"
+    echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
+    echo >&2
+    return 0
+  fi
+
+  grep "${GO_PACKAGE_BASENAME}\$" "${INSTALLER_DIR}/packaging/go.d.checksums" >"${tmp}/sha256sums.txt" 2>/dev/null
+  grep "config.tar.gz" "${INSTALLER_DIR}/packaging/go.d.checksums" >>"${tmp}/sha256sums.txt" 2>/dev/null
+
+  # Checksum validation
+  if ! (cd "${tmp}" && safe_sha256sum -c "sha256sums.txt"); then
+
+    echo >&2 "go.d plugin checksum validation failure."
+    echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
+    echo >&2
+
+    run_failed "go.d.plugin package files checksum validation failed."
+    return 0
+  fi
+
+  # Install new files
+  run rm -rf "${NETDATA_STOCK_CONFIG_DIR}/go.d"
+  run rm -rf "${NETDATA_STOCK_CONFIG_DIR}/go.d.conf"
+  run tar -xf "${tmp}/config.tar.gz" -C "${NETDATA_STOCK_CONFIG_DIR}/"
+  run chown -R "${ROOT_USER}:${ROOT_GROUP}" "${NETDATA_STOCK_CONFIG_DIR}"
+
+  run tar xf "${tmp}/${GO_PACKAGE_BASENAME}"
+  run mv "${GO_PACKAGE_BASENAME/\.tar\.gz/}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
+  if [ "${UID}" -eq 0 ]; then
+    run chown "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
+  fi
+  run chmod 0750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
+  rm -rf "${tmp}"
   return 0
 }
+
 install_go
 
 # -----------------------------------------------------------------------------

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -852,7 +852,7 @@ should_install_go() {
   #
   # we download if:
   # - error during determining latest/actual version and parsing
-  # - actual version > latest version
+  # - actual version < latest version
   #
   # we dont if:
   # - actual version = latest version

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -852,7 +852,7 @@ should_install_go() {
   local binary_version
 
   version_in_file="$(cat packaging/go.d.version 2>/dev/null)"
-  binary_version=$(${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin -v 2>/dev/null)
+  binary_version=$("${NETDATA_PREFIX}"/usr/libexec/netdata/plugins.d/go.d.plugin -v 2>/dev/null)
 
   govercomp "$version_in_file" "$binary_version"
   case $? in

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -827,15 +827,15 @@ govercomp() {
   read -ra ver1 <<<"$ver1"
   read -ra ver2 <<<"$ver2"
 
-  if [[ ${#ver1[@]} -eq 0 ]] || [[ ${#ver2[@]} -eq 0 ]]; then
+  if [ ${#ver1[@]} -eq 0 ] || [ ${#ver2[@]} -eq 0 ]; then
     return 3
   fi
 
   local i
   for ((i = 0; i < ${#ver1[@]}; i++)); do
-    if [[ ${ver1[i]} > ${ver2[i]} ]]; then
+    if [ "${ver1[i]}" -gt "${ver2[i]}" ]; then
       return 1
-    elif [[ ${ver1[i]} < ${ver2[i]} ]]; then
+    elif [ "${ver1[i]}" -gt "${ver2[i]}" ]; then
       return 2
     fi
   done
@@ -844,7 +844,7 @@ govercomp() {
 }
 
 should_install_go() {
-  if [[ -n "${NETDATA_DISABLE_GO+x}" ]]; then
+  if [ -n "${NETDATA_DISABLE_GO+x}" ]; then
     return 1
   fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -818,7 +818,7 @@ govercomp() {
   read -ra ver1 <<<"$1"
   read -ra ver2 <<<"$2"
 
-  if [[ ! $ver1 ]] || [[ ! $ver2 ]]; then
+  if [[ ${#ver1[@]} -eq 0 ]] || [[ ${#ver2[@]} -eq 0 ]]; then
     return 3
   fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -833,9 +833,9 @@ govercomp() {
 
   local i
   for ((i = 0; i < ${#ver1[@]}; i++)); do
-    if ((10#${ver1[i]} > 10#${ver2[i]})); then
+    if [[ ${ver1[i]} > ${ver2[i]} ]]; then
       return 1
-    elif ((10#${ver1[i]} < 10#${ver2[i]})); then
+    elif [[ ${ver1[i]} < ${ver2[i]} ]]; then
       return 2
     fi
   done


### PR DESCRIPTION
##### Summary

Fixes: #7799

##### Component Name

netdata-installer

##### Additional Information

Tests:

download latest if:

- [x] no go.d.plugin
- [x] go.d.plugin actual version is less then latest
- [x] error during checking/parsing versions

skip downloading if:
- [x] NETDATA_DISABLE_GO param is set
- [x] go.d.plugin actual version is equal to the latest
- [x] go.d.plugin actual version is greater then the latest
