### PR TITLE
Dynamic memory cleanup for MongoDB exporting connector

### DIFF
--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -30,6 +30,7 @@ static void exporting_main_cleanup(void *ptr)
         if (!instance->exited) {
             found++;
             info("stopping worker for instance %s", instance->config.name);
+            uv_mutex_unlock(&instance->mutex);
             uv_cond_signal(&instance->cond_var);
         } else
             info("found stopped worker for instance %s", instance->config.name);

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -241,6 +241,17 @@ void mongodb_cleanup(struct instance *instance)
     }
 
     buffer_free(instance->buffer);
+
+    struct bson_buffer *next_buffer = connector_specific_data->first_buffer;
+    for (int i = 0; i < instance->config.buffer_on_failures; i++) {
+        struct bson_buffer *current_buffer = next_buffer;
+        next_buffer = next_buffer->next;
+
+        if (current_buffer->insert)
+            free_bson(current_buffer->insert, current_buffer->documents_inserted);
+        freez(current_buffer);
+    }
+
     freez(connector_specific_data);
 
     info("EXPORTING: instance %s exited", instance->config.name);

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -254,6 +254,12 @@ void mongodb_cleanup(struct instance *instance)
 
     freez(connector_specific_data);
 
+    struct mongodb_specific_config *connector_specific_config =
+        (struct mongodb_specific_config *)instance->config.connector_specific_config;
+    freez(connector_specific_config->database);
+    freez(connector_specific_config->collection);
+    freez(connector_specific_config);
+
     info("EXPORTING: instance %s exited", instance->config.name);
     instance->exited = 1;
 

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -356,7 +356,7 @@ void mongodb_connector_worker(void *instance_p)
         uv_mutex_unlock(&instance->mutex);
 
 #ifdef UNIT_TESTING
-        break;
+        return;
 #endif
     }
 

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -286,8 +286,10 @@ void mongodb_connector_worker(void *instance_p)
         uv_mutex_lock(&instance->mutex);
         uv_cond_wait(&instance->cond_var, &instance->mutex);
 
-        if (unlikely(instance->engine->exit))
+        if (unlikely(instance->engine->exit)) {
+            uv_mutex_unlock(&instance->mutex);
             break;
+        }
 
         // reset the monitoring chart counters
         stats->received_bytes =

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -80,34 +80,6 @@ int mongodb_init(struct instance *instance)
 }
 
 /**
- * Clean a MongoDB connector instance up
- *
- * @param instance an instance data structure.
- */
-void mongodb_cleanup(struct instance *instance)
-{
-    info("EXPORTING: cleaning up instance %s ...", instance->config.name);
-
-    struct mongodb_specific_data *connector_specific_data =
-        (struct mongodb_specific_data *)instance->connector_specific_data;
-
-    mongoc_collection_destroy(connector_specific_data->collection);
-    mongoc_client_destroy(connector_specific_data->client);
-    if (instance->engine->mongoc_initialized) {
-        mongoc_cleanup();
-        instance->engine->mongoc_initialized = 0;
-    }
-
-    buffer_free(instance->buffer);
-    freez(connector_specific_data);
-
-    info("EXPORTING: instance %s exited", instance->config.name);
-    instance->exited = 1;
-
-    return;
-}
-
-/**
  * Initialize a MongoDB connector instance
  *
  * @param instance an instance data structure.
@@ -247,6 +219,34 @@ int format_batch_mongodb(struct instance *instance)
     connector_specific_data->last_buffer = connector_specific_data->last_buffer->next;
 
     return 0;
+}
+
+/**
+ * Clean a MongoDB connector instance up
+ *
+ * @param instance an instance data structure.
+ */
+void mongodb_cleanup(struct instance *instance)
+{
+    info("EXPORTING: cleaning up instance %s ...", instance->config.name);
+
+    struct mongodb_specific_data *connector_specific_data =
+        (struct mongodb_specific_data *)instance->connector_specific_data;
+
+    mongoc_collection_destroy(connector_specific_data->collection);
+    mongoc_client_destroy(connector_specific_data->client);
+    if (instance->engine->mongoc_initialized) {
+        mongoc_cleanup();
+        instance->engine->mongoc_initialized = 0;
+    }
+
+    buffer_free(instance->buffer);
+    freez(connector_specific_data);
+
+    info("EXPORTING: instance %s exited", instance->config.name);
+    instance->exited = 1;
+
+    return;
 }
 
 /**


### PR DESCRIPTION
##### Summary
Part of #7172

##### Component Name
exporting engine

##### Test Plan
Configure a MongoDB exporting connector instance. Run Netdata. Kill it with SIGTERM.