### PR TITLE
Show cgroups ran by kubelet without access to k8s cluster info

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -181,7 +181,11 @@ done
 if [ -z "${NAME}" ]; then
 	if [[ ${CGROUP} =~ ^.*kubepods.* ]]; then
 		k8s_get_name "${CGROUP}"
-	elif [[ ${CGROUP} =~ ^.*docker[-_/\.][a-fA-F0-9]+[-_\.]?.*$ ]]; then
+	fi
+fi
+
+if [ -z "${NAME}" ]; then
+	if [[ ${CGROUP} =~ ^.*docker[-_/\.][a-fA-F0-9]+[-_\.]?.*$ ]]; then
 		# docker containers
 		#shellcheck disable=SC1117
 		DOCKERID="$(echo "${CGROUP}" | sed "s|^.*docker[-_/]\([a-fA-F0-9]\+\)[-_\.]\?.*$|\1|")"


### PR DESCRIPTION
Fixes #9287 

If a container is detected to be a k8s one, try the k8s naming. If it fails, default to normal container naming.

