### PR TITLE
Switched to using Python 3 by default instead of Python 2.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1833,8 +1833,11 @@ if [[ "${pv}" =~ ^Python\ 2.* ]]; then
 elif [[ "${pv}" =~ ^Python\ 3.* ]]; then
   pv=3
   PACKAGES_NETDATA_PYTHON3=1
-else
+elif [[ "${tree}" == "centos" ]] && [ "${version}" -lt 8 ]; then
   pv=2
+else
+  pv=3
+  PACKAGES_NETDATA_PYTHON3=1
 fi
 
 [ "${detection}" = "/etc/os-release" ] && cat << EOF


### PR DESCRIPTION
##### Summary

Most distros have Python 3, and some are already looking at dropping Python 2 in upcomming releases. All of our code works correctly on Python 3, so just use it by default for platforms that have it.

##### Component Name

area/packaging

##### Description of testing that the developer performed

Verified that package installation still works correctly on all platforms we officially support.

##### Additional Information

Fixes: #8316 
Fixes: #7364 