### PR TITLE
Fix crash in #9291

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -11,10 +11,12 @@ static void rrdpush_receiver_thread_cleanup(void *ptr) {
         struct receiver_state *rpt = (struct receiver_state *) ptr;
 
         // Make sure that we detach this thread and don't kill a freshly arriving receiver
-        netdata_mutex_lock(&rpt->host->receiver_lock);
-        if (rpt->host->receiver == rpt)
-            rpt->host->receiver = NULL;
-        netdata_mutex_unlock(&rpt->host->receiver_lock);
+        if (rpt->host) {
+            netdata_mutex_lock(&rpt->host->receiver_lock);
+            if (rpt->host->receiver == rpt)
+                rpt->host->receiver = NULL;
+            netdata_mutex_unlock(&rpt->host->receiver_lock);
+        }
 
         info("STREAM %s [receive from [%s]:%s]: receive thread ended (task id %d)", rpt->hostname, rpt->client_ip, rpt->client_port, gettid());
 


### PR DESCRIPTION


##### Summary
Fixes the crash part of #9291 - Did not account for the path where rrdhost_find_or_create fails and terminates the thread before setting rpt->host to a valid pointer.

##### Component Name
streaming

##### Test Plan
Not sure how to replicate the database failure, but the code change is simple enough to read.

##### Additional Information
