### PR TITLE
Docs: Add custom label to collectors frontmatter to fix sidebar titles

### DIFF
--- a/collectors/charts.d.plugin/README.md
+++ b/collectors/charts.d.plugin/README.md
@@ -1,8 +1,6 @@
 <!--
----
 title: "charts.d.plugin"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/README.md
----
 -->
 
 # charts.d.plugin

--- a/collectors/charts.d.plugin/ap/README.md
+++ b/collectors/charts.d.plugin/ap/README.md
@@ -1,11 +1,12 @@
 <!--
 ---
-title: "Access Point monitoring with Netdata"
+title: "Access point monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/ap/README.md
+sidebar_label: "Access point"
 ---
 -->
 
-# Access Point monitoring with Netdata
+# Access point monitoring with Netdata
 
 The `ap` collector visualizes data related to access points.
 

--- a/collectors/charts.d.plugin/ap/README.md
+++ b/collectors/charts.d.plugin/ap/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Access point monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/ap/README.md
-sidebar_label: "Access point"
----
+sidebar_label: "Access points"
 -->
 
 # Access point monitoring with Netdata

--- a/collectors/charts.d.plugin/apcupsd/README.md
+++ b/collectors/charts.d.plugin/apcupsd/README.md
@@ -2,6 +2,7 @@
 ---
 title: "APC UPS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/apcupsd/README.md
+sidebar_label: "APC UPS"
 ---
 -->
 

--- a/collectors/charts.d.plugin/apcupsd/README.md
+++ b/collectors/charts.d.plugin/apcupsd/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "APC UPS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/apcupsd/README.md
 sidebar_label: "APC UPS"
----
 -->
 
 # APC UPS monitoring with Netdata

--- a/collectors/charts.d.plugin/example/README.md
+++ b/collectors/charts.d.plugin/example/README.md
@@ -1,8 +1,6 @@
 <!--
----
 title: "Example"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/example/README.md
----
 -->
 
 # Example

--- a/collectors/charts.d.plugin/libreswan/README.md
+++ b/collectors/charts.d.plugin/libreswan/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Libreswan IPSec tunnel monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/libreswan/README.md
+sidebar_label: "Libreswan IPSec tunnels"
 ---
 -->
 

--- a/collectors/charts.d.plugin/libreswan/README.md
+++ b/collectors/charts.d.plugin/libreswan/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Libreswan IPSec tunnel monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/libreswan/README.md
 sidebar_label: "Libreswan IPSec tunnels"
----
 -->
 
 # Libreswan IPSec tunnel monitoring with Netdata

--- a/collectors/charts.d.plugin/nut/README.md
+++ b/collectors/charts.d.plugin/nut/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "UPS/PDU monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/nut/README.md
 sidebar_label: "UPS/PDU"
----
 -->
 
 # UPS/PDU monitoring with Netdata

--- a/collectors/charts.d.plugin/nut/README.md
+++ b/collectors/charts.d.plugin/nut/README.md
@@ -2,6 +2,7 @@
 ---
 title: "UPS/PDU monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/nut/README.md
+sidebar_label: "UPS/PDU"
 ---
 -->
 

--- a/collectors/charts.d.plugin/opensips/README.md
+++ b/collectors/charts.d.plugin/opensips/README.md
@@ -2,6 +2,7 @@
 ---
 title: "OpenSIPS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/opensips/README.md
+sidebar_label: "OpenSIPS"
 ---
 -->
 

--- a/collectors/charts.d.plugin/opensips/README.md
+++ b/collectors/charts.d.plugin/opensips/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "OpenSIPS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/opensips/README.md
 sidebar_label: "OpenSIPS"
----
 -->
 
 # OpenSIPS monitoring with Netdata

--- a/collectors/charts.d.plugin/sensors/README.md
+++ b/collectors/charts.d.plugin/sensors/README.md
@@ -1,8 +1,6 @@
 <!--
----
 title: "Linux machine sensors monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/charts.d.plugin/sensors/README.md
----
 -->
 
 # Linux machine sensors monitoring with Netdata

--- a/collectors/ebpf_process.plugin/README.md
+++ b/collectors/ebpf_process.plugin/README.md
@@ -2,6 +2,7 @@
 ---
 title: "eBPF monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/ebpf_process.plugin/README.md
+sidebar_label: "eBPF"
 ---
 -->
 

--- a/collectors/node.d.plugin/README.md
+++ b/collectors/node.d.plugin/README.md
@@ -1,8 +1,6 @@
 <!--
----
 title: "node.d.plugin"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/README.md
----
 -->
 
 # node.d.plugin

--- a/collectors/node.d.plugin/fronius/README.md
+++ b/collectors/node.d.plugin/fronius/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Fronius Symo monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/fronius/README.md
 sidebar_label: "Fronius Symo"
----
 -->
 
 # Fronius Symo monitoring with Netdata

--- a/collectors/node.d.plugin/fronius/README.md
+++ b/collectors/node.d.plugin/fronius/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Fronius Symo monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/fronius/README.md
+sidebar_label: "Fronius Symo"
 ---
 -->
 

--- a/collectors/node.d.plugin/named/README.md
+++ b/collectors/node.d.plugin/named/README.md
@@ -1,7 +1,8 @@
 <!--
 ---
-title: "ISC BIND monitoring with Netdata "
+title: "ISC BIND monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/named/README.md
+sidebar_label: "ISC BIND"
 ---
 -->
 

--- a/collectors/node.d.plugin/named/README.md
+++ b/collectors/node.d.plugin/named/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "ISC BIND monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/named/README.md
 sidebar_label: "ISC BIND"
----
 -->
 
 # ISC BIND monitoring with Netdata 

--- a/collectors/node.d.plugin/sma_webbox/README.md
+++ b/collectors/node.d.plugin/sma_webbox/README.md
@@ -2,6 +2,7 @@
 ---
 title: "SMA Sunny WebBox monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/sma_webbox/README.md
+sidebar_label: "SMA Sunny WebBox"
 ---
 -->
 

--- a/collectors/node.d.plugin/sma_webbox/README.md
+++ b/collectors/node.d.plugin/sma_webbox/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "SMA Sunny WebBox monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/sma_webbox/README.md
 sidebar_label: "SMA Sunny WebBox"
----
 -->
 
 # SMA Sunny WebBox monitoring with Netdata

--- a/collectors/node.d.plugin/snmp/README.md
+++ b/collectors/node.d.plugin/snmp/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "SNMP device monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/snmp/README.md
 sidebar_label: "SNMP"
----
 -->
 
 # SNMP device monitoring with Netdata

--- a/collectors/node.d.plugin/snmp/README.md
+++ b/collectors/node.d.plugin/snmp/README.md
@@ -2,6 +2,7 @@
 ---
 title: "SNMP device monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/snmp/README.md
+sidebar_label: "SNMP"
 ---
 -->
 

--- a/collectors/node.d.plugin/stiebeleltron/README.md
+++ b/collectors/node.d.plugin/stiebeleltron/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Stiebel Eltron ISG monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/stiebeleltron/README.md
 sidebar_label: "Stiebel Eltron ISG"
