### PR TITLE
Add processes and move clamav

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -119,7 +119,7 @@ columndb: clickhouse-server*
 # -----------------------------------------------------------------------------
 # email servers
 
-email: dovecot imapd pop3d amavis* master zmstat* zmmailboxdmgr qmgr oqmgr saslauthd opendkim clamd freshclam tlsmgr postfwd2 postscreen postfix smtp* lmtp* sendmail
+email: dovecot imapd pop3d amavis* zmstat* zmmailboxdmgr saslauthd opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr
 
 # -----------------------------------------------------------------------------
 # network, routing, VPN
@@ -232,12 +232,12 @@ backup: rsync lsyncd bacula* borg rclone
 # -----------------------------------------------------------------------------
 # cron
 
-cron: cron* atd anacron systemd-cron*
+cron: cron* atd anacron systemd-cron* incrond
 
 # -----------------------------------------------------------------------------
 # UPS
 
-ups: upsmon upsd */nut/*
+ups: upsmon upsd */nut/* apcupsd
 
 # -----------------------------------------------------------------------------
 # media players, servers, clients


### PR DESCRIPTION
Added additional postfix processes to "email servers" group: pickup showq
Removed from group email: clamd freshclam
These are in the group "antivirus" and they don't show up there if they are also in "email" group.
Also added to group cron: incrond
Also added to group ups: apcupsd

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
