### PR TITLE
Add support for collectors updating their metadata

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -673,6 +673,9 @@ static struct _collector *_add_collector(const char *hostname, const char *plugi
 void aclk_add_collector(const char *hostname, const char *plugin_name, const char *module_name)
 {
     struct _collector *tmp_collector;
+    if (unlikely(!netdata_ready)) {
+        return;
+    }
 
     COLLECTOR_LOCK;
 
@@ -704,6 +707,9 @@ void aclk_add_collector(const char *hostname, const char *plugin_name, const cha
 void aclk_del_collector(const char *hostname, const char *plugin_name, const char *module_name)
 {
     struct _collector *tmp_collector;
+    if (unlikely(!netdata_ready)) {
+        return;
+    }
 
     COLLECTOR_LOCK;
 
@@ -1823,6 +1829,9 @@ int aclk_update_chart(RRDHOST *host, char *chart_name, ACLK_CMD aclk_cmd)
     UNUSED(chart_name);
     return 0;
 #else
+    if (unlikely(!netdata_ready))
+        return 0;
+
     if (!netdata_cloud_setting)
         return 0;
 
@@ -1849,6 +1858,9 @@ int aclk_update_chart(RRDHOST *host, char *chart_name, ACLK_CMD aclk_cmd)
 int aclk_update_alarm(RRDHOST *host, ALARM_ENTRY *ae)
 {
     BUFFER *local_buffer = NULL;
+
+    if (unlikely(!netdata_ready))
+        return 0;
 
     if (host != localhost)
         return 0;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -31,6 +31,11 @@ struct pg_cache_page_index;
 #include "rrdcalctemplate.h"
 #include "../streaming/rrdpush.h"
 
+#define META_CHART_UPDATED 1
+#define META_PLUGIN_UPDATED 2
+#define META_MODULE_UPDATED 4
+#define META_CHART_ACTIVATED 8
+
 #define UPDATE_EVERY 1
 #define UPDATE_EVERY_MAX 3600
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -16,6 +16,7 @@ typedef struct alarm_entry ALARM_ENTRY;
 
 // forward declarations
 struct rrddim_volatile;
+struct rrdset_volatile;
 #ifdef ENABLE_DBENGINE
 struct rrdeng_page_descr;
 struct rrdengine_instance;
@@ -361,6 +362,14 @@ struct rrddim_volatile {
 };
 
 // ----------------------------------------------------------------------------
+// volatile state per chart
+struct rrdset_volatile {
+    char *old_title;
+    char *old_family;
+    char *old_context;
+};
+
+// ----------------------------------------------------------------------------
 // these loop macros make sure the linked list is accessed with the right lock
 
 #define rrddim_foreach_read(rd, st) \
@@ -476,6 +485,8 @@ struct rrdset {
     uuid_t *chart_uuid;                             // Store the global GUID for this chart
     size_t compaction_id;                           // The last metadata log compaction procedure that has processed
                                                     // this object.
+    size_t unused[3];
+    struct rrdset_volatile *state;                  // volatile state that is not persistently stored
     size_t unused[3];
 
     size_t rrddim_page_alignment;                   // keeps metric pages in alignment when using dbengine

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -862,6 +862,26 @@ extern RRDHOST *rrdhost_find_or_create(
         , struct rrdhost_system_info *system_info
 );
 
+extern void rrdhost_update(RRDHOST *host
+    , const char *hostname
+    , const char *registry_hostname
+    , const char *guid
+    , const char *os
+    , const char *timezone
+    , const char *tags
+    , const char *program_name
+    , const char *program_version
+    , int update_every
+    , long history
+    , RRD_MEMORY_MODE mode
+    , unsigned int health_enabled
+    , unsigned int rrdpush_enabled
+    , char *rrdpush_destination
+    , char *rrdpush_api_key
+    , char *rrdpush_send_charts_matching
+    , struct rrdhost_system_info *system_info
+);
+
 extern int rrdhost_set_system_info_variable(struct rrdhost_system_info *system_info, char *name, char *value);
 
 #if defined(NETDATA_INTERNAL_CHECKS) && defined(NETDATA_VERIFY_LOCKS)

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -485,9 +485,8 @@ struct rrdset {
     uuid_t *chart_uuid;                             // Store the global GUID for this chart
     size_t compaction_id;                           // The last metadata log compaction procedure that has processed
                                                     // this object.
-    size_t unused[3];
     struct rrdset_volatile *state;                  // volatile state that is not persistently stored
-    size_t unused[3];
+    size_t unused[2];
 
     size_t rrddim_page_alignment;                   // keeps metric pages in alignment when using dbengine
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -211,6 +211,14 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
             rrddim_flag_clear(rd, RRDDIM_FLAG_ARCHIVED);
         }
 
+        int rc = rrddim_set_name(st, rd, name);
+        rc += rrddim_set_algorithm(st, rd, algorithm);
+        rc += rrddim_set_multiplier(st, rd, multiplier);
+        rc += rrddim_set_divisor(st, rd, divisor);
+        if (likely(!rc))
+            info("Dimension %s  (name, algorithm, multiplier and divisor) unchanged", rd->id);
+        else
+            rrdset_flag_set(st, RRDSET_FLAG_UPDATE_METADATA);
         rrdset_unlock(st);
         return rd;
     }

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -219,7 +219,6 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
         if(memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
             if (unlikely(rc)) {
-                rrdset_flag_set(st, RRDSET_FLAG_UPDATE_METADATA);
                 metalog_commit_update_dimension(rd);
             }
 #endif

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -215,10 +215,15 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
         rc += rrddim_set_algorithm(st, rd, algorithm);
         rc += rrddim_set_multiplier(st, rd, multiplier);
         rc += rrddim_set_divisor(st, rd, divisor);
-        if (likely(!rc))
-            info("Dimension %s  (name, algorithm, multiplier and divisor) unchanged", rd->id);
-        else
-            rrdset_flag_set(st, RRDSET_FLAG_UPDATE_METADATA);
+        // DBENGINE available and activated?
+        if(memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+            if (unlikely(rc))
+                rrdset_flag_set(st, RRDSET_FLAG_UPDATE_METADATA);
+            else
+                info("Dimension %s (name, algorithm, multiplier and divisor) unchanged", rd->id);
+#endif
+        }
         rrdset_unlock(st);
         return rd;
     }

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -218,6 +218,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
         // DBENGINE available and activated?
 #ifdef ENABLE_DBENGINE
         if (likely(rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) && unlikely(rc)) {
+            debug(D_METADATALOG, "DIMENSION [%s] metadata updated", rd->id);
             metalog_commit_update_dimension(rd);
         }
 #endif

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -216,13 +216,11 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
         rc += rrddim_set_multiplier(st, rd, multiplier);
         rc += rrddim_set_divisor(st, rd, divisor);
         // DBENGINE available and activated?
-        if(memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
-            if (unlikely(rc)) {
-                metalog_commit_update_dimension(rd);
-            }
-#endif
+        if (likely(rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) && unlikely(rc)) {
+            metalog_commit_update_dimension(rd);
         }
+#endif
         rrdset_unlock(st);
         return rd;
     }

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -202,22 +202,17 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     if(unlikely(rd)) {
         debug(D_RRD_CALLS, "Cannot create rrd dimension '%s/%s', it already exists.", st->id, name?name:"<NONAME>");
 
-        rrddim_set_name(st, rd, name);
-        rrddim_set_algorithm(st, rd, algorithm);
-        rrddim_set_multiplier(st, rd, multiplier);
-        rrddim_set_divisor(st, rd, divisor);
-        if (!is_archived && rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
-            rd->state->collect_ops.init(rd);
-            rrddim_flag_clear(rd, RRDDIM_FLAG_ARCHIVED);
-        }
-
         int rc = rrddim_set_name(st, rd, name);
         rc += rrddim_set_algorithm(st, rd, algorithm);
         rc += rrddim_set_multiplier(st, rd, multiplier);
         rc += rrddim_set_divisor(st, rd, divisor);
+        if (!is_archived && rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
+            rd->state->collect_ops.init(rd);
+            rrddim_flag_clear(rd, RRDDIM_FLAG_ARCHIVED);
+        }
         // DBENGINE available and activated?
 #ifdef ENABLE_DBENGINE
-        if (likely(rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) && unlikely(rc)) {
+        if (likely(!is_archived && rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) && unlikely(rc)) {
             debug(D_METADATALOG, "DIMENSION [%s] metadata updated", rd->id);
             metalog_commit_update_dimension(rd);
         }

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -218,10 +218,10 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
         // DBENGINE available and activated?
         if(memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
-            if (unlikely(rc))
+            if (unlikely(rc)) {
                 rrdset_flag_set(st, RRDSET_FLAG_UPDATE_METADATA);
-            else
-                info("Dimension %s (name, algorithm, multiplier and divisor) unchanged", rd->id);
+                metalog_commit_update_dimension(rd);
+            }
 #endif
         }
         rrdset_unlock(st);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -364,7 +364,89 @@ RRDHOST *rrdhost_create(const char *hostname,
 
     rrd_hosts_available++;
 
+#ifdef ENABLE_DBENGINE
+    if (likely(!is_localhost && host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE))
+            metalog_commit_update_host(host);
+#endif
     return host;
+}
+
+void rrdhost_update(RRDHOST *host
+                    , const char *hostname
+                    , const char *registry_hostname
+                    , const char *guid
+                    , const char *os
+                    , const char *timezone
+                    , const char *tags
+                    , const char *program_name
+                    , const char *program_version
+                    , int update_every
+                    , long history
+                    , RRD_MEMORY_MODE mode
+                    , unsigned int health_enabled
+                    , unsigned int rrdpush_enabled
+                    , char *rrdpush_destination
+                    , char *rrdpush_api_key
+                    , char *rrdpush_send_charts_matching
+                    , struct rrdhost_system_info *system_info
+)
+{
+    UNUSED(guid);
+    UNUSED(rrdpush_enabled);
+    UNUSED(rrdpush_destination);
+    UNUSED(rrdpush_api_key);
+    UNUSED(rrdpush_send_charts_matching);
+
+    host->health_enabled = health_enabled;
+    //host->stream_version = STREAMING_PROTOCOL_CURRENT_VERSION;        Unused?
+
+    rrdhost_system_info_free(host->system_info);
+    host->system_info = system_info;
+
+    rrdhost_init_os(host, os);
+    rrdhost_init_timezone(host, timezone);
+
+    freez(host->registry_hostname);
+    host->registry_hostname = strdupz((registry_hostname && *registry_hostname)?registry_hostname:hostname);
+
+    if(strcmp(host->hostname, hostname) != 0) {
+        info("Host '%s' has been renamed to '%s'. If this is not intentional it may mean multiple hosts are using the same machine_guid.", host->hostname, hostname);
+        char *t = host->hostname;
+        host->hostname = strdupz(hostname);
+        host->hash_hostname = simple_hash(host->hostname);
+        freez(t);
+    }
+
+    if(strcmp(host->program_name, program_name) != 0) {
+        info("Host '%s' switched program name from '%s' to '%s'", host->hostname, host->program_name, program_name);
+        char *t = host->program_name;
+        host->program_name = strdupz(program_name);
+        freez(t);
+    }
+
+    if(strcmp(host->program_version, program_version) != 0) {
+        info("Host '%s' switched program version from '%s' to '%s'", host->hostname, host->program_version, program_version);
+        char *t = host->program_version;
+        host->program_version = strdupz(program_version);
+        freez(t);
+    }
+
+    if(host->rrd_update_every != update_every)
+        error("Host '%s' has an update frequency of %d seconds, but the wanted one is %d seconds. Restart netdata here to apply the new settings.", host->hostname, host->rrd_update_every, update_every);
+
+    if(host->rrd_history_entries < history)
+        error("Host '%s' has history of %ld entries, but the wanted one is %ld entries. Restart netdata here to apply the new settings.", host->hostname, host->rrd_history_entries, history);
+
+    if(host->rrd_memory_mode != mode)
+        error("Host '%s' has memory mode '%s', but the wanted one is '%s'. Restart netdata here to apply the new settings.", host->hostname, rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
+
+    // update host tags
+    rrdhost_init_tags(host, tags);
+#ifdef ENABLE_DBENGINE
+    if (likely(host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE))
+        metalog_commit_update_host(host);
+#endif
+    return;
 }
 
 RRDHOST *rrdhost_find_or_create(
@@ -413,56 +495,24 @@ RRDHOST *rrdhost_find_or_create(
         );
     }
     else {
-        host->health_enabled = health_enabled;
-        //host->stream_version = STREAMING_PROTOCOL_CURRENT_VERSION;        Unused?
-
-        rrdhost_system_info_free(host->system_info);
-        host->system_info = system_info;
-
-        rrdhost_init_os(host, os);
-        rrdhost_init_timezone(host, timezone);
-
-        freez(host->registry_hostname);
-        host->registry_hostname = strdupz((registry_hostname && *registry_hostname)?registry_hostname:hostname);
-
-        if(strcmp(host->hostname, hostname) != 0) {
-            info("Host '%s' has been renamed to '%s'. If this is not intentional it may mean multiple hosts are using the same machine_guid.", host->hostname, hostname);
-            char *t = host->hostname;
-            host->hostname = strdupz(hostname);
-            host->hash_hostname = simple_hash(host->hostname);
-            freez(t);
-        }
-
-        if(strcmp(host->program_name, program_name) != 0) {
-            info("Host '%s' switched program name from '%s' to '%s'", host->hostname, host->program_name, program_name);
-            char *t = host->program_name;
-            host->program_name = strdupz(program_name);
-            freez(t);
-        }
-
-        if(strcmp(host->program_version, program_version) != 0) {
-            info("Host '%s' switched program version from '%s' to '%s'", host->hostname, host->program_version, program_version);
-            char *t = host->program_version;
-            host->program_version = strdupz(program_version);
-            freez(t);
-        }
-
-        if(host->rrd_update_every != update_every)
-            error("Host '%s' has an update frequency of %d seconds, but the wanted one is %d seconds. Restart netdata here to apply the new settings.", host->hostname, host->rrd_update_every, update_every);
-
-        if(host->rrd_history_entries < history)
-            error("Host '%s' has history of %ld entries, but the wanted one is %ld entries. Restart netdata here to apply the new settings.", host->hostname, host->rrd_history_entries, history);
-
-        if(host->rrd_memory_mode != mode)
-            error("Host '%s' has memory mode '%s', but the wanted one is '%s'. Restart netdata here to apply the new settings.", host->hostname, rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
-
-        // update host tags
-        rrdhost_init_tags(host, tags);
-#ifdef ENABLE_DBENGINE
-        if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-            metalog_commit_update_host(host);
-        }
-#endif
+        rrdhost_update(host
+           , hostname
+           , registry_hostname
+           , guid
+           , os
+           , timezone
+           , tags
+           , program_name
+           , program_version
+           , update_every
+           , history
+           , mode
+           , health_enabled
+           , rrdpush_enabled
+           , rrdpush_destination
+           , rrdpush_api_key
+           , rrdpush_send_charts_matching
+           , system_info);
     }
 
     rrdhost_cleanup_orphan_hosts_nolock(host);
@@ -471,84 +521,6 @@ RRDHOST *rrdhost_find_or_create(
 
     return host;
 }
-
-void rrdhost_update(RRDHOST *host,
-    const char *hostname
-    , const char *registry_hostname
-    , const char *guid
-    , const char *os
-    , const char *timezone
-    , const char *tags
-    , const char *program_name
-    , const char *program_version
-    , int update_every
-    , long history
-    , RRD_MEMORY_MODE mode
-    , unsigned int health_enabled
-    , unsigned int rrdpush_enabled
-    , char *rrdpush_destination
-    , char *rrdpush_api_key
-    , char *rrdpush_send_charts_matching
-    , struct rrdhost_system_info *system_info
-) {
-
-#ifndef ENABLE_DBENGINE
-        return;
-#endif
-
-    if (host->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE) {
-        return;
-    }
-    host->health_enabled = health_enabled;
-    //host->stream_version = STREAMING_PROTOCOL_CURRENT_VERSION;        Unused?
-
-    rrdhost_system_info_free(host->system_info);
-    host->system_info = system_info;
-
-    rrdhost_init_os(host, os);
-    rrdhost_init_timezone(host, timezone);
-
-    freez(host->registry_hostname);
-    host->registry_hostname = strdupz((registry_hostname && *registry_hostname)?registry_hostname:hostname);
-
-    if(strcmp(host->hostname, hostname) != 0) {
-        info("Host '%s' has been renamed to '%s'. If this is not intentional it may mean multiple hosts are using the same machine_guid.", host->hostname, hostname);
-        char *t = host->hostname;
-        host->hostname = strdupz(hostname);
-        host->hash_hostname = simple_hash(host->hostname);
-        freez(t);
-    }
-
-    if(strcmp(host->program_name, program_name) != 0) {
-        info("Host '%s' switched program name from '%s' to '%s'", host->hostname, host->program_name, program_name);
-        char *t = host->program_name;
-        host->program_name = strdupz(program_name);
-        freez(t);
-    }
-
-    if(strcmp(host->program_version, program_version) != 0) {
-        info("Host '%s' switched program version from '%s' to '%s'", host->hostname, host->program_version, program_version);
-        char *t = host->program_version;
-        host->program_version = strdupz(program_version);
-        freez(t);
-    }
-
-    if(host->rrd_update_every != update_every)
-        error("Host '%s' has an update frequency of %d seconds, but the wanted one is %d seconds. Restart netdata here to apply the new settings.", host->hostname, host->rrd_update_every, update_every);
-
-    if(host->rrd_history_entries < history)
-        error("Host '%s' has history of %ld entries, but the wanted one is %ld entries. Restart netdata here to apply the new settings.", host->hostname, host->rrd_history_entries, history);
-
-    if(host->rrd_memory_mode != mode)
-        error("Host '%s' has memory mode '%s', but the wanted one is '%s'. Restart netdata here to apply the new settings.", host->hostname, rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
-
-    // update host tags
-    rrdhost_init_tags(host, tags);
-    metalog_commit_update_host(host);
-    return;
-}
-
-
 inline int rrdhost_should_be_removed(RRDHOST *host, RRDHOST *protected, time_t now) {
     if(host != protected
        && host != localhost

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -413,8 +413,19 @@ RRDHOST *rrdhost_find_or_create(
         );
     }
     else {
+        // TODO:update_every
+        // TODO: Metdata updated OK: hostname, registry_hostname, tags, os
         host->health_enabled = health_enabled;
         //host->stream_version = STREAMING_PROTOCOL_CURRENT_VERSION;        Unused?
+
+        rrdhost_system_info_free(host->system_info);
+        host->system_info = system_info;
+
+        rrdhost_init_os(host, os);
+        rrdhost_init_timezone(host, timezone);
+
+        freez(host->registry_hostname);
+        host->registry_hostname = strdupz((registry_hostname && *registry_hostname)?registry_hostname:hostname);
 
         if(strcmp(host->hostname, hostname) != 0) {
             info("Host '%s' has been renamed to '%s'. If this is not intentional it may mean multiple hosts are using the same machine_guid.", host->hostname, hostname);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -413,8 +413,6 @@ RRDHOST *rrdhost_find_or_create(
         );
     }
     else {
-        // TODO:update_every
-        // TODO: Metdata updated OK: hostname, registry_hostname, tags, os
         host->health_enabled = health_enabled;
         //host->stream_version = STREAMING_PROTOCOL_CURRENT_VERSION;        Unused?
 
@@ -460,6 +458,11 @@ RRDHOST *rrdhost_find_or_create(
 
         // update host tags
         rrdhost_init_tags(host, tags);
+#ifdef ENABLE_DBENGINE
+        if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+            metalog_commit_update_host(host);
+        }
+#endif
     }
 
     rrdhost_cleanup_orphan_hosts_nolock(host);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -472,6 +472,83 @@ RRDHOST *rrdhost_find_or_create(
     return host;
 }
 
+void rrdhost_update(RRDHOST *host,
+    const char *hostname
+    , const char *registry_hostname
+    , const char *guid
+    , const char *os
+    , const char *timezone
+    , const char *tags
+    , const char *program_name
+    , const char *program_version
+    , int update_every
+    , long history
+    , RRD_MEMORY_MODE mode
+    , unsigned int health_enabled
+    , unsigned int rrdpush_enabled
+    , char *rrdpush_destination
+    , char *rrdpush_api_key
+    , char *rrdpush_send_charts_matching
+    , struct rrdhost_system_info *system_info
+) {
+
+#ifndef ENABLE_DBENGINE
+        return;
+#endif
+
+    if (host->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE) {
+        return;
+    }
+    host->health_enabled = health_enabled;
+    //host->stream_version = STREAMING_PROTOCOL_CURRENT_VERSION;        Unused?
+
+    rrdhost_system_info_free(host->system_info);
+    host->system_info = system_info;
+
+    rrdhost_init_os(host, os);
+    rrdhost_init_timezone(host, timezone);
+
+    freez(host->registry_hostname);
+    host->registry_hostname = strdupz((registry_hostname && *registry_hostname)?registry_hostname:hostname);
+
+    if(strcmp(host->hostname, hostname) != 0) {
+        info("Host '%s' has been renamed to '%s'. If this is not intentional it may mean multiple hosts are using the same machine_guid.", host->hostname, hostname);
+        char *t = host->hostname;
+        host->hostname = strdupz(hostname);
+        host->hash_hostname = simple_hash(host->hostname);
+        freez(t);
+    }
+
+    if(strcmp(host->program_name, program_name) != 0) {
+        info("Host '%s' switched program name from '%s' to '%s'", host->hostname, host->program_name, program_name);
+        char *t = host->program_name;
+        host->program_name = strdupz(program_name);
+        freez(t);
+    }
+
+    if(strcmp(host->program_version, program_version) != 0) {
+        info("Host '%s' switched program version from '%s' to '%s'", host->hostname, host->program_version, program_version);
+        char *t = host->program_version;
+        host->program_version = strdupz(program_version);
+        freez(t);
+    }
+
+    if(host->rrd_update_every != update_every)
+        error("Host '%s' has an update frequency of %d seconds, but the wanted one is %d seconds. Restart netdata here to apply the new settings.", host->hostname, host->rrd_update_every, update_every);
+
+    if(host->rrd_history_entries < history)
+        error("Host '%s' has history of %ld entries, but the wanted one is %ld entries. Restart netdata here to apply the new settings.", host->hostname, host->rrd_history_entries, history);
+
+    if(host->rrd_memory_mode != mode)
+        error("Host '%s' has memory mode '%s', but the wanted one is '%s'. Restart netdata here to apply the new settings.", host->hostname, rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
+
+    // update host tags
+    rrdhost_init_tags(host, tags);
+    metalog_commit_update_host(host);
+    return;
+}
+
+
 inline int rrdhost_should_be_removed(RRDHOST *host, RRDHOST *protected, time_t now) {
     if(host != protected
        && host != localhost

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -535,7 +535,10 @@ RRDSET *rrdset_create_custom(
         else
             rrdset_set_name(st, id);
 
-        info("CHART request for updated metadata");
+        info("CHART request for updated metadata [%s]", st->id);
+#ifdef ENABLE_DBENGINE
+        metalog_commit_update_chart(st);
+#endif
         // name
         // title
         // family

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -2,6 +2,7 @@
 
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
+#include <sched.h>
 
 void __rrdset_check_rdlock(RRDSET *st, const char *file, const char *function, const unsigned long line) {
     debug(D_RRD_CALLS, "Checking read lock on chart '%s'", st->id);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -643,7 +643,7 @@ RRDSET *rrdset_create_custom(
             freez(old_title);
             freez(old_family);
             freez(old_context);
-            if (mark_rebuild != META_CHART_ACTIVATED)
+            if (mark_rebuild != META_CHART_ACTIVATED) {
                 info("Collector updated metadata for chart %s", st->id);
                 sched_yield();
             }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -367,6 +367,10 @@ void rrdset_free(RRDSET *st) {
     freez(st->config_section);
     freez(st->plugin_name);
     freez(st->module_name);
+    freez(st->state->old_title);
+    freez(st->state->old_family);
+    freez(st->state->old_context);
+    freez(st->state);
 
     switch(st->rrd_memory_mode) {
         case RRD_MEMORY_MODE_SAVE:
@@ -532,7 +536,8 @@ RRDSET *rrdset_create_custom(
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
             mark_rebuild |= META_CHART_ACTIVATED;
         }
-        char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_family = NULL, *old_context = NULL;
+        char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_family = NULL, *old_context = NULL,
+             *old_title_v = NULL, *old_family_v = NULL, *old_context_v = NULL;
         const char *new_name = name ? name : id;
 
         if (unlikely((st->name && !strcmp(st->name, new_name)) || !st->name)) {
@@ -579,15 +584,14 @@ RRDSET *rrdset_create_custom(
             }
         }
 
-        char *new_title = title ? strdupz(title) : NULL;
-        if (new_title) {
+        if (unlikely(title && st->state->old_title && strcmp(st->state->old_title, title))) {
+            char *new_title = strdupz(title);
+            old_title_v = st->state->old_title;
+            st->state->old_title = strdupz(title);
             json_fix_string(new_title);
-            if (unlikely(strcmp(st->title, new_title))) {
-                old_title = st->title;
-                st->title = new_title;
-                mark_rebuild |= META_CHART_UPDATED;
-            } else
-                freez(new_title);
+            old_title = st->title;
+            st->title = new_title;
+            mark_rebuild |= META_CHART_UPDATED;
         }
 
         RRDSET_TYPE new_chart_type =
@@ -597,29 +601,27 @@ RRDSET *rrdset_create_custom(
             mark_rebuild |= META_CHART_UPDATED;
         }
 
-        char *new_family = family ? strdupz(family): NULL;
-        if (new_family) {
+        if (unlikely(family && st->state->old_family && strcmp(st->state->old_family, family))) {
+            char *new_family = strdupz(family);
+            old_family_v = st->state->old_family;
+            st->state->old_family = strdupz(family);
             json_fix_string(new_family);
-            if (unlikely((strcmp(st->family, new_family)))) {
-                old_family = st->family;
-                rrdfamily_free(host, st->rrdfamily);
-                st->family = new_family;
-                st->rrdfamily = rrdfamily_create(host, st->family);
-                mark_rebuild |= META_CHART_UPDATED;
-            } else
-                freez(new_family);
+            old_family = st->family;
+            rrdfamily_free(host, st->rrdfamily);
+            st->family = new_family;
+            st->rrdfamily = rrdfamily_create(host, st->family);
+            mark_rebuild |= META_CHART_UPDATED;
         }
 
-        char *new_context = context ? strdupz(context) : NULL;
-        if (new_context) {
+        if (unlikely(context && st->state->old_context && strcmp(st->state->old_context, context))) {
+            char *new_context = strdupz(context);
+            old_context_v = st->state->old_context;
+            st->state->old_context = strdupz(context);
             json_fix_string(new_context);
-            if (unlikely((strcmp(st->context, new_context)))) {
-                old_context = st->context;
-                st->context = new_context;
-                st->hash_context = simple_hash(st->context);
-                mark_rebuild |= META_CHART_UPDATED;
-            } else
-                freez(new_context);
+            old_context = st->context;
+            st->context = new_context;
+            st->hash_context = simple_hash(st->context);
+            mark_rebuild |= META_CHART_UPDATED;
         }
 
         if (mark_rebuild) {
@@ -644,6 +646,9 @@ RRDSET *rrdset_create_custom(
             freez(old_title);
             freez(old_family);
             freez(old_context);
+            freez(old_title_v);
+            freez(old_family_v);
+            freez(old_context_v);
             if (mark_rebuild != META_CHART_ACTIVATED) {
                 info("Collector updated metadata for chart %s", st->id);
                 sched_yield();
@@ -823,13 +828,16 @@ RRDSET *rrdset_create_custom(
     st->chart_type = rrdset_type_id(config_get(st->config_section, "chart type", rrdset_type_name(chart_type)));
     st->type       = config_get(st->config_section, "type", type);
 
+    st->state = mallocz(sizeof(*st->state));
     st->family     = config_get(st->config_section, "family", family?family:st->type);
+    st->state->old_family = strdupz(st->family);
     json_fix_string(st->family);
 
     st->units      = config_get(st->config_section, "units", units?units:"");
     json_fix_string(st->units);
 
     st->context    = config_get(st->config_section, "context", context?context:st->id);
+    st->state->old_context = strdupz(st->context);
     json_fix_string(st->context);
     st->hash_context = simple_hash(st->context);
 
@@ -881,6 +889,7 @@ RRDSET *rrdset_create_custom(
         rrdset_set_name(st, id);
 
     st->title = config_get(st->config_section, "title", title);
+    st->state->old_title = strdupz(st->title);
     json_fix_string(st->title);
 
     st->rrdfamily = rrdfamily_create(host, st->family);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -535,6 +535,18 @@ RRDSET *rrdset_create_custom(
         else
             rrdset_set_name(st, id);
 
+        info("CHART request for updated metadata");
+        // name
+        // title
+        // family
+        // context
+        // charttype
+        // priority
+        // update_every
+        // options
+        // plugin
+        // module
+
         return st;
     }
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -524,41 +524,42 @@ RRDSET *rrdset_create_custom(
 
     RRDSET *st = rrdset_find_on_create(host, fullid);
     if (st) {
+        int mark_rebuild = 0;
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
         if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
+            mark_rebuild |= 8;
         }
         char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_family = NULL, *old_context = NULL;
-        int mark_rebuild = 0;
         const char *new_name = name ? name : id;
 
         if (unlikely((st->name && !strcmp(st->name, new_name)) || !st->name)) {
-            mark_rebuild = 1;
+            mark_rebuild |= 1;
             rrdset_set_name(st, new_name);
         }
 
         if (unlikely(st->priority != priority)) {
             st->priority = priority;
-            mark_rebuild = 1;
+            mark_rebuild |= 1;
         }
         if (unlikely(st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && st->update_every != update_every)) {
             st->update_every = update_every;
-            mark_rebuild = 1;
+            mark_rebuild |= 1;
         }
 
         if (plugin && st->plugin_name) {
             if (unlikely(strcmp(plugin, st->plugin_name))) {
                 old_plugin = st->plugin_name;
                 st->plugin_name = strdupz(plugin);
-                mark_rebuild = 1;
+                mark_rebuild |= 2;
             }
         } else {
             if (plugin != st->plugin_name) { // one is NULL?
                 if (st->plugin_name)
                     old_plugin = st->plugin_name;
                 st->plugin_name = plugin ? strdupz(plugin) : NULL;
-                mark_rebuild = 1;
+                mark_rebuild |= 2;
             }
         }
 
@@ -566,14 +567,15 @@ RRDSET *rrdset_create_custom(
             if (unlikely(strcmp(module, st->module_name))) {
                 old_module = st->module_name;
                 st->module_name = strdupz(module);
-                mark_rebuild = 1;
+                mark_rebuild |= 4;
             }
         } else {
             if (module != st->module_name) {
-                if (st->module_name)
+                if (st->module_name && *st->module_name) {
                     old_module = st->module_name;
-                st->module_name = module ? strdupz(module) : NULL;
-                mark_rebuild = 1;
+                    st->module_name = module ? strdupz(module) : NULL;
+                    mark_rebuild |= 4;
+                }
             }
         }
 
@@ -583,7 +585,7 @@ RRDSET *rrdset_create_custom(
             if (unlikely(strcmp(st->title, new_title))) {
                 old_title = st->title;
                 st->title = new_title;
-                mark_rebuild = 1;
+                mark_rebuild |= 1;
             } else
                 freez(new_title);
         }
@@ -592,7 +594,7 @@ RRDSET *rrdset_create_custom(
             rrdset_type_id(config_get(st->config_section, "chart type", rrdset_type_name(chart_type)));
         if (st->chart_type != new_chart_type) {
             st->chart_type = new_chart_type;
-            mark_rebuild = 1;
+            mark_rebuild |= 1;
         }
 
         char *new_family = family ? strdup(family): NULL;
@@ -600,8 +602,10 @@ RRDSET *rrdset_create_custom(
             json_fix_string(new_family);
             if (unlikely((strcmp(st->family, new_family)))) {
                 old_family = st->family;
+                rrdfamily_free(host, st->rrdfamily);
                 st->family = new_family;
-                mark_rebuild = 1;
+                st->rrdfamily = rrdfamily_create(host, st->family);
+                mark_rebuild |= 1;
             } else
                 freez(new_family);
         }
@@ -613,22 +617,41 @@ RRDSET *rrdset_create_custom(
                 old_context = st->context;
                 st->context = new_context;
                 st->hash_context = simple_hash(st->context);
-                mark_rebuild = 1;
+                mark_rebuild |= 1;
             } else
                 freez(new_context);
         }
 
         if (mark_rebuild) {
+#ifdef ENABLE_ACLK
+            if (netdata_cloud_setting) {
+                if ((mark_rebuild & 8) == 8) {
+                    aclk_add_collector(host->hostname, st->plugin_name, st->module_name);
+                }
+                else {
+                    if (mark_rebuild & 6) {
+                        aclk_del_collector(
+                            host->hostname, mark_rebuild & 2 ? old_plugin : st->plugin_name,
+                            mark_rebuild & 4 ? old_module : st->module_name);
+                        aclk_add_collector(host->hostname, st->plugin_name, st->module_name);
+                    }
+                }
+                aclk_update_chart(host, st->id, ACLK_CMD_CHART);
+            }
+#endif
             freez(old_plugin);
             freez(old_module);
             freez(old_title);
             freez(old_family);
             freez(old_context);
-            info("Collector updated metadata for chart %s" , st->id);
+            if (mark_rebuild == 8)
+                info("Collector activated chart %s" , st->id);
+            else
+                info("Collector updated metadata for chart %s" , st->id);
             sched_yield();
         }
 #ifdef ENABLE_DBENGINE
-        if (is_archived == 0 && st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && mark_rebuild) {
+        if (is_archived == 0 && st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && (mark_rebuild & 7)) {
             debug(D_METADATALOG, "CHART [%s] metadata updated", st->id);
             metalog_commit_update_chart(st);
         }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -529,37 +529,36 @@ RRDSET *rrdset_create_custom(
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
         if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
-            mark_rebuild |= 8;
+            mark_rebuild |= META_CHART_ACTIVATED;
         }
         char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_family = NULL, *old_context = NULL;
         const char *new_name = name ? name : id;
 
         if (unlikely((st->name && !strcmp(st->name, new_name)) || !st->name)) {
-            mark_rebuild |= 1;
+            mark_rebuild |= META_CHART_UPDATED;
             rrdset_set_name(st, new_name);
         }
 
         if (unlikely(st->priority != priority)) {
             st->priority = priority;
-            mark_rebuild |= 1;
+            mark_rebuild |= META_CHART_UPDATED;
         }
         if (unlikely(st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && st->update_every != update_every)) {
             st->update_every = update_every;
-            mark_rebuild |= 1;
+            mark_rebuild |= META_CHART_UPDATED;
         }
 
         if (plugin && st->plugin_name) {
             if (unlikely(strcmp(plugin, st->plugin_name))) {
                 old_plugin = st->plugin_name;
                 st->plugin_name = strdupz(plugin);
-                mark_rebuild |= 2;
+                mark_rebuild |= META_PLUGIN_UPDATED;
             }
         } else {
             if (plugin != st->plugin_name) { // one is NULL?
-                if (st->plugin_name)
-                    old_plugin = st->plugin_name;
+                old_plugin = st->plugin_name;
                 st->plugin_name = plugin ? strdupz(plugin) : NULL;
-                mark_rebuild |= 2;
+                mark_rebuild |= META_PLUGIN_UPDATED;
             }
         }
 
@@ -567,14 +566,14 @@ RRDSET *rrdset_create_custom(
             if (unlikely(strcmp(module, st->module_name))) {
                 old_module = st->module_name;
                 st->module_name = strdupz(module);
-                mark_rebuild |= 4;
+                mark_rebuild |= META_MODULE_UPDATED;
             }
         } else {
             if (module != st->module_name) {
                 if (st->module_name && *st->module_name) {
                     old_module = st->module_name;
                     st->module_name = module ? strdupz(module) : NULL;
-                    mark_rebuild |= 4;
+                    mark_rebuild |= META_MODULE_UPDATED;
                 }
             }
         }
@@ -585,7 +584,7 @@ RRDSET *rrdset_create_custom(
             if (unlikely(strcmp(st->title, new_title))) {
                 old_title = st->title;
                 st->title = new_title;
-                mark_rebuild |= 1;
+                mark_rebuild |= META_CHART_UPDATED;
             } else
                 freez(new_title);
         }
@@ -594,7 +593,7 @@ RRDSET *rrdset_create_custom(
             rrdset_type_id(config_get(st->config_section, "chart type", rrdset_type_name(chart_type)));
         if (st->chart_type != new_chart_type) {
             st->chart_type = new_chart_type;
-            mark_rebuild |= 1;
+            mark_rebuild |= META_CHART_UPDATED;
         }
 
         char *new_family = family ? strdup(family): NULL;
@@ -605,7 +604,7 @@ RRDSET *rrdset_create_custom(
                 rrdfamily_free(host, st->rrdfamily);
                 st->family = new_family;
                 st->rrdfamily = rrdfamily_create(host, st->family);
-                mark_rebuild |= 1;
+                mark_rebuild |= META_CHART_UPDATED;
             } else
                 freez(new_family);
         }
@@ -617,7 +616,7 @@ RRDSET *rrdset_create_custom(
                 old_context = st->context;
                 st->context = new_context;
                 st->hash_context = simple_hash(st->context);
-                mark_rebuild |= 1;
+                mark_rebuild |= META_CHART_UPDATED;
             } else
                 freez(new_context);
         }
@@ -625,14 +624,14 @@ RRDSET *rrdset_create_custom(
         if (mark_rebuild) {
 #ifdef ENABLE_ACLK
             if (netdata_cloud_setting) {
-                if ((mark_rebuild & 8) == 8) {
+                if (mark_rebuild & META_CHART_ACTIVATED) {
                     aclk_add_collector(host->hostname, st->plugin_name, st->module_name);
                 }
                 else {
-                    if (mark_rebuild & 6) {
+                    if (mark_rebuild & (META_PLUGIN_UPDATED | META_MODULE_UPDATED)) {
                         aclk_del_collector(
-                            host->hostname, mark_rebuild & 2 ? old_plugin : st->plugin_name,
-                            mark_rebuild & 4 ? old_module : st->module_name);
+                            host->hostname, mark_rebuild & META_PLUGIN_UPDATED ? old_plugin : st->plugin_name,
+                            mark_rebuild & META_MODULE_UPDATED ? old_module : st->module_name);
                         aclk_add_collector(host->hostname, st->plugin_name, st->module_name);
                     }
                 }
@@ -644,14 +643,14 @@ RRDSET *rrdset_create_custom(
             freez(old_title);
             freez(old_family);
             freez(old_context);
-            if (mark_rebuild == 8)
-                info("Collector activated chart %s" , st->id);
-            else
-                info("Collector updated metadata for chart %s" , st->id);
-            sched_yield();
+            if (mark_rebuild != META_CHART_ACTIVATED)
+                info("Collector updated metadata for chart %s", st->id);
+                sched_yield();
+            }
         }
 #ifdef ENABLE_DBENGINE
-        if (is_archived == 0 && st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && (mark_rebuild & 7)) {
+        if (is_archived == 0 && st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE &&
+            (mark_rebuild & (META_CHART_UPDATED | META_PLUGIN_UPDATED | META_MODULE_UPDATED))) {
             debug(D_METADATALOG, "CHART [%s] metadata updated", st->id);
             metalog_commit_update_chart(st);
         }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -597,7 +597,7 @@ RRDSET *rrdset_create_custom(
             mark_rebuild |= META_CHART_UPDATED;
         }
 
-        char *new_family = family ? strdup(family): NULL;
+        char *new_family = family ? strdupz(family): NULL;
         if (new_family) {
             json_fix_string(new_family);
             if (unlikely((strcmp(st->family, new_family)))) {
@@ -610,7 +610,7 @@ RRDSET *rrdset_create_custom(
                 freez(new_family);
         }
 
-        char *new_context = context ? strdup(context) : NULL;
+        char *new_context = context ? strdupz(context) : NULL;
         if (new_context) {
             json_fix_string(new_context);
             if (unlikely((strcmp(st->context, new_context)))) {

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -530,100 +530,105 @@ RRDSET *rrdset_create_custom(
         if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
         }
+        rrdhost_wrlock(host);
+        st = rrdset_find_on_create(host, fullid);
+        if (st) {
+            int mark_rebuild = 0;
+            rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
+            rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
 
-        if(unlikely(name))
-            rrdset_set_name(st, name);
-        else
-            rrdset_set_name(st, id);
+            st = rrdset_find_on_create(host, fullid);
+            if (st)
 
-        info("CHART request for updated metadata [%s]", st->id);
+                if (unlikely(name))
+                    rrdset_set_name(st, name);
+                else
+                    rrdset_set_name(st, id);
 
-        if (unlikely(st->priority != priority)) {
-            st->priority = priority;
-            mark_rebuild = 1;
-        }
+            info("CHART request for updated metadata [%s]", st->id);
 
-        if (unlikely(st->update_every != update_every)) {
-            st->update_every = update_every;
-            mark_rebuild = 1;
-        }
-
-        if (plugin && st->plugin_name) {
-            if (unlikely(strcmp(plugin, st->plugin_name))) {
-                freez(st->plugin_name);
-                st->plugin_name = strdupz(plugin);
+            if (unlikely(st->priority != priority)) {
+                st->priority = priority;
                 mark_rebuild = 1;
             }
-        } else {
-            if (plugin != st->plugin_name) {
-                if (st->plugin_name)
+
+            if (unlikely(st->update_every != update_every)) {
+                st->update_every = update_every;
+                mark_rebuild = 1;
+            }
+
+            if (plugin && st->plugin_name) {
+                if (unlikely(strcmp(plugin, st->plugin_name))) {
                     freez(st->plugin_name);
-                st->plugin_name = plugin ? strdupz(plugin) : NULL;
-                mark_rebuild = 1;
+                    st->plugin_name = strdupz(plugin);
+                    mark_rebuild = 1;
+                }
+            } else {
+                if (plugin != st->plugin_name) {
+                    if (st->plugin_name)
+                        freez(st->plugin_name);
+                    st->plugin_name = plugin ? strdupz(plugin) : NULL;
+                    mark_rebuild = 1;
+                }
             }
-        }
 
-        if (module && st->module_name) {
-            if (unlikely(strcmp(module, st->module_name))) {
-                freez(st->module_name);
-                st->module_name = strdupz(module);
-                mark_rebuild = 1;
-            }
-        } else {
-            if (module != st->module_name) {
-                if (st->module_name)
+            if (module && st->module_name) {
+                if (unlikely(strcmp(module, st->module_name))) {
                     freez(st->module_name);
-                st->module_name = module ? strdupz(module) : NULL;
+                    st->module_name = strdupz(module);
+                    mark_rebuild = 1;
+                }
+            } else {
+                if (module != st->module_name) {
+                    if (st->module_name)
+                        freez(st->module_name);
+                    st->module_name = module ? strdupz(module) : NULL;
+                    mark_rebuild = 1;
+                }
+            }
+
+            char *new_title = config_get(st->config_section, "title", title);
+            json_fix_string(new_title);
+
+            if (unlikely(strcmp(st->title, title))) {
+                freez(st->title);
+                st->title = new_title;
                 mark_rebuild = 1;
             }
-        }
 
-        char *new_title = config_get(st->config_section, "title", title);
-        json_fix_string(new_title);
+            RRDSET_TYPE new_chart_type =
+                rrdset_type_id(config_get(st->config_section, "chart type", rrdset_type_name(chart_type)));
+            if (st->chart_type != new_chart_type) {
+                st->chart_type = new_chart_type;
+                mark_rebuild = 1;
+            }
 
-        if (unlikely(strcmp(st->title, title))) {
-            freez(st->title);
-            st->title = new_title;
-            mark_rebuild = 1;
-        }
+            char *new_family = config_get(st->config_section, "family", family ? family : st->type);
+            json_fix_string(new_family);
+            if (unlikely((strcmp(st->family, new_family)))) {
+                freez(st->family);
+                st->family = new_family;
+                mark_rebuild = 1;
+            }
 
-        RRDSET_TYPE new_chart_type = rrdset_type_id(config_get(st->config_section, "chart type", rrdset_type_name(chart_type)));
-        if (st->chart_type != new_chart_type) {
-            st->chart_type = new_chart_type;
-            mark_rebuild = 1;
-        }
+            char *new_context = config_get(st->config_section, "context", context ? context : st->id);
+            json_fix_string(new_context);
+            if (unlikely((strcmp(st->context, new_context)))) {
+                freez(st->context);
+                st->context = new_context;
+                st->hash_context = simple_hash(st->context);
+                mark_rebuild = 1;
+            }
 
-        char *new_family = config_get(st->config_section, "family", family?family:st->type);
-        json_fix_string(new_family);
-        if (unlikely((strcmp(st->family, new_family)))) {
-            freez(st->family);
-            st->family = new_family;
-            mark_rebuild = 1;
-        }
-
-        char *new_context = config_get(st->config_section, "context", context?context:st->id);
-        json_fix_string(new_context);
-        if (unlikely((strcmp(st->context, new_context)))) {
-            freez(st->context);
-            st->context = new_context;
-            st->hash_context = simple_hash(st->context);
-            mark_rebuild = 1;
-        }
+            rrdhost_unlock(host);
 
 #ifdef ENABLE_DBENGINE
-        if (mark_rebuild)
-            metalog_commit_update_chart(st);
+            if (mark_rebuild)
+                metalog_commit_update_chart(st);
 #endif
-        // name
-        // - title
-        // family
-        // context
-        // charttype
-        // options
-        // - plugin
-        // - module
-
-        return st;
+             return st;
+        }
+        rrdhost_unlock(host);
     }
 
     rrdhost_wrlock(host);

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -63,9 +63,6 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, PARSER_INPUT_TYPE fl
         rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_END, pluginsd_end);
         rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_BEGIN, pluginsd_begin);
         rc += parser_add_keyword(parser, "SET", pluginsd_set);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_GUID, pluginsd_guid);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_CONTEXT, pluginsd_context);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_TOMBSTONE, pluginsd_tombstone);
     }
 
     return parser;

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -63,6 +63,9 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, PARSER_INPUT_TYPE fl
         rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_END, pluginsd_end);
         rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_BEGIN, pluginsd_begin);
         rc += parser_add_keyword(parser, "SET", pluginsd_set);
+        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_GUID, pluginsd_guid);
+        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_CONTEXT, pluginsd_context);
+        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_TOMBSTONE, pluginsd_tombstone);
     }
 
     return parser;

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -277,6 +277,25 @@ static int rrdpush_receive(struct receiver_state *rpt)
         }
         netdata_mutex_unlock(&rpt->host->receiver_lock);
     }
+    else rrdhost_update(rpt->host
+            , rpt->hostname
+            , rpt->registry_hostname
+            , rpt->machine_guid
+            , rpt->os
+            , rpt->timezone
+            , rpt->tags
+            , program_name
+            , program_version
+            , rpt->update_every
+            , history
+            , mode
+            , (unsigned int)(health_enabled != CONFIG_BOOLEAN_NO)
+            , (unsigned int)(rrdpush_enabled && rrdpush_destination && *rrdpush_destination && rrdpush_api_key && *rrdpush_api_key)
+            , rrdpush_destination
+            , rrdpush_api_key
+            , rrdpush_send_charts_matching
+            , rpt->system_info);
+
 
     int ssl = 0;
 #ifdef ENABLE_HTTPS


### PR DESCRIPTION
Fixes #8924 
##### Summary
Expand the attributes of a chart / dimension / Host that can be dynamically updated

- Handle changes in dimensions (already there)
  - Queue a metadata log update by calling `metalog_commit_update_dimension`
- Perform checks on chart updates
  - Queue a metadata log update by calling  `metalog_commit_update_chart`

##### Component Name

##### Test Plan
- TBA
