### PR TITLE
Fix compiler warnings in the claiming code

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -107,8 +107,8 @@ void claim_agent(char *claiming_arguments)
     error("Agent failed to be claimed with the following error message:");
     error("\"%s\"", claiming_errors[exit_code]);
 #else
-    (void)claiming_arguments;
-    (void)claiming_errors;
+    UNUSED(claiming_arguments);
+    UNUSED(claiming_errors);
 #endif
 }
 

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -25,7 +25,6 @@ static char *claiming_errors[] = {
         "Service Unavailable"                           // 15
 };
 
-
 static char *claimed_id = NULL;
 
 char *is_agent_claimed(void)
@@ -107,6 +106,9 @@ void claim_agent(char *claiming_arguments)
     }
     error("Agent failed to be claimed with the following error message:");
     error("\"%s\"", claiming_errors[exit_code]);
+#else
+    (void)claiming_arguments;
+    (void)claiming_errors;
 #endif
 }
 


### PR DESCRIPTION
#### Summary
When the `--disable-cloud` option is used to build Netdata there are compiler warnings
```
claim/claim.c: In function 'claim_agent':
claim/claim.c:42:24: warning: unused parameter 'claiming_arguments' [-Wunused-parameter]
   42 | void claim_agent(char *claiming_arguments)
      |                  ~~~~~~^~~~~~~~~~~~~~~~~~
At top level:
claim/claim.c:9:14: warning: 'claiming_errors' defined but not used [-Wunused-variable]
    9 | static char *claiming_errors[] = {
      |  
```

##### Component Name
cloud

##### Test Plan
Run `sudo ./netdata-installer.sh --disable-cloud`. 