### PR TITLE
Fix transition from archived to active charts not generating alarms.

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -534,9 +534,9 @@ RRDSET *rrdset_create_custom(
     char fullid[RRD_ID_LENGTH_MAX + 1];
     snprintfz(fullid, RRD_ID_LENGTH_MAX, "%s.%s", type, id);
 
+    int changed_from_archived_to_active = 0;
     RRDSET *st = rrdset_find_on_create(host, fullid);
     if (st) {
-        int changed_from_archived_to_active = 0;
         int mark_rebuild = 0;
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
@@ -670,7 +670,7 @@ RRDSET *rrdset_create_custom(
 
     st = rrdset_find_on_create(host, fullid);
     if(st) {
-        if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
+        if (changed_from_archived_to_active) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
             rrdsetvar_create(st, "last_collected_t",    RRDVAR_TYPE_TIME_T,     &st->last_collected_time.tv_sec, RRDVAR_OPTION_DEFAULT);
             rrdsetvar_create(st, "collected_total_raw", RRDVAR_TYPE_TOTAL,      &st->last_collected_total,       RRDVAR_OPTION_DEFAULT);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #9534
##### Component Name
health
database
##### Test Plan

- stop netdata
- delete dbengine data
- start netdata
- check all alarms
- restart netdata
- check all alarms


<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->