### PR TITLE
Memory leak with labels on stream

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -642,6 +642,8 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
             }
 
             new_labels = add_label_to_list(new_labels, words[1], store, strtol(words[2], NULL, 10));
+            if (store != words[3])
+                freez(store);
         }
         else if(likely(hash == OVERWRITE_HASH && !strcmp(s, PLUGINSD_KEYWORD_OVERWRITE))) {
             debug(D_PLUGINSD, "requested a OVERWITE a variable");

--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -627,10 +627,15 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int 
                 store = words[3];
             else {
                 store = callocz(PLUGINSD_LINE_MAX + 1, sizeof(char));
+                size_t remaining = PLUGINSD_LINE_MAX;
                 char *move = store;
                 int i = 3;
                 while (i < w) {
                     size_t length = strlen(words[i]);
+                    if ((length + 1) >= remaining)
+                        break;
+
+                    remaining -= (length +1);
                     memcpy(move, words[i], length);
                     move += length;
                     *move++ = ' ';


### PR DESCRIPTION
##### Summary
Fixes #8459 

This commit removes the memory leak present on Netdata.
##### Component Name
Stream

##### Test Plan
It is necessary to set a master and slave with labels.
The labels visualized on Slave must be on master.

##### Additional Information
