### PR TITLE
Fixed missing folders in `/var/` by creating them during postinst

### DIFF
--- a/contrib/debian/netdata.postinst.in
+++ b/contrib/debian/netdata.postinst.in
@@ -38,6 +38,14 @@ case "$1" in
               dpkg-statoverride --update --add netdata netdata 0755 /var/cache/netdata
           fi
 
+          if ! dpkg-statoverride --list /var/run/netdata >/dev/null 2>&1; then
+              dpkg-statoverride --update --add netdata netdata 0755 /var/run/netdata
+          fi
+
+          if ! dpkg-statoverride --list /var/log/netdata >/dev/null 2>&1; then
+              dpkg-statoverride --update --add netdata adm 02750 /var/log/netdata
+          fi
+
         fi
 
         dpkg-statoverride --update --add --force root netdata 0775 /var/lib/netdata/registry

--- a/contrib/debian/netdata.postrm
+++ b/contrib/debian/netdata.postrm
@@ -34,6 +34,14 @@ case "$1" in
     if dpkg-statoverride --list | grep -qw /var/lib/netdata; then
       dpkg-statoverride --remove /var/lib/netdata
     fi
+
+    if dpkg-statoverride --list | grep -qw /var/run/netdata; then
+      dpkg-statoverride --remove /var/run/netdata
+    fi
+
+    if dpkg-statoverride --list | grep -qw /var/log/netdata; then
+      dpkg-statoverride --remove /var/log/netdata
+    fi
     ;;
 
   *) ;;

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -46,6 +46,9 @@ override_dh_install: debian/netdata.postinst
 	cp -rp $(TEMPTOP)/usr $(TOP)
 	cp -rp $(TEMPTOP)/var $(TOP)
 	cp -rp $(TEMPTOP)/etc $(TOP)
+	mkdir -p "$(TOP)/var/log/netdata"
+	mkdir -p "$(TOP)/var/cache/netdata"
+	mkdir -p "$(TOP)/var/run/netdata"
 
 	# Move files that local user shouldn't be editing to /usr/share/netdata
 	#


### PR DESCRIPTION
##### Summary

This commit creates the following folders during the installation
of Debian packages:

- /var/log/netdata (missing in Ubuntu 18.04)
- /var/cache/netdata (missing in Debian Buster as described in #8173 and Ubuntu 18.04)
- /var/run/netdata (missing in Debian Buster as described in #8173)

During the purge of the package, these folders are removed if empty.

Note that the permissions of `/var/log/netdata` allow the members of
the `adm` group to read the content.

Fixes #8173

##### Component Name
* contrib/debian
<!--
If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Description of testing that the developer performed
I built the package locally with `dpkg-buildpackage -us -uc -rfakeroot` and installed the package locally with `dpkg -i ../netdata_*.deb`.
I made sure the service was running correctly after the installation.
Note: only tested on Ubuntu 18.04.

<!---
Please be detailed enough that your reviewer can understand which test-cases you
have covered, and recreate them if necessary.
-->
##### Additional Information
None.
