### PR TITLE
Don't pretend we're building i386 RPM packages when we aren't.

### DIFF
--- a/.travis/trigger_package_generation.sh
+++ b/.travis/trigger_package_generation.sh
@@ -54,10 +54,4 @@ sleep "${WAIT_TIME}"
 commit_change "amd64" "RPM"
 push_change
 
-echo "---- Waiting for ${WAIT_TIME} seconds before triggering next process ----"
-sleep "${WAIT_TIME}"
-
-commit_change "i386" "RPM"
-push_change
-
 echo "---- Done! ----"


### PR DESCRIPTION
##### Summary

We're not actually building any i386 RPM packages, and it makes essentially no sense to do so as the various major RPM-based distros don't even really support 32-bit x86 installs anymore.

This will actually speed up the builds for the other package types because they won't be competing for CI resources. It will also make the commit history tidier in the repo.

##### Component Name

area/ci
area/packaging

##### Additional Information

As far as I can tell, we've never actually built any i386 RPM packages.

Fedora dropped support for 32-bit x86 installs with Fedora 29.

CentOS/RHEL dropped official support for 32-bit x86 installs with RHEL/CentOS 7.0.

OpenSUSE does not appear to support 32-bit x86 installs, but I cannot figure out when they dropped support.