### PR TITLE
Improved the performance of the ACLK. (#8391)

### DIFF
--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -27,7 +27,7 @@ void lws_wss_check_queues(size_t *write_len, size_t *write_len_bytes, size_t *re
             for(w=0, wb=0, write_b = engine_instance->write_buffer_head; write_b != NULL; write_b = write_b->next)
             {
                 w++;
-                wb += write_b->data_size;
+                wb += write_b->data_size - write_b->written;
             }
             *write_len = w;
             *write_len_bytes = wb;
@@ -399,7 +399,7 @@ static int aclk_lws_wss_callback(struct lws *wsi, enum lws_callback_reasons reas
 {
     UNUSED(user);
     struct lws_wss_packet_buffer *data;
-    int retval = 0, rc;
+    int retval = 0;
 
     // Callback servicing is forced when we are closed from above.
     if (engine_instance->upstream_reconnect_request) {
@@ -419,21 +419,17 @@ static int aclk_lws_wss_callback(struct lws *wsi, enum lws_callback_reasons reas
             data = engine_instance->write_buffer_head;
             if (likely(data)) {
                 size_t bytes_left = data->data_size - data->written;
-                if ( bytes_left > 65536 )
-                    bytes_left = 65536;
-                rc = lws_write(wsi, data->data + LWS_PRE + data->written, bytes_left, LWS_WRITE_BINARY);
-                error("lws_write(req=%u,written=%u) %zu of %zu",bytes_left, rc, data->written,data->data_size,rc);
-                data->written += bytes_left;
+                if ( bytes_left > FRAGMENT_SIZE)
+                    bytes_left = FRAGMENT_SIZE;
+                data->written += lws_write(wsi, data->data + LWS_PRE + data->written, bytes_left, LWS_WRITE_BINARY);
+                //error("lws_write(req=%u,written=%u) %zu of %zu",bytes_left, rc, data->written,data->data_size,rc);
                 if (data->written == data->data_size)
                 {
                     lws_wss_packet_buffer_pop(&engine_instance->write_buffer_head);
                     lws_wss_packet_buffer_free(data);
                 }
                 if (engine_instance->write_buffer_head)
-                {
-                    error("Req write");
                     lws_callback_on_writable(engine_instance->lws_wsi);
-                }
             }
             aclk_lws_mutex_unlock(&engine_instance->write_buf_mutex);
             return retval;
@@ -544,10 +540,10 @@ void aclk_lws_wss_service_loop()
 {
     if (engine_instance)
     {
-        if (engine_instance->lws_wsi) {
+        /*if (engine_instance->lws_wsi) {
             lws_cancel_service(engine_instance->lws_context);
             lws_callback_on_writable(engine_instance->lws_wsi);
-        }
+        }*/
         lws_service(engine_instance->lws_context, 0);
     }
 }

--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -421,7 +421,9 @@ static int aclk_lws_wss_callback(struct lws *wsi, enum lws_callback_reasons reas
                 size_t bytes_left = data->data_size - data->written;
                 if ( bytes_left > FRAGMENT_SIZE)
                     bytes_left = FRAGMENT_SIZE;
-                data->written += lws_write(wsi, data->data + LWS_PRE + data->written, bytes_left, LWS_WRITE_BINARY);
+                int n = lws_write(wsi, data->data + LWS_PRE + data->written, bytes_left, LWS_WRITE_BINARY);
+                if (n>=0)
+                    data->written += n;
                 //error("lws_write(req=%u,written=%u) %zu of %zu",bytes_left, rc, data->written,data->data_size,rc);
                 if (data->written == data->data_size)
                 {

--- a/aclk/aclk_lws_wss_client.h
+++ b/aclk/aclk_lws_wss_client.h
@@ -79,5 +79,5 @@ void aclk_lws_connection_data_received();
 void aclk_lws_connection_closed();
 void lws_wss_check_queues(size_t *write_len, size_t *write_len_bytes, size_t *read_len);
 
-
+#define FRAGMENT_SIZE 4096
 #endif

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1413,8 +1413,8 @@ void *aclk_main(void *ptr)
         static int first_init = 0;
         size_t write_q, write_q_bytes, read_q;
         lws_wss_check_queues(&write_q, &write_q_bytes, &read_q);
-        info("loop state first_init_%d connected=%d connecting=%d wq=%zu (%zu-bytes) rq=%zu",
-             first_init, aclk_connected, aclk_connecting, write_q, read_q);
+        //info("loop state first_init_%d connected=%d connecting=%d wq=%zu (%zu-bytes) rq=%zu",
+        //     first_init, aclk_connected, aclk_connecting, write_q, write_q_bytes, read_q);
         if (unlikely(!aclk_connected)) {
             if (unlikely(!first_init)) {
                 aclk_try_to_connect(aclk_hostname, aclk_port, port_num);
@@ -1441,10 +1441,12 @@ void *aclk_main(void *ptr)
         }
 
         _link_event_loop();
-        //sleep_usec(USEC_PER_MS * 50);
-        static int stress_counter = 0;
-        if (stress_counter++ % 100 == 0 && write_q==0)
-            aclk_send_stress_test(2000000);
+        /*static int stress_counter = 0;
+        if (write_q_bytes==0 && stress_counter ++ >5)
+        {
+            aclk_send_stress_test(8000000);
+            stress_counter = 0;
+        }*/
 
         // TODO: Move to on-connect
         if (unlikely(!aclk_subscribed)) {


### PR DESCRIPTION
##### Summary
Closes #8391 

* Introduced a docker container with a paho client that can be used as an inspection point on the link.
* The inspection point calculates the latency from  `aclk_send_message()`, out of LWS, via VerneMQ to the inspection point and the decoding in the container.
* Introduced a stress-tester to the ACLK to generate large payloads.
* Wrote a fragmentation layer to avoid large writes into LWS.
* Verified that the latency is low without saturating the CPU.
* Fixed the encoding of JSON messages on the link.

(part of these changes are in PR 8399)

##### Component Name
ACLK

##### Test Plan

* Used the stress-tester, htop and the inspection point.
* Ran against the local cloud dev env.
* Verified that 2MB payloads had a constant latency of about 1s.
* Verified that the CPU-load was the same with the link running and not running.
* Checked that the on-connect messages were delivered promptly.

##### Additional Information

https://libwebsockets.org/pipermail/libwebsockets/2016-May/002382.html
https://github.com/warmcat/libwebsockets/issues/1158
https://github.com/eclipse/mosquitto/issues/411
https://github.com/warmcat/libwebsockets/issues/1157
