### PR TITLE
Added CI to verify JSON-C bundling code in installer.

### DIFF
--- a/.github/dockerfiles/Dockerfile.build_test
+++ b/.github/dockerfiles/Dockerfile.build_test
@@ -7,5 +7,6 @@ ENV PRE=${PRE}
 
 COPY . /netdata
 
+RUN chmod +x /netdata/rmjsonc.sh
 RUN /bin/sh /netdata/prep-cmd.sh
 RUN /netdata/packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata-all

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -49,12 +49,9 @@ jobs:
 
           - distro: 'archlinux:latest'
             pre: 'pacman --noconfirm -Sy grep libffi'
-            rmjsonc: 'pacman -R --noconfirm json-c'
 
           - distro: 'centos:8'
             rmjsonc: 'dnf remove -y json-c-devel'
-          - distro: 'centos:7'
-            rmjsonc: 'yum remove -y json-c-devel'
 
           - distro: 'debian:bullseye'
             pre: 'apt-get update'
@@ -114,6 +111,7 @@ jobs:
         run: |
           docker run -w /netdata test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'
       - name: netdata-installer on ${{ matrix.distro }}, require cloud, no JSON-C
+        if: matrix.rmjsonc != ''
         run: |
           docker run -w /netdata test \
               /bin/sh -c '/netdata/rmjsonc.sh && ./netdata-installer.sh --dont-wait --dont-start-it --require-cloud'

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -35,30 +35,62 @@ jobs:
         include:
           - distro: 'alpine:edge'
             pre: 'apk add -U bash'
+            rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.11'
             pre: 'apk add -U bash'
+            rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.10'
             pre: 'apk add -U bash'
+            rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.9'
             pre: 'apk add -U bash'
+            rmjsonc: 'apk del json-c-dev'
 
           - distro: 'archlinux:latest'
             pre: 'pacman --noconfirm -Sy grep libffi'
+            rmjsonc: 'pacman -R --noconfirm json-c'
+
+          - distro: 'centos:8'
+            rmjsonc: 'dnf remove -y json-c-devel'
+          - distro: 'centos:7'
+            rmjsonc: 'yum remove -y json-c-devel'
 
           - distro: 'debian:bullseye'
             pre: 'apt-get update'
+            rmjsonc: 'apt-get remove -y libjson-c-dev'
           - distro: 'debian:buster'
             pre: 'apt-get update'
+            rmjsonc: 'apt-get remove -y libjson-c-dev'
           - distro: 'debian:stretch'
             pre: 'apt-get update'
+            rmjsonc: 'apt-get remove -y libjson-c-dev'
+
+          - distro: 'fedora:32'
+            rmjsonc: 'dnf remove -y json-c-devel'
+          - distro: 'fedora:31'
+            rmjsonc: 'dnf remove -y json-c-devel'
+          - distro: 'fedora:30'
+            rmjsonc: 'dnf remove -y json-c-devel'
+
+          - distro: 'opensuse/leap:15.2'
+            rmjsonc: 'zypper rm -y libjson-c-devel'
+          - distro: 'opensuse/leap:15.1'
+            rmjsonc: 'zypper rm -y libjson-c-devel'
+          - distro: 'opensuse/tumbleweed:latest'
+            rmjsonc: 'zypper rm -y libjson-c-devel'
+
           - distro: 'ubuntu:20.04'
             pre: 'apt-get update'
+            rmjsonc: 'apt-get remove -y libjson-c-dev'
           - distro: 'ubuntu:19.10'
             pre: 'apt-get update'
+            rmjsonc: 'apt-get remove -y libjson-c-dev'
           - distro: 'ubuntu:18.04'
             pre: 'apt-get update'
+            rmjsonc: 'apt-get remove -y libjson-c-dev'
           - distro: 'ubuntu:16.04'
             pre: 'apt-get update'
+            rmjsonc: 'apt-get remove -y libjson-c-dev'
     runs-on: ubuntu-latest
     steps:
       - name: Git clone repository
@@ -66,15 +98,20 @@ jobs:
       - name: install-required-packages.sh on ${{ matrix.distro }}
         env:
           PRE: ${{ matrix.pre }}
+          RMJSONC: ${{ matrix.rmjsonc }}
         run: |
           echo $PRE > ./prep-cmd.sh
+          echo $RMJSONC > ./rmjsonc.sh
           docker build . -f .github/dockerfiles/Dockerfile.build_test -t test --build-arg BASE=${{ matrix.distro }}
       - name: Regular build on ${{ matrix.distro }}
         run: |
           docker run -w /netdata test /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
-      - name: netdata-installer on ${{ matrix.distro }}
+      - name: netdata-installer on ${{ matrix.distro }}, disable cloud
         run: |
           docker run -w /netdata test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --disable-cloud'
-      - name: netdata-installer on ${{ matrix.distro }}
+      - name: netdata-installer on ${{ matrix.distro }}, require cloud
         run: |
           docker run -w /netdata test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'
+      - name: netdata-installer on ${{ matrix.distro }}, require cloud, no JSON-C
+        run: |
+          docker run -w /netdata test /bin/sh -c '/netdata/rmjsonc.sh && ./netdata-installer.sh --dont-wait --dont-start-it --require-cloud'

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Build & Install
     strategy:
+      fail-fast: false
       matrix:
         distro:
           - 'alpine:edge'
@@ -25,9 +26,9 @@ jobs:
           - 'fedora:32'
           - 'fedora:31'
           - 'fedora:30'
-            #- 'opensuse/leap:15.2'
-            #- 'opensuse/leap:15.1'
-            #- 'opensuse/tumbleweed:latest'
+          - 'opensuse/leap:15.2'
+          - 'opensuse/leap:15.1'
+          - 'opensuse/tumbleweed:latest'
           - 'ubuntu:20.04'
           - 'ubuntu:19.10'
           - 'ubuntu:18.04'
@@ -114,4 +115,5 @@ jobs:
           docker run -w /netdata test /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'
       - name: netdata-installer on ${{ matrix.distro }}, require cloud, no JSON-C
         run: |
-          docker run -w /netdata test /bin/sh -c '/netdata/rmjsonc.sh && ./netdata-installer.sh --dont-wait --dont-start-it --require-cloud'
+          docker run -w /netdata test \
+              /bin/sh -c '/netdata/rmjsonc.sh && ./netdata-installer.sh --dont-wait --dont-start-it --require-cloud'


### PR DESCRIPTION
##### Summary

This adds CI code to verify the JSON-C bundling functionality introduced by #8838 and #8836.

##### Component Name

area/packaging

##### Test Plan

CI passes on this PR.

##### Additional Information

The new CI check explicitly requires the cloud functionality to build successfully when JSON-C is not provided by the system itself.

We skip this check on Arch Linux as JSON-C is part of the base install there (as a result of it being a dependenc of `cryptsetup`, which is part of the Arch Linux base install).

We skip this check on CentOS 7 as the version of `cmake` it provides is incompatible with the JSON-C build infrastructure. Installs on CentOS 7 when JSON-C is not installed through the package manager will succeed but will not have Netdata Cloud functionality.