### PR TITLE
Check if ACLK can be built

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -594,7 +594,7 @@ netdata_SOURCES = $(NETDATA_FILES)
 
 if ENABLE_ACLK
 netdata_LDADD = \
-    mosquitto/lib/libmosquitto.a \
+    externaldeps/mosquitto/lib/libmosquitto.a \
     $(NETDATA_COMMON_LIBS) \
     $(NULL)
 else

--- a/Makefile.am
+++ b/Makefile.am
@@ -594,7 +594,7 @@ netdata_SOURCES = $(NETDATA_FILES)
 
 if ENABLE_ACLK
 netdata_LDADD = \
-    externaldeps/mosquitto/lib/libmosquitto.a \
+    externaldeps/mosquitto/libmosquitto.a \
     $(NETDATA_COMMON_LIBS) \
     $(NULL)
 else

--- a/aclk/mqtt.h
+++ b/aclk/mqtt.h
@@ -4,7 +4,7 @@
 #define NETDATA_MQTT_H
 
 #ifdef ENABLE_ACLK
-#include "externaldeps/mosquitto/lib/mosquitto.h"
+#include "externaldeps/mosquitto/mosquitto.h"
 #endif
 
 void _show_mqtt_info();

--- a/aclk/mqtt.h
+++ b/aclk/mqtt.h
@@ -4,7 +4,7 @@
 #define NETDATA_MQTT_H
 
 #ifdef ENABLE_ACLK
-#include "mosquitto/lib/mosquitto.h"
+#include "externaldeps/mosquitto/lib/mosquitto.h"
 #endif
 
 void _show_mqtt_info();

--- a/configure.ac
+++ b/configure.ac
@@ -432,7 +432,7 @@ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 #currenlty env var ACLK must be set to 'yes' to even consider building ACLK
 if test "${ACLK}" = "yes"; then
     AC_MSG_CHECKING([if libmosquitto static lib is present])
-    if test -f "externaldeps/mosquitto/lib/libmosquitto.a"; then
+    if test -f "externaldeps/mosquitto/libmosquitto.a"; then
         HAVE_libmosquitto_a="yes"
     else 
         HAVE_libmosquitto_a="no"

--- a/configure.ac
+++ b/configure.ac
@@ -432,7 +432,7 @@ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 #currenlty env var ACLK must be set to 'yes' to even consider building ACLK
 if test "${ACLK}" = "yes"; then
     AC_MSG_CHECKING([if libmosquitto static lib is present])
-    if test -f "mosquitto/lib/libmosquitto.a"; then
+    if test -f "externaldeps/mosquitto/lib/libmosquitto.a"; then
         HAVE_libmosquitto_a="yes"
     else 
         HAVE_libmosquitto_a="no"

