### PR TITLE
Metadata log compaction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,8 @@ set(RRD_PLUGIN_FILES
         database/engine/metadata_log/metadatalogprotocol.h
         database/engine/metadata_log/metalogpluginsd.c
         database/engine/metadata_log/metalogpluginsd.h
+        database/engine/metadata_log/compaction.c
+        database/engine/metadata_log/compaction.h
         database/engine/global_uuid_map/global_uuid_map.c
         database/engine/global_uuid_map/global_uuid_map.h
         )

--- a/Makefile.am
+++ b/Makefile.am
@@ -384,6 +384,8 @@ if ENABLE_DBENGINE
         database/engine/metadata_log/metadatalogprotocol.h \
         database/engine/metadata_log/metalogpluginsd.c \
         database/engine/metadata_log/metalogpluginsd.h \
+        database/engine/metadata_log/compaction.c \
+        database/engine/metadata_log/compaction.h \
         database/engine/global_uuid_map/global_uuid_map.c \
         database/engine/global_uuid_map/global_uuid_map.h \
         $(NULL)

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1834,9 +1834,10 @@ int test_dbengine(void)
     }
 error_out:
     rrd_wrlock();
+    rrdeng_prepare_exit(host->rrdeng_ctx);
     rrdhost_delete_charts(host);
-    rrd_unlock();
     rrdeng_exit(host->rrdeng_ctx);
+    rrd_unlock();
 
     return errors;
 }
@@ -2223,9 +2224,10 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
     }
     freez(query_threads);
     rrd_wrlock();
+    rrdeng_prepare_exit(host->rrdeng_ctx);
     rrdhost_delete_charts(host);
-    rrd_unlock();
     rrdeng_exit(host->rrdeng_ctx);
+    rrd_unlock();
 }
 
 #endif

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -40,8 +40,12 @@ void   dump_object(uuid_t *index, void *object)
     }
 }
 
