### PR TITLE
Ebpf options

### DIFF
--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -907,6 +907,39 @@ static inline void ebpf_set_thread_mode(int mode) {
 }
 
 void ebpf_print_help() {
+    const time_t t = time(NULL);
+    struct tm *ct = localtime(&t);
+
+    fprintf(stderr,
+            "\n"
+            " Netdata ebpf.plugin %s\n"
+            " Copyright (C) 2016-%d Costa Tsaousis <costa@tsaousis.gr>\n"
+            " Released under GNU General Public License v3 or later.\n"
+            " All rights reserved.\n"
+            "\n"
+            " This program is a data collector plugin for netdata.\n"
+            "\n"
+            " Available command line options:\n"
+            "\n"
+            " SECONDS              set the data collection frequency.\n"
+            "\n"
+            " help or -h or -H      show this help.\n"
+            "\n"
+            " version or -v or -V   show software version.\n"
+            "\n"
+            " global or -g or -G    disable charts per application.\n"
+            "\n"
+            " all or -a or -A       Enable all chart groups (global and apps), unless -g is also given.\n"
+            "\n"
+            " net or -n or -N       Enable network viewer charts.\n"
+            "\n"
+            " process or -p or -P   Enable charts related to process run time.\n"
+            "\n"
+            " return or -r or -R    Run the collector in return mode.\n"
+            "\n"
+            , VERSION
+            , (ct->tm_year >= 116)?ct->tm_year + 1900: 2020
+    );
 }
 
 static void parse_args(int argc, char **argv)
@@ -934,23 +967,16 @@ static void parse_args(int argc, char **argv)
             exit(0);
         }
 
-        if (strcmp("return", w) == 0 || strcmp("-return", w) == 0 || strcmp("--return", w) == 0 || strcmp("-r", w) == 0 || strcmp("-R", w) == 0) {
-            mode = 0;
-            ebpf_set_thread_mode(mode);
-            debug(D_OPTIONS, "EBPF working in \"return\" mode, because it was started with the option %s.", w);
-            continue;
-        }
-
         if (strcmp("global", w) == 0 || strcmp("-global", w) == 0 || strcmp("--global", w) == 0 || strcmp("-g", w) == 0 || strcmp("-G", w) == 0) {
             disable_apps = 1;
             ebpf_disable_apps();
-            debug(D_OPTIONS, "EBPF working only with global charts, because it was started with the option %s.", w);
+            debug(D_OPTIONS, "EBPF running with global chart group, because it was started with the option %s.", w);
             continue;
         }
 
         if (strcmp("all", w) == 0 || strcmp("-all", w) == 0 || strcmp("--all", w) == 0 || strcmp("-a", w) == 0 || strcmp("-A", w) == 0) {
             ebpf_enable_all_charts(disable_apps);
-            debug(D_OPTIONS, "EBPF working only with global charts, because it was started with the option %s.", w);
+            debug(D_OPTIONS, "EBPF running with all chart groups, because it was started with the option %s.", w);
             continue;
         }
 
@@ -965,6 +991,13 @@ static void parse_args(int argc, char **argv)
             ebpf_enable_chart(0, disable_apps);
             debug(D_OPTIONS, "EBPF enabling \"PROCESS\" charts, because it was started with the option %s.", w);
             enabled = 1;
+            continue;
+        }
+
+        if (strcmp("return", w) == 0 || strcmp("-return", w) == 0 || strcmp("--return", w) == 0 || strcmp("-r", w) == 0 || strcmp("-R", w) == 0) {
+            mode = 0;
+            ebpf_set_thread_mode(mode);
+            debug(D_OPTIONS, "EBPF running in \"return\" mode, because it was started with the option %s.", w);
             continue;
         }
     }

--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -899,16 +899,22 @@ static inline void ebpf_enable_chart(int enable, int disable_apps) {
     }
 }
 
