### PR TITLE
ACLK: Implemented Last Will and Testament

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1196,9 +1196,6 @@ void aclk_get_challenge(char *aclk_hostname, char *aclk_port)
     }
     struct dictionary_singleton challenge = { .key = "challenge", .result = NULL };
 
-    if (strchr(data_buffer, '\n'))
-        *(strchr(data_buffer, '\n')) = '\0';
-
     debug(D_ACLK, "Challenge response from cloud: %s", data_buffer);
     if ( json_parse(data_buffer, &challenge, json_extract_singleton) != JSON_OK)
     {

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -944,6 +944,8 @@ static void aclk_main_cleanup(void *ptr)
     // Wakeup thread to cleanup
     QUERY_THREAD_WAKEUP;
 
+    aclk_shutdown();
+
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
@@ -1451,6 +1453,7 @@ void aclk_disconnect()
     if (likely(aclk_connected))
         info("Disconnect detected (%"PRIu64" queued queries)", aclk_queue.count);
     aclk_subscribed = 0;
+    aclk_will_set = 0;
     aclk_metadata_submitted = ACLK_METADATA_REQUIRED;
     waiting_init = 1;
     aclk_connected = 0;

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -44,6 +44,8 @@ pthread_mutex_t query_lock_wait = PTHREAD_MUTEX_INITIALIZER;
 #define QUERY_THREAD_UNLOCK pthread_mutex_unlock(&query_lock_wait)
 #define QUERY_THREAD_WAKEUP pthread_cond_signal(&query_cond_wait)
 
+void lws_wss_check_queues(size_t *write_len, size_t *write_len_bytes, size_t *read_len);
+
 /*
  * Maintain a list of collectors and chart count
  * If all the charts of a collector are deleted
@@ -1285,7 +1287,6 @@ static void aclk_try_to_connect(char *hostname, char *port, int port_num)
  *
  * @return It always returns NULL
  */
-void lws_wss_check_queues(size_t *write_len, size_t *write_len_bytes, size_t *read_len);
 void *aclk_main(void *ptr)
 {
     struct netdata_static_thread *query_thread;

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1453,7 +1453,6 @@ void aclk_disconnect()
     if (likely(aclk_connected))
         info("Disconnect detected (%"PRIu64" queued queries)", aclk_queue.count);
     aclk_subscribed = 0;
-    aclk_will_set = 0;
     aclk_metadata_submitted = ACLK_METADATA_REQUIRED;
     waiting_init = 1;
     aclk_connected = 0;

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -943,7 +943,7 @@ static void aclk_main_cleanup(void *ptr)
 
     info("cleaning up...");
 
-    if (is_agent_claimed()) {
+    if (is_agent_claimed() && mosq) {
 
         // Wakeup thread to cleanup
         QUERY_THREAD_WAKEUP;
@@ -1327,8 +1327,8 @@ void *aclk_main(void *ptr)
         static int first_init = 0;
         size_t write_q, write_q_bytes, read_q;
         lws_wss_check_queues(&write_q, &write_q_bytes, &read_q);
-        //info("loop state first_init_%d connected=%d connecting=%d wq=%zu (%zu-bytes) rq=%zu",
-        //     first_init, aclk_connected, aclk_connecting, write_q, write_q_bytes, read_q);
+        info("loop state first_init_%d connected=%d connecting=%d wq=%zu (%zu-bytes) rq=%zu",
+             first_init, aclk_connected, aclk_connecting, write_q, write_q_bytes, read_q);
         if (unlikely(!netdata_exit && !aclk_connected)) {
             if (unlikely(!first_init)) {
                 aclk_try_to_connect(aclk_hostname, aclk_port, port_num);

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -937,7 +937,7 @@ void *aclk_query_main_thread(void *ptr)
 // Thread cleanup
 static void aclk_main_cleanup(void *ptr)
 {
-    char payload[sizeof(ACLK_LWT_MSG)+128+1];
+    char payload[512];
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
@@ -950,7 +950,16 @@ static void aclk_main_cleanup(void *ptr)
         // Send a graceful disconnect message
         time_t time_created = now_realtime_sec();
         char *msg_id = create_uuid();
-        snprintfz(payload, sizeof(ACLK_LWT_MSG) + 128, ACLK_LWT_MSG, msg_id, time_created, "graceful");
+
+        snprintfz(
+            payload, 511,
+            "{ \"type\": \"disconnect\","
+            " \"msg-id\": \"%s\","
+            " \"timestamp\": %ld,"
+            " \"version\": %d,"
+            " \"payload\": \"graceful\" }",
+            msg_id, time_created, ACLK_VERSION);
+
         aclk_send_message(ACLK_METADATA_TOPIC, payload, msg_id);
         freez(msg_id);
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1204,7 +1204,7 @@ void aclk_get_challenge(char *aclk_hostname, char *aclk_port)
         goto CLEANUP;
     }
     if (challenge.result == NULL ) {
-        error("Could not retrieve challenge from auth response: [%s]", data_buffer);
+        error("Could not retrieve challenge from auth response: %s", data_buffer);
         goto CLEANUP;
     }
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -943,26 +943,28 @@ static void aclk_main_cleanup(void *ptr)
 
     info("cleaning up...");
 
-    // Wakeup thread to cleanup
-    QUERY_THREAD_WAKEUP;
+    if (is_agent_claimed()) {
 
-    // Send a graceful disconnect message
-    time_t time_created = now_realtime_sec();
-    char *msg_id = create_uuid();
-    snprintfz(payload, sizeof(ACLK_LWT_MSG) + 128, ACLK_LWT_MSG, msg_id, time_created, "graceful");
-    aclk_send_message(ACLK_METADATA_TOPIC, payload, msg_id);
-    freez(msg_id);
+        // Wakeup thread to cleanup
+        QUERY_THREAD_WAKEUP;
+        // Send a graceful disconnect message
+        time_t time_created = now_realtime_sec();
+        char *msg_id = create_uuid();
+        snprintfz(payload, sizeof(ACLK_LWT_MSG) + 128, ACLK_LWT_MSG, msg_id, time_created, "graceful");
+        aclk_send_message(ACLK_METADATA_TOPIC, payload, msg_id);
+        freez(msg_id);
 
-    _link_event_loop();
-    sleep_usec(USEC_PER_MS * 100);
-    _link_event_loop();
+        _link_event_loop();
+        sleep_usec(USEC_PER_MS * 100);
+        _link_event_loop();
 
-    aclk_shutting_down = 1;
-    _link_shutdown();
-    aclk_lws_wss_mqtt_layer_disconect_notif();
+        aclk_shutting_down = 1;
+        _link_shutdown();
+        aclk_lws_wss_mqtt_layer_disconect_notif();
 
-    sleep_usec(USEC_PER_MS * 100);
-    _link_event_loop();
+        sleep_usec(USEC_PER_MS * 100);
+        _link_event_loop();
+    }
 
     info("Disconnected");
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1336,8 +1336,8 @@ void *aclk_main(void *ptr)
         static int first_init = 0;
         size_t write_q, write_q_bytes, read_q;
         lws_wss_check_queues(&write_q, &write_q_bytes, &read_q);
-        info("loop state first_init_%d connected=%d connecting=%d wq=%zu (%zu-bytes) rq=%zu",
-             first_init, aclk_connected, aclk_connecting, write_q, write_q_bytes, read_q);
+        //info("loop state first_init_%d connected=%d connecting=%d wq=%zu (%zu-bytes) rq=%zu",
+        //   first_init, aclk_connected, aclk_connecting, write_q, write_q_bytes, read_q);
         if (unlikely(!netdata_exit && !aclk_connected)) {
             if (unlikely(!first_init)) {
                 aclk_try_to_connect(aclk_hostname, aclk_port, port_num);

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -29,6 +29,15 @@
 #define ACLK_DEFAULT_PORT 9002
 #define ACLK_DEFAULT_HOST "localhost"
 
+#define ACLK_LWT_MSG    "{ \
+\"type\" : \"disconnect\", \
+\"version\" : 1, \
+\"msg-id\" : \"%s\", \
+\"timestamp\" : %ld, \
+\"payload\" : \"%s\" \
+}"
+
+
 struct aclk_request {
     char *type_id;
     char *msg_id;

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -73,6 +73,7 @@ void *aclk_main(void *ptr);
       .start_routine = aclk_main },
 
 extern int aclk_send_message(char *sub_topic, char *message, char *msg_id);
+extern void aclk_lws_wss_mqtt_layer_disconect_notif();
 
 //int     aclk_init();
 //char    *get_base_topic();

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -5,6 +5,7 @@
 
 #include "../daemon/common.h"
 #include "mqtt.h"
+#include "aclk_lws_wss_client.h"
 
 #define ACLK_VERSION 1
 #define ACLK_THREAD_NAME "ACLK_Query"
@@ -73,7 +74,6 @@ void *aclk_main(void *ptr);
       .start_routine = aclk_main },
 
 extern int aclk_send_message(char *sub_topic, char *message, char *msg_id);
-extern void aclk_lws_wss_mqtt_layer_disconect_notif();
 
 //int     aclk_init();
 //char    *get_base_topic();

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -29,15 +29,6 @@
 #define ACLK_DEFAULT_PORT 9002
 #define ACLK_DEFAULT_HOST "localhost"
 
-#define ACLK_LWT_MSG    "{ \
-\"type\" : \"disconnect\", \
-\"version\" : 1, \
-\"msg-id\" : \"%s\", \
-\"timestamp\" : %ld, \
-\"payload\" : \"%s\" \
-}"
-
-
 struct aclk_request {
     char *type_id;
     char *msg_id;

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -5,7 +5,6 @@
 
 #include "../daemon/common.h"
 #include "mqtt.h"
-#include "aclk_lws_wss_client.h"
 
 #define ACLK_VERSION 1
 #define ACLK_THREAD_NAME "ACLK_Query"
@@ -79,6 +78,7 @@ extern int aclk_send_message(char *sub_topic, char *message, char *msg_id);
 //char    *get_base_topic();
 
 extern char *is_agent_claimed(void);
+extern void aclk_lws_wss_mqtt_layer_disconect_notif();
 char *create_uuid();
 
 // callbacks for agent cloud link

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -176,6 +176,10 @@ static inline void _link_mosquitto_write()
 {
     int rc;
 
+    if (unlikely(!mosq)) {
+        return;
+    }
+
     rc = mosquitto_loop_misc(mosq);
     if (unlikely(rc != MOSQ_ERR_SUCCESS))
         debug(D_ACLK, "ACLK: failure during mosquitto_loop_misc %s", mosquitto_strerror(rc));
@@ -248,16 +252,6 @@ void _link_shutdown()
             info("MQTT invalid structure");
             break;
     };
-
-    if (netdata_exit)
-        return;
-
-    _link_event_loop();
-
-    mosquitto_destroy(mosq);
-    mosq = NULL;
-
-    aclk_lws_wss_client_destroy();
 }
 
 

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -274,7 +274,7 @@ int _link_set_lwt(char *sub_topic, int qos)
     snprintfz(payload, sizeof(ACLK_LWT_MSG)+128, ACLK_LWT_MSG, msg_id, time_created, "unexpected");
     freez(msg_id);
 
-    rc = mosquitto_will_set(mosq, topic, strlen(payload), (const void *) payload, qos, 1);
+    rc = mosquitto_will_set(mosq, topic, strlen(payload), (const void *) payload, qos, 0);
     return rc;
 }
 

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -265,7 +265,7 @@ int _link_set_lwt(char *sub_topic, int qos)
 {
     int rc;
     char topic[ACLK_MAX_TOPIC + 1];
-    char payload[sizeof(ACLK_LWT_MSG)+128+1];
+    char payload[512];
     char *final_topic;
 
     final_topic = get_topic(sub_topic, topic, ACLK_MAX_TOPIC);
@@ -277,7 +277,16 @@ int _link_set_lwt(char *sub_topic, int qos)
 
     time_t time_created = now_realtime_sec();
     char *msg_id = create_uuid();
-    snprintfz(payload, sizeof(ACLK_LWT_MSG)+128, ACLK_LWT_MSG, msg_id, time_created, "unexpected");
+
+    snprintfz(
+        payload, 511,
+        "{ \"type\": \"disconnect\","
+        " \"msg-id\": \"%s\","
+        " \"timestamp\": %ld,"
+        " \"version\": %d,"
+        " \"payload\": \"unexpected\" }",
+        msg_id, time_created, ACLK_VERSION);
+
     freez(msg_id);
 
     rc = mosquitto_will_set(mosq, topic, strlen(payload), (const void *) payload, qos, 0);

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -236,6 +236,9 @@ void _link_shutdown()
 {
     int rc;
 
+    if (likely(!mosq))
+        return;
+
     rc = mosquitto_disconnect(mosq);
     switch (rc) {
         case MOSQ_ERR_SUCCESS:
@@ -245,6 +248,9 @@ void _link_shutdown()
             info("MQTT invalid structure");
             break;
     };
+
+    if (netdata_exit)
+        return;
 
     _link_event_loop();
 

--- a/aclk/mqtt.h
+++ b/aclk/mqtt.h
@@ -16,6 +16,8 @@ int _mqtt_lib_init();
 int _link_subscribe(char *topic, int qos);
 int _link_send_message(char *topic, unsigned char *message, int *mid);
 const char *_link_strerror(int rc);
+int _link_set_lwt(char *topic, int qos);
+
 
 int aclk_handle_cloud_request(char *);
 

--- a/aclk/mqtt.h
+++ b/aclk/mqtt.h
@@ -20,5 +20,6 @@ int _link_set_lwt(char *topic, int qos);
 
 
 int aclk_handle_cloud_request(char *);
+extern char *get_topic(char *sub_topic, char *final_topic, int max_size);
 
 #endif //NETDATA_MQTT_H


### PR DESCRIPTION
Fixes #8369
##### Summary
Defines a Last Will and Testament message that the broker will send to the `outbound/meta`
topic if an unexpected (agent or link) failure occurs. 

When the agent performs a normal shutdown an MQTT disconnect packet notifies the broker
that the LWT message should not be sent. In that case a different disconnect message is transmitted and indicates a graceful agent shutdown.

##### Component Name
ACLK

##### Test Plan

###### Graceful agent shutdown
- Start a claimed agent
- Subscribe to the broker on the `outbound/meta` topic
- Verify ACLK is up and running
- Notice the on connect messages
- Press control - C or send a `kill` signal to the agent
  - Notice a LWT message on `outbound/meta` similar to 
    - `{ "type" : "disconnect", "version" : 1, "msg-id" : "e7558504-eb6f-4bdf-9700-df972e0940e6", "timestamp" : 1584372301, "payload" : "graceful" } `
-----
###### Abnormal agent shutdown
- Start a claimed agent
- Subscribe to the broker on the `outbound/meta` topic
- Verify ACLK is up and running
- Notice the on connect messages
- Send `kill -9` signal to the agent
  - Notice a LWT message on `outbound/meta` similar to 
    - `{ "type" : "disconnect", "version" : 1, "msg-id" : "8ecde43f-5e97-4443-b314-5abab793a8d7", "timestamp" : 1584374934, "payload" : "unexpected" } `



##### Additional Information
