### PR TITLE
Report ACLK Connection Failure

### DIFF
--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -383,7 +383,7 @@ static int aclk_lws_wss_callback(struct lws *wsi, enum lws_callback_reasons reas
     static int lws_shutting_down = 0;
     int i;
 
-    for (i = ACLK_LWS_CALLBACK_HISTORY; i > 0; i--)
+    for (i = ACLK_LWS_CALLBACK_HISTORY - 1; i > 0; i--)
         engine_instance->lws_callback_history[i] = engine_instance->lws_callback_history[i - 1];
     engine_instance->lws_callback_history[0] = (int)reason;
 

--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -264,11 +264,15 @@ int aclk_lws_wss_connect(char *host, int port)
 {
     struct lws_client_connect_info i;
     struct lws_vhost *vhost;
+    int n;
 
     if (!engine_instance) {
         return aclk_lws_wss_client_init(host, port);
         // PROTOCOL_INIT callback will call again.
     }
+
+    for (n = 0; n < ACLK_LWS_CALLBACK_HISTORY; n++)
+        engine_instance->lws_callback_history[n] = 0;
 
     if (engine_instance->lws_wsi) {
         error("Already Connected. Only one connection supported at a time.");
@@ -346,12 +350,41 @@ static const char *aclk_lws_callback_name(enum lws_callback_reasons reason)
             return "unknown";
     }
 }
+
+void aclk_lws_wss_fail_report()
+{
+    int i;
+    int anything_to_send = 0;
+    BUFFER *buf;
+
+    if (netdata_anonymous_statistics_enabled <= 0)
+        return;
+
+    buf = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
+
+    for (i = 0; i < ACLK_LWS_CALLBACK_HISTORY; i++)
+        if (engine_instance->lws_callback_history[i]) {
+            buffer_sprintf(buf, "%s%d", (i ? "," : ""), engine_instance->lws_callback_history[i]);
+            anything_to_send = 1;
+        }
+
+    if (anything_to_send)
+        send_statistics("ACLK_CONN_FAIL", "FAIL", buffer_tostring(buf));
+
+    buffer_free(buf);
+}
+
 static int aclk_lws_wss_callback(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len)
 {
     UNUSED(user);
     struct lws_wss_packet_buffer *data;
     int retval = 0;
     static int lws_shutting_down = 0;
+    int i;
+
+    for (i = ACLK_LWS_CALLBACK_HISTORY; i > 0; i--)
+        engine_instance->lws_callback_history[i] = engine_instance->lws_callback_history[i - 1];
+    engine_instance->lws_callback_history[0] = (int)reason;
 
     if (unlikely(aclk_shutting_down && !lws_shutting_down)) {
             lws_shutting_down = 1;
@@ -443,6 +476,8 @@ static int aclk_lws_wss_callback(struct lws *wsi, enum lws_callback_reasons reas
             return -1;                       // the callback response is ignored, hope the above remains true
         case LWS_CALLBACK_WSI_DESTROY:
             aclk_lws_wss_clear_io_buffers(engine_instance);
+            if (!engine_instance->websocket_connection_up)
+                aclk_lws_wss_fail_report();
             engine_instance->lws_wsi = NULL;
             engine_instance->websocket_connection_up = 0;
             aclk_lws_connection_closed();

--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -360,7 +360,8 @@ void aclk_lws_wss_fail_report()
     if (netdata_anonymous_statistics_enabled <= 0)
         return;
 
-    buf = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
+    // guess - most of the callback will be 1-99 + ',' + \0
+    buf = buffer_create((ACLK_LWS_CALLBACK_HISTORY * 2) + 10);
 
     for (i = 0; i < ACLK_LWS_CALLBACK_HISTORY; i++)
         if (engine_instance->lws_callback_history[i]) {

--- a/aclk/aclk_lws_wss_client.h
+++ b/aclk/aclk_lws_wss_client.h
@@ -16,6 +16,8 @@
 
 #define ACLK_LWS_WSS_RECV_BUFF_SIZE_BYTES (128 * 1024)
 
+#define ACLK_LWS_CALLBACK_HISTORY 10
+
 #ifdef ACLK_LWS_MOSQUITTO_IO_CALLS_MULTITHREADED
 #define aclk_lws_mutex_init(x) netdata_mutex_init(x)
 #define aclk_lws_mutex_lock(x) netdata_mutex_lock(x)
@@ -63,6 +65,8 @@ struct aclk_lws_wss_engine_instance {
 
     int data_to_read;
     int upstream_reconnect_request;
+
+    int lws_callback_history[ACLK_LWS_CALLBACK_HISTORY];
 };
 
 void aclk_lws_wss_client_destroy();


### PR DESCRIPTION
##### Summary
If ACLK fails to connect report it in case telemetry is enabled (e.g. respect DO_NOT_TRACK of course)

We send up to last 10 events of LWS to the GA to be able to analyse at what point connection failed.

Fixes #8051 

##### Component Name
ACLK
##### Test Plan
Fail connection in different ways. Look at the reports in Google Analytics

Example of event data when connection failed on certificate verification: "30,1,58,19,29"

##### Additional Information
