### PR TITLE
Fixed bundling of dashboard in binary packages.

### DIFF
--- a/packaging/bundle-dashboard.sh
+++ b/packaging/bundle-dashboard.sh
@@ -12,7 +12,3 @@ sha256sum -c "${SRCDIR}/packaging/dashboard.checksums" || exit 1
 tar -xzf "${DASHBOARD_TARBALL}" -C "${SRCDIR}/tmp" || exit 1
 # shellcheck disable=SC2046
 cp -a $(find "${SRCDIR}/tmp" -mindepth 1 -maxdepth 1) "${WEBDIR}"
-cp -a "${WEBDIR}/old/dashboard_info.js" "${WEBDIR}"
-cp -a "${WEBDIR}/old/dashboard.slate.css" "${WEBDIR}"
-cp -a "${WEBDIR}/old/dashboard.css" "${WEBDIR}"
-cp -a "${WEBDIR}/old/main.css" "${WEBDIR}"


### PR DESCRIPTION
##### Summary

This removes some code from the dashboard bundling script that was left over from before we changed how we were handling prefixing the old dashboard. The script did not get properly tested after that change in design, so the code unfortunately made it into master and broke package builds.

##### Component Name

area/packaging

##### Test Plan

Verified locally for both DEB and RPM packages.