### PR TITLE
Fix Travis CI test builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ jobs:
 
       name: Standard netdata build
       script: fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it --enable-plugin-nfacct --enable-plugin-freeipmi --disable-lto
-      env: CFLAGS='-O1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -fno-common   -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1'
+      env: CFLAGS='-O1 -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1'
       after_failure: post_message "TRAVIS_MESSAGE" "<!here> standard netdata build is failing (Still dont know which one, will improve soon)"
 
     - name: Docker container build process (alpine installation)


### PR DESCRIPTION
##### Summary

This strips out a handful of largely pointless CFLAGS from our standard test build on Travis CI.

Of these flags being removed:

* The various `-W` flags change nothing about the build since we don't have `-Werror` enabled, so they're just _there_ since nobody looks at the build logs as long as it passes.
* `-fstack-protector=all` is largely pointless for our usage. It doesn't break things at build time, it breaks them at runtime if they happen to break, and this shouldn't break anything for us as we're not doing stupid things with the stack or using inline assembly code.
* `-fno-common` only changes where uninitialized variables go. This _should_ have no impact on us since, again, we're not using inline assembly.

This ends up fixing the Travis CI test builds. I'm not 100% certain _why_ it fixes them, but the reasoning for trying this as a fix is outlined in the additional information section below.

##### Component Name

area/ci

##### Description of testing that the developer performed

Verified the build at https://travis-ci.org/Ferroin/netdata/builds/660243878

##### Additional information

The error that prompted this is the usual largely useless 'C compiler cannot produce esecutables' message from autoconf generated configure scripts that tells you nothing useful about what's actually broken. Sample failed build log can be seen at https://travis-ci.com/netdata/netdata/jobs/296079422.

About 99% of the time on most platforms, this message really means that the C compiler didn't like the arguments it got passed, usually through the `CFLAGS` variable. The fact that we only pass any flags for this particular build step reinforces this as the source of the problem.