### PR TITLE
Write the failure reason during ACLK challenge / response

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1209,7 +1209,7 @@ void aclk_get_challenge(char *aclk_hostname, char *aclk_port)
     info("Retrieving challenge from cloud: %s %s %s", aclk_hostname, aclk_port, url);
     if(aclk_send_https_request("GET", aclk_hostname, aclk_port, url, data_buffer, NETDATA_WEB_RESPONSE_INITIAL_SIZE, NULL))
     {
-        error("Challenge failed");
+        error("Challenge failed: %s", data_buffer);
         goto CLEANUP;
     }
     struct dictionary_singleton challenge = { .key = "challenge", .result = NULL };
@@ -1246,7 +1246,7 @@ void aclk_get_challenge(char *aclk_hostname, char *aclk_port)
     sprintf(url, "/api/v1/auth/node/%s/password", agent_id);
     if(aclk_send_https_request("POST", aclk_hostname, aclk_port, url, data_buffer, NETDATA_WEB_RESPONSE_INITIAL_SIZE, response_json))
     {
-        error("Challenge-response failed");
+        error("Challenge-response failed: %s", data_buffer);
         goto CLEANUP;
     }
 


### PR DESCRIPTION
##### Summary
Log the reason of the ACLK challenge  / failure. Right now when the initial challenge fails the `error.log` shows `Challenge failed`

In the case of password failure it says `Challenge-response failed`

##### Component Name
ACLK

##### Test Plan
The `error.log` now contains the cloud response as follows (example) :

##### In case of node not found

```
Challenge failed: {"errorCode":"TODO traceid","errorMsgKey":"ErrNodeNotFound","errorMessage":"node not found"}
```

##### In case of wrong challenge (password)
```
Challenge-response failed: {"errorCode":"TODO trace-id","errorMsgKey":"ErrIncorrectResponse","errorMessage":"incorrect challenge response"}
```
