### PR TITLE
Fixed JSON parsing

### DIFF
--- a/aclk/aclk_lws_https_client.c
+++ b/aclk/aclk_lws_https_client.c
@@ -35,7 +35,7 @@ static int simple_https_client_callback(struct lws *wsi, enum lws_callback_reaso
             return -1;
         }
         ptr = perconn_data->data;
-        n = perconn_data->data_size;
+        n = perconn_data->data_size - 1;
         if (lws_http_client_read(wsi, &ptr, &n) < 0)
             return -1;
         ptr[n] = '\0';

--- a/aclk/aclk_lws_https_client.c
+++ b/aclk/aclk_lws_https_client.c
@@ -38,6 +38,7 @@ static int simple_https_client_callback(struct lws *wsi, enum lws_callback_reaso
         n = perconn_data->data_size;
         if (lws_http_client_read(wsi, &ptr, &n) < 0)
             return -1;
+        ptr[n] = '\0';
         return 0;
     case LWS_CALLBACK_WSI_DESTROY:
         debug(D_ACLK, "LWS_CALLBACK_WSI_DESTROY");

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -365,7 +365,7 @@ size_t json_walk_object(char *js, jsmntok_t *t, size_t nest, size_t start, JSON_
     ne.original_string = &js[t[start].start];
     memcpy(&ne, e, sizeof(JSON_ENTRY));
     ne.type = JSON_OBJECT;
-    ne.callback_function = NULL;
+    ne.callback_function = e->callback_function;
     if(e->callback_function) e->callback_function(&ne);
     js[t[start].end] = old;
 

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -299,7 +299,7 @@ size_t json_walk_array(char *js, jsmntok_t *t, size_t nest, size_t start, JSON_E
     memcpy(&ne, e, sizeof(JSON_ENTRY));
     ne.type = JSON_ARRAY;
     ne.data.items = t[start].size;
-    ne.callback_function = NULL;
+    ne.callback_function = e->callback_function;
     ne.name[0]='\0';
     ne.fullname[0]='\0';
     if(e->callback_function) e->callback_function(&ne);


### PR DESCRIPTION
Fixes #8349
##### Summary
When the internal JSON parser was used the callback function supplied was not called in some cases so the calling function would not get the complete parsed results.

##### Component Name
ACLK

##### Test Plan
Before the PR is applied
- Start a claimed agent without the optional json-c library
- When attempting to establish the ACLK, notice in the logfile error messages 
  `Could not retrieve challenge from auth response:.....`

After the PR is applied
- Start a claimed agent without the optional json-c library
- Challenge response completes successfully
- ACLK is established
