### PR TITLE
Fixed RPM default permissions for /usr/libexec/netdata

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -454,7 +454,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_sysconfdir}/rc.d/init.d/netdata
 %endif
 
-%defattr(4750,root,netdata,0750)
+%defattr(0750,root,netdata,0750)
 
 %dir %{_libexecdir}/%{name}/python.d
 %dir %{_libexecdir}/%{name}/charts.d


### PR DESCRIPTION
##### Summary

Fixes #9620 : bad default permission in specfile lead to all files in /usr/libexec/netdata to be setuid.

##### Component Name
netdata.spec.in

##### Test Plan

```
git clone https://github.com/netdata/netdata.git
cd netdata
./contrib/rhel/build-netdata-rpm.sh
rpm -qvlp ~/rpmbuild/RPMS/x86_64/netdata-*.rpm | grep /usr/libexec/netdata 
```

##### Additional Information
