### PR TITLE
Add proper parsing/stripping of comments around docs frontmatter

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,10 +1,3 @@
-<!--
----
-title: "Netdata Documentation"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/DOCUMENTATION.md
----
--->
-
 # Netdata Documentation
 
 **Netdata is real-time health monitoring and performance troubleshooting for systems and applications.** It helps you

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
 ---
-title: "Netdata [![Build Status](https://travis-ci.com/netdata/netdata.svg?branch=master)](https://travis-ci.com/netdata/netdata) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2231/badge)](https://bestpractices.coreinfrastructure.org/projects/2231) [![License: GPL v3+](https://img.shields.io/badge/License-GPL%20v3%2B-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Freadme&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)"
+title: "Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/README.md
 ---
 -->

--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -33,6 +33,9 @@ cp -a ./${GENERATOR_DIR}/custom ./${SRC_DIR}/
 echo "Modifying README header"
 sed -i -e '0,/# Netdata /s//# Netdata Documentation\n\n/' ${SRC_DIR}/README.md
 
+# Strip comments around frontmatter.
+find ${SRC_DIR} -name '*.md' -exec sed -i "/<!--/d;/-->/d;" {} \;
+
 # Remove all GA tracking code
 find ${SRC_DIR} -name "*.md" -print0 | xargs -0 sed -i -e 's/\[!\[analytics.*UA-64295674-3)\]()//g'
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

I neglected to add in some logic in the `buildhtml.sh` script to strip the comments around our new frontmatter tags, which has resulted in some weirdness with page titles in the current documentation. This PR adds that logic and also fixes 2 other frontmatter items that did not handle the bulk add well.

##### Component Name

docs

##### Description of testing that the developer performed

<!---
Please be detailed enough that your reviewer can understand which test-cases you
have covered, and recreate them if necessary.
-->
##### Additional Information


