### PR TITLE
Update netdata-installer.sh to fix #8862

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -29,6 +29,7 @@ fi
 # Pull in OpenSSL properly if on macOS
 if [ "$(uname -s)" = 'Darwin' ] && [ -d /usr/local/opt/openssl/include ]; then
   export C_INCLUDE_PATH="/usr/local/opt/openssl/include"
+  export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Added an LDFLAG export to macOS to properly find openssl when compiling with netdata-cloud.

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes compile issue while installing netdata with cloud support in macOS

##### Component Name
netdata-installer.sh

##### Test Plan
compile on macOS system with force cloud and get a successful compilation. 

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
