### PR TITLE
Remove PrivateMounts

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -60,7 +60,6 @@ ProtectHome=read-only
 # PrivateTmp break netdatacli functionality. See - https://github.com/netdata/netdata/issues/7587
 #PrivateTmp=true
 ProtectControlGroups=true
-PrivateMounts=true
 # We whitelist this because it's the standard location to listen on a UNIX socket.
 ReadWriteDirectories=/run/netdata
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Since commit #9234 the following has been showing up in my journal logs:

>  /lib/systemd/system/netdata.service:63: Unknown lvalue 'PrivateMounts' in section 'Service'

Running `systemd-analyze verify netdata.service`

> /lib/systemd/system/netdata.service:63: Unknown lvalue 'PrivateMounts' in section 'Service'
> Attempted to remove disk file system, and we can't allow that.

It would appear that the `Attempted to remove disk file system, and we can't allow that.` message is due to a [bug](https://github.com/systemd/systemd/issues/8592) in version 237 of systemd, which is what my Ubuntu 18.04 is currently running. But that doesn't explain the "PrivateMounts" issue.

Looking at the [systemd man page](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) for PrivateMounts it would seem that we do not need the `PrivateMounts=true` setting because the service file has `ProtectSystem=full` set:

> Other file system namespace unit settings — PrivateMounts=, PrivateTmp=, PrivateDevices=, ProtectSystem=, ProtectHome=, ReadOnlyPaths=, InaccessiblePaths=, ReadWritePaths=, … — also enable file system namespacing in a fashion equivalent to this option. Hence it is primarily useful to explicitly request this behaviour if none of the other settings are used.


##### Component Name
netdata/system/netdata.service

##### Test Plan
I have tested this on Ubuntu 18.04 running systemd version 237 and everything seems to be working fine.
Probably needs tested on other distros.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
