### PR TITLE
Add alarms for FreeBSD interface errors

### DIFF
--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -110,6 +110,34 @@ families: *
     info: the ratio of outbound dropped packets vs the total number of sent packets of the network interface, during the last 10 minutes
       to: sysadmin
 
+# -----------------------------------------------------------------------------
+# interface errors
+
+template: interface_inbound_errors
+      on: net.errors
+      os: freebsd
+   hosts: *
+families: *
+  lookup: sum -10m unaligned absolute of inbound
+   units: errors
+   every: 1m
+    warn: $this >= 5
+   delay: down 1h multiplier 1.5 max 2h
+    info: interface inbound errors in the last 10 minutes
+      to: sysadmin
+
+template: interface_outbound_errors
+      on: net.errors
+      os: freebsd
+   hosts: *
+families: *
+  lookup: sum -10m unaligned absolute of outbound
+   units: errors
+   every: 1m
+    warn: $this >= 5
+   delay: down 1h multiplier 1.5 max 2h
+    info: interface outbound errors in the last 10 minutes
+      to: sysadmin
 
 # -----------------------------------------------------------------------------
 # FIFO errors
@@ -131,7 +159,6 @@ families: *
    delay: down 1h multiplier 1.5 max 2h
     info: interface fifo errors in the last 10 minutes
       to: sysadmin
-
 
 # -----------------------------------------------------------------------------
 # check for packet storms


### PR DESCRIPTION
##### Summary
This PR add alarms for FreeBSD interface errors, inbound and outbound, based on net.drops alarms.

##### Component Name
health.d

##### Description of testing that the developer performed
Used for weeks on multiple FreeBSD routers running Netdata 1.19.0.
