### PR TITLE
ACLK: Improved the agent "pop-corning" phase

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -898,7 +898,6 @@ void *aclk_query_main_thread(void *ptr)
         time_t checkpoint;
 
         checkpoint = now_realtime_sec() - last_init_sequence;
-        info("Waiting for agent collectors to initialize last activity %ld seconds ago" , checkpoint);
         if (checkpoint > ACLK_STABLE_TIMEOUT) {
             agent_state = AGENT_STABLE;
             info("AGENT stable, last collector initialization activity was %ld seconds ago", checkpoint);
@@ -907,6 +906,7 @@ void *aclk_query_main_thread(void *ptr)
 #endif
             break;
         }
+        info("Waiting for agent collectors to initialize. Last activity was %ld seconds ago" , checkpoint);
         sleep_usec(USEC_PER_SEC * 1);
     }
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -300,12 +300,6 @@ int aclk_queue_query(char *topic, char *data, char *msg_id, char *query, int run
     if (unlikely(waiting_init))
         return 0;
 
-    // Ignore all commands if agent not stable and reset the last_init_sequence mark
-    if (agent_state == AGENT_INITIALIZING) {
-        last_init_sequence = now_realtime_sec();
-        return 0;
-    }
-
     run_after = now_realtime_sec() + run_after;
 
     QUERY_LOCK;
@@ -689,7 +683,10 @@ void aclk_add_collector(const char *hostname, const char *plugin_name, const cha
         return;
     }
 
-    aclk_queue_query("connector", NULL, NULL, NULL, 0, 1, ACLK_CMD_ONCONNECT);
+    if (unlikely(agent_state == AGENT_INITIALIZING))
+        last_init_sequence = now_realtime_sec();
+    else
+        aclk_queue_query("connector", NULL, NULL, NULL, 0, 1, ACLK_CMD_ONCONNECT);
 
     COLLECTOR_UNLOCK;
 }
@@ -721,7 +718,10 @@ void aclk_del_collector(const char *hostname, const char *plugin_name, const cha
 
     COLLECTOR_UNLOCK;
 
-    aclk_queue_query("on_connect", NULL, NULL, NULL, 0, 1, ACLK_CMD_ONCONNECT);
+    if (unlikely(agent_state == AGENT_INITIALIZING))
+        last_init_sequence = now_realtime_sec();
+    else
+        aclk_queue_query("on_connect", NULL, NULL, NULL, 0, 1, ACLK_CMD_ONCONNECT);
 
     _free_collector(tmp_collector);
 }
@@ -1742,7 +1742,7 @@ void aclk_single_update_enable()
 // Trigged by a health reload, sends the alarm metadata
 void aclk_alarm_reload()
 {
-    if (unlikely(agent_state != AGENT_STABLE))
+    if (unlikely(agent_state == AGENT_INITIALIZING))
         return;
 
     aclk_queue_query("on_connect", NULL, NULL, NULL, 0, 1, ACLK_CMD_ONCONNECT);
@@ -1794,7 +1794,10 @@ int aclk_update_chart(RRDHOST *host, char *chart_name, ACLK_CMD aclk_cmd)
     if (unlikely(aclk_disable_single_updates))
         return 0;
 
-    aclk_queue_query("_chart", host->hostname, NULL, chart_name, 0, 1, aclk_cmd);
+    if (unlikely(agent_state == AGENT_INITIALIZING))
+        last_init_sequence = now_realtime_sec();
+    else
+        aclk_queue_query("_chart", host->hostname, NULL, chart_name, 0, 1, aclk_cmd);
     return 0;
 #endif
 }
@@ -1806,7 +1809,7 @@ int aclk_update_alarm(RRDHOST *host, ALARM_ENTRY *ae)
     if (host != localhost)
         return 0;
 
-    if (agent_state != AGENT_STABLE)
+    if (unlikely(agent_state == AGENT_INITIALIZING))
         return 0;
 
     /*

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -25,7 +25,7 @@
 #define ACLK_MAX_TOPIC 255
 
 #define ACLK_RECONNECT_DELAY 1 // reconnect delay -- with backoff stragegy fow now
-#define ACLK_STABLE_TIMEOUT 10 // Minimum delay to mark AGENT as stable
+#define ACLK_STABLE_TIMEOUT 5 // Minimum delay to mark AGENT as stable
 #define ACLK_DEFAULT_PORT 9002
 #define ACLK_DEFAULT_HOST "localhost"
 

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -25,7 +25,7 @@
 #define ACLK_MAX_TOPIC 255
 
 #define ACLK_RECONNECT_DELAY 1 // reconnect delay -- with backoff stragegy fow now
-#define ACLK_STABLE_TIMEOUT 5 // Minimum delay to mark AGENT as stable
+#define ACLK_STABLE_TIMEOUT 10 // Minimum delay to mark AGENT as stable
 #define ACLK_DEFAULT_PORT 9002
 #define ACLK_DEFAULT_HOST "localhost"
 


### PR DESCRIPTION
Fixes #8350 
##### Summary
- The agent stability status during pop-corning is now checked every second. 
- The agents switches to a stable state after ACLK_STABLE_TIMEOUT+1 seconds (currently 10+1)
- Commands from the cloud during pop-corning are ignored

##### Test Plan
- Run the agent in local dev environment
  - Notice a new message similar to 
    `Waiting for agent collectors to initialize. Last activity was 7 seconds ago` while the agent is waiting for the collectors to initialize
