### PR TITLE
Fixes the race-hazard in streaming during the shutdown sequence

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -682,7 +682,8 @@ void rrdhost_free(RRDHOST *host) {
     host->sender = NULL;
     netdata_mutex_lock(&host->receiver_lock);
     if (host->receiver) {
-        netdata_thread_cancel(host->receiver->thread);
+        if (!host->receiver->exited)
+            netdata_thread_cancel(host->receiver->thread);
         destroy_receiver_state(host->receiver);
     }
     netdata_mutex_unlock(&host->receiver_lock);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -681,8 +681,10 @@ void rrdhost_free(RRDHOST *host) {
     freez(host->sender);
     host->sender = NULL;
     netdata_mutex_lock(&host->receiver_lock);
-    if (host->receiver)
-        host->receiver->shutdown = 1;
+    if (host->receiver) {
+        netdata_thread_cancel(host->receiver->thread);
+        destroy_receiver_state(host->receiver);
+    }
     netdata_mutex_unlock(&host->receiver_lock);
 
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -674,12 +674,18 @@ void rrdhost_free(RRDHOST *host) {
     rrd_check_wrlock();     // make sure the RRDs are write locked
 
     // ------------------------------------------------------------------------
-    // clean up the sender
+    // clean up streaming
     rrdpush_sender_thread_stop(host); // stop a possibly running thread
     cbuffer_free(host->sender->buffer);
     buffer_free(host->sender->build);
     freez(host->sender);
     host->sender = NULL;
+    netdata_mutex_lock(&host->receiver_lock);
+    if (host->receiver)
+        host->receiver->shutdown = 1;
+    netdata_mutex_unlock(&host->receiver_lock);
+
+
 
     rrdhost_wrlock(host);   // lock this RRDHOST
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -413,13 +413,11 @@ static int rrdpush_receive(struct receiver_state *rpt)
 
 
     size_t count = streaming_parser(rpt, &cd, fp);
-    //size_t count = pluginsd_process(host, &cd, fp, 1);
-
-    log_stream_connection(rpt->client_ip, rpt->client_port, rpt->key, rpt->host->machine_guid, rpt->host->hostname, "DISCONNECTED");
-    error("STREAM %s [receive from [%s]:%s]: disconnected (completed %zu updates).", rpt->host->hostname, rpt->client_ip, rpt->client_port, count);
 
     // During a shutdown there is cleanup code in rrdhost that will cancel the sender thread
     if (!netdata_exit) {
+        log_stream_connection(rpt->client_ip, rpt->client_port, rpt->key, rpt->host->machine_guid, rpt->host->hostname, "DISCONNECTED");
+        error("STREAM %s [receive from [%s]:%s]: disconnected (completed %zu updates).", rpt->host->hostname, rpt->client_ip, rpt->client_port, count);
         netdata_mutex_lock(&rpt->host->receiver_lock);
         if (rpt->host->receiver == rpt) {
             rrdhost_wrlock(rpt->host);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -31,8 +31,10 @@ static void rrdpush_receiver_thread_cleanup(void *ptr) {
         struct receiver_state *rpt = (struct receiver_state *) ptr;
         // If the shutdown sequence has started, and this receiver is still attached to the host then we cannot touch
         // the host pointer as it is unpredicable when the RRDHOST is deleted. Do the cleanup from rrdhost_free().
-        if (netdata_exit && rpt->host)
+        if (netdata_exit && rpt->host) {
+            rpt->exited = 1;
             return;
+        }
 
         // Make sure that we detach this thread and don't kill a freshly arriving receiver
         if (!netdata_exit && rpt->host) {

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -418,17 +418,20 @@ static int rrdpush_receive(struct receiver_state *rpt)
     log_stream_connection(rpt->client_ip, rpt->client_port, rpt->key, rpt->host->machine_guid, rpt->host->hostname, "DISCONNECTED");
     error("STREAM %s [receive from [%s]:%s]: disconnected (completed %zu updates).", rpt->host->hostname, rpt->client_ip, rpt->client_port, count);
 
-    netdata_mutex_lock(&rpt->host->receiver_lock);
-    if (rpt->host->receiver == rpt) {
-        rrdhost_wrlock(rpt->host);
-        rpt->host->senders_disconnected_time = now_realtime_sec();
-        rrdhost_flag_set(rpt->host, RRDHOST_FLAG_ORPHAN);
-        if(health_enabled == CONFIG_BOOLEAN_AUTO)
-            rpt->host->health_enabled = 0;
-        rrdhost_unlock(rpt->host);
-        rrdpush_sender_thread_stop(rpt->host);
+    // During a shutdown there is cleanup code in rrdhost that will cancel the sender thread
+    if (!netdata_exit) {
+        netdata_mutex_lock(&rpt->host->receiver_lock);
+        if (rpt->host->receiver == rpt) {
+            rrdhost_wrlock(rpt->host);
+            rpt->host->senders_disconnected_time = now_realtime_sec();
+            rrdhost_flag_set(rpt->host, RRDHOST_FLAG_ORPHAN);
+            if(health_enabled == CONFIG_BOOLEAN_AUTO)
+                rpt->host->health_enabled = 0;
+            rrdhost_unlock(rpt->host);
+            rrdpush_sender_thread_stop(rpt->host);
+        }
+        netdata_mutex_unlock(&rpt->host->receiver_lock);
     }
-    netdata_mutex_unlock(&rpt->host->receiver_lock);
 
     // cleanup
     fclose(fp);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -673,14 +673,13 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
     }
 
 
-    netdata_thread_t thread;
 
     debug(D_SYSTEM, "starting STREAM receive thread.");
 
     char tag[FILENAME_MAX + 1];
     snprintfz(tag, FILENAME_MAX, "STREAM_RECEIVER[%s,[%s]:%s]", rpt->hostname, w->client_ip, w->client_port);
 
-    if(netdata_thread_create(&thread, tag, NETDATA_THREAD_OPTION_DEFAULT, rrdpush_receiver_thread, (void *)rpt))
+    if(netdata_thread_create(&rpt->thread, tag, NETDATA_THREAD_OPTION_DEFAULT, rrdpush_receiver_thread, (void *)rpt))
         error("Failed to create new STREAM receive thread for client.");
 
     // prevent the caller from closing the streaming socket

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -86,7 +86,8 @@ struct receiver_state {
 #ifdef ENABLE_HTTPS
     struct netdata_ssl ssl;
 #endif
-    unsigned int shutdown:1;
+    unsigned int shutdown:1;    // Tell the thread to exit
+    unsigned int exited;      // Indicates that the thread has exited  (NOT A BITFIELD!)
 };
 
 

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -64,6 +64,7 @@ struct sender_state {
 
 struct receiver_state {
     RRDHOST *host;
+    netdata_thread_t thread;
     int fd;
     char *key;
     char *hostname;


### PR DESCRIPTION
##### Summary
Fixes #9369 
The streaming component detects when a receiver stream has closed, and stops an attached sender on the same host. This is to support proxy configurations where the stream is passed through. During the shutdown sequence, once `netdata_exit` has been set no thread should touch any `RRDHOST` structure as the non-static threads are not joined before the database shuts down. 

During the shutdown sequence any attached sender is killed by the database during cleanup, so this patch just stops the receiver from trying to do the same.

##### Component Name
streaming

##### Test Plan

* Connect many Child nodes to stream to the Parent.
* Shutdown the Parent and observe the valgrind output.

##### Additional Information
