### PR TITLE
Typo.

### DIFF
--- a/docs/Running-behind-haproxy.md
+++ b/docs/Running-behind-haproxy.md
@@ -167,7 +167,7 @@ backend netdata_backend
 
 ## Enable authentication
 
-To use basic HTTP Authentication, create a authentication list:
+To use basic HTTP Authentication, create an authentication list:
 
 ```conf
 # HTTP Auth


### PR DESCRIPTION
Fixed grammar error in HAProxy documentation.