### PR TITLE
Added statusimage chart library

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -130,5 +130,6 @@ This is the list of contributors that have signed this agreement:
 |@akwan|Alan Kwan||
 |@underhood|Timotej Šiškovič||
 |@stevenh|Steven Hartland|steven.hartland@multiplay.co.uk|
+|@lab-w|Norbert Werner|norbert.werner@lab-w.org|
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2FCONTRIBUTORS&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -130,6 +130,6 @@ This is the list of contributors that have signed this agreement:
 |@akwan|Alan Kwan||
 |@underhood|Timotej Šiškovič||
 |@stevenh|Steven Hartland|steven.hartland@multiplay.co.uk|
-|@lab-w|Norbert Werner|norbert.werner@lab-w.org|
+|@lab-w|Norbert Werner|opensource@lab-w.org|
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2FCONTRIBUTORS&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/web/gui/Makefile.am
+++ b/web/gui/Makefile.am
@@ -29,6 +29,7 @@ DASHBOARD_JS_FILES = \
     src/dashboard.js/charting/d3pie.js \
     src/dashboard.js/charting/d3.js \
     src/dashboard.js/charting/peity.js \
+    src/dashboard.js/charting/statusimage.js \
     src/dashboard.js/charting/textonly.js \
     src/dashboard.js/charting.js \
     src/dashboard.js/chart-registry.js \

--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -4303,6 +4303,23 @@ NETDATA.peityChartCreate = function (state, data) {
 };
 
 // ----------------------------------------------------------------------------------------------------------------
+// "Status Image" chart - Displays binary status images in the DOM
+
+NETDATA.statusImageCreate = function(state, data) {
+    var trueImage = NETDATA.dataAttribute(state.element, 'statusimage-true-image', '');
+    var falseImage = NETDATA.dataAttribute(state.element, 'statusimage-false-image', '');
+
+    var imageUrl = trueImage;
+    if (data.result[0] == 0) imageUrl = falseImage;
+
+    state.element.innerHTML = "<img src=" + imageUrl + "></img>";
+    return true;
+}
+
+NETDATA.statusImageUpdate = NETDATA.statusImageCreate;
+
+
+// ----------------------------------------------------------------------------------------------------------------
 // "Text-only" chart - Just renders the raw value to the DOM
 
 NETDATA.textOnlyCreate = function(state, data) {
@@ -4756,6 +4773,48 @@ NETDATA.chartLibraries = {
             void(state);
             return 'netdata-container-gauge';
         }
+    },
+    "statusimage": {
+        autoresize: function (state) {
+            void(state);
+            return false;
+        },
+        container_class: function (state) {
+            void(state);
+            return 'netdata-container';
+        },
+        create: NETDATA.statusImageCreate,
+        enabled: true,
+        format: function (state) {
+            void(state);
+            return 'array';
+        },
+        initialized: true,
+        initialize: function (callback) {
+            callback();
+        },
+        legend: function (state) {
+            void(state);
+            return null;
+        },
+        max_updates_to_recreate: function (state) {
+            void(state);
+            return 5000;
+        },
+        options: function (state) {
+            void(state);
+            return 'absolute';
+        },
+        pixels_per_point: function (state) {
+            void(state);
+            return 3;
+        },
+        track_colors: function (state) {
+            void(state);
+            return false;
+        },
+        update: NETDATA.statusImageUpdate,
+        xssRegexIgnore: new RegExp('^/api/v1/data\.result$'),
     },
     "textonly": {
         autoresize: function (state) {

--- a/web/gui/src/dashboard.js/charting.js
+++ b/web/gui/src/dashboard.js/charting.js
@@ -437,6 +437,48 @@ NETDATA.chartLibraries = {
             return 'netdata-container-gauge';
         }
     },
+    "statusimage": {
+        autoresize: function (state) {
+            void(state);
+            return false;
+        },
+        container_class: function (state) {
+            void(state);
+            return 'netdata-container';
+        },
+        create: NETDATA.statusImageCreate,
+        enabled: true,
+        format: function (state) {
+            void(state);
+            return 'array';
+        },
+        initialized: true,
+        initialize: function (callback) {
+            callback();
+        },
+        legend: function (state) {
+            void(state);
+            return null;
+        },
+        max_updates_to_recreate: function (state) {
+            void(state);
+            return 5000;
+        },
+        options: function (state) {
+            void(state);
+            return 'absolute';
+        },
+        pixels_per_point: function (state) {
+            void(state);
+            return 3;
+        },
+        track_colors: function (state) {
+            void(state);
+            return false;
+        },
+        update: NETDATA.statusImageUpdate,
+        xssRegexIgnore: new RegExp('^/api/v1/data\.result$'),
+    },
     "textonly": {
         autoresize: function (state) {
             void(state);

--- a/web/gui/src/dashboard.js/charting/statusimage.js
+++ b/web/gui/src/dashboard.js/charting/statusimage.js
@@ -1,0 +1,17 @@
+
+// ----------------------------------------------------------------------------------------------------------------
+// "Status Image" chart - Displays binary status images in the DOM
+
+NETDATA.statusImageCreate = function(state, data) {
+    var trueImage = NETDATA.dataAttribute(state.element, 'statusimage-true-image', '');
+    var falseImage = NETDATA.dataAttribute(state.element, 'statusimage-false-image', '');
+
+    var imageUrl = trueImage;
+    if (data.result[0] == 0) imageUrl = falseImage;
+
+    state.element.innerHTML = "<img src=" + imageUrl + "></img>";
+    return true;
+}
+
+NETDATA.statusImageUpdate = NETDATA.statusImageCreate;
+


### PR DESCRIPTION
##### Summary
This PR adds a chart library displaying an image depending on the data. If the data equals zero the image given by statusimage-false-image is displayed, otherwise the image given by statusimage-true-image.
Fixes #8265 by displaying a state (value equals zero or not) via an image.

##### Component Name
Chart libraries

##### Test Plan
Can be tested by adding these section to a custom dashboard:

    <div data-netdata="<data to analyze>"
                data-chart-library="statusimage"
                data-update-every="1"
                data-statusimage-true-image="true.png"
                data-statusimage-false-image="false.png"
                data-after="-300"
                data-points="300"
    ></div>

Two images (true.png and false.png) needs to be available for testing.

##### Additional Information
