### PR TITLE
Fixes enable/start of netdata service in debian package

### DIFF
--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -67,4 +67,6 @@ case "$1" in
     ;;
 esac
 
+#DEBHELPER#
+
 exit 0

--- a/contrib/debian/netdata.postrm
+++ b/contrib/debian/netdata.postrm
@@ -48,4 +48,6 @@ case "$1" in
 
 esac
 
+#DEBHELPER#
+
 exit 0

--- a/contrib/debian/netdata.preinst
+++ b/contrib/debian/netdata.preinst
@@ -14,3 +14,5 @@ dpkg-maintscript-helper dir_to_symlink \
 	/var/lib/netdata/www/lib /usr/share/netdata/www/lib 1.18.1~ netdata -- "$@"
 dpkg-maintscript-helper dir_to_symlink \
 	/var/lib/netdata/www/static /usr/share/netdata/www/static 1.18.1~ netdata -- "$@"
+
+#DEBHELPER#

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -2,7 +2,6 @@
 
 # Find the arch we are building for, as this determines
 # the location of plugins in /usr/lib
-DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 TOP = $(CURDIR)/debian/netdata
 TEMPTOP = $(CURDIR)/debian/tmp
 
@@ -41,10 +40,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib \
 	--libexecdir=/usr/libexec --with-user=netdata --with-math --with-zlib --with-webdir=/var/lib/netdata/www
 
-debian/%.postinst: debian/%.postinst.in
-	sed 's/@DEB_HOST_MULTIARCH@/$(DEB_HOST_MULTIARCH)/g' $< > $@
-
-override_dh_install: debian/netdata.postinst
+override_dh_install:
 	cp -v $(BASE_CONFIG) debian/netdata.conf
 
 	dh_install
@@ -79,19 +75,6 @@ override_dh_install: debian/netdata.postinst
 		mv "$(TOP)/var/lib/netdata/www/$$D" "$(TOP)/usr/share/netdata/www/$$D"; \
 		ln -s "/usr/share/netdata/www/$$D" "$(TOP)/var/lib/netdata/www/$$D"; \
 	done
-
-	# Update postinst to set correct group for www files on installation.
-	# Should probably be dpkg-statoverride really, but that gets *really*
-	# messy. We also set all web files in /var as conffiles so an upgrade
-	# doesn't splat them.
-	#
-	for D in $$(find "$(TOP)/var/lib/netdata/www/" -maxdepth 1 -type f -printf '%f '); do \
-		echo Updating postinst for $$D; \
-		sed -i "s/^#PERMS#/chgrp netdata \/var\/lib\/netdata\/www\/$$D\n#PERMS#/g" \
-			$(CURDIR)/debian/netdata.postinst; \
-		echo "/var/lib/netdata/www/$$D" >> $(CURDIR)/debian/netdata.conffiles; \
-	done
-	sed -i "/^#PERMS#/d" $(CURDIR)/debian/netdata.postinst
 
 	# Install go
 	#
@@ -137,5 +120,4 @@ override_dh_clean:
 	# Tidy up copied/generated files
 	#
 	-[ -r $(CURDIR)/debian/netdata.logrotate ] && rm $(CURDIR)/debian/netdata.logrotate
-	-[ -r $(CURDIR)/debian/netdata.postinst ] && rm $(CURDIR)/debian/netdata.postinst
 	-[ -r $(CURDIR)/debian/netdata.conffiles ] && rm $(CURDIR)/debian/netdata.conffiles


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

Fixes #8878 

##### Summary
Fixes start/enable of netdata because of missing `#DEBHELPER#` in debian scripts.
I also removed the templating for postinst, AFAIK It is unused as the templated script and the final script are identical.

##### Component Name
packaging
##### Additional Information