----
 -->
 
 # Stiebel Eltron ISG monitoring with Netdata

--- a/collectors/node.d.plugin/stiebeleltron/README.md
+++ b/collectors/node.d.plugin/stiebeleltron/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Stiebel Eltron ISG monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/stiebeleltron/README.md
+sidebar_label: "Stiebel Eltron ISG"
 ---
 -->
 

--- a/collectors/python.d.plugin/README.md
+++ b/collectors/python.d.plugin/README.md
@@ -1,8 +1,6 @@
 <!--
----
 title: "python.d.plugin"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/README.md
----
 -->
 
 # python.d.plugin

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Adaptec RAID controller monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/adaptec_raid/README.md
+sidebar_label: "adaptec_raid"
 ---
 -->
 

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Adaptec RAID controller monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/adaptec_raid/README.md
 sidebar_label: "Adaptec RAID"
----
 -->
 
 # Adaptec RAID controller monitoring with Netdata

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Adaptec RAID controller monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/adaptec_raid/README.md
-sidebar_label: "adaptec_raid"
+sidebar_label: "Adaptec RAID"
 ---
 -->
 

--- a/collectors/python.d.plugin/am2320/README.md
+++ b/collectors/python.d.plugin/am2320/README.md
@@ -2,6 +2,7 @@
 ---
 title: "AM2320 sensor monitoring with netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/am2320/README.md
+sidebar_label: "am2320"
 ---
 -->
 

--- a/collectors/python.d.plugin/am2320/README.md
+++ b/collectors/python.d.plugin/am2320/README.md
@@ -2,7 +2,7 @@
 ---
 title: "AM2320 sensor monitoring with netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/am2320/README.md
-sidebar_label: "am2320"
+sidebar_label: "AM2320"
 ---
 -->
 

--- a/collectors/python.d.plugin/am2320/README.md
+++ b/collectors/python.d.plugin/am2320/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "AM2320 sensor monitoring with netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/am2320/README.md
 sidebar_label: "AM2320"
----
 -->
 
 # AM2320 sensor monitoring with netdata

--- a/collectors/python.d.plugin/apache/README.md
+++ b/collectors/python.d.plugin/apache/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Apache monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/apache/README.md
+sidebar_label: "apache"
 ---
 -->
 

--- a/collectors/python.d.plugin/apache/README.md
+++ b/collectors/python.d.plugin/apache/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Apache monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/apache/README.md
 sidebar_label: "Apache"
----
 -->
 
 # Apache monitoring with Netdata

--- a/collectors/python.d.plugin/apache/README.md
+++ b/collectors/python.d.plugin/apache/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Apache monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/apache/README.md
-sidebar_label: "apache"
+sidebar_label: "Apache"
 ---
 -->
 

--- a/collectors/python.d.plugin/beanstalk/README.md
+++ b/collectors/python.d.plugin/beanstalk/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Beanstalk monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/beanstalk/README.md
+sidebar_label: "beanstalk"
 ---
 -->
 

--- a/collectors/python.d.plugin/beanstalk/README.md
+++ b/collectors/python.d.plugin/beanstalk/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Beanstalk monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/beanstalk/README.md
 sidebar_label: "Beanstalk"
----
 -->
 
 # Beanstalk monitoring with Netdata

--- a/collectors/python.d.plugin/beanstalk/README.md
+++ b/collectors/python.d.plugin/beanstalk/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Beanstalk monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/beanstalk/README.md
-sidebar_label: "beanstalk"
+sidebar_label: "Beanstalk"
 ---
 -->
 

--- a/collectors/python.d.plugin/bind_rndc/README.md
+++ b/collectors/python.d.plugin/bind_rndc/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "ISC Bind monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/bind_rndc/README.md
 sidebar_label: "ISC Bind"
----
 -->
 
 # ISC Bind monitoring with Netdata

--- a/collectors/python.d.plugin/bind_rndc/README.md
+++ b/collectors/python.d.plugin/bind_rndc/README.md
@@ -2,6 +2,7 @@
 ---
 title: "ISC Bind monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/bind_rndc/README.md
+sidebar_label: "bind_rndc"
 ---
 -->
 

--- a/collectors/python.d.plugin/bind_rndc/README.md
+++ b/collectors/python.d.plugin/bind_rndc/README.md
@@ -2,7 +2,7 @@
 ---
 title: "ISC Bind monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/bind_rndc/README.md
-sidebar_label: "bind_rndc"
+sidebar_label: "ISC Bind"
 ---
 -->
 

--- a/collectors/python.d.plugin/boinc/README.md
+++ b/collectors/python.d.plugin/boinc/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "BOINC monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/boinc/README.md
 sidebar_label: "BOINC"
----
 -->
 
 # BOINC monitoring with Netdata

--- a/collectors/python.d.plugin/boinc/README.md
+++ b/collectors/python.d.plugin/boinc/README.md
@@ -2,7 +2,7 @@
 ---
 title: "BOINC monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/boinc/README.md
-sidebar_label: "boinc"
+sidebar_label: "BOINC"
 ---
 -->
 

--- a/collectors/python.d.plugin/boinc/README.md
+++ b/collectors/python.d.plugin/boinc/README.md
@@ -2,6 +2,7 @@
 ---
 title: "BOINC monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/boinc/README.md
+sidebar_label: "boinc"
 ---
 -->
 

--- a/collectors/python.d.plugin/ceph/README.md
+++ b/collectors/python.d.plugin/ceph/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "CEPH monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ceph/README.md
 sidebar_label: "CEPH"
----
 -->
 
 # CEPH monitoring with Netdata

--- a/collectors/python.d.plugin/ceph/README.md
+++ b/collectors/python.d.plugin/ceph/README.md
@@ -2,6 +2,7 @@
 ---
 title: "CEPH monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ceph/README.md
+sidebar_label: "ceph"
 ---
 -->
 

--- a/collectors/python.d.plugin/ceph/README.md
+++ b/collectors/python.d.plugin/ceph/README.md
@@ -2,7 +2,7 @@
 ---
 title: "CEPH monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ceph/README.md
-sidebar_label: "ceph"
+sidebar_label: "CEPH"
 ---
 -->
 

--- a/collectors/python.d.plugin/chrony/README.md
+++ b/collectors/python.d.plugin/chrony/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Chrony monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/chrony/README.md
-sidebar_label: "chrony"
+sidebar_label: "Chrony"
 ---
 -->
 

--- a/collectors/python.d.plugin/chrony/README.md
+++ b/collectors/python.d.plugin/chrony/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Chrony monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/chrony/README.md
+sidebar_label: "chrony"
 ---
 -->
 

--- a/collectors/python.d.plugin/chrony/README.md
+++ b/collectors/python.d.plugin/chrony/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Chrony monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/chrony/README.md
 sidebar_label: "Chrony"
----
 -->
 
 # Chrony monitoring with Netdata

--- a/collectors/python.d.plugin/couchdb/README.md
+++ b/collectors/python.d.plugin/couchdb/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Apache CouchDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/couchdb/README.md
-sidebar_label: "couchdb"
+sidebar_label: "Apache CouchDB"
 ---
 -->
 

