### PR TITLE
Add support to new kernels

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1068,7 +1068,10 @@ get_compatible_kernel_for_ebpf() {
 
   # XXX: Logic taken from Slack discussion in #ebpf
   # everything that has a version <= 4.14 can use the code built to 4.14
-  # Continue the logic, everything that has a version <= 4.19 and >= 4.15 can use the code built to 4.19
+  # also all distributions that has a version <= 4.15.256 can use the code built to 4.15
+  # Continue the logic, everything that has a version < 4.19.102 and >= 4.15 can use the code built to 4.19
+  # Kernel 4.19 had a feature added in the version 4.19.102 that force us to break it in two, so version >= 4.19.102
+  # and smaller than < 5.0 runs with code built to 4.19.102
   # Finally,  everybody that is using 5.X can use what is compiled with 5.4
 
   kpkg=
@@ -1076,9 +1079,18 @@ get_compatible_kernel_for_ebpf() {
   if [ "${kver}" -ge 005000000 ]; then
     echo >&2 " Using eBPF Kernel Package built against Linux 5.4"
     kpkg="5_4"
-  elif [ "${kver}" -ge 004015000 ] && [ "${kver}" -le 004020017 ]; then
+  elif [ "${kver}" -ge 004019102 ] && [ "${kver}" -le 004020017 ]; then
+    echo >&2 " Using eBPF Kernel Package built against Linux 4.19"
+    kpkg="4_19_104"
+  elif [ "${kver}" -ge 004015000 ] && [ "${kver}" -le 004019101 ]; then
     echo >&2 " Using eBPF Kernel Package built against Linux 4.19"
     kpkg="4_19"
+  elif [ "${kver}" -ge 004016000 ] && [ "${kver}" -le 004020017 ]; then
+    echo >&2 " Using eBPF Kernel Package built against Linux 4.19"
+    kpkg="4_19"
+  elif [ "${kver}" -ge 004015000 ] && [ "${kver}" -le 004015256 ]; then
+    echo >&2 " Using eBPF Kernel Package built against Linux 4.15"
+    kpkg="4_15"
   elif [ "${kver}" -le 004014999 ]; then
     echo >&2 " Using eBPF Kernel Package built against Linux 4.14"
     kpkg="4_14"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1207,7 +1207,7 @@ install_ebpf() {
   run cp -a -v "${tmp}/libnetdata_ebpf.so" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d"
   run cp -a -v "${tmp}"/pnetdata_ebpf_process.o "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d"
   run cp -a -v "${tmp}"/rnetdata_ebpf_process.o "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d"
-  run ln -v -f -s "${libdir}"/libbpf_kernel.so "${libdir}"libbpf_kernel.so.0
+  run ln -v -f -s "${libdir}"/libbpf_kernel.so "${libdir}"/libbpf_kernel.so.0
   run ldconfig
 
   echo >&2 "ePBF installation all done!"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1077,23 +1077,20 @@ get_compatible_kernel_for_ebpf() {
   kpkg=
 
   if [ "${kver}" -ge 005000000 ]; then
-    echo >&2 " Using eBPF Kernel Package built against Linux 5.4"
-    kpkg="5_4"
+    echo >&2 " Using eBPF Kernel Package built against Linux 5.4.20"
+    kpkg="5_4_20"
   elif [ "${kver}" -ge 004019102 ] && [ "${kver}" -le 004020017 ]; then
-    echo >&2 " Using eBPF Kernel Package built against Linux 4.19"
+    echo >&2 " Using eBPF Kernel Package built against Linux 4.19.104"
     kpkg="4_19_104"
-  elif [ "${kver}" -ge 004015000 ] && [ "${kver}" -le 004019101 ]; then
-    echo >&2 " Using eBPF Kernel Package built against Linux 4.19"
-    kpkg="4_19"
   elif [ "${kver}" -ge 004016000 ] && [ "${kver}" -le 004020017 ]; then
-    echo >&2 " Using eBPF Kernel Package built against Linux 4.19"
-    kpkg="4_19"
+    echo >&2 " Using eBPF Kernel Package built against Linux 4.19.98"
+    kpkg="4_19_98"
   elif [ "${kver}" -ge 004015000 ] && [ "${kver}" -le 004015256 ]; then
-    echo >&2 " Using eBPF Kernel Package built against Linux 4.15"
-    kpkg="4_15"
+    echo >&2 " Using eBPF Kernel Package built against Linux 4.15.18"
+    kpkg="4_15_18"
   elif [ "${kver}" -le 004014999 ]; then
-    echo >&2 " Using eBPF Kernel Package built against Linux 4.14"
-    kpkg="4_14"
+    echo >&2 " Using eBPF Kernel Package built against Linux 4.14.171"
+    kpkg="4_14_171"
   else
     echo >&2 " ERROR: Cannot detect a supported kernel on your system!"
     return 1


### PR DESCRIPTION
##### Summary
Fixes #8164 

This brings two missing kernels necessary to extend the collector installation for more platforms. The problems were identified at Debian 10.2 and Ubuntu 18.04
##### Component Name
Netdata installer
##### Description of testing that the developer performed
It is only necessary to run `netdata-installer.sh`.
##### Additional Information


