### PR TITLE
Added SRE team as code owners for Debian packaging files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@ backends/json/ @thiagoftsm @vlvkobal
 backends/opentsdb/ @thiagoftsm @vlvkobal
 backends/prometheus/ @vlvkobal @thiagoftsm
 build/ @cosmix @Ferroin @knatsakis @ncmans @prologic
+contrib/debian @cosmix @Ferroin @knatsakis @ncmans @prologic
 collectors/ @vlvkobal @mfundul @cosmix
 collectors/charts.d.plugin/ @ilyam8 @Ferroin @prologic @cosmix
 collectors/freebsd.plugin/ @vlvkobal @thiagoftsm @cosmix


### PR DESCRIPTION
##### Summary

This adds the SRE team as code owners for `contrib/debian`, which is where all the files needed for Debian packaging are. Long-term, this probably needs to be cleaned up and moved to the root directory where it belongs, but for the moment we just need to make sure the right people are being requested for review for these files.

##### Component Name

area/packaging