### PR TITLE
Fixed issue in `system-info.sh`regarding the parsing of `lscpu` output.

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -191,9 +191,9 @@ if [ -n "${lscpu}" ] && lscpu >/dev/null 2>&1 ; then
         LCPU_COUNT="$(echo "${lscpu_output}" | grep "^CPU(s):" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
         CPU_VENDOR="$(echo "${lscpu_output}" | grep "^Vendor ID:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
         CPU_MODEL="$(echo "${lscpu_output}" | grep "^Model name:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-        possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "^CPU max MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
+        possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "CPU max MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
         if [ "${possible_cpu_freq}" = " MHz" ] ; then
-            possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "^CPU MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
+            possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "CPU MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
         fi
 elif [ -n "${dmidecode}" ] && dmidecode -t processor >/dev/null 2>&1 ; then
         dmidecode_output="$(${dmidecode} -t processor 2>/dev/null)"

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -191,7 +191,10 @@ if [ -n "${lscpu}" ] && lscpu >/dev/null 2>&1 ; then
         LCPU_COUNT="$(echo "${lscpu_output}" | grep "^CPU(s):" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
         CPU_VENDOR="$(echo "${lscpu_output}" | grep "^Vendor ID:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
         CPU_MODEL="$(echo "${lscpu_output}" | grep "^Model name:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-        possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "CPU max MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
+        possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "^CPU max MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
+        if [ "${possible_cpu_freq}" -eq 0 ] ; then
+            possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "^CPU MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
+        fi
 elif [ -n "${dmidecode}" ] && dmidecode -t processor >/dev/null 2>&1 ; then
         dmidecode_output="$(${dmidecode} -t processor 2>/dev/null)"
         CPU_INFO_SOURCE="dmidecode"

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -192,7 +192,7 @@ if [ -n "${lscpu}" ] && lscpu >/dev/null 2>&1 ; then
         CPU_VENDOR="$(echo "${lscpu_output}" | grep "^Vendor ID:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
         CPU_MODEL="$(echo "${lscpu_output}" | grep "^Model name:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
         possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "^CPU max MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
-        if [ "${possible_cpu_freq}" -eq 0 ] ; then
+        if [ "${possible_cpu_freq}" = " MHz" ] ; then
             possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "^CPU MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
         fi
 elif [ -n "${dmidecode}" ] && dmidecode -t processor >/dev/null 2>&1 ; then


### PR DESCRIPTION
##### Summary

When using `lscpu` to determine the CPU frequency, we want to preferentially use the `CPU max MHz` value over `CPU MHz`, as the later reflects the current CPU frequency in most cases, not the frequency that the CPU would be advertised with.

Unfortunately, the original code for parsing this info out of `lscpu` output did not take into account that some systems do not report a `CPU max MHz` value, but still report `CPU MHz`. Reporting something on such systems is better than reporting nothing, so we should fall back to `CPU MHz` if it's present.

##### Component Name

area/daemon

##### Test Plan

Verified locally to not change behavior for systems that weren't affected, and to fix it for systems that were.

##### Additional Information

Originally spotted by @manos-saratsis.