### PR TITLE
Add libuv thread names support to FATAL log level

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,12 @@ LIBS="${PTHREAD_LIBS} ${LIBS}"
 CFLAGS="${CFLAGS} ${PTHREAD_CFLAGS}"
 CC="${PTHREAD_CC}"
 
+AC_CHECK_LIB(
+[pthread],
+[pthread_getname_np],
+[AC_DEFINE([HAVE_PTHREAD_GETNAME_NP], [1], [Is set if pthread_getname_np is available])]
+)
+
 
 # -----------------------------------------------------------------------------
 # libm

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -796,11 +796,21 @@ void fatal_int( const char *file, const char *function, const unsigned long line
     // save a copy of errno - just in case this function generates a new error
     int __errno = errno;
     va_list args;
+    const char *thread_tag;
+    char os_threadname[NETDATA_THREAD_NAME_MAX + 1];
 
     if(error_log_syslog) {
         va_start( args, fmt );
         vsyslog(LOG_CRIT,  fmt, args );
         va_end( args );
+    }
+
+    thread_tag = netdata_thread_tag();
+    if (!netdata_thread_tag_exists()) {
+        os_thread_get_current_name_np(os_threadname);
+        if ('\0' != os_threadname[0]) { /* If it is not an empty string replace "MAIN" thread_tag */
+            thread_tag = os_threadname;
+        }
     }
 
     char date[LOG_DATE_LENGTH];
@@ -809,8 +819,8 @@ void fatal_int( const char *file, const char *function, const unsigned long line
     log_lock();
 
     va_start( args, fmt );
-    if(debug_flags) fprintf(stderr, "%s: %s FATAL : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
-    else            fprintf(stderr, "%s: %s FATAL : %s :", date, program_name, netdata_thread_tag());
+    if(debug_flags) fprintf(stderr, "%s: %s FATAL : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
+    else            fprintf(stderr, "%s: %s FATAL : %s: ", date, program_name, thread_tag);
     vfprintf( stderr, fmt, args );
     va_end( args );
 
@@ -823,7 +833,7 @@ void fatal_int( const char *file, const char *function, const unsigned long line
     snprintfz(action_data, 70, "%04lu@%-10.10s:%-15.15s/%d", line, file, function, __errno);
     char action_result[60+1];
 
-    snprintfz(action_result, 60, "%s:%s", program_name, strncmp(netdata_thread_tag(), "STREAM_RECEIVER", strlen("STREAM_RECEIVER"))?netdata_thread_tag():"[x]");
+    snprintfz(action_result, 60, "%s:%s", program_name, strncmp(thread_tag, "STREAM_RECEIVER", strlen("STREAM_RECEIVER")) ? thread_tag : "[x]");
     send_statistics("FATAL", action_result, action_data);
 
     netdata_cleanup_and_exit(1);

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -820,7 +820,7 @@ void fatal_int( const char *file, const char *function, const unsigned long line
 
     va_start( args, fmt );
     if(debug_flags) fprintf(stderr, "%s: %s FATAL : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
-    else            fprintf(stderr, "%s: %s FATAL : %s: ", date, program_name, thread_tag);
+    else            fprintf(stderr, "%s: %s FATAL : %s : ", date, program_name, thread_tag);
     vfprintf( stderr, fmt, args );
     va_end( args );
 

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -18,8 +18,12 @@ typedef struct {
 
 static __thread NETDATA_THREAD *netdata_thread = NULL;
 
+inline int netdata_thread_tag_exists(void) {
+    return (netdata_thread && netdata_thread->tag && *netdata_thread->tag);
+}
+
 const char *netdata_thread_tag(void) {
-    return ((netdata_thread && netdata_thread->tag && *netdata_thread->tag)?netdata_thread->tag:"MAIN");
+    return (netdata_thread_tag_exists() ? netdata_thread->tag : "MAIN");
 }
 
 // ----------------------------------------------------------------------------
@@ -149,6 +153,21 @@ void uv_thread_set_name_np(uv_thread_t ut, const char* name) {
 
     if (ret)
         info("cannot set libuv thread name to %s. Err: %d", threadname, ret);
+}
+
+void os_thread_get_current_name_np(char threadname[NETDATA_THREAD_NAME_MAX + 1])
+{
+    int ret = 0;
+
+#if defined(__FreeBSD__)
+    pthread_get_name_np(pthread_self(), threadname, NETDATA_THREAD_NAME_MAX + 1);
+#else /* Linux & macOS */
+    ret = pthread_getname_np(pthread_self(), threadname, NETDATA_THREAD_NAME_MAX + 1);
+#endif
+
+    if (ret) {
+        threadname[0] = '\0';
+    }
 }
 
 static void *thread_start(void *ptr) {

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -159,15 +159,12 @@ void os_thread_get_current_name_np(char threadname[NETDATA_THREAD_NAME_MAX + 1])
 {
     int ret = 0;
 
+    threadname[0] = '\0';
 #if defined(__FreeBSD__)
     pthread_get_name_np(pthread_self(), threadname, NETDATA_THREAD_NAME_MAX + 1);
-#else /* Linux & macOS */
-    ret = pthread_getname_np(pthread_self(), threadname, NETDATA_THREAD_NAME_MAX + 1);
+#elif defined(HAVE_PTHREAD_GETNAME_NP) /* Linux & macOS */
+    (void)pthread_getname_np(pthread_self(), threadname, NETDATA_THREAD_NAME_MAX + 1);
 #endif
-
-    if (ret) {
-        threadname[0] = '\0';
-    }
 }
 
 static void *thread_start(void *ptr) {

--- a/libnetdata/threads/threads.h
+++ b/libnetdata/threads/threads.h
@@ -22,6 +22,7 @@ typedef pthread_t netdata_thread_t;
 
 #define NETDATA_THREAD_TAG_MAX 100
 extern const char *netdata_thread_tag(void);
+extern int netdata_thread_tag_exists(void);
 
 extern size_t netdata_threads_init(void);
 extern void netdata_threads_init_after_fork(size_t stacksize);
@@ -33,6 +34,7 @@ extern int netdata_thread_detach(pthread_t thread);
 
 #define NETDATA_THREAD_NAME_MAX 15
 extern void uv_thread_set_name_np(uv_thread_t ut, const char* name);
+extern void os_thread_get_current_name_np(char threadname[NETDATA_THREAD_NAME_MAX + 1]);
 
 #define netdata_thread_self pthread_self
 #define netdata_thread_testcancel pthread_testcancel


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Add support for the` fatal()` family of calls to detect non-netdata thread names from the OS.
##### Component Name
daemon
##### Test Plan
Make the following change to trigger fatal error to a libuv thread.
```
--- a/spawn/spawn_client.c
+++ b/spawn/spawn_client.c
@@ -202,6 +202,8 @@ void spawn_client(void *arg)
     spawn_thread_shutdown = 0;
     /* wake up initialization thread */
     complete(completion);
+sleep(1);
+fatal_assert(1 == 0);
 
     prot_buffer_len = 0;
     ret = uv_read_start((uv_stream_t *)&spawn_channel, on_read_alloc, on_pipe_read);

```
You should observe the real name and not `"MAIN"` in `error.log` .

I've been having problems building netdata in freeBSD and I don't have macOS access so please test those 2 platforms.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->
