### PR TITLE
Fixed Arch Linux Ci checks.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -42,7 +42,7 @@ jobs:
             pre: 'apk add -U bash'
 
           - distro: 'archlinux:latest'
-            pre: 'pacman --noconfirm -Sy grep'
+            pre: 'pacman --noconfirm -Sy grep libffi'
 
           - distro: 'debian:bullseye'
             pre: 'apt-get update'

--- a/tests/updater_checks.sh
+++ b/tests/updater_checks.sh
@@ -52,7 +52,7 @@ case "${running_os}" in
 	;;
 "arch")
 	pacman -Sy
-	pacman --noconfirm --needed -S bash-bats curl
+	pacman --noconfirm --needed -S bash-bats curl libffi
 	;;
 "alpine")
 	apk update


### PR DESCRIPTION
##### Summary

This explicitly pulls in libffi during CI checks on Arch Linux.

The `make` command depends on it (becaus it uses GNU Guile, which depends on libffi) but does not pull it in as a dependency. This isn't likely to affect user systems in most cases as they will almost certainly have Python installed, which also depends on libffi and pulls it in correctly, but our CI systems don't install anything unnecessary, so they don't have it.

##### Component Name

area/ci

##### Test Plan

CI checks for Arch Linux pass on this PR.

##### Additional Information

This is a workaround for an upstream bug in Arch.