### PR TITLE
openldap: fix dict access with python3

### DIFF
--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -199,7 +199,7 @@ class Service(SimpleService):
 
             try:
                 if result_type == 101:
-                    val = int(result_data[0][1].values()[0][0])
+                    val = int(list(result_data[0][1].values())[0][0])
             except (ValueError, IndexError) as error:
                 self.debug(error)
                 continue


### PR DESCRIPTION


<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fixes the following error:

Feb 22 19:38:23 eve netdata[11810]: 2020-02-22 19:38:23: python.d WARNING: plugin[main] : openldap[localhost] : unhandled exception on check : TypeError("'dict_values' object is not subscriptable"), skipping the job

##### Component Name

openldap

##### Description of testing that the developer performed

Testing it on my server: netdata.thalheim.io

<!---
Please be detailed enough that your reviewer can understand which test-cases you
have covered, and recreate them if necessary.
-->
##### Additional Information

Happens with python3.7 on NixOS.