### PR TITLE
Implemented the HOST command in metadata log replay

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -627,6 +627,33 @@ PARSER_RC pluginsd_tombstone(char **words, void *user, PLUGINSD_ACTION *plugins_
     return PARSER_RC_OK;
 }
 
+PARSER_RC metalog_pluginsd_host(char **words, void *user, PLUGINSD_ACTION  *plugins_action)
+{
+    char *machine_guid = words[1];
+    char *hostname = words[2];
+    char *registry_hostname = words[3];
+    char *update_every_s = words[4];
+    char *os = words[5];
+    char *timezone = words[6];
+    char *tags = words[7];
+
+    int update_every = 1;
+    if (likely(update_every_s && *update_every_s))
+        update_every = str2i(update_every_s);
+    if (unlikely(!update_every))
+        update_every = 1;
+
+    debug(D_PLUGINSD, "HOST PARSED: guid=%s, hostname=%s, reg_host=%s, update=%d, os=%s, timezone=%s, tags=%s",
+         machine_guid, hostname, registry_hostname, update_every, os, timezone, tags);
+
+    if (plugins_action->host_action) {
+        return plugins_action->host_action(
+            user, machine_guid, hostname, registry_hostname, update_every, os, timezone, tags);
+    }
+
+    return PARSER_RC_OK;
+}
+
 // New plugins.d parser
 
 inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp, int trust_durations)

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -155,6 +155,7 @@ GUID_TYPE find_object_by_guid(uuid_t *uuid, char *object, size_t max_bytes)
                     return GUID_TYPE_NOSPACE;
                 strncpyz(object, (char *) *PValue+1, max_bytes - 1);
                 break;
+            case GUID_TYPE_HOST:
             case GUID_TYPE_CHART:
             case GUID_TYPE_DIMENSION:
                 if (unlikely(max_bytes < (size_t) value_type * 16))
@@ -220,6 +221,11 @@ int find_or_generate_guid(void *object, uuid_t *uuid, GUID_TYPE object_type, int
             target_object[0] = object_type;
             memcpy(target_object + 1, (((RRDSET *)object))->rrdhost->host_uuid, 16);
             memcpy(target_object + 17, temp_uuid, 16);
+            break;
+        case GUID_TYPE_HOST:
+            target_object = mallocz(17);
+            target_object[0] = object_type;
+            memcpy(target_object + 1, (((RRDHOST *)object))->host_uuid, 16);
             break;
         case GUID_TYPE_CHAR:
             target_object = mallocz(strlen((char *) object)+2);

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -129,8 +129,9 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
             }
             break;
         case GUID_TYPE_HOST:
-            error_with_guid(uuid, "Compaction: Processing HOST record");
-            RRDHOST *this_host = metalog_get_host_from_uuid(ctx, uuid);
+            RRDHOST *this_host = ctx->rrdeng_ctx->host;
+            //TODO: will be enabled when multidb is activated
+            //RRDHOST *this_host = metalog_get_host_from_uuid(ctx, uuid);
             if (ctx->current_compaction_id > this_host->compaction_id) {
                 this_host->compaction_id = ctx->current_compaction_id;
                 buffer = metalog_update_host_buffer(this_host);

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -118,12 +118,6 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
                     error("Forcing compaction of CHART %s", rd->rrdset->id);
                     compact_record_by_uuid(ctx, rd->rrdset->chart_uuid);
                 }
