### PR TITLE
Fix broken pipe ignoring in apps plugin

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -4173,6 +4173,9 @@ int main(int argc, char **argv) {
         usec_t dt = heartbeat_next(&hb, step);
 #endif
 
+        if (unlikely(write(fileno(stdout), "\n", 1) < 1 && errno == EPIPE))
+            fatal("Cannot write to a pipe");
+
         if(!collect_data_for_all_processes()) {
             error("Cannot collect /proc data for running processes. Disabling apps.plugin...");
             printf("DISABLE\n");

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -4173,7 +4173,10 @@ int main(int argc, char **argv) {
         usec_t dt = heartbeat_next(&hb, step);
 #endif
 
-        if (unlikely(write(fileno(stdout), "\n", 1) < 1 && errno == EPIPE))
+        struct pollfd pollfd = { .fd = fileno(stdout), .events = POLLERR };
+        if (unlikely(poll(&pollfd, 1, 0) < 0))
+            fatal("Cannot check if a pipe is available");
+        if (unlikely(pollfd.revents & POLLERR))
             fatal("Cannot write to a pipe");
 
         if(!collect_data_for_all_processes()) {


### PR DESCRIPTION
##### Summary
Apps plugin never died if a pipe to netdata was broken.

Fixes #8530

##### Component Name
apps plugin

##### Test Plan
Kill `netdata` with `SIGKILL` in CentOS 6.10 - `apps.plugin` should stop.