### PR TITLE
Fix the netdata-updater.sh to correctly pass REINSTALL_OPTIONS (finally)

### DIFF
--- a/build-artifacts.sh
+++ b/build-artifacts.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+BASENAME="netdata-$(git describe)"
+
+mkdir -p artifacts
+
+autoreconf -ivf
+./configure \
+  --prefix=/usr \
+  --sysconfdir=/etc \
+  --localstatedir=/var \
+  --libexecdir=/usr/libexec \
+  --with-zlib \
+  --with-math \
+  --with-user=netdata \
+  CFLAGS=-O2
+make dist
+mv "${BASENAME}.tar.gz" artifacts/
+
+USER="" ./packaging/makeself/build-x86_64-static.sh
+
+cp packaging/version artifacts/latest-version.txt
+
+cd artifacts || exit 1
+ln -s "${BASENAME}.tar.gz" netdata-latest.tar.gz
+ln -s "${BASENAME}.gz.run" netdata-latest.gz.run
+sha256sum -b ./* > "sha256sums.txt"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -131,8 +131,8 @@ set_tarball_urls() {
     export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.${extension}"
     export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
   else
-    export NETDATA_TARBALL_URL="$NETDATA_TARBALL_BASEURL/netdata-latest.${extension}"
-    export NETDATA_TARBALL_CHECKSUM_URL="$NETDATA_TARBALL_BASEURL/sha256sums.txt"
+    export NETDATA_TARBALL_URL="$NETDATA_NIGHTLIES_BASEURL/netdata-latest.${extension}"
+    export NETDATA_TARBALL_CHECKSUM_URL="$NETDATA_NIGHTLIES_BASEURL/sha256sums.txt"
   fi
 }
 
@@ -242,8 +242,8 @@ export NETDATA_LIB_DIR="${NETDATA_LIB_DIR:-${NETDATA_PREFIX}/var/lib/netdata}"
 # Source the tarbal checksum, if not already available from environment (for existing installations with the old logic)
 [[ -z "${NETDATA_TARBALL_CHECKSUM}" ]] && [[ -f ${NETDATA_LIB_DIR}/netdata.tarball.checksum ]] && NETDATA_TARBALL_CHECKSUM="$(cat "${NETDATA_LIB_DIR}/netdata.tarball.checksum")"
 
-# Netdata Tarball Base URL (defaults to our Google Storage Bucket)
-[ -z "$NETDATA_TARBALL_BASEURL" ] && NETDATA_TARBALL_BASEURL=https://storage.googleapis.com/netdata-nightlies
+# Grab the nightlies baseurl (defaulting to our Google Storage bucket)
+export NETDATA_NIGHTLIES_BASEURL="${NETDATA_NIGHTLIES_BASEURL:-https://storage.googleapis.com/netdata-nightlies}"
 
 if [ "${INSTALL_UID}" != "$(id -u)" ]; then
   fatal "You are running this script as user with uid $(id -u). We recommend to run this script as root (user with uid 0)"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -277,7 +277,8 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
   fi
 
   # Do not pass any options other than the accept, for now
-  if sh "${TMPDIR}/netdata-latest.gz.run" --accept -- "${REINSTALL_OPTIONS}"; then
+  # shellcheck disable=SC2086
+  if sh "${TMPDIR}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS}; then
     rm -r "${TMPDIR}"
   else
     echo >&2 "NOTE: did not remove: ${TMPDIR}"


### PR DESCRIPTION
Fixes #8782
Fixes #9763 

##### Summary

ssia

##### Component Name

- area/packaging

##### Test Plan

__WARNING:__ Testing this is a _bit tricky_ to say the least. It's a bit of a chicken 'n egg type problem until this PR is merved.

1. First of all, you need to patch the `netdata-updater.sh` on your system with teh following patch:

```#!diff
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -123,13 +123,12 @@ set_tarball_urls() {
   if [ "$1" = "stable" ]; then
     local latest
     # Simple version
-    # latest="$(curl -sSL https://api.github.com/repos/netdata/netdata/releases/latest | grep tag_name | cut -d'"' -f4)"
     latest="$(download "https://api.github.com/repos/netdata/netdata/releases/latest" /dev/stdout | grep tag_name | cut -d'"' -f4)"
     export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.${extension}"
     export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
   else
-    export NETDATA_TARBALL_URL="https://storage.googleapis.com/netdata-nightlies/netdata-latest.${extension}"
-    export NETDATA_TARBALL_CHECKSUM_URL="https://storage.googleapis.com/netdata-nightlies/sha256sums.txt"
+    export NETDATA_TARBALL_URL="$NETDATA_NIGHTLIES_BASEURL/netdata-latest.${extension}"
+    export NETDATA_TARBALL_CHECKSUM_URL="$NETDATA_NIGHTLIES_BASEURL/sha256sums.txt"
   fi
 }

@@ -185,8 +184,8 @@ update() {
       do_not_start="--dont-start-it"
     fi

-    if [ -n "${NETDATA_SELECTED_DASHBOARD}" ] ; then
-        env="NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
+    if [ -n "${NETDATA_SELECTED_DASHBOARD}" ]; then
+      env="NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
     fi

     info "Re-installing netdata..."
@@ -222,6 +221,9 @@ export NETDATA_LIB_DIR="${NETDATA_LIB_DIR:-${NETDATA_PREFIX}/var/lib/netdata}"
 # Source the tarbal checksum, if not already available from environment (for existing installations with the old logic)
 [[ -z "${NETDATA_TARBALL_CHECKSUM}" ]] && [[ -f ${NETDATA_LIB_DIR}/netdata.tarball.checksum ]] && NETDATA_TARBALL_CHECKSUM="$(cat "${NETDATA_LIB_DIR}/netdata.tarball.checksum")"

+# Grab the nightlies baseurl (defaulting to our Google Storage bucket)
+export NETDATA_NIGHTLIES_BASEURL="${NETDATA_NIGHTLIES_BASEURL:-https://storage.googleapis.com/netdata-nightlies}"
+
 if [ "${INSTALL_UID}" != "$(id -u)" ]; then
   fatal "You are running this script as user with uid $(id -u). We recommend to run this script as root (user with uid 0)"
 fi
```

2. Then you need to rebuild the artifacts with the `./build-artifacts.sh` which I plan to commit to this PR and the repo at the top-level (_I have future plans to refactor how we build the dist and makeself archives and how we publish them_).

```#!sh
$ ./build-artifacts.sh
.
.
.
CRC: 3614907360
MD5: fd7b57a2dd851c819dca3694808c7d65

Self-extractable archive "/opt/netdata.gz.run" successfully created.
 OK

[/usr/src/netdata.git]# rm /usr/src/netdata.git/packaging/makeself/./makeself.lsm.tmp
 OK

[/usr/src/netdata.git]# mkdir -p artifacts
 OK

[/usr/src/netdata.git]# mv /opt/netdata.gz.run artifacts/netdata-v1.21.1-75-g150140a1.gz.run
 OK

[/usr/src/netdata.git]# ln -s artifacts/netdata-v1.21.1-75-g150140a1.gz.run netdata-latest.gz.run
ln: netdata-latest.gz.run: File exists
```

3. Then you need to serve up the files in `./artifacts` with a web server that is capable of serving static resources. I use [prologic/static](https://github.com/prologic/static) for this purpose:

```#!sh
$ static -root ./artifacts/
[static] 2020/04/23 12:45:03 (10.0.0.3:54050) "GET /sha256sums.txt HTTP/1.1" 200 558 6.337534ms
[static] 2020/04/23 12:45:04 (10.0.0.3:54052) "GET /netdata-latest.gz.run HTTP/1.1" 200 37390233 633.729474ms
```

4. Fix the broken `REINSTALL_OPTIONS` on a system with teh static NetData Agent installed by inserting ` --auto-update` (_note the space_) into the `.environment` file, normally located at `/opt/netdata/etc/netdata/.enviornment`. I just use vi/vim here.

5. And finally you need to run the `netdata-updater.sh` with a custom `NETDATA_NIGHTLIES_BASEURL` LIKE SO:

```#!SH
root@vz1:~# NETDATA_NIGHTLIES_BASEURL=http://10.0.0.109:8000 /opt/netdata/usr/libexec/netdata/netdata-updater.sh
Entering /tmp/netdata-updater-MWdHDW

  ^
  |.-.   .-.   .-.   .-.   .  netdata
  |   '-'   '-'   '-'   '-'   real-time performance monitoring, done right!
  +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->

  (C) Copyright 2017, Costa Tsaousis
  All rights reserved
  Released under GPL v3+

  You are about to install netdata to this system.
  netdata will be installed at:

                    /opt/netdata

  The following changes will be made to your system:

  # USERS / GROUPS
  User 'netdata' and group 'netdata' will be added, if not present.

  # LOGROTATE
  This file will be installed if logrotate is present.

   - /etc/logrotate.d/netdata

  # SYSTEM INIT
  This file will be installed if this system runs with systemd:

   - /lib/systemd/system/netdata.service

   or, for older Centos, Debian/Ubuntu or OpenRC Gentoo:

   - /etc/init.d/netdata         will be created


  This package can also update a netdata installation that has been
  created with another version of it.

  Your netdata configuration will be retained.
  After installation, netdata will be (re-)started.

  netdata re-distributes a lot of open source software components.
  Check its full license at:
  https://github.com/netdata/netdata/blob/master/LICENSE.md
Creating directory /opt/netdata
Verifying archive integrity...  100%   All good.
Uncompressing netdata, the real-time performance and health monitoring system  100%
 --- Attempt to create user/group netdata/netadata ---
.
.
.
 --- Install (but not enable) netdata updater tool ---
Update script is located at /opt/netdata/usr/libexec/netdata/netdata-updater.sh

 --- Check if we must enable/disable the netdata updater tool ---
Adding to cron
Auto-updating has been enabled. Updater script linked to: /etc/cron.daily/netdata-updater

netdata-updater.sh works from cron. It will trigger an email from cron
only if it fails (it should not print anything when it can update netdata).

 --- creating quick links ---
Stopping all netdata threads
[/opt/netdata]# stop_all_netdata
 OK

Starting netdata using command 'systemctl start netdata'
[/opt/netdata]# systemctl start netdata
 OK


  ^
  |.-.   .-.   .-.   .-.   .-.   .  netdata              .-.   .-.   .-.   .-
  |   '-'   '-'   '-'   '-'   '-'   is installed now!  -'   '-'   '-'   '-'
  +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->

[/opt/netdata]# chmod 0644 /opt/netdata/etc/netdata/netdata.conf
 OK

Switching back to /root
```

_Note_ that the error `Invalid option: " --auto-update"` is now gone.

And just to confirm:

```#!sh
root@vz1:~# ls -lah /etc/cron.daily/
total 52K
drwxr-xr-x   2 root root 4.0K Apr 23 12:45 .
drwxr-xr-x 110 root root  12K Apr 21 14:12 ..
-rwxr-xr-x   1 root root 1.5K May 29  2019 apt-compat
-rwxr-xr-x   1 root root  314 Nov  8  2014 aptitude
-rwxr-xr-x   1 root root  355 Oct 17  2014 bsdmainutils
-rwxr-xr-x   1 root root 1.2K Apr 19  2019 dpkg
-rwxr-xr-x   1 root root  377 Aug 29  2018 logrotate
-rwxr-xr-x   1 root root 1.1K Feb 10  2019 man-db
-rwxr-xr-x   1 root root  543 Nov 15  2018 mlocate
lrwxrwxrwx   1 root root   51 Apr 23 12:45 netdata-updater -> /opt/netdata/usr/libexec/netdata/netdata-updater.sh
-rwxr-xr-x   1 root root  249 Nov 21  2014 passwd
-rw-r--r--   1 root root  102 Jun 11  2015 .placeholder
root@vz1:~#
```

And:

```#!sh
root@vz1:~# grep REINSTALL_OPTIONS /opt/netdata/etc/netdata/.environment
REINSTALL_OPTIONS=" --auto-update"
root@vz1:~#
```

##### Additional Information

This is a long standing bug that was attempted to eb fixed twice. Both times
didn't actually fix the bug becuase tehre was in fact another bug. We never
properly handled `REINSTALL_OPTIONS` in the first place and properly passed
this to the Makeself archive. The arguments need to be word-split.