-
-                if (strcmp(rd->id, "iwlwifi_1-virtual-0_temp1") == 0) {
-                    error("SKIPPING %s on purpose (chart = %s)", rd->id, rd->rrdset->id);
-                   break;
-                }
-
                 if (ctx->current_compaction_id > rd->state->compaction_id) {
                     rd->state->compaction_id = ctx->current_compaction_id;
                     buffer = metalog_update_dimension_buffer(rd);

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -82,6 +82,7 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
     RRDSET *st;
     RRDDIM *rd;
     BUFFER *buffer;
+    RRDHOST *host = ctx->rrdeng_ctx->host;
 
     ret = find_object_by_guid(uuid, NULL, 0);
     switch (ret) {
@@ -129,12 +130,11 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
             }
             break;
         case GUID_TYPE_HOST:
-            RRDHOST *this_host = ctx->rrdeng_ctx->host;
             //TODO: will be enabled when multidb is activated
-            //RRDHOST *this_host = metalog_get_host_from_uuid(ctx, uuid);
-            if (ctx->current_compaction_id > this_host->compaction_id) {
-                this_host->compaction_id = ctx->current_compaction_id;
-                buffer = metalog_update_host_buffer(this_host);
+            //RRDHOST *host = metalog_get_host_from_uuid(ctx, uuid);
+            if (ctx->current_compaction_id > host->compaction_id) {
+                host->compaction_id = ctx->current_compaction_id;
+                buffer = metalog_update_host_buffer(host);
                 metalog_commit_record(ctx, buffer, METALOG_COMMIT_CREATION_RECORD, uuid, 1);
             } else {
                 debug(D_METADATALOG, "Host has already been compacted, ignoring record.");

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -117,8 +117,7 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
                 if (ctx->current_compaction_id > rd->rrdset->compaction_id) {
                     error("Forcing compaction of CHART %s", rd->rrdset->id);
                     compact_record_by_uuid(ctx, rd->rrdset->chart_uuid);
-                }
-                if (ctx->current_compaction_id > rd->state->compaction_id) {
+                } else if (ctx->current_compaction_id > rd->state->compaction_id) {
                     rd->state->compaction_id = ctx->current_compaction_id;
                     buffer = metalog_update_dimension_buffer(rd);
                     metalog_commit_record(ctx, buffer, METALOG_COMMIT_CREATION_RECORD, uuid, 1);

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -675,6 +675,7 @@ static int scan_metalog_files(struct metalog_instance *ctx)
         failed_to_load = matched_files;
         goto after_failed_to_parse;
     }
+    parser_add_keyword(parser, PLUGINSD_KEYWORD_HOST, metalog_pluginsd_host);
     parser_add_keyword(parser, PLUGINSD_KEYWORD_GUID, pluginsd_guid);
     parser_add_keyword(parser, PLUGINSD_KEYWORD_CONTEXT, pluginsd_context);
     parser_add_keyword(parser, PLUGINSD_KEYWORD_TOMBSTONE, pluginsd_tombstone);
@@ -683,6 +684,8 @@ static int scan_metalog_files(struct metalog_instance *ctx)
     parser->plugins_action->guid_action      = &metalog_pluginsd_guid_action;
     parser->plugins_action->context_action   = &metalog_pluginsd_context_action;
     parser->plugins_action->tombstone_action = &metalog_pluginsd_tombstone_action;
+    parser->plugins_action->host_action      = &metalog_pluginsd_host_action;
+
 
     metalog_parser_object.parser = parser;
     ctx->metalog_parser_object = &metalog_parser_object;

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -266,6 +266,22 @@ void metalog_commit_delete_dimension(RRDDIM *rd)
     metalog_commit_deletion_record(ctx, buffer);
 }
 
+RRDHOST *metalog_get_host_from_uuid(struct metalog_instance *ctx, uuid_t *host_guid)
+{
+    UNUSED(ctx);
+    GUID_TYPE ret;
+    char machine_guid[37];
+
+    uuid_unparse_lower(*host_guid, machine_guid);
+    ret = find_object_by_guid(host_guid, NULL, 0);
+    if (unlikely(GUID_TYPE_HOST != ret)) {
+        error("Host with GUID %s not found in the global map", machine_guid);
+        return NULL;
+    }
+    RRDHOST *host = rrdhost_find_by_guid(machine_guid, 0);
+    return host;
+}
+
 RRDSET *metalog_get_chart_from_uuid(struct metalog_instance *ctx, uuid_t *chart_uuid)
 {
     GUID_TYPE ret;

--- a/database/engine/metadata_log/metadatalogapi.h
+++ b/database/engine/metadata_log/metadatalogapi.h
@@ -16,6 +16,7 @@ extern void metalog_commit_delete_dimension(RRDDIM *rd);
 
 extern RRDSET *metalog_get_chart_from_uuid(struct metalog_instance *ctx, uuid_t *chart_uuid);
 extern RRDDIM *metalog_get_dimension_from_uuid(struct metalog_instance *ctx, uuid_t *metric_uuid);
+extern RRDHOST *metalog_get_host_from_uuid(struct metalog_instance *ctx, uuid_t *uuid);
 extern void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metric_uuid);
 
 /* must call once before using anything */

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -4,6 +4,13 @@
 #include "metadatalog.h"
 #include "metalogpluginsd.h"
 
+PARSER_RC metalog_pluginsd_host_action(
+    void *user, char *machine_guid, char *hostname, char *registry_hostname, int update_every, char *os, char *timezone,
+    char *tags)
+{
+    return PARSER_RC_OK;
+}
+
 PARSER_RC metalog_pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family, char *context,
                                         char *title, char *units, char *plugin, char *module, int priority,
                                         int update_every, RRDSET_TYPE chart_type, char *options)
@@ -202,6 +209,39 @@ PARSER_RC metalog_pluginsd_tombstone_action(void *user, uuid_t *uuid)
         default:
             break;
     }
