### PR TITLE
Perf fixes

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -13,3 +13,4 @@ exclude_paths:
   - web/gui/src/**
   - web/gui/main.js
   - tests/**
+  - aclk/tests/**

--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -487,7 +487,7 @@ abort:
 void aclk_lws_wss_service_loop()
 {
     if (engine_instance)
-        lws_service(engine_instance->lws_context, 0);
+        lws_service(engine_instance->lws_context, -1);
 }
 
 // in case the MQTT connection disconnect while lws transport is still operational

--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -12,9 +12,29 @@ struct aclk_lws_wss_perconnect_data {
 
 static struct aclk_lws_wss_engine_instance *engine_instance = NULL;
 
-void lws_wss_check_queues(size_t *write_len, size_t *read_len)
+void lws_wss_check_queues(size_t *write_len, size_t *write_len_bytes, size_t *read_len)
 {
-    if (write_len != NULL)
+    if (write_len != NULL && write_len_bytes != NULL)
+    {
+        *write_len = 0;
+        *write_len_bytes = 0;
+        if (engine_instance != NULL)
+        {
+            aclk_lws_mutex_lock(&engine_instance->write_buf_mutex);
+
+            struct lws_wss_packet_buffer *write_b;
+            size_t w,wb;
+            for(w=0, wb=0, write_b = engine_instance->write_buffer_head; write_b != NULL; write_b = write_b->next)
+            {
+                w++;
+                wb += write_b->data_size;
+            }
+            *write_len = w;
+            *write_len_bytes = wb;
+            aclk_lws_mutex_unlock(&engine_instance->write_buf_mutex);
+        }
+    }
+    else if (write_len != NULL)
     {
         *write_len = 0;
         if (engine_instance != NULL)
@@ -378,7 +398,7 @@ static int aclk_lws_wss_callback(struct lws *wsi, enum lws_callback_reasons reas
 {
     UNUSED(user);
     struct lws_wss_packet_buffer *data;
-    int retval = 0;
+    int retval = 0, rc;
 
     // Callback servicing is forced when we are closed from above.
     if (engine_instance->upstream_reconnect_request) {
@@ -397,7 +417,8 @@ static int aclk_lws_wss_callback(struct lws *wsi, enum lws_callback_reasons reas
             aclk_lws_mutex_lock(&engine_instance->write_buf_mutex);
             data = lws_wss_packet_buffer_pop(&engine_instance->write_buffer_head);
             if (likely(data)) {
-                lws_write(wsi, data->data + LWS_PRE, data->data_size, LWS_WRITE_BINARY);
+                rc = lws_write(wsi, data->data + LWS_PRE, data->data_size, LWS_WRITE_BINARY);
+                error("lws_write(%u)=%d",data->data_size,rc);
                 lws_wss_packet_buffer_free(data);
                 if (engine_instance->write_buffer_head)
                     lws_callback_on_writable(engine_instance->lws_wsi);

--- a/aclk/aclk_lws_wss_client.h
+++ b/aclk/aclk_lws_wss_client.h
@@ -31,7 +31,11 @@ struct aclk_lws_wss_engine_callbacks {
     void (*connection_closed)();
 };
 
-struct lws_wss_packet_buffer;
+struct lws_wss_packet_buffer {
+    unsigned char *data;
+    size_t data_size;
+    struct lws_wss_packet_buffer *next;
+};
 
 struct aclk_lws_wss_engine_instance {
     //target host/port for connection
@@ -73,6 +77,7 @@ void aclk_lws_wss_mqtt_layer_disconect_notif();
 void aclk_lws_connection_established();
 void aclk_lws_connection_data_received();
 void aclk_lws_connection_closed();
+void lws_wss_check_queues(size_t *write_len, size_t *read_len);
 
 
 #endif

--- a/aclk/aclk_lws_wss_client.h
+++ b/aclk/aclk_lws_wss_client.h
@@ -77,7 +77,7 @@ void aclk_lws_wss_mqtt_layer_disconect_notif();
 void aclk_lws_connection_established();
 void aclk_lws_connection_data_received();
 void aclk_lws_connection_closed();
-void lws_wss_check_queues(size_t *write_len, size_t *read_len);
+void lws_wss_check_queues(size_t *write_len, size_t *write_len_bytes, size_t *read_len);
 
 
 #endif

--- a/aclk/aclk_lws_wss_client.h
+++ b/aclk/aclk_lws_wss_client.h
@@ -33,7 +33,7 @@ struct aclk_lws_wss_engine_callbacks {
 
 struct lws_wss_packet_buffer {
     unsigned char *data;
-    size_t data_size;
+    size_t data_size, written;
     struct lws_wss_packet_buffer *next;
 };
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1605,8 +1605,6 @@ inline void aclk_create_header(BUFFER *dest, char *type, char *msg_id)
     debug(D_ACLK, "Sending v%d msgid [%s] type [%s] time [%ld]", ACLK_VERSION, msg_id, type, time_created);
 }
 
-//#define EYE_FRIENDLY
-
 /*
  * Take a buffer, encode it and rewrite it
  *
@@ -1614,10 +1612,6 @@ inline void aclk_create_header(BUFFER *dest, char *type, char *msg_id)
 
 BUFFER *aclk_encode_response(BUFFER *contents)
 {
-#ifdef EYE_FRIENDLY
-
-    return contents;
-#else
     char *tmp_buffer = mallocz(contents->len * 2);
     char *src, *dst;
 
@@ -1654,7 +1648,6 @@ BUFFER *aclk_encode_response(BUFFER *contents)
 
     freez(tmp_buffer);
     return contents;
-#endif
 }
 
 /*
@@ -1686,7 +1679,7 @@ void aclk_send_alarm_metadata()
     debug(D_ACLK, "Metadata %s with alarms_active has %zu bytes", msg_id, local_buffer->len);
 
     buffer_sprintf(local_buffer, "\n}\n}");
-    aclk_send_message(ACLK_ALARMS_TOPIC, aclk_encode_response(local_buffer)->buffer, msg_id);
+    aclk_send_message(ACLK_ALARMS_TOPIC, local_buffer->buffer, msg_id);
     debug(D_ACLK, "Metadata %s encoded has %zu bytes", msg_id, local_buffer->len);
 
     freez(msg_id);
@@ -1713,7 +1706,7 @@ int aclk_send_info_metadata()
     buffer_sprintf(local_buffer, "\n}\n}");
     debug(D_ACLK, "Metadata %s with chart has %zu bytes", msg_id, local_buffer->len);
 
-    aclk_send_message(ACLK_METADATA_TOPIC, aclk_encode_response(local_buffer)->buffer, msg_id);
+    aclk_send_message(ACLK_METADATA_TOPIC, local_buffer->buffer, msg_id);
     debug(D_ACLK, "Metadata %s encoded has %zu bytes", msg_id, local_buffer->len);
     freez(msg_id);
 
@@ -1776,7 +1769,7 @@ int aclk_send_single_chart(char *hostname, char *chart)
     rrdset2json(st, local_buffer, NULL, NULL, 1);
     buffer_sprintf(local_buffer, "\t\n}");
 
-    aclk_send_message(ACLK_CHART_TOPIC, aclk_encode_response(local_buffer)->buffer, msg_id);
+    aclk_send_message(ACLK_CHART_TOPIC, local_buffer->buffer, msg_id);
 
     freez(msg_id);
     buffer_free(local_buffer);

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1442,8 +1442,8 @@ void *aclk_main(void *ptr)
         _link_event_loop();
         sleep_usec(USEC_PER_MS * 50);
         static int stress_counter = 0;
-        //if (stress_counter++ % 500 == 0)
-        //    aclk_send_stress_test(2000000);
+        if (stress_counter++ % 10 == 0 && write_q==0)
+            aclk_send_stress_test(2000000);
 
         // TODO: Move to on-connect
         if (unlikely(!aclk_subscribed)) {

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1850,7 +1850,7 @@ int aclk_update_alarm(RRDHOST *host, ALARM_ENTRY *ae)
     netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
 
     buffer_sprintf(local_buffer, "\n}");
-    aclk_queue_query(ACLK_ALARMS_TOPIC, NULL, msg_id, aclk_encode_response(local_buffer)->buffer, 0, 1, ACLK_CMD_ALARM);
+    aclk_queue_query(ACLK_ALARMS_TOPIC, NULL, msg_id, local_buffer->buffer, 0, 1, ACLK_CMD_ALARM);
 
     freez(msg_id);
     buffer_free(local_buffer);

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1412,7 +1412,6 @@ void *aclk_main(void *ptr)
         static int first_init = 0;
 
         info("loop state first_init_%d connected=%d connecting=%d", first_init, aclk_connected, aclk_connecting);
-        sleep_usec(USEC_PER_MS * 500);
         if (unlikely(!aclk_connected)) {
             if (unlikely(!first_init)) {
                 aclk_try_to_connect(aclk_hostname, aclk_port, port_num);
@@ -1439,7 +1438,10 @@ void *aclk_main(void *ptr)
         }
 
         _link_event_loop();
-        sleep_usec(USEC_PER_MS * 100);
+        sleep_usec(USEC_PER_MS * 5);
+        //static int stress_counter = 0;
+        //if (stress_counter++ % 500 == 0)
+        //    aclk_send_stress_test(2000000);
 
         // TODO: Move to on-connect
         if (unlikely(!aclk_subscribed)) {

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1362,6 +1362,7 @@ static void aclk_try_to_connect(char *hostname, char *port, int port_num)
  *
  * @return It always returns NULL
  */
