### PR TITLE
apps_groups.conf: add agent-service-discovery

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -87,6 +87,9 @@ ioping: ioping
 go.d.plugin: *go.d.plugin*
 slabinfo.plugin: slabinfo.plugin
 
+# agent-service-discovery
+agent_sd: agent_sd
+
 # -----------------------------------------------------------------------------
 # authentication/authorization related servers
 


### PR DESCRIPTION
##### Summary

This service available only in k8s.

##### Component Name

`collectors/apps.plugin`

##### Test Plan

- [x] ensure there is `agent_sd` dimension on apps plugin charts

##### Additional Information
