### PR TITLE
Add infiniband monitoring to collector proc.plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,7 @@ set(PROC_PLUGIN_FILES
         collectors/proc.plugin/sys_block_zram.c
         collectors/proc.plugin/sys_devices_system_edac_mc.c
         collectors/proc.plugin/sys_devices_system_node.c
+        collectors/proc.plugin/sys_class_infiniband.c
         collectors/proc.plugin/sys_fs_btrfs.c
         collectors/proc.plugin/sys_class_power_supply.c
         )

--- a/Makefile.am
+++ b/Makefile.am
@@ -319,6 +319,7 @@ PROC_PLUGIN_FILES = \
     collectors/proc.plugin/sys_devices_system_node.c \
     collectors/proc.plugin/sys_fs_btrfs.c \
     collectors/proc.plugin/sys_class_power_supply.c \
+    collectors/proc.plugin/sys_class_infiniband.c \
     $(NULL)
 
 TC_PLUGIN_FILES = \

--- a/collectors/all.h
+++ b/collectors/all.h
@@ -282,6 +282,8 @@
 #define NETDATA_CHART_PRIO_TC_QOS_TOCKENS             7030
 #define NETDATA_CHART_PRIO_TC_QOS_CTOCKENS            7040
 
+// Infiniband
+#define NETDATA_CHART_PRIO_INFINIBAND                 7100
 
 // Netfilter
 

--- a/collectors/proc.plugin/README.md
+++ b/collectors/proc.plugin/README.md
@@ -483,7 +483,7 @@ Each port will have its counters metrics monitored, grouped in the following cha
     - Link: downed, recovered, integrity error, minor error
     - Other events: Tick Wait to send, buffer overrun
 
-If your vendor is supported, you'll also get HW-Counters statistics. These being vendor specific, please report to their documentation.
+If your vendor is supported, you'll also get HW-Counters statistics. These being vendor specific, please refer to their documentation.
 
 - Mellanox: [see statistics documentation](https://community.mellanox.com/s/article/understanding-mlx5-linux-counters-and-status-parameters)
 

--- a/collectors/proc.plugin/README.md
+++ b/collectors/proc.plugin/README.md
@@ -28,6 +28,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/proc.
 -   `/proc/pressure/{cpu,memory,io}` (pressure stall information)
 -   `/proc/sys/kernel/random/entropy_avail` (random numbers pool availability - used in cryptography)
 -   `/sys/class/power_supply` (power supply properties)
+-   `/sys/class/infiniband` (infiniband interconnect)
 -   `ipc` (IPC semaphores and message queues)
 -   `ksm` Kernel Same-Page Merging performance (several files under `/sys/kernel/mm/ksm`).
 -   `netdata` (internal Netdata resources utilization)
@@ -461,6 +462,48 @@ and metrics:
     corresponding `min` or `empty` attribute, then Netdata will still provide
     the corresponding `min` or `empty`, which will then always read as zero.
     This way, alerts which match on these will still work.
+
+## Infiniband interconnect
+
+This module monitors every active Infiniband port. It provides generic counters statistics, and per-vendor hw-counters (if vendor is supported).
+
+### Monitored interface metrics
+
+Each port will have its counters metrics monitored, grouped in the following charts:
+
+-   **Bandwidth usage**
+    Sent/Received data, in KB/s
+
+-   **Packets Statistics**
+    Sent/Received packets, in 3 categories: total, unicast and multicast.
+
+-  **Errors Statistics**
+    Many errors counters are provided, presenting statistics for:
+    - Packets: malformated, sent/received discarded by card/switch, missing ressource
+    - Link: downed, recovered, integrity error, minor error
+    - Other events: Tick Wait to send, buffer overrun
+
+If your vendor is supported, you'll also get HW-Counters statistics. These being vendor specific, please report to their documentation.
+
+- Mellanox: [see statistics documentation](https://community.mellanox.com/s/article/understanding-mlx5-linux-counters-and-status-parameters)
+
+### configuration
+
+Default configuration will monitor only enabled infiniband ports, and refresh newly activated or created ports every 30 seconds
+
+```
+[plugin:proc:/sys/class/infiniband]
+  # dirname to monitor = /sys/class/infiniband
+  # bandwidth counters = yes
+  # packets counters = yes
+  # errors counters = yes
+  # hardware packets counters = auto
+  # hardware errors counters = auto
+  # monitor only ports being active = auto
+  # disable by default interfaces matching = 
+  # refresh ports state every seconds = 30
+```
+
 
 ## IPC
 

--- a/collectors/proc.plugin/plugin_proc.c
+++ b/collectors/proc.plugin/plugin_proc.c
@@ -47,6 +47,7 @@ static struct proc_module {
         { .name = "/proc/net/sctp/snmp", .dim = "sctp", .func = do_proc_net_sctp_snmp },
         { .name = "/proc/net/softnet_stat", .dim = "softnet", .func = do_proc_net_softnet_stat },
         { .name = "/proc/net/ip_vs/stats", .dim = "ipvs", .func = do_proc_net_ip_vs_stats },
+        { .name = "/sys/class/infiniband",   .dim = "infiniband", .func = do_sys_class_infiniband },
 
         // firewall metrics
         { .name = "/proc/net/stat/conntrack", .dim = "conntrack", .func = do_proc_net_stat_conntrack },

--- a/collectors/proc.plugin/plugin_proc.h
+++ b/collectors/proc.plugin/plugin_proc.h
@@ -57,6 +57,7 @@ extern int do_proc_net_sctp_snmp(int update_every, usec_t dt);
 extern int do_ipc(int update_every, usec_t dt);
 extern int do_sys_class_power_supply(int update_every, usec_t dt);
 extern int do_proc_pagetypeinfo(int update_every, usec_t dt);
+extern int do_sys_class_infiniband(int update_every, usec_t dt);
 extern int get_numa_node_count(void);
 
 // metrics that need to be shared among data collectors

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -211,21 +211,19 @@ struct ibporthw_mlx {
 };
 void infiniband_hwcounters_parse_mlx(struct ibport *port)
 {
-    if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
-        FOREACH_HWCOUNTER_MLX_ERRORS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
-    }
-    if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
+    if (port->do_hwerrors != CONFIG_BOOLEAN_NO)
+        FOREACH_HWCOUNTER_MLX_ERRORS(GEN_DO_HWCOUNTER_READ,  port, port->hwcounters_mlx)
+    if (port->do_hwpackets != CONFIG_BOOLEAN_NO)
         FOREACH_HWCOUNTER_MLX_PACKETS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
-    }
 }
 void infiniband_hwcounters_dorrd_mlx(struct ibport *port)
 {
     if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
-        FOREACH_HWCOUNTER_MLX_ERRORS(GEN_RRD_DIM_SETP_HW, port, port->hwcounters_mlx)
+        FOREACH_HWCOUNTER_MLX_ERRORS(GEN_RRD_DIM_SETP_HW,    port, port->hwcounters_mlx)
         rrdset_done(port->st_hwerrors);
     }
     if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
-        FOREACH_HWCOUNTER_MLX_PACKETS(GEN_RRD_DIM_SETP_HW, port, port->hwcounters_mlx)
+        FOREACH_HWCOUNTER_MLX_PACKETS(GEN_RRD_DIM_SETP_HW,   port, port->hwcounters_mlx)
         rrdset_done(port->st_hwpackets);
     }
 }
@@ -258,28 +256,28 @@ static struct ibport *get_ibport(const char *dev, const char *port)
     // create a new one
     p = callocz(1, sizeof(struct ibport));
     p->name = strdupz(name);
-    p->len = strlen(p->name);
+    p->len  = strlen(p->name);
 
-    p->chart_type_bytes = strdupz("infiniband_cnt_bytes");
-    p->chart_type_packets = strdupz("infiniband_cnt_packets");
-    p->chart_type_errors = strdupz("infiniband_cnt_errors");
+    p->chart_type_bytes     = strdupz("infiniband_cnt_bytes");
+    p->chart_type_packets   = strdupz("infiniband_cnt_packets");
+    p->chart_type_errors    = strdupz("infiniband_cnt_errors");
     p->chart_type_hwpackets = strdupz("infiniband_hwc_packets");
-    p->chart_type_hwerrors = strdupz("infiniband_hwc_errors");
+    p->chart_type_hwerrors  = strdupz("infiniband_hwc_errors");
 
     char buffer[RRD_ID_LENGTH_MAX + 1];
-    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntbytes_%s", p->name);
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntbytes_%s",     p->name);
     p->chart_id_bytes = strdupz(buffer);
 
-    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntpackets_%s", p->name);
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntpackets_%s",   p->name);
     p->chart_id_packets = strdupz(buffer);
 
-    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cnterrors_%s", p->name);
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cnterrors_%s",    p->name);
     p->chart_id_errors = strdupz(buffer);
 
     snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcntpackets_%s", p->name);
     p->chart_id_hwpackets = strdupz(buffer);
 
-    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcnterrors_%s", p->name);
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcnterrors_%s",  p->name);
     p->chart_id_hwerrors = strdupz(buffer);
 
     p->chart_family = strdupz(p->name);
@@ -315,19 +313,19 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
         sys_class_infiniband_dirname =
             config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "dirname to monitor", dirname);
 
-        do_bytes = config_get_boolean_ondemand(
-            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "bandwidth counters", CONFIG_BOOLEAN_YES);
-        do_packets = config_get_boolean_ondemand(
-            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "packets counters", CONFIG_BOOLEAN_YES);
-        do_errors = config_get_boolean_ondemand(
-            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "errors counters", CONFIG_BOOLEAN_YES);
+        do_bytes     = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "bandwidth counters",        CONFIG_BOOLEAN_YES);
+        do_packets   = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "packets counters",          CONFIG_BOOLEAN_YES);
+        do_errors    = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "errors counters",           CONFIG_BOOLEAN_YES);
         do_hwpackets = config_get_boolean_ondemand(
             CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware packets counters", CONFIG_BOOLEAN_AUTO);
-        do_hwerrors = config_get_boolean_ondemand(
-            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware errors counters", CONFIG_BOOLEAN_AUTO);
+        do_hwerrors  = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware errors counters",  CONFIG_BOOLEAN_AUTO);
 
         enable_only_active = config_get_boolean_ondemand(
-            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "monitor only ports being active", CONFIG_BOOLEAN_AUTO);
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "monitor only active ports", CONFIG_BOOLEAN_AUTO);
         disabled_list = simple_pattern_create(
             config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "disable by default interfaces matching", ""), NULL,
             SIMPLE_PATTERN_EXACT);
@@ -396,15 +394,15 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                     // Enable by default, will be filtered out later
                     p->enabled = 1;
 
-                    p->counters_path = strdupz(counters_dirname);
+                    p->counters_path   = strdupz(counters_dirname);
                     p->hwcounters_path = strdupz(hwcounters_dirname);
 
                     snprintfz(buffer, FILENAME_MAX, "plugin:proc:/sys/class/infiniband:%s", p->name);
 
                     // Standard counters
-                    p->do_bytes = config_get_boolean_ondemand(buffer, "bytes", do_bytes);
+                    p->do_bytes   = config_get_boolean_ondemand(buffer, "bytes",   do_bytes);
                     p->do_packets = config_get_boolean_ondemand(buffer, "packets", do_packets);
-                    p->do_errors = config_get_boolean_ondemand(buffer, "errors", do_errors);
+                    p->do_errors  = config_get_boolean_ondemand(buffer, "errors",  do_errors);
 
 // Gen filename allocation and concatenation
 #define GEN_DO_COUNTER_NAME(NAME, GRP, DESC, DIR, PORT, ...)                                                           \
