### PR TITLE
Add the new cloud info in the info endpoint

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,14 +161,27 @@ AC_ARG_ENABLE(
     ,
     [enable_jsonc="detect"]
 )
-if test "${ACLK}" = "yes"; then
+
+# -----------------------------------------------------------------------------
+# Check if cloud is enabled and if the functionality is available
+
 AC_ARG_ENABLE(
-    [aclk],
-    ,
-    [aclk_required="${enableval}"],
-    [aclk_required="detect"]
+    [cloud],
+    [AS_HELP_STRING([--disable-cloud],
+                    [Disables all cloud functionality])],
+    [],
+    [enable_cloud="no"]
 )
+
+AC_MSG_CHECKING([if cloud functionality should be enabled])
+if test "${enable_cloud}" != "no"; then
+    AC_DEFINE([ENABLE_CLOUD], [1], [netdata cloud functionality])
+    aclk_required="detect"
+else
+    aclk_required="no"
 fi
+AC_MSG_RESULT([${enable_cloud}])
+AM_CONDITIONAL([ENABLE_CLOUD], [test "${enable_cloud}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # netdata required checks
@@ -543,8 +556,7 @@ AM_CONDITIONAL([ENABLE_CAPABILITY], [test "${with_libcap}" = "yes"])
 # -----------------------------------------------------------------------------
 # ACLK
 
-#currently env var ACLK must be set to 'yes' to even consider building ACLK
-if test "${ACLK}" = "yes"; then
+if test "$enable_cloud" = "yes"; then
     AC_MSG_CHECKING([if libmosquitto static lib is present])
     if test -f "externaldeps/mosquitto/libmosquitto.a"; then
         HAVE_libmosquitto_a="yes"
@@ -1257,6 +1269,7 @@ AC_ARG_ENABLE(
      [],
      [enable_unit_tests="yes"]
 )
+
 
 PKG_CHECK_MODULES(
     [CMOCKA],

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -189,7 +189,7 @@ USAGE: ${PROGRAM} [options]
                              This results in more frequent updates.
   --disable-go               Disable installation of go.d.plugin.
   --enable-ebpf              Enable eBPF Kernel plugin (Default: disabled, feature preview)
-  --disable-cloud            Disable the agent-cloud link, required for Netdata Cloud functionality.
+  --disable-cloud            Disable all cloud functionality.
   --enable-plugin-freeipmi   Enable the FreeIPMI plugin. Default: enable it when libipmimonitoring is available.
   --disable-plugin-freeipmi
   --disable-https            Explicitly disable TLS support
@@ -277,7 +277,11 @@ while [ -n "${1}" ]; do
     "--enable-ebpf") NETDATA_ENABLE_EBPF=1 ;;
     "--disable-cloud")
       NETDATA_DISABLE_CLOUD=1
-      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
+      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-cloud/} --disable-cloud"
+      ;;
+    "--cloud-testing")          # Temporary, until we flip the feature flag. Internal use only
+      NETDATA_DISABLE_CLOUD=0
+      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-cloud/} --enable-cloud"
       ;;
     "--install")
       NETDATA_PREFIX="${2}/netdata"

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -859,7 +859,22 @@ inline int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb)
 
     buffer_strcat(wb, "\t\"collectors\": [");
     chartcollectors2json(host, wb);
-    buffer_strcat(wb, "\n\t]\n");
+    buffer_strcat(wb, "\n\t],\n");
+
+#ifdef ENABLE_CLOUD
+    buffer_strcat(wb, "\t\"cloud-enabled\": true,\n");
+#else
+    buffer_strcat(wb, "\t\"cloud-enabled\": false,\n");
+#endif
+#ifdef ENABLE_ACLK
+    buffer_strcat(wb, "\t\"cloud-available\": true,\n");
+#else
+    buffer_strcat(wb, "\t\"cloud-available\": false,\n");
+#endif
+    if (is_agent_claimed() == NULL)
+        buffer_strcat(wb, "\t\"agent-claimed\": false\n");
+    else
+        buffer_strcat(wb, "\t\"agent-claimed\": true\n");
 
     buffer_strcat(wb, "}");
     return 0;


### PR DESCRIPTION
##### Summary
Added the fields to the `/api/v1/info` endpoint that the dashboard needs to display the status of the cloud support.

Changed the way the flags propagate through the installer and configure script.

**The ACLK environmental variable is no longer used**. It has been removed in preparation for flipping the feature flag. Supply `--cloud-testing` to the installer to enable everything. This is an internal only option as access to the cloud platform requires iauthentication.

##### Component Name
ACLK
web/api

##### Test Plan

* Tested with a claimed / unclaimed agent.
* Tested with the cloud disabled / enabled.
* Checked the availability flag tracks the dependency state.

##### Additional Information
