### PR TITLE
Don't overwrite netdata.conf on update on static installs.

### DIFF
--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -22,6 +22,10 @@ run ./netdata-installer.sh --install "${NETDATA_INSTALL_PARENT}" \
     --dont-start-it \
     ${NULL}
 
+# Remove the netdata.conf file from the tree. It gets created at install
+# time instead.
+rm -f "${NETDATA_INSTALL_PARENT}/etc/netdata/netdata.conf"
+
 if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]
 then
     run strip ${NETDATA_INSTALL_PATH}/bin/netdata

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -22,8 +22,7 @@ run ./netdata-installer.sh --install "${NETDATA_INSTALL_PARENT}" \
     --dont-start-it \
     ${NULL}
 
-# Remove the netdata.conf file from the tree. It gets created at install
-# time instead.
+# Remove the netdata.conf file from the tree. It has hard-coded sensible defaults builtin.
 rm -f "${NETDATA_INSTALL_PARENT}/etc/netdata/netdata.conf"
 
 if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]


### PR DESCRIPTION
##### Summary

The current code overwrites netdata.conf when updating a static install because we include a copy of the default empty netdata.conf in the package itself.

This removes that file from the generated package, but does not modify the install-time logic which attempts to create the file if it does not already exist (which appears to be working correctly.

##### Component Name

area/packaging

##### Test Plan

Locally built and verified that the static installer does not include `netdata.conf` in the archive anymore.

##### Additional Information

Fixes: #8531 
Fixes: #8679 

To all our users who were affected by this, sorry it took so long to fix it.