### PR TITLE
charts.d: fix `current_time_ms_from_date` on macOS

### DIFF
--- a/collectors/charts.d.plugin/loopsleepms.sh.inc
+++ b/collectors/charts.d.plugin/loopsleepms.sh.inc
@@ -10,16 +10,24 @@ fi
 # -----------------------------------------------------------------------------
 # use the date command as a high resolution timer
 
+# macOS 'date' doesnt support '%N' precision
+# echo $(/bin/date +"%N") is "N"
+if [ "$($LOOPSLEEP_DATE +"%N")" = "N" ]; then
+  DATE_FORMAT="%s * 1000"
+else
+  DATE_FORMAT="%s * 1000 + 10#%-N / 1000000"
+fi
+
 now_ms=
 LOOPSLEEPMS_HIGHRES=1
 test "$($LOOPSLEEP_DATE +%N)" = "%N" && LOOPSLEEPMS_HIGHRES=0
 test -z "$($LOOPSLEEP_DATE +%N)" && LOOPSLEEPMS_HIGHRES=0
 current_time_ms_from_date() {
-	if [ $LOOPSLEEPMS_HIGHRES -eq 0 ]; then
-		now_ms="$($LOOPSLEEP_DATE +'%s')000"
-	else
-		now_ms="$(($($LOOPSLEEP_DATE +'%s * 1000 + 10#%-N / 1000000')))"
-	fi
+  if [ $LOOPSLEEPMS_HIGHRES -eq 0 ]; then
+    now_ms="$($LOOPSLEEP_DATE +'%s')000"
+  else
+    now_ms="$(($($LOOPSLEEP_DATE +"$DATE_FORMAT")))"
+  fi
 }
 
 # -----------------------------------------------------------------------------

--- a/collectors/charts.d.plugin/loopsleepms.sh.inc
+++ b/collectors/charts.d.plugin/loopsleepms.sh.inc
@@ -13,9 +13,9 @@ fi
 # macOS 'date' doesnt support '%N' precision
 # echo $(/bin/date +"%N") is "N"
 if [ "$($LOOPSLEEP_DATE +"%N")" = "N" ]; then
-  DATE_FORMAT="%s * 1000"
+  LOOPSLEEP_DATE_FORMAT="%s * 1000"
 else
-  DATE_FORMAT="%s * 1000 + 10#%-N / 1000000"
+  LOOPSLEEP_DATE_FORMAT="%s * 1000 + 10#%-N / 1000000"
 fi
 
 now_ms=
@@ -26,7 +26,7 @@ current_time_ms_from_date() {
   if [ $LOOPSLEEPMS_HIGHRES -eq 0 ]; then
     now_ms="$($LOOPSLEEP_DATE +'%s')000"
   else
-    now_ms="$(($($LOOPSLEEP_DATE +"$DATE_FORMAT")))"
+    now_ms="$(($($LOOPSLEEP_DATE +"$LOOPSLEEP_DATE_FORMAT")))"
   fi
 }
 


### PR DESCRIPTION
##### Summary

Fixes: #9635

macOS `date` doesnt support `%N`

```cmd
0 ~ $ /bin/date +'%N'
N

0 ~ $ gdate +'%N'
672878000
```

It stopped to work on macOS after https://github.com/netdata/netdata/pull/9510

Before [the PR](https://github.com/netdata/netdata/pull/9510) it was `(( ... N / 1000000))` which is 0 (var `N` was not set, bash arithmetic expansion treats it as zero), after it - `10#N`.

```cmd
1 ~ $ ((10#N))
-bash: ((: 10#N: value too great for base (error token is "10#N")
```

##### Component Name

`collectors/charts.d`

##### Test Plan

- run `charts.d.plugin` in debug mode, ensure it works
- change `= "N"` condition to `!= "N"`, run `charts.d.plugin` in debug mode, ensure it works
- i didnt install netdata on macOS but i am sure the problem is fixed because it was working before #9510



##### Additional Information
