### PR TITLE
Fix Prometheus Remote Write build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1059,6 +1059,7 @@ endif()
         PRIVATE
         -DUNIT_TESTING
     )
+    target_include_directories(${TEST_NAME}_testdriver PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
     target_link_options(
         ${TEST_NAME}_testdriver
         PRIVATE

--- a/backends/prometheus/remote_write/remote_write.cc
+++ b/backends/prometheus/remote_write/remote_write.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <snappy.h>
-#include "../../../exporting/prometheus/remote_write/remote_write.pb.h"
+#include "remote_write.pb.h"
 #include "remote_write.h"
 
 using namespace prometheus;

--- a/configure.ac
+++ b/configure.ac
@@ -1088,7 +1088,7 @@ if test "${enable_backend_prometheus_remote_write}" != "no" -a "${have_libprotob
                                                            -a "${have_protoc}" = "yes" -a "${have_CXX_compiler}" = "yes"; then
     enable_backend_prometheus_remote_write="yes"
     AC_DEFINE([ENABLE_PROMETHEUS_REMOTE_WRITE], [1], [Prometheus remote write API usability])
-    OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS="${PROTOBUF_CFLAGS} ${SNAPPY_CFLAGS}"
+    OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS="${PROTOBUF_CFLAGS} ${SNAPPY_CFLAGS} -Iexporting/prometheus/remote_write"
     CXX11FLAG="-std=c++11"
     OPTIONAL_PROMETHEUS_REMOTE_WRITE_LIBS="${PROTOBUF_LIBS} ${SNAPPY_LIBS}"
 else


### PR DESCRIPTION
##### Summary
If Netdata was compiled using CMake, there was a compilation error
```
[ 31%] Building CXX object CMakeFiles/exporting_engine_testdriver.dir/exporting/prometheus/remote_write/remote_write_request.cc.o
/home/runner/work/netdata/netdata/exporting/prometheus/remote_write/remote_write_request.cc:4:10: fatal error: remote_write.pb.h: No such file or directory
 #include "remote_write.pb.h"
```
It was because `remote_write.pb.h` and `remote_write.pb.cc` are created in the build directory in CMake, instead of the current directory of the source tree, like in Autotools. The PR fixes include paths.

##### Component Name
build

##### Test Plan
```
sudo git clean -dxf
netdata-install.sh
```
```
sudo git clean -dxf
autoreconf -ivf
./configure
mkdir cmake-build-debug
cmake -DCMAKE_BUILD_TYPE="Debug" -DUNIT_TESTING=ON ..
make
```