### PR TITLE
ipfs-plugin: change HTTP method to make it compatible with ipfs 0.5.0+

### DIFF
--- a/collectors/python.d.plugin/ipfs/ipfs.chart.py
+++ b/collectors/python.d.plugin/ipfs/ipfs.chart.py
@@ -63,6 +63,7 @@ class Service(UrlService):
         self.order = ORDER
         self.definitions = CHARTS
         self.baseurl = self.configuration.get('url', 'http://localhost:5001')
+        self.method = "POST"
         self.do_pinapi = self.configuration.get('pinapi')
         self.__storage_max = None
 


### PR DESCRIPTION
##### Component Name

python.d plugin for IPFS

https://docs.ipfs.io/reference/http/api/#api-v0-stats-bw

##### Test Plan

Tested in the default installation under arch-linux

