### PR TITLE
health: fix mdstat `failed devices` alarm

### DIFF
--- a/health/health.d/mdstat.conf
+++ b/health/health.d/mdstat.conf
@@ -12,7 +12,7 @@ template: mdstat_disks
       on: md.disks
    units: failed devices
    every: 10s
-    calc: $total - $inuse
+    calc: $down
     crit: $this > 0
     info: Array is degraded!
       to: sysadmin


### PR DESCRIPTION
##### Summary

Fixes: #8793

> The default alarm for failed mdstat disks no longer works, the "total" variable was replaced by "down" in #6164 but the alarm wasn't updated to reflect this change.

##### Component Name

`health/alarms`

##### Test Plan

Not needed. It is pretty obvious change.


##### Additional Information
