### PR TITLE
Add alarms_values under components

### DIFF
--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -873,7 +873,8 @@
             "schema": {
               "type": "boolean"
             }
-        ],
+          }
+          ],
         "responses": {
           "200": {
             "description": "An object containing general info and a linked list of alarms.",
@@ -1363,6 +1364,30 @@
             "type": "number",
             "nullable": true,
             "description": "Chart health red threshold."
+          }
+        }
+      },
+      "alarms_values": {
+        "type": "object",
+        "properties": {
+          "hostname": {
+            "type": "string",
+            "description": "The hostname of the netdata server."
+          },
+          "chart-name.alarm-name": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "value": {
+                "type": "number"
+              },
+              "status": {
+                "type": "string"
+              }
+            }
           }
         }
       },

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -874,7 +874,7 @@
               "type": "boolean"
             }
           }
-          ],
+        ],
         "responses": {
           "200": {
             "description": "An object containing general info and a linked list of alarms.",

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -1107,6 +1107,22 @@ components:
           type: number
           nullable: true
           description: Chart health red threshold.
+    alarms_values:
+      type: object
+      properties:
+        hostname:
+          type: string
+          description: The hostname of the netdata server.
+        chart-name.alarm-name:
+          type: object
+          properties:
+            id:
+              type: integer
+              format: int32
+            value:
+              type: number
+            status:
+              type: string
     alarm_variables:
       type: object
       properties:


### PR DESCRIPTION
Fixes #8512

##### Summary
Fixes `alarms_values` parsing error 

```
Parser error missed comma between flow collection entries
Jump to line 876
```

and adds the `alarms_values` schema component that is missing
##### Component Name
Web, Docs
##### Test Plan
To verify the error follow

https://editor.swagger.io/?url=https://raw.githubusercontent.com/netdata/netdata/master/web/api/netdata-swagger.json

To check the fix follow

https://editor.swagger.io/?url=https://raw.githubusercontent.com/stelfrag/netdata/fix_swagger_documentation_error/web/api/netdata-swagger.json
