### PR TITLE
Fix children version on stream

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -255,8 +255,8 @@ static int rrdpush_receive(struct receiver_state *rpt)
                 , rpt->os
                 , rpt->timezone
                 , rpt->tags
-                , program_name
-                , program_version
+                , rpt->program_name
+                , rpt->program_version
                 , rpt->update_every
                 , history
                 , mode

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -294,8 +294,8 @@ static int rrdpush_receive(struct receiver_state *rpt)
             , rpt->os
             , rpt->timezone
             , rpt->tags
-            , program_name
-            , program_version
+            , rpt->program_name
+            , rpt->program_version
             , rpt->update_every
             , history
             , mode


### PR DESCRIPTION
##### Summary
Fixes #9437 

When we brought updates for the stream, instead we give as argument the children version to create or update the host structure we are given the global local variable. This commit fixes this bug.
##### Component Name
Stream
##### Test Plan

1 - Install this branch on the `parent`.
2 - Install an old stable version on the `child` node.
3 - Do the request `https://localhost:19999/host/CHILD_HOSTNAME/api/v1/info`  on the `parent` node, you need to see the `child` version instead `parent` version defined for `version` variable.


##### Additional Information
