### PR TITLE
Make temporary directories relative to $TEMPDIR.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ docs/generator/mkdocs.yml
 
 #CLion files
 netdata.cbp
+
+# External dependencies
+externaldeps/

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -455,7 +455,7 @@ bundle_libmosquitto() {
 
   MOSQUITTO_PACKAGE_VERSION="$(cat packaging/mosquitto.version)"
 
-  tmp=$(mktemp -d netdata-mosquitto-XXXXXX)
+  tmp=$(mktemp -t -d netdata-mosquitto-XXXXXX)
   MOSQUITTO_PACKAGE_BASENAME="${MOSQUITTO_PACKAGE_VERSION}.tar.gz"
 
   if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_MOSQUITTO}" ]; then
@@ -966,7 +966,7 @@ install_go() {
       break
     fi
   done
-  tmp=$(mktemp -d /tmp/netdata-go-XXXXXX)
+  tmp=$(mktemp -t -d netdata-go-XXXXXX)
   GO_PACKAGE_BASENAME="go.d.plugin-${GO_PACKAGE_VERSION}.${OS}-${ARCH}.tar.gz"
 
   if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" ]; then


### PR DESCRIPTION
##### Summary

This corrects the invocations of `mktemp` so that they produce temporary directories in `$TEMPDIR` instead of the current directory. We need to use `-t` for this for compatibility with busybox `mktemp`.

##### Component Name

area/packaging

##### Additional Information

Fixes: #8064 