### PR TITLE
Fixes Ubuntu build with both libcap-dev and libcapng

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -642,6 +642,7 @@ if ENABLE_ACLK
 netdata_LDADD = \
     externaldeps/mosquitto/libmosquitto.a \
     externaldeps/libwebsockets/libwebsockets.a \
+    $(OPTIONAL_LIBCAP_LIBS) \
     $(NETDATA_COMMON_LIBS) \
     $(NULL)
 else

--- a/configure.ac
+++ b/configure.ac
@@ -583,7 +583,7 @@ if test "$enable_cloud" != "no"; then
 
     AC_MSG_CHECKING([if libwebsockets static lib is present])
     if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
-        LWS_LIBS="-I externaldeps/libwebsockets/include"
+        LWS_CFLAGS="-I externaldeps/libwebsockets/include"
         HAVE_libwebsockets_a="yes"
     else
         HAVE_libwebsockets_a="no"
@@ -596,7 +596,7 @@ if test "$enable_cloud" != "no"; then
             AC_MSG_ERROR([agent-cloud-link can't be built without libcap. Disable it by --disable-cloud or enable libcap])
         fi
         if test "${with_libcap}" = "yes"; then
-            LWS_LIBS+=" -lcap"
+            LWS_CFLAGS+=" ${LIBCAP_CFLAGS}"
         fi
     fi
 
@@ -1230,7 +1230,7 @@ AC_SUBST([webdir])
 
 CFLAGS="${CFLAGS} ${OPTIONAL_MATH_CFLAGS} ${OPTIONAL_NFACCT_CFLAGS} ${OPTIONAL_ZLIB_CFLAGS} ${OPTIONAL_UUID_CFLAGS} \
     ${OPTIONAL_LIBCAP_CFLAGS} ${OPTIONAL_IPMIMONITORING_CFLAGS} ${OPTIONAL_CUPS_CFLAGS} ${OPTIONAL_XENSTAT_FLAGS} \
-    ${OPTIONAL_KINESIS_CFLAGS} ${OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS} ${OPTIONAL_MONGOC_CFLAGS} ${LWS_LIBS}"
+    ${OPTIONAL_KINESIS_CFLAGS} ${OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS} ${OPTIONAL_MONGOC_CFLAGS} ${LWS_CFLAGS}"
 
 CXXFLAGS="${CFLAGS} ${CXX11FLAG}"
 


### PR DESCRIPTION
##### Summary
Fixes #8589 

also cleans up some ugly parts (`-lcap` in CFLAGS)

##### Component Name

##### Test Plan
on ubuntu install both `libcap-dev` and `libcap-ng` packages. Try to build netdata with intaller.

`dpkg -l | grep libcap` should say:
```
ii libcap-dev:amd64 1:2.25-1.2 amd64 POSIX 1003.1e capabilities (development)
ii libcap-ng0:amd64 0.7.7-3.1 amd64 An alternate POSIX capabilities library
ii libcap2:amd64 1:2.25-1.2 amd64 POSIX 1003.1e capabilities (library)
ii libcap2-bin 1:2.25-1.2 amd64 POSIX 1003.1e capabilities (utilities)
```


To test for regressions also test without `libcap-dev` (run installer again to recompile LWS)

