### PR TITLE
Improve PRE step in our Docker build & install test cycles in CI

### DIFF
--- a/.github/dockerfiles/Dockerfile.build_test
+++ b/.github/dockerfiles/Dockerfile.build_test
@@ -4,7 +4,7 @@ FROM ${BASE}
 
 ARG PRE
 
-RUN /bin/sh -c 'if [ -n "${PRE}" ]; then /bin/sh -c "${PRE}"; if [ $? -ne 0 ]; then printf "ERROR: PRE failed:\n%s\n" "${PRE}"; exit 1; fi; fi'
+RUN if [ -n "${PRE}" ]; then /bin/sh -c "${PRE}"; if [ $? -ne 0 ]; then printf "ERROR: PRE failed:\n%s\n" "${PRE}"; exit 1; fi; fi
 
 WORKDIR /netdata
 COPY . .

--- a/.github/dockerfiles/Dockerfile.build_test
+++ b/.github/dockerfiles/Dockerfile.build_test
@@ -3,9 +3,10 @@ ARG BASE
 FROM ${BASE}
 
 ARG PRE
-ENV PRE=${PRE}
 
-COPY . /netdata
+RUN /bin/sh -c 'if [ -n "${PRE}" ]; then /bin/sh -c "${PRE}"; if [ $? -ne 0 ]; then printf "ERROR: PRE failed:\n%s\n" "${PRE}"; exit 1; fi; fi'
 
-RUN /bin/sh /netdata/prep-cmd.sh
+WORKDIR /netdata
+COPY . .
+
 RUN /netdata/packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata-all

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -71,14 +71,16 @@ jobs:
       - name: Git clone repository
         uses: actions/checkout@v2
       - name: install-required-packages.sh on ${{ matrix.distro }}
-        env:
-          PRE: ${{ matrix.pre }}
         run: |
-          echo $PRE > ./prep-cmd.sh
-          docker build . -f .github/dockerfiles/Dockerfile.build_test -t build_test --build-arg BASE=${{ matrix.distro }}
+          docker build \
+            -f .github/dockerfiles/Dockerfile.build_test \
+            -t build_test \
+            --build-arg BASE=${{ matrix.distro }} \
+            --build-arg PRE='${{ matrix.pre }}' \
+            .
       - name: Regular build on ${{ matrix.distro }}
         run: |
-          docker run --rm -e PRE -w /netdata build_test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
+          docker run --rm build_test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
       - name: netdata-installer on ${{ matrix.distro }}
         run: |
-          docker run --rm -e PRE -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it'
+          docker run --rm build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it'

--- a/foo.sh
+++ b/foo.sh
@@ -1,0 +1,7 @@
+#/bin/sh
+
+if [ ! -t 1 ] && ! printf "\n"; then
+  echo "foo"
+else
+  echo "bar"
+fi

--- a/foo.sh
+++ b/foo.sh
@@ -1,7 +1,0 @@
-#/bin/sh
-
-if [ ! -t 1 ] && ! printf "\n"; then
-  echo "foo"
-else
-  echo "bar"
-fi


### PR DESCRIPTION
##### Summary

As per title

##### Component Name

- area/ci

##### Test Plan

```#!sh
prologic@Jamess-iMac
Mon Mar 30 12:34:43
~/NetData/netdata
 (master) 0
$ docker build -f .github/dockerfiles/Dockerfile.build_test -t build_test --build-arg BASE=alpine:edge --build-arg PRE='apk update && apk add foobarbaz' .
Sending build context to Docker daemon  78.22MB
Step 1/7 : ARG BASE
Step 2/7 : FROM ${BASE}
 ---> 24cae4d038c0
Step 3/7 : ARG PRE
 ---> Using cache
 ---> 3b7c22be0c8c
Step 4/7 : RUN /bin/sh -c 'if [ -n "${PRE}" ]; then /bin/sh -c "${PRE}"; if [ $? -ne 0 ]; then printf "ERROR: PRE failed:\n%s\n" "${PRE}"; exit 1; fi; fi'
 ---> Running in bcbc26258d70
fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
v20200319-637-gded33d3894 [http://dl-cdn.alpinelinux.org/alpine/edge/main]
v20200319-636-gde74aecdb9 [http://dl-cdn.alpinelinux.org/alpine/edge/community]
OK: 12098 distinct packages available
  foobarbaz (missing):
ERROR: unsatisfiable constraints:
    required by: world[foobarbaz]
ERROR: PRE failed:
apk update && apk add foobarbaz
The command '/bin/sh -c /bin/sh -c 'if [ -n "${PRE}" ]; then /bin/sh -c "${PRE}"; if [ $? -ne 0 ]; then printf "ERROR: PRE failed:\n%s\n" "${PRE}"; exit 1; fi; fi'' returned a non-zero code: 1
```

- [x] Test no `PRE`.
- [x] Test a valid `PRE`.
- [x] Test a more complex `PRE`.
- [x] Test an invalid `PRE` that fails.

##### Additional Information

Note that we should ideally not be creating files in the repository during CI
if we can avoid it that aren't Git ignored. We can do without the `echo $PRE > /netdata/prep-cmd.sh` step altogether.