### PR TITLE
Missing error aws

### DIFF
--- a/exporting/aws_kinesis/aws_kinesis.c
+++ b/exporting/aws_kinesis/aws_kinesis.c
@@ -45,6 +45,11 @@ int init_aws_kinesis_instance(struct instance *instance)
     struct aws_kinesis_specific_data *connector_specific_data = callocz(1, sizeof(struct aws_kinesis_specific_data));
     instance->connector_specific_data = (void *)connector_specific_data;
 
+    if (!strcmp(connector_specific_config->stream_name, "")) {
+        error("stream name is a mandatory Kinesis parameter but it is not configured");
+        return 1;
+    }
+
     kinesis_init(
         (void *)connector_specific_data,
         instance->config.destination,

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -390,7 +390,7 @@ struct engine *read_exporting_config()
             tmp_instance->config.connector_specific_config = connector_specific_config;
 
             connector_specific_config->stream_name = strdupz(exporter_get(instance_name, "stream name", ""));
-            if (!connector_specific_config->stream_name)
+            if (!strcmp(connector_specific_config->stream_name, ""))
                 error("stream name is a mandatory Kinesis parameter but it is not configured");
 
             connector_specific_config->auth_key_id = strdupz(exporter_get(instance_name, "aws_access_key_id", ""));

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -390,8 +390,6 @@ struct engine *read_exporting_config()
             tmp_instance->config.connector_specific_config = connector_specific_config;
 
             connector_specific_config->stream_name = strdupz(exporter_get(instance_name, "stream name", ""));
-            if (!strcmp(connector_specific_config->stream_name, ""))
-                error("stream name is a mandatory Kinesis parameter but it is not configured");
 
             connector_specific_config->auth_key_id = strdupz(exporter_get(instance_name, "aws_access_key_id", ""));
             connector_specific_config->secure_key = strdupz(exporter_get(instance_name, "aws_secret_access_key", ""));

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -389,7 +389,10 @@ struct engine *read_exporting_config()
 
             tmp_instance->config.connector_specific_config = connector_specific_config;
 
-            connector_specific_config->stream_name = strdupz(exporter_get(instance_name, "stream name", "netdata"));
+            connector_specific_config->stream_name = strdupz(exporter_get(instance_name, "stream name", ""));
+            if (!connector_specific_config->stream_name)
+                error("stream name is a mandatory Kinesis parameter but it is not configured");
+
             connector_specific_config->auth_key_id = strdupz(exporter_get(instance_name, "aws_access_key_id", ""));
             connector_specific_config->secure_key = strdupz(exporter_get(instance_name, "aws_secret_access_key", ""));
         }


### PR DESCRIPTION
##### Summary
This PR brings the missing error report  as specified at #8461.

##### Component Name
Exporting
##### Test Plan

1 - Compile the branch
2 - Configure `exporting.conf` without the necessary parameter:

```
[kinesis:my_instance2]
    enabled = yes
    destination = us-east-1
    #stream name = netdata
    # aws_access_key_id = 
    #aws_secret_access_key = 
    data source = as collected
    #data source = sum
    update every = 2
    send charts matching = system.processes
```

3 - Run Netdata
4 - Verify if the message was written inside error.log

##### Additional Information
This PR does not brings everything listed on #8461 and it is not a blocker for any other action there.