### PR TITLE
Added deferred error message handling to the installer.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -41,6 +41,24 @@ fi
 cd "${NETDATA_SOURCE_DIR}" || exit 1
 
 # -----------------------------------------------------------------------------
+# set up handling for deferred error messages
+NETDATA_DEFERRED_ERRORS=""
+
+defer_error() {
+  NETDATA_DEFERRED_ERRORS="${NETDATA_DEFERRED_ERRORS}\n* ${1}"
+}
+
+print_deferred_errors() {
+  if [ -n "${NETDATA_DEFERRED_ERRORS}" ] ; then
+    echo >&2
+    echo >&2 "The following non-fatal errors were encountered during the installation process:"
+    # shellcheck disable=SC2059
+    printf >&2 "${NETDATA_DEFERRED_ERRORS}"
+    echo >&2
+  fi
+}
+
+# -----------------------------------------------------------------------------
 # load the required functions
 
 if [ -f "${INSTALLER_DIR}/packaging/installer/functions.sh" ]; then
@@ -480,9 +498,11 @@ bundle_libmosquitto() {
       run_ok "libmosquitto built and prepared."
     else
       run_failed "Failed to build libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
+      defer_error "Failed to build libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
     fi
   else
     run_failed "Unable to fetch sources for libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
+    defer_error "Unable to fetch sources for libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
   fi
 }
 
@@ -532,9 +552,11 @@ bundle_libwebsockets() {
       run_ok "libwebsockets built and prepared."
     else
       run_failed "Failed to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+      defer_error "Failed to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
     fi
   else
     run_failed "Unable to fetch sources for libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+    defer_error "Unable to fetch sources for libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
   fi
 }
 
@@ -1042,6 +1064,7 @@ install_go() {
 
   if [ ! -f "${tmp}/${GO_PACKAGE_BASENAME}" ] || [ ! -f "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/${GO_PACKAGE_BASENAME}" ]; then
     run_failed "go.d plugin download failed, go.d plugin will not be available"
+    defer_error "go.d plugin download failed, go.d plugin will not be available"
     echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
     echo >&2
     return 0
@@ -1058,6 +1081,7 @@ install_go() {
     echo >&2
 
     run_failed "go.d.plugin package files checksum validation failed."
+    defer_error "go.d.plugin package files checksum validation failed, go.d.plugin will not be available"
     return 0
   fi
 
@@ -1486,6 +1510,8 @@ echo >&2 "Setting netdata.tarball.checksum to 'new_installation'"
 cat << EOF > "${NETDATA_LIB_DIR}/netdata.tarball.checksum"
 new_installation
 EOF
+
+print_deferred_errors
 
 # -----------------------------------------------------------------------------
 echo >&2


### PR DESCRIPTION
##### Summary

This adds some code to the Netdata installer to allow deferring non-fatal errors so that their messages get printed at the end of the install process. It does this by constructing the list of errors as they occur and then printing them all at the end if the list is non-empty.

With these changes, failures to download, validate, or install libmosquitto, LWS, or the go.d plugin will cause the errors to be reported when the install script otherwise finishes successfully, making it much easier for users to notice that there was a non-fatal error.

##### Component Name

area/packaging

##### Description of testing that the developer performed

Verified locally by artificially inducing the errors in question that this is now deferring messages for.