### PR TITLE
/collectors/charts.d.plugin: format modules

### DIFF
--- a/collectors/charts.d.plugin/ap/ap.chart.sh
+++ b/collectors/charts.d.plugin/ap/ap.chart.sh
@@ -16,9 +16,9 @@ declare -A ap_devs=()
 
 # _check is called once, to find out if this chart should be enabled or not
 ap_check() {
-	require_cmd iw || return 1
-	local ev
-	ev=$(run iw dev | awk '
+  require_cmd iw || return 1
+  local ev
+  ev=$(run iw dev | awk '
 		BEGIN {
 			i = "";
 			ssid = "";
@@ -41,26 +41,26 @@ ap_check() {
 			}
 		}
 	')
-	eval "${ev}"
+  eval "${ev}"
 
-	# this should return:
-	#  - 0 to enable the chart
-	#  - 1 to disable the chart
+  # this should return:
+  #  - 0 to enable the chart
+  #  - 1 to disable the chart
 
-	[ ${#ap_devs[@]} -gt 0 ] && return 0
-	error "no devices found in AP mode, with 'iw dev'"
-	return 1
+  [ ${#ap_devs[@]} -gt 0 ] && return 0
+  error "no devices found in AP mode, with 'iw dev'"
+  return 1
 }
 
 # _create is called once, to create the charts
 ap_create() {
-	local ssid dev
+  local ssid dev
 
-	for dev in "${!ap_devs[@]}"; do
-		ssid="${ap_devs[${dev}]}"
+  for dev in "${!ap_devs[@]}"; do
+    ssid="${ap_devs[${dev}]}"
 
-		# create the chart with 3 dimensions
-		cat <<EOF
+    # create the chart with 3 dimensions
+    cat << EOF
 CHART ap_clients.${dev} '' "Connected clients to ${ssid} on ${dev}" "clients" ${dev} ap.clients line $((ap_priority + 1)) $ap_update_every
 DIMENSION clients '' absolute 1 1
 
@@ -84,25 +84,25 @@ DIMENSION receive '' absolute 1 1000
 DIMENSION transmit '' absolute -1 1000
 DIMENSION expected 'expected throughput' absolute 1 1000
 EOF
-	done
+  done
 
-	return 0
+  return 0
 }
 
 # _update is called continuously, to collect the values
 ap_update() {
-	# the first argument to this function is the microseconds since last update
-	# pass this parameter to the BEGIN statement (see bellow).
+  # the first argument to this function is the microseconds since last update
+  # pass this parameter to the BEGIN statement (see bellow).
 
-	# do all the work to collect / calculate the values
-	# for each dimension
-	# remember: KEEP IT SIMPLE AND SHORT
+  # do all the work to collect / calculate the values
+  # for each dimension
+  # remember: KEEP IT SIMPLE AND SHORT
 
-	for dev in "${!ap_devs[@]}"; do
-		echo
-		echo "DEVICE ${dev}"
-		iw "${dev}" station dump
-	done | awk '
+  for dev in "${!ap_devs[@]}"; do
+    echo
+    echo "DEVICE ${dev}"
+    iw "${dev}" station dump
+  done | awk '
         function zero_data() {
             dev = "";
             c = 0;
@@ -175,5 +175,5 @@ ap_update() {
         }
     '
 
-	return 0
+  return 0
 }

--- a/collectors/charts.d.plugin/example/example.chart.sh
+++ b/collectors/charts.d.plugin/example/example.chart.sh
@@ -32,63 +32,63 @@ example_last=0
 example_count=0
 
 example_get() {
-	# do all the work to collect / calculate the values
-	# for each dimension
-	#
-	# Remember:
-	# 1. KEEP IT SIMPLE AND SHORT
-	# 2. AVOID FORKS (avoid piping commands)
-	# 3. AVOID CALLING TOO MANY EXTERNAL PROGRAMS
-	# 4. USE LOCAL VARIABLES (global variables may overlap with other modules)
+  # do all the work to collect / calculate the values
+  # for each dimension
+  #
+  # Remember:
+  # 1. KEEP IT SIMPLE AND SHORT
+  # 2. AVOID FORKS (avoid piping commands)
+  # 3. AVOID CALLING TOO MANY EXTERNAL PROGRAMS
+  # 4. USE LOCAL VARIABLES (global variables may overlap with other modules)
 
-	example_value1=$RANDOM
-	example_value2=$RANDOM
-	example_value3=$RANDOM
-	example_value4=$((8192 + (RANDOM * 16383 / 32767)))
+  example_value1=$RANDOM
+  example_value2=$RANDOM
+  example_value3=$RANDOM
+  example_value4=$((8192 + (RANDOM * 16383 / 32767)))
 
-	if [ $example_count -gt 0 ]; then
-		example_count=$((example_count - 1))
+  if [ $example_count -gt 0 ]; then
+    example_count=$((example_count - 1))
 
-		[ $example_last -gt 16383 ] && example_value4=$((example_last + (RANDOM * ((32767 - example_last) / 2) / 32767)))
-		[ $example_last -le 16383 ] && example_value4=$((example_last - (RANDOM * (example_last / 2) / 32767)))
-	else
-		example_count=$((1 + (RANDOM * 5 / 32767)))
+    [ $example_last -gt 16383 ] && example_value4=$((example_last + (RANDOM * ((32767 - example_last) / 2) / 32767)))
+    [ $example_last -le 16383 ] && example_value4=$((example_last - (RANDOM * (example_last / 2) / 32767)))
+  else
+    example_count=$((1 + (RANDOM * 5 / 32767)))
 
-		if [ $example_last -gt 16383 ] && [ $example_value4 -gt 16383 ]; then
-			example_value4=$((example_value4 - 16383))
-		fi
-		if [ $example_last -le 16383 ] && [ $example_value4 -lt 16383 ]; then
-			example_value4=$((example_value4 + 16383))
-		fi
-	fi
-	example_last=$example_value4
+    if [ $example_last -gt 16383 ] && [ $example_value4 -gt 16383 ]; then
+      example_value4=$((example_value4 - 16383))
+    fi
+    if [ $example_last -le 16383 ] && [ $example_value4 -lt 16383 ]; then
+      example_value4=$((example_value4 + 16383))
+    fi
+  fi
+  example_last=$example_value4
 
-	# this should return:
-	#  - 0 to send the data to netdata
-	#  - 1 to report a failure to collect the data
+  # this should return:
+  #  - 0 to send the data to netdata
+  #  - 1 to report a failure to collect the data
 
-	return 0
+  return 0
 }
 
 # _check is called once, to find out if this chart should be enabled or not
 example_check() {
-	# this should return:
-	#  - 0 to enable the chart
-	#  - 1 to disable the chart
+  # this should return:
+  #  - 0 to enable the chart
+  #  - 1 to disable the chart
 
-	# check something
-	[ "${example_magic_number}" != "12345" ] && error "manual configuration required: you have to set example_magic_number=$example_magic_number in example.conf to start example chart." && return 1
+  # check something
+  [ "${example_magic_number}" != "12345" ] && error "manual configuration required: you have to set example_magic_number=$example_magic_number in example.conf to start example chart." && return 1
 
-	# check that we can collect data
-	example_get || return 1
+  # check that we can collect data
+  example_get || return 1
 
-	return 0
+  return 0
 }
 
 # _create is called once, to create the charts
 example_create() {
-	# create the chart with 3 dimensions
-	cat <<EOF
+  # create the chart with 3 dimensions
+  cat << EOF
 CHART example.random '' "Random Numbers Stacked Chart" "% of random numbers" random random stacked $((example_priority)) $example_update_every
 DIMENSION random1 '' percentage-of-absolute-row 1 1
 DIMENSION random2 '' percentage-of-absolute-row 1 1
@@ -97,18 +97,18 @@ CHART example.random2 '' "A random number" "random number" random random area $(
 DIMENSION random '' absolute 1 1
 EOF
 
-	return 0
+  return 0
 }
 
 # _update is called continuously, to collect the values
 example_update() {
-	# the first argument to this function is the microseconds since last update
-	# pass this parameter to the BEGIN statement (see bellow).
+  # the first argument to this function is the microseconds since last update
+  # pass this parameter to the BEGIN statement (see bellow).
 
-	example_get || return 1
+  example_get || return 1
 
-	# write the result of the work.
-	cat <<VALUESEOF
+  # write the result of the work.
+  cat << VALUESEOF
 BEGIN example.random $1
 SET random1 = $example_value1
 SET random2 = $example_value2
@@ -119,5 +119,5 @@ SET random = $example_value4
 END
 VALUESEOF
 
-	return 0
+  return 0
 }

--- a/collectors/charts.d.plugin/libreswan/libreswan.chart.sh
+++ b/collectors/charts.d.plugin/libreswan/libreswan.chart.sh
@@ -39,76 +39,76 @@ declare -A libreswan_tunnel_charts=()
 
 # run the ipsec command
 libreswan_ipsec() {
-	if [ ${libreswan_sudo} -ne 0 ]; then
-		sudo -n "${IPSEC_CMD}" "${@}"
-		return $?
-	else
-		"${IPSEC_CMD}" "${@}"
-		return $?
-	fi
+  if [ ${libreswan_sudo} -ne 0 ]; then
+    sudo -n "${IPSEC_CMD}" "${@}"
+    return $?
+  else
+    "${IPSEC_CMD}" "${@}"
+    return $?
+  fi
 }
 
 # fetch latest values - fill the arrays
 libreswan_get() {
-	# do all the work to collect / calculate the values
-	# for each dimension
+  # do all the work to collect / calculate the values
+  # for each dimension
 
-	# empty the variables
-	libreswan_traffic_in=()
-	libreswan_traffic_out=()
-	libreswan_established_add_time=()
-	libreswan_connected_tunnels=()
+  # empty the variables
+  libreswan_traffic_in=()
+  libreswan_traffic_out=()
+  libreswan_established_add_time=()
+  libreswan_connected_tunnels=()
 
-	# convert the ipsec command output to a shell script
-	# and source it to get the values
-	# shellcheck disable=SC1090
-	source <(
-		{
-			libreswan_ipsec whack --status
-			libreswan_ipsec whack --trafficstatus
-		} | sed -n \
-			-e "s|[0-9]\+ #\([0-9]\+\): \"\(.*\)\".*IPsec SA established.*newest IPSEC.*|libreswan_connected_tunnels[\"\1\"]=\"\2\"|p" \
-			-e "s|[0-9]\+ #\([0-9]\+\): \"\(.*\)\",.* add_time=\([0-9]\+\),.* inBytes=\([0-9]\+\),.* outBytes=\([0-9]\+\).*|libreswan_traffic_in[\"\1\"]=\"\4\"; libreswan_traffic_out[\"\1\"]=\"\5\"; libreswan_established_add_time[\"\1\"]=\"\3\";|p"
-	) || return 1
+  # convert the ipsec command output to a shell script
+  # and source it to get the values
+  # shellcheck disable=SC1090
+  source <(
+    {
+      libreswan_ipsec whack --status
+      libreswan_ipsec whack --trafficstatus
+    } | sed -n \
+      -e "s|[0-9]\+ #\([0-9]\+\): \"\(.*\)\".*IPsec SA established.*newest IPSEC.*|libreswan_connected_tunnels[\"\1\"]=\"\2\"|p" \
+      -e "s|[0-9]\+ #\([0-9]\+\): \"\(.*\)\",.* add_time=\([0-9]\+\),.* inBytes=\([0-9]\+\),.* outBytes=\([0-9]\+\).*|libreswan_traffic_in[\"\1\"]=\"\4\"; libreswan_traffic_out[\"\1\"]=\"\5\"; libreswan_established_add_time[\"\1\"]=\"\3\";|p"
+  ) || return 1
 
-	# check we got some data
-	[ ${#libreswan_connected_tunnels[@]} -eq 0 ] && return 1
+  # check we got some data
+  [ ${#libreswan_connected_tunnels[@]} -eq 0 ] && return 1
 
-	return 0
+  return 0
 }
 
 # _check is called once, to find out if this chart should be enabled or not
 libreswan_check() {
-	# this should return:
-	#  - 0 to enable the chart
-	#  - 1 to disable the chart
+  # this should return:
+  #  - 0 to enable the chart
+  #  - 1 to disable the chart
 
-	require_cmd ipsec || return 1
+  require_cmd ipsec || return 1
 
-	# make sure it is libreswan
-	# shellcheck disable=SC2143
-	if [ -z "$(ipsec --version | grep -i libreswan)" ]; then
-		error "ipsec command is not Libreswan. Disabling Libreswan plugin."
-		return 1
-	fi
+  # make sure it is libreswan
+  # shellcheck disable=SC2143
+  if [ -z "$(ipsec --version | grep -i libreswan)" ]; then
+    error "ipsec command is not Libreswan. Disabling Libreswan plugin."
+    return 1
+  fi
 
-	# check that we can collect data
-	libreswan_get || return 1
+  # check that we can collect data
+  libreswan_get || return 1
 
-	return 0
+  return 0
 }
 
 # create the charts for an ipsec tunnel
 libreswan_create_one() {
-	local n="${1}" name
+  local n="${1}" name
 
-	name="${libreswan_connected_tunnels[${n}]}"
+  name="${libreswan_connected_tunnels[${n}]}"
 
-	[ ! -z "${libreswan_tunnel_charts[${name}]}" ] && return 0
+  [ ! -z "${libreswan_tunnel_charts[${name}]}" ] && return 0
 
-	libreswan_tunnel_charts[${name}]="$(fixid "${name}")"
+  libreswan_tunnel_charts[${name}]="$(fixid "${name}")"
 
-	cat <<EOF
+  cat << EOF
 CHART libreswan.${libreswan_tunnel_charts[${name}]}_net '${name}_net' "LibreSWAN Tunnel ${name} Traffic" "kilobits/s" "${name}" libreswan.net area $((libreswan_priority)) $libreswan_update_every
 DIMENSION in '' incremental 8 1000
 DIMENSION out '' incremental -8 1000
@@ -116,35 +116,35 @@ CHART libreswan.${libreswan_tunnel_charts[${name}]}_uptime '${name}_uptime' "Lib
 DIMENSION uptime '' absolute 1 1
 EOF
 
-	return 0
+  return 0
 
 }
 
 # _create is called once, to create the charts
 libreswan_create() {
-	local n
-	for n in "${!libreswan_connected_tunnels[@]}"; do
-		libreswan_create_one "${n}"
-	done
-	return 0
+  local n
+  for n in "${!libreswan_connected_tunnels[@]}"; do
+    libreswan_create_one "${n}"
+  done
+  return 0
 }
 
 libreswan_now=$(date +%s)
 
 # send the values to netdata for an ipsec tunnel
 libreswan_update_one() {
-	local n="${1}" microseconds="${2}" name id uptime
+  local n="${1}" microseconds="${2}" name id uptime
 
-	name="${libreswan_connected_tunnels[${n}]}"
-	id="${libreswan_tunnel_charts[${name}]}"
+  name="${libreswan_connected_tunnels[${n}]}"
+  id="${libreswan_tunnel_charts[${name}]}"
 
-	[ -z "${id}" ] && libreswan_create_one "${name}"
+  [ -z "${id}" ] && libreswan_create_one "${name}"
 
-	uptime=$((libreswan_now - libreswan_established_add_time[${n}]))
-	[ ${uptime} -lt 0 ] && uptime=0
+  uptime=$((libreswan_now - libreswan_established_add_time[${n}]))
+  [ ${uptime} -lt 0 ] && uptime=0
 
-	# write the result of the work.
-	cat <<VALUESEOF
+  # write the result of the work.
+  cat << VALUESEOF
 BEGIN libreswan.${id}_net ${microseconds}
 SET in = ${libreswan_traffic_in[${n}]}
 SET out = ${libreswan_traffic_out[${n}]}
@@ -157,16 +157,16 @@ VALUESEOF
 
 # _update is called continiously, to collect the values
 libreswan_update() {
-	# the first argument to this function is the microseconds since last update
-	# pass this parameter to the BEGIN statement (see bellow).
+  # the first argument to this function is the microseconds since last update
+  # pass this parameter to the BEGIN statement (see bellow).
 
-	libreswan_get || return 1
-	libreswan_now=$(date +%s)
+  libreswan_get || return 1
+  libreswan_now=$(date +%s)
 
-	local n
-	for n in "${!libreswan_connected_tunnels[@]}"; do
-		libreswan_update_one "${n}" "${@}"
-	done
+  local n
+  for n in "${!libreswan_connected_tunnels[@]}"; do
+    libreswan_update_one "${n}" "${@}"
+  done
 
-	return 0
+  return 0
 }

--- a/collectors/charts.d.plugin/libreswan/libreswan.chart.sh
+++ b/collectors/charts.d.plugin/libreswan/libreswan.chart.sh
@@ -104,7 +104,7 @@ libreswan_create_one() {
 
   name="${libreswan_connected_tunnels[${n}]}"
 
-  [ ! -z "${libreswan_tunnel_charts[${name}]}" ] && return 0
+  [ -n "${libreswan_tunnel_charts[${name}]}" ] && return 0
 
   libreswan_tunnel_charts[${name}]="$(fixid "${name}")"
 

--- a/collectors/charts.d.plugin/nut/nut.chart.sh
+++ b/collectors/charts.d.plugin/nut/nut.chart.sh
@@ -56,7 +56,7 @@ nut_check() {
     nut_get "$x" > /dev/null
     # shellcheck disable=SC2181
     if [ $? -eq 0 ]; then
-      if [ ! -z "${nut_names[${x}]}" ]; then
+      if [ -n "${nut_names[${x}]}" ]; then
         nut_ids[$x]="$(fixid "${nut_names[${x}]}")"
       else
         nut_ids[$x]="$(fixid "$x")"

--- a/collectors/charts.d.plugin/nut/nut.chart.sh
+++ b/collectors/charts.d.plugin/nut/nut.chart.sh
@@ -28,59 +28,59 @@ declare -A nut_ids=()
 declare -A nut_names=()
 
 nut_get_all() {
-	run -t $nut_timeout upsc -l
+  run -t $nut_timeout upsc -l
 }
 
 nut_get() {
-	run -t $nut_timeout upsc "$1"
+  run -t $nut_timeout upsc "$1"
 
-	if [ "${nut_clients_chart}" -eq "1" ]; then
-		printf "ups.connected_clients: "
-		run -t $nut_timeout upsc -c "$1" | wc -l
-	fi
+  if [ "${nut_clients_chart}" -eq "1" ]; then
+    printf "ups.connected_clients: "
+    run -t $nut_timeout upsc -c "$1" | wc -l
+  fi
 }
 
 nut_check() {
 
-	# this should return:
-	#  - 0 to enable the chart
-	#  - 1 to disable the chart
+  # this should return:
+  #  - 0 to enable the chart
+  #  - 1 to disable the chart
 
-	local x
+  local x
 
-	require_cmd upsc || return 1
+  require_cmd upsc || return 1
 
-	[ -z "$nut_ups" ] && nut_ups="$(nut_get_all)"
+  [ -z "$nut_ups" ] && nut_ups="$(nut_get_all)"
 
-	for x in $nut_ups; do
-		nut_get "$x" >/dev/null
-		# shellcheck disable=SC2181
-		if [ $? -eq 0 ]; then
-			if [ ! -z "${nut_names[${x}]}" ]; then
-				nut_ids[$x]="$(fixid "${nut_names[${x}]}")"
-			else
-				nut_ids[$x]="$(fixid "$x")"
-			fi
-			continue
-		fi
-		error "cannot get information for NUT UPS '$x'."
-	done
+  for x in $nut_ups; do
+    nut_get "$x" > /dev/null
+    # shellcheck disable=SC2181
+    if [ $? -eq 0 ]; then
+      if [ ! -z "${nut_names[${x}]}" ]; then
+        nut_ids[$x]="$(fixid "${nut_names[${x}]}")"
+      else
+        nut_ids[$x]="$(fixid "$x")"
+      fi
+      continue
+    fi
+    error "cannot get information for NUT UPS '$x'."
+  done
 
-	if [ ${#nut_ids[@]} -eq 0 ]; then
-		# shellcheck disable=SC2154
-		error "Cannot find UPSes - please set nut_ups='ups_name' in $confd/nut.conf"
-		return 1
-	fi
+  if [ ${#nut_ids[@]} -eq 0 ]; then
+    # shellcheck disable=SC2154
+    error "Cannot find UPSes - please set nut_ups='ups_name' in $confd/nut.conf"
+    return 1
+  fi
 
-	return 0
+  return 0
 }
 
 nut_create() {
-	# create the charts
-	local x
+  # create the charts
+  local x
 
-	for x in "${nut_ids[@]}"; do
-		cat <<EOF
+  for x in "${nut_ids[@]}"; do
+    cat << EOF
 CHART nut_$x.charge '' "UPS Charge" "percentage" ups nut.charge area $((nut_priority + 1)) $nut_update_every
 DIMENSION battery_charge charge absolute 1 100
 
@@ -115,30 +115,30 @@ CHART nut_$x.temp '' "UPS Temperature" "temperature" ups nut.temperature line $(
 DIMENSION temp temp absolute 1 100
 EOF
 
-		if [ "${nut_clients_chart}" = "1" ]; then
-			cat <<EOF2
+    if [ "${nut_clients_chart}" = "1" ]; then
+      cat << EOF2
 CHART nut_$x.clients '' "UPS Connected Clients" "clients" ups nut.clients area $((nut_priority + 9)) $nut_update_every
 DIMENSION clients '' absolute 1 1
 EOF2
-		fi
+    fi
 
-	done
+  done
 
-	return 0
+  return 0
 }
 
 nut_update() {
-	# the first argument to this function is the microseconds since last update
-	# pass this parameter to the BEGIN statement (see bellow).
+  # the first argument to this function is the microseconds since last update
+  # pass this parameter to the BEGIN statement (see bellow).
 
-	# do all the work to collect / calculate the values
-	# for each dimension
-	# remember: KEEP IT SIMPLE AND SHORT
+  # do all the work to collect / calculate the values
+  # for each dimension
+  # remember: KEEP IT SIMPLE AND SHORT
 
-	local i x
-	for i in "${!nut_ids[@]}"; do
-		x="${nut_ids[$i]}"
-		nut_get "$i" | awk "
+  local i x
+  for i in "${!nut_ids[@]}"; do
+    x="${nut_ids[$i]}"
+    nut_get "$i" | awk "
 BEGIN {
 	battery_charge = 0;
     battery_runtime = 0;
@@ -223,10 +223,10 @@ END {
 		print \"END\"
 	}
 }"
-		# shellcheck disable=2181
-		[ $? -ne 0 ] && unset "nut_ids[$i]" && error "failed to get values for '$i', disabling it."
-	done
+    # shellcheck disable=2181
+    [ $? -ne 0 ] && unset "nut_ids[$i]" && error "failed to get values for '$i', disabling it."
+  done
 
-	[ ${#nut_ids[@]} -eq 0 ] && error "no UPSes left active." && return 1
-	return 0
+  [ ${#nut_ids[@]} -eq 0 ] && error "no UPSes left active." && return 1
+  return 0
 }


### PR DESCRIPTION
##### Summary

Auto format modules, it seems my bash shell linter has (almost) same rules as @prologic 

i changed only 2 things:
- indent switch will be indented
- redirect operator will be followed by a space

I tested it by auto formatting [install-requred-packages.sh](https://github.com/netdata/netdata/blob/master/packaging/installer/install-required-packages.sh) script - zero changes.

##### Component Name

[`/collectors/charts.d.plugin`](https://github.com/netdata/netdata/tree/master/collectors/charts.d.plugin)

##### Additional Information

i format following modules:
- ap
- apcupds
- example
- libreswan
- nut
- opensips

Ohter modules will be removed (i hope) after https://github.com/netdata/netdata/pull/7962 is merged.

