### PR TITLE
Package: obsoletes conflicting EPEL packages (#6879 #8784)

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -93,6 +93,10 @@ Group:		Applications/System
 Source0:	https://github.com/netdata/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
 URL:		http://my-netdata.io
 
+# Remove conflicting EPEL packages
+Obsoletes:  %{name}-conf
+Obsoletes:  %{name}-data
+
 # #####################################################################
 # Core build/install/runtime dependencies
 # #####################################################################


### PR DESCRIPTION
##### Summary
EPEL is splitting the main netdata package into 3:
- **netdata** that gets updated by our upstream package and is the core
- **netdata-data** that contains the dashboard (/usr/share/)
- **netdata-conf** that contains the configuratio (/etc/netata)

When users try to use netdata installer, it'll update only the "netdata" package. As this package also provides `/etc/netdata` and `/usr/share` files (currnetly belonging to netdata-conf and netdata-data) it'll fail during the post-transaction check.

Using "obsoletes" keyword, if official netdata package is installed, it'll also remove the 2 conflicting epel packages.

I didn't want to add the keyword "Provides", and rather break external packages that are dependant on EPEL versions.
That way, they can either:
* update their `Require` field to specify a file if they only need it (instead of a package)
* fail explicitely if they absolutely need the EPEL package (and potentially a patch in their tree) instead of a silent potential failure later.

Fixes #6879 #8784

##### Component Name
netdata.spec.in

##### Test Plan
- install epel:  `sudo yum install epel-release`
- install all 3 epel netdata packages: ` sudo yum install netdata netdata-{data,conf}`
- build netdata from source with script: `git clone https://github.com/netdata/netdata.git && netdata/contrib/rhel/build-netdata-rpm.sh`
- install netdata built rpm: `sudo yum install $HOME/rpmbuild/RPMS/netdata-v1*.rpm

This should specify the removal of **netdata-conf** (and/or **netdata-data**):
```
Installing:
 netdata                            x86_64                            v1.22.2-1.fc29                               @commandline                            9.8 M
     replacing  netdata-conf.noarch 1.18.1-1.fc29
```

##### Additional Information
