### PR TITLE
Added JSON-C dependency handling to instlal and packaging.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -441,7 +441,12 @@ You may need to check these:
    If your system cannot find zlib, although it is installed
    run me with the option:  --libs-are-really-here
 
-3. You need basic build tools installed, like:
+3. The pacakge json-c-dev (or json-c-devel)has to be installed.
+
+   If your system cannot find json-c, although it is installed
+   run me with the option:  --libs-are-really-here
+
+4. You need basic build tools installed, like:
 
    gcc make autoconf automake pkg-config
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -120,7 +120,7 @@ BuildRequires: openssl-devel
 %if 0%{?suse_version}
 BuildRequires: judy-devel
 BuildRequires: liblz4-devel
-BuildRequires: json-glib-devel
+BuildRequires: libjson-c-devel
 %else
 BuildRequires: Judy-devel
 BuildRequires: lz4-devel
@@ -138,7 +138,7 @@ Requires:      zlib
 # for libuv, Requires version >= 1
 Requires:      libuv1
 Requires:      libJudy1
-Requires:      json-glib
+Requires:      libjson-c4
 Requires:      libuuid1
 %else
 # for libuv, Requires version >= 1

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -597,6 +597,17 @@ declare -A pkg_cmake=(
   ['default']="cmake"
 )
 
+declare -A pkg_json_c_dev=(
+  ['alpine']="json-c-dev"
+  ['arch']="json-c"
+  ['clearlinux']="devpkg-json-c"
+  ['debian']="libjson-c-dev"
+  ['gentoo']="dev-libs/json-c"
+  ['sabayon']="dev-libs/json-c"
+  ['suse']="libjson-c-devel"
+  ['default']="json-c-devel"
+)
+
 declare -A pkg_bridge_utils=(
   ['gentoo']="net-misc/bridge-utils"
   ['clearlinux']="network-basic"
@@ -1170,6 +1181,7 @@ packages() {
     suitable_package libz-dev
     suitable_package libuuid-dev
     suitable_package libmnl-dev
+    suitable_package json-c-dev
   fi
 
   # -------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

This adds support to the installer and the packaging code to properly pull in JSON-C so that we can use that instead of our buggy internal JSON parser.

##### Component Name

area/packaging

##### Test Plan

Tested locally and verified in CI.

##### Additional Information

This will require netdata/helper-images#74 to be merged before the CI can pass

Fixes: #8775