### PR TITLE
fixes vulnerability in JSON parsing

### DIFF
--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -137,10 +137,12 @@ int json_callback_print(JSON_ENTRY *e)
  * @param e the output structure
  */
 static inline void json_jsonc_set_string(JSON_ENTRY *e,char *key,const char *value) {
-    size_t length = strlen(key);
+    size_t len = strlen(key);
+    if(len > JSON_NAME_LEN)
+        len = JSON_NAME_LEN;
     e->type = JSON_STRING;
-    memcpy(e->name,key,length);
-    e->name[length] = 0x00;
+    memcpy(e->name,key,len);
+    e->name[len] = 0x00;
     e->data.string = (char *) value;
 }
 


### PR DESCRIPTION
#### Summary
If JSON-C is used function:
```
static inline void json_jsonc_set_string(JSON_ENTRY *e,char *key,const char *value) {
    size_t length = strlen(key);
    e->type = JSON_STRING;
    memcpy(e->name,key,length);
    e->name[length] = 0x00;
    e->data.string = (char *) value;
}
```
will use `memcpy` without checking length is less than `256`. Reason `JSON_NAME_LEN` is defined as `256`:
```
typedef struct json_entry {
    JSON_ENTRY_TYPE type;
    char name[JSON_NAME_LEN + 1];
    char fullname[JSON_FULLNAME_LEN + 1];
    union {
        char *string;			// type == JSON_STRING
        long double number;		// type == JSON_NUMBER
        int boolean;			// type == JSON_BOOLEAN
        size_t items;			// type == JSON_ARRAY
    } data;
    size_t pos;					// the position of this item in its parent

    char *original_string;

    void *callback_data;
    int (*callback_function)(struct json_entry *);
} JSON_ENTRY;
```

By parsing JSON with a key name longer than 256 characters I am able to overwrite memory after with honorable mention being the address of `callback_function` later in the same struct!

**By sending such a JSON trough ACLK I was able to verify that such a key will be parsed by `JSON-C` and arrive at this function with `size_t length = strlen(key);` returning 4096! (which is key name length in my crafted JSON dictionary)**

Sample from debugger:
![Screenshot from 2020-07-06 17-29-16](https://user-images.githubusercontent.com/6674623/86611843-8af95700-bfaf-11ea-9d25-ae0429f277ed.png)

![Screenshot from 2020-07-06 17-51-00](https://user-images.githubusercontent.com/6674623/86613130-7322d280-bfb1-11ea-89c5-de56462ec4a9.png)




##### Component Name
Agent JSON switch _(code that allows to use of internal JSON and JSON-C parser)_

##### Test Plan
Parsing JSON with key with a name longer than 256 should not create buffer overflow. Example send custom JSON over ACLK link with such key.

##### Additional Information
