### PR TITLE
Added hack to sha256sums.txt to force users of NetData on v1.19.0-483 with a broken updater to update to latest

### DIFF
--- a/.travis/create_artifacts.sh
+++ b/.travis/create_artifacts.sh
@@ -62,5 +62,10 @@ cd artifacts
 ln -s "${BASENAME}.tar.gz" netdata-latest.tar.gz
 ln -s "${BASENAME}.gz.run" netdata-latest.gz.run
 sha256sum -b ./* >"sha256sums.txt"
+
+# TODO: Remove this after 1 successfuly nightly or until there are no v1.19.0-432 instances left
+# XXX: See: https://github.com/netdata/netdata/issues/8056
+sed -i -e '/netdata-v/d' sha256sums.txt
+
 echo "checksums:"
 cat sha256sums.txt


### PR DESCRIPTION
See #8056

##### What I did

Commented out a bunch of irrelevant things in `./.travis/create_artifacts.sh`
so I could make sure this change will work and is correct. Then ran inside
a Docker container:

```sh
/netdata # ./.travis/create_artifacts.sh
.
.
.
--- Copy artifacts to separate directory ---
checksums:
70294f6daf017811448658fd415286773a8fead2372f39c67521fdb4a617ff61  ./latest-version.txt
b63ef24a57d013e63da383f9e89c6aedc2ad1e400048fdafb91da7d708279169  ./netdata-latest.tar.gz
```

Observed that the `netdata-vx.y.z` lines are removed.

The result is the broken logic in the NetData Updater should not be able to
find a valid version and there fail the condition and fall through.

Even though it will still error with `[: : integer expression expected`
the next condition will run as demonstrated by this simple script:

````sh
#!/bin/sh

latest_version=
current_version=
#current_version="001019000432"

if [ "${latest_version}" -gt 0 ] && [ "${current_version}" -gt 0 ] && [ "${current_version}" -ge "${current_version}" ]; then
  echo "Newest version ${current_version} <= ${latest_version} is already installed"
elif [ "${current_version}" -gt 0 ]; then
  echo "Current version: ${current_version}"
else
  echo "No version"
fi
```