### PR TITLE
collectors: apps.plugin: apps_groups: create 'dns' group.

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -115,7 +115,7 @@ columndb: clickhouse-server*
 # -----------------------------------------------------------------------------
 # email servers
 
-email: dovecot imapd pop3d amavis* master zmstat* zmmailboxdmgr qmgr oqmgr saslauthd opendkim clamd freshclam unbound tlsmgr postfwd2 postscreen postfix smtp* lmtp* sendmail
+email: dovecot imapd pop3d amavis* master zmstat* zmmailboxdmgr qmgr oqmgr saslauthd opendkim clamd freshclam tlsmgr postfwd2 postscreen postfix smtp* lmtp* sendmail
 
 # -----------------------------------------------------------------------------
 # network, routing, VPN
@@ -201,7 +201,7 @@ dhcp: *dhcp*
 # -----------------------------------------------------------------------------
 # name servers and clients
 
-named: named rncd dig
+dns: named unbound nsd pdns_server knotd gdnsd yadifad dnsmasq systemd-resolve*
 dnsdist: dnsdist
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
I found that `unbound` placed in `email` group, but actually is a validating, recursive, caching DNS resolver. Also I was add another name server daemons in new `dns` group:
- [unbound](https://nlnetlabs.nl/projects/unbound/about/) 
- [nsd](https://www.nlnetlabs.nl/nsd/)
- [powerdns](https://www.powerdns.com)
- [knot](https://www.knot-dns.cz)
- [gdnsd](https://gdnsd.org/)
- [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html)
- [yadifa](https://www.yadifa.eu/)
- [systemd-resolved](https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html)