### PR TITLE
Fix for ignored LXC containers

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -101,10 +101,10 @@ function k8s_get_name() {
 			fi
 			if kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces >/dev/null 2>&1; then
 				#shellcheck disable=SC2086
-				NAME="$(kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces --output='json' | 
-				jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_" + (.status.containerStatuses[]? | "\(.name) \(.containerID)")' | 
-				grep "$id" | 
-				cut -d' ' -f1 
+				NAME="$(kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces --output='json' |
+				jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_" + (.status.containerStatuses[]? | "\(.name) \(.containerID)")' |
+				grep "$id" |
+				cut -d' ' -f1
 				)"
 			else
 				warning "kubectl cannot get pod list, check for configuration file in $KUBE_CONFIG, or set this path to env \$KUBE_CONFIG"
@@ -227,6 +227,9 @@ if [ -z "${NAME}" ]; then
 		else
 			error "proxmox config file missing ${FILENAME} or netdata does not have read access.  Please ensure netdata is a member of www-data group."
 		fi
+	elif [[ ${CGROUP} =~ lxc.payload.* ]]; then
+		# LXC 4.0
+		NAME="$(echo "${CGROUP}" | sed 's/lxc\.payload\.\(.*\)/\1/g')"
 	fi
 
 	[ -z "${NAME}" ] && NAME="${CGROUP}"

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -379,7 +379,7 @@ void read_cgroup_plugin_configuration() {
                     " !/libvirt "
                     " !/lxc "
                     " !/lxc/*/* "                          //  #1397 #2649
-                    " !/lxc.monitor "
+                    " !/lxc.monitor* "
                     " !/lxc.pivot "
                     " !/lxc.payload "
                     " !/machine "
@@ -403,6 +403,7 @@ void read_cgroup_plugin_configuration() {
                     " !/lxc/*/* "                          //  #2161 #2649
                     " !/lxc.monitor "
                     " !/lxc.payload/*/* "
+                    " !/lxc.payload.* "
                     " * "
             ), NULL, SIMPLE_PATTERN_EXACT);
 


### PR DESCRIPTION
##### Summary
There are [changes in LXC container layout](https://linuxcontainers.org/lxc/news/#major-changes) since version 4.0. The PR fixes the default configuration for ignored LXC containers. In addition, the renaming script removes `lxc.payload.` from container names.

Fixes #9697

##### Component Name
cgroups plugin

##### Test Plan
Run Netdata on a machine with LXC 4.x containers. Check if they are displayed correctly and there are no unnecessary containers. Check if there aren't a lot of disabled containers in the `[plugin:cgroups]` section in `http://localhost:19999/netdata.conf`.