### PR TITLE
Enconde slave fields

### DIFF
--- a/libnetdata/url/url.c
+++ b/libnetdata/url/url.c
@@ -31,8 +31,11 @@ char *url_encode(char *str) {
         else if (*str == ' ')
             *pbuf++ = '+';
 
-        else
-            *pbuf++ = '%', *pbuf++ = to_hex(*str >> 4), *pbuf++ = to_hex(*str & 15);
+        else{
+            *pbuf++ = '%';
+            *pbuf++ = to_hex(*str >> 4);
+            *pbuf++ = to_hex(*str & 15);
+        }
 
         str++;
     }


### PR DESCRIPTION
##### Summary
Fixes #8022 

This PR fixes the missing characters described in the issue #8022 , we began to encode texts before to send from slave to master
##### Component Name
Stream
##### Description of testing that the developer performed
It is necessary to set master and slave with this PR and verify using the endpoint `/api/v1/info` on slave and `host/name/api/v1/info` on master that the fields are exactly the same. 

##### Additional Information
The problem reported on #8022 was discovered using Raspberry-PI, ideally the slave should be it.
