### PR TITLE
Fixed unicode decode in internal JSON parser

### DIFF
--- a/libnetdata/json/jsmn.c
+++ b/libnetdata/json/jsmn.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 
+#include "../libnetdata.h"
 #include "jsmn.h"
 
 /**
@@ -114,7 +115,7 @@ static jsmnerr_t jsmn_parse_primitive(jsmn_parser *parser, const char *js,
  *
  * @return It returns 0 on success and another integer otherwise
  */
-static jsmnerr_t jsmn_parse_string(jsmn_parser *parser, const char *js,
+static jsmnerr_t jsmn_parse_string(jsmn_parser *parser, char *js,
                                    size_t len, jsmntok_t *tokens, size_t num_tokens) {
     jsmntok_t *token;
 
@@ -145,6 +146,7 @@ static jsmnerr_t jsmn_parse_string(jsmn_parser *parser, const char *js,
 
         /* Backslash: Quoted symbol expected */
         if (c == '\\') {
+            long unicode_char = 0;
             parser->pos++;
             switch (js[parser->pos]) {
                 /* Allowed escaped symbols */
@@ -157,15 +159,30 @@ static jsmnerr_t jsmn_parse_string(jsmn_parser *parser, const char *js,
                     int i = 0;
                     for(; i < 4 && js[parser->pos] != '\0'; i++) {
                         /* If it isn't a hex character we have an error */
-                        if(!((js[parser->pos] >= 48 && js[parser->pos] <= 57) || /* 0-9 */
-                             (js[parser->pos] >= 65 && js[parser->pos] <= 70) || /* A-F */
-                             (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
-                            parser->pos = start;
-                            return JSMN_ERROR_INVAL;
+                        unicode_char = unicode_char << 4;
+                        switch (js[parser->pos]) {
+                            case 48 ... 57: /* 0-9 */
+                                unicode_char += (js[parser->pos] - 48);
+                                break;
+                            case 65 ... 70: /* A-F */
+                                unicode_char += (js[parser->pos] - 55);
+                                break;
+                            case 97 ... 102: /* a-f */
+                                unicode_char += (js[parser->pos] - 87);
+                                break;
+                            default:
+                                parser->pos = start;
+                                return JSMN_ERROR_INVAL;
                         }
                         parser->pos++;
                     }
-                    parser->pos--;
+                    js[parser->pos-6] = (char) unicode_char;
+                    char *tmp = &js[parser->pos-1];
+                    while (*tmp) {
+                        *(tmp - 4) = *(tmp + 1);
+                        tmp++;
+                    }
+                    parser->pos = parser->pos - 5;
                     break;
                     /* Unexpected symbol */
                 default:

--- a/libnetdata/json/jsmn.c
+++ b/libnetdata/json/jsmn.c
@@ -218,13 +218,12 @@ static jsmnerr_t jsmn_parse_string(jsmn_parser *parser, char *js,
                     }
                     // The last character on unicode
                     char *tmp = &js[parser->pos-1];
-
                     // unicode symbol exists from parser (pos - 4, pos - 1)
                     // should be written on pos - 6
                     parser->pos = parser->pos - 6;
                     // position will be on last valid character and it will advanced
-                    parser->pos = parser->pos + output_characters(js[parser->pos], unicode_char);
-                    char *dest = js[parser->pos];
+                    parser->pos = parser->pos + output_characters(&js[parser->pos], unicode_char);
+                    char *dest = &js[parser->pos];
                     while (*tmp) {
                         *dest = *(tmp + 1);
                         tmp++;

--- a/libnetdata/json/jsmn.h
+++ b/libnetdata/json/jsmn.h
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2010 Serge Zaitsev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 #ifndef __JSMN_H_
 #define __JSMN_H_
 

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -6,6 +6,115 @@
 
 #define JSON_TOKENS 1024
 
+static inline char *output_characters(char *wstr, long unicode_char)
+{
+    char c1=0, c2=0, c3=0, c4=0;
+    int print_size=0;
+
+    if (unicode_char < 0x80) {
+        c1 = (unicode_char >> 0 & 0x7F | 0x00);
+        print_size = sprintf(wstr, "%%%2x", c1);
+    }
+    else if (unicode_char < 0x0800) {
+        c1 = (unicode_char >> 6 & 0x1F | 0xc0);
+        c2 = (unicode_char >> 0 & 0x3F | 0x80);
+        print_size = sprintf(wstr, "%%%2x%%%2x", c1, c2);
+    }
+    else if (unicode_char < 0x010000) {
+        c1 = (unicode_char >> 12 & 0x0F | 0xE0);
+        c2 = (unicode_char >> 6 & 0x3F | 0x80);
+        c3 = (unicode_char >> 0 & 0x3F | 0x80);
+        print_size = sprintf(wstr, "%%%2x%%%2x%%%2x", c1, c2, c3);
+    } else {
+        c1 = (unicode_char >> 18 & 0x07 | 0xF0);
+        c2 = (unicode_char >> 12 & 0x3F | 0x80);
+        c3 = (unicode_char >> 6 & 0x3F | 0x80);
+        c4 = (unicode_char >> 0 & 0x3F | 0x80);
+        print_size = sprintf(wstr, "%%%2x%%%2x%%%2x%%%2x", c1, c2, c3, c4);
+    }
+    return wstr + print_size;
+}
+
+char *decode_string(char *input)
+{
+    size_t len = strlen(input) * 2;
+    char *tmp = input;
+    char *wstr = (char *) mallocz(len + 1);
+    char *output = wstr;
+
+    while (*tmp) {
+        /* Backslash: Quoted symbol expected */
+        if (*tmp == '\\') {
+            long unicode_char = 0;
+            tmp++;
+            switch (*tmp) {
+                /* Allowed escaped symbols */
+                case '\"':
+                case '/':
+                case '\\':
+                    *wstr++ = *tmp;
+                    break;
+                case 'b':
+                    *wstr++ = '\b';
+                    break;
+                case 'f':
+                    *wstr++ = '\f';
+                    break;
+                case 'r':
+                    *wstr++ = '\r';
+                    break;
+                case 'n':
+                    *wstr++ = '\n';
+                    break;
+                case 't':
+                    *wstr++ = '\t';
+                    break;
+                    /* Allows escaped symbol \uXXXX */
+                case 'u':
+                    tmp++;
+                    int i = 0;
+                    for (; i < 4 && *tmp != '\0'; i++) {
+                        /* If it isn't a hex character we have an error */
+                        unicode_char = unicode_char << 4;
+                        switch (*tmp) {
+                            case 48 ... 57: /* 0-9 */
+                                unicode_char += (*tmp - 48);
+                                break;
+                            case 65 ... 70: /* A-F */
+                                unicode_char += (*tmp - 55);
+                                break;
+                            case 97 ... 102: /* a-f */
+                                unicode_char += (*tmp - 87);
+                                break;
+                            default:
+                                // Parser has checked that this won't happen
+                                break;
+                        }
+                        tmp++;
+                    }
+                    tmp--;
+                    // Need at most 12 bytes + \0. We will add more to have room
+                    if (wstr - output + 13 > len) {
+                        int offset = wstr - output;
+                        len = len + 32;
+                        output = reallocz(output, len + 1);
+                        wstr = output + offset;
+                    }
+                    wstr = output_characters(wstr, unicode_char);
+                    break;
+                    /* Unexpected symbol */
+                default:
+                    break;
+            }
+            tmp++;
+        }
+        else
+            *wstr++ = *tmp++;
+    }
+    *wstr = '\0';
+    return output;
+}
+
 int json_tokens = JSON_TOKENS;
 
 /**
@@ -224,8 +333,10 @@ size_t json_walk_string(char *js, jsmntok_t *t, size_t start, JSON_ENTRY *e)
     e->original_string = &js[t[start].start];
 
     e->type = JSON_STRING;
-    e->data.string = e->original_string;
-    if(e->callback_function) e->callback_function(e);
+    e->data.string = decode_string(e->original_string);
+    if (e->callback_function)
+        e->callback_function(e);
+    freez(e->data.string);
     js[t[start].end] = old;
     return 1;
 }


### PR DESCRIPTION
Fixes #8480 
##### Summary
The internal JSON parser identified \uxxxx type symbols but no decoding was done. This affected the way incoming ACLK queries were handled as they contain `\u0026` which should be decoded to `&` (to form valid URLs)
##### Component Name
ACLK

##### Test Plan
###### To replicate the problem before PR is applied
- Make sure `libjson-c-dev` dependency is not installed in your system
- Compile an ACLK enabled and claimed agent with `-DNETDATA_INTERNAL_CHECKS`
- Activate the `D_ACLK` flag (`debug flags = 0x0000000200000000`) in `netdata.conf`
- Start the agent and go to view charts in the dev cloud or local environment
- Monitor the `debug.log` for incoming cloud requests
- Notice an incoming payload of the form
  `"payload":"/api/v1/data?chart=system.load\u0026_=1585549971725 ... ` followed by an added query in the form
  `/api/v1/data?chart=system.load\u0026_=1585549971725 ...`
  This will fail as the webapi will not handle the `\u0026` properly.

####### To test the fix
- Compile the PR with the proposed fix
- Restart the agent (ACLK enabled and claimed as above)  and go to view charts in the dev cloud or local environment
- Notice an incoming payload of the form
  `"payload":"/api/v1/data?chart=system.load\u0026_=1585549971725 ... ` followed by an added query in the form
  `/api/v1/data?chart=system.load&_=1585549971725 ...`
  which is now correctly handled by the webapi

##### Additional Information
