### PR TITLE
Fix CentOS 7 RPM build failures.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -395,7 +395,7 @@ install_go() {
 	return 0
 }
 install_go
-install -m 0750 -p go.d.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/go.d.plugin"
+install -m 0640 -p go.d.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/go.d.plugin"
 
 %pre
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -517,7 +517,7 @@ are sensor monitoring, system event monitoring, power control, and serial-over-L
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 
 %changelog
-* Thu Jan 01 2020 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-12
+* Wed Jan 01 2020 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-12
 - Add explicit installation of log and cache directories
 - Clean up build dependencies.
 * Thu Dec 19 2019 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-11


### PR DESCRIPTION
##### Summary

This fixes the issue causing CentOS 7 RPM builds to fai, as well as removing a warning shown on all RPM builds of Netdata.

The issue on CentOS 7 arises from the fact that unless built with `cgo` (which we do not do), Go code compiled using `go build` does not contain debugging information in the format that the RPM build process expects, causing the process to terminate.

By not marking the `go.d.plugin` executable when putting it into the install staging area during the RPM build, we can force the check to be skipped for it, thus avoiding the issue.

##### Component Name

area/packaging

##### Additional Information

Fixes: #7991 