+/* Returns 0 if it successfully stores the uuid-object mapping or if an identical mapping already exists */
 static inline int guid_store_nolock(uuid_t *uuid, void *object, GUID_TYPE object_type)
 {
+    char *existing_object;
+    GUID_TYPE existing_object_type;
+
     if (unlikely(!object) || uuid == NULL)
         return 0;
 
@@ -50,8 +54,29 @@ static inline int guid_store_nolock(uuid_t *uuid, void *object, GUID_TYPE object
     PValue = JudyHSIns(&JGUID_map, (void *) uuid, (Word_t) sizeof(uuid_t), PJE0);
     if (PPJERR == PValue)
         fatal("JudyHSIns() fatal error.");
-    if (*PValue)
+    if (*PValue) {
+        existing_object = *PValue;
+        existing_object_type = existing_object[0];
+        if (existing_object_type != object_type)
+            return 1;
+        switch (existing_object_type) {
+            case GUID_TYPE_DIMENSION:
+                if (memcmp(existing_object, object, 1 + 16 + 16 + 16))
+                    return 1;
+                break;
+            case GUID_TYPE_CHART:
+                if (memcmp(existing_object, object, 1 + 16 + 16))
+                    return 1;
+                break;
+            case GUID_TYPE_CHAR:
+                if (strcmp(existing_object + 1, (char *)object))
+                    return 1;
+                break;
+            default:
+                return 1;
+        }
         return 1;
+    }
 
     *PValue = (Pvoid_t *) object;
 

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -75,6 +75,7 @@ static inline int guid_store_nolock(uuid_t *uuid, void *object, GUID_TYPE object
             default:
                 return 1;
         }
+        freez(existing_object);
     }
 
     *PValue = (Pvoid_t *) object;

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -75,7 +75,6 @@ static inline int guid_store_nolock(uuid_t *uuid, void *object, GUID_TYPE object
             default:
                 return 1;
         }
-        return 1;
     }
 
     *PValue = (Pvoid_t *) object;

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#define NETDATA_RRD_INTERNALS
+
+#include "metadatalog.h"
+
+void after_compact_old_records(struct metalog_worker_config* wc)
+{
+    struct metalog_instance *ctx = wc->ctx;
+    int error;
+
+    mlf_flush_records_buffer(wc, &ctx->compaction_state.records_log, &ctx->compaction_state.new_metadata_logfiles);
+    uv_run(wc->loop, UV_RUN_DEFAULT);
+
+    error = uv_thread_join(wc->now_compacting_files);
+    if (error) {
+        error("uv_thread_join(): %s", uv_strerror(error));
+    }
+    freez(wc->now_compacting_files);
+    /* unfreeze command processing */
+    wc->now_compacting_files = NULL;
+
+    wc->cleanup_thread_compacting_files = 0;
+
+    /* interrupt event loop */
+    uv_stop(wc->loop);
+
+    info("Finished metadata log compaction (id:%"PRIu32").", ctx->current_compaction_id);
+}
+
+static void metalog_flush_compaction_records(struct metalog_instance *ctx)
+{
+    struct metalog_cmd cmd;
+    struct completion compaction_completion;
+
+    init_completion(&compaction_completion);
+
+    cmd.opcode = METALOG_COMPACTION_FLUSH;
+    cmd.record_io_descr.completion = &compaction_completion;
+    metalog_enq_cmd(&ctx->worker_config, &cmd);
+
+    wait_for_completion(&compaction_completion);
+    destroy_completion(&compaction_completion);
+}
+
+/* The caller must have called metalog_flush_compaction_records() before to synchronize and quiesce the event loop. */
+static void compaction_test_quota(struct metalog_worker_config *wc)
+{
+    struct metalog_instance *ctx = wc->ctx;
+    struct logfile_compaction_state *compaction_state;
+    struct metadata_logfile *oldmetalogfile, *newmetalogfile;
+    unsigned current_size;
+    int ret;
+
+    compaction_state = &ctx->compaction_state;
+    newmetalogfile = compaction_state->new_metadata_logfiles.last;
+
+    oldmetalogfile = ctx->metadata_logfiles.first;
+
+    current_size = newmetalogfile->pos;
+    if (unlikely(current_size >= MAX_METALOGFILE_SIZE && newmetalogfile->starting_fileno < oldmetalogfile->fileno)) {
+        /* It's safe to finalize the compacted metadata log file and create a new one since it has already replaced
+         * an older one. */
+
+        /* Finalize as the immediately previous file than the currently compacted one. */
+        ret = rename_metadata_logfile(newmetalogfile, 0, newmetalogfile->fileno - 1);
+        if (ret < 0)
+            return;
+
+        ret = add_new_metadata_logfile(ctx, &compaction_state->new_metadata_logfiles,
+                                       ctx->metadata_logfiles.first->fileno, ctx->metadata_logfiles.first->fileno);
+
+        if (likely(!ret)) {
+            compaction_state->fileno = ctx->metadata_logfiles.first->fileno;
+        }
+    }
+}
+
+
+static void compact_record_by_uuid(struct metalog_instance *ctx, struct metadata_logfile *metalogfile,
+                                   struct metadata_logfile *newmetalogfile, uuid_t *uuid)
+{
+    struct metalog_worker_config* wc = &ctx->worker_config;
+    GUID_TYPE ret;
+    RRDHOST *host = ctx->rrdeng_ctx->host;
+    RRDSET *st;
+    RRDDIM *rd;
+    BUFFER *buffer;
+
+    ret = find_object_by_guid(uuid, NULL, 0);
+    switch (ret) {
+        case GUID_TYPE_CHAR:
+            assert(0);
+            break;
+        case GUID_TYPE_CHART:
+            st = metalog_get_chart_from_uuid(ctx, uuid);
+            if (st) {
+                if (ctx->current_compaction_id > st->compaction_id) {
+                    st->compaction_id = ctx->current_compaction_id;
+                    buffer = metalog_update_chart_buffer(st, ctx->current_compaction_id);
+                    metalog_commit_record(ctx, buffer, METALOG_COMMIT_CREATION_RECORD, uuid, 1);
+                } else {
+                    info("Chart has already been compacted, ignoring record.");
+                }
+            } else {
+                info("Ignoring nonexistent chart metadata record.");
+            }
+            break;
+        case GUID_TYPE_DIMENSION:
+            rd = metalog_get_dimension_from_uuid(ctx, uuid);
+            if (rd) {
+                if (ctx->current_compaction_id > rd->state->compaction_id) {
+                    rd->state->compaction_id = ctx->current_compaction_id;
+                    buffer = metalog_update_dimension_buffer(rd);
+                    metalog_commit_record(ctx, buffer, METALOG_COMMIT_CREATION_RECORD, uuid, 1);
+                } else {
+                    info("Chart has already been compacted, ignoring record.");
+                }
+            } else {
+                info("Ignoring nonexistent dimension metadata record.");
+            }
+            break;
+        case GUID_TYPE_HOST:
+            if (ctx->current_compaction_id > host->compaction_id) {
+                host->compaction_id = ctx->current_compaction_id;
+                buffer = metalog_update_host_buffer(host);
+                metalog_commit_record(ctx, buffer, METALOG_COMMIT_CREATION_RECORD, uuid, 1);
+            } else {
+                info("Host has already been compacted, ignoring record.");
+            }
+            break;
+        case GUID_TYPE_NOTFOUND:
+            info("Ignoring nonexistent metadata record.");
+            break;
+        default:
+            assert(0);
+            break;
+    }
+}
+
+/* Returns 0 on success. */
+static int compact_metadata_logfile_records(struct metalog_instance *ctx, struct metadata_logfile *metalogfile)
+{
+    struct metalog_worker_config* wc = &ctx->worker_config;
+    struct logfile_compaction_state *compaction_state;
+    struct metalog_record *record;
+    struct metalog_record_block *record_block, *prev_record_block;
+    struct metadata_logfile *newmetalogfile;
+    int ret;
+    unsigned iterated_records;
+#define METADATA_LOG_RECORD_BATCH 128 /* Flush I/O and check sizes every times this many records have been iterated */
+
+    info("Compacting metadata log file \"%s/"METALOG_PREFIX METALOG_FILE_NUMBER_PRINT_TMPL METALOG_EXTENSION"\".",
+         ctx->rrdeng_ctx->dbfiles_path, metalogfile->starting_fileno, metalogfile->fileno);
+
+    compaction_state = &ctx->compaction_state;
+    newmetalogfile = compaction_state->new_metadata_logfiles.last;
+    record_block = prev_record_block = NULL;
+    iterated_records = 0;
+    for (record = mlf_record_get_first(metalogfile) ; record != NULL ; record = mlf_record_get_next(metalogfile)) {
+        if ((record_block = metalogfile->records.iterator.current) != prev_record_block) {
+            if (prev_record_block) { /* Deallocate iterated record blocks */
+                ctx->records_nr -= prev_record_block->records_nr; /* FIXME: racy */
+                freez(prev_record_block);
+            }
+            prev_record_block = record_block;
+        }
+        compact_record_by_uuid(ctx, metalogfile, newmetalogfile, &record->uuid);
+        if (0 == ++iterated_records % METADATA_LOG_RECORD_BATCH) {
+            metalog_flush_compaction_records(ctx);
+            if (compaction_state->throttle) {
+                (void)sleep_usec(10000); /* 10 msec throttle compaction */
+            }
+            compaction_test_quota(wc);
+            newmetalogfile = compaction_state->new_metadata_logfiles.last;
+        }
+    }
+    if (prev_record_block) { /* Deallocate iterated record blocks */
+        ctx->records_nr -= prev_record_block->records_nr; /* FIXME: racy */
+        freez(prev_record_block);
+    }
+
+    info("Compacted metadata log file \"%s/"METALOG_PREFIX METALOG_FILE_NUMBER_PRINT_TMPL METALOG_EXTENSION"\".",
+         ctx->rrdeng_ctx->dbfiles_path, metalogfile->starting_fileno, metalogfile->fileno);
+
+    metadata_logfile_list_delete(&ctx->metadata_logfiles, metalogfile);
+    ret = destroy_metadata_logfile(metalogfile);
+    if (!ret) {
+        info("Deleted file \"%s/"METALOG_PREFIX METALOG_FILE_NUMBER_PRINT_TMPL METALOG_EXTENSION"\".",
+             ctx->rrdeng_ctx->dbfiles_path, metalogfile->starting_fileno, metalogfile->fileno);
+        ctx->disk_space -= metalogfile->pos; /* racy, currently unsafe */
+    } else {
+        error("Failed to delete file \"%s/"METALOG_PREFIX METALOG_FILE_NUMBER_PRINT_TMPL METALOG_EXTENSION"\".",
+             ctx->rrdeng_ctx->dbfiles_path, metalogfile->starting_fileno, metalogfile->fileno);
+    }
+    freez(metalogfile);
+
+    return ret;
+}
+
+static void compact_old_records(void *arg)
+{
+    struct metalog_instance *ctx = arg;
+    struct metalog_worker_config* wc = &ctx->worker_config;
+    struct logfile_compaction_state *compaction_state;
+    struct metadata_logfile *metalogfile, *nextmetalogfile, *newmetalogfile;
+    int ret;
+
+    compaction_state = &ctx->compaction_state;
+
+    nextmetalogfile = NULL;
+    for (metalogfile = ctx->metadata_logfiles.first ;
+         metalogfile != compaction_state->last_original_logfile ;
+         metalogfile = nextmetalogfile) {
+        nextmetalogfile = metalogfile->next;
+
+        newmetalogfile = compaction_state->new_metadata_logfiles.last;
+        ret = rename_metadata_logfile(newmetalogfile, newmetalogfile->starting_fileno, metalogfile->fileno);
+        if (ret < 0) {
+            error("Failed to rename file \"%s/"METALOG_PREFIX METALOG_FILE_NUMBER_PRINT_TMPL METALOG_EXTENSION"\".",
+                  ctx->rrdeng_ctx->dbfiles_path, newmetalogfile->starting_fileno, newmetalogfile->fileno);
+        }
+
+        ret = compact_metadata_logfile_records(ctx, metalogfile);
+        if (ret) {
+            error("Metadata log compaction failed, cancelling.");
+            break;
+        }
+    }
+    assert(nextmetalogfile); /* There are always more than 1 metadata log files during compaction */
+
+    newmetalogfile = compaction_state->new_metadata_logfiles.last;
+    if (newmetalogfile->starting_fileno != 0) { /* Must rename the last compacted file */
+        ret = rename_metadata_logfile(newmetalogfile, 0, nextmetalogfile->fileno - 1);
+        if (ret < 0) {
+            error("Failed to rename file \"%s/"METALOG_PREFIX METALOG_FILE_NUMBER_PRINT_TMPL METALOG_EXTENSION"\".",
+                  ctx->rrdeng_ctx->dbfiles_path, newmetalogfile->starting_fileno, newmetalogfile->fileno);
+        }
+    }
+    /* Connect the compacted files to the metadata log */
+    newmetalogfile->next = nextmetalogfile;
+    ctx->metadata_logfiles.first = compaction_state->new_metadata_logfiles.first;
+
+    wc->cleanup_thread_compacting_files = 1;
+    /* wake up event loop */
+    assert(0 == uv_async_send(&wc->async));
+}
+
+/* Returns 0 on success. */
+static int init_compaction_state(struct metalog_instance *ctx)
+{
+    struct metadata_logfile *newmetalogfile;
+    struct logfile_compaction_state *compaction_state;
+    int ret;
+
+    compaction_state = &ctx->compaction_state;
+    compaction_state->new_metadata_logfiles.first = NULL;
+    compaction_state->new_metadata_logfiles.last = NULL;
+    compaction_state->starting_fileno = ctx->metadata_logfiles.first->fileno;
+    compaction_state->fileno = ctx->metadata_logfiles.first->fileno;
+    compaction_state->last_original_logfile = ctx->metadata_logfiles.last;
+    compaction_state->throttle = 0;
+
+    ret = add_new_metadata_logfile(ctx, &compaction_state->new_metadata_logfiles, compaction_state->starting_fileno,
+                                   compaction_state->fileno);
+    if (unlikely(ret)) {
+        error("Cannot create new metadata log files, compaction aborted.");
+        return ret;
+    }
+    newmetalogfile = compaction_state->new_metadata_logfiles.first;
+    assert(newmetalogfile == compaction_state->new_metadata_logfiles.last);
+    init_metadata_record_log(&compaction_state->records_log);
+
+    return 0;
+}
+
+void metalog_do_compaction(struct metalog_worker_config *wc)
+{
+    struct metalog_instance *ctx = wc->ctx;
+    int ret, error;
+
+    if (wc->now_compacting_files) {
+        /* already compacting metadata log files */
+        return;
+    }
+    wc->now_compacting_files = mallocz(sizeof(*wc->now_compacting_files));
+    wc->cleanup_thread_compacting_files = 0;
+    metalog_try_link_new_metadata_logfile(wc);
+
+    error = init_compaction_state(ctx);
+    if (unlikely(error)) {
+        error("Cannot create new metadata log files, compaction aborted.");
+        return;
+    }
+    ++ctx->current_compaction_id; /* Signify a new compaction */
+
+    info("Starting metadata log compaction (id:%"PRIu32").", ctx->current_compaction_id);
+    error = uv_thread_create(wc->now_compacting_files, compact_old_records, ctx);
+    if (error) {
+        error("uv_thread_create(): %s", uv_strerror(error));
+        freez(wc->now_compacting_files);
+        wc->now_compacting_files = NULL;
+    }
+
+}

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -97,10 +97,10 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
                     buffer = metalog_update_chart_buffer(st, ctx->current_compaction_id);
                     metalog_commit_record(ctx, buffer, METALOG_COMMIT_CREATION_RECORD, uuid, 1);
                 } else {
-                    info("Chart has already been compacted, ignoring record.");
+                    debug(D_METADATALOG, "Chart has already been compacted, ignoring record.");
                 }
             } else {
-                info("Ignoring nonexistent chart metadata record.");
+                debug(D_METADATALOG, "Ignoring nonexistent chart metadata record.");
             }
             break;
         case GUID_TYPE_DIMENSION:
