### PR TITLE
mysql: respect `my.cnf` parameter using PyMySQL library

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py
@@ -50,6 +50,8 @@ class MySQLService(SimpleService):
             elif conf.get('host'):
                 properties['host'] = conf['host']
                 properties['port'] = int(conf.get('port', 3306))
+            elif conf.get('my.cnf'):
+                properties['read_default_file'] = conf['my.cnf']
 
             if conf.get('ssl'):
                 properties['ssl'] = conf['ssl']

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/MySQLService.py
@@ -50,12 +50,6 @@ class MySQLService(SimpleService):
             elif conf.get('host'):
                 properties['host'] = conf['host']
                 properties['port'] = int(conf.get('port', 3306))
-            elif conf.get('my.cnf'):
-                if MySQLdb.__name__ == 'pymysql':
-                    # TODO: this is probablt wrong, it depends on version
-                    self.error('"my.cnf" parsing is not working for pymysql')
-                else:
-                    properties['read_default_file'] = conf['my.cnf']
 
             if conf.get('ssl'):
                 properties['ssl'] = conf['ssl']


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #7518

##### Component Name
MySQLService.py

##### Test Plan
Have original users who raised the issue verify it

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
As mentioned in one of the issue comment, the requisite code block responsible for the issue has been removed so that no one faces this issue again