### PR TITLE
Fix suid bits on plugin for debian packaging

### DIFF
--- a/contrib/debian/netdata.postinst.in
+++ b/contrib/debian/netdata.postinst.in
@@ -55,6 +55,15 @@ case "$1" in
     chown -R root:netdata /var/lib/netdata/www
     setcap cap_dac_read_search,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin
 
+    chmod 4750 /usr/libexec/netdata/plugins.d/perf.plugin
+    chmod 4750 /usr/libexec/netdata/plugins.d/slabinfo.plugin
+    chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network
+    chmod 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin
+    chmod 4750 /usr/libexec/netdata/plugins.d/ebpf.plugin
+
+    # Workaround for other plugins not installed directly by this package
+    chmod -f 4750 /usr/libexec/netdata/plugins.d/freeipmi.plugin || true
+
     ;;
 esac
 

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -125,7 +125,7 @@ override_dh_fixperms:
 	chmod 0750 $(TOP)-plugin-cups/usr/libexec/netdata/plugins.d/cups.plugin
 
 	# freeIPMI plugin package
-	chmod 0754 $(TOP)-plugin-freeipmi/usr/libexec/netdata/plugins.d/freeipmi.plugin
+	chmod 4750 $(TOP)-plugin-freeipmi/usr/libexec/netdata/plugins.d/freeipmi.plugin
 
 override_dh_installlogrotate:
 	cp system/netdata.logrotate debian/netdata.logrotate


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

Fixes #8888 

##### Summary
Fix installation of suid plugins in debian packaging
##### Component Name
packaging

##### Test Plan

##### Additional Information
`chown -R root:netdata /usr/libexec/netdata/plugins.d` in postint also remove the suid bit for all binaries in the directory. This PR fix that by adding some `chmod` in postint after the `chown`.