### PR TITLE
Update to new release of libmosquitto fork.

### DIFF
--- a/packaging/mosquitto.checksums
+++ b/packaging/mosquitto.checksums
@@ -1,1 +1,1 @@
-1bcf9caaaf28fcc3ede4bccca32c74db5d37139a1f1ba4c6cf1811722fde203b  v.1.6.8_Netdata-2.tar.gz
+387faaf026b86d52dcba87e80b97946eb2775bcfcfdafaabc828b6e17f7bf5ea  v.1.6.8_Netdata-3.tar.gz

--- a/packaging/mosquitto.version
+++ b/packaging/mosquitto.version
@@ -1,1 +1,1 @@
-v.1.6.8_Netdata-2
+v.1.6.8_Netdata-3


### PR DESCRIPTION
##### Summary

As in the title.

##### Component Name

area/packaging

##### Additional Information

For future reference, this is all that's needed on this side. The `mosquitto.version` file just contains the exact tag from the release, and `mosquitto.checksums` is the output of `sha256sum` run on the source archive produced by the release.