### PR TITLE
Added logic to bail early on LWS build if cmake is not present.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -536,6 +536,12 @@ bundle_libwebsockets() {
     return 0
   fi
 
+  if [ -z "$(command -v cmake)" ] ; then
+    run_failed "Could not find cmake, which is required to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+    defer_error_highlighted "Could not find cmake, which is required to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+    return 0
+  fi
+
   progress "Prepare libwebsockets"
 
   LIBWEBSOCKETS_PACKAGE_VERSION="$(cat packaging/libwebsockets.version)"


### PR DESCRIPTION
##### Summary

This adds some basic logic to the installer to check if `cmake` is present or not and just skip attempting to build lbwebsockets.

##### Component Name

area/packaging

##### Test Plan

Verified locally by checking in Docker containers that it behaves correctly.

##### Additional Information

Fixes: #8558 