### PR TITLE
Added various fixes and improvements to the installers.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1283,10 +1283,7 @@ install_apt_get() {
   read -r -a apt_opts <<< "$opts"
 
   # install the required packages
-  for pkg in "${@}"; do
-    [[ ${DRYRUN} -eq 0 ]] && echo >&2 "Adding package ${pkg}"
-    run ${sudo} apt-get "${apt_opts[@]}" install "${pkg}"
-  done
+  run ${sudo} apt-get "${apt_opts[@]}" install "${@}"
 }
 
 # -----------------------------------------------------------------------------
@@ -1450,10 +1447,7 @@ install_emerge() {
   read -r -a emerge_opts <<< "$opts"
 
   # install the required packages
-  for pkg in "${@}"; do
-    [[ ${DRYRUN} -eq 0 ]] && echo >&2 "Adding package ${pkg}"
-    run ${sudo} emerge "${emerge_opts[@]}" -v --noreplace "${pkg}"
-  done
+  run ${sudo} emerge "${emerge_opts[@]}" -v --noreplace "${@}"
 }
 
 # -----------------------------------------------------------------------------
@@ -1511,10 +1505,7 @@ install_equo() {
   read -r -a equo_opts <<< "$opts"
 
   # install the required packages
-  for pkg in "${@}"; do
-    [[ ${DRYRUN} -eq 0 ]] && echo >&2 "Adding package ${pkg}"
-    run ${sudo} equo i "${equo_opts[@]}" "${pkg}"
-  done
+  run ${sudo} equo i "${equo_opts[@]}" "${@}"
 }
 
 # -----------------------------------------------------------------------------
@@ -1570,17 +1561,10 @@ install_pacman() {
   if [ "${NON_INTERACTIVE}" -eq 1 ]; then
     echo >&2 "Running in non-interactive mode"
     # http://unix.stackexchange.com/questions/52277/pacman-option-to-assume-yes-to-every-question/52278
-    for pkg in "${@}"; do
-      [[ ${DRYRUN} -eq 0 ]] && echo >&2 "Adding package ${pkg}"
-      # Try the noconfirm option, if that fails, go with the legacy way for non-interactive
-      run ${sudo} pacman --noconfirm --needed -S "${pkg}" || yes | run ${sudo} pacman --needed -S "${pkg}"
-    done
-
+    # Try the noconfirm option, if that fails, go with the legacy way for non-interactive
+    run ${sudo} pacman --noconfirm --needed -S "${@}" || yes | run ${sudo} pacman --needed -S "${@}"
   else
-    for pkg in "${@}"; do
-      [[ ${DRYRUN} -eq 0 ]] && echo >&2 "Adding package ${pkg}"
-      run ${sudo} pacman --needed -S "${pkg}"
-    done
+    run ${sudo} pacman --needed -S "${@}"
   fi
 }
 

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1032,6 +1032,7 @@ declare -A pkg_ulogd=(
   ['rhel']="WARNING|"
   ['clearlinux']="WARNING|"
   ['gentoo']="app-admin/ulogd"
+  ['arch']="ulogd"
   ['default']="ulogd2"
 )
 

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1660,6 +1660,17 @@ if [ -z "${1}" ]; then
   exit 1
 fi
 
+pv=$(python --version 2>&1)
+if [[ "${pv}" =~ ^Python\ 2.* ]]; then
+  pv=2
+elif [[ "${pv}" =~ ^Python\ 3.* ]]; then
+  pv=3
+elif [[ "${tree}" == "centos" ]] && [ "${version}" -lt 8 ]; then
+  pv=2
+else
+  pv=3
+fi
+
 # parse command line arguments
 DONT_WAIT=0
 NON_INTERACTIVE=0
@@ -1701,17 +1712,24 @@ while [ -n "${1}" ]; do
     netdata-all)
       PACKAGES_NETDATA=1
       PACKAGES_NETDATA_NODEJS=1
-      PACKAGES_NETDATA_PYTHON=1
-      PACKAGES_NETDATA_PYTHON_MYSQL=1
-      PACKAGES_NETDATA_PYTHON_POSTGRES=1
-      PACKAGES_NETDATA_PYTHON_MONGO=1
+      if [ "${pv}" -eq 2 ] ; then
+        PACKAGES_NETDATA_PYTHON=1
+        PACKAGES_NETDATA_PYTHON_MYSQL=1
+        PACKAGES_NETDATA_PYTHON_POSTGRES=1
+        PACKAGES_NETDATA_PYTHON_MONGO=1
+      else
+        PACKAGES_NETDATA_PYTHON3=1
+        PACKAGES_NETDATA_PYTHON3_MYSQL=1
+        PACKAGES_NETDATA_PYTHON3_POSTGRES=1
+        PACKAGES_NETDATA_PYTHON3_MONGO=1
+      fi
       PACKAGES_NETDATA_SENSORS=1
       PACKAGES_NETDATA_DATABASE=1
       ;;
 
     netdata)
       PACKAGES_NETDATA=1
-      PACKAGES_NETDATA_PYTHON=1
+      PACKAGES_NETDATA_PYTHON3=1
       PACKAGES_NETDATA_DATABASE=1
       ;;
 
@@ -1724,18 +1742,33 @@ while [ -n "${1}" ]; do
       ;;
 
     python-mysql | mysql-python | mysqldb | netdata-mysql)
-      PACKAGES_NETDATA_PYTHON=1
-      PACKAGES_NETDATA_PYTHON_MYSQL=1
+      if [ "${pv}" -eq 2 ] ; then
+        PACKAGES_NETDATA_PYTHON=1
+        PACKAGES_NETDATA_PYTHON_MYSQL=1
+      else
+        PACKAGES_NETDATA_PYTHON3=1
+        PACKAGES_NETDATA_PYTHON3_MYSQL=1
+      fi
       ;;
 
     python-postgres | postgres-python | psycopg2 | netdata-postgres)