@@ -417,7 +415,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                     if (hwcounters_dir) {
                         // By default set standard
                         p->do_hwpackets = config_get_boolean_ondemand(buffer, "hwpackets", do_hwpackets);
-                        p->do_hwerrors = config_get_boolean_ondemand(buffer, "hwerrors", do_hwerrors);
+                        p->do_hwerrors  = config_get_boolean_ondemand(buffer, "hwerrors",  do_hwerrors);
 
 // VENDORS: Set your own
 
@@ -521,9 +519,18 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
             // First creation of RRD Set (charts)
             if (unlikely(!port->st_bytes)) {
                 port->st_bytes = rrdset_create_localhost(
-                    "Infiniband", port->chart_id_bytes, NULL, port->chart_family, "ib.bytes", "Bandwidth usage",
-                    "kilobits/s", PLUGIN_PROC_NAME, PLUGIN_PROC_MODULE_INFINIBAND_NAME, port->priority + 1,
-                    update_every, RRDSET_TYPE_AREA);
+                    "Infiniband",
+                    port->chart_id_bytes,
+                    NULL,
+                    port->chart_family,
+                    "ib.bytes",
+                    "Bandwidth usage",
+                    "kilobits/s",
+                    PLUGIN_PROC_NAME,
+                    PLUGIN_PROC_MODULE_INFINIBAND_NAME,
+                    port->priority + 1,
+                    update_every,
+                    RRDSET_TYPE_AREA);
                 // Create Dimensions
                 rrdset_flag_set(port->st_bytes, RRDSET_FLAG_DETAIL);
                 // On this chart, we want to have a KB/s so the dashboard will autoscale it
@@ -550,8 +557,17 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
             // First creation of RRD Set (charts)
             if (unlikely(!port->st_packets)) {
                 port->st_packets = rrdset_create_localhost(
-                    "Infiniband", port->chart_id_packets, NULL, port->chart_family, "ib.packets", "Packets Statistics",
-                    "packets/s", PLUGIN_PROC_NAME, PLUGIN_PROC_MODULE_INFINIBAND_NAME, port->priority + 2, update_every,
+                    "Infiniband",
+                    port->chart_id_packets,
+                    NULL,
+                    port->chart_family,
+                    "ib.packets",
+                    "Packets Statistics",
+                    "packets/s",
+                    PLUGIN_PROC_NAME,
+                    PLUGIN_PROC_MODULE_INFINIBAND_NAME,
+                    port->priority + 2,
+                    update_every,
                     RRDSET_TYPE_AREA);
                 // Create Dimensions
                 rrdset_flag_set(port->st_packets, RRDSET_FLAG_DETAIL);
@@ -571,8 +587,17 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
             // First creation of RRD Set (charts)
             if (unlikely(!port->st_errors)) {
                 port->st_errors = rrdset_create_localhost(
-                    "Infiniband", port->chart_id_errors, NULL, port->chart_family, "ib.errors", "Error Counters",
-                    "errors/s", PLUGIN_PROC_NAME, PLUGIN_PROC_MODULE_INFINIBAND_NAME, port->priority + 3, update_every,
+                    "Infiniband",
+                    port->chart_id_errors,
+                    NULL,
+                    port->chart_family,
+                    "ib.errors",
+                    "Error Counters",
+                    "errors/s",
+                    PLUGIN_PROC_NAME,
+                    PLUGIN_PROC_MODULE_INFINIBAND_NAME,
+                    port->priority + 3,
+                    update_every,
                     RRDSET_TYPE_LINE);
                 // Create Dimensions
                 rrdset_flag_set(port->st_errors, RRDSET_FLAG_DETAIL);
@@ -598,9 +623,18 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                 // First creation of RRD Set (charts)
                 if (unlikely(!port->st_hwerrors)) {
                     port->st_hwerrors = rrdset_create_localhost(
-                        "Infiniband", port->chart_id_hwerrors, NULL, port->chart_family, "ib.hwerrors",
-                        "Hardware Errors", "errors/s", PLUGIN_PROC_NAME, PLUGIN_PROC_MODULE_INFINIBAND_NAME,
-                        port->priority + 4, update_every, RRDSET_TYPE_LINE);
+                        "Infiniband",
+                        port->chart_id_hwerrors,
+                        NULL,
+                        port->chart_family,
+                        "ib.hwerrors",
+                        "Hardware Errors",
+                        "errors/s",
+                        PLUGIN_PROC_NAME,
+                        PLUGIN_PROC_MODULE_INFINIBAND_NAME,
+                        port->priority + 4,
+                        update_every,
+                        RRDSET_TYPE_LINE);
 
                     rrdset_flag_set(port->st_hwerrors, RRDSET_FLAG_DETAIL);
 
@@ -626,9 +660,18 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                 // First creation of RRD Set (charts)
                 if (unlikely(!port->st_hwpackets)) {
                     port->st_hwpackets = rrdset_create_localhost(
-                        "Infiniband", port->chart_id_hwpackets, NULL, port->chart_family, "ib.hwpackets",
-                        "Hardware Packets Statistics", "packets/s", PLUGIN_PROC_NAME,
-                        PLUGIN_PROC_MODULE_INFINIBAND_NAME, port->priority + 5, update_every, RRDSET_TYPE_LINE);
+                        "Infiniband",
+                        port->chart_id_hwpackets,
+                        NULL,
+                        port->chart_family,
+                        "ib.hwpackets",
+                        "Hardware Packets Statistics",
+                        "packets/s",
+                        PLUGIN_PROC_NAME,
+                        PLUGIN_PROC_MODULE_INFINIBAND_NAME,
+                        port->priority + 5,
+                        update_every,
+                        RRDSET_TYPE_LINE);
 
                     rrdset_flag_set(port->st_hwpackets, RRDSET_FLAG_DETAIL);
 

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -484,7 +484,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 					p->width = str2ull(buffer_width);
 				}
 
-
+				info("Infiniband card %s port %s at speed %llu width %llu", dev_dent->d_name, port_dent->d_name, p->speed, p->width);
 
 			}
 			closedir(ports_dir);

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -167,7 +167,7 @@ static struct ibport {
 		RRDDIM    *rd_##NAME;
 	FOREACH_COUNTER(GEN_DEF_COUNTER)
 
-	// Vendor specific hwcounters from /$device/ports/$portid/hwcounters
+	// Vendor specific hwcounters from /$device/ports/$portid/hw_counters
 	// We will generate one struct pointer per vendor to avoid future casting
 	#define GEN_DEF_HWCOUNTER_PTR(VENDOR, ...) \
 		struct ibporthw_##VENDOR *hwcounters_##VENDOR;
@@ -268,11 +268,21 @@ static struct ibport *get_ibport(const char *dev, const char *port) {
 	p->chart_type_hwpackets = strdupz("infiniband_hwc_packets");
 	p->chart_type_hwerrors  = strdupz("infiniband_hwc_errors");
 
-	p->chart_id_bytes     = strdupz(p->name);
-	p->chart_id_packets   = strdupz(p->name);
-	p->chart_id_errors    = strdupz(p->name);
-	p->chart_id_hwpackets = strdupz(p->name);
-	p->chart_id_hwerrors  = strdupz(p->name);
+	char buffer[RRD_ID_LENGTH_MAX + 1];
+	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntbytes_%s", p->name);
+	p->chart_id_bytes     = strdupz(buffer);
+
+	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntpackets_%s", p->name);
+	p->chart_id_packets   = strdupz(buffer);
+
+	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cnterrors_%s", p->name);
+	p->chart_id_errors    = strdupz(buffer);
+
+	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcntpackets_%s", p->name);
+	p->chart_id_hwpackets = strdupz(buffer);
+
+	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcnterrors_%s", p->name);
+	p->chart_id_hwerrors  = strdupz(buffer);
 
 	p->chart_family        = strdupz(p->name);
 	p->priority            = NETDATA_CHART_PRIO_INFINIBAND;
@@ -361,7 +371,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 
 				// Nearly same with hardware counters
 				char hwcounters_dirname[FILENAME_MAX +1];
-				snprintfz(hwcounters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "hwcounters");
+				snprintfz(hwcounters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "hw_counters");
 				DIR *hwcounters_dir = opendir(hwcounters_dirname);
 
 				// Get new ibport
@@ -467,7 +477,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 			// First creation of RRD Set (charts)
 			if(unlikely(!port->st_bytes)) {
 				port->st_bytes = rrdset_create_localhost(
-					port->chart_type_bytes
+					"Infiniband"
 					, port->chart_id_bytes
 					, NULL
 					, port->chart_family
@@ -500,7 +510,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 			// First creation of RRD Set (charts)
 			if(unlikely(!port->st_packets)) {
 				port->st_packets = rrdset_create_localhost(
-					port->chart_type_packets
+					"Infiniband"
 					, port->chart_id_packets
 					, NULL
 					, port->chart_family
@@ -533,7 +543,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 			// First creation of RRD Set (charts)
 			if(unlikely(!port->st_errors)) {
 				port->st_errors = rrdset_create_localhost(
-					port->chart_type_errors
+					"Infiniband"
 					, port->chart_id_errors
 					, NULL
 					, port->chart_family
@@ -574,7 +584,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 				// First creation of RRD Set (charts)
 				if(unlikely(!port->st_hwerrors)) {
 					port->st_hwerrors = rrdset_create_localhost(
-						port->chart_type_hwerrors
+						"Infiniband"
 						, port->chart_id_hwerrors
 						, NULL
 						, port->chart_family
@@ -612,7 +622,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 				// First creation of RRD Set (charts)
 				if(unlikely(!port->st_hwpackets)) {
 					port->st_hwpackets = rrdset_create_localhost(
-						port->chart_type_hwpackets
+						"Infiniband"
 						, port->chart_id_hwpackets
 						, NULL
 						, port->chart_family

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -15,36 +15,36 @@
 // I use macro as there's no single file acting as summary, but a lot of different files, so can't use helpers like
 // procfile(). Also, omnipath generates other counters, that are not provided by infiniband
 #define FOREACH_COUNTER(GEN, ...) \
-	FOREACH_COUNTER_BYTES(GEN,   __VA_ARGS__) \
-	FOREACH_COUNTER_PACKETS(GEN, __VA_ARGS__) \
-	FOREACH_COUNTER_ERRORS(GEN,  __VA_ARGS__)
+    FOREACH_COUNTER_BYTES(GEN,   __VA_ARGS__) \
+    FOREACH_COUNTER_PACKETS(GEN, __VA_ARGS__) \
+    FOREACH_COUNTER_ERRORS(GEN,  __VA_ARGS__)
 
 #define FOREACH_COUNTER_BYTES(GEN, ...) \
-	GEN(port_rcv_data,                   bytes,  "Received", 1, __VA_ARGS__) \
-	GEN(port_xmit_data,                  bytes,  "Sent",    -1, __VA_ARGS__)
+    GEN(port_rcv_data,                   bytes,  "Received", 1, __VA_ARGS__) \
+    GEN(port_xmit_data,                  bytes,  "Sent",    -1, __VA_ARGS__)
 
 #define FOREACH_COUNTER_PACKETS(GEN, ...) \
-	GEN(port_rcv_packets,                packets, "Received",    1, __VA_ARGS__) \
-	GEN(port_xmit_packets,               packets, "Sent",       -1, __VA_ARGS__) \
-	GEN(multicast_rcv_packets,           packets, "Mcast rcvd",  1, __VA_ARGS__) \
-	GEN(multicast_xmit_packets,          packets, "Mcast sent", -1, __VA_ARGS__) \
-	GEN(unicast_rcv_packets,             packets, "Ucast rcvd",  1, __VA_ARGS__) \
-	GEN(unicast_xmit_packets,            packets, "Ucast sent", -1, __VA_ARGS__) \
+    GEN(port_rcv_packets,                packets, "Received",    1, __VA_ARGS__) \
+    GEN(port_xmit_packets,               packets, "Sent",       -1, __VA_ARGS__) \
+    GEN(multicast_rcv_packets,           packets, "Mcast rcvd",  1, __VA_ARGS__) \
+    GEN(multicast_xmit_packets,          packets, "Mcast sent", -1, __VA_ARGS__) \
+    GEN(unicast_rcv_packets,             packets, "Ucast rcvd",  1, __VA_ARGS__) \
+    GEN(unicast_xmit_packets,            packets, "Ucast sent", -1, __VA_ARGS__) \
 
 #define FOREACH_COUNTER_ERRORS(GEN, ...) \
-	GEN(port_rcv_errors,                 errors, "Pkts malformated",      1, __VA_ARGS__) \
-	GEN(port_rcv_constraint_errors,      errors, "Pkts rcvd discarded ",  1, __VA_ARGS__) \
-	GEN(port_xmit_discards,              errors, "Pkts sent discarded",   1, __VA_ARGS__) \
-	GEN(port_xmit_wait,                  errors, "Tick Wait to send",     1, __VA_ARGS__) \
-	GEN(VL15_dropped,                    errors, "Pkts missed ressource", 1, __VA_ARGS__) \
-	GEN(excessive_buffer_overrun_errors, errors, "Buffer overrun",        1, __VA_ARGS__) \
-	GEN(link_downed,                     errors, "Link Downed",           1, __VA_ARGS__) \
-	GEN(link_error_recovery,             errors, "Link recovered",        1, __VA_ARGS__) \
-	GEN(local_link_integrity_errors,     errors, "Link integrity err",    1, __VA_ARGS__) \
-	GEN(symbol_error,                    errors, "Link minor errors",     1, __VA_ARGS__) \
-	GEN(port_rcv_remote_physical_errors, errors, "Pkts rcvd with EBP",    1, __VA_ARGS__) \
-	GEN(port_rcv_switch_relay_errors,    errors, "Pkts rcvd discarded by switch",  1, __VA_ARGS__) \
-	GEN(port_xmit_constraint_errors,     errors, "Pkts sent discarded by switch",  1, __VA_ARGS__)
+    GEN(port_rcv_errors,                 errors, "Pkts malformated",      1, __VA_ARGS__) \
+    GEN(port_rcv_constraint_errors,      errors, "Pkts rcvd discarded ",  1, __VA_ARGS__) \
+    GEN(port_xmit_discards,              errors, "Pkts sent discarded",   1, __VA_ARGS__) \
+    GEN(port_xmit_wait,                  errors, "Tick Wait to send",     1, __VA_ARGS__) \
+    GEN(VL15_dropped,                    errors, "Pkts missed ressource", 1, __VA_ARGS__) \
+    GEN(excessive_buffer_overrun_errors, errors, "Buffer overrun",        1, __VA_ARGS__) \
+    GEN(link_downed,                     errors, "Link Downed",           1, __VA_ARGS__) \
+    GEN(link_error_recovery,             errors, "Link recovered",        1, __VA_ARGS__) \
+    GEN(local_link_integrity_errors,     errors, "Link integrity err",    1, __VA_ARGS__) \
+    GEN(symbol_error,                    errors, "Link minor errors",     1, __VA_ARGS__) \
+    GEN(port_rcv_remote_physical_errors, errors, "Pkts rcvd with EBP",    1, __VA_ARGS__) \
+    GEN(port_rcv_switch_relay_errors,    errors, "Pkts rcvd discarded by switch",  1, __VA_ARGS__) \
+    GEN(port_xmit_constraint_errors,     errors, "Pkts sent discarded by switch",  1, __VA_ARGS__)
 
 
 
@@ -62,181 +62,181 @@
 
 // VENDORS: List of implemented hardware vendors
 #define FOREACH_HWCOUNTER_NAME(GEN, ...) \
-	GEN(mlx, __VA_ARGS__)
+    GEN(mlx, __VA_ARGS__)
 
 // VENDOR-MLX: HW Counters for Mellanox ConnectX Devices
 #define FOREACH_HWCOUNTER_MLX(GEN, ...) \
-	FOREACH_HWCOUNTER_MLX_PACKETS(GEN, __VA_ARGS__) \
-	FOREACH_HWCOUNTER_MLX_ERRORS(GEN, __VA_ARGS__)
+    FOREACH_HWCOUNTER_MLX_PACKETS(GEN, __VA_ARGS__) \
+    FOREACH_HWCOUNTER_MLX_ERRORS(GEN, __VA_ARGS__)
 
 #define FOREACH_HWCOUNTER_MLX_PACKETS(GEN, ...) \
-	GEN(np_cnp_sent,                 hwpackets, "RoCEv2 Congestion sent",  1, __VA_ARGS__) \
-	GEN(np_ecn_marked_roce_packets,  hwpackets, "RoCEv2 Congestion rcvd", -1, __VA_ARGS__) \
-	GEN(rp_cnp_handled,              hwpackets, "IB Congestion handled",   1, __VA_ARGS__) \
-	GEN(rx_atomic_requests,          hwpackets, "ATOMIC req. rcvd",        1, __VA_ARGS__) \
-	GEN(rx_dct_connect,              hwpackets, "Connection req. rcvd",    1, __VA_ARGS__) \
-	GEN(rx_read_requests,            hwpackets, "Read req. rcvd",          1, __VA_ARGS__) \
-	GEN(rx_write_requests,           hwpackets, "Write req. rcvd",         1, __VA_ARGS__) \
-	GEN(roce_adp_retrans,            hwpackets, "RoCE retrans adaptive",   1, __VA_ARGS__) \
-	GEN(roce_adp_retrans_to,         hwpackets, "RoCE retrans timeout",    1, __VA_ARGS__) \
-	GEN(roce_slow_restart,           hwpackets, "RoCE slow restart",       1, __VA_ARGS__) \
-	GEN(roce_slow_restart_cnps,      hwpackets, "RoCE slow restart congestion",  1, __VA_ARGS__) \
-	GEN(roce_slow_restart_trans,     hwpackets, "RoCE slow restart count", 1, __VA_ARGS__)
+    GEN(np_cnp_sent,                 hwpackets, "RoCEv2 Congestion sent",  1, __VA_ARGS__) \
+    GEN(np_ecn_marked_roce_packets,  hwpackets, "RoCEv2 Congestion rcvd", -1, __VA_ARGS__) \
+    GEN(rp_cnp_handled,              hwpackets, "IB Congestion handled",   1, __VA_ARGS__) \
+    GEN(rx_atomic_requests,          hwpackets, "ATOMIC req. rcvd",        1, __VA_ARGS__) \
+    GEN(rx_dct_connect,              hwpackets, "Connection req. rcvd",    1, __VA_ARGS__) \
+    GEN(rx_read_requests,            hwpackets, "Read req. rcvd",          1, __VA_ARGS__) \
+    GEN(rx_write_requests,           hwpackets, "Write req. rcvd",         1, __VA_ARGS__) \
+    GEN(roce_adp_retrans,            hwpackets, "RoCE retrans adaptive",   1, __VA_ARGS__) \
+    GEN(roce_adp_retrans_to,         hwpackets, "RoCE retrans timeout",    1, __VA_ARGS__) \
+    GEN(roce_slow_restart,           hwpackets, "RoCE slow restart",       1, __VA_ARGS__) \
+    GEN(roce_slow_restart_cnps,      hwpackets, "RoCE slow restart congestion",  1, __VA_ARGS__) \
+    GEN(roce_slow_restart_trans,     hwpackets, "RoCE slow restart count", 1, __VA_ARGS__)
 
 #define FOREACH_HWCOUNTER_MLX_ERRORS(GEN, ...) \
-	GEN(duplicate_request,           hwerrors, "Duplicated packets",   -1, __VA_ARGS__) \
-	GEN(implied_nak_seq_err,         hwerrors, "Pkt Seq Num gap",       1, __VA_ARGS__) \
-	GEN(local_ack_timeout_err,       hwerrors, "Ack timer expired",     1, __VA_ARGS__) \
-	GEN(out_of_buffer,               hwerrors, "Drop missing buffer",   1, __VA_ARGS__) \
-	GEN(out_of_sequence,             hwerrors, "Drop out of sequence",  1, __VA_ARGS__) \
-	GEN(packet_seq_err,              hwerrors, "NAK sequence rcvd",     1, __VA_ARGS__) \
-	GEN(req_cqe_error,               hwerrors, "CQE err Req",           1, __VA_ARGS__) \
-	GEN(resp_cqe_error,              hwerrors, "CQE err Resp",          1, __VA_ARGS__) \
-	GEN(req_cqe_flush_error,         hwerrors, "CQE Flushed err Req",   1, __VA_ARGS__) \
-	GEN(resp_cqe_flush_error,        hwerrors, "CQE Flushed err Resp",  1, __VA_ARGS__) \
-	GEN(req_remote_access_errors,    hwerrors, "Remote access err Req", 1, __VA_ARGS__) \
-	GEN(resp_remote_access_errors,   hwerrors, "Remote access err Resp",1, __VA_ARGS__) \
-	GEN(req_remote_invalid_request,  hwerrors, "Remote invalid req",    1, __VA_ARGS__) \
-	GEN(resp_local_length_error,     hwerrors, "Local length err Resp", 1, __VA_ARGS__) \
-	GEN(rnr_nak_retry_err,           hwerrors, "RNR NAK Packets",       1, __VA_ARGS__) \
-	GEN(rp_cnp_ignored,              hwerrors, "CNP Pkts ignored",      1, __VA_ARGS__) \
-	GEN(rx_icrc_encapsulated,        hwerrors, "RoCE ICRC Errors",      1, __VA_ARGS__)
+    GEN(duplicate_request,           hwerrors, "Duplicated packets",   -1, __VA_ARGS__) \
+    GEN(implied_nak_seq_err,         hwerrors, "Pkt Seq Num gap",       1, __VA_ARGS__) \
+    GEN(local_ack_timeout_err,       hwerrors, "Ack timer expired",     1, __VA_ARGS__) \
+    GEN(out_of_buffer,               hwerrors, "Drop missing buffer",   1, __VA_ARGS__) \
+    GEN(out_of_sequence,             hwerrors, "Drop out of sequence",  1, __VA_ARGS__) \
+    GEN(packet_seq_err,              hwerrors, "NAK sequence rcvd",     1, __VA_ARGS__) \
+    GEN(req_cqe_error,               hwerrors, "CQE err Req",           1, __VA_ARGS__) \
+    GEN(resp_cqe_error,              hwerrors, "CQE err Resp",          1, __VA_ARGS__) \
+    GEN(req_cqe_flush_error,         hwerrors, "CQE Flushed err Req",   1, __VA_ARGS__) \
+    GEN(resp_cqe_flush_error,        hwerrors, "CQE Flushed err Resp",  1, __VA_ARGS__) \
+    GEN(req_remote_access_errors,    hwerrors, "Remote access err Req", 1, __VA_ARGS__) \
+    GEN(resp_remote_access_errors,   hwerrors, "Remote access err Resp",1, __VA_ARGS__) \
+    GEN(req_remote_invalid_request,  hwerrors, "Remote invalid req",    1, __VA_ARGS__) \
+    GEN(resp_local_length_error,     hwerrors, "Local length err Resp", 1, __VA_ARGS__) \
+    GEN(rnr_nak_retry_err,           hwerrors, "RNR NAK Packets",       1, __VA_ARGS__) \
+    GEN(rp_cnp_ignored,              hwerrors, "CNP Pkts ignored",      1, __VA_ARGS__) \
+    GEN(rx_icrc_encapsulated,        hwerrors, "RoCE ICRC Errors",      1, __VA_ARGS__)
 
 
 
 
 // Common definitions used more than once
 #define GEN_RRD_DIM_ADD(NAME,GRP,DESC,DIR, PORT) \
-	GEN_RRD_DIM_ADD_CUSTOM(NAME,GRP,DESC,DIR, PORT, 1, 1, RRD_ALGORITHM_INCREMENTAL)
+    GEN_RRD_DIM_ADD_CUSTOM(NAME,GRP,DESC,DIR, PORT, 1, 1, RRD_ALGORITHM_INCREMENTAL)
 
 #define GEN_RRD_DIM_ADD_CUSTOM(NAME,GRP,DESC,DIR, PORT,MULT,DIV,ALGO) \
-	PORT->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR*MULT, DIV, ALGO);
+    PORT->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR*MULT, DIV, ALGO);
 
 #define GEN_RRD_DIM_ADD_HW(NAME,GRP,DESC,DIR, PORT,HW) \
-	HW->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR, 1, RRD_ALGORITHM_INCREMENTAL);
+    HW->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR, 1, RRD_ALGORITHM_INCREMENTAL);
 
 #define GEN_RRD_DIM_SETP(NAME,GRP,DESC,DIR, PORT) \
-	rrddim_set_by_pointer(PORT->st_##GRP, PORT->rd_##NAME, (collected_number)PORT->NAME);
+    rrddim_set_by_pointer(PORT->st_##GRP, PORT->rd_##NAME, (collected_number)PORT->NAME);
 
 #define GEN_RRD_DIM_SETP_HW(NAME,GRP,DESC,DIR, PORT,HW) \
-	rrddim_set_by_pointer(PORT->st_##GRP, HW->rd_##NAME, (collected_number)HW->NAME);
+    rrddim_set_by_pointer(PORT->st_##GRP, HW->rd_##NAME, (collected_number)HW->NAME);
 
 
 // https://community.mellanox.com/s/article/understanding-mlx5-linux-counters-and-status-parameters
 // https://community.mellanox.com/s/article/infiniband-port-counters
 static struct ibport {
-	char *name;
-	char *counters_path;
-	char *hwcounters_path;
-	int  len;
+    char *name;
+    char *counters_path;
+    char *hwcounters_path;
+    int  len;
 
-	// flags
-	int configured;
-	int enabled;
-	int updated;
+    // flags
+    int configured;
+    int enabled;
+    int updated;
 
-	int do_bytes;
-	int do_packets;
-	int do_errors;
-	int do_hwpackets;
-	int do_hwerrors;
+    int do_bytes;
+    int do_packets;
+    int do_errors;
+    int do_hwpackets;
+    int do_hwerrors;
 
-	const char *chart_type_bytes;
-	const char *chart_type_packets;
-	const char *chart_type_errors;
-	const char *chart_type_hwpackets;
-	const char *chart_type_hwerrors;
+    const char *chart_type_bytes;
+    const char *chart_type_packets;
+    const char *chart_type_errors;
+    const char *chart_type_hwpackets;
+    const char *chart_type_hwerrors;
 
-	const char *chart_id_bytes;
-	const char *chart_id_packets;
-	const char *chart_id_errors;
-	const char *chart_id_hwpackets;
-	const char *chart_id_hwerrors;
+    const char *chart_id_bytes;
+    const char *chart_id_packets;
+    const char *chart_id_errors;
+    const char *chart_id_hwpackets;
+    const char *chart_id_hwerrors;
 
-	const char *chart_family;
+    const char *chart_family;
 
-	unsigned long priority;
+    unsigned long priority;
 
-	// Port details using drivers/infiniband/core/sysfs.c :: rate_show()
-	RRDDIM *rd_speed;
-	uint64_t speed;
-	uint64_t width;
+    // Port details using drivers/infiniband/core/sysfs.c :: rate_show()
+    RRDDIM *rd_speed;
+    uint64_t speed;
+    uint64_t width;
 
-	// Stats from /$device/ports/$portid/counters
-	// as drivers/infiniband/hw/qib/qib_verbs.h
-	// All uint64 except vl15_dropped, local_link_integrity_errors, excessive_buffer_overrun_errors uint32
-	// Will generate 2 elements for each counter:
-	// - uint64_t to store the value
-	// - char*    to store the filename path
-	// - RRDDIM*  to store the RRD Dimension
-	#define GEN_DEF_COUNTER(NAME, ...) \
-		uint64_t  NAME; \
-		char      *file_##NAME; \
-		RRDDIM    *rd_##NAME;
-	FOREACH_COUNTER(GEN_DEF_COUNTER)
+    // Stats from /$device/ports/$portid/counters
+    // as drivers/infiniband/hw/qib/qib_verbs.h
+    // All uint64 except vl15_dropped, local_link_integrity_errors, excessive_buffer_overrun_errors uint32
+    // Will generate 2 elements for each counter:
+    // - uint64_t to store the value
+    // - char*    to store the filename path
+    // - RRDDIM*  to store the RRD Dimension
+    #define GEN_DEF_COUNTER(NAME, ...) \
+        uint64_t  NAME; \
+        char      *file_##NAME; \
+        RRDDIM    *rd_##NAME;
+    FOREACH_COUNTER(GEN_DEF_COUNTER)
 
-	// Vendor specific hwcounters from /$device/ports/$portid/hw_counters
-	// We will generate one struct pointer per vendor to avoid future casting
-	#define GEN_DEF_HWCOUNTER_PTR(VENDOR, ...) \
-		struct ibporthw_##VENDOR *hwcounters_##VENDOR;
-	FOREACH_HWCOUNTER_NAME(GEN_DEF_HWCOUNTER_PTR)
+    // Vendor specific hwcounters from /$device/ports/$portid/hw_counters
+    // We will generate one struct pointer per vendor to avoid future casting
+    #define GEN_DEF_HWCOUNTER_PTR(VENDOR, ...) \
+        struct ibporthw_##VENDOR *hwcounters_##VENDOR;
+    FOREACH_HWCOUNTER_NAME(GEN_DEF_HWCOUNTER_PTR)
 
-	// Function pointer to the "infiniband_hwcounters_parse_<vendor>" function
-	void (*hwcounters_parse)(struct ibport *);
-	void (*hwcounters_dorrd)(struct ibport *);
+    // Function pointer to the "infiniband_hwcounters_parse_<vendor>" function
+    void (*hwcounters_parse)(struct ibport *);
+    void (*hwcounters_dorrd)(struct ibport *);
 
 
-	// charts and dim
-	RRDSET *st_bytes;
-	RRDSET *st_packets;
-	RRDSET *st_errors;
-	RRDSET *st_hwpackets;
-	RRDSET *st_hwerrors;
+    // charts and dim
+    RRDSET *st_bytes;
+    RRDSET *st_packets;
+    RRDSET *st_errors;
+    RRDSET *st_hwpackets;
+    RRDSET *st_hwerrors;
 
-	RRDSETVAR *stv_speed;
+    RRDSETVAR *stv_speed;
 
-	usec_t speed_last_collected_usec;
+    usec_t speed_last_collected_usec;
 
-	struct ibport *next;
+    struct ibport *next;
 } *ibport_root = NULL, *ibport_last_used = NULL;
 
 
 
 // VENDORS: reading / calculation functions
 #define GEN_DEF_HWCOUNTER(NAME, ...) \
-	uint64_t  NAME; \
-	char      *file_##NAME; \
-	RRDDIM    *rd_##NAME;
+    uint64_t  NAME; \
+    char      *file_##NAME; \
+    RRDDIM    *rd_##NAME;
 
 #define GEN_DO_HWCOUNTER_READ(NAME,GRP,DESC,DIR,PORT,HW, ...) \
-	if (HW->file_##NAME) { \
-		if (read_single_number_file(HW->file_##NAME, (unsigned long long *) &HW->NAME)) { \
-			error("cannot read iface '%s' hwcounter '"#HW"'", PORT->name); \
-			HW->file_##NAME = NULL; \
-		} \
-	}
+    if (HW->file_##NAME) { \
+        if (read_single_number_file(HW->file_##NAME, (unsigned long long *) &HW->NAME)) { \
+            error("cannot read iface '%s' hwcounter '"#HW"'", PORT->name); \
+            HW->file_##NAME = NULL; \
+        } \
+    }
 
 // VENDOR-MLX: Mellanox
 struct ibporthw_mlx {
-	FOREACH_HWCOUNTER_MLX(GEN_DEF_HWCOUNTER)
+    FOREACH_HWCOUNTER_MLX(GEN_DEF_HWCOUNTER)
 };
 void infiniband_hwcounters_parse_mlx(struct ibport *port) {
-	if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
-		FOREACH_HWCOUNTER_MLX_ERRORS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
-	}
-	if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
-		FOREACH_HWCOUNTER_MLX_PACKETS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
-	}
+    if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
+        FOREACH_HWCOUNTER_MLX_ERRORS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
+    }
+    if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
+        FOREACH_HWCOUNTER_MLX_PACKETS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
+    }
 }
 void infiniband_hwcounters_dorrd_mlx(struct ibport *port) {
-	if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
-		FOREACH_HWCOUNTER_MLX_ERRORS(GEN_RRD_DIM_SETP_HW, port, port->hwcounters_mlx)
-		rrdset_done(port->st_hwerrors);
-	}
-	if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
-		FOREACH_HWCOUNTER_MLX_PACKETS(GEN_RRD_DIM_SETP_HW, port, port->hwcounters_mlx)
-		rrdset_done(port->st_hwpackets);
-	}
+    if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
+        FOREACH_HWCOUNTER_MLX_ERRORS(GEN_RRD_DIM_SETP_HW, port, port->hwcounters_mlx)
+        rrdset_done(port->st_hwerrors);
+    }
+    if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
+        FOREACH_HWCOUNTER_MLX_PACKETS(GEN_RRD_DIM_SETP_HW, port, port->hwcounters_mlx)
+        rrdset_done(port->st_hwpackets);
+    }
 }
 
 
@@ -244,476 +244,476 @@ void infiniband_hwcounters_dorrd_mlx(struct ibport *port) {
 
 
 static struct ibport *get_ibport(const char *dev, const char *port) {
-	struct ibport *p;
+    struct ibport *p;
 
-	char name[IBNAME_MAX+1];
-	snprintfz(name, IBNAME_MAX, "%s-%s", dev, port);
-
-
-	// search it, resuming from the last position in sequence
-	for(p = ibport_last_used ; p ; p = p->next) {
-		if(unlikely(!strcmp(name, p->name))) {
-			ibport_last_used = p->next;
-			return p;
-		}
-	}
-
-	// new round, from the beginning to the last position used this time
-	for(p = ibport_root ; p != ibport_last_used ; p = p->next) {
-		if(unlikely(!strcmp(name, p->name))) {
-			ibport_last_used = p->next;
-			return p;
-		}
-	}
-
-	// create a new one
-	p       = callocz(1, sizeof(struct ibport));
-	p->name = strdupz(name);
-	p->len  = strlen(p->name);
+    char name[IBNAME_MAX+1];
+    snprintfz(name, IBNAME_MAX, "%s-%s", dev, port);
 
 
-	p->chart_type_bytes     = strdupz("infiniband_cnt_bytes");
-	p->chart_type_packets   = strdupz("infiniband_cnt_packets");
-	p->chart_type_errors    = strdupz("infiniband_cnt_errors");
-	p->chart_type_hwpackets = strdupz("infiniband_hwc_packets");
-	p->chart_type_hwerrors  = strdupz("infiniband_hwc_errors");
+    // search it, resuming from the last position in sequence
+    for(p = ibport_last_used ; p ; p = p->next) {
+        if(unlikely(!strcmp(name, p->name))) {
+            ibport_last_used = p->next;
+            return p;
+        }
+    }
 
-	char buffer[RRD_ID_LENGTH_MAX + 1];
-	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntbytes_%s", p->name);
-	p->chart_id_bytes     = strdupz(buffer);
+    // new round, from the beginning to the last position used this time
+    for(p = ibport_root ; p != ibport_last_used ; p = p->next) {
+        if(unlikely(!strcmp(name, p->name))) {
+            ibport_last_used = p->next;
+            return p;
+        }
+    }
 
-	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntpackets_%s", p->name);
-	p->chart_id_packets   = strdupz(buffer);
+    // create a new one
+    p       = callocz(1, sizeof(struct ibport));
+    p->name = strdupz(name);
+    p->len  = strlen(p->name);
 
-	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cnterrors_%s", p->name);
-	p->chart_id_errors    = strdupz(buffer);
 
-	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcntpackets_%s", p->name);
-	p->chart_id_hwpackets = strdupz(buffer);
+    p->chart_type_bytes     = strdupz("infiniband_cnt_bytes");
+    p->chart_type_packets   = strdupz("infiniband_cnt_packets");
+    p->chart_type_errors    = strdupz("infiniband_cnt_errors");
+    p->chart_type_hwpackets = strdupz("infiniband_hwc_packets");
+    p->chart_type_hwerrors  = strdupz("infiniband_hwc_errors");
 
-	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcnterrors_%s", p->name);
-	p->chart_id_hwerrors  = strdupz(buffer);
+    char buffer[RRD_ID_LENGTH_MAX + 1];
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntbytes_%s", p->name);
+    p->chart_id_bytes     = strdupz(buffer);
 
-	p->chart_family        = strdupz(p->name);
-	p->priority            = NETDATA_CHART_PRIO_INFINIBAND;
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntpackets_%s", p->name);
+    p->chart_id_packets   = strdupz(buffer);
 
-	// Link current ibport to last one in the list
-	if (ibport_root) {
-		struct ibport *t;
-		for (t = ibport_root; t->next ; t = t->next) ;
-		t->next = p;
-	}
-	else
-		ibport_root = p;
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cnterrors_%s", p->name);
+    p->chart_id_errors    = strdupz(buffer);
 
-	return p;
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcntpackets_%s", p->name);
+    p->chart_id_hwpackets = strdupz(buffer);
+
+    snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcnterrors_%s", p->name);
+    p->chart_id_hwerrors  = strdupz(buffer);
+
+    p->chart_family        = strdupz(p->name);
+    p->priority            = NETDATA_CHART_PRIO_INFINIBAND;
+
+    // Link current ibport to last one in the list
+    if (ibport_root) {
+        struct ibport *t;
+        for (t = ibport_root; t->next ; t = t->next) ;
+        t->next = p;
+    }
+    else
+        ibport_root = p;
+
+    return p;
 
 }
 
 
 int do_sys_class_infiniband(int update_every, usec_t dt) {
-	(void)dt;
-	static SIMPLE_PATTERN *disabled_list = NULL;
-	static int initialized = 0;
-	static int enable_new_ports = -1, enable_only_active = CONFIG_BOOLEAN_YES;
-	static int do_bytes = -1, do_packets = -1, do_errors = -1, do_hwpackets = -1, do_hwerrors= -1;
-	static char *sys_class_infiniband_dirname = NULL;
+    (void)dt;
+    static SIMPLE_PATTERN *disabled_list = NULL;
+    static int initialized = 0;
+    static int enable_new_ports = -1, enable_only_active = CONFIG_BOOLEAN_YES;
+    static int do_bytes = -1, do_packets = -1, do_errors = -1, do_hwpackets = -1, do_hwerrors= -1;
+    static char *sys_class_infiniband_dirname = NULL;
 
-	static long long int dt_to_refresh_speed = 0;
-	
-	if(unlikely(enable_new_ports == -1)) {
-		char dirname[FILENAME_MAX + 1];
+    static long long int dt_to_refresh_speed = 0;
 
-		snprintfz(dirname, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/class/infiniband");
-		sys_class_infiniband_dirname = config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "dirname to monitor", dirname);
+    if(unlikely(enable_new_ports == -1)) {
+        char dirname[FILENAME_MAX + 1];
 
-		do_bytes     = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "bandwidth counters", CONFIG_BOOLEAN_AUTO);
-		do_packets   = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "packets counters", CONFIG_BOOLEAN_AUTO);
-		do_errors    = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "errors counters", CONFIG_BOOLEAN_AUTO);
-		do_hwpackets = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware packets counters", CONFIG_BOOLEAN_AUTO);
-		do_hwerrors  = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware errors counters", CONFIG_BOOLEAN_AUTO);
+        snprintfz(dirname, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/class/infiniband");
+        sys_class_infiniband_dirname = config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "dirname to monitor", dirname);
 
-		disabled_list = simple_pattern_create(config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "disable by default interfaces matching", ""), NULL, SIMPLE_PATTERN_EXACT);
+        do_bytes     = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "bandwidth counters", CONFIG_BOOLEAN_AUTO);
+        do_packets   = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "packets counters", CONFIG_BOOLEAN_AUTO);
+        do_errors    = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "errors counters", CONFIG_BOOLEAN_AUTO);
+        do_hwpackets = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware packets counters", CONFIG_BOOLEAN_AUTO);
+        do_hwerrors  = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware errors counters", CONFIG_BOOLEAN_AUTO);
 
-		dt_to_refresh_speed = config_get_number(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "refresh interface speed every seconds", 10) * USEC_PER_SEC;
-		if(dt_to_refresh_speed < 0) dt_to_refresh_speed = 0;
+        disabled_list = simple_pattern_create(config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "disable by default interfaces matching", ""), NULL, SIMPLE_PATTERN_EXACT);
 
-		enable_new_ports = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "Monitor ports going online during runtime", CONFIG_BOOLEAN_AUTO);
-		enable_only_active = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "Monitor only ports being active", CONFIG_BOOLEAN_AUTO);
-	}
+        dt_to_refresh_speed = config_get_number(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "refresh interface speed every seconds", 10) * USEC_PER_SEC;
+        if(dt_to_refresh_speed < 0) dt_to_refresh_speed = 0;
 
+        enable_new_ports = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "Monitor ports going online during runtime", CONFIG_BOOLEAN_AUTO);
+        enable_only_active = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "Monitor only ports being active", CONFIG_BOOLEAN_AUTO);
+    }
 
