### PR TITLE
Remove mkdocs from docs generator

### DIFF
--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -52,10 +52,10 @@ for f in "${EXCLUDE_LIST[@]}"; do
 	rm "${SRC_DIR}/$f"
 done
 
-echo "Fetching localization project"
-LOC_DIR=${GENERATOR_DIR}/localization
-rm -rf ${LOC_DIR}
-git clone https://github.com/netdata/localization.git ${LOC_DIR}
+# echo "Fetching localization project"
+# LOC_DIR=${GENERATOR_DIR}/localization
+# rm -rf ${LOC_DIR}
+# git clone https://github.com/netdata/localization.git ${LOC_DIR}
 
 echo "Preparing directories"
 MKDOCS_CONFIG_FILE="${GENERATOR_DIR}/mkdocs.yml"
@@ -84,26 +84,23 @@ prep_html() {
 	echo "Calling mkdocs"
 
 	# Build html docs
-	mkdocs build --config-file="${MKDOCS_CONFIG_FILE}"
+	# mkdocs build --config-file="${MKDOCS_CONFIG_FILE}"
 
-	# Fix edit buttons for the markdowns that are not on the main Netdata repo
-	find "${GENERATOR_DIR}/${SITE_DIR}/${GO_D_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/collectors\/go.d.plugin/https:\/\/github.com\/netdata\/go.d.plugin\/blob\/master/g'
-	if [ "${lang}" != "en" ] ; then
-		find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
-	fi
+	# # Fix edit buttons for the markdowns that are not on the main Netdata repo
+	# find "${GENERATOR_DIR}/${SITE_DIR}/${GO_D_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/collectors\/go.d.plugin/https:\/\/github.com\/netdata\/go.d.plugin\/blob\/master/g'
+	# if [ "${lang}" != "en" ] ; then
+	# 	find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
+	# fi
 
-	# Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
-	echo "Replacing index.html with DOCUMENTATION/index.html"
-	sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
+	# # Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
+	# echo "Replacing index.html with DOCUMENTATION/index.html"
+	# sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
 
 }
 
 for d in "en" ; do
 	echo "Preparing source for $d"
 	cp -r ${SRC_DIR} ${DOCS_DIR}
