### PR TITLE
Clean type_name in exporting connector instance configuration

### DIFF
--- a/exporting/clean_connectors.c
+++ b/exporting/clean_connectors.c
@@ -12,6 +12,7 @@ static void clean_instance_config(struct instance_config *config)
     if(!config)
         return;
 
+    freez((void *)config->type_name);
     freez((void *)config->name);
     freez((void *)config->destination);
 


### PR DESCRIPTION
##### Summary
Clean a string with a connector type on Netdata exit.

##### Component Name
exporting engine