### PR TITLE
Add TODOs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ C](https://img.shields.io/lgtm/grade/cpp/g/netdata/netdata.svg?logo=lgtm)](https
 JS](https://img.shields.io/lgtm/grade/javascript/g/netdata/netdata.svg?logo=lgtm)](https://lgtm.com/projects/g/netdata/netdata/context:javascript)
 [![LGTM
 PYTHON](https://img.shields.io/lgtm/grade/python/g/netdata/netdata.svg?logo=lgtm)](https://lgtm.com/projects/g/netdata/netdata/context:python)
+[![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/netdata/netdata)](https://www.tickgit.com/browse?repo=github.com/netdata/netdata)
 
 ---
 


### PR DESCRIPTION
Fixes #8103

Adds a TODOs badge to the README. Here's the content of the linked issue:

> Hi there! I wanted to propose adding the following badge to the README to indicate how many TODO comments are in this codebase:
>
> [![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/netdata/netdata)](https://www.tickgit.com/browse?repo=github.com/netdata/netdata)
>
> The badge links to tickgit.com which is a free service that indexes and displays TODO comments in public github repos. It can help surface latent work and be a way for contributors to find areas of code to improve, that might not be otherwise documented.
>
> Thanks for considering, feel free to close this issue if it's not appropriate or you prefer not to!


