### PR TITLE
docs: Corrected instructions for running Netdata behind Apache

### DIFF
--- a/docs/Running-behind-apache.md
+++ b/docs/Running-behind-apache.md
@@ -14,7 +14,7 @@ Make sure your apache has installed `mod_proxy` and `mod_proxy_http`.
 On debian/ubuntu systems, install them with this: 
 
 ```sh
-sudo apt-get install apache2-bin
+sudo apt-get install apache2
 ```
 
 Also make sure they are enabled:


### PR DESCRIPTION
##### Summary
Corrected instruction to install `apache2-bin` to `apache2`, as the former doesn't install `a2enmod` on Ubuntu 18.04



