### PR TITLE
Improved ACLK reconnection sequence

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1257,12 +1257,11 @@ static void aclk_try_to_connect(char *hostname, char *port, int port_num)
     if (aclk_password == NULL)
         return;
     int rc;
+    aclk_connecting = 1;
     rc = mqtt_attempt_connection(hostname, port_num, aclk_username, aclk_password);
     if (unlikely(rc)) {
         error("Failed to initialize the agent cloud link library");
     }
-    // The event loop will be called 200 times (100ms delay) before resetting
-    aclk_connecting = 200;
 }
 
 
@@ -1351,12 +1350,13 @@ void *aclk_main(void *ptr)
             if (aclk_connecting) {
                 _link_event_loop();
                 sleep_usec(USEC_PER_MS * 100);
-                aclk_connecting--;
             }
             continue;
         }
 
         _link_event_loop();
+        if (unlikely(!aclk_connected))
+            continue;
         /*static int stress_counter = 0;
         if (write_q_bytes==0 && stress_counter ++ >5)
         {
@@ -1365,7 +1365,7 @@ void *aclk_main(void *ptr)
         }*/
 
         // TODO: Move to on-connect
-        if (unlikely(!aclk_subscribed && aclk_connected)) {
+        if (unlikely(!aclk_subscribed)) {
             aclk_subscribed = !aclk_subscribe(ACLK_COMMAND_TOPIC, 1);
         }
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1261,7 +1261,8 @@ static void aclk_try_to_connect(char *hostname, char *port, int port_num)
     if (unlikely(rc)) {
         error("Failed to initialize the agent cloud link library");
     }
-    aclk_connecting = 1;
+    // The event loop will be called 200 times (100ms delay) before resetting
+    aclk_connecting = 200;
 }
 
 
@@ -1350,6 +1351,7 @@ void *aclk_main(void *ptr)
             if (aclk_connecting) {
                 _link_event_loop();
                 sleep_usec(USEC_PER_MS * 100);
+                aclk_connecting--;
             }
             continue;
         }
@@ -1363,7 +1365,7 @@ void *aclk_main(void *ptr)
         }*/
 
         // TODO: Move to on-connect
-        if (unlikely(!aclk_subscribed)) {
+        if (unlikely(!aclk_subscribed && aclk_connected)) {
             aclk_subscribed = !aclk_subscribe(ACLK_COMMAND_TOPIC, 1);
         }
 


### PR DESCRIPTION
Fixes #8675

#### Summary
When ACLK fails and a reconnect is started, the LWS layer may fail immediately leaving
the agent in a false reconnecting state (but the lws layer is essentially dead)

#### Component Name
ACLK

#### Test Plan
Agent ACLK was tested on a link with simulated extreme timeouts (50000ms or more)
Example (adjust as need; careful if test machine is remote)

```
sudo tc qdisc add  dev eth0 root netem delay 50000ms 
sleep 15m
sudo tc qdisc del  dev eth0 root netem
```

- The ACLK will fail in multiple stages
 - LWS drops
 - Challenge fails
 - LWS cannot be established

The agent enters a "connecting state", aclk_connecting is set but the actual LWS layer has failed (no callbacks to reset aclk_connecting) and it stays there even after the network issues are resolved
This state does not happen always, but it does happen randomly.