### PR TITLE
Cleans up cloud config files [agent_cloud_link] -> [cloud]

### DIFF
--- a/aclk/README.md
+++ b/aclk/README.md
@@ -13,7 +13,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/aclk/README.md
 In `netdata.conf`:
 
 ```ini
-[agent_cloud_link]
+[cloud]
     proxy = none
 ```
 

--- a/aclk/aclk_common.c
+++ b/aclk/aclk_common.c
@@ -124,7 +124,7 @@ static inline int check_http_enviroment(const char **proxy)
 
 const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type)
 {
-    const char *proxy = config_get(CONFIG_SECTION_ACLK, ACLK_PROXY_CONFIG_VAR, ACLK_PROXY_ENV);
+    const char *proxy = config_get(CONFIG_SECTION_CLOUD, ACLK_PROXY_CONFIG_VAR, ACLK_PROXY_ENV);
     *type = PROXY_DISABLED;
 
     if (strcmp(proxy, "none") == 0)

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -88,9 +88,9 @@ int _mqtt_lib_init()
 
     // show library info so can have it in the logfile
     //libmosq_version = mosquitto_lib_version(&libmosq_major, &libmosq_minor, &libmosq_revision);
-    ca_crt = config_get(CONFIG_SECTION_ACLK, "agent cloud link cert", "*");
-    server_crt = config_get(CONFIG_SECTION_ACLK, "agent cloud link server cert", "*");
-    server_key = config_get(CONFIG_SECTION_ACLK, "agent cloud link server key", "*");
+    ca_crt = config_get(CONFIG_SECTION_CLOUD, "link cert", "*");
+    server_crt = config_get(CONFIG_SECTION_CLOUD, "link server cert", "*");
+    server_key = config_get(CONFIG_SECTION_CLOUD, "link server key", "*");
 
     if (ca_crt[0] == '*') {
         freez(ca_crt);

--- a/claim/README.md
+++ b/claim/README.md
@@ -89,7 +89,7 @@ netdata-claim.sh -token=MYTOKEN1234567 -rooms=room1,room2 -proxy=socks5h://127.0
 
 When claiming via the `netdata` binary set the following options in the config:
 ```
-[agent_cloud_link]
+[cloud]
     proxy = socks5://X.X.X.X:YYYY
 ```
 Proceed to claim using the command-line syntax:

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -93,7 +93,6 @@
 #define CONFIG_SECTION_STREAM    "stream"
 #define CONFIG_SECTION_EXPORTING "exporting:global"
 #define CONFIG_SECTION_HOST_LABEL   "host labels"
-#define CONFIG_SECTION_ACLK        "agent_cloud_link"
 #define EXPORTING_CONF           "exporting.conf"
 
 // these are used to limit the configuration names and values lengths


### PR DESCRIPTION
##### Summary
Removes config section `[agent_cloud_link]` and move it's keys under `[cloud]` so that they are all in a common place.

##### Component Name

Agent/ACLK

##### Additional Information
@andrew I remember we wanted to put it all under `[cloud]` if not true just close this PR.

