### PR TITLE
Use static-build of LWS library created by installer

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -624,6 +624,12 @@ netdata_LDADD = \
     $(NULL)
 endif
 
+if STATIC_LWS
+netdata_LDADD += \
+    externaldeps/libwebsockets/libwebsockets.a \
+    $(NULL)
+endif
+
 if ENABLE_CXX_LINKER
     netdata_LINK = $(CXXLD) $(CXXFLAGS) $(LDFLAGS) -o $@
 else

--- a/Makefile.am
+++ b/Makefile.am
@@ -616,17 +616,12 @@ netdata_SOURCES = $(NETDATA_FILES)
 if ENABLE_ACLK
 netdata_LDADD = \
     externaldeps/mosquitto/libmosquitto.a \
+    externaldeps/libwebsockets/libwebsockets.a \
     $(NETDATA_COMMON_LIBS) \
     $(NULL)
 else
 netdata_LDADD = \
     $(NETDATA_COMMON_LIBS) \
-    $(NULL)
-endif
-
-if STATIC_LWS
-netdata_LDADD += \
-    externaldeps/libwebsockets/libwebsockets.a \
     $(NULL)
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -450,6 +450,21 @@ if test "${ACLK}" = "yes"; then
     fi
     AC_MSG_RESULT([${HAVE_libmosquitto_a}])
 
+    if test -z "${LWS_LIBS}"; then
+        AC_MSG_CHECKING([if libwebsockets static lib is present])
+        if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
+            AC_MSG_RESULT([yes])
+            USE_static_libwebsockets="yes"
+            LWS_LIBS="-I externaldeps/libwebsockets/include"
+            if test "${build_target}" = "linux"; then
+                # TODO is possible to build LWS to not need this?
+                LWS_LIBS=" -lcap"
+            fi
+        else
+            AC_MSG_RESULT([no])
+        fi
+    fi
+
     AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
     if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}"; then
         can_enable_aclk="yes"
@@ -474,6 +489,7 @@ if test "${ACLK}" = "yes"; then
 
     AC_MSG_RESULT([${enable_aclk}])
 fi
+AM_CONDITIONAL([STATIC_LWS], [test "${USE_static_libwebsockets}" = "yes"])
 AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
 
 # -----------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -440,7 +440,7 @@ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 # -----------------------------------------------------------------------------
 # ACLK
 
-#currenlty env var ACLK must be set to 'yes' to even consider building ACLK
+#currently env var ACLK must be set to 'yes' to even consider building ACLK
 if test "${ACLK}" = "yes"; then
     AC_MSG_CHECKING([if libmosquitto static lib is present])
     if test -f "externaldeps/mosquitto/libmosquitto.a"; then

--- a/configure.ac
+++ b/configure.ac
@@ -426,56 +426,6 @@ AC_MSG_RESULT([${enable_https}])
 AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 
 # -----------------------------------------------------------------------------
