### PR TITLE
Fix crash when shutdown with ACLK disabled

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1281,6 +1281,8 @@ void *aclk_main(void *ptr)
 
     if (!netdata_cloud_setting) {
         info("Killing ACLK thread -> cloud functionality has been disabled");
+        struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
+        static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
         return NULL;
     }
 


### PR DESCRIPTION
### Summary

This PR fixes a crash (segfault, `pthread_cancel()` on non-existent thread) when Netdata is shutdown with ACLK disabled, currently the default.

##### Component Name

ACLK

##### Test Plan

Verify no crash is observed when Netdata is shutdown. Perform verification in official Docker container (Alpine Linux/musl).