### PR TITLE
packaging/docker/{build,publish}.sh: Simplify scripts. Support only single ARCH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -375,25 +375,25 @@ jobs:
       <<: *RELEASE_TEMPLATE
       env:
         - ALLOW_SOFT_FAILURE_HERE=true
-        - ARCHS=i386
+        - ARCH=i386
 
     - name: Build & Publish docker image for amd64
       <<: *RELEASE_TEMPLATE
       env:
         - ALLOW_SOFT_FAILURE_HERE=true
-        - ARCHS=amd64
+        - ARCH=amd64
 
     - name: Build & Publish docker image for armhf
       <<: *RELEASE_TEMPLATE
       env:
         - ALLOW_SOFT_FAILURE_HERE=true
-        - ARCHS=armhf
+        - ARCH=armhf
 
     - name: Build & Publish docker image for aarch64
       <<: *RELEASE_TEMPLATE
       env:
         - ALLOW_SOFT_FAILURE_HERE=true
-        - ARCHS=aarch64
+        - ARCH=aarch64
 
     - name: Create release draft
       git:
@@ -456,25 +456,25 @@ jobs:
       <<: *NIGHTLY_TEMPLATE
       env:
         - ALLOW_SOFT_FAILURE_HERE=true
-        - ARCHS=i386
+        - ARCH=i386
 
     - name: Build & Publish docker image for amd64
       <<: *NIGHTLY_TEMPLATE
       env:
         - ALLOW_SOFT_FAILURE_HERE=true
-        - ARCHS=amd64
+        - ARCH=amd64
 
     - name: Build & Publish docker image for armhf
       <<: *NIGHTLY_TEMPLATE
       env:
         - ALLOW_SOFT_FAILURE_HERE=true
-        - ARCHS=armhf
+        - ARCH=armhf
 
     - name: Build & Publish docker image for aarch64
       <<: *NIGHTLY_TEMPLATE
       env:
         - ALLOW_SOFT_FAILURE_HERE=true
-        - ARCHS=aarch64
+        - ARCH=aarch64
 
     - name: Create nightly release artifacts, publish to GCS
       script:

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -62,11 +62,11 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset
 # Build images using multi-arch Dockerfile.
 TAG="${REPOSITORY,,}:${VERSION}-${ARCH}"
 echo "Building tag ${TAG}.."
-eval docker build --no-cache \
-     --build-arg ARCH="${ARCH}" \
-     --build-arg RELEASE_CHANNEL="${RELEASE_CHANNEL}" \
-     --tag "${TAG}" \
-     --file packaging/docker/Dockerfile ./
+docker build --no-cache                                  \
+	--build-arg ARCH="${ARCH}"                       \
+	--build-arg RELEASE_CHANNEL="${RELEASE_CHANNEL}" \
+	--tag "${TAG}"                                   \
+	--file packaging/docker/Dockerfile .
 echo "..Done!"
 
 echo "Docker build process completed!"

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -14,9 +14,11 @@ if [ "${BASH_VERSINFO[0]}" -lt "4" ]; then
 fi
 
 VERSION="$1"
-declare -A ARCH_MAP
-ARCH_MAP=(["i386"]="386" ["amd64"]="amd64" ["armhf"]="arm" ["aarch64"]="arm64")
-[ "${ARCHS}" ] || ARCHS="${!ARCH_MAP[@]}" # Use default ARCHS unless ARCHS are externally provided
+
+if [ -z "${ARCH}" ]; then
+  echo "ARCH not set, build cannot proceed"
+  exit 1
+fi
 
 if [ "${RELEASE_CHANNEL}" != "nightly" ] && [ "${RELEASE_CHANNEL}" != "stable" ]; then
   echo "RELEASE_CHANNEL must be set to either 'nightly' or 'stable' - build cannot proceed"
@@ -51,22 +53,20 @@ if [ ! -z $CWD ] || [ ! "${TOP_LEVEL}" == "netdata" ]; then
 fi
 
 echo "Docker image build in progress.."
-echo "Version       : ${VERSION}"
-echo "Repository    : ${REPOSITORY}"
-echo "Architectures : ${ARCHS[*]}"
+echo "Version     : ${VERSION}"
+echo "Repository  : ${REPOSITORY}"
+echo "Architecture: ${ARCH}"
 
 docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 # Build images using multi-arch Dockerfile.
