### PR TITLE
Fixed duplicate alarm ids in health-log.db

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -252,6 +252,9 @@ inline uint32_t rrdcalc_get_unique_id(RRDHOST *host, const char *chart, const ch
         }
     }
 
+    if (unlikely(!host->health_log.next_alarm_id))
+        host->health_log.next_alarm_id = (uint32_t)now_realtime_sec();
+
     return host->health_log.next_alarm_id++;
 }
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -243,6 +243,34 @@ RRDHOST *rrdhost_create(const char *hostname,
        }
 
     }
+
+    if(host->health_enabled) {
+        snprintfz(filename, FILENAME_MAX, "%s/health", host->varlib_dir);
+        int r = mkdir(filename, 0775);
+        if(r != 0 && errno != EEXIST)
+            error("Host '%s': cannot create directory '%s'", host->hostname, filename);
+    }
+
+    snprintfz(filename, FILENAME_MAX, "%s/health/health-log.db", host->varlib_dir);
+    host->health_log_filename = strdupz(filename);
+
+    snprintfz(filename, FILENAME_MAX, "%s/alarm-notify.sh", netdata_configured_primary_plugins_dir);
+    host->health_default_exec = strdupz(config_get(CONFIG_SECTION_HEALTH, "script to execute on alarm", filename));
+    host->health_default_recipient = strdupz("root");
+
+
+    // ------------------------------------------------------------------------
+    // load health configuration
+
+    if(host->health_enabled) {
+        rrdhost_wrlock(host);
+        health_readdir(host, health_user_config_dir(), health_stock_config_dir(), NULL);
+        rrdhost_unlock(host);
+
+        health_alarm_log_load(host);
+        health_alarm_log_open(host);
+    }
+
     if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
         if (unlikely(-1 == uuid_parse(host->machine_guid, host->host_uuid))) {
@@ -272,34 +300,6 @@ RRDHOST *rrdhost_create(const char *hostname,
         fatal("RRD_MEMORY_MODE_DBENGINE is not supported in this platform.");
 #endif
     }
-
-    if(host->health_enabled) {
-        snprintfz(filename, FILENAME_MAX, "%s/health", host->varlib_dir);
-        int r = mkdir(filename, 0775);
-        if(r != 0 && errno != EEXIST)
-            error("Host '%s': cannot create directory '%s'", host->hostname, filename);
-    }
-
-    snprintfz(filename, FILENAME_MAX, "%s/health/health-log.db", host->varlib_dir);
-    host->health_log_filename = strdupz(filename);
-
-    snprintfz(filename, FILENAME_MAX, "%s/alarm-notify.sh", netdata_configured_primary_plugins_dir);
-    host->health_default_exec = strdupz(config_get(CONFIG_SECTION_HEALTH, "script to execute on alarm", filename));
-    host->health_default_recipient = strdupz("root");
-
-
-    // ------------------------------------------------------------------------
-    // load health configuration
-
-    if(host->health_enabled) {
-        rrdhost_wrlock(host);
-        health_readdir(host, health_user_config_dir(), health_stock_config_dir(), NULL);
-        rrdhost_unlock(host);
-
-        health_alarm_log_load(host);
-        health_alarm_log_open(host);
-    }
-
 
     // ------------------------------------------------------------------------
     // link it and add it to the index

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -199,8 +199,8 @@ RRDHOST *rrdhost_create(const char *hostname,
     host->health_log.next_log_id = 1;
     host->health_log.next_alarm_id = 1;
     host->health_log.max = 1000;
-    host->health_log.next_log_id =
-    host->health_log.next_alarm_id = (uint32_t)now_realtime_sec();
+    host->health_log.next_log_id = (uint32_t)now_realtime_sec();
+    host->health_log.next_alarm_id = 0;
 
     long n = config_get_number(CONFIG_SECTION_HEALTH, "in memory max health log entries", host->health_log.max);
     if(n < 10) {

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -394,7 +394,7 @@ inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char *filena
     if(!host->health_max_alarm_id)  host->health_max_alarm_id  = (uint32_t)now_realtime_sec();
 
     host->health_log.next_log_id = host->health_max_unique_id + 1;
-    if (unlikely(host->health_log.next_alarm_id && host->health_log.next_alarm_id <= host->health_max_alarm_id))
+    if (unlikely(!host->health_log.next_alarm_id || host->health_log.next_alarm_id <= host->health_max_alarm_id))
         host->health_log.next_alarm_id = host->health_max_alarm_id + 1;
 
     debug(D_HEALTH, "HEALTH [%s]: loaded file '%s' with %zd new alarm entries, updated %zd alarms, errors %zd entries, duplicate %zd", host->hostname, filename, loaded, updated, errored, duplicate);

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -394,7 +394,8 @@ inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char *filena
     if(!host->health_max_alarm_id)  host->health_max_alarm_id  = (uint32_t)now_realtime_sec();
 
     host->health_log.next_log_id = host->health_max_unique_id + 1;
-    host->health_log.next_alarm_id = host->health_max_alarm_id + 1;
+    if (unlikely(host->health_log.next_alarm_id && host->health_log.next_alarm_id <= host->health_max_alarm_id))
+        host->health_log.next_alarm_id = host->health_max_alarm_id + 1;
 
     debug(D_HEALTH, "HEALTH [%s]: loaded file '%s' with %zd new alarm entries, updated %zd alarms, errors %zd entries, duplicate %zd", host->hostname, filename, loaded, updated, errored, duplicate);
     return loaded;


### PR DESCRIPTION
##### Summary
The metadata log replay creates charts with linked alarms that may not reuse alarm_ids already present in the
heath-log.db. This will result in entries with different alarm ids for the same chart / name e.g. when shown 
via `http://localhost:19999/api/v1/alarm_log`, used in ACLK etc

To make sure we reuse the alarm id originally assigned and recorded in the `health-log.db` and `health-log.db.old` files process those files before metadata log replay

Add check to recover from corrupted files (`health-log.db` and `health-log.db.old`) that may already have different alarm_id for the
same chart / name

1. For each recorded alarm_id
    - If it exists in another chart / name already loaded, generate a new one


##### Component Name
health
ACLK

##### Test Plan


##### Additional Information
