### PR TITLE
Network Viewer options

### DIFF
--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -198,32 +198,26 @@ You can configure the information shown on `outbound` and `inbound` charts with 
 ```conf
 [network viewer]
     maximum dimensions = 500
-    included ports = 19999 100-1024
-    excluded ports = 145 139
-    included services = ssh http
-    excluded services = ftp
-    included hostnames = netdata.cloud netdata.io
-    excluded hostnames = example.com
-    excluded ips = 127.0.0.1 192.168.0.1-192.168.0.5
-    included ips = 192.168.0.0/24 2001:DB8::/32 
+    ports = 1-1024 !145 !domain
+    hostnames = !example.com
+    ips = !127.0.0.1/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 fc00::/7
 ```
 
-When you define an `included ports` setting, Netdata will collect network metrics for that specific port. For example, if you
-write `included ports = 19999`, Netdata will collect only connections for itself. If you list values in the `excluded`
-setting, Netdata will collect metrics on all included ports except those values. Other included options have a similar behavior.
+When you define a `ports` setting, Netdata will collect network metrics for that specific port. For example, if you
+write `ports = 19999`, Netdata will collect only connections for itself. Except for `maximum dimensions`, 
+all options have a similar behavior.
 
-In the above example, Netdata will collect metrics for all ports between 100 and 1024, with the exception of 145 and
-139.
+In the above example, Netdata will collect metrics for all ports between 1 and 443, with the exception of 53 (domain) 
+and 145.
 
-The following pairs of `included` and `excluded` are available:
+The following options are available:
 
 -   `ports`: Define the destination ports for Netdata to monitor.
--   `services`: If you do not know which port number you want to monitor, you can list the service. Netdata will resolve
-    the service name to its associated port to monitor the connection.
--   `hostnames`: The list of hostnames that can be resolved to an IP address. This option accept [simple
-    patterns](/libnetdata/simple_pattern/README.md).
+-   `hostnames`: The list of hostnames that can be resolved to an IP address. 
 -   `ips`: The IP or range of IPs that you want to monitor. You can use IPv4 or IPv6 addresses, use dashes to define a
     range of IPs, or use CIDR values.
+    
+ All options accept accept [simple patterns](/libnetdata/simple_pattern/README.md).   
     
 By default, Netdata displays up to 500 dimensions on network viewer charts. If there are more possible dimensions, they
 will be bundled into the `other` dimension. You can increase the number of shown dimensions by changing the `maximum

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -225,7 +225,7 @@ The following pairs of `included` and `excluded` are available:
 -   `ips`: The IP or range of IPs that you want to monitor. You can use IPv4 or IPv6 addresses, use dashes to define a
     range of IPs, or use CIDR values.
     
-By default, Netdata displayes up to 500 dimensions on network viewer charts. If there are more possible dimensions, they
+By default, Netdata displays up to 500 dimensions on network viewer charts. If there are more possible dimensions, they
 will be bundled into the `other` dimension. You can increase the number of shown dimensions by changing the `maximum
 dimensions` setting.
 

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -192,8 +192,7 @@ The eBPF collector enables and runs the following eBPF programs by default:
     bandwidth consumed by each.
 
 ### `[network viewer]`
-
-You can configure the information that you will see on `outbund` and `inbound` charts with options inside this section. 
+You can configure the information shown on `outbund` and `inbound` charts with the settings in this section. 
 
 ```conf
 [network viewer]
@@ -208,27 +207,31 @@ You can configure the information that you will see on `outbund` and `inbound` c
     included ips = 192.168.0.0/24 2804:14c:5b72:888d:6ee2:1aee:9b62:cbb5
 ```
 
-When an `included` option is defined, Netdata will not collect all possible values of that option, it will restrict 
- the collection for the values listed, for example, if you write `included ports = 19999` Netdata will collect  only connections 
- for itself.  On the other hand if a value is listed for an `excluded` option, Netdata will collect everything except that values.
-The following pairs of `included` and `excluded` are available.
+When you define an `included` setting, Netdat will collect network metrics for that specific port. For example, if you
+write `included ports = 19999`, Netdata will collect only connections for itself. If you list values in the `excluded`
+setting, Netdata will collect metrics on all included ports except those values.
+In the above example, Netdata will collect metrics for all ports between 100 and 1024, with the exception of 145 and
+139.
 
--  `ports`: Define the destination ports that will be monitored.
--  `services`: When you do not know the port number, you can list the ports as a service. Netdata will resolve the service
-name to its associated port to monitor the connection.
--  `hostnames`: The list of hostnames that can be resolved to an IP address. This is the unique option that accepts
-simple pattern.
--  `ips`: The IP or range of IPs that you want to monitor. You can use dash as separator of IPs, or a CIDR value.
-
-By default Netdata displays 500 dimensions on these charts, and any other possible value will 
-be stored in the dimension `other`. You can change the number of dimensions according to your necessities setting a new
-value for the option `maximum dimensions`.
+The following pairs of `included` and `excluded` are available:
+-   `ports`: Define the destination ports for Netdata to monitor.
+-   `services`: If you do not know which port number you want to monitor, you can list the service. Netdata will resolve
+    the service name to its associated port to monitor the connection.
+-   `hostnames`: The list of hostnames that can be resolved to an IP address. This option accept [simple
+    patterns](/libnetdata/simple_pattern/README.md).
+-   `ips`: The IP or range of IPs that you want to monitor. You can use IPv4 or IPv6 addresses, use dashes to define a
+    range of IPs, or use CIDR values.
+    
+By default, Netdata displayes up to 500 dimensions on network viewer charts. If there are more possible dimensions, they
+will be bundled into the `other` dimension. You can increase the number of shown dimensions by changing the `maximum
+dimensions` setting.
 
 ### `[service name]`
 
-Netdata uses the service listed inside the file `/etc/services` to plot the charts, but this file does not have name for 
-all the ports, for example, Netdata default port cannot find inside it. If you want to see names for specific services
-instead their ports, you can use this section to define them.
+Netdata uses the list of services in `/etc/services` to plot network viewer charts. If this file does not contain the
+name for a particular service you use in your infrastructure, you will need to add it to the `[service name]` section.
+For example, Netdata's default port (`19999`) is not listed in `/etc/services`. To associate that port with the Netdata
+service in network viewer charts, and thus see the name of the service instead of its port, define it:
 
 ```conf
 [service name]

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -192,6 +192,7 @@ The eBPF collector enables and runs the following eBPF programs by default:
     bandwidth consumed by each.
 
 ### `[network viewer]`
