### PR TITLE
Add support for eBPF for Netdata static64 (kickstart-static64.sh)

### DIFF
--- a/.github/scripts/build-artifacts.sh
+++ b/.github/scripts/build-artifacts.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# Builds the netdata-vX.y.Z-xxxx.tar.gz source tarball (dist)
+# and netdata-vX.Y.Z-xxxx.gz.run (static x86_64) artifacts.
+
+set -e
+
+# shellcheck source=.github/scripts/functions.sh
+. "$(dirname "$0")/functions.sh"
+
+NAME="${NAME:-netdata}"
+VERSION="${VERSION:-"$(git describe)"}"
+BASENAME="$NAME-$VERSION"
+
+prepare_build() {
+  progress "Preparing build"
+  (
+    test -d artifacts || mkdir -p artifacts
+  ) >&2
+}
+
+build_dist() {
+  progress "Building dist"
+  (
+    autoreconf -ivf
+    ./configure \
+      --prefix=/usr \
+      --sysconfdir=/etc \
+      --localstatedir=/var \
+      --libexecdir=/usr/libexec \
+      --with-zlib \
+      --with-math \
+      --with-user=netdata \
+      CFLAGS=-O2
+    make dist
+    mv "${BASENAME}.tar.gz" artifacts/
+  ) >&2
+}
+
+build_static_x86_64() {
+  progress "Building static x86_64"
+  (
+    USER="" ./packaging/makeself/build-x86_64-static.sh
+  ) >&2
+}
+
+prepare_assets() {
+  progress "Preparing assets"
+  (
+    cp packaging/version artifacts/latest-version.txt
+
+    cd artifacts || exit 1
+    ln -s "${BASENAME}.tar.gz" netdata-latest.tar.gz
+    ln -s "${BASENAME}.gz.run" netdata-latest.gz.run
+    sha256sum -b ./* > "sha256sums.txt"
+  ) >&2
+}
+
+steps="prepare_build build_dist build_static_x86_64"
+steps="$steps prepare_assets"
+
+_main() {
+  for step in $steps; do
+    if ! run "$step"; then
+      if [ -t 1 ]; then
+        debug
+      else
+        fail "Build failed"
+      fi
+    fi
+  done
+
+  echo "🎉 All Done!"
+}
+
+if [ -n "$0" ] && [ x"$0" != x"-bash" ]; then
+  _main "$@"
+fi

--- a/.github/scripts/bump-packaging-version.sh
+++ b/.github/scripts/bump-packaging-version.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+VERSION="$(git describe)"
+echo "$VERSION" > packaging/version
+git add -A
+git ci -m "[netdata nightly] $VERSION"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1355,7 +1355,7 @@ install_ebpf() {
   progress "Installing eBPF plugin"
 
   # Detect libc
-  libc="$(detect_libc)"
+  libc="${EBPF_LIBC:-"$(detect_libc)"}"
 
   EBPF_VERSION="$(cat packaging/ebpf.version)"
   EBPF_TARBALL="netdata-kernel-collector-${libc}-${EBPF_VERSION}.tar.xz"

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -202,6 +202,11 @@ safe_pidof() {
 
 # -----------------------------------------------------------------------------
 find_processors() {
+  # Most UNIX systems have `nproc` as part of their userland (including macOS, Linux and BSD)
+  if command -v nproc > /dev/null; then
+    nproc && return
+  fi
+
   local cpus
   if [ -f "/proc/cpuinfo" ]; then
     # linux

--- a/packaging/makeself/build.sh
+++ b/packaging/makeself/build.sh
@@ -4,6 +4,8 @@
 # -----------------------------------------------------------------------------
 # parse command line arguments
 
+set -e
+
 export NETDATA_BUILD_WITH_DEBUG=0
 
 while [ -n "${1}" ]; do
@@ -37,17 +39,13 @@ if [ ! -f ../../netdata-installer.sh ]; then
 fi
 
 cat >&2 << EOF
-
 This program will create a self-extracting shell package containing
 a statically linked netdata, able to run on any 64bit Linux system,
 without any dependencies from the target system.
 
 It can be used to have netdata running in no-time, or in cases the
 target Linux system cannot compile netdata.
-
 EOF
-
-# read -p "Press ENTER to continue > "
 
 if [ ! -d tmp ]; then
   mkdir tmp || exit 1

--- a/packaging/makeself/functions.sh
+++ b/packaging/makeself/functions.sh
@@ -6,19 +6,20 @@
 # allow running the jobs by hand
 [ -z "${NETDATA_BUILD_WITH_DEBUG}" ] && export NETDATA_BUILD_WITH_DEBUG=0
 [ -z "${NETDATA_INSTALL_PATH}" ] && export NETDATA_INSTALL_PATH="${1-/opt/netdata}"
-[ -z "${NETDATA_MAKESELF_PATH}" ] && export NETDATA_MAKESELF_PATH="$(dirname "${0}")/../.."
-[ "${NETDATA_MAKESELF_PATH:0:1}" != "/" ] && export NETDATA_MAKESELF_PATH="$(pwd)/${NETDATA_MAKESELF_PATH}"
+[ -z "${NETDATA_MAKESELF_PATH}" ] && NETDATA_MAKESELF_PATH="$(dirname "${0}")/../.."
+[ "${NETDATA_MAKESELF_PATH:0:1}" != "/" ] && NETDATA_MAKESELF_PATH="$(pwd)/${NETDATA_MAKESELF_PATH}"
 [ -z "${NETDATA_SOURCE_PATH}" ] && export NETDATA_SOURCE_PATH="${NETDATA_MAKESELF_PATH}/../.."
+export NETDATA_MAKESELF_PATH NETDATA_MAKESELF_PATH
 export NULL=
 
 # make sure the path does not end with /
-if [ "${NETDATA_INSTALL_PATH:$(( ${#NETDATA_INSTALL_PATH} - 1)):1}" = "/" ]
-    then
-    export NETDATA_INSTALL_PATH="${NETDATA_INSTALL_PATH:0:$(( ${#NETDATA_INSTALL_PATH} - 1))}"
+if [ "${NETDATA_INSTALL_PATH:$((${#NETDATA_INSTALL_PATH} - 1)):1}" = "/" ]; then
+  export NETDATA_INSTALL_PATH="${NETDATA_INSTALL_PATH:0:$((${#NETDATA_INSTALL_PATH} - 1))}"
 fi
 
 # find the parent directory
-export NETDATA_INSTALL_PARENT="$(dirname "${NETDATA_INSTALL_PATH}")"
+NETDATA_INSTALL_PARENT="$(dirname "${NETDATA_INSTALL_PATH}")"
+export NETDATA_INSTALL_PARENT
 
 # -----------------------------------------------------------------------------
 
@@ -28,27 +29,26 @@ set -euo pipefail
 # -----------------------------------------------------------------------------
 
 fetch() {
-    local dir="${1}" url="${2}"
-    local tar="${dir}.tar.gz"
+  local dir="${1}" url="${2}"
+  local tar="${dir}.tar.gz"
 
-    if [ ! -f "${NETDATA_MAKESELF_PATH}/tmp/${tar}" ]
-        then
-        run wget -O "${NETDATA_MAKESELF_PATH}/tmp/${tar}" "${url}"
-    fi
+  if [ ! -f "${NETDATA_MAKESELF_PATH}/tmp/${tar}" ]; then
+    run wget -O "${NETDATA_MAKESELF_PATH}/tmp/${tar}" "${url}"
+  fi
 
-    if [ ! -d "${NETDATA_MAKESELF_PATH}/tmp/${dir}" ]
-        then
-        cd "${NETDATA_MAKESELF_PATH}/tmp"
-        run tar -zxpf "${tar}"
-        cd -
-    fi
+  if [ ! -d "${NETDATA_MAKESELF_PATH}/tmp/${dir}" ]; then
+    cd "${NETDATA_MAKESELF_PATH}/tmp"
+    run tar -zxpf "${tar}"
+    cd -
+  fi
 
-    run cd "${NETDATA_MAKESELF_PATH}/tmp/${dir}"
+  run cd "${NETDATA_MAKESELF_PATH}/tmp/${dir}"
 }
 
 # -----------------------------------------------------------------------------
 
 # load the functions of the netdata-installer.sh
+# shellcheck source=packaging/installer/functions.sh
 . "${NETDATA_SOURCE_PATH}/packaging/installer/functions.sh"
 
 # -----------------------------------------------------------------------------
@@ -59,4 +59,4 @@ echo "NETDATA_INSTALL_PARENT=${NETDATA_INSTALL_PARENT}"
 echo "NETDATA_INSTALL_PATH=${NETDATA_INSTALL_PATH}"
 echo "NETDATA_MAKESELF_PATH=${NETDATA_MAKESELF_PATH}"
 echo "NETDATA_SOURCE_PATH=${NETDATA_SOURCE_PATH}"
-echo "PROCESSORS=$(find_processors)"
+echo "PROCESSORS=$(nproc)"

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -34,8 +34,9 @@ apk add --no-cache -U \
   openssl-dev \
   snappy-dev \
   protobuf-dev \
-  binutils ||
-  exit 1
+  binutils \
+  gzip \
+  xz || exit 1
 
 # snappy doesnt have static version in alpine, let's compile it
 export SNAPPY_VER="1.1.7"

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -7,11 +7,8 @@
 #
 # Author: Paul Emm. Katsoulakis <paul@netdata.cloud>
 
-# Packaging update
-apk update
-
 # Add required APK packages
-apk add --no-cache \
+apk add --no-cache -U \
   bash \
   wget \
   curl \
@@ -43,22 +40,20 @@ apk add --no-cache \
 # snappy doesnt have static version in alpine, let's compile it
 export SNAPPY_VER="1.1.7"
 wget -O /snappy.tar.gz https://github.com/google/snappy/archive/${SNAPPY_VER}.tar.gz
-cd /
-tar -xf snappy.tar.gz
-rm snappy.tar.gz
-cd /snappy-${SNAPPY_VER}
+tar -C / -xf /snappy.tar.gz
+rm /snappy.tar.gz
+cd /snappy-${SNAPPY_VER} || exit 1
 mkdir build
-cd build
+cd build || exit 1
 cmake -DCMAKE_BUILD_SHARED_LIBS=true -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR=lib ../
 make && make install
 
 # Judy doesnt seem to be available on the repositories, download manually and install it
 export JUDY_VER="1.0.5"
 wget -O /judy.tar.gz http://downloads.sourceforge.net/project/judy/judy/Judy-${JUDY_VER}/Judy-${JUDY_VER}.tar.gz
-cd /
-tar -xf judy.tar.gz
-rm judy.tar.gz
-cd /judy-${JUDY_VER}
+tar -C / -xf /judy.tar.gz
+rm /judy.tar.gz
+cd /judy-${JUDY_VER} || exit 1
 CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure
 make
 make install

--- a/packaging/makeself/jobs/10-prepare-destination.install.sh
+++ b/packaging/makeself/jobs/10-prepare-destination.install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-. $(dirname "${0}")/../functions.sh "${@}" || exit 1
+# shellcheck source=packaging/makeself/functions.sh
+. "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
 [ -d "${NETDATA_INSTALL_PATH}.old" ] && run rm -rf "${NETDATA_INSTALL_PATH}.old"
 [ -d "${NETDATA_INSTALL_PATH}" ] && run mv -f "${NETDATA_INSTALL_PATH}" "${NETDATA_INSTALL_PATH}.old"

--- a/packaging/makeself/jobs/50-bash-4.4.18.install.sh
+++ b/packaging/makeself/jobs/50-bash-4.4.18.install.sh
@@ -1,46 +1,24 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-. $(dirname "${0}")/../functions.sh "${@}" || exit 1
+# shellcheck source=packaging/makeself/functions.sh
+. "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
 fetch "bash-4.4.18" "http://ftp.gnu.org/gnu/bash/bash-4.4.18.tar.gz"
 
 run ./configure \
-	--prefix=${NETDATA_INSTALL_PATH} \
-	--without-bash-malloc \
-	--enable-static-link \
-	--enable-net-redirections \
-	--enable-array-variables \
-	--disable-profiling \
-	--disable-nls \
-#	--disable-rpath \
-#	--enable-alias \
-#	--enable-arith-for-command \
-#	--enable-array-variables \
-#	--enable-brace-expansion \
-#	--enable-casemod-attributes \
-#	--enable-casemod-expansions \
-#	--enable-command-timing \
-#	--enable-cond-command \
-#	--enable-cond-regexp \
-#	--enable-directory-stack \
-#	--enable-dparen-arithmetic \
-#	--enable-function-import \
-#	--enable-glob-asciiranges-default \
-#	--enable-help-builtin \
-#	--enable-job-control \
-#	--enable-net-redirections \
-#	--enable-process-substitution \
-#	--enable-progcomp \
-#	--enable-prompt-string-decoding \
-#	--enable-readline \
-#	--enable-select \
-
+  --prefix="${NETDATA_INSTALL_PATH}" \
+  --without-bash-malloc \
+  --enable-static-link \
+  --enable-net-redirections \
+  --enable-array-variables \
+  --disable-profiling \
+  --disable-nls
 
 run make clean
-run make -j$(find_processors)
+run make -j "$(nproc)"
 
-cat >examples/loadables/Makefile <<EOF
+cat > examples/loadables/Makefile << EOF
 all:
 clean:
 install:
@@ -48,7 +26,6 @@ EOF
 
 run make install
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]
-then
-    run strip ${NETDATA_INSTALL_PATH}/bin/bash
+if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+  run strip "${NETDATA_INSTALL_PATH}"/bin/bash
 fi

--- a/packaging/makeself/jobs/50-curl-7.60.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.60.0.install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-. $(dirname "${0}")/../functions.sh "${@}" || exit 1
+# shellcheck source=packaging/makeself/functions.sh
+. "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
 fetch "curl-curl-7_60_0" "https://github.com/curl/curl/archive/curl-7_60_0.tar.gz"
 
@@ -11,24 +12,22 @@ export PKG_CONFIG="pkg-config --static"
 run ./buildconf
 
 run ./configure \
-	--prefix=${NETDATA_INSTALL_PATH} \
-	--enable-optimize \
-	--disable-shared \
-	--enable-static \
-	--enable-http \
-	--enable-proxy \
-	--enable-ipv6 \
-	--enable-cookies \
-	${NULL}
+  --prefix="${NETDATA_INSTALL_PATH}" \
+  --enable-optimize \
+  --disable-shared \
+  --enable-static \
+  --enable-http \
+  --enable-proxy \
+  --enable-ipv6 \
+  --enable-cookies
 
 # Curl autoconf does not honour the curl_LDFLAGS environment variable
 run sed -i -e "s/curl_LDFLAGS =/curl_LDFLAGS = -all-static/" src/Makefile
 
 run make clean
-run make -j$(find_processors)
+run make -j "$(nproc)"
 run make install
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]
-then
-    run strip ${NETDATA_INSTALL_PATH}/bin/curl
+if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+  run strip "${NETDATA_INSTALL_PATH}"/bin/curl
 fi

--- a/packaging/makeself/jobs/50-fping-4.2.install.sh
+++ b/packaging/makeself/jobs/50-fping-4.2.install.sh
@@ -1,29 +1,28 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-. $(dirname "${0}")/../functions.sh "${@}" || exit 1
+# shellcheck source=packaging/makeself/functions.sh
+. "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
 fetch "fping-4.2" "https://github.com/schweikert/fping/releases/download/v4.2/fping-4.2.tar.gz"
 
 export CFLAGS="-static"
 
 run ./configure \
-	--prefix=${NETDATA_INSTALL_PATH} \
-	--enable-ipv4 \
-	--enable-ipv6 \
-	${NULL}
+  --prefix="${NETDATA_INSTALL_PATH}" \
+  --enable-ipv4 \
+  --enable-ipv6
 
-cat >doc/Makefile <<EOF
+cat > doc/Makefile << EOF
 all:
 clean:
 install:
 EOF
 
 run make clean
-run make -j$(find_processors)
+run make -j "$(nproc)"
 run make install
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]
-then
-    run strip ${NETDATA_INSTALL_PATH}/bin/fping
+if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+  run strip "${NETDATA_INSTALL_PATH}"/bin/fping
 fi

--- a/packaging/makeself/jobs/50-ioping-1.1.install.sh
+++ b/packaging/makeself/jobs/50-ioping-1.1.install.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-. $(dirname "${0}")/../functions.sh "${@}" || exit 1
+# shellcheck source=packaging/makeself/functions.sh
+. "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
 fetch "netdata-ioping-43d15a5" "https://github.com/netdata/ioping/tarball/master"
 
 export CFLAGS="-static"
 
 run make clean
-run make -j$(find_processors)
-run mkdir -p ${NETDATA_INSTALL_PATH}/usr/libexec/netdata/plugins.d/
-run install -o root -g root -m 4750 ioping ${NETDATA_INSTALL_PATH}/usr/libexec/netdata/plugins.d/
+run make -j "$(nproc)"
+run mkdir -p "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/
+run install -o root -g root -m 4750 ioping "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]
-then
-    run strip ${NETDATA_INSTALL_PATH}/usr/libexec/netdata/plugins.d/ioping
+if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+  run strip "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/ioping
 fi

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -10,17 +10,16 @@ if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
   export CFLAGS="-static -O3"
 else
   export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1"
-#    export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness"
 fi
 
 # We export this to 'yes', installer sets this to .environment.
 # The updater consumes this one, so that it can tell whether it should update a static install or a non-static one
 export IS_NETDATA_STATIC_BINARY="yes"
 
-run ./netdata-installer.sh --install "${NETDATA_INSTALL_PARENT}" \
+run ./netdata-installer.sh \
+  --install "${NETDATA_INSTALL_PARENT}" \
   --dont-wait \
-  --dont-start-it \
-  "${NULL}"
+  --dont-start-it
 
 # Remove the netdata.conf file from the tree. It has hard-coded sensible defaults builtin.
 rm -f "${NETDATA_INSTALL_PARENT}/etc/netdata/netdata.conf"

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -16,6 +16,9 @@ fi
 # The updater consumes this one, so that it can tell whether it should update a static install or a non-static one
 export IS_NETDATA_STATIC_BINARY="yes"
 
+# Set eBPF LIBC to "static" to bundle the `-static` variant of the kernel-collector
+export EBPF_LIBC="static"
+
 run ./netdata-installer.sh \
   --install "${NETDATA_INSTALL_PARENT}" \
   --dont-wait \

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-. $(dirname "${0}")/../functions.sh "${@}" || exit 1
+# shellcheck source=packaging/makeself/functions.sh
+. "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
 run cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 # -----------------------------------------------------------------------------
 # find the netdata version
 
-VERSION="$(git describe 2>/dev/null)"
+VERSION="$(git describe 2> /dev/null)"
 if [ -z "${VERSION}" ]; then
-    VERSION=$(cat packaging/version)
+  VERSION=$(cat packaging/version)
 fi
 
 if [ "${VERSION}" == "" ]; then
-    echo >&2 "Cannot find version number. Create makeself executable from source code with git tree structure."
-    exit 1
+  echo >&2 "Cannot find version number. Create makeself executable from source code with git tree structure."
+  exit 1
 fi
 
 # -----------------------------------------------------------------------------
@@ -24,17 +25,16 @@ fi
 run mkdir -p "${NETDATA_INSTALL_PATH}/system"
 
 run cp \
-    packaging/makeself/post-installer.sh \
-    packaging/makeself/install-or-update.sh \
-    packaging/installer/functions.sh \
-    configs.signatures \
-    system/netdata-init-d \
-    system/netdata-lsb \
-    system/netdata-openrc \
-    system/netdata.logrotate \
-    system/netdata.service \
-    "${NETDATA_INSTALL_PATH}/system/"
-
+  packaging/makeself/post-installer.sh \
+  packaging/makeself/install-or-update.sh \
+  packaging/installer/functions.sh \
+  configs.signatures \
+  system/netdata-init-d \
+  system/netdata-lsb \
+  system/netdata-openrc \
+  system/netdata.logrotate \
+  system/netdata.service \
+  "${NETDATA_INSTALL_PATH}/system/"
 
 # -----------------------------------------------------------------------------
 # create a wrapper to start our netdata with a modified path
@@ -42,9 +42,9 @@ run cp \
 run mkdir -p "${NETDATA_INSTALL_PATH}/bin/srv"
 
 run mv "${NETDATA_INSTALL_PATH}/bin/netdata" \
-    "${NETDATA_INSTALL_PATH}/bin/srv/netdata" || exit 1
+  "${NETDATA_INSTALL_PATH}/bin/srv/netdata" || exit 1
 
-cat >"${NETDATA_INSTALL_PATH}/bin/netdata" <<EOF
+cat > "${NETDATA_INSTALL_PATH}/bin/netdata" << EOF
 #!${NETDATA_INSTALL_PATH}/bin/bash
 export NETDATA_BASH_LOADABLES="DISABLE"
 export PATH="${NETDATA_INSTALL_PATH}/bin:\${PATH}"
@@ -52,36 +52,33 @@ exec "${NETDATA_INSTALL_PATH}/bin/srv/netdata" "\${@}"
 EOF
 run chmod 755 "${NETDATA_INSTALL_PATH}/bin/netdata"
 
-
 # -----------------------------------------------------------------------------
 # remove the links to allow untaring the archive
 
 run rm "${NETDATA_INSTALL_PATH}/sbin" \
-    "${NETDATA_INSTALL_PATH}/usr/bin" \
-    "${NETDATA_INSTALL_PATH}/usr/sbin" \
-    "${NETDATA_INSTALL_PATH}/usr/local"
-
+  "${NETDATA_INSTALL_PATH}/usr/bin" \
+  "${NETDATA_INSTALL_PATH}/usr/sbin" \
+  "${NETDATA_INSTALL_PATH}/usr/local"
 
 # -----------------------------------------------------------------------------
 # create the makeself archive
 
-run sed "s|NETDATA_VERSION|${VERSION}|g" <"${NETDATA_MAKESELF_PATH}/makeself.lsm" >"${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
+run sed "s|NETDATA_VERSION|${VERSION}|g" < "${NETDATA_MAKESELF_PATH}/makeself.lsm" > "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
 
 run "${NETDATA_MAKESELF_PATH}/makeself.sh" \
-    --gzip \
-    --complevel 9 \
-    --notemp \
-    --needroot \
-    --target "${NETDATA_INSTALL_PATH}" \
-    --header "${NETDATA_MAKESELF_PATH}/makeself-header.sh" \
-    --lsm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp" \
-    --license "${NETDATA_MAKESELF_PATH}/makeself-license.txt" \
-    --help-header "${NETDATA_MAKESELF_PATH}/makeself-help-header.txt" \
-    "${NETDATA_INSTALL_PATH}" \
-    "${NETDATA_INSTALL_PATH}.gz.run" \
-    "netdata, the real-time performance and health monitoring system" \
-    ./system/post-installer.sh \
-    ${NULL}
+  --gzip \
+  --complevel 9 \
+  --notemp \
+  --needroot \
+  --target "${NETDATA_INSTALL_PATH}" \
+  --header "${NETDATA_MAKESELF_PATH}/makeself-header.sh" \
+  --lsm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp" \
+  --license "${NETDATA_MAKESELF_PATH}/makeself-license.txt" \
+  --help-header "${NETDATA_MAKESELF_PATH}/makeself-help-header.txt" \
+  "${NETDATA_INSTALL_PATH}" \
+  "${NETDATA_INSTALL_PATH}.gz.run" \
+  "netdata, the real-time performance and health monitoring system" \
+  ./system/post-installer.sh
 
 run rm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
 

--- a/packaging/makeself/run-all-jobs.sh
+++ b/packaging/makeself/run-all-jobs.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+set -e
+
 LC_ALL=C
 umask 002
-
-# be nice
-renice 19 $$ >/dev/null 2>/dev/null
 
 # -----------------------------------------------------------------------------
 # prepare the environment for the jobs
@@ -14,10 +13,11 @@ renice 19 $$ >/dev/null 2>/dev/null
 export NETDATA_INSTALL_PATH="${1-/opt/netdata}"
 
 # our source directory
-export NETDATA_MAKESELF_PATH="$(dirname "${0}")"
-if [ "${NETDATA_MAKESELF_PATH:0:1}" != "/" ]
-	then
-	export NETDATA_MAKESELF_PATH="$(pwd)/${NETDATA_MAKESELF_PATH}"
+NETDATA_MAKESELF_PATH="$(dirname "${0}")"
+export NETDATA_MAKESELF_PATH
+if [ "${NETDATA_MAKESELF_PATH:0:1}" != "/" ]; then
+  NETDATA_MAKESELF_PATH="$(pwd)/${NETDATA_MAKESELF_PATH}"
+  export NETDATA_MAKESELF_PATH
 fi
 
 # netdata source directory
@@ -30,12 +30,12 @@ export NULL=
 
 cd "${NETDATA_MAKESELF_PATH}" || exit 1
 
+# shellcheck source=packaging/makeself/functions.sh
 . ./functions.sh "${@}" || exit 1
 
-for x in jobs/*.install.sh
-do
-	progress "running ${x}"
-	"${x}" "${NETDATA_INSTALL_PATH}"
+for x in jobs/*.install.sh; do
+  progress "running ${x}"
+  "${x}" "${NETDATA_INSTALL_PATH}"
 done
 
 echo >&2 "All jobs for static packaging done successfully."


### PR DESCRIPTION
##### Summary

ssia

- Fixes #9093

##### Component Name

- area/packaging

##### Test Plan

TBD

##### Additional Information

**NB:** This effectivly disables the error resulting from `check-kernel.sh`
and instead displays a warning. This means `./netdata-installer.sh` will still
install the eBPF kernel-collector package but it _may_ not work on a user's
system that either a) Lack a Linux Kernel (_currently_) or b) Lack required Kernel
config options.

This is okay; because the `ebpf.plugin` will just fail to load and backoff.
(_at some point we should build logic inot the Agent to disable plugins that continue to fail_)