+void lws_wss_check_queues(size_t *write_len, size_t *write_len_bytes, size_t *read_len);
 void *aclk_main(void *ptr)
 {
     struct netdata_static_thread *query_thread;
@@ -1410,10 +1411,10 @@ void *aclk_main(void *ptr)
 
     while (!netdata_exit) {
         static int first_init = 0;
-        size_t write_q, read_q;
-        lws_wss_check_queues(&write_q, &read_q);
-        info("loop state first_init_%d connected=%d connecting=%d wq=%zu rq=%zu",
-             first_init, aclk_connected, aclk_connecting, write_q, read_q);
+        size_t write_q, write_q_bytes, read_q;
+        lws_wss_check_queues(&write_q, &write_q_bytes, &read_q);
+        /*info("loop state first_init_%d connected=%d connecting=%d wq=%zu (%zu-bytes) rq=%zu",
+             first_init, aclk_connected, aclk_connecting, write_q, read_q);*/
         if (unlikely(!aclk_connected)) {
             if (unlikely(!first_init)) {
                 aclk_try_to_connect(aclk_hostname, aclk_port, port_num);
@@ -1441,9 +1442,10 @@ void *aclk_main(void *ptr)
 
         _link_event_loop();
         sleep_usec(USEC_PER_MS * 50);
-        static int stress_counter = 0;
+        /*static int stress_counter = 0;
         if (stress_counter++ % 10 == 0 && write_q==0)
             aclk_send_stress_test(2000000);
+        */
 
         // TODO: Move to on-connect
         if (unlikely(!aclk_subscribed)) {

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1410,8 +1410,10 @@ void *aclk_main(void *ptr)
 
     while (!netdata_exit) {
         static int first_init = 0;
-
-        info("loop state first_init_%d connected=%d connecting=%d", first_init, aclk_connected, aclk_connecting);
+        size_t write_q, read_q;
+        lws_wss_check_queues(&write_q, &read_q);
+        info("loop state first_init_%d connected=%d connecting=%d wq=%zu rq=%zu",
+             first_init, aclk_connected, aclk_connecting, write_q, read_q);
         if (unlikely(!aclk_connected)) {
             if (unlikely(!first_init)) {
                 aclk_try_to_connect(aclk_hostname, aclk_port, port_num);

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1413,8 +1413,8 @@ void *aclk_main(void *ptr)
         static int first_init = 0;
         size_t write_q, write_q_bytes, read_q;
         lws_wss_check_queues(&write_q, &write_q_bytes, &read_q);
-        /*info("loop state first_init_%d connected=%d connecting=%d wq=%zu (%zu-bytes) rq=%zu",
-             first_init, aclk_connected, aclk_connecting, write_q, read_q);*/
+        info("loop state first_init_%d connected=%d connecting=%d wq=%zu (%zu-bytes) rq=%zu",
+             first_init, aclk_connected, aclk_connecting, write_q, read_q);
         if (unlikely(!aclk_connected)) {
             if (unlikely(!first_init)) {
                 aclk_try_to_connect(aclk_hostname, aclk_port, port_num);
@@ -1441,11 +1441,10 @@ void *aclk_main(void *ptr)
         }
 
         _link_event_loop();
-        sleep_usec(USEC_PER_MS * 50);
-        /*static int stress_counter = 0;
-        if (stress_counter++ % 10 == 0 && write_q==0)
+        //sleep_usec(USEC_PER_MS * 50);
+        static int stress_counter = 0;
+        if (stress_counter++ % 100 == 0 && write_q==0)
             aclk_send_stress_test(2000000);
-        */
 
         // TODO: Move to on-connect
         if (unlikely(!aclk_subscribed)) {

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1504,7 +1504,7 @@ int aclk_send_message(char *sub_topic, char *message, char *msg_id)
     }
 
     ACLK_LOCK;
-    rc = _link_send_message(final_topic, message, &mid);
+    rc = _link_send_message(final_topic, (unsigned char *)message, &mid);
     // TODO: link the msg_id with the mid so we can trace it
     ACLK_UNLOCK;
 
@@ -1720,19 +1720,19 @@ int aclk_send_info_metadata()
 
 void aclk_send_stress_test(size_t size)
 {
-    unsigned char *buffer = mallocz(size);
+    char *buffer = mallocz(size);
     if (buffer != NULL)
     {
         for(size_t i=0; i<size; i++)
             buffer[i] = 'x';
         buffer[size-1] = 0;
         time_t time_created = now_realtime_sec();
-        sprintf(buffer,"{\"type\":\"stress\", \"timestamp\":%u,\"payload\":", time_created);
+        sprintf(buffer,"{\"type\":\"stress\", \"timestamp\":%ld,\"payload\":", time_created);
         buffer[strlen(buffer)] = '"';
         buffer[size-2] = '}';
         buffer[size-3] = '"';
         aclk_send_message(ACLK_METADATA_TOPIC, buffer, NULL);
-        error("Sending stress of size %zu at time %u", size, time_created);
+        error("Sending stress of size %zu at time %ld", size, time_created);
     }
     free(buffer);
 }

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -275,7 +275,7 @@ int _link_subscribe(char *topic, int qos)
  *
  */
 
-int _link_send_message(char *topic, char *message, int *mid)
+int _link_send_message(char *topic, unsigned char *message, int *mid)
 {
     int rc;
 
@@ -285,7 +285,7 @@ int _link_send_message(char *topic, char *message, int *mid)
         return rc;
 
     int msg_len = strlen(message);
-
+    error("Sending MQTT len=%d starts %02x %02x %02x", msg_len, message[0], message[1], message[2]);
     rc = mosquitto_publish(mosq, mid, topic, msg_len, message, ACLK_QOS, 0);
 
     // TODO: Add better handling -- error will flood the logfile here

--- a/aclk/mqtt.h
+++ b/aclk/mqtt.h
@@ -14,7 +14,7 @@ int mqtt_attempt_connection(char *aclk_hostname, int aclk_port, char *username, 
 //int _link_lib_init();
 int _mqtt_lib_init();
 int _link_subscribe(char *topic, int qos);
-int _link_send_message(char *topic, char *message, int *mid);
+int _link_send_message(char *topic, unsigned char *message, int *mid);
 const char *_link_strerror(int rc);
 
 int aclk_handle_cloud_request(char *);

--- a/aclk/tests/launch-paho.sh
+++ b/aclk/tests/launch-paho.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker build -f paho.Dockerfile . --build-arg HOST_HOSTNAME=$(ping -c1 "$(hostname).local" | head -n1 | grep -o '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*') -t paho-client
+docker run -it paho-client

--- a/aclk/tests/launch-paho.sh
+++ b/aclk/tests/launch-paho.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-docker build -f paho.Dockerfile . --build-arg HOST_HOSTNAME=$(ping -c1 "$(hostname).local" | head -n1 | grep -o '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*') -t paho-client
+docker build -f paho.Dockerfile . --build-arg "HOST_HOSTNAME=$(ping -c1 "$(hostname).local" | head -n1 | grep -o '[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*')" -t paho-client
 docker run -it paho-client

--- a/aclk/tests/paho-inspection.py
+++ b/aclk/tests/paho-inspection.py
@@ -1,0 +1,57 @@
+import ssl
+import paho.mqtt.client as mqtt
+import json
+import time
+import sys
+
+def on_connect(mqttc, obj, flags, rc):
+    if rc==0:
+        print("Successful connection", flush=True)
+    else :
+        print(f"Connection error rc={rc}", flush=True)
+    mqttc.subscribe("/agent/#",0)
+
+def on_disconnect(mqttc, obj, flags, rc):
+    print("disconnected rc: "+str(rc), flush=True)
+
+def on_message(mqttc, obj, msg):
+    print(f"{msg.topic} {len(msg.payload)}-bytes qos={msg.qos}", flush=True)
+    try:
+        print(f"Trying decode of {msg.payload[:60]}",flush=True)
+        api_msg = json.loads(msg.payload)
+    except Exception as e:
+        print(e,flush=True)
+        return
+    ts = api_msg["timestamp"]
+    mtype = api_msg["type"]
+    print(f"Message {mtype} time={ts} size {len(api_msg)}", flush=True)
+    now = time.time()
+    print(f"Current {now} -> Delay {now-ts}", flush=True)
+
+def on_publish(mqttc, obj, mid):
+    print("mid: "+str(mid), flush=True)
+
+def on_subscribe(mqttc, obj, mid, granted_qos):
+    print("Subscribed: "+str(mid)+" "+str(granted_qos), flush=True)
+
+def on_log(mqttc, obj, level, string):
+    print(string)
+
+print(f"Starting paho-inspection on {sys.argv[1]}", flush=True)
+mqttc = mqtt.Client(transport='websockets',client_id="paho")
+#mqttc.tls_set(certfile="server.crt", keyfile="server.key", cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_TLS, ciphers=None)
+#mqttc.tls_set(ca_certs="server.crt", cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_TLS, ciphers=None)
+mqttc.tls_set(cert_reqs=ssl.CERT_NONE, tls_version=ssl.PROTOCOL_TLS, ciphers=None)
+mqttc.tls_insecure_set(True)
+mqttc.on_message = on_message
+mqttc.on_connect = on_connect
+mqttc.on_disconnect = on_disconnect
+mqttc.on_publish = on_publish
+mqttc.on_subscribe = on_subscribe
+mqttc.username_pw_set("paho","paho")
+mqttc.connect(sys.argv[1], 8443, 60)
+
+#mqttc.publish("/agent/mine","Test1")
+#mqttc.subscribe("$SYS/#", 0)
+print("Connected succesfully, monitoring /agent/#", flush=True)
+mqttc.loop_forever()

--- a/aclk/tests/paho.Dockerfile
+++ b/aclk/tests/paho.Dockerfile
@@ -1,0 +1,14 @@
+FROM archlinux/base:latest
+
+RUN pacman -Syyu --noconfirm
+RUN pacman --noconfirm --needed -S python-pip
+
+RUN pip install paho-mqtt
+
+RUN mkdir -p /opt/paho
+COPY paho-inspection.py /opt/paho/
+
+WORKDIR /opt/paho
+ARG HOST_HOSTNAME
+RUN echo $HOST_HOSTNAME >host
+CMD ["/bin/bash", "-c", "/usr/sbin/python paho-inspection.py $(cat host)"]


### PR DESCRIPTION
##### Summary

Initial work on fixing the performance problems in LWS / MQTT. Reduces the visible latency from 120s for the initial on-connect payloads to 10-20s. May increase CPU. Fixes the encoding errors for the JSON messages on the link allowing the alarms to work.

##### Component Name
ACLK

##### Test Plan

* Run against the cloud local dev env and ensure that performance is no worse that it was.
* Run the paho inspection container inside aclk/testing/ and verify that messages are arriving at VerneMQ.

##### Additional Information

Although this is not a complete fix for the performance problems - it does improve performance and allows other PRs to be merged on top. 