### PR TITLE
Add support for long (dash dash) options for all command-line options

### DIFF
--- a/daemon/main.h
+++ b/daemon/main.h
@@ -17,6 +17,8 @@ extern struct config netdata_config;
 struct option_def {
     /** The option character */
     const char val;
+    /** The long option string */
+    const char *long_name;
     /** The name of the long option. */
     const char *description;
     /** Short descripton what the option does */


### PR DESCRIPTION
##### Summary

ssia

##### Component Name

- area/daemon

##### Test Plan

```#!sh
(⎈ |netdata-production:infra)
prologic@Jamess-iMac
Fri Jun 05 14:25:56
~/Netdata/netdata
 (dash-dash-version) 0
$ ./netdata -v
netdata v1.22.1-209-g253b2f6a
(⎈ |netdata-production:infra)
prologic@Jamess-iMac
Fri Jun 05 14:26:04
~/Netdata/netdata
 (dash-dash-version) 0
$ ./netdata --version
netdata v1.22.1-209-g253b2f6a
(⎈ |netdata-production:infra)
prologic@Jamess-iMac
Fri Jun 05 14:26:07
~/Netdata/netdata
 (dash-dash-version) 0
$ ./netdata --help

 ^
 |.-.   .-.   .-.   .-.   .  netdata
 |   '-'   '-'   '-'   '-'   real-time performance monitoring, done right!
 +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->

 Copyright (C) 2016-2020, Netdata, Inc. <info@netdata.cloud>
 Released under GNU General Public License v3 or later.
 All rights reserved.

 Home Page  : https://netdata.cloud
 Source Code: https://github.com/netdata/netdata
 Docs       : https://learn.netdata.cloud
 Support    : https://github.com/netdata/netdata/issues
 License    : https://github.com/netdata/netdata/blob/master/LICENSE.md

 Twitter    : https://twitter.com/linuxnetdata
 Facebook   : https://www.facebook.com/linuxnetdata/


 SYNOPSIS: netdata [options]

 Options:

  -c/--config filename              Configuration file to load.
   -                        Default: /usr/local/etc/netdata/netdata.conf

  -D/--no-fork                       Do not fork. Run in the foreground.
   -                        Default: run in the background

  -d/--daemon                       Fork. Run in the background.
   -                        Default: run in the background

  -h/--help                       Display this help message.

  -P/--pid-file filename              File to save a pid while running.
   -                        Default: do not save pid to a file

  -i/--interface IP                    The IP address to listen to.
   -                        Default: all IP addresses IPv4 and IPv6

  -p/--port port                  API/Web port to use.
   -                        Default: 19999

  -s/--prefix path                  Prefix for /proc and /sys (for containers).
   -                        Default: no prefix

  -t/--internal-clock seconds               The internal clock of netdata.
   -                        Default: 1

  -u/--user username              Run as user.
   -                        Default: netdata

  -v/--version                       Print netdata version and exit.

  -W/--set-options options               See Advanced options below.


 Advanced options:

  -W stacksize=N           Set the stacksize (in bytes).

  -W debug_flags=N         Set runtime tracing to debug.log.

  -W unittest              Run internal unittests and exit.

  -W set section option value
                           set netdata.conf option from the command line.

  -W simple-pattern pattern string
                           Check if string matches pattern and exit.

  -W "claim -token=TOKEN -rooms=ROOM1,ROOM2"
                           Claim the agent to the workspace rooms pointed to by TOKEN and ROOM*.


 Signals netdata handles:

  - HUP                    Close and reopen log files.
  - USR1                   Save internal DB to disk.
  - USR2                   Reload health configuration.
```

##### Additional Information

This has been asked for a number of times by our users from various
sources (_some of which includes our IRC channel on FreeNode :D_).

__Note:__ Please review with "Ignore Whitespace".