### PR TITLE
Caddy section lacked data persist volumes

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -261,11 +261,17 @@ services:
     security_opt:
       - apparmor:unconfined
     volumes:
+      - netdatalib:/var/lib/netdata
+      - netdatacache:/var/cache/netdata
       - /etc/passwd:/host/etc/passwd:ro
       - /etc/group:/host/etc/group:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+
+volumes:
+  netdatalib:
+  netdatacache:
 ```
 
 ### Restrict access with basic auth


### PR DESCRIPTION
The Docker Compose example in the Caddy section didn't include the important volumes:
      - netdatalib:/var/lib/netdata
      - netdatacache:/var/cache/netdata

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name
documentation

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
