### PR TITLE
yamllint: enable truthy rule

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -32,3 +32,4 @@ rules:
   trailing-spaces: enable
   truthy:
     check-keys: false
+    allowed-values: ["true", "false", "yes", "no"]

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -30,4 +30,5 @@ rules:
   octal-values: enable
   quoted-strings: disable
   trailing-spaces: enable
-  truthy: disable
+  truthy:
+    check-keys: false


### PR DESCRIPTION
##### Summary

Fixes: #8303

`check-keys` option was added in [v1.22.0](https://github.com/adrienverge/yamllint/releases/tag/v1.22.0)

> https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy



##### Component Name

`ci`

##### Test Plan

- [X] create image from the Dockerfile

```dockerfile
FROM python:alpine

RUN pip install yamllint

WORKDIR /data

ENTRYPOINT ["yamllint"]
```

- [X] run yamllint, ensure there is no `truthy` errors

```cmd
0 ilyam:netdata (yamllint_enable_truthy_rule *)$ docker run --rm -v $(pwd):/data myyamllint -f colored --no-warnings . 2>&1 | grep truthy
1 ilyam:netdata (yamllint_enable_truthy_rule)$
```

##### Additional Information
