### PR TITLE
Added switch to installer to fail if Netdata Cloud functionality can't be built.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -18,7 +18,6 @@ jobs:
           - 'archlinux:latest'
           - 'centos:8'
           - 'centos:7'
-          - 'centos:6'
           - 'debian:bullseye'
           - 'debian:buster'
           - 'debian:stretch'

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -74,13 +74,13 @@ jobs:
           PRE: ${{ matrix.pre }}
         run: |
           echo $PRE > ./prep-cmd.sh
-          docker build . -f .github/dockerfiles/Dockerfile.build_test -t build_test --build-arg BASE=${{ matrix.distro }}
+          docker build . -f .github/dockerfiles/Dockerfile.build_test -t test --build-arg BASE=${{ matrix.distro }}
       - name: Regular build on ${{ matrix.distro }}
         run: |
-          docker run --rm -w /netdata build_test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
+          docker run -w /netdata test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
       - name: netdata-installer on ${{ matrix.distro }}
         run: |
-          docker run --rm -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --disable-cloud'
+          docker run -w /netdata test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --disable-cloud'
       - name: netdata-installer on ${{ matrix.distro }}
         run: |
-          docker run --rm -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'
+          docker run -w /netdata test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -78,7 +78,10 @@ jobs:
           docker build . -f .github/dockerfiles/Dockerfile.build_test -t build_test --build-arg BASE=${{ matrix.distro }}
       - name: Regular build on ${{ matrix.distro }}
         run: |
-          docker run --rm -e PRE -w /netdata build_test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
+          docker run --rm -w /netdata build_test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
       - name: netdata-installer on ${{ matrix.distro }}
         run: |
-          docker run --rm -e PRE -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it'
+          docker run --rm -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --disable-cloud'
+      - name: netdata-installer on ${{ matrix.distro }}
+        run: |
+          docker run --rm -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -193,7 +193,8 @@ USAGE: ${PROGRAM} [options]
                              This results in more frequent updates.
   --disable-go               Disable installation of go.d.plugin.
   --enable-ebpf              Enable eBPF Kernel plugin (Default: disabled, feature preview)
-  --disable-cloud            Disable all cloud functionality.
+  --disable-cloud            Disable all Netdata Cloud functionality.
+  --require-cloud            Fail the install if it can't build Netdata Cloud support.
   --enable-plugin-freeipmi   Enable the FreeIPMI plugin. Default: enable it when libipmimonitoring is available.
   --disable-plugin-freeipmi
   --disable-https            Explicitly disable TLS support
@@ -280,8 +281,20 @@ while [ -n "${1}" ]; do
     "--disable-go") NETDATA_DISABLE_GO=1 ;;
     "--enable-ebpf") NETDATA_ENABLE_EBPF=1 ;;
     "--disable-cloud")
-      NETDATA_DISABLE_CLOUD=1
-      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-cloud/} --disable-cloud"
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+        echo "Cloud explicitly enabled, not re-enabling it"
+      else
+        NETDATA_DISABLE_CLOUD=1
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
+      fi
+      ;;
+    "--require-cloud")
+      if [ -n "${NETDATA_DISABLE_CLOUD}" ] ; then
+        echo "Cloud explicitly disabled, not re-enabling it"
+      else
+        NETDATA_REQUIRE_CLOUD=1
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-aclk/} --enable-aclk"
+      fi
       ;;
     "--install")
       NETDATA_PREFIX="${2}/netdata"
@@ -502,12 +515,20 @@ bundle_libmosquitto() {
     then
       run_ok "libmosquitto built and prepared."
     else
-      run_failed "Failed to build libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
-      defer_error_highlighted "Failed to build libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
+      run_failed "Failed to build libmosquitto."
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+        exit 1
+      else
+        defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
+      fi
     fi
   else
-    run_failed "Unable to fetch sources for libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
-    defer_error_highlighted "Unable to fetch sources for libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
+    run_failed "Unable to fetch sources for libmosquitto."
+    if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+      exit 1
+    else
+      defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
+    fi
   fi
 }
 
