### PR TITLE
Regenerate topic base on connect

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1307,9 +1307,10 @@ void aclk_get_challenge(char *aclk_hostname, char *aclk_port)
     }
     if (aclk_password != NULL )
         freez(aclk_password);
-    if (aclk_username == NULL)
-        aclk_username = strdupz(agent_id);
     aclk_password = password.result;
+    if (aclk_username != NULL)
+        freez(aclk_username);
+    aclk_username = strdupz(agent_id);
 
 CLEANUP:
     freez(data_buffer);

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -438,7 +438,7 @@ struct aclk_query *aclk_queue_pop()
 
 char *create_publish_base_topic()
 {
-char *agent_id = is_agent_claimed();
+    char *agent_id = is_agent_claimed();
     if (unlikely(!agent_id))
         return NULL;
 
@@ -1606,14 +1606,6 @@ void aclk_disconnect()
     aclk_connecting = 0;
     aclk_force_reconnect = 1;
 }
-
-/*void aclk_shutdown()
-{
-    info("Shutdown initiated");
-    aclk_connected = 0;
-    _link_shutdown();
-    info("Shutdown complete");
-}*/
 
 inline void aclk_create_header(BUFFER *dest, char *type, char *msg_id, time_t ts_secs, usec_t ts_us)
 {

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -109,11 +109,25 @@ void claim_agent(char *claiming_arguments)
 #endif
 }
 
+extern int aclk_connected, aclk_kill_link;
+extern void aclk_graceful_disconnect();
+/* Change the claimed state of the agent.
+ *
+ * This only happens when the user has explicitly requested it:
+ *   - via the cli tool by reloading the claiming state
+ *   - after spawning the claim because of a command-line argument
+ * If this happens with the ACLK active under an old claim then we MUST KILL THE LINK
+ */
 void load_claiming_state(void)
 {
     if (claimed_id != NULL) {
         freez(claimed_id);
         claimed_id = NULL;
+    }
+    if (aclk_connected)
+    {
+        info("Agent was already connected to Cloud - forcing reconnection under new credentials");
+        aclk_kill_link = 1;
     }
 
     // Propagate into aclk and registry. Be kind of atomic...

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -116,8 +116,11 @@ void claim_agent(char *claiming_arguments)
 #endif
 }
 
+#ifdef ENABLE_ACLK
 extern int aclk_connected, aclk_kill_link;
 extern void aclk_graceful_disconnect();
+#endif
+
 /* Change the claimed state of the agent.
  *
  * This only happens when the user has explicitly requested it:
@@ -127,6 +130,11 @@ extern void aclk_graceful_disconnect();
  */
 void load_claiming_state(void)
 {
+    // --------------------------------------------------------------------
+    // Check if the cloud is enabled
+#if defined( DISABLE_CLOUD ) || !defined( ENABLE_ACLK )
+    netdata_cloud_setting = 0;
+#else
     netdata_mutex_lock(&claim_mutex);
     if (claimed_id != NULL) {
         freez(claimed_id);
@@ -153,12 +161,6 @@ void load_claiming_state(void)
     }
 
     info("File '%s' was found. Setting state to AGENT_CLAIMED.", filename);
-
-    // --------------------------------------------------------------------
-    // Check if the cloud is enabled
-#if defined( DISABLE_CLOUD ) || !defined( ENABLE_ACLK )
-    netdata_cloud_setting = 0;
-#else
     netdata_cloud_setting = appconfig_get_boolean(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", 1);
 #endif
 }

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -34,7 +34,7 @@ static char *claimed_id = NULL;
 */
 char *is_agent_claimed()
 {
-char *result;
+    char *result;
     netdata_mutex_lock(&claim_mutex);
     result = (claimed_id == NULL) ? NULL : strdup(claimed_id);
     netdata_mutex_unlock(&claim_mutex);
@@ -118,7 +118,6 @@ void claim_agent(char *claiming_arguments)
 
 #ifdef ENABLE_ACLK
 extern int aclk_connected, aclk_kill_link;
-extern void aclk_graceful_disconnect();
 #endif
 
 /* Change the claimed state of the agent.

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -874,10 +874,13 @@ inline int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb)
 #else
     buffer_strcat(wb, "\t\"cloud-available\": false,\n");
 #endif
-    if (is_agent_claimed() == NULL)
+    char *agent_id = is_agent_claimed();
+    if (agent_id == NULL)
         buffer_strcat(wb, "\t\"agent-claimed\": false,\n");
-    else
+    else {
         buffer_strcat(wb, "\t\"agent-claimed\": true,\n");
+        freez(agent_id);
+    }
 #ifdef ENABLE_ACLK
     if (aclk_connected)
         buffer_strcat(wb, "\t\"aclk-available\": true\n");


### PR DESCRIPTION
##### Summary
Closes #9032 

If the agent is re-claimed at run-time then the new claim_id is not applied to the base-topic for the ACLK. This causes the broker to kick the agent for writing to the wrong topic.

##### Component Name
ACLK

##### Test Plan

* Start a claimed agent
* Remove the agent from its room
* Re-claim the agent (without stopping it), using -id=$(uuidgen)
* Re-connect the agent

##### Additional Information
