### PR TITLE
Fix regressions in cloud functionality (build, CI, claiming)

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -18,7 +18,6 @@ jobs:
           - 'archlinux:latest'
           - 'centos:8'
           - 'centos:7'
-          - 'centos:6'
           - 'debian:bullseye'
           - 'debian:buster'
           - 'debian:stretch'

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -74,13 +74,13 @@ jobs:
           PRE: ${{ matrix.pre }}
         run: |
           echo $PRE > ./prep-cmd.sh
-          docker build . -f .github/dockerfiles/Dockerfile.build_test -t build_test --build-arg BASE=${{ matrix.distro }}
+          docker build . -f .github/dockerfiles/Dockerfile.build_test -t test --build-arg BASE=${{ matrix.distro }}
       - name: Regular build on ${{ matrix.distro }}
         run: |
-          docker run --rm -w /netdata build_test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
+          docker run -w /netdata test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
       - name: netdata-installer on ${{ matrix.distro }}
         run: |
-          docker run --rm -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --disable-cloud'
+          docker run -w /netdata test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --disable-cloud'
       - name: netdata-installer on ${{ matrix.distro }}
         run: |
-          docker run --rm -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'
+          docker run -w /netdata test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -78,7 +78,10 @@ jobs:
           docker build . -f .github/dockerfiles/Dockerfile.build_test -t build_test --build-arg BASE=${{ matrix.distro }}
       - name: Regular build on ${{ matrix.distro }}
         run: |
-          docker run --rm -e PRE -w /netdata build_test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
+          docker run --rm -w /netdata build_test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
       - name: netdata-installer on ${{ matrix.distro }}
         run: |
-          docker run --rm -e PRE -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it'
+          docker run --rm -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --disable-cloud'
+      - name: netdata-installer on ${{ matrix.distro }}
+        run: |
+          docker run --rm -w /netdata build_test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -109,7 +109,7 @@ RELOAD=1
 NETDATA_USER=netdata
 [ -z "$EUID" ] && EUID="$(id -u)"
 
-CONF_USER=$(grep '^[^#]*run as user[ \t]*=' "${NETDATA_USER_CONFIG_DIR}/netdata.conf" 2>/dev/null)
+CONF_USER=$(grep '^[ \t#]*run as user[ \t]*=' "${NETDATA_USER_CONFIG_DIR}/netdata.conf" 2>/dev/null)
 if [ -n "$CONF_USER" ]; then
     NETDATA_USER=$(echo "$CONF_USER" | sed 's/^[^=]*=[ \t]*//' | sed 's/[ \t]*$//')
 fi

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -109,7 +109,7 @@ RELOAD=1
 NETDATA_USER=netdata
 [ -z "$EUID" ] && EUID="$(id -u)"
 
-CONF_USER=$(grep '^[ \t#]*run as user[ \t]*=' "${NETDATA_USER_CONFIG_DIR}/netdata.conf" 2>/dev/null)
+CONF_USER=$(grep '^[ 	#]*run as user[ 	]*=' "${NETDATA_USER_CONFIG_DIR}/netdata.conf" 2>/dev/null)
 if [ -n "$CONF_USER" ]; then
     NETDATA_USER=$(echo "$CONF_USER" | sed 's/^[^=]*=[ \t]*//' | sed 's/[ \t]*$//')
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -174,11 +174,9 @@ AC_ARG_ENABLE(
 )
 
 aclk_required="${enable_cloud}"
-AC_MSG_CHECKING([if cloud functionality should be enabled])
 if test "${enable_cloud}" = "no"; then
     AC_DEFINE([DISABLE_CLOUD], [1], [disable netdata cloud functionality])
 fi
-AC_MSG_RESULT([${enable_cloud}])
 
 # -----------------------------------------------------------------------------
 # netdata required checks
@@ -553,6 +551,8 @@ AM_CONDITIONAL([ENABLE_CAPABILITY], [test "${with_libcap}" = "yes"])
 # -----------------------------------------------------------------------------
 # ACLK
 
