### PR TITLE
Fixed compiler warnings

### DIFF
--- a/database/engine/metadata_log/metadatalog.c
+++ b/database/engine/metadata_log/metadatalog.c
@@ -285,6 +285,7 @@ void metalog_worker(void* arg)
     struct metalog_cmd cmd;
     unsigned cmd_batch_size;
 
+    sanity_check();
     metalog_init_cmd_queue(wc);
 
     loop = wc->loop = mallocz(sizeof(uv_loop_t));

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -460,6 +460,9 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
 
 void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
 {
+#ifndef ENABLE_ACLK
+    UNUSED(db_rotated);
+#endif
     debug(D_RRD_CALLS, "rrddim_free() %s.%s", st->name, rd->name);
 
     if (!rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
@@ -494,7 +497,9 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
 
     // free(rd->annotations);
 
+#ifdef ENABLE_ACLK
     RRD_MEMORY_MODE rrd_memory_mode = rd->rrd_memory_mode;
+#endif
     switch(rd->rrd_memory_mode) {
         case RRD_MEMORY_MODE_SAVE:
         case RRD_MEMORY_MODE_MAP:

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -497,10 +497,8 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
 
     // free(rd->annotations);
 
-#ifdef ENABLE_ACLK
     RRD_MEMORY_MODE rrd_memory_mode = rd->rrd_memory_mode;
-#endif
-    switch(rd->rrd_memory_mode) {
+    switch(rrd_memory_mode) {
         case RRD_MEMORY_MODE_SAVE:
         case RRD_MEMORY_MODE_MAP:
         case RRD_MEMORY_MODE_RAM:

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -413,7 +413,9 @@ void rrdset_save(RRDSET *st) {
 
 void rrdset_delete_custom(RRDSET *st, int db_rotated) {
     RRDDIM *rd;
-
+#ifndef ENABLE_ACLK
+    UNUSED(db_rotated);
+#endif
     rrdset_check_rdlock(st);
 
     info("Deleting chart '%s' ('%s') from disk...", st->id, st->name);


### PR DESCRIPTION
##### Summary
Fixed compiler warnings e.g. if agent compiled with the `--disable-cloud` flag

```
  CC       database/rrddim.o
database/rrddim.c: In function 'rrddim_free_custom':
database/rrddim.c:497:21: warning: unused variable 'rrd_memory_mode' [-Wunused-variable]
  497 |     RRD_MEMORY_MODE rrd_memory_mode = rd->rrd_memory_mode;
      |                     ^~~~~~~~~~~~~~~
database/rrddim.c:461:53: warning: unused parameter 'db_rotated' [-Wunused-parameter]
  461 | void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
      |                                                 ~~~~^~~~~~~~~~
...
  CC       database/rrdset.o
database/rrdset.c: In function 'rrdset_delete_custom':
database/rrdset.c:414:43: warning: unused parameter 'db_rotated' [-Wunused-parameter]
  414 | void rrdset_delete_custom(RRDSET *st, int db_rotated) {
      |                                       ~~~~^~~~~~~~~~
...
  CC       database/engine/metadata_log/metadatalog.o
database/engine/metadata_log/metadatalog.c:6:13: warning: 'sanity_check' defined but not used [-Wunused-function]
    6 | static void sanity_check(void)
      |             ^~~~~~~~~~~~
```

##### Component Name
database

##### Test Plan

