### PR TITLE
Rename function inside OpenTSDB  exporter

### DIFF
--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -233,7 +233,7 @@ int format_dimension_stored_opentsdb_telnet(struct instance *instance, RRDDIM *r
  * @param hostname the name of the host that sends the message.
  * @param length the length of the message body.
  */
-static inline void opentsdb_build_message(BUFFER *buffer, char *message, const char *hostname, int length)
+static inline void opentsdb_send_header(BUFFER *buffer, char *message, const char *hostname, int length)
 {
     buffer_sprintf(
         buffer,
@@ -333,7 +333,7 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
         instance->labels ? buffer_tostring(instance->labels) : "");
 
     if (length > 0) {
-        opentsdb_build_message(instance->buffer, message, engine->config.hostname, length);
+        opentsdb_send_header(instance->buffer, message, engine->config.hostname, length);
     }
 
     return 0;
@@ -393,7 +393,7 @@ int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd)
         instance->labels ? buffer_tostring(instance->labels) : "");
 
     if (length > 0) {
-        opentsdb_build_message(instance->buffer, message, engine->config.hostname, length);
+        opentsdb_send_header(instance->buffer, message, engine->config.hostname, length);
     }
 
     return 0;


### PR DESCRIPTION
##### Summary

This PR renames the function as specified at #8461.

##### Component Name
Exporting
##### Test Plan
1 - Start hbase
2 - Start zookeper
3 - Start opentsdb running: `./tsdb tsd --port=4242 --staticroot=staticroot/ --cachedir=/tmp/tsd --zkquorum=localhost:2181 --auto-metric`
4 - Configure the file `exporting.conf`:

```
[exporting:global]
    enabled = yes
    send configured labels = yes
    send automatic labels = no

[opentsdb:http:my_instance]
    enabled = yes
    destination = localhost:4242
```

5 - Starts Netdata
6 - After few seconds access on your web browser the URL `http://localhost:4242` and confirm that you have data on OpenTSDB.

##### Additional Information
This PR does not brings everything listed on #8461 and it is not a blocker for any other action there.