### PR TITLE
Suppress warning -Wformat-truncation in ACLK

### DIFF
--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -488,7 +488,8 @@ void aclk_query_threads_start(struct aclk_query_threads *query_threads)
     for (int i = 0; i < query_threads->count; i++) {
         query_threads->thread_list[i].idx = i; //thread needs to know its index for statistics
 
-        snprintf(thread_name, TASK_LEN_MAX, "%s_%d", ACLK_THREAD_NAME, i);
+        if(unlikely(snprintf(thread_name, TASK_LEN_MAX, "%s_%d", ACLK_THREAD_NAME, i) < 0))
+            error("snprintf encoding error");
         netdata_thread_create(
             &query_threads->thread_list[i].thread, thread_name, NETDATA_THREAD_OPTION_JOINABLE, aclk_query_main_thread,
             &query_threads->thread_list[i]);

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -167,7 +167,8 @@ static void aclk_stats_query_threads(uint32_t *queries_per_thread)
             "netdata", "stats", 200007, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
         for (int i = 0; i < query_thread_count; i++) {
-            snprintf(dim_name, MAX_DIM_NAME, "Query %d", i);
+            if (snprintf(dim_name, MAX_DIM_NAME, "Query %d", i) < 0)
+                error("snprintf encoding error");
             aclk_qt_data[i].dim = rrddim_add(st, dim_name, NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
         }
     } else


### PR DESCRIPTION
##### Summary
We truncate there on purpose (`thread_set_name_np` would do that later anyway). This is just to remove the following warning _(we don't really care about the retval)_:
```
  CC       aclk/aclk_query.o
aclk/aclk_query.c: In function ‘aclk_query_threads_start’:
aclk/aclk_query.c:491:49: warning: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 5 [-Wformat-truncation=]
  491 |         snprintf(thread_name, TASK_LEN_MAX, "%s_%d", ACLK_THREAD_NAME, i);
      |                                                 ^~
aclk/aclk_query.c:491:45: note: directive argument in the range [0, 2147483647]
  491 |         snprintf(thread_name, TASK_LEN_MAX, "%s_%d", ACLK_THREAD_NAME, i);
```

when flags `-Og -ggdb -pg -DACLK_SSL_ALLOW_SELF_SIGNED -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_VERIFY_LOCKS=1'` are used.

##### Component Name
ACLK

##### Test Plan
Compile with CFLAGS mentioned.

##### Additional Information
