### PR TITLE
Added JSON-C packaging fils to make dist.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,8 @@ dist_noinst_DATA = \
     packaging/dashboard.checksums \
     packaging/go.d.version \
     packaging/go.d.checksums \
+    packaging/jsonc.version \
+    packaging/jsonc.checksums \
     packaging/libwebsockets.version \
     packaging/libwebsockets.checksums \
     packaging/mosquitto.version \


### PR DESCRIPTION
##### Summary

These got missed due to a lack of CI checking the case of installing from an archive produced using `make dist` on a system without JSON-C.

##### Component Name

area/packaging

##### Test Plan

Manually verified that `make dist` produces an archive with these files after this change.

This can be tested locally by creating a dist tarball (`autoreconf -ivf && ./configure && make dist` from the top level of the Netdata source tree), and then running the `netdata-installer.sh` script included in the dist tarball.

##### Additional Information

Fixes: #8970

@prologic This got bumped to top priority by @cakrit as needing to go into an imminently upcoming v1.22.1 bugfix release.