### PR TITLE
Added docmentation about workaround for clang build errors.

### DIFF
--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -206,6 +206,10 @@ You can edit this file to set options. One common option to tweak is `history`, 
 
 To apply the changes you made, you have to restart Netdata.
 
+### 'nonrepresentable section on output' errors
+
+Our current build process unfortunately has some issues when using certain configurations of the `clang` C compiler on Linux. If the installation fails with errors like `/bin/ld: externaldeps/libwebsockets/libwebsockets.a(context.c.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC` and you are trying to build with `clang` on Linux, you will need to instead build using GCC to get a fully functional install of Netdata. In most cases, you can do this by running `CC=gcc ./netdata-installer.sh`.
+
 ## What's next?
 
 When you finish installing Netdata, be sure to visit our [step-by-step tutorial](../../../docs/step-by-step/step-00.md)

--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -208,7 +208,11 @@ To apply the changes you made, you have to restart Netdata.
 
 ### 'nonrepresentable section on output' errors
 
-Our current build process unfortunately has some issues when using certain configurations of the `clang` C compiler on Linux. If the installation fails with errors like `/bin/ld: externaldeps/libwebsockets/libwebsockets.a(context.c.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC` and you are trying to build with `clang` on Linux, you will need to instead build using GCC to get a fully functional install of Netdata. In most cases, you can do this by running `CC=gcc ./netdata-installer.sh`.
+Our current build process unfortunately has some issues when using certain configurations of the `clang` C compiler on Linux.
+
+If the installation fails with errors like `/bin/ld: externaldeps/libwebsockets/libwebsockets.a(context.c.o): relocation R_X86_64_32 against '.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC`, and you are trying to build with `clang` on Linux, you will need to build Netdata using GCC to get a fully functional install. 
+
+In most cases, you can do this by running `CC=gcc ./netdata-installer.sh`.
 
 ## What's next?
 


### PR DESCRIPTION
##### Summary

This is based on discussion today during the standup about the handling of issue #8854. It ideally should be merged before the 1.22 release.

##### Component Name

area/docs

##### Test Plan

n/a

##### Additional Information

I'm not 100% certain that the place I'm putting this documentation is the best one, but I can't think of anywhere better myself. If anyone from the documentation/marketing team has suggestions for a better place to put it in the docs, I'll be happy to move it.

Long-term, the issue this is documenting a workaround for is planned to be fixed, but we've decided that it should not be put in the upcoming release as a fix would require modifying things in a way that would require rigorous re-testing o the cloud functionality in the agent, which we really don't have time for at the moment. This should be removed/reverted once #8863 is merged.