### PR TITLE
Adding support for ACLK build-configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.9 AS build
 # Install Dependencies
 RUN apk add --no-cache -U alpine-sdk bash curl libuv-dev zlib-dev \
                           util-linux-dev libmnl-dev gcc make git autoconf \
-                          automake pkgconfig python logrotate openssl-dev
+                          automake pkgconfig python logrotate openssl-dev cmake
 
 # Pass optional ./netdata-installer.sh args with --build-arg INSTALLER_ARGS=...
 ARG INSTALLER_ARGS=""

--- a/Makefile.am
+++ b/Makefile.am
@@ -616,6 +616,7 @@ netdata_SOURCES = $(NETDATA_FILES)
 if ENABLE_ACLK
 netdata_LDADD = \
     externaldeps/mosquitto/libmosquitto.a \
+    externaldeps/libwebsockets/libwebsockets.a \
     $(NETDATA_COMMON_LIBS) \
     $(NULL)
 else

--- a/configure.ac
+++ b/configure.ac
@@ -561,17 +561,17 @@ if test "${ACLK}" = "yes"; then
         AC_MSG_RESULT([no])
     fi
 
-    if test "${build_target}" = "linux"; then
-        if test "${with_libcap}" != "no" -a "${have_libcap}" == "yes"; then
+    if test "${build_target}" = "linux" -a "${aclk_required}" != "no"; then
+        if test "${have_libcap}" = "yes" -a "${with_libcap}" = "no"; then
+            AC_MSG_ERROR([agent-cloud-link can't be built without libcap. Disable it by --disable-aclk or enable libcap])
+        fi
+        if test "${with_libcap}" = "yes"; then
             LWS_LIBS+=" -lcap"
-        else
-            #to make it more obvious why aclk can't be built
-            AC_MSG_WARN([-lcap is needed to build aclk on linux])
         fi
     fi
 
     AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
-    if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}" -a "${have_libcap}" == "yes"; then
+    if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}"; then
         can_enable_aclk="yes"
     else
         can_enable_aclk="no"

--- a/configure.ac
+++ b/configure.ac
@@ -556,10 +556,11 @@ if test "${ACLK}" = "yes"; then
     AC_MSG_CHECKING([if libwebsockets static lib is present])
     if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
         LWS_LIBS="-I externaldeps/libwebsockets/include"
-        AC_MSG_RESULT([yes])
+        HAVE_libwebsockets_a="yes"
     else
-        AC_MSG_RESULT([no])
+        HAVE_libwebsockets_a="no"
     fi
+    AC_MSG_RESULT([${HAVE_libwebsockets_a}])
 
     if test "${build_target}" = "linux" -a "${aclk_required}" != "no"; then
         if test "${have_libcap}" = "yes" -a "${with_libcap}" = "no"; then
@@ -571,7 +572,7 @@ if test "${ACLK}" = "yes"; then
     fi
 
     AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
-    if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}"; then
+    if test "${HAVE_libmosquitto_a}" = "yes" -a "${HAVE_libwebsockets_a}" = "yes"; then
         can_enable_aclk="yes"
     else
         can_enable_aclk="no"

--- a/configure.ac
+++ b/configure.ac
@@ -304,18 +304,6 @@ AC_CHECK_LIB(
 )
 
 # -----------------------------------------------------------------------------
