### PR TITLE
Update installer checks to check the whole installer.

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -60,7 +60,7 @@ jobs:
           - distro: 'debian:buster'
             pre: 'apt-get update'
           - distro: 'debian:jessie'
-            pre: 'apt-get update'
+            pre: '/bin/sh -c "echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list && apt-get update -o Acquire::Check-Valid-Until=false"'
           - distro: 'debian:stretch'
             pre: 'apt-get update'
 
@@ -82,4 +82,4 @@ jobs:
         env:
           PRE: ${{ matrix.pre }}
         run: |
-          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE}; ./packaging/installer/install-required-packages.sh netdata --dont-wait --non-interactive && ./netdata-installer.sh --dont-wait --dont-start-it'
+          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE} ; ./packaging/installer/install-required-packages.sh netdata --dont-wait --non-interactive && ./netdata-installer.sh --dont-wait --dont-start-it'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -17,7 +17,7 @@ on:
       - 'netdata-installer.sh'
 jobs:
   install:
-    name: netdata-installer.sh
+    name: Installer
     strategy:
       matrix:
         distro:

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -60,7 +60,7 @@ jobs:
           - distro: 'debian:buster'
             pre: 'apt-get update'
           - distro: 'debian:jessie'
-            pre: <
+            pre: >
               /bin/sh -c 'echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list.d/99-archived.list && apt-get update -o Acquire::Check-Valid-Until=false'
           - distro: 'debian:stretch'
             pre: 'apt-get update'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -80,4 +80,4 @@ jobs:
         env:
           PRE: ${{ matrix.pre }}
         run: |
-          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE}; ./netdata-installer.sh --dont-wait --dont-start-it'
+          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE}; ./packaging/installer/install-required-packages.sh netdata --dont-wait --non-interactive && ./netdata-installer.sh --dont-wait --dont-start-it'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -17,7 +17,7 @@ on:
       - 'netdata-installer.sh'
 jobs:
   install:
-    name: Installer
+    name: Install
     strategy:
       matrix:
         distro:
@@ -60,7 +60,8 @@ jobs:
           - distro: 'debian:buster'
             pre: 'apt-get update'
           - distro: 'debian:jessie'
-            pre: '/bin/sh -c "echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list && apt-get update -o Acquire::Check-Valid-Until=false"'
+            pre: <
+              /bin/sh -c 'echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list.d/99-archived.list && apt-get update -o Acquire::Check-Valid-Until=false'
           - distro: 'debian:stretch'
             pre: 'apt-get update'
 

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -80,4 +80,4 @@ jobs:
         env:
           PRE: ${{ matrix.pre }}
         run: |
-          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE}; ./netdata-installer.sh --dont-wait --non-interactive'
+          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE}; ./netdata-installer.sh --dont-wait --dont-start-it'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - master
     paths:
+      - '.github/workflows/installer.yml'
       - 'packaging/*'
       - 'packaging/installer/**'
       - 'netdata-installer.sh'
   pull_request:
     paths:
+      - '.github/workflows/installer.yml'
       - 'packaging/*'
       - 'packaging/installer/**'
       - 'netdata-installer.sh'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -5,16 +5,21 @@ on:
     branches:
       - master
     paths:
-      - 'packaging/installer/install-required-packages.sh'
+      - 'packaging/*'
+      - 'packaging/installer/**'
+      - 'netdata-installer.sh'
   pull_request:
     paths:
-      - 'packaging/installer/install-required-packages.sh'
+      - 'packaging/*'
+      - 'packaging/installer/**'
+      - 'netdata-installer.sh'
 jobs:
-  install-required-packages:
-    name: Required Packages
+  install:
+    name: netdata-installer.sh
     strategy:
       matrix:
         distro:
+          - 'alpine:edge'
           - 'alpine:3.11'
           - 'alpine:3.10'
           - 'alpine:3.9'
@@ -69,8 +74,8 @@ jobs:
     steps:
       - name: Git clone repository
         uses: actions/checkout@v2
-      - name: Test installed-required-packages.sh on ${{ matrix.distro }}
+      - name: Test netdata-installer.sh on ${{ matrix.distro }}
         env:
           PRE: ${{ matrix.pre }}
         run: |
-          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE}; ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive'
+          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE}; ./netdata-installer.sh --dont-wait --non-interactive'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -61,7 +61,7 @@ jobs:
             pre: 'apt-get update'
           - distro: 'debian:jessie'
             pre: >
-              echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list &&
+              echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list.d/99-archived.list &&
               apt-get update -o Acquire::Check-Valid-Until=false
           - distro: 'debian:stretch'
             pre: 'apt-get update'
@@ -84,4 +84,4 @@ jobs:
         env:
           PRE: ${{ matrix.pre }}
         run: |
-          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE} ; ./packaging/installer/install-required-packages.sh netdata --dont-wait --non-interactive && ./netdata-installer.sh --dont-wait --dont-start-it'
+          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && /bin/sh -c "${PRE}" ; ./packaging/installer/install-required-packages.sh netdata --dont-wait --non-interactive && ./netdata-installer.sh --dont-wait --dont-start-it'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -61,7 +61,7 @@ jobs:
             pre: 'apt-get update'
           - distro: 'debian:jessie'
             pre: >
-              echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list && \
+              echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list &&
               apt-get update -o Acquire::Check-Valid-Until=false
           - distro: 'debian:stretch'
             pre: 'apt-get update'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -45,6 +45,8 @@ jobs:
           - 'ubuntu:18.04'
           - 'ubuntu:16.04'
         include:
+          - distro: 'alpine:edge'
+            pre: 'apk add -U bash'
           - distro: 'alpine:3.11'
             pre: 'apk add -U bash'
           - distro: 'alpine:3.10'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -61,7 +61,8 @@ jobs:
             pre: 'apt-get update'
           - distro: 'debian:jessie'
             pre: >
-              /bin/sh -c 'echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list.d/99-archived.list && apt-get update -o Acquire::Check-Valid-Until=false'
+              echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list && \
+              apt-get update -o Acquire::Check-Valid-Until=false
           - distro: 'debian:stretch'
             pre: 'apt-get update'
 


### PR DESCRIPTION
##### Summary

This updates the PR checks used for checking the installation script to actually test the whole thing, instead of just checking the dependency installation sub-script.

It also adds the Edge branch of Alpine to the checks, and ensures that the checks run against PR's and commits that modify the workflow itself (simplifying testing and verification of the workflow file itself).

##### Component Name

area/ci
area/packaging

##### Description of testing that the developer performed

Verified that this properly runs on this PR.

##### Additional Information

This is part of an ongoing process of replacing usage of Travis CI with GitHub Actions.
