### PR TITLE
Added support for macOS/Homebrew in `install-required-packages.sh`.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -748,7 +748,7 @@ declare -A pkg_libz_dev=(
   ['rhel']="zlib-devel"
   ['suse']="zlib-devel"
   ['clearlinux']="devpkg-zlib"
-  ['macos']="zlib"
+  ['macos']="NOTREQUIRED"
   ['default']=""
 )
 

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -11,6 +11,7 @@ renice 19 $$ > /dev/null 2> /dev/null
 ME="${0}"
 
 if [ "${BASH_VERSINFO[0]}" -lt "4" ]; then
+
   echo >&2 "Sorry! This script needs BASH version 4+, but you have BASH version ${BASH_VERSION}"
   exit 1
 fi
@@ -1791,7 +1792,9 @@ if [ -z "${1}" ]; then
 fi
 
 pv=$(python --version 2>&1)
-if [[ "${pv}" =~ ^Python\ 2.* ]]; then
+if [ "${tree}" = macos ] ; then
+  pv=3
+elif [[ "${pv}" =~ ^Python\ 2.* ]]; then
   pv=2
 elif [[ "${pv}" =~ ^Python\ 3.* ]]; then
   pv=3

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -652,14 +652,14 @@ declare -A pkg_json_c_dev=(
 declare -A pkg_bridge_utils=(
   ['gentoo']="net-misc/bridge-utils"
   ['clearlinux']="network-basic"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="bridge-utils"
 )
 
 declare -A pkg_chrony=(
   ['gentoo']="net-misc/chrony"
   ['clearlinux']="time-server-basic"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="chrony"
 )
 
@@ -702,7 +702,7 @@ declare -A pkg_gdb=(
 
 declare -A pkg_iotop=(
   ['gentoo']="sys-process/iotop"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="iotop"
 )
 
@@ -712,7 +712,7 @@ declare -A pkg_iproute2=(
   ['gentoo']="sys-apps/iproute2"
   ['sabayon']="sys-apps/iproute2"
   ['clearlinux']="iproute2"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="iproute"
 
   # exceptions
@@ -722,7 +722,7 @@ declare -A pkg_iproute2=(
 declare -A pkg_ipset=(
   ['gentoo']="net-firewall/ipset"
   ['clearlinux']="network-basic"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="ipset"
 )
 
@@ -733,7 +733,7 @@ declare -A pkg_jq=(
 
 declare -A pkg_iptables=(
   ['gentoo']="net-firewall/iptables"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="iptables"
 )
 
@@ -789,28 +789,28 @@ declare -A pkg_lm_sensors=(
   ['rhel']="lm_sensors"
   ['suse']="sensors"
   ['clearlinux']="lm-sensors"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="lm_sensors"
 )
 
 declare -A pkg_logwatch=(
   ['gentoo']="sys-apps/logwatch"
   ['clearlinux']="WARNING|"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="logwatch"
 )
 
 declare -A pkg_lxc=(
   ['gentoo']="app-emulation/lxc"
   ['clearlinux']="WARNING|"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="lxc"
 )
 
 declare -A pkg_mailutils=(
   ['gentoo']="net-mail/mailutils"
   ['clearlinux']="WARNING|"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="mailutils"
 )
 
@@ -859,7 +859,7 @@ declare -A pkg_nodejs=(
 
 declare -A pkg_postfix=(
   ['gentoo']="mail-mta/postfix"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="postfix"
 )
 
@@ -883,7 +883,7 @@ declare -A pkg_python=(
   ['default']="python"
 
   # Exceptions
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['centos-8']="python2"
 )
 
@@ -913,7 +913,7 @@ declare -A pkg_python3_mysqldb=(
   ['rhel']="WARNING|"
   ['suse']="WARNING|"
   ['clearlinux']="WARNING|"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="WARNING|"
 
   # exceptions
@@ -940,7 +940,7 @@ declare -A pkg_python_psycopg2=(
   ['rhel']="python-psycopg2"
   ['suse']="python-psycopg2"
   ['clearlinux']="WARNING|"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="python-psycopg2"
 )
 
@@ -954,7 +954,7 @@ declare -A pkg_python3_psycopg2=(
   ['rhel']="WARNING|"
   ['suse']="WARNING|"
   ['clearlinux']="WARNING|"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="WARNING|"
 )
 
@@ -963,7 +963,7 @@ declare -A pkg_python_pip=(
   ['gentoo']="dev-python/pip"
   ['sabayon']="dev-python/pip"
   ['clearlinux']="python-basic"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="python-pip"
 )
 
@@ -987,7 +987,7 @@ declare -A pkg_python_pymongo=(
   ['gentoo']="dev-python/pymongo"
   ['suse']="python-pymongo"
   ['clearlinux']="WARNING|"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="python-pymongo"
 )
 
@@ -999,7 +999,7 @@ declare -A pkg_python3_pymongo=(
   ['gentoo']="dev-python/pymongo"
   ['suse']="python3-pymongo"
   ['clearlinux']="WARNING|"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="python3-pymongo"
 )
 
@@ -1013,7 +1013,7 @@ declare -A pkg_python_requests=(
   ['rhel']="python-requests"
   ['suse']="python-requests"
   ['clearlinux']="python-extras"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="python-requests"
   ['alpine-3.1.4']="WARNING|"
   ['alpine-3.2.3']="WARNING|"
@@ -1029,7 +1029,7 @@ declare -A pkg_python3_requests=(
   ['rhel']="WARNING|"
   ['suse']="WARNING|"
   ['clearlinux']="python-extras"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="WARNING|"
 )
 
@@ -1106,7 +1106,7 @@ declare -A pkg_sudo=(
 
 declare -A pkg_sysstat=(
   ['gentoo']="app-admin/sysstat"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="sysstat"
 )
 
@@ -1135,7 +1135,7 @@ declare -A pkg_ulogd=(
   ['clearlinux']="WARNING|"
   ['gentoo']="app-admin/ulogd"
   ['arch']="ulogd"
-  ['macos']="WAARNING|"
+  ['macos']="WARNING|"
   ['default']="ulogd2"
 )
 

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -11,7 +11,6 @@ renice 19 $$ > /dev/null 2> /dev/null
 ME="${0}"
 
 if [ "${BASH_VERSINFO[0]}" -lt "4" ]; then
-
   echo >&2 "Sorry! This script needs BASH version 4+, but you have BASH version ${BASH_VERSION}"
   exit 1
 fi
@@ -1361,7 +1360,7 @@ run() {
 }
 
 sudo=
-if [ ${UID} -ne 0 ] && [ ${tree} != 'macos' ] ; then
+if [ ${UID} -ne 0 ] ; then
   sudo="sudo"
 fi
 
@@ -1746,11 +1745,11 @@ install_brew() {
   if [ "${DRYRUN}" -eq 1 ]; then
     echo >&2 " >> IMPORTANT << "
     echo >&2 "    Please make sure your system is up to date"
-    echo >&2 "    by running:  ${sudo} brew upgrade "
+    echo >&2 "    by running:  brew upgrade "
     echo >&2
   fi
 
-  run ${sudo} brew install "${@}"
+  run brew install "${@}"
 }
 
 # -----------------------------------------------------------------------------

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -280,6 +280,11 @@ autodetect_distribution() {
       distribution="macos"
       version="$(uname -r)"
       detection="uname"
+
+      if [ ${EUID} -eq 0 ] ; then
+        echo >&2 "This script does not support running as EUID 0 on macOS. Please run it as a regular user."
+        exit 1
+      fi
       ;;
     *)
       return 1
@@ -1356,7 +1361,7 @@ run() {
 }
 
 sudo=
-if [ ${UID} -ne 0 ]; then
+if [ ${UID} -ne 0 ] && [ ${tree} != 'macos' ] ; then
   sudo="sudo"
 fi
 


### PR DESCRIPTION
##### Summary

This adds basic support for macOS with Homebrew to `install-required-packages.sh`.

It installs everything required to actually build Netdata (except Judy, which is not available through Homebrew).

It has two significant limitations compared to using it on Linux:

* It requires the user to have already installed bash via Homebrew. macOS only includes an ancient version of bash for licensing reasons, and the script requires bash 4.x or newer.
* It can't run as root. Homebrew explicitly refuses to run as EUID 0 for safety reasons.

##### Component Name

area/packaging

##### Description of testing that the developer performed

Verified operational on my local mac Mini running macOS Catalina.

##### Additional Information

This will preferentially use libraries provided directly by macOS to ones installed through Homebrew. It also forces Python 3 as Homebrew does not provide Python 2.7 (and it's a pain to support the version provided directly by macOS).

Fixes: #8282 
