### PR TITLE
Docs: Fix Node and Bash collector module titles

### DIFF
--- a/docs/generator/buildyaml.sh
+++ b/docs/generator/buildyaml.sh
@@ -241,20 +241,12 @@ navpart 4 collectors/python.d.plugin "" "Modules" 3 excludefirstlevel useLastDir
 echo -ne "        - Node.js:
             - 'collectors/node.d.plugin/README.md'
 "
-navpart 4 collectors/node.d.plugin "" "Modules" 3 excludefirstlevel
+navpart 4 collectors/node.d.plugin "" "Modules" 3 excludefirstlevel useLastDirAsPageName
 
 echo -ne "        - BASH:
             - 'collectors/charts.d.plugin/README.md'
-            - Modules:
-                - 'collectors/charts.d.plugin/ap/README.md'
-                - 'collectors/charts.d.plugin/apcupsd/README.md'
-                - 'collectors/charts.d.plugin/example/README.md'
-                - 'collectors/charts.d.plugin/libreswan/README.md'
-                - 'collectors/charts.d.plugin/nut/README.md'
-                - 'collectors/charts.d.plugin/opensips/README.md'
-            - Obsolete Modules:
-                - 'collectors/charts.d.plugin/sensors/README.md'
 "
+navpart 4 collectors/charts.d.plugin "" "Modules" 3 excludefirstlevel useLastDirAsPageName
 
 navpart 3 collectors/apps.plugin
 navpart 3 collectors/cups.plugin


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR follows up on #8074 to change the titles of Node/Bash collector modules in the left-hand navigation, to return them to their previous state and make them consistent with the Go/Python navigation after #8009.

**Before**
![image](https://user-images.githubusercontent.com/1153921/74480099-8c45ae00-4e6d-11ea-9075-9796e6583c87.png)

**After**
![image](https://user-images.githubusercontent.com/1153921/74480144-a1bad800-4e6d-11ea-91ad-df931e40eee0.png)

##### Component Name

docs/
collectors/

##### Description of testing that the developer performed

Launched local webserver with generated documentation and verified the titles changed properly.

<!---
Please be detailed enough that your reviewer can understand which test-cases you
have covered, and recreate them if necessary.
-->
##### Additional Information


