### PR TITLE
Added missing path

### DIFF
--- a/docs/netdata-for-IoT.md
+++ b/docs/netdata-for-IoT.md
@@ -56,7 +56,14 @@ supported by `lm-sensors`.
 Netdata also has a bash version of the sensors plugin that can read RPi temperatures. It is disabled by default to avoid
 the conflicts with the python version.
 
-To enable it, run `sudo /etc/netdata/edit-config charts.d.conf` and uncomment this line:
+To enable it, run:
+
+```bash
+cd /etc/netdata
+sudo ./edit-config charts.d.conf
+```
+
+and uncomment this line:
 
 ```sh
 sensors=force

--- a/docs/netdata-for-IoT.md
+++ b/docs/netdata-for-IoT.md
@@ -56,7 +56,7 @@ supported by `lm-sensors`.
 Netdata also has a bash version of the sensors plugin that can read RPi temperatures. It is disabled by default to avoid
 the conflicts with the python version.
 
-To enable it, run `sudo edit-config charts.d.conf` and uncomment this line:
+To enable it, run `sudo /etc/netdata/edit-config charts.d.conf` and uncomment this line:
 
 ```sh
 sensors=force

--- a/docs/netdata-for-IoT.md
+++ b/docs/netdata-for-IoT.md
@@ -59,7 +59,7 @@ the conflicts with the python version.
 To enable it, run:
 
 ```bash
-cd /etc/netdata
+cd /etc/netdata # Replace this path with your Netdata config directory
 sudo ./edit-config charts.d.conf
 ```
 


### PR DESCRIPTION
##### Summary

In the command line given to edit the file `charts.d.conf`, the path to the script `edit-config` is missing so if you type it or paste it that way it won't work. So I think the easiest way to fix it would be to add the path in the command line given in the documentation.

##### Component Name

Documentation

##### Test Plan

Run the command as given in the documentation and with the added path to see the difference.

##### Additional Information

The other solution would be add to the path `/etc/netdata` to the global `PATH` variable.