@@ -556,12 +577,20 @@ bundle_libwebsockets() {
     then
       run_ok "libwebsockets built and prepared."
     else
-      run_failed "Failed to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
-      defer_error_highlighted "Failed to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+      run_failed "Failed to build libwebsockets."
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+        exit 1
+      else
+        defer_error_highlighted "Failed to build libwebsockets. You may not be able to connect this node to Netdata Cloud."
+      fi
     fi
   else
-    run_failed "Unable to fetch sources for libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
-    defer_error_highlighted "Unable to fetch sources for libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+    run_failed "Unable to fetch sources for libwebsockets."
+    if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+      exit 1
+    else
+      defer_error_highlighted "Unable to fetch sources for libwebsockets. You may not be able to connect this node to Netdata Cloud."
+    fi
   fi
 }
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -282,7 +282,7 @@ while [ -n "${1}" ]; do
     "--enable-ebpf") NETDATA_ENABLE_EBPF=1 ;;
     "--disable-cloud")
       if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
-        echo "Cloud explicitly enabled, not re-enabling it"
+        echo "Cloud explicitly enabled, ignoring --disable-cloud."
       else
         NETDATA_DISABLE_CLOUD=1
         NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
@@ -290,7 +290,7 @@ while [ -n "${1}" ]; do
       ;;
     "--require-cloud")
       if [ -n "${NETDATA_DISABLE_CLOUD}" ] ; then
-        echo "Cloud explicitly disabled, not re-enabling it"
+        echo "Cloud explicitly disabled, ignoring --require-cloud."
       else
         NETDATA_REQUIRE_CLOUD=1
         NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-aclk/} --enable-aclk"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -285,7 +285,7 @@ while [ -n "${1}" ]; do
         echo "Cloud explicitly enabled, ignoring --disable-cloud."
       else
         NETDATA_DISABLE_CLOUD=1
-        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-cloud/} --disable-cloud"
       fi
       ;;
     "--require-cloud")
@@ -293,7 +293,7 @@ while [ -n "${1}" ]; do
         echo "Cloud explicitly disabled, ignoring --require-cloud."
       else
         NETDATA_REQUIRE_CLOUD=1
-        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-aclk/} --enable-aclk"
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-cloud/} --enable-cloud"
       fi
       ;;
     "--install")

--- a/packaging/mosquitto.checksums
+++ b/packaging/mosquitto.checksums
@@ -1,1 +1,1 @@
-387faaf026b86d52dcba87e80b97946eb2775bcfcfdafaabc828b6e17f7bf5ea  v.1.6.8_Netdata-3.tar.gz
+6af837c388b1bcd459220936c422b70a987c60f4d5f88b09eada43d713529284  v.1.6.8_Netdata-4.tar.gz

--- a/packaging/mosquitto.version
+++ b/packaging/mosquitto.version
@@ -1,1 +1,1 @@
-v.1.6.8_Netdata-3
+v.1.6.8_Netdata-4


### PR DESCRIPTION
##### Summary

This adds a switch called `--require-cloud` to the installer script. When specified, it causes the script to explicitly fail if it can't build Netdata with Netdata Cloud support. It is mutually exclusive with the `--disable-cloud` switch, with only the first one specified being honored.

This is mostly intended to ensure that CI can test the build/install both with and without the cloud, but it is likely to be of interest to users who want to ensure they can use their systems with netdata Cloud.

This PR also updates the build testing CI to explicitly check builds both with and without Netdata Cloud built.

##### Component Name

area/packaging
area/ci

##### Description of testing that the developer performed

Verified behavior by running the script locally and manually inducing failures. 

##### Additional Information

This is blocked pending completion of #8378, as the configure scripts don't correctly handle the case of being passed `--enable-aclk` when the feature flag is not set.