@@ -111,10 +111,10 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
                     buffer = metalog_update_dimension_buffer(rd);
                     metalog_commit_record(ctx, buffer, METALOG_COMMIT_CREATION_RECORD, uuid, 1);
                 } else {
-                    info("Dimension has already been compacted, ignoring record.");
+                    debug(D_METADATALOG, "Dimension has already been compacted, ignoring record.");
                 }
             } else {
-                info("Ignoring nonexistent dimension metadata record.");
+                debug(D_METADATALOG, "Ignoring nonexistent dimension metadata record.");
             }
             break;
         case GUID_TYPE_HOST:
@@ -123,11 +123,11 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
                 buffer = metalog_update_host_buffer(host);
                 metalog_commit_record(ctx, buffer, METALOG_COMMIT_CREATION_RECORD, uuid, 1);
             } else {
-                info("Host has already been compacted, ignoring record.");
+                debug(D_METADATALOG, "Host has already been compacted, ignoring record.");
             }
             break;
         case GUID_TYPE_NOTFOUND:
-            info("Ignoring nonexistent metadata record.");
+            debug(D_METADATALOG, "Ignoring nonexistent metadata record.");
             break;
         default:
             assert(0);

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -111,7 +111,7 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
                     buffer = metalog_update_dimension_buffer(rd);
                     metalog_commit_record(ctx, buffer, METALOG_COMMIT_CREATION_RECORD, uuid, 1);
                 } else {
-                    info("Chart has already been compacted, ignoring record.");
+                    info("Dimension has already been compacted, ignoring record.");
                 }
             } else {
                 info("Ignoring nonexistent dimension metadata record.");
@@ -142,7 +142,6 @@ static int compact_metadata_logfile_records(struct metalog_instance *ctx, struct
     struct logfile_compaction_state *compaction_state;
     struct metalog_record *record;
     struct metalog_record_block *record_block, *prev_record_block;
-    struct metadata_logfile *newmetalogfile;
     int ret;
     unsigned iterated_records;
 #define METADATA_LOG_RECORD_BATCH 128 /* Flush I/O and check sizes whenever this many records have been iterated */
@@ -151,7 +150,6 @@ static int compact_metadata_logfile_records(struct metalog_instance *ctx, struct
          ctx->rrdeng_ctx->dbfiles_path, metalogfile->starting_fileno, metalogfile->fileno);
 
     compaction_state = &ctx->compaction_state;
-    newmetalogfile = compaction_state->new_metadata_logfiles.last;
     record_block = prev_record_block = NULL;
     iterated_records = 0;
     for (record = mlf_record_get_first(metalogfile) ; record != NULL ; record = mlf_record_get_next(metalogfile)) {
@@ -169,7 +167,6 @@ static int compact_metadata_logfile_records(struct metalog_instance *ctx, struct
                 (void)sleep_usec(10000); /* 10 msec throttle compaction */
             }
             compaction_test_quota(wc);
-            newmetalogfile = compaction_state->new_metadata_logfiles.last;
         }
     }
     if (prev_record_block) { /* Deallocate iterated record blocks */

--- a/database/engine/metadata_log/compaction.h
+++ b/database/engine/metadata_log/compaction.h
@@ -18,6 +18,8 @@ struct logfile_compaction_state {
     uint8_t throttle; /* set non-zero to throttle compaction */
 };
 
+extern int compaction_failure_recovery(struct metalog_instance *ctx, struct metadata_logfile **metalogfiles,
+                                       unsigned *matched_files);
 extern void metalog_do_compaction(struct metalog_worker_config *wc);
 extern void after_compact_old_records(struct metalog_worker_config* wc);
 

--- a/database/engine/metadata_log/compaction.h
+++ b/database/engine/metadata_log/compaction.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_COMPACTION_H
+#define NETDATA_COMPACTION_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include "../rrdengine.h"
+
+struct logfile_compaction_state {
+    unsigned fileno; /* Starts at 1 */
+    unsigned starting_fileno; /* 0 for normal files, staring number during compaction */
+
+    struct metadata_record_commit_log records_log;
+    struct metadata_logfile_list new_metadata_logfiles;
+    struct metadata_logfile *last_original_logfile; /* Marks the end of compaction */
+    uint8_t throttle; /* set non-zero to throttle compaction */
+};
+
+extern void metalog_do_compaction(struct metalog_worker_config *wc);
+extern void after_compact_old_records(struct metalog_worker_config* wc);
+
+#endif /* NETDATA_COMPACTION_H */

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -479,6 +479,7 @@ static void iterate_records(struct metadata_logfile *metalogfile)
                                    sizeof(header->header_length);
 
     file_size = metalogfile->pos;
+    state->metalogfile = metalogfile;
 
     buf = mallocz(MAX_READ_BYTES);
 

--- a/database/engine/metadata_log/logfile.h
+++ b/database/engine/metadata_log/logfile.h
@@ -83,6 +83,7 @@ extern void metadata_logfile_init(struct metadata_logfile *metadatalog, struct m
 extern int rename_metadata_logfile(struct metadata_logfile *metalogfile, unsigned new_starting_fileno,
                                    unsigned new_fileno);
 extern int close_metadata_logfile(struct metadata_logfile *metadatalog);
+extern int unlink_metadata_logfile(struct metadata_logfile *metalogfile);
 extern int destroy_metadata_logfile(struct metadata_logfile *metalogfile);
 extern int create_metadata_logfile(struct metadata_logfile *metalogfile);
 extern int load_metadata_logfile(struct metalog_instance *ctx, struct metadata_logfile *logfile);

--- a/database/engine/metadata_log/logfile.h
+++ b/database/engine/metadata_log/logfile.h
@@ -13,21 +13,32 @@ struct metalog_worker_config;
 #define METALOG_PREFIX "metadatalog-"
 #define METALOG_EXTENSION ".mlf"
 
-#define MAX_METALOGFILE_SIZE   (1073741824LU)
-#define MIN_METALOGFILE_SIZE   (16777216LU)
-#define TARGET_METALOGFILES (20)
+#define MAX_METALOGFILE_SIZE   (524288LU)
 
-struct metalog_record_info {
-    uint64_t offset;
-    uint32_t size;
-    struct metadata_logfile *metalogfile;
-    struct metalog_record_info *next;
+/* Deletions are ignored during compaction, so only creation UUIDs are stored */
+struct metalog_record {
+    uuid_t uuid;
+};
+
+#define MAX_METALOG_RECORDS_PER_BLOCK   (1024LU)
+struct metalog_record_block {
+    uint64_t file_offset;
+    uint32_t io_size;
+
+    struct metalog_record record_array[MAX_METALOG_RECORDS_PER_BLOCK];
+    uint16_t records_nr;
+
+    struct metalog_record_block *next;
 };
 
 struct metalog_records {
-    /* the record list is sorted based on disk offset */
-    struct metalog_record_info *first;
-    struct metalog_record_info *last;
+    /* the record block list is sorted based on disk offset */
+    struct metalog_record_block *first;
+    struct metalog_record_block *last;
+    struct {
+        struct metalog_record_block *current;
+        uint16_t record_i;
+    } iterator;
 };
 
 /* only one event loop is supported for now */
@@ -46,7 +57,6 @@ struct metadata_logfile_list {
     struct metadata_logfile *last; /* newest */
 };
 
-/* only one event loop is supported for now */
 struct metadata_record_commit_log {
     uint64_t record_id;
 
@@ -56,20 +66,29 @@ struct metadata_record_commit_log {
     unsigned buf_size;
 };
 
-extern void mlf_record_insert(struct metalog_record_info *record);
-extern void mlf_flush_records_buffer(struct metalog_worker_config *wc);
-extern void *mlf_get_records_buffer(struct metalog_worker_config *wc, unsigned size);
-extern void metadata_logfile_list_insert(struct metalog_instance *ctx, struct metadata_logfile *metalogfile);
-extern void metadata_logfile_list_delete(struct metalog_instance *ctx, struct metadata_logfile *metalogfile);
+extern void mlf_record_insert(struct metadata_logfile *metalogfile, struct metalog_record *record);
+extern struct metalog_record *mlf_record_get_first(struct metadata_logfile *metalogfile);
+extern struct metalog_record *mlf_record_get_next(struct metadata_logfile *metalogfile);
+extern void mlf_flush_records_buffer(struct metalog_worker_config *wc, struct metadata_record_commit_log *records_log,
+                                     struct metadata_logfile_list *metadata_logfiles);
+extern void *mlf_get_records_buffer(struct metalog_worker_config *wc, struct metadata_record_commit_log *records_log,
+                                    struct metadata_logfile_list *metadata_logfiles, unsigned size);
+extern void metadata_logfile_list_insert(struct metadata_logfile_list *metadata_logfiles,
+                                         struct metadata_logfile *metalogfile);
+extern void metadata_logfile_list_delete(struct metadata_logfile_list *metadata_logfiles,
+                                         struct metadata_logfile *metalogfile);
 extern void generate_metadata_logfile_path(struct metadata_logfile *metadatalog, char *str, size_t maxlen);
 extern void metadata_logfile_init(struct metadata_logfile *metadatalog, struct metalog_instance *ctx,
                               unsigned tier, unsigned fileno);
+extern int rename_metadata_logfile(struct metadata_logfile *metalogfile, unsigned new_starting_fileno,
+                                   unsigned new_fileno);
 extern int close_metadata_logfile(struct metadata_logfile *metadatalog);
 extern int destroy_metadata_logfile(struct metadata_logfile *metalogfile);
 extern int create_metadata_logfile(struct metadata_logfile *metalogfile);
 extern int load_metadata_logfile(struct metalog_instance *ctx, struct metadata_logfile *logfile);
-extern void init_metadata_record_log(struct metalog_instance *ctx);
-extern int add_new_metadata_logfile(struct metalog_instance *ctx, unsigned tier, unsigned fileno);
+extern void init_metadata_record_log(struct metadata_record_commit_log *records_log);
+extern int add_new_metadata_logfile(struct metalog_instance *ctx, struct metadata_logfile_list *logfile_list,
+                                    unsigned tier, unsigned fileno);
 extern int init_metalog_files(struct metalog_instance *ctx);
 extern void finalize_metalog_files(struct metalog_instance *ctx);
 

--- a/database/engine/metadata_log/metadatalog.c
+++ b/database/engine/metadata_log/metadatalog.c
@@ -156,7 +156,8 @@ void metalog_test_quota(struct metalog_worker_config *wc)
 
     metalogfile = ctx->metadata_logfiles.last;
     only_one_metalogfile = (metalogfile == ctx->metadata_logfiles.first) ? 1 : 0;
-    info("records=%lu objects=%lu", (long unsigned)ctx->records_nr, (long unsigned)ctx->rrdeng_ctx->host->objects_nr);
+    debug(D_METADATALOG, "records=%lu objects=%lu", (long unsigned)ctx->records_nr,
+          (long unsigned)ctx->rrdeng_ctx->host->objects_nr);
     if (unlikely(!only_one_metalogfile &&
                  ctx->records_nr > (ctx->rrdeng_ctx->host->objects_nr * (uint64_t)MAX_DUPLICATION_PERCENTAGE) / 100) &&
                 NO_QUIESCE == ctx->quiesce) {

--- a/database/engine/metadata_log/metadatalog.c
+++ b/database/engine/metadata_log/metadatalog.c
@@ -123,7 +123,7 @@ static void do_commit_record(struct metalog_worker_config* wc, uint8_t type, voi
     }
 }
 
-/* Only crates a new metadata file and links it to the metadata log if the last one is non empty. */
+/* Only creates a new metadata file and links it to the metadata log if the last one is non empty. */
 void metalog_try_link_new_metadata_logfile(struct metalog_worker_config *wc)
 {
     struct metalog_instance *ctx = wc->ctx;

--- a/database/engine/metadata_log/metadatalog.c
+++ b/database/engine/metadata_log/metadatalog.c
@@ -129,10 +129,8 @@ void metalog_try_link_new_metadata_logfile(struct metalog_worker_config *wc)
     struct metalog_instance *ctx = wc->ctx;
     struct metadata_logfile *metalogfile;
     int ret;
-    unsigned current_size;
 
     metalogfile = ctx->metadata_logfiles.last;
-    current_size = metalogfile->pos;
     if (metalogfile->records.first) { /* it has records */
         /* Finalize metadata log file and create a new one */
         mlf_flush_records_buffer(wc, &ctx->records_log, &ctx->metadata_logfiles);
@@ -149,7 +147,6 @@ void metalog_test_quota(struct metalog_worker_config *wc)
     struct metadata_logfile *metalogfile;
     unsigned current_size;
     uint8_t only_one_metalogfile;
-    int ret;
 
     metalogfile = ctx->metadata_logfiles.last;
     current_size = metalogfile->pos;

--- a/database/engine/metadata_log/metadatalog.h
+++ b/database/engine/metadata_log/metadatalog.h
@@ -45,6 +45,7 @@ enum metalog_opcode {
     METALOG_COMMIT_CREATION_RECORD,
     METALOG_COMMIT_DELETION_RECORD,
     METALOG_COMPACTION_FLUSH,
+    METALOG_QUIESCE,
 
     METALOG_MAX_OPCODE
 };
@@ -112,6 +113,12 @@ struct metalog_instance {
     unsigned long disk_space;
     unsigned long records_nr;
     unsigned last_fileno; /* newest index of metadata log file */
+
+    uint8_t quiesce; /*
+                      * 0 initial state when all operations function normally
+                      * 1 set it before shutting down the instance, quiesce long running operations
+                      * 2 is set after all threads have finished running
+                      */
 
     struct metalog_statistics stats;
 };

--- a/database/engine/metadata_log/metadatalog.h
+++ b/database/engine/metadata_log/metadatalog.h
@@ -109,7 +109,7 @@ struct metalog_instance {
     struct parser_user_object *metalog_parser_object;
     struct logfile_compaction_state compaction_state;
     uint32_t current_compaction_id; /* Every compaction run increments this by 1 */
-    uint64_t disk_space;
+    unsigned long disk_space;
     unsigned long records_nr;
     unsigned last_fileno; /* newest index of metadata log file */
 

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -355,7 +355,9 @@ void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metr
 
     if (empty_chart) {
         rrdhost_wrlock(host);
+        rrdset_rdlock(st);
         rrdset_delete_custom(st, 1);
+        rrdset_unlock(st);
         rrdset_free(st);
         rrdhost_unlock(host);
     }

--- a/database/engine/metadata_log/metadatalogapi.h
+++ b/database/engine/metadata_log/metadatalogapi.h
@@ -5,9 +5,12 @@
 
 #include "metadatalog.h"
 
+extern BUFFER *metalog_update_host_buffer(RRDHOST *host);
 extern void metalog_commit_update_host(RRDHOST *host);
+extern BUFFER *metalog_update_chart_buffer(RRDSET *st, uint32_t compaction_id);
 extern void metalog_commit_update_chart(RRDSET *st);
 extern void metalog_commit_delete_chart(RRDSET *st);
+extern BUFFER *metalog_update_dimension_buffer(RRDDIM *rd);
 extern void metalog_commit_update_dimension(RRDDIM *rd);
 extern void metalog_commit_delete_dimension(RRDDIM *rd);
 

--- a/database/engine/metadata_log/metadatalogapi.h
+++ b/database/engine/metadata_log/metadatalogapi.h
@@ -21,5 +21,6 @@ extern void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_
 /* must call once before using anything */
 extern int metalog_init(struct rrdengine_instance *rrdeng_parent_ctx);
 extern int metalog_exit(struct metalog_instance *ctx);
+extern void metalog_prepare_exit(struct metalog_instance *ctx);
 
 #endif /* NETDATA_METADATALOGAPI_H */

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -9,7 +9,6 @@ PARSER_RC metalog_pluginsd_chart_action(void *user, char *type, char *id, char *
                                         int update_every, RRDSET_TYPE chart_type, char *options)
 {
     struct metalog_pluginsd_state *state = ((PARSER_USER_OBJECT *)user)->private;
-    struct metalog_instance *ctx = state->ctx;
     RRDSET *st = NULL;
     RRDHOST *host = ((PARSER_USER_OBJECT *) user)->host;
     uuid_t *chart_uuid;
@@ -54,7 +53,6 @@ PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char *id, ch
                                             long multiplier, long divisor, char *options, RRD_ALGORITHM algorithm_type)
 {
     struct metalog_pluginsd_state *state = ((PARSER_USER_OBJECT *)user)->private;
-    struct metalog_instance *ctx = state->ctx;
     UNUSED(user);
     UNUSED(algorithm);
     uuid_t *dim_uuid;
@@ -85,7 +83,6 @@ PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char *id, ch
 PARSER_RC metalog_pluginsd_guid_action(void *user, uuid_t *uuid)
 {
     struct metalog_pluginsd_state *state = ((PARSER_USER_OBJECT *)user)->private;
-    struct metalog_instance *ctx = state->ctx;
 
     uuid_copy(state->uuid, *uuid);
 

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -46,6 +46,14 @@ PARSER_RC metalog_pluginsd_chart_action(void *user, char *type, char *id, char *
     }
     ((PARSER_USER_OBJECT *)user)->st = st;
 
+    if (chart_uuid) { /* It's a valid object */
+        struct metalog_record record;
+        struct metadata_logfile *metalogfile = state->metalogfile;
+
+        uuid_copy(record.uuid, state->uuid);
+        mlf_record_insert(metalogfile, &record);
+        uuid_clear(state->uuid); /* Consume UUID */
+    }
     return PARSER_RC_OK;
 }
 
@@ -76,6 +84,14 @@ PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char *id, ch
             rrddim_flag_set(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
     } else {
         rrddim_isnot_obsolete(st, rd);
+    }
+    if (dim_uuid) { /* It's a valid object */
+        struct metalog_record record;
+        struct metadata_logfile *metalogfile = state->metalogfile;
+
+        uuid_copy(record.uuid, state->uuid);
+        mlf_record_insert(metalogfile, &record);
+        uuid_clear(state->uuid); /* Consume UUID */
     }
     return PARSER_RC_OK;
 }
@@ -186,4 +202,5 @@ void metalog_pluginsd_state_init(struct metalog_pluginsd_state *state, struct me
     state->ctx = ctx;
     state->skip_record = 0;
     uuid_clear(state->uuid);
+    state->metalogfile = NULL;
 }

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -19,8 +19,6 @@ PARSER_RC metalog_pluginsd_chart_action(void *user, char *type, char *id, char *
         host, type, id, name, family, context, title, units,
         plugin, module, priority, update_every,
         chart_type, RRD_MEMORY_MODE_DBENGINE, (host)->rrd_history_entries, 1, chart_uuid);
-    if (chart_uuid)
-        uuid_clear(state->uuid);
 
     if (options && *options) {
         if (strstr(options, "obsolete"))
@@ -65,8 +63,6 @@ PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char *id, ch
 
     RRDDIM *rd = rrddim_add_custom(st, id, name, multiplier, divisor, algorithm_type, RRD_MEMORY_MODE_DBENGINE, 1,
                                    dim_uuid);
-    if (dim_uuid)
-        uuid_clear(state->uuid);
     rrddim_flag_clear(rd, RRDDIM_FLAG_HIDDEN);
     rrddim_flag_clear(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
     if (options && *options) {

--- a/database/engine/metadata_log/metalogpluginsd.h
+++ b/database/engine/metadata_log/metalogpluginsd.h
@@ -11,6 +11,7 @@ struct metalog_pluginsd_state {
     struct metalog_instance *ctx;
     uuid_t uuid;
     uint8_t skip_record; /* skip this record due to errors in parsing */
+    struct metadata_logfile *metalogfile; /* current metadata log file being replayed */
 };
 
 extern void metalog_pluginsd_state_init(struct metalog_pluginsd_state *state, struct metalog_instance *ctx);

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -326,6 +326,9 @@ void rrdeng_invalidate_oldest_committed(struct rrdengine_worker_config* wc)
     unsigned nr_committed_pages;
     int error;
 
+    if (unlikely(ctx->quiesce != NO_QUIESCE)) /* Shutting down */
+        return;
+
     uv_rwlock_rdlock(&pg_cache->committed_page_index.lock);
     nr_committed_pages = pg_cache->committed_page_index.nr_committed_pages;
     uv_rwlock_rdunlock(&pg_cache->committed_page_index.lock);
@@ -683,7 +686,7 @@ void rrdeng_test_quota(struct rrdengine_worker_config* wc)
             ++ctx->last_fileno;
         }
     }
-    if (unlikely(out_of_space)) {
+    if (unlikely(out_of_space && NO_QUIESCE == ctx->quiesce)) {
         /* delete old data */
         if (wc->now_deleting_files) {
             /* already deleting data */
@@ -719,11 +722,17 @@ static inline int rrdeng_threads_alive(struct rrdengine_worker_config* wc)
 
 static void rrdeng_cleanup_finished_threads(struct rrdengine_worker_config* wc)
 {
+    struct rrdengine_instance *ctx = wc->ctx;
+
     if (unlikely(wc->cleanup_thread_invalidating_dirty_pages)) {
         after_invalidate_oldest_committed(wc);
     }
     if (unlikely(wc->cleanup_thread_deleting_files)) {
         after_delete_old_data(wc);
+    }
+    if (unlikely(SET_QUIESCE == ctx->quiesce && !rrdeng_threads_alive(wc))) {
+        ctx->quiesce = QUIESCED;
+        complete(&ctx->rrdengine_completion);
     }
 }
 
@@ -931,7 +940,20 @@ void rrdeng_worker(void* arg)
                 break;
             case RRDENG_SHUTDOWN:
                 shutdown = 1;
+                break;
+            case RRDENG_QUIESCE:
                 ctx->drop_metrics_under_page_cache_pressure = 0;
+                ctx->quiesce = SET_QUIESCE;
+                assert(0 == uv_timer_stop(&timer_req));
+                uv_close((uv_handle_t *)&timer_req, NULL);
+                while (do_flush_pages(wc, 1, NULL)) {
+                    ; /* Force flushing of all committed pages. */
+                }
+                wal_flush_transaction_buffer(wc);
+                if (!rrdeng_threads_alive(wc)) {
+                    ctx->quiesce = QUIESCED;
+                    complete(&ctx->rrdengine_completion);
+                }
                 break;
             case RRDENG_READ_PAGE:
                 do_read_extent(wc, &cmd.read_page.page_cache_descr, 1, 0);
@@ -970,8 +992,6 @@ void rrdeng_worker(void* arg)
      * an issue in the future.
      */
     uv_close((uv_handle_t *)&wc->async, NULL);
-    assert(0 == uv_timer_stop(&timer_req));
-    uv_close((uv_handle_t *)&timer_req, NULL);
 
     while (do_flush_pages(wc, 1, NULL)) {
         ; /* Force flushing of all committed pages. */

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -51,6 +51,7 @@ enum rrdeng_opcode {
     RRDENG_FLUSH_PAGES,
     RRDENG_SHUTDOWN,
     RRDENG_INVALIDATE_OLDEST_MEMORY_PAGE,
+    RRDENG_QUIESCE,
 
     RRDENG_MAX_OPCODE
 };
@@ -170,6 +171,10 @@ extern rrdeng_stats_t rrdeng_reserved_file_descriptors;
 extern rrdeng_stats_t global_pg_cache_over_half_dirty_events;
 extern rrdeng_stats_t global_flushing_pressure_page_deletions; /* number of deleted pages */
 
+#define NO_QUIESCE  (0) /* initial state when all operations function normally */
+#define SET_QUIESCE (1) /* set it before shutting down the instance, quiesce long running operations */
+#define QUIESCED    (2) /* is set after all threads have finished running */
+
 struct rrdengine_instance {
     RRDHOST *host;
     struct metalog_instance *metalog_ctx;
@@ -187,6 +192,8 @@ struct rrdengine_instance {
     unsigned long max_cache_pages;
     unsigned long cache_pages_low_watermark;
     unsigned long metric_API_max_producers;
+
+    uint8_t quiesce; /* set to SET_QUIESCE before shutdown of the engine */
 
     struct rrdengine_statistics stats;
 };

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -889,6 +889,7 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
     ctx->dbfiles_path[sizeof(ctx->dbfiles_path) - 1] = '\0';
     ctx->drop_metrics_under_page_cache_pressure = rrdeng_drop_metrics_under_page_cache_pressure;
     ctx->metric_API_max_producers = 0;
+    ctx->quiesce = NO_QUIESCE;
     ctx->metalog_ctx = NULL; /* only set this after the metadata log has finished initializing */
     ctx->host = host;
 
@@ -956,3 +957,23 @@ int rrdeng_exit(struct rrdengine_instance *ctx)
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
     return 0;
 }
+
+void rrdeng_prepare_exit(struct rrdengine_instance *ctx)
+{
+    struct rrdeng_cmd cmd;
+
+    if (NULL == ctx) {
+        return;
+    }
+
+    init_completion(&ctx->rrdengine_completion);
+    cmd.opcode = RRDENG_QUIESCE;
+    rrdeng_enq_cmd(&ctx->worker_config, &cmd);
+
+    /* wait for dbengine to quiesce */
+    wait_for_completion(&ctx->rrdengine_completion);
+    destroy_completion(&ctx->rrdengine_completion);
+
+    metalog_prepare_exit(ctx->metalog_ctx);
+}
+

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -114,6 +114,7 @@ void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid)
     }
     rd->state->rrdeng_uuid = &page_index->id;
     rd->state->page_index = page_index;
+    rd->state->compaction_id = 0;
 }
 
 /*

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -56,5 +56,6 @@ extern int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *db
                        unsigned disk_space_mb);
 
 extern int rrdeng_exit(struct rrdengine_instance *ctx);
+extern void rrdeng_prepare_exit(struct rrdengine_instance *ctx);
 
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -316,6 +316,7 @@ struct rrddim_volatile {
     uuid_t *rrdeng_uuid;                 // database engine metric UUID
     uuid_t *metric_uuid;                 // global UUID for this metric (unique_across hosts)
     struct pg_cache_page_index *page_index;
+    uint32_t compaction_id;              // The last metadata log compaction procedure that has processed this object.
 #endif
     union rrddim_collect_handle handle;
     // ------------------------------------------------------------------------
@@ -468,7 +469,9 @@ struct rrdset {
     char *plugin_name;                              // the name of the plugin that generated this
     char *module_name;                              // the name of the plugin module that generated this
     uuid_t *chart_uuid;                             // Store the global GUID for this chart
-    size_t unused[4];
+    size_t compaction_id;                           // The last metadata log compaction procedure that has processed
+                                                    // this object.
+    size_t unused[3];
 
     size_t rrddim_page_alignment;                   // keeps metric pages in alignment when using dbengine
 
@@ -791,7 +794,10 @@ struct rrdhost {
 
 #ifdef ENABLE_DBENGINE
     struct rrdengine_instance *rrdeng_ctx;          // DB engine instance for this host
-    uuid_t  host_uuid;                             // Global GUID for this host
+    uuid_t  host_uuid;                              // Global GUID for this host
+    unsigned long objects_nr;                       // Number of charts and dimensions in this host
+    uint32_t compaction_id;                         // The last metadata log compaction procedure that has processed
+                                                    // this object.
 #endif
 
 #ifdef ENABLE_HTTPS

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -442,6 +442,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
         aclk_update_chart(host, st->id, ACLK_CMD_CHART);
 #endif
 #ifdef ENABLE_DBENGINE
+    rrd_atomic_fetch_add(&st->rrdhost->objects_nr, 1);
     metalog_commit_update_dimension(rd);
 #endif
 
@@ -510,7 +511,9 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
     if ((netdata_cloud_setting) && (db_rotated || RRD_MEMORY_MODE_DBENGINE != rd->rrd_memory_mode))
         aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
 #endif
-
+#ifdef ENABLE_DBENGINE
+    rrd_atomic_fetch_add(&st->rrdhost->objects_nr, -1);
+#endif
 }
 
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -621,6 +621,9 @@ void rrdhost_free(RRDHOST *host) {
     // ------------------------------------------------------------------------
     // release its children resources
 
+#ifdef ENABLE_DBENGINE
+    rrdeng_prepare_exit(host->rrdeng_ctx);
+#endif
     while(host->rrdset_root)
         rrdset_free(host->rrdset_root);
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -246,6 +246,8 @@ RRDHOST *rrdhost_create(const char *hostname,
     if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
         uuid_parse(host->machine_guid, host->host_uuid);
+        host->objects_nr = 1;
+        host->compaction_id = 0;
         char dbenginepath[FILENAME_MAX + 1];
         int ret;
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -381,6 +381,10 @@ void rrdset_free(RRDSET *st) {
             freez(st);
             break;
     }
+#ifdef ENABLE_DBENGINE
+    rrd_atomic_fetch_add(&host->objects_nr, -1);
+#endif
+
 }
 
 void rrdset_save(RRDSET *st) {
@@ -793,6 +797,7 @@ RRDSET *rrdset_create_custom(
             st->chart_uuid = NULL;
             assert(0);
         }
+        st->compaction_id = 0;
     }
 #endif
 
@@ -806,6 +811,7 @@ RRDSET *rrdset_create_custom(
     }
 #endif
 #ifdef ENABLE_DBENGINE
+    rrd_atomic_fetch_add(&st->rrdhost->objects_nr, 1);
     metalog_commit_update_chart(st);
 #endif
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #8902

The metadata log needs to be limited in disk space size. This PR implements a log compaction algorithm as described in #8902.

##### Component Name
database
daemon
##### Test Plan
You may start/stop the agent many times so as to accelerate the rate at which the metadata logs grow. Observe in `error.log` the ratio of `records` to `objects`:
```
netdata INFO  : MAIN : records=2057 objects=1661
```

When this ratio is over 1.5 the compaction process should trigger, which should decrease the ratio and replace the metadata log files with new ones.

You may also kill the agent during compaction to test fault-tolerance. During start-up, the agent should decide what to do with the compaction temporary files and the original metadata log files.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->