### PR TITLE
Fix Debian 8 (jessie) support

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -49,12 +49,6 @@ jobs:
           - distro: 'debian:buster'
             pre: 'apt-get update'
           - distro: 'debian:stretch'
-            pre: 'apt-get update'
-          - distro: 'debian:jessie'
-            pre: >
-              echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list.d/99-archived.list &&
-              apt-get update -o Acquire::Check-Valid-Until=false
-
           - distro: 'ubuntu:20.04'
             pre: 'apt-get update'
           - distro: 'ubuntu:19.10'

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1280,6 +1280,12 @@ install_apt_get() {
   echo >&2 "NOTE: Running apt-get update and updating your APT caches ..."
   if [ "${version}" = 8 ]; then
     echo >&2 "WARNING: You seem to be on Debian 8 (jessie) which is old enough we have to disable Check-Valid-Until checks"
+    echo >&2 "We also have to enable the jessie-backports repository"
+    if prompt "Is this okay?"; then
+      echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" \
+        >> /etc/apt/sources.list.d/99-archived.list
+    fi
+    apt-get update -o Acquire::Check-Valid-Until=false
     run ${sudo} apt-get "${apt_opts[@]}" -o Acquire::Check-Valid-Until=false update
   else
     run ${sudo} apt-get "${apt_opts[@]}" update


### PR DESCRIPTION
##### Summary

ssia

##### Component Name

- area/ci
- area/packaging

##### Test Plan

- [X] Tested maually:

```#!sh
$ dki -t --rm -v "$PWD":/netdata -w /netdata debian:jessie /bin/bash -c './packaging/installer/install-required-packages.sh netdata-all'
.
.
.
All done!
```

##### Additional Information

**NB:** `PRE` in our CI workflows are **NOT** for doings things that should
be done in our `install-required-packages.sh` :/