### PR TITLE
Use netdatacli to reopen the log file

### DIFF
--- a/system/netdata.logrotate.in
+++ b/system/netdata.logrotate.in
@@ -7,6 +7,6 @@
 	notifempty
 	sharedscripts
 	postrotate
-		/bin/kill -HUP `cat @localstatedir_POST@/run/netdata/netdata.pid 2>/dev/null` 2>/dev/null || true
+		/usr/sbin/netdatacli reopen-logs
 	endscript
 }


### PR DESCRIPTION
When systemd is used there's no pid to send the signal to. See bug #8898 and #8244