--- a/collectors/python.d.plugin/couchdb/README.md
+++ b/collectors/python.d.plugin/couchdb/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Apache CouchDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/couchdb/README.md
+sidebar_label: "couchdb"
 ---
 -->
 

--- a/collectors/python.d.plugin/couchdb/README.md
+++ b/collectors/python.d.plugin/couchdb/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Apache CouchDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/couchdb/README.md
 sidebar_label: "CouchDB"
----
 -->
 
 # Apache CouchDB monitoring with Netdata

--- a/collectors/python.d.plugin/couchdb/README.md
+++ b/collectors/python.d.plugin/couchdb/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Apache CouchDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/couchdb/README.md
-sidebar_label: "Apache CouchDB"
+sidebar_label: "CouchDB"
 ---
 -->
 

--- a/collectors/python.d.plugin/dns_query_time/README.md
+++ b/collectors/python.d.plugin/dns_query_time/README.md
@@ -2,6 +2,7 @@
 ---
 title: "DNS query RTT monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dns_query_time/README.md
+sidebar_label: "dns_query_time"
 ---
 -->
 

--- a/collectors/python.d.plugin/dns_query_time/README.md
+++ b/collectors/python.d.plugin/dns_query_time/README.md
@@ -2,7 +2,7 @@
 ---
 title: "DNS query RTT monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dns_query_time/README.md
-sidebar_label: "dns_query_time"
+sidebar_label: "DNS query RTT"
 ---
 -->
 

--- a/collectors/python.d.plugin/dns_query_time/README.md
+++ b/collectors/python.d.plugin/dns_query_time/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "DNS query RTT monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dns_query_time/README.md
 sidebar_label: "DNS query RTT"
----
 -->
 
 # DNS query RTT monitoring with Netdata

--- a/collectors/python.d.plugin/dnsdist/README.md
+++ b/collectors/python.d.plugin/dnsdist/README.md
@@ -2,7 +2,7 @@
 ---
 title: "PowerDNS dnsdist monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dnsdist/README.md
-sidebar_label: "dnsdist"
+sidebar_label: "PowerDNS dnsdist"
 ---
 -->
 

--- a/collectors/python.d.plugin/dnsdist/README.md
+++ b/collectors/python.d.plugin/dnsdist/README.md
@@ -2,6 +2,7 @@
 ---
 title: "PowerDNS dnsdist monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dnsdist/README.md
+sidebar_label: "dnsdist"
 ---
 -->
 

--- a/collectors/python.d.plugin/dnsdist/README.md
+++ b/collectors/python.d.plugin/dnsdist/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "PowerDNS dnsdist monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dnsdist/README.md
 sidebar_label: "PowerDNS dnsdist"
----
 -->
 
 # PowerDNS dnsdist monitoring with Netdata

--- a/collectors/python.d.plugin/dockerd/README.md
+++ b/collectors/python.d.plugin/dockerd/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Docker engine monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dockerd/README.md
+sidebar_label: "dockerd"
 ---
 -->
 

--- a/collectors/python.d.plugin/dockerd/README.md
+++ b/collectors/python.d.plugin/dockerd/README.md
@@ -1,12 +1,12 @@
 <!--
 ---
-title: "Docker engine monitoring with Netdata"
+title: "Docker Engine monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dockerd/README.md
-sidebar_label: "dockerd"
+sidebar_label: "Docker Engine"
 ---
 -->
 
-# Docker engine monitoring with Netdata
+# Docker Engine monitoring with Netdata
 
 Collects docker container health metrics.
 

--- a/collectors/python.d.plugin/dockerd/README.md
+++ b/collectors/python.d.plugin/dockerd/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Docker Engine monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dockerd/README.md
 sidebar_label: "Docker Engine"
----
 -->
 
 # Docker Engine monitoring with Netdata

--- a/collectors/python.d.plugin/dovecot/README.md
+++ b/collectors/python.d.plugin/dovecot/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Dovecot monitoring with Netdata"
 custom_edit_url: <https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dovecot/README.md>
 sidebar_label: "Dovecot"
----
 -->
 
 # Dovecot monitoring with Netdata

--- a/collectors/python.d.plugin/dovecot/README.md
+++ b/collectors/python.d.plugin/dovecot/README.md
@@ -1,6 +1,6 @@
 <!--
 title: "Dovecot monitoring with Netdata"
-custom_edit_url: <https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dovecot/README.md>
+custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dovecot/README.md
 sidebar_label: "Dovecot"
 -->
 

--- a/collectors/python.d.plugin/dovecot/README.md
+++ b/collectors/python.d.plugin/dovecot/README.md
@@ -1,7 +1,8 @@
 <!--
 ---
 title: "Dovecot monitoring with Netdata"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dovecot/README.md
+custom_edit_url: <https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dovecot/README.md>
+sidebar_label: "dovecot"
 ---
 -->
 

--- a/collectors/python.d.plugin/dovecot/README.md
+++ b/collectors/python.d.plugin/dovecot/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Dovecot monitoring with Netdata"
 custom_edit_url: <https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/dovecot/README.md>
-sidebar_label: "dovecot"
+sidebar_label: "Dovecot"
 ---
 -->
 

--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Elasticsearch monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/elasticsearch/README.md
 sidebar_label: "Elasticsearch"
----
 -->
 
 # Elasticsearch monitoring with Netdata

--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Elasticsearch monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/elasticsearch/README.md
+sidebar_label: "elasticsearch"
 ---
 -->
 

--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Elasticsearch monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/elasticsearch/README.md
-sidebar_label: "elasticsearch"
+sidebar_label: "Elasticsearch"
 ---
 -->
 

--- a/collectors/python.d.plugin/energid/README.md
+++ b/collectors/python.d.plugin/energid/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Energi Core node monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/energid/README.md
-sidebar_label: "energid"
+sidebar_label: "Energi Core"
 ---
 -->
 

--- a/collectors/python.d.plugin/energid/README.md
+++ b/collectors/python.d.plugin/energid/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Energi Core node monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/energid/README.md
 sidebar_label: "Energi Core"
----
 -->
 
 # Energi Core node monitoring with Netdata

--- a/collectors/python.d.plugin/energid/README.md
+++ b/collectors/python.d.plugin/energid/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Energi Core node monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/energid/README.md
+sidebar_label: "energid"
 ---
 -->
 

--- a/collectors/python.d.plugin/example/README.md
+++ b/collectors/python.d.plugin/example/README.md
@@ -1,8 +1,6 @@
 <!--
----
 title: "Example"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/example/README.md
----
 -->
 
 # Example

--- a/collectors/python.d.plugin/example/README.md
+++ b/collectors/python.d.plugin/example/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Example"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/example/README.md
+sidebar_label: "example"
 ---
 -->
 

--- a/collectors/python.d.plugin/example/README.md
+++ b/collectors/python.d.plugin/example/README.md
@@ -2,7 +2,6 @@
 ---
 title: "Example"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/example/README.md
-sidebar_label: "example"
 ---
 -->
 

