### PR TITLE
Show internal stats for the exporting engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1112,6 +1112,8 @@ endif()
         -Wl,--wrap=recv
         -Wl,--wrap=send
         -Wl,--wrap=connect_to_one_of
+        -Wl,--wrap=create_main_rusage_chart
+        -Wl,--wrap=send_main_rusage
         ${PROMETHEUS_REMOTE_WRITE_LINK_OPTIONS}
         ${KINESIS_LINK_OPTIONS}
         ${MONGODB_LINK_OPTIONS}

--- a/Makefile.am
+++ b/Makefile.am
@@ -873,6 +873,8 @@ if ENABLE_UNITTESTS
         -Wl,--wrap=recv \
         -Wl,--wrap=send \
         -Wl,--wrap=connect_to_one_of \
+        -Wl,--wrap=create_main_rusage_chart \
+        -Wl,--wrap=send_main_rusage \
         $(TEST_LDFLAGS) \
         $(NULL)
     exporting_tests_exporting_engine_testdriver_LDADD = $(NETDATA_COMMON_LIBS) $(TEST_LIBS)

--- a/exporting/aws_kinesis/aws_kinesis.c
+++ b/exporting/aws_kinesis/aws_kinesis.c
@@ -115,7 +115,7 @@ void aws_kinesis_connector_worker(void *instance_p)
                 connector_specific_data, connector_specific_config->stream_name, partition_key, first_char, record_len);
 
             sent += record_len;
-            stats->chart_transmission_successes++;
+            stats->transmission_successes++;
 
             size_t sent_bytes = 0, lost_bytes = 0;
 
@@ -127,27 +127,27 @@ void aws_kinesis_connector_worker(void *instance_p)
                     "EXPORTING: failed to write data to database backend '%s'. Willing to write %zu bytes, wrote %zu bytes.",
                     instance->config.destination, sent_bytes, sent_bytes - lost_bytes);
 
-                stats->chart_transmission_failures++;
-                stats->chart_data_lost_events++;
-                stats->chart_lost_bytes += lost_bytes;
+                stats->transmission_failures++;
+                stats->data_lost_events++;
+                stats->lost_bytes += lost_bytes;
 
                 // estimate the number of lost metrics
-                stats->chart_lost_metrics += (collected_number)(
-                    stats->chart_buffered_metrics *
+                stats->lost_metrics += (collected_number)(
+                    stats->buffered_metrics *
                     (buffer_len && (lost_bytes > buffer_len) ? (double)lost_bytes / buffer_len : 1));
 
                 break;
             } else {
-                stats->chart_receptions++;
+                stats->receptions++;
             }
 
             if (unlikely(netdata_exit))
                 break;
         }
 
-        stats->chart_sent_bytes += sent;
+        stats->sent_bytes += sent;
         if (likely(sent == buffer_len))
-            stats->chart_sent_metrics = stats->chart_buffered_metrics;
+            stats->sent_metrics = stats->buffered_metrics;
 
         buffer_flush(buffer);
 

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -35,6 +35,11 @@ void *exporting_main(void *ptr)
         goto cleanup;
     }
 
+    RRDSET *st_main_rusage = NULL;
+    RRDDIM *rd_main_user = NULL;
+    RRDDIM *rd_main_system = NULL;
+    create_main_rusage_chart(&st_main_rusage, &rd_main_user, &rd_main_system);
+
     usec_t step_ut = localhost->rrd_update_every * USEC_PER_SEC;
     heartbeat_t hb;
     heartbeat_init(&hb);
@@ -55,10 +60,7 @@ void *exporting_main(void *ptr)
             break;
         }
 
-        if (send_internal_metrics(engine) != 0) {
-            error("EXPORTING: cannot send metrics for the operation of exporting engine");
-            break;
-        }
+        send_main_rusage(st_main_rusage, rd_main_user, rd_main_system);
 
 #ifdef UNIT_TESTING
         break;

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -99,18 +99,18 @@ struct engine_config {
 };
 
 struct stats {
-    collected_number chart_buffered_metrics;
-    collected_number chart_lost_metrics;
-    collected_number chart_sent_metrics;
-    collected_number chart_buffered_bytes;
-    collected_number chart_lost_bytes;
-    collected_number chart_sent_bytes;
-    collected_number chart_received_bytes;
-    collected_number chart_transmission_successes;
-    collected_number chart_data_lost_events;
-    collected_number chart_reconnects;
-    collected_number chart_transmission_failures;
-    collected_number chart_receptions;
+    collected_number buffered_metrics;
+    collected_number lost_metrics;
+    collected_number sent_metrics;
+    collected_number buffered_bytes;
+    collected_number lost_bytes;
+    collected_number sent_bytes;
+    collected_number received_bytes;
+    collected_number transmission_successes;
+    collected_number data_lost_events;
+    collected_number reconnects;
+    collected_number transmission_failures;
+    collected_number receptions;
 
     int initialized;
 

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -217,6 +217,7 @@ int end_chart_formatting(struct engine *engine, RRDSET *st);
 int end_host_formatting(struct engine *engine, RRDHOST *host);
 int end_batch_formatting(struct engine *engine);
 int flush_host_labels(struct instance *instance, RRDHOST *host);
+int simple_connector_update_buffered_bytes(struct instance *instance);
 
 int exporting_discard_response(BUFFER *buffer, struct instance *instance);
 void simple_connector_receive_response(int *sock, struct instance *instance);

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -103,14 +103,38 @@ struct stats {
     collected_number chart_lost_metrics;
     collected_number chart_sent_metrics;
     collected_number chart_buffered_bytes;
-    collected_number chart_received_bytes;
-    collected_number chart_sent_bytes;
-    collected_number chart_receptions;
-    collected_number chart_transmission_successes;
-    collected_number chart_transmission_failures;
-    collected_number chart_data_lost_events;
     collected_number chart_lost_bytes;
+    collected_number chart_sent_bytes;
+    collected_number chart_received_bytes;
+    collected_number chart_transmission_successes;
+    collected_number chart_data_lost_events;
     collected_number chart_reconnects;
+    collected_number chart_transmission_failures;
+    collected_number chart_receptions;
+
+    int initialized;
+
+    RRDSET *st_metrics;
+    RRDDIM *rd_buffered_metrics;
+    RRDDIM *rd_lost_metrics;
+    RRDDIM *rd_sent_metrics;
+
+    RRDSET *st_bytes;
+    RRDDIM *rd_buffered_bytes;
+    RRDDIM *rd_lost_bytes;
+    RRDDIM *rd_sent_bytes;
+    RRDDIM *rd_received_bytes;
+
+    RRDSET *st_ops;
+    RRDDIM *rd_transmission_successes;
+    RRDDIM *rd_data_lost_events;
+    RRDDIM *rd_reconnects;
+    RRDDIM *rd_transmission_failures;
+    RRDDIM *rd_receptions;
+
+    RRDSET *st_rusage;
+    RRDDIM *rd_user;
+    RRDDIM *rd_system;
 };
 
 struct instance {
@@ -199,7 +223,9 @@ void simple_connector_receive_response(int *sock, struct instance *instance);
 void simple_connector_send_buffer(int *sock, int *failures, struct instance *instance);
 void simple_connector_worker(void *instance_p);
 
-int send_internal_metrics(struct engine *engine);
+void create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_system);
+void send_main_rusage(RRDSET *st_rusage, RRDDIM *rd_user, RRDDIM *rd_system);
+void send_internal_metrics(struct instance *instance);
 
 #include "exporting/prometheus/prometheus.h"
 

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -27,7 +27,7 @@ int init_graphite_instance(struct instance *instance)
 
     instance->end_chart_formatting = NULL;
     instance->end_host_formatting = flush_host_labels;
-    instance->end_batch_formatting = NULL;
+    instance->end_batch_formatting = simple_connector_update_buffered_bytes;
 
     instance->send_header = NULL;
     instance->check_response = exporting_discard_response;

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -27,7 +27,7 @@ int init_json_instance(struct instance *instance)
 
     instance->end_chart_formatting = NULL;
     instance->end_host_formatting = flush_host_labels;
-    instance->end_batch_formatting = NULL;
+    instance->end_batch_formatting = simple_connector_update_buffered_bytes;
 
     instance->send_header = NULL;
     instance->check_response = exporting_discard_response;

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -184,7 +184,7 @@ int format_batch_mongodb(struct instance *instance)
         connector_specific_data->first_buffer = connector_specific_data->first_buffer->next;
         free_bson(insert, connector_specific_data->last_buffer->documents_inserted);
     }