-for ARCH in ${ARCHS[@]}; do
-     TAG="${REPOSITORY,,}:${VERSION}-${ARCH}"
-     echo "Building tag ${TAG}.."
-     eval docker build --no-cache \
-          --build-arg ARCH="${ARCH}" \
-          --build-arg RELEASE_CHANNEL="${RELEASE_CHANNEL}" \
-          --tag "${TAG}" \
-          --file packaging/docker/Dockerfile ./
-     echo "..Done!"
-done
+TAG="${REPOSITORY,,}:${VERSION}-${ARCH}"
+echo "Building tag ${TAG}.."
+eval docker build --no-cache \
+     --build-arg ARCH="${ARCH}" \
+     --build-arg RELEASE_CHANNEL="${RELEASE_CHANNEL}" \
+     --tag "${TAG}" \
+     --file packaging/docker/Dockerfile ./
+echo "..Done!"
 
 echo "Docker build process completed!"

--- a/packaging/docker/publish.sh
+++ b/packaging/docker/publish.sh
@@ -16,9 +16,12 @@ fi
 
 WORKDIR="$(mktemp -d)" # Temporary folder, removed after script is done
 VERSION="$1"
-declare -A ARCH_MAP
-ARCH_MAP=(["i386"]="386" ["amd64"]="amd64" ["armhf"]="arm" ["aarch64"]="arm64")
-[ "${ARCHS}" ] || ARCHS="${!ARCH_MAP[@]}" # Use default ARCHS unless ARCHS are externally provided
+
+if [ -z "${ARCH}" ]; then
+  echo "ARCH not set, build cannot proceed"
+  exit 1
+fi
+
 DOCKER_CMD="docker --config ${WORKDIR}"
 GIT_MAIL=${GIT_MAIL:-"bot@netdata.cloud"}
 GIT_USER=${GIT_USER:-"netdatabot"}
@@ -58,10 +61,10 @@ if [ ! -z $CWD ] || [ ! "${TOP_LEVEL}" == "netdata" ]; then
 fi
 
 echo "Docker image publishing in progress.."
-echo "Version       : ${VERSION}"
-echo "Repository    : ${REPOSITORY}"
-echo "Architectures : ${ARCHS[*]}"
-echo "Manifest list : ${MANIFEST_LIST}"
+echo "Version      : ${VERSION}"
+echo "Repository   : ${REPOSITORY}"
+echo "Architecture : ${ARCH}"
+echo "Manifest list: ${MANIFEST_LIST}"
 
 # Create temporary docker CLI config with experimental features enabled (manifests v2 need it)
 echo '{"experimental":"enabled"}' > "${WORKDIR}"/config.json
@@ -70,18 +73,16 @@ echo '{"experimental":"enabled"}' > "${WORKDIR}"/config.json
 echo "$DOCKER_PWD" | $DOCKER_CMD login -u "$DOCKER_USERNAME" --password-stdin
 
 # Push images to registry
-for ARCH in ${ARCHS[@]}; do
-    TAG="${MANIFEST_LIST}-${ARCH}"
-    echo "Publishing image ${TAG}.."
-    $DOCKER_CMD push "${TAG}"
+TAG="${MANIFEST_LIST}-${ARCH}"
+echo "Publishing image ${TAG}.."
+$DOCKER_CMD push "${TAG}"
 
-    published() {
-        curl -s "https://registry.hub.docker.com/v2/repositories/${REPOSITORY}/tags" | jq -e -r '.results[] | select(.name == "'"${VERSION}-${ARCH}"'")' > /dev/null
-    }
-    retry 5 published
+published() {
+	curl -s "https://registry.hub.docker.com/v2/repositories/${REPOSITORY}/tags" | jq -e -r '.results[] | select(.name == "'"${VERSION}-${ARCH}"'")' > /dev/null
+}
+retry 5 published
 
-    echo "Image ${TAG} published succesfully!"
-done
+echo "Image ${TAG} published succesfully!"
 
 # Recreate docker manifest list
 echo "Getting tag list for version '${VERSION}'.."
@@ -91,6 +92,8 @@ echo "Creating manifest list.."
 $DOCKER_CMD manifest create --amend "${MANIFEST_LIST}" "${TAGS[@]/#/${REPOSITORY}:}"
 
 # Annotate manifest with CPU architecture information
+declare -A ARCH_MAP
+ARCH_MAP=(["i386"]="386" ["amd64"]="amd64" ["armhf"]="arm" ["aarch64"]="arm64")
 
 echo "Executing manifest annotate.."
 for TAG in "${TAGS[@]}"; do


### PR DESCRIPTION
##### Summary
Simplify the docker packaging build and publish shell scripts. Support building and packaging only one ARCH at a time.