### PR TITLE
Docs: Add Docker instructions to claiming

### DIFF
--- a/aclk/README.md
+++ b/aclk/README.md
@@ -27,7 +27,7 @@ in the `[cloud]` section of `netdata.conf`.
 ```
 
 If your Agent needs to use a proxy to access the internet, you must [set up a proxy for
-claiming](/claim/README.md#claiming-through-a-proxy).
+claiming](/claim/README.md#claim-through-a-proxy).
 
 ## Disable the ACLK
 

--- a/claim/README.md
+++ b/claim/README.md
@@ -61,7 +61,56 @@ Hit **Enter**. The script should return `Agent was successfully claimed.`.
 
 If the claiming script returns errors, see the [troubleshooting information](#troubleshooting).
 
-### Claiming through a proxy
+### Claim an Agent running in Docker
+
+First, stop the container, replacing `netdata` with the name of your Agent container.
+
+```bash
+docker stop netdata
+```
+
+Then, start the container again with the `docker run` command, passing 
+
+```bash
+docker run -it netdata/netdata /usr/sbin/netdata -D -W "claim -token=BSH_u2gRGweLVttLOL4k00zhgedGWXdBObc_X1-7G9iBKJJUFFVq0MWwCg-gFIbm_d8_eMKmoY-HXsDVj0vh2qQZZ6gJ6T9jc60nU9QVO2fgPPfwNh-p3TeemCdPMtEQk6ZiKps -rooms=a380abef-2244-40e7-a193-ff880c4604ed -url=https://staging.netdata.cloud"
+```
+
+
+
+docker run -it netdata/netdata --entry-point '/usr/sbin/netdata -D -W "claim -token=BSH_u2gRGweLVttLOL4k00zhgedGWXdBObc_X1-7G9iBKJJUFFVq0MWwCg-gFIbm_d8_eMKmoY-HXsDVj0vh2qQZZ6gJ6T9jc60nU9QVO2fgPPfwNh-p3TeemCdPMtEQk6ZiKps -rooms=a380abef-2244-40e7-a193-ff880c4604ed -url=https://staging.netdata.cloud"'
+
+
+
+
+
+
+
+
+
+
+
+
+
+```bash
+docker run -d -it --name=netdata \
+  -p 20000:19999 \
+  -v /etc/passwd:/host/etc/passwd:ro \
+  -v /etc/group:/host/etc/group:ro \
+  -v /proc:/host/proc:ro \
+  -v /sys:/host/sys:ro \
+  -v /etc/os-release:/host/etc/os-release:ro \
+  --cap-add SYS_PTRACE \
+  --security-opt apparmor=unconfined \
+  netdata/netdata \
+  /usr/sbin/netdata -D -W "claim -token=BSH_u2gRGweLVttLOL4k00zhgedGWXdBObc_X1-7G9iBKJJUFFVq0MWwCg-gFIbm_d8_eMKmoY-HXsDVj0vh2qQZZ6gJ6T9jc60nU9QVO2fgPPfwNh-p3TeemCdPMtEQk6ZiKps -rooms=a380abef-2244-40e7-a193-ff880c4604ed -url=https://staging.netdata.cloud"
+```
+
+```bash
+docker exec -it netdata netdata-claim.sh -token=DK3XktBOvJ_CiWXlHtGlPWBdcwc-aLajq_1TuytQv8ATOv1ycpmKXXruFJhFZoUMCsJcjRchb1zxUBAFyropTpNF38Tz4QCb8TEITndfL-2aDtMrHFCK9j_TfcWG8XEX9s-BFkk -rooms=8a796d97-7901-47c6-9e46-9eae56bd6942 -url=https://app.netdata.cloud
+```
+
+
+### Claim through a proxy
 
 A Space's administrator can claim a node through a SOCKS5 or HTTP(S) proxy.
 

--- a/claim/README.md
+++ b/claim/README.md
@@ -54,61 +54,22 @@ With `sudo`:
 sudo netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud
 ```
 
