### PR TITLE
Fixed ACLK shutdown sequence

### DIFF
--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -160,6 +160,7 @@ void *aclk_stats_main_thread(void *ptr)
         // Wait for the next iteration point.
 
         heartbeat_next(&hb, step_ut);
+        if (netdata_exit) break;
 
         ACLK_STATS_LOCK;
         // to not hold lock longer than necessary, especially not to hold it

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1063,9 +1063,6 @@ static void aclk_main_cleanup(void *ptr)
         QUERY_THREAD_WAKEUP;
         aclk_graceful_disconnect();
     }
-
-
-    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
 struct dictionary_singleton {
@@ -1538,6 +1535,13 @@ exited:
         freez(stats_thread);
     }
 
+    /*
+     * this must be last -> if all static threads signal
+     * THREAD_EXITED rrdengine will dealloc the RRDSETs
+     * and RRDDIMs that are used by still runing stat thread.
+     * see netdata_cleanup_and_exit() for reference
+     */
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
     return NULL;
 }
 


### PR DESCRIPTION
#### Summary
During the development of #9355 and also independently by Markos it was noticed that Aclk stats thread is accessing RRDDIMs and RRDSETs sometimes after they are already gone during the shutdown.

This fixes that and Fixes #9365

##### Component Name

##### Test Plan

##### Additional Information
