### PR TITLE
fix resource leak (Coverity CID 349684)

### DIFF
--- a/libnetdata/health/health.c
+++ b/libnetdata/health/health.c
@@ -138,8 +138,7 @@ int health_silencers_json_read_callback(JSON_ENTRY *e)
                 else if (!strcmp(e->data.string,"DISABLE")) silencers->stype = STYPE_DISABLE_ALARMS;
             } else {
                 debug(D_HEALTH, "JSON: Adding %s=%s", e->name, e->data.string);
-                SILENCER *test = health_silencers_addparam(e->callback_data, e->name, e->data.string);
-                (void)test;
+                (void)health_silencers_addparam(e->callback_data, e->name, e->data.string);
             }
             break;
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes Coverity CID 349684 

Resource leak (RESOURCE_LEAK) leaked_storage: Variable `test` going out of scope leaks the storage it points to.

```
3. alloc_fn: Storage is returned from allocation function health_silencers_addparam. [show details]
4. var_assign: Assigning: test = storage returned from health_silencers_addparam(e->callback_data, e->name, e->data.string).
141                SILENCER *test = health_silencers_addparam(e->callback_data, e->name, e->data.string);
142                (void)test;
CID 349684 (#1 of 1): Resource leak (RESOURCE_LEAK)
5. leaked_storage: Variable test going out of scope leaks the storage it points to.
143            }
144            break;
```

##### Component Name
health
