### PR TITLE
Allow ebpf_process.plugin to set rlimit

### DIFF
--- a/contrib/debian/netdata.postinst.in
+++ b/contrib/debian/netdata.postinst.in
@@ -54,6 +54,7 @@ case "$1" in
     chown -R root:netdata /usr/libexec/netdata/plugins.d
     chown -R root:netdata /var/lib/netdata/www
     setcap cap_dac_read_search,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin
+    setcap cap_sys_resource+ep /usr/libexec/netdata/plugins.d/ebpf_process.plugin
 
     ;;
 esac


### PR DESCRIPTION
##### Summary
Without this capability the plugin will not start and fail with:

ebpf_process.plugin ERROR : MAIN : [EBPF PROCESS] 
setrlimit(RLIMIT_MEMLOCK) (errno 1, Operation not
 permitted)

##### Component Name
- ebpf
-packaging
