### PR TITLE
charts.d.plugin: never use `-t` option for `timeout`

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -294,15 +294,7 @@ run() {
 	if [ "z${1}" = "z-t" -a "${2}" != "0" ]; then
 		t="${2}"
 		shift 2
-
-		case "$(getosid)" in
-		"alpine")
-			timeout -t ${t} "${@}" 2>"${TMP_DIR}/run.${pid}"
-			;;
-		*)
-			timeout ${t} "${@}" 2>"${TMP_DIR}/run.${pid}"
-			;;
-		esac
+		timeout "${t}" "${@}" 2>"${TMP_DIR}/run.${pid}"
 		ret=$?
 	else
 		"${@}" 2>"${TMP_DIR}/run.${pid}"


### PR DESCRIPTION
##### Summary

Fixes: #9565

We switched from alpine `3.9` to `3.12` in https://github.com/netdata/helper-images/pull/80.

It uses `Busybox 1.31.1`. There is no `-t` parameter since `Busybox 1.30.0`

> https://www.busybox.net/

>  timeout: fix arguments to match coreutils




##### Component Name

`collectors/charts.d`

##### Test Plan

Changes look straightforward, we no longer need `-t`. Tested by @kmlucy in https://github.com/netdata/netdata/issues/9565#issuecomment-661077363.


##### Additional Information
