### PR TITLE
JSON-c as hard dep. for ACLK

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -624,6 +624,10 @@ NETDATA_COMMON_LIBS = \
     $(OPTIONAL_EBPF_LIBS) \
     $(NULL)
 
+if LINK_STATIC_JSONC
+    NETDATA_COMMON_LIBS += externaldeps/jsonc/libjson-c.a
+endif
+
 NETDATACLI_FILES = \
     daemon/commands.h \
     $(LIBNETDATA_FILES) \

--- a/configure.ac
+++ b/configure.ac
@@ -436,8 +436,8 @@ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 # JSON-C
 
 if test "${enable_jsonc}" != "no" -a -z "${JSONC_LIBS}"; then
-	# Try and detect manual static build presence (from netdata-installer.h)
-	AC_MSG_CHECKING([if staticaly built json-c is present])
+	# Try and detect manual static build presence (from netdata-installer.sh)
+	AC_MSG_CHECKING([if statically built json-c is present])
 	if test -f "externaldeps/jsonc/libjson-c.a"; then
 		AC_DEFINE([LINK_STATIC_JSONC], [1], [static json-c should be used])
 		JSONC_LIBS="static"

--- a/configure.ac
+++ b/configure.ac
@@ -173,7 +173,6 @@ AC_ARG_ENABLE(
     [ enable_cloud="detect" ]
 )
 
-aclk_required="${enable_cloud}"
 if test "${enable_cloud}" = "no"; then
     AC_DEFINE([DISABLE_CLOUD], [1], [disable netdata cloud functionality])
 fi
@@ -592,7 +591,7 @@ if test "$enable_cloud" != "no"; then
     fi
     AC_MSG_RESULT([${HAVE_libwebsockets_a}])
 
