### PR TITLE
Account for zfs.arc_size.min, and correct calc

### DIFF
--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -5,7 +5,7 @@
       on: system.ram
       os: linux freebsd
    hosts: *
-    calc: ($zfs.arc_size.arcsz = nan)?(0):($zfs.arc_size.arcsz)
+    calc: ($zfs.arc_size.arcsz = nan)?(0):($zfs.arc_size.arcsz - $zfs.arc_size.min)
    every: 10s
     info: the amount of memory that is reported as used, but it is actually capable for resizing itself based on the system needs (eg. ZFS ARC)
 
@@ -14,7 +14,7 @@
       os: linux
    hosts: *
 #   calc: $used * 100 / ($used + $cached + $free)
-    calc: ($used - $used_ram_to_ignore) * 100 / ($used - $used_ram_to_ignore + $cached + $free)
+    calc: ($used - $used_ram_to_ignore) * 100 / ($used  + $cached + $free)
    units: %
    every: 10s
     warn: $this > (($status >= $WARNING)  ? (80) : (90))


### PR DESCRIPTION
##### Summary
ram_in_use was not correctly deducting the used_ram_to_ignore -
it deducted it from both the 'used' and 'unused' side of the equation,
which made a large ZFS ARC (like all of them) report high ram
utilization all the time, firing off the 90% alert despite 40% of the used
ram being reclaimable cache.

Fixes #7871

##### Component Name
health.d/ram.conf

##### Test Plan
Review the system - ram alarm on a system with ZFS which has been running long enough to fill up the ZFS arc.  Without this patch, you see the entire size of the arc reflected in this alarm as unavailable RAM.  With this patch, the ZFS arc (minus the minimum size) is treated as available cached memory when calculating this alert.