+
 You can configure the information shown on `outbund` and `inbound` charts with the settings in this section. 
 
 ```conf
@@ -207,13 +208,15 @@ You can configure the information shown on `outbund` and `inbound` charts with t
     included ips = 192.168.0.0/24 0001:0000:0000:0000:0000:0000:0000:0000/32 
 ```
 
-When you define an `included` setting, Netdat will collect network metrics for that specific port. For example, if you
+When you define an `included` setting, Netdata will collect network metrics for that specific port. For example, if you
 write `included ports = 19999`, Netdata will collect only connections for itself. If you list values in the `excluded`
 setting, Netdata will collect metrics on all included ports except those values.
+
 In the above example, Netdata will collect metrics for all ports between 100 and 1024, with the exception of 145 and
 139.
 
 The following pairs of `included` and `excluded` are available:
+
 -   `ports`: Define the destination ports for Netdata to monitor.
 -   `services`: If you do not know which port number you want to monitor, you can list the service. Netdata will resolve
     the service name to its associated port to monitor the connection.
@@ -230,6 +233,7 @@ dimensions` setting.
 
 Netdata uses the list of services in `/etc/services` to plot network viewer charts. If this file does not contain the
 name for a particular service you use in your infrastructure, you will need to add it to the `[service name]` section.
+
 For example, Netdata's default port (`19999`) is not listed in `/etc/services`. To associate that port with the Netdata
 service in network viewer charts, and thus see the name of the service instead of its port, define it:
 

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -193,7 +193,7 @@ The eBPF collector enables and runs the following eBPF programs by default:
 
 ### `[network viewer]`
 
-You can configure the information shown on `outbund` and `inbound` charts with the settings in this section. 
+You can configure the information shown on `outbound` and `inbound` charts with the settings in this section. 
 
 ```conf
 [network viewer]

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -204,7 +204,7 @@ You can configure the information shown on `outbund` and `inbound` charts with t
     included hostnames = netdata.cloud netdata.io
     excluded hostnames = example.com
     excluded ips = 127.0.0.1 192.168.0.1-192.168.0.5
-    included ips = 192.168.0.0/24 2804:14c:5b72:888d:6ee2:1aee:9b62:cbb5
+    included ips = 192.168.0.0/24 0001:0000:0000:0000:0000:0000:0000:0000/32 
 ```
 
 When you define an `included` setting, Netdat will collect network metrics for that specific port. For example, if you

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -204,8 +204,9 @@ You can configure the information shown on `outbound` and `inbound` charts with 
 ```
 
 When you define a `ports` setting, Netdata will collect network metrics for that specific port. For example, if you
-write `ports = 19999`, Netdata will collect only connections for itself. The `ports`, `hostnames`, and `ips` settings
-all accept [simple patterns](/libnetdata/simple_pattern/README.md).
+write `ports = 19999`, Netdata will collect only connections for itself. The `hostnames` setting accepts  
+[simple patterns](/libnetdata/simple_pattern/README.md).  The `ports`, and `ips` settings accept negation (`!`) to
+ deny specific values or asterisk alone to define all values.
 
 In the above example, Netdata will collect metrics for all ports between 1 and 443, with the exception of 53 (domain)
 and 145.

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -191,6 +191,50 @@ The eBPF collector enables and runs the following eBPF programs by default:
 -   `network viewer`: This eBPF program creates charts with information about `TCP` and `UDP` functions, including the
     bandwidth consumed by each.
 
