### PR TITLE
Fix openSUSE 15.1 RPM Package Buidls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -345,7 +345,7 @@ jobs:
       <<: *RPM_TEMPLATE
       if: commit_message =~ /\[Package (amd64|arm64) RPM( openSUSE)?\]/
       env:
-        - BUILDER_NAME="builder" BUILD_DISTRO="opensuse" BUILD_RELEASE="15.0" BUILD_STRING="opensuse/15.1"
+        - BUILDER_NAME="builder" BUILD_DISTRO="opensuse" BUILD_RELEASE="15.1" BUILD_STRING="opensuse/15.1"
         - PACKAGE_TYPE="rpm" REPO_TOOL="zypper"
         - ALLOW_SOFT_FAILURE_HERE=true
     # ###### End of packaging workflow section ###### #


### PR DESCRIPTION
##### Summary

As per title.

##### Component Name

- area/ci

##### Test Plan

- [ ] This PR itself and the resulting Travis CI run to build openSUSE 15.1 RPM packages.

##### Additional Information

I _think_ this was always wrong and just worked by accident :/

There seem to be no `openSUSE:15.0` upstream LXC Images anymore as of otday.