### PR TITLE
[ReOpen #8626] Improved offline installation instructions to point to correct installation scripts and clarify process

### DIFF
--- a/packaging/installer/methods/offline.md
+++ b/packaging/installer/methods/offline.md
@@ -34,7 +34,7 @@ curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "bro
 curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*txt" | cut -d '"' -f 4 | wget -qi -
 
 # Netdata dependency handling script
-curl -s https://raw.githubusercontent.com/netdata/netdata-demo-site/master/install-required-packages.sh | wget -qi -
+wget -q - https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh
 
 # go.d plugin 
 # For binaries for OS types and architectures not listed on [go.d releases](https://github.com/netdata/go.d.plugin/releases/latest), kindly open a github issue and we will do our best to serve your request
@@ -70,10 +70,10 @@ option requires you to specify the location and names of the files you just down
 
 ```bash
 # kickstart.sh
-bash kickstart.sh --local-files /tmp/netdata-version-number-here.tar.gz /tmp/sha256sums.txt /tmp/go.d-binary-filename.tar.gz /tmp/config.tar.gz /tmp/install-required-packages.sh
+bash kickstart.sh --local-files /tmp/netdata-(version-number-here).tar.gz /tmp/sha256sums.txt /tmp/go.d.plugin-(version-number-here).(OS)-(architecture).tar.gz /tmp/config.tar.gz /tmp/install-required-packages.sh
 
 # kickstart-static64.sh
-bash kickstart-static64.sh --local-files /tmp/netdata-version-number-here.gz.run /tmp/sha256sums.txt
+bash kickstart-static64.sh --local-files /tmp/netdata-(version-number-here).gz.run /tmp/sha256sums.txt
 ```
 
 Now that Netdata is installed, be sure to visit our [getting started guide](../../../docs/getting-started.md) for a


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
0. Amend an incorrect command in the document, also correct the link to _install-required-packages.sh_ script.(https://github.com/netdata/netdata/blame/9342704a41cbd20a315e55f0b1ff3efd9f039498/packaging/installer/methods/offline.md#L37)

1. Make the parts of the example command that need to be filled by the user be clearly separated from other parts.(https://github.com/IceCodeNew/netdata/commit/e13d9a60a6d587ae80b2bfc7326b9a809aa48d69#diff-40714f9627176dfafc102507b4ffb471R73)

##### Component Name
None.

##### Test Plan
None. It's just a rewording of the document.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
Re-open [PR#8626](https://github.com/netdata/netdata/pull/8626), As I re-commit this change, the PR was automatically closed. Never thought about such consequence before I issue `git reset --hard HEAD~N` and `git push -f` :-(