### PR TITLE
Add a random offset to the update script when running non-interactively.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -185,8 +185,8 @@ update() {
       do_not_start="--dont-start-it"
     fi
 
-    if [ -n "${NETDATA_SELECTED_DASHBOARD}" ] ; then
-        env="NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
+    if [ -n "${NETDATA_SELECTED_DASHBOARD}" ]; then
+      env="NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
     fi
 
     info "Re-installing netdata..."
@@ -209,6 +209,14 @@ logfile=
 tmpdir=
 
 trap cleanup EXIT
+
+# Random sleep to aileviate stampede effect of Agents upgrading
+# and disconnecting/reconnecting at the same time (or near to).
+# But only we're not a controlling terminal (tty)
+# Randomly sleep between 1s and 60m
+if [ ! -t 1 ]; then
+  sleep $(((RANDOM % 3600) + 1))s
+fi
 
 # Usually stored in /etc/netdata/.environment
 : "${ENVIRONMENT_FILE:=THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT}"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -210,11 +210,20 @@ tmpdir=
 
 trap cleanup EXIT
 
+while [ -n "${1}" ]; do
+  if [ "${1}" = "--not-running-from-cron" ]; then
+    NETDATA_SPECIAL_NONINTERACTIVE=1
+    shift 1
+  else
+    break
+  fi
+done
+
 # Random sleep to aileviate stampede effect of Agents upgrading
 # and disconnecting/reconnecting at the same time (or near to).
 # But only we're not a controlling terminal (tty)
 # Randomly sleep between 1s and 60m
-if [ ! -t 1 ]; then
+if [ ! -t 1 ] && [ -z "${NETDATA_SPECIAL_NONINTERACTIVE}" ]; then
   sleep $(((RANDOM % 3600) + 1))s
 fi
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -212,7 +212,7 @@ trap cleanup EXIT
 
 while [ -n "${1}" ]; do
   if [ "${1}" = "--not-running-from-cron" ]; then
-    NETDATA_SPECIAL_NONINTERACTIVE=1
+    NETDATA_NOT_RUNNING_FROM_CRON=1
     shift 1
   else
     break
@@ -223,7 +223,7 @@ done
 # and disconnecting/reconnecting at the same time (or near to).
 # But only we're not a controlling terminal (tty)
 # Randomly sleep between 1s and 60m
-if [ ! -t 1 ] && [ -z "${NETDATA_SPECIAL_NONINTERACTIVE}" ]; then
+if [ ! -t 1 ] && [ -z "${NETDATA_NOT_RUNNING_FROM_CRON}" ]; then
   sleep $(((RANDOM % 3600) + 1))s
 fi
 

--- a/tests/lifecycle.bats
+++ b/tests/lifecycle.bats
@@ -50,7 +50,7 @@ setup() {
 
 @test "update netdata" {
 	export ENVIRONMENT_FILE="${ENV}"
-	/etc/cron.daily/netdata-updater
+	${INSTALLATION}/installation/usr/libexec/netdata/netdata-updater.sh --not-running-from-cron
 	! grep "new_installation" "${ENV}"
 }
 

--- a/tests/lifecycle.bats
+++ b/tests/lifecycle.bats
@@ -50,7 +50,7 @@ setup() {
 
 @test "update netdata" {
 	export ENVIRONMENT_FILE="${ENV}"
-	${INSTALLATION}/installation/usr/libexec/netdata/netdata-updater.sh --not-running-from-cron
+	${INSTALLATION}/netdata/usr/libexec/netdata/netdata-updater.sh --not-running-from-cron
 	! grep "new_installation" "${ENV}"
 }
 

--- a/tests/updater_checks.bats
+++ b/tests/updater_checks.bats
@@ -56,6 +56,9 @@ setup() {
 	# Run the updater, with the override so that it uses the local repo we have at hand
 	# Try to run the installed, if any, otherwise just run the one from the repo
 	export NETDATA_LOCAL_TARBAL_OVERRIDE="${PWD}"
+	# Disable random sleep / splay for netdata-updater to avoid sampede effect
+	# of many agents (dis|re)connecting too quickly all at onace to Netdata Cloud
+	unset RANDOM; export RANDOM=0
 	/etc/cron.daily/netdata-updater || ./packaging/installer/netdata-updater.sh
 	! grep "new_installation" "${ENV}"
 }

--- a/tests/updater_checks.bats
+++ b/tests/updater_checks.bats
@@ -55,7 +55,7 @@ setup() {
 	export ENVIRONMENT_FILE="${ENV}"
 	# Run the updater, with the override so that it uses the local repo we have at hand
 	export NETDATA_LOCAL_TARBAL_OVERRIDE="${PWD}"
-	${INSTALLATION}/installation/usr/libexec/netdata/netdata-updater.sh --not-running-from-cron
+	${INSTALLATION}/netdata/usr/libexec/netdata/netdata-updater.sh --not-running-from-cron
 	! grep "new_installation" "${ENV}"
 }
 

--- a/tests/updater_checks.bats
+++ b/tests/updater_checks.bats
@@ -54,12 +54,8 @@ setup() {
 @test "update netdata using the new updater" {
 	export ENVIRONMENT_FILE="${ENV}"
 	# Run the updater, with the override so that it uses the local repo we have at hand
-	# Try to run the installed, if any, otherwise just run the one from the repo
 	export NETDATA_LOCAL_TARBAL_OVERRIDE="${PWD}"
-	# Disable random sleep / splay for netdata-updater to avoid sampede effect
-	# of many agents (dis|re)connecting too quickly all at onace to Netdata Cloud
-	unset RANDOM; export RANDOM=0
-	/etc/cron.daily/netdata-updater || ./packaging/installer/netdata-updater.sh
+	${INSTALLATION}/installation/usr/libexec/netdata/netdata-updater.sh --not-running-from-cron
 	! grep "new_installation" "${ENV}"
 }
 


### PR DESCRIPTION
##### Summary

This reuses the code from #9079 but adds a CLI option to the script itself to disable the random offset when running from CI.

##### Component Name

area/packaging

##### Test Plan

Verified locally that the offset code works correctly.

CI fixes verified on this PR.