### PR TITLE
Fixes error in Swagger Documentation

### DIFF
--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -1977,6 +1977,39 @@
             "nullable": true
           }
         }
+      },
+      "alarms_values": {
+        "type": "object",
+        "description": "Fixed keys together with HashMap where keys are alarm names",
+        "properties": {
+          "hostname": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "value": {
+                "type": "integer"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "REMOVED",
+                  "UNDEFINED",
+                  "UNINITIALIZED",
+                  "CLEAR",
+                  "RAISED",
+                  "WARNING",
+                  "CRITICAL",
+                  "UNKNOWN"
+                ]
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -1980,32 +1980,35 @@
       },
       "alarms_values": {
         "type": "object",
-        "description": "Fixed keys together with HashMap where keys are alarm names",
         "properties": {
           "hostname": {
             "type": "string"
           },
-          "additionalProperties": {
+          "alarms": {
             "type": "object",
-            "properties": {
-              "id": {
-                "type": "integer"
-              },
-              "value": {
-                "type": "integer"
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "REMOVED",
-                  "UNDEFINED",
-                  "UNINITIALIZED",
-                  "CLEAR",
-                  "RAISED",
-                  "WARNING",
-                  "CRITICAL",
-                  "UNKNOWN"
-                ]
+            "description": "HashMap with keys being alarm names",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "value": {
+                  "type": "integer"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "REMOVED",
+                    "UNDEFINED",
+                    "UNINITIALIZED",
+                    "CLEAR",
+                    "RAISED",
+                    "WARNING",
+                    "CRITICAL",
+                    "UNKNOWN"
+                  ]
+                }
               }
             }
           }

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -1546,25 +1546,27 @@ components:
           nullable: true
     alarms_values:
       type: object
-      description: "Fixed keys together with HashMap where keys are alarm names"
       properties:
         hostname:
           type: string
-        additionalProperties:
+        alarms:
           type: object
-          properties:
-            id: 
-              type: integer
-            value:
-              type: integer
-            status:
-              type: string
-              enum:
-                - REMOVED
-                - UNDEFINED
-                - UNINITIALIZED
-                - CLEAR
-                - RAISED
-                - WARNING
-                - CRITICAL
-                - UNKNOWN
+          description: HashMap with keys being alarm names
+          additionalProperties:
+            type: object
+            properties:
+              id: 
+                type: integer
+              value:
+                type: integer
+              status:
+                type: string
+                enum:
+                  - REMOVED
+                  - UNDEFINED
+                  - UNINITIALIZED
+                  - CLEAR
+                  - RAISED
+                  - WARNING
+                  - CRITICAL
+                  - UNKNOWN

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -1544,3 +1544,27 @@ components:
         old_value:
           type: number
           nullable: true
+    alarms_values:
+      type: object
+      description: "Fixed keys together with HashMap where keys are alarm names"
+      properties:
+        hostname:
+          type: string
+        additionalProperties:
+          type: object
+          properties:
+            id: 
+              type: integer
+            value:
+              type: integer
+            status:
+              type: string
+              enum:
+                - REMOVED
+                - UNDEFINED
+                - UNINITIALIZED
+                - CLEAR
+                - RAISED
+                - WARNING
+                - CRITICAL
+                - UNKNOWN

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -1555,7 +1555,7 @@ components:
           additionalProperties:
             type: object
             properties:
-              id: 
+              id:
                 type: integer
               value:
                 type: integer


### PR DESCRIPTION
#### Summary
Fixes #9416
Fixes #8512

![Screenshot from 2020-06-25 13-55-51](https://user-images.githubusercontent.com/6674623/85717774-25bf7f00-b6ee-11ea-90a0-f3105b6e84dd.png)

<details><summary>Sample of actual object generated by Netdata:</summary>

```
{
	"hostname": "timowss",
	"alarms": {
		"system.active_processes.active_processes_limit": {
			"id": 1593082694,
			"value":1638,
			"status": "CLEAR"
		},
		"netdata.dbengine_global_errors.10min_dbengine_global_fs_errors": {
			"id": 1593082695,
			"value":0,
			"status": "CLEAR"
		},
		"netdata.dbengine_global_errors.10min_dbengine_global_io_errors": {
			"id": 1593082696,
			"value":0,
			"status": "CLEAR"
		}
	}
}
```

</details>

##### Component Name
OpenAPI Docu

##### Test Plan
Open in the swagger editor:
https://editor.swagger.io/?url=https://raw.githubusercontent.com/netdata/netdata/d1fd2949d7dc121eec3d4232203ef2fb53f0ac51/web/api/netdata-swagger.json

##### Additional Information
