### PR TITLE
collectors: apps.plugin: apps_groups: update ceph & samba collections.

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -155,8 +155,8 @@ azure: mdsd *waagent* *omiserver* *omiagent* hv_kvp_daemon hv_vss_daemon *auoms*
 # -----------------------------------------------------------------------------
 # storage, file systems and file servers
 
-ceph: ceph-mds ceph-mgr ceph-mon ceph-osd radosgw* rbd-*
-samba: smbd nmbd winbindd
+ceph: ceph-* ceph_* radosgw* rbd-* cephfs-* osdmaptool crushtool
+samba: smbd nmbd winbindd ctdbd ctdb-* ctdb_*
 nfs: rpcbind rpc.* nfs*
 zfs: spl_* z_* txg_* zil_* arc_* l2arc*
 btrfs: btrfs*


### PR DESCRIPTION
samba: added [ctdb](https://wiki.samba.org/index.php/CTDB_and_Clustered_Samba) tools and daemons.
ceph: fixed patterns for cover most of Ceph binaries and crush tools than can eat many of CPU.
Current list of Ceph /bin

```
ceph
ceph-authtool
ceph_bench_log
ceph-bluestore-tool
ceph-client-debug
ceph-clsinfo
ceph-conf
ceph-coverage
ceph-crash
ceph-create-keys
ceph-debugpack
cephdeduptool
ceph-dencoder
ceph_erasure_code
ceph_erasure_code_benchmark
cephfs-data-scan
cephfs-journal-tool
cephfs-shell
cephfs-table-tool
ceph-fuse
ceph_kvstorebench
ceph-kvstore-tool
ceph-mds
ceph-mon
ceph-monstore-tool
ceph_multi_stress_watch
ceph_objectstore_bench
ceph-objectstore-tool
ceph_omapbench
ceph-osd
ceph-osdomap-tool
ceph_perf_local
ceph_perf_msgr_client
ceph_perf_msgr_server
ceph_perf_objectstore
ceph-post-file
ceph_psim
ceph_radosacl
ceph-rbdnamer
ceph_rgw_jsonparser
ceph_rgw_multiparser
ceph-run
ceph_scratchtool
ceph_scratchtoolpp
ceph-syn
ceph-volume
ceph-volume-systemd
crushtool
librados-config
monmaptool
mount.ceph
mount.fuse.ceph
osdmaptool
rados
radosgw
radosgw-admin
radosgw-es
radosgw-object-expirer
radosgw-token
rbd
rbd-fuse
rbdmap
rbd-mirror
rbd-nbd
rbd-replay
rbd-replay-many
```