### PR TITLE
Improved behavior of the installer around the handling of Netdata Cloud support.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,4 +69,4 @@ jobs:
         env:
           PRE: ${{ matrix.pre }}
         run: |
-          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE}; ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive all && ./netdata-installer.sh -u --dont-wait --dont-start-it --disable-go'
+          docker run --rm -e PRE -v $PWD:/netdata -w /netdata ${{ matrix.distro }} /bin/sh -c '[ -n "${PRE}" ] && ${PRE}; ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata-all && ./netdata-installer.sh -u --dont-wait --dont-start-it --require-cloud'

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -172,6 +172,7 @@ USAGE: ${PROGRAM} [options]
   --disable-go               Disable installation of go.d.plugin.
   --enable-ebpf              Enable eBPF Kernel plugin (Default: disabled, feature preview)
   --disable-cloud            Disable the agent-cloud link, required for Netdata Cloud functionality.
+  --require-cloud            Fail the install if it can't build Netdata Cloud support.
   --enable-plugin-freeipmi   Enable the FreeIPMI plugin. Default: enable it when libipmimonitoring is available.
   --disable-plugin-freeipmi
   --disable-https            Explicitly disable TLS support
@@ -258,8 +259,20 @@ while [ -n "${1}" ]; do
     "--disable-go") NETDATA_DISABLE_GO=1 ;;
     "--enable-ebpf") NETDATA_ENABLE_EBPF=1 ;;
     "--disable-cloud")
-      NETDATA_DISABLE_CLOUD=1
-      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+        echo "Cloud explicitly enabled, not re-enabling it"
+      else
+        NETDATA_DISABLE_CLOUD=1
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
+      fi
+      ;;
+    "--require-cloud")
+      if [ -n "${NETDATA_DISABLE_CLOUD}" ] ; then
+        echo "Cloud explicitly disabled, not re-enabling it"
+      else
+        NETDATA_REQUIRE_CLOUD=1
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-aclk/} --enable-aclk"
+      fi
       ;;
     "--install")
       NETDATA_PREFIX="${2}/netdata"
@@ -480,9 +493,15 @@ bundle_libmosquitto() {
       run_ok "libmosquitto built and prepared."
     else
       run_failed "Failed to build libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+        exit 1
+      fi
     fi
   else
     run_failed "Unable to fetch sources for libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
+    if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+      exit 1
+    fi
   fi
 }
 
@@ -532,9 +551,15 @@ bundle_libwebsockets() {
       run_ok "libwebsockets built and prepared."
     else
       run_failed "Failed to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+        exit 1
+      fi
     fi
   else
     run_failed "Unable to fetch sources for libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+    if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+      exit 1
+    fi
   fi
 }
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -280,6 +280,7 @@ while [ -n "${1}" ]; do
       if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
         echo "Cloud explicitly enabled, not re-enabling it"
       else
+        ACLK=no
         NETDATA_DISABLE_CLOUD=1
         NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
       fi
@@ -288,6 +289,7 @@ while [ -n "${1}" ]; do
       if [ -n "${NETDATA_DISABLE_CLOUD}" ] ; then
         echo "Cloud explicitly disabled, not re-enabling it"
       else
+        ACLK=yes
         NETDATA_REQUIRE_CLOUD=1
         NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-aclk/} --enable-aclk"
       fi
@@ -480,7 +482,7 @@ copy_libmosquitto() {
 }
 
 bundle_libmosquitto() {
-  if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
+  if [ -n "${NETDATA_DISABLE_CLOUD}" ] || [ "x${ACLK}" != "xyes" ]; then
     return 0
   fi
 
@@ -548,7 +550,7 @@ copy_libwebsockets() {
 }
 
 bundle_libwebsockets() {
-  if [ -n "${NETDATA_DISABLE_CLOUD}" ] ; then
+  if [ -n "${NETDATA_DISABLE_CLOUD}" ] || [ "x${ACLK}" != "xyes" ]; then
     return 0
   fi
 


### PR DESCRIPTION
##### Summary

This adds two specific improvements to the installer related to the Netdata Cloud support:

* It adds a command-line option `--require-cloud` which will explictly request that the build fails if Netdata Cloud support can't be built. This is mostly intended for use in our CI to test the build functionality around Netdata Cloud, but it is also potentially of interest to some users, so ti's properly documented. It is mutually exclusive with `--disable-cloud`, if both are specified, only the first one is honored (and an error message is logged).
* It adds support code for deferring non-fatal error messages so that they get printed at the end of the install process (if the install otherwise completes successfully), and adds this functionality to the handling code for libmosquitto, LWS, and the go.d plugin (so that you end up with a nice summary of errors at the end of the install process indicating a lack of support for Netdata Cloud or for the go.d plugin.

##### Component Name

area/packaging

##### Description of testing that the developer performed

Minimal verification so far, will mark ready for review once Ive finished thorough testing.