### PR TITLE
OpenTSDB and TLS

### DIFF
--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -25,6 +25,7 @@ typedef enum exporting_options {
 
     EXPORTING_OPTION_SEND_CONFIGURED_LABELS = (1 << 3),
     EXPORTING_OPTION_SEND_AUTOMATIC_LABELS  = (1 << 4),
+    EXPORTING_OPTION_USE_TLS                = (1 << 5),
 
     EXPORTING_OPTION_SEND_NAMES             = (1 << 16)
 } EXPORTING_OPTIONS;
@@ -77,6 +78,10 @@ struct instance_config {
 
 struct simple_connector_config {
     int default_port;
+#ifdef ENABLE_HTTPS
+    SSL *conn; //SSL connection
+    int flags; //The flags for SSL connection
+#endif
 };
 
 struct prometheus_remote_write_specific_config {

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -78,10 +78,6 @@ struct instance_config {
 
 struct simple_connector_config {
     int default_port;
-#ifdef ENABLE_HTTPS
-    SSL *conn; //SSL connection
-    int flags; //The flags for SSL connection
-#endif
 };
 
 struct prometheus_remote_write_specific_config {
@@ -257,6 +253,7 @@ static inline void disable_instance(struct instance *instance)
 }
 
 #include "exporting/prometheus/prometheus.h"
+#include "exporting/opentsdb/opentsdb.h"
 #if ENABLE_PROMETHEUS_REMOTE_WRITE
 #include "exporting/prometheus/remote_write/remote_write.h"
 #endif

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -56,12 +56,15 @@ int init_opentsdb_http_instance(struct instance *instance)
     struct simple_connector_config *connector_specific_config = callocz(1, sizeof(struct simple_connector_config));
     instance->config.connector_specific_config = (void *)connector_specific_config;
     connector_specific_config->default_port = 4242;
+
 #ifdef ENABLE_HTTPS
-    connector_specific_config->flags = NETDATA_SSL_START;
-    connector_specific_config->conn = NULL;
+    struct opentsdb_specific_data *connector_specific_data = callocz(1, sizeof(struct opentsdb_specific_data));
+    connector_specific_data->flags = NETDATA_SSL_START;
+    connector_specific_data->conn = NULL;
     if (instance->config.options & EXPORTING_OPTION_USE_TLS) {
         security_start_ssl(NETDATA_SSL_CONTEXT_OPENTSDB);
     }
+    instance->connector_specific_data = connector_specific_data;
 #endif
 
     instance->start_batch_formatting = NULL;

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -56,6 +56,12 @@ int init_opentsdb_http_instance(struct instance *instance)
     struct simple_connector_config *connector_specific_config = callocz(1, sizeof(struct simple_connector_config));
     instance->config.connector_specific_config = (void *)connector_specific_config;
     connector_specific_config->default_port = 4242;
+#ifdef ENABLE_HTTPS
+    if (instance->config.options & EXPORTING_OPTION_USE_TLS) {
+        connector_specific_config->flags = NETDATA_SSL_START;
+        connector_specific_config->conn = NULL;
+    }
+#endif
 
     instance->start_batch_formatting = NULL;
     instance->start_host_formatting = format_host_labels_opentsdb_http;

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -57,9 +57,10 @@ int init_opentsdb_http_instance(struct instance *instance)
     instance->config.connector_specific_config = (void *)connector_specific_config;
     connector_specific_config->default_port = 4242;
 #ifdef ENABLE_HTTPS
+    connector_specific_config->flags = NETDATA_SSL_START;
+    connector_specific_config->conn = NULL;
     if (instance->config.options & EXPORTING_OPTION_USE_TLS) {
-        connector_specific_config->flags = NETDATA_SSL_START;
-        connector_specific_config->conn = NULL;
+        security_start_ssl(NETDATA_SSL_CONTEXT_OPENTSDB);
     }
 #endif
 

--- a/exporting/opentsdb/opentsdb.h
+++ b/exporting/opentsdb/opentsdb.h
@@ -18,4 +18,13 @@ int format_dimension_stored_opentsdb_telnet(struct instance *instance, RRDDIM *r
 int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *rd);
 int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd);
 
+struct opentsdb_specific_data {
+#ifdef ENABLE_HTTPS
+    SSL *conn; //SSL connection
+#else
+    void *conn;
+#endif
+    int flags; //The flags for SSL connection
+};
+
 #endif //NETDATA_EXPORTING_OPENTSDB_H

--- a/exporting/opentsdb/opentsdb.h
+++ b/exporting/opentsdb/opentsdb.h
@@ -18,13 +18,11 @@ int format_dimension_stored_opentsdb_telnet(struct instance *instance, RRDDIM *r
 int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *rd);
 int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd);
 
-struct opentsdb_specific_data {
 #ifdef ENABLE_HTTPS
+struct opentsdb_specific_data {
     SSL *conn; //SSL connection
-#else
-    void *conn;
-#endif
     int flags; //The flags for SSL connection
 };
+#endif
 
 #endif //NETDATA_EXPORTING_OPENTSDB_H

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -429,6 +429,12 @@ struct engine *read_exporting_config()
 
         tmp_instance->config.destination = strdupz(exporter_get(instance_name, "destination", default_destination));
 
+#ifdef ENABLE_HTTPS
+        if (tmp_instance->config.type == EXPORTING_CONNECTOR_TYPE_OPENTSDB_USING_HTTP && !strncmp(tmp_ci_list->local_ci.connector_name, "opentsdb:https", 14)) {
+            tmp_instance->config.options |= EXPORTING_OPTION_USE_TLS;
+        }
+#endif
+
 #ifdef NETDATA_INTERNAL_CHECKS
         info(
             "     Dest=[%s], upd=[%d], buffer=[%d] timeout=[%ld] options=[%u]",

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -76,10 +76,7 @@ void simple_connector_receive_response(int *sock, struct instance *instance)
                 switch (sslerrno) {
                     case SSL_ERROR_WANT_READ:
                     case SSL_ERROR_WANT_WRITE:
-                        if (r > 0)
-                            continue;
-                        else // Reached timeout
-                            goto endloop;
+                        goto endloop;
                     default:
                         ERR_error_string_n(sslerr, buf, sizeof(buf));
                         error("SSL error (%s)",

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -124,7 +124,14 @@ SSL_CTX * security_initialize_openssl_client() {
     ctx = SSL_CTX_new(TLS_client_method());
 #endif
     if(ctx) {
-        security_openssl_common_options(ctx, 1);
+        SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION);
+#if defined(TLS_MAX_VERSION)
+        SSL_CTX_set_max_proto_version(ctx, TLS_MAX_VERSION);
+#elif defined(TLS1_3_VERSION)
+        SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION);
+#elif defined(TLS1_2_VERSION)
+        SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION);
+#endif
     }
 
     return ctx;

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -124,13 +124,17 @@ SSL_CTX * security_initialize_openssl_client() {
     ctx = SSL_CTX_new(TLS_client_method());
 #endif
     if(ctx) {
+#if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110
+        SSL_CTX_set_options (ctx,SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_COMPRESSION);
+#else
         SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION);
-#if defined(TLS_MAX_VERSION)
+# if defined(TLS_MAX_VERSION)
         SSL_CTX_set_max_proto_version(ctx, TLS_MAX_VERSION);
-#elif defined(TLS1_3_VERSION)
+# elif defined(TLS1_3_VERSION)
         SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION);
-#elif defined(TLS1_2_VERSION)
+# elif defined(TLS1_2_VERSION)
         SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION);
+# endif
 #endif
     }
 

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -66,12 +66,16 @@ int tls_select_version(const char *lversion) {
         return TLS1_1_VERSION;
     else if (!strcmp(lversion, "1.2"))
         return TLS1_2_VERSION;
-#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_111
+#if defined(TLS1_3_VERSION)
     else if (!strcmp(lversion, "1.3"))
         return TLS1_3_VERSION;
 #endif
 
+#if defined(TLS_MAX_VERSION)
     return TLS_MAX_VERSION;
+#else
+    return TLS1_2_VERSION;
+#endif
 }
 #endif
 


### PR DESCRIPTION
##### Summary
Fixes #8111
Fixes #8847
This PR also brings another feature described at #8461.

##### Component Name
Exporting
##### Test Plan
To test this PR, the suggestion is to use OpenTSDB to confirm that it continues sending data using `HTTP` and InfluxDB to test `HTTPS`, this is the simplest road.

######  OpenTSDB and HTTP
1 - Start hbase
2 - Start zookeper
3 - Run OpenTSDB with the command: `tsdb tsd --port=4242 --staticroot=staticroot/ --cachedir=/tmp/tsd --zkquorum=localhost:2181 --auto-metric` 
4 - Configure your `exporting.conf`:

```
[exporting:global]
    enabled = yes

[opentsdb:http:my_instance0]
    enabled = yes
    destination = localhost:4242
    #database = netdata
```
5 - Start Netdata
6  - Access localhost:4242 and confirm the metrics are there.

######  InfluxDB and HTTP

1 - Stop Netdata and OpenTSDB
2 - Edit `influxdb.conf` and uncomment the lines related to OpenTSDB:

```
[[opentsdb]]
  enabled = true
  bind-address = ":4242"
  database = "opentsdb"
``` 

3 - Start InfluxDB
4 - Access it running `influx` 
5 - Verify whether the databases already created runing
```
$  show databases;
```
If and only if, you already have the database `opentsdb`, you can jump to step 8.

6 - Create the database opentsdb:
```
$  create database opentsdb;
```
7 - Start Netdata
8 - After few seconds, confirm that Netada is sending data correctly using `influx`:
```
$ use opentsdb;
$ show measurements limit 10
```

######  InfluxDB and HTTPS

1 - Stop Netdata and influxdb
2 - Generate the certificates with the command: `openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -sha512 -subj "/C=US/ST=Denied/L=Somewhere/O=Dis/CN=www.example.com" -keyout key.pem  -out cert.pem`
3 - Concatenate both keys and certificate in one unique file:
cat cert.pem key.pem >> influx.pem
4 - Edit `influxdb.conf` and change the lines for `opentsdb` protocol to be like this:
```
[[opentsdb]]
  enabled = true
  bind-address = ":4242"
  database = "opentsdb"
  tls-enabled = true
  certificate= "/etc/influxdb/influxdb.pem"
```
5 - I never worked before with InfluxDB, so in my tests I decided to drop the database and create again:

```
$ drop database opentsdb;
$ create database opentsdb;
```

6 - Change `exporting.conf` to:

```
[exporting:global]
    enabled = yes

[opentsdb:https:my_instance0]
    enabled = yes
    destination = localhost:4242
    #database = netdata
```

7 - Start InfluxDB
8 - Start Netdata
9 - Wait few minutes and confirm that we have data inside influxdb

```
$ use opentsdb;
$ show measurements limit 10
``` 

##### Additional Information
