### PR TITLE
Docs: Fixed figure+image without closing tag

### DIFF
--- a/collectors/ebpf_process.plugin/README.md
+++ b/collectors/ebpf_process.plugin/README.md
@@ -4,7 +4,7 @@ This collector plugin uses eBPF to monitor system calls inside your operating sy
 this plugin is to monitor IO and process management on the host where it is running.
 
 <figure>
-  <img src="https://user-images.githubusercontent.com/1153921/74746434-ad6a1e00-5222-11ea-858a-a7882617ae02.png" alt="n example of VFS charts, made possible by the eBPF collector plugin">
+  <img src="https://user-images.githubusercontent.com/1153921/74746434-ad6a1e00-5222-11ea-858a-a7882617ae02.png" alt="A n example of VFS charts, made possible by the eBPF collector plugin" />
   <figcaption>An example of VFS charts, made possible by the eBPF collector plugin</figcaption>
 </figure>
 

--- a/collectors/ebpf_process.plugin/README.md
+++ b/collectors/ebpf_process.plugin/README.md
@@ -4,7 +4,7 @@ This collector plugin uses eBPF to monitor system calls inside your operating sy
 this plugin is to monitor IO and process management on the host where it is running.
 
 <figure>
-  <img src="https://user-images.githubusercontent.com/1153921/74746434-ad6a1e00-5222-11ea-858a-a7882617ae02.png" alt="A n example of VFS charts, made possible by the eBPF collector plugin" />
+  <img src="https://user-images.githubusercontent.com/1153921/74746434-ad6a1e00-5222-11ea-858a-a7882617ae02.png" alt="An example of VFS charts, made possible by the eBPF collector plugin" />
   <figcaption>An example of VFS charts, made possible by the eBPF collector plugin</figcaption>
 </figure>
 

--- a/docs/tutorials/monitor-cockroachdb.md
+++ b/docs/tutorials/monitor-cockroachdb.md
@@ -86,7 +86,7 @@ charts for each job. Once you've edited `cockroachdb.conf` according to the need
 Netdata to see your new charts.
 
 <figure>
-  <img src="https://user-images.githubusercontent.com/1153921/73564469-d7e36b00-441c-11ea-8333-02ba0e1c294c.png" alt="Charts showing a node failure during a simulated test">
+  <img src="https://user-images.githubusercontent.com/1153921/73564469-d7e36b00-441c-11ea-8333-02ba0e1c294c.png" alt="Charts showing a node failure during a simulated test" />
   <figcaption>Charts showing a node failure during a simulated test</figcaption>
 </figure>
 

--- a/docs/tutorials/monitor-cockroachdb.md
+++ b/docs/tutorials/monitor-cockroachdb.md
@@ -30,7 +30,7 @@ method](../getting-started.md#start-stop-and-restart-netdata) for your system, a
 CockroachDB metrics in your Netdata dashboard!
 
 <figure>
-  <img src="https://user-images.githubusercontent.com/1153921/73564467-d7e36b00-441c-11ea-9ec9-b5d5ea7277d4.png" alt="CPU utilization charts from a CockroachDB database monitored by Netdata">
+  <img src="https://user-images.githubusercontent.com/1153921/73564467-d7e36b00-441c-11ea-9ec9-b5d5ea7277d4.png" alt="CPU utilization charts from a CockroachDB database monitored by Netdata" />
   <figcaption>CPU utilization charts from a CockroachDB database monitored by Netdata</figcaption>
 </figure>
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

In working with Ian on the `learn` repo, we found some new errors in that Markdown parser due to me not properly closing image tags.

Before: `<img src="...">`
After: `<img src="..." />`

I confirmed this will fix the errors we're currently seeing in Gatsby by editing the files locally and loading them into Gatsby that way instead of from Git.

##### Component Name

docs

##### Description of testing that the developer performed

<!---
Please be detailed enough that your reviewer can understand which test-cases you
have covered, and recreate them if necessary.
-->
##### Additional Information


