### PR TITLE
Properly include eBPF collector in binary packages.

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -76,6 +76,8 @@ override_dh_install:
 		ln -s "/usr/share/netdata/www/$$D" "$(TOP)/var/lib/netdata/www/$$D"; \
 	done
 
+	packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d
+
 	# Install go
 	#
 	debian/install_go.sh $$(cat ${CURDIR}/packaging/go.d.version) $(TOP)/usr/lib/netdata $(TOP)/usr/libexec/netdata
@@ -92,6 +94,9 @@ override_dh_installdocs:
 		--parents \
 		--target $(TOP)/usr/share/doc/netdata/ \
 		{} \;
+
+override_dh_shlibdeps:
+	dh_shlibdeps -X libnetdata_ebpf
 
 override_dh_fixperms:
 	dh_fixperms

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -412,6 +412,7 @@ install_go
 install -m 0640 -p go.d.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/go.d.plugin"
 
 ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-dashboard.sh ${RPM_BUILD_DIR}/%{name}-%{version} ${RPM_BUILD_ROOT}%{_datadir}/%{name}/web
+${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-ebpf.sh ${RPM_BUILD_DIR}/%{name}-%{version} ${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d
 
 %pre
 

--- a/packaging/bundle-dashboard.sh
+++ b/packaging/bundle-dashboard.sh
@@ -6,9 +6,9 @@ WEBDIR="${2}"
 DASHBOARD_TARBALL="dashboard.tar.gz"
 DASHBOARD_VERSION="$(cat "${SRCDIR}/packaging/dashboard.version")"
 
-mkdir -p "${SRCDIR}/tmp"
+mkdir -p "${SRCDIR}/tmp/dashboard"
 curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/dashboard/releases/download/${DASHBOARD_VERSION}/${DASHBOARD_TARBALL}" > "${DASHBOARD_TARBALL}" || exit 1
 sha256sum -c "${SRCDIR}/packaging/dashboard.checksums" || exit 1
-tar -xzf "${DASHBOARD_TARBALL}" -C "${SRCDIR}/tmp" || exit 1
+tar -xzf "${DASHBOARD_TARBALL}" -C "${SRCDIR}/tmp/dashboard" || exit 1
 # shellcheck disable=SC2046
-cp -a $(find "${SRCDIR}/tmp/build" -mindepth 1 -maxdepth 1) "${WEBDIR}"
+cp -a $(find "${SRCDIR}/tmp/dashboard/build" -mindepth 1 -maxdepth 1) "${WEBDIR}"

--- a/packaging/bundle-ebpf.sh
+++ b/packaging/bundle-ebpf.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+SRCDIR="${1}"
+PLUGINDIR="${2}"
+
+EBPF_VERSION="$(cat "${SRCDIR}/packaging/ebpf.version")"
+EBPF_TARBALL="netdata-kernel-collector-glibc-${EBPF_VERSION}.tar.xz"
+
+mkdir -p "${SRCDIR}/tmp/ebpf"
+curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/kernel-collector/releases/download/${EBPF_VERSION}/${EBPF_TARBALL}" > "${EBPF_TARBALL}" || exit 1
+sha256sum -c --ignore-missing "${SRCDIR}/packaging/ebpf.checksums" || exit 1
+tar -xaf "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
+# shellcheck disable=SC2046
+cp -a $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}"


### PR DESCRIPTION
##### Summary

This adds the required logic to properly bundle the eBPF collector code in our binary DEB and RPM packages.

##### Component Name

area/packaging

##### Test Plan

Package builds locally verified using Docker

Packages verified by installing on clean VM instances and then confirming that the required files are where they're supposed to be.

##### Additional Information

This is intentionally based on master and not develop as it's assumed it will not be merged prior to the patch release that's occurring tomorrow.

Fixes: #9423 