### PR TITLE
Correctly fixed RPM package builds on Fedora.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -329,7 +329,6 @@ jobs:
       <<: *RPM_TEMPLATE
       if: commit_message =~ /\[Package (amd64|arm64) RPM( Fedora)?\]/
       env:
-        - CFLAGS="-fPIC"
         - BUILDER_NAME="builder" BUILD_DISTRO="fedora" BUILD_RELEASE="31" BUILD_STRING="fedora/31"
         - PACKAGE_TYPE="rpm" REPO_TOOL="dnf"
         - ALLOW_SOFT_FAILURE_HERE=true
@@ -338,7 +337,6 @@ jobs:
       <<: *RPM_TEMPLATE
       if: commit_message =~ /\[Package (amd64|arm64) RPM( Fedora)?\]/
       env:
-        - CFLAGS="-fPIC"
         - BUILDER_NAME="builder" BUILD_DISTRO="fedora" BUILD_RELEASE="30" BUILD_STRING="fedora/30"
         - PACKAGE_TYPE="rpm" REPO_TOOL="dnf"
         - ALLOW_SOFT_FAILURE_HERE=true

--- a/.travis/package_management/trigger_rpm_lxc_build.py
+++ b/.travis/package_management/trigger_rpm_lxc_build.py
@@ -50,6 +50,6 @@ common.run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "rpmdev
 
 # Run the build process on the container
 print("Starting RPM build process")
-common.run_command(container, ["sudo", "-E", "-u", os.environ['BUILDER_NAME'], "rpmbuild", "-ba", "--rebuild", "/home/%s/rpmbuild/SPECS/netdata.spec" % os.environ['BUILDER_NAME']])
+common.run_command(container, ["sudo", "-u", os.environ['BUILDER_NAME'], "rpmbuild", "-ba", "--rebuild", "/home/%s/rpmbuild/SPECS/netdata.spec" % os.environ['BUILDER_NAME']])
 
 print('Done!')

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -233,8 +233,8 @@ happened, on your systems and applications.
 
 %prep
 %setup -q -n %{name}-%{version}
-${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}/%{name}-%{version}
-${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-lws.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-lws.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 
 %build
 # Conf step


### PR DESCRIPTION
##### Summary

Fedora builds it's packages using `-fPIC`, but we were not building LWS and mosquitto with this flag, causing the final link to fail.  This modifies the RPM file to ensure they get built with this flag independent of the environment, which will work everywhere unless someone tries to build the package with PIC disabled (which no distribution currently does).

##### Component Name

area/packaging

##### Test Plan

Verified locally using Docker package builds. Verified in Travis at https://travis-ci.org/github/Ferroin/netdata/builds/670595759

##### Additional Information

This differs from the original attempts at fixing this in that it modifies the environment the scripts we use to bundle LWS and mosquitto run in directly, instead of relying on multiple layers to pass through the required environment variables.