### PR TITLE
[python.d/samba] Only use sudo when not running as root user

### DIFF
--- a/collectors/python.d.plugin/samba/samba.chart.py
+++ b/collectors/python.d.plugin/samba/samba.chart.py
@@ -112,7 +112,7 @@ class Service(ExecutableService):
         if not smbstatus_binary:
             self.error("can't locate '{0}' binary".format(SMBSTATUS))
             return False
-        
+
         if os.getuid() != 0:
             sudo_binary = find_binary(SUDO)
             if not sudo_binary:

--- a/collectors/python.d.plugin/samba/samba.chart.py
+++ b/collectors/python.d.plugin/samba/samba.chart.py
@@ -113,22 +113,22 @@ class Service(ExecutableService):
             self.error("can't locate '{0}' binary".format(SMBSTATUS))
             return False
 
-        if os.getuid() != 0:
-            sudo_binary = find_binary(SUDO)
-            if not sudo_binary:
-                self.error("can't locate '{0}' binary".format(SUDO))
-                return False
-            command = [sudo_binary, '-n', '-l', smbstatus_binary, '-P']
-            smbstatus = '{0} -P'.format(smbstatus_binary)
-            allowed = self._get_raw_data(command=command)
-            if not (allowed and allowed[0].strip() == smbstatus):
-                self.error("not allowed to run sudo for command '{0}'".format(smbstatus))
-                return False
-            self.command = ' '.join([sudo_binary, '-n', smbstatus_binary, '-P'])
-            return ExecutableService.check(self)
-        else:
+        if os.getuid() == 0:
             self.command = ' '.join([smbstatus_binary, '-P'])
             return ExecutableService.check(self)
+        
+        sudo_binary = find_binary(SUDO)
+        if not sudo_binary:
+            self.error("can't locate '{0}' binary".format(SUDO))
+            return False
+        command = [sudo_binary, '-n', '-l', smbstatus_binary, '-P']
+        smbstatus = '{0} -P'.format(smbstatus_binary)
+        allowed = self._get_raw_data(command=command)
+        if not (allowed and allowed[0].strip() == smbstatus):
+            self.error("not allowed to run sudo for command '{0}'".format(smbstatus))
+            return False
+        self.command = ' '.join([sudo_binary, '-n', smbstatus_binary, '-P'])
+        return ExecutableService.check(self)
 
     def _get_data(self):
         """

--- a/collectors/python.d.plugin/samba/samba.chart.py
+++ b/collectors/python.d.plugin/samba/samba.chart.py
@@ -17,6 +17,7 @@
 # (like find and notify... good examples).
 
 import re
+import os
 
 from bases.FrameworkServices.ExecutableService import ExecutableService
 from bases.collection import find_binary
@@ -107,25 +108,27 @@ class Service(ExecutableService):
         self.rgx_smb2 = re.compile(r'(smb2_[^:]+|syscall_.*file_bytes):\s+(\d+)')
 
     def check(self):
-        sudo_binary = find_binary(SUDO)
-        if not sudo_binary:
-            self.error("can't locate '{0}' binary".format(SUDO))
-            return False
-
         smbstatus_binary = find_binary(SMBSTATUS)
         if not smbstatus_binary:
             self.error("can't locate '{0}' binary".format(SMBSTATUS))
             return False
-
-        command = [sudo_binary, '-n', '-l', smbstatus_binary, '-P']
-        smbstatus = '{0} -P'.format(smbstatus_binary)
-        allowed = self._get_raw_data(command=command)
-        if not (allowed and allowed[0].strip() == smbstatus):
-            self.error("not allowed to run sudo for command '{0}'".format(smbstatus))
-            return False
-
-        self.command = ' '.join([sudo_binary, '-n', smbstatus_binary, '-P'])
-        return ExecutableService.check(self)
+        
+        if os.getuid() != 0:
+            sudo_binary = find_binary(SUDO)
+            if not sudo_binary:
+                self.error("can't locate '{0}' binary".format(SUDO))
+                return False
+            command = [sudo_binary, '-n', '-l', smbstatus_binary, '-P']
+            smbstatus = '{0} -P'.format(smbstatus_binary)
+            allowed = self._get_raw_data(command=command)
+            if not (allowed and allowed[0].strip() == smbstatus):
+                self.error("not allowed to run sudo for command '{0}'".format(smbstatus))
+                return False
+            self.command = ' '.join([sudo_binary, '-n', smbstatus_binary, '-P'])
+            return ExecutableService.check(self)
+        else:
+            self.command = ' '.join([smbstatus_binary, '-P'])
+            return ExecutableService.check(self)
 
     def _get_data(self):
         """


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Only use sudo when not running as root user

##### Component Name
python.d samba collector

##### Test Plan
I have applied this patch to my instance and all is good so far monitoring samba.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
