### PR TITLE
Update pfSense doc and add warning for apcupsd users

### DIFF
--- a/packaging/installer/methods/pfsense.md
+++ b/packaging/installer/methods/pfsense.md
@@ -36,7 +36,7 @@ URL instead, or you can try manually changing the netdata version in the URL to 
 
 You must edit `/usr/local/etc/netdata/netdata.conf` and change `bind to = 127.0.0.1` to `bind to = 0.0.0.0`.
 
-To start Netdata manually, run `service netdata onestart`
+To start Netdata manually, run `service netdata onestart`.
 
 **Warning:** If you are using the plugin `apcupsd`, you need to make sure that apcupsd is up before starting netdata. Otherwise a infinitely running `cat` process triggerd by the default activated netdata apcuspd charts plugin will eat up CPU and RAM (`/tmp/.netdata-charts.d-*/run-*`). This also applies for `OPNsense`.
 

--- a/packaging/installer/methods/pfsense.md
+++ b/packaging/installer/methods/pfsense.md
@@ -38,7 +38,7 @@ You must edit `/usr/local/etc/netdata/netdata.conf` and change `bind to = 127.0.
 
 To start Netdata manually, run `service netdata onestart`.
 
-**Warning:** If you are using the plugin `apcupsd`, you need to make sure that apcupsd is up before starting netdata. Otherwise a infinitely running `cat` process triggerd by the default activated netdata apcuspd charts plugin will eat up CPU and RAM (`/tmp/.netdata-charts.d-*/run-*`). This also applies for `OPNsense`.
+**Warning:** If you are using the `apcupsd` collector, you need to make sure that apcupsd is up before starting Netdata. Otherwise a infinitely running `cat` process triggered by the default activated apcuspd charts plugin will eat up CPU and RAM (`/tmp/.netdata-charts.d-*/run-*`). This also applies to `OPNsense`.
 
 Visit the Netdata dashboard to confirm it's working: `http://<pfsenseIP>:19999`
 

--- a/packaging/installer/methods/pfsense.md
+++ b/packaging/installer/methods/pfsense.md
@@ -14,14 +14,20 @@ Note that the first four packages are downloaded from the pfSense repository for
 Netdata, Judy and Python are downloaded from the FreeBSD repository.
 
 ```sh
-pkg install pkgconf
-pkg install bash
-pkg install e2fsprogs-libuuid
-pkg install libuv
+pkg install -y pkgconf bash e2fsprogs-libuuid libuv nano
 pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/Judy-1.0.5_2.txz
-pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/python36-3.6.9.txz
-ln -s /usr/local/lib/libjson-c.so /usr/local/lib/libjson-c.so.4
-pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/netdata-1.17.1.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-certifi-2020.4.5.1.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-asn1crypto-1.3.0.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-pycparser-2.19.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-cffi-1.14.0.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-six-1.14.0.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-cryptography-2.6.1.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-idna-2.8.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-openssl-19.0.0.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-pysocks-1.7.1.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-urllib3-1.25.7,1.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/py37-yaml-5.2.txz
+pkg add http://pkg.freebsd.org/FreeBSD:11:amd64/latest/All/netdata-1.20.0_3.txz
 ```
 
 **Note:** If you receive a `Not Found` error during the last two commands above, you will either need to manually look
@@ -30,7 +36,9 @@ URL instead, or you can try manually changing the netdata version in the URL to 
 
 You must edit `/usr/local/etc/netdata/netdata.conf` and change `bind to = 127.0.0.1` to `bind to = 0.0.0.0`.
 
-To start Netdata manually, run `service netdata onestart`  
+To start Netdata manually, run `service netdata onestart`
+
+**Warning:** If you are using the plugin `apcupsd`, you need to make sure that apcupsd is up before starting netdata. Otherwise a infinitely running `cat` process triggerd by the default activated netdata apcuspd charts plugin will eat up CPU and RAM (`/tmp/.netdata-charts.d-*/run-*`). This also applies for `OPNsense`.
 
 Visit the Netdata dashboard to confirm it's working: `http://<pfsenseIP>:19999`
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
* update to latest netdata package versions in pfSense installation documentation and add missing dependencies

* add warning when using apcupsd to prevent memory leak and high cpu usage

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information

If netdata is started before `apcupsd` (happens when starting apcupsd automatically through checkbox in GUI and netdata through shellcmd mechanism) a `cat` process will eat up CPU and RAM. The `cat` process seems to be triggered by the default activated `apcupsd` netdata charts plugin (writes to `/tmp/.netdata-charts.d-foo/run.foo`). When disabling the netdata apcupsd plugin, the cat process is not spawned at boot.

But without disabling the netdata apcupsd plugin it can be prevented by ensuring apcupsd is started before netdata with for example the following as a shellcmd command:

`service apcupsd onestart; service netdata onestart`
