### PR TITLE
Removeed Polyverse Polymorphic Linux from Docker builds.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -57,17 +57,6 @@ ARG ARCH
 # This image contains preinstalled dependecies
 FROM netdata/base:${ARCH}
 
-# Conditional subscription to Polyverse's Polymorphic Linux repositories
-RUN if [ "$(uname -m)" == "x86_64" ]; then \
-        apk update && apk upgrade; \
-        curl https://sh.polyverse.io | sh -s install gcxce5byVQbtRz0iwfGkozZwy support+netdata@polyverse.io; \
-        if [ $? -eq 0 ]; then \
-                apk update && \
-                apk upgrade --available --no-cache && \
-                sed -in 's/^#//g' /etc/apk/repositories; \
-        fi \
-    fi
-
 # Copy files over
 RUN mkdir -p /opt/src
 COPY --from=builder /app /

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -27,9 +27,10 @@ documentation](https://docs.docker.com/engine/reference/builder/#understand-how-
 
 ### Package scrambling in runtime (x86_64 only)
 
-Our x86_64 Docker images use [Polymorphic Polyverse Linux package scrambling](https://polyverse.io/how-it-works/). For
-increased security, you can enable rescrambling of Netdata packages during runtime by setting the environment variable
-`RESCRAMBLE=true` while starting Netdata with a Docker container.
+Our x86_64 Docker images provide support for using [Polymorphic Polyverse
+Linux package scrambling](https://polyverse.io/how-it-works/) to protect
+against buffer overflow errors. To activate this, set the environemnt
+variable `RESCRAMBLE=true` while starting Netdata with a Docker container.
 
 ## Run Netdata with the docker command
 

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -12,9 +12,14 @@ if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
 fi
 
 echo "Netdata entrypoint script starting"
-if [ ${RESCRAMBLE+x} ]; then
-  echo "Reinstalling all packages to get the latest Polymorphic Linux scramble"
-  apk upgrade --update-cache --available
+if [ ${RESCRAMBLE+x} ] && [ "$(uname -m)" == "x86_64" ]; then
+  echo "Injecting packages from Polymorphic Linux"
+  apk update && apk upgrade
+  curl https://sh.polyverse.io | sh -s install gcxce5byVQbtRz0iwfGkozZwy support+netdata@polyverse.io
+  # shellcheck disable=SC2181
+  if [ $? -eq 0 ]; then
+    apk update && apk upgrade --available --no-cache && sed -in 's/^#//g' /etc/apk/repositories
+  fi
 fi
 
 if [ -n "${PGID}" ]; then


### PR DESCRIPTION
##### Summary

This cuts the final Docker image sizes for 64-it x86 by approximately 140MB.

The functionality being removed here only ever gets used on 64-bit x86 Docker images.

The claimed benefit to the functionality being removed is improved resistance to exploits that rely on knowledge of the memory layout of certain structures. This is great in theory, but is of questionable benefit in practice for a couple of reasons:

* Because it's being done at build time and not startup, each instance of our containers started from a given image is the same. That consistency at least partially undermines the randomization being done. It was deemed in the original request that doing this unconditionally at runtime would be too much overhead.
* It doesn't actually protect Netdata itself, which is the primary attack surface for the container.
* While the class of bugs this protects against is indeed rather common, actually exploiting them generally requires access to vulnerable code in the target system. Our Docker image only runs Netdata, so being able to exploit these will usually mean that Netdata has already been compromised within the container, which is in turn also the only thing worth compromising in the container.

This still allows for runtime support similarly to how we previously supported it.

##### Component Name

area/packaging

##### Test Plan

Image builds verified in CI on this PR. Actual image sizes and continued correct fnctionality verified locally.

##### Additional Information

Originally added by #5137 based on proposal in #5034.