### PR TITLE
Fix broken Fedora 30/31 RPM builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -329,6 +329,7 @@ jobs:
       <<: *RPM_TEMPLATE
       if: commit_message =~ /\[Package (amd64|arm64) RPM( Fedora)?\]/
       env:
+        - CFLAGS="-fPIC"
         - BUILDER_NAME="builder" BUILD_DISTRO="fedora" BUILD_RELEASE="31" BUILD_STRING="fedora/31"
         - PACKAGE_TYPE="rpm" REPO_TOOL="dnf"
         - ALLOW_SOFT_FAILURE_HERE=true
@@ -337,6 +338,7 @@ jobs:
       <<: *RPM_TEMPLATE
       if: commit_message =~ /\[Package (amd64|arm64) RPM( Fedora)?\]/
       env:
+        - CFLAGS="-fPIC"
         - BUILDER_NAME="builder" BUILD_DISTRO="fedora" BUILD_RELEASE="30" BUILD_STRING="fedora/30"
         - PACKAGE_TYPE="rpm" REPO_TOOL="dnf"
         - ALLOW_SOFT_FAILURE_HERE=true

--- a/.travis/package_management/trigger_rpm_lxc_build.py
+++ b/.travis/package_management/trigger_rpm_lxc_build.py
@@ -50,6 +50,6 @@ common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "rpmdev
 
 # Run the build process on the container
 print("Starting RPM build process")
-common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "rpmbuild", "-ba", "--rebuild", "/home/%s/rpmbuild/SPECS/netdata.spec" % os.environ['BUILDER_NAME']])
+common.run_command(container, ["sudo", "-E", "-u", os.environ['BUILDER_NAME'], "rpmbuild", "-ba", "--rebuild", "/home/%s/rpmbuild/SPECS/netdata.spec" % os.environ['BUILDER_NAME']])
 
 print('Done!')


### PR DESCRIPTION
##### Summary

SSIA

##### Component Name

- area/ci

##### Test Plan

Hmmm 🤔 This is __really__ hard to test in Travis :/

- [x] Independtly test the `CFLAGS="-fPIC"` option:

```sh
$ OS=fedora30; git clean -d -f -x && dki -t --rm -e CFLAGS='-fPIC' -e VERSION="1.20.0" -v "$PWD":/netdata -w /netdata netdata/package-builders:"${OS}"
.
.
.
```

##### Additional Information

Discovered during recently nightly build:

- https://travis-ci.com/github/netdata/netdata/builds/157657428
  - https://travis-ci.com/github/netdata/netdata/jobs/311796424
  - https://travis-ci.com/github/netdata/netdata/jobs/311796425

I cannot explain currently why a normal build works on Fedora 30/31 but fails
inside the `rpmbuild` environment (_regardless of which CI is in usde_).