### PR TITLE
Send anonymous statistics from backends and exporting engine

### DIFF
--- a/backends/backends.c
+++ b/backends/backends.c
@@ -697,6 +697,7 @@ void *backends_main(void *ptr) {
     // prepare the backend main loop
 
     info("BACKEND: configured ('%s' on '%s' sending '%s' data, every %d seconds, as host '%s', with prefix '%s')", type, destination, source, global_backend_update_every, hostname, global_backend_prefix);
+    send_statistics("BACKENDS_START", "OK", type);
 
     usec_t step_ut = global_backend_update_every * USEC_PER_SEC;
     time_t after = now_realtime_sec();

--- a/backends/backends.c
+++ b/backends/backends.c
@@ -697,7 +697,7 @@ void *backends_main(void *ptr) {
     // prepare the backend main loop
 
     info("BACKEND: configured ('%s' on '%s' sending '%s' data, every %d seconds, as host '%s', with prefix '%s')", type, destination, source, global_backend_update_every, hostname, global_backend_prefix);
-    send_statistics("BACKENDS_START", "OK", type);
+    send_statistics("BACKEND_START", "OK", type);
 
     usec_t step_ut = global_backend_update_every * USEC_PER_SEC;
     time_t after = now_realtime_sec();

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -84,6 +84,7 @@ void *exporting_main(void *ptr)
 
     if (init_connectors(engine) != 0) {
         error("EXPORTING: cannot initialize exporting connectors");
+        send_statistics("EXPORTING_START", "FAIL", "-");
         goto cleanup;
     }
 

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -59,6 +59,7 @@ struct engine;
 
 struct instance_config {
     EXPORTING_CONNECTOR_TYPE type;
+    const char *type_name;
 
     const char *name;
     const char *destination;

--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -90,6 +90,8 @@ int init_connectors(struct engine *engine)
         char threadname[NETDATA_THREAD_NAME_MAX + 1];
         snprintfz(threadname, NETDATA_THREAD_NAME_MAX, "EXPORTING-%zu", instance->index);
         uv_thread_set_name_np(instance->thread, threadname);
+
+        send_statistics("EXPORTING_START", "OK", instance->config.type_name);
     }
 
     return 0;

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -336,6 +336,7 @@ struct engine *read_exporting_config()
 
         instance_name = tmp_ci_list->local_ci.instance_name;
 
+        tmp_instance->config.type_name = strdupz(tmp_ci_list->local_ci.connector_name);
         tmp_instance->config.name = strdupz(tmp_ci_list->local_ci.instance_name);
 
 


### PR DESCRIPTION
##### Summary
In order to make the transition from backends to the new exporting engine smoother, we need to understand if Netdata users are ready for removing the backends subsystem completely.

Part of #8461

##### Component Name
exporting engine

##### Test Plan
Check `error.log`.