### PR TITLE
Missing checks exporting

### DIFF
--- a/exporting/aws_kinesis/aws_kinesis.c
+++ b/exporting/aws_kinesis/aws_kinesis.c
@@ -56,9 +56,10 @@ int init_aws_kinesis_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for AWS Kinesis exporting connector instance %s", instance->config.name);
         return 1;
     }
-    if(uv_mutex_init(&instance->mutex))
+    if (uv_mutex_init(&instance->mutex))
         return 1;
-    uv_cond_init(&instance->cond_var);
+    if (uv_cond_init(&instance->cond_var))
+        return 1;
 
     if (!instance->engine->aws_sdk_initialized) {
         aws_sdk_init();

--- a/exporting/aws_kinesis/aws_kinesis.c
+++ b/exporting/aws_kinesis/aws_kinesis.c
@@ -56,7 +56,8 @@ int init_aws_kinesis_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for AWS Kinesis exporting connector instance %s", instance->config.name);
         return 1;
     }
-    uv_mutex_init(&instance->mutex);
+    if(uv_mutex_init(&instance->mutex))
+        return 1;
     uv_cond_init(&instance->cond_var);
 
     if (!instance->engine->aws_sdk_initialized) {

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -37,7 +37,8 @@ int init_graphite_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for graphite exporting connector instance %s", instance->config.name);
         return 1;
     }
-    uv_mutex_init(&instance->mutex);
+    if(uv_mutex_init(&instance->mutex))
+        return 1;
     uv_cond_init(&instance->cond_var);
 
     return 0;

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -37,9 +37,10 @@ int init_graphite_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for graphite exporting connector instance %s", instance->config.name);
         return 1;
     }
-    if(uv_mutex_init(&instance->mutex))
+    if (uv_mutex_init(&instance->mutex))
         return 1;
-    uv_cond_init(&instance->cond_var);
+    if (uv_cond_init(&instance->cond_var))
+        return 1;
 
     return 0;
 }

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -37,9 +37,10 @@ int init_json_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for json exporting connector instance %s", instance->config.name);
         return 1;
     }
-    if(uv_mutex_init(&instance->mutex))
+    if (uv_mutex_init(&instance->mutex))
         return 1;
-    uv_cond_init(&instance->cond_var);
+    if (uv_cond_init(&instance->cond_var))
+        return 1;
 
     return 0;
 }

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -37,7 +37,8 @@ int init_json_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for json exporting connector instance %s", instance->config.name);
         return 1;
     }
-    uv_mutex_init(&instance->mutex);
+    if(uv_mutex_init(&instance->mutex))
+        return 1;
     uv_cond_init(&instance->cond_var);
 
     return 0;

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -37,9 +37,10 @@ int init_opentsdb_telnet_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for opentsdb telnet exporting connector instance %s", instance->config.name);
         return 1;
     }
-    if(uv_mutex_init(&instance->mutex))
+    if (uv_mutex_init(&instance->mutex))
         return 1;
-    uv_cond_init(&instance->cond_var);
+    if (uv_cond_init(&instance->cond_var))
+        return 1;
 
     return 0;
 }
@@ -79,9 +80,10 @@ int init_opentsdb_http_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for opentsdb HTTP exporting connector instance %s", instance->config.name);
         return 1;
     }
-    if(uv_mutex_init(&instance->mutex))
+    if (uv_mutex_init(&instance->mutex))
         return 1;
-    uv_cond_init(&instance->cond_var);
+    if (uv_cond_init(&instance->cond_var))
+        return 1;
 
     return 0;
 }

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -37,7 +37,8 @@ int init_opentsdb_telnet_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for opentsdb telnet exporting connector instance %s", instance->config.name);
         return 1;
     }
-    uv_mutex_init(&instance->mutex);
+    if(uv_mutex_init(&instance->mutex))
+        return 1;
     uv_cond_init(&instance->cond_var);
 
     return 0;
@@ -78,7 +79,8 @@ int init_opentsdb_http_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for opentsdb HTTP exporting connector instance %s", instance->config.name);
         return 1;
     }
-    uv_mutex_init(&instance->mutex);
+    if(uv_mutex_init(&instance->mutex))
+        return 1;
     uv_cond_init(&instance->cond_var);
 
     return 0;

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -122,7 +122,8 @@ int init_prometheus_remote_write_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for AWS Kinesis exporting connector instance %s", instance->config.name);
         return 1;
     }
-    uv_mutex_init(&instance->mutex);
+    if(uv_mutex_init(&instance->mutex))
+        return 1;
     uv_cond_init(&instance->cond_var);
 
     struct prometheus_remote_write_specific_data *connector_specific_data =

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -122,9 +122,10 @@ int init_prometheus_remote_write_instance(struct instance *instance)
         error("EXPORTING: cannot create buffer for AWS Kinesis exporting connector instance %s", instance->config.name);
         return 1;
     }
-    if(uv_mutex_init(&instance->mutex))
+    if (uv_mutex_init(&instance->mutex))
         return 1;
-    uv_cond_init(&instance->cond_var);
+    if (uv_cond_init(&instance->cond_var))
+        return 1;
 
     struct prometheus_remote_write_specific_data *connector_specific_data =
         callocz(1, sizeof(struct prometheus_remote_write_specific_data));


### PR DESCRIPTION
##### Summary
This PR brings the missing tests to returns for `uv_`  functions as specified at #8461.
##### Component Name
Exporting
##### Test Plan

1 - Start hbase
2 - Start zookeper
3 - Start opentsdb running: ./tsdb tsd --port=4242 --staticroot=staticroot/ --cachedir=/tmp/tsd --zkquorum=localhost:2181 --auto-metric
4 - Start JSON backend running:  `nc -lntp 5448`
5 - Start MongoDB: The command here depends of the distribution.
6 - Configure `exporting.conf`:

```
[exporting:global]
    enabled = yes
    send configured labels = yes
    send automatic labels = no

[json:my_instance]
    enabled = yes
    destination = localhost:5448

[opentsdb:http:my_instance2]
    enabled = yes
    destination = localhost:4242

[mongodb:instanceA]
    enabled = yes
    destination = mongodb://localhost
    database = netdata
    collection = instanceA

```
@vlvkobal , please, update the example bringing the options for AWS.

7 - Start Netdata
8 - Verify all the exporters received the data.

##### Additional Information
This PR does not brings everything listed on #8461 and it is not a blocker for any other action there.