### PR TITLE
Remove chart specific configuration from netdata.conf

### DIFF
--- a/database/rrd.c
+++ b/database/rrd.c
@@ -140,6 +140,7 @@ const char *rrdset_type_name(RRDSET_TYPE chart_type) {
 // RRD - cache directory
 
 char *rrdset_cache_dir(RRDHOST *host, const char *id, const char *config_section) {
+    UNUSED(config_section);
     char *ret = NULL;
 
     char b[FILENAME_MAX + 1];
@@ -147,7 +148,7 @@ char *rrdset_cache_dir(RRDHOST *host, const char *id, const char *config_section
     rrdset_strncpyz_name(b, id, FILENAME_MAX);
 
     snprintfz(n, FILENAME_MAX, "%s/%s", host->cache_dir, b);
-    ret = config_get(config_section, "cache directory", n);
+    ret = strdupz(n);
 
     if(host->rrd_memory_mode == RRD_MEMORY_MODE_MAP || host->rrd_memory_mode == RRD_MEMORY_MODE_SAVE) {
         int r = mkdir(ret, 0775);

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -252,7 +252,6 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     char filename[FILENAME_MAX + 1];
     char fullfilename[FILENAME_MAX + 1];
 
-    char varname[CONFIG_MAX_NAME + 1];
     unsigned long size = sizeof(RRDDIM) + (st->entries * sizeof(storage_number));
 
     debug(D_RRD_CALLS, "Adding dimension '%s/%s'.", st->id, id);
@@ -350,18 +349,14 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
 
     rd->cache_filename = strdupz(fullfilename);
 
-    snprintfz(varname, CONFIG_MAX_NAME, "dim %s name", rd->id);
-    rd->name = config_get(st->config_section, varname, (name && *name)?name:rd->id);
+    rd->name = (name && *name)?strdupz(name):strdupz(rd->id);
     rd->hash_name = simple_hash(rd->name);
 
-    snprintfz(varname, CONFIG_MAX_NAME, "dim %s algorithm", rd->id);
-    rd->algorithm = rrd_algorithm_id(config_get(st->config_section, varname, rrd_algorithm_name(algorithm)));
+    rd->algorithm = algorithm;
 
-    snprintfz(varname, CONFIG_MAX_NAME, "dim %s multiplier", rd->id);
-    rd->multiplier = config_get_number(st->config_section, varname, multiplier);
+    rd->multiplier = multiplier;
 
-    snprintfz(varname, CONFIG_MAX_NAME, "dim %s divisor", rd->id);
-    rd->divisor = config_get_number(st->config_section, varname, divisor);
+    rd->divisor = divisor;
     if(!rd->divisor) rd->divisor = 1;
 
     rd->entries = st->entries;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -157,12 +157,12 @@ int rrdset_set_name(RRDSET *st, const char *name) {
 
     if(st->name) {
         rrdset_index_del_name(host, st);
-        st->name = config_set_default(st->config_section, "name", b);
+        st->name = strdupz(b);
         st->hash_name = simple_hash(st->name);
         rrdsetvar_rename_all(st);
     }
     else {
-        st->name = config_get(st->config_section, "name", b);
+        st->name = strdupz(b);
         st->hash_name = simple_hash(st->name);
     }
 
@@ -617,10 +617,8 @@ RRDSET *rrdset_create_custom(
             mark_rebuild |= META_CHART_UPDATED;
         }
 
-        RRDSET_TYPE new_chart_type =
-            rrdset_type_id(config_get(st->config_section, "chart type", rrdset_type_name(chart_type)));
-        if (st->chart_type != new_chart_type) {
-            st->chart_type = new_chart_type;
+        if (st->chart_type != chart_type) {
+            st->chart_type = chart_type;
             mark_rebuild |= META_CHART_UPDATED;
         }
 
@@ -709,19 +707,11 @@ RRDSET *rrdset_create_custom(
     // get the options from the config, we need to create it
 
     long entries;
-    if(memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-        // only sets it the first time
-        entries = config_get_number(config_section, "history", 5);
-    } else {
-        long rentries = config_get_number(config_section, "history", history_entries);
-        entries = align_entries_to_pagesize(memory_mode, rentries);
-        if (entries != rentries) entries = config_set_number(config_section, "history", entries);
-
-        if (memory_mode == RRD_MEMORY_MODE_NONE && entries != rentries)
-            entries = config_set_number(config_section, "history", 10);
-    }
     int enabled = config_get_boolean(config_section, "enabled", 1);
-    if(!enabled) entries = 5;
+    if(!enabled || memory_mode == RRD_MEMORY_MODE_DBENGINE)
+        entries = 5;
+    else
+        entries = align_entries_to_pagesize(memory_mode, history_entries);
 
     unsigned long size = sizeof(RRDSET);
     char *cache_dir = rrdset_cache_dir(host, fullid, config_section);
@@ -840,22 +830,22 @@ RRDSET *rrdset_create_custom(
 
     st->cache_dir = cache_dir;
 
-    st->chart_type = rrdset_type_id(config_get(st->config_section, "chart type", rrdset_type_name(chart_type)));
-    st->type       = config_get(st->config_section, "type", type);
+    st->chart_type = chart_type;
+    st->type       = strdupz(type);
 
     st->state = callocz(1, sizeof(*st->state));
-    st->family     = config_get(st->config_section, "family", family?family:st->type);
+    st->family = family ? strdupz(family) : strdupz(st->type);
     json_fix_string(st->family);
 
-    st->units      = config_get(st->config_section, "units", units?units:"");
+    st->units = units ? strdupz(units) : strdupz("");
     json_fix_string(st->units);
 
-    st->context    = config_get(st->config_section, "context", context?context:st->id);
+    st->context = context ? strdupz(context) : strdupz(st->id);
     st->state->old_context = strdupz(st->context);
     json_fix_string(st->context);
     st->hash_context = simple_hash(st->context);
 
-    st->priority = config_get_number(st->config_section, "priority", priority);
+    st->priority = priority;
     if(enabled)
         rrdset_flag_set(st, RRDSET_FLAG_ENABLED);
     else
@@ -905,7 +895,7 @@ RRDSET *rrdset_create_custom(
         // could not use the name, use the id
         rrdset_set_name(st, id);
 
-    st->title = config_get(st->config_section, "title", title);
+    st->title = strdupz(title);
     st->state->old_title = strdupz(st->title);
     json_fix_string(st->title);
 


### PR DESCRIPTION
Fixes #9320
##### Summary
Remove support for 'per chart' configuration in `netdata.conf` (except the `enabled` option)

Right now on every chart creation there is a lookup in the config file to determine if a section that matches the chart exists

- For parent nodes the section matches the chart name
- For child nodes the section is in the form guid/chart_name

##### Component Name
database
agent

##### Test Plan
- Fetch netdata.conf using ` http://host:19999/netdata.conf` to notice the absence of chart specific configuration.

##### Additional Information
