### PR TITLE
Redirect traffic from docs.netdata.cloud -> learn.netdata.cloud

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,12 +12,12 @@
   command = "./buildhtml.sh"
 
 [[redirects]]
-  from = /docs/*
-  to   = https://learn.netdata.cloud/docs/agent/:splat
+  from = "/docs/*"
+  to   = "https://learn.netdata.cloud/docs/agent/:splat"
 
 [[redirects]]
-  from = /*
-  to   = https://learn.netdata.cloud/docs/agent/:splat
+  from = "/*"
+  to   = "https://learn.netdata.cloud/docs/agent/:splat"
 
 [[redirects]]
   from = "/docs/GettingStarted/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,11 @@
   command = "./buildhtml.sh"
 
 [[redirects]]
+  from  = "/"
+  to    = "https://learn.netdata.cloud/docs/agent/"
+  force = true
+
+[[redirects]]
   from  = "/docs/*"
   to    = "https://learn.netdata.cloud/docs/agent/:splat"
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,14 +17,39 @@
   force = true
 
 [[redirects]]
-  from  = "/*"
+  from  = "/aclk/*"
+  to    = "https://learn.netdata.cloud/docs/agent/aclk/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/build_external/*"
+  to    = "https://learn.netdata.cloud/docs/agent/build_external/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/claim/*"
+  to    = "https://learn.netdata.cloud/docs/agent/claim/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/cli/*"
+  to    = "https://learn.netdata.cloud/docs/agent/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/collectors/*"
+  to    = "https://learn.netdata.cloud/docs/agent/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/packaging/*"
   to    = "https://learn.netdata.cloud/docs/agent/:splat"
   force = true
 
 [[redirects]]
   from = "/docs/GettingStarted/"
-  to = "/docs/getting-started"
+  to = "https://learn.netdata.cloud/docs/agent/getting-started"
 
 [[redirects]]
   from = "/docs/tutorials/dimension-templates/"
-  to = "/health/tutorials/dimension-templates/"
+  to = "https://learn.netdata.cloud/docs/agent/health/tutorials/dimension-templates/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,14 @@
   command = "./buildhtml.sh"
 
 [[redirects]]
+  from = /docs/*
+  to   = https://learn.netdata.cloud/docs/agent/:splat
+
+[[redirects]]
+  from = /*
+  to   = https://learn.netdata.cloud/docs/agent/:splat
+
+[[redirects]]
   from = "/docs/GettingStarted/"
   to = "/docs/getting-started"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,11 @@
   force = true
 
 [[redirects]]
+  from  = "/backends/*"
+  to    = "https://learn.netdata.cloud/docs/agent/backends/:splat"
+  force = true
+
+[[redirects]]
   from  = "/build_external/*"
   to    = "https://learn.netdata.cloud/docs/agent/build_external/:splat"
   force = true
@@ -49,6 +54,11 @@
 [[redirects]]
   from  = "/database/*"
   to    = "https://learn.netdata.cloud/docs/agent/database/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/diagrams/*"
+  to    = "https://learn.netdata.cloud/docs/agent/diagrams/:splat"
   force = true
 
 [[redirects]]
@@ -104,6 +114,16 @@
 [[redirects]]
   from  = "/code_of_conduct/"
   to    = "https://learn.netdata.cloud/docs/agent/code_of_conduct/"
+  force = true
+
+[[redirects]]
+  from  = "/contributing/"
+  to    = "https://learn.netdata.cloud/docs/agent/contributing/"
+  force = true
+
+[[redirects]]
+  from  = "/contributors/"
+  to    = "https://learn.netdata.cloud/docs/agent/contributors/"
   force = true
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,12 +12,14 @@
   command = "./buildhtml.sh"
 
 [[redirects]]
-  from = "/docs/*"
-  to   = "https://learn.netdata.cloud/docs/agent/:splat"
+  from  = "/docs/*"
+  to    = "https://learn.netdata.cloud/docs/agent/:splat"
+  force = true
 
 [[redirects]]
-  from = "/*"
-  to   = "https://learn.netdata.cloud/docs/agent/:splat"
+  from  = "/*"
+  to    = "https://learn.netdata.cloud/docs/agent/:splat"
+  force = true
 
 [[redirects]]
   from = "/docs/GettingStarted/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -33,17 +33,87 @@
 
 [[redirects]]
   from  = "/cli/*"
-  to    = "https://learn.netdata.cloud/docs/agent/:splat"
+  to    = "https://learn.netdata.cloud/docs/agent/cli/:splat"
   force = true
 
 [[redirects]]
   from  = "/collectors/*"
-  to    = "https://learn.netdata.cloud/docs/agent/:splat"
+  to    = "https://learn.netdata.cloud/docs/agent/collectors/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/daemon/*"
+  to    = "https://learn.netdata.cloud/docs/agent/daemon/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/database/*"
+  to    = "https://learn.netdata.cloud/docs/agent/database/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/exporting/*"
+  to    = "https://learn.netdata.cloud/docs/agent/exporting/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/health/*"
+  to    = "https://learn.netdata.cloud/docs/agent/health/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/libnetdata/*"
+  to    = "https://learn.netdata.cloud/docs/agent/libnetdata/:splat"
   force = true
 
 [[redirects]]
   from  = "/packaging/*"
-  to    = "https://learn.netdata.cloud/docs/agent/:splat"
+  to    = "https://learn.netdata.cloud/docs/agent/packaging/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/registry/*"
+  to    = "https://learn.netdata.cloud/docs/agent/registry/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/streaming/*"
+  to    = "https://learn.netdata.cloud/docs/agent/streaming/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/tests/*"
+  to    = "https://learn.netdata.cloud/docs/agent/tests/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/web/*"
+  to    = "https://learn.netdata.cloud/docs/agent/web/:splat"
+  force = true
+
+[[redirects]]
+  from  = "/breaking_changes/"
+  to    = "https://learn.netdata.cloud/docs/agent/breaking_changes/"
+  force = true
+
+[[redirects]]
+  from  = "/changelog/"
+  to    = "https://learn.netdata.cloud/docs/agent/changelog/"
+  force = true
+
+[[redirects]]
+  from  = "/code_of_conduct/"
+  to    = "https://learn.netdata.cloud/docs/agent/code_of_conduct/"
+  force = true
+
+[[redirects]]
+  from  = "/redistributed/"
+  to    = "https://learn.netdata.cloud/docs/agent/redistributed/"
+  force = true
+
+[[redirects]]
+  from  = "/security/"
+  to    = "https://learn.netdata.cloud/docs/agent/security/"
   force = true
 
 [[redirects]]


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds 301 redirects to point pages on `docs.netdata.cloud` to `learn.netdata.cloud`. 301 redirects will ensure any deep links pointing to the old documentation site will redirect without interruption, and hopefully without any SEO de-value.

This PR does _not_ redirect the translations. I want to maintain them as-is for now, as we don't yet have a plan on the Learn roadmap to replace them.

My only hesitation to deploy this change is that I would prefer if the Learn site's endpoint was `netdata.cloud/learn`. @prologic has a ticket (netdata/internal#24) for this, but he's a busy guy and I'm not sure about the timeframe for getting CF running and figuring out the routing. If we _can_ get that endpoint enabled, I'll just change all the redirects before we merge this and begin redirecting traffic.

#### Caveats/bugs

- By making this change, we lose deploy previews. I'm not sure how heavily engineers use them. I generally do not.

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

I tested every single link. Yes.

You can verify it yourself by opening the Netlify deploy. That should take you directly to `learn.netdata.cloud`. You can then try any deep link, like [the installation guide](https://deploy-preview-8756--netdata.netlify.app/packaging/installer/) to get redirected.

##### Additional Information
