### PR TITLE
Fix missing NETDATA_STOP_CMD in netdata-installer.sh

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -53,7 +53,7 @@ defer_error_highlighted() {
 }
 
 print_deferred_errors() {
-  if [ -n "${NETDATA_DEFERRED_ERRORS}" ] ; then
+  if [ -n "${NETDATA_DEFERRED_ERRORS}" ]; then
     echo >&2
     echo >&2 "The following non-fatal errors were encountered during the installation process:"
     # shellcheck disable=SC2059
@@ -281,7 +281,7 @@ while [ -n "${1}" ]; do
     "--disable-go") NETDATA_DISABLE_GO=1 ;;
     "--enable-ebpf") NETDATA_ENABLE_EBPF=1 ;;
     "--disable-cloud")
-      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
         echo "Cloud explicitly enabled, ignoring --disable-cloud."
       else
         NETDATA_DISABLE_CLOUD=1
@@ -289,7 +289,7 @@ while [ -n "${1}" ]; do
       fi
       ;;
     "--require-cloud")
-      if [ -n "${NETDATA_DISABLE_CLOUD}" ] ; then
+      if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
         echo "Cloud explicitly disabled, ignoring --require-cloud."
       else
         NETDATA_REQUIRE_CLOUD=1
@@ -529,7 +529,7 @@ bundle_libmosquitto() {
       run_ok "libmosquitto built and prepared."
     else
       run_failed "Failed to build libmosquitto."
-      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
         exit 1
       else
         defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
@@ -537,7 +537,7 @@ bundle_libmosquitto() {
     fi
   else
     run_failed "Unable to fetch sources for libmosquitto."
-    if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+    if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
       exit 1
     else
       defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
@@ -578,7 +578,7 @@ bundle_libwebsockets() {
     return 0
   fi
 
-  if [ -z "$(command -v cmake)" ] ; then
+  if [ -z "$(command -v cmake)" ]; then
     run_failed "Could not find cmake, which is required to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
     defer_error_highlighted "Could not find cmake, which is required to build libwebsockets. The install process will continue, but you may not be able to connect this node to Netdata Cloud."
     return 0
@@ -603,7 +603,7 @@ bundle_libwebsockets() {
       run_ok "libwebsockets built and prepared."
     else
       run_failed "Failed to build libwebsockets."
-      if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+      if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
         exit 1
       else
         defer_error_highlighted "Failed to build libwebsockets. You may not be able to connect this node to Netdata Cloud."
@@ -611,7 +611,7 @@ bundle_libwebsockets() {
     fi
   else
     run_failed "Unable to fetch sources for libwebsockets."
-    if [ -n "${NETDATA_REQUIRE_CLOUD}" ] ; then
+    if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
       exit 1
     else
       defer_error_highlighted "Unable to fetch sources for libwebsockets. You may not be able to connect this node to Netdata Cloud."
@@ -624,7 +624,7 @@ bundle_libwebsockets
 # -----------------------------------------------------------------------------
 # If we have the dashboard switching logic, make sure we're on the classic
 # dashboard during the install (updates don't work correctly otherwise).
-if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata-switch-dashboard.sh" ] ; then
+if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata-switch-dashboard.sh" ]; then
   "${NETDATA_PREFIX}/usr/libexec/netdata-switch-dashboard.sh" classic
 fi
 
@@ -1035,15 +1035,13 @@ install_react_dashboard() {
   DASHBOARD_PACKAGE_BASENAME="dashboard.tar.gz"
 
   if fetch_and_verify "dashboard" \
-                      "https://github.com/netdata/dashboard/releases/download/${DASHBOARD_PACKAGE_VERSION}/${DASHBOARD_PACKAGE_BASENAME}" \
-                      "${DASHBOARD_PACKAGE_BASENAME}" \
-                      "${tmp}" \
-                      "${NETDATA_LOCAL_TARBALL_OVERRIDE_DASHBOARD}"
-  then
-    if run tar -xf "${tmp}/${DASHBOARD_PACKAGE_BASENAME}" -C "${tmp}" && \
-       copy_react_dashboard "${tmp}/build" && \
-       rm -rf "${tmp}"
-    then
+    "https://github.com/netdata/dashboard/releases/download/${DASHBOARD_PACKAGE_VERSION}/${DASHBOARD_PACKAGE_BASENAME}" \
+    "${DASHBOARD_PACKAGE_BASENAME}" \
+    "${tmp}" \
+    "${NETDATA_LOCAL_TARBALL_OVERRIDE_DASHBOARD}"; then
+    if run tar -xf "${tmp}/${DASHBOARD_PACKAGE_BASENAME}" -C "${tmp}" &&
+      copy_react_dashboard "${tmp}/build" &&
+      rm -rf "${tmp}"; then
       run_ok "React dashboard installed."
     else
       run_failed "Failed to install React dashboard. The install process will continue, but you will not be able to use the new dashboard."
@@ -1405,6 +1403,10 @@ fi
 # -----------------------------------------------------------------------------
 progress "Install netdata at system init"
 
+# By default we assume the shutdown/startup of the Netdata Agent are effectively
+# without any system supervisor/init like SystemD or SysV. So we assume the most
+# basic startup/shutdown commands...
+NETDATA_STOP_CMD="${NETDATA_PREFIX}/usr/bin/netdatacli shutdown-agent"
 NETDATA_START_CMD="${NETDATA_PREFIX}/usr/sbin/netdata"
 
 if grep -q docker /proc/1/cgroup > /dev/null 2>&1; then

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -402,7 +402,7 @@ install_non_systemd_init() {
 
 # This is used by netdata-installer.sh
 # shellcheck disable=SC2034
-NETDATA_SHUTDOWN_CMD="netdatacli shutdown-agent"
+NETDATA_STOP_CMD="netdatacli shutdown-agent"
 
 NETDATA_START_CMD="netdata"
 NETDATA_INSTALLER_START_CMD=""
@@ -429,6 +429,8 @@ install_netdata_service() {
         return 0
       else
         echo >&2 "Installing MacOS X plist file..."
+        # This is used by netdata-installer.sh
+        # shellcheck disable=SC2034
         run cp system/netdata.plist /Library/LaunchDaemons/com.github.netdata.plist &&
           run launchctl load /Library/LaunchDaemons/com.github.netdata.plist &&
           NETDATA_START_CMD="launchctl start com.github.netdata" &&
@@ -437,7 +439,8 @@ install_netdata_service() {
       fi
 
     elif [ "${uname}" = "FreeBSD" ]; then
-
+      # This is used by netdata-installer.sh
+      # shellcheck disable=SC2034
       run cp system/netdata-freebsd /etc/rc.d/netdata && NETDATA_START_CMD="service netdata start" &&
         NETDATA_STOP_CMD="service netdata stop" &&
         NETDATA_INSTALLER_START_CMD="service netdata onestart" &&
@@ -451,6 +454,8 @@ install_netdata_service() {
     elif issystemd; then
       # systemd is running on this system
       NETDATA_START_CMD="systemctl start netdata"
+      # This is used by netdata-installer.sh
+      # shellcheck disable=SC2034
       NETDATA_STOP_CMD="systemctl stop netdata"
       NETDATA_INSTALLER_START_CMD="${NETDATA_START_CMD}"
 
@@ -491,9 +496,13 @@ install_netdata_service() {
       if [ ${ret} -eq 0 ]; then
         if [ -n "${service_cmd}" ]; then
           NETDATA_START_CMD="service netdata start"
+          # This is used by netdata-installer.sh
+          # shellcheck disable=SC2034
           NETDATA_STOP_CMD="service netdata stop"
         elif [ -n "${rcservice_cmd}" ]; then
           NETDATA_START_CMD="rc-service netdata start"
+          # This is used by netdata-installer.sh
+          # shellcheck disable=SC2034
           NETDATA_STOP_CMD="rc-service netdata stop"
         fi
         NETDATA_INSTALLER_START_CMD="${NETDATA_START_CMD}"

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -400,6 +400,7 @@ install_non_systemd_init() {
   return 1
 }
 
+NETDATA_SHUTDOWN_CMD="netdatacli shutdown-agent"
 NETDATA_START_CMD="netdata"
 NETDATA_INSTALLER_START_CMD=""
 
@@ -427,12 +428,15 @@ install_netdata_service() {
         echo >&2 "Installing MacOS X plist file..."
         run cp system/netdata.plist /Library/LaunchDaemons/com.github.netdata.plist &&
           run launchctl load /Library/LaunchDaemons/com.github.netdata.plist &&
-          return 0
+          NETDATA_START_CMD="launchctl start com.github.netdata" &&
+          NETDATA_STOP_CMD="launchctl stop com.github.netdata"
+        return 0
       fi
 
     elif [ "${uname}" = "FreeBSD" ]; then
 
       run cp system/netdata-freebsd /etc/rc.d/netdata && NETDATA_START_CMD="service netdata start" &&
+        NETDATA_STOP_CMD="service netdata stop" &&
         NETDATA_INSTALLER_START_CMD="service netdata onestart" &&
         myret=$?
 
@@ -444,6 +448,7 @@ install_netdata_service() {
     elif issystemd; then
       # systemd is running on this system
       NETDATA_START_CMD="systemctl start netdata"
+      NETDATA_STOP_CMD="systemctl stop netdata"
       NETDATA_INSTALLER_START_CMD="${NETDATA_START_CMD}"
 
       SYSTEMD_DIRECTORY=""
@@ -483,8 +488,10 @@ install_netdata_service() {
       if [ ${ret} -eq 0 ]; then
         if [ -n "${service_cmd}" ]; then
           NETDATA_START_CMD="service netdata start"
+          NETDATA_STOP_CMD="service netdata stop"
         elif [ -n "${rcservice_cmd}" ]; then
           NETDATA_START_CMD="rc-service netdata start"
+          NETDATA_STOP_CMD="rc-service netdata stop"
         fi
         NETDATA_INSTALLER_START_CMD="${NETDATA_START_CMD}"
       fi

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -400,7 +400,10 @@ install_non_systemd_init() {
   return 1
 }
 
+# This is used by netdata-installer.sh
+# shellcheck disable=SC2034
 NETDATA_SHUTDOWN_CMD="netdatacli shutdown-agent"
+
 NETDATA_START_CMD="netdata"
 NETDATA_INSTALLER_START_CMD=""
 


### PR DESCRIPTION
##### Summary

ssia

##### Component Name

- area/packaging

##### Test Plan

- [x] Test on a SystemD system
- [x] Test on macOS
- [x] Test on FreeBSD
- [ ] Test on a SysV system
- [x] Test on something non-standard

##### Additional Information

Looks like this was always missing in our packaging tooling :/