### PR TITLE
Fixed dependency names for Arch Linux.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -948,6 +948,7 @@ declare -A pkg_lz4=(
   ['suse']="liblz4-devel"
   ['gentoo']="app-arch/lz4"
   ['clearlinux']="devpkg-lz4"
+  ['arch']="lz4"
   ['default']="lz4-devel"
 )
 
@@ -967,6 +968,7 @@ declare -A pkg_openssl=(
   ['ubuntu']="libssl-dev"
   ['suse']="libopenssl-devel"
   ['clearlinux']="devpkg-openssl"
+  ['arch']="openssl"
   ['default']="openssl-devel"
 )
 

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -752,6 +752,7 @@ declare -A pkg_netcat=(
   ['rhel']="nmap-ncat"
   ['suse']="netcat-openbsd"
   ['clearlinux']="sysadmin-basic"
+  ['arch']="gnu-netcat"
   ['default']="netcat"
 
   # exceptions

--- a/tests/updater_checks.bats
+++ b/tests/updater_checks.bats
@@ -35,10 +35,7 @@ setup() {
 }
 
 @test "install stable netdata using kickstart" {
-	kickstart_file="/tmp/kickstart.$$"
-	curl -Ss -o ${kickstart_file} https://my-netdata.io/kickstart.sh
-	chmod +x ${kickstart_file}
-	${kickstart_file} --dont-wait --dont-start-it --auto-update --install ${INSTALLATION}
+	./packaging/installer/kickstart.sh --dont-wait --dont-start-it --auto-update --install ${INSTALLATION}
 
 	# Validate particular files
 	for file in $FILES; do

--- a/tests/updater_checks.sh
+++ b/tests/updater_checks.sh
@@ -25,9 +25,7 @@ blind_arch_grep_install() {
 }
 blind_arch_grep_install || echo "Workaround failed, proceed as usual"
 
-running_os="$(cat /etc/os-release |grep '^ID=' | cut -d'=' -f2 | sed -e 's/"//g')"
-# Special case for older centos
-[[ -f /etc/centos-release ]] && [[ -z "${running_os}" ]] && running_os="$(cat /etc/centos-release | grep "CentOS release 6" | cut -d' ' -f 1)"
+running_os="$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | sed -e 's/"//g')"
 
 case "${running_os}" in
 "centos"|"fedora"|"CentOS")
@@ -65,20 +63,9 @@ case "${running_os}" in
 	;;
 esac
 
-# Download and run depednency scriptlet, before anything else
+# Run depednency scriptlet, before anything else
 #
-deps_tool="/tmp/deps_tool.$$.sh"
-curl -Ss -o ${deps_tool} https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh
-if [ -f "${deps_tool}" ]; then
-	echo "Running dependency handling script.."
-	chmod +x "${deps_tool}"
-	${deps_tool} --non-interactive netdata
-	rm -f "${deps_tool}"
-	echo "Done!"
-else
-	echo "Failed to fetch dependency script, aborting the test"
-	exit 1
-fi
+./packaging/installer/install-required-packages.sh --non-interactive netdata
 
 echo "Running BATS file.."
 bats --tap tests/updater_checks.bats


### PR DESCRIPTION
##### Summary

This adds specific overrides for a couple of packages on Arch Linux that we were trying to install using the wrong names.

This also switches the lifecycle tests to use the `install-required-packages.sh` script from the branch being tested instead of always pulling from `master`, which will help prevent issues like this from happening again in the future.

##### Component Name

area/packaging

##### Description of testing that the developer performed

Verified the script on a local Arch VM.

##### Additional Information

This fixes the recurring lifecycle failures for Arch in CI. I'm not sure why they were working before.