### PR TITLE
Fix broken dependencies for Ubuntu 19.10 (eoan)

### DIFF
--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -90,6 +90,9 @@ if str(os.environ["BUILD_STRING"]).count("ubuntu/xenial") == 1:
 if str(os.environ["BUILD_STRING"]).count("debian/buster") == 1:
     common.run_command_in_host(['sudo', 'rm', 'contrib/debian/control'])
     common.run_command_in_host(['sudo', 'cp', 'contrib/debian/control.buster', 'contrib/debian/control'])
+if str(os.environ["BUILD_STRING"]).count("debian/eoan") == 1:
+    common.run_command_in_host(['sudo', 'rm', 'contrib/debian/control'])
+    common.run_command_in_host(['sudo', 'cp', 'contrib/debian/control.eoan', 'contrib/debian/control'])
 
 common.prepare_version_source(dest_archive, friendly_version, tag=tag)
 

--- a/contrib/debian/control.eoan
+++ b/contrib/debian/control.eoan
@@ -1,0 +1,73 @@
+Source: netdata
+Build-Depends: debhelper (>= 9),
+               dh-autoreconf,
+               dh-systemd (>= 1.5),
+               dpkg-dev (>= 1.13.19),
+               zlib1g-dev,
+               uuid-dev,
+               libuv1-dev,
+               liblz4-dev,
+               libjudy-dev,
+               libssl-dev,
+               libmnl-dev,
+               libjson-c-dev,
+               libcups2-dev,
+               libipmimonitoring-dev,
+               libnetfilter-acct-dev,
+               libsnappy-dev,
+               libprotobuf-dev,
+               libprotoc-dev,
+               cmake,
+               autogen,
+               autoconf,
+               automake,
+               pkg-config,
+               curl,
+               gcc,
+               g++
+Section: net
+Priority: optional
+Maintainer: Netdata Builder <bot@netdata.cloud>
+Standards-Version: 3.9.6
+Homepage: https://netdata.cloud
+
+Package: netdata
+Architecture: any
+Depends: adduser,
+         libcap2-bin (>= 1:2.0),
+         lsb-base (>= 3.1-23.2),
+         zlib1g,
+         libuuid1,
+         libuv1,
+         liblz4-1,
+         libjudydebian1,
+         openssl,
+         libmnl0,
+         libjson-c4,
+         libnetfilter-acct1,
+         libprotobuf-c1,
+         libsnappy1v5,
+         libprotoc17,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Pre-Depends: dpkg (>= 1.17.14)
+Description: real-time charts for system monitoring
+ Netdata is a daemon that collects data in realtime (per second)
+ and presents a web site to view and analyze them. The presentation
+ is also real-time and full of interactive charts that precisely
+ render all collected values.
+
+Package: netdata-plugin-cups
+Architecture: any
+Depends: cups,
+         netdata (>= ${source:Version})
+Description: The Common Unix Printing System plugin for metrics collection from cupsd
+
+Package: netdata-plugin-freeipmi
+Architecture: any
+Depends: freeipmi,
+         netdata (= ${source:Version})
+Description: FreeIPMI - The Intelligent Platform Management System.
+ The IPMI specification defines a set of interfaces for platform management.
+ It is implemented by a number vendors for system management. The features of IPMI that most users will be interested in 
+ are sensor monitoring, system event monitoring, power control, and serial-over-LAN (SOL).


### PR DESCRIPTION
##### Summary

Fixes #8393

##### Component Name

- area/packaging

##### Test Plan

- [x] Manually build new Ubuntu 19.10 (eoan) packages with the Docker package-builders
- [x] Manually test the installation of the new Ubuntu 19.10 (eoan) packages
- [x] Manually upload new Ubuntu 19.10 (eoan) packages to PackageCloud

##### Additional Information

We _may_ have to temporarily add some CI to Travis since we're not fully
migrated yet to the new Docker-based GHA workflows for building Native Binary
Packages (_just yet_).