### PR TITLE
Docs: Change sed to allow parentheses in heading links

### DIFF
--- a/docs/generator/checklinks.sh
+++ b/docs/generator/checklinks.sh
@@ -55,7 +55,7 @@ testinternal () {
 	ilnk=${3}
 	header=${ilnk//-/}
 	dbg "   - Searching for \"$header\" in $ifile"
-	tr -d '[],_.:? `'< "$ifile" | sed -e 's/-//g' -e "s/'//g" | grep -i "^\\#*$header\$" >/dev/null
+	tr -d '[],_.:? `'< "$ifile" | sed -e 's/-//g' -e "s/'//g" -e "s/(//g" -e "s/)//g" | grep -i "^\\#*$header\$" >/dev/null
 	if [ $? -eq 0 ] ; then
 		dbg "   - $ilnk found in $ifile"
 		return 0


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Similar to #7431, I found that when you putting parentheses in headings in the documentation you can't link to them using an anchor link. I struggled with this when trying to work on collectors docs with @ilyam8 and #7878.

For example, this pair of anchor link and header will fail during build.

```
[this is an anchor link to the heading below](#lets-try-this-test)

## Let's try this (test)
```

This change will cut parentheses from the string when building the anchor tag so it all works OK.

##### Component Name

docs

##### Additional Information

