### PR TITLE
Fix frontmatter in circular_buffer README

### DIFF
--- a/libnetdata/circular_buffer/README.md
+++ b/libnetdata/circular_buffer/README.md
@@ -1,5 +1,5 @@
 <!--
---
+---
 title: "circular_buffer"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/libnetdata/circular_buffer/README.md
 ---


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

There's a missing dash `-` in the frontmatter for the `libnetdata/circular_buffer/README.md` document introduced in #9214, which is causing build failures on Learn. This PR adds that dash.

I should have caught this in the initial PR. That's my mistake.

##### Component Name

libnetdata
docs

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
