### PR TITLE
Ebpf coverity

### DIFF
--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -170,10 +170,10 @@ static void int_exit(int sig)
                 dup2 (fd, STDIN_FILENO);
                 dup2 (fd, STDOUT_FILENO);
                 dup2 (fd, STDERR_FILENO);
-
-                if (fd > 2)
-                    close (fd);
             }
+
+            if (fd > 2)
+                close (fd);
 
             int sid = setsid();
             if(sid >= 0) {
@@ -213,9 +213,9 @@ static inline void netdata_write_chart_cmd(char *type
             , order);
 }
 
-static void netdata_write_global_dimension(char *dimension, char *name)
+static void netdata_write_global_dimension(char *d, char *n)
 {
-    printf("DIMENSION %s %s absolute 1 1\n", dimension, name);
+    printf("DIMENSION %s %s absolute 1 1\n", d, n);
 }
 
 static void netdata_create_global_dimension(void *ptr, int end)

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -62,9 +62,11 @@ int get_kernel_version() {
     if (fd < 0)
         return -1;
 
-    ssize_t len = read(fd, version, sizeof(version));
-    if (len < 0)
+    ssize_t len = read(fd, ver, sizeof(ver));
+    if (len < 0) {
+        close(fd);
         return -1;
+    }
 
     close(fd);
 
@@ -79,6 +81,9 @@ int get_kernel_version() {
 
     if (*version)
         version++;
+    else
+        return -1;
+
     move = patch;
     while (*version) *move++ = *version++;
     *move = '\0';


### PR DESCRIPTION
##### Summary
Fixes #8134

This commit brings fixes to problems reports for Coverity.
##### Component Name
Collector
##### Description of testing that the developer performed
The problems were present in the functions that closes the collector, so it is expected the collector will close without errors.

##### Additional Information
** CID 354249:  Resource leaks  (RESOURCE_LEAK)
/libnetdata/ebpf/ebpf.c: 67 in get_kernel_version()


________________________________________________________________________________________________________
*** CID 354249:  Resource leaks  (RESOURCE_LEAK)
/libnetdata/ebpf/ebpf.c: 67 in get_kernel_version()
61         int fd = open("/proc/sys/kernel/osrelease", O_RDONLY);
62         if (fd < 0)
63             return -1;
64     
65         ssize_t len = read(fd, version, sizeof(version));
66         if (len < 0)
>>>     CID 354249:  Resource leaks  (RESOURCE_LEAK)
>>>     Handle variable "fd" going out of scope leaks the handle.
67             return -1;
68     
69         close(fd);
70     
71         char *move = major;
72         while (*version && *version != '.') *move++ = *version++;

** CID 354248:  Memory - illegal accesses  (STRING_NULL)
/libnetdata/ebpf/ebpf.c: 83 in get_kernel_version()


________________________________________________________________________________________________________
*** CID 354248:  Memory - illegal accesses  (STRING_NULL)
/libnetdata/ebpf/ebpf.c: 83 in get_kernel_version()
77         while (*version && *version != '.') *move++ = *version++;
78         *move = '\0';
79     
80         if (*version)
81             version++;
82         move = patch;
>>>     CID 354248:  Memory - illegal accesses  (STRING_NULL)
>>>     Searching for null termination in an unterminated string "version".
83         while (*version) *move++ = *version++;
84         *move = '\0';
85     
86         return ((int)(str2l(major)*65536) + (int)(str2l(minor)*256) + (int)str2l(patch));
87     }
88     

** CID 354247:  Incorrect expression  (SIZEOF_MISMATCH)
/libnetdata/ebpf/ebpf.c: 65 in get_kernel_version()


________________________________________________________________________________________________________
*** CID 354247:  Incorrect expression  (SIZEOF_MISMATCH)
/libnetdata/ebpf/ebpf.c: 65 in get_kernel_version()
59         char *version = ver;
60     
61         int fd = open("/proc/sys/kernel/osrelease", O_RDONLY);
62         if (fd < 0)
63             return -1;
64     
>>>     CID 354247:  Incorrect expression  (SIZEOF_MISMATCH)
>>>     Passing argument "version" of type "char *" and argument "8UL /* sizeof (version) */" to function "read" is suspicious.
65         ssize_t len = read(fd, version, sizeof(version));
66         if (len < 0)
67             return -1;
68     
69         close(fd);
70     

** CID 354246:  Resource leaks  (RESOURCE_LEAK)
/collectors/ebpf_process.plugin/ebpf_process.c: 189 in int_exit()


________________________________________________________________________________________________________
*** CID 354246:  Resource leaks  (RESOURCE_LEAK)
/collectors/ebpf_process.plugin/ebpf_process.c: 189 in int_exit()
183                     }
184                     debug(D_EXIT, "Wait for father %d die", event_pid);
185                     clean_kprobe_events(developer_log, event_pid, collector_events);
186                 } else {
187                     error("Cannot become session id leader, so I won't try to clean kprobe_events.\n");
188                 }
>>>     CID 354246:  Resource leaks  (RESOURCE_LEAK)
>>>     Handle variable "fd" going out of scope leaks the handle.
189             } else { //parent
190                 exit(0);
191             }
192     
193             if (developer_log) {
194                 fclose(developer_log);

** CID 354245:  API usage errors  (SWAPPED_ARGUMENTS)


________________________________________________________________________________________________________
*** CID 354245:  API usage errors  (SWAPPED_ARGUMENTS)
/collectors/ebpf_process.plugin/ebpf_process.c: 227 in netdata_create_global_dimension()
221     static void netdata_create_global_dimension(void *ptr, int end)
222     {
223         netdata_publish_syscall_t *move = ptr;
224     
225         int i = 0;
226         while (move && i < end) {
>>>     CID 354245:  API usage errors  (SWAPPED_ARGUMENTS)
>>>     The positions of arguments in the call to "netdata_write_global_dimension" do not match the ordering of the parameters:
* "move->name" is passed to "dimension"
* "move->dimension" is passed to "name"
227             netdata_write_global_dimension(move->name, move->dimension);
228     
229             move = move->next;
230             i++;
231         }
232     }


