### PR TITLE
Make cloud-enabled flag  be independent of ACLK

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -865,11 +865,10 @@ inline int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb)
 #ifdef DISABLE_CLOUD
     buffer_strcat(wb, "\t\"cloud-enabled\": false,\n");
 #else
-    if (netdata_cloud_setting)
-        buffer_strcat(wb, "\t\"cloud-enabled\": true,\n");
-    else
-        buffer_strcat(wb, "\t\"cloud-enabled\": false,\n");
+    buffer_sprintf(wb, "\t\"cloud-enabled\": %s,\n",
+                   appconfig_get_boolean(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", 1) ? "true" : "false");
 #endif
+
 #ifdef ENABLE_ACLK
     buffer_strcat(wb, "\t\"cloud-available\": true,\n");
 #else


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Make cloud-enabled flag in web/api/v1/info be independent of ACLK build success
##### Component Name
web
##### Test Plan
Have ACLK build fail and check dashboard info page
