### PR TITLE
apache: fix `bytespersec` chart context

### DIFF
--- a/collectors/python.d.plugin/apache/apache.chart.py
+++ b/collectors/python.d.plugin/apache/apache.chart.py
@@ -37,7 +37,7 @@ CHARTS = {
         ]},
     'bytespersec': {
         'options': [None, 'Lifetime Avg. Bandwidth/s', 'kilobits/s', 'statistics',
-                    'apache.bytesperreq', 'area'],
+                    'apache.bytespersec', 'area'],
         'lines': [
             ['size_sec', None, 'absolute', 8, 1000 * 100000]
         ]},


### PR DESCRIPTION
##### Summary

This PR fixes python apache collector chart `bytespersec` context

`apache.bytesperreq` => `apache.bytespersec`

##### Component Name

`collectors/python.d`

##### Test Plan

Test are not needed, the change is trivial

##### Additional Information
