### PR TITLE
fix compilation for older systems

### DIFF
--- a/aclk/aclk_lws_https_client.c
+++ b/aclk/aclk_lws_https_client.c
@@ -193,7 +193,8 @@ int aclk_send_https_request(char *method, char *host, char *port, char *url, cha
 #else
     i.ssl_connection = LCCSCF_USE_SSL;
 #endif
-#ifndef HAVE_X509_VERIFY_PARAM_set1_host
+#if defined(HAVE_X509_VERIFY_PARAM_set1_host) && HAVE_X509_VERIFY_PARAM_set1_host == 0
+#warning DISABLING SSL HOSTNAME VALIDATION BECAUSE IT IS NOT AVAILABLE ON THIS SYSTEM.
     i.ssl_connection |= LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK;
 #endif
 

--- a/aclk/aclk_lws_https_client.c
+++ b/aclk/aclk_lws_https_client.c
@@ -193,6 +193,9 @@ int aclk_send_https_request(char *method, char *host, char *port, char *url, cha
 #else
     i.ssl_connection = LCCSCF_USE_SSL;
 #endif
+#ifndef HAVE_X509_VERIFY_PARAM_set1_host
+    i.ssl_connection |= LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK;
+#endif
 
     i.port = atoi(port);
     i.address = host;

--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -322,7 +322,8 @@ int aclk_lws_wss_connect(char *host, int port)
 #else
     i.ssl_connection = LCCSCF_USE_SSL;
 #endif
-#ifndef HAVE_X509_VERIFY_PARAM_set1_host
+#if defined(HAVE_X509_VERIFY_PARAM_set1_host) && HAVE_X509_VERIFY_PARAM_set1_host == 0
+#warning DISABLING SSL HOSTNAME VALIDATION BECAUSE IT IS NOT AVAILABLE ON THIS SYSTEM.
     i.ssl_connection |= LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK;
 #endif
     lws_client_connect_via_info(&i);

--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -322,6 +322,9 @@ int aclk_lws_wss_connect(char *host, int port)
 #else
     i.ssl_connection = LCCSCF_USE_SSL;
 #endif
+#ifndef HAVE_X509_VERIFY_PARAM_set1_host
+    i.ssl_connection |= LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK;
+#endif
     lws_client_connect_via_info(&i);
     return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -371,6 +371,12 @@ AC_CHECK_LIB(
     [SSL_LIBS="-lcrypto -lssl"]
 )
 
+AC_CHECK_LIB(
+    [crypto],
+    [X509_VERIFY_PARAM_set1_host],
+    [AC_DEFINE([HAVE_X509_VERIFY_PARAM_set1_host], [1], [X509_VERIFY_PARAM_set1_host])]
+)
+
 # -----------------------------------------------------------------------------
 # JSON-C library
 
@@ -586,7 +592,7 @@ if test "$enable_cloud" != "no"; then
     AC_MSG_CHECKING([if libmosquitto static lib is present (and builds)])
     if test -f "externaldeps/mosquitto/libmosquitto.a"; then
         LIBS_BKP="${LIBS}"
-        LIBS="externaldeps/mosquitto/libmosquitto.a ${OPTIONAL_SSL_LIBS}"
+        LIBS="externaldeps/mosquitto/libmosquitto.a ${OPTIONAL_SSL_LIBS} ${LIBS_BKP}"
         AC_LINK_IFELSE([AC_LANG_SOURCE([[#include "externaldeps/mosquitto/mosquitto.h"
                                          int main (int argc, char **argv) {
                                              int m,mm,r;

--- a/configure.ac
+++ b/configure.ac
@@ -374,8 +374,16 @@ AC_CHECK_LIB(
 AC_CHECK_LIB(
     [crypto],
     [X509_VERIFY_PARAM_set1_host],
-    [AC_DEFINE([HAVE_X509_VERIFY_PARAM_set1_host], [1], [X509_VERIFY_PARAM_set1_host])]
+    [ssl_host_validation="yes"],
+    [ssl_host_validation="no"]
 )
+
+if test "${ssl_host_validation}" = "no"; then
+    AC_DEFINE([HAVE_X509_VERIFY_PARAM_set1_host], [0], [ssl host validation])
+    AC_MSG_WARN([DISABLING SSL HOSTNAME VALIDATION BECAUSE IT IS NOT AVAILABLE ON THIS SYSTEM.])
+else
+    AC_DEFINE([HAVE_X509_VERIFY_PARAM_set1_host], [1], [ssl host validation])
+fi
 
 # -----------------------------------------------------------------------------
 # JSON-C library


### PR DESCRIPTION
##### Summary

This PR allows building netdata in operating systems:

1. that `clock_gettime()` is not part for libc, but `librt` or `libposix4`
2. that have an openssl version that does not support `X509_VERIFY_PARAM_set1_host()`

##### Component Name
netdata-installer.sh

##### Test Plan

On Centos 6 ACLK was disabled because of this:
```
checking if libmosquitto static lib is present (and builds)... no
```

The log was giving the error:

```
configure:8965: checking if libmosquitto static lib is present (and builds)
configure:8978: gcc -std=gnu99 -o conftest -O2    conftest.c externaldeps/mosquitto/libmosquitto.a -lcrypto -lssl >&5
externaldeps/mosquitto/libmosquitto.a(mosquitto.o): In function `mosquitto_lib_init':
mosquitto.c:(.text+0x5f): undefined reference to `clock_gettime'
externaldeps/mosquitto/libmosquitto.a(time_mosq.o): In function `mosquitto_time':
time_mosq.c:(.text+0x15): undefined reference to `clock_gettime'
collect2: ld returned 1 exit status
configure:8978: $? = 1
```

With this PR `-lrt` or whatever was needed to link with `clock_gettime()` is added to the above check, so the result is this:

```
checking if libmosquitto static lib is present (and builds)... yes
```

Because of an old OpenSSL library, we also see in the log:

```
checking for X509_VERIFY_PARAM_set1_host in -lcrypto... no
```

The following operating systems have been tested:

O/S|version|netdata compiles|with host validation?|ACLK working
----|:----:|:----:|:----:|:---:
centos|6.10|yes (requires EPEL repo for deps)|**NO**|yes
centos|7|yes|yes|yes
centos|8|yes|yes|yes
debian|7|no (cannot install libuv1)|-|-
debian|8|yes|**NO**|yes
debian|9|yes|yes|yes
debian|10|yes|yes|yes
ubuntu|12.04 LTS|no (cannot install libuv1)|-|-
ubuntu|14.04 LTS|yes (requires special repo for libuv1 #8905 #8916)|**NO**|yes
ubuntu|16.04 LTS|yes|yes|yes
ubuntu|18.04 LTS|yes|yes|yes
ubuntu|20.04 LTS|yes|yes|yes

So, this PR provides a working ACLK for centos 6, debian 8 and ubuntu 14.04 LTS.
