### PR TITLE
Added proper handling for autogen on Ubuntu 18.04

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -642,7 +642,6 @@ declare -A pkg_autogen=(
   # exceptions
   ['centos-6']="WARNING|"
   ['rhel-6']="WARNING|"
-  ['ubuntu-18']="WARNING|"
 )
 
 declare -A pkg_automake=(


### PR DESCRIPTION
##### Summary

Ubuntu 18.04 really does have autogen, even though we claim it doesn't. Fix our dependency handling script to recognize this.

##### Component Name

area/packaging

##### Test Plan

Verified locally that the autogen package on Ubuntu 18.04 works as we need it to.

##### Additional Information

Fixes: #8869 