+### `[network viewer]`
+
+You can configure the information that you will see on `outbund` and `inbound` charts with options inside this section. 
+
+```conf
+[network viewer]
+    maximum dimensions = 500
+    included ports = 19999 100-1024
+    excluded ports = 145 139
+    included services = ssh http
+    excluded services = ftp
+    included hostnames = netdata.cloud netdata.io
+    excluded hostnames = example.com
+    excluded ips = 127.0.0.1 192.168.0.1-192.168.0.5
+    included ips = 192.168.0.0/24 2804:14c:5b72:888d:6ee2:1aee:9b62:cbb5
+```
+
+When an `included` option is defined, Netdata will not collect all possible values of that option, it will restrict 
+ the collection for the values listed, for example, if you write `included ports = 19999` Netdata will collect  only connections 
+ for itself.  On the other hand if a value is listed for an `excluded` option, Netdata will collect everything except that values.
+The following pairs of `included` and `excluded` are available.
+
+-  `ports`: Define the destination ports that will be monitored.
+-  `services`: When you do not know the port number, you can list the ports as a service. Netdata will resolve the service
+name to its associated port to monitor the connection.
+-  `hostnames`: The list of hostnames that can be resolved to an IP address. This is the unique option that accepts
+simple pattern.
+-  `ips`: The IP or range of IPs that you want to monitor. You can use dash as separator of IPs, or a CIDR value.
+
+By default Netdata displays 500 dimensions on these charts, and any other possible value will 
+be stored in the dimension `other`. You can change the number of dimensions according to your necessities setting a new
+value for the option `maximum dimensions`.
+
+### `[service name]`
+
+Netdata uses the service listed inside the file `/etc/services` to plot the charts, but this file does not have name for 
+all the ports, for example, Netdata default port cannot find inside it. If you want to see names for specific services
+instead their ports, you can use this section to define them.
+
+```conf
+[service name]
+    19999 = Netdata
+```
+
 ## Troubleshooting
 
 If the eBPF collector does not work, you can troubleshoot it by running the `ebpf.plugin` command and investigating its

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -208,9 +208,9 @@ You can configure the information shown on `outbound` and `inbound` charts with 
     included ips = 192.168.0.0/24 0001:0000:0000:0000:0000:0000:0000:0000/32 
 ```
 
-When you define an `included` setting, Netdata will collect network metrics for that specific port. For example, if you
+When you define an `included ports` setting, Netdata will collect network metrics for that specific port. For example, if you
 write `included ports = 19999`, Netdata will collect only connections for itself. If you list values in the `excluded`
-setting, Netdata will collect metrics on all included ports except those values.
+setting, Netdata will collect metrics on all included ports except those values. Other included options have a similar behavior.
 
 In the above example, Netdata will collect metrics for all ports between 100 and 1024, with the exception of 145 and
 139.

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -204,10 +204,10 @@ You can configure the information shown on `outbound` and `inbound` charts with 
 ```
 
 When you define a `ports` setting, Netdata will collect network metrics for that specific port. For example, if you
-write `ports = 19999`, Netdata will collect only connections for itself. Except for `maximum dimensions`, 
-all options have a similar behavior.
+write `ports = 19999`, Netdata will collect only connections for itself. The `ports`, `hostnames`, and `ips` settings
+all accept [simple patterns](/libnetdata/simple_pattern/README.md).
 
-In the above example, Netdata will collect metrics for all ports between 1 and 443, with the exception of 53 (domain) 
+In the above example, Netdata will collect metrics for all ports between 1 and 443, with the exception of 53 (domain)
 and 145.
 
 The following options are available:
@@ -215,9 +215,8 @@ The following options are available:
 -   `ports`: Define the destination ports for Netdata to monitor.
 -   `hostnames`: The list of hostnames that can be resolved to an IP address. 
 -   `ips`: The IP or range of IPs that you want to monitor. You can use IPv4 or IPv6 addresses, use dashes to define a
-    range of IPs, or use CIDR values.
-    
- All options accept accept [simple patterns](/libnetdata/simple_pattern/README.md).   
+    range of IPs, or use CIDR values. The default behavior is to only collect data for private IP addresess, but this
+    can be changed with the `ips` setting.
     
 By default, Netdata displays up to 500 dimensions on network viewer charts. If there are more possible dimensions, they
 will be bundled into the `other` dimension. You can increase the number of shown dimensions by changing the `maximum

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -205,7 +205,7 @@ You can configure the information shown on `outbound` and `inbound` charts with 
     included hostnames = netdata.cloud netdata.io
     excluded hostnames = example.com
     excluded ips = 127.0.0.1 192.168.0.1-192.168.0.5
-    included ips = 192.168.0.0/24 0001:0000:0000:0000:0000:0000:0000:0000/32 
+    included ips = 192.168.0.0/24 2001:DB8::/32 
 ```
 
 When you define an `included ports` setting, Netdata will collect network metrics for that specific port. For example, if you

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -764,7 +764,7 @@ static void parse_port_list(void **out, char *range)
     if (likely(*end)) {
         *end++ = '\0';
         if (*end == '!') {
-            info("The exclusion cannot be in the second part of the range %s, it will be ignored.", copied);
+            info("The exclusion cannot be in the second part of the range, the range %s will be ignored.", copied);
             freez(copied);
             return;
         }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1189,7 +1189,7 @@ static void link_dimension_name(char *port, uint32_t hash, char *value)
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    info("Adding values %s( %u) to dimension name list used on network viewer", w->name, w->port);
+    info("Adding values %s( %u) to dimension name list used on network viewer", w->name, htons(w->port));
 #endif
 }
 
@@ -1210,14 +1210,18 @@ static void parse_service_name_section()
 
     //Always associated the default port to Netdata
     ebpf_network_viewer_dim_name_t *names = network_viewer_opt.names;
-    uint16_t default_port = htons(19999);
-    for (; names->next; names = names->next) {
-        if (names->port == default_port) {
-            return;
+    if (names) {
+        uint16_t default_port = htons(19999);
+        for (; names->next; names = names->next) {
+            if (names->port == default_port) {
+                return;
+            }
         }
     }
 
-    link_dimension_name("19999", simple_hash("19999"), "Netdata");
+    char *port_string = getenv("NETDATA_LISTEN_PORT");
+    if (port_string)
+        link_dimension_name(port_string, simple_hash(port_string), "Netdata");
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -899,9 +899,9 @@ static void parse_ip_list(void **out, char *ip)
             }
 
             in_addr_t myip = inet_addr(ip);
-            in_addr_t br = htonl(broadcast(htonl(myip), select));
-
-            last.addr32[0] = br;
+            last.addr32[0] = (uint32_t)htonl(broadcast(htonl(myip), select));
+            //This was added to remove https://app.codacy.com/manual/netdata/netdata/pullRequest?prid=5810941&bid=19021977
+            UNUSED(last.addr32[0]);
         } else { //Range
             select = ip2nl(first.addr8, ip, AF_INET, ipdup);
             if (select)

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -732,10 +732,9 @@ static void parse_port_list(void **out, char *range)
     }
 
     if (first > last) {
-        info("The specified order [%d, %d] is inverted, Netdata is fixing it!", first, last);
-        int tmp = first;
-        first = last;
-        last = tmp;
+        info("The specified order %s is wrong, the smallest value is always the first!", copied);
+        freez(copied);
+        return;
     }
 
     ebpf_network_viewer_port_list_t *w = callocz(1, sizeof(ebpf_network_viewer_port_list_t));

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -885,6 +885,9 @@ static void get_ipv6_last_addr(union netdata_ip_t *out, union netdata_ip_t *in, 
     }
 
     prefix = 128 - prefix;
