### PR TITLE
Get netdata execution path early to avoid user permission issues

### DIFF
--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -17,7 +17,7 @@ void get_netdata_execution_path(void)
     passwd = getpwuid(getuid());
     user = (passwd && passwd->pw_name) ? passwd->pw_name : "";
 
-    exepath_size = sizeof(exepath);
+    exepath_size = sizeof(exepath) - 1;
     ret = uv_exepath(exepath, &exepath_size);
     if (0 != ret) {
         error("uv_exepath(\"%s\", %u) (user: %s) failed (%s).", exepath, (unsigned)exepath_size, user,

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -5,6 +5,27 @@
 
 char pidfile[FILENAME_MAX + 1] = "";
 char claimingdirectory[FILENAME_MAX + 1];
+char exepath[FILENAME_MAX + 1];
+
+void get_netdata_execution_path(void)
+{
+    int ret;
+    size_t exepath_size = 0;
+    struct passwd *passwd = NULL;
+    char *user = NULL;
+
+    passwd = getpwuid(getuid());
+    user = (passwd && passwd->pw_name) ? passwd->pw_name : "";
+
+    exepath_size = sizeof(exepath);
+    ret = uv_exepath(exepath, &exepath_size);
+    if (0 != ret) {
+        error("uv_exepath(\"%s\", %u) (user: %s) failed (%s).", exepath, (unsigned)exepath_size, user,
+              uv_strerror(ret));
+        fatal("Cannot start netdata without getting execution path.");
+    }
+    exepath[exepath_size] = '\0';
+}
 
 static void chown_open_file(int fd, uid_t uid, gid_t gid) {
     if(fd == -1) return;

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -10,7 +10,9 @@ extern int become_daemon(int dont_fork, const char *user);
 extern void netdata_cleanup_and_exit(int i);
 extern void send_statistics(const char *action, const char *action_result, const char *action_data);
 
-extern char pidfile[];
+extern void get_netdata_execution_path(void);
 
+extern char pidfile[];
+extern char exepath[];
 
 #endif /* NETDATA_DAEMON_H */

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1272,6 +1272,9 @@ int main(int argc, char **argv) {
         // files using relative filenames
         if(chdir(netdata_configured_user_config_dir) == -1)
             fatal("Cannot cd to '%s'", netdata_configured_user_config_dir);
+
+        // Get execution path before switching user to avoid permission issues
+        get_netdata_execution_path();
     }
 
     {

--- a/spawn/spawn.c
+++ b/spawn/spawn.c
@@ -190,8 +190,6 @@ struct spawn_cmd_info *spawn_get_unprocessed_cmd(void)
 int create_spawn_server(uv_loop_t *loop, uv_pipe_t *spawn_channel, uv_process_t *process)
 {
     uv_process_options_t options = {0};
-    size_t exepath_size;
-    char exepath[FILENAME_MAX];
     char *args[3];
     int ret;
 #define SPAWN_SERVER_DESCRIPTORS (3)
@@ -202,15 +200,6 @@ int create_spawn_server(uv_loop_t *loop, uv_pipe_t *spawn_channel, uv_process_t 
     passwd = getpwuid(getuid());
     user = (passwd && passwd->pw_name) ? passwd->pw_name : "";
 
-    exepath_size = sizeof(exepath);
-    ret = uv_exepath(exepath, &exepath_size);
-    if (0 != ret) {
-        error("uv_exepath(\"%s\", %u) (user: %s) failed (%s).", exepath, (unsigned)exepath_size, user,
-              uv_strerror(ret));
-        fatal("Cannot start netdata without the spawn server.");
-    }
-
-    exepath[exepath_size] = '\0';
     args[0] = exepath;
     args[1] = SPAWN_SERVER_COMMAND_LINE_ARGUMENT;
     args[2] = NULL;
@@ -231,8 +220,7 @@ int create_spawn_server(uv_loop_t *loop, uv_pipe_t *spawn_channel, uv_process_t 
 
     ret = uv_spawn(loop, process, &options); /* execute the netdata binary again as the netdata user */
     if (0 != ret) {
-        error("uv_spawn (process: \"%s\", %u) (user: %s) failed (%s).", exepath, (unsigned)exepath_size, user,
-              uv_strerror(ret));
+        error("uv_spawn (process: \"%s\") (user: %s) failed (%s).", exepath, user, uv_strerror(ret));
         fatal("Cannot start netdata without the spawn server.");
     }
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #9331 
Fixes #9113 

##### Component Name
daemon

##### Test Plan

Run it in affected CentOS 6 systems, see if the problem is resolved.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information

For some unknown reason some CentOS 6 installations fail to get the netdata binary execution path with libuv library calls and get "permission denied" errors. This PR attempts to get the path early before switching user to work around potential permission issues in path resolution or elsewhere.
