### PR TITLE
Remove error message on netdata restart

### DIFF
--- a/libnetdata/popen/popen.c
+++ b/libnetdata/popen/popen.c
@@ -296,8 +296,14 @@ int custom_pclose(FILE *fp, pid_t pid) {
                 return(info.si_status);
 
             case CLD_KILLED:
-                error("child pid %d killed by signal %d.", info.si_pid, info.si_status);
-                return(-1);
+                if(info.si_status == 15) {
+                    info("child pid %d killed by signal %d.", info.si_pid, info.si_status);
+                    return(0);
+                }
+                else {
+                    error("child pid %d killed by signal %d.", info.si_pid, info.si_status);
+                    return(-1);
+                }
 
             case CLD_DUMPED:
                 error("child pid %d core dumped by signal %d.", info.si_pid, info.si_status);


### PR DESCRIPTION
When issuing a SIGTERM with `systemctl restart netdata.service` an ERROR message is created in the log for every plugin:
> netdata ERROR : PLUGINSD[apps] : child pid 23901 killed by signal 15.
> netdata ERROR : PLUGINSD[python.d] : child pid 23908 killed by signal 15.
> netdata ERROR : PLUGINSD[nfacct] : child pid 23909 killed by signal 15.
> netdata ERROR : PLUGINSD[go.d] : child pid 23899 killed by signal 15.

Seems like it would be worth silencing this to an INFO message if we did a proper restart or shutdown.
Also, I wasn't sure what the proper return code should be so I put it in as `return(0);`

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
