### PR TITLE
Fixes documentation ambiguity leading into issue #8239

### DIFF
--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -200,8 +200,8 @@ Everything is the same with [badges](../web/api/badges/). In short:
 
 -   `of DIMENSIONS` is optional and has to be the last parameter. Dimensions have to be separated
      by `,` or `|`. The space characters found in dimensions will be kept as-is (a few dimensions
-     have spaces in their names). This accepts Netdata simple patterns *(with rules separated by 
-     `,` or `|` instead of space)* and the `match-ids` and `match-names` options affect the searches
+     have spaces in their names). This accepts Netdata simple patterns _(with `words` separated by
+     `,` or `|` instead of spaces)_ and the `match-ids` and `match-names` options affect the searches
      for dimensions.
 
 -   `foreach DIMENSIONS` is optional, will always be the last parameter, and uses the same `,`/`|`

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -200,8 +200,9 @@ Everything is the same with [badges](../web/api/badges/). In short:
 
 -   `of DIMENSIONS` is optional and has to be the last parameter. Dimensions have to be separated
      by `,` or `|`. The space characters found in dimensions will be kept as-is (a few dimensions
-     have spaces in their names). This accepts Netdata simple patterns and the `match-ids` and
-     `match-names` options affect the searches for dimensions.
+     have spaces in their names). This accepts Netdata simple patterns *(with rules separated by 
+     `,` or `|` instead of space)* and the `match-ids` and `match-names` options affect the searches
+     for dimensions.
 
 -   `foreach DIMENSIONS` is optional, will always be the last parameter, and uses the same `,`/`|`
      rules as the `of` parameter. Each dimension you specify in `foreach` will use the same rule


### PR DESCRIPTION
##### Summary

Fixes #8239

After studying the code, testing, and then verifying with colleagues the functionality works but the syntax is a bit different than the expected *(which confuses people and makes them think it is broken)*. The issue is therefore solved by small clarification in the documentation.

##### Component Name
Documentation

##### Test Plan
##### Additional Information