### PR TITLE
Fixes build if --cloud-testing set but LWS build fails

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -470,11 +470,11 @@ BACKENDS_PLUGIN_FILES = \
 CLAIM_PLUGIN_FILES = \
     claim/claim.c \
     claim/claim.h \
+    aclk/aclk_common.c \
+    aclk/aclk_common.h \
     $(NULL)
 
 ACLK_PLUGIN_FILES = \
-    aclk/aclk_common.c \
-    aclk/aclk_common.h \
     aclk/agent_cloud_link.c \
     aclk/agent_cloud_link.h \
     aclk/mqtt.c \


### PR DESCRIPTION
##### Summary

There was regression detected with last commits. If `--cloud-testing` flag is enabled and libwebsockets build fails `config.h` looks following:
```C
/* netdata ACLK */
/* #undef ENABLE_ACLK */

/* netdata cloud functionality */
#define ENABLE_CLOUD 1
```

This disables following in `claim.c`:
```C
void claim_agent(char *claiming_arguments)
{
#ifndef ENABLE_CLOUD
    info("The claiming feature has been disabled");
    return;
#endif
```

which hides the problem (as CI doesn't enable cloud flag) of claim_agent now being dependent on `aclk_decode_base_url` from `aclk_common.h` which is built only when `ENABLE_ACLK` is set.

SOLUTION:
when claim.c is built also `aclk_common.[ch]` must be built regardless of `ENABLE_CLOUD` define *(at least if ENABLE_CLOUD is set)*


##### Component Name

##### Test Plan
modify installer to fail LWS dependency build at line `550` from
```bash
  if fetch_and_verify "libwebsockets" \
                      "https://github.com/warmcat/libwebsockets/archive/${LIBWEBSOCKETS_PACKAGE_BASENAME}" \
                      "${LIBWEBSOCKETS_PACKAGE_BASENAME}" \
                      "${tmp}" \
                      "${NETDATA_LOCAL_TARBALL_OVERRIDE_LIBWEBSOCKETS}"
```
to
```bash
if false
```

run the installer with `--cloud-testing`

##### Additional Information
