### PR TITLE
Fix cosmetic error checking for CentOS 8 version in install-required-packages

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1325,7 +1325,7 @@ validate_tree_centos() {
     fi
   fi
 
-  if [ "$version" -eq 8 ]; then
+  if [[ "${version}" =~ ^8\..*$ ]]; then
     echo >&2 " > Checking for config-manager ..."
     if ! run yum ${sudo} config-manager; then
       if prompt "config-manager not found, shall I install it?"; then

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1325,7 +1325,7 @@ validate_tree_centos() {
     fi
   fi
 
-  if [[ "${version}" =~ ^8\..*$ ]]; then
+  if [[ "${version}" =~ ^8(\..*)?$ ]]; then
     echo >&2 " > Checking for config-manager ..."
     if ! run yum ${sudo} config-manager; then
       if prompt "config-manager not found, shall I install it?"; then


### PR DESCRIPTION
##### Summary

As pointed out in #8080 by @8080 (_Thank you!_)

##### Component Name

- area/packaging

##### Test Plan

__Before__:

```sh
$ version="6.10"; if [ "$version" -eq 8 ]; then echo "CentOS 8.x"; else echo "NOT CentOS 8.x"; fi
-bash: [: 6.10: integer expression expected
NOT CentOS 8.x
```

__After__:

```sh
$ version="6.10"; if [[ "${version}" =~ ^8\..*$ ]]; then echo "CentOS 8.x"; else echo "NOT CentOS 8.x"; fi
NOT CentOS 8.x
```

##### Additional Information