### PR TITLE
/docs/generator: add an option to use last dir name for page name 

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -8,11 +8,12 @@ language="${3}"
 
 cd ${GENERATOR_DIR}/${docs_dir}
 
-# getlastdir parses path and returns last directory name. It expects path to be not empty and '/' as a delimeter.
+# getlastdir parses file path and returns last directory name.
+# It expects path to be not empty , '/' as a delimeter and at least one '/' in the path.
 getlastdir() {
   local IFS=/
   read -ra array <<< "$1"
-  echo "${array[-2]}"
+  echo "${array[((${#array[@]} - 2))]}"
 }
 
 # create yaml nav subtree with all the files directly under a specific directory

--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -8,6 +8,13 @@ language="${3}"
 
 cd ${GENERATOR_DIR}/${docs_dir}
 
+# getlastdir parses path and returns last directory name. It expects path to be not empty and '/' as a delimeter.
+getlastdir() {
+  local IFS=/
+  read -ra array <<< "$1"
+  echo "${array[-2]}"
+}
+
 # create yaml nav subtree with all the files directly under a specific directory
 # arguments:
 # tabs - how deep do we show it in the hierarchy. Level 1 is the top level, max should probably be 3
@@ -24,6 +31,7 @@ navpart() {
 	section=$4
 	maxdepth=$5
 	excludefirstlevel=$6
+	useLastDirAsPageName=$7
 	spc=""
 
 	i=1
@@ -37,12 +45,18 @@ navpart() {
 	if [ -z "$maxdepth" ]; then maxdepth=1; fi
 	if [[ -n $excludefirstlevel ]]; then mindepth=2; else mindepth=1; fi
 
-	for f in $(find $dir -mindepth $mindepth -maxdepth $maxdepth -name "${file}.md" -printf '%h|%d|%p\n' | sort -t '|' -n | awk -F '|' '{print $3}'); do
+  local pagename
+	for f in $(find "$dir" -mindepth $mindepth -maxdepth $maxdepth -name "${file}.md" -printf '%h|%d|%p\n' | sort -t '|' -n | awk -F '|' '{print $3}'); do
 		# If I'm adding a section, I need the child links to be one level deeper than the requested level in "tabs"
+		pagename="'$f'"
+		if [ -n "$useLastDirAsPageName" ]; then
+			pagename="'$(getlastdir "$f")' : '$f'"
+		fi
+
 		if [ -z "$section" ]; then
-			echo "$spc- '$f'"
+			echo "$spc- $pagename"
 		else
-			echo "$spc    - '$f'"
+			echo "$spc    - $pagename"
 		fi
 	done
 }
@@ -223,12 +237,12 @@ navpart 2 collectors/plugins.d "" "External plugins"
 echo -ne "        - Go:
             - 'collectors/go.d.plugin/README.md'
 "
-navpart 4 collectors/go.d.plugin "" "Modules" 3 excludefirstlevel
+navpart 4 collectors/go.d.plugin "" "Modules" 3 excludefirstlevel useLastDirAsPageName
 
 echo -ne "        - Python:
             - 'collectors/python.d.plugin/README.md'
 "
-navpart 4 collectors/python.d.plugin "" "Modules" 3 excludefirstlevel
+navpart 4 collectors/python.d.plugin "" "Modules" 3 excludefirstlevel useLastDirAsPageName
 
 echo -ne "        - Node.js:
             - 'collectors/node.d.plugin/README.md'


### PR DESCRIPTION
##### Summary

Fixes: netdata/marketing#79 (try number 2)

This PR adds `useLastDirAsPageName` option to the `navpart` func. It allows to use last directory name as a page name.

I use this option for python.d and go.d modules.

As a result `buildyaml.sh` generates (syntax from [mkdocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation)):

Result

```yaml
        - Go:
            - 'collectors/go.d.plugin/README.md'
            - Modules:
                - 'activemq' : 'collectors/go.d.plugin/modules/activemq/README.md'
                - 'apache' : 'collectors/go.d.plugin/modules/apache/README.md'
                - 'bind' : 'collectors/go.d.plugin/modules/bind/README.md'
                - 'cockroachdb' : 'collectors/go.d.plugin/modules/cockroachdb/README.md'
                - 'consul' : 'collectors/go.d.plugin/modules/consul/README.md'
                - 'coredns' : 'collectors/go.d.plugin/modules/coredns/README.md'
                - 'dnsmasq_dhcp' : 'collectors/go.d.plugin/modules/dnsmasq_dhcp/README.md'
                - 'dnsquery' : 'collectors/go.d.plugin/modules/dnsquery/README.md'
                - 'docker_engine' : 'collectors/go.d.plugin/modules/docker_engine/README.md'
                - 'dockerhub' : 'collectors/go.d.plugin/modules/dockerhub/README.md'
                - 'fluentd' : 'collectors/go.d.plugin/modules/fluentd/README.md'
                - 'freeradius' : 'collectors/go.d.plugin/modules/freeradius/README.md'
                - 'hdfs' : 'collectors/go.d.plugin/modules/hdfs/README.md'
                - 'httpcheck' : 'collectors/go.d.plugin/modules/httpcheck/README.md'
                - 'k8s_kubelet' : 'collectors/go.d.plugin/modules/k8s_kubelet/README.md'
                - 'k8s_kubeproxy' : 'collectors/go.d.plugin/modules/k8s_kubeproxy/README.md'
                - 'lighttpd2' : 'collectors/go.d.plugin/modules/lighttpd2/README.md'
                - 'lighttpd' : 'collectors/go.d.plugin/modules/lighttpd/README.md'
                - 'logstash' : 'collectors/go.d.plugin/modules/logstash/README.md'
                - 'mysql' : 'collectors/go.d.plugin/modules/mysql/README.md'
                - 'nginx' : 'collectors/go.d.plugin/modules/nginx/README.md'
                - 'openvpn' : 'collectors/go.d.plugin/modules/openvpn/README.md'
                - 'phpdaemon' : 'collectors/go.d.plugin/modules/phpdaemon/README.md'
                - 'phpfpm' : 'collectors/go.d.plugin/modules/phpfpm/README.md'
                - 'pihole' : 'collectors/go.d.plugin/modules/pihole/README.md'
                - 'portcheck' : 'collectors/go.d.plugin/modules/portcheck/README.md'
                - 'rabbitmq' : 'collectors/go.d.plugin/modules/rabbitmq/README.md'
                - 'scaleio' : 'collectors/go.d.plugin/modules/scaleio/README.md'
                - 'solr' : 'collectors/go.d.plugin/modules/solr/README.md'
                - 'springboot2' : 'collectors/go.d.plugin/modules/springboot2/README.md'
                - 'squidlog' : 'collectors/go.d.plugin/modules/squidlog/README.md'
                - 'tengine' : 'collectors/go.d.plugin/modules/tengine/README.md'
                - 'unbound' : 'collectors/go.d.plugin/modules/unbound/README.md'
                - 'vcsa' : 'collectors/go.d.plugin/modules/vcsa/README.md'
                - 'vsphere' : 'collectors/go.d.plugin/modules/vsphere/README.md'
                - 'weblog' : 'collectors/go.d.plugin/modules/weblog/README.md'
                - 'wmi' : 'collectors/go.d.plugin/modules/wmi/README.md'
                - 'x509check' : 'collectors/go.d.plugin/modules/x509check/README.md'
                - 'zookeeper' : 'collectors/go.d.plugin/modules/zookeeper/README.md'
                - 'matcher' : 'collectors/go.d.plugin/pkg/matcher/README.md'
        - Python:
            - 'collectors/python.d.plugin/README.md'
            - Modules:
                - 'adaptec_raid' : 'collectors/python.d.plugin/adaptec_raid/README.md'
                - 'am2320' : 'collectors/python.d.plugin/am2320/README.md'
                - 'apache' : 'collectors/python.d.plugin/apache/README.md'
                - 'beanstalk' : 'collectors/python.d.plugin/beanstalk/README.md'
                - 'bind_rndc' : 'collectors/python.d.plugin/bind_rndc/README.md'
                - 'boinc' : 'collectors/python.d.plugin/boinc/README.md'
                - 'ceph' : 'collectors/python.d.plugin/ceph/README.md'
                - 'chrony' : 'collectors/python.d.plugin/chrony/README.md'
                - 'couchdb' : 'collectors/python.d.plugin/couchdb/README.md'
                - 'dnsdist' : 'collectors/python.d.plugin/dnsdist/README.md'
                - 'dns_query_time' : 'collectors/python.d.plugin/dns_query_time/README.md'
                - 'dockerd' : 'collectors/python.d.plugin/dockerd/README.md'
                - 'dovecot' : 'collectors/python.d.plugin/dovecot/README.md'
                - 'elasticsearch' : 'collectors/python.d.plugin/elasticsearch/README.md'
                - 'energid' : 'collectors/python.d.plugin/energid/README.md'
                - 'example' : 'collectors/python.d.plugin/example/README.md'
                - 'exim' : 'collectors/python.d.plugin/exim/README.md'
                - 'fail2ban' : 'collectors/python.d.plugin/fail2ban/README.md'
                - 'freeradius' : 'collectors/python.d.plugin/freeradius/README.md'
                - 'gearman' : 'collectors/python.d.plugin/gearman/README.md'
                - 'go_expvar' : 'collectors/python.d.plugin/go_expvar/README.md'
                - 'haproxy' : 'collectors/python.d.plugin/haproxy/README.md'
                - 'hddtemp' : 'collectors/python.d.plugin/hddtemp/README.md'
                - 'hpssa' : 'collectors/python.d.plugin/hpssa/README.md'
                - 'httpcheck' : 'collectors/python.d.plugin/httpcheck/README.md'
                - 'icecast' : 'collectors/python.d.plugin/icecast/README.md'
                - 'ipfs' : 'collectors/python.d.plugin/ipfs/README.md'
                - 'isc_dhcpd' : 'collectors/python.d.plugin/isc_dhcpd/README.md'
                - 'litespeed' : 'collectors/python.d.plugin/litespeed/README.md'
                - 'logind' : 'collectors/python.d.plugin/logind/README.md'
                - 'megacli' : 'collectors/python.d.plugin/megacli/README.md'
                - 'memcached' : 'collectors/python.d.plugin/memcached/README.md'
                - 'mongodb' : 'collectors/python.d.plugin/mongodb/README.md'
                - 'monit' : 'collectors/python.d.plugin/monit/README.md'
                - 'mysql' : 'collectors/python.d.plugin/mysql/README.md'
                - 'nginx' : 'collectors/python.d.plugin/nginx/README.md'
                - 'nginx_plus' : 'collectors/python.d.plugin/nginx_plus/README.md'
                - 'nsd' : 'collectors/python.d.plugin/nsd/README.md'
                - 'ntpd' : 'collectors/python.d.plugin/ntpd/README.md'
                - 'nvidia_smi' : 'collectors/python.d.plugin/nvidia_smi/README.md'
                - 'openldap' : 'collectors/python.d.plugin/openldap/README.md'
                - 'oracledb' : 'collectors/python.d.plugin/oracledb/README.md'
                - 'ovpn_status_log' : 'collectors/python.d.plugin/ovpn_status_log/README.md'
                - 'phpfpm' : 'collectors/python.d.plugin/phpfpm/README.md'
                - 'portcheck' : 'collectors/python.d.plugin/portcheck/README.md'
                - 'postfix' : 'collectors/python.d.plugin/postfix/README.md'
                - 'postgres' : 'collectors/python.d.plugin/postgres/README.md'
                - 'powerdns' : 'collectors/python.d.plugin/powerdns/README.md'
                - 'proxysql' : 'collectors/python.d.plugin/proxysql/README.md'
                - 'puppet' : 'collectors/python.d.plugin/puppet/README.md'
                - 'rabbitmq' : 'collectors/python.d.plugin/rabbitmq/README.md'
                - 'redis' : 'collectors/python.d.plugin/redis/README.md'
                - 'rethinkdbs' : 'collectors/python.d.plugin/rethinkdbs/README.md'
                - 'retroshare' : 'collectors/python.d.plugin/retroshare/README.md'
                - 'riakkv' : 'collectors/python.d.plugin/riakkv/README.md'
                - 'samba' : 'collectors/python.d.plugin/samba/README.md'
                - 'sensors' : 'collectors/python.d.plugin/sensors/README.md'
                - 'smartd_log' : 'collectors/python.d.plugin/smartd_log/README.md'
                - 'spigotmc' : 'collectors/python.d.plugin/spigotmc/README.md'
                - 'springboot' : 'collectors/python.d.plugin/springboot/README.md'
                - 'squid' : 'collectors/python.d.plugin/squid/README.md'
                - 'tomcat' : 'collectors/python.d.plugin/tomcat/README.md'
                - 'tor' : 'collectors/python.d.plugin/tor/README.md'
                - 'traefik' : 'collectors/python.d.plugin/traefik/README.md'
                - 'uwsgi' : 'collectors/python.d.plugin/uwsgi/README.md'
                - 'varnish' : 'collectors/python.d.plugin/varnish/README.md'
                - 'w1sensor' : 'collectors/python.d.plugin/w1sensor/README.md'
                - 'web_log' : 'collectors/python.d.plugin/web_log/README.md'
```



##### Component Name

`/doc`

##### Additional Information

