### PR TITLE
Added Docker build tests to PR checks.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,10 +16,18 @@ on:
 jobs:
   docker-build:
     name: Docker Build
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - i386
+          - arm
+          - arm64
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Test Docker Build
         run:
-          docker build -f packaging/docker/Dockerfile .
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker build --build-arg ARCH=${{ matrix.arch }} -f packaging/docker/Dockerfile .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
         arch:
           - amd64
           - i386
-          - arm
+          - armhf
           - arm64
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,25 @@
+---
+name: Docker
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/docker.yml'
+      - 'netdata-installer.sh'
+      - 'packaging/**'
+  pull_request:
+    paths:
+      - '.github/workflows/docker.yml'
+      - 'netdata-installer.sh'
+      - 'packaging/**'
+jobs:
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Test Docker Build
+        run:
+          docker build -f packaging/docker/Dockerfile .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Test Docker Build
+      - name: Prepare Docker Environment
         run:
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Test Docker Build
+        run:
           docker build --build-arg ARCH=${{ matrix.arch }} -f packaging/docker/Dockerfile .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
           - amd64
           - i386
           - armhf
-          - arm64
+          - aarch64
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
##### Summary

This adds PR checks to verify that Docker builds work correctly when PR's change the packaging code. Due to a lack of BuildKit support and no ability to use `--build-arg` in the version of 'Docker' provided in the GitHub hosted runners for GHA, we are only able to build for one architecture.

##### Component Name

area/ci

##### Description of testing that the developer performed

Verified that the checks run correctly on this PR.

##### Additional Information

This is part of an ongoing effort to replace usage of Travis CI with GitHub Actions.
