### PR TITLE
postgres.chart.py: fix template databases ignore

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -394,7 +394,7 @@ FROM pg_stat_database
 WHERE
     has_database_privilege(
       (SELECT current_user), datname, 'connect')
-    AND NOT datname ~* '^template\d ';
+    AND NOT datname ~* '^template\d';
 """,
 }
 


### PR DESCRIPTION
##### Summary
template1 and template0 are system postgres tables. It's no need to monitor them, which was intended by a code, but it regex contains space that breaks everything.

##### Component Name
postgres.chart.py
##### Test Plan

template0/tempate1 should not be visible