### PR TITLE
 Fix the unittest execution

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -995,6 +995,7 @@ int main(int argc, char **argv) {
                             default_rrd_update_every = 1;
                             default_rrd_memory_mode = RRD_MEMORY_MODE_RAM;
                             default_health_enabled = 0;
+                            registry_init();
                             if(rrd_init("unittest", NULL)) {
                                 fprintf(stderr, "rrd_init failed for unittest\n");
                                 return 1;


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/9435#issuecomment-651201925

This PR  fixes the missing call to `registry_init()` during the unittests.
##### Component Name
Unit test
##### Test Plan

1 - Compile the branch
2 - Execute `/usr/sbin/netdata -W unittest`
3 - Confirm the final output:

```

ALL TESTS PASSED
```

##### Additional Information
