### PR TITLE
Adds support for SOCKS5 proxy in claiming with curl

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -48,6 +48,15 @@ void claim_agent(char *claiming_arguments)
     char command_buffer[CLAIMING_COMMAND_LENGTH + 1];
     FILE *fp;
 
+    char *cloud_base_hostname = NULL; // Initializers are over-written but prevent gcc complaining about clobbering.
+    char *cloud_base_port = NULL;
+    char *cloud_base_url = config_get(CONFIG_SECTION_CLOUD, "cloud base url", "https://netdata.cloud");
+    if( aclk_decode_base_url(cloud_base_url, &cloud_base_hostname, &cloud_base_port))
+    {
+        error("Configuration error - cannot decode \"cloud base ur;\"");
+        return;
+    }
+
     const char *proxy_str;
     ACLK_PROXY_TYPE proxy_type;
     char proxy_flag[CLAIMING_PROXY_LENGTH] = "-noproxy";
@@ -61,7 +70,7 @@ void claim_agent(char *claiming_arguments)
               CLAIMING_COMMAND_LENGTH,
               "exec netdata-claim.sh %s -hostname=%s -id=%s -url=%s %s",
               proxy_flag,
-              netdata_configured_hostname,
+              cloud_base_url,
               localhost->machine_guid,
               registry.cloud_base_url,
               claiming_arguments);

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -197,7 +197,7 @@ if [ "${URLTOOL}" = "curl" ] ; then
 	URLCOMMAND="curl --connect-timeout 5 --retry 3 -s -i -X PUT -d \"@${CLAIMING_DIR}/tmpin.txt\""
 	if [ "${NOPROXY}" = "yes" ] ; then
 		URLCOMMAND="${URLCOMMAND} -x \"\""
-	else
+	elif [ -n "${PROXY}" ] ; then
 		URLCOMMAND="${URLCOMMAND} -x \"${PROXY}\""
 	fi
 else

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -125,11 +125,19 @@ do
 		-id=*) ID=${arg:4} ;;
 		-rooms=*) ROOMS=${arg:7} ;;
 		-hostname=*) HOSTNAME=${arg:10} ;;
+		-noproxy) NOPROXY=yes ;;
+		-proxy=socks*) PROXY=${arg:7} ;;
 		*)  echo >&2 "Unknown argument ${arg}"
 		    exit 1 ;;
 	esac
 	shift 1
 done
+
+# if curl not installed give warning SOCKS can't be used
+if [[ "${URLTOOL}" != "curl" && "${PROXY}" = socks* ]] ; then
+	echo >&2 "wget doesn't support SOCKS. Please install curl or disable SOCKS proxy."
+	exit 1
+fi
 
 echo >&2 "Token: ****************"
 echo >&2 "Base URL: $URL_BASE"
@@ -187,9 +195,17 @@ EMBED_JSON
 
 if [ "${URLTOOL}" = "curl" ] ; then
 	URLCOMMAND="curl --connect-timeout 5 --retry 3 -s -i -X PUT -d \"@${CLAIMING_DIR}/tmpin.txt\""
+	if [ "${NOPROXY}" = "yes" ] ; then
+		URLCOMMAND="${URLCOMMAND} -x \"\""
+	else
+		URLCOMMAND="${URLCOMMAND} -x \"${PROXY}\""
+	fi
 else
 	URLCOMMAND="wget -T 15 -O -  -q --save-headers --content-on-error=on --method=PUT \
 	--body-file=\"${CLAIMING_DIR}/tmpin.txt\""
+	if [ "${NOPROXY}" = "yes" ] ; then
+		URLCOMMAND="${URLCOMMAND} --no-proxy"
+	fi
 fi
 
 if [ -r "${CLOUD_CERTIFICATE_FILE}" ] ; then

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -84,7 +84,7 @@ else
 	exit 3
 fi
 if ! command -v openssl >/dev/null 2>&1 ; then
-	echo >&2 "I need openssl to proceed, but neither is available on this system."
+	echo >&2 "I need openssl to proceed, but it is not available on this system."
 	exit 3
 fi
 


### PR DESCRIPTION
##### Summary
some things in claiming script have to be fixed as well for this to be 100% (see #8263) - therefore this PR works and brings SOCKS5 proxy but there are error reporting issues that will be fixes in #8263.

If agent configured with SOCKS5 proxy `[agent_cloud_link]` key `proxy` it should pass that setting to curl when claiming script is called from within netdata agent with `netdata -D -Wclaim`.

If agent configured with `proxy = none` claiming script should not use proxy even if environment variables are set.

Fixes #8090 

##### Component Name
ACLK/claiming

##### Test Plan
Make sure claiming script can be found by $PATH (e.g. if you test with NETDATA installed in custom dir)!

Test with local cloud test environment hidden behind socks5 proxy. *(example: run agent on VM that doesn't have direct access to `local cloud environment`)*

In config file of Netdata set options:


```
[agent_cloud_link]
    proxy = socks5://X.X.X.X:YYYY
and for other test
    proxy = none
```

When curl not present in system and wget present. Show error when trying to use SOCKS with wget (as wget doesn't have support).

##### Additional Information
