### PR TITLE
Fix remote write HTTP header

### DIFF
--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -35,6 +35,7 @@ int prometheus_remote_write_send_header(int *sock, struct instance *instance)
         "POST %s HTTP/1.1\r\n"
         "Host: %s\r\n"
         "Accept: */*\r\n"
+        "X-Prometheus-Remote-Write-Version: 0.1.0\r\n"
         "Content-Length: %zu\r\n"
         "Content-Type: application/x-www-form-urlencoded\r\n\r\n",
         connector_specific_config->remote_write_path,


### PR DESCRIPTION
#### Summary
[Cortex](https://cortexmetrics.io/docs/apis/#remote-api) requires an additional HTTP header field in order to remote write requests work correctly:
> The HTTP request should contain the header X-Prometheus-Remote-Write-Version set to 0.1.0

Fixes #9220

##### Component Name
exporting engine