### PR TITLE
Really prevent overwriting netdata.conf on static installs.

### DIFF
--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -23,7 +23,7 @@ run ./netdata-installer.sh --install "${NETDATA_INSTALL_PARENT}" \
   "${NULL}"
 
 # Remove the netdata.conf file from the tree. It has hard-coded sensible defaults builtin.
-rm -f "${NETDATA_INSTALL_PARENT}/etc/netdata/netdata.conf"
+run rm -f "${NETDATA_INSTALL_PATH}/etc/netdata/netdata.conf"
 
 # Ensure the netdata binary is in fact statically linked
 if run readelf -l "${NETDATA_INSTALL_PATH}"/bin/netdata | grep 'INTERP'; then


### PR DESCRIPTION
##### Summary

The previous fix was incompletely tested and didn't actually workdue to
using an incorrect variable name. This fixes that.

##### Component Name

area/packaging

##### Test Plan

Original testing only looked at intermediate stages, this one is now confirmed by testing the final output.

##### Additional Information

Fixes: #8531