+    //To prevent undefined behavior
+    if (prefix > 63)
+        prefix = 63;
     mask = (0xFFFFFFFFFFFFFFFFULL >> (64 - prefix));
     out->addr64[1] &= ~mask;
 }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -875,16 +875,16 @@ static void get_ipv6_last_addr(union netdata_ip_t *out, union netdata_ip_t *in, 
         return;
     }
 
-    if (prefix <= 64) {
+    if (prefix < 64) {
         out->addr64[1] = 0xFFFFFFFFFFFFFFFF;
-        mask = (out->addr64[1] >> (64 - prefix));
+        mask = (0xFFFFFFFFFFFFFFFFULL >> (64 - prefix));
 
         out->addr64[0] &= ~mask;
         return;
     }
 
     prefix = 128 - prefix;
-    mask = (0xFFFFFFFFFFFFFFFF >> (64 - prefix));
+    mask = (0xFFFFFFFFFFFFFFFFULL >> (64 - prefix));
     out->addr64[1] &= ~mask;
 }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -851,7 +851,7 @@ static void link_dimension_name(char *port, uint32_t hash, char *value)
 
     ebpf_network_viewer_dim_name_t *names = network_viewer_opt.names;
     if (unlikely(!names)) {
-        names = w;
+        network_viewer_opt.names = w;
     } else {
         for (; names->next; names = names->next) {
             if (names->port == w->port) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -798,7 +798,7 @@ static void parse_port_list(void **out, char *range)
     ebpf_network_viewer_port_list_t *w;
 fillenvpl:
     w = callocz(1, sizeof(ebpf_network_viewer_port_list_t));
-    w->value = strdup(copied);
+    w->value = copied;
     w->hash = simple_hash(copied);
     w->first = (uint16_t)htons((uint16_t)first);
     w->last = (uint16_t)htons((uint16_t)last);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1004,6 +1004,13 @@ static void get_ipv6_last_addr(union netdata_ip_t *out, union netdata_ip_t *in, 
     if (prefix == 128) {
         memcpy(out->addr32, in->addr32, sizeof(union netdata_ip_t));
         return;
+    } else if (!prefix) {
+        ret[0] = ret[1] = 0;
+        memcpy(in->addr32, ret, sizeof(union netdata_ip_t));
+
+        ret[0] = ret[1] = 0xFFFFFFFFFFFFFFFF;
+        memcpy(out->addr32, ret, sizeof(union netdata_ip_t));
+        return;
     }
 
     if (prefix <= 64) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1003,7 +1003,7 @@ static void parse_ip_list(void **out, char *ip)
  * Parse the port ranges given and create Network Viewer Port Structure
  *
  * @param out is the output link list
- * @param ptr is a pointer with the text to parser.
+ * @param ptr is a pointer with the text to parse.
  * @param valid_char the function from ctype.h used to find the first valid value
  */
 static void parse_values(void **out,
@@ -1206,7 +1206,7 @@ static void parse_service_name_section()
         }
     }
 
-    link_dimension_name("Netdata", simple_hash("Netdata"), "19999");
+    link_dimension_name("19999", simple_hash("19999"), "Netdata");
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1303,7 +1303,8 @@ static void parse_network_viewer_section()
     value = appconfig_get(&collector_config, EBPF_NETWORK_VIEWER_SECTION, "hostnames", NULL);
     link_hostnames(value);
 
-    value = appconfig_get(&collector_config, EBPF_NETWORK_VIEWER_SECTION, "ips", NULL);
+    value = appconfig_get(&collector_config, EBPF_NETWORK_VIEWER_SECTION,
+                          "ips", "!127.0.0.1/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 fc00::/7");
     parse_ips(value);
 }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -885,6 +885,36 @@ static inline int ip2nl(uint8_t *dst, char *ip, int domain, char *source)
 }
 
 /**
+ * Is ip inside the range
+ *
+ * Check if the ip is inside a IP range
+ *
+ * @param rfirst    the first ip address of the range
+ * @param rlast     the last ip address of the range
+ * @param cmpfirst  the first ip to compare
+ * @param cmplast   the last ip to compare
+ * @param family    the IP family
+ *
+ * @return It returns 1 if the IP is inside the range and 0 otherwise
+ */
+static int is_ip_inside_range(union netdata_ip_t *rfirst, union netdata_ip_t *rlast,
+                              union netdata_ip_t *cmpfirst, union netdata_ip_t *cmplast, int family)
+{
+    if (family == AF_INET) {
+        if (ntohl(rfirst->addr32[0]) <= ntohl(cmpfirst->addr32[0]) &&
+            ntohl(rlast->addr32[0]) >= ntohl(cmplast->addr32[0]))
+            return 1;
+    } else {
+        if (memcmp(rfirst->addr8, cmpfirst->addr8, sizeof(union netdata_ip_t)) <= 0 &&
+            memcmp(rlast->addr8, cmplast->addr8, sizeof(union netdata_ip_t) >= 0)) {
+            return 1;
+        }
+
+    }
+    return 0;
+}
+
+/**
  * Fill IP list
  *
  * @param out a pointer to the link list.
@@ -893,24 +923,20 @@ static inline int ip2nl(uint8_t *dst, char *ip, int domain, char *source)
 static inline void fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_ip_list_t *in)
 {
     if (likely(*out)) {
-        ebpf_network_viewer_ip_list_t *move = *out;
-        for (; move->next ; move = move->next ) {
-            if (!memcmp(move->first.addr8,
-                        in->first.addr8,
-                        sizeof(union netdata_ip_t)) &&
-                !memcmp(move->last.addr8,
-                        in->last.addr8,
-                        sizeof(union netdata_ip_t))
-                ) {
+        ebpf_network_viewer_ip_list_t *move = *out, *store = *out;
+        while (move) {
+            if (in->ver == move->ver && is_ip_inside_range(&move->first, &move->last, &in->first, &in->last, in->ver)) {
                 info("The range/value (%s) is inside the range/value (%s) already inserted, it will be ignored.",
                      in->value, move->value);
                 freez(in->value);
                 freez(in);
                 return;
             }
+            store = move;
+            move = move->next;
         }
 
-        move->next = in;
+        store->next = in;
     } else {
         *out = in;
     }
@@ -1024,8 +1050,7 @@ static void parse_ip_list(void **out, char *ip)
                 goto cleanipdup;
             }
 
-            in_addr_t myip = inet_addr(ip);
-            last.addr32[0] = (uint32_t)htonl(broadcast(htonl(myip), select));
+            last.addr32[0] = htonl(broadcast(ntohl(first.addr32[0]), select));
             //This was added to remove https://app.codacy.com/manual/netdata/netdata/pullRequest?prid=5810941&bid=19021977
             UNUSED(last.addr32[0]);
         } else { //Range

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -866,7 +866,7 @@ static inline void fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_networ
  * @param in the address used to do the math.
  * @param prefix number of bits used to calculate the address
  */
