### PR TITLE
/collectors/charts.d.plugin: fix `os_id` detection in `run`

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -275,13 +275,27 @@ fixid() {
 		tr "[A-Z]" "[a-z]"
 }
 
+isvarset() {
+  [ -n "$1" ] && [ "$1" != "unknown" ] && [ "$1" != "none" ]
+  return $?
+}
+
+getosid() {
+  if isvarset "${NETDATA_CONTAINER_OS_ID}"; then
+    echo "${NETDATA_CONTAINER_OS_ID}"
+  else
+    echo "${NETDATA_SYSTEM_OS_ID}"
+  fi
+}
+
 run() {
 	local ret pid="${BASHPID}" t
 
 	if [ "z${1}" = "z-t" -a "${2}" != "0" ]; then
 		t="${2}"
 		shift 2
-		case "${NETDATA_SYSTEM_OS_ID}" in
+
+		case "$(getosid)" in
 		"alpine")
 			timeout -t ${t} "${@}" 2>"${TMP_DIR}/run.${pid}"
 			;;


### PR DESCRIPTION
##### Summary
Fixes: #7998

This PR improves os_id detection in docker container. See https://github.com/netdata/netdata/issues/5935

- alpine `timeout`

```console
Usage: timeout [-t SECS] [-s SIG] PROG ARGS
```

- NOT alpine `timeout`

```console
Usage: timeout [OPTION] DURATION COMMAND [ARG]...
```

netdata docker info

```json
"os_id": "debian",
"container_os_id": "alpine",
```

Correct os_id detection order:

- `NETDATA_CONTAINER_OS_ID` // not set if netdata is not running in a container
- `NETDATA_SYSTEM_OS_ID`

##### Component Name

[`/collectors/charts.d.plugin`](https://github.com/netdata/netdata/tree/master/collectors/charts.d.plugin)


##### Additional Information

Current `netdata/netdata` image

- BEFORE

```console
test@DEB10-1:~$ docker logs netdata  2>&1 | grep upsc -A 3
2020-02-07 14:18:06: charts.d: : nut: command 'upsc -l ' failed with code 127:
 --- BEGIN TRACE ---
timeout: can't execute '2': No such file or directory
 --- END TRACE ---
```

^^ there is a problem, `timeout` invoked with incorrect arguments

- AFTER

my test image with changes:

```console
test@DEB10-1:~$ docker logs netdata  2>&1 | grep upsc -A 3
2020-02-07 14:15:55: charts.d: : nut: command 'upsc -l ' failed with code 1:
 --- BEGIN TRACE ---
Error: Connection failure: Address not available
 --- END TRACE ---
```

^^ the problem is fixed, `timeout` invoked with correct arguments