--- a/collectors/python.d.plugin/exim/README.md
+++ b/collectors/python.d.plugin/exim/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Exim monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/exim/README.md
-sidebar_label: "exim"
+sidebar_label: "Exim"
 ---
 -->
 

--- a/collectors/python.d.plugin/exim/README.md
+++ b/collectors/python.d.plugin/exim/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Exim monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/exim/README.md
 sidebar_label: "Exim"
----
 -->
 
 # Exim monitoring with Netdata

--- a/collectors/python.d.plugin/exim/README.md
+++ b/collectors/python.d.plugin/exim/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Exim monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/exim/README.md
+sidebar_label: "exim"
 ---
 -->
 

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Fail2ban monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/fail2ban/README.md
 sidebar_label: "Fail2ban"
----
 -->
 
 # Fail2ban monitoring with Netdata

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Fail2ban monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/fail2ban/README.md
+sidebar_label: "fail2ban"
 ---
 -->
 

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Fail2ban monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/fail2ban/README.md
-sidebar_label: "fail2ban"
+sidebar_label: "Fail2ban"
 ---
 -->
 

--- a/collectors/python.d.plugin/freeradius/README.md
+++ b/collectors/python.d.plugin/freeradius/README.md
@@ -2,7 +2,7 @@
 ---
 title: "FreeRADIUS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/freeradius/README.md
-sidebar_label: "freeradius"
+sidebar_label: "FreeRADIUS"
 ---
 -->
 

--- a/collectors/python.d.plugin/freeradius/README.md
+++ b/collectors/python.d.plugin/freeradius/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "FreeRADIUS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/freeradius/README.md
 sidebar_label: "FreeRADIUS"
----
 -->
 
 # FreeRADIUS monitoring with Netdata

--- a/collectors/python.d.plugin/freeradius/README.md
+++ b/collectors/python.d.plugin/freeradius/README.md
@@ -2,6 +2,7 @@
 ---
 title: "FreeRADIUS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/freeradius/README.md
+sidebar_label: "freeradius"
 ---
 -->
 

--- a/collectors/python.d.plugin/gearman/README.md
+++ b/collectors/python.d.plugin/gearman/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Gearman monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/gearman/README.md
+sidebar_label: "gearman"
 ---
 -->
 

--- a/collectors/python.d.plugin/gearman/README.md
+++ b/collectors/python.d.plugin/gearman/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Gearman monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/gearman/README.md
-sidebar_label: "gearman"
+sidebar_label: "Gearman"
 ---
 -->
 

--- a/collectors/python.d.plugin/gearman/README.md
+++ b/collectors/python.d.plugin/gearman/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Gearman monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/gearman/README.md
 sidebar_label: "Gearman"
----
 -->
 
 # Gearman monitoring with Netdata

--- a/collectors/python.d.plugin/go_expvar/README.md
+++ b/collectors/python.d.plugin/go_expvar/README.md
@@ -1,12 +1,12 @@
 <!--
 ---
-title: "Go application monitoring with Netdata"
+title: "Go applications monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/go_expvar/README.md
-sidebar_label: "go_expvar"
+sidebar_label: "Go applications"
 ---
 -->
 
-# Go application monitoring with Netdata
+# Go applications monitoring with Netdata
 
 Monitors Go application that exposes its metrics with the use of `expvar` package from the Go standard library.  The package produces charts for Go runtime memory statistics and optionally any number of custom charts.
 

--- a/collectors/python.d.plugin/go_expvar/README.md
+++ b/collectors/python.d.plugin/go_expvar/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Go application monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/go_expvar/README.md
+sidebar_label: "go_expvar"
 ---
 -->
 

--- a/collectors/python.d.plugin/go_expvar/README.md
+++ b/collectors/python.d.plugin/go_expvar/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Go applications monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/go_expvar/README.md
 sidebar_label: "Go applications"
----
 -->
 
 # Go applications monitoring with Netdata

--- a/collectors/python.d.plugin/haproxy/README.md
+++ b/collectors/python.d.plugin/haproxy/README.md
@@ -2,6 +2,7 @@
 ---
 title: "HAProxy monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/haproxy/README.md
+sidebar_label: "haproxy"
 ---
 -->
 

--- a/collectors/python.d.plugin/haproxy/README.md
+++ b/collectors/python.d.plugin/haproxy/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "HAProxy monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/haproxy/README.md
 sidebar_label: "HAProxy"
----
 -->
 
 # HAProxy monitoring with Netdata

--- a/collectors/python.d.plugin/haproxy/README.md
+++ b/collectors/python.d.plugin/haproxy/README.md
@@ -2,7 +2,7 @@
 ---
 title: "HAProxy monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/haproxy/README.md
-sidebar_label: "haproxy"
+sidebar_label: "HAProxy"
 ---
 -->
 

--- a/collectors/python.d.plugin/hddtemp/README.md
+++ b/collectors/python.d.plugin/hddtemp/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Hard drive temperature monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/hddtemp/README.md
-sidebar_label: "hddtemp"
+sidebar_label: "Hard drive temperature"
 ---
 -->
 

--- a/collectors/python.d.plugin/hddtemp/README.md
+++ b/collectors/python.d.plugin/hddtemp/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Hard drive temperature monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/hddtemp/README.md
 sidebar_label: "Hard drive temperature"
----
 -->
 
 # Hard drive temperature monitoring with Netdata

--- a/collectors/python.d.plugin/hddtemp/README.md
+++ b/collectors/python.d.plugin/hddtemp/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Hard drive temperature monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/hddtemp/README.md
+sidebar_label: "hddtemp"
 ---
 -->
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -2,7 +2,7 @@
 ---
 title: "HP Smart Storage Arrays monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/hpssa/README.md
-sidebar_label: ""HP Smart Storage Arrays"
+sidebar_label: "HP Smart Storage Arrays"
 ---
 -->
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "HP Smart Storage Arrays monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/hpssa/README.md
 sidebar_label: "HP Smart Storage Arrays"
----
 -->
 
 # HP Smart Storage Arrays monitoring with Netdata

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -2,6 +2,7 @@
 ---
 title: "HP Smart Storage Arrays monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/hpssa/README.md
+sidebar_label: "hpssa"
 ---
 -->
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -2,7 +2,7 @@
 ---
 title: "HP Smart Storage Arrays monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/hpssa/README.md
-sidebar_label: "hpssa"
+sidebar_label: ""HP Smart Storage Arrays"
 ---
 -->
 

--- a/collectors/python.d.plugin/httpcheck/README.md
+++ b/collectors/python.d.plugin/httpcheck/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "HTTP endpoint monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/httpcheck/README.md
 sidebar_label: "HTTP endpoints"
----
 -->
 
 # HTTP endpoint monitoring with Netdata

--- a/collectors/python.d.plugin/httpcheck/README.md
+++ b/collectors/python.d.plugin/httpcheck/README.md
@@ -2,7 +2,7 @@
 ---
 title: "HTTP endpoint monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/httpcheck/README.md
-sidebar_label: "HTTP endpoint"
+sidebar_label: "HTTP endpoints"
 ---
 -->
 

