### PR TITLE
bind to should be in [web] section and update netdata.service.v235.in too

### DIFF
--- a/system/netdata.conf
+++ b/system/netdata.conf
@@ -16,9 +16,6 @@
     # the default database size - 1 hour
     history = 3600
 
-    # by default do not expose the netdata port
-    bind to = localhost
-
     # some defaults to run netdata with least priority
     process scheduling policy = idle
     OOM score = 1000
@@ -26,3 +23,6 @@
 [web]
     web files owner = root
     web files group = netdata
+
+    # by default do not expose the netdata port
+    bind to = localhost

--- a/system/netdata.service.v235.in
+++ b/system/netdata.service.v235.in
@@ -21,7 +21,7 @@ PIDFile=netdata/netdata.pid
 ExecStart=@sbindir_POST@/netdata -P $PIDFILE -D
 
 # saving a big db on slow disks may need some time
-TimeoutStopSec=60
+TimeoutStopSec=150
 
 # restart netdata if it crashes
 Restart=on-failure


### PR DESCRIPTION
##### Summary
1. In netdata.conf file, bind to is mentioned under [global] section but it should be under [web] section as per documentation here, https://docs.netdata.cloud/web/server/

2. Recently netdata.service.in was updated but same changes were not made to netdata.service.v235.in file. This PR does that.