### PR TITLE
Dynamic memory cleanup for Pub/Sub exporting connector

### DIFF
--- a/exporting/pubsub/pubsub.c
+++ b/exporting/pubsub/pubsub.c
@@ -61,7 +61,7 @@ int init_pubsub_instance(struct instance *instance)
  *
  * @param instance an instance data structure.
  */
-void pubsub_cleanup(struct instance *instance)
+void clean_pubsub_instance(struct instance *instance)
 {
     info("EXPORTING: cleaning up instance %s ...", instance->config.name);
 
@@ -178,5 +178,5 @@ void pubsub_connector_worker(void *instance_p)
 #endif
     }
 
-    pubsub_cleanup(instance);
+    clean_pubsub_instance(instance);
 }

--- a/exporting/pubsub/pubsub.c
+++ b/exporting/pubsub/pubsub.c
@@ -67,10 +67,17 @@ void clean_pubsub_instance(struct instance *instance)
 
     struct pubsub_specific_data *connector_specific_data =
         (struct pubsub_specific_data *)instance->connector_specific_data;
+    pubsub_cleanup(connector_specific_data);
+    freez(connector_specific_data);
 
     buffer_free(instance->buffer);
 
-    freez(connector_specific_data);
+    struct pubsub_specific_config *connector_specific_config =
+        (struct pubsub_specific_config *)instance->config.connector_specific_config;
+    freez(connector_specific_config->credentials_file);
+    freez(connector_specific_config->project_id);
+    freez(connector_specific_config->topic_id);
+    freez(connector_specific_config);
 
     info("EXPORTING: instance %s exited", instance->config.name);
     instance->exited = 1;

--- a/exporting/pubsub/pubsub.c
+++ b/exporting/pubsub/pubsub.c
@@ -105,8 +105,10 @@ void pubsub_connector_worker(void *instance_p)
         uv_mutex_lock(&instance->mutex);
         uv_cond_wait(&instance->cond_var, &instance->mutex);
 
-        if (unlikely(instance->engine->exit))
+        if (unlikely(instance->engine->exit)) {
+            uv_mutex_unlock(&instance->mutex);
             break;
+        }
 
         // reset the monitoring chart counters
         stats->received_bytes =

--- a/exporting/pubsub/pubsub.c
+++ b/exporting/pubsub/pubsub.c
@@ -174,7 +174,7 @@ void pubsub_connector_worker(void *instance_p)
         uv_mutex_unlock(&instance->mutex);
 
 #ifdef UNIT_TESTING
-        break;
+        return;
 #endif
     }
 

--- a/exporting/pubsub/pubsub.h
+++ b/exporting/pubsub/pubsub.h
@@ -8,7 +8,7 @@
 #include "pubsub_publish.h"
 
 int init_pubsub_instance(struct instance *instance);
-void pubsub_cleanup(struct instance *instance);
+void clean_pubsub_instance(struct instance *instance);
 void pubsub_connector_worker(void *instance_p);
 
 #endif //NETDATA_EXPORTING_PUBSUB_H

--- a/exporting/pubsub/pubsub.h
+++ b/exporting/pubsub/pubsub.h
@@ -8,6 +8,7 @@
 #include "pubsub_publish.h"
 
 int init_pubsub_instance(struct instance *instance);
+void pubsub_cleanup(struct instance *instance);
 void pubsub_connector_worker(void *instance_p);
 
 #endif //NETDATA_EXPORTING_PUBSUB_H

--- a/exporting/pubsub/pubsub_publish.h
+++ b/exporting/pubsub/pubsub_publish.h
@@ -21,6 +21,7 @@ struct pubsub_specific_data {
 int pubsub_init(
     void *pubsub_specific_data_p, char *error_message, const char *destination, const char *credentials_file,
     const char *project_id, const char *topic_id);
+void pubsub_cleanup(void *pubsub_specific_data_p);
 
 int pubsub_add_message(void *pubsub_specific_data_p, char *data);
 

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -1117,7 +1117,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(void **state)
         "netdata_info{instance=\"test_hostname\",application=\"(null)\",version=\"(null)\"} 1\n"
         "netdata_host_tags_info{key1=\"value1\",key2=\"value2\"} 1\n"
         "netdata_host_tags{key1=\"value1\",key2=\"value2\"} 1\n"
-        "# COMMENT TYPE test_prefix_test_context gauge\n"
+        "# TYPE test_prefix_test_context gauge\n"
         "test_prefix_test_context{chart=\"chart_name\",family=\"test_family\",dimension=\"dimension_name\"} 690565856.0000000\n");
 
     buffer_flush(buffer);


### PR DESCRIPTION
##### Summary
Part of #7172

##### Component Name
exporting engine

##### Test Plan
Configure a Pub/Sub exporting connector instance. Run Netdata. Kill it with SIGTERM.