### PR TITLE
Adding pihole to the dns app group

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -205,7 +205,7 @@ dhcp: *dhcp*
 # -----------------------------------------------------------------------------
 # name servers and clients
 
-dns: named unbound nsd pdns_server knotd gdnsd yadifad dnsmasq systemd-resolve*
+dns: named unbound nsd pdns_server knotd gdnsd yadifad dnsmasq systemd-resolve* pihole*
 dnsdist: dnsdist
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

Pi-hole https://github.com/pi-hole/pi-hole is an open source DNS server of sorts. I recently had an issue I needed to debug and sadly netdata showed the useful application data in the "other" bucket for pi-hole. This PR includes pi-hole related processes in the appropriate app group.

The primary daemon process is pihole-FTL but pihole as a stand-alone command can also be expensive to run, so I'm capturing both via `pihole*`.

Thanks in advance.

##### Component Name

apps.plugin

##### Test Plan

Installed pi-hole, updated apps_groups.conf with the proposed change, ensured that data for pihole was captured correctly.

##### Additional Information
