### PR TITLE
Remove an automatic restart of the apps.plugin

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -4110,8 +4110,6 @@ int main(int argc, char **argv) {
 
     procfile_adaptive_initial_allocation = 1;
 
-    time_t started_t = now_monotonic_sec();
-
     get_system_HZ();
 #ifdef __FreeBSD__
     time_factor = 1000000ULL / RATES_DETAIL; // FreeBSD uses usecs
@@ -4212,8 +4210,5 @@ int main(int argc, char **argv) {
         show_guest_time_old = show_guest_time;
 
         debug_log("done Loop No %zu", global_iterations_counter);
-
-        // restart check (14400 seconds)
-        if(now_monotonic_sec() - started_t > 14400) exit(0);
     }
 }


### PR DESCRIPTION
##### Summary
Every 4 hours the apps plugin was restarting. It was done to be safe if there are any memory leaks in the plugin. I think the plugin is in active use for quite a long time and should be in good condition, so we can remove the restart.

Fixes #8469

##### Component Name
apps.plugin