### PR TITLE
Add handling of libmosquitto to binary packages.

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -18,6 +18,7 @@ TEMPTOP = $(CURDIR)/debian/tmp
 	#dh $@ --with autoreconf
 
 override_dh_auto_configure:
+	packaging/bundle-mosquitto.sh .
 	autoreconf -ivf
 	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib \
 	--libexecdir=/usr/libexec --with-user=netdata --with-math --with-zlib --with-webdir=/var/lib/netdata/www

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -229,6 +229,7 @@ happened, on your systems and applications.
 
 %prep
 %setup -q -n %{name}-%{version}
+${RPM_BUILD_DIR}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}
 
 %build
 # Conf step
@@ -517,6 +518,8 @@ are sensor monitoring, system event monitoring, power control, and serial-over-L
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 
 %changelog
+* Thu Feb 13 2020 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-13
+- Add handling for custom libmosquitto fork
 * Wed Jan 01 2020 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-12
 - Add explicit installation of log and cache directories
 - Clean up build dependencies.

--- a/packaging/bundle-mosquitto.sh
+++ b/packaging/bundle-mosquitto.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+MOSQUITTO_TARBALL="$(cat "${1}/packaging/mosquitto.version").tar.gz"
+MOSQUITTO_BUILD_PATH="${1}/externaldeps/mosquitto/mosquitto-$(cat "${1}/packaging/mosquitto.version")/lib"
+
+mkdir -p "${1}/externaldeps/mosquitto" || exit 1
+curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/mosquitto/archive/${MOSQUITTO_TARBALL}" > "${MOSQUITTO_TARBALL}" || exit 1
+sha256sum -c "${1}/packaging/mosquitto.checksums" || exit 1
+tar -xzf "${MOSQUITTO_TARBALL}" -C "${1}/externaldeps/mosquitto" || exit 1
+make -C "${MOSQUITTO_BUILD_PATH}" || exit 1
+cp -a "${MOSQUITTO_BUILD_PATH}/libmosquitto.a" "${1}/externaldeps/mosquitto" || exit 1
+cp -a "${MOSQUITTO_BUILD_PATH}/mosquitto.h" "${1}/externaldeps/mosquitto" || exit 1


### PR DESCRIPTION
##### Summary

This adds code to handle bundling our custom fork of libmosquitto into our binary packages. It pulls down the required sources, builds them, and copies the build artifacts into the right place so that the build of Netdata actually uses them.

##### Component Name

area/packaging

##### Description of testing that the developer performed

Tested locally on all platforms we currently build packages for by building with the packager images (using `packaging/Dockerfile.packager` and running the resulting images to verify that the package was built, isntalled, and ran correctly.

##### Additional Information

This is the last remaining item for the libmosquitto support required for the agent-cloud link.