### PR TITLE
Fix nightly RPM builds.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,9 @@ dist_noinst_DATA = \
     packaging/version \
     packaging/go.d.version \
     packaging/go.d.checksums \
+    packaging/mosquitto.version \
+    packaging/mosquitto.checksums \
+    packaging/bundle-mosquitto.sh \
     packaging/installer/README.md \
     packaging/installer/UNINSTALL.md \
     packaging/installer/UPDATE.md \

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -229,7 +229,7 @@ happened, on your systems and applications.
 
 %prep
 %setup -q -n %{name}-%{version}
-${RPM_BUILD_DIR}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}
+${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 
 %build
 # Conf step


### PR DESCRIPTION
##### Summary

This fixes the issues with the RPM nightly builds resulting from the bundled libmosquitto functionality that was recently merged.

##### Component Name

area/packaging
area/ci

##### Description of testing that the developer performed

Sample working Travis builds:

https://travis-ci.org/Ferroin/netdata/jobs/651505255
https://travis-ci.org/Ferroin/netdata/jobs/651505259
https://travis-ci.org/Ferroin/netdata/jobs/651505256

##### Additional Information

Fixes: #8108 
