### PR TITLE
Add Fedora 32 to build checks.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -22,6 +22,7 @@ jobs:
           - 'debian:buster'
           - 'debian:stretch'
           - 'debian:jessie'
+          - 'fedora:32'
           - 'fedora:31'
           - 'fedora:30'
           - 'opensuse/leap:15.2'


### PR DESCRIPTION
##### Summary

The beta release of Fedora 32, including official Docker images, is officially out as of 2020-03-17. Final release is expected on 2020-04-21.

This PR adds Fedora 32 to the list of distribution releases we run build tests on.

##### Component Name

area/ci

##### Test Plan

Verified that checks pass on this PR.

##### Additional Information

This is intended to act as a bellwether for basic Fedora 32 support. It will be marked ready for review when Fedora 32 is formally released, but until then I will be rebasing it regularly onto master to verify the build checks, and filing issues for any problems that I see.