### PR TITLE
chore: add missing os-release volume

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -67,6 +67,7 @@ services:
       - /etc/group:/host/etc/group:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
+      - /etc/os-release:/host/etc/os-release:ro
 ```
 
 Some of the bind-mounts are optional depending on how you use Netdata:


### PR DESCRIPTION
##### Summary

This is a documentation only fix.

##### Additional Information

The `docker-compose.yml` equivalent of the docker command line example given in the file was missing another volume.