### PR TITLE
[WIP] Fix HOST record being ignored by compaction

### DIFF
--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -84,7 +84,11 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
     RRDDIM *rd;
     BUFFER *buffer;
 
-    ret = find_object_by_guid(uuid, NULL, 0);
+    if (unlikely(!uuid_compare(host->host_uuid, *uuid))) {
+        /* We don't support host UUIDs in the GUID map yet so we hard code it for now */
+        ret = GUID_TYPE_HOST;
+    } else
+        ret = find_object_by_guid(uuid, NULL, 0);
     switch (ret) {
         case GUID_TYPE_CHAR:
             error_with_guid(uuid, "Ignoring unexpected type GUID_TYPE_CHAR");


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #9407
##### Component Name
database
##### Test Plan

1. Observe the `HOST` record in the agent metadata log file in `var/cache/netdata/dbengine/metadatalog-00000-00001.mlf` by running:
```
cat /var/cache/netdata/dbengine/metadatalog-00000-00001.mlf | strings -n 5 | grep HOST
```
2. Restart the netdata agent a bunch of times to trigger compaction.
3. Observe the absence of the `HOST` record.


<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->
