### PR TITLE
fix ACLK protocol version always parsed as 0

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -133,7 +133,7 @@ int cloud_to_agent_parse(JSON_ENTRY *e)
             break;
         case JSON_NUMBER:
             if (!strcmp(e->name, "version")) {
-                data->version = atoi(e->original_string);
+                data->version = e->data.number;
                 break;
             }
             break;

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -161,6 +161,16 @@ static inline void json_jsonc_set_boolean(JSON_ENTRY *e,int value) {
     e->data.boolean = value;
 }
 
+static inline void json_jsonc_set_integer(JSON_ENTRY *e, char *key, int64_t value) {
+    size_t len = strlen(key);
+    if(len > JSON_NAME_LEN)
+        len = JSON_NAME_LEN;
+    e->type = JSON_NUMBER;
+    memcpy(e->name, key, len);
+    e->name[len] = 0;
+    e->data.number = value;
+}
+
 /**
  * Parse Array
  *
@@ -448,6 +458,9 @@ size_t json_walk(json_object *t, void *callback_data, int (*callback_function)(s
             callback_function(&e);
         } else if (type == json_type_boolean) {
             json_jsonc_set_boolean(&e,json_object_get_boolean(val));
+            callback_function(&e);
+        } else if (type == json_type_int) {
+            json_jsonc_set_integer(&e,key,json_object_get_int64(val));
             callback_function(&e);
         }
     }


### PR DESCRIPTION
##### Summary
If you add log in master branch file `agent_cloud_link.c` function `int aclk_handle_cloud_request(char *payload)` after line `1974` like following:
```
    int rc = json_parse(payload, &cloud_to_agent, cloud_to_agent_parse);

    error("!!!!!!!!!!!!!!!!!!! VERSION %d", cloud_to_agent.version);
```

Then visit the agent on the cloud so that Agent is Queried. You will see the version is always 0!!

Reason is in function `int cloud_to_agent_parse(JSON_ENTRY *e)` the branch `case JSON_NUMBER:` is never taken. This is due to this not being implemented with JSON-C.

This PR fixes that.

We should think about hotfix release together with buffer overflow fix from yesterday (#9491 10e6b747dae6fa42ccfeeb7b4511e8fec31c61b2) as this is important for ACLK upgrades so that the old agent will detect and reject unknown messages with higher version numbers.

##### Component Name
JSON-C JSON parsing

##### Test Plan
As per description (add debug log for testing). After this patch agent should correctly report V1 instead of V0 on the cloud. VX is correctly reported if sending modified messages manually over ACLK

##### Additional Information
