### PR TITLE
Fix SHA256 handling in eBPF bundling code.

### DIFF
--- a/packaging/bundle-ebpf.sh
+++ b/packaging/bundle-ebpf.sh
@@ -8,7 +8,7 @@ EBPF_TARBALL="netdata-kernel-collector-glibc-${EBPF_VERSION}.tar.xz"
 
 mkdir -p "${SRCDIR}/tmp/ebpf"
 curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/kernel-collector/releases/download/${EBPF_VERSION}/${EBPF_TARBALL}" > "${EBPF_TARBALL}" || exit 1
-sha256sum -c --ignore-missing "${SRCDIR}/packaging/ebpf.checksums" || exit 1
+grep "${EBPF_TARBALL}" "${SRCDIR}/packaging/ebpf.checksums" | sha256sum -c - || exit 1
 tar -xaf "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
 # shellcheck disable=SC2046
 cp -a $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}"


### PR DESCRIPTION
##### Summary

This makes it compatible both with busybox and older GNU userspaces.

##### Component Name

area/packaging

##### Test Plan

Verified locally by building in a CentOS 7 environment.

##### Additional Information

@prologic This will fix the currently broken CentOS 7 RPM builds, and should go in before the upcoming patch release.