### PR TITLE
Fix permissions issues caused by 986bc2052.

### DIFF
--- a/packaging/makeself/build-x86_64-static.sh
+++ b/packaging/makeself/build-x86_64-static.sh
@@ -38,5 +38,5 @@ run docker run -a stdin -a stdout -a stderr -i -t -v \
   /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
 
 if [ "${USER}" ]; then
-  chown -R "${USER}" .
+  sudo chown -R "${USER}" .
 fi


### PR DESCRIPTION
##### Summary

For some reason, without `sudo` here, we get permissions issues in CI,so re-add it.

##### Component Name

area/packaging

##### Additional Information

I'm honestly not even sure _why_ we're changing file ownership here. Looking at the git history gives no real insights.

This is, however, what's causing nightlies to fail.