### PR TITLE
doc: netdata user is also a default

### DIFF
--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -331,7 +331,7 @@ This module will produce following charts (if data is available):
 2.  **Commands** in commands/s
 
     -   select
-    -   updater
+    -   update
     -   other
 
 ## Configuration

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -331,7 +331,7 @@ This module will produce following charts (if data is available):
 2.  **Commands** in commands/s
 
     -   select
-    -   update
+    -   updater
     -   other
 
 ## Configuration
@@ -385,7 +385,7 @@ remote:
 ```
 
 If no configuration is given, the module will attempt to connect to MySQL server via a unix socket at
-`/var/run/mysqld/mysqld.sock` without password and with username `root`.
+`/var/run/mysqld/mysqld.sock` without password and with username `root` or `netdata` (you granted permissions for `netdata` user in the Requirements section of this document).
 
 `userstats` graph works only if you enable the plugin in MariaDB server and set proper MySQL privileges (SUPER or
 PROCESS). For more details, please check the [MariaDB User Statistics


### PR DESCRIPTION
Both `root` and `netdata` users will try to connect using the socket connection and only `root` user was specified in the doc.
Just added `netdata` and some quick comment

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Enhance MySQL plugin documentation
##### Component Name
Mysql
##### Test Plan
just some documentation
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
I added that by default, both users `root` / `netdata` will try to connect using the socket connection by default.