### PR TITLE
invalid literal for float(): NN.NNt

### DIFF
--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
@@ -513,6 +513,8 @@ def convert_index_store_size_to_bytes(size):
         return round(float(size[:-2]) * 1024 * 1024)
     elif size.endswith('gb'):
         return round(float(size[:-2]) * 1024 * 1024 * 1024)
+    elif size.endswith('t'):
+        return round(float(size[:-2]) * 1024 * 1024 * 1024 * 1024)
     elif size.endswith('b'):
         return round(float(size[:-1]))
     return -1

--- a/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
+++ b/collectors/python.d.plugin/elasticsearch/elasticsearch.chart.py
@@ -513,7 +513,7 @@ def convert_index_store_size_to_bytes(size):
         return round(float(size[:-2]) * 1024 * 1024)
     elif size.endswith('gb'):
         return round(float(size[:-2]) * 1024 * 1024 * 1024)
-    elif size.endswith('t'):
+    elif size.endswith('tb'):
         return round(float(size[:-2]) * 1024 * 1024 * 1024 * 1024)
     elif size.endswith('b'):
         return round(float(size[:-1]))


### PR DESCRIPTION
### Summary
Fix for missing terabyte unit parsing

```
  File "/usr/libexec/netdata/python.d/elasticsearch.chart.py", line 534, in w
    method(*args)
  File "/usr/libexec/netdata/python.d/elasticsearch.chart.py", line 659, in _get_indices
    size = convert_index_store_size_to_bytes(idx['store.size'])
  File "/usr/libexec/netdata/python.d/elasticsearch.chart.py", line 517, in convert_index_store_size_to_bytes
    return round(float(size[:-1]))
ValueError: invalid literal for float(): 1.0t
```
##### Component Name

python.d/elasticsearch.chart.py

##### Additional Information

