### PR TITLE
Removed runtime support for Polymorphic Linux from our Docker containers.

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -32,12 +32,6 @@ directive, not a COMMAND directive. Please adapt your execution scripts accordin
 ENTRYPOINT vs COMMAND in the [Docker
 documentation](https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact).
 
-### Package scrambling in runtime (x86_64 only)
-
-Our x86_64 Docker images provide support for using [Polymorphic Polyverse Linux package
-scrambling](https://polyverse.com/products/polymorphing-linux-security/) to protect against buffer overflow errors. To
-activate this, set the environemnt variable `RESCRAMBLE=true` while starting Netdata with a Docker container.
-
 ## Run the Agent with the Docker command
 
 Quickly start a new Agent with the `docker run` command.

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -12,16 +12,6 @@ if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
 fi
 
 echo "Netdata entrypoint script starting"
-if [ ${RESCRAMBLE+x} ] && [ "$(uname -m)" == "x86_64" ]; then
-  echo "Injecting packages from Polymorphic Linux"
-  apk update && apk upgrade
-  curl https://sh.polyverse.io | sh -s install gcxce5byVQbtRz0iwfGkozZwy support+netdata@polyverse.io
-  # shellcheck disable=SC2181
-  if [ $? -eq 0 ]; then
-    apk update && apk upgrade --available --no-cache && sed -in 's/^#//g' /etc/apk/repositories
-  fi
-fi
-
 if [ -n "${PGID}" ]; then
   echo "Creating docker group ${PGID}"
   addgroup -g "${PGID}" "docker" || echo >&2 "Could not add group docker with ID ${PGID}, its already there probably"


### PR DESCRIPTION
##### Summary

This removes our runtime support for Polyverse's Polymorphic Linux from our Docker containers. The actual support is currently broken due to upstream changes, but we have decided to just remove it instead of fixing it due to it providing limited practical benefit to our users and not being supported across all of our supported platforms.

We had previously removed build-time usage of this functionality for the same reasons to reduce the final image size for our 64-bit x86 Docker images.

Users who still want to use this can derive their own container images from our official image and inject the required repositories and package updates. Note that we will ask any users who take this approach to reproduce any bugs they find on our official Docker images.

##### Component Name

area/packaging

##### Test Plan

Container locally built and tested.

##### Additional Information

Fixes: #9498 