### PR TITLE
Add eBPF bundling script to `make dist`.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,7 @@ dist_noinst_DATA = \
     packaging/mosquitto.version \
     packaging/mosquitto.checksums \
     packaging/bundle-dashboard.sh \
+    packaging/bundle-ebpf.sh \
     packaging/bundle-mosquitto.sh \
     packaging/check-kernel-config.sh \
     packaging/ebpf.checksums \


### PR DESCRIPTION
##### Summary

It got missed when initially adding eBPF support to our packaging process.

##### Component Name

area/packaging

##### Test Plan

Verified locally that the file is properly included.

##### Additional Information

This fixes the currently broken production RPM builds, which we still have not fixed to not use `make dist` and just use the regular source tree.

@prologic This needs to go in before any patch release is made, as we otherwise will not have working RPM builds.