### PR TITLE
Adds missing files to ACLK CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,6 +612,8 @@ set(CLAIM_PLUGIN_FILES
         )
 
 set(ACLK_PLUGIN_FILES
+        aclk/aclk_common.c
+        aclk/aclk_common.h
         aclk/agent_cloud_link.c
         aclk/agent_cloud_link.h
         aclk/aclk_lws_wss_client.c


### PR DESCRIPTION
##### Summary
aclk_common.c/aclk_common.h missing from CMAKE list of files for ACLK.

Noticed when reviewing #8411

##### Component Name

##### Test Plan
ACLK builds with CMAKE
##### Additional Information
