### PR TITLE
Added explicit CODEOWNERS rule for `system/`.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,7 @@ libnetdata/ @thiagofsm @mfundul @amoss
 packaging/ @amoss @Ferroin @prologic
 registry/ @jacekkolasa @amoss
 streaming/ @thiagoftsm @vlvkobal @amoss
+system/ @prologic @Ferroin @amoss
 web/ @thiagoftsm @mfundul @vlvkobal @amoss
 web/gui/ @jacekkolasa @amoss
 


### PR DESCRIPTION
##### Summary

It's part of the packaging code, so it should be owned by the people responsible for packaging.

##### Component Name

GitHub infra

##### Test Plan

n/a