-static void get_ipv6_last_addr(union netdata_ip_t *out, union netdata_ip_t *in, uint32_t prefix)
+static void get_ipv6_last_addr(union netdata_ip_t *out, union netdata_ip_t *in, uint64_t prefix)
 {
     uint64_t mask;
     memcpy(out->addr64, in->addr64, sizeof(union netdata_ip_t));
@@ -876,8 +876,9 @@ static void get_ipv6_last_addr(union netdata_ip_t *out, union netdata_ip_t *in, 
     }
 
     if (prefix < 64) {
+        prefix = 64 - prefix;
         out->addr64[1] = 0xFFFFFFFFFFFFFFFF;
-        mask = (0xFFFFFFFFFFFFFFFFULL >> (64 - prefix));
+        mask = (0xFFFFFFFFFFFFFFFFULL >> (prefix));
 
         out->addr64[0] &= ~mask;
         return;
@@ -969,7 +970,7 @@ static void parse_ip_list(void **out, char *ip)
             if (select)
                 return;
 
-            get_ipv6_last_addr(&last, &first, (uint32_t)select);
+            get_ipv6_last_addr(&last, &first, (uint64_t)select);
         }
     } else { //Unique ip
         select = ip2nl(first.addr8, ip, AF_INET, ipdup);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -906,7 +906,7 @@ static int is_ip_inside_range(union netdata_ip_t *rfirst, union netdata_ip_t *rl
             return 1;
     } else {
         if (memcmp(rfirst->addr8, cmpfirst->addr8, sizeof(union netdata_ip_t)) <= 0 &&
-            memcmp(rlast->addr8, cmplast->addr8, sizeof(union netdata_ip_t) >= 0)) {
+            memcmp(rlast->addr8, cmplast->addr8, sizeof(union netdata_ip_t)) >= 0) {
             return 1;
         }
 
@@ -981,7 +981,7 @@ static void get_ipv6_last_addr(union netdata_ip_t *out, union netdata_ip_t *in, 
         ret[1] = 0xFFFFFFFFFFFFFFFFULL;
 
         tmp = be64toh(ret[0]);
-        if (prefix != 64) {
+        if (prefix > 0) {
             mask = 0xFFFFFFFFFFFFFFFFULL << (64 - prefix);
             tmp |= ~mask;
         }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -884,6 +884,7 @@ static void get_ipv6_last_addr(union netdata_ip_t *out, union netdata_ip_t *in, 
     memcpy(ret, in->addr32, sizeof(union netdata_ip_t));
 
     if (prefix == 128) {
+        memcpy(out->addr32, in->addr32, sizeof(union netdata_ip_t));
         return;
     }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -818,7 +818,6 @@ static inline int ip2nl(uint8_t *dst, char *ip, int domain, char *source)
 {
     if (inet_pton(domain, ip, dst) <= 0) {
         error("The address specified (%s) is invalid ", source);
-        freez(source);
         return -1;
     }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1046,7 +1046,7 @@ static void get_ipv6_first_addr(union netdata_ip_t *out, union netdata_ip_t *in,
         return;
     } else if (!prefix) {
         ret[0] = ret[1] = 0;
-        memcpy(in->addr32, ret, sizeof(union netdata_ip_t));
+        memcpy(out->addr32, ret, sizeof(union netdata_ip_t));
         return;
     } else if (prefix <= 64) {
         ret[1] = 0ULL;

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1137,7 +1137,7 @@ static void link_dimension_name(char *port, uint32_t hash, char *value)
  *
  * This function gets the values that will be used to overwrite dimensions.
  */
-static void parse_serice_name_section()
+static void parse_service_name_section()
 {
     struct section *co = appconfig_get_section(&collector_config, EBPF_SERVICE_NAME_SECTION);
     if (co) {
@@ -1146,6 +1146,17 @@ static void parse_serice_name_section()
             link_dimension_name(cv->name, cv->hash, cv->value);
         }
     }
+
+    //Always associated the default port to Netdata
+    ebpf_network_viewer_dim_name_t *names = network_viewer_opt.names;
+    uint16_t default_port = htons(19999);
+    for (; names->next; names = names->next) {
+        if (names->port == default_port) {
+            return;
+        }
+    }
+
+    link_dimension_name("Netdata", simple_hash("Netdata"), "19999");
 }
 
 /**
@@ -1180,7 +1191,7 @@ static void read_collector_values(int *disable_apps)
         ebpf_enable_chart(EBPF_MODULE_SOCKET_IDX, *disable_apps);
         //Read network viewer section if network viewer is enabled
         parse_network_viewer_section();
-        parse_serice_name_section();
+        parse_service_name_section();
         started++;
     }
 
@@ -1188,7 +1199,7 @@ static void read_collector_values(int *disable_apps)
         ebpf_enable_all_charts(*disable_apps);
         //Read network viewer section
         parse_network_viewer_section();
-        parse_serice_name_section();
+        parse_service_name_section();
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf.conf
+++ b/collectors/ebpf.plugin/ebpf.conf
@@ -5,3 +5,17 @@
 [ebpf programs]
     process = yes
     network viewer = yes
+
+[network viewer]
+    maximum dimensions = 500
+    excluded ips = 127.0.0.1
+    #included ips = *
+    #excluded hostnames = example.com
+    #included hostnames = *
+    #excluded ports =
+    #included ports = 19999 1-1024 *
+    #excluded services = <simple pattern>
+    #included services = ssh
+
+[service name]
+    19999 = Netdata

--- a/collectors/ebpf.plugin/ebpf.conf
+++ b/collectors/ebpf.plugin/ebpf.conf
@@ -8,14 +8,9 @@
 
 [network viewer]
     maximum dimensions = 500
-    excluded ips = 127.0.0.1
-    #included ips = *
-    #excluded hostnames = example.com
-    #included hostnames = *
-    #excluded ports =
-    #included ports = 19999 1-1024 *
-    #excluded services = compressnet iafserver
-    #included services = ssh ftp https http
+    ports = *
+    ips = !127.0.0.1/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 fc00::/7
+    hostnames = !example.com
 
 [service name]
     19999 = Netdata

--- a/collectors/ebpf.plugin/ebpf.conf
+++ b/collectors/ebpf.plugin/ebpf.conf
@@ -14,8 +14,8 @@
     #included hostnames = *
     #excluded ports =
     #included ports = 19999 1-1024 *
-    #excluded services = <simple pattern>
-    #included services = ssh
+    #excluded services = compressnet iafserver
+    #included services = ssh ftp https http
 
 [service name]
     19999 = Netdata

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -184,8 +184,9 @@ extern void ebpf_create_charts_on_apps(char *name,
 
 extern void write_end_chart();
 
-#define EBPF_GLOBAL_SECTION "global"
-#define EBPF_PROGRAMS_SECTION "ebpf programs"
+# define EBPF_GLOBAL_SECTION "global"
+# define EBPF_PROGRAMS_SECTION "ebpf programs"
+# define EBPF_NETWORK_VIEWER_SECTION "network viewer"
 
 #define EBPF_COMMON_DIMENSION_CALL "Calls"
 #define EBPF_COMMON_DIMENSION_BYTESS "bytes/s"

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -187,6 +187,7 @@ extern void write_end_chart();
 # define EBPF_GLOBAL_SECTION "global"
 # define EBPF_PROGRAMS_SECTION "ebpf programs"
 # define EBPF_NETWORK_VIEWER_SECTION "network viewer"
+# define EBPF_SERVICE_NAME_SECTION "service name"
 
 #define EBPF_COMMON_DIMENSION_CALL "Calls"
 #define EBPF_COMMON_DIMENSION_BYTESS "bytes/s"

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -497,6 +497,25 @@ static void clean_service_names(ebpf_network_viewer_dim_name_t *names)
 }
 
 /**
+ * Clean hostnames
+ *
+ * @param hostnames the hostnames to clean
+ */
+static void clean_hostnames(ebpf_network_viewer_hostname_list_t *hostnames)
+{
+    if (unlikely(!hostnames))
+        return;
+
+    while (hostnames) {
+        ebpf_network_viewer_hostname_list_t *next = hostnames->next;
+        freez(hostnames->value);
+        simple_pattern_free(hostnames->value_pattern);
+        freez(hostnames);
+        hostnames = next;
+    }
+}
+
+/**
  * Clean up the main thread.
  *
  * @param ptr thread data.
@@ -518,6 +537,8 @@ static void ebpf_socket_cleanup(void *ptr)
     clean_network_ports(network_viewer_opt.included_port);
     clean_network_ports(network_viewer_opt.excluded_port);
     clean_service_names(network_viewer_opt.names);
+    clean_hostnames(network_viewer_opt.included_hostnames);
+    clean_hostnames(network_viewer_opt.excluded_hostnames);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -459,6 +459,23 @@ static void socket_collector(usec_t step, ebpf_module_t *em)
  *****************************************************************/
 
 /**
+ * Clean netowrk ports allocated during initializaion.
+ *
+ * @param ptr a pointer to the link list.
+ */
+static void clean_network_ports(ebpf_network_viewer_port_list_t *ptr)
+{
+    if (unlikely(!ptr))
+        return;
+
+    while (ptr) {
+        ebpf_network_viewer_port_list_t *next = ptr->next;
+        freez(ptr);
+        ptr = next;
+    }
+}
+
+/**
  * Clean up the main thread.
  *
  * @param ptr thread data.
@@ -476,6 +493,9 @@ static void ebpf_socket_cleanup(void *ptr)
     freez(bandwidth_vector);
 
     ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled = 0;
+
+    clean_network_ports(network_viewer_opt.included_port);
+    clean_network_ports(network_viewer_opt.excluded_port);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -470,8 +470,29 @@ static void clean_network_ports(ebpf_network_viewer_port_list_t *ptr)
 
     while (ptr) {
         ebpf_network_viewer_port_list_t *next = ptr->next;
+        freez(ptr->value);
         freez(ptr);
         ptr = next;
+    }
+}
+
+/**
+ * Clean service names
+ *
+ * Clean the allocated link list that stores names.
+ *
+ * @param names the link list.
+ */
+static void clean_service_names(ebpf_network_viewer_dim_name_t *names)
+{
+    if (unlikely(!names))
+        return;
+
+    while (names) {
+        ebpf_network_viewer_dim_name_t *next = names->next;
+        freez(names->name);
+        freez(names);
+        names = next;
     }
 }
 
@@ -496,6 +517,7 @@ static void ebpf_socket_cleanup(void *ptr)
 
     clean_network_ports(network_viewer_opt.included_port);
     clean_network_ports(network_viewer_opt.excluded_port);
+    clean_service_names(network_viewer_opt.names);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -54,7 +54,8 @@ typedef struct ebpf_socket_publish_apps {
 } ebpf_socket_publish_apps_t;
 
 typedef struct ebpf_network_viewer_port_list {
-    char *range;
+    char *value;
+    uint32_t hash;
     uint16_t first;
     uint16_t last;
     struct ebpf_network_viewer_port_list *next;

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -44,7 +44,7 @@ typedef enum ebpf_socket_idx {
 #define NETDATA_NET_APPS_BANDWIDTH_RECV "bandwidth_recv"
 
 //Port range
-# define NETDATA_MINIMUM_PORT_VALUE 0
+# define NETDATA_MINIMUM_PORT_VALUE 1
 # define NETDATA_MAXIMUM_PORT_VALUE 65535
 
 # define NETDATA_MINIMUM_IPV4_CIDR 0

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -47,6 +47,9 @@ typedef enum ebpf_socket_idx {
 # define NETDATA_MINIMUM_PORT_VALUE 0
 # define NETDATA_MAXIMUM_PORT_VALUE 65535
 
+# define NETDATA_MINIMUM_IPV4_CIDR 0
+# define NETDATA_MAXIMUM_IPV4_CIDR 32
+
 typedef struct ebpf_socket_publish_apps {
     // Data read
     uint64_t sent;
@@ -76,9 +79,9 @@ typedef struct ebpf_network_viewer_port_list {
 } ebpf_network_viewer_port_list_t;
 
 union netdata_ip_t {
-    __u8 addr8[16];
-    __u16 addr16[8];
-    __u32 addr32[4];
+    uint8_t  addr8[16];
+    uint16_t addr16[8];
+    uint32_t addr32[4];
 };
 
 typedef struct ebpf_network_viewer_ip_list {
@@ -87,8 +90,8 @@ typedef struct ebpf_network_viewer_ip_list {
 
     uint8_t ver;            //IP version
 
-    union netdata_ip_t ip;        //The IP address informed
-    uint32_t mask;          //The mask
+    union netdata_ip_t first;        //The IP address informed
+    union netdata_ip_t last;        //The IP address informed
 
     struct ebpf_network_viewer_ip_list *next;
 } ebpf_network_viewer_ip_list_t;

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -87,7 +87,7 @@ typedef struct ebpf_network_viewer_ip_list {
 
     uint8_t ver;            //IP version
 
-    netdata_ip_t ip;        //The IP address informed
+    union netdata_ip_t ip;        //The IP address informed
     uint32_t mask;          //The mask
 
     struct ebpf_network_viewer_ip_list *next;
@@ -96,6 +96,8 @@ typedef struct ebpf_network_viewer_ip_list {
 typedef struct ebpf_network_viewer_hostname_list {
     char *value;            //IP value
     uint32_t hash;          //IP hash
+
+    SIMPLE_PATTERN *value_pattern;
 
     struct ebpf_network_viewer_hostname_list *next;
 } ebpf_network_viewer_hostname_list_t;

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -82,6 +82,7 @@ union netdata_ip_t {
     uint8_t  addr8[16];
     uint16_t addr16[8];
     uint32_t addr32[4];
+    uint64_t addr64[2];
 };
 
 typedef struct ebpf_network_viewer_ip_list {

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -75,6 +75,31 @@ typedef struct ebpf_network_viewer_port_list {
     struct ebpf_network_viewer_port_list *next;
 } ebpf_network_viewer_port_list_t;
 
+union netdata_ip_t {
+    __u8 addr8[16];
+    __u16 addr16[8];
+    __u32 addr32[4];
+};
+
+typedef struct ebpf_network_viewer_ip_list {
+    char *value;            //IP value
+    uint32_t hash;          //IP hash
+
+    uint8_t ver;            //IP version
+
+    netdata_ip_t ip;        //The IP address informed
+    uint32_t mask;          //The mask
+
+    struct ebpf_network_viewer_ip_list *next;
+} ebpf_network_viewer_ip_list_t;
+
+typedef struct ebpf_network_viewer_hostname_list {
+    char *value;            //IP value
+    uint32_t hash;          //IP hash
+
+    struct ebpf_network_viewer_hostname_list *next;
+} ebpf_network_viewer_hostname_list_t;
+
 typedef struct ebpf_network_viewer_options {
     uint32_t max_dim;   //Store value read from 'maximum dimensions'
 
@@ -82,6 +107,12 @@ typedef struct ebpf_network_viewer_options {
     ebpf_network_viewer_port_list_t *included_port;
 
     ebpf_network_viewer_dim_name_t *names;
+
+    ebpf_network_viewer_ip_list_t *excluded_ips;
+    ebpf_network_viewer_ip_list_t *included_ips;
+
+    ebpf_network_viewer_hostname_list_t *excluded_hostnames;
+    ebpf_network_viewer_hostname_list_t *included_hostnames;
 } ebpf_network_viewer_options_t;
 
 extern ebpf_network_viewer_options_t network_viewer_opt;

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -53,4 +53,20 @@ typedef struct ebpf_socket_publish_apps {
     uint64_t publish_recv;
 } ebpf_socket_publish_apps_t;
 
-#endif /* NETDATA_EBPF_SOCKET_H */
+typedef struct ebpf_network_viewer_port_list {
+    char *range;
+    uint16_t first;
+    uint16_t last;
+    struct ebpf_network_viewer_port_list *next;
+} ebpf_network_viewer_port_list_t;
+
+typedef struct ebpf_network_viewer_options {
+    uint32_t max_dim;   //Store value read from 'maximum dimensions'
+
+    ebpf_network_viewer_port_list_t *excluded_port;
+    ebpf_network_viewer_port_list_t *included_port;
+} ebpf_network_viewer_options_t;
+
+extern ebpf_network_viewer_options_t network_viewer_opt;
+
+#endif

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -43,6 +43,10 @@ typedef enum ebpf_socket_idx {
 #define NETDATA_NET_APPS_BANDWIDTH_SENT "bandwidth_sent"
 #define NETDATA_NET_APPS_BANDWIDTH_RECV "bandwidth_recv"
 
+//Port range
+# define NETDATA_MINIMUM_PORT_VALUE 0
+# define NETDATA_MAXIMUM_PORT_VALUE 65535
+
 typedef struct ebpf_socket_publish_apps {
     // Data read
     uint64_t sent;
@@ -53,9 +57,19 @@ typedef struct ebpf_socket_publish_apps {
     uint64_t publish_recv;
 } ebpf_socket_publish_apps_t;
 
+typedef struct ebpf_network_viewer_dimension_names {
+    char *name;
+    uint32_t hash;
+
+    uint16_t port;
+
+    struct ebpf_network_viewer_dimension_names *next;
+} ebpf_network_viewer_dim_name_t ;
+
 typedef struct ebpf_network_viewer_port_list {
     char *value;
     uint32_t hash;
+
     uint16_t first;
     uint16_t last;
     struct ebpf_network_viewer_port_list *next;
@@ -66,6 +80,8 @@ typedef struct ebpf_network_viewer_options {
 
     ebpf_network_viewer_port_list_t *excluded_port;
     ebpf_network_viewer_port_list_t *included_port;
+
+    ebpf_network_viewer_dim_name_t *names;
 } ebpf_network_viewer_options_t;
 
 extern ebpf_network_viewer_options_t network_viewer_opt;

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -82,7 +82,6 @@ union netdata_ip_t {
     uint8_t  addr8[16];
     uint16_t addr16[8];
     uint32_t addr32[4];
-    uint64_t addr64[2];
 };
 
 typedef struct ebpf_network_viewer_ip_list {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -689,6 +689,17 @@ void set_global_environment() {
     setenv("HOME"                     , verify_required_directory(netdata_configured_home_dir),         1);
     setenv("NETDATA_HOST_PREFIX"      , netdata_configured_host_prefix, 1);
 
+    char *default_port = appconfig_get(&netdata_config, CONFIG_SECTION_WEB, "default port", NULL);
+    int clean = 0;
+    if (!default_port) {
+        default_port = strdupz("19999");
+        clean = 1;
+    }
+
+    setenv("NETDATA_LISTEN_PORT"      , default_port, 1);
+    if(clean)
+        freez(default_port);
+
     get_system_timezone();
 
     // set the path we need


### PR DESCRIPTION
##### Summary
Fixes #9455

##### Component Name
Collector

##### Test Plan

1 -  Compile Netdata with the option `-DNETDATA_INTERNAL_CHECKS`
2 - Configure your `ebpf.conf` inside `/etc/netdata/`, for example, use
```
[global]
    ebpf load mode = return
    #ebpf load mode = entry
    disable apps = no

[ebpf programs]
    process = yes
    network viewer = yes

[network viewer]
    maximum dimensions = 20
    ports = !145 !139 100-1024 144  ssh * https 3128:2000 60000-70000 78945 !compressnet iafservers
    hostnames = netdata.cloud netdata.io    !*example*
    ips = 127.0.0.1 192.168.0.0/6 172.20.0.0-172.20.2.255 4204:14c:5b72:1234:5678:1aee:ac11:cbb5/24 1200:10c:1234:5678:1ee2:1aee:ac11:cbb5/90 192.168.0.100-192.168.0.50 192.168.0.0/24     c704:14c:5b72:888d:1ee2:1aee:ac11:cbb5  9436:14c:1234:5678:1ee2:1aee:ac11:cbb0-9436:14c:1234:5678:1ee2:1aee:ac11:cbff 9436:14c:1234:5678:1ee2:1aee:ac11:cbf2 !*

[service name]
    19999 = NetdataTLS
    20000 = Netdata
```

3 - Start your Netdata
4 - Wait for few seconds and run the next command and confirm that the options was parsed and linked as expected:

```
$ grep "network viewer" /var/log/netdata/error.log ; grep "ignored" /var/log/netdata/error.log 
```

##### Additional Information
