### PR TITLE
Adding the claiming script to the multi-stage whitelist

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN mkdir -p /app/usr/sbin/ \
     mv /var/lib/netdata     /app/var/lib/ && \
     mv /etc/netdata         /app/etc/ && \
     mv /usr/sbin/netdata    /app/usr/sbin/ && \
+    mv /usr/sbin/netdata-claim.sh    /app/usr/sbin/ && \
     mv packaging/docker/run.sh        /app/usr/sbin/ && \
     cp -rp /deps/* /app/usr/local/ && \
     chmod +x /app/usr/sbin/run.sh


### PR DESCRIPTION
##### Summary

The packaging Dockerfile did not include the claiming script in the white-list used to move files between stages.


##### Component Name
packaging

##### Test Plan

Building the container


##### Additional Information
