### PR TITLE
Fixes static builds and nightlies

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -511,12 +511,11 @@ require_cmd() {
 
   local wanted found
   for wanted in "${@}"; do
-    if command -v "${wanted}" 2> /dev/null; then
+    if command -v "${wanted}" > /dev/null 2>&1; then
       found="$(command -v "$wanted" 2> /dev/null)"
     fi
     [ -n "${found}" ] && [ -x "${found}" ] && return 0
   done
-
   return 1
 }
 

--- a/packaging/makeself/build-x86_64-static.sh
+++ b/packaging/makeself/build-x86_64-static.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,34 +8,34 @@ set -e
 
 DOCKER_CONTAINER_NAME="netdata-package-x86_64-static-alpine37"
 
-if ! docker inspect "${DOCKER_CONTAINER_NAME}" >/dev/null 2>&1; then
-    # To run interactively:
-    #   docker run -it netdata-package-x86_64-static /bin/sh
-    # (add -v host-dir:guest-dir:rw arguments to mount volumes)
-    #
-    # To remove images in order to re-create:
-    #   docker rm -v $(sudo docker ps -a -q -f status=exited)
-    #   docker rmi netdata-package-x86_64-static
-    #
-    # This command maps the current directory to
-    #   /usr/src/netdata.git
-    # inside the container and runs the script install-alpine-packages.sh
-    # (also inside the container)
-    #
-    run docker run -v $(pwd):/usr/src/netdata.git:rw alpine:3.7 \
-        /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh
+if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
+  # To run interactively:
+  #   docker run -it netdata-package-x86_64-static /bin/sh
+  # (add -v host-dir:guest-dir:rw arguments to mount volumes)
+  #
+  # To remove images in order to re-create:
+  #   docker rm -v $(sudo docker ps -a -q -f status=exited)
+  #   docker rmi netdata-package-x86_64-static
+  #
+  # This command maps the current directory to
+  #   /usr/src/netdata.git
+  # inside the container and runs the script install-alpine-packages.sh
+  # (also inside the container)
+  #
+  run docker run -v $(pwd):/usr/src/netdata.git:rw alpine:3.7 \
+    /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh
 
-    # save the changes made permanently
-    id=$(docker ps -l -q)
-    run docker commit ${id} "${DOCKER_CONTAINER_NAME}"
+  # save the changes made permanently
+  id=$(docker ps -l -q)
+  run docker commit ${id} "${DOCKER_CONTAINER_NAME}"
 fi
 
 # Run the build script inside the container
 run docker run -a stdin -a stdout -a stderr -i -t -v \
-    $(pwd):/usr/src/netdata.git:rw \
-    "${DOCKER_CONTAINER_NAME}" \
-    /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
+  $(pwd):/usr/src/netdata.git:rw \
+  "${DOCKER_CONTAINER_NAME}" \
+  /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
 
 if [ "${USER}" ]; then
-    chown -R "${USER}" .
+  chown -R "${USER}" .
 fi

--- a/packaging/makeself/build-x86_64-static.sh
+++ b/packaging/makeself/build-x86_64-static.sh
@@ -2,7 +2,8 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-. $(dirname "$0")/../installer/functions.sh || exit 1
+# shellcheck source=./packaging/installer/functions.sh
+. "$(dirname "$0")"/../installer/functions.sh || exit 1
 
 set -e
 
@@ -22,17 +23,17 @@ if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
   # inside the container and runs the script install-alpine-packages.sh
   # (also inside the container)
   #
-  run docker run -v $(pwd):/usr/src/netdata.git:rw alpine:3.7 \
+  run docker run -v "$(pwd)":/usr/src/netdata.git:rw alpine:3.7 \
     /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh
 
   # save the changes made permanently
   id=$(docker ps -l -q)
-  run docker commit ${id} "${DOCKER_CONTAINER_NAME}"
+  run docker commit "${id}" "${DOCKER_CONTAINER_NAME}"
 fi
 
 # Run the build script inside the container
 run docker run -a stdin -a stdout -a stderr -i -t -v \
-  $(pwd):/usr/src/netdata.git:rw \
+  "$(pwd)":/usr/src/netdata.git:rw \
   "${DOCKER_CONTAINER_NAME}" \
   /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
 


### PR DESCRIPTION
##### Summary

This was the cause for our nightlies being broken for so long :/

#7725 broke this :/ So sorry :/

##### Component Name

area/packaging

##### Additional Information

🤦‍♂️

##### Test Plan

**Beofre:**

```sh
prologic@Jamess-iMac
Tue Feb 04 17:12:28
~/NetData/netdata
 (master) 0
$ dki -t -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/netdata -w /netdata debian:buster /bin/bash
root@9d864f5524d8:/netdata# ./packaging/makeself/build-x86_64-static.sh
./packaging/makeself/build-x86_64-static.sh: 327: ./packaging/makeself/../installer/functions.sh: Syntax error: "(" unexpected (expecting "then")
```

**After:**

```sh
prologic@Jamess-iMac
Tue Feb 04 17:16:44
~/NetData/netdata
 (master) 0
$ dki -t -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/netdata -w /netdata debian:buster /bin/bash
root@f6bb12d81e86:/netdata# ./packaging/makeself/build-x86_64-static.sh
[/netdata]# docker run -v /netdata:/usr/src/netdata.git:rw alpine:3.7 /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh \n./packaging/makeself/../installer/functions.sh: line 227: docker: command not found
root@f6bb12d81e86:/netdata# exit
```