### PR TITLE
Fix bold text surplus stars

### DIFF
--- a/backends/README.md
+++ b/backends/README.md
@@ -39,7 +39,7 @@ So, although Netdata collects metrics every second, it can send to the backend s
         metrics are labeled in the format, which is used by Netdata for the [plaintext prometheus
         protocol](prometheus/). Notes on using the remote write backend are [here](prometheus/remote_write/).
 
-    -   ****TimescaleDB** via [community-built connector](TIMESCALE.md) that takes JSON streams from a Netdata client
+    -   **TimescaleDB** via [community-built connector](TIMESCALE.md) that takes JSON streams from a Netdata client
         and writes them to a TimescaleDB table.
 
     -   **AWS Kinesis Data Streams**


### PR DESCRIPTION
Fix documentation formatting: there was two stars surplus for that bold text. 

(aka. Reducing the amount of stars (I Am Entropy))