-static inline void ebpf_set_thread_mode(int mode) {
+static inline void ebpf_set_thread_mode(int lmode) {
     int i ;
     for (i = 0 ; ebpf_modules[i].thread_name ; i++ ) {
-        ebpf_modules[i].mode = mode;
+        ebpf_modules[i].mode = lmode;
     }
 }
 
 void ebpf_print_help() {
     const time_t t = time(NULL);
-    struct tm *ct = localtime(&t);
+    struct tm ct;
+    struct tm *test = localtime_r(&t, &ct);
+    int year;
+    if (test)
+        year = ct.tm_year;
+    else
+        year = 0;
 
     fprintf(stderr,
             "\n"
@@ -938,7 +944,7 @@ void ebpf_print_help() {
             " --return or -r    Run the collector in return mode.\n"
             "\n"
             , VERSION
-            , (ct->tm_year >= 116)?ct->tm_year + 1900: 2020
+            , (year >= 116)?year + 1900: 2020
     );
 }
 

--- a/collectors/ebpf_process.plugin/ebpf_process.c
+++ b/collectors/ebpf_process.plugin/ebpf_process.c
@@ -970,26 +970,34 @@ static void parse_args(int argc, char **argv)
         if (strcmp("global", w) == 0 || strcmp("-global", w) == 0 || strcmp("--global", w) == 0 || strcmp("-g", w) == 0 || strcmp("-G", w) == 0) {
             disable_apps = 1;
             ebpf_disable_apps();
-            debug(D_OPTIONS, "EBPF running with global chart group, because it was started with the option %s.", w);
+#ifdef NETDATA_INTERNAL_CHECKS
+            info("EBPF running with global chart group, because it was started with the option \"%s\".", w);
+#endif
             continue;
         }
 
         if (strcmp("all", w) == 0 || strcmp("-all", w) == 0 || strcmp("--all", w) == 0 || strcmp("-a", w) == 0 || strcmp("-A", w) == 0) {
             ebpf_enable_all_charts(disable_apps);
-            debug(D_OPTIONS, "EBPF running with all chart groups, because it was started with the option %s.", w);
+#ifdef NETDATA_INTERNAL_CHECKS
+            info("EBPF running with all chart groups, because it was started with the option \"%s\".", w);
+#endif
             continue;
         }
 
         if (strcmp("net", w) == 0 || strcmp("-net", w) == 0 || strcmp("--net", w) == 0 || strcmp("-n", w) == 0 || strcmp("-N", w) == 0) {
             ebpf_enable_chart(1, disable_apps);
-            debug(D_OPTIONS, "EBPF enabling \"NET\" charts, because it was started with the option %s.", w);
+#ifdef NETDATA_INTERNAL_CHECKS
+            info("EBPF enabling \"NET\" charts, because it was started with the option \"%s\".", w);
+#endif
             enabled = 1;
             continue;
         }
 
         if (strcmp("process", w) == 0 || strcmp("-process", w) == 0 || strcmp("--process", w) == 0 || strcmp("-p", w) == 0 || strcmp("-P", w) == 0) {
             ebpf_enable_chart(0, disable_apps);
-            debug(D_OPTIONS, "EBPF enabling \"PROCESS\" charts, because it was started with the option %s.", w);
+#ifdef NETDATA_INTERNAL_CHECKS
+            info("EBPF enabling \"PROCESS\" charts, because it was started with the option \"%s\".", w);
+#endif
             enabled = 1;
             continue;
         }
@@ -997,8 +1005,9 @@ static void parse_args(int argc, char **argv)
         if (strcmp("return", w) == 0 || strcmp("-return", w) == 0 || strcmp("--return", w) == 0 || strcmp("-r", w) == 0 || strcmp("-R", w) == 0) {
             mode = 0;
             ebpf_set_thread_mode(mode);
-            debug(D_OPTIONS, "EBPF running in \"return\" mode, because it was started with the option %s.", w);
-            continue;
+#ifdef NETDATA_INTERNAL_CHECKS
+            info("EBPF running in \"return\" mode, because it was started with the option \"%s\".", w);
+#endif
         }
     }
 
@@ -1008,6 +1017,9 @@ static void parse_args(int argc, char **argv)
 
     if (!enabled) {
         ebpf_enable_all_charts(disable_apps);
+#ifdef NETDATA_INTERNAL_CHECKS
+        info("EBPF running with all charts, because neither \"-n\" or \"-p\" was given.");
+#endif
     }
 }
 

--- a/collectors/ebpf_process.plugin/ebpf_process.h
+++ b/collectors/ebpf_process.plugin/ebpf_process.h
@@ -41,6 +41,12 @@
 # include "../../libnetdata/config/appconfig.h"
 # include "../../libnetdata/ebpf/ebpf.h"
 
+typedef enum {
+    MODE_RETURN = 0,    //This attaches kprobe when the function returns
+    MODE_DEVMODE,       //This stores log given description about the errors raised
+    MODE_ENTRY          //This attaches kprobe when the function is called
+} netdata_run_mode_t;
+
 typedef struct netdata_syscall_stat {
     unsigned long bytes;                //total number of bytes
     uint64_t call;                      //total number of calls


### PR DESCRIPTION
##### Summary
Fixes #8716 

This PR brings the features described on #8716 and also brings the basis to develop #8731, #7873 and #8727.
##### Component Name
Collector
##### Test Plan
Compile this PR with the option `-DNETDATA_INTERNAL_CHECKS=1` and add the following options inside your `netdata.conf`:

```
[plugin:ebpf_process]
        # update every = 1
        command options = --global --all --net --process --return
        #command options = -a -r
        #command options = -a -n -p -r
        #command options = -g -n -p -r
```

When Netdata starts it is expected it will show messages related the option given.
There are two options that needs to be tested using terminal:

```bash
# ./ebpf_process.plugin --help
# ./ebpf_process.plugin --version
```

##### Additional Information
