### PR TITLE
Added required bundle for libuuid on ClearLinux.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -19,6 +19,7 @@ jobs:
           - 'archlinux:latest'
           - 'centos:8'
           - 'centos:7'
+          - 'clearlinux:latest'
           - 'debian:bullseye'
           - 'debian:buster'
           - 'debian:stretch'

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -699,6 +699,7 @@ declare -A pkg_libuuid_dev=(
   ['alpine']="util-linux-dev"
   ['arch']="util-linux"
   ['centos']="libuuid-devel"
+  ['clearlinux']="devpkg-util-linux"
   ['debian']="uuid-dev"
   ['gentoo']="sys-apps/util-linux"
   ['sabayon']="sys-apps/util-linux"


### PR DESCRIPTION
##### Summary

We somehow forgot to include the bundle for libuuid in our dependencies on ClearLinux, this fixes that.

##### Component Name

area/packaging.

##### Test Plan

Checked locally that the correct package is installed and verified the build of Netdata.

##### Additional Information

Fixes: #9051 