### PR TITLE
Installer creates claim.d but is run as root, patch to correct ownership

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -89,6 +89,8 @@ RUN \
         /var/cache/netdata \
         /var/lib/netdata \
         /var/log/netdata && \
+    chown -R netdata:netdata /etc/netdata/claim.d && \
+    chmod 0700 /etc/netdata/claim.d && \
     chmod 0755 /usr/libexec/netdata/plugins.d/*.plugin && \
     chmod 4755 \
         /usr/libexec/netdata/plugins.d/cgroup-network \


### PR DESCRIPTION
#### Summary

Fixes problems with claiming agents in the local dev env.

##### Component Name
packaging
claiming

##### Test Plan

Claiming an agent in the local dev env.

##### Additional Information
