### PR TITLE
Add lock dir

### DIFF
--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -464,7 +464,7 @@ class FileLockRegistry:
     def register(self, name):
         if name in self.locks:
             return
-        file = os.path.join(self.path, name)
+        file = os.path.join(self.path, '{0}.collector.lock'.format(name))
         lock = filelock.FileLock(file)
         lock.acquire(timeout=0)
         self.locks[name] = lock

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -485,22 +485,16 @@ class DummyRegistry:
         pass
 
 
-def create_jobs_registry():
-    if not DIRS.locks:
-        return DummyRegistry()
-    return FileLockRegistry(DIRS.locks)
-
-
 class Plugin:
     config_name = 'python.d.conf'
     jobs_status_dump_name = 'pythond-jobs-statuses.json'
 
-    def __init__(self, modules_to_run, min_update_every):
+    def __init__(self, modules_to_run, min_update_every, registry):
         self.modules_to_run = modules_to_run
         self.min_update_every = min_update_every
         self.config = PluginConfig(PLUGIN_BASE_CONF)
         self.log = PythonDLogger()
-        self.registry = create_jobs_registry()
+        self.registry = registry
         self.started_jobs = collections.defaultdict(dict)
         self.jobs = list()
         self.saver = None
@@ -748,6 +742,7 @@ def parse_command_line():
 
     debug = False
     trace = False
+    nolock = False
     update_every = 1
     modules_to_run = list()
 
@@ -764,6 +759,9 @@ def parse_command_line():
     if 'trace' in opts:
         trace = True
         opts.remove('trace')
+    if 'nolock' in opts:
+        nolock = True
+        opts.remove('nolock')
     if opts:
         modules_to_run = list(opts)
 
@@ -773,13 +771,15 @@ def parse_command_line():
             'update_every',
             'debug',
             'trace',
+            'nolock',
             'modules_to_run',
         ])
     return cmd(
         update_every,
         debug,
         trace,
-        modules_to_run
+        nolock,
+        modules_to_run,
     )
 
 
@@ -827,9 +827,15 @@ def main():
             log.info('probably you meant : \n{0}'.format(pprint.pformat(guessed, width=1)))
         return
 
+    if DIRS.locks and not cmd.nolock:
+        registry = FileLockRegistry(DIRS.locks)
+    else:
+        registry = DummyRegistry()
+
     p = Plugin(
         cmd.modules_to_run or AVAILABLE_MODULES,
         cmd.update_every,
+        registry,
     )
 
     try:

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -52,7 +52,7 @@ ENV_NETDATA_STOCK_CONFIG_DIR = 'NETDATA_STOCK_CONFIG_DIR'
 ENV_NETDATA_PLUGINS_DIR = 'NETDATA_PLUGINS_DIR'
 ENV_NETDATA_LIB_DIR = 'NETDATA_LIB_DIR'
 ENV_NETDATA_UPDATE_EVERY = 'NETDATA_UPDATE_EVERY'
-ENV_NETDATA_LOCKS_DIR = 'NETDATA_LOCKS_DIR'
+ENV_NETDATA_LOCK_DIR = 'NETDATA_LOCK_DIR'
 
 
 def add_pythond_packages():
@@ -93,8 +93,8 @@ def dirs():
         os.path.dirname(__file__),
     )
     locks = os.getenv(
-        ENV_NETDATA_LOCKS_DIR,
-        # TODO: add '@locksdir_POST@
+        ENV_NETDATA_LOCK_DIR,
+        os.path.join('@varlibdir_POST@', 'lock')
     )
     modules_user_config = os.path.join(plugin_user_config, 'python.d')
     modules_stock_config = os.path.join(plugin_stock_config, 'python.d')

--- a/daemon/common.c
+++ b/daemon/common.c
@@ -10,6 +10,7 @@ char *netdata_configured_primary_plugins_dir = NULL;
 char *netdata_configured_web_dir             = WEB_DIR;
 char *netdata_configured_cache_dir           = CACHE_DIR;
 char *netdata_configured_varlib_dir          = VARLIB_DIR;
+char *netdata_configured_lock_dir            = NULL;
 char *netdata_configured_home_dir            = CACHE_DIR;
 char *netdata_configured_host_prefix         = NULL;
 char *netdata_configured_timezone            = NULL;

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -92,6 +92,7 @@ extern char *netdata_configured_primary_plugins_dir;
 extern char *netdata_configured_web_dir;
 extern char *netdata_configured_cache_dir;
 extern char *netdata_configured_varlib_dir;
