### PR TITLE
Check update interval for exporting connector instance

### DIFF
--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -355,6 +355,12 @@ struct engine *read_exporting_config()
         char *data_source = exporter_get(instance_name, "data source", "average");
 
         tmp_instance->config.options = exporting_parse_data_source(data_source, tmp_instance->config.options);
+        if (EXPORTING_OPTIONS_DATA_SOURCE(tmp_instance->config.options) != EXPORTING_SOURCE_DATA_AS_COLLECTED &&
+            tmp_instance->config.update_every % localhost->rrd_update_every)
+            info(
+                "The update interval %d for instance %s is not a multiple of the database update interval %d. "
+                "Metric values will deviate at different points in time.",
+                tmp_instance->config.update_every, tmp_instance->config.name, localhost->rrd_update_every);
 
         if (exporter_get_boolean(instance_name, "send configured labels", CONFIG_BOOLEAN_YES))
             tmp_instance->config.options |= EXPORTING_OPTION_SEND_CONFIGURED_LABELS;


### PR DESCRIPTION
##### Summary
Warn a user if the update interval of an exporting connector instance is not a multiple of the database update interval.

Part of #8461

##### Component Name
exporting engine

##### Test Plan
Set the "update interval" option in the `[general]` section of `netdata.conf` and for a connector instance. Check `error.log`.