### PR TITLE
health/alarm_notify: add dynatrace enabled check

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1914,6 +1914,8 @@ EOF
 # -----------------------------------------------------------------------------
 # Dynatrace sender
 send_dynatrace() {
+  [ "${SEND_DYNATRACE}" != "YES" ] && return 1
+
   local dynatrace_url="${DYNATRACE_SERVER}/e/${DYNATRACE_SPACE}/api/v1/events"
   local description="NetData Notification for: ${host} ${chart}.${name} is ${status}"
   local payload=""


### PR DESCRIPTION
##### Summary

This PR adds check to the `send_dynatrace` function. If method is disabled we need to exit early. 

##### Component Name

`health`

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

 - ask @mfundul to test it

##### Additional Information
