### PR TITLE
Fix broken link in Kavenegar notification doc

### DIFF
--- a/health/notifications/kavenegar/README.md
+++ b/health/notifications/kavenegar/README.md
@@ -16,7 +16,7 @@ Will look like this on your Android device:
 You will need:
 
 1.  Signup and Login to kavenegar.com
-2.  Get your APIKEY and Sender from <http://panel.kavenegar.com/client/setting/account>
+2.  Get your APIKEY and Sender from `http://panel.kavenegar.com/client/setting/account`
 3.  Fill in KAVENEGAR_API_KEY="" KAVENEGAR_SENDER=""
 4.  Add the recipient phone numbers to DEFAULT_RECIPIENT_KAVENEGAR=""
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fixes netdata/netdata-learn-docusaurus#215

This is a direct link to Kavenegar's user admin pages, and it's showing up as a broken link on the documentation site. Let's just put it into a code block, since I don't like the idea of deep linking into something that's gated behind a sign-in.

##### Component Name

area/docs
area/notifications

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
