### PR TITLE
python.d: fix `find_binary`

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/collection.py
+++ b/collectors/python.d.plugin/python_modules/bases/collection.py
@@ -77,7 +77,7 @@ def find_binary(binary):
     :return:
     """
     for directory in PATH:
-        binary_name = '/'.join([directory, binary])
+        binary_name = os.path.join(directory, binary)
         if os.path.isfile(binary_name) and os.access(binary_name, os.X_OK):
             return binary_name
     return None


### PR DESCRIPTION
##### Summary

Fixes: #9640

##### Component Name

`/collectors/python.d`

##### Test Plan

The correct way is to use `os.path.join` and not `'/'.join()` 😄 

##### Additional Information
