### PR TITLE
charts.d: loopsleepms: fix now_ms

### DIFF
--- a/collectors/charts.d.plugin/loopsleepms.sh.inc
+++ b/collectors/charts.d.plugin/loopsleepms.sh.inc
@@ -18,7 +18,7 @@ current_time_ms_from_date() {
 	if [ $LOOPSLEEPMS_HIGHRES -eq 0 ]; then
 		now_ms="$($LOOPSLEEP_DATE +'%s')000"
 	else
-		now_ms="$(($($LOOPSLEEP_DATE +'%s * 1000 + %-N / 1000000')))"
+		now_ms="$(($($LOOPSLEEP_DATE +'%s * 1000 + 10#%-N / 1000000')))"
 	fi
 }
 


### PR DESCRIPTION
#### Summary

Fixes: #9493

Bug and fix descriptions are in https://github.com/netdata/netdata/issues/9493#issuecomment-656117588

```cmd
   By default, date  pads  numeric  fields  with  zeroes.   The  following
   optional flags may follow '%':

   -      (hyphen) do not pad the field
```

We need to remove leading zeros from the `%-N` or treat it as base 10 number because of leading zeros.

```cmd
[ilyam@ilyam-pc ~]$ date +'%-N'
603606142
[ilyam@ilyam-pc ~]$ date +'%-N'
046524868
[ilyam@ilyam-pc ~]$ date +'%-N'
419173701
```

> Constants with a leading 0 are interpreted as octal numbers. A leading ‘0x’ or ‘0X’ denotes hexadecimal. Otherwise, numbers take the form [base#]n, where the optional base is a decimal number between 2 and 64 representing the arithmetic base, and n is a number in that base. If base# is omitted, then base 10 is used.

##### Component Name

- `charts.d`
- `tc.plugin`

##### Test Plan


##### Additional Information
