### PR TITLE
Add Prometheus custom labels

### DIFF
--- a/backends/prometheus/backend_prometheus.c
+++ b/backends/prometheus/backend_prometheus.c
@@ -276,8 +276,8 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(RRDHOST *host, BUFFER 
         }
     }
 
-    if(host->labels && *(host->labels)) {
-        snprintfz(labels, PROMETHEUS_LABELS_MAX, ",%s", host->labels);
+    if(host->labels_backend && *(host->labels_backend)) {
+        snprintfz(labels, PROMETHEUS_LABELS_MAX, ",%s", host->labels_backend);
     }
 
     // send custom variables set for the host

--- a/backends/prometheus/backend_prometheus.c
+++ b/backends/prometheus/backend_prometheus.c
@@ -276,6 +276,10 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(RRDHOST *host, BUFFER 
         }
     }
 
+    if(host->labels && *(host->labels)) {
+        snprintfz(labels, PROMETHEUS_LABELS_MAX, ",%s", host->labels);
+    }
+
     // send custom variables set for the host
     if(output_options & PROMETHEUS_OUTPUT_VARIABLES){
         struct host_variables_callback_options opts = {

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1501,6 +1501,7 @@ static RRDHOST *dbengine_rrdhost_find_or_create(char *name)
             , os_type
             , netdata_configured_timezone
             , config_get(CONFIG_SECTION_BACKEND, "host tags", "")
+            , config_get(CONFIG_SECTION_BACKEND, "host labels", "")
             , program_name
             , program_version
             , default_rrd_update_every

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -830,6 +830,7 @@ extern RRDHOST *rrdhost_find_or_create(
         , const char *os
         , const char *timezone
         , const char *tags
+        , const char *labels
         , const char *program_name
         , const char *program_version
         , int update_every

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -659,6 +659,7 @@ struct rrdhost {
 
     const char *os;                                 // the O/S type of the host
     const char *tags;                               // tags for this host
+    const char *labels_backend;                     // custom labels for this host
     const char *timezone;                           // the timezone of the host
 
     RRDHOST_FLAGS flags;                            // flags about this RRDHOST

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -176,7 +176,7 @@ RRDHOST *rrdhost_create(const char *hostname,
     rrdhost_init_os(host, os);
     rrdhost_init_timezone(host, timezone);
     rrdhost_init_tags(host, tags);
-    rrdhost_init_labels(host, labels);
+    rrdhost_init_labels_backend(host, labels);
 
     host->program_name = strdupz((program_name && *program_name)?program_name:"unknown");
     host->program_version = strdupz((program_version && *program_version)?program_version:"unknown");
@@ -457,7 +457,7 @@ RRDHOST *rrdhost_find_or_create(
 
         // update host tags and labels
         rrdhost_init_tags(host, tags);
-        rrdhost_init_labels(host, labels);
+        rrdhost_init_labels_backend(host, labels);
     }
 
     rrdhost_cleanup_orphan_hosts_nolock(host);
@@ -1014,7 +1014,7 @@ struct label *parse_json_tags(struct label *label_list, const char *tags)
     return label_list;
 }
 
-struct label *parse_backend_configs_string(char *config_string)
+struct label *parse_backend_configs_string(const char *config_string)
 {
     struct label *label_list = NULL;
     BACKEND_TYPE type = BACKEND_TYPE_UNKNOWN;
@@ -1052,7 +1052,7 @@ struct label *parse_backend_configs_string(char *config_string)
             break;
     }
 
-    return label_list
+    return label_list;
 }
 
 struct label *load_labels_from_tags()
@@ -1060,7 +1060,7 @@ struct label *load_labels_from_tags()
     if (!localhost->tags)
         return NULL;
 
-    return parse_backend_configs_string(localhost->tags)
+    return parse_backend_configs_string(localhost->tags);
 }
 
 struct label *load_labels_from_labels_backend()
@@ -1068,7 +1068,7 @@ struct label *load_labels_from_labels_backend()
     if (!localhost->labels_backend)
         return NULL;
 
-    return parse_backend_configs_string(localhost->labels_backend)
+    return parse_backend_configs_string(localhost->labels_backend);
 }
 
 struct label *load_kubernetes_labels()

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -1097,6 +1097,7 @@ static int rrdpush_receive(int fd
     char *rrdpush_destination = default_rrdpush_destination;
     char *rrdpush_api_key = default_rrdpush_api_key;
     char *rrdpush_send_charts_matching = default_rrdpush_send_charts_matching;
+    const char *backend_labels = NULL;
     time_t alarms_delay = 60;
     RRDPUSH_MULTIPLE_CONNECTIONS_STRATEGY rrdpush_multiple_connections_strategy = RRDPUSH_MULTIPLE_CONNECTIONS_ALLOW;
 
@@ -1148,6 +1149,7 @@ static int rrdpush_receive(int fd
                 , os
                 , timezone
                 , tags
+                , backend_labels
                 , program_name
                 , program_version
                 , update_every


### PR DESCRIPTION
##### Summary
Add Prometheus custom labels support for all metrics
- Fix part of #6503

##### Component Name
Prometheus Backend

##### Description of testing that the developer performed
A new config field `host labels` in `backend` section is available for Prometheus backend.
You can put a list of statics labels (such as `host tags`). 
If it's defined, they will be append to each metric on `/api/v1/allmetrics?format=prometheus`

It's very usefull to automate installation of netdata and feedback host informations to prometheus