### PR TITLE
health/portcheck: remove no-clear-notification option

### DIFF
--- a/health/health.d/portcheck.conf
+++ b/health/health.d/portcheck.conf
@@ -31,7 +31,6 @@ families: *
     crit: $this >= 40
    delay: down 5m multiplier 1.5 max 1h
     info: average of timeouts during the last 5 minutes
- options: no-clear-notification
       to: sysadmin
 
 template: connection_fails
@@ -44,5 +43,4 @@ families: *
     crit: $this >= 40
    delay: down 5m multiplier 1.5 max 1h
     info: average of failed connections during the last 5 minutes
- options: no-clear-notification
       to: sysadmin


### PR DESCRIPTION
##### Summary

ssia

Fixes: #8741

Reasoning in the issue

##### Component Name

`health/alarms`

##### Test Plan

Not needed

##### Additional Information