--- a/collectors/python.d.plugin/httpcheck/README.md
+++ b/collectors/python.d.plugin/httpcheck/README.md
@@ -2,6 +2,7 @@
 ---
 title: "HTTP endpoint monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/httpcheck/README.md
+sidebar_label: "httpcheck"
 ---
 -->
 

--- a/collectors/python.d.plugin/httpcheck/README.md
+++ b/collectors/python.d.plugin/httpcheck/README.md
@@ -2,7 +2,7 @@
 ---
 title: "HTTP endpoint monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/httpcheck/README.md
-sidebar_label: "httpcheck"
+sidebar_label: "HTTP endpoint"
 ---
 -->
 

--- a/collectors/python.d.plugin/icecast/README.md
+++ b/collectors/python.d.plugin/icecast/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Icecast monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/icecast/README.md
+sidebar_label: "icecast"
 ---
 -->
 

--- a/collectors/python.d.plugin/icecast/README.md
+++ b/collectors/python.d.plugin/icecast/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Icecast monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/icecast/README.md
 sidebar_label: "Icecast"
----
 -->
 
 # Icecast monitoring with Netdata

--- a/collectors/python.d.plugin/icecast/README.md
+++ b/collectors/python.d.plugin/icecast/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Icecast monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/icecast/README.md
-sidebar_label: "icecast"
+sidebar_label: "Icecast"
 ---
 -->
 

--- a/collectors/python.d.plugin/ipfs/README.md
+++ b/collectors/python.d.plugin/ipfs/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "IPFS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ipfs/README.md
 sidebar_label: "IPFS"
----
 -->
 
 # IPFS monitoring with Netdata

--- a/collectors/python.d.plugin/ipfs/README.md
+++ b/collectors/python.d.plugin/ipfs/README.md
@@ -2,7 +2,7 @@
 ---
 title: "IPFS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ipfs/README.md
-sidebar_label: "ipfs"
+sidebar_label: "IPFS"
 ---
 -->
 

--- a/collectors/python.d.plugin/ipfs/README.md
+++ b/collectors/python.d.plugin/ipfs/README.md
@@ -2,6 +2,7 @@
 ---
 title: "IPFS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ipfs/README.md
+sidebar_label: "ipfs"
 ---
 -->
 

--- a/collectors/python.d.plugin/isc_dhcpd/README.md
+++ b/collectors/python.d.plugin/isc_dhcpd/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "ISC DHCP monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/isc_dhcpd/README.md
 sidebar_label: "ISC DHCP"
----
 -->
 
 # ISC DHCP monitoring with Netdata

--- a/collectors/python.d.plugin/isc_dhcpd/README.md
+++ b/collectors/python.d.plugin/isc_dhcpd/README.md
@@ -2,6 +2,7 @@
 ---
 title: "ISC DHCP monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/isc_dhcpd/README.md
+sidebar_label: "isc_dhcpd"
 ---
 -->
 

--- a/collectors/python.d.plugin/isc_dhcpd/README.md
+++ b/collectors/python.d.plugin/isc_dhcpd/README.md
@@ -2,7 +2,7 @@
 ---
 title: "ISC DHCP monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/isc_dhcpd/README.md
-sidebar_label: "isc_dhcpd"
+sidebar_label: "ISC DHCP"
 ---
 -->
 

--- a/collectors/python.d.plugin/litespeed/README.md
+++ b/collectors/python.d.plugin/litespeed/README.md
@@ -2,7 +2,7 @@
 ---
 title: "LiteSpeed monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/litespeed/README.md
-sidebar_label: "litespeed"
+sidebar_label: "LiteSpeed"
 ---
 -->
 

--- a/collectors/python.d.plugin/litespeed/README.md
+++ b/collectors/python.d.plugin/litespeed/README.md
@@ -2,6 +2,7 @@
 ---
 title: "LiteSpeed monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/litespeed/README.md
+sidebar_label: "litespeed"
 ---
 -->
 

--- a/collectors/python.d.plugin/litespeed/README.md
+++ b/collectors/python.d.plugin/litespeed/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "LiteSpeed monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/litespeed/README.md
 sidebar_label: "LiteSpeed"
----
 -->
 
 # LiteSpeed monitoring with Netdata

--- a/collectors/python.d.plugin/logind/README.md
+++ b/collectors/python.d.plugin/logind/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "systemd-logind monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/logind/README.md
 sidebar_label: "systemd-logind"
----
 -->
 
 # Systemd-Logind monitoring with Netdata

--- a/collectors/python.d.plugin/logind/README.md
+++ b/collectors/python.d.plugin/logind/README.md
@@ -1,7 +1,8 @@
 <!--
 ---
-title: "Systemd-Logind monitoring with Netdata"
+title: "systemd-logind monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/logind/README.md
+sidebar_label: "systemd-logind"
 ---
 -->
 

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -2,7 +2,7 @@
 ---
 title: "MegaRAID controller monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/megacli/README.md
-sidebar_label: "MegaRAID controller"
+sidebar_label: "MegaRAID controllers"
 ---
 -->
 

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "MegaRAID controller monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/megacli/README.md
 sidebar_label: "MegaRAID controllers"
----
 -->
 
 # MegaRAID controller monitoring with Netdata

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -2,6 +2,7 @@
 ---
 title: "MegaRAID controller monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/megacli/README.md
+sidebar_label: "MegaRAID controller"
 ---
 -->
 

--- a/collectors/python.d.plugin/memcached/README.md
+++ b/collectors/python.d.plugin/memcached/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Memcached monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/memcached/README.md
 sidebar_label: "Memcached"
----
 -->
 
 # Memcached monitoring with Netdata

--- a/collectors/python.d.plugin/memcached/README.md
+++ b/collectors/python.d.plugin/memcached/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Memcached monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/memcached/README.md
+sidebar_label: "Memcached"
 ---
 -->
 

--- a/collectors/python.d.plugin/mongodb/README.md
+++ b/collectors/python.d.plugin/mongodb/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "MongoDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/mongodb/README.md
 sidebar_label: "MongoDB"
----
 -->
 
 # MongoDB monitoring with Netdata

--- a/collectors/python.d.plugin/mongodb/README.md
+++ b/collectors/python.d.plugin/mongodb/README.md
@@ -2,6 +2,7 @@
 ---
 title: "MongoDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/mongodb/README.md
+sidebar_label: "MongoDB"
 ---
 -->
 

--- a/collectors/python.d.plugin/monit/README.md
+++ b/collectors/python.d.plugin/monit/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Monit monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/monit/README.md
+sidebar_label: "Monit"
 ---
 -->
 

--- a/collectors/python.d.plugin/monit/README.md
+++ b/collectors/python.d.plugin/monit/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Monit monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/monit/README.md
 sidebar_label: "Monit"
----
 -->
 
 # Monit monitoring with Netdata

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -2,6 +2,7 @@
 ---
 title: "MySQL monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/mysql/README.md
+sidebar_label: "MySQL"
 ---
 -->
 

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "MySQL monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/mysql/README.md
 sidebar_label: "MySQL"
----
 -->
 
 # MySQL monitoring with Netdata

