### PR TITLE
Report Why ACLK build failed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -562,6 +562,7 @@ if test "$enable_cloud" = "yes"; then
         HAVE_libmosquitto_a="yes"
     else
         HAVE_libmosquitto_a="no"
+        AC_DEFINE([ACLK_NO_LIBMOSQ], [1], [Libmosquitto.a was not found during build.])
     fi
     AC_MSG_RESULT([${HAVE_libmosquitto_a}])
 
@@ -571,6 +572,7 @@ if test "$enable_cloud" = "yes"; then
         HAVE_libwebsockets_a="yes"
     else
         HAVE_libwebsockets_a="no"
+        AC_DEFINE([ACLK_NO_LWS], [1], [libwebsockets.a was not found during build.])
     fi
     AC_MSG_RESULT([${HAVE_libwebsockets_a}])
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1342,6 +1342,7 @@ int main(int argc, char **argv) {
     // ------------------------------------------------------------------------
     // Report ACLK build failure
 #ifndef ENABLE_ACLK
+    error("This agent doesn't have ACLK.");
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s/.aclk_report_sent", netdata_configured_varlib_dir);
     if( netdata_anonymous_statistics_enabled > 0 && access( filename, F_OK ) ) { // -1 -> not initialized

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1338,6 +1338,15 @@ int main(int argc, char **argv) {
     netdata_ready = 1;
 
     send_statistics("START", "-",  "-");
+#ifndef ENABLE_ACLK
+    send_statistics("ACLK_DISABLED", "-", "-");
+#ifdef ACLK_NO_LWS
+    send_statistics("BUILD_FAIL_LWS", "-", "-");
+#endif
+#ifdef ACLK_NO_LIBMOSQ
+    send_statistics("BUILD_FAIL_MOSQ", "-", "-");
+#endif
+#endif
 
     // ------------------------------------------------------------------------
     // unblock signals

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1345,7 +1345,7 @@ int main(int argc, char **argv) {
     error("This agent doesn't have ACLK.");
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s/.aclk_report_sent", netdata_configured_varlib_dir);
-    if( netdata_anonymous_statistics_enabled > 0 && access( filename, F_OK ) ) { // -1 -> not initialized
+    if (netdata_anonymous_statistics_enabled > 0 && access(filename, F_OK)) { // -1 -> not initialized
         send_statistics("ACLK_DISABLED", "-", "-");
 #ifdef ACLK_NO_LWS
         send_statistics("BUILD_FAIL_LWS", "-", "-");
@@ -1353,8 +1353,8 @@ int main(int argc, char **argv) {
 #ifdef ACLK_NO_LIBMOSQ
         send_statistics("BUILD_FAIL_MOSQ", "-", "-");
 #endif
-        int fd = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 444);
-        if(fd == -1)
+        int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 444);
+        if (fd == -1)
             fatal("Cannot create file '%s'. Please fix this.", filename);
         close(fd);
     }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1355,8 +1355,9 @@ int main(int argc, char **argv) {
 #endif
         int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 444);
         if (fd == -1)
-            fatal("Cannot create file '%s'. Please fix this.", filename);
-        close(fd);
+            error("Cannot create file '%s'. Please fix this.", filename);
+        else
+            close(fd);
     }
 #endif
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1338,14 +1338,25 @@ int main(int argc, char **argv) {
     netdata_ready = 1;
 
     send_statistics("START", "-",  "-");
+
+    // ------------------------------------------------------------------------
+    // Report ACLK build failure
 #ifndef ENABLE_ACLK
-    send_statistics("ACLK_DISABLED", "-", "-");
+    char filename[FILENAME_MAX + 1];
+    snprintfz(filename, FILENAME_MAX, "%s/.aclk_report_sent", netdata_configured_varlib_dir);
+    if( netdata_anonymous_statistics_enabled > 0 && access( filename, F_OK ) ) { // -1 -> not initialized
+        send_statistics("ACLK_DISABLED", "-", "-");
 #ifdef ACLK_NO_LWS
-    send_statistics("BUILD_FAIL_LWS", "-", "-");
+        send_statistics("BUILD_FAIL_LWS", "-", "-");
 #endif
 #ifdef ACLK_NO_LIBMOSQ
-    send_statistics("BUILD_FAIL_MOSQ", "-", "-");
+        send_statistics("BUILD_FAIL_MOSQ", "-", "-");
 #endif
+        int fd = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 444);
+        if(fd == -1)
+            fatal("Cannot create file '%s'. Please fix this.", filename);
+        close(fd);
+    }
 #endif
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
Report reason why ACLK build failed. Respect opt out.

Fixes #8050

##### Component Name

##### Test Plan
Simulate ACLK build failure (e.g. by removing libomosq.a from `externaldeps` folder and rerun configure without running installer).

You should see events in Google Analytics.

Keep in mind changes merged by Andrew meanwhile (you must pass --with-cloud to configure instead of ACLK=yes). If cloud is not enabled by purpose do not report anything.

##### Additional Information
