### PR TITLE
packaging/installer: fix bundle_libwebsockets

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -507,7 +507,7 @@ copy_libwebsockets() {
 }
 
 bundle_libwebsockets() {
-  if [ -n "${DISABLE_CLOUD}" ] ; then
+  if [ -n "${NETDATA_DISABLE_CLOUD}" ] ; then
     return 0
   fi
 


### PR DESCRIPTION
##### Summary

Installer always bundles `libwebsockets`

There is a wrong check in the `bundle_libwebsockets` function.

##### Component Name

`packaging/installer`

##### Description of testing that the developer performed

I did 

> sudo ./netdata-installer.sh --install /opt --disable-cloud

Installer doesnt try to bundle libwebsockets

##### Additional Information

