### PR TITLE
Fix the lack of cleanup in the netdata updater

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -19,6 +19,8 @@
 # Author: Paweł Krupa <paulfantom@gmail.com>
 # Author: Pavlos Emm. Katsoulakis <paul@netdata.cloud>
 
+set -e
+
 info() {
   echo >&3 "$(date) : INFO: " "${@}"
 }
@@ -42,12 +44,18 @@ safe_sha256sum() {
 # this is what we will do if it fails (head-less only)
 fatal() {
   error "FAILED TO UPDATE NETDATA : ${1}"
+  exit 1
+}
 
+cleanup() {
   if [ -n "${logfile}" ]; then
     cat >&2 "${logfile}"
     rm "${logfile}"
   fi
-  exit 1
+
+  if [ -n "$tmpdir" ] && [ -d "$tmpdir" ]; then
+    rm -rf "$tmpdir"
+  fi
 }
 
 create_tmp_directory() {
@@ -73,7 +81,7 @@ download() {
   fi
 }
 
-function parse_version() {
+parse_version() {
   r="${1}"
   if echo "${r}" | grep -q '^v.*'; then
     # shellcheck disable=SC2001
@@ -193,6 +201,11 @@ update() {
   return 0
 }
 
+logfile=
+tmpdir=
+
+trap cleanup 0 1 2 3 6
+
 # Usually stored in /etc/netdata/.environment
 : "${ENVIRONMENT_FILE:=THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT}"
 
@@ -209,7 +222,6 @@ if [ "${INSTALL_UID}" != "$(id -u)" ]; then
   fatal "You are running this script as user with uid $(id -u). We recommend to run this script as root (user with uid 0)"
 fi
 
-logfile=
 if [ -t 2 ]; then
   # we are running on a terminal
   # open fd 3 and send it to stderr

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -204,7 +204,7 @@ update() {
 logfile=
 tmpdir=
 
-trap cleanup 0 1 2 3 6
+trap cleanup EXIT
 
 # Usually stored in /etc/netdata/.environment
 : "${ENVIRONMENT_FILE:=THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT}"


### PR DESCRIPTION
##### Summary

This PR adds some proper cleanup to the NetData Updater such that we actually
properly cleanup log files we created or temporary directories. We do so on
any signal we can intercept as well as normal script termination
(_regardless of exit status_).

Previously we would only cleanup _some_ limited number of things after
successive steps in the process and potentially leave things behind like
in #8128

##### Component Name

- area/packaging

##### Test Plan

- Tested this inside a simualted environment with simulated failures

1. Run `docker build -f Dockerfile.dev -t netdata:dev . | tee prepare.log && dki -t --rm -v "$PWD":/netdata -w /netdata --network none netdata:dev`
2. Make sure there are no `netdata-updater-*` directories: `find / -type d -name 'netdata-updater-*'`
3. Run the netdata updater (_cron does this automatically_): `/usr/libexec/netdata/netdata-updater.sh`
4. Confirm the failure and exit status: `echo $?`
5. Observe there are no more `netdata-updater-*` directoires left over: `find / -type d -name 'netdata-updater-*'`

__Before__:

```sh
$ docker build -f Dockerfile.dev -t netdata:dev . | tee prepare.log && dki -t --rm -v "$PWD":/netdata -w /netdata --network none netdata:dev
.
.
.
Step 6/6 : CMD ["/bin/sh"]
 ---> Running in 525196e8ad4a
Removing intermediate container 525196e8ad4a
 ---> df073f961da0
Successfully built df073f961da0
Successfully tagged netdata:dev
/netdata # find / -type d -name 'netdata-updater-*'
/netdata # /usr/libexec/netdata/netdata-updater.sh
Tue Mar 17 02:51:39 UTC 2020 : INFO:  Running on a terminal - (this script also supports running headless from crontab)
curl: (6) Could not resolve host: storage.googleapis.com
curl: (6) Could not resolve host: storage.googleapis.com
curl: (6) Could not resolve host: storage.googleapis.com
curl: (6) Could not resolve host: storage.googleapis.com
Tue Mar 17 02:52:06 UTC 2020 : ERROR:  FAILED TO UPDATE NETDATA : Cannot download https://storage.googleapis.com/netdata-nightlies/sha256sums.txt
/netdata # echo $?
1
/netdata # find / -type d -name 'netdata-updater-*'
/netdata #
```

__After__:

```sh
$ docker build -f Dockerfile.dev -t netdata:dev . | tee prepare.log && dki -t --rm -v "$PWD":/netdata -w /netdata --network none netdata:dev
.
.
.
Step 6/6 : CMD ["/bin/sh"]
 ---> Running in 0db3b6f49005
Removing intermediate container 0db3b6f49005
 ---> 02b56cefabc0
Successfully built 02b56cefabc0
Successfully tagged netdata:dev
/netdata # find / -type d -name 'netdata-updater-*'
/netdata # /usr/libexec/netdata/netdata-updater.sh
Tue Mar 17 03:07:42 UTC 2020 : INFO:  Running on a terminal - (this script also supports running headless from crontab)
curl: (6) Could not resolve host: storage.googleapis.com
curl: (6) Could not resolve host: storage.googleapis.com
curl: (6) Could not resolve host: storage.googleapis.com
curl: (6) Could not resolve host: storage.googleapis.com
Tue Mar 17 03:08:09 UTC 2020 : ERROR:  FAILED TO UPDATE NETDATA : Cannot download https://storage.googleapis.com/netdata-nightlies/sha256sums.txt
/netdata # echo $?
1
/netdata # find / -type d -name 'netdata-updater-*'
/tmp/netdata-updater-JCDAOF
/netdata #
```

##### Additional Information

I still do not know what to do about the fact that, we assume we can just blindly
(_no pun intended_) use`$(pwd)` as the place to create temporary directories,
if we can't or rather won't create them in the normal system `$TMPDIR` or `/tmp`
locations.

Would `/var/lib/netdata` be okay?

I may add another commit once I figure this tid bit out or another PR.