--- a/collectors/python.d.plugin/nginx/README.md
+++ b/collectors/python.d.plugin/nginx/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "NGINX monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nginx/README.md
 sidebar_label: "NGINX"
----
 -->
 
 # NGINX monitoring with Netdata

--- a/collectors/python.d.plugin/nginx/README.md
+++ b/collectors/python.d.plugin/nginx/README.md
@@ -2,6 +2,7 @@
 ---
 title: "NGINX monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nginx/README.md
+sidebar_label: "NGINX"
 ---
 -->
 

--- a/collectors/python.d.plugin/nginx_plus/README.md
+++ b/collectors/python.d.plugin/nginx_plus/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "NGINX Plus monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nginx_plus/README.md
 sidebar_label: "NGINX Plus"
----
 -->
 
 # NGINX Plus monitoring with Netdata

--- a/collectors/python.d.plugin/nginx_plus/README.md
+++ b/collectors/python.d.plugin/nginx_plus/README.md
@@ -2,6 +2,7 @@
 ---
 title: "NGINX Plus monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nginx_plus/README.md
+sidebar_label: "NGINX Plus"
 ---
 -->
 

--- a/collectors/python.d.plugin/nsd/README.md
+++ b/collectors/python.d.plugin/nsd/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "NSD monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nsd/README.md
 sidebar_label: "NSD"
----
 -->
 
 # NSD monitoring with Netdata

--- a/collectors/python.d.plugin/nsd/README.md
+++ b/collectors/python.d.plugin/nsd/README.md
@@ -2,6 +2,7 @@
 ---
 title: "NSD monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nsd/README.md
+sidebar_label: "NSD"
 ---
 -->
 

--- a/collectors/python.d.plugin/ntpd/README.md
+++ b/collectors/python.d.plugin/ntpd/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "NTP daemon monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ntpd/README.md
 sidebar_label: "NTP daemon"
----
 -->
 
 # NTP daemon monitoring with Netdata

--- a/collectors/python.d.plugin/ntpd/README.md
+++ b/collectors/python.d.plugin/ntpd/README.md
@@ -2,6 +2,7 @@
 ---
 title: "NTP daemon monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ntpd/README.md
+sidebar_label: "NTP daemon"
 ---
 -->
 

--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Nvidia GPU monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nvidia_smi/README.md
-sidebar_label: "Nvidia GPU"
+sidebar_label: "Nvidia GPUs"
 ---
 -->
 

--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -1,11 +1,12 @@
 <!--
 ---
-title: "NVIDIA GPU monitoring with Netdata"
+title: "Nvidia GPU monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nvidia_smi/README.md
+sidebar_label: "Nvidia GPU"
 ---
 -->
 
-# NVIDIA GPU monitoring with Netdata
+# Nvidia GPU monitoring with Netdata
 
 Monitors performance metrics (memory usage, fan speed, pcie bandwidth utilization, temperature, etc.) using `nvidia-smi` cli tool.
 

--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Nvidia GPU monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nvidia_smi/README.md
 sidebar_label: "Nvidia GPUs"
----
 -->
 
 # Nvidia GPU monitoring with Netdata

--- a/collectors/python.d.plugin/openldap/README.md
+++ b/collectors/python.d.plugin/openldap/README.md
@@ -2,6 +2,7 @@
 ---
 title: "OpenLDAP monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/openldap/README.md
+sidebar_label: "OpenLDAP"
 ---
 -->
 

--- a/collectors/python.d.plugin/openldap/README.md
+++ b/collectors/python.d.plugin/openldap/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "OpenLDAP monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/openldap/README.md
 sidebar_label: "OpenLDAP"
----
 -->
 
 # OpenLDAP monitoring with Netdata

--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "OracleDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/oracledb/README.md
 sidebar_label: "OracleDB"
----
 -->
 
 # OracleDB monitoring with Netdata

--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -2,6 +2,7 @@
 ---
 title: "OracleDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/oracledb/README.md
+sidebar_label: "OracleDB"
 ---
 -->
 

--- a/collectors/python.d.plugin/ovpn_status_log/README.md
+++ b/collectors/python.d.plugin/ovpn_status_log/README.md
@@ -2,6 +2,7 @@
 ---
 title: "OpenVPN monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ovpn_status_log/README.md
+sidebar_label: "OpenVPN"
 ---
 -->
 

--- a/collectors/python.d.plugin/ovpn_status_log/README.md
+++ b/collectors/python.d.plugin/ovpn_status_log/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "OpenVPN monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/ovpn_status_log/README.md
 sidebar_label: "OpenVPN"
----
 -->
 
 # OpenVPN monitoring with Netdata

--- a/collectors/python.d.plugin/phpfpm/README.md
+++ b/collectors/python.d.plugin/phpfpm/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "PHP-FPM monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/phpfpm/README.md
 sidebar_label: "PHP-FPM"
----
 -->
 
 # PHP-FPM monitoring with Netdata

--- a/collectors/python.d.plugin/phpfpm/README.md
+++ b/collectors/python.d.plugin/phpfpm/README.md
@@ -2,6 +2,7 @@
 ---
 title: "PHP-FPM monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/phpfpm/README.md
+sidebar_label: "PHP-FPM"
 ---
 -->
 

--- a/collectors/python.d.plugin/portcheck/README.md
+++ b/collectors/python.d.plugin/portcheck/README.md
@@ -2,7 +2,7 @@
 ---
 title: "TCP endpoint monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/portcheck/README.md
-sidebar_label: "TCP endpoint"
+sidebar_label: "TCP endpoints"
 ---
 -->
 

--- a/collectors/python.d.plugin/portcheck/README.md
+++ b/collectors/python.d.plugin/portcheck/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "TCP endpoint monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/portcheck/README.md
 sidebar_label: "TCP endpoints"
----
 -->
 
 # TCP endpoint monitoring with Netdata

--- a/collectors/python.d.plugin/portcheck/README.md
+++ b/collectors/python.d.plugin/portcheck/README.md
@@ -2,6 +2,7 @@
 ---
 title: "TCP endpoint monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/portcheck/README.md
+sidebar_label: "TCP endpoint"
 ---
 -->
 

--- a/collectors/python.d.plugin/postfix/README.md
+++ b/collectors/python.d.plugin/postfix/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Postfix monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/postfix/README.md
+sidebar_label: "Postfix"
 ---
 -->
 

--- a/collectors/python.d.plugin/postfix/README.md
+++ b/collectors/python.d.plugin/postfix/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Postfix monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/postfix/README.md
 sidebar_label: "Postfix"
----
 -->
 
 # Postfix monitoring with Netdata

--- a/collectors/python.d.plugin/postgres/README.md
+++ b/collectors/python.d.plugin/postgres/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "PostgreSQL monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/postgres/README.md
 sidebar_label: "PostgreSQL"
----
 -->
 
 # PostgreSQL monitoring with Netdata

--- a/collectors/python.d.plugin/postgres/README.md
+++ b/collectors/python.d.plugin/postgres/README.md
@@ -2,6 +2,7 @@
 ---
 title: "PostgreSQL monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/postgres/README.md
