### PR TITLE
Fixed formatting in API swagger json file

### DIFF
--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -873,6 +873,7 @@
             "schema": {
               "type": "boolean"
             }
+          }
         ],
         "responses": {
           "200": {


### PR DESCRIPTION
##### Summary
This change adds a missing bracket to the Netdata API swagger json file. 

##### Component Name
web/api

##### Test Plan
Before this change, passing this swagger document into openapi-generator (https://github.com/OpenAPITools/openapi-generator) would fail with syntax errors. After this change, the client and models are properly generated.

##### Additional Information
I'm not sure if this file is generated from the `.yml` file or maintained by a real person. Let me know if this is the right place for this type of change.