-    if test "${build_target}" = "linux" -a "${aclk_required}" != "no"; then
+    if test "${build_target}" = "linux" -a "${enable_cloud}" != "no"; then
         if test "${have_libcap}" = "yes" -a "${with_libcap}" = "no"; then
             AC_MSG_ERROR([agent-cloud-link can't be built without libcap. Disable it by --disable-cloud or enable libcap])
         fi
@@ -605,7 +604,7 @@ if test "$enable_cloud" != "no"; then
     AC_MSG_CHECKING([if json-c available for ACLK])
     AC_MSG_RESULT([${enable_jsonc}])
 
-    test "${aclk_required}" = "yes" -a "${enable_jsonc}" = "no" && \
+    test "${enable_cloud}" = "yes" -a "${enable_jsonc}" = "no" && \
         AC_MSG_ERROR([You have asked for ACLK to be built but no json-c available. ACLK requires json-c])
 
     AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
@@ -616,14 +615,14 @@ if test "$enable_cloud" != "no"; then
     fi
     AC_MSG_RESULT([${can_enable_aclk}])
 
-    test "${aclk_required}" = "yes" -a "${can_enable_aclk}" = "no" && \
+    test "${enable_cloud}" = "yes" -a "${can_enable_aclk}" = "no" && \
         AC_MSG_ERROR([User required agent-cloud-link but it can't be built!])
 
     AC_MSG_CHECKING([if netdata agent-cloud-link should/will be enabled])
-    if test "${aclk_required}" = "detect"; then
+    if test "${enable_cloud}" = "detect"; then
         enable_aclk=$can_enable_aclk
     else
-        enable_aclk=$aclk_required
+        enable_aclk=$enable_cloud
     fi
     AC_SUBST([can_enable_aclk])
 

--- a/configure.ac
+++ b/configure.ac
@@ -435,19 +435,19 @@ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 # -----------------------------------------------------------------------------
 # JSON-C
 
-static_jsonc="no"
 if test "${enable_jsonc}" != "no" -a -z "${JSONC_LIBS}"; then
 	# Try and detect manual static build presence (from netdata-installer.h)
 	AC_MSG_CHECKING([if staticaly built json-c is present])
 	if test -f "externaldeps/jsonc/libjson-c.a"; then
 		AC_DEFINE([LINK_STATIC_JSONC], [1], [static json-c should be used])
 		JSONC_LIBS="static"
-		static_jsonc="yes"
 		OPTIONAL_JSONC_STATIC_CFLAGS="-I externaldeps/jsonc"
+		AC_MSG_RESULT([yes])
+	else
+		AC_MSG_RESULT([no])
 	fi
-	AC_MSG_RESULT([${static_jsonc}])
 fi
-AM_CONDITIONAL([LINK_STATIC_JSONC], [test "${static_jsonc}" = "yes"])
+AM_CONDITIONAL([LINK_STATIC_JSONC], [test "${JSONC_LIBS}" = "static"])
 
 test "${enable_jsonc}" = "yes" -a -z "${JSONC_LIBS}" && \
     AC_MSG_ERROR([JSON-C required but not found. Try installing 'libjson-c-dev' or 'json-c'.])

--- a/configure.ac
+++ b/configure.ac
@@ -601,8 +601,15 @@ if test "$enable_cloud" != "no"; then
         fi
     fi
 
+    # next 2 lines are just to have info for ACLK dependencies in common place
+    AC_MSG_CHECKING([if json-c available for ACLK])
+    AC_MSG_RESULT([${enable_jsonc}])
+
+    test "${aclk_required}" = "yes" -a "${enable_jsonc}" = "no" && \
+        AC_MSG_ERROR([You have asked for ACLK to be built but no json-c available. ACLK requires json-c])
+
     AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
-    if test "${HAVE_libmosquitto_a}" = "yes" -a "${HAVE_libwebsockets_a}" = "yes" -a -n "${SSL_LIBS}"; then
+    if test "${HAVE_libmosquitto_a}" = "yes" -a "${HAVE_libwebsockets_a}" = "yes" -a -n "${SSL_LIBS}" -a "${enable_jsonc}" = "yes"; then
         can_enable_aclk="yes"
     else
         can_enable_aclk="no"

--- a/configure.ac
+++ b/configure.ac
@@ -438,14 +438,28 @@ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 if test "${enable_jsonc}" != "no" -a -z "${JSONC_LIBS}"; then
 	# Try and detect manual static build presence (from netdata-installer.sh)
 	AC_MSG_CHECKING([if statically built json-c is present])
+	HAVE_libjson_c_a="no"
 	if test -f "externaldeps/jsonc/libjson-c.a"; then
+		LIBS_BKP="${LIBS}"
+		LIBS="externaldeps/jsonc/libjson-c.a"
+		AC_LINK_IFELSE([AC_LANG_SOURCE([[#include "externaldeps/jsonc/json-c/json.h"
+										 int main (int argc, char **argv) {
+											 struct json_object *jobj;
+											 char *str = "{ \"msg-type\": \"random\" }";
+											 jobj = json_tokener_parse(str);
+											 json_object_get_type(jobj);
+										 }]])],
+										[HAVE_libjson_c_a="yes"],
+										[HAVE_libjson_c_a="no"])
+		LIBS="${LIBS_BKP}"
+	fi
+
+	if test "${HAVE_libjson_c_a}" = "yes"; then
 		AC_DEFINE([LINK_STATIC_JSONC], [1], [static json-c should be used])
 		JSONC_LIBS="static"
 		OPTIONAL_JSONC_STATIC_CFLAGS="-I externaldeps/jsonc"
-		AC_MSG_RESULT([yes])
-	else
-		AC_MSG_RESULT([no])
 	fi
+	AC_MSG_RESULT([${HAVE_libjson_c_a}])
 fi
 AM_CONDITIONAL([LINK_STATIC_JSONC], [test "${JSONC_LIBS}" = "static"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -435,6 +435,21 @@ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # JSON-C
+AC_MSG_WARN([XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXxx])
+static_jsonc="no"
+if test "${enable_jsonc}" != "no" -a -z "${JSONC_LIBS}"; then
+	# Try and detect manual static build presence (from netdata-installer.h)
+	AC_MSG_CHECKING([if staticaly built json-c is present])
+	if test -f "externaldeps/jsonc/libjson-c.a"; then
+		AC_DEFINE([LINK_STATIC_JSONC], [1], [static json-c should be used])
+		JSONC_LIBS="static"
+		static_jsonc="yes"
+		OPTIONAL_JSONC_STATIC_CFLAGS="-I externaldeps/jsonc"
+	fi
+	AC_MSG_RESULT([${static_jsonc}])
+fi
+AM_CONDITIONAL([LINK_STATIC_JSONC], [test "${static_jsonc}" = "yes"])
+
 test "${enable_jsonc}" = "yes" -a -z "${JSONC_LIBS}" && \
     AC_MSG_ERROR([JSON-C required but not found. Try installing 'libjson-c-dev' or 'json-c'.])
 
@@ -1218,7 +1233,8 @@ AC_SUBST([webdir])
 
 CFLAGS="${CFLAGS} ${OPTIONAL_MATH_CFLAGS} ${OPTIONAL_NFACCT_CFLAGS} ${OPTIONAL_ZLIB_CFLAGS} ${OPTIONAL_UUID_CFLAGS} \
     ${OPTIONAL_LIBCAP_CFLAGS} ${OPTIONAL_IPMIMONITORING_CFLAGS} ${OPTIONAL_CUPS_CFLAGS} ${OPTIONAL_XENSTAT_FLAGS} \
-    ${OPTIONAL_KINESIS_CFLAGS} ${OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS} ${OPTIONAL_MONGOC_CFLAGS} ${LWS_CFLAGS}"
+    ${OPTIONAL_KINESIS_CFLAGS} ${OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS} ${OPTIONAL_MONGOC_CFLAGS} ${LWS_CFLAGS} \
+	${OPTIONAL_JSONC_STATIC_CFLAGS}"
 
 CXXFLAGS="${CFLAGS} ${CXX11FLAG}"
 

--- a/configure.ac
+++ b/configure.ac
@@ -435,7 +435,7 @@ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # JSON-C
-AC_MSG_WARN([XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXxx])
+
 static_jsonc="no"
 if test "${enable_jsonc}" != "no" -a -z "${JSONC_LIBS}"; then
 	# Try and detect manual static build presence (from netdata-installer.h)


### PR DESCRIPTION
##### Summary

1. If `json-c-devel` (or equivalent pkg in other distros) available use it.
1. If not try and check if static build is available in `externaldeps` folder (by installer) and use it.
1. If no json-c is available don't build ACLK in `detect` (default mode - build ACLK if you can but build netdata always) and error out in configure if `--enable-aclk` flag given (telling us user specifically wants ACLK to be built)

##### Component Name

##### Test Plan
Test with and without system JSON-c dev package. Test with configure flags `--enable-cloud`, `--disable-cloud`, and no flag (default autodetect mode). Test with renaming `libjson-c.a` and running configure (without installer who would build new lib) to simulate the case where the installer was not able to build static json-c.

##### Additional Information
