### PR TITLE
Docs: Pin mkdocs-material to older version to re-enable builds

### DIFF
--- a/docs/generator/requirements.txt
+++ b/docs/generator/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs>=1.0.1
-mkdocs-material
+mkdocs-material==4.6.3


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

After discovering that our docs site builds were failing, I also noticed that the mkdocs-material project released a new major version at the exact same time. Netlify was trying to pull this latest version, resulting in the build errors.

This PR pins `mkdocs-material` to the previous stable release (4.6.3), which is what Netlify was building with until this morning.

##### Component Name

docs

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

See if Netlify respects the new requirements and builds the docs site again.

##### Additional Information
