### PR TITLE
Add support for SOCKS5 proxy to the ACLK.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -470,6 +470,8 @@ CLAIM_PLUGIN_FILES = \
     $(NULL)
 
 ACLK_PLUGIN_FILES = \
+    aclk/aclk_common.c \
+    aclk/aclk_common.h \
     aclk/agent_cloud_link.c \
     aclk/agent_cloud_link.h \
     aclk/mqtt.c \

--- a/aclk/aclk_common.c
+++ b/aclk/aclk_common.c
@@ -1,0 +1,35 @@
+#include "aclk_common.h"
+
+struct {
+    ACLK_PROXY_TYPE type;
+    const char *url_str;
+} supported_proxy_types[] = {
+    { .type = PROXY_TYPE_SOCKS5,   .url_str = "socks5" ACLK_PROXY_PROTO_ADDR_SEPARATOR  },
+    { .type = PROXY_TYPE_SOCKS5,   .url_str = "socks5h" ACLK_PROXY_PROTO_ADDR_SEPARATOR },
+    { .type = PROXY_TYPE_UNKNOWN,  .url_str = NULL                                      },
+};
+
+static inline ACLK_PROXY_TYPE aclk_find_proxy(const char *string)
+{
+    int i = 0;
+    while( supported_proxy_types[i].url_str ) {
+        if(!strncmp(supported_proxy_types[i].url_str, string, strlen(supported_proxy_types[i].url_str)))
+            return supported_proxy_types[i].type;
+        i++;
+    }
+    return PROXY_TYPE_UNKNOWN;
+}
+
+ACLK_PROXY_TYPE aclk_verify_proxy(const char *string)
+{
+    if(!string)
+        return PROXY_TYPE_UNKNOWN;
+
+    while(*string == 0x20)
+        string++;
+
+    if(!*string)
+        return PROXY_TYPE_UNKNOWN;
+
+    return aclk_find_proxy(string);
+}

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -1,0 +1,21 @@
+#ifndef ACLK_COMMON_H
+#define ACLK_COMMON_H
+
+#include "libnetdata/libnetdata.h"
+
+typedef enum aclk_proxy_type {
+    PROXY_TYPE_UNKNOWN = 0,
+    PROXY_TYPE_SOCKS5,
+    PROXY_TYPE_HTTP,
+    PROXY_DISABLED,
+    PROXY_NOT_SET,
+} ACLK_PROXY_TYPE;
+
+#define ACLK_PROXY_PROTO_ADDR_SEPARATOR "://"
+#define ACLK_PROXY_ENV "env"
+#define ACLK_PROXY_CONFIG_VAR "proxy"
+#define ACLK_PROXY_MAXLEN 256
+
+ACLK_PROXY_TYPE aclk_verify_proxy(const char *string);
+
+#endif //ACLK_COMMON_H

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -29,8 +29,6 @@
 #define ACLK_DEFAULT_PORT 9002
 #define ACLK_DEFAULT_HOST "localhost"
 
-#define CONFIG_SECTION_ACLK "agent_cloud_link"
-
 struct aclk_request {
     char *type_id;
     char *msg_id;

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -93,6 +93,7 @@
 #define CONFIG_SECTION_STREAM    "stream"
 #define CONFIG_SECTION_EXPORTING "exporting:global"
 #define CONFIG_SECTION_HOST_LABEL   "host labels"
+#define CONFIG_SECTION_ACLK        "agent_cloud_link"
 #define EXPORTING_CONF           "exporting.conf"
 
 // these are used to limit the configuration names and values lengths


### PR DESCRIPTION
##### Summary
Closes #8089 

We read config value `agent_cloud_link` value `proxy`. Which can have following values:
- `none` - don't use proxy
- `env` - use environment variable`socks_proxy` if can otherwise disabled
- `socks5[h]://[user:pass@]host:port` - use this configured proxy regardless of any environment variables


##### Component Name
ACLK

##### Description of testing that the developer performed
VerneMQ running in VM (listening on port 9002 on VM, all ports to VM blocked except ssh), socks proxy created by `ssh user@VM -D 8888`, `netdata -D -x socks5://127.0.0.1:8888` and set to connect to verneMQ `127.0.0.1:9002` (this IP is interpreted from proxy server side).

##### Additional Information
`export ACLK=yes` must be set before running netdata installer. If testing with selfsigned certificate on VernMQ then `-DACLK_SSL_ALLOW_SELF_SIGNED` must be set.

