### PR TITLE
Correct the repo in the docs for CentOS 8.

### DIFF
--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -168,10 +168,10 @@ yum config-manager --set-enabled PowerTools
 yum install -y epel-release
 
 # Install Repo for libuv-devl (NEW)
-yum install -y http://repo.okay.com.mx/centos/8/x86_64/release/okay-release-1-3.el8.noarch.rpm?
+yum install -y http://repo.okay.com.mx/centos/8/x86_64/release/okay-release-1-3.el8.noarch.rpm
 
 # Install Devel Packages
-yum install autoconf automake curl gcc git libmnl-devel libuuid-devel openssl-devel libuv-devel lz4-devel make nc pkgconfig python3 zlib-devel
+yum install autoconf automake curl gcc git cmake libuuid-devel openssl-devel libuv-devel lz4-devel make nc pkgconfig python3 zlib-devel
 
 # Install Judy-Devel directly
 yum install -y http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.1.0+217+4d875839.x86_64.rpm


### PR DESCRIPTION
##### Summary

GetPageSpeed requires payment to actually use their repos, so we shouldn't be telling users to use them.

This updates the docs to point users at the repo we are already using in our installer for pulling in required dependencies.

##### Component Name

area/docs

##### Test Plan

n/a

##### Additional Information

Credit to @vlvkobal for noticing this.