### PR TITLE
collectors/python.d/mysql: fix `threads_creation_rate` chart context

### DIFF
--- a/collectors/python.d.plugin/mysql/mysql.chart.py
+++ b/collectors/python.d.plugin/mysql/mysql.chart.py
@@ -347,7 +347,7 @@ CHARTS = {
         ]
     },
     'threads_creation_rate': {
-        'options': [None, 'Threads Creation Rate', 'threads/s', 'threads', 'mysql.threads', 'line'],
+        'options': [None, 'Threads Creation Rate', 'threads/s', 'threads', 'mysql.threads_creation_rate', 'line'],
         'lines': [
             ['Threads_created', 'created', 'incremental'],
         ]


### PR DESCRIPTION
##### Summary

Fixes: #8634

`threads` and `threads_creation_rate` charts have same context

https://github.com/netdata/netdata/blob/3c4cb607d6b77b9fd9076dd6662d3bc13975c871/collectors/python.d.plugin/mysql/mysql.chart.py#L341-L354

This PR changes `threads_creation_rate` chart context to `mysql.threads_creation_rate`

##### Component Name

`collectors/python.d`

##### Test Plan

No tests needed.

##### Additional Information
