### PR TITLE
Fix exporting unit tests

### DIFF
--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -666,9 +666,6 @@ static void test_simple_connector_worker(void **state)
     expect_value(__wrap_send_internal_metrics, instance, instance);
     will_return(__wrap_send_internal_metrics, 0);
 
-    expect_function_call(__wrap_info_int);
-    expect_function_call(__wrap_info_int);
-
     simple_connector_worker(instance);
 
     assert_int_equal(stats->buffered_metrics, 0);
@@ -796,7 +793,7 @@ static void test_create_main_rusage_chart(void **state)
     expect_string(rrdset_create_custom, id, "exporting_main_thread_cpu");
     expect_value(rrdset_create_custom, name, NULL);
     expect_string(rrdset_create_custom, family, "exporting");
-    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, context, "exporting_cpu_usage");
     expect_string(rrdset_create_custom, units, "milliseconds/s");
     expect_string(rrdset_create_custom, plugin, "exporting");
     expect_value(rrdset_create_custom, module, NULL);
@@ -865,7 +862,7 @@ static void test_send_internal_metrics(void **state)
     expect_string(rrdset_create_custom, id, "exporting_test_instance_metrics");
     expect_value(rrdset_create_custom, name, NULL);
     expect_string(rrdset_create_custom, family, "exporting_test_instance");
-    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, context, "exporting_buffer");
     expect_string(rrdset_create_custom, units, "metrics");
     expect_string(rrdset_create_custom, plugin, "exporting");
     expect_value(rrdset_create_custom, module, NULL);
@@ -889,7 +886,7 @@ static void test_send_internal_metrics(void **state)
     expect_string(rrdset_create_custom, id, "exporting_test_instance_bytes");
     expect_value(rrdset_create_custom, name, NULL);
     expect_string(rrdset_create_custom, family, "exporting_test_instance");
-    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, context, "exporting_data_size");
     expect_string(rrdset_create_custom, units, "KiB");
     expect_string(rrdset_create_custom, plugin, "exporting");
     expect_value(rrdset_create_custom, module, NULL);
@@ -913,7 +910,7 @@ static void test_send_internal_metrics(void **state)
     expect_string(rrdset_create_custom, id, "exporting_test_instance_ops");
     expect_value(rrdset_create_custom, name, NULL);
     expect_string(rrdset_create_custom, family, "exporting_test_instance");
-    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, context, "exporting_operations");
     expect_string(rrdset_create_custom, units, "operations");
     expect_string(rrdset_create_custom, plugin, "exporting");
     expect_value(rrdset_create_custom, module, NULL);
@@ -937,7 +934,7 @@ static void test_send_internal_metrics(void **state)
     expect_string(rrdset_create_custom, id, "exporting_test_instance_thread_cpu");
     expect_value(rrdset_create_custom, name, NULL);
     expect_string(rrdset_create_custom, family, "exporting_test_instance");
-    expect_value(rrdset_create_custom, context, NULL);
+    expect_string(rrdset_create_custom, context, "exporting_instance");
     expect_string(rrdset_create_custom, units, "milliseconds/s");
     expect_string(rrdset_create_custom, plugin, "exporting");
     expect_value(rrdset_create_custom, module, NULL);


### PR DESCRIPTION
#### Summary
Unit tests for the exporting engine were broken after #9075.

##### Component Name
exporting engine

##### Test Plan
Run `sudo make check` in Netdata build directory