### PR TITLE
Add required build dep for ACLK dependencies to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM alpine:3.9 AS build
 
 # Install Dependencies
 RUN apk add --no-cache -U alpine-sdk bash curl libuv-dev zlib-dev \
-	                  util-linux-dev libmnl-dev gcc make git autoconf \
-                          automake pkgconfig python logrotate
+                          util-linux-dev libmnl-dev gcc make git autoconf \
+                          automake pkgconfig python logrotate openssl-dev
 
 # Pass optional ./netdata-installer.sh args with --build-arg INSTALLER_ARGS=...
 ARG INSTALLER_ARGS=""


### PR DESCRIPTION
##### Summary

This ensures that we have OpenSSL development files when building the Docker image, so that we can build the libmosquitto component of the ACLK functionality.

##### Component Name

area/packaging

##### Additional Information

This is literally the only change needed now for libmosquitto to work in the Docker images.