### PR TITLE
Investigate Fedora 30/31 build errors in Nightly

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -52,7 +52,8 @@ jobs:
             pre: 'apt-get update'
           - distro: 'debian:jessie'
             pre: >
-              echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list.d/99-archived.list &&
+              echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free"
+              >> /etc/apt/sources.list.d/99-archived.list &&
               apt-get update -o Acquire::Check-Valid-Until=false
 
           - distro: 'ubuntu:20.04'


### PR DESCRIPTION
##### Summary

SSIA

##### Component Name

- area/ci

##### Test Plan

- [ ] This PR

##### Additional Information

This Travis CI build is broken for Fedora 30 and Fedora 31:

- https://travis-ci.com/github/netdata/netdata/builds/157657428
  - https://travis-ci.com/github/netdata/netdata/jobs/311796424
  - https://travis-ci.com/github/netdata/netdata/jobs/311796425

Confirming this is also broken on current master.