### PR TITLE
Add documentation for installing Netdata on k8s clusters

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -1,8 +1,6 @@
 <!--
----
 title: "Installation guide"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/README.md
----
 -->
 
 # Installation guide
@@ -82,8 +80,7 @@ Netdata on Docker](/packaging/docker/README.md)
 
 [![Install Netdata on
 Kubernetes](https://user-images.githubusercontent.com/1153921/76029478-cc8ad000-5ef1-11ea-8981-dd04744b00da.png) Install
-Netdata on Kubernetes with a Helm
-chart](https://github.com/netdata/helmchart#netdata-helm-chart-for-kubernetes-deployments)
+Netdata on a Kubernetes cluster](/packaging/installer/methods/kubernetes.md)
 
 [![Install Netdata on cloud providers
 (GCP/AWS/Azure)](https://user-images.githubusercontent.com/1153921/76029431-aebd6b00-5ef1-11ea-92b4-06704dabb93e.png)

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -36,8 +36,7 @@ Download the [Netdata Helm chart](https://github.com/netdata/helmchart) on the a
 `helm` binary installed.
 
 ```bash
-helm repo add netdata https://netdata.github.io/helmchart/
-helm repo update
+git clone https://github.com/netdata/helmchart.git netdata-helmchart
 ```
 
 > You may not need to configure the Helm chart to get a functioning service on your cluster, but you should read the
@@ -47,7 +46,7 @@ helm repo update
 Install the Helm chart to your cluster with `helm install`:
 
 ```bash
-helm install netdata netdata/netdata
+helm install netdata ./netdata-helmchart
 ```
 
 Run `kubectl get services` and `kubectl get pods` to confirm that your cluster now runs a `netdata` service, one
@@ -66,13 +65,13 @@ on your cluster's setup.
 To change a setting, use the `--set` or `--values` arguments along with `helm install`:
 
 ```bash
-helm install --set a.b.c=xyz netdata netdata/netdata
+helm install --set a.b.c=xyz netdata ./netdata-helmchart
 ```
 
 For example, to change the size of the persistent metrics volume, you would run the following:
 
 ```bash
-helm install --set parent.database.volumesize=4Gi netdata
+helm install --set parent.database.volumesize=4Gi ./netdata-helmchart
 ```
 
 ### Configure service discovery
@@ -91,7 +90,7 @@ configurations based on the service that pod runs, and begin monitoring them imm
 
 However, if you have changed some of these defaults, you'll need to open the `netdata-helmchart/sd-child.yml` file and
 edit the ports or image names that service discovery uses to find supported pods. You can then run `helm upgrade netdata
-netdata/netdata` to push changes to your cluster.
+./netdata-helmchart` to push changes to your cluster.
 
 ## Access the Netdata dashboard
 
@@ -125,7 +124,7 @@ If you update the Helm chart's configuration, either via `values.yml` or `sd-chi
 replacing `netdata` with the name of the release if you changed it upon installtion:
 
 ```bash
-helm upgrade netdata netdata/netdata
+helm upgrade netdata ./netdata-helmchart
 ```
 
 ## What's next?

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -90,9 +90,24 @@ services](https://github.com/netdata/helmchart#service-discovery-and-supported-s
 If you haven't changed listening ports or other defaults, service discovery should find your pods, create the proper
 configurations based on the service that pod runs, and begin monitoring them immediately after depolyment.
 
-However, if you have changed some of these defaults, you'll need to open the `netdata-helmchart/sd-child.yml` file and
-edit the ports or image names that service discovery uses to find supported pods. You can then run `helm upgrade netdata
-./netdata-helmchart` to push changes to your cluster.
+However, if you have changed some of these defaults, you'll need to copy the `netdata-helmchart/sdconfig/child.yml`
+file, edit it, and pass the changed file to `helm install`. First, copy the file to a new location.
+
+```bash
+cp netdata-helmchart/sdconfig/child.yml .
+```
+
+Edit the new `child.yml` file according to your needs. See the [Helm chart
+configuration](https://github.com/netdata/helmchart#configuration) and the file itself for details. You can then run
+`helm install`/`helm upgrade` with the `--set-file` argument to use your configured `child.yml` file instead of the
+default.
+
+```bash
+helm install --set-file sd.child.configmap.from.value=../child.yml netdata ./netdata-helmchart
+helm upgrade --set-file sd.child.configmap.from.value=../child.yml netdata ./netdata-helmchart
+```
+
+Your configured service discovery is now pushed to your cluster.
 
 ## Access the Netdata dashboard
 
@@ -122,8 +137,8 @@ In the above example, access the dashboard by navigating to `http://203.0.113.0:
 
 ## Update/reinstall the Netdata Helm chart
 
-If you update the Helm chart's configuration, either via `values.yml` or `sd-child.yml`, you can run `helm upgrade`,
-replacing `netdata` with the name of the release if you changed it upon installtion:
+If you update the Helm chart's configuration, run `helm upgrade` to redeploy your Netdata service, replacing `netdata` 
+with the name of the release if you changed it upon installtion:
 
 ```bash
 helm upgrade netdata ./netdata-helmchart

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -26,9 +26,11 @@ To install Netdata on a Kubernetes cluster, you need:
     administrative system.
 -   The [Helm package manager](https://helm.sh/) v3.0.0 or newer on the same administrative system.
 
-The default configuration creates four pods in your cluster: three `child` pods and one `parent` pod. The `child` pods
-collect metrics and stream the information to the `parent` pod, which uses two persistent volumes to store metrics and
-alarms. The `parent` pod also handles alarm notifications and enables the Netdata dashboard using an ingress controller.
+The default configuration creates one `parent` pod, installed on one of your cluster's nodes, and a DaemonSet for
+additional `child` pods. This DaemonSet ensures that every node in your k8s cluster also runs a `child` pod, including
+the node that also runs `parent`. The `child` pods collect metrics and stream the information to the `parent` pod, which
+uses two persistent volumes to store metrics and alarms. The `parent` pod also handles alarm notifications and enables
+the Netdata dashboard using an ingress controller.
 
 ## Install the Netdata Helm chart
 

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -91,7 +91,10 @@ If you haven't changed listening ports or other defaults, service discovery shou
 configurations based on the service that pod runs, and begin monitoring them immediately after depolyment.
 
 However, if you have changed some of these defaults, you'll need to copy the `netdata-helmchart/sdconfig/child.yml`
-file, edit it, and pass the changed file to `helm install`. First, copy the file to a new location.
+file, edit it, and pass the changed file to `helm install`/`helm upgrade`. 
+
+First, copy the file to a new location outside the `netdata-helmchart` directory. The destination can be anywhere you
+like, but the following examples assume it resides next to the `netdata-helmchart` directory.
 
 ```bash
 cp netdata-helmchart/sdconfig/child.yml .
@@ -100,11 +103,11 @@ cp netdata-helmchart/sdconfig/child.yml .
 Edit the new `child.yml` file according to your needs. See the [Helm chart
 configuration](https://github.com/netdata/helmchart#configuration) and the file itself for details. You can then run
 `helm install`/`helm upgrade` with the `--set-file` argument to use your configured `child.yml` file instead of the
-default.
+default, changing the path if you copied it elsewhere.
 
 ```bash
-helm install --set-file sd.child.configmap.from.value=../child.yml netdata ./netdata-helmchart
-helm upgrade --set-file sd.child.configmap.from.value=../child.yml netdata ./netdata-helmchart
+helm install --set-file sd.child.configmap.from.value=./child.yml netdata ./netdata-helmchart
+helm upgrade --set-file sd.child.configmap.from.value=./child.yml netdata ./netdata-helmchart
 ```
 
 Your configured service discovery is now pushed to your cluster.

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -21,8 +21,10 @@ discovery](https://github.com/netdata/agent-service-discovery/). Each child pod 
 To install Netdata on a Kubernetes cluster, you need:
 
 -   A working cluster running Kubernetes v1.9 or newer.
--   The [Helm package manager](https://helm.sh/) on an administrative system.
--   The [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) command line tool on the same system.
+-   The [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) command line tool, within [one minor version
+    difference](https://kubernetes.io/docs/tasks/tools/install-kubectl/#before-you-begin) of your cluster, on an
+    administrative system.
+-   The [Helm package manager](https://helm.sh/) v3.0.0 or newer on the same administrative system.
 
 The default configuration creates four pods in your cluster: three `child` pods and one `parent` pod. The `child` pods
 collect metrics and stream the information to the `parent` pod, which uses two persistent volumes to store metrics and
@@ -34,18 +36,18 @@ Download the [Netdata Helm chart](https://github.com/netdata/helmchart) on the a
 `helm` binary installed.
 
 ```bash
-git clone https://github.com/netdata/helmchart.git netdata-helmchart
+helm repo add netdata https://netdata.github.io/helmchart/
+helm repo update
 ```
 
 > You may not need to configure the Helm chart to get a functioning service on your cluster, but you should read the
 > sections on [configuring the Helm chart](#configure-the-netdata-helm-chart) and [configuring service
 > discovery](#configure-service-discovery) for details.
 
-Install the Helm chart to your cluster with `helm install`, replacing `--name netdata` with the release name of your
-choosing:
+Install the Helm chart to your cluster with `helm install`:
 
 ```bash
-helm install --name netdata ./netdata-helmchart
+helm install netdata netdata/netdata
 ```
 
 Run `kubectl get services` and `kubectl get pods` to confirm that your cluster now runs a `netdata` service, one
@@ -61,16 +63,17 @@ Read up on the various configuration options in the [Helm chart
 documentation](https://github.com/netdata/helmchart#configuration) to see if you need to change any of the options based
 on your cluster's setup.
 
-To change a setting, you can edit the `values.yml` file inside of the `netdata-helmchart` folder. Then install the chart
-as described in the previous step, or upgrade an existing Helm deployment with `helm upgrade`:
+To change a setting, use the `--set` or `--values` arguments along with `helm install`:
 
 ```bash
-helm upgrade netdata ./netdata-helmchart
+helm install --set a.b.c=xyz netdata netdata/netdata
 ```
 
-You can also change a setting with the `--set` option for `helm install`. For example, to change the size of the
-persistent metrics volume, you would run `helm install --name netdata ./netdata-helmchart --set
-parent.database.volumesize=4Gi`.
+For example, to change the size of the persistent metrics volume, you would run the following:
+
+```bash
+helm install --set parent.database.volumesize=4Gi netdata
+```
 
 ### Configure service discovery
 
@@ -88,7 +91,7 @@ configurations based on the service that pod runs, and begin monitoring them imm
 
 However, if you have changed some of these defaults, you'll need to open the `netdata-helmchart/sd-child.yml` file and
 edit the ports or image names that service discovery uses to find supported pods. You can then run `helm upgrade netdata
-./netdata-helmchart` to push changes to your cluster.
+netdata/netdata` to push changes to your cluster.
 
 ## Access the Netdata dashboard
 
@@ -122,7 +125,7 @@ If you update the Helm chart's configuration, either via `values.yml` or `sd-chi
 replacing `netdata` with the name of the release if you changed it upon installtion:
 
 ```bash
-helm upgrade netdata ./netdata-helmchart
+helm upgrade netdata netdata/netdata
 ```
 
 ## What's next?
@@ -132,3 +135,5 @@ especially if you want to change any of the configuration settings for either th
 
 To futher configure Netdata for your cluster, see our [Helm chart repository](https://github.com/netdata/helmchart) and
 the [service discovery repository](https://github.com/netdata/agent-service-discovery/).
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Finstaller%2Fmethods%2Fkubernetes&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -1,0 +1,128 @@
+<!--
+title: "Install Netdata on a Kubernetes cluster"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/kubernetes.md
+-->
+
+# Install Netdata on a Kubernetes cluster
+
+This document details how to install Netdata on an existing Kubernetes (k8s) cluster. By following this installation
+method, you enable five different types of Kubernetes monitoring with Netdata:
+
+-   
+
+To install Netdata on a Kubernetes cluster, you need:
+
+-   A working cluster running Kubernetes v1.9 or newer.
+-   The [Helm package manager](https://helm.sh/) on an administrative system.
+-   The [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) command line tool on the same system.
+
+The default configuration creates four pods in your cluster: three `child` pods and one `parent` pod. The `child` pods
+collect metrics and stream the information to the `parent` pod, which uses two persistent volumes to store metrics and
+alarms. The `parent` pod also handles alarm notifications and enables the Netdata dashboard using an ingress controller.
+
+## Install the Netdata Helm chart
+
+Download the [Netdata Helm chart](https://github.com/netdata/helmchart) on the administative system where you have the
+`helm` binary installed.
+
+```bash
+git clone https://github.com/netdata/helmchart.git netdata-helmchart
+```
+
+> You may not need to configure the Helm chart to get a functioning service on your cluster, but you should read the
+> sections on [configuring the Helm chart](#configure-the-netdata-helm-chart) and [configuring service
+> discovery](#configure-service-discovery) for details.
+
+Install the Helm chart to your cluster with `helm install`, replacing `--name netdata` with the release name of your
+choosing:
+
+```bash
+helm install --name netdata ./netdata-helmchart
+```
+
+Run `kubectl get services` and `kubectl get pods` to confirm that your cluster now runs a `netdata` service, one
+`parent` pod, and three `child` pods.
+
+You've now installed Netdata on your Kubernetes cluster. See how to [access the Netdata
+dashboard](#access-the-netdata-dashboard) to confirm it's working as expected, or see the next section to [configure the
+Helm chart](#configure-the-netdata-helm-chart) to suit your cluster's particular setup.
+
+## Configure the Netdata Helm chart
+
+Read up on the various configuration options in the [Helm chart
+documentation](https://github.com/netdata/helmchart#configuration) to see if you need to change any of the options based
+on your cluster's setup.
+
+To change a setting, you can edit the `values.yml` file inside of the `netdata-helmchart` folder. Then upgrade the Helm
+deployment with `helm upgrade`:
+
+```bash
+helm upgrade netdata ./netdata-helmchart
+```
+
+You can also change a setting with the `--set` option for `helm install`. For example, to change the size of the
+persistent metrics volume, you would run `helm install --name netdata ./netdata-helmchart --set
+parent.database.volumesize=4Gi`.
+
+### Configure service discovery
+
+As mentioned in the introduction, Netdata has a [service discovery
+plugin](https://github.com/netdata/agent-service-discovery/#service-discovery) to identify compatible pods and collect
+metrics from the service they run. This service discovery plugin is installed into your k8s cluster when you use the
+Netdata Helm chart.
+
+Service discovery scans your cluster for pods exposed on certain ports and with certain image names. By default, it
+looks for its supported services on the ports they most commonly listen on, and using default image names. Service
+discovery currently supports [22 popular services](https://github.com/netdata/).
+
+If you haven't changed listening ports or other defaults, service discovery should find your pods and the services
+running inside of them, create the proper configurations, and begin monitoring them as soon as the Netdata child pods
+finish deploying.
+
+However, if you have changed some of these defaults, you'll need to open the `netdata-helmchart/sd-child.yml` file and
+edit the ports or image names that service discovery uses to find supported pods. You can then run `helm upgrade netdata
+./netdata-helmchart` to push this change to your cluster.
+
+## Access the Netdata dashboard
+
+Accessing the Netdata dashboard itself depends on how you set up your k8s cluster and the Netdata Helm chart. If you
+installed the Helm chart with the default `service.type=ClusterIP`, you will need to forward a port to the parent pod.
+
+```bash
+kubectl port-forward netdata-parent-0 19999:19999 
+```
+
+You can now access the dashboard at `http://CLUSTER:19999`, replacing `CLUSTER` with the IP address or hostname of your
+k8s cluster.
+
+If you set up the Netdata Helm chart with `service.type=LoadBalancer`, you can often find the external IP for your load
+balancer with `kubectl get services`, under the `EXTERNAL-IP` column.
+
+```bash
+kubectl get services
+NAME                 TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)              AGE
+cockroachdb          ClusterIP      None             <none>         26257/TCP,8080/TCP   46h
+cockroachdb-public   ClusterIP      10.245.148.233   <none>         26257/TCP,8080/TCP   46h
+kubernetes           ClusterIP      10.245.0.1       <none>         443/TCP              47h
+netdata              LoadBalancer   10.245.160.131   203.0.113.0    19999:32231/TCP      74m
+```
+
+In the above example, access the dashboard by navigating to `http://203.0.113.0:19999`.
+
+## Update/reinstall the Netdata Helm chart
+
+If you update the Helm chart's configuration, either via `values.yml` or `sd-child.yml`, you can run `helm upgrade`,
+replacing `netdata` with the name of the release if you changed it upon installtion:
+
+```bash
+helm upgrade netdata ./netdata-helmchart
+```
+
+## What's next?
+
+Check out our [Agent's getting started guide](/docs/getting-started.md) for a quick overview of Netdata's capabilities,
+especially if you want to change any of the configuration settings for either the parent or child nodes.
+
+To futher configure Netdata for your cluster, see our [Helm chart repository](https://github.com/netdata/helmchart) and
+the [service discovery repository](https://github.com/netdata/agent-service-discovery/).


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

After wading my way through a crash-course in k8s over the last few days, I've realized we need some better information about how users can install Netdata on their k8s clusters. I'm no longer convinced simply linking to the Helm chart is enough, particularly when you add in things like service discovery.

I'm working on a second part to this—a guide that focuses on finding and interpreting all the charts this deployment creates (especially service discovery, which is awesome!), but I need a bit more time to put all the pieces together.

##### Component Name

area/docs
area/packaging

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
