### PR TITLE
Fix shutdown via netdatacli with musl C library

### DIFF
--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -449,6 +449,10 @@ static void parse_commands(struct command_context *cmd_ctx)
     for (pos = cmd_ctx->command_string ; isspace(*pos) && ('\0' != *pos) ; ++pos) {;}
     for (i = 0 ; i < CMD_TOTAL_COMMANDS ; ++i) {
         if (!strncmp(pos, command_info_array[i].cmd_str, strlen(command_info_array[i].cmd_str))) {
+            if (CMD_EXIT == i) {
+                /* musl C does not like libuv workqueues calling exit() */
+                execute_command(CMD_EXIT, NULL, NULL);
+            }
             for (lstrip=pos + strlen(command_info_array[i].cmd_str); isspace(*lstrip) && ('\0' != *lstrip); ++lstrip) {;}
             for (rstrip=lstrip+strlen(lstrip)-1; rstrip>lstrip && isspace(*rstrip); *(rstrip--) = 0 );
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes clean shutdown via `netdatacli shutdown-agent` when using musl C library.

- Fixes #8945

##### Component Name
daemon
##### Test Plan
Link with musl C library (e.g. alpine linux).
Run `./netdata -D`.
Shut it down with `netdatacli shutdown-agent`