+AC_MSG_CHECKING([if cloud functionality should be enabled])
+AC_MSG_RESULT([${enable_cloud}])
 if test "$enable_cloud" != "no"; then
     # just to have all messages that can fail ACLK build in one place
     # so it is easier to see why it can't be built

--- a/configure.ac
+++ b/configure.ac
@@ -170,15 +170,13 @@ AC_ARG_ENABLE(
     [AS_HELP_STRING([--disable-cloud],
                     [Disables all cloud functionality])],
     [ enable_cloud="$enableval" ],
-    [ enable_cloud="yes" ]
+    [ enable_cloud="detect" ]
 )
 
+aclk_required="${enable_cloud}"
 AC_MSG_CHECKING([if cloud functionality should be enabled])
 if test "${enable_cloud}" = "no"; then
     AC_DEFINE([DISABLE_CLOUD], [1], [disable netdata cloud functionality])
-    aclk_required="no"
-else
-    aclk_required="detect"
 fi
 AC_MSG_RESULT([${enable_cloud}])
 
@@ -555,17 +553,28 @@ AM_CONDITIONAL([ENABLE_CAPABILITY], [test "${with_libcap}" = "yes"])
 # -----------------------------------------------------------------------------
 # ACLK
 
-if test "$enable_cloud" = "yes"; then
+if test "$enable_cloud" != "no"; then
+    # just to have all messages that can fail ACLK build in one place
+    # so it is easier to see why it can't be built
+    if test -n "${SSL_LIBS}"; then
+        OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
+        OPTIONAL_SSL_LIBS="${SSL_LIBS}"
+    else
+        AC_MSG_WARN([OpenSSL required for agent-cloud-link but not found. Try installing 'libssl-dev' or 'openssl-devel'.])
+    fi
+
     AC_MSG_CHECKING([if libmosquitto static lib is present (and builds)])
     if test -f "externaldeps/mosquitto/libmosquitto.a"; then
-        LIBS_SAVES="$LIBS"
-        LIBS="externaldeps/mosquitto/libmosquitto.a"
-        AC_LINK_IFELSE([AC_LANG_SOURCE([[int main (int argc, char **argv)) {
+        LIBS_BKP="${LIBS}"
+        LIBS="externaldeps/mosquitto/libmosquitto.a ${OPTIONAL_SSL_LIBS}"
+        AC_LINK_IFELSE([AC_LANG_SOURCE([[#include "externaldeps/mosquitto/mosquitto.h"
+                                         int main (int argc, char **argv) {
                                              int m,mm,r;
                                              mosquitto_lib_version(&m, &mm, &r);
-                                         }]]),
+                                         }]])],
                                         [HAVE_libmosquitto_a="yes"],
-                                        [HAVE_libmosquitto_a="no"]])
+                                        [HAVE_libmosquitto_a="no"])
+        LIBS="${LIBS_BKP}"
     else
         HAVE_libmosquitto_a="no"
         AC_DEFINE([ACLK_NO_LIBMOSQ], [1], [Libmosquitto.a was not found during build.])
@@ -584,7 +593,7 @@ if test "$enable_cloud" = "yes"; then
 
     if test "${build_target}" = "linux" -a "${aclk_required}" != "no"; then
         if test "${have_libcap}" = "yes" -a "${with_libcap}" = "no"; then
