### PR TITLE
Removed extra printed `\n`

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -264,7 +264,7 @@ run() {
 
   printf >&2 "%s" "${info_console}${TPUT_BOLD}${TPUT_YELLOW}"
   escaped_print >&2 "${@}"
-  printf >&2 "%s" "${TPUT_RESET}\n"
+  printf >&2 "%s" "${TPUT_RESET}"
 
   "${@}"
 


### PR DESCRIPTION
##### Summary

When running the installation script, a lot of `\n` got printed before the return status `[OK]` or `[ERROR]`.

##### Component Name

Installer

##### Description of testing that the developer performed

Ran the install script locally

##### Additional Information


