### PR TITLE
Fix coverity errors CID 359774 and CID 359773

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -245,7 +245,9 @@ RRDHOST *rrdhost_create(const char *hostname,
     }
     if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
-        uuid_parse(host->machine_guid, host->host_uuid);
+        if (unlikely(-1 == uuid_parse(host->machine_guid, host->host_uuid))) {
+            error("Host machine GUID is not valid.");
+        }
         host->objects_nr = 1;
         host->compaction_id = 0;
         char dbenginepath[FILENAME_MAX + 1];

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1904,6 +1904,8 @@ void rrdset_done(RRDSET *st) {
                             metalog_commit_delete_dimension(rd);
                         } else {
                             /* Do not delete this dimension */
+                            last = rd;
+                            rd = rd->next;
                             continue;
                         }
                     }


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fix New Defects reported by Coverity Scan for netdata/netdata

##### Component Name
database 

##### Additional Information
New defect(s) Reported-by: Coverity Scan
Showing 2 of 2 defect(s)


** CID 359774:  Memory - illegal accesses  (USE_AFTER_FREE)
/database/rrdset.c: 1901 in rrdset_done()


________________________________________________________________________________________________________
*** CID 359774:  Memory - illegal accesses  (USE_AFTER_FREE)
/database/rrdset.c: 1901 in rrdset_done()
1895     
1896     #ifdef ENABLE_DBENGINE
1897                         if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
1898                             rrddim_flag_set(rd, RRDDIM_FLAG_ARCHIVED);
1899                             rrddim_flag_clear(rd, RRDDIM_FLAG_OBSOLETE);
1900                             /* only a collector can mark a chart as obsolete, so we must remove the reference */
>>>     CID 359774:  Memory - illegal accesses  (USE_AFTER_FREE)
>>>     Dereferencing freed pointer "rd->state".
1901                             uint8_t can_delete_metric = rd->state->collect_ops.finalize(rd);
1902                             if (can_delete_metric) {
1903                                 /* This metric has no data and no references */
1904                                 metalog_commit_delete_dimension(rd);
1905                             } else {
1906                                 /* Do not delete this dimension */

** CID 359773:  Error handling issues  (CHECKED_RETURN)
/database/rrdhost.c: 248 in rrdhost_create()


________________________________________________________________________________________________________
*** CID 359773:  Error handling issues  (CHECKED_RETURN)
/database/rrdhost.c: 248 in rrdhost_create()
242                     error("Host '%s': cannot create directory '%s'", host->hostname, host->varlib_dir);
243            }
244     
245         }
246         if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
247     #ifdef ENABLE_DBENGINE
>>>     CID 359773:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "uuid_parse" without checking return value (as is done elsewhere 6 out of 7 times).
248             uuid_parse(host->machine_guid, host->host_uuid);
249             host->objects_nr = 1;
250             host->compaction_id = 0;
251             char dbenginepath[FILENAME_MAX + 1];
252             int ret;
253     