### PR TITLE
Add better checks for existing installs to the kickstart scripts.

### DIFF
--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -4,12 +4,13 @@
 # shellcheck disable=SC1117,SC2039,SC2059,SC2086
 #
 #  Options to run
-#  --dont-wait              do not wait for input
-#  --non-interactive        do not wait for input
-#  --dont-start-it          do not start netdata after install
-#  --stable-channel         Use the stable release channel, rather than the nightly to fetch sources
-#  --disable-telemetry      Opt-out of anonymous telemetry program (DO_NOT_TRACK=1)
-#  --local-files            Use a manually provided tarball for the installation
+#  --dont-wait                do not wait for input
+#  --non-interactive          do not wait for input
+#  --dont-start-it            do not start netdata after install
+#  --stable-channel           Use the stable release channel, rather than the nightly to fetch sources
+#  --disable-telemetry        Opt-out of anonymous telemetry program (DO_NOT_TRACK=1)
+#  --local-files              Use a manually provided tarball for the installation
+#  --allow-duplicate-install  do not bail if we detect a duplicate install
 #
 # Environment options:
 #
@@ -179,6 +180,65 @@ sudo=""
 [ -z "${UID}" ] && UID="$(id -u)"
 [ "${UID}" -ne "0" ] && sudo="sudo"
 
+# ---------------------------------------------------------------------------------------------------------------------
+# look for an existing install and try to update that instead if it exists
+
+ndpath="$(command -v netdata)"
+if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ] ; then
+    ndpath="/opt/netdata/bin/netdata"
+fi
+
+if [ -n "$ndpath" ] ; then
+  ndprefix="$(dirname "$(dirname "${ndpath}")")"
+
+  if [ "${ndprefix}" = /usr ] ; then
+    ndprefix="/"
+  fi
+
+  progress "Found existing install of Netdata under: ${ndprefix}"
+
+  if [ -r "${ndprefix}/etc/netdata/.environment" ] ; then
+    if [ -x "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ] ; then
+      # the crazy statement below pulls the value of a single variable out of the environment file without polluting the runtime environment
+      is_static="$(env "$(cat "${ndprefix}/etc/netdata/.environment") /bin/sh -c 'echo ${IS_NETDATA_STATIC_BINARY}'")"
+      if [ -n "${is_static}" ] ; then
+        progress "Attempting to update existing static install instead of creating a new one"
+        if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
+          progress "Updated existing static install at ${ndpath}"
+          exit 0
+        else
+          fatal "Failed to update existing Netdata install"
+          exit 1
+        fi
+      else
+        progress "Attempting to update existing kickstart install instead of creating a new one"
+        if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
+          progress "Updated existing kickstart install at ${ndpath}"
+          exit 0
+        else
+          fatal "Failed to update existing Netdata install"
+          exit 1
+        fi
+      fi
+    else
+      if [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] ; then
+        fatal "Existing installation detected which cannot be safely updated by this script, refusing to continue."
+        exit 1
+      else
+        progress "User explicitly requested duplicate install, proceeding."
+      fi
+    fi
+  else
+    progress "Existing install appears to be handled manually or through the system package manager."
+    if [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] ; then
+      fatal "Existing installation detected which cannot be safely updated by this script, refusing to continue."
+      exit 1
+    else
+      progress "User explicitly requested duplicate install, proceeding."
+    fi
+  fi
+fi
+
 # ----------------------------------------------------------------------------
 if [ "$(uname -m)" != "x86_64" ]; then
   fatal "Static binary versions of netdata are available only for 64bit Intel/AMD CPUs (x86_64), but yours is: $(uname -m)."
@@ -227,6 +287,9 @@ while [ -n "${1}" ]; do
     fi
 
     NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM="${1}"
+    shift 1
+  elif [ "${1}" = "--allow-duplicate-install" ]; then
+    NETDATA_ALLOW_DUPLICATE_INSTALL=1
     shift 1
   else
     echo >&2 "Unknown option '${1}' or invalid number of arguments. Please check the README for the available arguments of ${0} and try again"

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -183,7 +183,7 @@ sudo=""
 # ---------------------------------------------------------------------------------------------------------------------
 # look for an existing install and try to update that instead if it exists
 
-ndpath="$(command -v netdata)"
+ndpath="$(command -v netdata 2>/dev/null)"
 if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ] ; then
     ndpath="/opt/netdata/bin/netdata"
 fi
