### PR TITLE
Fix check for remote write header in unit tests

### DIFF
--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -1194,9 +1194,10 @@ static void test_prometheus_remote_write_send_header(void **state)
         "POST /receive HTTP/1.1\r\n"
         "Host: test-host\r\n"
         "Accept: */*\r\n"
+        "X-Prometheus-Remote-Write-Version: 0.1.0\r\n"
         "Content-Length: 11\r\n"
         "Content-Type: application/x-www-form-urlencoded\r\n\r\n");
-    expect_value(__wrap_send, len, 125);
+    expect_value(__wrap_send, len, 167);
     expect_value(__wrap_send, flags, MSG_NOSIGNAL);
 
     assert_int_equal(prometheus_remote_write_send_header(&sock, instance),0);


### PR DESCRIPTION
##### Summary
A Unit test was failing after HTTP header formatting was changed in #9302.

##### Component Name
exporting engine