### PR TITLE
python.d: thread safe safe_print (stdout write)

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/collection.py
+++ b/collectors/python.d.plugin/python_modules/bases/collection.py
@@ -5,12 +5,16 @@
 
 import os
 
+from threading import Lock
+
 PATH = os.getenv('PATH', '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin').split(':')
 
 CHART_BEGIN = 'BEGIN {0} {1}\n'
 CHART_CREATE = "CHART {0} '{1}' '{2}' '{3}' '{4}' '{5}' {6} {7} {8}\n"
 DIMENSION_CREATE = "DIMENSION '{0}' '{1}' {2} {3} {4} '{5}'\n"
 DIMENSION_SET = "SET '{0}' = {1}\n"
+
+print_lock = Lock()
 
 
 def setdefault_values(config, base_dict):
@@ -62,7 +66,9 @@ def safe_print(*msg):
     :param msg:
     :return:
     """
+    print_lock.acquire()
     print(''.join(msg))
+    print_lock.release()
 
 
 def find_binary(binary):


### PR DESCRIPTION
#### Summary

Fixes: #9486

All jobs (threads) use `safe_print` to send charts (wrtie to stdout), this PR adds a lock to this function.

##### Component Name

`python.d/`

##### Test Plan

- [X] run plugin with several jobs (threads), ensure it works @ilyam8 
- [x] ensure the patch fixes races @mjnaderi (i cant reproduce it myself)

##### Additional Information
