### PR TITLE
gihtub/actions: switch to checkout@v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
             pre: 'apt-get update'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Build on ${{ matrix.distro }}
         env:
           PRE: ${{ matrix.pre }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,8 @@ jobs:
             pre: 'apt-get update'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Git clone repository
+        uses: actions/checkout@v2
       - name: Build on ${{ matrix.distro }}
         env:
           PRE: ${{ matrix.pre }}

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -67,7 +67,8 @@ jobs:
             pre: 'apt-get update'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Git clone repository
+        uses: actions/checkout@v2
       - name: Test installed-required-packages.sh on ${{ matrix.distro }}
         env:
           PRE: ${{ matrix.pre }}

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -67,7 +67,7 @@ jobs:
             pre: 'apt-get update'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Test installed-required-packages.sh on ${{ matrix.distro }}
         env:
           PRE: ${{ matrix.pre }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,7 +5,8 @@ jobs:
     name: runner / golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Git clone repository
+        uses: actions/checkout@v2
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
         with:
@@ -16,7 +17,8 @@ jobs:
     name: runner / eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Git clone repository
+        uses: actions/checkout@v2
       - name: eslint
         uses: reviewdog/action-eslint@v1
         with:
@@ -28,7 +30,8 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Git clone repository
+        uses: actions/checkout@v2
       - name: shellcheck
         uses: reviewdog/action-shellcheck@v1
         with:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,7 +5,7 @@ jobs:
     name: runner / golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
         with:
@@ -16,7 +16,7 @@ jobs:
     name: runner / eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: eslint
         uses: reviewdog/action-eslint@v1
         with:
@@ -28,7 +28,7 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: shellcheck
         uses: reviewdog/action-shellcheck@v1
         with:


### PR DESCRIPTION
##### Summary

Use `actions/checkout@v2` instead of `actions/checkout@v1` in all actions.

v2 is current stable version

It is faster, better ~~stronger~~

See

> https://github.com/actions/checkout#checkout-v2

##### Component Name

`github/actions`

##### Description of testing that the developer performed

No testing, `checkout@v2` is stable.

##### Additional Information