-      PACKAGES_NETDATA_PYTHON=1
-      PACKAGES_NETDATA_PYTHON_POSTGRES=1
+      if [ "${pv}" -eq 2 ] ; then
+        PACKAGES_NETDATA_PYTHON=1
+        PACKAGES_NETDATA_PYTHON_POSTGRES=1
+      else
+        PACKAGES_NETDATA_PYTHON3=1
+        PACKAGES_NETDATA_PYTHON3_POSTGRES=1
+      fi
       ;;
 
     python-pymongo)
-      PACKAGES_NETDATA_PYTHON=1
-      PACKAGES_NETDATA_PYTHON_MONGO=1
+      if [ "${pv}" -eq 2 ] ; then
+        PACKAGES_NETDATA_PYTHON=1
+        PACKAGES_NETDATA_PYTHON_MONGO=1
+      else
+        PACKAGES_NETDATA_PYTHON3=1
+        PACKAGES_NETDATA_PYTHON3_MONGO=1
+      fi
       ;;
 
     nodejs | netdata-nodejs)
@@ -1746,7 +1779,7 @@ while [ -n "${1}" ]; do
 
     sensors | netdata-sensors)
       PACKAGES_NETDATA=1
-      PACKAGES_NETDATA_PYTHON=1
+      PACKAGES_NETDATA_PYTHON3=1
       PACKAGES_NETDATA_SENSORS=1
       PACKAGES_NETDATA_DATABASE=1
       ;;
@@ -1762,11 +1795,17 @@ while [ -n "${1}" ]; do
     demo | all)
       PACKAGES_NETDATA=1
       PACKAGES_NETDATA_NODEJS=1
-      PACKAGES_NETDATA_PYTHON=1
-      PACKAGES_NETDATA_PYTHON3=1
-      PACKAGES_NETDATA_PYTHON_MYSQL=1
-      PACKAGES_NETDATA_PYTHON_POSTGRES=1
-      PACKAGES_NETDATA_PYTHON_MONGO=1
+      if [ "${pv}" -eq 2 ] ; then
+        PACKAGES_NETDATA_PYTHON=1
+        PACKAGES_NETDATA_PYTHON_MYSQL=1
+        PACKAGES_NETDATA_PYTHON_POSTGRES=1
+        PACKAGES_NETDATA_PYTHON_MONGO=1
+      else
+        PACKAGES_NETDATA_PYTHON3=1
+        PACKAGES_NETDATA_PYTHON3_MYSQL=1
+        PACKAGES_NETDATA_PYTHON3_POSTGRES=1
+        PACKAGES_NETDATA_PYTHON3_MONGO=1
+      fi
       PACKAGES_DEBUG=1
       PACKAGES_IPRANGE=1
       PACKAGES_FIREHOL=1
@@ -1813,19 +1852,6 @@ if [ -z "${package_installer}" ] || [ -z "${tree}" ]; then
 
   # Validate package manager trees
   validate_package_trees
-fi
-
-pv=$(python --version 2>&1)
-if [[ "${pv}" =~ ^Python\ 2.* ]]; then
-  pv=2
-elif [[ "${pv}" =~ ^Python\ 3.* ]]; then
-  pv=3
-  PACKAGES_NETDATA_PYTHON3=1
-elif [[ "${tree}" == "centos" ]] && [ "${version}" -lt 8 ]; then
-  pv=2
-else
-  pv=3
-  PACKAGES_NETDATA_PYTHON3=1
 fi
 
 [ "${detection}" = "/etc/os-release" ] && cat << EOF

--- a/packaging/makeself/makeself-header.sh
+++ b/packaging/makeself/makeself-header.sh
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+# shellcheck shell=sh
+# shellcheck disable=SC2154,SC2039
 cat << EOF  > "$archname"
 #!/bin/sh
 # This script was generated using Makeself $MS_VERSION
@@ -288,7 +290,7 @@ do
 	echo CRCsum=\"\$CRCsum\"
 	echo MD5sum=\"\$MD5\"
 	echo OLDUSIZE=$USIZE
-	echo OLDSKIP=`expr $SKIP + 1`
+	echo OLDSKIP=$((SKIP + 1))
 	exit 0
 	;;
     --lsm)
@@ -437,9 +439,6 @@ if test x"\$nox11" = xn; then
         fi
     fi
 fi
-
-[ -d "\$targetdir/etc/netdata.old" ] && echo "Moving existing old directory" && mv "\$targetdir/etc/netdata.old" "\$targetdir/etc/netdata.old.$$"
-[ -d \$targetdir/etc/netdata ] && echo "Backing up existing directory" && cp -r \$targetdir/etc/netdata "\$targetdir/etc/netdata.old"
 
 if test x"\$targetdir" = x.; then
     tmpdir="."


### PR DESCRIPTION
##### Summary

Assorted fixes and improvements related to the installers:

* Stop rotating old Netdata configuration during a static install (this should have been removed when we quit shipping stock configs in `/etc/netdata`).
* Stop using a loop over multiple invocations of the package manager when installing dependencies. It hides errors, hurts efficiency, and also is a pain in the arse when installing interactively.
* Fixes another package naming issue for Arch Linux.
* Properly completes the switch to Python 3 as the default for new installs (I missed a number of things in #8318.

##### Component Name

area/ci
area/packaging

##### Description of testing that the developer performed

Verified using the PR checks and manual testing in Docker.

##### Additional Information

Fixes: #8155
Fixes: #8294 