### PR TITLE
Added CAP_SYS_RESOURCE to capability bounding set.

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -51,6 +51,7 @@ CapabilityBoundingSet=CAP_FOWNER          # is required for freeipmi plugin
 CapabilityBoundingSet=CAP_SETPCAP         # is required for apps, perf and slabinfo plugins
 CapabilityBoundingSet=CAP_SYS_ADMIN       # is required for perf plugin
 CapabilityBoundingSet=CAP_SYS_PTRACE      # is required for apps plugin
+CapabilityBoundingSet=CAP_SYS_RESOURCE    # is required for ebpf plugin
 CapabilityBoundingSet=CAP_NET_RAW         # is required for fping app
 
 # Sandboxing


### PR DESCRIPTION
##### Summary

This is a mitigation for an issue caused by #9234, whereby the eBPF collector's attempts to call `setrlimit()` (in preparation for locking memory) fail on systemd-based systems.

I do not consider this a final fix (yet) because it's not clear that we actually _need_ to lock memory, and therefore we may not actually need this `setrlimit()` call. I suspect that locking memory allows for more accurate data collection, but is not actually required for the plugin to work, in which case it should be optional and not mandatory, but we should still merge this PR (so that people who want it don't have to change anything else). If, however, we truly gain no benefit from locking memory, then this change should be scrapped and we should just remove the calls to `setrlimit()` and `memlock()` instead.

##### Component Name

area/packaging

##### Test Plan

Without this change, the `ebpf.plugin` fails on systemd systems, with it it works correctly.

##### Additional Information

Mitigates (but does not necessarily fix): #9567 