### PR TITLE
github/workflow: remove duplicate key (`line-length`) from the yamlli…

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -25,7 +25,6 @@ rules:
   indentation: enable
   key-duplicates: enable
   key-ordering: disable
-  line-length: disable
   new-line-at-end-of-file: enable
   new-lines: enable
   octal-values: enable


### PR DESCRIPTION
##### Summary

Was doing the change in #8542 via github ui (it is wrong i know!), didnt notice the option is already in there.


##### Component Name

`ci`

##### Test Plan

No tests needed

##### Additional Information
