### PR TITLE
Fix consistency of kubernetes cgroup names

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -91,7 +91,7 @@ function k8s_get_name() {
 			KUBE_TOKEN="$(</var/run/secrets/kubernetes.io/serviceaccount/token)"
 			NAME="$(
 			curl -sSk -H "Authorization: Bearer $KUBE_TOKEN"  "https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/pods" |
-			jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_\(.status.containerStatuses[0].name) \(.status.containerStatuses[0].containerID)"' |
+			jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_" + (.status.containerStatuses[]? | "\(.name) \(.containerID)")' |
 			grep "$id" |
 			cut -d' ' -f1
 			)"
@@ -101,8 +101,11 @@ function k8s_get_name() {
 			fi
 			if kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces >/dev/null 2>&1; then
 				#shellcheck disable=SC2086
-				NAME="$(kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces --output='json' | \
-				jq -r '.items[] | select(.metadata.uid == "'$id'") | .metadata.name')"
+				NAME="$(kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces --output='json' | 
+				jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_" + (.status.containerStatuses[]? | "\(.name) \(.containerID)")' | 
+				grep "$id" | 
+				cut -d' ' -f1 
+				)"
 			else
 				warning "kubectl cannot get pod list, check for configuration file in $KUBE_CONFIG, or set this path to env \$KUBE_CONFIG"
 			fi


### PR DESCRIPTION
Fixes #8044
Moved from #8671 due to rebase conflicts.

##### Summary

Ensures we get consistent kubernetes cgroup container names, regardless of whether netdata runs from within a kubernetes pod, or directly on the host machine.

##### Component Name

##### Test Plan

@ilyam8 to test on our k8s test cluster and on a minikube environment.

##### Additional Information

Fixes a bug that was originally fixed in #6885 and re-introduced in #7416.
Fixes the seemingly non-functional selector in #7416 