@@ -199,26 +199,13 @@ if [ -n "$ndpath" ] ; then
 
   if [ -r "${ndprefix}/etc/netdata/.environment" ] ; then
     if [ -x "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ] ; then
-      # the crazy statement below pulls the value of a single variable out of the environment file without polluting the runtime environment
-      is_static="$(env "$(cat "${ndprefix}/etc/netdata/.environment") /bin/sh -c 'echo ${IS_NETDATA_STATIC_BINARY}'")"
-      if [ -n "${is_static}" ] ; then
-        progress "Attempting to update existing static install instead of creating a new one"
-        if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
-          progress "Updated existing static install at ${ndpath}"
-          exit 0
-        else
-          fatal "Failed to update existing Netdata install"
-          exit 1
-        fi
+      progress "Attempting to update existing install instead of creating a new one"
+      if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
+        progress "Updated existing install at ${ndpath}"
+        exit 0
       else
-        progress "Attempting to update existing kickstart install instead of creating a new one"
-        if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
-          progress "Updated existing kickstart install at ${ndpath}"
-          exit 0
-        else
-          fatal "Failed to update existing Netdata install"
-          exit 1
-        fi
+        fatal "Failed to update existing Netdata install"
+        exit 1
       fi
     else
       if [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] ; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -281,7 +281,7 @@ export PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 # ---------------------------------------------------------------------------------------------------------------------
 # look for an existing install and try to update that instead if it exists
 
-ndpath="$(command -v netdata)"
+ndpath="$(command -v netdata 2>/dev/null)"
 if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ] ; then
     ndpath="/opt/netdata/bin/netdata"
 fi
@@ -297,26 +297,13 @@ if [ -n "$ndpath" ] ; then
 
   if [ -r "${ndprefix}/etc/netdata/.environment" ] ; then
     if [ -x "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ] ; then
-      # the crazy statement below pulls the value of a single variable out of the environment file without polluting the runtime environment
-      is_static="$(env "$(cat "${ndprefix}/etc/netdata/.environment") /bin/sh -c 'echo ${IS_NETDATA_STATIC_BINARY}'")"
-      if [ -n "${is_static}" ] ; then
-        progress "Attempting to update existing static install instead of creating a new one"
-        if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
-          progress "Updated existing static install at ${ndpath}"
-          exit 0
-        else
-          fatal "Failed to update existing Netdata install"
-          exit 1
-        fi
+      progress "Attempting to update existing install instead of creating a new one"
+      if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
+        progress "Updated existing install at ${ndpath}"
+        exit 0
       else
-        progress "Attempting to update existing kickstart install instead of creating a new one"
-        if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
-          progress "Updated existing kickstart install at ${ndpath}"
-          exit 0
-        else
-          fatal "Failed to update existing Netdata install"
-          exit 1
-        fi
+        fatal "Failed to update existing Netdata install"
+        exit 1
       fi
     else
       if [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] ; then

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -76,7 +76,7 @@ To use `md5sum` to verify the intregity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "7f97b8ec330c193614524d411ab1f7c3" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "f47630f78c0c5e651cb6788301d8e05c" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -76,7 +76,7 @@ To use `md5sum` to verify the intregity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "ff717737ccc2212a3363dad7fa8bd20d" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "7f97b8ec330c193614524d411ab1f7c3" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -58,7 +58,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "2057599f8b11ce56f85aa7f26ce7b15b" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "76c0fa048d0750f062239360b48dbf39" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -58,7 +58,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "76c0fa048d0750f062239360b48dbf39" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "05e3a23be90de1c2c62b2dbd8a3fb682" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

This adds more robust checks to our Kickstart install scripts to prevent users from accidentally installing Netdata over top of an existing install (which can lead to all kinds of problematic situations).

The logic for these checks works as follows:

* See if `netdata` is located somewhere in `$PATH` (using `command -v`), and if present assume there's an existing install.
* Otherwise, check if `/opt/netdata/bin/netdata` exists, if so assume there's an existing install, otherwise continue under the assumption there isn't.
* If there is an existing install, check if it's one done through our install scripts, if not stop the installation process.
* If it is one of our installs, look for and attempt to use the updater script to update the existing install (exiting with an error message if that fails).

This also adds a switch called '--allow-duplicate-install' which will cause the install to continue if it would normally refuse to continue due to an existing install.

##### Component Name

- area/packaging

##### Test Plan

Due to only impacting the `kickstart.sh` scripts themselves, this can be tested by just using the copies of the scripts form this PR to run through the 'normal' usage.

##### Additional Information

- Fixes: #8198
- Fixes: #8186 (_specifically fixes the last issue outlined there_).