### PR TITLE
Fixes cmake build failing if ACLK is disabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,12 @@ on:
     branches:
       - master
     paths:
+      - 'CMakeLists.txt'
       - '**.c'
       - '**.h'
   pull_request:
     paths:
+      - 'CMakeLists.txt'
       - '**.c'
       - '**.h'
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ check_symbol_exists("JudyLLast" "Judy.h" HAVE_JUDY)
 IF(HAVE_JUDY)
     message(STATUS "Judy library found")
 ELSE()
-    message( FATAL_ERROR "libJudy required but not found. Try installing 'libjudy-dev' or 'Judy-devel'." )
+#    message( FATAL_ERROR "libJudy required but not found. Try installing 'libjudy-dev' or 'Judy-devel'." )
 ENDIF()
 
 # -----------------------------------------------------------------------------
@@ -658,11 +658,11 @@ set(BACKENDS_PLUGIN_FILES
 set(CLAIM_PLUGIN_FILES
         claim/claim.c
         claim/claim.h
+        aclk/aclk_common.c
+        aclk/aclk_common.h
         )
 
 set(ACLK_PLUGIN_FILES
-        aclk/aclk_common.c
-        aclk/aclk_common.h
         aclk/agent_cloud_link.c
         aclk/agent_cloud_link.h
         aclk/aclk_query.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ check_symbol_exists("JudyLLast" "Judy.h" HAVE_JUDY)
 IF(HAVE_JUDY)
     message(STATUS "Judy library found")
 ELSE()
-#    message( FATAL_ERROR "libJudy required but not found. Try installing 'libjudy-dev' or 'Judy-devel'." )
+    message( FATAL_ERROR "libJudy required but not found. Try installing 'libjudy-dev' or 'Judy-devel'." )
 ENDIF()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
Fixes cmake build if ACLK is disabled. It was causing link error `undefined reference to `aclk_get_proxy'`.

This was causing `cmocka` test `build` step to always fail in CI (as ACLK is disabled there for some reason).
Does not fix other preexistent/possible problems with `cmocka`.

Problem was if you compile `claim` you need to also compile `aclk_common`. This was not reflected in Cmake makefiles (only in autotools) and shows only when building without ACLK.

##### Component Name
cmake buildsystem

##### Test Plan
rename `*.a` files in `externaldeps` folder (keep headers in). Make sure `config.h` has no `#define ENABLE_ACLK` (as this file is done by autotools and if autotools/cmake don't agree on ACLK it will fail 100%).

It should be possible to compile using CMake without ACLK now

##### Additional Information
