### PR TITLE
github/workflow: add ACLK to the labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,10 @@
 #
 # Please keep the labels sorted and deduplicated.
 
+ACLK:
+  - aclk/*
+  - aclk/**/*
+
 area/backends:
   - backends/*
   - backends/**/*


### PR DESCRIPTION


##### Summary

I noticed there are no labels in the https://github.com/netdata/netdata/pull/8499

This PR adds `aclk/` to the labeler config. 

##### Component Name

`.github/workflow`

##### Test Plan

No tests are needed


##### Additional Information
