### PR TITLE
Removed delay in updater script for non-interactive runs from install scripts.

### DIFF
--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -200,7 +200,7 @@ if [ -n "$ndpath" ] ; then
   if [ -r "${ndprefix}/etc/netdata/.environment" ] ; then
     if [ -x "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ] ; then
       progress "Attempting to update existing install instead of creating a new one"
-      if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
+      if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" --not-running-from-cron ; then
         progress "Updated existing install at ${ndpath}"
         exit 0
       else

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -298,7 +298,7 @@ if [ -n "$ndpath" ] ; then
   if [ -r "${ndprefix}/etc/netdata/.environment" ] ; then
     if [ -x "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ] ; then
       progress "Attempting to update existing install instead of creating a new one"
-      if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ; then
+      if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" --not-running-from-cron ; then
         progress "Updated existing install at ${ndpath}"
         exit 0
       else

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -77,7 +77,7 @@ To use `md5sum` to verify the intregity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "f47630f78c0c5e651cb6788301d8e05c" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "6c3c2957caeeeb1decaf6b6178a3a3cd" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -58,7 +58,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "05e3a23be90de1c2c62b2dbd8a3fb682" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "86abaea95a24df12fe444c1b3e5cfa33" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

Our updater script has a built-in random delay of up to 1 hour when run non-interactively to avoid a stampede effect for reconnections to Netdata Cloud due to auto-updates. Due to an oversight in handling of updates to existing installs in the installer scripts, this delay was also occurring when the installer scripts were run non-interactively. This fixes that so that non-interactive runs complete without a delay.

##### Component Name

area/packaging

##### Test Plan

Verified locally that running the updates via the kickstart scripts non-interactively now has no delay (checked using `nohup`).

##### Additional Information

Fixes: #9588 