### PR TITLE
Adds install-fake-charts.d.sh to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ tests/acls/acl.sh
 tests/urls/request.sh
 tests/alarm_repetition/alarm.sh
 tests/template_dimension/template_dim.sh
+aclk/tests/install-fake-charts.d.sh
 
 # tests and temp files
 test-driver


### PR DESCRIPTION

##### Summary

Commit `Fake collector to provoke ACLK messages` *(9ee4478f9a9eedbaff5887a415a897d984e74828)* misses adding this file to .gitignore
