### PR TITLE
Restore SIGCHLD signal handler after being replaced by libuv

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1384,6 +1384,14 @@ int main(int argc, char **argv) {
 
     // fork the spawn server
     spawn_init();
+    /*
+     * Libuv uv_spawn() uses SIGCHLD internally:
+     * https://github.com/libuv/libuv/blob/cc51217a317e96510fbb284721d5e6bc2af31e33/src/unix/process.c#L485
+     * and inadvertently replaces the netdata signal handler which was setup during initialization.
+     * Thusly, we must explicitly restore the signal handler for SIGCHLD.
+     * Warning: extreme care is needed when mixing and matching POSIX and libuv.
+     */
+    signals_restore_SIGCHLD();
 
     // ------------------------------------------------------------------------
     // initialize rrd, registry, health, rrdpush, etc.

--- a/daemon/signals.c
+++ b/daemon/signals.c
@@ -111,6 +111,21 @@ void signals_init(void) {
     }
 }
 
+void signals_restore_SIGCHLD(void)
+{
+    struct sigaction sa;
+
+    if (reaper_enabled == 0)
+        return;
+
+    sa.sa_flags = 0;
+    sigfillset(&sa.sa_mask);
+    sa.sa_handler = signal_handler;
+
+    if(sigaction(SIGCHLD, &sa, NULL) == -1)
+        error("SIGNAL: Failed to change signal handler for: SIGCHLD");
+}
+
 void signals_reset(void) {
     struct sigaction sa;
     sigemptyset(&sa.sa_mask);

--- a/daemon/signals.h
+++ b/daemon/signals.h
@@ -6,6 +6,7 @@
 extern void signals_init(void);
 extern void signals_block(void);
 extern void signals_unblock(void);
+extern void signals_restore_SIGCHLD(void);
 extern void signals_reset(void);
 extern void signals_handle(void) NORETURN;
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #9084
Fixes #9070
##### Component Name
daemon
##### Test Plan
Install in netdata docker image, observe no zombie processes.
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
As described [here](https://github.com/libuv/libuv/issues/154) libuv `uv_spawn()` uses `SIGCHLD` internally:
https://github.com/libuv/libuv/blob/cc51217a317e96510fbb284721d5e6bc2af31e33/src/unix/process.c#L485
and inadvertently replaces the netdata signal handler which was setup during initialization. Thusly, we must explicitly restore the signal handler for SIGCHLD. Note to self: extreme care is needed when mixing and matching POSIX and libuv.