### PR TITLE
Fix Static Netdata to correctly build with Netdata Cloud support.

### DIFF
--- a/.github/scripts/build-artifacts.sh
+++ b/.github/scripts/build-artifacts.sh
@@ -23,6 +23,7 @@ prepare_build() {
 build_dist() {
   progress "Building dist"
   (
+    command -v git > /dev/null && [ -d .git ] && git clean -d -f
     autoreconf -ivf
     ./configure \
       --prefix=/usr \
@@ -41,6 +42,7 @@ build_dist() {
 build_static_x86_64() {
   progress "Building static x86_64"
   (
+    command -v git > /dev/null && [ -d .git ] && git clean -d -f
     USER="" ./packaging/makeself/build-x86_64-static.sh
   ) >&2
 }

--- a/.travis/create_artifacts.sh
+++ b/.travis/create_artifacts.sh
@@ -17,15 +17,14 @@ set -e
 TOP_LEVEL=$(basename "$(git rev-parse --show-toplevel)")
 CWD=$(git rev-parse --show-cdup || echo "")
 if [ -n "${CWD}" ] || [ ! "${TOP_LEVEL}" == "netdata" ]; then
-    echo "Run as .travis/$(basename "$0") from top level directory of netdata git repository"
-    exit 1
+  echo "Run as .travis/$(basename "$0") from top level directory of netdata git repository"
+  exit 1
 fi
 
 if [ ! "${TRAVIS_REPO_SLUG}" == "netdata/netdata" ]; then
-	echo "Beta mode on ${TRAVIS_REPO_SLUG}, not running anything here"
-	exit 0
-fi;
-
+  echo "Beta mode on ${TRAVIS_REPO_SLUG}, not running anything here"
+  exit 0
+fi
 
 echo "--- Initialize git configuration ---"
 git checkout "${1-master}"
@@ -46,12 +45,14 @@ BASENAME="netdata-$(git describe)"
 # See https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959 for details.
 python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
 echo "--- Create tarball ---"
+command -v git > /dev/null && [ -d .git ] && git clean -d -f
 autoreconf -ivf
 ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libexecdir=/usr/libexec --with-zlib --with-math --with-user=netdata CFLAGS=-O2
 make dist
 mv "${BASENAME}.tar.gz" artifacts/
 
 echo "--- Create self-extractor ---"
+command -v git > /dev/null && [ -d .git ] && git clean -d -f
 ./packaging/makeself/build-x86_64-static.sh
 
 # Needed for GCS
@@ -61,6 +62,6 @@ cp packaging/version artifacts/latest-version.txt
 cd artifacts
 ln -s "${BASENAME}.tar.gz" netdata-latest.tar.gz
 ln -s "${BASENAME}.gz.run" netdata-latest.gz.run
-sha256sum -b ./* >"sha256sums.txt"
+sha256sum -b ./* > "sha256sums.txt"
 echo "checksums:"
 cat sha256sums.txt

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -235,6 +235,7 @@ while [ -n "${1}" ]; do
   case "${1}" in
     "--zlib-is-really-here") LIBS_ARE_HERE=1 ;;
     "--libs-are-really-here") LIBS_ARE_HERE=1 ;;
+    "--dont-scrub-cflags-even-though-it-may-break-things") DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS=1 ;;
     "--dont-start-it") DONOTSTART=1 ;;
     "--dont-wait") DONOTWAIT=1 ;;
     "--auto-update" | "-u") AUTOUPDATE=1 ;;
@@ -460,20 +461,26 @@ trap build_error EXIT
 # -----------------------------------------------------------------------------
 
 build_libmosquitto() {
+  local env_cmd=''
+
+  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ] ; then
+    env_cmd="env CFLAGS= CXXFLAGS= LDFLAGS="
+  fi
+
   if [ "$(uname -s)" = Linux ]; then
-    run env CFLAGS= CXXFLAGS= LDFLAGS= make -C "${1}/lib"
+    run ${env_cmd} make -C "${1}/lib"
   else
     pushd ${1} > /dev/null || return 1
     if [ "$(uname)" = "Darwin" ] && [ -d /usr/local/opt/openssl ]; then
-      run env CFLAGS= CXXFLAGS= LDFLAGS= cmake \
+      run ${env_cmd} cmake \
         -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
         -D OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib \
         -D WITH_STATIC_LIBRARIES:boolean=YES \
         .
     else
-      run env CFLAGS= CXXFLAGS= LDFLAGS= cmake -D WITH_STATIC_LIBRARIES:boolean=YES .
+      run ${env_cmd} cmake -D WITH_STATIC_LIBRARIES:boolean=YES .
     fi
-    run env CFLAGS= CXXFLAGS= LDFLAGS= make -C lib
+    run ${env_cmd} make -C lib
     run mv lib/libmosquitto_static.a lib/libmosquitto.a
     popd || return 1
   fi
@@ -534,17 +541,23 @@ bundle_libmosquitto
 # -----------------------------------------------------------------------------
 
 build_libwebsockets() {
+  local env_cmd=''
+
+  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ] ; then
+    env_cmd="env CFLAGS= CXXFLAGS= LDFLAGS="
+  fi
+
   pushd "${1}" > /dev/null || exit 1
   if [ "$(uname)" = "Darwin" ] && [ -d /usr/local/opt/openssl ]; then
-    run env CFLAGS= CXXFLAGS= LDFLAGS= cmake \
+    run ${env_cmd} cmake \
       -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
       -D OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib \
       -D LWS_WITH_SOCKS5:bool=ON \
       .
   else
-    run env CFLAGS= CXXFLAGS= LDFLAGS= cmake -D LWS_WITH_SOCKS5:bool=ON .
+    run ${env_cmd} cmake -D LWS_WITH_SOCKS5:bool=ON .
   fi
-  run env CFLAGS= CXXFLAGS= LDFLAGS= make
+  run ${env_cmd} make
   popd > /dev/null || exit 1
 }
 
@@ -608,9 +621,15 @@ bundle_libwebsockets
 # -----------------------------------------------------------------------------
 
 build_jsonc() {
+  local env_cmd=''
+
+  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ] ; then
+    env_cmd="env CFLAGS= CXXFLAGS= LDFLAGS="
+  fi
+
   pushd "${1}" > /dev/null || exit 1
-  run env CFLAGS= CXXFLAGS= LDFLAGS= cmake -DBUILD_SHARED_LIBS=OFF .
-  run env CFLAGS= CXXFLAGS= LDFLAGS= make
+  run ${env_cmd} cmake -DBUILD_SHARED_LIBS=OFF .
+  run ${env_cmd} make
   popd > /dev/null || exit 1
 }
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -463,7 +463,7 @@ trap build_error EXIT
 build_libmosquitto() {
   local env_cmd=''
 
-  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ] ; then
+  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
     env_cmd="env CFLAGS= CXXFLAGS= LDFLAGS="
   fi
 
@@ -543,7 +543,7 @@ bundle_libmosquitto
 build_libwebsockets() {
   local env_cmd=''
 
-  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ] ; then
+  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
     env_cmd="env CFLAGS= CXXFLAGS= LDFLAGS="
   fi
 
@@ -553,9 +553,10 @@ build_libwebsockets() {
       -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
       -D OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib \
       -D LWS_WITH_SOCKS5:bool=ON \
+      $CMAKE_FLAGS \
       .
   else
-    run ${env_cmd} cmake -D LWS_WITH_SOCKS5:bool=ON .
+    run ${env_cmd} cmake -D LWS_WITH_SOCKS5:bool=ON $CMAKE_FLAGS .
   fi
   run ${env_cmd} make
   popd > /dev/null || exit 1
@@ -623,7 +624,7 @@ bundle_libwebsockets
 build_jsonc() {
   local env_cmd=''
 
-  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ] ; then
+  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
     env_cmd="env CFLAGS= CXXFLAGS= LDFLAGS="
   fi
 

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -24,14 +24,12 @@ apk add --no-cache -U \
   libtool \
   pkgconfig \
   util-linux-dev \
-  openssl-dev \
   gnutls-dev \
   zlib-dev \
   libmnl-dev \
   libnetfilter_acct-dev \
   libuv-dev \
   lz4-dev \
-  openssl-dev \
   snappy-dev \
   protobuf-dev \
   binutils \

--- a/packaging/makeself/jobs/20-openssl.install.sh
+++ b/packaging/makeself/jobs/20-openssl.install.sh
@@ -9,7 +9,10 @@ version="$(cat "$(dirname "${0}")/../openssl.version")"
 export LDFLAGS='-static'
 export PKG_CONFIG="pkg-config --static"
 
-run git clone --branch "${version}" --single-branch git://git.openssl.org/openssl.git "${NETDATA_MAKESELF_PATH}/tmp/openssl"
+# Might be bind-mounted
+if [ ! -d "${NETDATA_MAKESELF_PATH}/tmp/openssl" ]; then
+  run git clone --branch "${version}" --single-branch git://git.openssl.org/openssl.git "${NETDATA_MAKESELF_PATH}/tmp/openssl"
+fi
 cd "${NETDATA_MAKESELF_PATH}/tmp/openssl" || exit 1
 
 run ./config no-shared no-tests --prefix=/openssl-static --openssldir=/opt/netdata/etc/ssl

--- a/packaging/makeself/jobs/50-bash-4.4.18.install.sh
+++ b/packaging/makeself/jobs/50-bash-4.4.18.install.sh
@@ -6,7 +6,7 @@
 
 fetch "bash-4.4.18" "http://ftp.gnu.org/gnu/bash/bash-4.4.18.tar.gz"
 
-export PKG_CONFIG_PATH="/opnessl/lib/pkgconfig"
+export PKG_CONFIG_PATH="/opnessl-static/lib/pkgconfig"
 
 run ./configure \
   --prefix="${NETDATA_INSTALL_PATH}" \

--- a/packaging/makeself/jobs/50-bash-4.4.18.install.sh
+++ b/packaging/makeself/jobs/50-bash-4.4.18.install.sh
@@ -6,7 +6,7 @@
 
 fetch "bash-4.4.18" "http://ftp.gnu.org/gnu/bash/bash-4.4.18.tar.gz"
 
-export PKG_CONFIG_PATH="/opnessl-static/lib/pkgconfig"
+export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
 run ./configure \
   --prefix="${NETDATA_INSTALL_PATH}" \

--- a/packaging/makeself/jobs/50-curl-7.60.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.60.0.install.sh
@@ -6,9 +6,10 @@
 
 fetch "curl-curl-7_60_0" "https://github.com/curl/curl/archive/curl-7_60_0.tar.gz"
 
-export LDFLAGS="-static"
+export CFLAGS="-I/openssl-static/include"
+export LDFLAGS="-static -L/openssl-static/lib"
 export PKG_CONFIG="pkg-config --static"
-export PKG_CONFIG_PATH="/opnessl/lib/pkgconfig"
+export PKG_CONFIG_PATH="/opnessl-static/lib/pkgconfig"
 
 run ./buildconf
 

--- a/packaging/makeself/jobs/50-curl-7.60.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.60.0.install.sh
@@ -9,7 +9,7 @@ fetch "curl-curl-7_60_0" "https://github.com/curl/curl/archive/curl-7_60_0.tar.g
 export CFLAGS="-I/openssl-static/include"
 export LDFLAGS="-static -L/openssl-static/lib"
 export PKG_CONFIG="pkg-config --static"
-export PKG_CONFIG_PATH="/opnessl-static/lib/pkgconfig"
+export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
 run ./buildconf
 

--- a/packaging/makeself/jobs/50-fping-4.2.install.sh
+++ b/packaging/makeself/jobs/50-fping-4.2.install.sh
@@ -6,8 +6,9 @@
 
 fetch "fping-4.2" "https://github.com/schweikert/fping/releases/download/v4.2/fping-4.2.tar.gz"
 
-export CFLAGS="-static"
-export PKG_CONFIG_PATH="/opnessl/lib/pkgconfig"
+export CFLAGS="-static -I/openssl-static/include"
+export LDFLAGS="-static -L/openssl-static/lib"
+export PKG_CONFIG_PATH="/opnessl-static/lib/pkgconfig"
 
 run ./configure \
   --prefix="${NETDATA_INSTALL_PATH}" \

--- a/packaging/makeself/jobs/50-fping-4.2.install.sh
+++ b/packaging/makeself/jobs/50-fping-4.2.install.sh
@@ -8,7 +8,7 @@ fetch "fping-4.2" "https://github.com/schweikert/fping/releases/download/v4.2/fp
 
 export CFLAGS="-static -I/openssl-static/include"
 export LDFLAGS="-static -L/openssl-static/lib"
-export PKG_CONFIG_PATH="/opnessl-static/lib/pkgconfig"
+export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
 run ./configure \
   --prefix="${NETDATA_INSTALL_PATH}" \

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -7,10 +7,12 @@
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
-  export CFLAGS="-static -O3"
+  export CFLAGS="-static -O3 -I/openssl-static/include"
 else
-  export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1"
+  export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include"
 fi
+
+export LDFLAGS="-static -L/openssl-static/lib"
 
 # We export this to 'yes', installer sets this to .environment.
 # The updater consumes this one, so that it can tell whether it should update a static install or a non-static one
@@ -18,12 +20,13 @@ export IS_NETDATA_STATIC_BINARY="yes"
 
 # Set eBPF LIBC to "static" to bundle the `-static` variant of the kernel-collector
 export EBPF_LIBC="static"
-export PKG_CONFIG_PATH="/opnessl/lib/pkgconfig"
+export PKG_CONFIG_PATH="/opnessl-static/lib/pkgconfig"
 
 run ./netdata-installer.sh \
   --install "${NETDATA_INSTALL_PARENT}" \
   --dont-wait \
-  --dont-start-it
+  --dont-start-it \
+  --dont-scrub-cflags-even-though-it-may-break-things
 
 # Remove the netdata.conf file from the tree. It has hard-coded sensible defaults builtin.
 run rm -f "${NETDATA_INSTALL_PATH}/etc/netdata/netdata.conf"

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -20,7 +20,11 @@ export IS_NETDATA_STATIC_BINARY="yes"
 
 # Set eBPF LIBC to "static" to bundle the `-static` variant of the kernel-collector
 export EBPF_LIBC="static"
-export PKG_CONFIG_PATH="/opnessl-static/lib/pkgconfig"
+export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
+
+# Set correct CMake flags for building against non-System OpenSSL
+# See: https://github.com/warmcat/libwebsockets/blob/master/READMEs/README.build.md
+export CMAKE_FLAGS="-DOPENSSL_ROOT_DIR=/openssl-static -DOPENSSL_LIBRARIES=/openssl-static/lib -DCMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE=/openssl-static -DLWS_OPENSSL_INCLUDE_DIRS=/openssl-static/include -DLWS_OPENSSL_LIBRARIES=/openssl-static/lib/libssl.a;/openssl-static/lib/libcrypto.a"
 
 run ./netdata-installer.sh \
   --install "${NETDATA_INSTALL_PARENT}" \

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -26,6 +26,7 @@ run ./netdata-installer.sh \
   --install "${NETDATA_INSTALL_PARENT}" \
   --dont-wait \
   --dont-start-it \
+  --require-cloud \
   --dont-scrub-cflags-even-though-it-may-break-things
 
 # Remove the netdata.conf file from the tree. It has hard-coded sensible defaults builtin.


### PR DESCRIPTION
##### Summary

ssia

##### Component Name

- area/packaging

##### Test Plan

1. Build a new static binary:

```#!sh
$ .github/scripts/build-artifacts.sh
```

2. Copy it on a box somewhere and run it:

```#!sh
$ scp ./artifacts/*.run user@yourboxen:
$ ssh user@yourboxen
$ ./netdata-*.run --accept
```

3. Claim it in [Netdata Cloud](https://app.netdata.cloud)

> I did this for Debian 10 and CentOS 7

##### Additional Information

Few things to note here:

- Missing `--require-cloud` and therefore we weren't enabling the build
  of the Netdata Cloud dependencies.
- Typo in some path names.
- Missing CMake flags to correctly build against the custom
  `/openssl-static` (_without it was incorrectly trying to build against
and build test programs against the system openssl -- Alpine 3.7_).
- In both Travis and the GHA Workflow that does CI for static builds we were not cleaning the local source tree before building something else. Unfortunately this is a bit of legacy/technical-debt here that we've inherited where the build environment uses Alpine 3.7 and bind-mounts the sources which get mutated when we build the source dist -- Which resulted in a successful but incorrect build and broken Static Netdata with non-functioning Netdata Cloud support (_but was also missing the above as well_).