### PR TITLE
Added libwebsockets files to `make dist`.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,8 @@ dist_noinst_DATA = \
     packaging/version \
     packaging/go.d.version \
     packaging/go.d.checksums \
+    packaging/libwebsockets.version \
+    packaging/libwebsockets.checksums \
     packaging/mosquitto.version \
     packaging/mosquitto.checksums \
     packaging/bundle-mosquitto.sh \


### PR DESCRIPTION
##### Summary

This adds the version and checksum files for LWS to the files preserved by `make dist`. Without this, they aren't present when users try to install.

##### Component Name

area/packaging

##### Description of testing that the developer performed

Verified that the installer script completes correctly after running `make dist`.

##### Additional Information

Fixes #8274 