### PR TITLE
Fix auto updates for static installs (kickstart_static64.sh)

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -250,7 +250,7 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
   fi
 
   # Do not pass any options other than the accept, for now
-  if sh "${TMPDIR}/netdata-latest.gz.run" --accept "${REINSTALL_OPTIONS}"; then
+  if sh "${TMPDIR}/netdata-latest.gz.run" --accept -- "${REINSTALL_OPTIONS}"; then
     rm -r "${TMPDIR}"
   else
     echo >&2 "NOTE: did not remove: ${TMPDIR}"


### PR DESCRIPTION
##### Summary

Fixes a longn standing bug with the static installation (`kickstart_static64.sh`)
where we use [Makeself](--auto-update) where we _were_ correctly reusing the
`REINSTALL_OPTIONS` we presist to `/etc/netdata/.environment`; but; we were not
passing this correctly to the embedded script inside the Makeself archive.

##### Component Name

- area/packaging

##### Test Plan

This is really hard to test because I have to fudge URL(s) everywhere to
properly test this e2e. So instead of doing that I tested the one piece
that was broken inside a VM by manually downloading the `netdata-nightlies/netdata-latest.gz.run`:

```sh
root@debian:~# curl -sSLO --connect-timeout 10 --retry 3 https://storage.googleapis.com/netdata-nightlies/netdata-latest.gz.run
root@debian:~# ls -lah
total 29M
drwx------  2 root root 4.0K Mar 27 06:57 .
drwxr-xr-x 18 root root 4.0K Mar 27 06:25 ..
-rw-------  1 root root 2.0K Mar 27 06:59 .bash_history
-rw-r--r--  1 root root  570 Jan 31  2010 .bashrc
-rw-r--r--  1 root root  29M Mar 27 07:05 netdata-latest.gz.run
-rw-r--r--  1 root root  148 Aug 18  2015 .profile
root@debian:~# netdata-latest.gz.run --help
-bash: netdata-latest.gz.run: command not found
root@debian:~# ./netdata-latest.gz.run --help
-bash: ./netdata-latest.gz.run: Permission denied
root@debian:~# ^C
root@debian:~#
root@debian:~# rm -rf *
root@debian:~#
root@debian:~# curl -sSLO --connect-timeout 10 --retry 3 https://storage.googleapis.com/netdata-nightlies/netdata-latest.gz.run
root@debian:~# ls -lah
total 29M
drwx------  2 root root 4.0K Mar 27 07:05 .
drwxr-xr-x 18 root root 4.0K Mar 27 06:25 ..
-rw-------  1 root root 2.0K Mar 27 06:59 .bash_history
-rw-r--r--  1 root root  570 Jan 31  2010 .bashrc
-rw-r--r--  1 root root  29M Mar 27 07:05 netdata-latest.gz.run
-rw-r--r--  1 root root  148 Aug 18  2015 .profile
root@debian:~# sh netdata-latest.gz.run --help

  ^
  |.-.   .-.   .-.   .-.   .  netdata
  |   '-'   '-'   '-'   '-'   real-time performance monitoring, done right!
  +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->

  (C) Copyright 2017, Costa Tsaousis
  All rights reserved
  Released under GPL v3+

  You are about to install netdata to this system.
  netdata will be installed at:

                    /opt/netdata

  The following changes will be made to your system:

  # USERS / GROUPS
  User 'netdata' and group 'netdata' will be added, if not present.

  # LOGROTATE
  This file will be installed if logrotate is present.

   - /etc/logrotate.d/netdata

  # SYSTEM INIT
  This file will be installed if this system runs with systemd:

   - /lib/systemd/system/netdata.service

   or, for older Centos, Debian/Ubuntu or OpenRC Gentoo:

   - /etc/init.d/netdata         will be created


  This package can also update a netdata installation that has been
  created with another version of it.

  Your netdata configuration will be retained.
  After installation, netdata will be (re-)started.

  netdata re-distributes a lot of open source software components.
  Check its full license at:
  https://github.com/netdata/netdata/blob/master/LICENSE.md

  Anonymous stat collection and reporting to Google Analytics is enabled
  by default. To disable, pass --disable-telemetry option to the installer
  or export the environment variable DO_NOT_TRACK to a non-zero or non-empty
  value (e.g export DO_NOT_TRACK=1).
Makeself version 2.3.1
 1) Getting help or info about netdata-latest.gz.run :
  netdata-latest.gz.run --help   Print this message
  netdata-latest.gz.run --info   Print embedded info : title, default target directory, embedded script ...
  netdata-latest.gz.run --lsm    Print embedded lsm entry (or no LSM)
  netdata-latest.gz.run --list   Print the list of files in the archive
  netdata-latest.gz.run --check  Checks integrity of the archive

 2) Running netdata-latest.gz.run :
  netdata-latest.gz.run [options] [--] [additional arguments to embedded script]
  with following options (in that order)
  --confirm             Ask before running embedded script
  --quiet		Do not print anything except error messages
  --accept              Accept the license
  --noexec              Do not run embedded script
  --keep                Do not erase target directory after running
			the embedded script
  --noprogress          Do not show the progress during the decompression
  --nox11               Do not spawn an xterm
  --nochown             Do not give the extracted files to the current user
  --nodiskspace         Do not check for available disk space
  --target dir          Extract directly to a target directory
                        directory path can be either absolute or relative
  --tar arg1 [arg2 ...] Access the contents of the archive through the tar command
  --                    Following arguments will be passed to the embedded script
root@debian:~# sh netdata-latest.gz.run --accept -- --auto-update

  ^
  |.-.   .-.   .-.   .-.   .  netdata
  |   '-'   '-'   '-'   '-'   real-time performance monitoring, done right!
  +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->

  (C) Copyright 2017, Costa Tsaousis
  All rights reserved
  Released under GPL v3+

  You are about to install netdata to this system.
  netdata will be installed at:

                    /opt/netdata

  The following changes will be made to your system:

  # USERS / GROUPS
  User 'netdata' and group 'netdata' will be added, if not present.

  # LOGROTATE
  This file will be installed if logrotate is present.

   - /etc/logrotate.d/netdata

  # SYSTEM INIT
  This file will be installed if this system runs with systemd:

   - /lib/systemd/system/netdata.service

   or, for older Centos, Debian/Ubuntu or OpenRC Gentoo:

   - /etc/init.d/netdata         will be created


  This package can also update a netdata installation that has been
  created with another version of it.

  Your netdata configuration will be retained.
  After installation, netdata will be (re-)started.

  netdata re-distributes a lot of open source software components.
  Check its full license at:
  https://github.com/netdata/netdata/blob/master/LICENSE.md
Creating directory /opt/netdata
Verifying archive integrity...  100%   All good.
Uncompressing netdata, the real-time performance and health monitoring system  100%
 --- Attempt to create user/group netdata/netadata ---
Group 'netdata' already exists.
User 'netdata' already exists.
 --- Add user netdata to required user groups ---
Group 'docker' does not exist.
 FAILED  Failed to add netdata user to secondary groups

Group 'nginx' does not exist.
 FAILED  Failed to add netdata user to secondary groups

Group 'varnish' does not exist.
 FAILED  Failed to add netdata user to secondary groups

Group 'haproxy' does not exist.
 FAILED  Failed to add netdata user to secondary groups

User 'netdata' is already in group 'adm'.
Group 'nsd' does not exist.
 FAILED  Failed to add netdata user to secondary groups

User 'netdata' is already in group 'proxy'.
Group 'squid' does not exist.
 FAILED  Failed to add netdata user to secondary groups

Group 'ceph' does not exist.
 FAILED  Failed to add netdata user to secondary groups

Group 'nobody' does not exist.
 FAILED  Failed to add netdata user to secondary groups

Group 'I2C' does not exist.
 FAILED  Failed to add netdata user to secondary groups

 --- Check SSL certificates paths ---
 --- Install logrotate configuration for netdata ---
[/opt/netdata]# chmod 644 /etc/logrotate.d/netdata
 OK

 --- Telemetry configuration ---
You can opt out from anonymous statistics via the --disable-telemetry option, or by creating an empty file /opt/netdata/etc/netdata/.opt-out-from-anonymous-statistics

 --- Install netdata at system init ---
Installing systemd service...
[/opt/netdata]# cp system/netdata.service /lib/systemd/system/netdata.service
 OK

[/opt/netdata]# systemctl daemon-reload
 OK

[/opt/netdata]# systemctl enable netdata
 OK

 --- Install (but not enable) netdata updater tool ---
Update script is located at /opt/netdata/usr/libexec/netdata/netdata-updater.sh

 --- Check if we must enable/disable the netdata updater tool ---
Adding to cron
Auto-updating has been enabled. Updater script linked to: /etc/cron.daily/netdata-updater

netdata-updater.sh works from cron. It will trigger an email from cron
only if it fails (it should not print anything when it can update netdata).
.
.
.
`

##### Additional Information