--- a/configure.ac
+++ b/configure.ac
@@ -309,7 +309,7 @@ AC_CHECK_LIB(
 if test "${ACLK}" = "yes"; then
     AC_CHECK_LIB(
         [websockets],
-        [lws_create_context],
+        [lws_set_timer_usecs],
         [LWS_LIBS="-lwebsockets"]
     )
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,17 @@ AC_CHECK_LIB(
     [LZ4_LIBS="-llz4"]
 )
 
+# -----------------------------------------------------------------------------
+# libwebsockets pure C library for implementing modern network protocols
+
+if test "${ACLK}" = "yes"; then
+    AC_CHECK_LIB(
+        [websockets],
+        [lws_create_context],
+        [LWS_LIBS="-lwebsockets"]
+    )
+fi
+
 
 # -----------------------------------------------------------------------------
 # Judy General purpose dynamic array
@@ -1129,7 +1140,7 @@ AC_SUBST([webdir])
 
 CFLAGS="${CFLAGS} ${OPTIONAL_MATH_CFLAGS} ${OPTIONAL_NFACCT_CFLAGS} ${OPTIONAL_ZLIB_CFLAGS} ${OPTIONAL_UUID_CFLAGS} \
     ${OPTIONAL_LIBCAP_CFLAGS} ${OPTIONAL_IPMIMONITORING_CFLAGS} ${OPTIONAL_CUPS_CFLAGS} ${OPTIONAL_XENSTAT_FLAGS} \
-    ${OPTIONAL_KINESIS_CFLAGS} ${OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS} ${OPTIONAL_MONGOC_CFLAGS}"
+    ${OPTIONAL_KINESIS_CFLAGS} ${OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS} ${OPTIONAL_MONGOC_CFLAGS} ${LWS_LIBS}"
 
 CXXFLAGS="${CFLAGS} ${CXX11FLAG}"
 

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,14 @@ AC_ARG_ENABLE(
     ,
     [enable_jsonc="detect"]
 )
+if test "${ACLK}" = "yes"; then
+AC_ARG_ENABLE(
+    [aclk],
+    ,
+    [aclk_required="${enableval}"],
+    [aclk_required="detect"]
+)
+fi
 
 # -----------------------------------------------------------------------------
 # netdata required checks
@@ -420,15 +428,41 @@ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # ACLK
-AC_MSG_CHECKING([if netdata ACLK should be enabled])
+
+#currenlty env var ACLK must be set to 'yes' to even consider building ACLK
 if test "${ACLK}" = "yes"; then
-    enable_aclk="yes"
-    AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
-    CFLAGS="${CFLAGS} -DENABLE_ACLK"
-else
-    enable_aclk="no"
+    AC_MSG_CHECKING([if libmosquitto static lib is present])
+    if test -f "mosquitto/lib/libmosquitto.a"; then
+        HAVE_libmosquitto_a="yes"
+    else 
+        HAVE_libmosquitto_a="no"
+    fi
+    AC_MSG_RESULT([${HAVE_libmosquitto_a}])
+
+    AC_MSG_CHECKING([if netdata ACLK can be enabled])
+    if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}"; then
+        can_enable_aclk="yes"
+    else
+        can_enable_aclk="no"
+    fi
+    AC_MSG_RESULT([${can_enable_aclk}])
+
+    test "${aclk_required}" = "yes" -a "${can_enable_aclk}" = "no" && \
+        AC_MSG_ERROR([User required ACLK but it can't be built!])
+
+    AC_MSG_CHECKING([if netdata ACLK should be enabled])
+    if test "${aclk_required}" = "detect"; then
+        enable_aclk=$can_enable_aclk
+    else
+        enable_aclk=$aclk_required
+    fi
+
+    if test "${enable_aclk}" = "yes"; then
+        AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
+    fi
+
+    AC_MSG_RESULT([${enable_aclk}])
 fi
-AC_MSG_RESULT([${enable_aclk}])
 AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
 
 # -----------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -439,7 +439,7 @@ if test "${ACLK}" = "yes"; then
     fi
     AC_MSG_RESULT([${HAVE_libmosquitto_a}])
 
-    AC_MSG_CHECKING([if netdata ACLK can be enabled])
+    AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
     if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}"; then
         can_enable_aclk="yes"
     else
@@ -448,9 +448,9 @@ if test "${ACLK}" = "yes"; then
     AC_MSG_RESULT([${can_enable_aclk}])
 
     test "${aclk_required}" = "yes" -a "${can_enable_aclk}" = "no" && \
-        AC_MSG_ERROR([User required ACLK but it can't be built!])
+        AC_MSG_ERROR([User required agent-cloud-link but it can't be built!])
 
-    AC_MSG_CHECKING([if netdata ACLK should be enabled])
+    AC_MSG_CHECKING([if netdata agent-cloud-link should/will be enabled])
     if test "${aclk_required}" = "detect"; then
         enable_aclk=$can_enable_aclk
     else


### PR DESCRIPTION
##### Summary

Closes #7740, to be used together with PR #8025 .

Check if ACLK can be built:
- is static lib build of forked mosquitto present?
- is libwebsockets present (standard library)?

By default `autodetect`. If `--enable-aclk` and ACLK cannot be build error during build. If `--disable-aclk` don't build even if possible.

Currently this switch is purposefully undocumented and hidden behind ACLK=yes enviroment variable.


