### PR TITLE
Fixed the check condition for chart name change

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -547,7 +547,7 @@ RRDSET *rrdset_create_custom(
              *old_title_v = NULL, *old_family_v = NULL, *old_context_v = NULL;
         const char *new_name = name ? name : id;
 
-        if (unlikely((st->name && !strcmp(st->name, new_name)) || !st->name)) {
+        if (unlikely((st->name && strcmp(st->name, new_name)) || !st->name)) {
             mark_rebuild |= META_CHART_UPDATED;
             rrdset_set_name(st, new_name);
         }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -181,7 +181,7 @@ int rrdset_set_name(RRDSET *st, const char *name) {
     rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_IGNORE);
     rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
 
-    return 1;
+    return 2;
 }
 
 inline void rrdset_is_obsolete(RRDSET *st) {
@@ -545,12 +545,15 @@ RRDSET *rrdset_create_custom(
         }
         char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_family = NULL, *old_context = NULL,
              *old_title_v = NULL, *old_family_v = NULL, *old_context_v = NULL;
-        const char *new_name = name ? name : id;
+        int rc;
 
-        if (unlikely((st->name && strcmp(st->name, new_name)) || !st->name)) {
+        if(unlikely(name))
+            rc = rrdset_set_name(st, name);
+        else
+            rc = rrdset_set_name(st, id);
+
+        if (rc == 2)
             mark_rebuild |= META_CHART_UPDATED;
-            rrdset_set_name(st, new_name);
-        }
 
         if (unlikely(st->priority != priority)) {
             st->priority = priority;


### PR DESCRIPTION
##### Summary
The condition check on whether a chart name change should take place was was incorrect which can
cause unpredictable results all over the code.

##### Component Name
database

##### Test Plan
The original code for that part was:

```
        if(unlikely(name))
            rrdset_set_name(st, name);
        else
            rrdset_set_name(st, id);
```

There is already a check in `rrdset_set_name` if  `st->name` and the provided name are the same. The faulty code would only call the function if st->name and new_name  were identical which would result in a no-op.
