### PR TITLE
Update step-10.md

### DIFF
--- a/docs/step-by-step/step-10.md
+++ b/docs/step-by-step/step-10.md
@@ -149,16 +149,15 @@ the following:
 sudo certbot --nginx
 ```
 
-If you receive an `error` after executing the command, like the one shown below: 
-`Saving debug log to /var/log/letsencrypt/letsencrypt.log`
-`The requested nginx plugin does not appear to be installed`
-
-Use this command:
-```bash
-sudo apt-get install python-certbot-nginx
-```
-
-
+> See this error after running `sudo certbot --nginx`?
+>
+> ```
+> Saving debug log to /var/log/letsencrypt/letsencrypt.log
+> The requested nginx plugin does not appear to be installed`
+> ```
+>
+> You must install `python-certbox-nginx`. On Ubuntu or Debian systems, you can run `sudo apt-get install
+> python-certbot-nginx` to download and install this package.
 You'll be prompted with a few questions. At the `Which names would you like to activate HTTPS for?` question, hit
 `Enter`. Next comes this question:
 

--- a/docs/step-by-step/step-10.md
+++ b/docs/step-by-step/step-10.md
@@ -149,6 +149,16 @@ the following:
 sudo certbot --nginx
 ```
 
+If you receive an `error` after executing the command, like the one shown below: 
+`Saving debug log to /var/log/letsencrypt/letsencrypt.log`
+`The requested nginx plugin does not appear to be installed`
+
+Use this command:
+```bash
+sudo apt-get install python-certbot-nginx
+```
+
+
 You'll be prompted with a few questions. At the `Which names would you like to activate HTTPS for?` question, hit
 `Enter`. Next comes this question:
 

--- a/docs/step-by-step/step-10.md
+++ b/docs/step-by-step/step-10.md
@@ -158,6 +158,7 @@ sudo certbot --nginx
 >
 > You must install `python-certbox-nginx`. On Ubuntu or Debian systems, you can run `sudo apt-get install
 > python-certbot-nginx` to download and install this package.
+
 You'll be prompted with a few questions. At the `Which names would you like to activate HTTPS for?` question, hit
 `Enter`. Next comes this question:
 


### PR DESCRIPTION
##### Summary
Cannot complete the steps to configure a proxy server on an Ubuntu server 20.04 when following the step-by-step guide. Multiple Ubuntu Server 20.04 have been used, all had been updated and upgraded beforehand to their latest version.

##### Component Name
python-certbot-nginx is most likely missing from the installer/bash script

##### Test Plan
Try to follow the current step-by-step guide and you will notice you are unable to get a ssl certificate using the certbot --nginx.

##### Additional Information
Excuse me for missing info etc, first time doing this.