### PR TITLE
Fixed bundling of React dashboard in DEB and RPM packages.

### DIFF
--- a/packaging/bundle-dashboard.sh
+++ b/packaging/bundle-dashboard.sh
@@ -11,4 +11,4 @@ curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/dashboard/r
 sha256sum -c "${SRCDIR}/packaging/dashboard.checksums" || exit 1
 tar -xzf "${DASHBOARD_TARBALL}" -C "${SRCDIR}/tmp" || exit 1
 # shellcheck disable=SC2046
-cp -a $(find "${SRCDIR}/tmp" -mindepth 1 -maxdepth 1) "${WEBDIR}"
+cp -a $(find "${SRCDIR}/tmp/build" -mindepth 1 -maxdepth 1) "${WEBDIR}"


### PR DESCRIPTION
##### Summary

This fixes an error in the code used to bundle the React dashboard in our DEB and RPM packages which caused it to not be installed correctly, resulting in the packages only displaying the old dashboard.

##### Component Name

area/packaging

##### Test Plan

Verified locally by reproducing the error and then re-running with the fixed code.

The particular issue this fixes can be verified without actually building the packages by using the following set of steps:

1. Create a test directory.
2. Run `packaging/bundle-dashboad.sh` from the Netdata source tree with the path to the source tree and the path to the test directory as arguments.
3. Check the contents of the test directory.

The result of those steps _should_ be that the test directory contains the contents of the `build` directory from the dashboard repo. The result before this fix is applied is that it contains the `build` directory itself.

##### Additional Information

Fixes #8981 

This affected both our DEB and RPM packages.