### PR TITLE
Implemented multihost database

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -379,10 +379,6 @@ PARSER_RC pluginsd_dimension(char **words, void *user, PLUGINSD_ACTION  *plugins
         debug(D_PLUGINSD, "Ignoring dimension belonging to missing or ignored host.");
         return PARSER_RC_OK;
     }
-    if (unlikely(!st)) {
-        debug(D_PLUGINSD, "Ignoring dimension belonging to missing or ignored chart.");
-        return PARSER_RC_OK;
-    }
 
     if (unlikely(!id)) {
         error(

--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -274,6 +274,10 @@ PARSER_RC pluginsd_end(char **words, void *user, PLUGINSD_ACTION  *plugins_actio
 PARSER_RC pluginsd_chart(char **words, void *user, PLUGINSD_ACTION  *plugins_action)
 {
     RRDHOST *host = ((PARSER_USER_OBJECT *) user)->host;
+    if (unlikely(!host)) {
+        debug(D_PLUGINSD, "Ignoring chart belonging to missing or ignored host.");
+        return PARSER_RC_OK;
+    }
 
     char *type = words[1];
     char *name = words[2];
@@ -371,6 +375,14 @@ PARSER_RC pluginsd_dimension(char **words, void *user, PLUGINSD_ACTION  *plugins
 
     RRDSET *st = ((PARSER_USER_OBJECT *) user)->st;
     RRDHOST *host = ((PARSER_USER_OBJECT *) user)->host;
+    if (unlikely(!host)) {
+        debug(D_PLUGINSD, "Ignoring dimension belonging to missing or ignored host.");
+        return PARSER_RC_OK;
+    }
+    if (unlikely(!st)) {
+        debug(D_PLUGINSD, "Ignoring dimension belonging to missing or ignored chart.");
+        return PARSER_RC_OK;
+    }
 
     if (unlikely(!id)) {
         error(

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1437,7 +1437,8 @@ int main(int argc, char **argv) {
     // Load host labels
     reload_host_labels();
 #ifdef ENABLE_DBENGINE
-    metalog_commit_update_host(localhost);
+    if (localhost->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+        metalog_commit_update_host(localhost);
 #endif
 
     // ------------------------------------------------------------------------

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -41,9 +41,12 @@ void netdata_cleanup_and_exit(int ret) {
 
         // free the database
         info("EXIT: freeing database memory...");
-        rrdhost_free_all();
 #ifdef ENABLE_DBENGINE
         rrdeng_prepare_exit(&multidb_ctx);
+#endif
+        rrdhost_free_all();
+#ifdef ENABLE_DBENGINE
+        rrdeng_exit(&multidb_ctx);
 #endif
     }
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -43,7 +43,7 @@ void netdata_cleanup_and_exit(int ret) {
         info("EXIT: freeing database memory...");
         rrdhost_free_all();
 #ifdef ENABLE_DBENGINE
-        rrdeng_prepare_exit(multidb_ctx);
+        rrdeng_prepare_exit(&multidb_ctx);
 #endif
     }
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -42,6 +42,9 @@ void netdata_cleanup_and_exit(int ret) {
         // free the database
         info("EXIT: freeing database memory...");
         rrdhost_free_all();
+#ifdef ENABLE_DBENGINE
+        rrdeng_prepare_exit(multidb_ctx);
+#endif
     }
 
     // unlink the pid

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -558,7 +558,7 @@ static void get_netdata_configured_variables() {
         default_rrdeng_disk_quota_mb = RRDENG_MIN_DISK_SPACE_MB;
     }
 
-    default_multidb_disk_quota_mb = (int) config_get_number(CONFIG_SECTION_GLOBAL, "multidb disk space", compute_multidb_diskspace());
+    default_multidb_disk_quota_mb = (int) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine multihost disk space", compute_multidb_diskspace());
     if(default_multidb_disk_quota_mb < RRDENG_MIN_DISK_SPACE_MB) {
         error("Invalid multidb disk space %d given. Defaulting to %d.", default_multidb_disk_quota_mb, RRDENG_MIN_DISK_SPACE_MB);
         default_multidb_disk_quota_mb = RRDENG_MIN_DISK_SPACE_MB;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -560,8 +560,8 @@ static void get_netdata_configured_variables() {
 
     default_multidb_disk_quota_mb = (int) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine multihost disk space", compute_multidb_diskspace());
     if(default_multidb_disk_quota_mb < RRDENG_MIN_DISK_SPACE_MB) {
-        error("Invalid multidb disk space %d given. Defaulting to %d.", default_multidb_disk_quota_mb, RRDENG_MIN_DISK_SPACE_MB);
-        default_multidb_disk_quota_mb = RRDENG_MIN_DISK_SPACE_MB;
+        error("Invalid multidb disk space %d given. Defaulting to %d.", default_multidb_disk_quota_mb, default_rrdeng_disk_quota_mb);
+        default_multidb_disk_quota_mb = default_rrdeng_disk_quota_mb;
     }
 
 #endif

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -131,7 +131,7 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
             break;
         case GUID_TYPE_HOST:
             //TODO: will be enabled when multidb is activated
-            //RRDHOST *host = metalog_get_host_from_uuid(ctx, uuid);
+            host = metalog_get_host_from_uuid(ctx, uuid);
             if (ctx->current_compaction_id > host->compaction_id) {
                 host->compaction_id = ctx->current_compaction_id;
                 buffer = metalog_update_host_buffer(host);

--- a/database/engine/metadata_log/compaction.c
+++ b/database/engine/metadata_log/compaction.c
@@ -82,7 +82,7 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
     RRDSET *st;
     RRDDIM *rd;
     BUFFER *buffer;
-    RRDHOST *host = ctx->rrdeng_ctx->host;
+    RRDHOST *host = NULL;
 
     ret = find_object_by_guid(uuid, NULL, 0);
     switch (ret) {
@@ -130,8 +130,9 @@ static void compact_record_by_uuid(struct metalog_instance *ctx, uuid_t *uuid)
             }
             break;
         case GUID_TYPE_HOST:
-            //TODO: will be enabled when multidb is activated
             host = metalog_get_host_from_uuid(ctx, uuid);
+            if (unlikely(!host))
+                break;
             if (ctx->current_compaction_id > host->compaction_id) {
                 host->compaction_id = ctx->current_compaction_id;
                 buffer = metalog_update_host_buffer(host);

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -330,6 +330,7 @@ int create_metadata_logfile(struct metadata_logfile *metalogfile)
     if (unlikely(ret)) {
         fatal("posix_memalign:%s", strerror(ret));
     }
+    memset(superblock, 0, sizeof(*superblock));
     (void) strncpy(superblock->magic_number, RRDENG_METALOG_MAGIC, RRDENG_MAGIC_SZ);
     superblock->version = RRDENG_METALOG_VER;
 

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -665,7 +665,7 @@ static int scan_metalog_files(struct metalog_instance *ctx)
 
     PARSER_USER_OBJECT metalog_parser_object;
     metalog_parser_object.enabled = cd.enabled;
-    metalog_parser_object.host = NULL;
+    metalog_parser_object.host = ctx->rrdeng_ctx->host;
     metalog_parser_object.cd = &cd;
     metalog_parser_object.trust_durations = 0;
     metalog_parser_object.private = &metalog_parser_state;

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -665,7 +665,7 @@ static int scan_metalog_files(struct metalog_instance *ctx)
 
     PARSER_USER_OBJECT metalog_parser_object;
     metalog_parser_object.enabled = cd.enabled;
-    metalog_parser_object.host = ctx->rrdeng_ctx->host;
+    metalog_parser_object.host = NULL;
     metalog_parser_object.cd = &cd;
     metalog_parser_object.trust_durations = 0;
     metalog_parser_object.private = &metalog_parser_state;

--- a/database/engine/metadata_log/metadatalog.c
+++ b/database/engine/metadata_log/metadatalog.c
@@ -157,9 +157,9 @@ void metalog_test_quota(struct metalog_worker_config *wc)
     metalogfile = ctx->metadata_logfiles.last;
     only_one_metalogfile = (metalogfile == ctx->metadata_logfiles.first) ? 1 : 0;
     debug(D_METADATALOG, "records=%lu objects=%lu", (long unsigned)ctx->records_nr,
-          (long unsigned)ctx->rrdeng_ctx->host->objects_nr);
+           (long unsigned)ctx->objects_nr);
     if (unlikely(!only_one_metalogfile &&
-                 ctx->records_nr > (ctx->rrdeng_ctx->host->objects_nr * (uint64_t)MAX_DUPLICATION_PERCENTAGE) / 100) &&
+                 ctx->records_nr > (ctx->objects_nr * (uint64_t)MAX_DUPLICATION_PERCENTAGE) / 100) &&
                 NO_QUIESCE == ctx->quiesce) {
         metalog_do_compaction(wc);
     }

--- a/database/engine/metadata_log/metadatalog.h
+++ b/database/engine/metadata_log/metadatalog.h
@@ -113,7 +113,7 @@ struct metalog_instance {
     unsigned long disk_space;
     unsigned long records_nr;
     unsigned long objects_nr; /* total objects (hosts, charts, dimensions) monitored in this context */
-    uint8_t initialized;      /* set to 1 to mark contyet initialized */
+    uint8_t initialized; /* set to 1 to mark context initialized */
     unsigned last_fileno; /* newest index of metadata log file */
 
     uint8_t quiesce; /*

--- a/database/engine/metadata_log/metadatalog.h
+++ b/database/engine/metadata_log/metadatalog.h
@@ -112,6 +112,8 @@ struct metalog_instance {
     uint32_t current_compaction_id; /* Every compaction run increments this by 1 */
     unsigned long disk_space;
     unsigned long records_nr;
+    unsigned long objects_nr; /* total objects monitored in this context */
+    uint8_t initialized;      /* set to 1 to mark contyet initialized */
     unsigned last_fileno; /* newest index of metadata log file */
 
     uint8_t quiesce; /*

--- a/database/engine/metadata_log/metadatalog.h
+++ b/database/engine/metadata_log/metadatalog.h
@@ -112,7 +112,7 @@ struct metalog_instance {
     uint32_t current_compaction_id; /* Every compaction run increments this by 1 */
     unsigned long disk_space;
     unsigned long records_nr;
-    unsigned long objects_nr; /* total objects monitored in this context */
+    unsigned long objects_nr; /* total objects (hosts, charts, dimensions) monitored in this context */
     uint8_t initialized;      /* set to 1 to mark contyet initialized */
     unsigned last_fileno; /* newest index of metadata log file */
 

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -81,9 +81,9 @@ void metalog_commit_update_host(RRDHOST *host)
 
     /* Metadata are only available with dbengine */
     ctx = get_metalog_ctx(host);
-    if (!ctx) /* metadata log has not been initialized yet */
+    if (!ctx)
         return;
-    if (ctx && !ctx->initialized)
+    if (!ctx->initialized) /* metadata log has not been initialized yet */
         return;
 
     buffer = metalog_update_host_buffer(host);
@@ -180,9 +180,9 @@ void metalog_commit_update_chart(RRDSET *st)
         return;
 
     ctx = get_metalog_ctx(st->rrdhost);
-    if (!ctx) /* metadata log has not been initialized yet */
+    if (!ctx)
         return;
-    if (ctx && !ctx->initialized)
+    if (!ctx->initialized) /* metadata log has not been initialized yet */
         return;
 
     buffer = metalog_update_chart_buffer(st, 0);
@@ -201,9 +201,9 @@ void metalog_commit_delete_chart(RRDSET *st)
         return;
 
     ctx = get_metalog_ctx(st->rrdhost);
-    if (!ctx) /* metadata log has not been initialized yet */
+    if (!ctx)
         return;
-    if (ctx && !ctx->initialized)
+    if (!ctx->initialized) /* metadata log has not been initialized yet */
         return;
     buffer = buffer_create(64); /* This will be freed after it has been committed to the metadata log buffer */
 
@@ -253,9 +253,9 @@ void metalog_commit_update_dimension(RRDDIM *rd)
         return;
 
     ctx = get_metalog_ctx(st->rrdhost);
-    if (!ctx) /* metadata log has not been initialized yet */
+    if (!ctx)
         return;
-    if (ctx && !ctx->initialized)
+    if (!ctx->initialized) /* metadata log has not been initialized yet */
         return;
 
     buffer = metalog_update_dimension_buffer(rd);
@@ -275,9 +275,9 @@ void metalog_commit_delete_dimension(RRDDIM *rd)
         return;
 
     ctx = get_metalog_ctx(st->rrdhost);
-    if (!ctx) /* metadata log has not been initialized yet */
+    if (!ctx)
         return;
-    if (ctx && !ctx->initialized)
+    if (!ctx->initialized) /* metadata log has not been initialized yet */
         return;
     buffer = buffer_create(64); /* This will be freed after it has been committed to the metadata log buffer */
 
@@ -459,7 +459,6 @@ int metalog_init(struct rrdengine_instance *rrdeng_parent_ctx)
     if (ctx->worker_config.error) {
         goto error_after_rrdeng_worker;
     }
-    //rrdeng_parent_ctx->metalog_ctx = ctx; /* notify dbengine that the metadata log has finished initializing */
     ctx->initialized = 1; /* notify dbengine that the metadata log has finished initializing */
     return 0;
 

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -392,7 +392,7 @@ void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metr
     uint8_t empty_chart;
 
     rd = metalog_get_dimension_from_uuid(ctx, metric_uuid);
-    if (!rd) { /* in the case of legacy UUID convert to multihost and try again */
+    if (!rd) { /* in 8the case of legacy UUID convert to multihost and try again */
         // TODO: Check what to do since we have no host
         uuid_t multihost_uuid;
 
@@ -405,6 +405,10 @@ void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metr
     }
     st = rd->rrdset;
     host = st->rrdhost;
+
+    /* In case there are active metrics in a different database engine do not delete the dimension object */
+    if (unlikely(host->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE))
+        return;
 
     /* Since the metric has no writer it will not be commited to the metadata log by rrddim_free_custom().
      * It must be commited explicitly before calling rrddim_free_custom(). */

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -8,12 +8,6 @@ static inline struct metalog_instance *get_metalog_ctx(RRDHOST *host)
     if (host->rrdeng_ctx)
         return host->rrdeng_ctx->metalog_ctx;
 
-    if (host != localhost && localhost->rrdeng_ctx) /*TODO: remove me */
-        return localhost->rrdeng_ctx->metalog_ctx;
-
-    if (multidb_ctx)
-        return multidb_ctx->metalog_ctx;
-
     return NULL;
 }
 

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -300,8 +300,9 @@ RRDSET *metalog_get_chart_from_uuid(struct metalog_instance *ctx, uuid_t *chart_
     if (unlikely(GUID_TYPE_CHART != ret))
         return NULL;
 
-    machine_guid = (uuid_t *)chart_object;
-    RRDHOST *host = ctx->rrdeng_ctx->host;
+    machine_guid = (uuid_t  *)chart_object;
+    //RRDHOST *host = ctx->rrdeng_ctx->host;
+    RRDHOST *host = metalog_get_host_from_uuid(ctx, machine_guid);
     if (unlikely(uuid_compare(host->host_uuid, *machine_guid))) {
         error("Metadata host machine GUID does not match the one assosiated with the chart");
         return NULL;
@@ -331,8 +332,9 @@ RRDDIM *metalog_get_dimension_from_uuid(struct metalog_instance *ctx, uuid_t *me
         return NULL;
 
     machine_guid = (uuid_t *)dim_object;
-    uuid_unparse_lower(*machine_guid, uuid_str);
-    RRDHOST *host = rrdhost_find_by_guid(uuid_str, 0);
+    //uuid_unparse_lower(*machine_guid, uuid_str);
+    //RRDHOST *host = rrdhost_find_by_guid(uuid_str, 0);
+    RRDHOST *host = metalog_get_host_from_uuid(ctx, machine_guid);
     if (unlikely(uuid_compare(host->host_uuid, *machine_guid))) {
         error("Metadata host machine GUID does not match the one assosiated with the dimension");
         return NULL;

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -323,7 +323,6 @@ RRDDIM *metalog_get_dimension_from_uuid(struct metalog_instance *ctx, uuid_t *me
     UNUSED(ctx);
 
     GUID_TYPE ret;
-    char uuid_str[37];
     char dim_object[49], chart_object[33], id_str[PLUGINSD_LINE_MAX], chart_fullid[RRD_ID_LENGTH_MAX + 1];
     uuid_t *machine_guid, *chart_guid, *chart_char_guid, *dim_char_guid;
 

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -8,7 +8,7 @@ static inline struct metalog_instance *get_metalog_ctx(RRDHOST *host)
     if (host->rrdeng_ctx)
         return host->rrdeng_ctx->metalog_ctx;
 
-    if (host != localhost && localhost->rrdeng_ctx)
+    if (host != localhost && localhost->rrdeng_ctx) /*TODO: remove me */
         return localhost->rrdeng_ctx->metalog_ctx;
 
     if (multidb_ctx)
@@ -400,9 +400,10 @@ void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metr
     rd = metalog_get_dimension_from_uuid(ctx, metric_uuid);
     if (!rd) { /* in the case of legacy UUID convert to multihost and try again */
         // TODO: Check what to do since we have no host
-        // uuid_t multihost_uuid;
-        //rrdeng_convert_legacy_uuid_to_multihost(ctx->rrdeng_ctx->host->machine_guid, metric_uuid, &multihost_uuid);
-        //rd = metalog_get_dimension_from_uuid(ctx, &multihost_uuid);
+        uuid_t multihost_uuid;
+
+        rrdeng_convert_legacy_uuid_to_multihost(ctx->rrdeng_ctx->machine_guid, metric_uuid, &multihost_uuid);
+        rd = metalog_get_dimension_from_uuid(ctx, &multihost_uuid);
     }
     if(!rd) {
         info("Rotated unknown archived metric.");
@@ -440,7 +441,7 @@ int metalog_init(struct rrdengine_instance *rrdeng_parent_ctx)
 
     ctx = callocz(1, sizeof(*ctx));
     ctx->records_nr = 0;
-    ctx->objects_nr = 1;
+    ctx->objects_nr = 0;
     ctx->current_compaction_id = 0;
     ctx->quiesce = NO_QUIESCE;
     ctx->initialized = 0;

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -332,8 +332,7 @@ RRDDIM *metalog_get_dimension_from_uuid(struct metalog_instance *ctx, uuid_t *me
         return NULL;
 
     machine_guid = (uuid_t *)dim_object;
-    //uuid_unparse_lower(*machine_guid, uuid_str);
-    //RRDHOST *host = rrdhost_find_by_guid(uuid_str, 0);
+
     RRDHOST *host = metalog_get_host_from_uuid(ctx, machine_guid);
     if (unlikely(uuid_compare(host->host_uuid, *machine_guid))) {
         error("Metadata host machine GUID does not match the one assosiated with the dimension");

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -399,9 +399,8 @@ void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metr
 
     rd = metalog_get_dimension_from_uuid(ctx, metric_uuid);
     if (!rd) { /* in the case of legacy UUID convert to multihost and try again */
-        uuid_t multihost_uuid;
-
         // TODO: Check what to do since we have no host
+        // uuid_t multihost_uuid;
         //rrdeng_convert_legacy_uuid_to_multihost(ctx->rrdeng_ctx->host->machine_guid, metric_uuid, &multihost_uuid);
         //rd = metalog_get_dimension_from_uuid(ctx, &multihost_uuid);
     }

--- a/database/engine/metadata_log/metadatalogapi.h
+++ b/database/engine/metadata_log/metadatalogapi.h
@@ -13,6 +13,7 @@ extern void metalog_commit_delete_chart(RRDSET *st);
 extern BUFFER *metalog_update_dimension_buffer(RRDDIM *rd);
 extern void metalog_commit_update_dimension(RRDDIM *rd);
 extern void metalog_commit_delete_dimension(RRDDIM *rd);
+extern void metalog_upd_objcount(RRDHOST *host, int count);
 
 extern RRDSET *metalog_get_chart_from_uuid(struct metalog_instance *ctx, uuid_t *chart_uuid);
 extern RRDDIM *metalog_get_dimension_from_uuid(struct metalog_instance *ctx, uuid_t *metric_uuid);

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -266,18 +266,14 @@ PARSER_RC metalog_pluginsd_tombstone_action(void *user, uuid_t *uuid)
             fatal_assert(0);
             break;
         case GUID_TYPE_CHART:
-            host = metalog_get_host_from_uuid(NULL, uuid);
-            if (host) {
-                st = metalog_get_chart_from_uuid(ctx, uuid);
-                if (st) {
-                    rrdhost_wrlock(host);
-                    rrdset_free(st);
-                    rrdhost_unlock(host);
-                } else {
-                    debug(D_METADATALOG, "Ignoring nonexistent chart metadata record.");
-                }
+            st = metalog_get_chart_from_uuid(ctx, uuid);
+            if (st) {
+                host = st->rrdhost;
+                rrdhost_wrlock(host);
+                rrdset_free(st);
+                rrdhost_unlock(host);
             } else {
-                debug(D_METADATALOG, "Ignoring nonexistent host metadata record.");
+                debug(D_METADATALOG, "Ignoring nonexistent chart metadata record.");
             }
             break;
         case GUID_TYPE_DIMENSION:

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -20,6 +20,9 @@ PARSER_RC metalog_pluginsd_host_action(
 
     struct metalog_pluginsd_state *state = ((PARSER_USER_OBJECT *)user)->private;
 
+//    if (is_legacy_child(machine_guid))
+//        return PARSER_RC_OK;
+
     RRDHOST *host = rrdhost_find_by_guid(machine_guid, 0);
     if (host)
         goto write_replay;
@@ -34,7 +37,7 @@ PARSER_RC metalog_pluginsd_host_action(
     }
 
     // Ignore HOST command for now
-    // TODO: Remove when the next task is completed ie. accept new children in the lcoalhost / multidb
+    // TODO: Remove when the next task is completed ie. accept new children in the localhost / multidb
     //return PARSER_RC_OK;
 
     // Fetch configuration options from streaming config
@@ -244,6 +247,8 @@ PARSER_RC metalog_pluginsd_context_action(void *user, uuid_t *uuid)
         case GUID_TYPE_HOST:
             /* Ignore for now */
             error_with_guid(uuid, "Found HOST but ignoring in CONTEXT ACTION");
+            ((PARSER_USER_OBJECT *)user)->host = metalog_get_host_from_uuid(NULL, (uuid_t *) &object);
+            info("Host detected = %s", ((PARSER_USER_OBJECT *)user)->host->hostname);
             break;
         case GUID_TYPE_NOSPACE:
             error_with_guid(uuid, "Not enough space for object retrieval");

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -39,8 +39,8 @@ PARSER_RC metalog_pluginsd_host_action(
         , update_every
         , 3600
         , RRD_MEMORY_MODE_DBENGINE
-        , 1   // health enabled
-        , 0   // Push enabled
+        , default_health_enabled    // health enabled
+        , default_rrdpush_enabled   // Push enabled
         , NULL
         , NULL
         , NULL

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -20,9 +20,6 @@ PARSER_RC metalog_pluginsd_host_action(
 
     struct metalog_pluginsd_state *state = ((PARSER_USER_OBJECT *)user)->private;
 
-//    if (is_legacy_child(machine_guid))
-//        return PARSER_RC_OK;
-
     RRDHOST *host = rrdhost_find_by_guid(machine_guid, 0);
     if (host)
         goto write_replay;
@@ -35,10 +32,6 @@ PARSER_RC metalog_pluginsd_host_action(
         mlf_record_insert(metalogfile, &record);
         return PARSER_RC_OK;
     }
-
-    // Ignore HOST command for now
-    // TODO: Remove when the next task is completed ie. accept new children in the localhost / multidb
-    //return PARSER_RC_OK;
 
     // Fetch configuration options from streaming config
     update_every = (int)appconfig_get_number(&stream_config, machine_guid, "update every", update_every);

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -25,7 +25,7 @@ PARSER_RC metalog_pluginsd_host_action(
 
     // Ignore HOST command for now
     // TODO: Remove when the next task is completed ie. accept new children in the lcoalhost / multidb
-    return PARSER_RC_OK;
+    //return PARSER_RC_OK;
 
     host = rrdhost_create(
         hostname
@@ -39,7 +39,7 @@ PARSER_RC metalog_pluginsd_host_action(
         , update_every
         , 3600
         , RRD_MEMORY_MODE_DBENGINE
-        , 0   // health enabled
+        , 1   // health enabled
         , 0   // Push enabled
         , NULL
         , NULL
@@ -57,7 +57,7 @@ write_replay:
         uuid_copy(record.uuid, host->host_uuid);
         mlf_record_insert(metalogfile, &record);
     }
-
+    ((PARSER_USER_OBJECT *) user)->host = host;
     return PARSER_RC_OK;
 }
 
@@ -172,7 +172,8 @@ PARSER_RC metalog_pluginsd_context_action(void *user, uuid_t *uuid)
             break;
         case GUID_TYPE_CHART:
         case GUID_TYPE_DIMENSION:
-            host = ctx->rrdeng_ctx->host;
+            //host = ctx->rrdeng_ctx->host;
+            host = metalog_get_host_from_uuid(NULL, (uuid_t *) &object);
             switch (ret) {
                 case GUID_TYPE_CHART:
                     chart_char_guid = (uuid_t *)(object + 16);
@@ -205,6 +206,7 @@ PARSER_RC metalog_pluginsd_context_action(void *user, uuid_t *uuid)
             break;
         case GUID_TYPE_HOST:
             /* Ignore for now */
+            error_with_guid(uuid, "Found HOST but ignoring in CONTEXT ACTION");
             break;
         case GUID_TYPE_NOSPACE:
             error_with_guid(uuid, "Not enough space for object retrieval");

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -644,7 +644,7 @@ static void delete_old_data(void *arg)
         for (i = 0 ; i < count ; ++i) {
             descr = extent->pages[i];
             can_delete_metric = pg_cache_punch_hole(ctx, descr, 0, 0, &metric_id);
-            if (unlikely(can_delete_metric && ctx->metalog_ctx)) {
+            if (unlikely(can_delete_metric && ctx->metalog_ctx->initialized)) {
                 /*
                  * If the metric is empty, has no active writers and if the metadata log has been initialized then
                  * attempt to delete the corresponding netdata dimension.
@@ -821,7 +821,7 @@ void timer_cb(uv_timer_t* handle)
 
     uv_stop(handle->loop);
     uv_update_time(handle->loop);
-    if (unlikely(!ctx->metalog_ctx))
+    if (unlikely(!ctx->metalog_ctx->initialized))
         return; /* Wait for the metadata log to initialize */
     rrdeng_test_quota(wc);
     debug(D_RRDENGINE, "%s: timeout reached.", __func__);

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -184,8 +184,9 @@ struct rrdengine_instance {
     uint8_t global_compress_alg;
     struct transaction_commit_log commit_log;
     struct rrdengine_datafile_list datafiles;
+    RRDHOST *host; /* the legacy host, or NULL for multi-host DB */
     char dbfiles_path[FILENAME_MAX + 1];
-    char machine_guid[GUID_LEN + 1]; // the unique ID of the corresponding host, or localhost for multihost DB
+    char machine_guid[GUID_LEN + 1]; /* the unique ID of the corresponding host, or localhost for multihost DB */
     uint64_t disk_space;
     uint64_t max_disk_space;
     unsigned last_fileno; /* newest index of datafile and journalfile */

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -184,7 +184,8 @@ struct rrdengine_instance {
     uint8_t global_compress_alg;
     struct transaction_commit_log commit_log;
     struct rrdengine_datafile_list datafiles;
-    char dbfiles_path[FILENAME_MAX+1];
+    char dbfiles_path[FILENAME_MAX + 1];
+    char machine_guid[GUID_LEN + 1]; // the unique ID of the corresponding host, or localhost for multihost DB
     uint64_t disk_space;
     uint64_t max_disk_space;
     unsigned last_fileno; /* newest index of datafile and journalfile */

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -176,7 +176,6 @@ extern rrdeng_stats_t global_flushing_pressure_page_deletions; /* number of dele
 #define QUIESCED    (2) /* is set after all threads have finished running */
 
 struct rrdengine_instance {
-    RRDHOST *host;
     struct metalog_instance *metalog_ctx;
     struct rrdengine_worker_config worker_config;
     struct completion rrdengine_completion;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -938,16 +938,12 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
     if (ctx->worker_config.error) {
         goto error_after_rrdeng_worker;
     }
-    //if ((strcmp(host->machine_guid, registry_get_this_machine_guid()) == 0) || (!rrdhost_flag_check(host, RRDHOST_FLAG_MULTIHOST))) {
-        //info("Metadatalog init for host %s starting...", host->hostname);
-        error = metalog_init(ctx);
-        if (error) {
-            error("Failed to initialize metadata log file event loop.");
-            goto error_after_rrdeng_worker;
-        }
-    //}
-    //else
-    //    info("No metadatalog init for host %s", host->hostname);
+    error = metalog_init(ctx);
+    if (error) {
+        error("Failed to initialize metadata log file event loop.");
+        goto error_after_rrdeng_worker;
+    }
+
     return 0;
 
 error_after_rrdeng_worker:

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -232,8 +232,6 @@ void rrdeng_store_metric_next(RRDDIM *rd, usec_t point_in_time, storage_number n
 
     handle = &rd->state->handle.rrdeng;
     ctx = handle->ctx;
-//    if (ctx == NULL && rd->rrdset->rrdhost != localhost)
-//        ctx = localhost->rrdeng_ctx;
     pg_cache = &ctx->pg_cache;
     descr = handle->descr;
 
@@ -317,8 +315,6 @@ int rrdeng_store_metric_finalize(RRDDIM *rd)
 
     handle = &rd->state->handle.rrdeng;
     ctx = handle->ctx;
-//    if (ctx == NULL && rd->rrdset->rrdhost != localhost)
-//        ctx = rd->rrdset->rrdhost->rrdeng_ctx;
     page_index = rd->state->page_index;
     rrdeng_store_metric_flush_current_page(rd);
     if (handle->prev_descr) {

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -918,6 +918,7 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
     ctx->metric_API_max_producers = 0;
     ctx->quiesce = NO_QUIESCE;
     ctx->metalog_ctx = NULL; /* only set this after the metadata log has finished initializing */
+    ctx->host = host;
 
     memset(&ctx->worker_config, 0, sizeof(ctx->worker_config));
     ctx->worker_config.ctx = ctx;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -54,6 +54,9 @@ void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid)
     int replace_instead_of_generate = 0;
 
     ctx = rd->rrdset->rrdhost->rrdeng_ctx;
+    if (ctx == NULL && rd->rrdset->rrdhost != localhost)
+        ctx = localhost->rrdeng_ctx;
+
     pg_cache = &ctx->pg_cache;
 
     rrdeng_generate_legacy_uuid(rd->id, rd->rrdset->id, &legacy_uuid);
@@ -171,6 +174,10 @@ void rrdeng_store_metric_flush_current_page(RRDDIM *rd)
 
     handle = &rd->state->handle.rrdeng;
     ctx = handle->ctx;
+    if (ctx == NULL && rd->rrdset->rrdhost != localhost)
+            ctx = localhost->rrdeng_ctx;
+    if (unlikely(!ctx))
+        return;
     descr = handle->descr;
     if (unlikely(NULL == descr)) {
         return;
@@ -221,6 +228,8 @@ void rrdeng_store_metric_next(RRDDIM *rd, usec_t point_in_time, storage_number n
 
     handle = &rd->state->handle.rrdeng;
     ctx = handle->ctx;
+    if (ctx == NULL && rd->rrdset->rrdhost != localhost)
+        ctx = localhost->rrdeng_ctx;
     pg_cache = &ctx->pg_cache;
     descr = handle->descr;
 
@@ -371,6 +380,8 @@ unsigned rrdeng_variable_step_boundaries(RRDSET *st, time_t start_time, time_t e
     uint8_t is_first_region_initialized;
 
     ctx = st->rrdhost->rrdeng_ctx;
+    if (ctx == NULL && st->rrdhost != localhost)
+        ctx = localhost->rrdeng_ctx;
     regions = 1;
     *max_intervalp = max_interval = 0;
     region_info_array = NULL;
@@ -533,6 +544,8 @@ void rrdeng_load_metric_init(RRDDIM *rd, struct rrddim_query_handle *rrdimm_hand
     unsigned pages_nr;
 
     ctx = rd->rrdset->rrdhost->rrdeng_ctx;
+    if (ctx == NULL && rd->rrdset->rrdhost != localhost)
+        ctx = localhost->rrdeng_ctx;
     rrdimm_handle->start_time = start_time;
     rrdimm_handle->end_time = end_time;
     handle = &rrdimm_handle->rrdeng;
@@ -801,6 +814,9 @@ void *rrdeng_get_page(struct rrdengine_instance *ctx, uuid_t *id, usec_t point_i
  */
 void rrdeng_get_37_statistics(struct rrdengine_instance *ctx, unsigned long long *array)
 {
+    if (ctx == NULL)
+        return;
+
     struct page_cache *pg_cache = &ctx->pg_cache;
 
     array[0] = (uint64_t)ctx->stats.metric_API_producers;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -136,6 +136,8 @@ void rrdeng_store_metric_init(RRDDIM *rd)
     struct pg_cache_page_index *page_index;
 
     ctx = rd->rrdset->rrdhost->rrdeng_ctx;
+    if (ctx == NULL && rd->rrdset->rrdhost != localhost)
+        ctx = localhost->rrdeng_ctx;
     handle = &rd->state->handle.rrdeng;
     handle->ctx = ctx;
 
@@ -313,6 +315,8 @@ int rrdeng_store_metric_finalize(RRDDIM *rd)
 
     handle = &rd->state->handle.rrdeng;
     ctx = handle->ctx;
+    if (ctx == NULL && rd->rrdset->rrdhost != localhost)
+        ctx = rd->rrdset->rrdhost->rrdeng_ctx;
     page_index = rd->state->page_index;
     rrdeng_store_metric_flush_current_page(rd);
     if (handle->prev_descr) {

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -16,7 +16,7 @@ extern int default_rrdeng_page_cache_mb;
 extern int default_rrdeng_disk_quota_mb;
 extern int default_multidb_disk_quota_mb;
 extern uint8_t rrdeng_drop_metrics_under_page_cache_pressure;
-extern struct rrdengine_instance *multidb_ctx;
+extern struct rrdengine_instance multidb_ctx;
 
 struct rrdeng_region_info {
     time_t start_time;

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -16,6 +16,7 @@ extern int default_rrdeng_page_cache_mb;
 extern int default_rrdeng_disk_quota_mb;
 extern int default_multidb_disk_quota_mb;
 extern uint8_t rrdeng_drop_metrics_under_page_cache_pressure;
+extern struct rrdengine_instance *multidb_ctx;
 
 struct rrdeng_region_info {
     time_t start_time;

--- a/database/engine/rrdenginelib.c
+++ b/database/engine/rrdenginelib.c
@@ -276,7 +276,7 @@ int compute_multidb_diskspace()
 
             fp = fopen(multidb_disk_space_file, "w");
             if (likely(fp)) {
-                fprintf(fp, "%d", rc * default_rrdeng_disk_quota_mb);
+                fprintf(fp, "%d", computed_multidb_disk_quota_mb);
                 info("Created file '%s' to store the computed value", multidb_disk_space_file);
                 fclose(fp);
             } else

--- a/database/engine/rrdenginelib.c
+++ b/database/engine/rrdenginelib.c
@@ -272,16 +272,15 @@ int compute_multidb_diskspace()
         int rc = count_legacy_children(netdata_configured_cache_dir);
         if (likely(rc >= 0)) {
             computed_multidb_disk_quota_mb = (rc + 1) * default_rrdeng_disk_quota_mb;
-            //info("Found %d legacy dbengines, setting multidb diskspace to %dMB", rc, computed_multidb_disk_quota_mb);
+            info("Found %d legacy dbengines, setting multidb diskspace to %dMB", rc, computed_multidb_disk_quota_mb);
 
-            // TODO: will activate the next block of code when multidb is in place
-//            fp = fopen(multidb_disk_space_file, "w");
-//            if (likely(fp)) {
-//                fprintf(fp, "%d", rc * default_rrdeng_disk_quota_mb);
-//                info("Created file '%s' to store the computed value", multidb_disk_space_file);
-//                fclose(fp);
-//            } else
-//                error("Failed to store the default multidb disk quota size on '%s'", multidb_disk_space_file);
+            fp = fopen(multidb_disk_space_file, "w");
+            if (likely(fp)) {
+                fprintf(fp, "%d", rc * default_rrdeng_disk_quota_mb);
+                info("Created file '%s' to store the computed value", multidb_disk_space_file);
+                fclose(fp);
+            } else
+                error("Failed to store the default multidb disk quota size on '%s'", multidb_disk_space_file);
         }
         else
             computed_multidb_disk_quota_mb = default_rrdeng_disk_quota_mb;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -698,10 +698,6 @@ struct rrdhost {
 
     int rrd_update_every;                           // the update frequency of the host
     long rrd_history_entries;                       // the number of history entries for the host's charts
-#ifdef ENABLE_DBENGINE
-    unsigned page_cache_mb;                         // Database Engine page cache size in MiB
-    unsigned disk_space_mb;                         // Database Engine disk space quota in MiB
-#endif
     RRD_MEMORY_MODE rrd_memory_mode;                // the memory more for the charts of this host
 
     char *cache_dir;                                // the directory to save RRD cache files

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -812,7 +812,6 @@ struct rrdhost {
 #ifdef ENABLE_DBENGINE
     struct rrdengine_instance *rrdeng_ctx;          // DB engine instance for this host
     uuid_t  host_uuid;                              // Global GUID for this host
-    //unsigned long objects_nr;                       // Number of charts and dimensions in this host
     uint32_t compaction_id;                         // The last metadata log compaction procedure that has processed
                                                     // this object.
 #endif

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -812,7 +812,7 @@ struct rrdhost {
 #ifdef ENABLE_DBENGINE
     struct rrdengine_instance *rrdeng_ctx;          // DB engine instance for this host
     uuid_t  host_uuid;                              // Global GUID for this host
-    unsigned long objects_nr;                       // Number of charts and dimensions in this host
+    //unsigned long objects_nr;                       // Number of charts and dimensions in this host
     uint32_t compaction_id;                         // The last metadata log compaction procedure that has processed
                                                     // this object.
 #endif

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -451,7 +451,8 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
         aclk_update_chart(host, st->id, ACLK_CMD_CHART);
 #endif
 #ifdef ENABLE_DBENGINE
-    rrd_atomic_fetch_add(&st->rrdhost->objects_nr, 1);
+//    rrd_atomic_fetch_add(&st->rrdhost->objects_nr, 1);
+    metalog_upd_objcount(st->rrdhost, 1);
     metalog_commit_update_dimension(rd);
 #endif
 
@@ -525,7 +526,8 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
         aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
 #endif
 #ifdef ENABLE_DBENGINE
-    rrd_atomic_fetch_add(&st->rrdhost->objects_nr, -1);
+    //rrd_atomic_fetch_add(&st->rrdhost->objects_nr, -1);
+    metalog_upd_objcount(st->rrdhost, -1);
 #endif
 }
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -451,7 +451,6 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
         aclk_update_chart(host, st->id, ACLK_CMD_CHART);
 #endif
 #ifdef ENABLE_DBENGINE
-//    rrd_atomic_fetch_add(&st->rrdhost->objects_nr, 1);
     metalog_upd_objcount(st->rrdhost, 1);
     metalog_commit_update_dimension(rd);
 #endif
@@ -526,7 +525,6 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
         aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
 #endif
 #ifdef ENABLE_DBENGINE
-    //rrd_atomic_fetch_add(&st->rrdhost->objects_nr, -1);
     metalog_upd_objcount(st->rrdhost, -1);
 #endif
 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -464,6 +464,12 @@ void rrdhost_update(RRDHOST *host
 
     // update host tags
     rrdhost_init_tags(host, tags);
+
+    if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
+        rrdhost_flag_clear(host, RRDHOST_FLAG_ARCHIVED);
+        rrd_hosts_available++;
+        info("Host %s is not in archived mode anymore", host->hostname);
+    }
 #ifdef ENABLE_DBENGINE
     if (likely(host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE))
         metalog_commit_update_host(host);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -521,7 +521,7 @@ RRDHOST *rrdhost_find_or_create(
 
     rrd_wrlock();
     RRDHOST *host = rrdhost_find_by_guid(guid, 0);
-    if (unlikely(RRD_MEMORY_MODE_DBENGINE != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))) {
+    if (unlikely(host && RRD_MEMORY_MODE_DBENGINE != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))) {
         /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
         error("Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
               host->hostname, rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -613,9 +613,10 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
             , 1
             , 0
     );
-    rrd_unlock();
-    if (unlikely(!localhost))
+    if (unlikely(!localhost)) {
+        rrd_unlock();
         return 1;
+    }
 
 #ifdef ENABLE_DBENGINE
     char dbenginepath[FILENAME_MAX + 1];
@@ -632,9 +633,11 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
             localhost->hostname, localhost->machine_guid, localhost->cache_dir);
         rrdhost_free(localhost);
         localhost = NULL;
+        rrd_unlock();
         return 1;
     }
 #endif
+    rrd_unlock();
 
     web_client_api_v1_management_init();
     return localhost==NULL;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -753,7 +753,8 @@ void rrdhost_free(RRDHOST *host) {
     // release its children resources
 
 #ifdef ENABLE_DBENGINE
-    rrdeng_prepare_exit(host->rrdeng_ctx);
+    if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && host->rrdeng_ctx != &multidb_ctx)
+        rrdeng_prepare_exit(host->rrdeng_ctx);
 #endif
     while(host->rrdset_root)
         rrdset_free(host->rrdset_root);
@@ -785,11 +786,10 @@ void rrdhost_free(RRDHOST *host) {
 
     health_alarm_log_free(host);
 
-    if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
+    if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && host->rrdeng_ctx != &multidb_ctx)
         rrdeng_exit(host->rrdeng_ctx);
 #endif
-    }
 
     // ------------------------------------------------------------------------
     // remove it from the indexes

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -494,6 +494,13 @@ RRDHOST *rrdhost_find_or_create(
 
     rrd_wrlock();
     RRDHOST *host = rrdhost_find_by_guid(guid, 0);
+    if (unlikely(RRD_MEMORY_MODE_DBENGINE != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))) {
+        /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
+        error("Arcived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
+              host->hostname, rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
+        rrdhost_free(host);
+        host = NULL;
+    }
     if(!host) {
         host = rrdhost_create(
                 hostname

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -886,6 +886,7 @@ void rrdhost_free(RRDHOST *host) {
 
 void rrdhost_free_all(void) {
     rrd_wrlock();
+    /* Make sure child-hosts are released before the localhost. */
     while(localhost->next) rrdhost_free(localhost->next);
     rrdhost_free(localhost);
     rrd_unlock();

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -665,7 +665,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
     if (ret != 0 && errno != EEXIST)
         error("Host '%s': cannot create directory '%s'", localhost->hostname, dbenginepath);
     else  // Unconditionally create multihost db to support on demand host creation
-        ret = rrdeng_init(localhost, NULL, dbenginepath, default_rrdeng_page_cache_mb, default_multidb_disk_quota_mb);
+        ret = rrdeng_init(NULL, NULL, dbenginepath, default_rrdeng_page_cache_mb, default_multidb_disk_quota_mb);
     if (ret) {
         error(
             "Host '%s' with machine guid '%s' failed to initialize multi-host DB engine instance at '%s'.",

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -621,8 +621,11 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
     char dbenginepath[FILENAME_MAX + 1];
     int ret;
     snprintfz(dbenginepath, FILENAME_MAX, "%s/dbengine", localhost->cache_dir);
-    ret = rrdeng_init( // Unconditionally create multihost db to support on demand host creation
-        localhost, NULL, dbenginepath, default_rrdeng_page_cache_mb, default_multidb_disk_quota_mb);
+    ret = mkdir(dbenginepath, 0775);
+    if (ret != 0 && errno != EEXIST)
+        error("Host '%s': cannot create directory '%s'", localhost->hostname, dbenginepath);
+    else  // Unconditionally create multihost db to support on demand host creation
+        ret = rrdeng_init(localhost, NULL, dbenginepath, default_rrdeng_page_cache_mb, default_multidb_disk_quota_mb);
     if (ret) {
         error(
             "Host '%s' with machine guid '%s' failed to initialize multi-host DB engine instance at '%s'.",

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1433,7 +1433,7 @@ void rrdhost_cleanup_all(void) {
 
     RRDHOST *host;
     rrdhost_foreach_read(host) {
-        if(host != localhost && rrdhost_flag_check(host, RRDHOST_FLAG_DELETE_OBSOLETE_CHARTS) && !host->receiver)
+        if(host != localhost && rrdhost_flag_check(host, RRDHOST_FLAG_DELETE_ORPHAN_HOST) && !host->receiver)
             rrdhost_delete_charts(host);
         else
             rrdhost_cleanup_charts(host);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -523,7 +523,7 @@ RRDHOST *rrdhost_find_or_create(
     RRDHOST *host = rrdhost_find_by_guid(guid, 0);
     if (unlikely(RRD_MEMORY_MODE_DBENGINE != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))) {
         /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
-        error("Arcived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
+        error("Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
               host->hostname, rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
         rrdhost_free(host);
         host = NULL;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -382,7 +382,6 @@ RRDHOST *rrdhost_create(const char *hostname,
          , host->health_default_exec
          , host->health_default_recipient
     );
-    //}
 
     if (!is_archived)
         rrd_hosts_available++;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -382,7 +382,8 @@ RRDHOST *rrdhost_create(const char *hostname,
         );
     }
 
-    rrd_hosts_available++;
+    if (!is_archived)
+        rrd_hosts_available++;
 
 #ifdef ENABLE_DBENGINE
     if (likely(!is_localhost && !is_archived && host && host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE))

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -192,7 +192,7 @@ RRDHOST *rrdhost_create(const char *hostname,
         info("Host %s is created in archived mode", hostname);
     }
     if(config_get_boolean(CONFIG_SECTION_GLOBAL, "delete obsolete charts files", 1))
-        rrdhost_flag_set(host, RRDHOST_FLAG_DELETE_OBSOLETE_CHARTS);
+        rrdhost_flag_set(host, RRDHOST_FLAG_DELETE_OBSOLETE_CHARTS);// TODO: if archived do not set the flag
 
     if(config_get_boolean(CONFIG_SECTION_GLOBAL, "delete orphan hosts files", 1) && !is_localhost)
         rrdhost_flag_set(host, RRDHOST_FLAG_DELETE_ORPHAN_HOST);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -281,6 +281,14 @@ RRDHOST *rrdhost_create(const char *hostname,
         health_alarm_log_open(host);
     }
 
+    RRDHOST *t = rrdhost_index_add(host);
+
+    if(t != host) {
+        error("Host '%s': cannot add host with machine guid '%s' to index. It already exists as host '%s' with machine guid '%s'.", host->hostname, host->machine_guid, t->hostname, t->machine_guid);
+        rrdhost_free(host);
+        return NULL;
+    }
+
     if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
         if (unlikely(-1 == uuid_parse(host->machine_guid, host->host_uuid))) {
@@ -336,53 +344,45 @@ RRDHOST *rrdhost_create(const char *hostname,
         else localhost = host;
     }
 
-    RRDHOST *t = rrdhost_index_add(host);
-
-    if(t != host) {
-        error("Host '%s': cannot add host with machine guid '%s' to index. It already exists as host '%s' with machine guid '%s'.", host->hostname, host->machine_guid, t->hostname, t->machine_guid);
-        rrdhost_free(host);
-        host = NULL;
-    }
-    else {
-        info("Host '%s' (at registry as '%s') with guid '%s' initialized"
-                     ", os '%s'"
-                     ", timezone '%s'"
-                     ", tags '%s'"
-                     ", program_name '%s'"
-                     ", program_version '%s'"
-                     ", update every %d"
-                     ", memory mode %s"
-                     ", history entries %ld"
-                     ", streaming %s"
-                     " (to '%s' with api key '%s')"
-                     ", health %s"
-                     ", cache_dir '%s'"
-                     ", varlib_dir '%s'"
-                     ", health_log '%s'"
-                     ", alarms default handler '%s'"
-                     ", alarms default recipient '%s'"
-             , host->hostname
-             , host->registry_hostname
-             , host->machine_guid
-             , host->os
-             , host->timezone
-             , (host->tags)?host->tags:""
-             , host->program_name
-             , host->program_version
-             , host->rrd_update_every
-             , rrd_memory_mode_name(host->rrd_memory_mode)
-             , host->rrd_history_entries
-             , host->rrdpush_send_enabled?"enabled":"disabled"
-             , host->rrdpush_send_destination?host->rrdpush_send_destination:""
-             , host->rrdpush_send_api_key?host->rrdpush_send_api_key:""
-             , host->health_enabled?"enabled":"disabled"
-             , host->cache_dir
-             , host->varlib_dir
-             , host->health_log_filename
-             , host->health_default_exec
-             , host->health_default_recipient
-        );
-    }
+    info("Host '%s' (at registry as '%s') with guid '%s' initialized"
+                 ", os '%s'"
+                 ", timezone '%s'"
+                 ", tags '%s'"
+                 ", program_name '%s'"
+                 ", program_version '%s'"
+                 ", update every %d"
+                 ", memory mode %s"
+                 ", history entries %ld"
+                 ", streaming %s"
+                 " (to '%s' with api key '%s')"
+                 ", health %s"
+                 ", cache_dir '%s'"
+                 ", varlib_dir '%s'"
+                 ", health_log '%s'"
+                 ", alarms default handler '%s'"
+                 ", alarms default recipient '%s'"
+         , host->hostname
+         , host->registry_hostname
+         , host->machine_guid
+         , host->os
+         , host->timezone
+         , (host->tags)?host->tags:""
+         , host->program_name
+         , host->program_version
+         , host->rrd_update_every
+         , rrd_memory_mode_name(host->rrd_memory_mode)
+         , host->rrd_history_entries
+         , host->rrdpush_send_enabled?"enabled":"disabled"
+         , host->rrdpush_send_destination?host->rrdpush_send_destination:""
+         , host->rrdpush_send_api_key?host->rrdpush_send_api_key:""
+         , host->health_enabled?"enabled":"disabled"
+         , host->cache_dir
+         , host->varlib_dir
+         , host->health_log_filename
+         , host->health_default_exec
+         , host->health_default_recipient
+    );
+    //}
 
     if (!is_archived)
         rrd_hosts_available++;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -129,7 +129,7 @@ RRDHOST *rrdhost_create(const char *hostname,
     debug(D_RRDHOST, "Host '%s': adding with guid '%s'", hostname, guid);
 
     int is_legacy = is_archived ? 0 : is_legacy_child(guid);
-    info("STEL: Creating host %s (GUID = %s) with legacy mode = %d", hostname, guid, is_legacy);
+    info("STEL: Creating host %s (GUID = %s) with legacy mode = %d (mode = %u)", hostname, guid, is_legacy, memory_mode);
 
     rrd_check_wrlock();
 
@@ -234,8 +234,8 @@ RRDHOST *rrdhost_create(const char *hostname,
         snprintfz(filename, FILENAME_MAX, "%s/%s", netdata_configured_cache_dir, host->machine_guid);
         host->cache_dir = strdupz(filename);
 
-        if(host->rrd_memory_mode == RRD_MEMORY_MODE_MAP || host->rrd_memory_mode == RRD_MEMORY_MODE_SAVE ||
-           host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+        if((host->rrd_memory_mode == RRD_MEMORY_MODE_MAP || host->rrd_memory_mode == RRD_MEMORY_MODE_SAVE ||
+           host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) && (is_localhost || is_legacy)) {
             int r = mkdir(host->cache_dir, 0775);
             if(r != 0 && errno != EEXIST)
                 error("Host '%s': cannot create directory '%s'", host->hostname, host->cache_dir);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -144,7 +144,10 @@ RRDHOST *rrdhost_create(const char *hostname,
     host->rrd_memory_mode     = memory_mode;
 #ifdef ENABLE_DBENGINE
     host->page_cache_mb       = default_rrdeng_page_cache_mb;
-    host->disk_space_mb       = default_rrdeng_disk_quota_mb;
+    if (init_multihost)
+        host->disk_space_mb   = default_multidb_disk_quota_mb;
+    else
+        host->disk_space_mb   = default_rrdeng_disk_quota_mb;
 #endif
     host->health_enabled      = (memory_mode == RRD_MEMORY_MODE_NONE)? 0 : health_enabled;
 
@@ -304,7 +307,6 @@ RRDHOST *rrdhost_create(const char *hostname,
             error("Failed to store machine GUID to global map");
         else
             info("Added %s to global map for host %s", host->machine_guid, host->hostname);
-//        host->objects_nr = 1;
         host->compaction_id = 0;
         char dbenginepath[FILENAME_MAX + 1];
         int ret;
@@ -333,6 +335,7 @@ RRDHOST *rrdhost_create(const char *hostname,
                 }
             }
         }
+        metalog_upd_objcount(host, 1);
 #else
         fatal("RRD_MEMORY_MODE_DBENGINE is not supported in this platform.");
 #endif

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -680,11 +680,6 @@ RRDSET *rrdset_create_custom(
             rrdsetcalc_link_matching(st);
             rrdcalctemplate_link_matching(st);
         }
-        if (rrdhost_flag_check(st->rrdhost, RRDHOST_FLAG_ARCHIVED)) {
-            rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
-            rrd_hosts_available++;
-            info("Host %s is not in archived mode anymore", st->rrdhost->hostname);
-        }
         rrdhost_unlock(host);
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -543,11 +543,6 @@ RRDSET *rrdset_create_custom(
         if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
             changed_from_archived_to_active = 1;
-//            if (rrdhost_flag_check(st->rrdhost, RRDHOST_FLAG_ARCHIVED)) {
-//                rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
-//                rrd_hosts_available++;
-//                info("Host %s is not in archived mode anymore", st->rrdhost->hostname);
-//            }
             mark_rebuild |= META_CHART_ACTIVATED;
         }
         char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_family = NULL, *old_context = NULL,
@@ -695,7 +690,6 @@ RRDSET *rrdset_create_custom(
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
         if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
-            //rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
         }
         return st;
     }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -392,7 +392,8 @@ void rrdset_free(RRDSET *st) {
             break;
     }
 #ifdef ENABLE_DBENGINE
-    rrd_atomic_fetch_add(&host->objects_nr, -1);
+    //rrd_atomic_fetch_add(&host->objects_nr, -1);
+    metalog_upd_objcount(host, -1);
 #endif
 
 }
@@ -966,7 +967,8 @@ RRDSET *rrdset_create_custom(
     }
 #endif
 #ifdef ENABLE_DBENGINE
-    rrd_atomic_fetch_add(&st->rrdhost->objects_nr, 1);
+    //rrd_atomic_fetch_add(&st->rrdhost->objects_nr, 1);
+    metalog_upd_objcount(host, 1);
     metalog_commit_update_chart(st);
 #endif
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -543,10 +543,11 @@ RRDSET *rrdset_create_custom(
         if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
             changed_from_archived_to_active = 1;
-            if (rrdhost_flag_check(st->rrdhost, RRDHOST_FLAG_ARCHIVED)) {
-                rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
-                info("Host %s is not in archived mode anymore", st->rrdhost->hostname);
-            }
+//            if (rrdhost_flag_check(st->rrdhost, RRDHOST_FLAG_ARCHIVED)) {
+//                rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
+//                rrd_hosts_available++;
+//                info("Host %s is not in archived mode anymore", st->rrdhost->hostname);
+//            }
             mark_rebuild |= META_CHART_ACTIVATED;
         }
         char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_family = NULL, *old_context = NULL,
@@ -684,12 +685,17 @@ RRDSET *rrdset_create_custom(
             rrdsetcalc_link_matching(st);
             rrdcalctemplate_link_matching(st);
         }
+        if (rrdhost_flag_check(st->rrdhost, RRDHOST_FLAG_ARCHIVED)) {
+            rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
+            rrd_hosts_available++;
+            info("Host %s is not in archived mode anymore", st->rrdhost->hostname);
+        }
         rrdhost_unlock(host);
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
         if (!is_archived && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
-            rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
+            //rrdhost_flag_clear(st->rrdhost, RRDHOST_FLAG_ARCHIVED);
         }
         return st;
     }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -392,7 +392,6 @@ void rrdset_free(RRDSET *st) {
             break;
     }
 #ifdef ENABLE_DBENGINE
-    //rrd_atomic_fetch_add(&host->objects_nr, -1);
     metalog_upd_objcount(host, -1);
 #endif
 
@@ -967,7 +966,6 @@ RRDSET *rrdset_create_custom(
     }
 #endif
 #ifdef ENABLE_DBENGINE
-    //rrd_atomic_fetch_add(&st->rrdhost->objects_nr, 1);
     metalog_upd_objcount(host, 1);
     metalog_commit_update_chart(st);
 #endif

--- a/streaming/README.md
+++ b/streaming/README.md
@@ -189,7 +189,7 @@ them `/var/lib/netdata/registry/netdata.unique.id`). So, metrics for Netdata `A`
 any number of other Netdata, will have the same `MACHINE_GUID`.
 
 You can also use `default memory mode = dbengine` for an API key or `memory mode = dbengine` for
- a single host. The additional `page cache size` and `dbengine disk space` configuration options
+ a single host. The additional `page cache size` and `dbengine multihost disk space` configuration options
  are inherited from the global Netdata configuration.
 
 ##### allow from

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -287,25 +287,6 @@ static int rrdpush_receive(struct receiver_state *rpt)
         }
         netdata_mutex_unlock(&rpt->host->receiver_lock);
     }
-    else rrdhost_update(rpt->host
-            , rpt->hostname
-            , rpt->registry_hostname
-            , rpt->machine_guid
-            , rpt->os
-            , rpt->timezone
-            , rpt->tags
-            , rpt->program_name
-            , rpt->program_version
-            , rpt->update_every
-            , history
-            , mode
-            , (unsigned int)(health_enabled != CONFIG_BOOLEAN_NO)
-            , (unsigned int)(rrdpush_enabled && rrdpush_destination && *rrdpush_destination && rrdpush_api_key && *rrdpush_api_key)
-            , rrdpush_destination
-            , rrdpush_api_key
-            , rrdpush_send_charts_matching
-            , rpt->system_info);
-
 
     int ssl = 0;
 #ifdef ENABLE_HTTPS

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -611,6 +611,8 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
      */
     struct receiver_state *rpt = callocz(1, sizeof(*rpt));
     RRDHOST *host = rrdhost_find_by_guid(machine_guid, 0);
+    if (unlikely(host && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))) /* Ignore archived hosts. */
+        host = NULL;
     if (host) {
         netdata_mutex_lock(&host->receiver_lock);
         if (host->receiver != NULL) {

--- a/web/api/formatters/charts2json.c
+++ b/web/api/formatters/charts2json.c
@@ -111,7 +111,7 @@ void charts2json(RRDHOST *host, BUFFER *wb, int skip_volatile, int show_archived
         size_t found = 0;
         RRDHOST *h;
         rrdhost_foreach_read(h) {
-            if(!rrdhost_should_be_removed(h, host, now)) {
+            if(!rrdhost_should_be_removed(h, host, now) && !rrdhost_flag_check(h, RRDHOST_FLAG_ARCHIVED)) {
                 buffer_sprintf(wb
                                , "%s\n\t\t{"
                                  "\n\t\t\t\"hostname\": \"%s\""

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -778,6 +778,8 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
     int count = 0;
     rrd_rdlock();
     rrdhost_foreach_read(rc) {
+        if (rrdhost_flag_check(rc, RRDHOST_FLAG_ARCHIVED))
+            continue;
         if(count > 0) buffer_strcat(wb, ",\n");
         buffer_sprintf(wb, "\t\t\"%s\"", rc->hostname);
         count++;


### PR DESCRIPTION
Fixes #9454
##### Summary
New children streaming to a parent with storage mode `dbengine` will now have their metrics stored in the parent's database. 
Old children that already have a database created in the parent will continue to use that one to store metrics.

##### Component Name
database

##### Test Plan
- TBA
##### Additional Information
- TBA
