### PR TITLE
Ceph: Added OSD size collection

### DIFF
--- a/collectors/python.d.plugin/ceph/ceph.chart.py
+++ b/collectors/python.d.plugin/ceph/ceph.chart.py
@@ -31,6 +31,7 @@ ORDER = [
     'pool_read_operations',
     'pool_write_operations',
     'osd_usage',
+    'osd_size',
     'osd_apply_latency',
     'osd_commit_latency'
 ]
@@ -99,6 +100,10 @@ CHARTS = {
     },
     'osd_usage': {
         'options': [None, 'Ceph OSDs', 'KiB', 'osd', 'ceph.osd_usage', 'line'],
+        'lines': []
+    },
+    'osd_size': {
+        'options': [None, 'Ceph OSDs size', 'KiB', 'osd', 'ceph.osd_size', 'line'],
         'lines': []
     },
     'osd_apply_latency': {
@@ -189,6 +194,9 @@ class Service(SimpleService):
             self.definitions['osd_usage']['lines'].append([osd['name'],
                                                            osd['name'],
                                                            'absolute'])
+            self.definitions['osd_size']['lines'].append([osd['name'],
+                                                           osd['name'],
+                                                           'absolute'])
             self.definitions['osd_apply_latency']['lines'].append(['apply_latency_{0}'.format(osd['name']),
                                                                    osd['name'],
                                                                    'absolute'])
@@ -217,6 +225,7 @@ class Service(SimpleService):
                 data.update(self._get_pool_rw(pool_io))
             for osd in osd_df['nodes']:
                 data.update(self._get_osd_usage(osd))
+                data.update(self._get_osd_size(osd))
             for osd_apply_commit in osd_perf_infos:
                 data.update(self._get_osd_latency(osd_apply_commit))
             return data
@@ -294,6 +303,14 @@ class Service(SimpleService):
         :return: A osd dict with osd name's key and usage bytes' value
         """
         return {osd['name']: float(osd['kb_used'])}
+
+    @staticmethod
+    def _get_osd_size(osd):
+        """
+        Process raw data into osd dict information to get osd size (kb)
+        :return: A osd dict with osd name's key and size bytes' value
+        """
+        return {osd['name']: float(osd['kb'])}
 
     @staticmethod
     def _get_osd_latency(osd):

--- a/collectors/python.d.plugin/ceph/ceph.chart.py
+++ b/collectors/python.d.plugin/ceph/ceph.chart.py
@@ -194,7 +194,7 @@ class Service(SimpleService):
             self.definitions['osd_usage']['lines'].append([osd['name'],
                                                            osd['name'],
                                                            'absolute'])
-            self.definitions['osd_size']['lines'].append([osd['name'],
+            self.definitions['osd_size']['lines'].append(['size_{0}'.format(osd['name']),
                                                            osd['name'],
                                                            'absolute'])
             self.definitions['osd_apply_latency']['lines'].append(['apply_latency_{0}'.format(osd['name']),
@@ -310,7 +310,7 @@ class Service(SimpleService):
         Process raw data into osd dict information to get osd size (kb)
         :return: A osd dict with osd name's key and size bytes' value
         """
-        return {osd['name']: float(osd['kb'])}
+        return {'size_{0}'.format(osd['name']): float(osd['kb'])}
 
     @staticmethod
     def _get_osd_latency(osd):

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1877,6 +1877,10 @@ netdataDashboard.context = {
         info: 'The usage space in each OSD.'
     },
 
+    'ceph.osd_size': {
+        info: "Each OSD's size"
+    },
+
     'ceph.apply_latency': {
         info: 'Time taken to flush an update in each OSD.'
     },


### PR DESCRIPTION
##### Summary

Added OSD size (=capacity) collection to the ceph plugin.
This will usually not vary:  an osd has a defined capacity based on the
underlying disk.
So it might not make sense to collect it, contrary to the osd_usage, which is the used space and varies as data is written to ceph.
But not collecting the osd_size prevents from computing used ratio (osd_usage / osd_size) or available space (osd_size - osd_usage), which are useful metrics.

##### Component Name

Ceph python plugin

##### Test Plan

I use the modified plugin on a production cluster:
 - PROXMOX Virtual Environment 6.1-8
 - Ceph version 14.2.8

I verified that the additional data was collected.

##### Additional Information

The 'kb' field has the same format as the 'kb_used' field in `ceph osd df --json` output.

Sample  `ceph osd df --json` output:

    {
      "nodes": [
        {
          "id": 12,
          "device_class": "ssd",
          "name": "osd.12",
          "type": "osd",
          "type_id": 0,
          "crush_weight": 1.8189849853515625,
          "depth": 2,
          "pool_weights": {},
          "reweight": 1,
          "kb": 1953513472,
          "kb_used": 723914120,
          "kb_used_data": 722465792,
          "kb_used_omap": 16,
          "kb_used_meta": 1448303,
          "kb_avail": 1229599352,
          "utilization": 37.05703238682349,
          "var": 0.6282679826388614,
          "pgs": 10,
          "status": "up"
        },
    
        (...)
    
      "stray": [],
      "summary": {
        "total_kb": 42477871104,
        "total_kb_used": 25054656432,
        "total_kb_used_data": 24961224336,
        "total_kb_used_omap": 13949325,
        "total_kb_used_meta": 79482162,
        "total_kb_avail": 17423214672,
        "average_utilization": 58.98284396281971,
        "min_var": 0.6262459694797988,
        "max_var": 1.2928955206659904,
        "dev": 13.779317402301619
      }
