### PR TITLE
Added connections (backend) usage to postgres monitoring

### DIFF
--- a/collectors/python.d.plugin/postgres/README.md
+++ b/collectors/python.d.plugin/postgres/README.md
@@ -16,44 +16,49 @@ Following charts are drawn:
 
     -   active
 
-3.  **Write-Ahead Logging Statistics** files/s
+3.  **Current Backend Processe Usage** percentage
+
+    -   used
+    -   available
+
+4.  **Write-Ahead Logging Statistics** files/s
 
     -   total
     -   ready
     -   done
 
-4.  **Checkpoints** writes/s
+5.  **Checkpoints** writes/s
 
     -   scheduled
     -   requested
 
-5.  **Current connections to db** count
+6.  **Current connections to db** count
 
     -   connections
 
-6.  **Tuples returned from db** tuples/s
+7.  **Tuples returned from db** tuples/s
 
     -   sequential
     -   bitmap
 
-7.  **Tuple reads from db** reads/s
+8.  **Tuple reads from db** reads/s
 
     -   disk
     -   cache
 
-8.  **Transactions on db** transactions/s
+9.  **Transactions on db** transactions/s
 
     -   committed
     -   rolled back
 
-9.  **Tuples written to db** writes/s
+10.  **Tuples written to db** writes/s
 
     -   inserted
     -   updated
     -   deleted
     -   conflicts
 
-10. **Locks on db** count per type
+11. **Locks on db** count per type
 
     -   locks
 

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -766,7 +766,7 @@ CHARTS = {
         ]
     },
     'backend_usage': {
-        'options': [None, '% of Connections in use', 'percentage', 'backend processes', 'postgres.backend_process', 'stacked'],
+        'options': [None, '% of Connections in use', 'percentage', 'backend processes', 'postgres.backend_usage', 'stacked'],
         'lines': [
             ['available', 'available', 'percentage-of-absolute-row'],
             ['used', 'used', 'percentage-of-absolute-row']

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -78,8 +78,8 @@ METRICS = {
         'backends_idle'
     ],
     QUERY_NAME_BACKEND_USAGE: [
-        'used',
-        'available'
+        'available',
+        'used'
     ],
     QUERY_NAME_INDEX_STATS: [
         'index_count',
@@ -768,8 +768,8 @@ CHARTS = {
     'backend_usage': {
         'options': [None, '% of Connections in use', 'percentage', 'backend processes', 'postgres.backend_process', 'stacked'],
         'lines': [
-            ['used', 'used', 'percentage-of-absolute-row'],
-            ['available', 'available', 'percentage-of-absolute-row']
+            ['available', 'available', 'percentage-of-absolute-row'],
+            ['used', 'used', 'percentage-of-absolute-row']
         ]
     },
     'index_count': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1402,6 +1402,14 @@ netdataDashboard.context = {
             '</ul>' +
             'For more information see <a href="https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS" target="_blank">Replication Slots</a>.'
     },
+    'postgres.backend_usage': {
+        info: 'Connections usage against maximum connections allowed, as defined in the <i>max_connections</i> setting.<ul>' +
+            '<li><strong>available:</strong> maximum new connections allowed.</li>' +
+            '<li><strong>used:</strong> connections currently in use.</li>' +
+            '</ul>' +
+            'Assuming non-superuser accounts are being used to connect to Postgres (so <i>superuser_reserved_connections</i> are subtracted from <i>max_connections</i>).<br/>' +
+            'For more information see <a href="https://www.postgresql.org/docs/current/runtime-config-connection.html" target="_blank">Connections and Authentication</a>.'
+    },
 
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
PostgreSQL monitoring is missing the total connections in use against the specified maximum (as defined in PG server config file).
This PR adds this metric (% of Connections in use) under backend processes.

##### Component Name
area/collectors
area/external/python

##### Description of testing that the developer performed
Tested against several PostgreSQL servers ranging from v9.4 to v12. Should be backwards compatible until v7.2