+
+    return PARSER_RC_OK;
+}
+
+    PARSER_RC metalog_pluginsd_host(char **words, void *user, PLUGINSD_ACTION  *plugins_action)
+{
+    RRDHOST *host = ((PARSER_USER_OBJECT *) user)->host;
+
+
+    char *machine_guid = words[1];
+    char *hostname = words[2];
+    char *registry_hostname = words[3];
+    char *update_every_s = words[4];
+    char *os = words[5];
+    char *timezone = words[6];
+    char *tags = words[7];
+
+    int update_every = 1;
+    if (likely(update_every_s && *update_every_s))
+        update_every = str2i(update_every_s);
+    if (unlikely(!update_every))
+        update_every = 1;
+
+    info("HOST PARSED: guid=%s, hostname=%s, reg_host=%s, update=%d, os=%s, timezone=%s, tags=%s",
+         machine_guid, hostname, registry_hostname, update_every, os, timezone, tags);
+
+
+//    if (have_action) {
+//        return plugins_action->chart_action(
+//            user, type, id, name, family, context, title, units,
+//            (plugin && *plugin) ? plugin : ((PARSER_USER_OBJECT *)user)->cd->filename, module, priority, update_every,
+//            chart_type, options);
+//    }
 
     return PARSER_RC_OK;
 }

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -14,8 +14,14 @@ PARSER_RC metalog_pluginsd_host_action(
     if (host)
         goto write_replay;
 
-    if (strcmp(machine_guid, registry_get_this_machine_guid()) == 0)
+    if (strcmp(machine_guid, registry_get_this_machine_guid()) == 0) {
+        struct metalog_record record;
+        struct metadata_logfile *metalogfile = state->metalogfile;
+
+        uuid_parse(machine_guid, record.uuid);
+        mlf_record_insert(metalogfile, &record);
         return PARSER_RC_OK;
+    }
 
     // Ignore HOST command for now
     // TODO: Remove when the next task is completed ie. accept new children in the lcoalhost / multidb
@@ -48,9 +54,8 @@ write_replay:
         struct metalog_record record;
         struct metadata_logfile *metalogfile = state->metalogfile;
 
-        uuid_copy(record.uuid, state->uuid);
+        uuid_copy(record.uuid, host->host_uuid);
         mlf_record_insert(metalogfile, &record);
-        uuid_clear(state->uuid); /* Consume UUID */
     }
 
     return PARSER_RC_OK;

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -263,33 +263,6 @@ PARSER_RC metalog_pluginsd_tombstone_action(void *user, uuid_t *uuid)
     return PARSER_RC_OK;
 }
 
