### PR TITLE
ACLK: Fixes the type value for alarm updates

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1844,7 +1844,7 @@ int aclk_update_alarm(RRDHOST *host, ALARM_ENTRY *ae)
     char *msg_id = create_uuid();
 
     buffer_flush(local_buffer);
-    aclk_create_header(local_buffer, "alarms", msg_id);
+    aclk_create_header(local_buffer, "status-change", msg_id);
 
     netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
     health_alarm_entry2json_nolock(local_buffer, ae, host);


### PR DESCRIPTION
Fixes #8035 
##### Summary
Change the type value to `status-change` in the generated alarm update message

##### Component Name
ACLK

##### Test Plan

* Start a claimed agent 
* Verify ACLK is up and running
* Force an alarm generation e.g. high cpu usage etc
* Monitor the alarm updates generated with a new type message of `status-change` instead of `alarms`  e.g
```
  {
        "type": "status-change",
	"msg-id": "b2e46230-43d0-47a1-bdd4-9a346ea676ba",
	"timestamp": 1584207884,
	"version": 1,
	"payload":  {
         :
         }
   }
```
