### PR TITLE
health/megacli: change all instances of alarm to template

### DIFF
--- a/health/health.d/megacli.conf
+++ b/health/health.d/megacli.conf
@@ -1,4 +1,4 @@
-   alarm: adapter_state
+template: adapter_state
       on: megacli.adapter_degraded
    units: is degraded
   lookup: sum -10s
@@ -27,7 +27,7 @@ template: bbu_cycle_count
     info: BBU cycle count
       to: sysadmin
 
-   alarm: pd_media_errors
+template: pd_media_errors
       on: megacli.pd_media_error
    units: media errors
   lookup: sum -10s
@@ -37,7 +37,7 @@ template: bbu_cycle_count
     info: physical drive media errors
       to: sysadmin
 
-   alarm: pd_predictive_failures
+template: pd_predictive_failures
       on: megacli.pd_predictive_failure
    units: predictive failures
   lookup: sum -10s


### PR DESCRIPTION
Degraded RAID array was not triggering an alarm in megacli.conf
Amended all instances of alarm to template as per https://github.com/netdata/netdata/issues/9551
This has started triggering alarms as expected.

Fixes: #9551