### PR TITLE
Add CI for our Static Netdata builds (which kickstart-static64 uses)

### DIFF
--- a/.github/scripts/build-static-x86_64.sh
+++ b/.github/scripts/build-static-x86_64.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# Builds the netdata-vX.Y.Z-xxxx.gz.run (static x86_64) artifact.
+
+set -e
+
+# shellcheck source=.github/scripts/functions.sh
+. "$(dirname "$0")/functions.sh"
+
+NAME="${NAME:-netdata}"
+VERSION="${VERSION:-"$(git describe)"}"
+BASENAME="$NAME-$VERSION"
+
+prepare_build() {
+  progress "Preparing build"
+  (
+    test -d artifacts || mkdir -p artifacts
+  ) >&2
+}
+
+build_static_x86_64() {
+  progress "Building static x86_64"
+  (
+    USER="" ./packaging/makeself/build-x86_64-static.sh
+  ) >&2
+}
+
+prepare_assets() {
+  progress "Preparing assets"
+  (
+    cp packaging/version artifacts/latest-version.txt
+
+    cd artifacts || exit 1
+    ln -s "${BASENAME}.gz.run" netdata-latest.gz.run
+    sha256sum -b ./* > "sha256sums.txt"
+  ) >&2
+}
+
+steps="prepare_build build_static_x86_64"
+steps="$steps prepare_assets"
+
+_main() {
+  for step in $steps; do
+    if ! run "$step"; then
+      if [ -t 1 ]; then
+        debug
+      else
+        fail "Build failed"
+      fi
+    fi
+  done
+
+  echo "🎉 All Done!"
+}
+
+if [ -n "$0" ] && [ x"$0" != x"-bash" ]; then
+  _main "$@"
+fi

--- a/.github/scripts/functions.sh
+++ b/.github/scripts/functions.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# This file is included by download.sh & build.sh
+
+set -e
+
+color() {
+  fg="$1"
+  bg="${2}"
+  ft="${3:-0}"
+
+  printf "\33[%s;%s;%s" "$ft" "$fg" "$bg"
+}
+
+color_reset() {
+  printf "\033[0m"
+}
+
+ok() {
+  if [ -t 1 ]; then
+    printf "%s[ OK ]%s\n" "$(color 37 42m 1)" "$(color_reset)"
+  else
+    printf "%s\n" "[ OK ]"
+  fi
+}
+
+err() {
+  if [ -t 1 ]; then
+    printf "%s[ ERR ]%s\n" "$(color 37 41m 1)" "$(color_reset)"
+  else
+    printf "%s\n" "[ ERR ]"
+  fi
+}
+
+run() {
+  retval=0
+  logfile="$(mktemp -t "run-XXXXXX")"
+  if "$@" 2> "$logfile"; then
+    ok
+  else
+    retval=$?
+    err
+    cat "$logfile" || true
+  fi
+  rm -rf "$logfile"
+  return $retval
+}
+
+progress() {
+  printf "%-40s" "$(printf "%s ... " "$1")"
+}
+
+log() {
+  printf "%s\n" "$1"
+}
+
+error() {
+  log "ERROR: ${1}"
+}
+
+fail() {
+  log "FATAL: ${1}"
+  exit 1
+}
+
+debug() {
+  log "Dropping into a shell for debugging ..."
+  exec /bin/sh
+}

--- a/.github/scripts/functions.sh
+++ b/.github/scripts/functions.sh
@@ -40,7 +40,7 @@ run() {
   else
     retval=$?
     err
-    cat "$logfile" || true
+    tail -n 100 "$logfile" || true
   fi
   rm -rf "$logfile"
   return $retval

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -6,7 +6,18 @@ on:
       - master
   pull_request:
 jobs:
-  build:
+  static-build:
+    name: Build (x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow --tags
+      - name: Build
+        run: |
+          .github/scripts/build-static-x86_64.sh
+  source-build:
     name: Build & Install
     strategy:
       fail-fast: false

--- a/packaging/makeself/build-x86_64-static.sh
+++ b/packaging/makeself/build-x86_64-static.sh
@@ -32,10 +32,16 @@ if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
 fi
 
 # Run the build script inside the container
-run docker run -a stdin -a stdout -a stderr -i -t -v \
-  "$(pwd)":/usr/src/netdata.git:rw \
-  "${DOCKER_CONTAINER_NAME}" \
-  /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
+if [ -t 1 ]; then
+  run docker run -a stdin -a stdout -a stderr -i -t -v \
+    "$(pwd)":/usr/src/netdata.git:rw \
+    "${DOCKER_CONTAINER_NAME}" \
+    /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
+else
+  run docker run -v "$(pwd)":/usr/src/netdata.git:rw \
+    "${DOCKER_CONTAINER_NAME}" \
+    /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
+fi
 
 if [ "${USER}" ]; then
   sudo chown -R "${USER}" .

--- a/packaging/makeself/build.sh
+++ b/packaging/makeself/build.sh
@@ -6,20 +6,18 @@
 
 export NETDATA_BUILD_WITH_DEBUG=0
 
-while [ ! -z "${1}" ]
-do
-    case "${1}" in
-        debug)
-            export NETDATA_BUILD_WITH_DEBUG=1
-            ;;
+while [ -n "${1}" ]; do
+  case "${1}" in
+    debug)
+      export NETDATA_BUILD_WITH_DEBUG=1
+      ;;
 
-        *)
-            ;;
-    esac
+    *) ;;
 
-    shift
+  esac
+
+  shift
 done
-
 
 # -----------------------------------------------------------------------------
 
@@ -27,19 +25,18 @@ done
 # the required packages. build-x86_64-static.sh will do this for you
 # using docker.
 
-cd $(dirname "$0") || exit 1
+cd "$(dirname "$0")" || exit 1
 
 # if we don't run inside the netdata repo
 # download it and run from it
-if [ ! -f ../../netdata-installer.sh ]
-then
-    git clone https://github.com/netdata/netdata.git netdata.git || exit 1
-    cd netdata.git/makeself || exit 1
-    ./build.sh "$@"
-    exit $?
+if [ ! -f ../../netdata-installer.sh ]; then
+  git clone https://github.com/netdata/netdata.git netdata.git || exit 1
+  cd netdata.git/makeself || exit 1
+  ./build.sh "$@"
+  exit $?
 fi
 
-cat >&2 <<EOF
+cat >&2 << EOF
 
 This program will create a self-extracting shell package containing
 a statically linked netdata, able to run on any 64bit Linux system,
@@ -52,10 +49,11 @@ EOF
 
 # read -p "Press ENTER to continue > "
 
-if [ ! -d tmp ]
-    then
-    mkdir tmp || exit 1
+if [ ! -d tmp ]; then
+  mkdir tmp || exit 1
 fi
 
-./run-all-jobs.sh "$@"
-exit $?
+if ! ./run-all-jobs.sh "$@"; then
+  printf >&2 "Build failed."
+  exit 1
+fi

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -12,32 +12,33 @@ apk update
 
 # Add required APK packages
 apk add --no-cache \
-    bash \
-    wget \
-    curl \
-    ncurses \
-    git \
-    netcat-openbsd \
-    alpine-sdk \
-    autoconf \
-    automake \
-    gcc \
-    make \
-    cmake \
-    libtool \
-    pkgconfig \
-    util-linux-dev \
-    openssl-dev \
-    gnutls-dev \
-    zlib-dev \
-    libmnl-dev \
-    libnetfilter_acct-dev \
-    libuv-dev \
-    lz4-dev \
-    openssl-dev \
-    snappy-dev \
-    protobuf-dev \
-    || exit 1
+  bash \
+  wget \
+  curl \
+  ncurses \
+  git \
+  netcat-openbsd \
+  alpine-sdk \
+  autoconf \
+  automake \
+  gcc \
+  make \
+  cmake \
+  libtool \
+  pkgconfig \
+  util-linux-dev \
+  openssl-dev \
+  gnutls-dev \
+  zlib-dev \
+  libmnl-dev \
+  libnetfilter_acct-dev \
+  libuv-dev \
+  lz4-dev \
+  openssl-dev \
+  snappy-dev \
+  protobuf-dev \
+  binutils ||
+  exit 1
 
 # snappy doesnt have static version in alpine, let's compile it
 export SNAPPY_VER="1.1.7"
@@ -60,4 +61,4 @@ rm judy.tar.gz
 cd /judy-${JUDY_VER}
 CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure
 make
-make install;
+make install

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-. ${NETDATA_MAKESELF_PATH}/functions.sh "${@}" || exit 1
+# shellcheck source=./packaging/makeself/functions.sh
+. "${NETDATA_MAKESELF_PATH}"/functions.sh "${@}" || exit 1
 
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]
-then
-    export CFLAGS="-static -O3"
+if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+  export CFLAGS="-static -O3"
 else
-    export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1"
+  export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1"
 #    export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness"
 fi
 
@@ -18,16 +18,22 @@ fi
 export IS_NETDATA_STATIC_BINARY="yes"
 
 run ./netdata-installer.sh --install "${NETDATA_INSTALL_PARENT}" \
-    --dont-wait \
-    --dont-start-it \
-    ${NULL}
+  --dont-wait \
+  --dont-start-it \
+  "${NULL}"
 
 # Remove the netdata.conf file from the tree. It has hard-coded sensible defaults builtin.
 rm -f "${NETDATA_INSTALL_PARENT}/etc/netdata/netdata.conf"
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]
-then
-    run strip ${NETDATA_INSTALL_PATH}/bin/netdata
-    run strip ${NETDATA_INSTALL_PATH}/usr/libexec/netdata/plugins.d/apps.plugin
-    run strip ${NETDATA_INSTALL_PATH}/usr/libexec/netdata/plugins.d/cgroup-network
+# Ensure the netdata binary is in fact statically linked
+if run readelf -l "${NETDATA_INSTALL_PATH}"/bin/netdata | grep 'INTERP'; then
+  printf >&2 "Ooops. %s is not a statically linked binary!\n" "${NETDATA_INSTALL_PATH}"/bin/netdata
+  ldd "${NETDATA_INSTALL_PATH}"/bin/netdata
+  exit 1
+fi
+
+if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+  run strip "${NETDATA_INSTALL_PATH}"/bin/netdata
+  run strip "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/apps.plugin
+  run strip "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/cgroup-network
 fi


### PR DESCRIPTION
##### Summary

ssia

- Fixes #9147

##### Component Name

- area/ci

##### Test Plan

- This PR.

##### Additional Information

In working on #9093 I discovered by acciden that something somewhere,
somehow had borkne our ability to build Netdata and statically link it.

~This means our recent kickstart-static64 builds are in very likely no longer
static and will start to cause problems for our users.~ They were in fact broken by #8865

~This PR is to prove that by putting up a CI check that fails if the following
shell expression also fails:~ This PR now ensures we do not break the static builds.