### PR TITLE
Read the prefix option from instance config sections

### DIFF
--- a/exporting/clean_connectors.c
+++ b/exporting/clean_connectors.c
@@ -15,6 +15,7 @@ static void clean_instance_config(struct instance_config *config)
     freez((void *)config->type_name);
     freez((void *)config->name);
     freez((void *)config->destination);
+    freez((void *)config->prefix);
 
     simple_pattern_free(config->charts_pattern);
 

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -36,7 +36,6 @@ static void exporting_clean_engine()
         clean_instance(current_instance);
     }
 
-    freez((void *)engine->config.prefix);
     freez((void *)engine->config.hostname);
     freez(engine);
 }

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -64,6 +64,7 @@ struct instance_config {
 
     const char *name;
     const char *destination;
+    const char *prefix;
 
     int update_every;
     int buffer_on_failures;
@@ -102,7 +103,6 @@ struct mongodb_specific_config {
 };
 
 struct engine_config {
-    const char *prefix;
     const char *hostname;
     int update_every;
 };

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -128,7 +128,7 @@ int format_dimension_collected_graphite_plaintext(struct instance *instance, RRD
     buffer_sprintf(
         instance->buffer,
         "%s.%s.%s.%s%s%s%s " COLLECTED_NUMBER_FORMAT " %llu\n",
-        engine->config.prefix,
+        instance->config.prefix,
         (host == localhost) ? engine->config.hostname : host->hostname,
         chart_name,
         dimension_name,
@@ -175,7 +175,7 @@ int format_dimension_stored_graphite_plaintext(struct instance *instance, RRDDIM
     buffer_sprintf(
         instance->buffer,
         "%s.%s.%s.%s%s%s%s " CALCULATED_NUMBER_FORMAT " %llu\n",
-        engine->config.prefix,
+        instance->config.prefix,
         (host == localhost) ? engine->config.hostname : host->hostname,
         chart_name,
         dimension_name,

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -133,7 +133,7 @@ int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM 
 
         "\"timestamp\":%llu}\n",
 
-        engine->config.prefix,
+        instance->config.prefix,
         (host == localhost) ? engine->config.hostname : host->hostname,
         tags_pre,
         tags,
@@ -210,7 +210,7 @@ int format_dimension_stored_json_plaintext(struct instance *instance, RRDDIM *rd
 
         "\"timestamp\": %llu}\n",
 
-        engine->config.prefix,
+        instance->config.prefix,
         (host == localhost) ? engine->config.hostname : host->hostname,
         tags_pre,
         tags,

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -179,7 +179,7 @@ int format_dimension_collected_opentsdb_telnet(struct instance *instance, RRDDIM
     buffer_sprintf(
         instance->buffer,
         "put %s.%s.%s %llu " COLLECTED_NUMBER_FORMAT " host=%s%s%s%s\n",
-        engine->config.prefix,
+        instance->config.prefix,
         chart_name,
         dimension_name,
         (unsigned long long)rd->last_collected_time.tv_sec,
@@ -226,7 +226,7 @@ int format_dimension_stored_opentsdb_telnet(struct instance *instance, RRDDIM *r
     buffer_sprintf(
         instance->buffer,
         "put %s.%s.%s %llu " CALCULATED_NUMBER_FORMAT " host=%s%s%s%s\n",
-        engine->config.prefix,
+        instance->config.prefix,
         chart_name,
         dimension_name,
         (unsigned long long)last_t,
@@ -336,7 +336,7 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
         "    \"host\": \"%s%s%s\"%s"
         "  }"
         "}",
-        engine->config.prefix,
+        instance->config.prefix,
         chart_name,
         dimension_name,
         (unsigned long long)rd->last_collected_time.tv_sec,
@@ -396,7 +396,7 @@ int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd)
         "    \"host\": \"%s%s%s\"%s"
         "  }"
         "}",
-        engine->config.prefix,
+        instance->config.prefix,
         chart_name,
         dimension_name,
         (unsigned long long)last_t,

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -258,7 +258,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                     dimension,
                     (instance->config.options & EXPORTING_OPTION_SEND_NAMES && rd->name) ? rd->name : rd->id,
                     PROMETHEUS_ELEMENT_MAX);
-                snprintf(name, PROMETHEUS_LABELS_MAX, "%s_%s%s", instance->engine->config.prefix, context, suffix);
+                snprintf(name, PROMETHEUS_LABELS_MAX, "%s_%s%s", instance->config.prefix, context, suffix);
 
                 add_metric(
                     connector_specific_data->write_request,
@@ -274,7 +274,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                     (instance->config.options & EXPORTING_OPTION_SEND_NAMES && rd->name) ? rd->name : rd->id,
                     PROMETHEUS_ELEMENT_MAX);
                 snprintf(
-                    name, PROMETHEUS_LABELS_MAX, "%s_%s_%s%s", instance->engine->config.prefix, context, dimension,
+                    name, PROMETHEUS_LABELS_MAX, "%s_%s_%s%s", instance->config.prefix, context, dimension,
                     suffix);
 
                 add_metric(
@@ -300,7 +300,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                     (instance->config.options & EXPORTING_OPTION_SEND_NAMES && rd->name) ? rd->name : rd->id,
                     PROMETHEUS_ELEMENT_MAX);
                 snprintf(
-                    name, PROMETHEUS_LABELS_MAX, "%s_%s%s%s", instance->engine->config.prefix, context, units, suffix);
+                    name, PROMETHEUS_LABELS_MAX, "%s_%s%s%s", instance->config.prefix, context, units, suffix);
 
                 add_metric(
                     connector_specific_data->write_request,

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -282,7 +282,6 @@ struct engine *read_exporting_config()
     if (exporting_config_exists) {
         engine->config.hostname =
             strdupz(exporter_get(CONFIG_SECTION_EXPORTING, "hostname", netdata_configured_hostname));
-        engine->config.prefix = strdupz(exporter_get(CONFIG_SECTION_EXPORTING, "prefix", "netdata"));
         engine->config.update_every = exporter_get_number(
             CONFIG_SECTION_EXPORTING, EXPORTING_UPDATE_EVERY_OPTION_NAME, EXPORTING_UPDATE_EVERY_DEFAULT);
     }
@@ -430,6 +429,8 @@ struct engine *read_exporting_config()
 
         tmp_instance->config.destination = strdupz(exporter_get(instance_name, "destination", default_destination));
 
+        tmp_instance->config.prefix = strdupz(exporter_get(instance_name, "prefix", "netdata"));
+
 #ifdef ENABLE_HTTPS
         if (tmp_instance->config.type == EXPORTING_CONNECTOR_TYPE_OPENTSDB_USING_HTTP && !strncmp(tmp_ci_list->local_ci.connector_name, "opentsdb:https", 14)) {
             tmp_instance->config.options |= EXPORTING_OPTION_USE_TLS;
@@ -448,7 +449,6 @@ struct engine *read_exporting_config()
 
         if (unlikely(!exporting_config_exists) && !engine->config.hostname) {
             engine->config.hostname = strdupz(config_get(instance_name, "hostname", netdata_configured_hostname));
-            engine->config.prefix = strdupz(config_get(instance_name, "prefix", "netdata"));
             engine->config.update_every =
                 config_get_number(instance_name, EXPORTING_UPDATE_EVERY_OPTION_NAME, EXPORTING_UPDATE_EVERY_DEFAULT);
         }

--- a/exporting/tests/exporting_doubles.c
+++ b/exporting/tests/exporting_doubles.c
@@ -12,7 +12,6 @@ struct engine *__wrap_read_exporting_config()
 struct engine *__mock_read_exporting_config()
 {
     struct engine *engine = calloc(1, sizeof(struct engine));
-    engine->config.prefix = strdupz("netdata");
     engine->config.hostname = strdupz("test-host");
     engine->config.update_every = 3;
 
@@ -23,6 +22,7 @@ struct engine *__mock_read_exporting_config()
     instance->config.type = EXPORTING_CONNECTOR_TYPE_GRAPHITE;
     instance->config.name = strdupz("instance_name");
     instance->config.destination = strdupz("localhost");
+    instance->config.prefix = strdupz("netdata");
     instance->config.update_every = 1;
     instance->config.buffer_on_failures = 10;
     instance->config.timeoutms = 10000;

--- a/exporting/tests/exporting_fixtures.c
+++ b/exporting/tests/exporting_fixtures.c
@@ -18,11 +18,11 @@ int teardown_configured_engine(void **state)
     struct instance *instance = engine->instance_root;
     free((void *)instance->config.destination);
     free((void *)instance->config.name);
+    free((void *)instance->config.prefix);
     simple_pattern_free(instance->config.charts_pattern);
     simple_pattern_free(instance->config.hosts_pattern);
     free(instance);
 
-    free((void *)engine->config.prefix);
     free((void *)engine->config.hostname);
     free(engine);
 

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -77,7 +77,6 @@ static void test_read_exporting_config(void **state)
     *state = engine;
 
     assert_ptr_not_equal(engine, NULL);
-    assert_string_equal(engine->config.prefix, "netdata");
     assert_string_equal(engine->config.hostname, "test-host");
     assert_int_equal(engine->config.update_every, 3);
     assert_int_equal(engine->instance_num, 0);
@@ -89,6 +88,7 @@ static void test_read_exporting_config(void **state)
     assert_ptr_equal(instance->engine, engine);
     assert_int_equal(instance->config.type, EXPORTING_CONNECTOR_TYPE_GRAPHITE);
     assert_string_equal(instance->config.destination, "localhost");
+    assert_string_equal(instance->config.prefix, "netdata");
     assert_int_equal(instance->config.update_every, 1);
     assert_int_equal(instance->config.buffer_on_failures, 10);
     assert_int_equal(instance->config.timeoutms, 10000);


### PR DESCRIPTION
##### Summary
The prefix option can be set in the global section only. It should be configurable for any separate instance as well.

Fixes #9405

##### Component Name
exporting engine

##### Test Plan
Test different exporting connectors with the prefix option set in the global and instance sections.