-	if [ "${d}" != "en" ] ; then
-		cp -a ${LOC_DIR}/${d}/* ${DOCS_DIR}/
-	fi
 	prep_html $d
 	rm -rf ${DOCS_DIR}
 done

--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -98,7 +98,7 @@ prep_html() {
 
 }
 
-for d in "en" "kr" "zh" "pt" ; do
+for d in "en" ; do
 	echo "Preparing source for $d"
 	cp -r ${SRC_DIR} ${DOCS_DIR}
 	if [ "${d}" != "en" ] ; then

--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -2,8 +2,6 @@
 
 # buildhtml.sh
 
-# Builds the html static site, using mkdocs
-
 set -e
 
 # Assumes that the script is executed either from the htmldoc folder (by netlify), or from the root repo dir (as originally intended)
@@ -26,22 +24,6 @@ rm -rf ${SRC_DIR}
 mkdir ${SRC_DIR}
 find . -type d \( -path ./${GENERATOR_DIR} -o -path ./node_modules \) -prune -o -name "*.md" -exec cp -pr --parents '{}' ./${SRC_DIR}/ ';'
 
-# Copy Netdata html resources
-cp -a ./${GENERATOR_DIR}/custom ./${SRC_DIR}/
-
-# Modify the first line of the main README.md, to enable proper static html generation
-echo "Modifying README header"
-sed -i -e '0,/# Netdata /s//# Netdata Documentation\n\n/' ${SRC_DIR}/README.md
-
-# Strip comments around frontmatter.
-find ${SRC_DIR} -name '*.md' -exec sed -i "/<!--/d;/-->/d;" {} \;
-
-# Remove all GA tracking code
-find ${SRC_DIR} -name "*.md" -print0 | xargs -0 sed -i -e 's/\[!\[analytics.*UA-64295674-3)\]()//g'
-
-# Use h1 heading as page title for collectors pages
-find ${SRC_DIR}/collectors/  -type f -name 'README.md' -exec sed -i -e '1 s|^# \(.*\)|title: \1\n---\n\n# \1\n|' {} \;
-
 # Remove specific files that don't belong in the documentation
 declare -a EXCLUDE_LIST=(
 	"HISTORICAL_CHANGELOG.md"
@@ -52,61 +34,17 @@ for f in "${EXCLUDE_LIST[@]}"; do
 	rm "${SRC_DIR}/$f"
 done
 
-echo "Fetching localization project"
-LOC_DIR=${GENERATOR_DIR}/localization
-# rm -rf ${LOC_DIR}
-# git clone https://github.com/netdata/localization.git ${LOC_DIR}
-
 echo "Preparing directories"
-MKDOCS_CONFIG_FILE="${GENERATOR_DIR}/mkdocs.yml"
 MKDOCS_DIR="doc"
 DOCS_DIR=${GENERATOR_DIR}/${MKDOCS_DIR}
 rm -rf ${DOCS_DIR}
 
-prep_html() {
-	lang="${1}"
-	echo "Creating ${lang} mkdocs.yaml"
+echo "Preparing source"
+cp -r ${SRC_DIR} ${DOCS_DIR}
 
-	if [ "${lang}" == "en" ] ; then
-		SITE_DIR="build"
-	else
-		SITE_DIR="build/${lang}"
-	fi
-
-	# Generate mkdocs.yaml
-	${GENERATOR_DIR}/buildyaml.sh ${MKDOCS_DIR} ${SITE_DIR} ${lang}>${MKDOCS_CONFIG_FILE}
-
-	echo "Fixing links"
-
-	# Fix links (recursively, all types, executing replacements)
-	${GENERATOR_DIR}/checklinks.sh -rax
-
-	echo "Calling mkdocs"
-
-	# Build html docs
-	mkdocs build --config-file="${MKDOCS_CONFIG_FILE}"
-
-	# Fix edit buttons for the markdowns that are not on the main Netdata repo
-	find "${GENERATOR_DIR}/${SITE_DIR}/${GO_D_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/collectors\/go.d.plugin/https:\/\/github.com\/netdata\/go.d.plugin\/blob\/master/g'
-	if [ "${lang}" != "en" ] ; then
-		find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
-	fi
-
-	# Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
-	echo "Replacing index.html with DOCUMENTATION/index.html"
-	sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
-
-}
-
-for d in "en" ; do
-	echo "Preparing source for $d"
-	cp -r ${SRC_DIR} ${DOCS_DIR}
-	# if [ "${d}" != "en" ] ; then
-	# 	cp -a ${LOC_DIR}/${d}/* ${DOCS_DIR}/
-	# fi
-	prep_html $d
-	rm -rf ${DOCS_DIR}
-done
+echo "Looking for broken links"
+# Fix links (recursively, all types, executing replacements)
+${GENERATOR_DIR}/checklinks.sh -rax
 
 # Remove cloned projects and temp directories
 rm -rf ${GO_D_DIR} ${LOC_DIR} ${DOCS_DIR} ${SRC_DIR}

--- a/docs/generator/buildhtml.sh
+++ b/docs/generator/buildhtml.sh
@@ -52,8 +52,8 @@ for f in "${EXCLUDE_LIST[@]}"; do
 	rm "${SRC_DIR}/$f"
 done
 
-# echo "Fetching localization project"
-# LOC_DIR=${GENERATOR_DIR}/localization
+echo "Fetching localization project"
+LOC_DIR=${GENERATOR_DIR}/localization
 # rm -rf ${LOC_DIR}
 # git clone https://github.com/netdata/localization.git ${LOC_DIR}
 
@@ -84,23 +84,26 @@ prep_html() {
 	echo "Calling mkdocs"
 
 	# Build html docs
-	# mkdocs build --config-file="${MKDOCS_CONFIG_FILE}"
+	mkdocs build --config-file="${MKDOCS_CONFIG_FILE}"
 
-	# # Fix edit buttons for the markdowns that are not on the main Netdata repo
-	# find "${GENERATOR_DIR}/${SITE_DIR}/${GO_D_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/collectors\/go.d.plugin/https:\/\/github.com\/netdata\/go.d.plugin\/blob\/master/g'
-	# if [ "${lang}" != "en" ] ; then
-	# 	find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
-	# fi
+	# Fix edit buttons for the markdowns that are not on the main Netdata repo
+	find "${GENERATOR_DIR}/${SITE_DIR}/${GO_D_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/collectors\/go.d.plugin/https:\/\/github.com\/netdata\/go.d.plugin\/blob\/master/g'
+	if [ "${lang}" != "en" ] ; then
+		find "${GENERATOR_DIR}/${SITE_DIR}" -name "*.html" -print0 | xargs -0 sed -i -e 's/https:\/\/github.com\/netdata\/netdata\/blob\/master\/\S*md/https:\/\/github.com\/netdata\/localization\//g'
+	fi
 
-	# # Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
-	# echo "Replacing index.html with DOCUMENTATION/index.html"
-	# sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
+	# Replace index.html with DOCUMENTATION/index.html. Since we're moving it up one directory, we need to remove ../ from the links
+	echo "Replacing index.html with DOCUMENTATION/index.html"
+	sed 's/\.\.\///g' ${GENERATOR_DIR}/${SITE_DIR}/DOCUMENTATION/index.html > ${GENERATOR_DIR}/${SITE_DIR}/index.html
 
 }
 
 for d in "en" ; do
 	echo "Preparing source for $d"
 	cp -r ${SRC_DIR} ${DOCS_DIR}
+	# if [ "${d}" != "en" ] ; then
+	# 	cp -a ${LOC_DIR}/${d}/* ${DOCS_DIR}/
+	# fi
 	prep_html $d
 	rm -rf ${DOCS_DIR}
 done


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

The second step in #8990, to be merged after #8991. This PR removes the logic to run/build the old docs site using `mkdocs` and simplifies the `buildhtml.sh` script so that it essentially only sets up a clean directory tree and runs the link-checking script against it.

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Again, I ran `buildhtml.sh` locally and it works fine. When I add an intentionally-broken link, the script returns with an error.

##### Additional Information
