### PR TITLE
netdata-updater.sh: explicitly return 0 from update

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -154,7 +154,8 @@ update() {
 
 	rm -rf "${tmpdir}" >&3 2>&3
 	[ -n "${logfile}" ] && rm "${logfile}" && logfile=
-	return
+
+	return 0
 }
 
 # Usually stored in /etc/netdata/.environment


### PR DESCRIPTION
##### Summary

Fixes: #7954

> If n is omitted, the return status is that of the last command executed in the function body.

It returns `1` when running on terminal. 

We need return 0

https://github.com/netdata/netdata/blob/b5d8898ed9fecc62cf10e7522c0e2f1213dc91ac/packaging/installer/netdata-updater.sh#L215-L218

##### Component Name

`/packagin/installer`

##### Additional Information