-    insert = callocz((size_t)stats->chart_buffered_metrics, sizeof(bson_t *));
+    insert = callocz((size_t)stats->buffered_metrics, sizeof(bson_t *));
     connector_specific_data->last_buffer->insert = insert;
 
     BUFFER *buffer = (BUFFER *)instance->buffer;
@@ -193,7 +193,7 @@ int format_batch_mongodb(struct instance *instance)
 
     size_t documents_inserted = 0;
 
-    while (*end && documents_inserted <= (size_t)stats->chart_buffered_metrics) {
+    while (*end && documents_inserted <= (size_t)stats->buffered_metrics) {
         while (*end && *end != '\n')
             end++;
 
@@ -279,9 +279,9 @@ void mongodb_connector_worker(void *instance_p)
                 NULL,
                 NULL,
                 &bson_error))) {
-            stats->chart_sent_bytes += data_size;
-            stats->chart_transmission_successes++;
-            stats->chart_receptions++;
+            stats->sent_bytes += data_size;
+            stats->transmission_successes++;
+            stats->receptions++;
         } else {
             // oops! we couldn't send (all or some of the) data
             error("EXPORTING: %s", bson_error.message);
@@ -290,10 +290,10 @@ void mongodb_connector_worker(void *instance_p)
                 "Willing to write %zu bytes, wrote %zu bytes.",
                 instance->config.destination, data_size, 0UL);
 
-            stats->chart_transmission_failures++;
-            stats->chart_data_lost_events++;
-            stats->chart_lost_bytes += data_size;
-            stats->chart_lost_metrics += stats->chart_buffered_metrics;
+            stats->transmission_failures++;
+            stats->data_lost_events++;
+            stats->lost_bytes += data_size;
+            stats->lost_metrics += stats->buffered_metrics;
         }
 
         free_bson(insert, documents_inserted);
@@ -301,8 +301,8 @@ void mongodb_connector_worker(void *instance_p)
         if (unlikely(netdata_exit))
             break;
 
-        stats->chart_sent_bytes += data_size;
-        stats->chart_sent_metrics = stats->chart_buffered_metrics;
+        stats->sent_bytes += data_size;
+        stats->sent_metrics = stats->buffered_metrics;
 
 #ifdef UNIT_TESTING
         break;

--- a/exporting/mongodb/mongodb.h
+++ b/exporting/mongodb/mongodb.h
@@ -10,6 +10,7 @@
 struct bson_buffer {
     bson_t **insert;
     size_t documents_inserted;
+    size_t buffered_bytes;
 
     struct bson_buffer *next;
 };
