### PR TITLE
Log malformed URLs instead of ignoring them silently

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -124,6 +124,10 @@ int cloud_to_agent_parse(JSON_ENTRY *e)
                     data->payload = mallocz(len+1);
                     if (!url_decode_r(data->payload, e->data.string, len + 1))
                         strcpy(data->payload, e->data.string);
+                    else {
+                        data->payload[0] = 0;
+                        error("Malformed URL from cloud, cannot decode: %s",e->data.string);
+                    }
                 }
                 break;
             }


### PR DESCRIPTION
##### Summary
Closes #8774 
Add a log message when the agent does not understand the cloud URL in a request.

##### Component Name
aclk

##### Test Plan
Run the agent without json-c installed (before we patch to make it a hard dep) and check the error is shown when the agent is connected to the cloud.

##### Additional Information
Problem will be hidden once json-c is a hard dep, must be tested before then.
