### PR TITLE
Fix Coverity Defect CID 304732

### DIFF
--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -157,8 +157,6 @@ void uv_thread_set_name_np(uv_thread_t ut, const char* name) {
 
 void os_thread_get_current_name_np(char threadname[NETDATA_THREAD_NAME_MAX + 1])
 {
-    int ret = 0;
-
     threadname[0] = '\0';
 #if defined(__FreeBSD__)
     pthread_get_name_np(pthread_self(), threadname, NETDATA_THREAD_NAME_MAX + 1);


### PR DESCRIPTION
##### Summary
@mfundul 's analysis of the defect report:

1. Receiver thread disconnects from stream and pops `rrdpush_receiver_thread_cleanup()` during shutdown of pthread.
2. Skips this:
```
        if (netdata_exit && rpt->host) {
            rpt->exited = 1;
            return;
        }
```
because netdata has not exited yet.
3. Takes this branch for the same reason:
```
        if (!netdata_exit && rpt->host) {
```
4. Before taking the `receiver_lock` it's scheduled out by the OS.
5. Now netdata exits. netdata_exit is set to 1 and rrdhost_free() runs the following code:
```
        netdata_mutex_lock(&host->receiver_lock);
        if (host->receiver) {
            if (!host->receiver->exited)
                netdata_thread_cancel(host->receiver->thread);
            while (!host->receiver->exited)
                sleep_usec(50 * USEC_PER_MS);
```
6. The receiver thread is scheduled back in, and hangs on:
```
            netdata_mutex_lock(&rpt->host->receiver_lock);
```
7. `rrdhost_free()` will spin on `while (!host->receiver->exited)` but rpt->exited = 1; is never set.

##### Component Name
streaming

##### Test Plan
"Beware of bugs in the above code; I have only proved it correct, not tried it."

##### Additional Information
