### PR TITLE
Fixed cmake build affected by #9074

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,6 +487,13 @@ set(MACOS_PLUGIN_FILES
 set(PLUGINSD_PLUGIN_FILES
         collectors/plugins.d/plugins_d.c
         collectors/plugins.d/plugins_d.h
+        collectors/plugins.d/pluginsd_parser.c
+        collectors/plugins.d/pluginsd_parser.h
+        )
+
+set(PARSER_PLUGIN_FILES
+        parser/parser.c
+        parser/parser.h
         )
 
 set(REGISTRY_PLUGIN_FILES
@@ -750,6 +757,7 @@ set(NETDATA_FILES
         ${WEB_PLUGIN_FILES}
         ${CLAIM_PLUGIN_FILES}
         ${SPAWN_PLUGIN_FILES}
+        ${PARSER_PLUGIN_FILES}
 )
 
 set(NETDATACLI_FILES


### PR DESCRIPTION
Fixes #9185
##### Summary
Added missing source code files to handle compilation errors using cmake e.g
```
[ 99%] Linking CXX executable netdata
/usr/bin/ld: CMakeFiles/netdata.dir/collectors/plugins.d/plugins_d.c.o: in function `pluginsd_worker_thread':
/home/vlad/netdata/collectors/plugins.d/plugins_d.c:346: undefined reference to `pluginsd_process'
/usr/bin/ld: CMakeFiles/netdata.dir/streaming/rrdpush.c.o: in function `rrdpush_receive':
/home/vlad/netdata/streaming/rrdpush.c:1295: undefined reference to `pluginsd_process'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/netdata.dir/build.make:2286: netdata] Error 1
make[1]: *** [CMakeFiles/Makefile2:773: CMakeFiles/netdata.dir/all] Error 2
make: *** [Makefile:115: all] Error 2
```

##### Component Name

##### Test Plan
- Should compile using cmake

##### Additional Information
