### PR TITLE
Fix the exporting engine unit tests

### DIFF
--- a/exporting/tests/netdata_doubles.c
+++ b/exporting/tests/netdata_doubles.c
@@ -149,7 +149,9 @@ RRDDIM *rrddim_add_custom(
     collected_number multiplier,
     collected_number divisor,
     RRD_ALGORITHM algorithm,
-    RRD_MEMORY_MODE memory_mode)
+    RRD_MEMORY_MODE memory_mode,
+    int is_archived,
+    uuid_t *dim_uuid)
 {
     check_expected_ptr(st);
     UNUSED(id);
@@ -158,6 +160,8 @@ RRDDIM *rrddim_add_custom(
     check_expected(divisor);
     check_expected(algorithm);
     UNUSED(memory_mode);
+    UNUSED(is_archived);
+    UNUSED(dim_uuid);
 
     function_called();
 

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -1859,7 +1859,7 @@ int main(void)
                    cmocka_run_group_tests_name("labels_in_exporting_engine", label_tests, NULL, NULL);
 
     const struct CMUnitTest internal_metrics_tests[] = {
-        cmocka_unit_test(test_create_main_rusage_chart),
+        cmocka_unit_test_setup_teardown(test_create_main_rusage_chart, setup_rrdhost, teardown_rrdhost),
         cmocka_unit_test(test_send_main_rusage),
         cmocka_unit_test(test_send_internal_metrics),
     };


### PR DESCRIPTION
##### Summary
After #9324 has been merged the exporting engine unit tests are failing.

##### Component Name
exporting engine

##### Test Plan
Check if the exporting engine unit tests pass.