### PR TITLE
Fixes mempcpy->memcpy

### DIFF
--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -249,7 +249,7 @@ void *aclk_stats_main_thread(void *ptr)
         memcpy(&permanent, &aclk_metrics, sizeof(struct aclk_metrics));
         memset(&aclk_metrics_per_sample, 0, sizeof(struct aclk_metrics_per_sample));
 
-        mempcpy(aclk_queries_per_thread_sample, aclk_queries_per_thread, sizeof(uint32_t) * query_thread_count);
+        memcpy(aclk_queries_per_thread_sample, aclk_queries_per_thread, sizeof(uint32_t) * query_thread_count);
         memset(aclk_queries_per_thread, 0, sizeof(uint32_t) * query_thread_count);
         ACLK_STATS_UNLOCK;
 


### PR DESCRIPTION
##### Summary

Due to typo, we call `mempcpy` instead of `memcpy`. Surprisingly function `mempcpy` actually exists (the reason why the compiler doesn't complain) in GNU but not everywhere. As a result, the compilation fails on FreeNAS.

`mempcpy` and `memcpy` do the same job and differ only in return value (which is not used anyway).

Fixes #9563

Credit to @mfundul and @abrbon for bringing attention to this.

##### Component Name

##### Test Plan

##### Additional Information
