### PR TITLE
charts.d.plugin: add keepalive to global_update

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -612,6 +612,12 @@ debug "run_charts='$run_charts'"
 
 [ -z "$run_charts" ] && fatal "No charts to collect data from."
 
+keepalive() {
+  if [ ! -t 1 ] && ! printf "\n"; then
+    chartsd_cleanup
+  fi
+}
+
 declare -A charts_last_update=() charts_update_every=() charts_retries=() charts_next_update=() charts_run_counter=() charts_serial_failures=()
 global_update() {
 	local exit_at \
@@ -642,6 +648,8 @@ global_update() {
 
 	# the main loop
 	while [ "${#next_charts[@]}" -gt 0 ]; do
+	  keepalive
+
 		c=$((c + 1))
 		now_charts=("${next_charts[@]}")
 		next_charts=()


### PR DESCRIPTION
### Summary

Fixes: #8448

`charts.d.plugin` doesnt exit on `SIGPIPE`.

```cmd
[root@localhost ~]# cat /etc/centos-release
CentOS release 6.10 (Final)
[root@localhost ~]# kill -9 $(pidof netdata)
[root@localhost ~]# ps faxu | grep ^netdata
netdata  20364  0.1  0.1  11568  1812 ?        S    18:34   0:00 bash /opt/netdata/usr/libexec/netdata/plugins.d/charts.d.plugin 1
netdata  20367  0.6  0.3  54312  3372 ?        S    18:34   0:00 /opt/netdata/usr/libexec/netdata/plugins.d/apps.plugin 1
```
___

Adding `PIPE` to [the list of trap signals](https://github.com/netdata/netdata/blob/74082011dfb7d3c33c7f2c972978b440666d2528/collectors/charts.d.plugin/charts.d.plugin.in#L28-L37) didnt work for me

So i added a keepalive function, it is executed in the beginning of every update loop.

It is simple `printf` exit code checking.

##### Component Name

`collectors/charts.d.plugin`

##### Test Plan

OS: CentOS release 6.10 (Final)

- [X] `kill -9 $(pidof netdata)` and make sure there is no `charts.d.plugin` in the `ps faxu | grep ^netdata` output



##### Additional Information
