### PR TITLE
github/workflow: change labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,7 +12,7 @@
 
 area/backends:
   - backends/*
-  - backends/**
+  - backends/**/*
   - exporting/*
   - exporting/**/*
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,7 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: paulfantom/periodic-labeler@master
+      - uses: docker://docker.io/ilyam8/periodic-pr-labeler:v0.0.1
         if: github.repository == 'netdata/netdata'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

Switch to new labeler
>  https://github.com/marketplace/actions/periodic-pr-labeler

This labeler uses @gobwas (👋) [glob](https://github.com/gobwas/glob) library for file pattern matching which supports `**`.

In addition our current labeler has zero tests, which is pretty bad

> https://github.com/paulfantom/periodic-labeler


In addition we can add any features we need to the new pretty fast (like label based on author team membership, etc if we need), because it is written by @ilyam8 

##### Component Name

`github/workflow`

##### Additional Information

I made a PR with `**` fix to the upstream

> https://github.com/paulfantom/periodic-labeler/pull/8

but it seems its author on vacation or something, that is why i decided to write a new one

