### PR TITLE
Improve installer output re newlines

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -264,7 +264,7 @@ run() {
 
   printf >&2 "%s" "${info_console}${TPUT_BOLD}${TPUT_YELLOW}"
   escaped_print >&2 "${@}"
-  printf >&2 "%s" "${TPUT_RESET}"
+  printf >&2 "%s\n" "${TPUT_RESET}"
 
   "${@}"
 


### PR DESCRIPTION
##### Summary

Closes #8422

##### Component Name

- area/packacing

##### Test Plan

__Before__:

```sh
Starting netdata using command 'systemctl start netdata'
[/tmp/netdata-kickstart-8zP6rR/netdata-v1.20.0-186-g459bedf9]# systemctl start netdata  OK

 OK  netdata started!
```

__After__:

```sh
Starting netdata using command 'systemctl start netdata'
[/home/prologic/netdata]# systemctl start netdata
 OK

 OK  netdata started!
```

##### Additional Information

#8422 was already fixed by #8326 #8325 and #8324. The OP was installing from the
current stable release of `v1.20.0` where the bug still existed.

This PR improves the output slightly more by removing the redundancy of the
command we're about to run (_we end up printing it twice_) and adds the `\n`
where it was really suppose to have gone in the first place.

#8446 also fixes similar things for the uninstaller.