### PR TITLE
/docs/generator: build docs only for go.d itself and its modules

### DIFF
--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -18,6 +18,7 @@ SRC_DIR="${GENERATOR_DIR}/src"
 GO_D_DIR="collectors/go.d.plugin"
 rm -rf ${GO_D_DIR}
 git clone https://github.com/netdata/go.d.plugin.git ${GO_D_DIR}
+find "${GO_D_DIR}" -maxdepth 1 -mindepth 1 -type d ! -name modules -exec rm -rf '{}' \;
 
 # Copy all Netdata .md files to docs/generator/src. Exclude htmldoc itself and also the directory node_modules generatord by Netlify
 echo "Copying files"


### PR DESCRIPTION
### Summary

We need to use only modules README files for Modules section.

See

> https://docs.netdata.cloud/collectors/go.d.plugin/pkg/matcher/

##### Component Name

`/docs`

##### Additional Information

- BEFORE

```console
test@DEB10-1:~/netdata/docs/generator$ ls -l src/collectors/go.d.plugin/
total 16
drwxr-xr-x 41 test test 4096 Feb  7 11:13 modules
drwxr-xr-x  3 test test 4096 Feb  7 11:13 pkg
-rw-r--r--  1 test test 6246 Feb  7 11:13 README.md
```

- AFTER

```console
test@DEB10-1:~/netdata/docs/generator$ ls -l src/collectors/go.d.plugin/
total 12
drwxr-xr-x 41 test test 4096 Feb  7 11:06 modules
-rw-r--r--  1 test test 6246 Feb  7 11:06 README.md
```

