### PR TITLE
libnetdata/log: fatal add missing space

### DIFF
--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -810,7 +810,7 @@ void fatal_int( const char *file, const char *function, const unsigned long line
 
     va_start( args, fmt );
     if(debug_flags) fprintf(stderr, "%s: %s FATAL : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
-    else            fprintf(stderr, "%s: %s FATAL : %s :", date, program_name, netdata_thread_tag());
+    else            fprintf(stderr, "%s: %s FATAL : %s : ", date, program_name, netdata_thread_tag());
     vfprintf( stderr, fmt, args );
     va_end( args );
 


### PR DESCRIPTION
##### Summary

ssia

```cmd
2020-04-11 21:56:13: netdata INFO  : MAIN : Cannot open the file /var/lib/netdata/health.silencers.json, so Netdata will work with the default health configuration.
2020-04-11 21:56:13: netdata FATAL : MAIN :Cannot create directory '/var/lib/netdata/registry'. # : Invalid argument
```

##### Component Name

`libnetdata/log`

##### Test Plan

Not needed

##### Additional Information