-            AC_MSG_ERROR([agent-cloud-link can't be built without libcap. Disable it by --disable-aclk or enable libcap])
+            AC_MSG_ERROR([agent-cloud-link can't be built without libcap. Disable it by --disable-cloud or enable libcap])
         fi
         if test "${with_libcap}" = "yes"; then
             LWS_LIBS+=" -lcap"
@@ -592,7 +601,7 @@ if test "$enable_cloud" = "yes"; then
     fi
 
     AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
-    if test "${HAVE_libmosquitto_a}" = "yes" -a "${HAVE_libwebsockets_a}" = "yes"; then
+    if test "${HAVE_libmosquitto_a}" = "yes" -a "${HAVE_libwebsockets_a}" = "yes" -a -n "${SSL_LIBS}"; then
         can_enable_aclk="yes"
     else
         can_enable_aclk="no"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -282,7 +282,7 @@ while [ -n "${1}" ]; do
     "--enable-ebpf") NETDATA_ENABLE_EBPF=1 ;;
     "--disable-cloud")
       if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
-        echo "Cloud explicitly enabled, not re-enabling it"
+        echo "Cloud explicitly enabled, ignoring --disable-cloud."
       else
         NETDATA_DISABLE_CLOUD=1
         NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
@@ -290,7 +290,7 @@ while [ -n "${1}" ]; do
       ;;
     "--require-cloud")
       if [ -n "${NETDATA_DISABLE_CLOUD}" ] ; then
-        echo "Cloud explicitly disabled, not re-enabling it"
+        echo "Cloud explicitly disabled, ignoring --require-cloud."
       else
         NETDATA_REQUIRE_CLOUD=1
         NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-aclk/} --enable-aclk"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -285,7 +285,7 @@ while [ -n "${1}" ]; do
         echo "Cloud explicitly enabled, ignoring --disable-cloud."
       else
         NETDATA_DISABLE_CLOUD=1
-        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-cloud/} --disable-cloud"
       fi
       ;;
     "--require-cloud")
@@ -293,7 +293,7 @@ while [ -n "${1}" ]; do
         echo "Cloud explicitly disabled, ignoring --require-cloud."
       else
         NETDATA_REQUIRE_CLOUD=1
-        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-aclk/} --enable-aclk"
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-cloud/} --enable-cloud"
       fi
       ;;
     "--install")

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -193,7 +193,8 @@ USAGE: ${PROGRAM} [options]
                              This results in more frequent updates.
   --disable-go               Disable installation of go.d.plugin.
   --enable-ebpf              Enable eBPF Kernel plugin (Default: disabled, feature preview)
-  --disable-cloud            Disable all cloud functionality.
+  --disable-cloud            Disable all Netdata Cloud functionality.
+  --require-cloud            Fail the install if it can't build Netdata Cloud support.
   --enable-plugin-freeipmi   Enable the FreeIPMI plugin. Default: enable it when libipmimonitoring is available.
   --disable-plugin-freeipmi
   --disable-https            Explicitly disable TLS support
@@ -280,8 +281,20 @@ while [ -n "${1}" ]; do
     "--disable-go") NETDATA_DISABLE_GO=1 ;;
     "--enable-ebpf") NETDATA_ENABLE_EBPF=1 ;;
     "--disable-cloud")
-      NETDATA_DISABLE_CLOUD=1
-      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-cloud/} --disable-cloud"
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+        echo "Cloud explicitly enabled, not re-enabling it"
+      else
+        NETDATA_DISABLE_CLOUD=1
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-aclk/} --disable-aclk"
+      fi
+      ;;
+    "--require-cloud")
+      if [ -n "${NETDATA_DISABLE_CLOUD}" ] ; then
+        echo "Cloud explicitly disabled, not re-enabling it"
+      else
+        NETDATA_REQUIRE_CLOUD=1
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-aclk/} --enable-aclk"
+      fi
       ;;
     "--install")
       NETDATA_PREFIX="${2}/netdata"
@@ -502,12 +515,20 @@ bundle_libmosquitto() {
     then
       run_ok "libmosquitto built and prepared."
     else
-      run_failed "Failed to build libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
-      defer_error_highlighted "Failed to build libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
+      run_failed "Failed to build libmosquitto."
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+        exit 1
+      else
+        defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
+      fi
     fi
   else
-    run_failed "Unable to fetch sources for libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
-    defer_error_highlighted "Unable to fetch sources for libmosquitto. The install process will continue, but you will not be able to connect this node to Netdata Cloud."
+    run_failed "Unable to fetch sources for libmosquitto."
+    if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+      exit 1
+    else
+      defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
+    fi
   fi
 }
 