+sidebar_label: "PostgreSQL"
 ---
 -->
 

--- a/collectors/python.d.plugin/powerdns/README.md
+++ b/collectors/python.d.plugin/powerdns/README.md
@@ -2,6 +2,7 @@
 ---
 title: "PowerDNS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/powerdns/README.md
+sidebar_label: "PowerDNS"
 ---
 -->
 

--- a/collectors/python.d.plugin/powerdns/README.md
+++ b/collectors/python.d.plugin/powerdns/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "PowerDNS monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/powerdns/README.md
 sidebar_label: "PowerDNS"
----
 -->
 
 # PowerDNS monitoring with Netdata

--- a/collectors/python.d.plugin/proxysql/README.md
+++ b/collectors/python.d.plugin/proxysql/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "ProxySQL monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/proxysql/README.md
 sidebar_label: "ProxySQL"
----
 -->
 
 # ProxySQL monitoring with Netdata

--- a/collectors/python.d.plugin/proxysql/README.md
+++ b/collectors/python.d.plugin/proxysql/README.md
@@ -2,6 +2,7 @@
 ---
 title: "ProxySQL monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/proxysql/README.md
+sidebar_label: "ProxySQL"
 ---
 -->
 

--- a/collectors/python.d.plugin/puppet/README.md
+++ b/collectors/python.d.plugin/puppet/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Puppet monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/puppet/README.md
 sidebar_label: "Puppet"
----
 -->
 
 # Puppet monitoring with Netdata

--- a/collectors/python.d.plugin/puppet/README.md
+++ b/collectors/python.d.plugin/puppet/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Puppet monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/puppet/README.md
+sidebar_label: "Puppet"
 ---
 -->
 

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "RabbitMQ monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/rabbitmq/README.md
 sidebar_label: "RabbitMQ"
----
 -->
 
 # RabbitMQ monitoring with Netdata

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -2,6 +2,7 @@
 ---
 title: "RabbitMQ monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/rabbitmq/README.md
+sidebar_label: "RabbitMQ"
 ---
 -->
 

--- a/collectors/python.d.plugin/redis/README.md
+++ b/collectors/python.d.plugin/redis/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Redis monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/redis/README.md
 sidebar_label: "Redis"
----
 -->
 
 # Redis monitoring with Netdata

--- a/collectors/python.d.plugin/redis/README.md
+++ b/collectors/python.d.plugin/redis/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Redis monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/redis/README.md
+sidebar_label: "Redis"
 ---
 -->
 

--- a/collectors/python.d.plugin/rethinkdbs/README.md
+++ b/collectors/python.d.plugin/rethinkdbs/README.md
@@ -2,6 +2,7 @@
 ---
 title: "RethinkDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/rethinkdbs/README.md
+sidebar_label: "RethinkDB"
 ---
 -->
 

--- a/collectors/python.d.plugin/rethinkdbs/README.md
+++ b/collectors/python.d.plugin/rethinkdbs/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "RethinkDB monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/rethinkdbs/README.md
 sidebar_label: "RethinkDB"
----
 -->
 
 # RethinkDB monitoring with Netdata

--- a/collectors/python.d.plugin/retroshare/README.md
+++ b/collectors/python.d.plugin/retroshare/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "RetroShare monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/retroshare/README.md
 sidebar_label: "RetroShare"
----
 -->
 
 # RetroShare monitoring with Netdata

--- a/collectors/python.d.plugin/retroshare/README.md
+++ b/collectors/python.d.plugin/retroshare/README.md
@@ -2,6 +2,7 @@
 ---
 title: "RetroShare monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/retroshare/README.md
+sidebar_label: "RetroShare"
 ---
 -->
 

--- a/collectors/python.d.plugin/riakkv/README.md
+++ b/collectors/python.d.plugin/riakkv/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Riak KV monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/riakkv/README.md
 sidebar_label: "Riak KV"
----
 -->
 
 # Riak KV monitoring with Netdata

--- a/collectors/python.d.plugin/riakkv/README.md
+++ b/collectors/python.d.plugin/riakkv/README.md
@@ -1,11 +1,12 @@
 <!--
 ---
-title: "RiakKV monitoring with Netdata"
+title: "Riak KV monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/riakkv/README.md
+sidebar_label: "Riak KV"
 ---
 -->
 
-# RiakKV monitoring with Netdata
+# Riak KV monitoring with Netdata
 
 Collects database stats from `/stats` endpoint.
 

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Samba monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/samba/README.md
 sidebar_label: "Samba"
----
 -->
 
 # Samba monitoring with Netdata

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Samba monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/samba/README.md
+sidebar_label: "Samba"
 ---
 -->
 

--- a/collectors/python.d.plugin/sensors/README.md
+++ b/collectors/python.d.plugin/sensors/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Linux machine sensors monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/sensors/README.md
 sidebar_label: "Linux machine sensors"
----
 -->
 
 # Linux machine sensors monitoring with Netdata

--- a/collectors/python.d.plugin/sensors/README.md
+++ b/collectors/python.d.plugin/sensors/README.md
@@ -1,11 +1,12 @@
 <!--
 ---
-title: "Linux machines sensors monitoring with Netdata"
+title: "Linux machine sensors monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/sensors/README.md
+sidebar_label: "Linux machine sensors"
 ---
 -->
 
-# Linux machines sensors monitoring with Netdata
+# Linux machine sensors monitoring with Netdata
 
 Reads system sensors information (temperature, voltage, electric current, power, etc.).
 

--- a/collectors/python.d.plugin/smartd_log/README.md
+++ b/collectors/python.d.plugin/smartd_log/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Storage devices monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/smartd_log/README.md
+sidebar_label: "S.M.A.R.T. attributes"
 ---
 -->
 

--- a/collectors/python.d.plugin/smartd_log/README.md
+++ b/collectors/python.d.plugin/smartd_log/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Storage devices monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/smartd_log/README.md
 sidebar_label: "S.M.A.R.T. attributes"
----
 -->
 
 # Storage devices monitoring with Netdata

--- a/collectors/python.d.plugin/spigotmc/README.md
+++ b/collectors/python.d.plugin/spigotmc/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "SpigotMC monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/spigotmc/README.md
 sidebar_label: "SpigotMC"
----
 -->
 
 # SpigotMC monitoring with Netdata

--- a/collectors/python.d.plugin/spigotmc/README.md
+++ b/collectors/python.d.plugin/spigotmc/README.md
@@ -2,6 +2,7 @@
 ---
 title: "SpigotMC monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/spigotmc/README.md
+sidebar_label: "SpigotMC"
 ---
 -->
 

--- a/collectors/python.d.plugin/springboot/README.md
+++ b/collectors/python.d.plugin/springboot/README.md
@@ -1,11 +1,12 @@
 <!--
 ---
-title: "Spring Boot2 monitoring with Netdata"
+title: "Spring Boot 2 monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/springboot/README.md
+sidebar_label: "Spring Boot 2"
 ---
 -->
 
