### PR TITLE
Read configuration when section is open

### DIFF
--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -285,15 +285,9 @@ cleanup:
     return ret;
 }
 
-
-char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value)
+char *appconfig_get_by_section(struct section *co, const char *name, const char *default_value)
 {
     struct config_option *cv;
-
-    debug(D_CONFIG, "request to get config in section '%s', name '%s', default_value '%s'", section, name, default_value);
-
-    struct section *co = appconfig_section_find(root, section);
-    if(!co) co = appconfig_section_create(root, section);
 
     cv = appconfig_option_index_find(co, name, 0);
     if(!cv) {
@@ -312,6 +306,16 @@ char *appconfig_get(struct config *root, const char *section, const char *name, 
     }
 
     return(cv->value);
+}
+
+char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value)
+{
+    debug(D_CONFIG, "request to get config in section '%s', name '%s', default_value '%s'", section, name, default_value);
+
+    struct section *co = appconfig_section_find(root, section);
+    if(!co) co = appconfig_section_create(root, section);
+
+    return appconfig_get_by_section(co, name, default_value);
 }
 
 long long appconfig_get_number(struct config *root, const char *section, const char *name, long long value)
@@ -336,6 +340,23 @@ LONG_DOUBLE appconfig_get_float(struct config *root, const char *section, const 
     return str2ld(s, NULL);
 }
 
+static inline int appconfig_test_boolean_value(char *s) {
+    if(!strcasecmp(s, "yes") || !strcasecmp(s, "true") || !strcasecmp(s, "on")
+       || !strcasecmp(s, "auto") || !strcasecmp(s, "on demand"))
+        return 1;
+
+    return 0;
+}
+
+int appconfig_get_boolean_by_section(struct section *co, const char *name, int value) {
+    char *s;
+
+    s = appconfig_get_by_section(co, name, (!value)?"no":"yes");
+    if(!s) return value;
+
+    return appconfig_test_boolean_value(s);
+}
+
 int appconfig_get_boolean(struct config *root, const char *section, const char *name, int value)
 {
     char *s;
@@ -345,8 +366,7 @@ int appconfig_get_boolean(struct config *root, const char *section, const char *
     s = appconfig_get(root, section, name, s);
     if(!s) return value;
 
-    if(!strcasecmp(s, "yes") || !strcasecmp(s, "true") || !strcasecmp(s, "on") || !strcasecmp(s, "auto") || !strcasecmp(s, "on demand")) return 1;
-    return 0;
+    return appconfig_test_boolean_value(s);
 }
 
 int appconfig_get_boolean_ondemand(struct config *root, const char *section, const char *name, int value)

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -159,9 +159,11 @@ extern int appconfig_load(struct config *root, char *filename, int overwrite_use
 extern void config_section_wrlock(struct section *co);
 extern void config_section_unlock(struct section *co);
 
+extern char *appconfig_get_by_section(struct section *co, const char *name, const char *default_value);
 extern char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
 extern long long appconfig_get_number(struct config *root, const char *section, const char *name, long long value);
 extern LONG_DOUBLE appconfig_get_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value);
+extern int appconfig_get_boolean_by_section(struct section *co, const char *name, int value);
 extern int appconfig_get_boolean(struct config *root, const char *section, const char *name, int value);
 extern int appconfig_get_boolean_ondemand(struct config *root, const char *section, const char *name, int value);
 extern int appconfig_get_duration(struct config *root, const char *section, const char *name, const char *value);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -174,7 +174,7 @@ int configured_as_master() {
         uuid_t uuid;
 
         if (uuid_parse(section->name, uuid) != -1 &&
-            appconfig_get_boolean(&stream_config, section->name, "enabled", 0)) {
+                appconfig_get_boolean_by_section(section, "enabled", 0)) {
             is_master = 1;
             break;
         }


### PR DESCRIPTION
##### Summary
Fixes #8415 

This PR fixes the bug reported on #8415.
##### Component Name
Libnetdata
Streaming
##### Test Plan

It is necessary to set a Netdata `master` and at least one  Netdata `slave` with this PR.

When both are running, please access the follow links on master:

```
https://localhost:19999/api/v1/info
https://localhost:19999/host/SLAVE_NAME/api/v1/info
```

For the master we will have the label `_is_master` as `true` and for the slave it will be `false`.

##### Additional Information
