### PR TITLE
Updated PR labeling to utilize new area/build label.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,8 @@ area/backends:
 area/build:
   - build/*
   - build/**/*
+  - build_external/*
+  - build_external/**/*
   - CMakeLists.txt
   - configure.ac
   - Makefile.am

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,14 @@ area/backends:
   - exporting/*
   - exporting/**/*
 
+area/build:
+  - build/*
+  - build/**/*
+  - CMakeLists.txt
+  - configure.ac
+  - Makefile.am
+  - "**/Makefile.am"
+
 area/ci:
   - .travis/*
   - .travis/**/*
@@ -55,8 +63,6 @@ area/health:
   - health/**/*
 
 area/packaging:
-  - build/*
-  - build/**/*
   - contrib/*
   - contrib/**/*
   - packaging/*
@@ -65,10 +71,6 @@ area/packaging:
   - system/**/*
   - Dockerfile*
   - netdata-installer.sh
-  - CMakeLists.txt
-  - configure.ac
-  - Makefile.am
-  - "**/Makefile.am"
   - netdata.spec.in
 
 area/registry:


### PR DESCRIPTION
##### Summary

This updates the configuration used for labeling PR's to utilize the newly added `area/build` label for PR's that change the build system.

##### Component Name

area/ci

##### Description of testing that the developer performed

Verified configuration against what files are actually part of the build system and ensured that the file parses correctly.

##### Additional Information

I've added @netdata/core for review on this one so that someone there can help verify that the split in the config as to what's `area/build` and what's `area/packaging` is correct.