### PR TITLE
Fix: Documentation states in one place default is dbengine and in another save is default

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -50,8 +50,8 @@ You can select the memory mode by editing `netdata.conf` and setting:
 
 ```conf
 [global]
-    # ram, save (the default, save on exit, load on start), map (swap like)
-    memory mode = save
+    # dbengine (default), ram, save (the default if dbengine not available), map (swap like), none, alloc
+    memory mode = dbengine
 
     # the directory where data are saved
     cache directory = /var/cache/netdata


### PR DESCRIPTION
##### Summary
Documentation states in one place default is dbengine and in another save is default which might confuse user.

##### Component Name

##### Additional Information

