### PR TITLE
Added Alpine 3.12 to CI and removed Alpine 3.9

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -24,9 +24,9 @@ jobs:
       matrix:
         distro:
           - 'alpine:edge'
+          - 'alpine:3.12'
           - 'alpine:3.11'
           - 'alpine:3.10'
-          - 'alpine:3.9'
           - 'archlinux:latest'
           - 'centos:8'
           - 'centos:7'
@@ -50,13 +50,13 @@ jobs:
           - distro: 'alpine:edge'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
+          - distro: 'alpine:3.12'
+            pre: 'apk add -U bash'
+            rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.11'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.10'
-            pre: 'apk add -U bash'
-            rmjsonc: 'apk del json-c-dev'
-          - distro: 'alpine:3.9'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
 


### PR DESCRIPTION
##### Summary

Alpine 3.12 was released on 2020-05-29.

Alpine 3.9 received it's last update on 2019-05-09, and is being removed here due to both it's age and a desire to keep the number of CI checks to a reasonable level.

##### Component Name

area/ci

##### Test Plan

Passes in CI.