### PR TITLE
Fixed invalid memory access

### DIFF
--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -494,6 +494,7 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
 
     // free(rd->annotations);
 
+    RRD_MEMORY_MODE rrd_memory_mode = rd->rrd_memory_mode;
     switch(rd->rrd_memory_mode) {
         case RRD_MEMORY_MODE_SAVE:
         case RRD_MEMORY_MODE_MAP:
@@ -514,7 +515,7 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
             break;
     }
 #ifdef ENABLE_ACLK
-    if ((netdata_cloud_setting) && (db_rotated || RRD_MEMORY_MODE_DBENGINE != rd->rrd_memory_mode))
+    if ((netdata_cloud_setting) && (db_rotated || RRD_MEMORY_MODE_DBENGINE != rrd_memory_mode))
         aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
 #endif
 #ifdef ENABLE_DBENGINE

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -365,7 +365,7 @@ RRDHOST *rrdhost_create(const char *hostname,
     rrd_hosts_available++;
 
 #ifdef ENABLE_DBENGINE
-    if (likely(!is_localhost && host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE))
+    if (likely(!is_localhost && host && host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE))
             metalog_commit_update_host(host);
 #endif
     return host;


### PR DESCRIPTION
##### Summary
Fixes issues to avoid coverity errors
- `Read from pointer after free (USE_AFTER_FREE)`
  - Invalid memory access in `rrddim_free_custom` 
- `Explicit null dereferenced (FORWARD_NULL)`
  - Use of NULL host variable if the host already exists  in `rrdhost_create`

##### Component Name
agent
