### PR TITLE
Fix claiming config

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1375,7 +1375,7 @@ void *aclk_main(void *ptr)
         }
         // The NULL return means the value was never initialised, but this value has been initialized in post_conf_load.
         // We trap the impossible NULL here to keep the linter happy without using a fatal() in the code.
-        char *cloud_base_url = config_get(CONFIG_SECTION_CLOUD, "cloud base url", NULL);
+        char *cloud_base_url = appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "cloud base url", NULL);
         if (cloud_base_url == NULL) {
             error("Do not move the cloud base url out of post_conf_load!!");
             goto exited;

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -149,7 +149,7 @@ static RSA *aclk_private_key = NULL;
 static int create_private_key()
 {
     char filename[FILENAME_MAX + 1];
-    snprintfz(filename, FILENAME_MAX, "%s/claim.d/private.pem", netdata_configured_user_config_dir);
+    snprintfz(filename, FILENAME_MAX, "%s/cloud.d/private.pem", netdata_configured_varlib_dir);
 
     long bytes_read;
     char *private_key = read_by_filename(filename, &bytes_read);

--- a/build_external/projects/aclk-testing/agent-compose.yml
+++ b/build_external/projects/aclk-testing/agent-compose.yml
@@ -9,7 +9,7 @@ services:
       - VERSION=current
     image: arch_current_dev:latest
     command: >
-      sh -c "echo -n 00000000-0000-0000-0000-000000000000 >/etc/netdata/claim.d/claimed_id &&
+      sh -c "echo -n 00000000-0000-0000-0000-000000000000 >/var/lib/netdata/cloud.d/claimed_id &&
              echo '[agent_cloud_link]' >>/etc/netdata/netdata.conf &&
              echo '  agent cloud link hostname = vernemq' >>/etc/netdata/netdata.conf &&
              echo '  agent cloud link port = 9002' >>/etc/netdata/netdata.conf &&

--- a/build_external/projects/aclk-testing/agent-valgrind-compose.yml
+++ b/build_external/projects/aclk-testing/agent-valgrind-compose.yml
@@ -9,7 +9,7 @@ services:
       - VERSION=extras
     image: arch_extras_dev:latest
     command: >
-      sh -c "echo -n 00000000-0000-0000-0000-000000000000 >/etc/netdata/claim.d/claimed_id &&
+      sh -c "echo -n 00000000-0000-0000-0000-000000000000 >/var/lib/netdata/cloud.d/claimed_id &&
              echo '[agent_cloud_link]' >>/etc/netdata/netdata.conf &&
              echo '  agent cloud link hostname = vernemq' >>/etc/netdata/netdata.conf &&
              echo '  agent cloud link port = 9002' >>/etc/netdata/netdata.conf &&

--- a/claim/README.md
+++ b/claim/README.md
@@ -234,23 +234,23 @@ with details about your system and relevant output from `error.log`.
 
 ### Unclaim (remove) an Agent from Netdata Cloud
 
-The best method to remove an Agent from Netdata Cloud is to unclaim it by deleting the `claim.d/` directory in your
-Netdata configuration directory.
+The best method to remove an Agent from Netdata Cloud is to unclaim it by deleting the `cloud.d/` directory in your
+Netdata library directory.
 
 ```bash
-cd /etc/netdata   # Replace with your Netdata configuration directory, if not /etc/netdata/
-rm -rf claim.d/
+cd /var/lib/netdata   # Replace with your Netdata library directory, if not /var/lib/netdata/
+rm -rf cloud.d/
 ```
 
 > You may need to use `sudo` or another method of elevating your privileges.
 
-Once you delete the `claim.d/` directory, the ACLK will not connect to Cloud the next time the Agent starts, and Cloud
+Once you delete the `cloud.d/` directory, the ACLK will not connect to Cloud the next time the Agent starts, and Cloud
 will then remove it from the interface.
 
 ## Claiming reference
 
 In the sections below, you can find reference material for the claiming script, claiming via the Agent's command line
-tool, and details about the files found in `claim.d`.
+tool, and details about the files found in `cloud.d`.
 
 ### Claiming script
 
@@ -306,14 +306,14 @@ If need be, the user can override the Agent's defaults by providing additional a
 
 ### Claiming directory
 
-Netdata stores the agent claiming-related state in the user configuration directory under `claim.d`, e.g. in
-`/etc/netdata/claim.d`. The user can put files in this directory to provide defaults to the `-token` and `-rooms`
+Netdata stores the agent claiming-related state in the Netdata library directory under `cloud.d`, e.g. in
+`/var/lib/netdata/cloud.d`. The user can put files in this directory to provide defaults to the `-token` and `-rooms`
 arguments. These files should be owned **by the `netdata` user**.
 
-The `claim.d/token` file should contain the claiming-token and the `claim.d/rooms` file should contain the list of 
+The `cloud.d/token` file should contain the claiming-token and the `cloud.d/rooms` file should contain the list of 
 war-rooms.
 
-The user can also put the Cloud endpoint's full certificate chain in `claim.d/cloud_fullchain.pem` so that the Agent
+The user can also put the Cloud endpoint's full certificate chain in `cloud.d/cloud_fullchain.pem` so that the Agent
 can trust the endpoint if necessary.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fclaim%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/claim/README.md
+++ b/claim/README.md
@@ -96,7 +96,7 @@ docker run -d --name=netdata \
   --cap-add SYS_PTRACE \
   --security-opt apparmor=unconfined \
   netdata/netdata \
-  /usr/sbin/netdata -D -W set global "netdata cloud" enable -W set cloud "cloud base url" "https://app.netdata.cloud" -W "claim -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud"
+  /usr/sbin/netdata -D -W set cloud global enabled true -W set cloud global "cloud base url" "https://app.netdata.cloud" -W "claim -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud"
 ```
 
 The container runs in detached mode, so you won't see any output. If the node does not appear in your Space, you can run
@@ -167,11 +167,11 @@ Use these keys and the information below to troubleshoot the ACLK.
 
 If `cloud-enabled` is `false`, you probably ran the installer with `--disable-cloud` option.
 
-Additionally, check that the `netdata cloud` setting in `netdata.conf` is set to `enable`:
+Additionally, check that the `enabled` setting in `var/lib/netdata/cloud.d/cloud.conf` is set to `true`:
 
 ```ini
-[general]
-    netadata cloud = enable
+[global]
+    enabled = true
 ```
 
 To fix this issue, reinstall Netdata using your [preferred method](/packaging/installer/README.md) and do not add the

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -118,7 +118,7 @@ void load_claiming_state(void)
     config_get(CONFIG_SECTION_CLOUD, "cloud base url", DEFAULT_CLOUD_BASE_URL);   
 
     char filename[FILENAME_MAX + 1];
-    snprintfz(filename, FILENAME_MAX, "%s/claim.d/claimed_id", netdata_configured_user_config_dir);
+    snprintfz(filename, FILENAME_MAX, "%s/cloud.d/claimed_id", netdata_configured_varlib_dir);
 
     long bytes_read;
     claimed_id = read_by_filename(filename, &bytes_read);

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -144,7 +144,7 @@ struct config cloud_config = { .first_section = NULL,
                                .index = { .avl_tree = { .root = NULL, .compar = appconfig_section_compare },
                                           .rwlock = AVL_LOCK_INITIALIZER } };
 
-void load_cloud_conf(void)
+void load_cloud_conf(int silent)
 {
     char *filename;
     errno = 0;
@@ -154,7 +154,7 @@ void load_cloud_conf(void)
     filename = strdupz_path_subpath(netdata_configured_varlib_dir, "cloud.d/cloud.conf");
 
     ret = appconfig_load(&cloud_config, filename, 1, NULL);
-    if(!ret) {
+    if(!ret && !silent) {
         info("CONFIG: cannot load cloud config '%s'. Running with internal defaults.", filename);
     }
     freez(filename);

--- a/claim/claim.h
+++ b/claim/claim.h
@@ -11,6 +11,6 @@ extern struct config cloud_config;
 void claim_agent(char *claiming_arguments);
 char *is_agent_claimed(void);
 void load_claiming_state(void);
-void load_cloud_conf(void);
+void load_cloud_conf(int silent);
 
 #endif //NETDATA_CLAIM_H

--- a/claim/claim.h
+++ b/claim/claim.h
@@ -6,9 +6,11 @@
 #include "../daemon/common.h"
 
 extern char *claiming_pending_arguments;
+extern struct config cloud_config;
 
 void claim_agent(char *claiming_arguments);
 char *is_agent_claimed(void);
 void load_claiming_state(void);
+void load_cloud_conf(void);
 
 #endif //NETDATA_CLAIM_H

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -78,13 +78,14 @@
 # Exit code: 15
 
 get_config_value() {
-    section="${1}"
-    key_name="${2}"
-    config_result=$(@sbindir_POST@/netdatacli 2>/dev/null read-config "$section|$key_name"; exit $?)
+    conf_file="${1}"
+    section="${2}"
+    key_name="${3}"
+    config_result=$(@sbindir_POST@/netdatacli 2>/dev/null read-config "$conf_file|$section|$key_name"; exit $?)
     # shellcheck disable=SC2181
     if [ "$?" != "0" ]; then
        echo >&2 "cli failed, assume netdata is not running and query the on-disk config"
-       config_result=$(@sbindir_POST@/netdata 2>/dev/null -W get "$section" "$key_name" unknown_default)
+       config_result=$(@sbindir_POST@/netdata 2>/dev/null -W get "$conf_file" "$section" "$key_name" unknown_default)
     fi
     echo "$config_result"
 }
@@ -119,7 +120,7 @@ fi
 MACHINE_GUID_FILE="@registrydir_POST@/netdata.public.unique.id"
 CLAIMING_DIR="${NETDATA_VARLIB_DIR}/cloud.d"
 TOKEN="unknown"
-URL_BASE=$(get_config_value cloud "cloud base url")
+URL_BASE=$(get_config_value cloud global "cloud base url")
 [ -z "$URL_BASE" ] && URL_BASE="https://app.netdata.cloud"  # Cover post-install with --dont-start
 ID="unknown"
 ROOMS=""
@@ -128,7 +129,7 @@ CLOUD_CERTIFICATE_FILE="${CLAIMING_DIR}/cloud_fullchain.pem"
 VERBOSE=0
 INSECURE=0
 RELOAD=1
-NETDATA_USER=$(get_config_value global "run as user")
+NETDATA_USER=$(get_config_value netdata global "run as user")
 [ -z "$EUID" ] && EUID="$(id -u)"
 
 
@@ -306,22 +307,22 @@ if [ "${HTTP_STATUS_CODE}" = "204" ] ; then
             chown -R "${NETDATA_USER}:${NETDATA_USER}" ${CLAIMING_DIR} || (echo >&2 "Claiming failed"; set -e; exit 2)
         fi
 
-        # Rewrite the netdata.conf on the disk
+        # Rewrite the cloud.conf on the disk
         T=$(mktemp)
-        sed -e '/[^#]*\[cloud]/,/[^#]*\[.*]/s/[^#]*enabled *= /#\0/;s/^[^#]*cloud base url *=/#\0/' "@configdir_POST@/netdata.conf" >"$T"
+        # sed -e '/[^#]*\[global]/,/[^#]*\[.*]/s/[^#]*enabled *= /#\0/;s/^[^#]*cloud base url *=/#\0/' "$CLAIMING_DIR/cloud.conf" >"$T"
         cat >>"$T" <<HERE_DOC
-[cloud]
+[global]
   enabled = yes
   cloud base url = $URL_BASE
 HERE_DOC
-        cp "$T" @configdir_POST@/netdata.conf
+        cp "$T" "$CLAIMING_DIR/cloud.conf"
         rm "$T"
         if [ "${RELOAD}" == "0" ] ; then
             exit 0
         fi
-        # Update the netdata.conf in the agent memory
-        @sbindir_POST@/netdatacli write-config 'cloud|enabled|yes' && \
-        @sbindir_POST@/netdatacli write-config "cloud|cloud base url|$URL_BASE" && \
+        # Update cloud.conf in the agent memory
+        @sbindir_POST@/netdatacli write-config 'cloud|global|enabled|yes' && \
+        @sbindir_POST@/netdatacli write-config "cloud|global|cloud base url|$URL_BASE" && \
         @sbindir_POST@/netdatacli reload-claiming-state && echo >&2 "Node was successfully claimed." && exit 0
         echo "The claim was successful but the agent could not be notified ($?)- it requires a restart to connect to the cloud"
         exit 6

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -85,7 +85,7 @@ get_config_value() {
     # shellcheck disable=SC2181
     if [ "$?" != "0" ]; then
        echo >&2 "cli failed, assume netdata is not running and query the on-disk config"
-       config_result=$(@sbindir_POST@/netdata 2>/dev/null -W get "$conf_file" "$section" "$key_name" unknown_default)
+       config_result=$(@sbindir_POST@/netdata 2>/dev/null -W get2 "$conf_file" "$section" "$key_name" unknown_default)
     fi
     echo "$config_result"
 }

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -115,9 +115,9 @@ fi
 # -----------------------------------------------------------------------------
 # defaults to allow running this script by hand
 
-[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="@configdir_POST@"
+[ -z "${NETDATA_VARLIB_DIR}" ] && NETDATA_VARLIB_DIR="@varlibdir_POST@"
 MACHINE_GUID_FILE="@registrydir_POST@/netdata.public.unique.id"
-CLAIMING_DIR="${NETDATA_USER_CONFIG_DIR}/claim.d"
+CLAIMING_DIR="${NETDATA_VARLIB_DIR}/cloud.d"
 TOKEN="unknown"
 URL_BASE=$(get_config_value cloud "cloud base url")
 [ -z "$URL_BASE" ] && URL_BASE="https://app.netdata.cloud"  # Cover post-install with --dont-start

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -437,7 +437,7 @@ int become_daemon(int dont_fork, const char *user)
     sched_setscheduler_set();
 
     // Set claiming directory based on user config directory with correct ownership
-    snprintfz(claimingdirectory, FILENAME_MAX, "%s/claim.d", netdata_configured_user_config_dir);
+    snprintfz(claimingdirectory, FILENAME_MAX, "%s/cloud.d", netdata_configured_varlib_dir);
 
     if(user && *user) {
         if(become_user(user, pidfd) != 0) {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1119,12 +1119,39 @@ int main(int argc, char **argv) {
                             // fprintf(stderr, "SET section '%s', key '%s', value '%s'\n", section, key, value);
                         }
                         else if(strcmp(optarg, "get") == 0) {
-                            if(optind + 4 > argc) {
-                                fprintf(stderr, "%s", "\nUSAGE: -W get 'conf_file' 'section' 'key' 'value'\n\n"
-                                        " Prints settings of netdata.conf or cloud.conf\n"
+                            if(optind + 3 > argc) {
+                                fprintf(stderr, "%s", "\nUSAGE: -W get 'section' 'key' 'value'\n\n"
+                                        " Prints settings of netdata.conf.\n"
                                         "\n"
                                         " These options interact with: -c netdata.conf\n"
                                         " -c netdata.conf has to be given before -W get.\n"
+                                        "\n"
+                                );
+                                return 1;
+                            }
+
+                            if(!config_loaded) {
+                                fprintf(stderr, "warning: no configuration file has been loaded. Use -c CONFIG_FILE, before -W get. Using default config.\n");
+                                load_netdata_conf(NULL, 0);
+                                post_conf_load(&user);
+                            }
+
+                            get_netdata_configured_variables();
+
+                            const char *section = argv[optind];
+                            const char *key = argv[optind + 1];
+                            const char *def = argv[optind + 2];
+                            const char *value = config_get(section, key, def);
+                            printf("%s\n", value);
+                            return 0;
+                        }
+                        else if(strcmp(optarg, "get2") == 0) {
+                            if(optind + 4 > argc) {
+                                fprintf(stderr, "%s", "\nUSAGE: -W get2 'conf_file' 'section' 'key' 'value'\n\n"
+                                        " Prints settings of netdata.conf or cloud.conf\n"
+                                        "\n"
+                                        " These options interact with: -c netdata.conf\n"
+                                        " -c netdata.conf has to be given before -W get2.\n"
                                         " conf_file can be \"cloud\" or \"netdata\".\n"
                                         "\n"
                                 );

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -936,7 +936,7 @@ int main(int argc, char **argv) {
                     else {
                         debug(D_OPTIONS, "Configuration loaded from %s.", optarg);
                         post_conf_load(&user);
-                        load_cloud_conf();
+                        load_cloud_conf(1);
                         config_loaded = 1;
                     }
                     break;
@@ -1135,7 +1135,7 @@ int main(int argc, char **argv) {
                                 fprintf(stderr, "warning: no configuration file has been loaded. Use -c CONFIG_FILE, before -W get. Using default config.\n");
                                 load_netdata_conf(NULL, 0);
                                 post_conf_load(&user);
-                                load_cloud_conf();
+                                load_cloud_conf(1);
                             }
 
                             get_netdata_configured_variables();
@@ -1181,7 +1181,7 @@ int main(int argc, char **argv) {
     {
         load_netdata_conf(NULL, 0);
         post_conf_load(&user);
-        load_cloud_conf();
+        load_cloud_conf(0);
     }
 
 

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -301,9 +301,9 @@ char *appconfig_get_by_section(struct section *co, const char *name, const char 
 
     if((cv->flags & CONFIG_VALUE_LOADED) || (cv->flags & CONFIG_VALUE_CHANGED)) {
         // this is a loaded value from the config file
-        // if it is different that the default, mark it
+        // if it is different than the default, mark it
         if(!(cv->flags & CONFIG_VALUE_CHECKED)) {
-            if(strcmp(cv->value, default_value) != 0) cv->flags |= CONFIG_VALUE_CHANGED;
+            if(default_value && strcmp(cv->value, default_value) != 0) cv->flags |= CONFIG_VALUE_CHANGED;
             cv->flags |= CONFIG_VALUE_CHECKED;
         }
     }

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -876,14 +876,14 @@ progress "Read installation options from netdata.conf"
 [ ! -f "${NETDATA_PREFIX}/etc/netdata/netdata.conf" ] &&
   touch "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
 
-# function to extract values from the config file
+# function to extract values from the netdata.conf config file
 config_option() {
   local section="${1}" key="${2}" value="${3}"
 
   if [ -s "${NETDATA_PREFIX}/etc/netdata/netdata.conf" ]; then
     "${NETDATA_PREFIX}/usr/sbin/netdata" \
       -c "${NETDATA_PREFIX}/etc/netdata/netdata.conf" \
-      -W get "${section}" "${key}" "${value}" ||
+      -W get netdata "${section}" "${key}" "${value}" ||
       echo "${value}"
   else
     echo "${value}"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -923,7 +923,7 @@ NETDATA_LOG_DIR="$(config_option "global" "log directory" "${NETDATA_PREFIX}/var
 NETDATA_USER_CONFIG_DIR="$(config_option "global" "config directory" "${NETDATA_PREFIX}/etc/netdata")"
 NETDATA_STOCK_CONFIG_DIR="$(config_option "global" "stock config directory" "${NETDATA_PREFIX}/usr/lib/netdata/conf.d")"
 NETDATA_RUN_DIR="${NETDATA_PREFIX}/var/run"
-NETDATA_CLAIMING_DIR="${NETDATA_USER_CONFIG_DIR}/claim.d"
+NETDATA_CLAIMING_DIR="${NETDATA_LIB_DIR}/cloud.d"
 
 cat << OPTIONSEOF
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -876,14 +876,14 @@ progress "Read installation options from netdata.conf"
 [ ! -f "${NETDATA_PREFIX}/etc/netdata/netdata.conf" ] &&
   touch "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
 
-# function to extract values from the netdata.conf config file
+# function to extract values from the config file
 config_option() {
   local section="${1}" key="${2}" value="${3}"
 
   if [ -s "${NETDATA_PREFIX}/etc/netdata/netdata.conf" ]; then
     "${NETDATA_PREFIX}/usr/sbin/netdata" \
       -c "${NETDATA_PREFIX}/etc/netdata/netdata.conf" \
-      -W get netdata "${section}" "${key}" "${value}" ||
+      -W get "${section}" "${key}" "${value}" ||
       echo "${value}"
   else
     echo "${value}"

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -98,8 +98,8 @@ RUN \
         /var/cache/netdata \
         /var/lib/netdata \
         /var/log/netdata && \
-    chown -R netdata:netdata /etc/netdata/claim.d && \
-    chmod 0700 /etc/netdata/claim.d && \
+    chown -R netdata:netdata /var/lib/netdata/cloud.d && \
+    chmod 0700 /var/lib/netdata/cloud.d && \
     chmod 0755 /usr/libexec/netdata/plugins.d/*.plugin && \
     chmod 4755 \
         /usr/libexec/netdata/plugins.d/cgroup-network \

--- a/registry/registry.c
+++ b/registry/registry.c
@@ -137,7 +137,7 @@ static inline int registry_person_url_callback_verify_machine_exists(void *entry
 void registry_update_cloud_base_url()
 {
     // This is guaranteed to be set early in main via post_conf_load()
-    registry.cloud_base_url = config_get(CONFIG_SECTION_CLOUD, "cloud base url", NULL);
+    registry.cloud_base_url = appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "cloud base url", NULL);
     if (registry.cloud_base_url == NULL)
         fatal("Do not move the cloud base url out of post_conf_load!!");
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes https://github.com/netdata/product/issues/839
Fixes #8622

##### Component Name
agent
claiming
cloud
##### Test Plan
Continuation of https://github.com/netdata/netdata/pull/8818

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
We agreed to:
- remove cloud enable and cloud base URL configuration from `netdata.conf` completely
- put them in the `claim.d` configuration folder
- move the `claim.d` folder to `/var/lib/netdata` and rename it to `cloud.d`
- update documentation