### PR TITLE
charts.d/apcupsd: fix ups status check

### DIFF
--- a/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
+++ b/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
@@ -28,7 +28,7 @@ apcupsd_get() {
 
 is_ups_status_ok() {
   case "$1" in
-    "ONLINE"* | "ONBATT"* | "TRIM ONLINE" | "CAL ONBATT") return 0 ;;
+    "ONLINE" | "ONBATT" | "TRIM ONLINE" | "CAL ONBATT") return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
+++ b/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
@@ -28,7 +28,7 @@ apcupsd_get() {
 
 is_ups_status_ok() {
   case "$1" in
-    "ONLINE"* | "ONBATT"* | "TRIM ONLINE") return 0 ;;
+    "ONLINE"* | "ONBATT"* | "TRIM ONLINE" | "CAL ONBATT") return 0 ;;
     *) return 1 ;;
   esac
 }


### PR DESCRIPTION
##### Summary

Fixes: #8687
Fixes: https://github.com/netdata/netdata/issues/5428#issuecomment-589941219

Current implementation treats all statuses except `ONLINE` and `ONBATT` as failed statuses.

https://github.com/netdata/netdata/blob/231d19351d0ea20aa66fd204215cbb24f34d7575/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh#L50-L51

All available statuses [according docs](https://www.systutorials.com/docs/linux/man/8-apcaccess/):

- One or more of the following (space-separated): CAL TRIM BOOST ONLINE ONBATT OVERLOAD LOWBATT REPLACEBATT NOBATT SLAVE SLAVEDOWN
- COMMLOST
- SHUTTING DOWN

We have 2 reported problems:
 - add `CAL ONBATT` status ([link](https://github.com/netdata/netdata/issues/5428#issuecomment-589941219))
 - add `TRIM ONLINE` status ([link](https://github.com/netdata/netdata/issues/5428#issuecomment-612635833))

I agree with @Mic-Pod that it is safe to treat all statuses except `COMMLOST` and `SHUTTING DOWN` as ok and try to collect data from upses. I am not 100% sure but it looks like a better alternative then keep adding statuses one by one. 


##### Component Name

`collectors/charts.d`

##### Test Plan

- [X] tested new logic with the following script

<details>
<summary>click click</summary>

```sh
is_ups_alive() {
  case "$1" in
    "" | "COMMLOST" | "SHUTTING DOWN") return 1 ;;
    *) return 0 ;;
  esac
}

extract_ups_status() {
  sed -e 's/STATUS.*: //' -e 't' -e 'd' <<< "$1"
}

tests=(
  "before\nSTATUS : ONBATT\n after"
  "before\nSTATUS : ONBATT SOMETHING\n after"
  "before\nSTATUS : ONLINE\n after"
  "before\nSTATUS : ONLINE SOMETHING\n after"
  "before\nSTATUS : TRIM ONLINE\n after"
  "before\nSTATUS : COMMLOST\n after"
  "before\nSTATUS : SHUTTING DOWN\n after"
  ""
)

for test in "${tests[@]}"; do
  if is_ups_alive "$(extract_ups_status "$(echo -e "$test")")"; then
    echo "OK: $test"
  else
    echo "FAIL: $test"
  fi
done
```


</details>

Result:

```cmd
OK: "before\nSTATUS : ONBATT\n after"
OK: "before\nSTATUS : ONBATT SOMETHING\n after"
OK: "before\nSTATUS : ONLINE\n after"
OK: "before\nSTATUS : ONLINE SOMETHING\n after"
OK: "before\nSTATUS : TRIM ONLINE\n after"
FAIL: "before\nSTATUS : COMMLOST\n after"
FAIL: "before\nSTATUS : SHUTTING DOWN\n after"
FAIL: ""
```

- [x] ask @Mic-Pod to test the PR

##### Additional Information
