### PR TITLE
Fix compilation warnings

### DIFF
--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -64,7 +64,7 @@ void * wal_get_transaction_buffer(struct rrdengine_worker_config* wc, unsigned s
 {
     struct rrdengine_instance *ctx = wc->ctx;
     int ret;
-    unsigned buf_pos, buf_size;
+    unsigned buf_pos = 0, buf_size;
 
     fatal_assert(size);
     if (ctx->commit_log.buf) {
@@ -275,7 +275,7 @@ static void restore_extent_metadata(struct rrdengine_instance *ctx, struct rrden
     for (i = 0, valid_pages = 0 ; i < count ; ++i) {
         uuid_t *temp_id;
         Pvoid_t *PValue;
-        struct pg_cache_page_index *page_index;
+        struct pg_cache_page_index *page_index = NULL;
 
         if (PAGE_METRICS != jf_metric_data->descr[i].type) {
             error("Unknown page type encountered.");

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -312,7 +312,7 @@ int compaction_failure_recovery(struct metalog_instance *ctx, struct metadata_lo
 {
     int ret;
     unsigned starting_fileno, fileno, i, j, recovered_files;
-    struct metadata_logfile *metalogfile, *compactionfile, **tmp_metalogfiles;
+    struct metadata_logfile *metalogfile = NULL, *compactionfile = NULL, **tmp_metalogfiles;
     char *dbfiles_path = ctx->rrdeng_ctx->dbfiles_path;
 
     for (i = 0 ; i < *matched_files ; ++i) {

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -130,7 +130,7 @@ void *mlf_get_records_buffer(struct metalog_worker_config *wc, struct metadata_r
                              struct metadata_logfile_list *metadata_logfiles, unsigned size)
 {
     int ret;
-    unsigned buf_pos, buf_size;
+    unsigned buf_pos = 0, buf_size;
 
     fatal_assert(size);
     if (records_log->buf) {

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -400,7 +400,7 @@ uint8_t pg_cache_punch_hole(struct rrdengine_instance *ctx, struct rrdeng_page_d
     struct page_cache *pg_cache = &ctx->pg_cache;
     struct page_cache_descr *pg_cache_descr = NULL;
     Pvoid_t *PValue;
-    struct pg_cache_page_index *page_index;
+    struct pg_cache_page_index *page_index = NULL;
     int ret;
     uint8_t can_delete_metric = 0;
 
@@ -622,7 +622,7 @@ usec_t pg_cache_oldest_time_in_range(struct rrdengine_instance *ctx, uuid_t *id,
     struct page_cache *pg_cache = &ctx->pg_cache;
     struct rrdeng_page_descr *descr = NULL;
     Pvoid_t *PValue;
-    struct pg_cache_page_index *page_index;
+    struct pg_cache_page_index *page_index = NULL;
 
     uv_rwlock_rdlock(&pg_cache->metrics_index.lock);
     PValue = JudyHSGet(pg_cache->metrics_index.JudyHS_array, id, sizeof(uuid_t));
@@ -703,7 +703,7 @@ unsigned pg_cache_preload(struct rrdengine_instance *ctx, uuid_t *id, usec_t sta
     unsigned i, j, k, preload_count, count, page_info_array_max_size;
     unsigned long flags;
     Pvoid_t *PValue;
-    struct pg_cache_page_index *page_index;
+    struct pg_cache_page_index *page_index = NULL;
     Word_t Index;
     uint8_t failed_to_reserve;
 
@@ -849,7 +849,7 @@ struct rrdeng_page_descr *
     struct page_cache_descr *pg_cache_descr = NULL;
     unsigned long flags;
     Pvoid_t *PValue;
-    struct pg_cache_page_index *page_index;
+    struct pg_cache_page_index *page_index = NULL;
     Word_t Index;
     uint8_t page_not_in_cache;
 
@@ -956,7 +956,7 @@ pg_cache_lookup_next(struct rrdengine_instance *ctx, struct pg_cache_page_index 
     struct page_cache_descr *pg_cache_descr = NULL;
     unsigned long flags;
     Pvoid_t *PValue;
-    struct pg_cache_page_index *page_index;
+    struct pg_cache_page_index *page_index = NULL;
     uint8_t page_not_in_cache;
 
     if (unlikely(NULL == index)) {

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -49,7 +49,7 @@ void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid)
     struct rrdengine_instance *ctx;
     uuid_t legacy_uuid;
     Pvoid_t *PValue;
-    struct pg_cache_page_index *page_index;
+    struct pg_cache_page_index *page_index = NULL;
     int replace_instead_of_generate = 0;
 
     ctx = rd->rrdset->rrdhost->rrdeng_ctx;
@@ -555,7 +555,7 @@ storage_number rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle
     struct rrdeng_page_descr *descr;
     storage_number *page, ret;
     unsigned position, entries;
-    usec_t next_page_time, current_position_time, page_end_time;
+    usec_t next_page_time = 0, current_position_time, page_end_time = 0;
     uint32_t page_length;
 
     handle = &rrdimm_handle->rrdeng;

--- a/database/engine/rrdenginelib.c
+++ b/database/engine/rrdenginelib.c
@@ -90,7 +90,7 @@ int check_file_properties(uv_file file, uint64_t *file_size, size_t min_size)
 int open_file_for_io(char *path, int flags, uv_file *file, int direct)
 {
     uv_fs_t req;
-    int fd, current_flags;
+    int fd = -1, current_flags;
 
     fatal_assert(0 == direct || 1 == direct);
     for ( ; direct >= 0 ; --direct) {


### PR DESCRIPTION
##### Summary
Initialize variables in the database engine to avoid compilation warnings we have with the `-Og` flag.

##### Component Name
database engine

##### Test Plan
Build Netdata with the `-Og` flag.