-# ACLK
-
-#currently env var ACLK must be set to 'yes' to even consider building ACLK
-if test "${ACLK}" = "yes"; then
-    AC_MSG_CHECKING([if libmosquitto static lib is present])
-    if test -f "externaldeps/mosquitto/libmosquitto.a"; then
-        HAVE_libmosquitto_a="yes"
-    else
-        HAVE_libmosquitto_a="no"
-    fi
-    AC_MSG_RESULT([${HAVE_libmosquitto_a}])
-
-    AC_MSG_CHECKING([if libwebsockets static lib is present])
-    if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
-        LWS_LIBS="-I externaldeps/libwebsockets/include"
-        if test "${build_target}" = "linux"; then
-            LWS_LIBS=" -lcap"
-        fi
-        AC_MSG_RESULT([yes])
-    else
-        AC_MSG_RESULT([no])
-    fi
-
-    AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
-    if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}"; then
-        can_enable_aclk="yes"
-    else
-        can_enable_aclk="no"
-    fi
-    AC_MSG_RESULT([${can_enable_aclk}])
-
-    test "${aclk_required}" = "yes" -a "${can_enable_aclk}" = "no" && \
-        AC_MSG_ERROR([User required agent-cloud-link but it can't be built!])
-
-    AC_MSG_CHECKING([if netdata agent-cloud-link should/will be enabled])
-    if test "${aclk_required}" = "detect"; then
-        enable_aclk=$can_enable_aclk
-    else
-        enable_aclk=$aclk_required
-    fi
-
-    if test "${enable_aclk}" = "yes"; then
-        AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
-    fi
-
-    AC_MSG_RESULT([${enable_aclk}])
-fi
-AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
-
-# -----------------------------------------------------------------------------
 # Exporting engine
 AC_MSG_CHECKING([if netdata exporting engine should be used])
 if test "${UV_LIBS}"; then
@@ -590,6 +540,61 @@ fi
 AC_MSG_RESULT([${with_libcap}])
 AM_CONDITIONAL([ENABLE_CAPABILITY], [test "${with_libcap}" = "yes"])
 
+# -----------------------------------------------------------------------------
+# ACLK
+
+#currently env var ACLK must be set to 'yes' to even consider building ACLK
+if test "${ACLK}" = "yes"; then
+    AC_MSG_CHECKING([if libmosquitto static lib is present])
+    if test -f "externaldeps/mosquitto/libmosquitto.a"; then
+        HAVE_libmosquitto_a="yes"
+    else
+        HAVE_libmosquitto_a="no"
+    fi
+    AC_MSG_RESULT([${HAVE_libmosquitto_a}])
+
+    AC_MSG_CHECKING([if libwebsockets static lib is present])
+    if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
+        LWS_LIBS="-I externaldeps/libwebsockets/include"
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
+    fi
+
+    if test "${build_target}" = "linux"; then
+        if test "${with_libcap}" != "no" -a "${have_libcap}" == "yes"; then
+            LWS_LIBS+=" -lcap"
+        else
+            #to make it more obvious why aclk can't be built
+            AC_MSG_WARN([-lcap is needed to build aclk on linux])
+        fi
+    fi
+
+    AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
+    if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}" -a "${have_libcap}" == "yes"; then
+        can_enable_aclk="yes"
+    else
+        can_enable_aclk="no"
+    fi
+    AC_MSG_RESULT([${can_enable_aclk}])
+
+    test "${aclk_required}" = "yes" -a "${can_enable_aclk}" = "no" && \
+        AC_MSG_ERROR([User required agent-cloud-link but it can't be built!])
+
+    AC_MSG_CHECKING([if netdata agent-cloud-link should/will be enabled])
+    if test "${aclk_required}" = "detect"; then
+        enable_aclk=$can_enable_aclk
+    else
+        enable_aclk=$aclk_required
+    fi
+
+    if test "${enable_aclk}" = "yes"; then
+        AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
+    fi
+
+    AC_MSG_RESULT([${enable_aclk}])
+fi
+AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # apps.plugin

--- a/configure.ac
+++ b/configure.ac
@@ -304,18 +304,6 @@ AC_CHECK_LIB(
 )
 
 # -----------------------------------------------------------------------------
-# libwebsockets pure C library for implementing modern network protocols
-
-if test "${ACLK}" = "yes"; then
-    AC_CHECK_LIB(
-        [websockets],
-        [lws_set_timer_usecs],
-        [LWS_LIBS="-lwebsockets"]
-    )
-fi
-
-
-# -----------------------------------------------------------------------------
 # Judy General purpose dynamic array
 
 AC_CHECK_LIB(
@@ -450,19 +438,15 @@ if test "${ACLK}" = "yes"; then
     fi
     AC_MSG_RESULT([${HAVE_libmosquitto_a}])
 
-    if test -z "${LWS_LIBS}"; then
-        AC_MSG_CHECKING([if libwebsockets static lib is present])
-        if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
-            AC_MSG_RESULT([yes])
-            USE_static_libwebsockets="yes"
-            LWS_LIBS="-I externaldeps/libwebsockets/include"
-            if test "${build_target}" = "linux"; then
-                # TODO is possible to build LWS to not need this?
-                LWS_LIBS=" -lcap"
-            fi
-        else
-            AC_MSG_RESULT([no])
+    AC_MSG_CHECKING([if libwebsockets static lib is present])
+    if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
+        LWS_LIBS="-I externaldeps/libwebsockets/include"
+        if test "${build_target}" = "linux"; then
+            LWS_LIBS=" -lcap"
         fi
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
     fi
 
     AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
@@ -489,7 +473,6 @@ if test "${ACLK}" = "yes"; then
 
     AC_MSG_RESULT([${enable_aclk}])
 fi
-AM_CONDITIONAL([STATIC_LWS], [test "${USE_static_libwebsockets}" = "yes"])
 AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
~~If shared library libwebsockets > 3.0.0 not present in system try if static version was built by installer. If yes use static lib otherwise dont build ACLK.~~

Update:
After discussion it has been decided to only use our custom build of LWS (by installer) or disable ACLK. This PR has been updated to mirror that decision.

Closes #8152 