-Hit **Enter**. The script should return `Agent was successfully claimed.`.
+Hit **Enter**. The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see the [troubleshooting information](#troubleshooting).
 
 > Your node may need up to 60 seconds to connect to Netdata Cloud after finishing the claiming process. Please be
 > patient!
 
-If the claiming script returns errors, see the [troubleshooting information](#troubleshooting).
-
 ### Claim an Agent running in Docker
 
-First, stop the container, replacing `netdata` with the name of your Agent container.
+You can execute the claiming script on a running agent by appending the script offered by Cloud to a `docker exec -it`
+command:
 
 ```bash
-docker stop netdata
+docker exec -it netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud
 ```
 
-Then, start the container again with the `docker run` command, passing 
-
-```bash
-docker run -it netdata/netdata /usr/sbin/netdata -D -W "claim -token=BSH_u2gRGweLVttLOL4k00zhgedGWXdBObc_X1-7G9iBKJJUFFVq0MWwCg-gFIbm_d8_eMKmoY-HXsDVj0vh2qQZZ6gJ6T9jc60nU9QVO2fgPPfwNh-p3TeemCdPMtEQk6ZiKps -rooms=a380abef-2244-40e7-a193-ff880c4604ed -url=https://staging.netdata.cloud"
-```
-
-
-
-docker run -it netdata/netdata --entry-point '/usr/sbin/netdata -D -W "claim -token=BSH_u2gRGweLVttLOL4k00zhgedGWXdBObc_X1-7G9iBKJJUFFVq0MWwCg-gFIbm_d8_eMKmoY-HXsDVj0vh2qQZZ6gJ6T9jc60nU9QVO2fgPPfwNh-p3TeemCdPMtEQk6ZiKps -rooms=a380abef-2244-40e7-a193-ff880c4604ed -url=https://staging.netdata.cloud"'
-
-
-
-
-
-
-
-
-
-
-
-
-
-```bash
-docker run -d -it --name=netdata \
-  -p 20000:19999 \
-  -v /etc/passwd:/host/etc/passwd:ro \
-  -v /etc/group:/host/etc/group:ro \
-  -v /proc:/host/proc:ro \
-  -v /sys:/host/sys:ro \
-  -v /etc/os-release:/host/etc/os-release:ro \
-  --cap-add SYS_PTRACE \
-  --security-opt apparmor=unconfined \
-  netdata/netdata \
-  /usr/sbin/netdata -D -W "claim -token=BSH_u2gRGweLVttLOL4k00zhgedGWXdBObc_X1-7G9iBKJJUFFVq0MWwCg-gFIbm_d8_eMKmoY-HXsDVj0vh2qQZZ6gJ6T9jc60nU9QVO2fgPPfwNh-p3TeemCdPMtEQk6ZiKps -rooms=a380abef-2244-40e7-a193-ff880c4604ed -url=https://staging.netdata.cloud"
-```
-
-```bash
-docker exec -it netdata netdata-claim.sh -token=DK3XktBOvJ_CiWXlHtGlPWBdcwc-aLajq_1TuytQv8ATOv1ycpmKXXruFJhFZoUMCsJcjRchb1zxUBAFyropTpNF38Tz4QCb8TEITndfL-2aDtMrHFCK9j_TfcWG8XEX9s-BFkk -rooms=8a796d97-7901-47c6-9e46-9eae56bd6942 -url=https://app.netdata.cloud
-```
-
+The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see the
+[troubleshooting information](#troubleshooting).
 
 ### Claim through a proxy
 
@@ -146,12 +107,7 @@ added to `netdata.conf`.
 netdata-claim.sh -token=MYTOKEN1234567 -rooms=room1,room2 -url=https://app.netdata.cloud -proxy=socks5h://203.0.113.0:1080
 ```
 
-Hit **Enter**. The script should return `Agent was successfully claimed.`.
-
-> Your node may need up to 60 seconds to connect to Netdata Cloud after finishing the claiming process. Please be
-> patient!
-
-If the claiming script returns errors, see the [troubleshooting information](#troubleshooting).
+Hit **Enter**. The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see the [troubleshooting information](#troubleshooting).
 
 ### Troubleshooting
 

--- a/claim/README.md
+++ b/claim/README.md
@@ -68,10 +68,10 @@ and immediately claim it.
 
 #### Running Agent containers
 
-Claim a _running Agent container_ by appending the script offered by Cloud to a `docker exec ...` command:
+Claim a _running Agent container_ by appending the script offered by Cloud to a `docker exec ...` command, replacing `netdata` with the name of your running container:
 
 ```bash
-docker exec -it netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud
+docker exec -it netdata netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud
 ```
 
 The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see the
@@ -99,10 +99,12 @@ docker run -d --name=netdata \
   /usr/sbin/netdata -D -W set global "netdata cloud" enable -W set cloud "cloud base url" "https://app.netdata.cloud" -W "claim -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud"
 ```
 
-The container runs in detached mode, so you won't see any output. If the node does not appear in your Space, you can run the following to find any error output and use that to guide your [troubleshooting](#troubleshooting):
+The container runs in detached mode, so you won't see any output. If the node does not appear in your Space, you can run
+the following to find any error output and use that to guide your [troubleshooting](#troubleshooting). Replace `netdata`
+with the name of your container if different.
 
 ```bash
-docker logs netdata 2>&1 | grep -E 'ACLK|claim|cloud'
+docker logs netdata 2>&1 | grep -E --line-buffered 'ACLK|claim|cloud'
 ```
 
 ### Claim through a proxy
@@ -149,8 +151,8 @@ the [troubleshooting information](#troubleshooting).
 
 If you're having trouble claiming a node, this may be because the ACLK cannot connect to Cloud.
 
-With the Netdata Agent running, visit `http://localhost:19999/api/v1/info` in your browser. The returned JSON contains four
-keys that will be helpful to diagnose any issues you might be having with the ACLK or claiming process.
+With the Netdata Agent running, visit `http://localhost:19999/api/v1/info` in your browser. The returned JSON contains
+four keys that will be helpful to diagnose any issues you might be having with the ACLK or claiming process.
 
 ```json
 	"cloud-enabled"

--- a/claim/README.md
+++ b/claim/README.md
@@ -99,7 +99,8 @@ For example, a SOCKS5 proxy setting may look like the following:
     proxy = socks5h://proxy.example.com:1080 # With a URL
 ```
 
-You can now move on to claiming. Be sure to switch to the `netdata` user or use `sudo` as explained in the [step above](#how-to-claim-a-node).
+You can now move on to claiming. Be sure to switch to the `netdata` user or use `sudo` as explained in the [step
+above](#how-to-claim-a-node).
 
 When you claim with the `netdata-claim.sh` script, add the `-proxy=` parameter and append the same proxy setting you
 added to `netdata.conf`.
@@ -108,7 +109,8 @@ added to `netdata.conf`.
 netdata-claim.sh -token=MYTOKEN1234567 -rooms=room1,room2 -url=https://app.netdata.cloud -proxy=socks5h://203.0.113.0:1080
 ```
 
-Hit **Enter**. The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see the [troubleshooting information](#troubleshooting).
+Hit **Enter**. The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see
+the [troubleshooting information](#troubleshooting).
 
 ### Troubleshooting
 
@@ -188,7 +190,7 @@ If `aclk-available` is `false` and all other keys are `true`, your Agent is havi
 through the ACLK. Please check your system's firewall.
 
 If your Agent needs to use a proxy to access the internet, you must [set up a proxy for
-claiming](#claiming-through-a-proxy).
+claiming](#claim-through-a-proxy).
 
 If you are certain firewall and proxy settings are not the issue, you should consult the Agent's `error.log` at
 `/var/log/netdata/error.log` and contact us by [creating an issue on

--- a/claim/README.md
+++ b/claim/README.md
@@ -62,7 +62,7 @@ the [troubleshooting information](#troubleshooting).
 
 ### Claim an Agent running in Docker
 
-You can execute the claiming script on a running agent by appending the script offered by Cloud to a `docker exec -it`
+You can execute the claiming script on a running agent by appending the script offered by Cloud to a `docker exec ...`
 command:
 
 ```bash
@@ -71,6 +71,29 @@ docker exec -it netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://ap
 
 The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see the
 [troubleshooting information](#troubleshooting).
+
+You can also claim a newly-created container with `docker run ...`, using our recommended [Docker
+installation](/packaging/docker/README.md#run-netdata-with-the-docker-command).
+
+```bash
+docker run -d --name=netdata \
+  -p 19999:19999 \
+  -v /etc/passwd:/host/etc/passwd:ro \
+  -v /etc/group:/host/etc/group:ro \
+  -v /proc:/host/proc:ro \
+  -v /sys:/host/sys:ro \
+  -v /etc/os-release:/host/etc/os-release:ro \
+  --cap-add SYS_PTRACE \
+  --security-opt apparmor=unconfined \
+  netdata/netdata \
+  /usr/sbin/netdata -D -W set global "netdata cloud" enable -W set cloud "cloud base url" "https://app.netdata.cloud" -W "claim -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud"
+```
+
+The container runs in detached mode, so you won't see any output. If the node does not appear in your Space, you can run the following to find any error output and use that to guide your [troubleshooting](#troubleshooting):
+
+```bash
+docker logs netdata 2>&1 | grep -E 'ACLK|claim|cloud'
+```
 
 ### Claim through a proxy
 
@@ -116,7 +139,7 @@ the [troubleshooting information](#troubleshooting).
 
 If you're having trouble claiming a node, this may be because the ACLK cannot connect to Cloud.
 
-With the Netdata Agent running, visit `http://127.0.0.1/api/v1/info` in your browser. The returned JSON contains four
+With the Netdata Agent running, visit `http://localhost:19999/api/v1/info` in your browser. The returned JSON contains four
 keys that will be helpful to diagnose any issues you might be having with the ACLK or claiming process.
 
 ```json

--- a/claim/README.md
+++ b/claim/README.md
@@ -62,8 +62,13 @@ the [troubleshooting information](#troubleshooting).
 
 ### Claim an Agent running in Docker
 
-You can execute the claiming script on a running agent by appending the script offered by Cloud to a `docker exec ...`
-command:
+The claiming process works with Agents running inside of Docker containers. You can use `docker exec` to run the
+claiming script on containers already running, or append the claiming script to `docker run` to create a new container
+and immediately claim it.
+
+#### Running Agent containers
+
+Claim a _running Agent container_ by appending the script offered by Cloud to a `docker exec ...` command:
 
 ```bash
 docker exec -it netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud
@@ -72,8 +77,13 @@ docker exec -it netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://ap
 The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see the
 [troubleshooting information](#troubleshooting).
 
-You can also claim a newly-created container with `docker run ...`, using our recommended [Docker
-installation](/packaging/docker/README.md#run-netdata-with-the-docker-command).
+#### New/ephemeral Agent containers
+
+Claim a newly-created container with `docker run ...`.
+
+In the example below, the last line calls the [daemon binary](/daemon/README.md), sets essential variables, and then
+executes claiming using the information after `-W "claim... `. You should copy the relevant token, rooms, and URL from
+Cloud.
 
 ```bash
 docker run -d --name=netdata \

--- a/claim/README.md
+++ b/claim/README.md
@@ -54,7 +54,8 @@ With `sudo`:
 sudo netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud
 ```
 
-Hit **Enter**. The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see the [troubleshooting information](#troubleshooting).
+Hit **Enter**. The script should return `Agent was successfully claimed.`. If the claiming script returns errors, see
+the [troubleshooting information](#troubleshooting).
 
 > Your node may need up to 60 seconds to connect to Netdata Cloud after finishing the claiming process. Please be
 > patient!


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fixes netdata/marketing#223

I've been getting requests to add instructions on how to claim a Docker-ized Agent, and this PR adds my best effort to document this process.

There seems to be a preference to tell users how to pass daemon command line options (see #8486), but I haven't been able to figure out how to successfully pass those. Using `docker exec -it` plus the claiming script straight from Cloud seems to work just fine, on the other hand, and seems much easier for users. Using `docker run` means they have to stop their container first.

If someone has successfully claimed a Docker node using a command like `docker run -it netdata --entrypoint '/usr/sbin/netdata -D -W "claim url=...."'`, and believes that is indeed the preferred method of claiming in this case, I'm happy to add it, but I have not been able to get that to work.

##### Component Name

claim

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
