### PR TITLE
Fixed an issue with random crashes when updating a chart's metadata on the fly

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -608,18 +608,6 @@ RRDSET *rrdset_create_custom(
             mark_rebuild |= META_CHART_UPDATED;
         }
 
-        if (unlikely(family && st->state->old_family && strcmp(st->state->old_family, family))) {
-            char *new_family = strdupz(family);
-            old_family_v = st->state->old_family;
-            st->state->old_family = strdupz(family);
-            json_fix_string(new_family);
-            old_family = st->family;
-            rrdfamily_free(host, st->rrdfamily);
-            st->family = new_family;
-            st->rrdfamily = rrdfamily_create(host, st->family);
-            mark_rebuild |= META_CHART_UPDATED;
-        }
-
         if (unlikely(context && st->state->old_context && strcmp(st->state->old_context, context))) {
             char *new_context = strdupz(context);
             old_context_v = st->state->old_context;


### PR DESCRIPTION
##### Summary
Disables the recently added ability to change a chart's family on the fly. 

The code removed may deallocate structures already in use in other parts of the agent

##### Component Name
database

##### Test Plan
