### PR TITLE
Fix command name for getting postfix queue

### DIFF
--- a/collectors/python.d.plugin/postfix/README.md
+++ b/collectors/python.d.plugin/postfix/README.md
@@ -9,7 +9,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/pytho
 
 Monitors MTA email queue statistics using postqueue tool.  
 
-Execute `postfix -p` to grab postfix queue.
+Execute `postqueue -p` to grab postfix queue.
 
 It produces only two charts:
 


### PR DESCRIPTION

##### Summary
Fix command name for getting postfix queue
##### Component Name
python.s.plugin/postfix

##### Test Plan
Change Readme, so not test needed

##### Additional Information