+extern char *netdata_configured_lock_dir;
 extern char *netdata_configured_home_dir;
 extern char *netdata_configured_host_prefix;
 extern char *netdata_configured_timezone;

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -63,11 +63,12 @@ void clean_directory(char *dirname)
     DIR *dir = opendir(dirname);
     if(!dir) return;
 
+    int dir_fd = dirfd(dir);
     struct dirent *de = NULL;
 
     while((de = readdir(dir)))
         if(de->d_type == DT_REG)
-            unlink(de->d_name);
+            unlinkat(dir_fd, de->d_name, 0);
 
     closedir(dir);
 }

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -68,7 +68,8 @@ void clean_directory(char *dirname)
 
     while((de = readdir(dir)))
         if(de->d_type == DT_REG)
-            unlinkat(dir_fd, de->d_name, 0);
+            if (unlinkat(dir_fd, de->d_name, 0))
+                error("Cannot delete %s/%s", dirname, de->d_name);
 
     closedir(dir);
 }

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -72,6 +72,7 @@ int become_user(const char *username, int pid_fd) {
 
     create_needed_dir(netdata_configured_cache_dir, uid, gid);
     create_needed_dir(netdata_configured_varlib_dir, uid, gid);
+    create_needed_dir(netdata_configured_lock_dir, uid, gid);
     create_needed_dir(claimingdirectory, uid, gid);
 
     if(pidfile[0]) {
@@ -469,6 +470,7 @@ int become_daemon(int dont_fork, const char *user)
     else {
         create_needed_dir(netdata_configured_cache_dir, getuid(), getgid());
         create_needed_dir(netdata_configured_varlib_dir, getuid(), getgid());
+        create_needed_dir(netdata_configured_lock_dir, getuid(), getgid());
         create_needed_dir(claimingdirectory, getuid(), getgid());
     }
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -434,6 +434,14 @@ static void log_init(void) {
     setenv("NETDATA_ERRORS_PER_PERIOD",      config_get(CONFIG_SECTION_GLOBAL, "errors to trigger flood protection", ""), 1);
 }
 
+char *initialize_lock_directory_path(char *prefix)
+{
+    char filename[FILENAME_MAX + 1];
+    snprintfz(filename, FILENAME_MAX, "%s/lock", prefix);
+
+    return config_get(CONFIG_SECTION_GLOBAL, "lock directory", filename);
+}
+
 static void backwards_compatible_config() {
     // move [global] options to the [web] section
     config_move(CONFIG_SECTION_GLOBAL, "http port listen backlog",
@@ -528,6 +536,8 @@ static void get_netdata_configured_variables() {
     netdata_configured_cache_dir        = config_get(CONFIG_SECTION_GLOBAL, "cache directory",        netdata_configured_cache_dir);
     netdata_configured_varlib_dir       = config_get(CONFIG_SECTION_GLOBAL, "lib directory",          netdata_configured_varlib_dir);
     netdata_configured_home_dir         = config_get(CONFIG_SECTION_GLOBAL, "home directory",         netdata_configured_home_dir);
+
+    netdata_configured_lock_dir = initialize_lock_directory_path(netdata_configured_varlib_dir);
 
     {
         pluginsd_initialize_plugin_directories();
@@ -692,6 +702,7 @@ void set_global_environment() {
     setenv("NETDATA_WEB_DIR"          , verify_required_directory(netdata_configured_web_dir),          1);
     setenv("NETDATA_CACHE_DIR"        , verify_required_directory(netdata_configured_cache_dir),        1);
     setenv("NETDATA_LIB_DIR"          , verify_required_directory(netdata_configured_varlib_dir),       1);
+    setenv("NETDATA_LOCK_DIR"         , netdata_configured_lock_dir, 1);
     setenv("NETDATA_LOG_DIR"          , verify_required_directory(netdata_configured_log_dir),          1);
     setenv("HOME"                     , verify_required_directory(netdata_configured_home_dir),         1);
     setenv("NETDATA_HOST_PREFIX"      , netdata_configured_host_prefix, 1);


### PR DESCRIPTION
##### Summary
In order to prevent python and go plugins from mutual conflicts, we are adding a directory for lock files.

Fixes #9347

##### Component Name
daemon

##### Test Plan
Run Netdata, check if `/var/lib/netdata/lock` is created and contains lock files only for running python plugins.