### PR TITLE
Fix build and add bundle-dashbaord.sh to dist_noinst_DATA

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,7 +68,7 @@ dist_noinst_DATA = \
     packaging/libwebsockets.checksums \
     packaging/mosquitto.version \
     packaging/mosquitto.checksums \
-    packaging/bundle-dashbaord.sh \
+    packaging/bundle-dashboard.sh \
     packaging/bundle-mosquitto.sh \
     packaging/bundle-lws.sh \
     packaging/installer/README.md \

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,7 @@ dist_noinst_DATA = \
     packaging/libwebsockets.checksums \
     packaging/mosquitto.version \
     packaging/mosquitto.checksums \
+    packaging/bundle-dashbaord.sh \
     packaging/bundle-mosquitto.sh \
     packaging/bundle-lws.sh \
     packaging/installer/README.md \


### PR DESCRIPTION
##### Summary

ssia

Fixes broken package buidls:

```
packaging/bundle-dashboard.sh . /home/builder/netdata-1.21.183/debian/netdata/var/lib/netdata/www
make[1]: packaging/bundle-dashboard.sh: Command not found
make[1]: *** [debian/rules:68: override_dh_install] Error 127
make[1]: Leaving directory '/home/builder/netdata-1.21.183'
make: *** [debian/rules:22: binary] Error 2
dpkg-buildpackage: error: fakeroot debian/rules binary subprocess returned exit status 2
DEB build script completed!
```

As seen [here](https://travis-ci.com/github/netdata/netdata/jobs/323238968)

Currently affecting nightlies.

##### Component Name

- area/packaging
- area/si

##### Test Plan

- Travis CI (_ we should have a test for this_)

##### Additional Information