-# Spring Boot2 monitoring with Netdata
+# Spring Boot 2 monitoring with Netdata
 
 Monitors one or more Java Spring-boot applications depending on configuration.
 Netdata can be used to monitor running Java [Spring Boot](https://spring.io/) applications that expose their metrics with the use of the **Spring Boot Actuator** included in Spring Boot library.

--- a/collectors/python.d.plugin/springboot/README.md
+++ b/collectors/python.d.plugin/springboot/README.md
@@ -1,12 +1,12 @@
 <!--
 ---
-title: "Spring Boot 2 monitoring with Netdata"
+title: "Java Spring Boot 2 application monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/springboot/README.md
-sidebar_label: "Spring Boot 2"
+sidebar_label: "Java Spring Boot 2 applications"
 ---
 -->
 
-# Spring Boot 2 monitoring with Netdata
+# Java Spring Boot 2 application monitoring with Netdata
 
 Monitors one or more Java Spring-boot applications depending on configuration.
 Netdata can be used to monitor running Java [Spring Boot](https://spring.io/) applications that expose their metrics with the use of the **Spring Boot Actuator** included in Spring Boot library.

--- a/collectors/python.d.plugin/springboot/README.md
+++ b/collectors/python.d.plugin/springboot/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Java Spring Boot 2 application monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/springboot/README.md
 sidebar_label: "Java Spring Boot 2 applications"
----
 -->
 
 # Java Spring Boot 2 application monitoring with Netdata

--- a/collectors/python.d.plugin/squid/README.md
+++ b/collectors/python.d.plugin/squid/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Squid monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/squid/README.md
+sidebar_label: "Squid"
 ---
 -->
 

--- a/collectors/python.d.plugin/squid/README.md
+++ b/collectors/python.d.plugin/squid/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Squid monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/squid/README.md
 sidebar_label: "Squid"
----
 -->
 
 # Squid monitoring with Netdata

--- a/collectors/python.d.plugin/tomcat/README.md
+++ b/collectors/python.d.plugin/tomcat/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Apache Tomcat monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/tomcat/README.md
 sidebar_label: "Tomcat"
----
 -->
 
 # Apache Tomcat monitoring with Netdata

--- a/collectors/python.d.plugin/tomcat/README.md
+++ b/collectors/python.d.plugin/tomcat/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Apache Tomcat monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/tomcat/README.md
+sidebar_label: "Apache Tomcat"
 ---
 -->
 

--- a/collectors/python.d.plugin/tomcat/README.md
+++ b/collectors/python.d.plugin/tomcat/README.md
@@ -2,7 +2,7 @@
 ---
 title: "Apache Tomcat monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/tomcat/README.md
-sidebar_label: "Apache Tomcat"
+sidebar_label: "Tomcat"
 ---
 -->
 

--- a/collectors/python.d.plugin/tor/README.md
+++ b/collectors/python.d.plugin/tor/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Tor monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/tor/README.md
+sidebar_label: "Tor"
 ---
 -->
 

--- a/collectors/python.d.plugin/tor/README.md
+++ b/collectors/python.d.plugin/tor/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Tor monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/tor/README.md
 sidebar_label: "Tor"
----
 -->
 
 # Tor monitoring with Netdata

--- a/collectors/python.d.plugin/traefik/README.md
+++ b/collectors/python.d.plugin/traefik/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Traefik monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/traefik/README.md
+sidebar_label: "Traefik"
 ---
 -->
 

--- a/collectors/python.d.plugin/traefik/README.md
+++ b/collectors/python.d.plugin/traefik/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Traefik monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/traefik/README.md
 sidebar_label: "Traefik"
----
 -->
 
 # Traefik monitoring with Netdata

--- a/collectors/python.d.plugin/uwsgi/README.md
+++ b/collectors/python.d.plugin/uwsgi/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "uWSGI monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/uwsgi/README.md
 sidebar_label: "uWSGI"
----
 -->
 
 # uWSGI monitoring with Netdata

--- a/collectors/python.d.plugin/uwsgi/README.md
+++ b/collectors/python.d.plugin/uwsgi/README.md
@@ -2,6 +2,7 @@
 ---
 title: "uWSGI monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/uwsgi/README.md
+sidebar_label: "uWSGI"
 ---
 -->
 

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -2,6 +2,7 @@
 ---
 title: "Varnish Cache monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/varnish/README.md
+sidebar_label: "Varnish Cache"
 ---
 -->
 

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Varnish Cache monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/varnish/README.md
 sidebar_label: "Varnish Cache"
----
 -->
 
 # Varnish Cache monitoring with Netdata

--- a/collectors/python.d.plugin/w1sensor/README.md
+++ b/collectors/python.d.plugin/w1sensor/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "1-Wire Sensors monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/w1sensor/README.md
 sidebar_label: "1-Wire sensors"
----
 -->
 
 # 1-Wire Sensors monitoring with Netdata

--- a/collectors/python.d.plugin/w1sensor/README.md
+++ b/collectors/python.d.plugin/w1sensor/README.md
@@ -2,6 +2,7 @@
 ---
 title: "1-Wire Sensors monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/w1sensor/README.md
+sidebar_label: "1-Wire sensors"
 ---
 -->
 

--- a/collectors/python.d.plugin/web_log/README.md
+++ b/collectors/python.d.plugin/web_log/README.md
@@ -1,9 +1,7 @@
 <!--
----
 title: "Web server log (Apache, NGINX, Squid) monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/web_log/README.md
 sidebar_label: "Web server logs (Apache, NGINX, Squid)"
----
 -->
 
 # Web server log (Apache, NGINX, Squid) monitoring with Netdata

--- a/collectors/python.d.plugin/web_log/README.md
+++ b/collectors/python.d.plugin/web_log/README.md
@@ -1,11 +1,12 @@
 <!--
 ---
-title: "Apache/NGINX/Squid monitoring with Netdata"
+title: "Web server log (Apache, NGINX, Squid) monitoring with Netdata"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/web_log/README.md
+sidebar_label: "Web server logs (Apache, NGINX, Squid)"
 ---
 -->
 
-# Apache/NGINX/Squid monitoring with Netdata
+# Web server log (Apache, NGINX, Squid) monitoring with Netdata
 
 Tails access log file and Collects web server/caching proxy metrics.
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Connected to netdata/netdata-learn-docusaurus#108 and netdata/go.d.plugin#376.

This PR fixes a bug that @ilyam8 brought up that in the sidebar, the Python/Bash/Node collectors had "... monitoring with Netdata" appended to them.

![image](https://user-images.githubusercontent.com/1153921/81322561-0b034f00-9049-11ea-82a0-78240c404ab3.png)

I added a new item to the frontmatter that lets us have different page and sidebar titles. I also changed the sidebar titles to reflect the name of the app/service being monitored, not the name of the collector module, and re-organized them alphabetically.

![image](https://user-images.githubusercontent.com/1153921/81322947-86fd9700-9049-11ea-9156-64d48509d692.png)

Once this is merged, I'll return to #8069 and re-group all these collectors by their type, not their orchestrator.

##### Component Name

collectors/

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Tested at https://deploy-preview-108--netdata-docusaurus.netlify.app/

##### Additional Information
