### PR TITLE
Added ability to change ID used to connect to ceph.

### DIFF
--- a/collectors/python.d.plugin/ceph/ceph.chart.py
+++ b/collectors/python.d.plugin/ceph/ceph.chart.py
@@ -120,7 +120,7 @@ class Service(SimpleService):
         self.definitions = CHARTS
         self.config_file = self.configuration.get('config_file')
         self.keyring_file = self.configuration.get('keyring_file')
-        self.rados_id = self.configuration.get('rados_id')
+        self.rados_id = self.configuration.get('rados_id', 'admin')
 
     def check(self):
         """

--- a/collectors/python.d.plugin/ceph/ceph.chart.py
+++ b/collectors/python.d.plugin/ceph/ceph.chart.py
@@ -120,6 +120,7 @@ class Service(SimpleService):
         self.definitions = CHARTS
         self.config_file = self.configuration.get('config_file')
         self.keyring_file = self.configuration.get('keyring_file')
+        self.rados_id = self.configuration.get('rados_id')
 
     def check(self):
         """
@@ -148,7 +149,8 @@ class Service(SimpleService):
             return False
         try:
             self.cluster = rados.Rados(conffile=self.config_file,
-                                       conf=dict(keyring=self.keyring_file))
+                                       conf=dict(keyring=self.keyring_file),
+                                       rados_id=self.rados_id)
             self.cluster.connect()
         except rados.Error as error:
             self.error(error)

--- a/collectors/python.d.plugin/ceph/ceph.conf
+++ b/collectors/python.d.plugin/ceph/ceph.conf
@@ -64,10 +64,12 @@
 #     config_file: 'config_file'       # Ceph config file.
 #     keyring_file: 'keyring_file'     # Ceph keyring file. netdata user must be added into ceph group
 #                                      # and keyring file must be read group permission.
+#     rados_id: 'rados username'       # ID used to connect to ceph cluster.  Allows
+#                                      # creating a read only key for pulling data v.s. admin
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
 # only one of them will run (they have the same name)
 #
 config_file: '/etc/ceph/ceph.conf'
 keyring_file: '/etc/ceph/ceph.client.admin.keyring'
-
+rados_id: 'admin'


### PR DESCRIPTION

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Allows the ability to change ID used to connect to ceph instead of default "admin"

##### Component Name
[`collectors/python.d.plugin/ceph`](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/ceph)


##### Description of testing that the developer performed
Changed file to pull rados ID from config file and pass it along to the connector.


##### Additional Information
Adding a user with read only caps to mon and mgr seemed to be enough to pull all relevant ceph data.  For my clusters, #8248 needed to be merged as well for this to be fully functional. I don't have a cluster that I can test this on "bare".  There are no reasons to believe it wouldn't work.

