### PR TITLE
Update the manual install documentation with better info.

### DIFF
--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -115,6 +115,19 @@ Netdata DB engine can be enabled when these are installed (they are optional):
 
 *Netdata will greatly benefit if you have the above packages installed, but it will still work without them.*
 
+### CentOS / RHEL 6.x
+
+On CentOS / RHEL 6.x, many of the dependencies for Netdata are only
+available with versions older than what we need, so special setup is
+required if manually installing packages.
+
+CentOS 6.x:
+
+- Enable the EPEL repo
+- Enable the additional repo from [okay.network](https://okay.network/blog-news/rpm-repositories-for-centos-6-and-7.html)
+
+And install the minimum required dependencies.
+
 ### CentOS / RHEL 8.x
 
 For CentOS / RHEL 8.x a lot of development packages have moved out into their

--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -41,13 +41,13 @@ should be installed on your system to build and run Netdata. It supports most ma
 Install the packages for having a **basic Netdata installation** (system monitoring and many applications, without  `mysql` / `mariadb`, `postgres`, `named`, hardware sensors and `SNMP`):
 
 ```sh
-curl -Ss 'https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh' >/tmp/install-required-packages.sh && bash /tmp/install-required-packages.sh -i netdata
+curl -Ss 'https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh' >/tmp/install-required-packages.sh && bash /tmp/install-required-packages.sh -i netdata
 ```
 
 Install all the required packages for **monitoring everything Netdata can monitor**:
 
 ```sh
-curl -Ss 'https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh' >/tmp/install-required-packages.sh && bash /tmp/install-required-packages.sh -i netdata-all
+curl -Ss 'https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh' >/tmp/install-required-packages.sh && bash /tmp/install-required-packages.sh -i netdata-all
 ```
 
 If the above do not work for you, please [open a github


### PR DESCRIPTION
##### Summary

This fixes the URI's in the manual install documentation to point to the correct location for the `install-required-packages.sh` script (it got moved to the main repo and is not kept up to date in the demo-site repo anymore), as well as adding more explicit instructions for CentOS / RHEL 6 about needing to enable EPEL and an additional repo.

##### Component Name

area/docs

##### Additional Information

Relevant to: #8081 