### PR TITLE
Fix internal registry 

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1386,6 +1386,7 @@ int main(int argc, char **argv) {
     netdata_threads_init_after_fork((size_t)config_get_number(CONFIG_SECTION_GLOBAL, "pthread stack size", (long)default_stacksize));
 
     // fork the spawn server
+    registry_init();
     spawn_init();
     /*
      * Libuv uv_spawn() uses SIGCHLD internally:

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1385,8 +1385,9 @@ int main(int argc, char **argv) {
 
     netdata_threads_init_after_fork((size_t)config_get_number(CONFIG_SECTION_GLOBAL, "pthread stack size", (long)default_stacksize));
 
-    // fork the spawn server
+    // initialyze internal registry
     registry_init();
+    // fork the spawn server
     spawn_init();
     /*
      * Libuv uv_spawn() uses SIGCHLD internally:

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -566,7 +566,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         gap_when_lost_iterations_above = 1;
 
     health_init();
-    registry_init();
+
     rrdpush_init();
 
     debug(D_RRDHOST, "Initializing localhost with hostname '%s'", hostname);


### PR DESCRIPTION
##### Summary
Fixes #9427 

The spawn server was initialized before the registry to be initialized, but environment variables set for the function `registry_init()` must be set before the spawn server to be called. This PR moves the registry initialization position to fix this bug. 

##### Component Name
Spawn Server
##### Test Plan
1 - Set registry server inside `netdata.conf`:

```
[registry]
        enabled = yes
        registry db directory = /var/lib/netdata/registry
        registry to announce = https://localhost:19999
        registry hostname = hades
```

2 - Create an alarm inside `/etc/netdata/health.d`, for example:

```
 alarm: dev_dim_template
    on: system.cpu
    os: linux
lookup: sum -3s at 0 every 3 percentage foreach *
 units: %
 every: 1s
  warn: $this > 1
  crit: $this > 4
```

3 - Configure `health_alarm_notify.conf` to send the alarm for a channel.
4 - Start Netdata
5 - Verify if the link sent with alarm has the `registry to announce` in the URL `https://localhost:19999/goto-host-from-alarm.html?host=hades&chart=system.cpu&family=cpu&alarm=dev_dim_template_user&alarm_unique_id=1593269432&alarm_id=1593269248&alarm_event_id=7&alarm_when=1593269205`

##### Additional Information
