### PR TITLE
Removed old function call in netdata-installer.sh

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1029,8 +1029,6 @@ copy_react_dashboard() {
 install_react_dashboard() {
   progress "Fetching and installing dashboard"
 
-  clean_existing_dashboard
-
   DASHBOARD_PACKAGE_VERSION="$(cat packaging/dashboard.version)"
 
   tmp="$(mktemp -d -t netdata-dashboard-XXXXXX)"


### PR DESCRIPTION
##### Summary

When updating the dashboard handling code, I forgot to remove this call to a now nonexistent function.

##### Component Name

area/packaging

##### Test Plan

Passes CI.