### PR TITLE
Fix MDX parsing in installation guide

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -56,7 +56,7 @@ operating systems.
 
 ### Alternative methods
 
-<div class="installer-grid" markdown=1>
+<div class="installer-grid" markdown="1">
 
 [![Install with .deb or .rpm
 packages](https://user-images.githubusercontent.com/1153921/76029431-aebd6b00-5ef1-11ea-92b4-06704dabb93e.png) Install


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

My latest PR #8319 introduced an MDX parsing error into the work @Soviut is doing on the new documentation site. I need to change `markdown=1` to `markdown="1"` for the MDX parser to not panic.

##### Component Name

docs
packaging/

##### Description of testing that the developer performed

<!---
Please be detailed enough that your reviewer can understand which test-cases you
have covered, and recreate them if necessary.
-->

Tested this by running the docs generator locally.

##### Additional Information


