### PR TITLE
[varnish] : added compatibility for varnish-plus

### DIFF
--- a/collectors/python.d.plugin/varnish/varnish.chart.py
+++ b/collectors/python.d.plugin/varnish/varnish.chart.py
@@ -175,7 +175,7 @@ def disk_charts_template(name):
 
 VARNISHSTAT = 'varnishstat'
 
-re_version = re.compile(r'varnish-(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)')
+re_version = re.compile(r'varnish-(?:plus-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)')
 
 
 class VarnishVersion:


### PR DESCRIPTION
##### Summary
Adds compatibility for varnish-plus

##### Component Name
varnish

##### Test Plan
Varnish-plus is required in order to perform tests.
Changes were tested with varnish and varnish-plus versions


##### Additional Information
Currently netdata cannot load varnish module when using varnish-plus package due to the regex to parse the version:

python.d ERROR: varnish[varnish] : failed to parse reply from '/usr/bin/varnishstat -V', used regex :'varnish-(?P\d+).(?P\d+).(?P\d+)', reply : [u'/usr/bin/varnishstat (varnish-plus-6.0.6r1 revision )\n', u'Copyright (c) 2006 Verdens Gang AS\n', u'Copyright (c) 2006-2019 Varnish Software AS\n']
