### PR TITLE
Added sandboxing exception for `/run/netdata`.

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -61,6 +61,8 @@ ProtectHome=read-only
 #PrivateTmp=true
 ProtectControlGroups=true
 PrivateMounts=true
+# We whitelist this because it's the standard location to listen on a UNIX socket.
+ReadWriteDirectories=/run/netdata
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
##### Summary

This marks `/run/netdata` as writable in our systemd unit files so that users who are listening on a UNIX socket in the 'standard' location can do so witout the sandboxing getting in their way.

##### Component Name

area/packaging

##### Test Plan

Verified through a local install that this lets Netdata listen on a UNIX socket located under `/run/netdata`.

##### Additional Information

Fixes: #9606 