### PR TITLE
Fix missing host variables on stream

### DIFF
--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -70,8 +70,10 @@ static int rrdpush_sender_thread_custom_host_variables_callback(void *rrdvar_ptr
 }
 
 static void rrdpush_sender_thread_send_custom_host_variables(RRDHOST *host) {
+    sender_start(host->sender);
     int ret = rrdvar_callback_for_all_host_variables(host, rrdpush_sender_thread_custom_host_variables_callback, host);
     (void)ret;
+    sender_commit(host->sender);
 
     debug(D_STREAM, "RRDVAR sent %d VARIABLES", ret);
 }


### PR DESCRIPTION
##### Summary
Fixes #9375 

We were not copying properly the data between buffer and with this the HOST variables were not properly copied to the parent.
##### Component Name
Stream
##### Test Plan
1 - Compile this PR mainly on children hosts.
2 - Start parent and after few seconds start the slave.
3 - Do the following request for the parent `https://localhost:19999/host/CHILD_NAME/api/v1/alarm_variables?chart=system.load` and check if the variable `active_processors` is present.
4 - Repeat the steps 1, 2 and 3 at least three times.

##### Additional Information