### PR TITLE
Fixes compatibility with RH 7.x family

### DIFF
--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -72,6 +72,7 @@ static int use_stdout = 0;
 struct config collector_config;
 static int mykernel = 0;
 static int nprocs;
+static int isrh;
 uint32_t *hash_values;
 
 pthread_mutex_t lock;
@@ -775,6 +776,8 @@ void set_global_variables() {
     if (nprocs > NETDATA_MAX_PROCESSOR) {
         nprocs = NETDATA_MAX_PROCESSOR;
     }
+
+    isrh = get_redhat_release();
 }
 
 static void change_collector_event() {
@@ -787,6 +790,14 @@ static void change_collector_event() {
         collector_events[i].name = NULL;
 }
 
+static void change_syscalls() {
+    static char *lfork = { "do_fork" };
+    static char *lclone = { "sys_clone" };
+    id_names[7] = lfork;
+    collector_events[8].name = lfork;
+    collector_events[10].name = lclone;
+}
+
 static inline void what_to_load(char *ptr) {
     if (!strcasecmp(ptr, "return"))
         mode = 0;
@@ -796,6 +807,9 @@ static inline void what_to_load(char *ptr) {
         */
     else
         change_collector_event();
+
+    if (isrh >= NETDATA_MINIMUM_RH_VERSION && isrh < NETDATA_RH_8)
+        change_syscalls();
 }
 
 static inline void enable_debug(char *ptr) {

--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -888,6 +888,9 @@ int main(int argc, char **argv)
 
     if (load_collector_file(user_config_dir)) {
         info("[EBPF PROCESS] does not have a configuration file. It is starting with default options.");
+        change_collector_event();
+        if (isrh >= NETDATA_MINIMUM_RH_VERSION && isrh < NETDATA_RH_8)
+            change_syscalls();
     }
 
     if(ebpf_load_libraries()) {

--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -861,8 +861,10 @@ int main(int argc, char **argv)
     (void)argv;
 
     mykernel =  get_kernel_version();
-    if(!has_condition_to_run(mykernel))
+    if(!has_condition_to_run(mykernel)) {
+        error("[EBPF PROCESS] The current collector cannot run on this kernel.");
         return 1;
+    }
 
     //set name
     program_name = "ebpf_process.plugin";
@@ -891,7 +893,6 @@ int main(int argc, char **argv)
         change_collector_event();
         if (isrh >= NETDATA_MINIMUM_RH_VERSION && isrh < NETDATA_RH_8)
             change_syscalls();
-        
     }
 
     if(ebpf_load_libraries()) {
@@ -930,6 +931,7 @@ int main(int argc, char **argv)
 
     if (pthread_mutex_init(&lock, NULL)) {
         thread_finished++;
+        error("[EBPF PROCESS] Cannot start the mutex.");
         int_exit(7);
     }
 

--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -792,10 +792,8 @@ static void change_collector_event() {
 
 static void change_syscalls() {
     static char *lfork = { "do_fork" };
-    static char *lclone = { "sys_clone" };
     id_names[7] = lfork;
     collector_events[8].name = lfork;
-    collector_events[10].name = lclone;
 }
 
 static inline void what_to_load(char *ptr) {

--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -891,6 +891,7 @@ int main(int argc, char **argv)
         change_collector_event();
         if (isrh >= NETDATA_MINIMUM_RH_VERSION && isrh < NETDATA_RH_8)
             change_syscalls();
+        
     }
 
     if(ebpf_load_libraries()) {

--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -782,12 +782,12 @@ void set_global_variables() {
 
 static void change_collector_event() {
     int i;
+    if (mykernel < NETDATA_KERNEL_V5_3)
+        collector_events[10].name = NULL;
+
     for (i = 0; collector_events[i].name ; i++ ) {
         collector_events[i].type = 'p';
     }
-
-    if (mykernel < 328448)
-        collector_events[i].name = NULL;
 }
 
 static void change_syscalls() {

--- a/collectors/ebpf_process.plugin/ebpf_process.h
+++ b/collectors/ebpf_process.plugin/ebpf_process.h
@@ -100,4 +100,6 @@ typedef struct netdata_error_report {
 
 # define NETDATA_MAX_PROCESSOR 512
 
+# define NETDATA_KERNEL_V5_3 328448
+
 #endif

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -91,7 +91,7 @@ int get_kernel_version() {
     return ((int)(str2l(major)*65536) + (int)(str2l(minor)*256) + (int)str2l(patch));
 }
 
-static int has_redhat_release()
+int get_redhat_release()
 {
     char buffer[256];
     int major,minor;
@@ -132,7 +132,7 @@ static int has_redhat_release()
 
 static int has_ebpf_kernel_version(int version) {
             //Kernel 4.11.0 or RH > 7.5
-    return (version >= NETDATA_MINIMUM_EBPF_KERNEL ||  has_redhat_release() >= NETDATA_MINIMUM_RH_VERSION);
+    return (version >= NETDATA_MINIMUM_EBPF_KERNEL ||  get_redhat_release() >= NETDATA_MINIMUM_RH_VERSION);
 }
 
 int has_condition_to_run(int version) {

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -100,7 +100,9 @@ int get_redhat_release()
     if (fp) {
         major = 0;
         minor = -1;
-        if (fread(buffer, sizeof(char), 255, fp) > 4 ) {
+        size_t length = fread(buffer, sizeof(char), 255, fp);
+        if (length > 4 ) {
+            buffer[length] = '\0';
             char *end = strchr(buffer, '.');
             char *start;
             if (end) {

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -91,8 +91,48 @@ int get_kernel_version() {
     return ((int)(str2l(major)*65536) + (int)(str2l(minor)*256) + (int)str2l(patch));
 }
 
+static int has_redhat_release()
+{
+    char buffer[256];
+    int major,minor;
+    FILE *fp = fopen("/etc/redhat-release", "r");
+
+    if (fp) {
+        major = 0;
+        minor = -1;
+        if (fread(buffer, sizeof(char), 255, fp) > 4 ) {
+            char *end = strchr(buffer, '.');
+            char *start;
+            if (end) {
+                *end = 0x0;
+
+                if (end > buffer) {
+                    start = end - 1;
+
+                    major = strtol( start, NULL, 10);
+                    start = ++end;
+
+                    end++;
+                    if(end) {
+                        end = 0x00;
+                        minor = strtol( start, NULL, 10);
+                    } else {
+                        minor = -1;
+                    }
+                }
+            }
+        }
+
+        fclose(fp);
+        return ((major*256) + minor);
+    } else {
+        return -1;
+    }
+}
+
 static int has_ebpf_kernel_version(int version) {
-    return (version >= 264960);
+            //Kernel 4.11.0 or RH > 7.5
+    return (version >= NETDATA_MINIMUM_EBPF_KERNEL ||  has_redhat_release() >= NETDATA_MINIMUM_RH_VERSION);
 }
 
 int has_condition_to_run(int version) {

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -21,6 +21,11 @@
  */
 # define NETDATA_MINIMUM_RH_VERSION 1797
 
+/**
+ * 2048 = 8*256 + 0
+ */
+# define NETDATA_RH_8 2048
+
 
 typedef struct netdata_ebpf_events {
     char type;
@@ -30,6 +35,7 @@ typedef struct netdata_ebpf_events {
 
 extern int clean_kprobe_events(FILE *out, int pid, netdata_ebpf_events_t *ptr);
 extern int get_kernel_version();
+extern int get_redhat_release();
 extern int has_condition_to_run(int version);
 
 #endif

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -3,6 +3,25 @@
 
 # define NETDATA_DEBUGFS "/sys/kernel/debug/tracing/"
 
+/**
+ * The next magic number is got doing the following math:
+ *  294960 = 4*65536 + 11*256 + 0
+ *
+ *  For more details, please, read /usr/include/linux/version.h
+ */
+# define NETDATA_MINIMUM_EBPF_KERNEL 264960
+
+/**
+ * The RedHat magic number was got doing:
+ *
+ * 1797 = 7*256 + 5
+ *
+ *  For more details, please, read /usr/include/linux/version.h
+ *  in any Red Hat installation.
+ */
+# define NETDATA_MINIMUM_RH_VERSION 1797
+
+
 typedef struct netdata_ebpf_events {
     char type;
     char *name;


### PR DESCRIPTION
##### Summary
Fixes #8621 

This PR brings the necessary changes inside the collector to it monitors correctly the kernel functions on RH 7.x and CentOS 7.x
##### Component Name
Collector
##### Test Plan
Install Netdata with the option `--enable-ebpf`  and enable the collector insider your `netdata.conf`.

##### Additional Information
We detected a problem  with systemD that was not fixed yet.