### PR TITLE
Add support for DEB packages for Ubuntu 20.04 (focal)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -278,6 +278,14 @@ jobs:
         - PACKAGE_TYPE="deb" REPO_TOOL="apt-get"
         - ALLOW_SOFT_FAILURE_HERE=true
 
+    - name: "Build & Publish DEB package for ubuntu/focal"
+      <<: *DEB_TEMPLATE
+      if: commit_message =~ /\[Package (amd64|arm64|i386) DEB( Ubuntu)?\]/
+      env:
+        - BUILDER_NAME="builder" BUILD_DISTRO="ubuntu" BUILD_RELEASE="focal" BUILD_STRING="ubuntu/focal"
+        - PACKAGE_TYPE="deb" REPO_TOOL="apt-get"
+        - ALLOW_SOFT_FAILURE_HERE=true
+
     - name: "Build & Publish DEB package for debian/buster"
       <<: *DEB_TEMPLATE
       if: commit_message =~ /\[Package (amd64|arm64|i386) DEB( Debian)?\]/

--- a/.travis/package_management/configure_deb_lxc_environment.py
+++ b/.travis/package_management/configure_deb_lxc_environment.py
@@ -91,6 +91,10 @@ if str(os.environ["BUILD_STRING"]).count("debian/buster") == 1:
     common.run_command_in_host(['sudo', 'cp', 'contrib/debian/control.buster', 'contrib/debian/control'])
 
 ### Ubuntu
+if str(os.environ["BUILD_STRING"]).count("ubuntu/focal") == 1:
+    print("5.1 We are building for Xenial, adjusting control file")
+    common.run_command_in_host(['sudo', 'rm', 'contrib/debian/control'])
+    common.run_command_in_host(['sudo', 'cp', 'contrib/debian/control.focal', 'contrib/debian/control'])
 if str(os.environ["BUILD_STRING"]).count("ubuntu/xenial") == 1:
     print("5.1 We are building for Xenial, adjusting control file")
     common.run_command_in_host(['sudo', 'rm', 'contrib/debian/control'])

--- a/contrib/debian/control.focal
+++ b/contrib/debian/control.focal
@@ -1,0 +1,73 @@
+Source: netdata
+Build-Depends: debhelper (>= 9),
+               dh-autoreconf,
+               dh-systemd (>= 1.5),
+               dpkg-dev (>= 1.13.19),
+               zlib1g-dev,
+               uuid-dev,
+               libuv1-dev,
+               liblz4-dev,
+               libjudy-dev,
+               libssl-dev,
+               libmnl-dev,
+               libjson-c-dev,
+               libcups2-dev,
+               libipmimonitoring-dev,
+               libnetfilter-acct-dev,
+               libsnappy-dev,
+               libprotobuf-dev,
+               libprotoc-dev,
+               cmake,
+               autogen,
+               autoconf,
+               automake,
+               pkg-config,
+               curl,
+               gcc,
+               g++
+Section: net
+Priority: optional
+Maintainer: Netdata Builder <bot@netdata.cloud>
+Standards-Version: 3.9.6
+Homepage: https://netdata.cloud
+
+Package: netdata
+Architecture: any
+Depends: adduser,
+         libcap2-bin (>= 1:2.0),
+         lsb-base (>= 3.1-23.2),
+         zlib1g,
+         libuuid1,
+         libuv1,
+         liblz4-1,
+         libjudydebian1,
+         openssl,
+         libmnl0,
+         libjson-c4,
+         libnetfilter-acct1,
+         libprotobuf-c1,
+         libsnappy1v5,
+         libprotoc17,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Pre-Depends: dpkg (>= 1.17.14)
+Description: real-time charts for system monitoring
+ Netdata is a daemon that collects data in realtime (per second)
+ and presents a web site to view and analyze them. The presentation
+ is also real-time and full of interactive charts that precisely
+ render all collected values.
+
+Package: netdata-plugin-cups
+Architecture: any
+Depends: cups,
+         netdata (>= ${source:Version})
+Description: The Common Unix Printing System plugin for metrics collection from cupsd
+
+Package: netdata-plugin-freeipmi
+Architecture: any
+Depends: freeipmi,
+         netdata (= ${source:Version})
+Description: FreeIPMI - The Intelligent Platform Management System.
+ The IPMI specification defines a set of interfaces for platform management.
+ It is implemented by a number vendors for system management. The features of IPMI that most users will be interested in 
+ are sensor monitoring, system event monitoring, power control, and serial-over-LAN (SOL).


### PR DESCRIPTION
##### Summary

- Fixes #8906

##### Component Name

- area/packaging

##### Test Plan

```#!sh
root@ubuntu2004:~# apt-get update
Get:1 http://10.0.0.109:8000 focal InRelease [2,774 B]
Get:2 http://10.0.0.109:8000 focal/main amd64 Packages [2,120 B]
Hit:3 http://au.archive.ubuntu.com/ubuntu focal InRelease
Hit:4 http://au.archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:5 http://au.archive.ubuntu.com/ubuntu focal-backports InRelease
Hit:6 http://au.archive.ubuntu.com/ubuntu focal-security InRelease
Fetched 4,894 B in 1s (3,315 B/s)
Reading package lists... Done
root@ubuntu2004:~# apt-get install netdata
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages will be upgraded:
  netdata
1 upgraded, 0 newly installed, 0 to remove and 63 not upgraded.
1 not fully installed or removed.
Need to get 9,382 kB of archives.
After this operation, 1,024 B disk space will be freed.
Get:1 http://10.0.0.109:8000 focal/main amd64 netdata amd64 1.23.2-49 [9,382 kB]
Fetched 9,382 kB in 0s (97.9 MB/s)
(Reading database ... 108526 files and directories currently installed.)
Preparing to unpack .../netdata_1.23.2-49_amd64.deb ...
Unpacking netdata (1.23.2-49) over (1.23.2-48) ...
Setting up netdata (1.23.2-49) ...
Processing triggers for systemd (245.4-4ubuntu3) ...
root@ubuntu2004:~# ps aux | grep netdata
netdata    58647  1.0  2.6 265432 26924 ?        Ssl  06:48   0:00 /usr/sbin/netdata -D
netdata    58695  0.0  0.6  26756  6448 ?        Sl   06:48   0:00 /usr/sbin/netdata --special-spawn-server
netdata    58889  0.0  0.3   4108  3304 ?        S    06:48   0:00 bash /usr/libexec/netdata/plugins.d/tc-qos-helper.sh 1
root       58893  0.0  0.0   4748   808 ?        S    06:48   0:00 /usr/libexec/netdata/plugins.d/nfacct.plugin 1
netdata    58895  0.5  0.3  53268  3380 ?        S    06:48   0:00 /usr/libexec/netdata/plugins.d/apps.plugin 1
netdata    58898  0.1  1.7 723396 17480 ?        SLl  06:48   0:00 /usr/libexec/netdata/plugins.d/go.d.plugin 1
root       59200  0.0  0.0   6432   736 pts/0    S+   06:48   0:00 grep --color=auto netdata
root@ubuntu2004:~#
```

##### Additional Information

Used this PR as an excuse to create a proper signed repo (_locally_) for
testing purposes using this very nicely written
[repogen](https://github.com/pgaskin/repogen) tool and performing normal
`apt-key add` and `apt-add-repository` operations.

We will use this to migrate off packagecloud and sign our packaged.

Kill two birds with one stone 🤣