### PR TITLE
Added dummy `--enable-ebpf` flag to avoid breaking updates.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -259,6 +259,7 @@ while [ -n "${1}" ]; do
     "--disable-x86-sse") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-x86-sse/} --disable-x86-sse" ;;
     "--disable-telemetry") NETDATA_DISABLE_TELEMETRY=1 ;;
     "--disable-go") NETDATA_DISABLE_GO=1 ;;
+    "--enable-ebpf") NETDATA_DISABLE_EBPF=0 ;;
     "--disable-ebpf") NETDATA_DISABLE_EBPF=1 ;;
     "--disable-cloud")
       if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then


### PR DESCRIPTION
##### Summary

When we made eBPF default enabled, we removed the `--enable-ebpf` flag that had been used to enable it. This broke updates of existing installs that had explicitly enabled it, so re-add the flag as a functional no-op.

##### Component Name

area/packaging

##### Test Plan

Tested locally in Docker, passes CI.