### PR TITLE
Fix support for Ubuntu 14.04 with Cloud support

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1423,6 +1423,40 @@ prompt() {
   done
 }
 
+validate_tree_debian() {
+  local opts=
+  if [ "${NON_INTERACTIVE}" -eq 1 ]; then
+    echo >&2 "Running in non-interactive mode"
+    opts="-y"
+    export DEBIAN_FRONTEND="noninteractive"
+  fi
+
+  if [ "$distribution" = "ubuntu" ]; then
+    echo >&2 " > Ubuntu Version: ${version} ..."
+
+    if [[ "${version}" =~ ^14\.([0-9])+$ ]]; then
+      echo >&2 " > You are on an old enough verison of Ubuntu we have to enable some extra repositories..."
+      echo >&2
+
+      echo >&2 " > Checking for ppa:acooks/libwebsockets6 ..."
+      if ! run apt-cache policy | grep 'ppa:acooks/libwebsockets6'; then
+        if ! command -v add-apt-repository > /dev/null; then
+          if prompt "software-properties-common not found, shall I install it?"; then
+            run ${sudo} apt-get install ${opts} software-properties-common
+          else
+            echo >&2 " WARNING: software-properties-common is required by this tool to manage apt repositories"
+          fi
+        fi
+        if prompt "ppa:acooks/libwebsockets6 not found, shall I install it?"; then
+          run ${sudo} add-apt-repository ${opts} ppa:acooks/libwebsockets6
+        fi
+      fi
+    fi
+  else
+    echo >&2 " > Debian Version: ${version} ..."
+  fi
+}
+
 validate_tree_centos() {
   local opts=
   if [ "${NON_INTERACTIVE}" -eq 1 ]; then

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1435,7 +1435,7 @@ validate_tree_debian() {
     echo >&2 " > Ubuntu Version: ${version} ..."
 
     if [[ "${version}" =~ ^14\.([0-9])+$ ]]; then
-      echo >&2 " > You are on an old enough verison of Ubuntu we have to enable some extra repositories..."
+      echo >&2 " > You are on an old enough version of Ubuntu we have to enable some extra repositories..."
       echo >&2
 
       echo >&2 " > Checking for ppa:acooks/libwebsockets6 ..."


### PR DESCRIPTION
##### Summary

ssia

- Fixes #8905
- Fixes #7258

##### Component Name

- area/packaging
- area/ci

##### Test Plan

- [x] Test that it builds correctly (_without cloud_)
<details>
<summary>Details</summary>

```#!sh
prologic@Jamess-iMac
Wed May 06 15:13:20
~/NetData/netdata
 (ubuntu_1404_support) 0
$ cat Dockerfile.dev
FROM ubuntu:14.04 AS build

ARG DEPS=netdata

# Install all build dependencies
COPY packaging/installer/install-required-packages.sh /tmp/install-required-packages.sh
RUN /tmp/install-required-packages.sh --dont-wait --non-interactive ${DEPS}

# Copy Sources
WORKDIR /netdata
COPY . .

# Build
ARG BUILD=1
RUN [ -n "$BUILD" ] && ./netdata-installer.sh -u --dont-wait --dont-start-it --disable-go || echo "Skipping build ..."

CMD ["/usr/sbin/netdata", "-D"]
```

```#!sh
prologic@Jamess-iMac
Wed May 06 15:09:55
~/NetData/netdata
 (ubuntu_1404_support) 0
$ docker build -f Dockerfile.dev -t prologic/netdata:dev . && dki -t --rm -p 29999:19999 prologic/netdata:dev
Sending build context to Docker daemon  100.8MB
Step 1/9 : FROM ubuntu:14.04 AS build
 ---> 6e4f1fe62ff1
Step 2/9 : ARG DEPS=netdata
 ---> Using cache
 ---> 658bfc786452
Step 3/9 : COPY packaging/installer/install-required-packages.sh /tmp/install-required-packages.sh
 ---> Using cache
 ---> 0dd7c034b98e
Step 4/9 : RUN /tmp/install-required-packages.sh --dont-wait --non-interactive ${DEPS}
 ---> Using cache
 ---> 8b1bc49f4249
Step 5/9 : WORKDIR /netdata
 ---> Using cache
 ---> ac653e1a8a8b
Step 6/9 : COPY . .
 ---> e51203640a68
Step 7/9 : ARG BUILD=1
 ---> Running in ef6094123c69
Removing intermediate container ef6094123c69
 ---> a3835a474644
Step 8/9 : RUN [ -n "$BUILD" ] && ./netdata-installer.sh -u --dont-wait --dont-start-it --disable-go || echo "Skipping build ..."
 ---> Running in 765eb2fe90b7

  ^
  |.-.   .-.   .-.   .-.   .  netdata
  |   '-'   '-'   '-'   '-'   real-time performance monitoring, done right!
  +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->


  You are about to build and install netdata to your system.

  It will be installed at these locations:

   - the daemon     at /usr/sbin/netdata
   - config files   in /etc/netdata
   - web files      in /usr/share/netdata
   - plugins        in /usr/libexec/netdata
   - cache files    in /var/cache/netdata
   - db files       in /var/lib/netdata
   - log files      in /var/log/netdata
   - pid file       at /var/run/netdata.pid
   - logrotate file at /etc/logrotate.d/netdata

  This installer allows you to change the installation path.
  Press Control-C and run the same command with --help for help.


  NOTE:
  Anonymous usage stats will be collected and sent to Google Analytics.
  To opt-out, pass --disable-telemetry option to the installer or export
  the enviornment variable DO_NOT_TRACK to a non-zero or non-empty value
  (e.g: export DO_NOT_TRACK=1).

 --- Prepare custom libmosquitto version ---
v.1.6.8_Netdata-4.tar.gz: OK
[/netdata]# tar -xf /tmp/netdata-mosquitto-sVYowN/v.1.6.8_Netdata-4.tar.gz -C /tmp/netdata-mosquitto-sVYowN
 OK

[/netdata]# env CFLAGS= CXXFLAGS= LDFLAGS= make -C /tmp/netdata-mosquitto-sVYowN/mosquitto-v.1.6.8_Netdata-4/lib
make: Entering directory `/tmp/netdata-mosquitto-sVYowN/mosquitto-v.1.6.8_Netdata-4/lib'
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c mosquitto.c -o mosquitto.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c actions.c -o actions.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c callbacks.c -o callbacks.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c connect.c -o connect.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_auth.c -o handle_auth.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_connack.c -o handle_connack.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_disconnect.c -o handle_disconnect.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_ping.c -o handle_ping.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_pubackcomp.c -o handle_pubackcomp.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_publish.c -o handle_publish.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_pubrec.c -o handle_pubrec.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_pubrel.c -o handle_pubrel.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_suback.c -o handle_suback.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c handle_unsuback.c -o handle_unsuback.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c helpers.c -o helpers.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c logging_mosq.c -o logging_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c loop.c -o loop.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c memory_mosq.c -o memory_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c messages_mosq.c -o messages_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c net_mosq_ocsp.c -o net_mosq_ocsp.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c net_mosq.c -o net_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c options.c -o options.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c packet_datatypes.c -o packet_datatypes.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c packet_mosq.c -o packet_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c property_mosq.c -o property_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c read_handle.c -o read_handle.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c send_connect.c -o send_connect.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c send_disconnect.c -o send_disconnect.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c send_mosq.c -o send_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c send_publish.c -o send_publish.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c send_subscribe.c -o send_subscribe.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c send_unsubscribe.c -o send_unsubscribe.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c socks_mosq.c -o socks_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c srv_mosq.c -o srv_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c thread_mosq.c -o thread_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c time_mosq.c -o time_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c tls_mosq.c -o tls_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c utf8_mosq.c -o utf8_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c util_mosq.c -o util_mosq.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c util_topic.c -o util_topic.o
cc  -I. -I.. -I../lib -I../src/deps -DWITH_THREADING -DWITH_SOCKS  -fPIC -c will_mosq.c -o will_mosq.o
cc -shared  -Wl,--version-script=linker.version -Wl,-soname,libmosquitto.so.1 mosquitto.o actions.o callbacks.o connect.o handle_auth.o handle_connack.o handle_disconnect.o handle_ping.o handle_pubackcomp.o handle_publish.o handle_pubrec.o handle_pubrel.o handle_suback.o handle_unsuback.o helpers.o logging_mosq.o loop.o memory_mosq.o messages_mosq.o net_mosq_ocsp.o net_mosq.o options.o packet_datatypes.o packet_mosq.o property_mosq.o read_handle.o send_connect.o send_disconnect.o send_mosq.o send_publish.o send_subscribe.o send_unsubscribe.o socks_mosq.o srv_mosq.o thread_mosq.o time_mosq.o tls_mosq.o utf8_mosq.o util_mosq.o util_topic.o will_mosq.o -o libmosquitto.so.1  -lrt -lpthread
ar cr libmosquitto.a mosquitto.o actions.o callbacks.o connect.o handle_auth.o handle_connack.o handle_disconnect.o handle_ping.o handle_pubackcomp.o handle_publish.o handle_pubrec.o handle_pubrel.o handle_suback.o handle_unsuback.o helpers.o logging_mosq.o loop.o memory_mosq.o messages_mosq.o net_mosq_ocsp.o net_mosq.o options.o packet_datatypes.o packet_mosq.o property_mosq.o read_handle.o send_connect.o send_disconnect.o send_mosq.o send_publish.o send_subscribe.o send_unsubscribe.o socks_mosq.o srv_mosq.o thread_mosq.o time_mosq.o tls_mosq.o utf8_mosq.o util_mosq.o util_topic.o will_mosq.o
make: Leaving directory `/tmp/netdata-mosquitto-sVYowN/mosquitto-v.1.6.8_Netdata-4/lib'
 OK

[/netdata]# mkdir -p /netdata/externaldeps/mosquitto
 OK

[/netdata]# cp /tmp/netdata-mosquitto-sVYowN/mosquitto-v.1.6.8_Netdata-4/lib/libmosquitto.a /netdata/externaldeps/mosquitto
 OK

[/netdata]# cp /tmp/netdata-mosquitto-sVYowN/mosquitto-v.1.6.8_Netdata-4/lib/mosquitto.h /netdata/externaldeps/mosquitto
 OK

 OK  libmosquitto built and prepared.

 --- Prepare libwebsockets ---
v3.2.2.tar.gz: OK
[/netdata]# tar -xf /tmp/netdata-libwebsockets-vVPxH4/v3.2.2.tar.gz -C /tmp/netdata-libwebsockets-vVPxH4
 OK

[/tmp/netdata-libwebsockets-vVPxH4/libwebsockets-3.2.2]# env CFLAGS= CXXFLAGS= LDFLAGS= cmake -D LWS_WITH_SOCKS5:bool=ON .
-- Compiled with LWS_WITH_DIR and LWS_WITH_DIR
-- The C compiler identification is GNU 4.8.4
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- CMAKE_TOOLCHAIN_FILE=''
-- Found Git: /usr/bin/git
fatal: Not a git repository (or any of the parent directories): .git
Git commit hash:
-- Performing Test LWS_HAVE_inline
-- Performing Test LWS_HAVE_inline - Success
-- Performing Test LWS_HAVE___inline__
-- Performing Test LWS_HAVE___inline__ - Success
-- Performing Test LWS_HAVE___inline
-- Performing Test LWS_HAVE___inline - Success
-- Performing Test LWS_HAVE_MALLOC_TRIM
-- Performing Test LWS_HAVE_MALLOC_TRIM - Success
-- Performing Test LWS_HAVE_MALLOC_USABLE_SIZE
-- Performing Test LWS_HAVE_MALLOC_USABLE_SIZE - Success
-- Looking for fork
-- Looking for fork - found
-- Looking for getenv
-- Looking for getenv - found
-- Looking for malloc
-- Looking for malloc - found
-- Looking for memset
-- Looking for memset - found
-- Looking for realloc
-- Looking for realloc - found
-- Looking for socket
-- Looking for socket - found
-- Looking for strerror
-- Looking for strerror - found
-- Looking for vfork
-- Looking for vfork - found
-- Looking for execvpe
-- Looking for execvpe - found
-- Looking for getifaddrs
-- Looking for getifaddrs - found
-- Looking for snprintf
-- Looking for snprintf - found
-- Looking for _snprintf
-- Looking for _snprintf - not found
-- Looking for _vsnprintf
-- Looking for _vsnprintf - not found
-- Looking for getloadavg
-- Looking for getloadavg - found
-- Looking for atoll
-- Looking for atoll - found
-- Looking for _atoi64
-- Looking for _atoi64 - not found
-- Looking for _stat32i64
-- Looking for _stat32i64 - not found
-- Looking for clock_gettime
-- Looking for clock_gettime - found
-- Looking for dlfcn.h
-- Looking for dlfcn.h - found
-- Looking for fcntl.h
-- Looking for fcntl.h - found
-- Looking for in6addr.h
-- Looking for in6addr.h - not found
-- Looking for memory.h
-- Looking for memory.h - found
-- Looking for netinet/in.h
-- Looking for netinet/in.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stdlib.h
-- Looking for stdlib.h - found
-- Looking for strings.h
-- Looking for strings.h - found
-- Looking for string.h
-- Looking for string.h - found
-- Looking for sys/prctl.h
-- Looking for sys/prctl.h - found
-- Looking for sys/socket.h
-- Looking for sys/socket.h - found
-- Looking for sys/sockio.h
-- Looking for sys/sockio.h - not found
-- Looking for sys/stat.h
-- Looking for sys/stat.h - found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Looking for vfork.h
-- Looking for vfork.h - not found
-- Looking for sys/capability.h
-- Looking for sys/capability.h - not found
-- Looking for malloc.h
-- Looking for malloc.h - found
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for inttypes.h
-- Looking for inttypes.h - found
-- Looking for cap_set_flag in cap
-- Looking for cap_set_flag in cap - not found
-- Looking for 4 include files stdlib.h, ..., float.h
-- Looking for 4 include files stdlib.h, ..., float.h - found
-- Performing Test LWS_HAS_INTPTR_T
-- Performing Test LWS_HAS_INTPTR_T - Success
-- Performing Test LWS_HAS_PTHREAD_SETNAME_NP
-- Performing Test LWS_HAS_PTHREAD_SETNAME_NP - Success
-- Performing Test LWS_HAS_GETOPT_LONG
-- Performing Test LWS_HAS_GETOPT_LONG - Success
-- Performing Test LWS_HAVE_VISIBILITY
-- Performing Test LWS_HAVE_VISIBILITY - Success
-- Performing Test LWS_GCC_HAS_IGNORED_QUALIFIERS
-- Performing Test LWS_GCC_HAS_IGNORED_QUALIFIERS - Success
-- Performing Test LWS_GCC_HAS_TYPE_LIMITS
-- Performing Test LWS_GCC_HAS_TYPE_LIMITS - Success
Compiling with SSL support
-- Found OpenSSL: /usr/lib/x86_64-linux-gnu/libssl.so;/usr/lib/x86_64-linux-gnu/libcrypto.so (found version "1.0.1f")
OpenSSL include dir: /usr/include
OpenSSL libraries: /usr/lib/x86_64-linux-gnu/libssl.so;/usr/lib/x86_64-linux-gnu/libcrypto.so
-- Looking for openssl/ecdh.h
-- Looking for openssl/ecdh.h - found
-- Looking for SSL_CTX_set1_param
-- Looking for SSL_CTX_set1_param - found
-- Looking for SSL_set_info_callback
-- Looking for SSL_set_info_callback - found
-- Looking for X509_VERIFY_PARAM_set1_host
-- Looking for X509_VERIFY_PARAM_set1_host - not found
-- Looking for RSA_set0_key
-- Looking for RSA_set0_key - not found
-- Looking for X509_get_key_usage
-- Looking for X509_get_key_usage - not found
-- Looking for EVP_PKEY_new_raw_private_key
-- Looking for EVP_PKEY_new_raw_private_key - not found
-- Looking for SSL_CTX_get0_certificate
-- Looking for SSL_CTX_get0_certificate - not found
-- Looking for SSL_get0_alpn_selected
-- Looking for SSL_get0_alpn_selected - not found
-- Looking for SSL_set_alpn_protos
-- Looking for SSL_set_alpn_protos - not found
-- Looking for EVP_aes_128_cfb8
-- Looking for EVP_aes_128_cfb8 - found
-- Looking for EVP_aes_128_cfb128
-- Looking for EVP_aes_128_cfb128 - found
-- Looking for EVP_aes_192_cfb8
-- Looking for EVP_aes_192_cfb8 - found
-- Looking for EVP_aes_192_cfb128
-- Looking for EVP_aes_192_cfb128 - found
-- Looking for EVP_aes_256_cfb8
-- Looking for EVP_aes_256_cfb8 - found
-- Looking for EVP_aes_256_cfb128
-- Looking for EVP_aes_256_cfb128 - found
-- Looking for EVP_aes_128_xts
-- Looking for EVP_aes_128_xts - found
-- Looking for RSA_verify_pss_mgf1
-- Looking for RSA_verify_pss_mgf1 - not found
-- Looking for HMAC_CTX_new
-- Looking for HMAC_CTX_new - not found
-- Looking for SSL_CTX_set_ciphersuites
-- Looking for SSL_CTX_set_ciphersuites - not found
-- Performing Test LWS_HAVE_SSL_EXTRA_CHAIN_CERTS
-- Performing Test LWS_HAVE_SSL_EXTRA_CHAIN_CERTS - Failed
-- Performing Test LWS_HAVE_EVP_MD_CTX_free
-- Performing Test LWS_HAVE_EVP_MD_CTX_free - Failed
-- Looking for ECDSA_SIG_set0
-- Looking for ECDSA_SIG_set0 - not found
-- Looking for BN_bn2binpad
-- Looking for BN_bn2binpad - not found
-- Looking for EVP_aes_128_wrap
-- Looking for EVP_aes_128_wrap - not found
-- Looking for EC_POINT_get_affine_coordinates
-- Looking for EC_POINT_get_affine_coordinates - not found
-- Looking for TLS_client_method
-- Looking for TLS_client_method - not found
-- Looking for TLSv1_2_client_method
-- Looking for TLSv1_2_client_method - found
-- Performing Test LWS_HAVE_PIPE2
-- Performing Test LWS_HAVE_PIPE2 - Success
-- Performing Test LWS_HAVE_TCP_USER_TIMEOUT
-- Performing Test LWS_HAVE_TCP_USER_TIMEOUT - Success
Searching for OpenSSL executable and dlls
OpenSSL executable: /usr/bin/openssl
 GENCERTS = 1
Generating SSL Certificates for the test-server...
Generating a 1024 bit RSA private key
.......++++++
....................++++++
writing new private key to '/tmp/netdata-libwebsockets-vVPxH4/libwebsockets-3.2.2/libwebsockets-test-server.key.pem'
-----
You are about to be asked to enter information that will be incorporated
into your certificate request.
What you are about to enter is what is called a Distinguished Name or a DN.
There are quite a few fields but you can leave some blank
For some fields there will be a default value,
If you enter '.', the field will be left blank.
-----
Country Name (2 letter code) [AU]:State or Province Name (full name) [Some-State]:Locality Name (eg, city) []:Organization Name (eg, company) [Internet Widgits Pty Ltd]:Organizational Unit Name (eg, section) []:Common Name (e.g. server FQDN or YOUR name) []:Email Address []:SUCCESSFULLY generated SSL certificate
---------------------------------------------------------------------
  Settings:  (For more help do cmake -LH <srcpath>)
---------------------------------------------------------------------
 LWS_WITH_STATIC = ON
 LWS_WITH_SHARED = ON
 LWS_WITH_SSL = ON (SSL Support)
-- Looking for RPMTools... - rpmbuild NOT FOUND
 LWS_SSL_CLIENT_USE_OS_CA_CERTS = 1
 LWS_WITH_WOLFSSL = OFF (wolfSSL/CyaSSL replacement for OpenSSL)
 LWS_WITH_MBEDTLS = OFF (mbedTLS replacement for OpenSSL)
 LWS_WITHOUT_BUILTIN_SHA1 = OFF
 LWS_WITHOUT_BUILTIN_GETIFADDRS = OFF
 LWS_WITHOUT_CLIENT = OFF
 LWS_WITHOUT_SERVER = OFF
 LWS_LINK_TESTAPPS_DYNAMIC = OFF
 LWS_WITHOUT_TESTAPPS = OFF
 LWS_WITHOUT_TEST_SERVER = OFF
 LWS_WITHOUT_TEST_SERVER_EXTPOLL = OFF
 LWS_WITHOUT_TEST_PING = OFF
 LWS_WITHOUT_TEST_CLIENT = OFF
 LWS_WITHOUT_EXTENSIONS = ON
 LWS_WITH_LATENCY = OFF
 LWS_WITHOUT_DAEMONIZE = ON
 LWS_WITH_LIBEV = OFF
 LWS_WITH_LIBUV = OFF
 LWS_WITH_LIBEVENT = OFF
 LWS_IPV6 = OFF
 LWS_UNIX_SOCK = OFF
 LWS_WITH_HTTP2 = 1
 LWS_SSL_SERVER_WITH_ECDH_CERT = OFF
 LWS_MAX_SMP = 1
 LWS_HAVE_PTHREAD_H = 1
 LWS_WITH_CGI = OFF
 LWS_HAVE_OPENSSL_ECDH_H = 1
 LWS_HAVE_SSL_CTX_set1_param = 1
 LWS_HAVE_RSA_SET0_KEY =
 LWS_WITH_HTTP_PROXY = OFF
 LIBHUBBUB_LIBRARIES =
 PLUGINS =
 LWS_WITH_ACCESS_LOG = OFF
 LWS_WITH_SERVER_STATUS = OFF
 LWS_WITH_LEJP = ON
 LWS_WITH_LEJP_CONF = ON
 LWS_WITH_SMTP = OFF
 LWS_WITH_GENERIC_SESSIONS = OFF
 LWS_STATIC_PIC = OFF
 LWS_WITH_RANGES = OFF
 LWS_PLAT_OPTEE = OFF
 LWS_WITH_ESP32 = OFF
 LWS_WITH_ZIP_FOPS = OFF
 LWS_AVOID_SIGPIPE_IGN = OFF
 LWS_WITH_STATS = OFF
 LWS_WITH_SOCKS5 = ON
 LWS_HAVE_SYS_CAPABILITY_H =
 LWS_HAVE_LIBCAP =
 LWS_WITH_PEER_LIMITS = OFF
 LWS_HAVE_ATOLL = 1
 LWS_HAVE__ATOI64 =
 LWS_HAVE_STAT32I64 =
 LWS_HAS_INTPTR_T = 1
 LWS_WITH_EXPORT_LWSTARGETS = ON
 LWS_WITH_ABSTRACT =
---------------------------------------------------------------------
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/netdata-libwebsockets-vVPxH4/libwebsockets-3.2.2
 OK

[/tmp/netdata-libwebsockets-vVPxH4/libwebsockets-3.2.2]# env CFLAGS= CXXFLAGS= LDFLAGS= make
Scanning dependencies of target websockets
[  1%] Building C object CMakeFiles/websockets.dir/lib/core/alloc.c.o
[  2%] Building C object CMakeFiles/websockets.dir/lib/core/buflist.c.o
[  3%] Building C object CMakeFiles/websockets.dir/lib/core/context.c.o
[  3%] Building C object CMakeFiles/websockets.dir/lib/core/lws_dll2.c.o
[  4%] Building C object CMakeFiles/websockets.dir/lib/core/libwebsockets.c.o
[  5%] Building C object CMakeFiles/websockets.dir/lib/core/logs.c.o
[  5%] Building C object CMakeFiles/websockets.dir/lib/misc/base64-decode.c.o
[  6%] Building C object CMakeFiles/websockets.dir/lib/core/vfs.c.o
[  7%] Building C object CMakeFiles/websockets.dir/lib/misc/lws-ring.c.o
[  8%] Building C object CMakeFiles/websockets.dir/lib/core-net/dummy-callback.c.o
[  8%] Building C object CMakeFiles/websockets.dir/lib/core-net/output.c.o
[  9%] Building C object CMakeFiles/websockets.dir/lib/core-net/close.c.o
[ 10%] Building C object CMakeFiles/websockets.dir/lib/core-net/network.c.o
[ 10%] Building C object CMakeFiles/websockets.dir/lib/core-net/vhost.c.o
[ 11%] Building C object CMakeFiles/websockets.dir/lib/core-net/pollfd.c.o
[ 12%] Building C object CMakeFiles/websockets.dir/lib/core-net/service.c.o
[ 13%] Building C object CMakeFiles/websockets.dir/lib/core-net/sorted-usec-list.c.o
[ 13%] Building C object CMakeFiles/websockets.dir/lib/core-net/stats.c.o
[ 14%] Building C object CMakeFiles/websockets.dir/lib/core-net/wsi.c.o
[ 15%] Building C object CMakeFiles/websockets.dir/lib/core-net/wsi-timeout.c.o
[ 15%] Building C object CMakeFiles/websockets.dir/lib/core-net/adopt.c.o
[ 16%] Building C object CMakeFiles/websockets.dir/lib/roles/pipe/ops-pipe.c.o
[ 17%] Building C object CMakeFiles/websockets.dir/lib/core-net/sequencer.c.o
[ 18%] Building C object CMakeFiles/websockets.dir/lib/misc/dir.c.o
[ 18%] Building C object CMakeFiles/websockets.dir/lib/roles/http/header.c.o
[ 19%] Building C object CMakeFiles/websockets.dir/lib/roles/http/server/parsers.c.o
[ 20%] Building C object CMakeFiles/websockets.dir/lib/roles/h1/ops-h1.c.o
[ 20%] Building C object CMakeFiles/websockets.dir/lib/roles/ws/ops-ws.c.o
[ 21%] Building C object CMakeFiles/websockets.dir/lib/roles/ws/client-ws.c.o
[ 22%] Building C object CMakeFiles/websockets.dir/lib/roles/ws/client-parser-ws.c.o
[ 23%] Building C object CMakeFiles/websockets.dir/lib/roles/ws/server-ws.c.o
[ 23%] Building C object CMakeFiles/websockets.dir/lib/roles/raw-skt/ops-raw-skt.c.o
[ 24%] Building C object CMakeFiles/websockets.dir/lib/roles/raw-file/ops-raw-file.c.o
[ 25%] Building C object CMakeFiles/websockets.dir/lib/misc/lwsac/lwsac.c.o
[ 25%] Building C object CMakeFiles/websockets.dir/lib/misc/lwsac/cached-file.c.o
[ 26%] Building C object CMakeFiles/websockets.dir/lib/misc/lws-struct-lejp.c.o
[ 27%] Building C object CMakeFiles/websockets.dir/lib/core-net/connect.c.o
[ 28%] Building C object CMakeFiles/websockets.dir/lib/core-net/client.c.o
[ 28%] Building C object CMakeFiles/websockets.dir/lib/roles/http/client/client.c.o
[ 29%] Building C object CMakeFiles/websockets.dir/lib/roles/http/client/client-handshake.c.o
[ 30%] Building C object CMakeFiles/websockets.dir/lib/core-net/server.c.o
[ 30%] Building C object CMakeFiles/websockets.dir/lib/roles/listen/ops-listen.c.o
[ 31%] Building C object CMakeFiles/websockets.dir/lib/tls/tls.c.o
[ 32%] Building C object CMakeFiles/websockets.dir/lib/tls/tls-network.c.o
[ 33%] Building C object CMakeFiles/websockets.dir/lib/tls/openssl/tls.c.o
[ 33%] Building C object CMakeFiles/websockets.dir/lib/tls/openssl/x509.c.o
[ 34%] Building C object CMakeFiles/websockets.dir/lib/tls/openssl/ssl.c.o
[ 35%] Building C object CMakeFiles/websockets.dir/lib/tls/tls-server.c.o
[ 35%] Building C object CMakeFiles/websockets.dir/lib/tls/openssl/openssl-server.c.o
[ 36%] Building C object CMakeFiles/websockets.dir/lib/tls/tls-client.c.o
[ 37%] Building C object CMakeFiles/websockets.dir/lib/tls/openssl/openssl-client.c.o
[ 38%] Building C object CMakeFiles/websockets.dir/lib/misc/sha-1.c.o
[ 38%] Building C object CMakeFiles/websockets.dir/lib/roles/h2/http2.c.o
[ 39%] Building C object CMakeFiles/websockets.dir/lib/roles/h2/hpack.c.o
[ 40%] Building C object CMakeFiles/websockets.dir/lib/roles/h2/ops-h2.c.o
[ 40%] Building C object CMakeFiles/websockets.dir/lib/plat/unix/unix-caps.c.o
[ 41%] Building C object CMakeFiles/websockets.dir/lib/plat/unix/unix-file.c.o
[ 42%] Building C object CMakeFiles/websockets.dir/lib/plat/unix/unix-misc.c.o
[ 43%] Building C object CMakeFiles/websockets.dir/lib/plat/unix/unix-init.c.o
[ 43%] Building C object CMakeFiles/websockets.dir/lib/plat/unix/unix-pipe.c.o
[ 44%] Building C object CMakeFiles/websockets.dir/lib/plat/unix/unix-service.c.o
[ 45%] Building C object CMakeFiles/websockets.dir/lib/plat/unix/unix-sockets.c.o
[ 45%] Building C object CMakeFiles/websockets.dir/lib/plat/unix/unix-fds.c.o
[ 46%] Building C object CMakeFiles/websockets.dir/lib/roles/http/server/server.c.o
[ 47%] Building C object CMakeFiles/websockets.dir/lib/roles/http/server/lws-spa.c.o
[ 48%] Building C object CMakeFiles/websockets.dir/lib/event-libs/poll/poll.c.o
[ 48%] Building C object CMakeFiles/websockets.dir/lib/misc/lejp.c.o
[ 49%] Building C object CMakeFiles/websockets.dir/lib/roles/http/server/lejp-conf.c.o
Linking C static library lib/libwebsockets.a
[ 49%] Built target websockets
Scanning dependencies of target test-client
[ 49%] Building C object CMakeFiles/test-client.dir/test-apps/test-client.c.o
Linking C executable bin/libwebsockets-test-client
[ 49%] Built target test-client
Scanning dependencies of target test-lejp
[ 50%] Building C object CMakeFiles/test-lejp.dir/test-apps/test-lejp.c.o
Linking C executable bin/libwebsockets-test-lejp
[ 50%] Built target test-lejp
Scanning dependencies of target test-server
[ 51%] Building C object CMakeFiles/test-server.dir/test-apps/test-server.c.o
Linking C executable bin/libwebsockets-test-server
[ 51%] Built target test-server
Scanning dependencies of target test-server-extpoll
[ 51%] Building C object CMakeFiles/test-server-extpoll.dir/test-apps/test-server.c.o
Linking C executable bin/libwebsockets-test-server-extpoll
[ 51%] Built target test-server-extpoll
Scanning dependencies of target websockets_shared
[ 52%] Building C object CMakeFiles/websockets_shared.dir/lib/core/alloc.c.o
[ 52%] Building C object CMakeFiles/websockets_shared.dir/lib/core/buflist.c.o
[ 53%] Building C object CMakeFiles/websockets_shared.dir/lib/core/context.c.o
[ 54%] Building C object CMakeFiles/websockets_shared.dir/lib/core/lws_dll2.c.o
[ 55%] Building C object CMakeFiles/websockets_shared.dir/lib/core/libwebsockets.c.o
[ 55%] Building C object CMakeFiles/websockets_shared.dir/lib/core/logs.c.o
[ 56%] Building C object CMakeFiles/websockets_shared.dir/lib/misc/base64-decode.c.o
[ 57%] Building C object CMakeFiles/websockets_shared.dir/lib/core/vfs.c.o
[ 57%] Building C object CMakeFiles/websockets_shared.dir/lib/misc/lws-ring.c.o
[ 58%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/dummy-callback.c.o
[ 59%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/output.c.o
[ 60%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/close.c.o
[ 60%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/network.c.o
[ 61%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/vhost.c.o
[ 62%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/pollfd.c.o
[ 62%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/service.c.o
[ 63%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/sorted-usec-list.c.o
[ 64%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/stats.c.o
[ 65%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/wsi.c.o
[ 65%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/wsi-timeout.c.o
[ 66%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/adopt.c.o
[ 67%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/pipe/ops-pipe.c.o
[ 67%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/sequencer.c.o
[ 68%] Building C object CMakeFiles/websockets_shared.dir/lib/misc/dir.c.o
[ 69%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/http/header.c.o
[ 70%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/http/server/parsers.c.o
[ 70%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/h1/ops-h1.c.o
[ 71%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/ws/ops-ws.c.o
[ 72%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/ws/client-ws.c.o
[ 72%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/ws/client-parser-ws.c.o
[ 73%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/ws/server-ws.c.o
[ 74%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/raw-skt/ops-raw-skt.c.o
[ 75%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/raw-file/ops-raw-file.c.o
[ 75%] Building C object CMakeFiles/websockets_shared.dir/lib/misc/lwsac/lwsac.c.o
[ 76%] Building C object CMakeFiles/websockets_shared.dir/lib/misc/lwsac/cached-file.c.o
[ 77%] Building C object CMakeFiles/websockets_shared.dir/lib/misc/lws-struct-lejp.c.o
[ 77%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/connect.c.o
[ 78%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/client.c.o
[ 79%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/http/client/client.c.o
[ 80%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/http/client/client-handshake.c.o
[ 80%] Building C object CMakeFiles/websockets_shared.dir/lib/core-net/server.c.o
[ 81%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/listen/ops-listen.c.o
[ 82%] Building C object CMakeFiles/websockets_shared.dir/lib/tls/tls.c.o
[ 82%] Building C object CMakeFiles/websockets_shared.dir/lib/tls/tls-network.c.o
[ 83%] Building C object CMakeFiles/websockets_shared.dir/lib/tls/openssl/tls.c.o
[ 84%] Building C object CMakeFiles/websockets_shared.dir/lib/tls/openssl/x509.c.o
[ 85%] Building C object CMakeFiles/websockets_shared.dir/lib/tls/openssl/ssl.c.o
[ 85%] Building C object CMakeFiles/websockets_shared.dir/lib/tls/tls-server.c.o
[ 86%] Building C object CMakeFiles/websockets_shared.dir/lib/tls/openssl/openssl-server.c.o
[ 87%] Building C object CMakeFiles/websockets_shared.dir/lib/tls/tls-client.c.o
[ 87%] Building C object CMakeFiles/websockets_shared.dir/lib/tls/openssl/openssl-client.c.o
[ 88%] Building C object CMakeFiles/websockets_shared.dir/lib/misc/sha-1.c.o
[ 89%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/h2/http2.c.o
[ 90%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/h2/hpack.c.o
[ 90%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/h2/ops-h2.c.o
[ 91%] Building C object CMakeFiles/websockets_shared.dir/lib/plat/unix/unix-caps.c.o
[ 92%] Building C object CMakeFiles/websockets_shared.dir/lib/plat/unix/unix-file.c.o
[ 92%] Building C object CMakeFiles/websockets_shared.dir/lib/plat/unix/unix-misc.c.o
[ 93%] Building C object CMakeFiles/websockets_shared.dir/lib/plat/unix/unix-init.c.o
[ 94%] Building C object CMakeFiles/websockets_shared.dir/lib/plat/unix/unix-pipe.c.o
[ 95%] Building C object CMakeFiles/websockets_shared.dir/lib/plat/unix/unix-service.c.o
[ 95%] Building C object CMakeFiles/websockets_shared.dir/lib/plat/unix/unix-sockets.c.o
[ 96%] Building C object CMakeFiles/websockets_shared.dir/lib/plat/unix/unix-fds.c.o
[ 97%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/http/server/server.c.o
[ 97%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/http/server/lws-spa.c.o
[ 98%] Building C object CMakeFiles/websockets_shared.dir/lib/event-libs/poll/poll.c.o
[ 99%] Building C object CMakeFiles/websockets_shared.dir/lib/misc/lejp.c.o
[100%] Building C object CMakeFiles/websockets_shared.dir/lib/roles/http/server/lejp-conf.c.o
Linking C shared library lib/libwebsockets.so
[100%] Built target websockets_shared
 OK

[/netdata]# mkdir -p /netdata/externaldeps/libwebsockets
 OK

[/netdata]# cp /tmp/netdata-libwebsockets-vVPxH4/libwebsockets-3.2.2/lib/libwebsockets.a /netdata/externaldeps/libwebsockets/libwebsockets.a
 OK

[/netdata]# cp -r /tmp/netdata-libwebsockets-vVPxH4/libwebsockets-3.2.2/include /netdata/externaldeps/libwebsockets
 OK

 OK  libwebsockets built and prepared.


 --- Run autotools to configure the build environment ---
[/netdata]# autoreconf -ivf
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I build/m4
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:38: installing './compile'
configure.ac:37: installing './config.guess'
configure.ac:37: installing './config.sub'
configure.ac:33: installing './install-sh'
configure.ac:33: installing './missing'
Makefile.am: installing './depcomp'
parallel-tests: installing './test-driver'
autoreconf: Leaving directory `.'
 OK

[/netdata]# ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libexecdir=/usr/libexec --libdir=/usr/lib --with-zlib --with-math --with-user=netdata CFLAGS=-O2 LDFLAGS=
checking whether to enable maintainer-specific portions of Makefiles... no
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... no
checking for mawk... mawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking how to create a pax tar archive... gnutar
checking whether make supports nested variables... (cached) yes
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking for style of include used by make... GNU
checking dependency style of gcc... gcc3
checking for gcc option to accept ISO C99... -std=gnu99
checking for g++... no
checking for c++... no
checking for gpp... no
checking for aCC... no
checking for CC... no
checking for cxx... no
checking for cc++... no
checking for cl.exe... no
checking for FCC... no
checking for KCC... no
checking for RCC... no
checking for xlC_r... no
checking for xlC... no
checking whether we are using the GNU C++ compiler... no
checking whether g++ accepts -g... no
checking dependency style of g++... none
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking how to run the C preprocessor... gcc -std=gnu99 -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for __attribute__((returns_nonnull))... no
checking for __attribute__((malloc))... yes
checking for __attribute__((noreturn))... yes
checking for __attribute__((noinline))... yes
checking for __attribute__((format))... yes
checking for __attribute__((warn_unused_result))... yes
checking for struct timespec... yes
checking for clockid_t... yes
checking for library containing clock_gettime... none required
checking for clock_gettime... yes
checking for sched_setscheduler... yes
checking for sched_getscheduler... yes
checking for sched_getparam... yes
checking for sched_get_priority_min... yes
checking for sched_get_priority_max... yes
checking for getpriority... yes
checking for setpriority... yes
checking for nice... yes
checking for recvmmsg... yes
checking for int8_t... yes
checking for int16_t... yes
checking for int32_t... yes
checking for int64_t... yes
checking for uint8_t... yes
checking for uint16_t... yes
checking for uint32_t... yes
checking for uint64_t... yes
checking for inline... inline
checking whether strerror_r is declared... yes
checking for strerror_r... yes
checking whether strerror_r returns char *... yes
checking for _Generic... no
checking for __atomic... yes
checking size of void *... 8
checking whether sys/types.h defines makedev... yes
checking for sys/types.h... (cached) yes
checking for netinet/in.h... yes
checking for arpa/nameser.h... yes
checking for netdb.h... yes
checking for resolv.h... yes
checking for sys/prctl.h... yes
checking for sys/vfs.h... yes
checking for sys/statfs.h... yes
checking for sys/statvfs.h... yes
checking for sys/mount.h... yes
checking for accept4... yes
checking operating system... linux with id 1
checking if compiler needs -Werror to reject unknown flags... no
checking for the pthreads library -lpthreads... no
checking whether pthreads work without any flags... no
checking whether pthreads work with -Kthread... no
checking whether pthreads work with -kthread... no
checking for the pthreads library -llthread... no
checking whether pthreads work with -pthread... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking if more special flags are required for pthreads... no
checking for PTHREAD_PRIO_INHERIT... yes
checking for sin in -lm... yes
checking if libm should be used... yes
checking for uv_fs_scandir_next in -luv... yes
checking for LZ4_compress_default in -llz4... no
checking for JudyLIns in -lJudy... yes
checking for ZLIB... yes
checking if zlib should be used... yes
checking for UUID... yes
checking for SHA256_Init in -lcrypto... yes
checking for JSON... yes
checking for json_object_get_type in -ljson-c... yes
checking for dlopen in -ldl... yes
checking if netdata dbengine should be used... no
checking if netdata https should be used... yes
checking if json-c should be used... yes
checking for memory allocator... system
checking for mallopt... yes
checking for mallinfo... yes
checking for LIBCAP... no
checking if libcap should be used... no
checking if cloud functionality should be enabled... detect
checking if libmosquitto static lib is present (and builds)... yes
checking if libwebsockets static lib is present... yes
checking if netdata agent-cloud-link can be enabled... yes
checking if netdata agent-cloud-link should/will be enabled... yes
checking if apps.plugin should be enabled... yes
checking for IPMIMONITORING... no
checking if freeipmi.plugin should be enabled... no
checking for httpConnect2 in -lcups... no
checking for cups-config... no
checking if cups.plugin should be enabled... no
checking linux/netfilter/nfnetlink_conntrack.h usability... yes
checking linux/netfilter/nfnetlink_conntrack.h presence... yes
checking for linux/netfilter/nfnetlink_conntrack.h... yes
checking whether CTA_STATS_MAX is declared... yes
checking for NFACCT... no
checking for LIBMNL... yes
checking for mnl_socket_open in -lmnl... yes
checking if nfacct.plugin should be enabled... no
checking for YAJL... no
checking for xenstat_init in -lxenstat... no
checking for XENLIGHT... no
checking if xenstat.plugin should be enabled... no
checking linux/perf_event.h usability... yes
checking linux/perf_event.h presence... yes
checking for linux/perf_event.h... yes
checking whether PERF_COUNT_HW_REF_CPU_CYCLES is declared... yes
checking if perf.plugin should be enabled... yes
checking if ebpf_process.plugin should be enabled... yes
checking if slabinfo.plugin should be enabled... yes
checking for LIBCRYPTO... yes
checking for CRYPTO_new_ex_data in -lcrypto... yes
checking for LIBSSL... yes
checking for SSL_connect in -lssl... yes
checking for LIBCURL... no
checking for cJSON_free in -laws-cpp-sdk-core... no
checking for Aws::Kinesis::Model::PutRecordRequest in -laws-cpp-sdk-kinesis... no
checking if kinesis backend should be enabled... no
checking for PROTOBUF... no
checking for snappy::RawCompress in -lsnappy... no
checking for protoc... no
checking for g++... no
checking if prometheus remote write backend should be enabled... no
checking for LIBMONGOC... no
checking if mongodb backend should be enabled... no
checking for setns... yes
checking if cgroup-network can be enabled... yes
checking whether C compiler accepts -flto... yes
checking if -flto builds executables... yes
checking if LTO should be enabled... yes
checking for CMOCKA... no
configure: CMocka not found on the system. Unit tests disabled
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating netdata.spec
config.status: creating backends/graphite/Makefile
config.status: creating backends/json/Makefile
config.status: creating backends/Makefile
config.status: creating backends/opentsdb/Makefile
config.status: creating backends/prometheus/Makefile
config.status: creating backends/prometheus/remote_write/Makefile
config.status: creating backends/aws_kinesis/Makefile
config.status: creating backends/mongodb/Makefile
config.status: creating collectors/Makefile
config.status: creating collectors/apps.plugin/Makefile
config.status: creating collectors/cgroups.plugin/Makefile
config.status: creating collectors/charts.d.plugin/Makefile
config.status: creating collectors/checks.plugin/Makefile
config.status: creating collectors/diskspace.plugin/Makefile
config.status: creating collectors/fping.plugin/Makefile
config.status: creating collectors/ioping.plugin/Makefile
config.status: creating collectors/freebsd.plugin/Makefile
config.status: creating collectors/freeipmi.plugin/Makefile
config.status: creating collectors/cups.plugin/Makefile
config.status: creating collectors/idlejitter.plugin/Makefile
config.status: creating collectors/macos.plugin/Makefile
config.status: creating collectors/nfacct.plugin/Makefile
config.status: creating collectors/node.d.plugin/Makefile
config.status: creating collectors/plugins.d/Makefile
config.status: creating collectors/proc.plugin/Makefile
config.status: creating collectors/python.d.plugin/Makefile
config.status: creating collectors/slabinfo.plugin/Makefile
config.status: creating collectors/statsd.plugin/Makefile
config.status: creating collectors/ebpf_process.plugin/Makefile
config.status: creating collectors/tc.plugin/Makefile
config.status: creating collectors/xenstat.plugin/Makefile
config.status: creating collectors/perf.plugin/Makefile
config.status: creating daemon/Makefile
config.status: creating database/Makefile
config.status: creating database/engine/Makefile
config.status: creating diagrams/Makefile
config.status: creating exporting/Makefile
config.status: creating exporting/graphite/Makefile
config.status: creating exporting/json/Makefile
config.status: creating exporting/opentsdb/Makefile
config.status: creating exporting/prometheus/Makefile
config.status: creating exporting/prometheus/remote_write/Makefile
config.status: creating exporting/aws_kinesis/Makefile
config.status: creating exporting/mongodb/Makefile
config.status: creating exporting/tests/Makefile
config.status: creating health/Makefile
config.status: creating health/notifications/Makefile
config.status: creating libnetdata/Makefile
config.status: creating libnetdata/tests/Makefile
config.status: creating libnetdata/adaptive_resortable_list/Makefile
config.status: creating libnetdata/avl/Makefile
config.status: creating libnetdata/buffer/Makefile
config.status: creating libnetdata/clocks/Makefile
config.status: creating libnetdata/config/Makefile
config.status: creating libnetdata/dictionary/Makefile
config.status: creating libnetdata/ebpf/Makefile
config.status: creating libnetdata/eval/Makefile
config.status: creating libnetdata/locks/Makefile
config.status: creating libnetdata/log/Makefile
config.status: creating libnetdata/popen/Makefile
config.status: creating libnetdata/procfile/Makefile
config.status: creating libnetdata/simple_pattern/Makefile
config.status: creating libnetdata/socket/Makefile
config.status: creating libnetdata/statistical/Makefile
config.status: creating libnetdata/storage_number/Makefile
config.status: creating libnetdata/storage_number/tests/Makefile
config.status: creating libnetdata/threads/Makefile
config.status: creating libnetdata/url/Makefile
config.status: creating libnetdata/json/Makefile
config.status: creating libnetdata/health/Makefile
config.status: creating registry/Makefile
config.status: creating streaming/Makefile
config.status: creating system/Makefile
config.status: creating tests/Makefile
config.status: creating web/Makefile
config.status: creating web/api/Makefile
config.status: creating web/api/badges/Makefile
config.status: creating web/api/exporters/Makefile
config.status: creating web/api/exporters/shell/Makefile
config.status: creating web/api/exporters/prometheus/Makefile
config.status: creating web/api/formatters/Makefile
config.status: creating web/api/formatters/csv/Makefile
config.status: creating web/api/formatters/json/Makefile
config.status: creating web/api/formatters/ssv/Makefile
config.status: creating web/api/formatters/value/Makefile
config.status: creating web/api/queries/Makefile
config.status: creating web/api/queries/average/Makefile
config.status: creating web/api/queries/des/Makefile
config.status: creating web/api/queries/incremental_sum/Makefile
config.status: creating web/api/queries/max/Makefile
config.status: creating web/api/queries/median/Makefile
config.status: creating web/api/queries/min/Makefile
config.status: creating web/api/queries/ses/Makefile
config.status: creating web/api/queries/stddev/Makefile
config.status: creating web/api/queries/sum/Makefile
config.status: creating web/api/health/Makefile
config.status: creating web/gui/Makefile
config.status: creating web/server/Makefile
config.status: creating web/server/static/Makefile
config.status: creating claim/Makefile
config.status: creating aclk/Makefile
config.status: creating config.h
config.status: executing depfiles commands
 OK

 --- Cleanup compilation directory ---
[/netdata]# make clean
Making clean in diagrams
make[1]: Entering directory `/netdata/diagrams'
make[1]: Nothing to be done for `clean'.
make[1]: Leaving directory `/netdata/diagrams'
Making clean in system
make[1]: Entering directory `/netdata/system'
test -z "edit-config netdata-openrc netdata.logrotate netdata.service netdata.service.v235 netdata-init-d netdata-lsb netdata-freebsd netdata.plist " || rm -f edit-config netdata-openrc netdata.logrotate netdata.service netdata.service.v235 netdata-init-d netdata-lsb netdata-freebsd netdata.plist
make[1]: Leaving directory `/netdata/system'
Making clean in tests
make[1]: Entering directory `/netdata/tests'
test -z "health_mgmtapi/health-cmdapi-test.sh acls/acl.sh urls/request.sh alarm_repetition/alarm.sh template_dimension/template_dim.sh " || rm -f health_mgmtapi/health-cmdapi-test.sh acls/acl.sh urls/request.sh alarm_repetition/alarm.sh template_dimension/template_dim.sh
make[1]: Leaving directory `/netdata/tests'
Making clean in backends
make[1]: Entering directory `/netdata/backends'
Making clean in graphite
make[2]: Entering directory `/netdata/backends/graphite'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/backends/graphite'
Making clean in json
make[2]: Entering directory `/netdata/backends/json'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/backends/json'
Making clean in opentsdb
make[2]: Entering directory `/netdata/backends/opentsdb'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/backends/opentsdb'
Making clean in prometheus
make[2]: Entering directory `/netdata/backends/prometheus'
Making clean in remote_write
make[3]: Entering directory `/netdata/backends/prometheus/remote_write'
test -z "remote_write.pb.cc remote_write.pb.h " || rm -f remote_write.pb.cc remote_write.pb.h
make[3]: Leaving directory `/netdata/backends/prometheus/remote_write'
make[3]: Entering directory `/netdata/backends/prometheus'
make[3]: Nothing to be done for `clean-am'.
make[3]: Leaving directory `/netdata/backends/prometheus'
make[2]: Leaving directory `/netdata/backends/prometheus'
Making clean in aws_kinesis
make[2]: Entering directory `/netdata/backends/aws_kinesis'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/backends/aws_kinesis'
Making clean in mongodb
make[2]: Entering directory `/netdata/backends/mongodb'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/backends/mongodb'
make[2]: Entering directory `/netdata/backends'
make[2]: Nothing to be done for `clean-am'.
make[2]: Leaving directory `/netdata/backends'
make[1]: Leaving directory `/netdata/backends'
Making clean in collectors
make[1]: Entering directory `/netdata/collectors'
Making clean in plugins.d
make[2]: Entering directory `/netdata/collectors/plugins.d'
make[3]: Entering directory `/netdata/collectors/plugins.d'
make[3]: Nothing to be done for `clean-am'.
make[3]: Leaving directory `/netdata/collectors/plugins.d'
make[2]: Leaving directory `/netdata/collectors/plugins.d'
Making clean in apps.plugin
make[2]: Entering directory `/netdata/collectors/apps.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/apps.plugin'
Making clean in cgroups.plugin
make[2]: Entering directory `/netdata/collectors/cgroups.plugin'
test -z "cgroup-name.sh " || rm -f cgroup-name.sh
make[2]: Leaving directory `/netdata/collectors/cgroups.plugin'
Making clean in charts.d.plugin
make[2]: Entering directory `/netdata/collectors/charts.d.plugin'
test -z "charts.d.plugin " || rm -f charts.d.plugin
make[2]: Leaving directory `/netdata/collectors/charts.d.plugin'
Making clean in checks.plugin
make[2]: Entering directory `/netdata/collectors/checks.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/checks.plugin'
Making clean in cups.plugin
make[2]: Entering directory `/netdata/collectors/cups.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/cups.plugin'
Making clean in diskspace.plugin
make[2]: Entering directory `/netdata/collectors/diskspace.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/diskspace.plugin'
Making clean in fping.plugin
make[2]: Entering directory `/netdata/collectors/fping.plugin'
test -z "fping.plugin " || rm -f fping.plugin
make[2]: Leaving directory `/netdata/collectors/fping.plugin'
Making clean in ioping.plugin
make[2]: Entering directory `/netdata/collectors/ioping.plugin'
test -z "ioping.plugin " || rm -f ioping.plugin
make[2]: Leaving directory `/netdata/collectors/ioping.plugin'
Making clean in freebsd.plugin
make[2]: Entering directory `/netdata/collectors/freebsd.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/freebsd.plugin'
Making clean in freeipmi.plugin
make[2]: Entering directory `/netdata/collectors/freeipmi.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/freeipmi.plugin'
Making clean in idlejitter.plugin
make[2]: Entering directory `/netdata/collectors/idlejitter.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/idlejitter.plugin'
Making clean in macos.plugin
make[2]: Entering directory `/netdata/collectors/macos.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/macos.plugin'
Making clean in nfacct.plugin
make[2]: Entering directory `/netdata/collectors/nfacct.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/nfacct.plugin'
Making clean in xenstat.plugin
make[2]: Entering directory `/netdata/collectors/xenstat.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/xenstat.plugin'
Making clean in perf.plugin
make[2]: Entering directory `/netdata/collectors/perf.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/perf.plugin'
Making clean in node.d.plugin
make[2]: Entering directory `/netdata/collectors/node.d.plugin'
test -z "node.d.plugin " || rm -f node.d.plugin
make[2]: Leaving directory `/netdata/collectors/node.d.plugin'
Making clean in proc.plugin
make[2]: Entering directory `/netdata/collectors/proc.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/proc.plugin'
Making clean in python.d.plugin
make[2]: Entering directory `/netdata/collectors/python.d.plugin'
test -z "python.d.plugin " || rm -f python.d.plugin
make[2]: Leaving directory `/netdata/collectors/python.d.plugin'
Making clean in slabinfo.plugin
make[2]: Entering directory `/netdata/collectors/slabinfo.plugin'
test -z "slabinfo.plugin " || rm -f slabinfo.plugin
make[2]: Leaving directory `/netdata/collectors/slabinfo.plugin'
Making clean in statsd.plugin
make[2]: Entering directory `/netdata/collectors/statsd.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/statsd.plugin'
Making clean in ebpf_process.plugin
make[2]: Entering directory `/netdata/collectors/ebpf_process.plugin'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/collectors/ebpf_process.plugin'
Making clean in tc.plugin
make[2]: Entering directory `/netdata/collectors/tc.plugin'
test -z "tc-qos-helper.sh " || rm -f tc-qos-helper.sh
make[2]: Leaving directory `/netdata/collectors/tc.plugin'
make[2]: Entering directory `/netdata/collectors'
make[2]: Nothing to be done for `clean-am'.
make[2]: Leaving directory `/netdata/collectors'
make[1]: Leaving directory `/netdata/collectors'
Making clean in daemon
make[1]: Entering directory `/netdata/daemon'
test -z "anonymous-statistics.sh " || rm -f anonymous-statistics.sh
make[1]: Leaving directory `/netdata/daemon'
Making clean in database
make[1]: Entering directory `/netdata/database'
Making clean in engine
make[2]: Entering directory `/netdata/database/engine'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/database/engine'
make[2]: Entering directory `/netdata/database'
make[2]: Nothing to be done for `clean-am'.
make[2]: Leaving directory `/netdata/database'
make[1]: Leaving directory `/netdata/database'
Making clean in exporting
make[1]: Entering directory `/netdata/exporting'
Making clean in tests
make[2]: Entering directory `/netdata/exporting/tests'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/exporting/tests'
Making clean in graphite
make[2]: Entering directory `/netdata/exporting/graphite'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/exporting/graphite'
Making clean in json
make[2]: Entering directory `/netdata/exporting/json'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/exporting/json'
Making clean in opentsdb
make[2]: Entering directory `/netdata/exporting/opentsdb'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/exporting/opentsdb'
Making clean in prometheus
make[2]: Entering directory `/netdata/exporting/prometheus'
Making clean in remote_write
make[3]: Entering directory `/netdata/exporting/prometheus/remote_write'
test -z "remote_write.pb.cc remote_write.pb.h " || rm -f remote_write.pb.cc remote_write.pb.h
make[3]: Leaving directory `/netdata/exporting/prometheus/remote_write'
make[3]: Entering directory `/netdata/exporting/prometheus'
make[3]: Nothing to be done for `clean-am'.
make[3]: Leaving directory `/netdata/exporting/prometheus'
make[2]: Leaving directory `/netdata/exporting/prometheus'
Making clean in aws_kinesis
make[2]: Entering directory `/netdata/exporting/aws_kinesis'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/exporting/aws_kinesis'
Making clean in mongodb
make[2]: Entering directory `/netdata/exporting/mongodb'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/exporting/mongodb'
make[2]: Entering directory `/netdata/exporting'
make[2]: Nothing to be done for `clean-am'.
make[2]: Leaving directory `/netdata/exporting'
make[1]: Leaving directory `/netdata/exporting'
Making clean in health
make[1]: Entering directory `/netdata/health'
Making clean in notifications
make[2]: Entering directory `/netdata/health/notifications'
test -z "alarm-notify.sh " || rm -f alarm-notify.sh
make[2]: Leaving directory `/netdata/health/notifications'
make[2]: Entering directory `/netdata/health'
test -z "" || rm -f
make[2]: Leaving directory `/netdata/health'
make[1]: Leaving directory `/netdata/health'
Making clean in libnetdata
make[1]: Entering directory `/netdata/libnetdata'
Making clean in adaptive_resortable_list
make[2]: Entering directory `/netdata/libnetdata/adaptive_resortable_list'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/adaptive_resortable_list'
Making clean in avl
make[2]: Entering directory `/netdata/libnetdata/avl'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/avl'
Making clean in buffer
make[2]: Entering directory `/netdata/libnetdata/buffer'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/buffer'
Making clean in clocks
make[2]: Entering directory `/netdata/libnetdata/clocks'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/clocks'
Making clean in config
make[2]: Entering directory `/netdata/libnetdata/config'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/config'
Making clean in dictionary
make[2]: Entering directory `/netdata/libnetdata/dictionary'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/dictionary'
Making clean in ebpf
make[2]: Entering directory `/netdata/libnetdata/ebpf'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/ebpf'
Making clean in eval
make[2]: Entering directory `/netdata/libnetdata/eval'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/eval'
Making clean in json
make[2]: Entering directory `/netdata/libnetdata/json'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/json'
Making clean in health
make[2]: Entering directory `/netdata/libnetdata/health'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/health'
Making clean in locks
make[2]: Entering directory `/netdata/libnetdata/locks'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/locks'
Making clean in log
make[2]: Entering directory `/netdata/libnetdata/log'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/log'
Making clean in popen
make[2]: Entering directory `/netdata/libnetdata/popen'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/popen'
Making clean in procfile
make[2]: Entering directory `/netdata/libnetdata/procfile'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/procfile'
Making clean in simple_pattern
make[2]: Entering directory `/netdata/libnetdata/simple_pattern'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/simple_pattern'
Making clean in socket
make[2]: Entering directory `/netdata/libnetdata/socket'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/socket'
Making clean in statistical
make[2]: Entering directory `/netdata/libnetdata/statistical'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/statistical'
Making clean in storage_number
make[2]: Entering directory `/netdata/libnetdata/storage_number'
Making clean in tests
make[3]: Entering directory `/netdata/libnetdata/storage_number/tests'
make[3]: Nothing to be done for `clean'.
make[3]: Leaving directory `/netdata/libnetdata/storage_number/tests'
make[3]: Entering directory `/netdata/libnetdata/storage_number'
make[3]: Nothing to be done for `clean-am'.
make[3]: Leaving directory `/netdata/libnetdata/storage_number'
make[2]: Leaving directory `/netdata/libnetdata/storage_number'
Making clean in threads
make[2]: Entering directory `/netdata/libnetdata/threads'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/threads'
Making clean in url
make[2]: Entering directory `/netdata/libnetdata/url'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/url'
Making clean in tests
make[2]: Entering directory `/netdata/libnetdata/tests'
make[2]: Nothing to be done for `clean'.
make[2]: Leaving directory `/netdata/libnetdata/tests'
make[2]: Entering directory `/netdata/libnetdata'
make[2]: Nothing to be done for `clean-am'.
make[2]: Leaving directory `/netdata/libnetdata'
make[1]: Leaving directory `/netdata/libnetdata'
Making clean in registry
make[1]: Entering directory `/netdata/registry'
make[1]: Nothing to be done for `clean'.
make[1]: Leaving directory `/netdata/registry'
Making clean in streaming
make[1]: Entering directory `/netdata/streaming'
make[1]: Nothing to be done for `clean'.
make[1]: Leaving directory `/netdata/streaming'
Making clean in web
make[1]: Entering directory `/netdata/web'
Making clean in api
make[2]: Entering directory `/netdata/web/api'
Making clean in badges
make[3]: Entering directory `/netdata/web/api/badges'
make[3]: Nothing to be done for `clean'.
make[3]: Leaving directory `/netdata/web/api/badges'
Making clean in queries
make[3]: Entering directory `/netdata/web/api/queries'
Making clean in average
make[4]: Entering directory `/netdata/web/api/queries/average'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/queries/average'
Making clean in des
make[4]: Entering directory `/netdata/web/api/queries/des'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/queries/des'
Making clean in incremental_sum
make[4]: Entering directory `/netdata/web/api/queries/incremental_sum'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/queries/incremental_sum'
Making clean in max
make[4]: Entering directory `/netdata/web/api/queries/max'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/queries/max'
Making clean in min
make[4]: Entering directory `/netdata/web/api/queries/min'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/queries/min'
Making clean in sum
make[4]: Entering directory `/netdata/web/api/queries/sum'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/queries/sum'
Making clean in median
make[4]: Entering directory `/netdata/web/api/queries/median'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/queries/median'
Making clean in ses
make[4]: Entering directory `/netdata/web/api/queries/ses'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/queries/ses'
Making clean in stddev
make[4]: Entering directory `/netdata/web/api/queries/stddev'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/queries/stddev'
make[4]: Entering directory `/netdata/web/api/queries'
make[4]: Nothing to be done for `clean-am'.
make[4]: Leaving directory `/netdata/web/api/queries'
make[3]: Leaving directory `/netdata/web/api/queries'
Making clean in exporters
make[3]: Entering directory `/netdata/web/api/exporters'
Making clean in shell
make[4]: Entering directory `/netdata/web/api/exporters/shell'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/exporters/shell'
Making clean in prometheus
make[4]: Entering directory `/netdata/web/api/exporters/prometheus'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/exporters/prometheus'
make[4]: Entering directory `/netdata/web/api/exporters'
make[4]: Nothing to be done for `clean-am'.
make[4]: Leaving directory `/netdata/web/api/exporters'
make[3]: Leaving directory `/netdata/web/api/exporters'
Making clean in formatters
make[3]: Entering directory `/netdata/web/api/formatters'
Making clean in csv
make[4]: Entering directory `/netdata/web/api/formatters/csv'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/formatters/csv'
Making clean in json
make[4]: Entering directory `/netdata/web/api/formatters/json'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/formatters/json'
Making clean in ssv
make[4]: Entering directory `/netdata/web/api/formatters/ssv'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/formatters/ssv'
Making clean in value
make[4]: Entering directory `/netdata/web/api/formatters/value'
make[4]: Nothing to be done for `clean'.
make[4]: Leaving directory `/netdata/web/api/formatters/value'
make[4]: Entering directory `/netdata/web/api/formatters'
make[4]: Nothing to be done for `clean-am'.
make[4]: Leaving directory `/netdata/web/api/formatters'
make[3]: Leaving directory `/netdata/web/api/formatters'
Making clean in health
make[3]: Entering directory `/netdata/web/api/health'
make[3]: Nothing to be done for `clean'.
make[3]: Leaving directory `/netdata/web/api/health'
make[3]: Entering directory `/netdata/web/api'
make[3]: Nothing to be done for `clean-am'.
make[3]: Leaving directory `/netdata/web/api'
make[2]: Leaving directory `/netdata/web/api'
Making clean in gui
make[2]: Entering directory `/netdata/web/gui'
test -z "version.txt " || rm -f version.txt
make[2]: Leaving directory `/netdata/web/gui'
Making clean in server
make[2]: Entering directory `/netdata/web/server'
Making clean in static
make[3]: Entering directory `/netdata/web/server/static'
make[4]: Entering directory `/netdata/web/server/static'
make[4]: Nothing to be done for `clean-am'.
make[4]: Leaving directory `/netdata/web/server/static'
make[3]: Leaving directory `/netdata/web/server/static'
make[3]: Entering directory `/netdata/web/server'
make[3]: Nothing to be done for `clean-am'.
make[3]: Leaving directory `/netdata/web/server'
make[2]: Leaving directory `/netdata/web/server'
make[2]: Entering directory `/netdata/web'
make[2]: Nothing to be done for `clean-am'.
make[2]: Leaving directory `/netdata/web'
make[1]: Leaving directory `/netdata/web'
Making clean in claim
make[1]: Entering directory `/netdata/claim'
test -z "netdata-claim.sh " || rm -f netdata-claim.sh
make[1]: Leaving directory `/netdata/claim'
Making clean in aclk
make[1]: Entering directory `/netdata/aclk'
test -z "tests/install-fake-charts.d.sh " || rm -f tests/install-fake-charts.d.sh
make[1]: Leaving directory `/netdata/aclk'
make[1]: Entering directory `/netdata'
test -z "" || rm -f
test -z "./netdata-v1.21.1-138-g263572a.tar.gz" || rm -f ./netdata-v1.21.1-138-g263572a.tar.gz
test -z "apps.plugin cgroup-network  ebpf_process.plugin    perf.plugin slabinfo.plugin" || rm -f apps.plugin cgroup-network  ebpf_process.plugin    perf.plugin slabinfo.plugin
test -z "netdata netdatacli" || rm -f netdata netdatacli
rm -f *.o
rm -f aclk/*.o
rm -f backends/*.o
rm -f backends/aws_kinesis/*.o
rm -f backends/graphite/*.o
rm -f backends/json/*.o
rm -f backends/mongodb/*.o
rm -f backends/opentsdb/*.o
rm -f backends/prometheus/*.o
rm -f backends/prometheus/remote_write/*.o
rm -f claim/*.o
rm -f cli/*.o
rm -f collectors/apps.plugin/*.o
rm -f collectors/cgroups.plugin/*.o
rm -f collectors/checks.plugin/*.o
rm -f collectors/cups.plugin/*.o
rm -f collectors/diskspace.plugin/*.o
rm -f collectors/ebpf_process.plugin/*.o
rm -f collectors/freebsd.plugin/*.o
rm -f collectors/freeipmi.plugin/*.o
rm -f collectors/idlejitter.plugin/*.o
rm -f collectors/macos.plugin/*.o
rm -f collectors/nfacct.plugin/*.o
rm -f collectors/perf.plugin/*.o
rm -f collectors/plugins.d/*.o
rm -f collectors/proc.plugin/*.o
rm -f collectors/slabinfo.plugin/*.o
rm -f collectors/statsd.plugin/*.o
rm -f collectors/tc.plugin/*.o
rm -f collectors/xenstat.plugin/*.o
rm -f daemon/*.o
rm -f database/*.o
rm -f database/engine/*.o
rm -f exporting/*.o
rm -f exporting/aws_kinesis/*.o
rm -f exporting/graphite/*.o
rm -f exporting/json/*.o
rm -f exporting/mongodb/*.o
rm -f exporting/opentsdb/*.o
rm -f exporting/prometheus/*.o
rm -f exporting/prometheus/remote_write/*.o
rm -f exporting/tests/*.o
rm -f health/*.o
rm -f libnetdata/*.o
rm -f libnetdata/adaptive_resortable_list/*.o
rm -f libnetdata/avl/*.o
rm -f libnetdata/buffer/*.o
rm -f libnetdata/clocks/*.o
rm -f libnetdata/config/*.o
rm -f libnetdata/dictionary/*.o
rm -f libnetdata/ebpf/*.o
rm -f libnetdata/eval/*.o
rm -f libnetdata/health/*.o
rm -f libnetdata/json/*.o
rm -f libnetdata/locks/*.o
rm -f libnetdata/log/*.o
rm -f libnetdata/popen/*.o
rm -f libnetdata/procfile/*.o
rm -f libnetdata/simple_pattern/*.o
rm -f libnetdata/socket/*.o
rm -f libnetdata/statistical/*.o
rm -f libnetdata/storage_number/*.o
rm -f libnetdata/storage_number/tests/*.o
rm -f libnetdata/tests/*.o
rm -f libnetdata/threads/*.o
rm -f libnetdata/url/*.o
rm -f registry/*.o
rm -f streaming/*.o
rm -f web/api/*.o
rm -f web/api/badges/*.o
rm -f web/api/exporters/*.o
rm -f web/api/exporters/shell/*.o
rm -f web/api/formatters/*.o
rm -f web/api/formatters/csv/*.o
rm -f web/api/formatters/json/*.o
rm -f web/api/formatters/ssv/*.o
rm -f web/api/formatters/value/*.o
rm -f web/api/health/*.o
rm -f web/api/queries/*.o
rm -f web/api/queries/average/*.o
rm -f web/api/queries/des/*.o
rm -f web/api/queries/incremental_sum/*.o
rm -f web/api/queries/max/*.o
rm -f web/api/queries/median/*.o
rm -f web/api/queries/min/*.o
rm -f web/api/queries/ses/*.o
rm -f web/api/queries/stddev/*.o
rm -f web/api/queries/sum/*.o
rm -f web/api/tests/*.o
rm -f web/server/*.o
rm -f web/server/static/*.o
test -z "" || rm -f
test -z "" || rm -f
test -z "test-suite.log" || rm -f test-suite.log
make[1]: Leaving directory `/netdata'
 OK

 --- Compile netdata ---
[/netdata]# make -j6
make  all-recursive
make[1]: Entering directory `/netdata'
Making all in diagrams
make[2]: Entering directory `/netdata/diagrams'
make[2]: Nothing to be done for `all'.
make[2]: Leaving directory `/netdata/diagrams'
Making all in system
make[2]: Entering directory `/netdata/system'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		edit-config.in > edit-config.tmp; then \
		mv "edit-config.tmp" "edit-config"; \
	else \
		rm -f "edit-config.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		netdata-openrc.in > netdata-openrc.tmp; then \
		mv "netdata-openrc.tmp" "netdata-openrc"; \
	else \
		rm -f "netdata-openrc.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		netdata.logrotate.in > netdata.logrotate.tmp; then \
		mv "netdata.logrotate.tmp" "netdata.logrotate"; \
	else \
		rm -f "netdata.logrotate.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		netdata.service.in > netdata.service.tmp; then \
		mv "netdata.service.tmp" "netdata.service"; \
	else \
		rm -f "netdata.service.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		netdata.service.v235.in > netdata.service.v235.tmp; then \
		mv "netdata.service.v235.tmp" "netdata.service.v235"; \
	else \
		rm -f "netdata.service.v235.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		netdata-init-d.in > netdata-init-d.tmp; then \
		mv "netdata-init-d.tmp" "netdata-init-d"; \
	else \
		rm -f "netdata-init-d.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		netdata-lsb.in > netdata-lsb.tmp; then \
		mv "netdata-lsb.tmp" "netdata-lsb"; \
	else \
		rm -f "netdata-lsb.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		netdata-freebsd.in > netdata-freebsd.tmp; then \
		mv "netdata-freebsd.tmp" "netdata-freebsd"; \
	else \
		rm -f "netdata-freebsd.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		netdata.plist.in > netdata.plist.tmp; then \
		mv "netdata.plist.tmp" "netdata.plist"; \
	else \
		rm -f "netdata.plist.tmp"; \
		false; \
	fi
make[2]: Leaving directory `/netdata/system'
Making all in tests
make[2]: Entering directory `/netdata/tests'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		health_mgmtapi/health-cmdapi-test.sh.in > health_mgmtapi/health-cmdapi-test.sh.tmp; then \
		mv "health_mgmtapi/health-cmdapi-test.sh.tmp" "health_mgmtapi/health-cmdapi-test.sh"; \
	else \
		rm -f "health_mgmtapi/health-cmdapi-test.sh.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		acls/acl.sh.in > acls/acl.sh.tmp; then \
		mv "acls/acl.sh.tmp" "acls/acl.sh"; \
	else \
		rm -f "acls/acl.sh.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		urls/request.sh.in > urls/request.sh.tmp; then \
		mv "urls/request.sh.tmp" "urls/request.sh"; \
	else \
		rm -f "urls/request.sh.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		alarm_repetition/alarm.sh.in > alarm_repetition/alarm.sh.tmp; then \
		mv "alarm_repetition/alarm.sh.tmp" "alarm_repetition/alarm.sh"; \
	else \
		rm -f "alarm_repetition/alarm.sh.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		template_dimension/template_dim.sh.in > template_dimension/template_dim.sh.tmp; then \
		mv "template_dimension/template_dim.sh.tmp" "template_dimension/template_dim.sh"; \
	else \
		rm -f "template_dimension/template_dim.sh.tmp"; \
		false; \
	fi
make[2]: Leaving directory `/netdata/tests'
Making all in backends
make[2]: Entering directory `/netdata/backends'
Making all in graphite
make[3]: Entering directory `/netdata/backends/graphite'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/backends/graphite'
Making all in json
make[3]: Entering directory `/netdata/backends/json'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/backends/json'
Making all in opentsdb
make[3]: Entering directory `/netdata/backends/opentsdb'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/backends/opentsdb'
Making all in prometheus
make[3]: Entering directory `/netdata/backends/prometheus'
Making all in remote_write
make[4]: Entering directory `/netdata/backends/prometheus/remote_write'
make[4]: Nothing to be done for `all'.
make[4]: Leaving directory `/netdata/backends/prometheus/remote_write'
make[4]: Entering directory `/netdata/backends/prometheus'
make[4]: Nothing to be done for `all-am'.
make[4]: Leaving directory `/netdata/backends/prometheus'
make[3]: Leaving directory `/netdata/backends/prometheus'
Making all in aws_kinesis
make[3]: Entering directory `/netdata/backends/aws_kinesis'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/backends/aws_kinesis'
Making all in mongodb
make[3]: Entering directory `/netdata/backends/mongodb'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/backends/mongodb'
make[3]: Entering directory `/netdata/backends'
make[3]: Nothing to be done for `all-am'.
make[3]: Leaving directory `/netdata/backends'
make[2]: Leaving directory `/netdata/backends'
Making all in collectors
make[2]: Entering directory `/netdata/collectors'
Making all in plugins.d
make[3]: Entering directory `/netdata/collectors/plugins.d'
make[4]: Entering directory `/netdata/collectors/plugins.d'
make[4]: Nothing to be done for `all-am'.
make[4]: Leaving directory `/netdata/collectors/plugins.d'
make[3]: Leaving directory `/netdata/collectors/plugins.d'
Making all in apps.plugin
make[3]: Entering directory `/netdata/collectors/apps.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/apps.plugin'
Making all in cgroups.plugin
make[3]: Entering directory `/netdata/collectors/cgroups.plugin'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		cgroup-name.sh.in > cgroup-name.sh.tmp; then \
		mv "cgroup-name.sh.tmp" "cgroup-name.sh"; \
	else \
		rm -f "cgroup-name.sh.tmp"; \
		false; \
	fi
make[3]: Leaving directory `/netdata/collectors/cgroups.plugin'
Making all in charts.d.plugin
make[3]: Entering directory `/netdata/collectors/charts.d.plugin'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		charts.d.plugin.in > charts.d.plugin.tmp; then \
		mv "charts.d.plugin.tmp" "charts.d.plugin"; \
	else \
		rm -f "charts.d.plugin.tmp"; \
		false; \
	fi
make[3]: Leaving directory `/netdata/collectors/charts.d.plugin'
Making all in checks.plugin
make[3]: Entering directory `/netdata/collectors/checks.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/checks.plugin'
Making all in cups.plugin
make[3]: Entering directory `/netdata/collectors/cups.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/cups.plugin'
Making all in diskspace.plugin
make[3]: Entering directory `/netdata/collectors/diskspace.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/diskspace.plugin'
Making all in fping.plugin
make[3]: Entering directory `/netdata/collectors/fping.plugin'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		fping.plugin.in > fping.plugin.tmp; then \
		mv "fping.plugin.tmp" "fping.plugin"; \
	else \
		rm -f "fping.plugin.tmp"; \
		false; \
	fi
make[3]: Leaving directory `/netdata/collectors/fping.plugin'
Making all in ioping.plugin
make[3]: Entering directory `/netdata/collectors/ioping.plugin'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		ioping.plugin.in > ioping.plugin.tmp; then \
		mv "ioping.plugin.tmp" "ioping.plugin"; \
	else \
		rm -f "ioping.plugin.tmp"; \
		false; \
	fi
make[3]: Leaving directory `/netdata/collectors/ioping.plugin'
Making all in freebsd.plugin
make[3]: Entering directory `/netdata/collectors/freebsd.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/freebsd.plugin'
Making all in freeipmi.plugin
make[3]: Entering directory `/netdata/collectors/freeipmi.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/freeipmi.plugin'
Making all in idlejitter.plugin
make[3]: Entering directory `/netdata/collectors/idlejitter.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/idlejitter.plugin'
Making all in macos.plugin
make[3]: Entering directory `/netdata/collectors/macos.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/macos.plugin'
Making all in nfacct.plugin
make[3]: Entering directory `/netdata/collectors/nfacct.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/nfacct.plugin'
Making all in xenstat.plugin
make[3]: Entering directory `/netdata/collectors/xenstat.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/xenstat.plugin'
Making all in perf.plugin
make[3]: Entering directory `/netdata/collectors/perf.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/perf.plugin'
Making all in node.d.plugin
make[3]: Entering directory `/netdata/collectors/node.d.plugin'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		node.d.plugin.in > node.d.plugin.tmp; then \
		mv "node.d.plugin.tmp" "node.d.plugin"; \
	else \
		rm -f "node.d.plugin.tmp"; \
		false; \
	fi
make[3]: Leaving directory `/netdata/collectors/node.d.plugin'
Making all in proc.plugin
make[3]: Entering directory `/netdata/collectors/proc.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/proc.plugin'
Making all in python.d.plugin
make[3]: Entering directory `/netdata/collectors/python.d.plugin'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		python.d.plugin.in > python.d.plugin.tmp; then \
		mv "python.d.plugin.tmp" "python.d.plugin"; \
	else \
		rm -f "python.d.plugin.tmp"; \
		false; \
	fi
make[3]: Leaving directory `/netdata/collectors/python.d.plugin'
Making all in slabinfo.plugin
make[3]: Entering directory `/netdata/collectors/slabinfo.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/slabinfo.plugin'
Making all in statsd.plugin
make[3]: Entering directory `/netdata/collectors/statsd.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/statsd.plugin'
Making all in ebpf_process.plugin
make[3]: Entering directory `/netdata/collectors/ebpf_process.plugin'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/collectors/ebpf_process.plugin'
Making all in tc.plugin
make[3]: Entering directory `/netdata/collectors/tc.plugin'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		tc-qos-helper.sh.in > tc-qos-helper.sh.tmp; then \
		mv "tc-qos-helper.sh.tmp" "tc-qos-helper.sh"; \
	else \
		rm -f "tc-qos-helper.sh.tmp"; \
		false; \
	fi
make[3]: Leaving directory `/netdata/collectors/tc.plugin'
make[3]: Entering directory `/netdata/collectors'
make[3]: Nothing to be done for `all-am'.
make[3]: Leaving directory `/netdata/collectors'
make[2]: Leaving directory `/netdata/collectors'
Making all in daemon
make[2]: Entering directory `/netdata/daemon'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		anonymous-statistics.sh.in > anonymous-statistics.sh.tmp; then \
		mv "anonymous-statistics.sh.tmp" "anonymous-statistics.sh"; \
	else \
		rm -f "anonymous-statistics.sh.tmp"; \
		false; \
	fi
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		get-kubernetes-labels.sh.in > get-kubernetes-labels.sh.tmp; then \
		mv "get-kubernetes-labels.sh.tmp" "get-kubernetes-labels.sh"; \
	else \
		rm -f "get-kubernetes-labels.sh.tmp"; \
		false; \
	fi
make[2]: Leaving directory `/netdata/daemon'
Making all in database
make[2]: Entering directory `/netdata/database'
Making all in engine
make[3]: Entering directory `/netdata/database/engine'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/database/engine'
make[3]: Entering directory `/netdata/database'
make[3]: Nothing to be done for `all-am'.
make[3]: Leaving directory `/netdata/database'
make[2]: Leaving directory `/netdata/database'
Making all in exporting
make[2]: Entering directory `/netdata/exporting'
Making all in tests
make[3]: Entering directory `/netdata/exporting/tests'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/exporting/tests'
Making all in graphite
make[3]: Entering directory `/netdata/exporting/graphite'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/exporting/graphite'
Making all in json
make[3]: Entering directory `/netdata/exporting/json'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/exporting/json'
Making all in opentsdb
make[3]: Entering directory `/netdata/exporting/opentsdb'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/exporting/opentsdb'
Making all in prometheus
make[3]: Entering directory `/netdata/exporting/prometheus'
Making all in remote_write
make[4]: Entering directory `/netdata/exporting/prometheus/remote_write'
make[4]: Nothing to be done for `all'.
make[4]: Leaving directory `/netdata/exporting/prometheus/remote_write'
make[4]: Entering directory `/netdata/exporting/prometheus'
make[4]: Nothing to be done for `all-am'.
make[4]: Leaving directory `/netdata/exporting/prometheus'
make[3]: Leaving directory `/netdata/exporting/prometheus'
Making all in aws_kinesis
make[3]: Entering directory `/netdata/exporting/aws_kinesis'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/exporting/aws_kinesis'
Making all in mongodb
make[3]: Entering directory `/netdata/exporting/mongodb'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/exporting/mongodb'
make[3]: Entering directory `/netdata/exporting'
make[3]: Nothing to be done for `all-am'.
make[3]: Leaving directory `/netdata/exporting'
make[2]: Leaving directory `/netdata/exporting'
Making all in health
make[2]: Entering directory `/netdata/health'
Making all in notifications
make[3]: Entering directory `/netdata/health/notifications'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		alarm-notify.sh.in > alarm-notify.sh.tmp; then \
		mv "alarm-notify.sh.tmp" "alarm-notify.sh"; \
	else \
		rm -f "alarm-notify.sh.tmp"; \
		false; \
	fi
make[3]: Leaving directory `/netdata/health/notifications'
make[3]: Entering directory `/netdata/health'
make[3]: Nothing to be done for `all-am'.
make[3]: Leaving directory `/netdata/health'
make[2]: Leaving directory `/netdata/health'
Making all in libnetdata
make[2]: Entering directory `/netdata/libnetdata'
Making all in adaptive_resortable_list
make[3]: Entering directory `/netdata/libnetdata/adaptive_resortable_list'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/adaptive_resortable_list'
Making all in avl
make[3]: Entering directory `/netdata/libnetdata/avl'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/avl'
Making all in buffer
make[3]: Entering directory `/netdata/libnetdata/buffer'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/buffer'
Making all in clocks
make[3]: Entering directory `/netdata/libnetdata/clocks'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/clocks'
Making all in config
make[3]: Entering directory `/netdata/libnetdata/config'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/config'
Making all in dictionary
make[3]: Entering directory `/netdata/libnetdata/dictionary'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/dictionary'
Making all in ebpf
make[3]: Entering directory `/netdata/libnetdata/ebpf'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/ebpf'
Making all in eval
make[3]: Entering directory `/netdata/libnetdata/eval'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/eval'
Making all in json
make[3]: Entering directory `/netdata/libnetdata/json'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/json'
Making all in health
make[3]: Entering directory `/netdata/libnetdata/health'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/health'
Making all in locks
make[3]: Entering directory `/netdata/libnetdata/locks'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/locks'
Making all in log
make[3]: Entering directory `/netdata/libnetdata/log'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/log'
Making all in popen
make[3]: Entering directory `/netdata/libnetdata/popen'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/popen'
Making all in procfile
make[3]: Entering directory `/netdata/libnetdata/procfile'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/procfile'
Making all in simple_pattern
make[3]: Entering directory `/netdata/libnetdata/simple_pattern'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/simple_pattern'
Making all in socket
make[3]: Entering directory `/netdata/libnetdata/socket'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/socket'
Making all in statistical
make[3]: Entering directory `/netdata/libnetdata/statistical'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/statistical'
Making all in storage_number
make[3]: Entering directory `/netdata/libnetdata/storage_number'
Making all in tests
make[4]: Entering directory `/netdata/libnetdata/storage_number/tests'
make[4]: Nothing to be done for `all'.
make[4]: Leaving directory `/netdata/libnetdata/storage_number/tests'
make[4]: Entering directory `/netdata/libnetdata/storage_number'
make[4]: Nothing to be done for `all-am'.
make[4]: Leaving directory `/netdata/libnetdata/storage_number'
make[3]: Leaving directory `/netdata/libnetdata/storage_number'
Making all in threads
make[3]: Entering directory `/netdata/libnetdata/threads'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/threads'
Making all in url
make[3]: Entering directory `/netdata/libnetdata/url'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/url'
Making all in tests
make[3]: Entering directory `/netdata/libnetdata/tests'
make[3]: Nothing to be done for `all'.
make[3]: Leaving directory `/netdata/libnetdata/tests'
make[3]: Entering directory `/netdata/libnetdata'
make[3]: Nothing to be done for `all-am'.
make[3]: Leaving directory `/netdata/libnetdata'
make[2]: Leaving directory `/netdata/libnetdata'
Making all in registry
make[2]: Entering directory `/netdata/registry'
make[2]: Nothing to be done for `all'.
make[2]: Leaving directory `/netdata/registry'
Making all in streaming
make[2]: Entering directory `/netdata/streaming'
make[2]: Nothing to be done for `all'.
make[2]: Leaving directory `/netdata/streaming'
Making all in web
make[2]: Entering directory `/netdata/web'
Making all in api
make[3]: Entering directory `/netdata/web/api'
Making all in badges
make[4]: Entering directory `/netdata/web/api/badges'
make[4]: Nothing to be done for `all'.
make[4]: Leaving directory `/netdata/web/api/badges'
Making all in queries
make[4]: Entering directory `/netdata/web/api/queries'
Making all in average
make[5]: Entering directory `/netdata/web/api/queries/average'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/queries/average'
Making all in des
make[5]: Entering directory `/netdata/web/api/queries/des'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/queries/des'
Making all in incremental_sum
make[5]: Entering directory `/netdata/web/api/queries/incremental_sum'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/queries/incremental_sum'
Making all in max
make[5]: Entering directory `/netdata/web/api/queries/max'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/queries/max'
Making all in min
make[5]: Entering directory `/netdata/web/api/queries/min'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/queries/min'
Making all in sum
make[5]: Entering directory `/netdata/web/api/queries/sum'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/queries/sum'
Making all in median
make[5]: Entering directory `/netdata/web/api/queries/median'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/queries/median'
Making all in ses
make[5]: Entering directory `/netdata/web/api/queries/ses'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/queries/ses'
Making all in stddev
make[5]: Entering directory `/netdata/web/api/queries/stddev'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/queries/stddev'
make[5]: Entering directory `/netdata/web/api/queries'
make[5]: Nothing to be done for `all-am'.
make[5]: Leaving directory `/netdata/web/api/queries'
make[4]: Leaving directory `/netdata/web/api/queries'
Making all in exporters
make[4]: Entering directory `/netdata/web/api/exporters'
Making all in shell
make[5]: Entering directory `/netdata/web/api/exporters/shell'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/exporters/shell'
Making all in prometheus
make[5]: Entering directory `/netdata/web/api/exporters/prometheus'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/exporters/prometheus'
make[5]: Entering directory `/netdata/web/api/exporters'
make[5]: Nothing to be done for `all-am'.
make[5]: Leaving directory `/netdata/web/api/exporters'
make[4]: Leaving directory `/netdata/web/api/exporters'
Making all in formatters
make[4]: Entering directory `/netdata/web/api/formatters'
Making all in csv
make[5]: Entering directory `/netdata/web/api/formatters/csv'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/formatters/csv'
Making all in json
make[5]: Entering directory `/netdata/web/api/formatters/json'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/formatters/json'
Making all in ssv
make[5]: Entering directory `/netdata/web/api/formatters/ssv'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/formatters/ssv'
Making all in value
make[5]: Entering directory `/netdata/web/api/formatters/value'
make[5]: Nothing to be done for `all'.
make[5]: Leaving directory `/netdata/web/api/formatters/value'
make[5]: Entering directory `/netdata/web/api/formatters'
make[5]: Nothing to be done for `all-am'.
make[5]: Leaving directory `/netdata/web/api/formatters'
make[4]: Leaving directory `/netdata/web/api/formatters'
Making all in health
make[4]: Entering directory `/netdata/web/api/health'
make[4]: Nothing to be done for `all'.
make[4]: Leaving directory `/netdata/web/api/health'
make[4]: Entering directory `/netdata/web/api'
make[4]: Nothing to be done for `all-am'.
make[4]: Leaving directory `/netdata/web/api'
make[3]: Leaving directory `/netdata/web/api'
Making all in gui
make[3]: Entering directory `/netdata/web/gui'
if test -f dashboard.js; then rm -f dashboard.js; fi
if test -d "../../.git"; then \
		git --git-dir="../../.git" log -n 1 --format=%H; \
	fi > version.txt.tmp
cat src/dashboard.js/prologue.js.inc src/dashboard.js/utils.js src/dashboard.js/server-detection.js src/dashboard.js/dependencies.js src/dashboard.js/error-handling.js src/dashboard.js/compatibility.js src/dashboard.js/xss.js src/dashboard.js/colors.js src/dashboard.js/units-conversion.js src/dashboard.js/options.js src/dashboard.js/localstorage.js src/dashboard.js/timeout.js src/dashboard.js/themes.js src/dashboard.js/charting/dygraph.js src/dashboard.js/charting/sparkline.js src/dashboard.js/charting/google-charts.js src/dashboard.js/charting/gauge.js src/dashboard.js/charting/easy-pie-chart.js src/dashboard.js/charting/d3pie.js src/dashboard.js/charting/d3.js src/dashboard.js/charting/peity.js src/dashboard.js/charting/textonly.js src/dashboard.js/charting.js src/dashboard.js/chart-registry.js src/dashboard.js/common.js src/dashboard.js/main.js src/dashboard.js/alarms.js src/dashboard.js/registry.js src/dashboard.js/boot.js src/dashboard.js/epilogue.js.inc  > dashboard.js.tmp && mv dashboard.js.tmp dashboard.js
test -s version.txt.tmp || echo 0 > version.txt.tmp
mv version.txt.tmp version.txt
make[3]: Leaving directory `/netdata/web/gui'
Making all in server
make[3]: Entering directory `/netdata/web/server'
Making all in static
make[4]: Entering directory `/netdata/web/server/static'
make[5]: Entering directory `/netdata/web/server/static'
make[5]: Nothing to be done for `all-am'.
make[5]: Leaving directory `/netdata/web/server/static'
make[4]: Leaving directory `/netdata/web/server/static'
make[4]: Entering directory `/netdata/web/server'
make[4]: Nothing to be done for `all-am'.
make[4]: Leaving directory `/netdata/web/server'
make[3]: Leaving directory `/netdata/web/server'
make[3]: Entering directory `/netdata/web'
make[3]: Nothing to be done for `all-am'.
make[3]: Leaving directory `/netdata/web'
make[2]: Leaving directory `/netdata/web'
Making all in claim
make[2]: Entering directory `/netdata/claim'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		netdata-claim.sh.in > netdata-claim.sh.tmp; then \
		mv "netdata-claim.sh.tmp" "netdata-claim.sh"; \
	else \
		rm -f "netdata-claim.sh.tmp"; \
		false; \
	fi
make[2]: Leaving directory `/netdata/claim'
Making all in aclk
make[2]: Entering directory `/netdata/aclk'
if sed \
		-e 's#[@]localstatedir_POST@#/var#g' \
		-e 's#[@]sbindir_POST@#/usr/sbin#g' \
		-e 's#[@]pluginsdir_POST@#/usr/libexec/netdata/plugins.d#g' \
		-e 's#[@]configdir_POST@#/etc/netdata#g' \
		-e 's#[@]libconfigdir_POST@#/usr/lib/netdata/conf.d#g' \
		-e 's#[@]cachedir_POST@#/var/cache/netdata#g' \
		-e 's#[@]registrydir_POST@#/var/lib/netdata/registry#g' \
		-e 's#[@]varlibdir_POST@#/var/lib/netdata#g' \
		-e 's#[@]webdir_POST@#/usr/share/netdata/web#g' \
		tests/install-fake-charts.d.sh.in > tests/install-fake-charts.d.sh.tmp; then \
		mv "tests/install-fake-charts.d.sh.tmp" "tests/install-fake-charts.d.sh"; \
	else \
		rm -f "tests/install-fake-charts.d.sh.tmp"; \
		false; \
	fi
make[2]: Leaving directory `/netdata/aclk'
make[2]: Entering directory `/netdata'
  CC       libnetdata/json/jsmn.o
  CC       collectors/apps.plugin/apps_plugin.o
  CC       libnetdata/adaptive_resortable_list/adaptive_resortable_list.o
  CC       libnetdata/config/appconfig.o
  CC       libnetdata/avl/avl.o
  CC       libnetdata/buffer/buffer.o
  CC       libnetdata/clocks/clocks.o
  CC       libnetdata/dictionary/dictionary.o
  CC       libnetdata/ebpf/ebpf.o
  CC       libnetdata/eval/eval.o
  CC       libnetdata/libnetdata.o
  CC       libnetdata/locks/locks.o
  CC       libnetdata/log/log.o
  CC       libnetdata/popen/popen.o
  CC       libnetdata/procfile/procfile.o
  CC       libnetdata/os.o
  CC       libnetdata/simple_pattern/simple_pattern.o
  CC       libnetdata/socket/socket.o
  CC       libnetdata/socket/security.o
  CC       libnetdata/statistical/statistical.o
  CC       libnetdata/storage_number/storage_number.o
  CC       libnetdata/threads/threads.o
  CC       libnetdata/url/url.o
  CC       libnetdata/json/json.o
  CC       libnetdata/health/health.o
  CC       collectors/cgroups.plugin/cgroup-network.o
  CC       collectors/ebpf_process.plugin/ebpf_process.o
  CC       collectors/perf.plugin/perf_plugin.o
  CC       collectors/slabinfo.plugin/slabinfo.o
  CC       daemon/common.o
  CC       daemon/daemon.o
  CC       daemon/global_statistics.o
  CC       daemon/main.o
  CC       daemon/signals.o
  CC       daemon/commands.o
  CC       daemon/unit_test.o
  CC       web/api/badges/web_buffer_svg.o
  CC       web/api/exporters/allmetrics.o
  CC       web/api/exporters/shell/allmetrics_shell.o
  CC       web/api/queries/average/average.o
  CC       web/api/queries/des/des.o
  CC       web/api/queries/incremental_sum/incremental_sum.o
  CC       web/api/queries/max/max.o
  CC       web/api/queries/median/median.o
  CC       web/api/queries/min/min.o
  CC       web/api/queries/query.o
  CC       web/api/queries/rrdr.o
  CC       web/api/queries/ses/ses.o
  CC       web/api/queries/stddev/stddev.o
  CC       web/api/queries/sum/sum.o
  CC       web/api/formatters/rrd2json.o
  CC       web/api/formatters/csv/csv.o
  CC       web/api/formatters/json/json.o
  CC       web/api/formatters/ssv/ssv.o
  CC       web/api/formatters/value/value.o
  CC       web/api/formatters/json_wrapper.o
  CC       web/api/formatters/charts2json.o
  CC       web/api/formatters/rrdset2json.o
  CC       web/api/health/health_cmdapi.o
  CC       web/api/web_api_v1.o
  CC       backends/backends.o
  CC       backends/graphite/graphite.o
  CC       backends/json/json.o
  CC       backends/opentsdb/opentsdb.o
  CC       backends/prometheus/backend_prometheus.o
  CC       exporting/exporting_engine.o
  CC       exporting/graphite/graphite.o
  CC       exporting/json/json.o
  CC       exporting/opentsdb/opentsdb.o
  CC       exporting/prometheus/prometheus.o
  CC       exporting/read_config.o
  CC       exporting/init_connectors.o
  CC       exporting/process_data.o
  CC       exporting/check_filters.o
  CC       exporting/send_data.o
  CC       exporting/send_internal_metrics.o
  CC       collectors/checks.plugin/plugin_checks.o
  CC       health/health.o
  CC       health/health_config.o
  CC       health/health_json.o
  CC       health/health_log.o
  CC       collectors/idlejitter.plugin/plugin_idlejitter.o
  CC       collectors/plugins.d/plugins_d.o
  CC       registry/registry.o
  CC       registry/registry_db.o
  CC       registry/registry_init.o
  CC       registry/registry_internals.o
  CC       registry/registry_log.o
  CC       registry/registry_machine.o
  CC       registry/registry_person.o
  CC       registry/registry_url.o
  CC       database/rrdcalc.o
  CC       database/rrdcalctemplate.o
  CC       database/rrddim.o
  CC       database/rrddimvar.o
  CC       database/rrdfamily.o
  CC       database/rrdhost.o
  CC       database/rrd.o
  CC       database/rrdset.o
  CC       database/rrdsetvar.o
  CC       database/rrdvar.o
  CC       streaming/rrdpush.o
  CC       collectors/statsd.plugin/statsd.o
  CC       web/server/web_client.o
  CC       web/server/web_server.o
  CC       web/server/web_client_cache.o
  CC       web/server/static/static-threaded.o
  CC       claim/claim.o
  CC       aclk/aclk_common.o
  CC       aclk/agent_cloud_link.o
  CC       aclk/mqtt.o
  CC       aclk/aclk_lws_wss_client.o
  CC       aclk/aclk_lws_https_client.o
  CC       collectors/cgroups.plugin/sys_fs_cgroup.o
  CC       collectors/diskspace.plugin/plugin_diskspace.o
  CC       collectors/proc.plugin/ipc.o
  CC       collectors/proc.plugin/plugin_proc.o
  CC       collectors/proc.plugin/proc_diskstats.o
  CC       collectors/proc.plugin/proc_mdstat.o
  CC       collectors/proc.plugin/proc_interrupts.o
  CC       collectors/proc.plugin/proc_softirqs.o
  CC       collectors/proc.plugin/proc_loadavg.o
  CC       collectors/proc.plugin/proc_meminfo.o
  CC       collectors/proc.plugin/proc_pagetypeinfo.o
  CC       collectors/proc.plugin/proc_pressure.o
  CC       collectors/proc.plugin/proc_net_dev.o
  CC       collectors/proc.plugin/proc_net_ip_vs_stats.o
  CC       collectors/proc.plugin/proc_net_netstat.o
  CC       collectors/proc.plugin/proc_net_rpc_nfs.o
  CC       collectors/proc.plugin/proc_net_rpc_nfsd.o
  CC       collectors/proc.plugin/proc_net_snmp.o
  CC       collectors/proc.plugin/proc_net_snmp6.o
  CC       collectors/proc.plugin/proc_net_sctp_snmp.o
  CC       collectors/proc.plugin/proc_net_sockstat.o
  CC       collectors/proc.plugin/proc_net_sockstat6.o
  CC       collectors/proc.plugin/proc_net_softnet_stat.o
  CC       collectors/proc.plugin/proc_net_stat_conntrack.o
  CC       collectors/proc.plugin/proc_net_stat_synproxy.o
  CC       collectors/proc.plugin/proc_self_mountinfo.o
  CC       collectors/proc.plugin/zfs_common.o
  CC       collectors/proc.plugin/proc_spl_kstat_zfs.o
  CC       collectors/proc.plugin/proc_stat.o
  CC       collectors/proc.plugin/proc_sys_kernel_random_entropy_avail.o
  CC       collectors/proc.plugin/proc_vmstat.o
  CC       collectors/proc.plugin/proc_uptime.o
  CC       collectors/proc.plugin/sys_kernel_mm_ksm.o
  CC       collectors/proc.plugin/sys_block_zram.o
  CC       collectors/proc.plugin/sys_devices_system_edac_mc.o
  CC       collectors/proc.plugin/sys_devices_system_node.o
  CC       collectors/proc.plugin/sys_fs_btrfs.o
  CC       collectors/proc.plugin/sys_class_power_supply.o
  CC       collectors/tc.plugin/plugin_tc.o
  CC       cli/cli.o
  CCLD     apps.plugin
  CCLD     cgroup-network
  CCLD     ebpf_process.plugin
  CCLD     perf.plugin
  CCLD     slabinfo.plugin
  GEN      netdatacli
  GEN      netdata
collectors/perf.plugin/perf_plugin.o (symbol from plugin): warning: memset used with constant zero length parameter; this could be due to transposed parameters
/usr/include/x86_64-linux-gnu/bits/poll2.h: In function 'rrdpush_sender_thread':
/usr/include/x86_64-linux-gnu/bits/poll2.h:41:2: warning: call to '__poll_chk_warn' declared with attribute warning: poll called with fds buffer too small file nfds entries [enabled by default]
  return __poll_chk (__fds, __nfds, __timeout, __bos (__fds));
  ^
make[2]: Leaving directory `/netdata'
make[1]: Leaving directory `/netdata'
 OK

 --- Migrate configuration files for node.d.plugin and charts.d.plugin ---
 --- Backup existing netdata configuration before installing it ---
find: `/etc/netdata': No such file or directory
touch: cannot touch '/etc/netdata/.installer-cleanup-of-stock-configs-done': No such file or directory
 --- Install netdata ---
[/netdata]# make install
make  install-recursive
make[1]: Entering directory `/netdata'
Making install in diagrams
make[2]: Entering directory `/netdata/diagrams'
make[3]: Entering directory `/netdata/diagrams'
make[3]: Nothing to be done for `install-exec-am'.
make[3]: Nothing to be done for `install-data-am'.
make[3]: Leaving directory `/netdata/diagrams'
make[2]: Leaving directory `/netdata/diagrams'
Making install in system
make[2]: Entering directory `/netdata/system'
make[3]: Entering directory `/netdata/system'
/usr/bin/install -c -d /etc/netdata
 /bin/mkdir -p '/etc/netdata'
 /usr/bin/install -c edit-config '/etc/netdata'
make[3]: Leaving directory `/netdata/system'
make[2]: Leaving directory `/netdata/system'
Making install in tests
make[2]: Entering directory `/netdata/tests'
make[3]: Entering directory `/netdata/tests'
make[3]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c health_mgmtapi/health-cmdapi-test.sh acls/acl.sh urls/request.sh alarm_repetition/alarm.sh template_dimension/template_dim.sh '/usr/libexec/netdata/plugins.d'
make[3]: Leaving directory `/netdata/tests'
make[2]: Leaving directory `/netdata/tests'
Making install in backends
make[2]: Entering directory `/netdata/backends'
Making install in graphite
make[3]: Entering directory `/netdata/backends/graphite'
make[4]: Entering directory `/netdata/backends/graphite'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/backends/graphite'
make[3]: Leaving directory `/netdata/backends/graphite'
Making install in json
make[3]: Entering directory `/netdata/backends/json'
make[4]: Entering directory `/netdata/backends/json'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/backends/json'
make[3]: Leaving directory `/netdata/backends/json'
Making install in opentsdb
make[3]: Entering directory `/netdata/backends/opentsdb'
make[4]: Entering directory `/netdata/backends/opentsdb'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/backends/opentsdb'
make[3]: Leaving directory `/netdata/backends/opentsdb'
Making install in prometheus
make[3]: Entering directory `/netdata/backends/prometheus'
Making install in remote_write
make[4]: Entering directory `/netdata/backends/prometheus/remote_write'
make[5]: Entering directory `/netdata/backends/prometheus/remote_write'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/backends/prometheus/remote_write'
make[4]: Leaving directory `/netdata/backends/prometheus/remote_write'
make[4]: Entering directory `/netdata/backends/prometheus'
make[5]: Entering directory `/netdata/backends/prometheus'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/backends/prometheus'
make[4]: Leaving directory `/netdata/backends/prometheus'
make[3]: Leaving directory `/netdata/backends/prometheus'
Making install in aws_kinesis
make[3]: Entering directory `/netdata/backends/aws_kinesis'
make[4]: Entering directory `/netdata/backends/aws_kinesis'
make[4]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 aws_kinesis.conf '/usr/lib/netdata/conf.d'
make[4]: Leaving directory `/netdata/backends/aws_kinesis'
make[3]: Leaving directory `/netdata/backends/aws_kinesis'
Making install in mongodb
make[3]: Entering directory `/netdata/backends/mongodb'
make[4]: Entering directory `/netdata/backends/mongodb'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/backends/mongodb'
make[3]: Leaving directory `/netdata/backends/mongodb'
make[3]: Entering directory `/netdata/backends'
make[4]: Entering directory `/netdata/backends'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/backends'
make[3]: Leaving directory `/netdata/backends'
make[2]: Leaving directory `/netdata/backends'
Making install in collectors
make[2]: Entering directory `/netdata/collectors'
Making install in plugins.d
make[3]: Entering directory `/netdata/collectors/plugins.d'
make[4]: Entering directory `/netdata/collectors/plugins.d'
make[5]: Entering directory `/netdata/collectors/plugins.d'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/collectors/plugins.d'
make[4]: Leaving directory `/netdata/collectors/plugins.d'
make[3]: Leaving directory `/netdata/collectors/plugins.d'
Making install in apps.plugin
make[3]: Entering directory `/netdata/collectors/apps.plugin'
make[4]: Entering directory `/netdata/collectors/apps.plugin'
make[4]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 apps_groups.conf '/usr/lib/netdata/conf.d'
make[4]: Leaving directory `/netdata/collectors/apps.plugin'
make[3]: Leaving directory `/netdata/collectors/apps.plugin'
Making install in cgroups.plugin
make[3]: Entering directory `/netdata/collectors/cgroups.plugin'
make[4]: Entering directory `/netdata/collectors/cgroups.plugin'
make[4]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c cgroup-name.sh cgroup-network-helper.sh '/usr/libexec/netdata/plugins.d'
make[4]: Leaving directory `/netdata/collectors/cgroups.plugin'
make[3]: Leaving directory `/netdata/collectors/cgroups.plugin'
Making install in charts.d.plugin
make[3]: Entering directory `/netdata/collectors/charts.d.plugin'
make[4]: Entering directory `/netdata/collectors/charts.d.plugin'
/usr/bin/install -c -d /etc/netdata/charts.d
 /bin/mkdir -p '/usr/libexec/netdata/charts.d'
 /usr/bin/install -c -m 644 ap/ap.chart.sh apcupsd/apcupsd.chart.sh example/example.chart.sh libreswan/libreswan.chart.sh nut/nut.chart.sh opensips/opensips.chart.sh sensors/sensors.chart.sh '/usr/libexec/netdata/charts.d'
 /bin/mkdir -p '/usr/lib/netdata/conf.d/charts.d'
 /usr/bin/install -c -m 644 ap/ap.conf apcupsd/apcupsd.conf example/example.conf libreswan/libreswan.conf nut/nut.conf opensips/opensips.conf sensors/sensors.conf '/usr/lib/netdata/conf.d/charts.d'
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 charts.d.conf '/usr/lib/netdata/conf.d'
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c charts.d.dryrun-helper.sh charts.d.plugin loopsleepms.sh.inc '/usr/libexec/netdata/plugins.d'
make[4]: Leaving directory `/netdata/collectors/charts.d.plugin'
make[3]: Leaving directory `/netdata/collectors/charts.d.plugin'
Making install in checks.plugin
make[3]: Entering directory `/netdata/collectors/checks.plugin'
make[4]: Entering directory `/netdata/collectors/checks.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/checks.plugin'
make[3]: Leaving directory `/netdata/collectors/checks.plugin'
Making install in cups.plugin
make[3]: Entering directory `/netdata/collectors/cups.plugin'
make[4]: Entering directory `/netdata/collectors/cups.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/cups.plugin'
make[3]: Leaving directory `/netdata/collectors/cups.plugin'
Making install in diskspace.plugin
make[3]: Entering directory `/netdata/collectors/diskspace.plugin'
make[4]: Entering directory `/netdata/collectors/diskspace.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/diskspace.plugin'
make[3]: Leaving directory `/netdata/collectors/diskspace.plugin'
Making install in fping.plugin
make[3]: Entering directory `/netdata/collectors/fping.plugin'
make[4]: Entering directory `/netdata/collectors/fping.plugin'
make[4]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 fping.conf '/usr/lib/netdata/conf.d'
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c fping.plugin '/usr/libexec/netdata/plugins.d'
make[4]: Leaving directory `/netdata/collectors/fping.plugin'
make[3]: Leaving directory `/netdata/collectors/fping.plugin'
Making install in ioping.plugin
make[3]: Entering directory `/netdata/collectors/ioping.plugin'
make[4]: Entering directory `/netdata/collectors/ioping.plugin'
make[4]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 ioping.conf '/usr/lib/netdata/conf.d'
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c ioping.plugin '/usr/libexec/netdata/plugins.d'
make[4]: Leaving directory `/netdata/collectors/ioping.plugin'
make[3]: Leaving directory `/netdata/collectors/ioping.plugin'
Making install in freebsd.plugin
make[3]: Entering directory `/netdata/collectors/freebsd.plugin'
make[4]: Entering directory `/netdata/collectors/freebsd.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/freebsd.plugin'
make[3]: Leaving directory `/netdata/collectors/freebsd.plugin'
Making install in freeipmi.plugin
make[3]: Entering directory `/netdata/collectors/freeipmi.plugin'
make[4]: Entering directory `/netdata/collectors/freeipmi.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/freeipmi.plugin'
make[3]: Leaving directory `/netdata/collectors/freeipmi.plugin'
Making install in idlejitter.plugin
make[3]: Entering directory `/netdata/collectors/idlejitter.plugin'
make[4]: Entering directory `/netdata/collectors/idlejitter.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/idlejitter.plugin'
make[3]: Leaving directory `/netdata/collectors/idlejitter.plugin'
Making install in macos.plugin
make[3]: Entering directory `/netdata/collectors/macos.plugin'
make[4]: Entering directory `/netdata/collectors/macos.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/macos.plugin'
make[3]: Leaving directory `/netdata/collectors/macos.plugin'
Making install in nfacct.plugin
make[3]: Entering directory `/netdata/collectors/nfacct.plugin'
make[4]: Entering directory `/netdata/collectors/nfacct.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/nfacct.plugin'
make[3]: Leaving directory `/netdata/collectors/nfacct.plugin'
Making install in xenstat.plugin
make[3]: Entering directory `/netdata/collectors/xenstat.plugin'
make[4]: Entering directory `/netdata/collectors/xenstat.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/xenstat.plugin'
make[3]: Leaving directory `/netdata/collectors/xenstat.plugin'
Making install in perf.plugin
make[3]: Entering directory `/netdata/collectors/perf.plugin'
make[4]: Entering directory `/netdata/collectors/perf.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/perf.plugin'
make[3]: Leaving directory `/netdata/collectors/perf.plugin'
Making install in node.d.plugin
make[3]: Entering directory `/netdata/collectors/node.d.plugin'
make[4]: Entering directory `/netdata/collectors/node.d.plugin'
/usr/bin/install -c -d /etc/netdata/node.d
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 node.d.conf '/usr/lib/netdata/conf.d'
 /bin/mkdir -p '/usr/libexec/netdata/node.d'
 /usr/bin/install -c -m 644 fronius/fronius.node.js named/named.node.js sma_webbox/sma_webbox.node.js snmp/snmp.node.js stiebeleltron/stiebeleltron.node.js '/usr/libexec/netdata/node.d'
 /bin/mkdir -p '/usr/libexec/netdata/node.d/node_modules'
 /usr/bin/install -c -m 644 node_modules/netdata.js node_modules/extend.js node_modules/pixl-xml.js node_modules/net-snmp.js node_modules/asn1-ber.js '/usr/libexec/netdata/node.d/node_modules'
 /bin/mkdir -p '/usr/libexec/netdata/node.d/node_modules/lib/ber'
 /usr/bin/install -c -m 644 node_modules/lib/ber/index.js node_modules/lib/ber/errors.js node_modules/lib/ber/reader.js node_modules/lib/ber/types.js node_modules/lib/ber/writer.js '/usr/libexec/netdata/node.d/node_modules/lib/ber'
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c node.d.plugin '/usr/libexec/netdata/plugins.d'
make[4]: Leaving directory `/netdata/collectors/node.d.plugin'
make[3]: Leaving directory `/netdata/collectors/node.d.plugin'
Making install in proc.plugin
make[3]: Entering directory `/netdata/collectors/proc.plugin'
make[4]: Entering directory `/netdata/collectors/proc.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/proc.plugin'
make[3]: Leaving directory `/netdata/collectors/proc.plugin'
Making install in python.d.plugin
make[3]: Entering directory `/netdata/collectors/python.d.plugin'
make[4]: Entering directory `/netdata/collectors/python.d.plugin'
/usr/bin/install -c -d /etc/netdata/python.d
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/bases'
 /usr/bin/install -c -m 644 python_modules/bases/__init__.py python_modules/bases/charts.py python_modules/bases/collection.py python_modules/bases/loaders.py python_modules/bases/loggers.py '/usr/libexec/netdata/python.d/python_modules/bases'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/bases/FrameworkServices'
 /usr/bin/install -c -m 644 python_modules/bases/FrameworkServices/__init__.py python_modules/bases/FrameworkServices/ExecutableService.py python_modules/bases/FrameworkServices/LogService.py python_modules/bases/FrameworkServices/MySQLService.py python_modules/bases/FrameworkServices/SimpleService.py python_modules/bases/FrameworkServices/SocketService.py python_modules/bases/FrameworkServices/UrlService.py '/usr/libexec/netdata/python.d/python_modules/bases/FrameworkServices'
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 python.d.conf '/usr/lib/netdata/conf.d'
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c python.d.plugin '/usr/libexec/netdata/plugins.d'
 /bin/mkdir -p '/usr/libexec/netdata/python.d'
 /usr/bin/install -c -m 644 adaptec_raid/adaptec_raid.chart.py am2320/am2320.chart.py apache/apache.chart.py beanstalk/beanstalk.chart.py bind_rndc/bind_rndc.chart.py boinc/boinc.chart.py ceph/ceph.chart.py chrony/chrony.chart.py couchdb/couchdb.chart.py dnsdist/dnsdist.chart.py dns_query_time/dns_query_time.chart.py dockerd/dockerd.chart.py dovecot/dovecot.chart.py elasticsearch/elasticsearch.chart.py energid/energid.chart.py example/example.chart.py exim/exim.chart.py fail2ban/fail2ban.chart.py freeradius/freeradius.chart.py gearman/gearman.chart.py go_expvar/go_expvar.chart.py haproxy/haproxy.chart.py hddtemp/hddtemp.chart.py httpcheck/httpcheck.chart.py hpssa/hpssa.chart.py icecast/icecast.chart.py ipfs/ipfs.chart.py isc_dhcpd/isc_dhcpd.chart.py litespeed/litespeed.chart.py logind/logind.chart.py megacli/megacli.chart.py memcached/memcached.chart.py mongodb/mongodb.chart.py monit/monit.chart.py mysql/mysql.chart.py nginx/nginx.chart.py nginx_plus/nginx_plus.chart.py nvidia_smi/nvidia_smi.chart.py nsd/nsd.chart.py ntpd/ntpd.chart.py '/usr/libexec/netdata/python.d'
 /usr/bin/install -c -m 644 ovpn_status_log/ovpn_status_log.chart.py openldap/openldap.chart.py oracledb/oracledb.chart.py phpfpm/phpfpm.chart.py portcheck/portcheck.chart.py postfix/postfix.chart.py postgres/postgres.chart.py powerdns/powerdns.chart.py proxysql/proxysql.chart.py puppet/puppet.chart.py rabbitmq/rabbitmq.chart.py redis/redis.chart.py rethinkdbs/rethinkdbs.chart.py retroshare/retroshare.chart.py riakkv/riakkv.chart.py samba/samba.chart.py sensors/sensors.chart.py smartd_log/smartd_log.chart.py spigotmc/spigotmc.chart.py springboot/springboot.chart.py squid/squid.chart.py tomcat/tomcat.chart.py tor/tor.chart.py traefik/traefik.chart.py uwsgi/uwsgi.chart.py varnish/varnish.chart.py w1sensor/w1sensor.chart.py web_log/web_log.chart.py '/usr/libexec/netdata/python.d'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/urllib3'
 /usr/bin/install -c -m 644 python_modules/urllib3/__init__.py python_modules/urllib3/_collections.py python_modules/urllib3/connection.py python_modules/urllib3/connectionpool.py python_modules/urllib3/exceptions.py python_modules/urllib3/fields.py python_modules/urllib3/filepost.py python_modules/urllib3/response.py python_modules/urllib3/poolmanager.py python_modules/urllib3/request.py '/usr/libexec/netdata/python.d/python_modules/urllib3'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/urllib3/packages/backports'
 /usr/bin/install -c -m 644 python_modules/urllib3/packages/backports/__init__.py python_modules/urllib3/packages/backports/makefile.py '/usr/libexec/netdata/python.d/python_modules/urllib3/packages/backports'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/urllib3/contrib'
 /usr/bin/install -c -m 644 python_modules/urllib3/contrib/__init__.py python_modules/urllib3/contrib/appengine.py python_modules/urllib3/contrib/ntlmpool.py python_modules/urllib3/contrib/pyopenssl.py python_modules/urllib3/contrib/securetransport.py python_modules/urllib3/contrib/socks.py '/usr/libexec/netdata/python.d/python_modules/urllib3/contrib'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/urllib3/packages'
 /usr/bin/install -c -m 644 python_modules/urllib3/packages/__init__.py python_modules/urllib3/packages/ordered_dict.py python_modules/urllib3/packages/six.py '/usr/libexec/netdata/python.d/python_modules/urllib3/packages'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/urllib3/contrib/_securetransport'
 /usr/bin/install -c -m 644 python_modules/urllib3/contrib/_securetransport/__init__.py python_modules/urllib3/contrib/_securetransport/bindings.py python_modules/urllib3/contrib/_securetransport/low_level.py '/usr/libexec/netdata/python.d/python_modules/urllib3/contrib/_securetransport'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/urllib3/packages/ssl_match_hostname'
 /usr/bin/install -c -m 644 python_modules/urllib3/packages/ssl_match_hostname/__init__.py python_modules/urllib3/packages/ssl_match_hostname/_implementation.py '/usr/libexec/netdata/python.d/python_modules/urllib3/packages/ssl_match_hostname'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/urllib3/util'
 /usr/bin/install -c -m 644 python_modules/urllib3/util/__init__.py python_modules/urllib3/util/connection.py python_modules/urllib3/util/request.py python_modules/urllib3/util/response.py python_modules/urllib3/util/retry.py python_modules/urllib3/util/selectors.py python_modules/urllib3/util/ssl_.py python_modules/urllib3/util/timeout.py python_modules/urllib3/util/url.py python_modules/urllib3/util/wait.py '/usr/libexec/netdata/python.d/python_modules/urllib3/util'
 /bin/mkdir -p '/usr/lib/netdata/conf.d/python.d'
 /usr/bin/install -c -m 644 adaptec_raid/adaptec_raid.conf am2320/am2320.conf apache/apache.conf beanstalk/beanstalk.conf bind_rndc/bind_rndc.conf boinc/boinc.conf ceph/ceph.conf chrony/chrony.conf couchdb/couchdb.conf dnsdist/dnsdist.conf dns_query_time/dns_query_time.conf dockerd/dockerd.conf dovecot/dovecot.conf elasticsearch/elasticsearch.conf energid/energid.conf example/example.conf exim/exim.conf fail2ban/fail2ban.conf freeradius/freeradius.conf gearman/gearman.conf go_expvar/go_expvar.conf haproxy/haproxy.conf hddtemp/hddtemp.conf httpcheck/httpcheck.conf hpssa/hpssa.conf icecast/icecast.conf ipfs/ipfs.conf isc_dhcpd/isc_dhcpd.conf litespeed/litespeed.conf logind/logind.conf megacli/megacli.conf memcached/memcached.conf mongodb/mongodb.conf monit/monit.conf mysql/mysql.conf nginx/nginx.conf nginx_plus/nginx_plus.conf nvidia_smi/nvidia_smi.conf nsd/nsd.conf ntpd/ntpd.conf '/usr/lib/netdata/conf.d/python.d'
 /usr/bin/install -c -m 644 ovpn_status_log/ovpn_status_log.conf openldap/openldap.conf oracledb/oracledb.conf phpfpm/phpfpm.conf portcheck/portcheck.conf postfix/postfix.conf postgres/postgres.conf powerdns/powerdns.conf proxysql/proxysql.conf puppet/puppet.conf rabbitmq/rabbitmq.conf redis/redis.conf rethinkdbs/rethinkdbs.conf retroshare/retroshare.conf riakkv/riakkv.conf samba/samba.conf sensors/sensors.conf smartd_log/smartd_log.conf spigotmc/spigotmc.conf springboot/springboot.conf squid/squid.conf tomcat/tomcat.conf tor/tor.conf traefik/traefik.conf uwsgi/uwsgi.conf varnish/varnish.conf w1sensor/w1sensor.conf web_log/web_log.conf '/usr/lib/netdata/conf.d/python.d'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules'
 /usr/bin/install -c -m 644 python_modules/__init__.py '/usr/libexec/netdata/python.d/python_modules'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/pyyaml2'
 /usr/bin/install -c -m 644 python_modules/pyyaml2/__init__.py python_modules/pyyaml2/composer.py python_modules/pyyaml2/constructor.py python_modules/pyyaml2/cyaml.py python_modules/pyyaml2/dumper.py python_modules/pyyaml2/emitter.py python_modules/pyyaml2/error.py python_modules/pyyaml2/events.py python_modules/pyyaml2/loader.py python_modules/pyyaml2/nodes.py python_modules/pyyaml2/parser.py python_modules/pyyaml2/reader.py python_modules/pyyaml2/representer.py python_modules/pyyaml2/resolver.py python_modules/pyyaml2/scanner.py python_modules/pyyaml2/serializer.py python_modules/pyyaml2/tokens.py '/usr/libexec/netdata/python.d/python_modules/pyyaml2'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/pyyaml3'
 /usr/bin/install -c -m 644 python_modules/pyyaml3/__init__.py python_modules/pyyaml3/composer.py python_modules/pyyaml3/constructor.py python_modules/pyyaml3/cyaml.py python_modules/pyyaml3/dumper.py python_modules/pyyaml3/emitter.py python_modules/pyyaml3/error.py python_modules/pyyaml3/events.py python_modules/pyyaml3/loader.py python_modules/pyyaml3/nodes.py python_modules/pyyaml3/parser.py python_modules/pyyaml3/reader.py python_modules/pyyaml3/representer.py python_modules/pyyaml3/resolver.py python_modules/pyyaml3/scanner.py python_modules/pyyaml3/serializer.py python_modules/pyyaml3/tokens.py '/usr/libexec/netdata/python.d/python_modules/pyyaml3'
 /bin/mkdir -p '/usr/libexec/netdata/python.d/python_modules/third_party'
 /usr/bin/install -c -m 644 python_modules/third_party/__init__.py python_modules/third_party/ordereddict.py python_modules/third_party/lm_sensors.py python_modules/third_party/mcrcon.py python_modules/third_party/boinc_client.py python_modules/third_party/monotonic.py '/usr/libexec/netdata/python.d/python_modules/third_party'
make[4]: Leaving directory `/netdata/collectors/python.d.plugin'
make[3]: Leaving directory `/netdata/collectors/python.d.plugin'
Making install in slabinfo.plugin
make[3]: Entering directory `/netdata/collectors/slabinfo.plugin'
make[4]: Entering directory `/netdata/collectors/slabinfo.plugin'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors/slabinfo.plugin'
make[3]: Leaving directory `/netdata/collectors/slabinfo.plugin'
Making install in statsd.plugin
make[3]: Entering directory `/netdata/collectors/statsd.plugin'
make[4]: Entering directory `/netdata/collectors/statsd.plugin'
/usr/bin/install -c -d /etc/netdata/statsd.d
 /bin/mkdir -p '/usr/lib/netdata/conf.d/statsd.d'
 /usr/bin/install -c -m 644 example.conf '/usr/lib/netdata/conf.d/statsd.d'
make[4]: Leaving directory `/netdata/collectors/statsd.plugin'
make[3]: Leaving directory `/netdata/collectors/statsd.plugin'
Making install in ebpf_process.plugin
make[3]: Entering directory `/netdata/collectors/ebpf_process.plugin'
make[4]: Entering directory `/netdata/collectors/ebpf_process.plugin'
make[4]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 ebpf_process.conf '/usr/lib/netdata/conf.d'
make[4]: Leaving directory `/netdata/collectors/ebpf_process.plugin'
make[3]: Leaving directory `/netdata/collectors/ebpf_process.plugin'
Making install in tc.plugin
make[3]: Entering directory `/netdata/collectors/tc.plugin'
make[4]: Entering directory `/netdata/collectors/tc.plugin'
make[4]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c tc-qos-helper.sh '/usr/libexec/netdata/plugins.d'
make[4]: Leaving directory `/netdata/collectors/tc.plugin'
make[3]: Leaving directory `/netdata/collectors/tc.plugin'
make[3]: Entering directory `/netdata/collectors'
make[4]: Entering directory `/netdata/collectors'
/usr/bin/install -c -d /etc/netdata/custom-plugins.d
/usr/bin/install -c -d /etc/netdata/go.d
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/collectors'
make[3]: Leaving directory `/netdata/collectors'
make[2]: Leaving directory `/netdata/collectors'
Making install in daemon
make[2]: Entering directory `/netdata/daemon'
make[3]: Entering directory `/netdata/daemon'
make[3]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c anonymous-statistics.sh system-info.sh get-kubernetes-labels.sh '/usr/libexec/netdata/plugins.d'
make[3]: Leaving directory `/netdata/daemon'
make[2]: Leaving directory `/netdata/daemon'
Making install in database
make[2]: Entering directory `/netdata/database'
Making install in engine
make[3]: Entering directory `/netdata/database/engine'
make[4]: Entering directory `/netdata/database/engine'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/database/engine'
make[3]: Leaving directory `/netdata/database/engine'
make[3]: Entering directory `/netdata/database'
make[4]: Entering directory `/netdata/database'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/database'
make[3]: Leaving directory `/netdata/database'
make[2]: Leaving directory `/netdata/database'
Making install in exporting
make[2]: Entering directory `/netdata/exporting'
Making install in tests
make[3]: Entering directory `/netdata/exporting/tests'
make[4]: Entering directory `/netdata/exporting/tests'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/exporting/tests'
make[3]: Leaving directory `/netdata/exporting/tests'
Making install in graphite
make[3]: Entering directory `/netdata/exporting/graphite'
make[4]: Entering directory `/netdata/exporting/graphite'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/exporting/graphite'
make[3]: Leaving directory `/netdata/exporting/graphite'
Making install in json
make[3]: Entering directory `/netdata/exporting/json'
make[4]: Entering directory `/netdata/exporting/json'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/exporting/json'
make[3]: Leaving directory `/netdata/exporting/json'
Making install in opentsdb
make[3]: Entering directory `/netdata/exporting/opentsdb'
make[4]: Entering directory `/netdata/exporting/opentsdb'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/exporting/opentsdb'
make[3]: Leaving directory `/netdata/exporting/opentsdb'
Making install in prometheus
make[3]: Entering directory `/netdata/exporting/prometheus'
Making install in remote_write
make[4]: Entering directory `/netdata/exporting/prometheus/remote_write'
make[5]: Entering directory `/netdata/exporting/prometheus/remote_write'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/exporting/prometheus/remote_write'
make[4]: Leaving directory `/netdata/exporting/prometheus/remote_write'
make[4]: Entering directory `/netdata/exporting/prometheus'
make[5]: Entering directory `/netdata/exporting/prometheus'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/exporting/prometheus'
make[4]: Leaving directory `/netdata/exporting/prometheus'
make[3]: Leaving directory `/netdata/exporting/prometheus'
Making install in aws_kinesis
make[3]: Entering directory `/netdata/exporting/aws_kinesis'
make[4]: Entering directory `/netdata/exporting/aws_kinesis'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/exporting/aws_kinesis'
make[3]: Leaving directory `/netdata/exporting/aws_kinesis'
Making install in mongodb
make[3]: Entering directory `/netdata/exporting/mongodb'
make[4]: Entering directory `/netdata/exporting/mongodb'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/exporting/mongodb'
make[3]: Leaving directory `/netdata/exporting/mongodb'
make[3]: Entering directory `/netdata/exporting'
make[4]: Entering directory `/netdata/exporting'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/exporting'
make[3]: Leaving directory `/netdata/exporting'
make[2]: Leaving directory `/netdata/exporting'
Making install in health
make[2]: Entering directory `/netdata/health'
Making install in notifications
make[3]: Entering directory `/netdata/health/notifications'
make[4]: Entering directory `/netdata/health/notifications'
make[4]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 health_alarm_notify.conf health_email_recipients.conf '/usr/lib/netdata/conf.d'
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
 /usr/bin/install -c alarm-notify.sh alarm-email.sh alarm-test.sh '/usr/libexec/netdata/plugins.d'
make[4]: Leaving directory `/netdata/health/notifications'
make[3]: Leaving directory `/netdata/health/notifications'
make[3]: Entering directory `/netdata/health'
make[4]: Entering directory `/netdata/health'
/usr/bin/install -c -d /etc/netdata/health.d
 /bin/mkdir -p '/usr/lib/netdata/conf.d/health.d'
 /usr/bin/install -c -m 644 health.d/adaptec_raid.conf health.d/am2320.conf health.d/apache.conf health.d/apcupsd.conf health.d/backend.conf health.d/bcache.conf health.d/beanstalkd.conf health.d/bind_rndc.conf health.d/boinc.conf health.d/btrfs.conf health.d/ceph.conf health.d/cgroups.conf health.d/cpu.conf health.d/cockroachdb.conf health.d/couchdb.conf health.d/disks.conf health.d/dnsmasq_dhcp.conf health.d/dns_query.conf health.d/dockerd.conf health.d/elasticsearch.conf health.d/entropy.conf health.d/fping.conf health.d/ioping.conf health.d/fronius.conf health.d/gearman.conf health.d/haproxy.conf health.d/hdfs.conf health.d/httpcheck.conf health.d/ipc.conf health.d/ipfs.conf health.d/ipmi.conf health.d/isc_dhcpd.conf health.d/kubelet.conf health.d/lighttpd.conf health.d/linux_power_supply.conf health.d/load.conf health.d/mdstat.conf health.d/megacli.conf health.d/memcached.conf health.d/memory.conf '/usr/lib/netdata/conf.d/health.d'
 /usr/bin/install -c -m 644 health.d/mongodb.conf health.d/mysql.conf health.d/named.conf health.d/net.conf health.d/netfilter.conf health.d/nginx.conf health.d/nginx_plus.conf health.d/pihole.conf health.d/phpfpm.conf health.d/portcheck.conf health.d/postgres.conf health.d/processes.conf health.d/pulsar.conf health.d/qos.conf health.d/ram.conf health.d/redis.conf health.d/retroshare.conf health.d/riakkv.conf health.d/scaleio.conf health.d/softnet.conf health.d/squid.conf health.d/stiebeleltron.conf health.d/swap.conf health.d/tcp_conn.conf health.d/tcp_listen.conf health.d/tcp_mem.conf health.d/tcp_orphans.conf health.d/tcp_resets.conf health.d/udp_errors.conf health.d/unbound.conf health.d/varnish.conf health.d/vcsa.conf health.d/vernemq.conf health.d/vsphere.conf health.d/web_log.conf health.d/whoisquery.conf health.d/wmi.conf health.d/x509check.conf health.d/zfs.conf health.d/zookeeper.conf '/usr/lib/netdata/conf.d/health.d'
 /usr/bin/install -c -m 644 health.d/dbengine.conf '/usr/lib/netdata/conf.d/health.d'
make[4]: Leaving directory `/netdata/health'
make[3]: Leaving directory `/netdata/health'
make[2]: Leaving directory `/netdata/health'
Making install in libnetdata
make[2]: Entering directory `/netdata/libnetdata'
Making install in adaptive_resortable_list
make[3]: Entering directory `/netdata/libnetdata/adaptive_resortable_list'
make[4]: Entering directory `/netdata/libnetdata/adaptive_resortable_list'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/adaptive_resortable_list'
make[3]: Leaving directory `/netdata/libnetdata/adaptive_resortable_list'
Making install in avl
make[3]: Entering directory `/netdata/libnetdata/avl'
make[4]: Entering directory `/netdata/libnetdata/avl'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/avl'
make[3]: Leaving directory `/netdata/libnetdata/avl'
Making install in buffer
make[3]: Entering directory `/netdata/libnetdata/buffer'
make[4]: Entering directory `/netdata/libnetdata/buffer'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/buffer'
make[3]: Leaving directory `/netdata/libnetdata/buffer'
Making install in clocks
make[3]: Entering directory `/netdata/libnetdata/clocks'
make[4]: Entering directory `/netdata/libnetdata/clocks'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/clocks'
make[3]: Leaving directory `/netdata/libnetdata/clocks'
Making install in config
make[3]: Entering directory `/netdata/libnetdata/config'
make[4]: Entering directory `/netdata/libnetdata/config'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/config'
make[3]: Leaving directory `/netdata/libnetdata/config'
Making install in dictionary
make[3]: Entering directory `/netdata/libnetdata/dictionary'
make[4]: Entering directory `/netdata/libnetdata/dictionary'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/dictionary'
make[3]: Leaving directory `/netdata/libnetdata/dictionary'
Making install in ebpf
make[3]: Entering directory `/netdata/libnetdata/ebpf'
make[4]: Entering directory `/netdata/libnetdata/ebpf'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/ebpf'
make[3]: Leaving directory `/netdata/libnetdata/ebpf'
Making install in eval
make[3]: Entering directory `/netdata/libnetdata/eval'
make[4]: Entering directory `/netdata/libnetdata/eval'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/eval'
make[3]: Leaving directory `/netdata/libnetdata/eval'
Making install in json
make[3]: Entering directory `/netdata/libnetdata/json'
make[4]: Entering directory `/netdata/libnetdata/json'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/json'
make[3]: Leaving directory `/netdata/libnetdata/json'
Making install in health
make[3]: Entering directory `/netdata/libnetdata/health'
make[4]: Entering directory `/netdata/libnetdata/health'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/health'
make[3]: Leaving directory `/netdata/libnetdata/health'
Making install in locks
make[3]: Entering directory `/netdata/libnetdata/locks'
make[4]: Entering directory `/netdata/libnetdata/locks'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/locks'
make[3]: Leaving directory `/netdata/libnetdata/locks'
Making install in log
make[3]: Entering directory `/netdata/libnetdata/log'
make[4]: Entering directory `/netdata/libnetdata/log'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/log'
make[3]: Leaving directory `/netdata/libnetdata/log'
Making install in popen
make[3]: Entering directory `/netdata/libnetdata/popen'
make[4]: Entering directory `/netdata/libnetdata/popen'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/popen'
make[3]: Leaving directory `/netdata/libnetdata/popen'
Making install in procfile
make[3]: Entering directory `/netdata/libnetdata/procfile'
make[4]: Entering directory `/netdata/libnetdata/procfile'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/procfile'
make[3]: Leaving directory `/netdata/libnetdata/procfile'
Making install in simple_pattern
make[3]: Entering directory `/netdata/libnetdata/simple_pattern'
make[4]: Entering directory `/netdata/libnetdata/simple_pattern'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/simple_pattern'
make[3]: Leaving directory `/netdata/libnetdata/simple_pattern'
Making install in socket
make[3]: Entering directory `/netdata/libnetdata/socket'
make[4]: Entering directory `/netdata/libnetdata/socket'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/socket'
make[3]: Leaving directory `/netdata/libnetdata/socket'
Making install in statistical
make[3]: Entering directory `/netdata/libnetdata/statistical'
make[4]: Entering directory `/netdata/libnetdata/statistical'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/statistical'
make[3]: Leaving directory `/netdata/libnetdata/statistical'
Making install in storage_number
make[3]: Entering directory `/netdata/libnetdata/storage_number'
Making install in tests
make[4]: Entering directory `/netdata/libnetdata/storage_number/tests'
make[5]: Entering directory `/netdata/libnetdata/storage_number/tests'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/libnetdata/storage_number/tests'
make[4]: Leaving directory `/netdata/libnetdata/storage_number/tests'
make[4]: Entering directory `/netdata/libnetdata/storage_number'
make[5]: Entering directory `/netdata/libnetdata/storage_number'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/libnetdata/storage_number'
make[4]: Leaving directory `/netdata/libnetdata/storage_number'
make[3]: Leaving directory `/netdata/libnetdata/storage_number'
Making install in threads
make[3]: Entering directory `/netdata/libnetdata/threads'
make[4]: Entering directory `/netdata/libnetdata/threads'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/threads'
make[3]: Leaving directory `/netdata/libnetdata/threads'
Making install in url
make[3]: Entering directory `/netdata/libnetdata/url'
make[4]: Entering directory `/netdata/libnetdata/url'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/url'
make[3]: Leaving directory `/netdata/libnetdata/url'
Making install in tests
make[3]: Entering directory `/netdata/libnetdata/tests'
make[4]: Entering directory `/netdata/libnetdata/tests'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata/tests'
make[3]: Leaving directory `/netdata/libnetdata/tests'
make[3]: Entering directory `/netdata/libnetdata'
make[4]: Entering directory `/netdata/libnetdata'
make[4]: Nothing to be done for `install-exec-am'.
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/libnetdata'
make[3]: Leaving directory `/netdata/libnetdata'
make[2]: Leaving directory `/netdata/libnetdata'
Making install in registry
make[2]: Entering directory `/netdata/registry'
make[3]: Entering directory `/netdata/registry'
make[3]: Nothing to be done for `install-exec-am'.
make[3]: Nothing to be done for `install-data-am'.
make[3]: Leaving directory `/netdata/registry'
make[2]: Leaving directory `/netdata/registry'
Making install in streaming
make[2]: Entering directory `/netdata/streaming'
make[3]: Entering directory `/netdata/streaming'
make[3]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/lib/netdata/conf.d'
 /usr/bin/install -c -m 644 stream.conf '/usr/lib/netdata/conf.d'
make[3]: Leaving directory `/netdata/streaming'
make[2]: Leaving directory `/netdata/streaming'
Making install in web
make[2]: Entering directory `/netdata/web'
Making install in api
make[3]: Entering directory `/netdata/web/api'
Making install in badges
make[4]: Entering directory `/netdata/web/api/badges'
make[5]: Entering directory `/netdata/web/api/badges'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/web/api/badges'
make[4]: Leaving directory `/netdata/web/api/badges'
Making install in queries
make[4]: Entering directory `/netdata/web/api/queries'
Making install in average
make[5]: Entering directory `/netdata/web/api/queries/average'
make[6]: Entering directory `/netdata/web/api/queries/average'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries/average'
make[5]: Leaving directory `/netdata/web/api/queries/average'
Making install in des
make[5]: Entering directory `/netdata/web/api/queries/des'
make[6]: Entering directory `/netdata/web/api/queries/des'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries/des'
make[5]: Leaving directory `/netdata/web/api/queries/des'
Making install in incremental_sum
make[5]: Entering directory `/netdata/web/api/queries/incremental_sum'
make[6]: Entering directory `/netdata/web/api/queries/incremental_sum'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries/incremental_sum'
make[5]: Leaving directory `/netdata/web/api/queries/incremental_sum'
Making install in max
make[5]: Entering directory `/netdata/web/api/queries/max'
make[6]: Entering directory `/netdata/web/api/queries/max'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries/max'
make[5]: Leaving directory `/netdata/web/api/queries/max'
Making install in min
make[5]: Entering directory `/netdata/web/api/queries/min'
make[6]: Entering directory `/netdata/web/api/queries/min'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries/min'
make[5]: Leaving directory `/netdata/web/api/queries/min'
Making install in sum
make[5]: Entering directory `/netdata/web/api/queries/sum'
make[6]: Entering directory `/netdata/web/api/queries/sum'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries/sum'
make[5]: Leaving directory `/netdata/web/api/queries/sum'
Making install in median
make[5]: Entering directory `/netdata/web/api/queries/median'
make[6]: Entering directory `/netdata/web/api/queries/median'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries/median'
make[5]: Leaving directory `/netdata/web/api/queries/median'
Making install in ses
make[5]: Entering directory `/netdata/web/api/queries/ses'
make[6]: Entering directory `/netdata/web/api/queries/ses'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries/ses'
make[5]: Leaving directory `/netdata/web/api/queries/ses'
Making install in stddev
make[5]: Entering directory `/netdata/web/api/queries/stddev'
make[6]: Entering directory `/netdata/web/api/queries/stddev'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries/stddev'
make[5]: Leaving directory `/netdata/web/api/queries/stddev'
make[5]: Entering directory `/netdata/web/api/queries'
make[6]: Entering directory `/netdata/web/api/queries'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/queries'
make[5]: Leaving directory `/netdata/web/api/queries'
make[4]: Leaving directory `/netdata/web/api/queries'
Making install in exporters
make[4]: Entering directory `/netdata/web/api/exporters'
Making install in shell
make[5]: Entering directory `/netdata/web/api/exporters/shell'
make[6]: Entering directory `/netdata/web/api/exporters/shell'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/exporters/shell'
make[5]: Leaving directory `/netdata/web/api/exporters/shell'
Making install in prometheus
make[5]: Entering directory `/netdata/web/api/exporters/prometheus'
make[6]: Entering directory `/netdata/web/api/exporters/prometheus'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/exporters/prometheus'
make[5]: Leaving directory `/netdata/web/api/exporters/prometheus'
make[5]: Entering directory `/netdata/web/api/exporters'
make[6]: Entering directory `/netdata/web/api/exporters'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/exporters'
make[5]: Leaving directory `/netdata/web/api/exporters'
make[4]: Leaving directory `/netdata/web/api/exporters'
Making install in formatters
make[4]: Entering directory `/netdata/web/api/formatters'
Making install in csv
make[5]: Entering directory `/netdata/web/api/formatters/csv'
make[6]: Entering directory `/netdata/web/api/formatters/csv'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/formatters/csv'
make[5]: Leaving directory `/netdata/web/api/formatters/csv'
Making install in json
make[5]: Entering directory `/netdata/web/api/formatters/json'
make[6]: Entering directory `/netdata/web/api/formatters/json'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/formatters/json'
make[5]: Leaving directory `/netdata/web/api/formatters/json'
Making install in ssv
make[5]: Entering directory `/netdata/web/api/formatters/ssv'
make[6]: Entering directory `/netdata/web/api/formatters/ssv'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/formatters/ssv'
make[5]: Leaving directory `/netdata/web/api/formatters/ssv'
Making install in value
make[5]: Entering directory `/netdata/web/api/formatters/value'
make[6]: Entering directory `/netdata/web/api/formatters/value'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/formatters/value'
make[5]: Leaving directory `/netdata/web/api/formatters/value'
make[5]: Entering directory `/netdata/web/api/formatters'
make[6]: Entering directory `/netdata/web/api/formatters'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/api/formatters'
make[5]: Leaving directory `/netdata/web/api/formatters'
make[4]: Leaving directory `/netdata/web/api/formatters'
Making install in health
make[4]: Entering directory `/netdata/web/api/health'
make[5]: Entering directory `/netdata/web/api/health'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/web/api/health'
make[4]: Leaving directory `/netdata/web/api/health'
make[4]: Entering directory `/netdata/web/api'
make[5]: Entering directory `/netdata/web/api'
make[5]: Nothing to be done for `install-exec-am'.
 /bin/mkdir -p '/usr/share/netdata/web'
 /usr/bin/install -c -m 644 netdata-swagger.yaml netdata-swagger.json '/usr/share/netdata/web'
make[5]: Leaving directory `/netdata/web/api'
make[4]: Leaving directory `/netdata/web/api'
make[3]: Leaving directory `/netdata/web/api'
Making install in gui
make[3]: Entering directory `/netdata/web/gui'
if test -f dashboard.js; then rm -f dashboard.js; fi
cat src/dashboard.js/prologue.js.inc src/dashboard.js/utils.js src/dashboard.js/server-detection.js src/dashboard.js/dependencies.js src/dashboard.js/error-handling.js src/dashboard.js/compatibility.js src/dashboard.js/xss.js src/dashboard.js/colors.js src/dashboard.js/units-conversion.js src/dashboard.js/options.js src/dashboard.js/localstorage.js src/dashboard.js/timeout.js src/dashboard.js/themes.js src/dashboard.js/charting/dygraph.js src/dashboard.js/charting/sparkline.js src/dashboard.js/charting/google-charts.js src/dashboard.js/charting/gauge.js src/dashboard.js/charting/easy-pie-chart.js src/dashboard.js/charting/d3pie.js src/dashboard.js/charting/d3.js src/dashboard.js/charting/peity.js src/dashboard.js/charting/textonly.js src/dashboard.js/charting.js src/dashboard.js/chart-registry.js src/dashboard.js/common.js src/dashboard.js/main.js src/dashboard.js/alarms.js src/dashboard.js/registry.js src/dashboard.js/boot.js src/dashboard.js/epilogue.js.inc  > dashboard.js.tmp && mv dashboard.js.tmp dashboard.js
if test -d "../../.git"; then \
		git --git-dir="../../.git" log -n 1 --format=%H; \
	fi > version.txt.tmp
test -s version.txt.tmp || echo 0 > version.txt.tmp
mv version.txt.tmp version.txt
make[4]: Entering directory `/netdata/web/gui'
make[4]: Nothing to be done for `install-exec-am'.
if test -f dashboard.js; then rm -f dashboard.js; fi
cat src/dashboard.js/prologue.js.inc src/dashboard.js/utils.js src/dashboard.js/server-detection.js src/dashboard.js/dependencies.js src/dashboard.js/error-handling.js src/dashboard.js/compatibility.js src/dashboard.js/xss.js src/dashboard.js/colors.js src/dashboard.js/units-conversion.js src/dashboard.js/options.js src/dashboard.js/localstorage.js src/dashboard.js/timeout.js src/dashboard.js/themes.js src/dashboard.js/charting/dygraph.js src/dashboard.js/charting/sparkline.js src/dashboard.js/charting/google-charts.js src/dashboard.js/charting/gauge.js src/dashboard.js/charting/easy-pie-chart.js src/dashboard.js/charting/d3pie.js src/dashboard.js/charting/d3.js src/dashboard.js/charting/peity.js src/dashboard.js/charting/textonly.js src/dashboard.js/charting.js src/dashboard.js/chart-registry.js src/dashboard.js/common.js src/dashboard.js/main.js src/dashboard.js/alarms.js src/dashboard.js/registry.js src/dashboard.js/boot.js src/dashboard.js/epilogue.js.inc  > dashboard.js.tmp && mv dashboard.js.tmp dashboard.js
if test -d "../../.git"; then \
		git --git-dir="../../.git" log -n 1 --format=%H; \
	fi > version.txt.tmp
test -s version.txt.tmp || echo 0 > version.txt.tmp
mv version.txt.tmp version.txt
 /bin/mkdir -p '/usr/share/netdata/web'
 /usr/bin/install -c -m 644 demo.html demo2.html demosites.html demosites2.html dashboard.html dashboard.js dashboard_info.js dashboard_info_custom_example.js dashboard.css dashboard.slate.css favicon.ico goto-host-from-alarm.html index.html main.css main.js console.html infographic.html robots.txt refresh-badges.js sitemap.xml tv.html dash-example.html version.txt '/usr/share/netdata/web'
 /bin/mkdir -p '/usr/share/netdata/web/css'
 /usr/bin/install -c -m 644 css/morris-0.5.1.css css/bootstrap-3.3.7.css css/bootstrap-theme-3.3.7.min.css css/bootstrap-slate-flat-3.3.7.css css/bootstrap-slider-10.0.0.min.css css/bootstrap-toggle-2.2.2.min.css css/c3-0.4.18.min.css '/usr/share/netdata/web/css'
 /bin/mkdir -p '/usr/share/netdata/web/.well-known/dnt'
 /usr/bin/install -c -m 644 .well-known/dnt/cookies '/usr/share/netdata/web/.well-known/dnt'
 /bin/mkdir -p '/usr/share/netdata/web/fonts'
 /usr/bin/install -c -m 644 fonts/glyphicons-halflings-regular.eot fonts/glyphicons-halflings-regular.svg fonts/glyphicons-halflings-regular.ttf fonts/glyphicons-halflings-regular.woff fonts/glyphicons-halflings-regular.woff2 '/usr/share/netdata/web/fonts'
 /bin/mkdir -p '/usr/share/netdata/web/images'
 /usr/bin/install -c -m 644 images/netdata-logomark.svg images/alert-128-orange.png images/alert-128-red.png images/alert-multi-size-orange.ico images/alert-multi-size-red.ico images/animated.gif images/check-mark-2-128-green.png images/check-mark-2-multi-size-green.ico images/netdata.svg images/post.png images/android-icon-36x36.png images/android-icon-48x48.png images/android-icon-72x72.png images/android-icon-96x96.png images/android-icon-144x144.png images/android-icon-192x192.png images/apple-icon-57x57.png images/apple-icon-60x60.png images/apple-icon-72x72.png images/apple-icon-76x76.png images/apple-icon-114x114.png images/apple-icon-120x120.png images/apple-icon-144x144.png images/apple-icon-152x152.png images/apple-icon-180x180.png images/apple-icon-precomposed.png images/apple-icon.png images/favicon-16x16.png images/favicon-32x32.png images/favicon-96x96.png images/favicon.ico images/ms-icon-70x70.png images/ms-icon-144x144.png images/ms-icon-150x150.png images/ms-icon-310x310.png images/banner-icon-144x144.png '/usr/share/netdata/web/images'
 /bin/mkdir -p '/usr/share/netdata/web/lib'
 /usr/bin/install -c -m 644 lib/bootstrap-3.3.7.min.js lib/bootstrap-slider-10.0.0.min.js lib/bootstrap-table-1.11.0.min.js lib/bootstrap-table-export-1.11.0.min.js lib/bootstrap-toggle-2.2.2.min.js lib/clipboard-polyfill-be05dad.js lib/d3-4.12.2.min.js lib/d3pie-0.2.1-netdata-3.js lib/dygraph-c91c859.min.js lib/dygraph-smooth-plotter-c91c859.js lib/fontawesome-all-5.0.1.min.js lib/gauge-1.3.2.min.js lib/jquery-2.2.4.min.js lib/jquery.easypiechart-97b5824.min.js lib/jquery.peity-3.2.0.min.js lib/jquery.sparkline-2.1.2.min.js lib/lz-string-1.4.4.min.js lib/pako-1.0.6.min.js lib/perfect-scrollbar-0.6.15.min.js lib/tableExport-1.6.0.min.js '/usr/share/netdata/web/lib'
 /bin/mkdir -p '/usr/share/netdata/web/old'
 /usr/bin/install -c -m 644 old/index.html '/usr/share/netdata/web/old'
 /bin/mkdir -p '/usr/share/netdata/web/static/img'
 /usr/bin/install -c -m 644 static/img/netdata-logomark.svg '/usr/share/netdata/web/static/img'
make[4]: Leaving directory `/netdata/web/gui'
make[3]: Leaving directory `/netdata/web/gui'
Making install in server
make[3]: Entering directory `/netdata/web/server'
Making install in static
make[4]: Entering directory `/netdata/web/server/static'
make[5]: Entering directory `/netdata/web/server/static'
make[6]: Entering directory `/netdata/web/server/static'
make[6]: Nothing to be done for `install-exec-am'.
make[6]: Nothing to be done for `install-data-am'.
make[6]: Leaving directory `/netdata/web/server/static'
make[5]: Leaving directory `/netdata/web/server/static'
make[4]: Leaving directory `/netdata/web/server/static'
make[4]: Entering directory `/netdata/web/server'
make[5]: Entering directory `/netdata/web/server'
make[5]: Nothing to be done for `install-exec-am'.
make[5]: Nothing to be done for `install-data-am'.
make[5]: Leaving directory `/netdata/web/server'
make[4]: Leaving directory `/netdata/web/server'
make[3]: Leaving directory `/netdata/web/server'
make[3]: Entering directory `/netdata/web'
make[4]: Entering directory `/netdata/web'
/usr/bin/install -c -d /etc/netdata/ssl
make[4]: Nothing to be done for `install-data-am'.
make[4]: Leaving directory `/netdata/web'
make[3]: Leaving directory `/netdata/web'
make[2]: Leaving directory `/netdata/web'
Making install in claim
make[2]: Entering directory `/netdata/claim'
make[3]: Entering directory `/netdata/claim'
 /bin/mkdir -p '/usr/sbin'
 /usr/bin/install -c netdata-claim.sh '/usr/sbin'
make[3]: Nothing to be done for `install-data-am'.
make[3]: Leaving directory `/netdata/claim'
make[2]: Leaving directory `/netdata/claim'
Making install in aclk
make[2]: Entering directory `/netdata/aclk'
make[3]: Entering directory `/netdata/aclk'
make[3]: Nothing to be done for `install-exec-am'.
make[3]: Nothing to be done for `install-data-am'.
make[3]: Leaving directory `/netdata/aclk'
make[2]: Leaving directory `/netdata/aclk'
make[2]: Entering directory `/netdata'
make[3]: Entering directory `/netdata'
 /bin/mkdir -p '/usr/sbin'
  /usr/bin/install -c netdata netdatacli '/usr/sbin'
 /bin/mkdir -p '/usr/libexec/netdata/plugins.d'
  /usr/bin/install -c apps.plugin cgroup-network ebpf_process.plugin perf.plugin slabinfo.plugin '/usr/libexec/netdata/plugins.d'
make[3]: Leaving directory `/netdata'
make[2]: Leaving directory `/netdata'
make[1]: Leaving directory `/netdata'
 OK

 --- Fix generated files permissions ---
[/netdata]# find ./system/ -type f -a \! -name \*.in -a \! -name Makefile\* -a \! -name \*.conf -a \! -name \*.service -a \! -name \*.logrotate -exec chmod 755 \{\} \;
 OK

 --- Creating standard user and groups for netdata ---
 --- Adding group 'netdata' ---
Adding netdata user group ...
[/netdata]# groupadd -r netdata
 OK

 --- Adding user 'netdata' ---
Adding netdata user account with home /var/lib/netdata ...
[/netdata]# useradd -r -g netdata -c netdata -s /usr/sbin/nologin --no-create-home -d /var/lib/netdata netdata
 OK

 --- Assign user 'netdata' to required groups ---
Group 'docker' does not exist.
Group 'nginx' does not exist.
Group 'varnish' does not exist.
Group 'haproxy' does not exist.
Adding netdata user to the adm group ...
[/netdata]# usermod -a -G adm netdata
 OK

Group 'nsd' does not exist.
Adding netdata user to the proxy group ...
[/netdata]# usermod -a -G proxy netdata
 OK

Group 'squid' does not exist.
Group 'ceph' does not exist.
Group 'nobody' does not exist.
 --- Install logrotate configuration for netdata ---
[/netdata]# cp system/netdata.logrotate /etc/logrotate.d/netdata
 OK

[/netdata]# chmod 644 /etc/logrotate.d/netdata
 OK

 --- Read installation options from netdata.conf ---
Netdata user and group is finally set to: netdata/netdata

    Permissions
    - netdata user             : netdata
    - netdata group            : netdata
    - web files user           : netdata
    - web files group          : netdata
    - root user                : root

    Directories
    - netdata user config dir  : /etc/netdata
    - netdata stock config dir : /usr/lib/netdata/conf.d
    - netdata log dir          : /var/log/netdata
    - netdata run dir          : /var/run
    - netdata lib dir          : /var/lib/netdata
    - netdata web dir          : /usr/share/netdata/web
    - netdata cache dir        : /var/cache/netdata

    Other
    - netdata port             : 19999

 --- Fix permissions of netdata directories (using user 'netdata') ---
[/netdata]# ln -s /usr/lib/netdata/conf.d /etc/netdata/orig
 OK

[/netdata]# chown -R netdata:netdata /usr/share/netdata/web
 OK

[/netdata]# find /usr/share/netdata/web -type f -exec chmod 0664 \{\} \;
 OK

[/netdata]# find /usr/share/netdata/web -type d -exec chmod 0775 \{\} \;
 OK

Creating directory '/var/lib/netdata'
[/netdata]# mkdir -p /var/lib/netdata
 OK

[/netdata]# chown -R netdata:netdata /var/lib/netdata
 OK

Creating directory '/var/cache/netdata'
[/netdata]# mkdir -p /var/cache/netdata
 OK

[/netdata]# chown -R netdata:netdata /var/cache/netdata
 OK

Creating directory '/var/log/netdata'
[/netdata]# mkdir -p /var/log/netdata
 OK

[/netdata]# chown -R netdata:netdata /var/log/netdata
 OK

[/netdata]# chmod 755 /var/log/netdata
 OK

Creating directory '/etc/netdata/claim.d'
[/netdata]# mkdir -p /etc/netdata/claim.d
 OK

[/netdata]# chown -R netdata:netdata /etc/netdata/claim.d
 OK

[/netdata]# chmod 770 /etc/netdata/claim.d
 OK

[/netdata]# chown netdata:root /var/log/netdata
 OK

[/netdata]# chown -R root:root /usr/libexec/netdata
 OK

[/netdata]# find /usr/libexec/netdata -type d -exec chmod 0755 \{\} \;
 OK

[/netdata]# find /usr/libexec/netdata -type f -exec chmod 0644 \{\} \;
 OK

[/netdata]# find /usr/libexec/netdata -type f -a -name \*.plugin -exec chown :netdata \{\} \;
 OK

[/netdata]# find /usr/libexec/netdata -type f -a -name \*.plugin -exec chmod 0750 \{\} \;
 OK

[/netdata]# find /usr/libexec/netdata -type f -a -name \*.sh -exec chmod 0755 \{\} \;
 OK

[/netdata]# chown root:netdata /usr/libexec/netdata/plugins.d/apps.plugin
 OK

[/netdata]# chmod 4750 /usr/libexec/netdata/plugins.d/apps.plugin
 OK

[/netdata]# chown root:netdata /usr/libexec/netdata/plugins.d/perf.plugin
 OK

[/netdata]# chmod 4750 /usr/libexec/netdata/plugins.d/perf.plugin
 OK

[/netdata]# chown root:netdata /usr/libexec/netdata/plugins.d/slabinfo.plugin
 OK

[/netdata]# chmod 4750 /usr/libexec/netdata/plugins.d/slabinfo.plugin
 OK

[/netdata]# chown root:netdata /usr/libexec/netdata/plugins.d/ebpf_process.plugin
 OK

[/netdata]# chmod 4750 /usr/libexec/netdata/plugins.d/ebpf_process.plugin
 OK

[/netdata]# chown root:netdata /usr/libexec/netdata/plugins.d/cgroup-network
 OK

[/netdata]# chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network
 OK

[/netdata]# chown root:netdata /usr/libexec/netdata/plugins.d/cgroup-network-helper.sh
 OK

[/netdata]# chmod 0750 /usr/libexec/netdata/plugins.d/cgroup-network-helper.sh
 OK

 --- Fetching and installing dashboard ---
dashboard.tar.gz: OK
[/netdata]# tar -xf /tmp/netdata-dashboard-aknhFb/dashboard.tar.gz -C /tmp/netdata-dashboard-aknhFb
 OK

[/netdata]# cp -a /tmp/netdata-dashboard-aknhFb/build/dashboard.slate.css /tmp/netdata-dashboard-aknhFb/build/console.html /tmp/netdata-dashboard-aknhFb/build/infographic.html /tmp/netdata-dashboard-aknhFb/build/asset-manifest.json /tmp/netdata-dashboard-aknhFb/build/dashboard-react.js /tmp/netdata-dashboard-aknhFb/build/dashboard.html /tmp/netdata-dashboard-aknhFb/build/tv.html /tmp/netdata-dashboard-aknhFb/build/demosites2.html /tmp/netdata-dashboard-aknhFb/build/dashboard.js /tmp/netdata-dashboard-aknhFb/build/demo2.html /tmp/netdata-dashboard-aknhFb/build/lib /tmp/netdata-dashboard-aknhFb/build/static /tmp/netdata-dashboard-aknhFb/build/dash-example.html /tmp/netdata-dashboard-aknhFb/build/images /tmp/netdata-dashboard-aknhFb/build/favicon.ico /tmp/netdata-dashboard-aknhFb/build/precache-manifest.7a9ced647e2a56a5dd5898ec136043e5.js /tmp/netdata-dashboard-aknhFb/build/index.html /tmp/netdata-dashboard-aknhFb/build/goto-host-from-alarm.html /tmp/netdata-dashboard-aknhFb/build/demo.html /tmp/netdata-dashboard-aknhFb/build/robots.txt /tmp/netdata-dashboard-aknhFb/build/css /tmp/netdata-dashboard-aknhFb/build/dashboard.css /tmp/netdata-dashboard-aknhFb/build/demosites.html /tmp/netdata-dashboard-aknhFb/build/fonts /tmp/netdata-dashboard-aknhFb/build/sitemap.xml /tmp/netdata-dashboard-aknhFb/build/refresh-badges.js /tmp/netdata-dashboard-aknhFb/build/manifest.json /tmp/netdata-dashboard-aknhFb/build/service-worker.js /usr/share/netdata/web
 OK

[/netdata]# chown -R netdata:netdata /usr/share/netdata/web
 OK

 OK  React dashboard installed.

 --- eBPF Kernel Collector (opt-in) ---
 FAILED  ebpf not enabled. --enable-ebpf to enable

 --- Telemetry configuration ---
 --- Install netdata at system init ---
You can opt out from anonymous statistics via the --disable-telemetry option, or by creating an empty file /etc/netdata/.opt-out-from-anonymous-statistics

We are running within a docker container, will not be installing netdata service

[/netdata]# chmod 0644 /etc/netdata/netdata.conf
 OK

 --- Check KSM (kernel memory deduper) ---

Memory de-duplication instructions

You have kernel memory de-duper (called Kernel Same-page Merging,
or KSM) available, but it is not currently enabled.

To enable it run:

    echo 1 >/sys/kernel/mm/ksm/run
    echo 1000 >/sys/kernel/mm/ksm/sleep_millisecs

If you enable it, you will save 40-60% of netdata memory.

 --- Check version.txt ---
 --- Check apps.plugin ---
 --- Copy uninstaller ---
 --- Basic netdata instructions ---

netdata by default listens on all IPs on port 19999,
so you can access it with:

  http://this.machine.ip:19999/

To stop netdata run:



To start netdata run:

  /usr/sbin/netdata

Uninstall script copied to: /usr/libexec/netdata/netdata-uninstaller.sh

 --- Installing (but not enabling) the netdata updater tool ---
Update script is located at /usr/libexec/netdata/netdata-updater.sh

 --- Check if we must enable/disable the netdata updater tool ---
Adding to cron
Auto-updating has been enabled. Updater script linked to: /etc/cron.daily/netdata-updater

netdata-updater.sh works from cron. It will trigger an email from cron
only if it fails (it should not print anything when it can update netdata).

 --- Wrap up environment set up ---
Preparing .environment file
[/netdata]# chmod 0644 /etc/netdata/.environment
 OK

Setting netdata.tarball.checksum to 'new_installation'

 --- We are done! ---

  ^
  |.-.   .-.   .-.   .-.   .-.   .  netdata              .-.   .-.   .-.   .-
  |   '-'   '-'   '-'   '-'   '-'   is installed now!  -'   '-'   '-'   '-'
  +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->

  enjoy real-time performance and health monitoring...

Removing intermediate container 765eb2fe90b7
 ---> 50b64f8338b5
Step 9/9 : CMD ["/usr/sbin/netdata", "-D"]
 ---> Running in 6a4cd88d3772
Removing intermediate container 6a4cd88d3772
 ---> 04169f48920b
Successfully built 04169f48920b
Successfully tagged prologic/netdata:dev
2020-05-06 05:12:54: netdata INFO  : MAIN : SIGNAL: Enabling reaper
2020-05-06 05:12:54: netdata INFO  : MAIN : process tracking enabled.
```
</details>

- [x] Test that it builds correctly __with cloud__ _AND_ self-signed cert option.
<details>
<summary>
Details
</summary>
TBD
</details>

- [x] Ensure that it runs and functions at a basic levle.
<details>
<summary>
Screenshot
</summary>
<img width="1312" alt="Screen Shot 2020-05-06 at 15 07 52" src="https://user-images.githubusercontent.com/1290234/81140170-c5dd0f80-8fab-11ea-9e37-4f6f5bda4cb5.png">
</details>

- [x] Test that it connects to our production cloud environment
<details>
<summary>
Details
</summary>
TBD
</details>

##### Additional Information