### PR TITLE
Remove knatsakis and ncmans from CODEOWNERS for the agent.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,15 +5,15 @@
 * @ktsaou @cosmix
 
 # Ownership by directory structure
-.travis/ @cosmix @Ferroin @knatsakis @ncmans @prologic
-.github/ @cosmix @Ferroin @knatsakis @ncmans @prologic
+.travis/ @cosmix @Ferroin @prologic
+.github/ @cosmix @Ferroin @prologic
 backends/ @thiagoftsm @vlvkobal
 backends/graphite/ @thiagoftsm @vlvkobal
 backends/json/ @thiagoftsm @vlvkobal
 backends/opentsdb/ @thiagoftsm @vlvkobal
 backends/prometheus/ @vlvkobal @thiagoftsm
 build/ @cosmix
-contrib/debian @cosmix @Ferroin @knatsakis @ncmans @prologic
+contrib/debian @cosmix @Ferroin @prologic
 collectors/ @vlvkobal @mfundul @cosmix
 collectors/charts.d.plugin/ @ilyam8 @Ferroin @prologic @cosmix
 collectors/freebsd.plugin/ @vlvkobal @thiagoftsm @cosmix
@@ -31,7 +31,7 @@ health/ @thiagoftsm @vlvkobal @cosmix
 health/health.d/ @thiagoftsm @vlvkobal @cosmix
 health/notifications/ @Ferroin @thiagoftsm @cosmix
 libnetdata/ @thiagofsm @mfundul @cosmix
-packaging/ @cosmix @Ferroin @knatsakis @ncmans @prologic
+packaging/ @cosmix @Ferroin @prologic
 registry/ @jacekkolasa @cosmix
 streaming/ @thiagoftsm @vlvkobal @cosmix
 web/ @thiagoftsm @mfundul @vlvkobal @cosmix
@@ -40,20 +40,20 @@ web/gui/ @jacekkolasa @cosmix
 # Ownership by filetype (overwrites ownership by directory)
 *.am @cosmix
 *.md @cosmix @joelhans @shortpatti
-Dockerfile* @Ferroin @knatsakis @ncmans @prologic @cosmix
+Dockerfile* @Ferroin @prologic @cosmix
 
 # Ownership of specific files
-.gitignore @cosmix @Ferroin @knatsakis @ncmans @prologic
-.travis.yml @cosmix @Ferroin @knatsakis @ncmans @prologic
-.lgtm.yml @cosmix @Ferroin @knatsakis @ncmans @prologic
-.eslintrc @cosmix @Ferroin @knatsakis @ncmans @prologic
-.eslintignore @cosmix @Ferroin @knatsakis @ncmans @prologic
-.csslintrc @cosmix @Ferroin @knatsakis @ncmans @prologic
-.codeclimate.yml @cosmix @Ferroin @knatsakis @ncmans @prologic
-.codacy.yml @cosmix @Ferroin @knatsakis @ncmans @prologic
-.yamllint.yml @cosmix @Ferroin @knatsakis @ncmans @prologic
-netdata.spec.in @cosmix @Ferroin @knatsakis @ncmans @prologic
-netdata-installer.sh @cosmix @Ferroin @knatsakis @ncmans @prologic
+.gitignore @cosmix @Ferroin @prologic
+.travis.yml @cosmix @Ferroin @prologic
+.lgtm.yml @cosmix @Ferroin @prologic
+.eslintrc @cosmix @Ferroin @prologic
+.eslintignore @cosmix @Ferroin @prologic
+.csslintrc @cosmix @Ferroin @prologic
+.codeclimate.yml @cosmix @Ferroin @prologic
+.codacy.yml @cosmix @Ferroin @prologic
+.yamllint.yml @cosmix @Ferroin @prologic
+netdata.spec.in @cosmix @Ferroin @prologic
+netdata-installer.sh @cosmix @Ferroin @prologic
 package.json @jacekkolasa
 packaging/version @netdatabot
 


### PR DESCRIPTION
##### Summary

Based on discussion within the SRE team. They are not directly involved anymore with the agent components maintained by the SRE team, so there's no point in pestering them all the time with review requests when the rest of the SRE team is suficient for a complete review.

In the event that a change warrants their attention, they'll be explicitly added as reviewers by hand.

##### Component Name

Infrastructure

##### Test Plan

n/a