### PR TITLE
cove354246 Reorginize process exit

### DIFF
--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -165,15 +165,19 @@ static void int_exit(int sig)
             for ( i=getdtablesize(); i>=0; --i)
                 close(i);
 
-            int fd = open("/dev/null",O_RDWR, 0);
+            char filename[FILENAME_MAX+1];
+            ret = sprintf(filename, "%s/%s",  netdata_configured_log_dir, "error.log");
+            if (ret < 0)
+                fprintf(stderr,"[EBPF PROCESS] Cannot fill filename with values %s/%s", netdata_configured_log_dir, "error.log" );
+
+            int fd = open(filename, O_RDWR, 0);
             if (fd != -1) {
                 dup2 (fd, STDIN_FILENO);
                 dup2 (fd, STDOUT_FILENO);
                 dup2 (fd, STDERR_FILENO);
-            }
 
-            if (fd > 2)
-                close (fd);
+                close(fd);
+            }
 
             int sid = setsid();
             if(sid >= 0) {
@@ -181,18 +185,19 @@ static void int_exit(int sig)
                 if(debug_log) {
                     open_developer_log();
                 }
+
                 debug(D_EXIT, "Wait for father %d die", event_pid);
                 clean_kprobe_events(developer_log, event_pid, collector_events);
+
+                if (developer_log) {
+                    fclose(developer_log);
+                    developer_log = NULL;
+                }
             } else {
                 error("Cannot become session id leader, so I won't try to clean kprobe_events.\n");
             }
         } else { //parent
             exit(0);
-        }
-
-        if (developer_log) {
-            fclose(developer_log);
-            developer_log = NULL;
         }
     }
 


### PR DESCRIPTION
##### Summary
Fixes #8577 

This PR reorganizes the process exit moving the file description close to inside a loop and moves the close error from `/dev/null` to the default error.log

##### Component Name
Collector
##### Test Plan

To test this PR you need to install Netdata with the parameter `--enable-ebpf` on a Linux compiled with `eBPF ` and `kprobe`. It is also necessary to have the following filesystems mounted: 

```
mount -t debugfs nodev /sys/kernel/debug
mount -t tracefs nodev /sys/kernel/tracing
```

After the installation, it is only necessary to start netdata verify if the eBPF charts are running fine and after this to stop Netdata.  During this process we cannot have any error related to `ebpf_process` inside `/var/log/netdata/error.log` and all probes must be removed from `/sys/kernel/debug/tracing/kprobe_events`.

##### Additional Information