-	// init listing of /sys/class/infiniband/ (or rediscovery)
-	if(unlikely(!initialized)) {
 
-		// If folder does not exists, return 1 to disable
-		DIR *devices_dir = opendir(sys_class_infiniband_dirname);
-		if(unlikely(!devices_dir)) return 1;
+    // init listing of /sys/class/infiniband/ (or rediscovery)
+    if(unlikely(!initialized)) {
 
-		// Work on all device available
-		struct dirent *dev_dent;
-		while ( (dev_dent = readdir(devices_dir)) ) {
+        // If folder does not exists, return 1 to disable
+        DIR *devices_dir = opendir(sys_class_infiniband_dirname);
+        if(unlikely(!devices_dir)) return 1;
 
-			// Skip special folders
-			if (!strcmp(dev_dent->d_name, "..") || !strcmp(dev_dent->d_name, "."))
-				continue;
+        // Work on all device available
+        struct dirent *dev_dent;
+        while ( (dev_dent = readdir(devices_dir)) ) {
 
-			// /sys/class/infiniband/<dev>/ports
-			char ports_dirname[FILENAME_MAX +1];
-			snprintfz(ports_dirname, FILENAME_MAX, "%s/%s/%s", sys_class_infiniband_dirname, dev_dent->d_name, "ports");
+            // Skip special folders
+            if (!strcmp(dev_dent->d_name, "..") || !strcmp(dev_dent->d_name, "."))
+                continue;
 
-			DIR *ports_dir = opendir(ports_dirname);
-			if(unlikely(!ports_dir)) continue;
+            // /sys/class/infiniband/<dev>/ports
+            char ports_dirname[FILENAME_MAX +1];
+            snprintfz(ports_dirname, FILENAME_MAX, "%s/%s/%s", sys_class_infiniband_dirname, dev_dent->d_name, "ports");
 
-			struct dirent *port_dent;
-			while ( (port_dent = readdir(ports_dir)) ) {
+            DIR *ports_dir = opendir(ports_dirname);
+            if(unlikely(!ports_dir)) continue;
 
-				// Skip special folders
-				if (!strcmp(port_dent->d_name, "..") || !strcmp(port_dent->d_name, "."))
-					continue;
+            struct dirent *port_dent;
+            while ( (port_dent = readdir(ports_dir)) ) {
 
-				char buffer[FILENAME_MAX + 1];
-
-				// Check if counters are availablea (mandatory)
-				// /sys/class/infiniband/<device>/ports/<port>/counters
-				char counters_dirname[FILENAME_MAX +1];
-				snprintfz(counters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "counters");
-				DIR *counters_dir = opendir(counters_dirname);
-				// Standard counters are mandatory
-				if (!counters_dir) continue;
-
-				// Nearly same with hardware counters
-				char hwcounters_dirname[FILENAME_MAX +1];
-				snprintfz(hwcounters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "hw_counters");
-				DIR *hwcounters_dir = opendir(hwcounters_dirname);
-
-				// Get new ibport
-				struct ibport *p = get_ibport(dev_dent->d_name, port_dent->d_name);
-				if(!p) continue;
-
-				p->updated = 1;
-
-				// Prepare configuration
-				if (!p->configured) {
-					p->configured = 1;
-
-
-					p->counters_path = strdupz(counters_dirname);
-					p->hwcounters_path = strdupz(hwcounters_dirname);
-
-					// Enable filtering
-					p->enabled = enable_new_ports;
-
-					// Check port state
-					if (enable_only_active) {
-						snprintfz(buffer, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "state");
-						unsigned long long active;
-						// File is "1: DOWN" or "4: ACTIVE", but str2ull will stop on first non-decimal char
-						read_single_number_file(buffer, &active);
-
-						// Want "IB_PORT_ACTIVE" == "4", as defined by drivers/infiniband/core/sysfs.c::state_show()
-						if (active != 4)
-							p->enabled = 0;
-					}
-
-					if (p->enabled)
-						p->enabled = !simple_pattern_matches(disabled_list, p->name);
-
-					snprintfz(buffer, FILENAME_MAX, "plugin:proc:/sys/class/infiniband:%s", p->name);
-
-					// Standard counters
-					p->do_bytes   = config_get_boolean_ondemand(buffer, "bytes",   do_bytes);
-					p->do_packets = config_get_boolean_ondemand(buffer, "packets", do_packets);
-					p->do_errors  = config_get_boolean_ondemand(buffer, "errors",  do_errors);
-
-					// Gen filename allocation and concatenation
-					#define GEN_DO_COUNTER_NAME(NAME,GRP,DESC,DIR,PORT, ...) \
-						PORT->file_##NAME = callocz(1, strlen(PORT->counters_path) + sizeof(#NAME) +3); \
-						strcat(PORT->file_##NAME, PORT->counters_path); \
-						strcat(PORT->file_##NAME, "/"#NAME);
-					FOREACH_COUNTER(GEN_DO_COUNTER_NAME, p)
-
-
-					// Check HW Counters vendor dependent
-					if (hwcounters_dir) {
-
-						// By default set standard
-						p->do_hwpackets = config_get_boolean_ondemand(buffer, "hwpackets", do_hwpackets);
-						p->do_hwerrors  = config_get_boolean_ondemand(buffer, "hwerrors",  do_hwerrors);
-
-						// VENDORS: Set your own 
-
-						// Allocate the chars to the filenames
-						#define GEN_DO_HWCOUNTER_NAME(NAME,GRP,DESC,DIR,PORT,HW, ...) \
-							HW->file_##NAME = callocz(1, strlen(PORT->hwcounters_path) + sizeof(#NAME) +3); \
-							strcat(HW->file_##NAME, PORT->hwcounters_path); \
-							strcat(HW->file_##NAME, "/"#NAME);
-
-						// VENDOR-MLX: Mellanox
-						if (strncmp(dev_dent->d_name, "mlx", 3) == 0) {
-							// Allocate the vendor specific struct
-							p->hwcounters_mlx = callocz(1, sizeof(struct ibporthw_mlx));
-
-							FOREACH_HWCOUNTER_MLX(GEN_DO_HWCOUNTER_NAME, p, p->hwcounters_mlx)
-
-							// Set the function pointer for hwcounter parsing
-							p->hwcounters_parse  = &infiniband_hwcounters_parse_mlx;
-							p->hwcounters_dorrd = &infiniband_hwcounters_dorrd_mlx;
-						}
-
-						// VENDOR: Unknown
-						else {
-							p->do_hwpackets = CONFIG_BOOLEAN_NO;
-							p->do_hwerrors  = CONFIG_BOOLEAN_NO;
-						}
-					}
-				}
-
-				// Check / Update the link speed & width frm "rate" file
-				// Sample output: "100 Gb/sec (4X EDR)"
-				snprintfz(buffer, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "rate");
-				char buffer_rate[65];
-				if (read_file(buffer, buffer_rate, 64)) {
-					error("Unable to read '%s'", buffer);
-					p->width = 1;
-				}
-				else {
-					char *buffer_width = strstr(buffer_rate, "(");
-					buffer_width++;
-					// str2ull will stop on first non-decimal value
-					p->speed = str2ull(buffer_rate);
-					p->width = str2ull(buffer_width);
-				}
-
-				info("Infiniband card %s port %s at speed %lu width %lu", dev_dent->d_name, port_dent->d_name, p->speed, p->width);
-
-			}
-			closedir(ports_dir);
-		}
-		closedir(devices_dir);
-
-		initialized = 1;
-	}
-
-	// Update all ports values
-	struct ibport *port;
-	for (port = ibport_root; port ; port = port->next) {
-
-		if (!port->enabled)
-			continue;
-
-		//
-		// Read values from system to struct
-		//
-
-		//  counter from file and place it in ibport struct
-		#define GEN_DO_COUNTER_READ(NAME,GRP,DESC,DIR,PORT, ...) \
-			if (PORT->file_##NAME) { \
-				if (read_single_number_file(PORT->file_##NAME, (unsigned long long *) &PORT->NAME)) { \
-					error("cannot read iface '%s' counter '"#NAME"'", PORT->name); \
-					PORT->file_##NAME = NULL; \
-				} \
-			}
-
-		// Update charts
-		if (port->do_bytes != CONFIG_BOOLEAN_NO) {
-
-			// Read values from sysfs
-			FOREACH_COUNTER_BYTES(GEN_DO_COUNTER_READ, port)
-
-			// First creation of RRD Set (charts)
-			if(unlikely(!port->st_bytes)) {
-				port->st_bytes = rrdset_create_localhost(
-					"Infiniband"
-					, port->chart_id_bytes
-					, NULL
-					, port->chart_family
-					, "ib.bytes"
-					, "Bandwidth usage"
-					, "kilobits/s"
-					, PLUGIN_PROC_NAME
-					, PLUGIN_PROC_MODULE_INFINIBAND_NAME
-					, port->priority + 1
-					, update_every
-					, RRDSET_TYPE_AREA
-				);
-				// Create Dimensions
-				rrdset_flag_set(port->st_bytes, RRDSET_FLAG_DETAIL);
-				// On this chart, we want to have a KB/s so the dashboard will autoscale it
-				// The reported values are also per-lane, so we must multiply it by the width
-				FOREACH_COUNTER_BYTES(GEN_RRD_DIM_ADD_CUSTOM, port, 8 * port->width, 1024, RRD_ALGORITHM_INCREMENTAL)
-
-				port->stv_speed = rrdsetvar_custom_chart_variable_create(port->st_bytes, "link_speed");
-			}
-			else
-				rrdset_next(port->st_bytes);
-
-			// Link read values to dimensions
-			FOREACH_COUNTER_BYTES(GEN_RRD_DIM_SETP, port)
-
-			// For link speed set only variable
-			rrdsetvar_custom_chart_variable_set(port->stv_speed, port->speed);
-
-			rrdset_done(port->st_bytes);
-		}
-
-		if (port->do_packets != CONFIG_BOOLEAN_NO) {
-
-			// Read values from sysfs
-			FOREACH_COUNTER_PACKETS(GEN_DO_COUNTER_READ, port)
-
-			// First creation of RRD Set (charts)
-			if(unlikely(!port->st_packets)) {
-				port->st_packets = rrdset_create_localhost(
-					"Infiniband"
-					, port->chart_id_packets
-					, NULL
-					, port->chart_family
-					, "ib.packets"
-					, "Packets Statistics"
-					, "packets/s"
-					, PLUGIN_PROC_NAME
-					, PLUGIN_PROC_MODULE_INFINIBAND_NAME
-					, port->priority + 2
-					, update_every
-					, RRDSET_TYPE_AREA
-				);
-				// Create Dimensions
-				rrdset_flag_set(port->st_packets, RRDSET_FLAG_DETAIL);
-				FOREACH_COUNTER_PACKETS(GEN_RRD_DIM_ADD, port)
-			}
-			else
-				rrdset_next(port->st_packets);
-
-			// Link read values to dimensions
-			FOREACH_COUNTER_PACKETS(GEN_RRD_DIM_SETP, port)
-			rrdset_done(port->st_packets);
-		}
-
-		if (port->do_errors != CONFIG_BOOLEAN_NO) {
-
-			// Read values from sysfs
-			FOREACH_COUNTER_ERRORS(GEN_DO_COUNTER_READ, port)
-
-			// First creation of RRD Set (charts)
-			if(unlikely(!port->st_errors)) {
-				port->st_errors = rrdset_create_localhost(
-					"Infiniband"
-					, port->chart_id_errors
-					, NULL
-					, port->chart_family
-					, "ib.errors"
-					, "Error Counters"
-					, "errors/s"
-					, PLUGIN_PROC_NAME
-					, PLUGIN_PROC_MODULE_INFINIBAND_NAME
-					, port->priority + 3
-					, update_every
-					, RRDSET_TYPE_LINE
-				);
-				// Create Dimensions
-				rrdset_flag_set(port->st_errors, RRDSET_FLAG_DETAIL);
-				FOREACH_COUNTER_ERRORS(GEN_RRD_DIM_ADD, port)
-			}
-			else
-				rrdset_next(port->st_errors);
-
-			// Link read values to dimensions
-			FOREACH_COUNTER_ERRORS(GEN_RRD_DIM_SETP, port)
-			rrdset_done(port->st_errors);
-		}
-
-
-		//
-		// HW Counters
-		//
-
-		// Call the function for parsing and setting hwcounters
-		if (port->hwcounters_parse && port->hwcounters_dorrd) {
-
-			// Read all values (done by vendor-specific function)
-			(*port->hwcounters_parse)(port);
-
-			if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
-
-				// First creation of RRD Set (charts)
-				if(unlikely(!port->st_hwerrors)) {
-					port->st_hwerrors = rrdset_create_localhost(
-						"Infiniband"
-						, port->chart_id_hwerrors
-						, NULL
-						, port->chart_family
-						, "ib.hwerrors"
-						, "Hardware Errors"
-						, "errors/s"
-						, PLUGIN_PROC_NAME
-						, PLUGIN_PROC_MODULE_INFINIBAND_NAME
-						, port->priority + 4
-						, update_every
-						, RRDSET_TYPE_LINE
-					);
-
-					rrdset_flag_set(port->st_hwerrors, RRDSET_FLAG_DETAIL);
-
-					// VENDORS: Set your selection
-
-					// VENDOR: Mellanox
-					if (strncmp(port->name, "mlx", 3) == 0) {
-						FOREACH_HWCOUNTER_MLX_ERRORS(GEN_RRD_DIM_ADD_HW, port, port->hwcounters_mlx)
-					}
-
-					// Unknown vendor, should not happen
-					else {
-						error("Unmanaged vendor for '%s', do_hwerrors should have been set to no. Please report this bug", port->name);
-						port->do_hwerrors = CONFIG_BOOLEAN_NO;
-					}
-				}
-				else
-					rrdset_next(port->st_hwerrors);
-			}
-
-
-			if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
-				// First creation of RRD Set (charts)
-				if(unlikely(!port->st_hwpackets)) {
-					port->st_hwpackets = rrdset_create_localhost(
-						"Infiniband"
-						, port->chart_id_hwpackets
-						, NULL
-						, port->chart_family
-						, "ib.hwpackets"
-						, "Hardware Packets Statistics"
-						, "packets/s"
-						, PLUGIN_PROC_NAME
-						, PLUGIN_PROC_MODULE_INFINIBAND_NAME
-						, port->priority + 5
-						, update_every
-						, RRDSET_TYPE_LINE
-					);
-
-					rrdset_flag_set(port->st_hwpackets, RRDSET_FLAG_DETAIL);
-
-					// VENDORS: Set your selection
-
-					// VENDOR: Mellanox
-					if (strncmp(port->name, "mlx", 3) == 0) {
-						FOREACH_HWCOUNTER_MLX_PACKETS(GEN_RRD_DIM_ADD_HW, port, port->hwcounters_mlx)
-					}
-
-					// Unknown vendor, should not happen
-					else {
-						error("Unmanaged vendor for '%s', do_hwpackets should have been set to no. Please report this bug", port->name);
-						port->do_hwpackets = CONFIG_BOOLEAN_NO;
-					}
-				}
-				else
-					rrdset_next(port->st_hwpackets);
-			}
-
-			// Update values to rrd (done by vendor-specific function)
-			(*port->hwcounters_dorrd)(port);
-		}
-	}
-
-	return 0;
+                // Skip special folders
+                if (!strcmp(port_dent->d_name, "..") || !strcmp(port_dent->d_name, "."))
+                    continue;
+
+                char buffer[FILENAME_MAX + 1];
+
+                // Check if counters are availablea (mandatory)
+                // /sys/class/infiniband/<device>/ports/<port>/counters
+                char counters_dirname[FILENAME_MAX +1];
+                snprintfz(counters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "counters");
+                DIR *counters_dir = opendir(counters_dirname);
+                // Standard counters are mandatory
+                if (!counters_dir) continue;
+
+                // Nearly same with hardware counters
+                char hwcounters_dirname[FILENAME_MAX +1];
+                snprintfz(hwcounters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "hw_counters");
+                DIR *hwcounters_dir = opendir(hwcounters_dirname);
+
+                // Get new ibport
+                struct ibport *p = get_ibport(dev_dent->d_name, port_dent->d_name);
+                if(!p) continue;
+
+                p->updated = 1;
+
+                // Prepare configuration
+                if (!p->configured) {
+                    p->configured = 1;
+
+
+                    p->counters_path = strdupz(counters_dirname);
+                    p->hwcounters_path = strdupz(hwcounters_dirname);
+
+                    // Enable filtering
+                    p->enabled = enable_new_ports;
+
+                    // Check port state
+                    if (enable_only_active) {
+                        snprintfz(buffer, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "state");
+                        unsigned long long active;
+                        // File is "1: DOWN" or "4: ACTIVE", but str2ull will stop on first non-decimal char
+                        read_single_number_file(buffer, &active);
+
+                        // Want "IB_PORT_ACTIVE" == "4", as defined by drivers/infiniband/core/sysfs.c::state_show()
+                        if (active != 4)
+                            p->enabled = 0;
+                    }
+
+                    if (p->enabled)
+                        p->enabled = !simple_pattern_matches(disabled_list, p->name);
+
+                    snprintfz(buffer, FILENAME_MAX, "plugin:proc:/sys/class/infiniband:%s", p->name);
+
+                    // Standard counters
+                    p->do_bytes   = config_get_boolean_ondemand(buffer, "bytes",   do_bytes);
+                    p->do_packets = config_get_boolean_ondemand(buffer, "packets", do_packets);
+                    p->do_errors  = config_get_boolean_ondemand(buffer, "errors",  do_errors);
+
+                    // Gen filename allocation and concatenation
+                    #define GEN_DO_COUNTER_NAME(NAME,GRP,DESC,DIR,PORT, ...) \
+                        PORT->file_##NAME = callocz(1, strlen(PORT->counters_path) + sizeof(#NAME) +3); \
+                        strcat(PORT->file_##NAME, PORT->counters_path); \
+                        strcat(PORT->file_##NAME, "/"#NAME);
+                    FOREACH_COUNTER(GEN_DO_COUNTER_NAME, p)
+
+
+                    // Check HW Counters vendor dependent
+                    if (hwcounters_dir) {
+
+                        // By default set standard
+                        p->do_hwpackets = config_get_boolean_ondemand(buffer, "hwpackets", do_hwpackets);
+                        p->do_hwerrors  = config_get_boolean_ondemand(buffer, "hwerrors",  do_hwerrors);
+
+                        // VENDORS: Set your own
+
+                        // Allocate the chars to the filenames
+                        #define GEN_DO_HWCOUNTER_NAME(NAME,GRP,DESC,DIR,PORT,HW, ...) \
+                            HW->file_##NAME = callocz(1, strlen(PORT->hwcounters_path) + sizeof(#NAME) +3); \
+                            strcat(HW->file_##NAME, PORT->hwcounters_path); \
+                            strcat(HW->file_##NAME, "/"#NAME);
+
+                        // VENDOR-MLX: Mellanox
+                        if (strncmp(dev_dent->d_name, "mlx", 3) == 0) {
+                            // Allocate the vendor specific struct
+                            p->hwcounters_mlx = callocz(1, sizeof(struct ibporthw_mlx));
+
+                            FOREACH_HWCOUNTER_MLX(GEN_DO_HWCOUNTER_NAME, p, p->hwcounters_mlx)
+
+                            // Set the function pointer for hwcounter parsing
+                            p->hwcounters_parse  = &infiniband_hwcounters_parse_mlx;
+                            p->hwcounters_dorrd = &infiniband_hwcounters_dorrd_mlx;
+                        }
+
+                        // VENDOR: Unknown
+                        else {
+                            p->do_hwpackets = CONFIG_BOOLEAN_NO;
+                            p->do_hwerrors  = CONFIG_BOOLEAN_NO;
+                        }
+                    }
+                }
+
+                // Check / Update the link speed & width frm "rate" file
+                // Sample output: "100 Gb/sec (4X EDR)"
+                snprintfz(buffer, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "rate");
+                char buffer_rate[65];
+                if (read_file(buffer, buffer_rate, 64)) {
+                    error("Unable to read '%s'", buffer);
+                    p->width = 1;
+                }
+                else {
+                    char *buffer_width = strstr(buffer_rate, "(");
+                    buffer_width++;
+                    // str2ull will stop on first non-decimal value
+                    p->speed = str2ull(buffer_rate);
+                    p->width = str2ull(buffer_width);
+                }
+
+                info("Infiniband card %s port %s at speed %lu width %lu", dev_dent->d_name, port_dent->d_name, p->speed, p->width);
+
+            }
+            closedir(ports_dir);
+        }
+        closedir(devices_dir);
+
+        initialized = 1;
+    }
+
+    // Update all ports values
+    struct ibport *port;
+    for (port = ibport_root; port ; port = port->next) {
+
+        if (!port->enabled)
+            continue;
+
+        //
+        // Read values from system to struct
+        //
+
+        //  counter from file and place it in ibport struct
+        #define GEN_DO_COUNTER_READ(NAME,GRP,DESC,DIR,PORT, ...) \
+            if (PORT->file_##NAME) { \
+                if (read_single_number_file(PORT->file_##NAME, (unsigned long long *) &PORT->NAME)) { \
+                    error("cannot read iface '%s' counter '"#NAME"'", PORT->name); \
+                    PORT->file_##NAME = NULL; \
+                } \
+            }
+
+        // Update charts
+        if (port->do_bytes != CONFIG_BOOLEAN_NO) {
+
+            // Read values from sysfs
+            FOREACH_COUNTER_BYTES(GEN_DO_COUNTER_READ, port)
+
+            // First creation of RRD Set (charts)
+            if(unlikely(!port->st_bytes)) {
+                port->st_bytes = rrdset_create_localhost(
+                    "Infiniband"
+                    , port->chart_id_bytes
+                    , NULL
+                    , port->chart_family
+                    , "ib.bytes"
+                    , "Bandwidth usage"
+                    , "kilobits/s"
+                    , PLUGIN_PROC_NAME
+                    , PLUGIN_PROC_MODULE_INFINIBAND_NAME
+                    , port->priority + 1
+                    , update_every
+                    , RRDSET_TYPE_AREA
+                );
+                // Create Dimensions
+                rrdset_flag_set(port->st_bytes, RRDSET_FLAG_DETAIL);
+                // On this chart, we want to have a KB/s so the dashboard will autoscale it
+                // The reported values are also per-lane, so we must multiply it by the width
+                FOREACH_COUNTER_BYTES(GEN_RRD_DIM_ADD_CUSTOM, port, 8 * port->width, 1024, RRD_ALGORITHM_INCREMENTAL)
+
+                port->stv_speed = rrdsetvar_custom_chart_variable_create(port->st_bytes, "link_speed");
+            }
+            else
+                rrdset_next(port->st_bytes);
+
+            // Link read values to dimensions
+            FOREACH_COUNTER_BYTES(GEN_RRD_DIM_SETP, port)
+
+            // For link speed set only variable
+            rrdsetvar_custom_chart_variable_set(port->stv_speed, port->speed);
+
+            rrdset_done(port->st_bytes);
+        }
+
+        if (port->do_packets != CONFIG_BOOLEAN_NO) {
+
+            // Read values from sysfs
+            FOREACH_COUNTER_PACKETS(GEN_DO_COUNTER_READ, port)
+
+            // First creation of RRD Set (charts)
+            if(unlikely(!port->st_packets)) {
+                port->st_packets = rrdset_create_localhost(
+                    "Infiniband"
+                    , port->chart_id_packets
+                    , NULL
+                    , port->chart_family
+                    , "ib.packets"
+                    , "Packets Statistics"
+                    , "packets/s"
+                    , PLUGIN_PROC_NAME
+                    , PLUGIN_PROC_MODULE_INFINIBAND_NAME
+                    , port->priority + 2
+                    , update_every
+                    , RRDSET_TYPE_AREA
+                );
+                // Create Dimensions
+                rrdset_flag_set(port->st_packets, RRDSET_FLAG_DETAIL);
+                FOREACH_COUNTER_PACKETS(GEN_RRD_DIM_ADD, port)
+            }
+            else
+                rrdset_next(port->st_packets);
+
+            // Link read values to dimensions
+            FOREACH_COUNTER_PACKETS(GEN_RRD_DIM_SETP, port)
+            rrdset_done(port->st_packets);
+        }
+
+        if (port->do_errors != CONFIG_BOOLEAN_NO) {
+
+            // Read values from sysfs
+            FOREACH_COUNTER_ERRORS(GEN_DO_COUNTER_READ, port)
+
+            // First creation of RRD Set (charts)
+            if(unlikely(!port->st_errors)) {
+                port->st_errors = rrdset_create_localhost(
+                    "Infiniband"
+                    , port->chart_id_errors
+                    , NULL
+                    , port->chart_family
+                    , "ib.errors"
+                    , "Error Counters"
+                    , "errors/s"
+                    , PLUGIN_PROC_NAME
+                    , PLUGIN_PROC_MODULE_INFINIBAND_NAME
+                    , port->priority + 3
+                    , update_every
+                    , RRDSET_TYPE_LINE
+                );
+                // Create Dimensions
+                rrdset_flag_set(port->st_errors, RRDSET_FLAG_DETAIL);
+                FOREACH_COUNTER_ERRORS(GEN_RRD_DIM_ADD, port)
+            }
+            else
+                rrdset_next(port->st_errors);
+
+            // Link read values to dimensions
+            FOREACH_COUNTER_ERRORS(GEN_RRD_DIM_SETP, port)
+            rrdset_done(port->st_errors);
+        }
+
+
+        //
+        // HW Counters
+        //
+
+        // Call the function for parsing and setting hwcounters
+        if (port->hwcounters_parse && port->hwcounters_dorrd) {
+
+            // Read all values (done by vendor-specific function)
+            (*port->hwcounters_parse)(port);
+
+            if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
+
+                // First creation of RRD Set (charts)
+                if(unlikely(!port->st_hwerrors)) {
+                    port->st_hwerrors = rrdset_create_localhost(
+                        "Infiniband"
+                        , port->chart_id_hwerrors
+                        , NULL
+                        , port->chart_family
+                        , "ib.hwerrors"
+                        , "Hardware Errors"
+                        , "errors/s"
+                        , PLUGIN_PROC_NAME
+                        , PLUGIN_PROC_MODULE_INFINIBAND_NAME
+                        , port->priority + 4
+                        , update_every
+                        , RRDSET_TYPE_LINE
+                    );
+
+                    rrdset_flag_set(port->st_hwerrors, RRDSET_FLAG_DETAIL);
+
+                    // VENDORS: Set your selection
+
+                    // VENDOR: Mellanox
+                    if (strncmp(port->name, "mlx", 3) == 0) {
+                        FOREACH_HWCOUNTER_MLX_ERRORS(GEN_RRD_DIM_ADD_HW, port, port->hwcounters_mlx)
+                    }
+
+                    // Unknown vendor, should not happen
+                    else {
+                        error("Unmanaged vendor for '%s', do_hwerrors should have been set to no. Please report this bug", port->name);
+                        port->do_hwerrors = CONFIG_BOOLEAN_NO;
+                    }
+                }
+                else
+                    rrdset_next(port->st_hwerrors);
+            }
+
+
+            if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
+                // First creation of RRD Set (charts)
+                if(unlikely(!port->st_hwpackets)) {
+                    port->st_hwpackets = rrdset_create_localhost(
+                        "Infiniband"
+                        , port->chart_id_hwpackets
+                        , NULL
+                        , port->chart_family
+                        , "ib.hwpackets"
+                        , "Hardware Packets Statistics"
+                        , "packets/s"
+                        , PLUGIN_PROC_NAME
+                        , PLUGIN_PROC_MODULE_INFINIBAND_NAME
+                        , port->priority + 5
+                        , update_every
+                        , RRDSET_TYPE_LINE
+                    );
+
+                    rrdset_flag_set(port->st_hwpackets, RRDSET_FLAG_DETAIL);
+
+                    // VENDORS: Set your selection
+
+                    // VENDOR: Mellanox
+                    if (strncmp(port->name, "mlx", 3) == 0) {
+                        FOREACH_HWCOUNTER_MLX_PACKETS(GEN_RRD_DIM_ADD_HW, port, port->hwcounters_mlx)
+                    }
+
+                    // Unknown vendor, should not happen
+                    else {
+                        error("Unmanaged vendor for '%s', do_hwpackets should have been set to no. Please report this bug", port->name);
+                        port->do_hwpackets = CONFIG_BOOLEAN_NO;
+                    }
+                }
+                else
+                    rrdset_next(port->st_hwpackets);
+            }
+
+            // Update values to rrd (done by vendor-specific function)
+            (*port->hwcounters_dorrd)(port);
+        }
+    }
+
+    return 0;
 }

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Heavily inspired from proc_net_dev.c
+#include "plugin_proc.h"
+
+#define PLUGIN_PROC_MODULE_INFINIBAND_NAME "/sys/class/infiniband"
+#define CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND "plugin:" PLUGIN_PROC_CONFIG_NAME ":" PLUGIN_PROC_MODULE_INFINIBAND_NAME
+
+// ib_device::name[IB_DEVICE_NAME_MAX(64)] + "-" + ib_device::phys_port_cnt[u8 = 3 chars]
+#define IBNAME_MAX 68
+
+// ----------------------------------------------------------------------------
+// infiniband & omnipath list
+
+// I use macro as there's no single file acting as summary, but a lot of different files, so can't use helpers like
+// procfile(). Also, omnipath generates other counters, that are not provided by infiniband
+#define FOREACH_COUNTER(GEN, ...) \
+	FOREACH_COUNTER_BYTES(GEN,   __VA_ARGS__) \
+	FOREACH_COUNTER_PACKETS(GEN, __VA_ARGS__) \
+	FOREACH_COUNTER_ERRORS(GEN,  __VA_ARGS__)
+
+#define FOREACH_COUNTER_BYTES(GEN, ...) \
+	GEN(port_rcv_data,                   bytes,  "Received", 1, __VA_ARGS__) \
+	GEN(port_xmit_data,                  bytes,  "Sent",    -1, __VA_ARGS__)
+
+#define FOREACH_COUNTER_PACKETS(GEN, ...) \
+	GEN(port_rcv_packets,                packets, "Received",    1, __VA_ARGS__) \
+	GEN(port_xmit_packets,               packets, "Sent",       -1, __VA_ARGS__) \
+	GEN(multicast_rcv_packets,           packets, "Mcast rcvd",  1, __VA_ARGS__) \
+	GEN(multicast_xmit_packets,          packets, "Mcast sent", -1, __VA_ARGS__) \
+	GEN(unicast_rcv_packets,             packets, "Ucast rcvd",  1, __VA_ARGS__) \
+	GEN(unicast_xmit_packets,            packets, "Ucast sent", -1, __VA_ARGS__) \
+
+#define FOREACH_COUNTER_ERRORS(GEN, ...) \
+	GEN(port_rcv_errors,                 errors, "Pkts malformated",      1, __VA_ARGS__) \
+	GEN(port_rcv_constraint_errors,      errors, "Pkts rcvd discarded ",  1, __VA_ARGS__) \
+	GEN(port_xmit_discards,              errors, "Pkts sent discarded",   1, __VA_ARGS__) \
+	GEN(port_xmit_wait,                  errors, "Tick Wait to send",     1, __VA_ARGS__) \
+	GEN(VL15_dropped,                    errors, "Pkts missed ressource", 1, __VA_ARGS__) \
+	GEN(excessive_buffer_overrun_errors, errors, "Buffer overrun",        1, __VA_ARGS__) \
+	GEN(link_downed,                     errors, "Link Downed",           1, __VA_ARGS__) \
+	GEN(link_error_recovery,             errors, "Link recovered",        1, __VA_ARGS__) \
+	GEN(local_link_integrity_errors,     errors, "Link integrity err",    1, __VA_ARGS__) \
+	GEN(symbol_error,                    errors, "Link minor errors",     1, __VA_ARGS__) \
+	GEN(port_rcv_remote_physical_errors, errors, "Pkts rcvd with EBP",    1, __VA_ARGS__) \
+	GEN(port_rcv_switch_relay_errors,    errors, "Pkts rcvd discarded by switch",  1, __VA_ARGS__) \
+	GEN(port_xmit_constraint_errors,     errors, "Pkts sent discarded by switch",  1, __VA_ARGS__)
+
+// Common definitions used more than once
+#define GEN_RRD_DIM_ADD(NAME,GRP,DESC,DIR, PORT, ...) \
+	PORT->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR, 1, RRD_ALGORITHM_INCREMENTAL);
+
+#define GEN_RRD_DIM_SETP(NAME,GRP,DESC,DIR, PORT, ...) \
+	rrddim_set_by_pointer(PORT->st_##GRP, PORT->rd_##NAME, (collected_number)PORT->NAME);
+
+
+// https://community.mellanox.com/s/article/understanding-mlx5-linux-counters-and-status-parameters
+// https://community.mellanox.com/s/article/infiniband-port-counters
+static struct ibport {
+	char *name;
+	char *counters_path;
+	int  len;
+
+	// flags
+	int configured;
+	int enabled;
+	int updated;
+
+	int do_bytes;
+	int do_packets;
+	int do_errors;
+
+	const char *chart_type_bytes;
+	const char *chart_type_packets;
+	const char *chart_type_errors;
+
+	const char *chart_id_bytes;
+	const char *chart_id_packets;
+	const char *chart_id_errors;
+
+	const char *chart_family;
+
+	unsigned long priority;
+
+	// Stats from /$verb/ports/$portid/counters
+	// as drivers/infiniband/hw/qib/qib_verbs.h
+	// All uint64 except vl15_dropped, local_link_integrity_errors, excessive_buffer_overrun_errors uint32
+	// Will generate 2 elements for each counter:
+	// - uint64_t to store the value
+	// - char*    to store the filename path
+	#define GEN_DEF_COUNTER_VALUE(NAME, ...) uint64_t  NAME;
+	FOREACH_COUNTER(GEN_DEF_COUNTER_VALUE)
+
+	#define GEN_DEF_COUNTER_FILE(NAME, ...)  char     *file_##NAME;
+	FOREACH_COUNTER(GEN_DEF_COUNTER_FILE)
+
+
+
+	// charts and dim
+	RRDSET *st_bytes;
+	RRDSET *st_packets;
+	RRDSET *st_errors;
+
+	#define GEN_DEF_RRD_DIM(NAME, ...)       RRDDIM   *rd_##NAME;
+	FOREACH_COUNTER(GEN_DEF_RRD_DIM)
+
+	usec_t speed_last_collected_usec;
+
+	struct ibport *next;
+} *ibport_root = NULL, *ibport_last_used = NULL;
+
+
+// ----------------------------------------------------------------------------
+
+
+static struct ibport *get_ibport(const char *verb, const char *port) {
+	struct ibport *p;
+
+	char name[IBNAME_MAX+1];
+	snprintfz(name, IBNAME_MAX, "%s-%s", verb, port);
+
+
+	// search it, resuming from the last position in sequence
+	for(p = ibport_last_used ; p ; p = p->next) {
+		if(unlikely(!strcmp(name, p->name))) {
+			ibport_last_used = p->next;
+			return p;
+		}
+	}
+
+	// new round, from the beginning to the last position used this time
+	for(p = ibport_root ; p != ibport_last_used ; p = p->next) {
+		if(unlikely(!strcmp(name, p->name))) {
+			ibport_last_used = p->next;
+			return p;
+		}
+	}
+
+	// create a new one
+	p       = callocz(1, sizeof(struct ibport));
+	p->name = strdupz(name);
+	p->len  = strlen(p->name);
+
+
+	p->chart_type_bytes    = strdupz("Infiniband");
+	p->chart_type_packets  = strdupz("Infiniband");
+	p->chart_type_errors   = strdupz("Infiniband");
+
+	char buffer[RRD_ID_LENGTH_MAX + 1];
+	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_bytes_%s", p->name);
+	p->chart_id_bytes   = strdupz(buffer);
+	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_packets_%s", p->name);
+	p->chart_id_packets = strdupz(buffer);
+	snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_errors_%s", p->name);
+	p->chart_id_errors  = strdupz(buffer);
+
+	p->chart_family        = strdupz(p->name);
+	p->priority            = NETDATA_CHART_PRIO_INFINIBAND;
+
+	// Link current ibport to last one in the list
+	if (ibport_root) {
+		struct ibport *t;
+		for (t = ibport_root; t->next ; t = t->next) ;
+		t->next = p;
+	}
+	else
+		ibport_root = p;
+
+	return p;
+
+}
+
+
+int do_sys_class_infiniband(int update_every, usec_t dt) {
+	(void)dt;
+	static SIMPLE_PATTERN *disabled_list = NULL;
+	static int initialized = 0;
+	static int enable_new_ports = -1;
+	static int do_bytes = -1, do_packets = -1, do_errors = -1;
+	static char *sys_class_infiniband_dirname = NULL;
+
+	static long long int dt_to_refresh_speed = 0;
+	
+	if(unlikely(enable_new_ports == -1)) {
+		char dirname[FILENAME_MAX + 1];
+
+		snprintfz(dirname, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/class/infiniband");
+		sys_class_infiniband_dirname = config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "dirname to monitor", dirname);
+
+		do_bytes   = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "bandwidth for all infiniband ports", CONFIG_BOOLEAN_AUTO);
+		do_packets = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "packets for all infiniband ports", CONFIG_BOOLEAN_AUTO);
+		do_errors  = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "errors for all infiniband ports", CONFIG_BOOLEAN_AUTO);
+
+		disabled_list = simple_pattern_create(config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "disable by default interfaces matching", ""), NULL, SIMPLE_PATTERN_EXACT);
+
+		dt_to_refresh_speed = config_get_number(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "refresh interface speed every seconds", 10) * USEC_PER_SEC;
+		if(dt_to_refresh_speed < 0) dt_to_refresh_speed = 0;
+
+		enable_new_ports = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "errors for all infiniband ports", CONFIG_BOOLEAN_AUTO);
+	}
+
+
+	// init listing of /sys/class/infiniband/
+	if(unlikely(!initialized)) {
+
+		// If folder does not exists, return 1 to disable
+		DIR *verbs_dir = opendir(sys_class_infiniband_dirname);
+		if(unlikely(!verbs_dir)) return 1;
+
+		// Work on all verbs (card) available
+		struct dirent *verb_dent;
+		while ( (verb_dent = readdir(verbs_dir)) ) {
+
+			if (!strcmp(verb_dent->d_name, "..") || !strcmp(verb_dent->d_name, "."))
+				continue;
+
+			// /sys/class/infiniband/<verb>/ports
+			char ports_dirname[FILENAME_MAX +1];
+			snprintfz(ports_dirname, FILENAME_MAX, "%s/%s/%s", sys_class_infiniband_dirname, verb_dent->d_name, "ports");
+
+			DIR *ports_dir = opendir(ports_dirname);
+			if(unlikely(!ports_dir)) continue;
+
+			struct dirent *port_dent;
+			while ( (port_dent = readdir(ports_dir)) ) {
+
+				if (!strcmp(port_dent->d_name, "..") || !strcmp(port_dent->d_name, "."))
+					continue;
+
+				// Check if counters are available
+				// /sys/class/infiniband/<verb>/ports/<port>/counters
+				char counters_dirname[FILENAME_MAX +1];
+				snprintfz(counters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "counters");
+				DIR *counters_dir = opendir(counters_dirname);
+				if (!counters_dir) continue;
+
+				// Get new ibport
+				struct ibport *p = get_ibport(verb_dent->d_name, port_dent->d_name);
+				if(!p) continue;
+
+				p->updated = 1;
+
+				// Prepare configuration
+				if (!p->configured) {
+					p->configured = 1;
+
+					p->counters_path = strdupz(counters_dirname);
+
+					p->enabled = enable_new_ports;
+
+					if (p->enabled)
+						p->enabled = !simple_pattern_matches(disabled_list, p->name);
+
+					char buffer[FILENAME_MAX + 1];
+					snprintfz(buffer, FILENAME_MAX, "plugin:proc:/sys/class/infiniband:%s", p->name);
+					p->do_bytes   = config_get_boolean_ondemand(buffer, "bytes",   do_bytes);
+					p->do_packets = config_get_boolean_ondemand(buffer, "packets", do_packets);
+					p->do_errors  = config_get_boolean_ondemand(buffer, "errors",  do_errors);
+
+
+					// Gen filename allocation and concatenation
+					#define GEN_DO_COUNTER_NAME(NAME,GRP,DESC,DIR,PORT, ...) \
+						PORT->file_##NAME = callocz(1, strlen(PORT->counters_path) + sizeof(#NAME) +3); \
+						strcat(PORT->file_##NAME, PORT->counters_path); \
+						strcat(PORT->file_##NAME, "/"#NAME);
+					FOREACH_COUNTER(GEN_DO_COUNTER_NAME, p)
+
+					// Dispatch the reads
+
+				}
+				
+			}
+			closedir(ports_dir);
+		}
+		closedir(verbs_dir);
+
+		initialized = 1;
+	}
+
+	// Update all ports values
+	struct ibport *port;
+	for (port = ibport_root; port ; port = port->next) {
+
+
+		// Read each counter
+		#define GEN_DO_COUNTER_READ(NAME,GRP,DESC,DIR,PORT, ...) \
+			if (PORT->do_##GRP != CONFIG_BOOLEAN_NO && PORT->file_##NAME) { \
+				if (read_single_number_file(PORT->file_##NAME, (unsigned long long *) &PORT->NAME)) { \
+					error("cannot read iface '%s' counter '"#NAME"'", PORT->name); \
+					PORT->file_##NAME = NULL; \
+				} \
+			}
+		FOREACH_COUNTER(GEN_DO_COUNTER_READ, port)
+
+
+		// Update charts
+		if (port->do_bytes != CONFIG_BOOLEAN_NO) {
+			// First creation of RRD Set (charts)
+			if(unlikely(!port->st_bytes)) {
+				port->st_bytes = rrdset_create_localhost(
+					port->chart_type_bytes
+					, port->chart_id_bytes
+					, NULL
+					, port->chart_family
+					, "ib.bytes"
+					, "Bytes"
+					, "Bytes/s"
+					, PLUGIN_PROC_NAME
+					, PLUGIN_PROC_MODULE_INFINIBAND_NAME
+					, port->priority + 1
+					, update_every
+					, RRDSET_TYPE_AREA
+				);
+
+				rrdset_flag_set(port->st_bytes, RRDSET_FLAG_DETAIL);
+				FOREACH_COUNTER_BYTES(GEN_RRD_DIM_ADD, port)
+
+			}
+			else
+				rrdset_next(port->st_bytes);
+
+			FOREACH_COUNTER_BYTES(GEN_RRD_DIM_SETP, port)
+			rrdset_done(port->st_bytes);
+		}
+
+		if (port->do_packets != CONFIG_BOOLEAN_NO) {
+			// First creation of RRD Set (charts)
+			if(unlikely(!port->st_packets)) {
+				port->st_packets = rrdset_create_localhost(
+					port->chart_type_packets
+					, port->chart_id_packets
+					, NULL
+					, port->chart_family
+					, "ib.packets"
+					, "Packets"
+					, "Packets/s"
+					, PLUGIN_PROC_NAME
+					, PLUGIN_PROC_MODULE_INFINIBAND_NAME
+					, port->priority + 1
+					, update_every
+					, RRDSET_TYPE_AREA
+				);
+
+				rrdset_flag_set(port->st_packets, RRDSET_FLAG_DETAIL);
+				FOREACH_COUNTER_PACKETS(GEN_RRD_DIM_ADD, port)
+			}
+			else
+				rrdset_next(port->st_packets);
+
+			FOREACH_COUNTER_PACKETS(GEN_RRD_DIM_SETP, port)
+			rrdset_done(port->st_packets);
+		}
+
+		if (port->do_errors != CONFIG_BOOLEAN_NO) {
+			// First creation of RRD Set (charts)
+			if(unlikely(!port->st_errors)) {
+				port->st_errors = rrdset_create_localhost(
+					port->chart_type_errors
+					, port->chart_id_errors
+					, NULL
+					, port->chart_family
+					, "ib.errors"
+					, "errors"
+					, "errors/s"
+					, PLUGIN_PROC_NAME
+					, PLUGIN_PROC_MODULE_INFINIBAND_NAME
+					, port->priority + 1
+					, update_every
+					, RRDSET_TYPE_LINE
+				);
+
+				rrdset_flag_set(port->st_errors, RRDSET_FLAG_DETAIL);
+				FOREACH_COUNTER_ERRORS(GEN_RRD_DIM_ADD, port)
+			}
+			else
+				rrdset_next(port->st_errors);
+
+			FOREACH_COUNTER_ERRORS(GEN_RRD_DIM_SETP, port)
+			rrdset_done(port->st_errors);
+		}
+
+	}
+
+
+	return 0;
+}

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -52,51 +52,55 @@
 // Hardware Counters
 //
 
-// List of implemented hardware vendors
+// IMPORTANT: These are vendor-specific fields.
+//  If you want to add a new vendor, search this for for 'VENDORS:' keyword and
+//  add your definition as 'VENDOR-<key>:' where <key> if the string part that
+//  is shown in /sys/class/infiniband/<key>X_Y
+//  EG: for Mellanox, shown as mlx0_1, it's 'mlx'
+//      for Intel, shown as hfi1_1, it's 'hfi'
+
+
+// VENDORS: List of implemented hardware vendors
 #define FOREACH_HWCOUNTER_NAME(GEN, ...) \
 	GEN(mlx, __VA_ARGS__)
 
-// HW Counters for Mellanox ConnectX Devices
+// VENDOR-MLX: HW Counters for Mellanox ConnectX Devices
 #define FOREACH_HWCOUNTER_MLX(GEN, ...) \
 	FOREACH_HWCOUNTER_MLX_PACKETS(GEN, __VA_ARGS__) \
 	FOREACH_HWCOUNTER_MLX_ERRORS(GEN, __VA_ARGS__)
 
 #define FOREACH_HWCOUNTER_MLX_PACKETS(GEN, ...) \
-	GEN(np_cnp_sent,                 packets, "RoCEv2 Congestion sent",  1, __VA_ARGS__) \
-	GEN(np_ecn_marked_roce_packets,  packets, "RoCEv2 Congestion rcvd", -1, __VA_ARGS__) \
-	GEN(rp_cnp_handled,              packets, "IB Congestion handled",   1, __VA_ARGS__) \
-	GEN(rx_atomic_requests,          packets, "ATOMIC req. rcvd",        1, __VA_ARGS__) \
-	GEN(rx_dct_connect,              packets, "Connection req. rcvd",    1, __VA_ARGS__) \
-	GEN(rx_read_requests,            packets, "Read req. rcvd",          1, __VA_ARGS__) \
-	GEN(rx_write_requests,           packets, "Write req. rcvd",         1, __VA_ARGS__) \
-	GEN(roce_adp_retrans,            packets, "RoCE retrans adaptive",   1, __VA_ARGS__) \
-	GEN(roce_adp_retrans_to,         packets, "RoCE retrans timeout",    1, __VA_ARGS__) \
-	GEN(roce_slow_restart,           packets, "RoCE slow restart",       1, __VA_ARGS__) \
-	GEN(roce_slow_restart_cnps,      packets, "RoCE slow restart congestion",  1, __VA_ARGS__) \
-	GEN(roce_slow_restart_trans,     packets, "RoCE slow restart count", 1, __VA_ARGS__)
+	GEN(np_cnp_sent,                 hwpackets, "RoCEv2 Congestion sent",  1, __VA_ARGS__) \
+	GEN(np_ecn_marked_roce_packets,  hwpackets, "RoCEv2 Congestion rcvd", -1, __VA_ARGS__) \
+	GEN(rp_cnp_handled,              hwpackets, "IB Congestion handled",   1, __VA_ARGS__) \
+	GEN(rx_atomic_requests,          hwpackets, "ATOMIC req. rcvd",        1, __VA_ARGS__) \
+	GEN(rx_dct_connect,              hwpackets, "Connection req. rcvd",    1, __VA_ARGS__) \
+	GEN(rx_read_requests,            hwpackets, "Read req. rcvd",          1, __VA_ARGS__) \
+	GEN(rx_write_requests,           hwpackets, "Write req. rcvd",         1, __VA_ARGS__) \
+	GEN(roce_adp_retrans,            hwpackets, "RoCE retrans adaptive",   1, __VA_ARGS__) \
+	GEN(roce_adp_retrans_to,         hwpackets, "RoCE retrans timeout",    1, __VA_ARGS__) \
+	GEN(roce_slow_restart,           hwpackets, "RoCE slow restart",       1, __VA_ARGS__) \
+	GEN(roce_slow_restart_cnps,      hwpackets, "RoCE slow restart congestion",  1, __VA_ARGS__) \
+	GEN(roce_slow_restart_trans,     hwpackets, "RoCE slow restart count", 1, __VA_ARGS__)
 
 #define FOREACH_HWCOUNTER_MLX_ERRORS(GEN, ...) \
-	GEN(duplicate_request,           errors, "Duplicated packets",   -1, __VA_ARGS__) \
-	GEN(implied_nak_seq_err,         errors, "Pkt Seq Num gap",       1, __VA_ARGS__) \
-	GEN(local_ack_timeout_err,       errors, "Ack timer expired",     1, __VA_ARGS__) \
-	GEN(out_of_buffer,               errors, "Drop missing buffer",   1, __VA_ARGS__) \
-	GEN(out_of_sequence,             errors, "Drop out of sequence",  1, __VA_ARGS__) \
-	GEN(packet_seq_err,              errors, "NAK sequence rcvd",     1, __VA_ARGS__) \
-	GEN(req_cqe_error,               errors, "CQE err Req",           1, __VA_ARGS__) \
-	GEN(resp_cqe_error,              errors, "CQE err Resp",          1, __VA_ARGS__) \
-	GEN(req_cqe_flush_error,         errors, "CQE Flushed err Req",   1, __VA_ARGS__) \
-	GEN(resp_cqe_flush_error,        errors, "CQE Flushed err Resp",  1, __VA_ARGS__) \
-	GEN(req_remote_access_errors,    errors, "Remote access err Req", 1, __VA_ARGS__) \
-	GEN(resp_remote_access_errors,   errors, "Remote access err Resp",1, __VA_ARGS__) \
-	GEN(req_remote_invalid_request,  errors, "Remote invalid req",    1, __VA_ARGS__) \
-	GEN(resp_local_length_error,     errors, "Local length err Resp", 1, __VA_ARGS__) \
-	GEN(rnr_nak_retry_err,           errors, "RNR NAK Packets",       1, __VA_ARGS__) \
-	GEN(rp_cnp_ignored,              errors, "CNP Pkts ignored",      1, __VA_ARGS__) \
-	GEN(rx_icrc_encapsulated,        errors, "RoCE ICRC Errors",      1, __VA_ARGS__)
-
-
-// HW Counters for Intel Omnipath devices
-// #define FOREACH_HWCOUNTER_HFI_ERRORS(GEN, ...) \
+	GEN(duplicate_request,           hwerrors, "Duplicated packets",   -1, __VA_ARGS__) \
+	GEN(implied_nak_seq_err,         hwerrors, "Pkt Seq Num gap",       1, __VA_ARGS__) \
+	GEN(local_ack_timeout_err,       hwerrors, "Ack timer expired",     1, __VA_ARGS__) \
+	GEN(out_of_buffer,               hwerrors, "Drop missing buffer",   1, __VA_ARGS__) \
+	GEN(out_of_sequence,             hwerrors, "Drop out of sequence",  1, __VA_ARGS__) \
+	GEN(packet_seq_err,              hwerrors, "NAK sequence rcvd",     1, __VA_ARGS__) \
+	GEN(req_cqe_error,               hwerrors, "CQE err Req",           1, __VA_ARGS__) \
+	GEN(resp_cqe_error,              hwerrors, "CQE err Resp",          1, __VA_ARGS__) \
+	GEN(req_cqe_flush_error,         hwerrors, "CQE Flushed err Req",   1, __VA_ARGS__) \
+	GEN(resp_cqe_flush_error,        hwerrors, "CQE Flushed err Resp",  1, __VA_ARGS__) \
+	GEN(req_remote_access_errors,    hwerrors, "Remote access err Req", 1, __VA_ARGS__) \
+	GEN(resp_remote_access_errors,   hwerrors, "Remote access err Resp",1, __VA_ARGS__) \
+	GEN(req_remote_invalid_request,  hwerrors, "Remote invalid req",    1, __VA_ARGS__) \
+	GEN(resp_local_length_error,     hwerrors, "Local length err Resp", 1, __VA_ARGS__) \
+	GEN(rnr_nak_retry_err,           hwerrors, "RNR NAK Packets",       1, __VA_ARGS__) \
+	GEN(rp_cnp_ignored,              hwerrors, "CNP Pkts ignored",      1, __VA_ARGS__) \
+	GEN(rx_icrc_encapsulated,        hwerrors, "RoCE ICRC Errors",      1, __VA_ARGS__)
 
 
 
@@ -105,8 +109,14 @@
 #define GEN_RRD_DIM_ADD(NAME,GRP,DESC,DIR, PORT, ...) \
 	PORT->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR, 1, RRD_ALGORITHM_INCREMENTAL);
 
+#define GEN_RRD_DIM_ADD_HW(NAME,GRP,DESC,DIR, PORT,HW, ...) \
+	HW->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR, 1, RRD_ALGORITHM_INCREMENTAL);
+
 #define GEN_RRD_DIM_SETP(NAME,GRP,DESC,DIR, PORT, ...) \
 	rrddim_set_by_pointer(PORT->st_##GRP, PORT->rd_##NAME, (collected_number)PORT->NAME);
+
+#define GEN_RRD_DIM_SETP_HW(NAME,GRP,DESC,DIR, PORT,HW, ...) \
+	rrddim_set_by_pointer(PORT->st_##GRP, HW->rd_##NAME, (collected_number)HW->NAME);
 
 
 // https://community.mellanox.com/s/article/understanding-mlx5-linux-counters-and-status-parameters
@@ -150,9 +160,11 @@ static struct ibport {
 	// Will generate 2 elements for each counter:
 	// - uint64_t to store the value
 	// - char*    to store the filename path
+	// - RRDDIM*  to store the RRD Dimension
 	#define GEN_DEF_COUNTER(NAME, ...) \
 		uint64_t  NAME; \
-		char      *file_##NAME;
+		char      *file_##NAME; \
+		RRDDIM    *rd_##NAME;
 	FOREACH_COUNTER(GEN_DEF_COUNTER)
 
 	// Vendor specific hwcounters from /$device/ports/$portid/hwcounters
@@ -161,8 +173,9 @@ static struct ibport {
 		struct ibporthw_##VENDOR *hwcounters_##VENDOR;
 	FOREACH_HWCOUNTER_NAME(GEN_DEF_HWCOUNTER_PTR)
 
-	// Function pointer to the "infiniband_parse_hwcounter_<vendor>" function
-	void (*parse_hwcounters)(struct ibport *);
+	// Function pointer to the "infiniband_hwcounters_parse_<vendor>" function
+	void (*hwcounters_parse)(struct ibport *);
+	void (*hwcounters_dorrd)(struct ibport *);
 
 
 	// charts and dim
@@ -172,22 +185,18 @@ static struct ibport {
 	RRDSET *st_hwpackets;
 	RRDSET *st_hwerrors;
 
-	#define GEN_DEF_RRD_DIM(NAME, ...)       RRDDIM   *rd_##NAME;
-	FOREACH_COUNTER(GEN_DEF_RRD_DIM)
-
 	usec_t speed_last_collected_usec;
 
 	struct ibport *next;
 } *ibport_root = NULL, *ibport_last_used = NULL;
 
 
-//
-// Vendor specific
-//
 
+// VENDORS: reading / calculation functions
 #define GEN_DEF_HWCOUNTER(NAME, ...) \
 	uint64_t  NAME; \
-	char      *file_##NAME;
+	char      *file_##NAME; \
+	RRDDIM    *rd_##NAME;
 
 #define GEN_DO_HWCOUNTER_READ(NAME,GRP,DESC,DIR,PORT,HW, ...) \
 	if (HW->file_##NAME) { \
@@ -197,12 +206,11 @@ static struct ibport {
 		} \
 	}
 
-
-// Mellanox
+// VENDOR-MLX: Mellanox
 struct ibporthw_mlx {
 	FOREACH_HWCOUNTER_MLX(GEN_DEF_HWCOUNTER)
 };
-void infiniband_parse_hwcounters_mlx(struct ibport *port) {
+void infiniband_hwcounters_parse_mlx(struct ibport *port) {
 	if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
 		FOREACH_HWCOUNTER_MLX_ERRORS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
 	}
@@ -210,8 +218,16 @@ void infiniband_parse_hwcounters_mlx(struct ibport *port) {
 		FOREACH_HWCOUNTER_MLX_PACKETS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
 	}
 }
-
-
+void infiniband_hwcounters_dorrd_mlx(struct ibport *port) {
+	if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
+		FOREACH_HWCOUNTER_MLX_ERRORS(GEN_RRD_DIM_SETP_HW, port, port->hwcounters_mlx)
+		rrdset_done(port->st_hwerrors);
+	}
+	if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
+		FOREACH_HWCOUNTER_MLX_PACKETS(GEN_RRD_DIM_SETP_HW, port, port->hwcounters_mlx)
+		rrdset_done(port->st_hwpackets);
+	}
+}
 
 
 // ----------------------------------------------------------------------------
@@ -389,22 +405,24 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 						p->do_hwpackets = config_get_boolean_ondemand(buffer, "hwpackets", do_hwpackets);
 						p->do_hwerrors  = config_get_boolean_ondemand(buffer, "hwerrors",  do_hwerrors);
 
+						// VENDORS: Set your own 
 
-						// VENDOR: Mellanox
+						// Allocate the chars to the filenames
+						#define GEN_DO_HWCOUNTER_NAME(NAME,GRP,DESC,DIR,PORT,HW, ...) \
+							HW->file_##NAME = callocz(1, strlen(PORT->hwcounters_path) + sizeof(#NAME) +3); \
+							strcat(HW->file_##NAME, PORT->hwcounters_path); \
+							strcat(HW->file_##NAME, "/"#NAME);
+
+						// VENDOR-MLX: Mellanox
 						if (strncmp(dev_dent->d_name, "mlx", 3) == 0) {
-
 							// Allocate the vendor specific struct
 							p->hwcounters_mlx = callocz(1, sizeof(struct ibporthw_mlx));
 
-							// Allocate the chars to the filenames
-							#define GEN_DO_HWCOUNTER_NAME(NAME,GRP,DESC,DIR,PORT,HW, ...) \
-								HW->file_##NAME = callocz(1, strlen(PORT->hwcounters_path) + sizeof(#NAME) +3); \
-								strcat(HW->file_##NAME, PORT->hwcounters_path); \
-								strcat(HW->file_##NAME, "/"#NAME);
 							FOREACH_HWCOUNTER_MLX(GEN_DO_HWCOUNTER_NAME, p, p->hwcounters_mlx)
 
 							// Set the function pointer for hwcounter parsing
-							p->parse_hwcounters = &infiniband_parse_hwcounters_mlx;
+							p->hwcounters_parse  = &infiniband_hwcounters_parse_mlx;
+							p->hwcounters_dorrd = &infiniband_hwcounters_dorrd_mlx;
 						}
 
 						// VENDOR: Unknown
@@ -427,26 +445,25 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 	struct ibport *port;
 	for (port = ibport_root; port ; port = port->next) {
 
-		// Read each counter
+		//
+		// Read values from system to struct
+		//
+
+		//  counter from file and place it in ibport struct
 		#define GEN_DO_COUNTER_READ(NAME,GRP,DESC,DIR,PORT, ...) \
-			if (PORT->do_##GRP != CONFIG_BOOLEAN_NO && PORT->file_##NAME) { \
+			if (PORT->file_##NAME) { \
 				if (read_single_number_file(PORT->file_##NAME, (unsigned long long *) &PORT->NAME)) { \
 					error("cannot read iface '%s' counter '"#NAME"'", PORT->name); \
 					PORT->file_##NAME = NULL; \
 				} \
 			}
-		FOREACH_COUNTER(GEN_DO_COUNTER_READ, port)
-
-
-		// Call the function for parsing hwcounters
-		if (port->parse_hwcounters) {
-			(*port->parse_hwcounters)(port);
-		}
-
-
 
 		// Update charts
 		if (port->do_bytes != CONFIG_BOOLEAN_NO) {
+
+			// Read values from sysfs
+			FOREACH_COUNTER_BYTES(GEN_DO_COUNTER_READ, port)
+
 			// First creation of RRD Set (charts)
 			if(unlikely(!port->st_bytes)) {
 				port->st_bytes = rrdset_create_localhost(
@@ -463,19 +480,23 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 					, update_every
 					, RRDSET_TYPE_AREA
 				);
-
+				// Create Dimensions
 				rrdset_flag_set(port->st_bytes, RRDSET_FLAG_DETAIL);
 				FOREACH_COUNTER_BYTES(GEN_RRD_DIM_ADD, port)
-
 			}
 			else
 				rrdset_next(port->st_bytes);
 
+			// Link read values to dimensions
 			FOREACH_COUNTER_BYTES(GEN_RRD_DIM_SETP, port)
 			rrdset_done(port->st_bytes);
 		}
 
 		if (port->do_packets != CONFIG_BOOLEAN_NO) {
+
+			// Read values from sysfs
+			FOREACH_COUNTER_PACKETS(GEN_DO_COUNTER_READ, port)
+
 			// First creation of RRD Set (charts)
 			if(unlikely(!port->st_packets)) {
 				port->st_packets = rrdset_create_localhost(
@@ -492,18 +513,23 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 					, update_every
 					, RRDSET_TYPE_AREA
 				);
-
+				// Create Dimensions
 				rrdset_flag_set(port->st_packets, RRDSET_FLAG_DETAIL);
 				FOREACH_COUNTER_PACKETS(GEN_RRD_DIM_ADD, port)
 			}
 			else
 				rrdset_next(port->st_packets);
 
+			// Link read values to dimensions
 			FOREACH_COUNTER_PACKETS(GEN_RRD_DIM_SETP, port)
 			rrdset_done(port->st_packets);
 		}
 
 		if (port->do_errors != CONFIG_BOOLEAN_NO) {
+
+			// Read values from sysfs
+			FOREACH_COUNTER_ERRORS(GEN_DO_COUNTER_READ, port)
+
 			// First creation of RRD Set (charts)
 			if(unlikely(!port->st_errors)) {
 				port->st_errors = rrdset_create_localhost(
@@ -520,21 +546,109 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 					, update_every
 					, RRDSET_TYPE_LINE
 				);
-
+				// Create Dimensions
 				rrdset_flag_set(port->st_errors, RRDSET_FLAG_DETAIL);
 				FOREACH_COUNTER_ERRORS(GEN_RRD_DIM_ADD, port)
 			}
 			else
 				rrdset_next(port->st_errors);
 
+			// Link read values to dimensions
 			FOREACH_COUNTER_ERRORS(GEN_RRD_DIM_SETP, port)
 			rrdset_done(port->st_errors);
 		}
 
-		// TODO: Add logic for hwcounters
 
+		//
+		// HW Counters
+		//
+
+		// Call the function for parsing and setting hwcounters
+		if (port->hwcounters_parse && port->hwcounters_dorrd) {
+
+			// Read all values (done by vendor-specific function)
+			(*port->hwcounters_parse)(port);
+
+			if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
+
+				// First creation of RRD Set (charts)
+				if(unlikely(!port->st_hwerrors)) {
+					port->st_hwerrors = rrdset_create_localhost(
+						port->chart_type_hwerrors
+						, port->chart_id_hwerrors
+						, NULL
+						, port->chart_family
+						, "ib.hwerrors"
+						, "errors"
+						, "errors/s"
+						, PLUGIN_PROC_NAME
+						, PLUGIN_PROC_MODULE_INFINIBAND_NAME
+						, port->priority + 1
+						, update_every
+						, RRDSET_TYPE_LINE
+					);
+
+					rrdset_flag_set(port->st_hwerrors, RRDSET_FLAG_DETAIL);
+
+					// VENDORS: Set your selection
+
+					// VENDOR: Mellanox
+					if (strncmp(port->name, "mlx", 3) == 0) {
+						FOREACH_HWCOUNTER_MLX_ERRORS(GEN_RRD_DIM_ADD_HW, port, port->hwcounters_mlx)
+					}
+
+					// Unknown vendor, should not happen
+					else {
+						error("Unmanaged vendor for '%s', do_hwerrors should have been set to no. Please report this bug", port->name);
+						port->do_hwerrors = CONFIG_BOOLEAN_NO;
+					}
+				}
+				else
+					rrdset_next(port->st_hwerrors);
+			}
+
+
+			if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
+				// First creation of RRD Set (charts)
+				if(unlikely(!port->st_hwpackets)) {
+					port->st_hwpackets = rrdset_create_localhost(
+						port->chart_type_hwpackets
+						, port->chart_id_hwpackets
+						, NULL
+						, port->chart_family
+						, "ib.hwpackets"
+						, "packets"
+						, "packets/s"
+						, PLUGIN_PROC_NAME
+						, PLUGIN_PROC_MODULE_INFINIBAND_NAME
+						, port->priority + 1
+						, update_every
+						, RRDSET_TYPE_LINE
+					);
+
+					rrdset_flag_set(port->st_hwpackets, RRDSET_FLAG_DETAIL);
+
+					// VENDORS: Set your selection
+
+					// VENDOR: Mellanox
+					if (strncmp(port->name, "mlx", 3) == 0) {
+						FOREACH_HWCOUNTER_MLX_PACKETS(GEN_RRD_DIM_ADD_HW, port, port->hwcounters_mlx)
+					}
+
+					// Unknown vendor, should not happen
+					else {
+						error("Unmanaged vendor for '%s', do_hwpackets should have been set to no. Please report this bug", port->name);
+						port->do_hwpackets = CONFIG_BOOLEAN_NO;
+					}
+				}
+				else
+					rrdset_next(port->st_hwpackets);
+			}
+
+			// Update values to rrd (done by vendor-specific function)
+			(*port->hwcounters_dorrd)(port);
+		}
 	}
-
 
 	return 0;
 }

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -4,7 +4,8 @@
 #include "plugin_proc.h"
 
 #define PLUGIN_PROC_MODULE_INFINIBAND_NAME "/sys/class/infiniband"
-#define CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND "plugin:" PLUGIN_PROC_CONFIG_NAME ":" PLUGIN_PROC_MODULE_INFINIBAND_NAME
+#define CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND                                                                     \
+    "plugin:" PLUGIN_PROC_CONFIG_NAME ":" PLUGIN_PROC_MODULE_INFINIBAND_NAME
 
 // ib_device::name[IB_DEVICE_NAME_MAX(64)] + "-" + ib_device::phys_port_cnt[u8 = 3 chars]
 #define IBNAME_MAX 68
@@ -14,39 +15,37 @@
 
 // I use macro as there's no single file acting as summary, but a lot of different files, so can't use helpers like
 // procfile(). Also, omnipath generates other counters, that are not provided by infiniband
-#define FOREACH_COUNTER(GEN, ...) \
-    FOREACH_COUNTER_BYTES(GEN,   __VA_ARGS__) \
-    FOREACH_COUNTER_PACKETS(GEN, __VA_ARGS__) \
-    FOREACH_COUNTER_ERRORS(GEN,  __VA_ARGS__)
+#define FOREACH_COUNTER(GEN, ...)                                                                                      \
+    FOREACH_COUNTER_BYTES(GEN, __VA_ARGS__)                                                                            \
+    FOREACH_COUNTER_PACKETS(GEN, __VA_ARGS__)                                                                          \
+    FOREACH_COUNTER_ERRORS(GEN, __VA_ARGS__)
 
-#define FOREACH_COUNTER_BYTES(GEN, ...) \
-    GEN(port_rcv_data,                   bytes,  "Received", 1, __VA_ARGS__) \
-    GEN(port_xmit_data,                  bytes,  "Sent",    -1, __VA_ARGS__)
+#define FOREACH_COUNTER_BYTES(GEN, ...)                                                                                \
+    GEN(port_rcv_data, bytes, "Received", 1, __VA_ARGS__)                                                              \
+    GEN(port_xmit_data, bytes, "Sent", -1, __VA_ARGS__)
 
-#define FOREACH_COUNTER_PACKETS(GEN, ...) \
-    GEN(port_rcv_packets,                packets, "Received",    1, __VA_ARGS__) \
-    GEN(port_xmit_packets,               packets, "Sent",       -1, __VA_ARGS__) \
-    GEN(multicast_rcv_packets,           packets, "Mcast rcvd",  1, __VA_ARGS__) \
-    GEN(multicast_xmit_packets,          packets, "Mcast sent", -1, __VA_ARGS__) \
-    GEN(unicast_rcv_packets,             packets, "Ucast rcvd",  1, __VA_ARGS__) \
-    GEN(unicast_xmit_packets,            packets, "Ucast sent", -1, __VA_ARGS__) \
+#define FOREACH_COUNTER_PACKETS(GEN, ...)                                                                              \
+    GEN(port_rcv_packets, packets, "Received", 1, __VA_ARGS__)                                                         \
+    GEN(port_xmit_packets, packets, "Sent", -1, __VA_ARGS__)                                                           \
+    GEN(multicast_rcv_packets, packets, "Mcast rcvd", 1, __VA_ARGS__)                                                  \
+    GEN(multicast_xmit_packets, packets, "Mcast sent", -1, __VA_ARGS__)                                                \
+    GEN(unicast_rcv_packets, packets, "Ucast rcvd", 1, __VA_ARGS__)                                                    \
+    GEN(unicast_xmit_packets, packets, "Ucast sent", -1, __VA_ARGS__)
 
-#define FOREACH_COUNTER_ERRORS(GEN, ...) \
-    GEN(port_rcv_errors,                 errors, "Pkts malformated",      1, __VA_ARGS__) \
-    GEN(port_rcv_constraint_errors,      errors, "Pkts rcvd discarded ",  1, __VA_ARGS__) \
-    GEN(port_xmit_discards,              errors, "Pkts sent discarded",   1, __VA_ARGS__) \
-    GEN(port_xmit_wait,                  errors, "Tick Wait to send",     1, __VA_ARGS__) \
-    GEN(VL15_dropped,                    errors, "Pkts missed ressource", 1, __VA_ARGS__) \
-    GEN(excessive_buffer_overrun_errors, errors, "Buffer overrun",        1, __VA_ARGS__) \
-    GEN(link_downed,                     errors, "Link Downed",           1, __VA_ARGS__) \
-    GEN(link_error_recovery,             errors, "Link recovered",        1, __VA_ARGS__) \
-    GEN(local_link_integrity_errors,     errors, "Link integrity err",    1, __VA_ARGS__) \
-    GEN(symbol_error,                    errors, "Link minor errors",     1, __VA_ARGS__) \
-    GEN(port_rcv_remote_physical_errors, errors, "Pkts rcvd with EBP",    1, __VA_ARGS__) \
-    GEN(port_rcv_switch_relay_errors,    errors, "Pkts rcvd discarded by switch",  1, __VA_ARGS__) \
-    GEN(port_xmit_constraint_errors,     errors, "Pkts sent discarded by switch",  1, __VA_ARGS__)
-
-
+#define FOREACH_COUNTER_ERRORS(GEN, ...)                                                                               \
+    GEN(port_rcv_errors, errors, "Pkts malformated", 1, __VA_ARGS__)                                                   \
+    GEN(port_rcv_constraint_errors, errors, "Pkts rcvd discarded ", 1, __VA_ARGS__)                                    \
+    GEN(port_xmit_discards, errors, "Pkts sent discarded", 1, __VA_ARGS__)                                             \
+    GEN(port_xmit_wait, errors, "Tick Wait to send", 1, __VA_ARGS__)                                                   \
+    GEN(VL15_dropped, errors, "Pkts missed ressource", 1, __VA_ARGS__)                                                 \
+    GEN(excessive_buffer_overrun_errors, errors, "Buffer overrun", 1, __VA_ARGS__)                                     \
+    GEN(link_downed, errors, "Link Downed", 1, __VA_ARGS__)                                                            \
+    GEN(link_error_recovery, errors, "Link recovered", 1, __VA_ARGS__)                                                 \
+    GEN(local_link_integrity_errors, errors, "Link integrity err", 1, __VA_ARGS__)                                     \
+    GEN(symbol_error, errors, "Link minor errors", 1, __VA_ARGS__)                                                     \
+    GEN(port_rcv_remote_physical_errors, errors, "Pkts rcvd with EBP", 1, __VA_ARGS__)                                 \
+    GEN(port_rcv_switch_relay_errors, errors, "Pkts rcvd discarded by switch", 1, __VA_ARGS__)                         \
+    GEN(port_xmit_constraint_errors, errors, "Pkts sent discarded by switch", 1, __VA_ARGS__)
 
 //
 // Hardware Counters
@@ -59,68 +58,62 @@
 //  EG: for Mellanox, shown as mlx0_1, it's 'mlx'
 //      for Intel, shown as hfi1_1, it's 'hfi'
 
-
 // VENDORS: List of implemented hardware vendors
-#define FOREACH_HWCOUNTER_NAME(GEN, ...) \
-    GEN(mlx, __VA_ARGS__)
+#define FOREACH_HWCOUNTER_NAME(GEN, ...) GEN(mlx, __VA_ARGS__)
 
 // VENDOR-MLX: HW Counters for Mellanox ConnectX Devices
-#define FOREACH_HWCOUNTER_MLX(GEN, ...) \
-    FOREACH_HWCOUNTER_MLX_PACKETS(GEN, __VA_ARGS__) \
+#define FOREACH_HWCOUNTER_MLX(GEN, ...)                                                                                \
+    FOREACH_HWCOUNTER_MLX_PACKETS(GEN, __VA_ARGS__)                                                                    \
     FOREACH_HWCOUNTER_MLX_ERRORS(GEN, __VA_ARGS__)
 
-#define FOREACH_HWCOUNTER_MLX_PACKETS(GEN, ...) \
-    GEN(np_cnp_sent,                 hwpackets, "RoCEv2 Congestion sent",  1, __VA_ARGS__) \
-    GEN(np_ecn_marked_roce_packets,  hwpackets, "RoCEv2 Congestion rcvd", -1, __VA_ARGS__) \
-    GEN(rp_cnp_handled,              hwpackets, "IB Congestion handled",   1, __VA_ARGS__) \
-    GEN(rx_atomic_requests,          hwpackets, "ATOMIC req. rcvd",        1, __VA_ARGS__) \
-    GEN(rx_dct_connect,              hwpackets, "Connection req. rcvd",    1, __VA_ARGS__) \
-    GEN(rx_read_requests,            hwpackets, "Read req. rcvd",          1, __VA_ARGS__) \
-    GEN(rx_write_requests,           hwpackets, "Write req. rcvd",         1, __VA_ARGS__) \
-    GEN(roce_adp_retrans,            hwpackets, "RoCE retrans adaptive",   1, __VA_ARGS__) \
-    GEN(roce_adp_retrans_to,         hwpackets, "RoCE retrans timeout",    1, __VA_ARGS__) \
-    GEN(roce_slow_restart,           hwpackets, "RoCE slow restart",       1, __VA_ARGS__) \
-    GEN(roce_slow_restart_cnps,      hwpackets, "RoCE slow restart congestion",  1, __VA_ARGS__) \
-    GEN(roce_slow_restart_trans,     hwpackets, "RoCE slow restart count", 1, __VA_ARGS__)
+#define FOREACH_HWCOUNTER_MLX_PACKETS(GEN, ...)                                                                        \
+    GEN(np_cnp_sent, hwpackets, "RoCEv2 Congestion sent", 1, __VA_ARGS__)                                              \
+    GEN(np_ecn_marked_roce_packets, hwpackets, "RoCEv2 Congestion rcvd", -1, __VA_ARGS__)                              \
+    GEN(rp_cnp_handled, hwpackets, "IB Congestion handled", 1, __VA_ARGS__)                                            \
+    GEN(rx_atomic_requests, hwpackets, "ATOMIC req. rcvd", 1, __VA_ARGS__)                                             \
+    GEN(rx_dct_connect, hwpackets, "Connection req. rcvd", 1, __VA_ARGS__)                                             \
+    GEN(rx_read_requests, hwpackets, "Read req. rcvd", 1, __VA_ARGS__)                                                 \
+    GEN(rx_write_requests, hwpackets, "Write req. rcvd", 1, __VA_ARGS__)                                               \
+    GEN(roce_adp_retrans, hwpackets, "RoCE retrans adaptive", 1, __VA_ARGS__)                                          \
+    GEN(roce_adp_retrans_to, hwpackets, "RoCE retrans timeout", 1, __VA_ARGS__)                                        \
+    GEN(roce_slow_restart, hwpackets, "RoCE slow restart", 1, __VA_ARGS__)                                             \
+    GEN(roce_slow_restart_cnps, hwpackets, "RoCE slow restart congestion", 1, __VA_ARGS__)                             \
+    GEN(roce_slow_restart_trans, hwpackets, "RoCE slow restart count", 1, __VA_ARGS__)
 
-#define FOREACH_HWCOUNTER_MLX_ERRORS(GEN, ...) \
-    GEN(duplicate_request,           hwerrors, "Duplicated packets",   -1, __VA_ARGS__) \
-    GEN(implied_nak_seq_err,         hwerrors, "Pkt Seq Num gap",       1, __VA_ARGS__) \
-    GEN(local_ack_timeout_err,       hwerrors, "Ack timer expired",     1, __VA_ARGS__) \
-    GEN(out_of_buffer,               hwerrors, "Drop missing buffer",   1, __VA_ARGS__) \
-    GEN(out_of_sequence,             hwerrors, "Drop out of sequence",  1, __VA_ARGS__) \
-    GEN(packet_seq_err,              hwerrors, "NAK sequence rcvd",     1, __VA_ARGS__) \
-    GEN(req_cqe_error,               hwerrors, "CQE err Req",           1, __VA_ARGS__) \
-    GEN(resp_cqe_error,              hwerrors, "CQE err Resp",          1, __VA_ARGS__) \
-    GEN(req_cqe_flush_error,         hwerrors, "CQE Flushed err Req",   1, __VA_ARGS__) \
-    GEN(resp_cqe_flush_error,        hwerrors, "CQE Flushed err Resp",  1, __VA_ARGS__) \
-    GEN(req_remote_access_errors,    hwerrors, "Remote access err Req", 1, __VA_ARGS__) \
-    GEN(resp_remote_access_errors,   hwerrors, "Remote access err Resp",1, __VA_ARGS__) \
-    GEN(req_remote_invalid_request,  hwerrors, "Remote invalid req",    1, __VA_ARGS__) \
-    GEN(resp_local_length_error,     hwerrors, "Local length err Resp", 1, __VA_ARGS__) \
-    GEN(rnr_nak_retry_err,           hwerrors, "RNR NAK Packets",       1, __VA_ARGS__) \
-    GEN(rp_cnp_ignored,              hwerrors, "CNP Pkts ignored",      1, __VA_ARGS__) \
-    GEN(rx_icrc_encapsulated,        hwerrors, "RoCE ICRC Errors",      1, __VA_ARGS__)
-
-
-
+#define FOREACH_HWCOUNTER_MLX_ERRORS(GEN, ...)                                                                         \
+    GEN(duplicate_request, hwerrors, "Duplicated packets", -1, __VA_ARGS__)                                            \
+    GEN(implied_nak_seq_err, hwerrors, "Pkt Seq Num gap", 1, __VA_ARGS__)                                              \
+    GEN(local_ack_timeout_err, hwerrors, "Ack timer expired", 1, __VA_ARGS__)                                          \
+    GEN(out_of_buffer, hwerrors, "Drop missing buffer", 1, __VA_ARGS__)                                                \
+    GEN(out_of_sequence, hwerrors, "Drop out of sequence", 1, __VA_ARGS__)                                             \
+    GEN(packet_seq_err, hwerrors, "NAK sequence rcvd", 1, __VA_ARGS__)                                                 \
+    GEN(req_cqe_error, hwerrors, "CQE err Req", 1, __VA_ARGS__)                                                        \
+    GEN(resp_cqe_error, hwerrors, "CQE err Resp", 1, __VA_ARGS__)                                                      \
+    GEN(req_cqe_flush_error, hwerrors, "CQE Flushed err Req", 1, __VA_ARGS__)                                          \
+    GEN(resp_cqe_flush_error, hwerrors, "CQE Flushed err Resp", 1, __VA_ARGS__)                                        \
+    GEN(req_remote_access_errors, hwerrors, "Remote access err Req", 1, __VA_ARGS__)                                   \
+    GEN(resp_remote_access_errors, hwerrors, "Remote access err Resp", 1, __VA_ARGS__)                                 \
+    GEN(req_remote_invalid_request, hwerrors, "Remote invalid req", 1, __VA_ARGS__)                                    \
+    GEN(resp_local_length_error, hwerrors, "Local length err Resp", 1, __VA_ARGS__)                                    \
+    GEN(rnr_nak_retry_err, hwerrors, "RNR NAK Packets", 1, __VA_ARGS__)                                                \
+    GEN(rp_cnp_ignored, hwerrors, "CNP Pkts ignored", 1, __VA_ARGS__)                                                  \
+    GEN(rx_icrc_encapsulated, hwerrors, "RoCE ICRC Errors", 1, __VA_ARGS__)
 
 // Common definitions used more than once
-#define GEN_RRD_DIM_ADD(NAME,GRP,DESC,DIR, PORT) \
-    GEN_RRD_DIM_ADD_CUSTOM(NAME,GRP,DESC,DIR, PORT, 1, 1, RRD_ALGORITHM_INCREMENTAL)
+#define GEN_RRD_DIM_ADD(NAME, GRP, DESC, DIR, PORT)                                                                    \
+    GEN_RRD_DIM_ADD_CUSTOM(NAME, GRP, DESC, DIR, PORT, 1, 1, RRD_ALGORITHM_INCREMENTAL)
 
-#define GEN_RRD_DIM_ADD_CUSTOM(NAME,GRP,DESC,DIR, PORT,MULT,DIV,ALGO) \
-    PORT->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR*MULT, DIV, ALGO);
+#define GEN_RRD_DIM_ADD_CUSTOM(NAME, GRP, DESC, DIR, PORT, MULT, DIV, ALGO)                                            \
+    PORT->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR * MULT, DIV, ALGO);
 
-#define GEN_RRD_DIM_ADD_HW(NAME,GRP,DESC,DIR, PORT,HW) \
+#define GEN_RRD_DIM_ADD_HW(NAME, GRP, DESC, DIR, PORT, HW)                                                             \
     HW->rd_##NAME = rrddim_add(PORT->st_##GRP, DESC, NULL, DIR, 1, RRD_ALGORITHM_INCREMENTAL);
 
-#define GEN_RRD_DIM_SETP(NAME,GRP,DESC,DIR, PORT) \
+#define GEN_RRD_DIM_SETP(NAME, GRP, DESC, DIR, PORT)                                                                   \
     rrddim_set_by_pointer(PORT->st_##GRP, PORT->rd_##NAME, (collected_number)PORT->NAME);
 
-#define GEN_RRD_DIM_SETP_HW(NAME,GRP,DESC,DIR, PORT,HW) \
+#define GEN_RRD_DIM_SETP_HW(NAME, GRP, DESC, DIR, PORT, HW)                                                            \
     rrddim_set_by_pointer(PORT->st_##GRP, HW->rd_##NAME, (collected_number)HW->NAME);
-
 
 // https://community.mellanox.com/s/article/understanding-mlx5-linux-counters-and-status-parameters
 // https://community.mellanox.com/s/article/infiniband-port-counters
@@ -128,12 +121,12 @@ static struct ibport {
     char *name;
     char *counters_path;
     char *hwcounters_path;
-    int  len;
+    int len;
 
     // flags
     int configured;
     int enabled;
-    int updated;
+    int discovered;
 
     int do_bytes;
     int do_packets;
@@ -162,29 +155,27 @@ static struct ibport {
     uint64_t speed;
     uint64_t width;
 
-    // Stats from /$device/ports/$portid/counters
-    // as drivers/infiniband/hw/qib/qib_verbs.h
-    // All uint64 except vl15_dropped, local_link_integrity_errors, excessive_buffer_overrun_errors uint32
-    // Will generate 2 elements for each counter:
-    // - uint64_t to store the value
-    // - char*    to store the filename path
-    // - RRDDIM*  to store the RRD Dimension
-    #define GEN_DEF_COUNTER(NAME, ...) \
-        uint64_t  NAME; \
-        char      *file_##NAME; \
-        RRDDIM    *rd_##NAME;
+// Stats from /$device/ports/$portid/counters
+// as drivers/infiniband/hw/qib/qib_verbs.h
+// All uint64 except vl15_dropped, local_link_integrity_errors, excessive_buffer_overrun_errors uint32
+// Will generate 2 elements for each counter:
+// - uint64_t to store the value
+// - char*    to store the filename path
+// - RRDDIM*  to store the RRD Dimension
+#define GEN_DEF_COUNTER(NAME, ...)                                                                                     \
+    uint64_t NAME;                                                                                                     \
+    char *file_##NAME;                                                                                                 \
+    RRDDIM *rd_##NAME;
     FOREACH_COUNTER(GEN_DEF_COUNTER)
 
-    // Vendor specific hwcounters from /$device/ports/$portid/hw_counters
-    // We will generate one struct pointer per vendor to avoid future casting
-    #define GEN_DEF_HWCOUNTER_PTR(VENDOR, ...) \
-        struct ibporthw_##VENDOR *hwcounters_##VENDOR;
+// Vendor specific hwcounters from /$device/ports/$portid/hw_counters
+// We will generate one struct pointer per vendor to avoid future casting
+#define GEN_DEF_HWCOUNTER_PTR(VENDOR, ...) struct ibporthw_##VENDOR *hwcounters_##VENDOR;
     FOREACH_HWCOUNTER_NAME(GEN_DEF_HWCOUNTER_PTR)
 
     // Function pointer to the "infiniband_hwcounters_parse_<vendor>" function
     void (*hwcounters_parse)(struct ibport *);
     void (*hwcounters_dorrd)(struct ibport *);
-
 
     // charts and dim
     RRDSET *st_bytes;
@@ -200,27 +191,26 @@ static struct ibport {
     struct ibport *next;
 } *ibport_root = NULL, *ibport_last_used = NULL;
 
-
-
 // VENDORS: reading / calculation functions
-#define GEN_DEF_HWCOUNTER(NAME, ...) \
-    uint64_t  NAME; \
-    char      *file_##NAME; \
-    RRDDIM    *rd_##NAME;
+#define GEN_DEF_HWCOUNTER(NAME, ...)                                                                                   \
+    uint64_t NAME;                                                                                                     \
+    char *file_##NAME;                                                                                                 \
+    RRDDIM *rd_##NAME;
 
-#define GEN_DO_HWCOUNTER_READ(NAME,GRP,DESC,DIR,PORT,HW, ...) \
-    if (HW->file_##NAME) { \
-        if (read_single_number_file(HW->file_##NAME, (unsigned long long *) &HW->NAME)) { \
-            error("cannot read iface '%s' hwcounter '"#HW"'", PORT->name); \
-            HW->file_##NAME = NULL; \
-        } \
+#define GEN_DO_HWCOUNTER_READ(NAME, GRP, DESC, DIR, PORT, HW, ...)                                                     \
+    if (HW->file_##NAME) {                                                                                             \
+        if (read_single_number_file(HW->file_##NAME, (unsigned long long *)&HW->NAME)) {                               \
+            error("cannot read iface '%s' hwcounter '" #HW "'", PORT->name);                                           \
+            HW->file_##NAME = NULL;                                                                                    \
+        }                                                                                                              \
     }
 
 // VENDOR-MLX: Mellanox
 struct ibporthw_mlx {
     FOREACH_HWCOUNTER_MLX(GEN_DEF_HWCOUNTER)
 };
-void infiniband_hwcounters_parse_mlx(struct ibport *port) {
+void infiniband_hwcounters_parse_mlx(struct ibport *port)
+{
     if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
         FOREACH_HWCOUNTER_MLX_ERRORS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
     }
@@ -228,7 +218,8 @@ void infiniband_hwcounters_parse_mlx(struct ibport *port) {
         FOREACH_HWCOUNTER_MLX_PACKETS(GEN_DO_HWCOUNTER_READ, port, port->hwcounters_mlx)
     }
 }
-void infiniband_hwcounters_dorrd_mlx(struct ibport *port) {
+void infiniband_hwcounters_dorrd_mlx(struct ibport *port)
+{
     if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
         FOREACH_HWCOUNTER_MLX_ERRORS(GEN_RRD_DIM_SETP_HW, port, port->hwcounters_mlx)
         rrdset_done(port->st_hwerrors);
@@ -239,135 +230,139 @@ void infiniband_hwcounters_dorrd_mlx(struct ibport *port) {
     }
 }
 
-
 // ----------------------------------------------------------------------------
 
-
-static struct ibport *get_ibport(const char *dev, const char *port) {
+static struct ibport *get_ibport(const char *dev, const char *port)
+{
     struct ibport *p;
 
-    char name[IBNAME_MAX+1];
+    char name[IBNAME_MAX + 1];
     snprintfz(name, IBNAME_MAX, "%s-%s", dev, port);
 
-
     // search it, resuming from the last position in sequence
-    for(p = ibport_last_used ; p ; p = p->next) {
-        if(unlikely(!strcmp(name, p->name))) {
+    for (p = ibport_last_used; p; p = p->next) {
+        if (unlikely(!strcmp(name, p->name))) {
             ibport_last_used = p->next;
             return p;
         }
     }
 
     // new round, from the beginning to the last position used this time
-    for(p = ibport_root ; p != ibport_last_used ; p = p->next) {
-        if(unlikely(!strcmp(name, p->name))) {
+    for (p = ibport_root; p != ibport_last_used; p = p->next) {
+        if (unlikely(!strcmp(name, p->name))) {
             ibport_last_used = p->next;
             return p;
         }
     }
 
     // create a new one
-    p       = callocz(1, sizeof(struct ibport));
+    p = callocz(1, sizeof(struct ibport));
     p->name = strdupz(name);
-    p->len  = strlen(p->name);
+    p->len = strlen(p->name);
 
-
-    p->chart_type_bytes     = strdupz("infiniband_cnt_bytes");
-    p->chart_type_packets   = strdupz("infiniband_cnt_packets");
-    p->chart_type_errors    = strdupz("infiniband_cnt_errors");
+    p->chart_type_bytes = strdupz("infiniband_cnt_bytes");
+    p->chart_type_packets = strdupz("infiniband_cnt_packets");
+    p->chart_type_errors = strdupz("infiniband_cnt_errors");
     p->chart_type_hwpackets = strdupz("infiniband_hwc_packets");
-    p->chart_type_hwerrors  = strdupz("infiniband_hwc_errors");
+    p->chart_type_hwerrors = strdupz("infiniband_hwc_errors");
 
     char buffer[RRD_ID_LENGTH_MAX + 1];
     snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntbytes_%s", p->name);
-    p->chart_id_bytes     = strdupz(buffer);
+    p->chart_id_bytes = strdupz(buffer);
 
     snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cntpackets_%s", p->name);
-    p->chart_id_packets   = strdupz(buffer);
+    p->chart_id_packets = strdupz(buffer);
 
     snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_cnterrors_%s", p->name);
-    p->chart_id_errors    = strdupz(buffer);
+    p->chart_id_errors = strdupz(buffer);
 
     snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcntpackets_%s", p->name);
     p->chart_id_hwpackets = strdupz(buffer);
 
     snprintfz(buffer, RRD_ID_LENGTH_MAX, "ib_hwcnterrors_%s", p->name);
-    p->chart_id_hwerrors  = strdupz(buffer);
+    p->chart_id_hwerrors = strdupz(buffer);
 
-    p->chart_family        = strdupz(p->name);
-    p->priority            = NETDATA_CHART_PRIO_INFINIBAND;
+    p->chart_family = strdupz(p->name);
+    p->priority = NETDATA_CHART_PRIO_INFINIBAND;
 
     // Link current ibport to last one in the list
     if (ibport_root) {
         struct ibport *t;
-        for (t = ibport_root; t->next ; t = t->next) ;
+        for (t = ibport_root; t->next; t = t->next)
+            ;
         t->next = p;
-    }
-    else
+    } else
         ibport_root = p;
 
     return p;
-
 }
 
-
-int do_sys_class_infiniband(int update_every, usec_t dt) {
+int do_sys_class_infiniband(int update_every, usec_t dt)
+{
     (void)dt;
     static SIMPLE_PATTERN *disabled_list = NULL;
     static int initialized = 0;
     static int enable_new_ports = -1, enable_only_active = CONFIG_BOOLEAN_YES;
-    static int do_bytes = -1, do_packets = -1, do_errors = -1, do_hwpackets = -1, do_hwerrors= -1;
+    static int do_bytes = -1, do_packets = -1, do_errors = -1, do_hwpackets = -1, do_hwerrors = -1;
     static char *sys_class_infiniband_dirname = NULL;
 
-    static long long int dt_to_refresh_speed = 0;
+    static long long int dt_to_refresh_ports = 0, last_refresh_ports_usec = 0;
 
-    if(unlikely(enable_new_ports == -1)) {
+    if (unlikely(enable_new_ports == -1)) {
         char dirname[FILENAME_MAX + 1];
 
         snprintfz(dirname, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/class/infiniband");
-        sys_class_infiniband_dirname = config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "dirname to monitor", dirname);
+        sys_class_infiniband_dirname =
+            config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "dirname to monitor", dirname);
 
-        do_bytes     = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "bandwidth counters", CONFIG_BOOLEAN_AUTO);
-        do_packets   = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "packets counters", CONFIG_BOOLEAN_AUTO);
-        do_errors    = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "errors counters", CONFIG_BOOLEAN_AUTO);
-        do_hwpackets = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware packets counters", CONFIG_BOOLEAN_AUTO);
-        do_hwerrors  = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware errors counters", CONFIG_BOOLEAN_AUTO);
+        do_bytes = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "bandwidth counters", CONFIG_BOOLEAN_YES);
+        do_packets = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "packets counters", CONFIG_BOOLEAN_YES);
+        do_errors = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "errors counters", CONFIG_BOOLEAN_YES);
+        do_hwpackets = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware packets counters", CONFIG_BOOLEAN_AUTO);
+        do_hwerrors = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "hardware errors counters", CONFIG_BOOLEAN_AUTO);
 
-        disabled_list = simple_pattern_create(config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "disable by default interfaces matching", ""), NULL, SIMPLE_PATTERN_EXACT);
+        enable_only_active = config_get_boolean_ondemand(
+            CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "monitor only ports being active", CONFIG_BOOLEAN_AUTO);
+        disabled_list = simple_pattern_create(
+            config_get(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "disable by default interfaces matching", ""), NULL,
+            SIMPLE_PATTERN_EXACT);
 
-        dt_to_refresh_speed = config_get_number(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "refresh interface speed every seconds", 10) * USEC_PER_SEC;
-        if(dt_to_refresh_speed < 0) dt_to_refresh_speed = 0;
-
-        enable_new_ports = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "Monitor ports going online during runtime", CONFIG_BOOLEAN_AUTO);
-        enable_only_active = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "Monitor only ports being active", CONFIG_BOOLEAN_AUTO);
+        dt_to_refresh_ports =
+            config_get_number(CONFIG_SECTION_PLUGIN_SYS_CLASS_INFINIBAND, "refresh ports state every seconds", 30) *
+            USEC_PER_SEC;
+        if (dt_to_refresh_ports < 0)
+            dt_to_refresh_ports = 0;
     }
 
-
     // init listing of /sys/class/infiniband/ (or rediscovery)
-    if(unlikely(!initialized)) {
-
+    if (unlikely(!initialized) || unlikely(last_refresh_ports_usec >= dt_to_refresh_ports)) {
         // If folder does not exists, return 1 to disable
         DIR *devices_dir = opendir(sys_class_infiniband_dirname);
-        if(unlikely(!devices_dir)) return 1;
+        if (unlikely(!devices_dir))
+            return 1;
 
         // Work on all device available
         struct dirent *dev_dent;
-        while ( (dev_dent = readdir(devices_dir)) ) {
-
+        while ((dev_dent = readdir(devices_dir))) {
             // Skip special folders
             if (!strcmp(dev_dent->d_name, "..") || !strcmp(dev_dent->d_name, "."))
                 continue;
 
             // /sys/class/infiniband/<dev>/ports
-            char ports_dirname[FILENAME_MAX +1];
+            char ports_dirname[FILENAME_MAX + 1];
             snprintfz(ports_dirname, FILENAME_MAX, "%s/%s/%s", sys_class_infiniband_dirname, dev_dent->d_name, "ports");
 
             DIR *ports_dir = opendir(ports_dirname);
-            if(unlikely(!ports_dir)) continue;
+            if (unlikely(!ports_dir))
+                continue;
 
             struct dirent *port_dent;
-            while ( (port_dent = readdir(ports_dir)) ) {
-
+            while ((port_dent = readdir(ports_dir))) {
                 // Skip special folders
                 if (!strcmp(port_dent->d_name, "..") || !strcmp(port_dent->d_name, "."))
                     continue;
@@ -376,78 +371,61 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 
                 // Check if counters are availablea (mandatory)
                 // /sys/class/infiniband/<device>/ports/<port>/counters
-                char counters_dirname[FILENAME_MAX +1];
+                char counters_dirname[FILENAME_MAX + 1];
                 snprintfz(counters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "counters");
                 DIR *counters_dir = opendir(counters_dirname);
                 // Standard counters are mandatory
-                if (!counters_dir) continue;
+                if (!counters_dir)
+                    continue;
 
                 // Nearly same with hardware counters
-                char hwcounters_dirname[FILENAME_MAX +1];
-                snprintfz(hwcounters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "hw_counters");
+                char hwcounters_dirname[FILENAME_MAX + 1];
+                snprintfz(
+                    hwcounters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "hw_counters");
                 DIR *hwcounters_dir = opendir(hwcounters_dirname);
 
-                // Get new ibport
+                // Get new or existing ibport
                 struct ibport *p = get_ibport(dev_dent->d_name, port_dent->d_name);
-                if(!p) continue;
-
-                p->updated = 1;
+                if (!p)
+                    continue;
 
                 // Prepare configuration
                 if (!p->configured) {
                     p->configured = 1;
 
+                    // Enable by default, will be filtered out later
+                    p->enabled = 1;
 
                     p->counters_path = strdupz(counters_dirname);
                     p->hwcounters_path = strdupz(hwcounters_dirname);
 
-                    // Enable filtering
-                    p->enabled = enable_new_ports;
-
-                    // Check port state
-                    if (enable_only_active) {
-                        snprintfz(buffer, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "state");
-                        unsigned long long active;
-                        // File is "1: DOWN" or "4: ACTIVE", but str2ull will stop on first non-decimal char
-                        read_single_number_file(buffer, &active);
-
-                        // Want "IB_PORT_ACTIVE" == "4", as defined by drivers/infiniband/core/sysfs.c::state_show()
-                        if (active != 4)
-                            p->enabled = 0;
-                    }
-
-                    if (p->enabled)
-                        p->enabled = !simple_pattern_matches(disabled_list, p->name);
-
                     snprintfz(buffer, FILENAME_MAX, "plugin:proc:/sys/class/infiniband:%s", p->name);
 
                     // Standard counters
-                    p->do_bytes   = config_get_boolean_ondemand(buffer, "bytes",   do_bytes);
+                    p->do_bytes = config_get_boolean_ondemand(buffer, "bytes", do_bytes);
                     p->do_packets = config_get_boolean_ondemand(buffer, "packets", do_packets);
-                    p->do_errors  = config_get_boolean_ondemand(buffer, "errors",  do_errors);
+                    p->do_errors = config_get_boolean_ondemand(buffer, "errors", do_errors);
 
-                    // Gen filename allocation and concatenation
-                    #define GEN_DO_COUNTER_NAME(NAME,GRP,DESC,DIR,PORT, ...) \
-                        PORT->file_##NAME = callocz(1, strlen(PORT->counters_path) + sizeof(#NAME) +3); \
-                        strcat(PORT->file_##NAME, PORT->counters_path); \
-                        strcat(PORT->file_##NAME, "/"#NAME);
+// Gen filename allocation and concatenation
+#define GEN_DO_COUNTER_NAME(NAME, GRP, DESC, DIR, PORT, ...)                                                           \
+    PORT->file_##NAME = callocz(1, strlen(PORT->counters_path) + sizeof(#NAME) + 3);                                   \
+    strcat(PORT->file_##NAME, PORT->counters_path);                                                                    \
+    strcat(PORT->file_##NAME, "/" #NAME);
                     FOREACH_COUNTER(GEN_DO_COUNTER_NAME, p)
-
 
                     // Check HW Counters vendor dependent
                     if (hwcounters_dir) {
-
                         // By default set standard
                         p->do_hwpackets = config_get_boolean_ondemand(buffer, "hwpackets", do_hwpackets);
-                        p->do_hwerrors  = config_get_boolean_ondemand(buffer, "hwerrors",  do_hwerrors);
+                        p->do_hwerrors = config_get_boolean_ondemand(buffer, "hwerrors", do_hwerrors);
 
-                        // VENDORS: Set your own
+// VENDORS: Set your own
 
-                        // Allocate the chars to the filenames
-                        #define GEN_DO_HWCOUNTER_NAME(NAME,GRP,DESC,DIR,PORT,HW, ...) \
-                            HW->file_##NAME = callocz(1, strlen(PORT->hwcounters_path) + sizeof(#NAME) +3); \
-                            strcat(HW->file_##NAME, PORT->hwcounters_path); \
-                            strcat(HW->file_##NAME, "/"#NAME);
+// Allocate the chars to the filenames
+#define GEN_DO_HWCOUNTER_NAME(NAME, GRP, DESC, DIR, PORT, HW, ...)                                                     \
+    HW->file_##NAME = callocz(1, strlen(PORT->hwcounters_path) + sizeof(#NAME) + 3);                                   \
+    strcat(HW->file_##NAME, PORT->hwcounters_path);                                                                    \
+    strcat(HW->file_##NAME, "/" #NAME);
 
                         // VENDOR-MLX: Mellanox
                         if (strncmp(dev_dent->d_name, "mlx", 3) == 0) {
@@ -457,17 +435,34 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
                             FOREACH_HWCOUNTER_MLX(GEN_DO_HWCOUNTER_NAME, p, p->hwcounters_mlx)
 
                             // Set the function pointer for hwcounter parsing
-                            p->hwcounters_parse  = &infiniband_hwcounters_parse_mlx;
+                            p->hwcounters_parse = &infiniband_hwcounters_parse_mlx;
                             p->hwcounters_dorrd = &infiniband_hwcounters_dorrd_mlx;
                         }
 
                         // VENDOR: Unknown
                         else {
                             p->do_hwpackets = CONFIG_BOOLEAN_NO;
-                            p->do_hwerrors  = CONFIG_BOOLEAN_NO;
+                            p->do_hwerrors = CONFIG_BOOLEAN_NO;
                         }
                     }
                 }
+
+                // Check port state to keep activation
+                if (enable_only_active) {
+                    snprintfz(buffer, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "state");
+                    unsigned long long active;
+                    // File is "1: DOWN" or "4: ACTIVE", but str2ull will stop on first non-decimal char
+                    read_single_number_file(buffer, &active);
+
+                    // Want "IB_PORT_ACTIVE" == "4", as defined by drivers/infiniband/core/sysfs.c::state_show()
+                    if (active == 4)
+                        p->enabled = 1;
+                    else
+                        p->enabled = 0;
+                }
+
+                if (p->enabled)
+                    p->enabled = !simple_pattern_matches(disabled_list, p->name);
 
                 // Check / Update the link speed & width frm "rate" file
                 // Sample output: "100 Gb/sec (4X EDR)"
@@ -476,8 +471,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
                 if (read_file(buffer, buffer_rate, 64)) {
                     error("Unable to read '%s'", buffer);
                     p->width = 1;
-                }
-                else {
+                } else {
                     char *buffer_width = strstr(buffer_rate, "(");
                     buffer_width++;
                     // str2ull will stop on first non-decimal value
@@ -485,58 +479,51 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
                     p->width = str2ull(buffer_width);
                 }
 
-                info("Infiniband card %s port %s at speed %lu width %lu", dev_dent->d_name, port_dent->d_name, p->speed, p->width);
+                if (!p->discovered)
+                    info(
+                        "Infiniband card %s port %s at speed %lu width %lu", dev_dent->d_name, port_dent->d_name,
+                        p->speed, p->width);
 
+                p->discovered = 1;
             }
             closedir(ports_dir);
         }
         closedir(devices_dir);
 
         initialized = 1;
+        last_refresh_ports_usec = 0;
     }
+    last_refresh_ports_usec += dt;
 
     // Update all ports values
     struct ibport *port;
-    for (port = ibport_root; port ; port = port->next) {
-
+    for (port = ibport_root; port; port = port->next) {
         if (!port->enabled)
             continue;
+    //
+    // Read values from system to struct
+    //
 
-        //
-        // Read values from system to struct
-        //
-
-        //  counter from file and place it in ibport struct
-        #define GEN_DO_COUNTER_READ(NAME,GRP,DESC,DIR,PORT, ...) \
-            if (PORT->file_##NAME) { \
-                if (read_single_number_file(PORT->file_##NAME, (unsigned long long *) &PORT->NAME)) { \
-                    error("cannot read iface '%s' counter '"#NAME"'", PORT->name); \
-                    PORT->file_##NAME = NULL; \
-                } \
-            }
+//  counter from file and place it in ibport struct
+#define GEN_DO_COUNTER_READ(NAME, GRP, DESC, DIR, PORT, ...)                                                           \
+    if (PORT->file_##NAME) {                                                                                           \
+        if (read_single_number_file(PORT->file_##NAME, (unsigned long long *)&PORT->NAME)) {                           \
+            error("cannot read iface '%s' counter '" #NAME "'", PORT->name);                                           \
+            PORT->file_##NAME = NULL;                                                                                  \
+        }                                                                                                              \
+    }
 
         // Update charts
         if (port->do_bytes != CONFIG_BOOLEAN_NO) {
-
             // Read values from sysfs
             FOREACH_COUNTER_BYTES(GEN_DO_COUNTER_READ, port)
 
             // First creation of RRD Set (charts)
-            if(unlikely(!port->st_bytes)) {
+            if (unlikely(!port->st_bytes)) {
                 port->st_bytes = rrdset_create_localhost(
-                    "Infiniband"
-                    , port->chart_id_bytes
-                    , NULL
-                    , port->chart_family
-                    , "ib.bytes"
-                    , "Bandwidth usage"
-                    , "kilobits/s"
-                    , PLUGIN_PROC_NAME
-                    , PLUGIN_PROC_MODULE_INFINIBAND_NAME
-                    , port->priority + 1
-                    , update_every
-                    , RRDSET_TYPE_AREA
-                );
+                    "Infiniband", port->chart_id_bytes, NULL, port->chart_family, "ib.bytes", "Bandwidth usage",
+                    "kilobits/s", PLUGIN_PROC_NAME, PLUGIN_PROC_MODULE_INFINIBAND_NAME, port->priority + 1,
+                    update_every, RRDSET_TYPE_AREA);
                 // Create Dimensions
                 rrdset_flag_set(port->st_bytes, RRDSET_FLAG_DETAIL);
                 // On this chart, we want to have a KB/s so the dashboard will autoscale it
@@ -544,8 +531,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
                 FOREACH_COUNTER_BYTES(GEN_RRD_DIM_ADD_CUSTOM, port, 8 * port->width, 1024, RRD_ALGORITHM_INCREMENTAL)
 
                 port->stv_speed = rrdsetvar_custom_chart_variable_create(port->st_bytes, "link_speed");
-            }
-            else
+            } else
                 rrdset_next(port->st_bytes);
 
             // Link read values to dimensions
@@ -558,31 +544,19 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
         }
 
         if (port->do_packets != CONFIG_BOOLEAN_NO) {
-
             // Read values from sysfs
             FOREACH_COUNTER_PACKETS(GEN_DO_COUNTER_READ, port)
 
             // First creation of RRD Set (charts)
-            if(unlikely(!port->st_packets)) {
+            if (unlikely(!port->st_packets)) {
                 port->st_packets = rrdset_create_localhost(
-                    "Infiniband"
-                    , port->chart_id_packets
-                    , NULL
-                    , port->chart_family
-                    , "ib.packets"
-                    , "Packets Statistics"
-                    , "packets/s"
-                    , PLUGIN_PROC_NAME
-                    , PLUGIN_PROC_MODULE_INFINIBAND_NAME
-                    , port->priority + 2
-                    , update_every
-                    , RRDSET_TYPE_AREA
-                );
+                    "Infiniband", port->chart_id_packets, NULL, port->chart_family, "ib.packets", "Packets Statistics",
+                    "packets/s", PLUGIN_PROC_NAME, PLUGIN_PROC_MODULE_INFINIBAND_NAME, port->priority + 2, update_every,
+                    RRDSET_TYPE_AREA);
                 // Create Dimensions
                 rrdset_flag_set(port->st_packets, RRDSET_FLAG_DETAIL);
                 FOREACH_COUNTER_PACKETS(GEN_RRD_DIM_ADD, port)
-            }
-            else
+            } else
                 rrdset_next(port->st_packets);
 
             // Link read values to dimensions
@@ -591,31 +565,19 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
         }
 
         if (port->do_errors != CONFIG_BOOLEAN_NO) {
-
             // Read values from sysfs
             FOREACH_COUNTER_ERRORS(GEN_DO_COUNTER_READ, port)
 
             // First creation of RRD Set (charts)
-            if(unlikely(!port->st_errors)) {
+            if (unlikely(!port->st_errors)) {
                 port->st_errors = rrdset_create_localhost(
-                    "Infiniband"
-                    , port->chart_id_errors
-                    , NULL
-                    , port->chart_family
-                    , "ib.errors"
-                    , "Error Counters"
-                    , "errors/s"
-                    , PLUGIN_PROC_NAME
-                    , PLUGIN_PROC_MODULE_INFINIBAND_NAME
-                    , port->priority + 3
-                    , update_every
-                    , RRDSET_TYPE_LINE
-                );
+                    "Infiniband", port->chart_id_errors, NULL, port->chart_family, "ib.errors", "Error Counters",
+                    "errors/s", PLUGIN_PROC_NAME, PLUGIN_PROC_MODULE_INFINIBAND_NAME, port->priority + 3, update_every,
+                    RRDSET_TYPE_LINE);
                 // Create Dimensions
                 rrdset_flag_set(port->st_errors, RRDSET_FLAG_DETAIL);
                 FOREACH_COUNTER_ERRORS(GEN_RRD_DIM_ADD, port)
-            }
-            else
+            } else
                 rrdset_next(port->st_errors);
 
             // Link read values to dimensions
@@ -623,35 +585,22 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
             rrdset_done(port->st_errors);
         }
 
-
         //
         // HW Counters
         //
 
         // Call the function for parsing and setting hwcounters
         if (port->hwcounters_parse && port->hwcounters_dorrd) {
-
             // Read all values (done by vendor-specific function)
             (*port->hwcounters_parse)(port);
 
             if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
-
                 // First creation of RRD Set (charts)
-                if(unlikely(!port->st_hwerrors)) {
+                if (unlikely(!port->st_hwerrors)) {
                     port->st_hwerrors = rrdset_create_localhost(
-                        "Infiniband"
-                        , port->chart_id_hwerrors
-                        , NULL
-                        , port->chart_family
-                        , "ib.hwerrors"
-                        , "Hardware Errors"
-                        , "errors/s"
-                        , PLUGIN_PROC_NAME
-                        , PLUGIN_PROC_MODULE_INFINIBAND_NAME
-                        , port->priority + 4
-                        , update_every
-                        , RRDSET_TYPE_LINE
-                    );
+                        "Infiniband", port->chart_id_hwerrors, NULL, port->chart_family, "ib.hwerrors",
+                        "Hardware Errors", "errors/s", PLUGIN_PROC_NAME, PLUGIN_PROC_MODULE_INFINIBAND_NAME,
+                        port->priority + 4, update_every, RRDSET_TYPE_LINE);
 
                     rrdset_flag_set(port->st_hwerrors, RRDSET_FLAG_DETAIL);
 
@@ -664,32 +613,22 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 
                     // Unknown vendor, should not happen
                     else {
-                        error("Unmanaged vendor for '%s', do_hwerrors should have been set to no. Please report this bug", port->name);
+                        error(
+                            "Unmanaged vendor for '%s', do_hwerrors should have been set to no. Please report this bug",
+                            port->name);
                         port->do_hwerrors = CONFIG_BOOLEAN_NO;
                     }
-                }
-                else
+                } else
                     rrdset_next(port->st_hwerrors);
             }
 
-
             if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
                 // First creation of RRD Set (charts)
-                if(unlikely(!port->st_hwpackets)) {
+                if (unlikely(!port->st_hwpackets)) {
                     port->st_hwpackets = rrdset_create_localhost(
-                        "Infiniband"
-                        , port->chart_id_hwpackets
-                        , NULL
-                        , port->chart_family
-                        , "ib.hwpackets"
-                        , "Hardware Packets Statistics"
-                        , "packets/s"
-                        , PLUGIN_PROC_NAME
-                        , PLUGIN_PROC_MODULE_INFINIBAND_NAME
-                        , port->priority + 5
-                        , update_every
-                        , RRDSET_TYPE_LINE
-                    );
+                        "Infiniband", port->chart_id_hwpackets, NULL, port->chart_family, "ib.hwpackets",
+                        "Hardware Packets Statistics", "packets/s", PLUGIN_PROC_NAME,
+                        PLUGIN_PROC_MODULE_INFINIBAND_NAME, port->priority + 5, update_every, RRDSET_TYPE_LINE);
 
                     rrdset_flag_set(port->st_hwpackets, RRDSET_FLAG_DETAIL);
 
@@ -702,11 +641,12 @@ int do_sys_class_infiniband(int update_every, usec_t dt) {
 
                     // Unknown vendor, should not happen
                     else {
-                        error("Unmanaged vendor for '%s', do_hwpackets should have been set to no. Please report this bug", port->name);
+                        error(
+                            "Unmanaged vendor for '%s', do_hwpackets should have been set to no. Please report this bug",
+                            port->name);
                         port->do_hwpackets = CONFIG_BOOLEAN_NO;
                     }
-                }
-                else
+                } else
                     rrdset_next(port->st_hwpackets);
             }
 

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -15,37 +15,37 @@
 
 // I use macro as there's no single file acting as summary, but a lot of different files, so can't use helpers like
 // procfile(). Also, omnipath generates other counters, that are not provided by infiniband
-#define FOREACH_COUNTER(GEN, ...)                                                                                      \
-    FOREACH_COUNTER_BYTES(GEN, __VA_ARGS__)                                                                            \
-    FOREACH_COUNTER_PACKETS(GEN, __VA_ARGS__)                                                                          \
-    FOREACH_COUNTER_ERRORS(GEN, __VA_ARGS__)
+#define FOREACH_COUNTER(GEN, ...)              \
+    FOREACH_COUNTER_BYTES(GEN,   __VA_ARGS__)  \
+    FOREACH_COUNTER_PACKETS(GEN, __VA_ARGS__)  \
+    FOREACH_COUNTER_ERRORS(GEN,  __VA_ARGS__)
 
-#define FOREACH_COUNTER_BYTES(GEN, ...)                                                                                \
-    GEN(port_rcv_data, bytes, "Received", 1, __VA_ARGS__)                                                              \
-    GEN(port_xmit_data, bytes, "Sent", -1, __VA_ARGS__)
+#define FOREACH_COUNTER_BYTES(GEN, ...)                                                             \
+    GEN(port_rcv_data,                   bytes,   "Received",                      1, __VA_ARGS__)  \
+    GEN(port_xmit_data,                  bytes,   "Sent",                         -1, __VA_ARGS__)
 
-#define FOREACH_COUNTER_PACKETS(GEN, ...)                                                                              \
-    GEN(port_rcv_packets, packets, "Received", 1, __VA_ARGS__)                                                         \
-    GEN(port_xmit_packets, packets, "Sent", -1, __VA_ARGS__)                                                           \
-    GEN(multicast_rcv_packets, packets, "Mcast rcvd", 1, __VA_ARGS__)                                                  \
-    GEN(multicast_xmit_packets, packets, "Mcast sent", -1, __VA_ARGS__)                                                \
-    GEN(unicast_rcv_packets, packets, "Ucast rcvd", 1, __VA_ARGS__)                                                    \
-    GEN(unicast_xmit_packets, packets, "Ucast sent", -1, __VA_ARGS__)
+#define FOREACH_COUNTER_PACKETS(GEN, ...)                                                           \
+    GEN(port_rcv_packets,                packets, "Received",                      1, __VA_ARGS__)  \
+    GEN(port_xmit_packets,               packets, "Sent",                         -1, __VA_ARGS__)  \
+    GEN(multicast_rcv_packets,           packets, "Mcast rcvd",                    1, __VA_ARGS__)  \
+    GEN(multicast_xmit_packets,          packets, "Mcast sent",                   -1, __VA_ARGS__)  \
+    GEN(unicast_rcv_packets,             packets, "Ucast rcvd",                    1, __VA_ARGS__)  \
+    GEN(unicast_xmit_packets,            packets, "Ucast sent",                   -1, __VA_ARGS__)
 
-#define FOREACH_COUNTER_ERRORS(GEN, ...)                                                                               \
-    GEN(port_rcv_errors, errors, "Pkts malformated", 1, __VA_ARGS__)                                                   \
-    GEN(port_rcv_constraint_errors, errors, "Pkts rcvd discarded ", 1, __VA_ARGS__)                                    \
-    GEN(port_xmit_discards, errors, "Pkts sent discarded", 1, __VA_ARGS__)                                             \
-    GEN(port_xmit_wait, errors, "Tick Wait to send", 1, __VA_ARGS__)                                                   \
-    GEN(VL15_dropped, errors, "Pkts missed ressource", 1, __VA_ARGS__)                                                 \
-    GEN(excessive_buffer_overrun_errors, errors, "Buffer overrun", 1, __VA_ARGS__)                                     \
-    GEN(link_downed, errors, "Link Downed", 1, __VA_ARGS__)                                                            \
-    GEN(link_error_recovery, errors, "Link recovered", 1, __VA_ARGS__)                                                 \
-    GEN(local_link_integrity_errors, errors, "Link integrity err", 1, __VA_ARGS__)                                     \
-    GEN(symbol_error, errors, "Link minor errors", 1, __VA_ARGS__)                                                     \
-    GEN(port_rcv_remote_physical_errors, errors, "Pkts rcvd with EBP", 1, __VA_ARGS__)                                 \
-    GEN(port_rcv_switch_relay_errors, errors, "Pkts rcvd discarded by switch", 1, __VA_ARGS__)                         \
-    GEN(port_xmit_constraint_errors, errors, "Pkts sent discarded by switch", 1, __VA_ARGS__)
+#define FOREACH_COUNTER_ERRORS(GEN, ...)                                                            \
+    GEN(port_rcv_errors,                 errors,  "Pkts malformated",              1, __VA_ARGS__)  \
+    GEN(port_rcv_constraint_errors,      errors,  "Pkts rcvd discarded ",          1, __VA_ARGS__)  \
+    GEN(port_xmit_discards,              errors,  "Pkts sent discarded",           1, __VA_ARGS__)  \
+    GEN(port_xmit_wait,                  errors,  "Tick Wait to send",             1, __VA_ARGS__)  \
+    GEN(VL15_dropped,                    errors,  "Pkts missed ressource",         1, __VA_ARGS__)  \
+    GEN(excessive_buffer_overrun_errors, errors,  "Buffer overrun",                1, __VA_ARGS__)  \
+    GEN(link_downed,                     errors,  "Link Downed",                   1, __VA_ARGS__)  \
+    GEN(link_error_recovery,             errors,  "Link recovered",                1, __VA_ARGS__)  \
+    GEN(local_link_integrity_errors,     errors,  "Link integrity err",            1, __VA_ARGS__)  \
+    GEN(symbol_error,                    errors,  "Link minor errors",             1, __VA_ARGS__)  \
+    GEN(port_rcv_remote_physical_errors, errors,  "Pkts rcvd with EBP",            1, __VA_ARGS__)  \
+    GEN(port_rcv_switch_relay_errors,    errors,  "Pkts rcvd discarded by switch", 1, __VA_ARGS__)  \
+    GEN(port_xmit_constraint_errors,     errors,  "Pkts sent discarded by switch", 1, __VA_ARGS__)
 
 //
 // Hardware Counters
@@ -62,42 +62,42 @@
 #define FOREACH_HWCOUNTER_NAME(GEN, ...) GEN(mlx, __VA_ARGS__)
 
 // VENDOR-MLX: HW Counters for Mellanox ConnectX Devices
-#define FOREACH_HWCOUNTER_MLX(GEN, ...)                                                                                \
-    FOREACH_HWCOUNTER_MLX_PACKETS(GEN, __VA_ARGS__)                                                                    \
-    FOREACH_HWCOUNTER_MLX_ERRORS(GEN, __VA_ARGS__)
+#define FOREACH_HWCOUNTER_MLX(GEN, ...)               \
+    FOREACH_HWCOUNTER_MLX_PACKETS(GEN, __VA_ARGS__)   \
+    FOREACH_HWCOUNTER_MLX_ERRORS(GEN,  __VA_ARGS__)
 
-#define FOREACH_HWCOUNTER_MLX_PACKETS(GEN, ...)                                                                        \
-    GEN(np_cnp_sent, hwpackets, "RoCEv2 Congestion sent", 1, __VA_ARGS__)                                              \
-    GEN(np_ecn_marked_roce_packets, hwpackets, "RoCEv2 Congestion rcvd", -1, __VA_ARGS__)                              \
-    GEN(rp_cnp_handled, hwpackets, "IB Congestion handled", 1, __VA_ARGS__)                                            \
-    GEN(rx_atomic_requests, hwpackets, "ATOMIC req. rcvd", 1, __VA_ARGS__)                                             \
-    GEN(rx_dct_connect, hwpackets, "Connection req. rcvd", 1, __VA_ARGS__)                                             \
-    GEN(rx_read_requests, hwpackets, "Read req. rcvd", 1, __VA_ARGS__)                                                 \
-    GEN(rx_write_requests, hwpackets, "Write req. rcvd", 1, __VA_ARGS__)                                               \
-    GEN(roce_adp_retrans, hwpackets, "RoCE retrans adaptive", 1, __VA_ARGS__)                                          \
-    GEN(roce_adp_retrans_to, hwpackets, "RoCE retrans timeout", 1, __VA_ARGS__)                                        \
-    GEN(roce_slow_restart, hwpackets, "RoCE slow restart", 1, __VA_ARGS__)                                             \
-    GEN(roce_slow_restart_cnps, hwpackets, "RoCE slow restart congestion", 1, __VA_ARGS__)                             \
-    GEN(roce_slow_restart_trans, hwpackets, "RoCE slow restart count", 1, __VA_ARGS__)
+#define FOREACH_HWCOUNTER_MLX_PACKETS(GEN, ...)                                                   \
+    GEN(np_cnp_sent,                hwpackets, "RoCEv2 Congestion sent",        1, __VA_ARGS__)   \
+    GEN(np_ecn_marked_roce_packets, hwpackets, "RoCEv2 Congestion rcvd",       -1, __VA_ARGS__)   \
+    GEN(rp_cnp_handled,             hwpackets, "IB Congestion handled",         1, __VA_ARGS__)   \
+    GEN(rx_atomic_requests,         hwpackets, "ATOMIC req. rcvd",              1, __VA_ARGS__)   \
+    GEN(rx_dct_connect,             hwpackets, "Connection req. rcvd",          1, __VA_ARGS__)   \
+    GEN(rx_read_requests,           hwpackets, "Read req. rcvd",                1, __VA_ARGS__)   \
+    GEN(rx_write_requests,          hwpackets, "Write req. rcvd",               1, __VA_ARGS__)   \
+    GEN(roce_adp_retrans,           hwpackets, "RoCE retrans adaptive",         1, __VA_ARGS__)   \
+    GEN(roce_adp_retrans_to,        hwpackets, "RoCE retrans timeout",          1, __VA_ARGS__)   \
+    GEN(roce_slow_restart,          hwpackets, "RoCE slow restart",             1, __VA_ARGS__)   \
+    GEN(roce_slow_restart_cnps,     hwpackets, "RoCE slow restart congestion",  1, __VA_ARGS__)   \
+    GEN(roce_slow_restart_trans,    hwpackets, "RoCE slow restart count",       1, __VA_ARGS__)
 
-#define FOREACH_HWCOUNTER_MLX_ERRORS(GEN, ...)                                                                         \
-    GEN(duplicate_request, hwerrors, "Duplicated packets", -1, __VA_ARGS__)                                            \
-    GEN(implied_nak_seq_err, hwerrors, "Pkt Seq Num gap", 1, __VA_ARGS__)                                              \
-    GEN(local_ack_timeout_err, hwerrors, "Ack timer expired", 1, __VA_ARGS__)                                          \
-    GEN(out_of_buffer, hwerrors, "Drop missing buffer", 1, __VA_ARGS__)                                                \
-    GEN(out_of_sequence, hwerrors, "Drop out of sequence", 1, __VA_ARGS__)                                             \
-    GEN(packet_seq_err, hwerrors, "NAK sequence rcvd", 1, __VA_ARGS__)                                                 \
-    GEN(req_cqe_error, hwerrors, "CQE err Req", 1, __VA_ARGS__)                                                        \
-    GEN(resp_cqe_error, hwerrors, "CQE err Resp", 1, __VA_ARGS__)                                                      \
-    GEN(req_cqe_flush_error, hwerrors, "CQE Flushed err Req", 1, __VA_ARGS__)                                          \
-    GEN(resp_cqe_flush_error, hwerrors, "CQE Flushed err Resp", 1, __VA_ARGS__)                                        \
-    GEN(req_remote_access_errors, hwerrors, "Remote access err Req", 1, __VA_ARGS__)                                   \
-    GEN(resp_remote_access_errors, hwerrors, "Remote access err Resp", 1, __VA_ARGS__)                                 \
-    GEN(req_remote_invalid_request, hwerrors, "Remote invalid req", 1, __VA_ARGS__)                                    \
-    GEN(resp_local_length_error, hwerrors, "Local length err Resp", 1, __VA_ARGS__)                                    \
-    GEN(rnr_nak_retry_err, hwerrors, "RNR NAK Packets", 1, __VA_ARGS__)                                                \
-    GEN(rp_cnp_ignored, hwerrors, "CNP Pkts ignored", 1, __VA_ARGS__)                                                  \
-    GEN(rx_icrc_encapsulated, hwerrors, "RoCE ICRC Errors", 1, __VA_ARGS__)
+#define FOREACH_HWCOUNTER_MLX_ERRORS(GEN, ...)                                                    \
+    GEN(duplicate_request,          hwerrors, "Duplicated packets",            -1, __VA_ARGS__)   \
+    GEN(implied_nak_seq_err,        hwerrors, "Pkt Seq Num gap",                1, __VA_ARGS__)   \
+    GEN(local_ack_timeout_err,      hwerrors, "Ack timer expired",              1, __VA_ARGS__)   \
+    GEN(out_of_buffer,              hwerrors, "Drop missing buffer",            1, __VA_ARGS__)   \
+    GEN(out_of_sequence,            hwerrors, "Drop out of sequence",           1, __VA_ARGS__)   \
+    GEN(packet_seq_err,             hwerrors, "NAK sequence rcvd",              1, __VA_ARGS__)   \
+    GEN(req_cqe_error,              hwerrors, "CQE err Req",                    1, __VA_ARGS__)   \
+    GEN(resp_cqe_error,             hwerrors, "CQE err Resp",                   1, __VA_ARGS__)   \
+    GEN(req_cqe_flush_error,        hwerrors, "CQE Flushed err Req",            1, __VA_ARGS__)   \
+    GEN(resp_cqe_flush_error,       hwerrors, "CQE Flushed err Resp",           1, __VA_ARGS__)   \
+    GEN(req_remote_access_errors,   hwerrors, "Remote access err Req",          1, __VA_ARGS__)   \
+    GEN(resp_remote_access_errors,  hwerrors, "Remote access err Resp",         1, __VA_ARGS__)   \
+    GEN(req_remote_invalid_request, hwerrors, "Remote invalid req",             1, __VA_ARGS__)   \
+    GEN(resp_local_length_error,    hwerrors, "Local length err Resp",          1, __VA_ARGS__)   \
+    GEN(rnr_nak_retry_err,          hwerrors, "RNR NAK Packets",                1, __VA_ARGS__)   \
+    GEN(rp_cnp_ignored,             hwerrors, "CNP Pkts ignored",               1, __VA_ARGS__)   \
+    GEN(rx_icrc_encapsulated,       hwerrors, "RoCE ICRC Errors",               1, __VA_ARGS__)
 
 // Common definitions used more than once
 #define GEN_RRD_DIM_ADD(NAME, GRP, DESC, DIR, PORT)                                                                    \


### PR DESCRIPTION
##### Summary
Implement infiniband monitoring. Fixes #2620 

Infiniband is a fabric heavily used in HPC and supercomputers. It's designed for short range (local to  datacenter), provides RDMA, low latency communication and is handled directly by MPI libraries.

It often is coupled with "IPoIB" (IP over InfiniBand) which adds the IP connectivity over Infiniband messaging and is also seen as a simple network card. However, the MPI libraries doesn't use it, and talk directly to IB cards. 

From the drivers, there's no single file that provides details and summary over all IB interfaces, so we have to parse `/sys/class/infiniband/<verb>/ports/<portid>/counters/` path to get the counters provided by driver.
Each statistics are per-port.

This prevents to use the `procfile` helpers. As there is a lot of single statistics files (21 for `counters`, and more than 120 in `hw_counters` for OmniPath), I used macros to generate the repetitive elements over `read_single_number_file`

The `counters` are grouped in 3 categories (graphs): `bytes` `packets` and `errors`.

The `hw_counters` needs to be done if possible, as it seems very interface-specific. More feedback will be needed to have more output.

##### Component Name
collectors/proc.plugin

##### Test Plan

Emulates infiniband hw:

Change default path with netdata.conf to use a fake folder:
```
[plugin:proc:/sys/class/infiniband]
  dirname to monitor = /opt/netdata/sys/class/infiniband
```

Create a fake tree and populate it
```bash
typeset ibpath="/opt/netdata/sys/class/infiniband/test1_1/ports/99/counters/"
mkdir -p "$ibpath"
typeset -A counters
# Generate fake traffic
while sleep 1; do
  for counter in {port,multicast,unicast}_{rcv,xmit}_packets port_{rcv,xmit}_data port_{rcv_{,constraint_,remote_physical_,switch_relay_}errors,xmit_{discards,wait,constraint_errors}} link_{downed,error_recovery}  local_link_integrity_errors excessive_buffer_overrun_errors VL15_dropped symbol_error; do
    counters[$counter]=$((${counters[$counter]} + $RANDOM % 100))
    echo ${counters[$counter]} > "$ibpath/$counter"
  done
done
```

Create a state file
``` bash
echo "4: ACTIVE" > /opt/netdata/sys/class/infiniband/test1_1/state
```

That must create 3 graphs, under family "infiniband" / "test1_1-99"

##### Additional Information
