### PR TITLE
Added Docker build tests to PR checks.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+---
+name: Docker
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/docker.yml'
+      - 'netdata-installer.sh'
+      - 'packaging/**'
+  pull_request:
+    paths:
+      - '.github/workflows/docker.yml'
+      - 'netdata-installer.sh'
+      - 'packaging/**'
+jobs:
+  docker-build:
+    name: 'Build'
+    strategy:
+      matrix:
+        arch:
+          - 'amd64'
+          - 'i386'
+          - 'arm'
+          - 'arm64'
+        include:
+          - arch: 'arm'
+            pre: 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes > /dev/null'
+          - arch: 'arm64'
+            pre: 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes > /dev/null'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Test Docker Build for ${{ matrix.arch }}
+        env:
+          PRE: ${{ matrix.pre }}
+        run:
+          docker build . --no-cache --build-arg ARCH=${{ matrix.arch }} --file Dockerfile


### PR DESCRIPTION
##### Summary

This adds PR checks to verify that Docker builds work correctly when PR's change the packaging code. It verifies all four architectures that we currently build Docker images for.

These checks only run on PR's which either modify the workflow itself, or alter the packaging or installer code.

##### Component Name

area/ci
area/packaging

##### Description of testing that the developer performed

Verified that the checks run and pass correctly on my personal fork.

##### Additional Information

This is part of an ongoing conversion from Travis CI to GitHub Actions for CI/CD.