@@ -562,12 +583,20 @@ bundle_libwebsockets() {
     then
       run_ok "libwebsockets built and prepared."
     else
-      run_failed "Failed to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
-      defer_error_highlighted "Failed to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+      run_failed "Failed to build libwebsockets."
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+        exit 1
+      else
+        defer_error_highlighted "Failed to build libwebsockets. You may not be able to connect this node to Netdata Cloud."
+      fi
     fi
   else
-    run_failed "Unable to fetch sources for libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
-    defer_error_highlighted "Unable to fetch sources for libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
+    run_failed "Unable to fetch sources for libwebsockets."
+    if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+      exit 1
+    else
+      defer_error_highlighted "Unable to fetch sources for libwebsockets. You may not be able to connect this node to Netdata Cloud."
+    fi
   fi
 }
 

--- a/packaging/mosquitto.checksums
+++ b/packaging/mosquitto.checksums
@@ -1,1 +1,1 @@
-387faaf026b86d52dcba87e80b97946eb2775bcfcfdafaabc828b6e17f7bf5ea  v.1.6.8_Netdata-3.tar.gz
+6af837c388b1bcd459220936c422b70a987c60f4d5f88b09eada43d713529284  v.1.6.8_Netdata-4.tar.gz

--- a/packaging/mosquitto.version
+++ b/packaging/mosquitto.version
@@ -1,1 +1,1 @@
-v.1.6.8_Netdata-3
+v.1.6.8_Netdata-4


### PR DESCRIPTION
##### Summary
Multiple bugs have been detected (while I was checking #8561) after recent changes in `configure.ac`. Fixes #8561 and 2 other bugs which do not have issues created.

List of found problems and their fixes:
- __*CRITICAL*__ (broken in master) the new detection, if mosquitto can be built, is not really working in `master` due to multiple problems *(syntax C `int main (int argc, char **argv)) {`, syntax configure, missing include, missing SSL link)*. This causes ACLK link to always fail - example OUTPUT of current master Fedora 31 CI build:
```
checking if libcap should be used... no
checking if libmosquitto static lib is present (and builds)... 
checking if libwebsockets static lib is present... yes
checking if netdata agent-cloud-link can be enabled... no
checking if netdata agent-cloud-link should/will be enabled... no
```
- add missing openssl check as it must be present for ACLK (this was missing since beginning mea culpa)
-  the 3 state behavior was lost when the flag was changed from ACLK to `--disable-cloud`. 

Behavior of configure flags:
    - `no flag` given to configure, try and build ACLK but if cannot just warn and build without
    - `--enable-cloud`, build ACLK if cannot ERROR - *build should FAIL in this case*
    - `--disable-cloud`, do not build ACLK (even if could)
##### Additionally (commits from Ferroin)
This PR cherry-picks Ferroin changes for installer and CI:
>This adds a switch called --require-cloud to the installer script. When specified, it causes the script to explicitly fail if it can't build Netdata with Netdata Cloud support. It is mutually exclusive with the --disable-cloud switch, with only the first one specified being honored.
>
>This is mostly intended to ensure that CI can test the build/install both with and without the cloud, but it is likely to be of interest to users who want to ensure they can use their systems with netdata Cloud.
>
>This PR also updates the build testing CI to explicitly check builds both with and without Netdata Cloud built.

##### Additionally (commits from Amoss)
Workaround for unrelated (to this PR) claiming issue that goes in as this is the last PR before code freeze.

##### Component Name
agent build

##### Test Plan
test all flags and without flag to configure script, test with purposefully missing `mosuiqtto.a/lws.a` in `externaldeps`, test with missing `openssl-dev` package on system.

Check config.h has correct flags in each case.

