### PR TITLE
Stop reading from /proc/sys/kernel/osrelease at trailing newline.

### DIFF
--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -87,7 +87,7 @@ int get_kernel_version(char *out, int size) {
         return -1;
 
     move = patch;
-    while (*version) *move++ = *version++;
+    while (*version && *version != '\n') *move++ = *version++;
     *move = '\0';
 
     fd = snprintf(out, (size_t)size, "%s.%s.%s", major, minor, patch);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

`ebpf.plugin` and several parts of the `kernel-collector` sibling project either read `/proc/sys/kernel/osrelease` directly or use it as a fallback. This file ends with a newline, which is read into the `kernel_string` variable. `ebpf.plugin` then fails to find the eBPF libraries because it's looking for a filename that ends with a newline.

Since it never makes sense for `osrelease` to include a newline, update `ebpf.plugin` to stop reading by the newline. This fixes the eBPF plugin on my system (which is running a custom kernel) and allows it to load the `kernel-collector` components.

##### Component Name

`ebpf.plugin`

##### Test Plan

I haven't added any tests, but it'd be a good thing to add a test for. I assume a test for this doesn't already exist or it wouldn't have been a problem. 😊 

##### Additional Information

Similar commit for the `kernel-collectors` is on my local and may get around to making a PR for it some day.