### PR TITLE
Fixed coverity warning (CID 358971)

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -297,7 +297,7 @@ PARSER_RC pluginsd_chart(char **words, void *user, PLUGINSD_ACTION  *plugins_act
     }
 
     // make sure we have the required variables
-    if (unlikely((!type || !*type || !id || !*id) && !have_action)) {
+    if (unlikely((!type || !*type || !id || !*id))) {
         error("requested a CHART, without a type.id, on host '%s'. Disabling it.", host->hostname);
         ((PARSER_USER_OBJECT *) user)->enabled = 0;
         return PARSER_RC_ERROR;


### PR DESCRIPTION
#### Summary
Fix coverity issue CID 358971

```
*** CID 358971:  Null pointer dereferences  (FORWARD_NULL)
/collectors/plugins.d/pluginsd_parser.c: 317 in pluginsd_chart()
311             size_t len = strlen(type);
312             if (strncmp(type, name, len) == 0 && name[len] == '.')
313                 name = &name[len + 1];
314     
315             // if the name is the same with the id,
316             // or is just 'NULL', clear it.
>>>     CID 358971:  Null pointer dereferences  (FORWARD_NULL)
>>>     Passing null pointer "id" to "strcmp", which dereferences it.
317             if (unlikely(strcmp(name, id) == 0 || strcasecmp(name, "NULL") == 0 || strcasecmp(name, "(NULL)") == 0))
318                 name = NULL;
319         }
320     
321         int priority = 1000;
322         if (likely(priority_s && *priority_s))
```
##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
