### PR TITLE
Fixes NetData installer on *BSD systems post libmosquitto / eBPF

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -460,7 +460,7 @@ bundle_libmosquitto() {
 
   MOSQUITTO_PACKAGE_VERSION="$(cat packaging/mosquitto.version)"
 
-  tmp=$(mktemp -t -d netdata-mosquitto-XXXXXX)
+  tmp="$(mktemp -d -t netdata-mosquitto-XXXXXX)"
   MOSQUITTO_PACKAGE_BASENAME="${MOSQUITTO_PACKAGE_VERSION}.tar.gz"
 
   if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_MOSQUITTO}" ]; then
@@ -975,7 +975,7 @@ install_go() {
       break
     fi
   done
-  tmp=$(mktemp -t -d netdata-go-XXXXXX)
+  tmp="$(mktemp -d -t netdata-go-XXXXXX)"
   GO_PACKAGE_BASENAME="go.d.plugin-${GO_PACKAGE_VERSION}.${OS}-${ARCH}.tar.gz"
 
   if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN}" ]; then
@@ -1105,7 +1105,7 @@ should_install_ebpf() {
 
   # Check Kernel Config
 
-  tmp="$(mktemp -t -d netdata-ebpf-XXXXXX)"
+  tmp="$(mktemp -d -t netdata-ebpf-XXXXXX)"
 
   echo >&2 " Downloading check-kernel-config.sh ..."
   if ! get "https://raw.githubusercontent.com/netdata/kernel-collector/master/tools/check-kernel-config.sh" > "${tmp}"/check-kernel-config.sh; then
@@ -1158,7 +1158,7 @@ install_ebpf() {
     return 1
   fi
 
-  tmp="$(mktemp -t -d netdata-ebpf-XXXXXX)"
+  tmp="$(mktemp -d -t netdata-ebpf-XXXXXX)"
 
   echo >&2 " Downloading eBPF Package ${PACKAGE_TARBALL_URL} ..."
   if ! get "${PACKAGE_TARBALL_URL}" > "${tmp}"/"${PACKAGE_TARBALL}"; then

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -475,9 +475,7 @@ bundle_libmosquitto() {
     return 0
   fi
 
-  grep "${MOSQUITTO_PACKAGE_BASENAME}\$" "${INSTALLER_DIR}/packaging/go.d.checksums" > "${tmp}/sha256sums.txt" 2> /dev/null
-
-  cp packaging/mosquitto.checksums "${tmp}/sha256sums.txt"
+  grep "${MOSQUITTO_PACKAGE_BASENAME}\$" "${INSTALLER_DIR}/packaging/mosquitto.checksums" > "${tmp}/sha256sums.txt" 2> /dev/null
 
   # Checksum validation
   if ! (cd "${tmp}" && safe_sha256sum -c "sha256sums.txt"); then

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -456,6 +456,12 @@ bundle_libmosquitto() {
     return 0
   fi
 
+  if [ "$(uname)" != "Linux" ]; then
+    echo >&2 " Sorry NetData with custom libmosquitto is unable on $(uname) at this time!"
+    echo >&2 " Please contact NetData suppoort! https://github.com/netdata/netdata/issues/new"
+    return 0
+  fi
+
   progress "Prepare custom libmosquitto version"
 
   MOSQUITTO_PACKAGE_VERSION="$(cat packaging/mosquitto.version)"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -865,10 +865,10 @@ if [ "${UID}" -eq 0 ]; then
     run chmod 4750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ioping"
   fi
 
-	if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ebpf_process.plugin" ]; then
-		run chown root:${NETDATA_GROUP} "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ebpf_process.plugin"
-		run chmod 4750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ebpf_process.plugin"
-	fi
+  if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ebpf_process.plugin" ]; then
+    run chown root:${NETDATA_GROUP} "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ebpf_process.plugin"
+    run chmod 4750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ebpf_process.plugin"
+  fi
 
   if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/cgroup-network" ]; then
     run chown "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/cgroup-network"
@@ -1093,6 +1093,12 @@ get_compatible_kernel_for_ebpf() {
 should_install_ebpf() {
   if [ "${NETDATA_ENABLE_EBPF:=0}" -ne 1 ]; then
     run_failed "ebpf not enabled. --enable-ebpf to enable"
+    return 1
+  fi
+
+  if [ "$(uname)" != "Linux" ]; then
+    echo >&2 " Sorry eBPF Collector is currently unsupproted on $(uname) Systems at this time."
+    echo >&2 " Please contact NetData suppoort! https://github.com/netdata/netdata/issues/new"
     return 1
   fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -457,7 +457,7 @@ bundle_libmosquitto() {
   fi
 
   if [ "$(uname)" != "Linux" ]; then
-    echo >&2 " Sorry NetData with custom libmosquitto is unable on $(uname) at this time!"
+    echo >&2 " Sorry NetData with custom libmosquitto is unsupported on $(uname) at this time!"
     echo >&2 " Please contact NetData suppoort! https://github.com/netdata/netdata/issues/new"
     return 0
   fi


### PR DESCRIPTION
Kills two birds with one stone:

- Fixes #8116 
- Fixes #8119 

Blame(s):

- #8075
- #8085

##### Summary

Theres a lesson to be learned here 😀

See: #8120

This PR fixes a whole bunch of issues I discovered post our custom
libmosquitto fork (#8085) and our new highly experimental / tech preview
eBPF Collector(s) (#8075) (_amazing how these are just 10 pRs apart!_).

Some notable things:

- Always make sure you use the _right_ options for UNIX tools -- BSD implemtnations of many tools are especially picky about this. We got `mktemp -t -d ...` wrong in so many places :/ TODO: Create a ReviewDog check for this.
- We just weren't handling errors and we just don't have `set -e` on the NetData Installer. We should: TODO: Create Issue and PR for this and fix other places we do not handle errors properly.
- _and a few others..._

##### Component Name

- area/packaging

##### Description of testing that the developer performed

I basically ran:

```sh
root@freebsd:~/netdata # ./netdata-installer.sh --enable-ebpf --install /usr/local --dont-wait --dont-start-it
```

On a fresh FreeBSD system until all errors and bugs were gone.

See the relevant issues where you can clearly see things working correctly again.

##### Additional Information

Humans _should not_ do CI; Computers should!

😳