-PARSER_RC metalog_pluginsd_host(char **words, void *user, PLUGINSD_ACTION  *plugins_action)
-{
-    char *machine_guid = words[1];
-    char *hostname = words[2];
-    char *registry_hostname = words[3];
-    char *update_every_s = words[4];
-    char *os = words[5];
-    char *timezone = words[6];
-    char *tags = words[7];
-
-    int update_every = 1;
-    if (likely(update_every_s && *update_every_s))
-        update_every = str2i(update_every_s);
-    if (unlikely(!update_every))
-        update_every = 1;
-
-    info("HOST PARSED: guid=%s, hostname=%s, reg_host=%s, update=%d, os=%s, timezone=%s, tags=%s",
-         machine_guid, hostname, registry_hostname, update_every, os, timezone, tags);
-
-    if (plugins_action->host_action) {
-        return plugins_action->host_action(
-            user, machine_guid, hostname, registry_hostname, update_every, os, timezone, tags);
-    }
-
-    return PARSER_RC_OK;
-}
-
 void metalog_pluginsd_state_init(struct metalog_pluginsd_state *state, struct metalog_instance *ctx)
 {
     state->ctx = ctx;

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -9,22 +9,13 @@ PARSER_RC metalog_pluginsd_host_action(
     char *tags)
 {
     UNUSED(user);
-    //return PARSER_RC_OK;
 
-    info(
-        "HOST action: guid=%s, hostname=%s, reg_host=%s, update=%d, os=%s, timezone=%s, tags=%s", machine_guid,
-        hostname, registry_hostname, update_every, os, timezone, tags);
-
-    if (strcmp(machine_guid, registry_get_this_machine_guid()) == 0) {
-        info("This is localhost will not replay HOST command");
+    if (strcmp(machine_guid, registry_get_this_machine_guid()) == 0)
         return PARSER_RC_OK;
-    }
 
     RRDHOST *host = rrdhost_find_by_guid(machine_guid, 0);
-    if (host) {
-        info("Ignoring host %s we have it already", hostname);
+    if (host)
         return PARSER_RC_OK;
-    }
 
     host = rrdhost_create(
         hostname
@@ -47,9 +38,6 @@ PARSER_RC metalog_pluginsd_host_action(
         , 0     // localhost
         , 1     // archived
     );
-
-    if (host)
-        info("HOST REPLAY created host ok");
 
     return PARSER_RC_OK;
 }

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -9,9 +9,48 @@ PARSER_RC metalog_pluginsd_host_action(
     char *tags)
 {
     UNUSED(user);
+    //return PARSER_RC_OK;
 
-    info("HOST action: guid=%s, hostname=%s, reg_host=%s, update=%d, os=%s, timezone=%s, tags=%s",
-         machine_guid, hostname, registry_hostname, update_every, os, timezone, tags);
+        info(
+        "HOST action: guid=%s, hostname=%s, reg_host=%s, update=%d, os=%s, timezone=%s, tags=%s", machine_guid,
+        hostname, registry_hostname, update_every, os, timezone, tags);
+
+    if (strcmp(machine_guid, registry_get_this_machine_guid()) == 0) {
+        info("This is localhost will not replay HOST command");
+        strcpy(machine_guid, "535767b4-83c9-11ea-a908-525400201d9b");
+        strcpy(hostname, "ubuntu1804");
+        //return PARSER_RC_OK;
+    }
+
+    RRDHOST *host = rrdhost_find_by_guid(machine_guid, 0);
+    if (host) {
+        info("Ignoring host %s we have it already", hostname);
+        return PARSER_RC_OK;
+    }
+
+    host = rrdhost_find_or_create(
+        hostname
+        , registry_hostname
+        , machine_guid
+        , os
+        , timezone
+        , tags
+        , NULL
+        , NULL
+        , update_every
+        , 3600
+        , RRD_MEMORY_MODE_DBENGINE
+        , 0   // health enabled
+        , 0   // Push enabled
+        , NULL
+        , NULL
+        , NULL
+        , callocz(1, sizeof(struct rrdhost_system_info))
+    );
+
+    if (host)
+        info("HOST REPLAY created host ok");
+
     return PARSER_RC_OK;
 }
 

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -8,6 +8,10 @@ PARSER_RC metalog_pluginsd_host_action(
     void *user, char *machine_guid, char *hostname, char *registry_hostname, int update_every, char *os, char *timezone,
     char *tags)
 {
+    UNUSED(user);
+
+    info("HOST action: guid=%s, hostname=%s, reg_host=%s, update=%d, os=%s, timezone=%s, tags=%s",
+         machine_guid, hostname, registry_hostname, update_every, os, timezone, tags);
     return PARSER_RC_OK;
 }
 
@@ -213,11 +217,8 @@ PARSER_RC metalog_pluginsd_tombstone_action(void *user, uuid_t *uuid)
     return PARSER_RC_OK;
 }
 
-    PARSER_RC metalog_pluginsd_host(char **words, void *user, PLUGINSD_ACTION  *plugins_action)
+PARSER_RC metalog_pluginsd_host(char **words, void *user, PLUGINSD_ACTION  *plugins_action)
 {
-    RRDHOST *host = ((PARSER_USER_OBJECT *) user)->host;
-
-
     char *machine_guid = words[1];
     char *hostname = words[2];
     char *registry_hostname = words[3];
@@ -235,13 +236,10 @@ PARSER_RC metalog_pluginsd_tombstone_action(void *user, uuid_t *uuid)
     info("HOST PARSED: guid=%s, hostname=%s, reg_host=%s, update=%d, os=%s, timezone=%s, tags=%s",
          machine_guid, hostname, registry_hostname, update_every, os, timezone, tags);
 
-
-//    if (have_action) {
-//        return plugins_action->chart_action(
-//            user, type, id, name, family, context, title, units,
-//            (plugin && *plugin) ? plugin : ((PARSER_USER_OBJECT *)user)->cd->filename, module, priority, update_every,
-//            chart_type, options);
-//    }
+    if (plugins_action->host_action) {
+        return plugins_action->host_action(
+            user, machine_guid, hostname, registry_hostname, update_every, os, timezone, tags);
+    }
 
     return PARSER_RC_OK;
 }

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -11,15 +11,13 @@ PARSER_RC metalog_pluginsd_host_action(
     UNUSED(user);
     //return PARSER_RC_OK;
 
-        info(
+    info(
         "HOST action: guid=%s, hostname=%s, reg_host=%s, update=%d, os=%s, timezone=%s, tags=%s", machine_guid,
         hostname, registry_hostname, update_every, os, timezone, tags);
 
     if (strcmp(machine_guid, registry_get_this_machine_guid()) == 0) {
         info("This is localhost will not replay HOST command");
-        strcpy(machine_guid, "535767b4-83c9-11ea-a908-525400201d9b");
-        strcpy(hostname, "ubuntu1804");
-        //return PARSER_RC_OK;
+        return PARSER_RC_OK;
     }
 
     RRDHOST *host = rrdhost_find_by_guid(machine_guid, 0);
@@ -28,7 +26,7 @@ PARSER_RC metalog_pluginsd_host_action(
         return PARSER_RC_OK;
     }
 
-    host = rrdhost_find_or_create(
+    host = rrdhost_create(
         hostname
         , registry_hostname
         , machine_guid
@@ -46,6 +44,8 @@ PARSER_RC metalog_pluginsd_host_action(
         , NULL
         , NULL
         , callocz(1, sizeof(struct rrdhost_system_info))
+        , 0     // localhost
+        , 1     // archived
     );
 
     if (host)

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -17,6 +17,10 @@ PARSER_RC metalog_pluginsd_host_action(
     if (host)
         return PARSER_RC_OK;
 
+    // Ignore HOST command for now
+    // TODO: Remove when the next task is completed ie. accept new children in the lcoalhost / multidb
+    return PARSER_RC_OK;
+
     host = rrdhost_create(
         hostname
         , registry_hostname

--- a/database/engine/metadata_log/metalogpluginsd.h
+++ b/database/engine/metadata_log/metalogpluginsd.h
@@ -25,5 +25,7 @@ extern PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char 
 extern PARSER_RC metalog_pluginsd_guid_action(void *user, uuid_t *uuid);
 extern PARSER_RC metalog_pluginsd_context_action(void *user, uuid_t *uuid);
 extern PARSER_RC metalog_pluginsd_tombstone_action(void *user, uuid_t *uuid);
+extern PARSER_RC metalog_pluginsd_host(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+extern PARSER_RC metalog_pluginsd_host_action(void *user, char *machine_guid, char *hostname, char *registry_hostname, int update_every, char *os, char *timezone, char *tags);
 
 #endif /* NETDATA_METALOGPLUGINSD_H */

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -916,7 +916,7 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
     if (ctx->worker_config.error) {
         goto error_after_rrdeng_worker;
     }
-    if (localhost == host || (!rrdhost_flag_check(host, RRDHOST_FLAG_MULTIHOST))) {
+    if ((strcmp(host->machine_guid, registry_get_this_machine_guid()) == 0) || (!rrdhost_flag_check(host, RRDHOST_FLAG_MULTIHOST))) {
         info("Metadatalog init for host %s starting...", host->hostname);
         error = metalog_init(ctx);
         if (error) {

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -916,11 +916,16 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
     if (ctx->worker_config.error) {
         goto error_after_rrdeng_worker;
     }
-    error = metalog_init(ctx);
-    if(error) {
-        error("Failed to initialize metadata log file event loop.");
-        goto error_after_rrdeng_worker;
+    if (localhost && localhost != host) {
+        info("Metadatalog init for host %s starting...", host->hostname);
+        error = metalog_init(ctx);
+        if (error) {
+            error("Failed to initialize metadata log file event loop.");
+            goto error_after_rrdeng_worker;
+        }
     }
+    else
+        info("No metadatalog init for host %s", host->hostname);
     return 0;
 
 error_after_rrdeng_worker:

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -916,7 +916,7 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
     if (ctx->worker_config.error) {
         goto error_after_rrdeng_worker;
     }
-    if (localhost && localhost != host) {
+    if (localhost == host || (!rrdhost_flag_check(host, RRDHOST_FLAG_MULTIHOST))) {
         info("Metadatalog init for host %s starting...", host->hostname);
         error = metalog_init(ctx);
         if (error) {

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -560,6 +560,8 @@ typedef enum rrdhost_flags {
     RRDHOST_FLAG_DELETE_ORPHAN_HOST     = 1 << 2, // delete the entire host when orphan
     RRDHOST_FLAG_BACKEND_SEND           = 1 << 3, // send it to backends
     RRDHOST_FLAG_BACKEND_DONT_SEND      = 1 << 4, // don't send it to backends
+    RRDHOST_FLAG_ARCHIVED               = 1 << 5, // The host is archived, no collected charts yet
+    RRDHOST_FLAG_MULTIHOST              = 1 << 6, // Host belongs to localhost/megadb
 } RRDHOST_FLAGS;
 
 #ifdef HAVE_C___ATOMIC
@@ -1195,6 +1197,12 @@ extern void rrdset_delete_custom(RRDSET *st, int db_rotated);
 extern void rrdset_delete_obsolete_dimensions(RRDSET *st);
 
 extern void rrdhost_cleanup_obsolete_charts(RRDHOST *host);
+extern RRDHOST *rrdhost_create(
+    const char *hostname, const char *registry_hostname, const char *guid, const char *os, const char *timezone,
+    const char *tags, const char *program_name, const char *program_version, int update_every, long entries,
+    RRD_MEMORY_MODE memory_mode, unsigned int health_enabled, unsigned int rrdpush_enabled, char *rrdpush_destination,
+    char *rrdpush_api_key, char *rrdpush_send_charts_matching, struct rrdhost_system_info *system_info,
+    int is_localhost, int is_archived);
 
 #endif /* NETDATA_RRD_INTERNALS */
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -276,7 +276,7 @@ RRDHOST *rrdhost_create(const char *hostname,
         health_alarm_log_open(host);
     }
 
-    if (host && host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+    if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
         if (unlikely(-1 == uuid_parse(host->machine_guid, host->host_uuid))) {
             error("Host machine GUID is not valid.");

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -596,6 +596,13 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
             , 1
     );
     rrd_unlock();
+    info("megadb metadatalog replay started");
+    //rrdeng_init(localhost, NULL, NULL, 0, 0);
+    int error = metalog_init(localhost->rrdeng_ctx);
+    if (error) {
+        error("Failed to initialize metadata log file event loop.");
+    }
+    info("megadb metadatalog replay finished");
 	web_client_api_v1_management_init();
     return localhost==NULL;
 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -276,6 +276,10 @@ RRDHOST *rrdhost_create(const char *hostname,
         if (unlikely(-1 == uuid_parse(host->machine_guid, host->host_uuid))) {
             error("Host machine GUID is not valid.");
         }
+        if (unlikely(find_or_generate_guid((void *) host, host->host_uuid, GUID_TYPE_HOST, 1)))
+            error("Failed to store machine GUID to global map");
+        else
+            info("Added %s to global map for host %s", host->machine_guid, host->hostname);
         host->objects_nr = 1;
         host->compaction_id = 0;
         char dbenginepath[FILENAME_MAX + 1];

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -276,6 +276,39 @@ RRDHOST *rrdhost_create(const char *hostname,
         health_alarm_log_open(host);
     }
 
+    if (host && host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        if (unlikely(-1 == uuid_parse(host->machine_guid, host->host_uuid))) {
+            error("Host machine GUID is not valid.");
+        }
+        if (unlikely(find_or_generate_guid((void *) host, &host->host_uuid, GUID_TYPE_HOST, 1)))
+            error("Failed to store machine GUID to global map");
+        else
+            info("Added %s to global map for host %s", host->machine_guid, host->hostname);
+        host->objects_nr = 1;
+        host->compaction_id = 0;
+        char dbenginepath[FILENAME_MAX + 1];
+        int ret;
+
+        snprintfz(dbenginepath, FILENAME_MAX, "%s/dbengine", host->cache_dir);
+        ret = mkdir(dbenginepath, 0775);
+        if(ret != 0 && errno != EEXIST)
+            error("Host '%s': cannot create directory '%s'", host->hostname, dbenginepath);
+        else
+            ret = rrdeng_init(host, &host->rrdeng_ctx, dbenginepath, host->page_cache_mb, host->disk_space_mb);
+        if(ret) {
+            error("Host '%s': cannot initialize host with machine guid '%s'. Failed to initialize DB engine at '%s'.",
+                  host->hostname, host->machine_guid, host->cache_dir);
+            rrdhost_free(host);
+            host = NULL;
+            //rrd_hosts_available++; //TODO: maybe we want this?
+
+            return host;
+        }
+#else
+        fatal("RRD_MEMORY_MODE_DBENGINE is not supported in this platform.");
+#endif
+    }
 
     // ------------------------------------------------------------------------
     // link it and add it to the index
@@ -338,41 +371,6 @@ RRDHOST *rrdhost_create(const char *hostname,
              , host->health_default_exec
              , host->health_default_recipient
         );
-    }
-
-
-    if (host && host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-#ifdef ENABLE_DBENGINE
-        if (unlikely(-1 == uuid_parse(host->machine_guid, host->host_uuid))) {
-            error("Host machine GUID is not valid.");
-        }
-        if (unlikely(find_or_generate_guid((void *) host, &host->host_uuid, GUID_TYPE_HOST, 1)))
-            error("Failed to store machine GUID to global map");
-        else
-            info("Added %s to global map for host %s", host->machine_guid, host->hostname);
-        host->objects_nr = 1;
-        host->compaction_id = 0;
-        char dbenginepath[FILENAME_MAX + 1];
-        int ret;
-
-        snprintfz(dbenginepath, FILENAME_MAX, "%s/dbengine", host->cache_dir);
-        ret = mkdir(dbenginepath, 0775);
-        if(ret != 0 && errno != EEXIST)
-            error("Host '%s': cannot create directory '%s'", host->hostname, dbenginepath);
-        else
-            ret = rrdeng_init(host, &host->rrdeng_ctx, dbenginepath, host->page_cache_mb, host->disk_space_mb);
-        if(ret) {
-            error("Host '%s': cannot initialize host with machine guid '%s'. Failed to initialize DB engine at '%s'.",
-                  host->hostname, host->machine_guid, host->cache_dir);
-            rrdhost_free(host);
-            host = NULL;
-            //rrd_hosts_available++; //TODO: maybe we want this?
-
-            return host;
-        }
-#else
-        fatal("RRD_MEMORY_MODE_DBENGINE is not supported in this platform.");
-#endif
     }
 
     rrd_hosts_available++;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -543,6 +543,10 @@ RRDSET *rrdset_create_custom(
         if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
             changed_from_archived_to_active = 1;
+            if (rrdhost_flag_check(st->rrdhost, RRDHOST_FLAG_ARCHIVED)) {
+                rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
+                info("Host %s is not in archived mode anymore", st->rrdhost->hostname);
+            }
             mark_rebuild |= META_CHART_ACTIVATED;
         }
         char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_family = NULL, *old_context = NULL,
@@ -683,6 +687,10 @@ RRDSET *rrdset_create_custom(
         rrdhost_unlock(host);
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
+        if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
+            rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
+            rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
+        }
         return st;
     }
 

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -35,6 +35,8 @@ typedef struct pluginsd_action {
     PARSER_RC (*guid_action)(void *user, uuid_t *uuid);
     PARSER_RC (*context_action)(void *user, uuid_t *uuid);
     PARSER_RC (*tombstone_action)(void *user, uuid_t *uuid);
+    PARSER_RC (*host_action)(char *machine_guid, char *hostname, char *registry_hostname, int update_every, char *os,
+        char *timezone, char *tags);
 } PLUGINSD_ACTION;
 
 typedef enum parser_input_type {

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -35,7 +35,7 @@ typedef struct pluginsd_action {
     PARSER_RC (*guid_action)(void *user, uuid_t *uuid);
     PARSER_RC (*context_action)(void *user, uuid_t *uuid);
     PARSER_RC (*tombstone_action)(void *user, uuid_t *uuid);
-    PARSER_RC (*host_action)(char *machine_guid, char *hostname, char *registry_hostname, int update_every, char *os,
+    PARSER_RC (*host_action)(void *user, char *machine_guid, char *hostname, char *registry_hostname, int update_every, char *os,
         char *timezone, char *tags);
 } PLUGINSD_ACTION;
 


### PR DESCRIPTION
Fixes #9453 
##### Summary
Register the HOST command in the metadata log parser and the corresponding action. Improve the detection of the
HOST GUID type (correctly registered in the global GUID map now) and make sure that during compaction the HOST
is written to the metadata log files before any CHART / DIMENSION

##### Component Name
database

##### Test Plan
- Start agent and wait for compaction to run
- Example the metadata log files using

`cat /home/stelios/netdata-inst/netdata//var/cache/netdata/dbengine/metadatalog-* | strings -n | head -n 30`

You should always observe the HOST command at the top e.g. (sample)

```
HOST "d6b37186-74db-11ea-88b2-0bf5095b1f9e" "futura" "futura" 1 "linux" "Europe/Athens" ""
LABEL "_os_name" = 0 Ubuntu
LABEL "_os_version" = 0 20.04 LTS (Focal Fossa)
LABEL "_kernel_version" = 0 5.4.0-40-generic
LABEL "_system_cores" = 0 12
LABEL "_system_cpu_freq" = 0 2600000
LABEL "_system_ram_total" = 0 16624041984
LABEL "_system_disk_space" = 0 1000204886016
LABEL "_architecture" = 0 x86_64
LABEL "_virtualization" = 0 none
LABEL "_container" = 0 unknown
LABEL "_container_detection" = 0 none
LABEL "_virt_detection" = 0 systemd-detect-virt
LABEL "_is_parent" = 0 true
OVERWRITE labels
CONTEXT d6b37186-74db-11ea-88b2-0bf5095b1f9e
GUID ab5de6e8-0303-40e4-8ade-cf6a5828586d
CHART "system.idlejitter" "" "CPU Idle Jitter" "microseconds lost/s" "idlejitter" "system.idlejitter" "area" 800 1 "   " "idlejitter.plugin" ""
GUID 0692372e-0ce9-f9a2-78ac-4208c9a74c4a
DIMENSION "min" "min" "absolute" 1 1 "  "
GUID 1bc106f9-8a10-376e-c7c2-492ba52367b8
DIMENSION "max" "max" "absolute" 1 1 "  "
GUID 566fd00e-a432-16d1-9090-b3b0b9255b1e
DIMENSION "average" "average" "absolute" 1 1 "  "
CONTEXT d6b37186-74db-11ea-88b2-0bf5095b1f9e
GUID 8130c6aa-15bf-4c15-9f91-a8b2f19e618a
CHART "netdata.statsd_metrics" "" "Metrics in the netdata statsd database" "metrics" "statsd" "netdata.statsd_metrics" "stacked" 132010 1 "   " "statsd.plugin" "stats"
GUID 83d940f6-4e96-ddfc-211f-92e728bc0eb5
DIMENSION "gauges" "gauges" "absolute" 1 1 "  "
```


##### Additional Information
