### PR TITLE
Microsoft Teams

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -163,7 +163,7 @@ pd
 fleep
 syslog
 custom
-msteam
+msteams
 kavenegar
 prowl
 irc
@@ -295,7 +295,7 @@ done
 SLACK_WEBHOOK_URL=
 
 # Microsoft Team configs
-MSTEAM_WEBHOOK_URL=
+MSTEAMS_WEBHOOK_URL=
 
 # rocketchat configs
 ROCKETCHAT_WEBHOOK_URL=
@@ -541,7 +541,7 @@ if [ "${SEND_PUSHOVER}" = "YES" ] ||
 	[ "${SEND_PROWL}" = "YES" ] ||
 	[ "${SEND_HANGOUTS}" = "YES" ] ||
 	[ "${SEND_CUSTOM}" = "YES" ] ||
-	[ "${SEND_MSTEAM}" = "YES" ] ||
+	[ "${SEND_MSTEAMS}" = "YES" ] ||
 	[ "${SEND_DYNATRACE}" = "YES" ]; then
 	# if we need curl, check for the curl command
 	if [ -z "${curl}" ]; then
@@ -553,7 +553,7 @@ if [ "${SEND_PUSHOVER}" = "YES" ] ||
 		SEND_PUSHBULLET="NO"
 		SEND_TELEGRAM="NO"
 		SEND_SLACK="NO"
-		SEND_MSTEAM="NO"
+		SEND_MSTEAMS="NO"
 		SEND_ROCKETCHAT="NO"
 		SEND_ALERTA="NO"
 		SEND_PD="NO"
@@ -695,8 +695,8 @@ for method in "${SEND_EMAIL}" \
 	"${SEND_AWSSNS}" \
 	"${SEND_SYSLOG}" \
 	"${SEND_SMS}" \
-	"${SEND_MSTEAM}" \
-    "${SEND_DYNATRACE}"; do
+	"${SEND_MSTEAMS}" \
+	"${SEND_DYNATRACE}"; do
 	
 	if [ "${method}" == "YES" ]; then
 		proceed=1
@@ -1183,22 +1183,22 @@ send_telegram() {
 # -----------------------------------------------------------------------------
 # Microsoft Team sender
 
-send_msteam() {
+send_msteams() {
 
 	local webhook="${1}" channels="${2}" httpcode sent=0 channel color payload
 
-	[ "${SEND_MSTEAM}" != "YES" ] && return 1
+	[ "${SEND_MSTEAMS}" != "YES" ] && return 1
 
 	case "${status}" in
-	WARNING) icon="${MSTEAM_ICON_WARNING}" && color="${MSTEAM_COLOR_WARNING}" ;;
-	CRITICAL) icon="${MSTEAM_ICON_CRITICAL}" && color="${MSTEAM_COLOR_CRITICAL}" ;;
-	CLEAR) icon="${MSTEAM_ICON_CLEAR}" && color="${MSTEAM_COLOR_CLEAR}" ;;
-	*) icon="${MSTEAM_ICON_DEFAULT}" && color="${MSTEAM_COLOR_DEFAULT}" ;;
+	WARNING) icon="${MSTEAMS_ICON_WARNING}" && color="${MSTEAMS_COLOR_WARNING}" ;;
+	CRITICAL) icon="${MSTEAMS_ICON_CRITICAL}" && color="${MSTEAMS_COLOR_CRITICAL}" ;;
+	CLEAR) icon="${MSTEAMS_ICON_CLEAR}" && color="${MSTEAMS_COLOR_CLEAR}" ;;
+	*) icon="${MSTEAMS_ICON_DEFAULT}" && color="${MSTEAMS_COLOR_DEFAULT}" ;;
 	esac
 
 	for channel in ${channels}; do
 		## More details are available here regarding the payload syntax options : https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference
