### PR TITLE
Revert "Fixed Source0 URL in RPM spec (#7794)"

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -87,7 +87,7 @@ Version:	%{version}
 Release:	1%{?dist}
 License:	GPLv3+
 Group:		Applications/System
-Source0:	https://github.com/netdata/%{name}/releases/download/v%{version}/%{name}-v%{version}.tar.gz
+Source0:	https://github.com/netdata/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
 URL:		http://my-netdata.io
 
 # #####################################################################


### PR DESCRIPTION
This reverts commit 1477784048319e84127e466add6eb4a092c235e1.

Fixes #8283


##### Summary

As discussed internally we believe we changed something between `v1.18.x` and
`v1.20.x` where we no longer strip the `v` prefix for what evetually becomes
`%{version}) in the `netdata.spec.in`.

- [ ] Prove this

##### Component Name

- area/packaging

##### Test Plan

Evidence

##### Additional Information

See `TBD` above.