### PR TITLE
Remove translation building/link-checking from docs generator

### DIFF
--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -52,10 +52,10 @@ for f in "${EXCLUDE_LIST[@]}"; do
 	rm "${SRC_DIR}/$f"
 done
 
-echo "Fetching localization project"
-LOC_DIR=${GENERATOR_DIR}/localization
-rm -rf ${LOC_DIR}
-git clone https://github.com/netdata/localization.git ${LOC_DIR}
+# echo "Fetching localization project"
+# LOC_DIR=${GENERATOR_DIR}/localization
+# rm -rf ${LOC_DIR}
+# git clone https://github.com/netdata/localization.git ${LOC_DIR}
 
 echo "Preparing directories"
 MKDOCS_CONFIG_FILE="${GENERATOR_DIR}/mkdocs.yml"
@@ -84,26 +84,23 @@ prep_html() {
 	echo "Calling mkdocs"
 
 	# Build html docs
-	mkdocs build --config-file="${MKDOCS_CONFIG_FILE}"
+	# mkdocs build --config-file="${MKDOCS_CONFIG_FILE}"
 
-	# Fix edit buttons for the markdowns that are not on the main Netdata repo
-	find "${GENERATOR_DIR}/${SITE_DIR}/${GO_D_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/collectors\/go.d.plugin/https:\/\/github.com\/netdata\/go.d.plugin\/blob\/master/g'
-	if [ "${lang}" != "en" ] ; then
-		find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
-	fi
+	# # Fix edit buttons for the markdowns that are not on the main Netdata repo
+	# find "${GENERATOR_DIR}/${SITE_DIR}/${GO_D_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/collectors\/go.d.plugin/https:\/\/github.com\/netdata\/go.d.plugin\/blob\/master/g'
+	# if [ "${lang}" != "en" ] ; then
+	# 	find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
+	# fi
 
-	# Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
-	echo "Replacing index.html with DOCUMENTATION/index.html"
-	sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
+	# # Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
+	# echo "Replacing index.html with DOCUMENTATION/index.html"
+	# sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
 
 }
 
 for d in "en" ; do
 	echo "Preparing source for $d"
 	cp -r ${SRC_DIR} ${DOCS_DIR}
-	if [ "${d}" != "en" ] ; then
-		cp -a ${LOC_DIR}/${d}/* ${DOCS_DIR}/
-	fi
 	prep_html $d
 	rm -rf ${DOCS_DIR}
 done

--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -98,7 +98,7 @@ prep_html() {
 
 }
 
-for d in "en" "kr" "zh" "pt" ; do
+for d in "en" ; do
 	echo "Preparing source for $d"
 	cp -r ${SRC_DIR} ${DOCS_DIR}
 	if [ "${d}" != "en" ] ; then

--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -52,8 +52,8 @@ for f in "${EXCLUDE_LIST[@]}"; do
 	rm "${SRC_DIR}/$f"
 done
 
-# echo "Fetching localization project"
-# LOC_DIR=${GENERATOR_DIR}/localization
+echo "Fetching localization project"
+LOC_DIR=${GENERATOR_DIR}/localization
 # rm -rf ${LOC_DIR}
 # git clone https://github.com/netdata/localization.git ${LOC_DIR}
 
@@ -84,23 +84,26 @@ prep_html() {
 	echo "Calling mkdocs"
 
 	# Build html docs
-	# mkdocs build --config-file="${MKDOCS_CONFIG_FILE}"
+	mkdocs build --config-file="${MKDOCS_CONFIG_FILE}"
 
-	# # Fix edit buttons for the markdowns that are not on the main Netdata repo
-	# find "${GENERATOR_DIR}/${SITE_DIR}/${GO_D_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/collectors\/go.d.plugin/https:\/\/github.com\/netdata\/go.d.plugin\/blob\/master/g'
-	# if [ "${lang}" != "en" ] ; then
-	# 	find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
-	# fi
+	# Fix edit buttons for the markdowns that are not on the main Netdata repo
+	find "${GENERATOR_DIR}/${SITE_DIR}/${GO_D_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/collectors\/go.d.plugin/https:\/\/github.com\/netdata\/go.d.plugin\/blob\/master/g'
+	if [ "${lang}" != "en" ] ; then
+		find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
+	fi
 
-	# # Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
-	# echo "Replacing index.html with DOCUMENTATION/index.html"
-	# sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
+	# Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
+	echo "Replacing index.html with DOCUMENTATION/index.html"
+	sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
 
 }
 
 for d in "en" ; do
 	echo "Preparing source for $d"
 	cp -r ${SRC_DIR} ${DOCS_DIR}
+	# if [ "${d}" != "en" ] ; then
+	# 	cp -a ${LOC_DIR}/${d}/* ${DOCS_DIR}/
+	# fi
 	prep_html $d
 	rm -rf ${DOCS_DIR}
 done


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

The first step in #8990. This PR removes the logic to build files from the localization project and check their links. These checks are not necessary any more and only cause erroneous failures on PRs.

##### Component Name

docs

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Tested by running the `buildhtml.sh` script locally, as I used to do when testing docs changes. It builds fine as-is, and when I added an intentionally-broken link, it showed a warning and failed as expected.

And the Netlify checks do not end in failure.

##### Additional Information