-		## Online designer : https://acdesignerbeta.azurewebsites.net/
+		## Online designer : https://adaptivecards.io/designer/
 		payload="$(
 			cat <<EOF
         {
@@ -2087,13 +2087,13 @@ send_hangouts "${to_hangouts}"
 SENT_HANGOUTS=$?
 
 # -----------------------------------------------------------------------------
-# send the Microsoft notification
+# send the Microsoft Teams notification
 
-# Microsoft team aggregates posts from the same username
+# Microsoft teams aggregates posts from the same username
 # so we use "${host} ${status}" as the bot username, to make them diff
 
-send_msteam "${MSTEAM_WEBHOOK_URL}" "${to_msteam}"
-SENT_MSTEAM=$?
+send_msteams "${MSTEAMS_WEBHOOK_URL}" "${to_msteams}"
+SENT_MSTEAMS=$?
 
 # -----------------------------------------------------------------------------
 # send the rocketchat notification
@@ -2493,7 +2493,7 @@ for state in "${SENT_EMAIL}" \
 	"${SENT_AWSSNS}" \
 	"${SENT_SYSLOG}" \
 	"${SENT_SMS}" \
-	"${SENT_MSTEAM}" \
+	"${SENT_MSTEAMS}" \
     "${SENT_DYNATRACE}"; do	
 	if [ "${state}" -eq 0 ]; then
 		# we sent something

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -294,7 +294,7 @@ done
 # slack configs
 SLACK_WEBHOOK_URL=
 
-# Microsoft Team configs
+# Microsoft Teams configs
 MSTEAMS_WEBHOOK_URL=
 
 # rocketchat configs

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -19,7 +19,7 @@
 # - notifications to Amazon SNS topics (aws.amazon.com)
 # - messages to your irc channel on your selected network
 # - messages to a local or remote syslog daemon
-# - message to Microsoft Team (through webhook)
+# - message to Microsoft Teams (through webhook)
 # - message to Rocket.Chat (through webhook)
 # - message to Google Hangouts Chat (through webhook)
 #
@@ -442,38 +442,38 @@ SLACK_WEBHOOK_URL=""
 DEFAULT_RECIPIENT_SLACK=""
 
 #------------------------------------------------------------------------------
-# Microsoft Team (office.com) global notification options
+# Microsoft Teams (office.com) global notification options
 # More details are available here regarding the payload syntax options : https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference
 # Online designer : https://acdesignerbeta.azurewebsites.net/
 # multiple recipients can be given like this:
 #                  "CHANNEL1 CHANNEL2 ..."
 
-# enable/disable sending team notifications
-SEND_MSTEAM="YES"
+# enable/disable sending teams notifications
+SEND_MSTEAMS="YES"
 
 # if a role's recipients are not configured, a notification will be send to
-# this slack channel (empty = do not send a notification for unconfigured
+# this Teams channel (empty = do not send a notification for unconfigured
 # roles):
-# For team the channel name is encoded in the URI after ....IncomingWebhook/___/.....
+# For teams the channel name is encoded in the URI after ....IncomingWebhook/___/.....
 # This value will be replaced in the webhook value to publish to several channels in a same Team.
 # In order to get it working properly, you have to replace the value between [] ....IncomingWebhook/[___]/..... by "CHANNEL" string.
-DEFAULT_RECIPIENT_MSTEAM=""
+DEFAULT_RECIPIENT_MSTEAMS=""
 # Based on the way MS Teams is working, put the differents channels here like : "CHANNEL1 CHANNEL2 ..."
 # AT LEAST ONE CHANNEL IS MANDATORY
-MSTEAM_WEBHOOK_URL=""
+MSTEAMS_WEBHOOK_URL=""
 
-# Define the default color scheme for alert to MS Team - icon and color
+# Define the default color scheme for alert to MS Teams - icon and color
 # Icons - go to https://emojipedia.org/bomb/
-MSTEAM_ICON_DEFAULT="♡"
-MSTEAM_ICON_CLEAR="💚"
-MSTEAM_ICON_WARNING="⚠️"
-MSTEAM_ICON_CRITICAL="🔥"
+MSTEAMS_ICON_DEFAULT="♡"
+MSTEAMS_ICON_CLEAR="💚"
+MSTEAMS_ICON_WARNING="⚠️"
+MSTEAMS_ICON_CRITICAL="🔥"
 
 # Colors
-MSTEAM_COLOR_DEFAULT="0076D7"
-MSTEAM_COLOR_CLEAR="65A677"
-MSTEAM_COLOR_WARNING="FFA500"
-MSTEAM_COLOR_CRITICAL="D93F3C"
+MSTEAMS_COLOR_DEFAULT="0076D7"
+MSTEAMS_COLOR_CLEAR="65A677"
+MSTEAMS_COLOR_WARNING="FFA500"
+MSTEAMS_COLOR_CRITICAL="D93F3C"
 
 
 #------------------------------------------------------------------------------
@@ -906,7 +906,7 @@ role_recipients_awssns[sysadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[sysadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteam[sysadmin]="${DEFAULT_RECIPIENT_MSTEAM}"
+role_recipients_msteams[sysadmin]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
 role_recipients_rocketchat[sysadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
@@ -954,7 +954,7 @@ role_recipients_awssns[domainadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[domainadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteam[domainadmin]="${DEFAULT_RECIPIENT_MSTEAM}"
+role_recipients_msteams[domainadmin]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
 role_recipients_rocketchat[domainadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
@@ -1005,7 +1005,7 @@ role_recipients_awssns[dba]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[dba]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteam[dba]="${DEFAULT_RECIPIENT_MSTEAM}"
+role_recipients_msteams[dba]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
 role_recipients_rocketchat[dba]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
@@ -1056,7 +1056,7 @@ role_recipients_awssns[webmaster]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[webmaster]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteam[webmaster]="${DEFAULT_RECIPIENT_MSTEAM}"
+role_recipients_msteams[webmaster]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
 role_recipients_rocketchat[webmaster]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
@@ -1107,7 +1107,7 @@ role_recipients_awssns[porxyadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[proxyadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteam[proxyadmin]="${DEFAULT_RECIPIENT_MSTEAM}"
+role_recipients_msteams[proxyadmin]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
 role_recipients_rocketchat[proxyadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
@@ -1156,7 +1156,7 @@ role_recipients_awssns[sitemgr]="${DEFAULT_RECIPIENT_AWSSNS}"
 
 role_recipients_custom[sitemgr]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteam[sitemgr]="${DEFAULT_RECIPIENT_MSTEAM}"
+role_recipients_msteams[sitemgr]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
 role_recipients_rocketchat[sitemgr]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -444,7 +444,7 @@ DEFAULT_RECIPIENT_SLACK=""
 #------------------------------------------------------------------------------
 # Microsoft Teams (office.com) global notification options
 # More details are available here regarding the payload syntax options : https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference
-# Online designer : https://acdesignerbeta.azurewebsites.net/
+# Online designer : https://adaptivecards.io/designer/
 # multiple recipients can be given like this:
 #                  "CHANNEL1 CHANNEL2 ..."
 


### PR DESCRIPTION
##### Summary
- Change `msteam` -> `msteams` (correct naming)
- Fix nonworking adaptive card designer URL
- Removed `slack` reference in Teams stanza

This is a minor change, since the official name of the product is **[Microsoft Teams](https://products.office.com/en-US/microsoft-teams/group-chat-software)** I thought the config should reflect that, otherwise it almost looks like a typo.

##### Component Name
- Alarms / config