### PR TITLE
Remove check for old alarm status (CID 358436)

### DIFF
--- a/health/health_json.c
+++ b/health/health_json.c
@@ -354,7 +354,6 @@ void health_active_log_alarms_2json(RRDHOST *host, BUFFER *wb) {
     for(ae = host->health_log.alarms; ae && count < max ; ae = ae->next) {
 
         if(likely(!((ae->new_status == RRDCALC_STATUS_WARNING || ae->new_status == RRDCALC_STATUS_CRITICAL)
-                   && (ae->old_status != RRDCALC_STATUS_WARNING || ae->old_status != RRDCALC_STATUS_CRITICAL)
                     && !ae->updated_by_id)))
             continue;
 


### PR DESCRIPTION
##### Summary
Fixes CID 358436

Remove check for old alarm status. We only care about events being in
CRITICAL or WARNING status and not superseded by another event 

##### Component Name
ACLK

##### Test plan
- Connect agent to the cloud
  - Setup an alarm that will be triggered easily e.g.
```
    template: 1min_cpu_usage
      on: system.cpu
      os: linux
   hosts: *
  lookup: average -1m unaligned of user,system,softirq,irq,guest
   units: %
   every: 30s
    warn: $this > 2
    crit: $this > 3
   delay: down 15s multiplier 1.5 max 30s
    info: average cpu utilization for the last 1 minute (excluding iowait, nice and steal)
      to: sysadmin
```
- When the alarm fires
  - Stop the agent
  - In the cloud the node will be marked as unreachable
  - Start the agent
  - When ACLK is established the alarm status will be available to the cloud via the on_connect message
