### PR TITLE
Migrate coverity-scan to Github Actions

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,17 +6,16 @@ on:
     - cron: '0 1 * * *'
 jobs:
   coverity:
+    if: github.repository == 'netdata/netdata'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        if: github.repository == 'netdata/netdata'
       - name: Prepare environment
-        if: github.repository == 'netdata/netdata'
         run: |
-          bash <(curl -sS https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh) --dont-wait --non-interactive netdata
-          sudo apt-get install -y libjson-c-dev libipmimonitoring-dev libcups2-dev libsnappy-dev libprotobuf-dev libprotoc-dev libssl-dev protobuf-compiler
+          ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata
+          sudo apt-get install -y libjson-c-dev libipmimonitoring-dev libcups2-dev libsnappy-dev \
+                                  libprotobuf-dev libprotoc-dev libssl-dev protobuf-compiler
       - name: Run coverity-scan
-        if: github.repository == 'netdata/netdata'
         run: |
           ./coverity-scan.sh --with-install

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,22 @@
+---
+# Runs coverity-scan.sh every 24h on `master`
+name: Coverity Scan
+on:
+  schedule:
+    - cron: '0 1 * * *'
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        if: github.repository == 'netdata/netdata'
+      - name: Prepare environment
+        if: github.repository == 'netdata/netdata'
+        run: |
+          bash <(curl -sS https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh) --dont-wait --non-interactive netdata
+          sudo apt-get install -y libjson-c-dev libipmimonitoring-dev libcups2-dev libsnappy-dev libprotobuf-dev libprotoc-dev libssl-dev protobuf-compiler
+      - name: Run coverity-scan
+        if: github.repository == 'netdata/netdata'
+        run: |
+          ./coverity-scan.sh --with-install

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -17,5 +17,8 @@ jobs:
           sudo apt-get install -y libjson-c-dev libipmimonitoring-dev libcups2-dev libsnappy-dev \
                                   libprotobuf-dev libprotoc-dev libssl-dev protobuf-compiler
       - name: Run coverity-scan
+        env:
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          COVERITY_SCAN_SUBMIT_MAIL: ${{ secrets.COVERITY_SCAN_SUBMIT_MAIL }}
         run: |
           ./coverity-scan.sh --with-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -485,15 +485,6 @@ jobs:
     # This is the nightly pre-execution step (Jobs, preparatory steps for nightly, etc)
     - stage: Nightly operations
 
-      name: Run coverity scan
-      before_script:
-        - bash <(curl -sS https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh) --dont-wait --non-interactive netdata
-        - sudo apt-get install -y libjson-c-dev libipmimonitoring-dev libcups2-dev libsnappy-dev libprotobuf-dev libprotoc-dev libssl-dev protobuf-compiler
-      script: ./coverity-scan.sh --with-install
-      after_failure: post_message "TRAVIS_MESSAGE" "<!here> Coverity nightly run has failed" "${NOTIF_CHANNEL}"
-      env:
-        - ALLOW_SOFT_FAILURE_HERE=true
-
     - name: Kickstart files integrity testing (extended)
       script: ./tests/installer/checksums.sh
 


### PR DESCRIPTION
##### Summary

Fixes #6749 

##### Component Name

- area/ci

##### Test Plan

- Test in my fork with temporary Github secrets added to my fork.

##### Additional Information

I need the following secrets / enviornment variables currently in Travis:

- `COVERITY_SCAN_SUBMIT_MAIL`
- `COVERITY_SCAN_TOKEN`

If someone can get those to me (_preferably @knatsakis_) and added to our SRE secrets repo that would be awesome :)
