### PR TITLE
Added libbpf patch to make dist.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,6 +59,7 @@ dist_noinst_DATA = \
     netdata.spec \
     package.json \
     docs \
+    libnetdata/ebpf/libbpf.c.diff \
     packaging/version \
     packaging/dashboard.version \
     packaging/dashboard.checksums \


### PR DESCRIPTION
##### Summary

This makes 3e84239ff work properly when using the kickstart installer.

##### Component Name

area/packaging

##### Test Plan

Verified that the required file is included in the dist archive and tested that the kickstart script works with the generated archive.

##### Additional Information

Partial fix for #9570.