### PR TITLE
Sends netdata.public.unique.id (machine GUID) with claim

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -25,6 +25,7 @@ static char *claiming_errors[] = {
         "Internal Server Error",                        // 15
         "Gateway Timeout",                              // 16
         "Service Unavailable"                           // 17
+        "Agent Unique Id Not Found"                     // 18
 };
 static netdata_mutex_t claim_mutex = NETDATA_MUTEX_INITIALIZER;
 static char *claimed_id = NULL;

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -25,7 +25,7 @@ static char *claiming_errors[] = {
         "Internal Server Error",                        // 15
         "Gateway Timeout",                              // 16
         "Service Unavailable"                           // 17
-        "Agent Unique Id Not Found"                     // 18
+        "Agent Unique Id Not Readable"                  // 18
 };
 static netdata_mutex_t claim_mutex = NETDATA_MUTEX_INITIALIZER;
 static char *claimed_id = NULL;

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -142,6 +142,10 @@ NETDATA_USER=$(get_config_value netdata global "run as user")
 # get the MACHINE_GUID by default
 if [ -r "${MACHINE_GUID_FILE}" ]; then
         ID="$(cat "${MACHINE_GUID_FILE}")"
+        MGUID=$ID
+else
+        echo >&2 "netdata.public.unique.id is not generated yet. Please run agent at least once before attempting to claim. Agent generates this file on first startup."
+        exit 22
 fi
 
 # get token from file
@@ -236,7 +240,8 @@ cat > "${CLAIMING_DIR}/tmpin.txt" <<EMBED_JSON
     },
     "token": "$TOKEN",
     "rooms" : [ $ROOMS ],
-    "publicKey" : "$KEY"
+    "publicKey" : "$KEY",
+    "mGUID" : "$MGUID"
 }
 EMBED_JSON
 

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -146,7 +146,7 @@ if [ -r "${MACHINE_GUID_FILE}" ]; then
         ID="$(cat "${MACHINE_GUID_FILE}")"
         MGUID=$ID
 else
-        echo >&2 "netdata.public.unique.id is not generated yet. Please run agent at least once before attempting to claim. Agent generates this file on first startup."
+        echo >&2 "netdata.public.unique.id is not generated yet or not readable. Please run agent at least once before attempting to claim. Agent generates this file on first startup. If the ID is generated already make sure you have rights to read it (Filename: ${MACHINE_GUID_FILE})."
         exit 18
 fi
 

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -83,6 +83,8 @@ ERROR_MESSAGES[16]="Gateway Timeout"
 ERROR_KEYS[17]="ErrServiceUnavailable"
 ERROR_MESSAGES[17]="Service Unavailable"
 
+# Exit code: 18 - Agent unique id is not generated yet.
+
 get_config_value() {
     conf_file="${1}"
     section="${2}"
@@ -145,7 +147,7 @@ if [ -r "${MACHINE_GUID_FILE}" ]; then
         MGUID=$ID
 else
         echo >&2 "netdata.public.unique.id is not generated yet. Please run agent at least once before attempting to claim. Agent generates this file on first startup."
-        exit 22
+        exit 18
 fi
 
 # get token from file


### PR DESCRIPTION
##### Summary
Send Netdata public unique id (machine GUID) when claiming. In case `claiming ID != machine GUID` cloud still knows the GUID.

This will be more important with MVP1 (Streaming support for Cloud)

##### Component Name

##### Test Plan
run claiming script with `-verbose` flag. You should see that we send also line:
```
Request to server:
{
    "node": {
        "id": "XXXX",
        "hostname": "timowss"
    },
    "token": "CENSORED",
    "rooms" : [ "YYYY" ],
    "publicKey" : "-----BEGIN PUBLIC KEY-----\nCENSORED\n-----END PUBLIC KEY-----\n",
    "m_guid" : "BBBB"
}
```
`BBBB` can be the same as `XXXX` if -id parameter not given to claiming script.

##### Additional Information