-# libwebsockets pure C library for implementing modern network protocols
-
-if test "${ACLK}" = "yes"; then
-    AC_CHECK_LIB(
-        [websockets],
-        [lws_set_timer_usecs],
-        [LWS_LIBS="-lwebsockets"]
-    )
-fi
-
-
-# -----------------------------------------------------------------------------
 # Judy General purpose dynamic array
 
 AC_CHECK_LIB(
@@ -438,45 +426,6 @@ AC_MSG_RESULT([${enable_https}])
 AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 
 # -----------------------------------------------------------------------------
-# ACLK
-
-#currenlty env var ACLK must be set to 'yes' to even consider building ACLK
-if test "${ACLK}" = "yes"; then
-    AC_MSG_CHECKING([if libmosquitto static lib is present])
-    if test -f "externaldeps/mosquitto/libmosquitto.a"; then
-        HAVE_libmosquitto_a="yes"
-    else
-        HAVE_libmosquitto_a="no"
-    fi
-    AC_MSG_RESULT([${HAVE_libmosquitto_a}])
-
-    AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
-    if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}"; then
-        can_enable_aclk="yes"
-    else
-        can_enable_aclk="no"
-    fi
-    AC_MSG_RESULT([${can_enable_aclk}])
-
-    test "${aclk_required}" = "yes" -a "${can_enable_aclk}" = "no" && \
-        AC_MSG_ERROR([User required agent-cloud-link but it can't be built!])
-
-    AC_MSG_CHECKING([if netdata agent-cloud-link should/will be enabled])
-    if test "${aclk_required}" = "detect"; then
-        enable_aclk=$can_enable_aclk
-    else
-        enable_aclk=$aclk_required
-    fi
-
-    if test "${enable_aclk}" = "yes"; then
-        AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
-    fi
-
-    AC_MSG_RESULT([${enable_aclk}])
-fi
-AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
-
-# -----------------------------------------------------------------------------
 # Exporting engine
 AC_MSG_CHECKING([if netdata exporting engine should be used])
 if test "${UV_LIBS}"; then
@@ -591,6 +540,61 @@ fi
 AC_MSG_RESULT([${with_libcap}])
 AM_CONDITIONAL([ENABLE_CAPABILITY], [test "${with_libcap}" = "yes"])
 
+# -----------------------------------------------------------------------------
+# ACLK
+
+#currently env var ACLK must be set to 'yes' to even consider building ACLK
+if test "${ACLK}" = "yes"; then
+    AC_MSG_CHECKING([if libmosquitto static lib is present])
+    if test -f "externaldeps/mosquitto/libmosquitto.a"; then
+        HAVE_libmosquitto_a="yes"
+    else
+        HAVE_libmosquitto_a="no"
+    fi
+    AC_MSG_RESULT([${HAVE_libmosquitto_a}])
+
+    AC_MSG_CHECKING([if libwebsockets static lib is present])
+    if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
+        LWS_LIBS="-I externaldeps/libwebsockets/include"
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
+    fi
+
+    if test "${build_target}" = "linux"; then
+        if test "${with_libcap}" != "no" -a "${have_libcap}" == "yes"; then
+            LWS_LIBS+=" -lcap"
+        else
+            #to make it more obvious why aclk can't be built
+            AC_MSG_WARN([-lcap is needed to build aclk on linux])
+        fi
+    fi
+
+    AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
+    if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${LWS_LIBS}" -a "${have_libcap}" == "yes"; then
+        can_enable_aclk="yes"
+    else
+        can_enable_aclk="no"
+    fi
+    AC_MSG_RESULT([${can_enable_aclk}])
+
+    test "${aclk_required}" = "yes" -a "${can_enable_aclk}" = "no" && \
+        AC_MSG_ERROR([User required agent-cloud-link but it can't be built!])
+
+    AC_MSG_CHECKING([if netdata agent-cloud-link should/will be enabled])
+    if test "${aclk_required}" = "detect"; then
+        enable_aclk=$can_enable_aclk
+    else
+        enable_aclk=$aclk_required
+    fi
+
+    if test "${enable_aclk}" = "yes"; then
+        AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
+    fi
+
+    AC_MSG_RESULT([${enable_aclk}])
+fi
+AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # apps.plugin

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -436,7 +436,7 @@ trap build_error EXIT
 # -----------------------------------------------------------------------------
 
 build_libmosquitto() {
-  run make -C "${1}/lib"
+  run env CFLAGS= CXXFLAGS= LDFLAGS= make -C "${1}/lib"
 }
 
 copy_libmosquitto() {
@@ -492,8 +492,8 @@ bundle_libmosquitto
 
 build_libwebsockets() {
   pushd "${1}" > /dev/null || exit 1
-  cmake -D LWS_WITH_SOCKS5:bool=ON .
-  make
+  run env CFLAGS= CXXFLAGS= LDFLAGS= cmake -D LWS_WITH_SOCKS5:bool=ON .
+  run env CFLAGS= CXXFLAGS= LDFLAGS= make
   popd > /dev/null || exit 1
 }
 

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -709,12 +709,6 @@ declare -A pkg_libmnl_dev=(
   ['default']=""
 )
 
-declare -A pkg_libwebsockets_dev=(
-  ['debian']="libwebsockets-dev"
-  ['ubuntu']="libwebsockets-dev"
-  ['default']="libwebsockets-devel"
-)
-
 declare -A pkg_lm_sensors=(
   ['alpine']="lm_sensors"
   ['arch']="lm_sensors"
@@ -1170,7 +1164,6 @@ packages() {
     suitable_package libz-dev
     suitable_package libuuid-dev
     suitable_package libmnl-dev
-    suitable_package libwebsockets-dev
   fi
 
   # -------------------------------------------------------------------------

--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -61,16 +61,16 @@ This is how to do it by hand:
 
 ```sh
 # Debian / Ubuntu
-apt-get install zlib1g-dev uuid-dev libuv1-dev liblz4-dev libjudy-dev libssl-dev libmnl-dev gcc make git autoconf autoconf-archive autogen automake pkg-config curl python cmake libwebsockets-dev
+apt-get install zlib1g-dev uuid-dev libuv1-dev liblz4-dev libjudy-dev libssl-dev libmnl-dev gcc make git autoconf autoconf-archive autogen automake pkg-config curl python cmake
 
 # Fedora
-dnf install zlib-devel libuuid-devel libuv-devel lz4-devel Judy-devel openssl-devel libmnl-devel gcc make git autoconf autoconf-archive autogen automake pkgconfig curl findutils python cmake libwebsockets-devel
+dnf install zlib-devel libuuid-devel libuv-devel lz4-devel Judy-devel openssl-devel libmnl-devel gcc make git autoconf autoconf-archive autogen automake pkgconfig curl findutils python cmake
 
 # CentOS / Red Hat Enterprise Linux
-yum install autoconf automake curl gcc git libmnl-devel libuuid-devel openssl-devel libuv-devel lz4-devel Judy-devel make nc pkgconfig python zlib-devel cmake libwebsockets-devel
+yum install autoconf automake curl gcc git libmnl-devel libuuid-devel openssl-devel libuv-devel lz4-devel Judy-devel make nc pkgconfig python zlib-devel cmake
 
 # openSUSE
-zypper install zlib-devel libuuid-devel libuv-devel liblz4-devel judy-devel libopenssl-devel libmnl-devel gcc make git autoconf autoconf-archive autogen automake pkgconfig curl findutils python cmake libwebsockets-devel
+zypper install zlib-devel libuuid-devel libuv-devel liblz4-devel judy-devel libopenssl-devel libmnl-devel gcc make git autoconf autoconf-archive autogen automake pkgconfig curl findutils python cmake
 ```
 
 Once Netdata is compiled, to run it the following packages are required (already installed using the above commands):
@@ -119,8 +119,6 @@ Netdata Cloud support may require the following packages to be installed:
 
 | package  | description
 |:--------:| -----------------------
-| `libwebsockets-devel` | Version 3 or higher is at needed build time for websockets support for Netdata Cloud
-| `libwebsockets` | Version 3 or higher is needed at runtime for websockets support for Netdata Cloud
 | `cmake` | Needed at build time if you aren't using your distribution's version of libwebsockets or are building on a platform other than Linux
 
 *Netdata will greatly benefit if you have the above packages installed, but it will still work without them.*


### PR DESCRIPTION
##### Summary
Closes #8152.
Work by @Ferroin and @underhood to improve the installer / build-system so that a working configuration exists for the ACLK.

##### Component Name
installer

##### Description of testing that the developers performed
Tested that the installer works correctly in the following configurations:
* Debian 10 with libcap unavailable, ACLK both enabled and disabled.
* The Arch Linux container in the build_external system.
* FreeBSD
* MacOS

In each case the ACLK can be enabled when the dependencies are met, and the build also works with it disabled in the other cases.

More specific cases on Debian 10:
1. Without -lcap in system build with and without ACLK, build with ACLK and --without-libcap (should not error)
2. With -lcap in system build with ACLK, without ACLK, --without-libcap (error on configure "cant build ACLK without lcap" and --without-libcap --disable-aclk (no error shoud be present)
3. Manually removing libmosquitto.a -> result disabled ACLK without error.

Also tested the build on:
* Fedora
* Ubuntu
* OpenSUSE
* Ubuntu
* CentOS
* Arch
* Manjaro
* Alpine
* Clear Linux
* Sabayon

##### Additional Information
Container images other than the Arch Linux will not support the ACLK until changes to our Dockerfiles have propagated to Docker Hub.

