### PR TITLE
update netdata.conf for debian build

### DIFF
--- a/contrib/debian/netdata.conf
+++ b/contrib/debian/netdata.conf
@@ -1,16 +1,28 @@
-# NetData Configuration
-
-# The current full configuration can be retrieved from the running
-# server at the URL
+# netdata configuration
 #
-#   http://localhost:19999/netdata.conf
+# You can download the latest version of this file, using:
 #
-# for example:
+#  wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
+# or
+#  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
 #
-#   wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
+# You can uncomment and change any of the options below.
+# The value shown in the commented settings, is the default value.
 #
 
 [global]
-	run as user = netdata
-	web files owner = root
-	web files group = netdata
+    run as user = netdata
+
+    # the default database size - 1 hour
+    history = 3600
+
+    # by default do not expose the netdata port
+    bind to = localhost
+
+    # some defaults to run netdata with least priority
+    process scheduling policy = idle
+    OOM score = 1000
+
+[web]
+    web files owner = root
+    web files group = netdata


### PR DESCRIPTION
##### Summary

`netdata.conf` in directory `system` was updated but debian build uses old version. The old version is potentially insecure, as it binds to all interfaces by default, thus exposing netdata on public interfaces.

##### Component Name

packaging