@@ -17,6 +18,8 @@ struct bson_buffer {
 struct mongodb_specific_data {
     mongoc_client_t *client;
     mongoc_collection_t *collection;
+
+    size_t total_documents_inserted;
 
     bson_t **current_insert;
     struct bson_buffer *first_buffer;

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -27,7 +27,7 @@ int init_opentsdb_telnet_instance(struct instance *instance)
 
     instance->end_chart_formatting = NULL;
     instance->end_host_formatting = flush_host_labels;
-    instance->end_batch_formatting = NULL;
+    instance->end_batch_formatting = simple_connector_update_buffered_bytes;
 
     instance->send_header = NULL;
     instance->check_response = exporting_discard_response;
@@ -68,7 +68,7 @@ int init_opentsdb_http_instance(struct instance *instance)
 
     instance->end_chart_formatting = NULL;
     instance->end_host_formatting = flush_host_labels;
-    instance->end_batch_formatting = NULL;
+    instance->end_batch_formatting = simple_connector_update_buffered_bytes;
 
     instance->send_header = NULL;
     instance->check_response = exporting_discard_response;

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -242,7 +242,7 @@ int metric_formatting(struct engine *engine, RRDDIM *rd)
                 error("EXPORTING: cannot format metric for %s", instance->config.name);
                 return 1;
             }
-            instance->stats.chart_buffered_metrics++;
+            instance->stats.buffered_metrics++;
         }
     }
 

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -397,7 +397,7 @@ int flush_host_labels(struct instance *instance, RRDHOST *host)
  */
 int simple_connector_update_buffered_bytes(struct instance *instance)
 {
-    instance->stats.buffered_bytes = (collected_number)buffer_strlen((BUFFER *)instance->buffer);
+    instance->stats.buffered_bytes = (collected_number)buffer_strlen((BUFFER *)(instance->buffer));
 
     return 0;
 }

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -390,6 +390,19 @@ int flush_host_labels(struct instance *instance, RRDHOST *host)
 }
 
 /**
+ * Update stats for buffered bytes
+ *
+ * @param instance an instance data structure.
+ * @return Always returns 0.
+ */
+int simple_connector_update_buffered_bytes(struct instance *instance)
+{
+    instance->stats.buffered_bytes = (collected_number)buffer_strlen((BUFFER *)instance->buffer);
+
+    return 0;
+}
+
+/**
  * Notify workers
  *
  * Notify exporting connector instance working threads that data is ready to send.

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -314,7 +314,7 @@ int format_batch_prometheus_remote_write(struct instance *instance)
         return 1;
     }
     buffer->len = data_size;
-    instance->stats.chart_buffered_bytes = (collected_number)buffer_strlen(buffer);
+    instance->stats.buffered_bytes = (collected_number)buffer_strlen(buffer);
 
     return 0;
 }

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -57,8 +57,8 @@ void simple_connector_receive_response(int *sock, struct instance *instance)
         if (likely(r > 0)) {
             // we received some data
             response->len += r;
-            stats->chart_received_bytes += r;
-            stats->chart_receptions++;
+            stats->received_bytes += r;
+            stats->receptions++;
         } else if (r == 0) {
             error("EXPORTING: '%s' closed the socket", instance->config.destination);
             close(*sock);
@@ -109,9 +109,9 @@ void simple_connector_send_buffer(int *sock, int *failures, struct instance *ins
 
     if(written != -1 && (size_t)written == len) {
         // we sent the data successfully
-        stats->chart_transmission_successes++;
-        stats->chart_sent_bytes += written;
-        stats->chart_sent_metrics = stats->chart_buffered_metrics;
+        stats->transmission_successes++;
+        stats->sent_bytes += written;
+        stats->sent_metrics = stats->buffered_metrics;
 
         // reset the failures count
         *failures = 0;
@@ -126,10 +126,10 @@ void simple_connector_send_buffer(int *sock, int *failures, struct instance *ins
             instance->config.destination,
             len,
             written);
-        stats->chart_transmission_failures++;
+        stats->transmission_failures++;
 
         if(written != -1)
-            stats->chart_sent_bytes += written;
+            stats->sent_bytes += written;
 
         // increment the counter we check for data loss
         (*failures)++;
@@ -179,7 +179,7 @@ void simple_connector_worker(void *instance_p)
                 &reconnects,
                 NULL,
                 0);
-            stats->chart_reconnects += reconnects;
+            stats->reconnects += reconnects;
         }
 
         if(unlikely(netdata_exit)) break;
@@ -194,7 +194,7 @@ void simple_connector_worker(void *instance_p)
             simple_connector_send_buffer(&sock, &failures, instance);
         } else {
             error("EXPORTING: failed to update '%s'", instance->config.destination);
-            stats->chart_transmission_failures++;
+            stats->transmission_failures++;
 
             // increment the counter we check for data loss
             failures++;

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -160,6 +160,19 @@ void simple_connector_worker(void *instance_p)
     int failures = 0;
 
     while(!netdata_exit) {
+
+        // reset the monitoring chart counters
+        stats->received_bytes =
+        stats->sent_bytes =
+        stats->sent_metrics =
+        stats->lost_metrics =
+        stats->receptions =
+        stats->transmission_successes =
+        stats->transmission_failures =
+        stats->data_lost_events =
+        stats->lost_bytes =
+        stats->reconnects = 0;
+
         // ------------------------------------------------------------------------
         // if we are connected, receive a response, without blocking
 
@@ -201,6 +214,9 @@ void simple_connector_worker(void *instance_p)
         }
 
         send_internal_metrics(instance);
+
+        if(likely(buffer_strlen((BUFFER *)instance->buffer) == 0))
+            stats->buffered_metrics = 0;
 
         uv_mutex_unlock(&instance->mutex);
 

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -200,6 +200,8 @@ void simple_connector_worker(void *instance_p)
             failures++;
         }
 
+        send_internal_metrics(instance);
+
         uv_mutex_unlock(&instance->mutex);
 
 #ifdef UNIT_TESTING

--- a/exporting/send_internal_metrics.c
+++ b/exporting/send_internal_metrics.c
@@ -4,6 +4,10 @@
 
 /**
  * Create a chart for the main exporting thread CPU usage
+ *
+ * @param st_rusage the thead CPU usage chart
+ * @param rd_user a dimension for user CPU usage
+ * @param rd_system a dimension for system CPU usage
  */
 void create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_system)
 {
@@ -12,7 +16,7 @@ void create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_
 
     *st_rusage = rrdset_create_localhost(
         "netdata", "exporting_main_thread_cpu", NULL, "exporting", NULL, "Netdata Main Exporting Thread CPU Usage",
-        "milliseconds/s", "exporting", NULL, 130630, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
+        "milliseconds/s", "exporting", NULL, 130600, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
     *rd_user = rrddim_add(*st_rusage, "user", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
     *rd_system = rrddim_add(*st_rusage, "system", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
@@ -20,6 +24,10 @@ void create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_
 
 /**
  * Send the main exporting thread CPU usage
+ *
+ * @param st_rusage a thead CPU usage chart
+ * @param rd_user a dimension for user CPU usage
+ * @param rd_system a dimension for system CPU usage
  */
 void send_main_rusage(RRDSET *st_rusage, RRDDIM *rd_user, RRDDIM *rd_system)
 {
@@ -60,7 +68,7 @@ void send_internal_metrics(struct instance *instance)
 
         stats->st_metrics = rrdset_create_localhost(
             "netdata", id, NULL, buffer_tostring(family), NULL, "Netdata Buffered Metrics", "metrics", "exporting", NULL,
-            130600, instance->config.update_every, RRDSET_TYPE_LINE);
+            130610, instance->config.update_every, RRDSET_TYPE_LINE);
 
         stats->rd_buffered_metrics = rrddim_add(stats->st_metrics, "buffered", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         stats->rd_lost_metrics     = rrddim_add(stats->st_metrics, "lost", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
@@ -73,7 +81,7 @@ void send_internal_metrics(struct instance *instance)
 
         stats->st_bytes = rrdset_create_localhost(
             "netdata", id, NULL, buffer_tostring(family), NULL, "Netdata Exporting Data Size", "KiB", "exporting", NULL,
-            130610, instance->config.update_every, RRDSET_TYPE_AREA);
+            130620, instance->config.update_every, RRDSET_TYPE_AREA);
 
         stats->rd_buffered_bytes = rrddim_add(stats->st_bytes, "buffered", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
         stats->rd_lost_bytes     = rrddim_add(stats->st_bytes, "lost", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
@@ -102,7 +110,7 @@ void send_internal_metrics(struct instance *instance)
 
         stats->st_rusage = rrdset_create_localhost(
             "netdata", id, NULL, buffer_tostring(family), NULL, "Netdata Exporting Instance Thread CPU Usage",
-            "milliseconds/s", "exporting", NULL, 130630, instance->config.update_every, RRDSET_TYPE_STACKED);
+            "milliseconds/s", "exporting", NULL, 130640, instance->config.update_every, RRDSET_TYPE_STACKED);
 
         stats->rd_user   = rrddim_add(stats->st_rusage, "user", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
         stats->rd_system = rrddim_add(stats->st_rusage, "system", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);

--- a/exporting/send_internal_metrics.c
+++ b/exporting/send_internal_metrics.c
@@ -55,7 +55,7 @@ void send_internal_metrics(struct instance *instance)
 
         buffer_sprintf(family, "exporting_%s", instance->config.name);
 
-        sprintf("exporting_%s_metrics", instance->config.name);
+        snprintf(id, RRD_ID_LENGTH_MAX, "exporting_%s_metrics", instance->config.name);
         netdata_fix_chart_id(id);
 
         stats->st_metrics = rrdset_create_localhost(
@@ -68,7 +68,7 @@ void send_internal_metrics(struct instance *instance)
 
         // ------------------------------------------------------------------------
 
-        sprintf("exporting_%s_bytes", instance->config.name);
+        snprintf(id, RRD_ID_LENGTH_MAX, "exporting_%s_bytes", instance->config.name);
         netdata_fix_chart_id(id);
 
         stats->st_bytes = rrdset_create_localhost(
@@ -82,7 +82,7 @@ void send_internal_metrics(struct instance *instance)
 
         // ------------------------------------------------------------------------
 
-        sprintf("exporting_%s_ops", instance->config.name);
+        snprintf(id, RRD_ID_LENGTH_MAX, "exporting_%s_ops", instance->config.name);
         netdata_fix_chart_id(id);
 
         stats->st_ops = rrdset_create_localhost(
@@ -97,7 +97,7 @@ void send_internal_metrics(struct instance *instance)
 
         // ------------------------------------------------------------------------
 
-        sprintf("exporting_%s_thread_cpu", instance->config.name);
+        snprintf(id, RRD_ID_LENGTH_MAX, "exporting_%s_thread_cpu", instance->config.name);
         netdata_fix_chart_id(id);
 
         stats->st_rusage = rrdset_create_localhost(

--- a/exporting/send_internal_metrics.c
+++ b/exporting/send_internal_metrics.c
@@ -118,9 +118,9 @@ void send_internal_metrics(struct instance *instance)
     if (likely(stats->st_metrics->counter_done))
         rrdset_next(stats->st_metrics);
 
-    rrddim_set_by_pointer(stats->st_metrics, stats->rd_buffered_metrics, stats->chart_buffered_metrics);
-    rrddim_set_by_pointer(stats->st_metrics, stats->rd_lost_metrics,     stats->chart_lost_metrics);
-    rrddim_set_by_pointer(stats->st_metrics, stats->rd_sent_metrics,     stats->chart_sent_metrics);
+    rrddim_set_by_pointer(stats->st_metrics, stats->rd_buffered_metrics, stats->buffered_metrics);
+    rrddim_set_by_pointer(stats->st_metrics, stats->rd_lost_metrics,     stats->lost_metrics);
+    rrddim_set_by_pointer(stats->st_metrics, stats->rd_sent_metrics,     stats->sent_metrics);
 
     rrdset_done(stats->st_metrics);
 
@@ -129,10 +129,10 @@ void send_internal_metrics(struct instance *instance)
     if (likely(stats->st_bytes->counter_done))
         rrdset_next(stats->st_bytes);
 
-    rrddim_set_by_pointer(stats->st_bytes, stats->rd_buffered_bytes, stats->chart_buffered_bytes);
-    rrddim_set_by_pointer(stats->st_bytes, stats->rd_lost_bytes,     stats->chart_lost_bytes);
-    rrddim_set_by_pointer(stats->st_bytes, stats->rd_sent_bytes,     stats->chart_sent_bytes);
-    rrddim_set_by_pointer(stats->st_bytes, stats->rd_received_bytes, stats->chart_received_bytes);
+    rrddim_set_by_pointer(stats->st_bytes, stats->rd_buffered_bytes, stats->buffered_bytes);
+    rrddim_set_by_pointer(stats->st_bytes, stats->rd_lost_bytes,     stats->lost_bytes);
+    rrddim_set_by_pointer(stats->st_bytes, stats->rd_sent_bytes,     stats->sent_bytes);
+    rrddim_set_by_pointer(stats->st_bytes, stats->rd_received_bytes, stats->received_bytes);
 
     rrdset_done(stats->st_bytes);
 
@@ -141,11 +141,11 @@ void send_internal_metrics(struct instance *instance)
     if (likely(stats->st_ops->counter_done))
         rrdset_next(stats->st_ops);
 
-    rrddim_set_by_pointer(stats->st_ops, stats->rd_transmission_successes, stats->chart_transmission_successes);
-    rrddim_set_by_pointer(stats->st_ops, stats->rd_data_lost_events,       stats->chart_data_lost_events);
-    rrddim_set_by_pointer(stats->st_ops, stats->rd_reconnects,             stats->chart_reconnects);
-    rrddim_set_by_pointer(stats->st_ops, stats->rd_transmission_failures,  stats->chart_transmission_failures);
-    rrddim_set_by_pointer(stats->st_ops, stats->rd_receptions,             stats->chart_receptions);
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_transmission_successes, stats->transmission_successes);
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_data_lost_events,       stats->data_lost_events);
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_reconnects,             stats->reconnects);
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_transmission_failures,  stats->transmission_failures);
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_receptions,             stats->receptions);
 
     rrdset_done(stats->st_ops);
 

--- a/exporting/send_internal_metrics.c
+++ b/exporting/send_internal_metrics.c
@@ -3,16 +3,162 @@
 #include "exporting_engine.h"
 
 /**
- * Send internal metrics
+ * Create a chart for the main exporting thread CPU usage
+ */
+void create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_system)
+{
+    if (*st_rusage && *rd_user && *rd_system)
+        return;
+
+    *st_rusage = rrdset_create_localhost(
+        "netdata", "exporting_main_thread_cpu", NULL, "exporting", NULL, "Netdata Main Exporting Thread CPU Usage",
+        "milliseconds/s", "exporting", NULL, 130630, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
+
+    *rd_user = rrddim_add(*st_rusage, "user", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
+    *rd_system = rrddim_add(*st_rusage, "system", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
+}
+
+/**
+ * Send the main exporting thread CPU usage
+ */
+void send_main_rusage(RRDSET *st_rusage, RRDDIM *rd_user, RRDDIM *rd_system)
+{
+    struct rusage thread;
+    getrusage(RUSAGE_THREAD, &thread);
+
+    if (likely(st_rusage->counter_done))
+        rrdset_next(st_rusage);
+
+    rrddim_set_by_pointer(st_rusage, rd_user,   thread.ru_utime.tv_sec * 1000000ULL + thread.ru_utime.tv_usec);
+    rrddim_set_by_pointer(st_rusage, rd_system, thread.ru_stime.tv_sec * 1000000ULL + thread.ru_stime.tv_usec);
+
+    rrdset_done(st_rusage);
+}
+
+/**
+ * Send internal metrics for an instance
  *
  * Send performance metrics for the operation of exporting engine itself to the Netdata database.
  *
- * @param engine an engine data structure.
- * @return Returns 0 on success, 1 on failure.
+ * @param instance an instance data structure.
  */
-int send_internal_metrics(struct engine *engine)
+void send_internal_metrics(struct instance *instance)
 {
-    (void)engine;
+    struct stats *stats = &instance->stats;
 
-    return 0;
+    // ------------------------------------------------------------------------
+    // create charts for monitoring the exporting operations
+
+    if (!stats->initialized) {
+        char id[RRD_ID_LENGTH_MAX + 1];
+        BUFFER *family = buffer_create(0);
+
+        buffer_sprintf(family, "exporting_%s", instance->config.name);
+
+        sprintf("exporting_%s_metrics", instance->config.name);
+        netdata_fix_chart_id(id);
+
+        stats->st_metrics = rrdset_create_localhost(
+            "netdata", id, NULL, buffer_tostring(family), NULL, "Netdata Buffered Metrics", "metrics", "exporting", NULL,
+            130600, instance->config.update_every, RRDSET_TYPE_LINE);
+
+        stats->rd_buffered_metrics = rrddim_add(stats->st_metrics, "buffered", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        stats->rd_lost_metrics     = rrddim_add(stats->st_metrics, "lost", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        stats->rd_sent_metrics     = rrddim_add(stats->st_metrics, "sent", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+        // ------------------------------------------------------------------------
+
+        sprintf("exporting_%s_bytes", instance->config.name);
+        netdata_fix_chart_id(id);
+
+        stats->st_bytes = rrdset_create_localhost(
+            "netdata", id, NULL, buffer_tostring(family), NULL, "Netdata Exporting Data Size", "KiB", "exporting", NULL,
+            130610, instance->config.update_every, RRDSET_TYPE_AREA);
+
+        stats->rd_buffered_bytes = rrddim_add(stats->st_bytes, "buffered", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+        stats->rd_lost_bytes     = rrddim_add(stats->st_bytes, "lost", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+        stats->rd_sent_bytes     = rrddim_add(stats->st_bytes, "sent", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+        stats->rd_received_bytes = rrddim_add(stats->st_bytes, "received", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+
+        // ------------------------------------------------------------------------
+
+        sprintf("exporting_%s_ops", instance->config.name);
+        netdata_fix_chart_id(id);
+
+        stats->st_ops = rrdset_create_localhost(
+            "netdata", id, NULL, buffer_tostring(family), NULL, "Netdata Exporting Operations", "operations", "exporting",
+            NULL, 130630, instance->config.update_every, RRDSET_TYPE_LINE);
+
+        stats->rd_transmission_successes = rrddim_add(stats->st_ops, "write", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        stats->rd_data_lost_events       = rrddim_add(stats->st_ops, "discard", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        stats->rd_reconnects             = rrddim_add(stats->st_ops, "reconnect", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        stats->rd_transmission_failures  = rrddim_add(stats->st_ops, "failure", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        stats->rd_receptions             = rrddim_add(stats->st_ops, "read", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+        // ------------------------------------------------------------------------
+
+        sprintf("exporting_%s_thread_cpu", instance->config.name);
+        netdata_fix_chart_id(id);
+
+        stats->st_rusage = rrdset_create_localhost(
+            "netdata", id, NULL, buffer_tostring(family), NULL, "Netdata Exporting Instance Thread CPU Usage",
+            "milliseconds/s", "exporting", NULL, 130630, instance->config.update_every, RRDSET_TYPE_STACKED);
+
+        stats->rd_user   = rrddim_add(stats->st_rusage, "user", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
+        stats->rd_system = rrddim_add(stats->st_rusage, "system", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
+
+        buffer_free(family);
+
+        stats->initialized = 1;
+    }
+
+    // ------------------------------------------------------------------------
+    // update the monitoring charts
+
+    if (likely(stats->st_metrics->counter_done))
+        rrdset_next(stats->st_metrics);
+
+    rrddim_set_by_pointer(stats->st_metrics, stats->rd_buffered_metrics, stats->chart_buffered_metrics);
+    rrddim_set_by_pointer(stats->st_metrics, stats->rd_lost_metrics,     stats->chart_lost_metrics);
+    rrddim_set_by_pointer(stats->st_metrics, stats->rd_sent_metrics,     stats->chart_sent_metrics);
+
+    rrdset_done(stats->st_metrics);
+
+    // ------------------------------------------------------------------------
+
+    if (likely(stats->st_bytes->counter_done))
+        rrdset_next(stats->st_bytes);
+
+    rrddim_set_by_pointer(stats->st_bytes, stats->rd_buffered_bytes, stats->chart_buffered_bytes);
+    rrddim_set_by_pointer(stats->st_bytes, stats->rd_lost_bytes,     stats->chart_lost_bytes);
+    rrddim_set_by_pointer(stats->st_bytes, stats->rd_sent_bytes,     stats->chart_sent_bytes);
+    rrddim_set_by_pointer(stats->st_bytes, stats->rd_received_bytes, stats->chart_received_bytes);
+
+    rrdset_done(stats->st_bytes);
+
+    // ------------------------------------------------------------------------
+
+    if (likely(stats->st_ops->counter_done))
+        rrdset_next(stats->st_ops);
+
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_transmission_successes, stats->chart_transmission_successes);
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_data_lost_events,       stats->chart_data_lost_events);
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_reconnects,             stats->chart_reconnects);
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_transmission_failures,  stats->chart_transmission_failures);
+    rrddim_set_by_pointer(stats->st_ops, stats->rd_receptions,             stats->chart_receptions);
+
+    rrdset_done(stats->st_ops);
+
+    // ------------------------------------------------------------------------
+
+    struct rusage thread;
+    getrusage(RUSAGE_THREAD, &thread);
+
+    if (likely(stats->st_rusage->counter_done))
+        rrdset_next(stats->st_rusage);
+
+    rrddim_set_by_pointer(stats->st_rusage, stats->rd_user,   thread.ru_utime.tv_sec * 1000000ULL + thread.ru_utime.tv_usec);
+    rrddim_set_by_pointer(stats->st_rusage, stats->rd_system, thread.ru_stime.tv_sec * 1000000ULL + thread.ru_stime.tv_usec);
+
+    rrdset_done(stats->st_rusage);
 }

--- a/exporting/tests/exporting_doubles.c
+++ b/exporting/tests/exporting_doubles.c
@@ -82,10 +82,26 @@ int __wrap_notify_workers(struct engine *engine)
     return mock_type(int);
 }
 
-int __wrap_send_internal_metrics(struct engine *engine)
+void __wrap_create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_system)
 {
     function_called();
-    check_expected_ptr(engine);
+    check_expected_ptr(st_rusage);
+    check_expected_ptr(rd_user);
+    check_expected_ptr(rd_system);
+}
+
+void __wrap_send_main_rusage(RRDSET *st_rusage, RRDDIM *rd_user, RRDDIM *rd_system)
+{
+    function_called();
+    check_expected_ptr(st_rusage);
+    check_expected_ptr(rd_user);
+    check_expected_ptr(rd_system);
+}
+
+int __wrap_send_internal_metrics(struct instance *instance)
+{
+    function_called();
+    check_expected_ptr(instance);
     return mock_type(int);
 }
 

--- a/exporting/tests/netdata_doubles.c
+++ b/exporting/tests/netdata_doubles.c
@@ -85,6 +85,92 @@ void __rrd_check_rdlock(const char *file, const char *function, const unsigned l
     (void)line;
 }
 
+RRDSET *rrdset_create_custom(
+    RRDHOST *host,
+    const char *type,
+    const char *id,
+    const char *name,
+    const char *family,
+    const char *context,
+    const char *title,
+    const char *units,
+    const char *plugin,
+    const char *module,
+    long priority,
+    int update_every,
+    RRDSET_TYPE chart_type,
+    RRD_MEMORY_MODE memory_mode,
+    long history_entries)
+{
+    check_expected_ptr(host);
+    check_expected_ptr(type);
+    check_expected_ptr(id);
+    check_expected_ptr(name);
+    check_expected_ptr(family);
+    check_expected_ptr(context);
+    UNUSED(title);
+    check_expected_ptr(units);
+    check_expected_ptr(plugin);
+    check_expected_ptr(module);
+    check_expected(priority);
+    check_expected(update_every);
+    check_expected(chart_type);
+    UNUSED(memory_mode);
+    UNUSED(history_entries);
+
+    function_called();
+
+    return mock_ptr_type(RRDSET *);
+}
+
+void rrdset_next_usec(RRDSET *st, usec_t microseconds)
+{
+    check_expected_ptr(st);
+    UNUSED(microseconds);
+
+    function_called();
+}
+
+void rrdset_done(RRDSET *st)
+{
+    check_expected_ptr(st);
+
+    function_called();
+}
+
+RRDDIM *rrddim_add_custom(
+    RRDSET *st,
+    const char *id,
+    const char *name,
+    collected_number multiplier,
+    collected_number divisor,
+    RRD_ALGORITHM algorithm,
+    RRD_MEMORY_MODE memory_mode)
+{
+    check_expected_ptr(st);
+    UNUSED(id);
+    check_expected_ptr(name);
+    check_expected(multiplier);
+    check_expected(divisor);
+    check_expected(algorithm);
+    UNUSED(memory_mode);
+
+    function_called();
+
+    return NULL;
+}
+
+collected_number rrddim_set_by_pointer(RRDSET *st, RRDDIM *rd, collected_number value)
+{
+    check_expected_ptr(st);
+    UNUSED(rd);
+    UNUSED(value);
+
+    function_called();
+
+    return 0;
+}
+
 const char *rrd_memory_mode_name(RRD_MEMORY_MODE id)
 {
     (void)id;

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -384,7 +384,7 @@ static void test_prepare_buffers(void **state)
 
     assert_int_equal(__real_prepare_buffers(engine), 0);
 
-    assert_int_equal(instance->stats.chart_buffered_metrics, 1);
+    assert_int_equal(instance->stats.buffered_metrics, 1);
 
     // check with NULL functions
     instance->start_batch_formatting = NULL;
@@ -573,8 +573,8 @@ static void test_simple_connector_receive_response(void **state)
         log_line,
         "EXPORTING: received 9 bytes from instance_name connector instance. Ignoring them. Sample: 'Test recv'");
 
-    assert_int_equal(stats->chart_received_bytes, 9);
-    assert_int_equal(stats->chart_receptions, 1);
+    assert_int_equal(stats->received_bytes, 9);
+    assert_int_equal(stats->receptions, 1);
     assert_int_equal(sock, 1);
 }
 
@@ -614,10 +614,10 @@ static void test_simple_connector_send_buffer(void **state)
     simple_connector_send_buffer(&sock, &failures, instance);
 
     assert_int_equal(failures, 0);
-    assert_int_equal(stats->chart_transmission_successes, 1);
-    assert_int_equal(stats->chart_sent_bytes, 84);
-    assert_int_equal(stats->chart_sent_metrics, 1);
-    assert_int_equal(stats->chart_transmission_failures, 0);
+    assert_int_equal(stats->transmission_successes, 1);
+    assert_int_equal(stats->sent_bytes, 84);
+    assert_int_equal(stats->sent_metrics, 1);
+    assert_int_equal(stats->transmission_failures, 0);
 
     assert_int_equal(buffer_strlen(buffer), 0);
 
@@ -1304,7 +1304,7 @@ static void test_format_batch_mongodb(void **state)
     BUFFER *buffer = buffer_create(0);
     buffer_sprintf(buffer, "{ \"metric\": \"test_metric\" }\n");
     instance->buffer = buffer;
-    stats->chart_buffered_metrics = 1;
+    stats->buffered_metrics = 1;
 
     assert_int_equal(format_batch_mongodb(instance), 0);
 
@@ -1362,11 +1362,11 @@ static void test_mongodb_connector_worker(void **state)
     assert_ptr_equal(connector_specific_data->first_buffer, connector_specific_data->first_buffer->next);
 
     struct stats *stats = &instance->stats;
-    assert_int_equal(stats->chart_sent_bytes, 60);
-    assert_int_equal(stats->chart_transmission_successes, 1);
-    assert_int_equal(stats->chart_receptions, 1);
-    assert_int_equal(stats->chart_sent_bytes, 60);
-    assert_int_equal(stats->chart_sent_metrics, 0);
+    assert_int_equal(stats->sent_bytes, 60);
+    assert_int_equal(stats->transmission_successes, 1);
+    assert_int_equal(stats->receptions, 1);
+    assert_int_equal(stats->sent_bytes, 60);
+    assert_int_equal(stats->sent_metrics, 0);
 
     free(connector_specific_config->database);
     free(connector_specific_config->collection);

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -44,6 +44,11 @@ static void test_exporting_engine(void **state)
     expect_memory(__wrap_init_connectors, engine, engine, sizeof(struct engine));
     will_return(__wrap_init_connectors, 0);
 
+    expect_function_call(__wrap_create_main_rusage_chart);
+    expect_not_value(__wrap_create_main_rusage_chart, st_rusage, NULL);
+    expect_not_value(__wrap_create_main_rusage_chart, rd_user, NULL);
+    expect_not_value(__wrap_create_main_rusage_chart, rd_system, NULL);
+
     expect_function_call(__wrap_now_realtime_sec);
     will_return(__wrap_now_realtime_sec, 2);
 
@@ -59,9 +64,10 @@ static void test_exporting_engine(void **state)
     expect_memory(__wrap_notify_workers, engine, engine, sizeof(struct engine));
     will_return(__wrap_notify_workers, 0);
 
-    expect_function_call(__wrap_send_internal_metrics);
-    expect_memory(__wrap_send_internal_metrics, engine, engine, sizeof(struct engine));
-    will_return(__wrap_send_internal_metrics, 0);
+    expect_function_call(__wrap_send_main_rusage);
+    expect_value(__wrap_send_main_rusage, st_rusage, NULL);
+    expect_value(__wrap_send_main_rusage, rd_user, NULL);
+    expect_value(__wrap_send_main_rusage, rd_system, NULL);
 
     expect_function_call(__wrap_info_int);
 
@@ -122,7 +128,7 @@ static void test_init_connectors(void **state)
     assert_ptr_equal(instance->metric_formatting, format_dimension_collected_graphite_plaintext);
     assert_ptr_equal(instance->end_chart_formatting, NULL);
     assert_ptr_equal(instance->end_host_formatting, flush_host_labels);
-    assert_ptr_equal(instance->end_batch_formatting, NULL);
+    assert_ptr_equal(instance->end_batch_formatting, simple_connector_update_buffered_bytes);
 
     BUFFER *buffer = instance->buffer;
     assert_ptr_not_equal(buffer, NULL);
@@ -628,6 +634,7 @@ static void test_simple_connector_worker(void **state)
 {
     struct engine *engine = *state;
     struct instance *instance = engine->instance_root;
+    struct stats *stats = &instance->stats;
     BUFFER *buffer = instance->buffer;
 
     __real_mark_scheduled_instances(engine);
@@ -661,7 +668,24 @@ static void test_simple_connector_worker(void **state)
     expect_value(__wrap_send, len, 84);
     expect_value(__wrap_send, flags, MSG_NOSIGNAL);
 
+    expect_function_call(__wrap_send_internal_metrics);
+    expect_value(__wrap_send_internal_metrics, instance, instance);
+    will_return(__wrap_send_internal_metrics, 0);
+
     simple_connector_worker(instance);
+
+    assert_int_equal(stats->buffered_metrics, 0);
+    assert_int_equal(stats->buffered_bytes, 84);
+    assert_int_equal(stats->received_bytes, 0);
+    assert_int_equal(stats->sent_bytes, 84);
+    assert_int_equal(stats->sent_metrics, 1);
+    assert_int_equal(stats->lost_metrics, 0);
+    assert_int_equal(stats->receptions, 0);
+    assert_int_equal(stats->transmission_successes, 1);
+    assert_int_equal(stats->transmission_failures, 0);
+    assert_int_equal(stats->data_lost_events, 0);
+    assert_int_equal(stats->lost_bytes, 0);
+    assert_int_equal(stats->reconnects, 0);
 }
 
 static void test_sanitize_json_string(void **state)
@@ -759,6 +783,233 @@ static void test_flush_host_labels(void **state)
 
     assert_int_equal(flush_host_labels(instance, localhost), 0);
     assert_int_equal(buffer_strlen(instance->labels), 0);
+}
+
+static void test_create_main_rusage_chart(void **state)
+{
+    UNUSED(state);
+
+    RRDSET *st_rusage = calloc(1, sizeof(RRDSET));
+    RRDDIM *rd_user = NULL;
+    RRDDIM *rd_system = NULL;
+
+    expect_function_call(rrdset_create_custom);
+    expect_value(rrdset_create_custom, host, localhost);
+    expect_string(rrdset_create_custom, type, "netdata");
+    expect_string(rrdset_create_custom, id, "exporting_main_thread_cpu");
+    expect_value(rrdset_create_custom, name, NULL);
+    expect_string(rrdset_create_custom, family, "exporting");
+    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, units, "milliseconds/s");
+    expect_string(rrdset_create_custom, plugin, "exporting");
+    expect_value(rrdset_create_custom, module, NULL);
+    expect_value(rrdset_create_custom, priority, 130600);
+    expect_value(rrdset_create_custom, update_every, localhost->rrd_update_every);
+    expect_value(rrdset_create_custom, chart_type, RRDSET_TYPE_STACKED);
+    will_return(rrdset_create_custom, st_rusage);
+
+    expect_function_calls(rrddim_add_custom, 2);
+    expect_value_count(rrddim_add_custom, st, st_rusage, 2);
+    expect_value_count(rrddim_add_custom, name, NULL, 2);
+    expect_value_count(rrddim_add_custom, multiplier, 1, 2);
+    expect_value_count(rrddim_add_custom, divisor, 1000, 2);
+    expect_value_count(rrddim_add_custom, algorithm, RRD_ALGORITHM_INCREMENTAL, 2);
+
+    __real_create_main_rusage_chart(&st_rusage, &rd_user, &rd_system);
+
+    free(st_rusage);
+}
+
+static void test_send_main_rusage(void **state)
+{
+    UNUSED(state);
+
+    RRDSET *st_rusage = calloc(1, sizeof(RRDSET));
+    st_rusage->counter_done = 1;
+
+    expect_function_call(rrdset_next_usec);
+    expect_value(rrdset_next_usec, st, st_rusage);
+
+    expect_function_calls(rrddim_set_by_pointer, 2);
+    expect_value_count(rrddim_set_by_pointer, st, st_rusage, 2);
+
+    expect_function_call(rrdset_done);
+    expect_value(rrdset_done, st, st_rusage);
+
+    __real_send_main_rusage(st_rusage, NULL, NULL);
+
+    free(st_rusage);
+}
+
+static void test_send_internal_metrics(void **state)
+{
+    UNUSED(state);
+
+    struct instance *instance = calloc(1, sizeof(struct instance));
+    instance->config.name = (const char *)strdupz("test_instance");
+    instance->config.update_every = 2;
+
+    struct stats *stats = &instance->stats;
+
+    stats->st_metrics = calloc(1, sizeof(RRDSET));
+    stats->st_metrics->counter_done = 1;
+    stats->st_bytes = calloc(1, sizeof(RRDSET));
+    stats->st_bytes->counter_done = 1;
+    stats->st_ops = calloc(1, sizeof(RRDSET));
+    stats->st_ops->counter_done = 1;
+    stats->st_rusage = calloc(1, sizeof(RRDSET));
+    stats->st_rusage->counter_done = 1;
+
+    // ------------------------------------------------------------------------
+
+    expect_function_call(rrdset_create_custom);
+    expect_value(rrdset_create_custom, host, localhost);
+    expect_string(rrdset_create_custom, type, "netdata");
+    expect_string(rrdset_create_custom, id, "exporting_test_instance_metrics");
+    expect_value(rrdset_create_custom, name, NULL);
+    expect_string(rrdset_create_custom, family, "exporting_test_instance");
+    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, units, "metrics");
+    expect_string(rrdset_create_custom, plugin, "exporting");
+    expect_value(rrdset_create_custom, module, NULL);
+    expect_value(rrdset_create_custom, priority, 130610);
+    expect_value(rrdset_create_custom, update_every, 2);
+    expect_value(rrdset_create_custom, chart_type, RRDSET_TYPE_LINE);
+    will_return(rrdset_create_custom, stats->st_metrics);
+
+    expect_function_calls(rrddim_add_custom, 3);
+    expect_value_count(rrddim_add_custom, st, stats->st_metrics, 3);
+    expect_value_count(rrddim_add_custom, name, NULL, 3);
+    expect_value_count(rrddim_add_custom, multiplier, 1, 3);
+    expect_value_count(rrddim_add_custom, divisor, 1, 3);
+    expect_value_count(rrddim_add_custom, algorithm, RRD_ALGORITHM_ABSOLUTE, 3);
+
+    // ------------------------------------------------------------------------
+
+    expect_function_call(rrdset_create_custom);
+    expect_value(rrdset_create_custom, host, localhost);
+    expect_string(rrdset_create_custom, type, "netdata");
+    expect_string(rrdset_create_custom, id, "exporting_test_instance_bytes");
+    expect_value(rrdset_create_custom, name, NULL);
+    expect_string(rrdset_create_custom, family, "exporting_test_instance");
+    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, units, "KiB");
+    expect_string(rrdset_create_custom, plugin, "exporting");
+    expect_value(rrdset_create_custom, module, NULL);
+    expect_value(rrdset_create_custom, priority, 130620);
+    expect_value(rrdset_create_custom, update_every, 2);
+    expect_value(rrdset_create_custom, chart_type, RRDSET_TYPE_AREA);
+    will_return(rrdset_create_custom, stats->st_bytes);
+
+    expect_function_calls(rrddim_add_custom, 4);
+    expect_value_count(rrddim_add_custom, st, stats->st_bytes, 4);
+    expect_value_count(rrddim_add_custom, name, NULL, 4);
+    expect_value_count(rrddim_add_custom, multiplier, 1, 4);
+    expect_value_count(rrddim_add_custom, divisor, 1024, 4);
+    expect_value_count(rrddim_add_custom, algorithm, RRD_ALGORITHM_ABSOLUTE, 4);
+
+    // ------------------------------------------------------------------------
+
+    expect_function_call(rrdset_create_custom);
+    expect_value(rrdset_create_custom, host, localhost);
+    expect_string(rrdset_create_custom, type, "netdata");
+    expect_string(rrdset_create_custom, id, "exporting_test_instance_ops");
+    expect_value(rrdset_create_custom, name, NULL);
+    expect_string(rrdset_create_custom, family, "exporting_test_instance");
+    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, units, "operations");
+    expect_string(rrdset_create_custom, plugin, "exporting");
+    expect_value(rrdset_create_custom, module, NULL);
+    expect_value(rrdset_create_custom, priority, 130630);
+    expect_value(rrdset_create_custom, update_every, 2);
+    expect_value(rrdset_create_custom, chart_type, RRDSET_TYPE_LINE);
+    will_return(rrdset_create_custom, stats->st_ops);
+
+    expect_function_calls(rrddim_add_custom, 5);
+    expect_value_count(rrddim_add_custom, st, stats->st_ops, 5);
+    expect_value_count(rrddim_add_custom, name, NULL, 5);
+    expect_value_count(rrddim_add_custom, multiplier, 1, 5);
+    expect_value_count(rrddim_add_custom, divisor, 1, 5);
+    expect_value_count(rrddim_add_custom, algorithm, RRD_ALGORITHM_ABSOLUTE, 5);
+
+    // ------------------------------------------------------------------------
+
+    expect_function_call(rrdset_create_custom);
+    expect_value(rrdset_create_custom, host, localhost);
+    expect_string(rrdset_create_custom, type, "netdata");
+    expect_string(rrdset_create_custom, id, "exporting_test_instance_thread_cpu");
+    expect_value(rrdset_create_custom, name, NULL);
+    expect_string(rrdset_create_custom, family, "exporting_test_instance");
+    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, units, "milliseconds/s");
+    expect_string(rrdset_create_custom, plugin, "exporting");
+    expect_value(rrdset_create_custom, module, NULL);
+    expect_value(rrdset_create_custom, priority, 130640);
+    expect_value(rrdset_create_custom, update_every, 2);
+    expect_value(rrdset_create_custom, chart_type, RRDSET_TYPE_STACKED);
+    will_return(rrdset_create_custom, stats->st_rusage);
+
+    expect_function_calls(rrddim_add_custom, 2);
+    expect_value_count(rrddim_add_custom, st, stats->st_rusage, 2);
+    expect_value_count(rrddim_add_custom, name, NULL, 2);
+    expect_value_count(rrddim_add_custom, multiplier, 1, 2);
+    expect_value_count(rrddim_add_custom, divisor, 1000, 2);
+    expect_value_count(rrddim_add_custom, algorithm, RRD_ALGORITHM_INCREMENTAL, 2);
+
+    // ------------------------------------------------------------------------
+
+    expect_function_call(rrdset_next_usec);
+    expect_value(rrdset_next_usec, st, stats->st_metrics);
+
+    expect_function_calls(rrddim_set_by_pointer, 3);
+    expect_value_count(rrddim_set_by_pointer, st, stats->st_metrics, 3);
+
+    expect_function_call(rrdset_done);
+    expect_value(rrdset_done, st, stats->st_metrics);
+
+    // ------------------------------------------------------------------------
+
+    expect_function_call(rrdset_next_usec);
+    expect_value(rrdset_next_usec, st, stats->st_bytes);
+
+    expect_function_calls(rrddim_set_by_pointer, 4);
+    expect_value_count(rrddim_set_by_pointer, st, stats->st_bytes, 4);
+
+    expect_function_call(rrdset_done);
+    expect_value(rrdset_done, st, stats->st_bytes);
+
+    // ------------------------------------------------------------------------
+
+    expect_function_call(rrdset_next_usec);
+    expect_value(rrdset_next_usec, st, stats->st_ops);
+
+    expect_function_calls(rrddim_set_by_pointer, 5);
+    expect_value_count(rrddim_set_by_pointer, st, stats->st_ops, 5);
+
+    expect_function_call(rrdset_done);
+    expect_value(rrdset_done, st, stats->st_ops);
+
+    // ------------------------------------------------------------------------
+
+    expect_function_call(rrdset_next_usec);
+    expect_value(rrdset_next_usec, st, stats->st_rusage);
+
+    expect_function_calls(rrddim_set_by_pointer, 2);
+    expect_value_count(rrddim_set_by_pointer, st, stats->st_rusage, 2);
+
+    expect_function_call(rrdset_done);
+    expect_value(rrdset_done, st, stats->st_rusage);
+
+    // ------------------------------------------------------------------------
+
+    __real_send_internal_metrics(instance);
+
+    free(stats->st_metrics);
+    free(stats->st_bytes);
+    free(stats->st_ops);
+    free(stats->st_rusage);
+    free((void *)instance->config.name);
+    free(instance);
 }
 
 static void test_can_send_rrdset(void **state)
@@ -1148,6 +1399,7 @@ static void test_aws_kinesis_connector_worker(void **state)
 {
     struct engine *engine = *state;
     struct instance *instance = engine->instance_root;
+    struct stats *stats = &instance->stats;
     BUFFER *buffer = instance->buffer;
 
     __real_mark_scheduled_instances(engine);
@@ -1193,7 +1445,24 @@ static void test_aws_kinesis_connector_worker(void **state)
     expect_not_value(__wrap_kinesis_get_result, lost_bytes, NULL);
     will_return(__wrap_kinesis_get_result, 0);
 
+    expect_function_call(__wrap_send_internal_metrics);
+    expect_value(__wrap_send_internal_metrics, instance, instance);
+    will_return(__wrap_send_internal_metrics, 0);
+
     aws_kinesis_connector_worker(instance);
+
+    assert_int_equal(stats->buffered_metrics, 0);
+    assert_int_equal(stats->buffered_bytes, 84);
+    assert_int_equal(stats->received_bytes, 0);
+    assert_int_equal(stats->sent_bytes, 84);
+    assert_int_equal(stats->sent_metrics, 1);
+    assert_int_equal(stats->lost_metrics, 0);
+    assert_int_equal(stats->receptions, 1);
+    assert_int_equal(stats->transmission_successes, 1);
+    assert_int_equal(stats->transmission_failures, 0);
+    assert_int_equal(stats->data_lost_events, 0);
+    assert_int_equal(stats->lost_bytes, 0);
+    assert_int_equal(stats->reconnects, 0);
 
     free(connector_specific_config->stream_name);
     free(connector_specific_config->auth_key_id);
@@ -1355,6 +1624,10 @@ static void test_mongodb_connector_worker(void **state)
     expect_not_value(__wrap_mongoc_collection_insert_many, error, NULL);
     will_return(__wrap_mongoc_collection_insert_many, true);
 
+    expect_function_call(__wrap_send_internal_metrics);
+    expect_value(__wrap_send_internal_metrics, instance, instance);
+    will_return(__wrap_send_internal_metrics, 0);
+
     mongodb_connector_worker(instance);
 
     assert_ptr_equal(connector_specific_data->first_buffer->insert, NULL);
@@ -1362,11 +1635,18 @@ static void test_mongodb_connector_worker(void **state)
     assert_ptr_equal(connector_specific_data->first_buffer, connector_specific_data->first_buffer->next);
 
     struct stats *stats = &instance->stats;
-    assert_int_equal(stats->sent_bytes, 60);
-    assert_int_equal(stats->transmission_successes, 1);
+    assert_int_equal(stats->buffered_metrics, 0);
+    assert_int_equal(stats->buffered_bytes, 0);
+    assert_int_equal(stats->received_bytes, 0);
+    assert_int_equal(stats->sent_bytes, 30);
+    assert_int_equal(stats->sent_metrics, 1);
+    assert_int_equal(stats->lost_metrics, 0);
     assert_int_equal(stats->receptions, 1);
-    assert_int_equal(stats->sent_bytes, 60);
-    assert_int_equal(stats->sent_metrics, 0);
+    assert_int_equal(stats->transmission_successes, 1);
+    assert_int_equal(stats->transmission_failures, 0);
+    assert_int_equal(stats->data_lost_events, 0);
+    assert_int_equal(stats->lost_bytes, 0);
+    assert_int_equal(stats->reconnects, 0);
 
     free(connector_specific_config->database);
     free(connector_specific_config->collection);
@@ -1444,6 +1724,14 @@ int main(void)
 
     int test_res = cmocka_run_group_tests_name("exporting_engine", tests, NULL, NULL) +
                    cmocka_run_group_tests_name("labels_in_exporting_engine", label_tests, NULL, NULL);
+
+    const struct CMUnitTest internal_metrics_tests[] = {
+        cmocka_unit_test(test_create_main_rusage_chart),
+        cmocka_unit_test(test_send_main_rusage),
+        cmocka_unit_test(test_send_internal_metrics),
+    };
+
+    test_res += cmocka_run_group_tests_name("internal_metrics", internal_metrics_tests, NULL, NULL);
 
     const struct CMUnitTest prometheus_web_api_tests[] = {
         cmocka_unit_test_setup_teardown(test_can_send_rrdset, setup_prometheus, teardown_prometheus),

--- a/exporting/tests/test_exporting_engine.h
+++ b/exporting/tests/test_exporting_engine.h
@@ -91,7 +91,14 @@ int __wrap_prepare_buffers(struct engine *engine);
 
 int __wrap_notify_workers(struct engine *engine);
 
-int __wrap_send_internal_metrics(struct engine *engine);
+void __real_create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_system);
+void __wrap_create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_system);
+
+void __real_send_main_rusage(RRDSET *st_rusage, RRDDIM *rd_user, RRDDIM *rd_system);
+void __wrap_send_main_rusage(RRDSET *st_rusage, RRDDIM *rd_user, RRDDIM *rd_system);
+
+int __real_send_internal_metrics(struct instance *instance);
+int __wrap_send_internal_metrics(struct instance *instance);
 
 int __real_rrdhost_is_exportable(struct instance *instance, RRDHOST *host);
 int __wrap_rrdhost_is_exportable(struct instance *instance, RRDHOST *host);


### PR DESCRIPTION
##### Summary
Internal stats for the exporting engine are collected and displayed.

Closes #7171

##### Component Name
exporting engine

##### Test Plan
Check internal statistics in "Netdta Monitoring" menu for every connector and for the main exporting engine thread
![image](https://user-images.githubusercontent.com/22008543/78693009-579d2280-7903-11ea-86bc-28cc2d1dadd8.png)
