### PR TITLE
installer: fix `govercomp`

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1211,7 +1211,7 @@ govercomp() {
   for ((i = 0; i < ${#ver1[@]}; i++)); do
     if [ "${ver1[i]}" -gt "${ver2[i]}" ]; then
       return 1
-    elif [ "${ver1[i]}" -gt "${ver2[i]}" ]; then
+    elif [ "${ver2[i]}" -gt "${ver1[i]}" ]; then
       return 2
     fi
   done


### PR DESCRIPTION
##### Summary

I noticed that installer downloads `v0.19.2` binary despite i have `v0.20.0` in the `/plugins.d`. This PR fixes it.

##### Component Name

`installer`

##### Test Plan


##### Additional Information

- [X] install this PR (master go version is `v0.19.2`), build go.d.plugin `v0.20.0`, put it in the `/plugins.d`, do reinstall, ensure `v0.19.2` is not downloaded