### PR TITLE
Fixed response payload to match the new specification

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -757,10 +757,10 @@ int aclk_execute_query(struct aclk_query *this_query)
 
         aclk_create_header(local_buffer, "http", this_query->msg_id);
 
-        if (rc != HTTP_RESP_OK || strcmp(mysep ? mysep + 1 : "noop", "badge.svg") == 0)
-            buffer_sprintf(local_buffer, "{\n\"code\": %d,\n\"body\": \"%s\"\n}", rc, aclk_encode_response(w->response.data)->buffer);
-        else
-            buffer_sprintf(local_buffer, "{\n\"code\": %d,\n\"body\": %s\n}", rc, aclk_encode_response(w->response.data)->buffer);
+        //if (rc != HTTP_RESP_OK || strcmp(mysep ? mysep + 1 : "noop", "badge.svg") == 0)
+        buffer_sprintf(local_buffer, "{\n\"code\": %d,\n\"body\": \"%s\"\n}", rc, aclk_encode_response(w->response.data)->buffer);
+        //else
+        //    buffer_sprintf(local_buffer, "{\n\"code\": %d,\n\"body\": %s\n}", rc, aclk_encode_response(w->response.data)->buffer);
 
         buffer_sprintf(local_buffer, "\n}");
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -758,9 +758,9 @@ int aclk_execute_query(struct aclk_query *this_query)
         aclk_create_header(local_buffer, "http", this_query->msg_id);
 
         if (rc != HTTP_RESP_OK || strcmp(mysep ? mysep + 1 : "noop", "badge.svg") == 0)
-            buffer_sprintf(local_buffer, "\"%s\"", aclk_encode_response(w->response.data)->buffer);
+            buffer_sprintf(local_buffer, "{\n\"code\": %d,\n\"body\": \"%s\"\n}", rc, aclk_encode_response(w->response.data)->buffer);
         else
-            buffer_sprintf(local_buffer, "%s", aclk_encode_response(w->response.data)->buffer);
+            buffer_sprintf(local_buffer, "{\n\"code\": %d,\n\"body\": %s\n}", rc, aclk_encode_response(w->response.data)->buffer);
 
         buffer_sprintf(local_buffer, "\n}");
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -758,9 +758,11 @@ int aclk_execute_query(struct aclk_query *this_query)
         aclk_create_header(local_buffer, "http", this_query->msg_id);
 
         //if (rc != HTTP_RESP_OK || strcmp(mysep ? mysep + 1 : "noop", "badge.svg") == 0)
-        buffer_sprintf(local_buffer, "{\n\"code\": %d,\n\"body\": \"%s\"\n}", rc, aclk_encode_response(w->response.data)->buffer);
+        buffer_sprintf(
+            local_buffer, "{\n\"code\": %d,\n\"body\": \"%s\"\n}", rc, aclk_encode_response(w->response.data)->buffer);
         //else
-        //    buffer_sprintf(local_buffer, "{\n\"code\": %d,\n\"body\": %s\n}", rc, aclk_encode_response(w->response.data)->buffer);
+        //    buffer_sprintf(local_buffer, "{\n\"code\": %d,\n\"body\": %s\n}", rc,
+        //      aclk_encode_response(w->response.data)->buffer);
 
         buffer_sprintf(local_buffer, "\n}");
 


### PR DESCRIPTION
Fixes #8124
##### Summary
Executing queries from the cloud mail fail so the payload response adjusted to include a code and a body section

The code is the HTTP response code from the internal webapi and the body carries the response

##### Component Name
ACLK

##### Test Plan
- Start a claimed agent
- Verify ACLK is up and running
- Construct and send a query command to the agents listening topic e.g. `inbound/cmd` with a payload similar to: 
  `{ "type" : "http", "version" : 1, "callback-topic" : "callback/topic", "msg-id" : "testmsg", "payload" : "/api/v1/info"}`
