### PR TITLE
Added Docker build arg to pass extra options to installer.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -12,6 +12,10 @@ ARG RELEASE_CHANNEL=nightly
 
 ENV JUDY_VER 1.0.5
 
+ARG EXTRA_INSTALL_OPTS
+
+ENV EXTRA_INSTALL_OPTS=$EXTRA_INSTALL_OPTS
+
 # Copy source
 COPY . /opt/netdata.git
 WORKDIR /opt/netdata.git
@@ -19,7 +23,7 @@ WORKDIR /opt/netdata.git
 # Install from source
 RUN chmod +x netdata-installer.sh && \
    cp -rp /deps/* /usr/local/ && \
-   ./netdata-installer.sh --dont-wait --dont-start-it \
+   ./netdata-installer.sh --dont-wait --dont-start-it ${EXTRA_INSTALL_OPTS} \
    $([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)
 
 # files to one directory


### PR DESCRIPTION
##### Summary

This adds a build argument to the main Dockerfile to allow passing extra options to the netdata-installer script during the build process.

The value specified in the `EXTRA_INSTALL_OPTS` argument wil be added verbatm to the netdata-installer.sh script. The arguments `--dont-start-it` and `--dont-wait` are still implicitly passed to the script as those are required to get a correctly functioning Docker image.

##### Component Name

area/packaging

##### Test Plan

Regular builds verified on PR checks, locally tested with arbitrary argument combinations to verify that the bild works correctly.

##### Additional Information

This originated as a way to build Netdata Cloud support in the Docker images while it's still being tested, but is intended to be kept moving forwards as an easy way to create custom Docker images and simplify testing optional features from Docker.

To actually use this, use a command like the following from the root of the source tree:

    docker build . --build-arg EXTRA_INSTALL_OPTS="--foo"