### PR TITLE
Included 'cmake' in the list of pkgs installed

### DIFF
--- a/packaging/installer/methods/freebsd.md
+++ b/packaging/installer/methods/freebsd.md
@@ -13,7 +13,7 @@ This is how to install the latest Netdata version from source on FreeBSD:
 
 ```sh
 # install required packages
-pkg install bash e2fsprogs-libuuid git curl autoconf automake pkgconf pidof Judy liblz4 libuv json-c
+pkg install bash e2fsprogs-libuuid git curl autoconf automake pkgconf pidof Judy liblz4 libuv json-c cmake
 
 # download Netdata
 git clone https://github.com/netdata/netdata.git --depth=100


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
After going through the installation on my FreeBSD system, I was told that the websockets couldn't be installed because cmake wasn't on my system. I believe 'cmake' is requred for websockets to be installed, but it isn't included for the FreeBSD installation. 

##### Component Name
cmake
##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
I'm not sure if this was left out intentionally for some reason. Thank you for reading.