### PR TITLE
Introduce a random sleep in the Netdata updater

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -213,8 +213,9 @@ trap cleanup EXIT
 # Random sleep to aileviate stampede effect of Agents upgrading
 # and disconnecting/reconnecting at the same time (or near to).
 # But only we're not a controlling terminal (tty)
+# Randomly sleep between 1s and 60m
 if [ ! -t 1 ]; then
-  sleep $((RANDOM % (3600 - 1800 + 1) + 1800))s
+  sleep $(((RANDOM % 3600) + 1))s
 fi
 
 # Usually stored in /etc/netdata/.environment

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -212,7 +212,10 @@ trap cleanup EXIT
 
 # Random sleep to aileviate stampede effect of Agents upgrading
 # and disconnecting/reconnecting at the same time (or near to).
-sleep $(((RANDOM % 10) + 1))s
+# But only we're not a controlling terminal (tty)
+if [ ! -t 1 ]; then
+  sleep $((RANDOM % (3600 - 1800 + 1) + 1800))s
+fi
 
 # Usually stored in /etc/netdata/.environment
 : "${ENVIRONMENT_FILE:=THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT}"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -185,8 +185,8 @@ update() {
       do_not_start="--dont-start-it"
     fi
 
-    if [ -n "${NETDATA_SELECTED_DASHBOARD}" ] ; then
-        env="NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
+    if [ -n "${NETDATA_SELECTED_DASHBOARD}" ]; then
+      env="NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
     fi
 
     info "Re-installing netdata..."
@@ -209,6 +209,10 @@ logfile=
 tmpdir=
 
 trap cleanup EXIT
+
+# Random sleep to aileviate stampede effect of Agents upgrading
+# and disconnecting/reconnecting at the same time (or near to).
+sleep $(((RANDOM % 10) + 1))s
 
 # Usually stored in /etc/netdata/.environment
 : "${ENVIRONMENT_FILE:=THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT}"

--- a/tests/updater_checks.bats
+++ b/tests/updater_checks.bats
@@ -56,6 +56,9 @@ setup() {
 	# Run the updater, with the override so that it uses the local repo we have at hand
 	# Try to run the installed, if any, otherwise just run the one from the repo
 	export NETDATA_LOCAL_TARBAL_OVERRIDE="${PWD}"
+	# Disable random sleep / splay for netdata-updater to avoid sampede effect
+	# of many agents (dis|re)connecting too quickly all at onace to Netdata Cloud
+	unset RANDOM; export RANDOM=0
 	/etc/cron.daily/netdata-updater || ./packaging/installer/netdata-updater.sh
 	! grep "new_installation" "${ENV}"
 }


### PR DESCRIPTION
##### Summary

ssia

##### Component Name

- area/packaging

##### Test Plan

Tested the shell expression:

```#!sh
sleep $(((RANDOM % 10) + 1))s
```

##### Additional Information

This will hopefully aliviate the stampede like effect we're seeing in Netdata
Cloud Production where we see spikes of disconnections and reconenctions.
The timing lines up with the default Debian crontab entry for "daily" jobs
and thus adding a random sleep into the updater should help spread this out
a bit and reduce load on our system9s) in short intervals.