### PR TITLE
Revert "Fix macOS builds building and linking against openssl"

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -479,27 +479,20 @@ trap build_error EXIT
 # -----------------------------------------------------------------------------
 
 build_libmosquitto() {
-  CFLAGS=
-  LDFLAGS=
-  CXXFLAGS=
-
   if [ "$(uname -s)" = Linux ]; then
-    run env CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" make -C "${1}/lib"
+    run env CFLAGS= CXXFLAGS= LDFLAGS= make -C "${1}/lib"
   else
     pushd ${1} > /dev/null || return 1
     if [ "$(uname)" = "Darwin" ] && [ -d /usr/local/opt/openssl ]; then
-      LDFLAGS="-L/usr/local/opt/openssl/lib"
-      CXXFLAGS="-I/usr/local/opt/openssl/include"
-
-      run env CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" cmake \
+      run env CFLAGS= CXXFLAGS= LDFLAGS= cmake \
         -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
         -D OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib \
         -D WITH_STATIC_LIBRARIES:boolean=YES \
         .
     else
-      run env CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" cmake -D WITH_STATIC_LIBRARIES:boolean=YES .
+      run env CFLAGS= CXXFLAGS= LDFLAGS= cmake -D WITH_STATIC_LIBRARIES:boolean=YES .
     fi
-    run env CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" make -C lib
+    run env CFLAGS= CXXFLAGS= LDFLAGS= make -C lib
     run mv lib/libmosquitto_static.a lib/libmosquitto.a
     popd || return 1
   fi
@@ -560,24 +553,17 @@ bundle_libmosquitto
 # -----------------------------------------------------------------------------
 
 build_libwebsockets() {
-  CFLAGS=
-  LDFLAGS=
-  CXXFLAGS=
-
   pushd "${1}" > /dev/null || exit 1
   if [ "$(uname)" = "Darwin" ] && [ -d /usr/local/opt/openssl ]; then
-    LDFLAGS="-L/usr/local/opt/openssl/lib"
-    CXXFLAGS="-I/usr/local/opt/openssl/include"
-
-    run env CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" cmake \
+    run env CFLAGS= CXXFLAGS= LDFLAGS= cmake \
       -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
       -D OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib \
       -D LWS_WITH_SOCKS5:bool=ON \
       .
   else
-    run env CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" cmake -D LWS_WITH_SOCKS5:bool=ON .
+    run env CFLAGS= CXXFLAGS= LDFLAGS= cmake -D LWS_WITH_SOCKS5:bool=ON .
   fi
-  run env CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" make
+  run env CFLAGS= CXXFLAGS= LDFLAGS= make
   popd > /dev/null || exit 1
 }
 


### PR DESCRIPTION
Reverts netdata/netdata#8865

This PR broke our static builds. SEe https://github.com/netdata/netdata/pull/9130

Rather than delay the fix (_it needs cleaning up and a proper CI in place_) I'd like to revert this so we can get correctly build static builds back out ASAP.

Fixes #9135