### PR TITLE
Fix buffer splitting in the Kinesis exporting connector

### DIFF
--- a/exporting/aws_kinesis/aws_kinesis.c
+++ b/exporting/aws_kinesis/aws_kinesis.c
@@ -108,7 +108,7 @@ void aws_kinesis_connector_worker(void *instance_p)
                 record_len = buffer_len - sent;
             } else {
                 record_len = KINESIS_RECORD_MAX - partition_key_len;
-                while (*(first_char + record_len) != '\n' && record_len)
+                while (record_len && *(first_char + record_len - 1) != '\n')
                     record_len--;
             }
             char error_message[ERROR_LINE_MAX + 1] = "";


### PR DESCRIPTION
##### Summary
When a buffer was larger than the maximum allowed size, it was split incorrectly and some messages didn't end with the new line character.

Part of #8461 

##### Component Name
exporting engine

##### Test Plan
Define a small value for `KINESIS_RECORD_MAX`, send metrics to a Kinesis stream. Check if every message ends with the new line character