### PR TITLE
Fix warning when compiled with gcc-10.1

### DIFF
--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -542,7 +542,7 @@ static inline void fill_resolved_name(netdata_socket_plot_t *ptr, char *hostname
         ptr->resolved_name = strdupz(hostname);
     else {
         length = NETDATA_MAX_NETWORK_COMBINED_LENGTH;
-        ptr->resolved_name = mallocz(NETDATA_DIM_LENGTH_WITHOUT_SERVICE_PROTOCOL + 1);
+        ptr->resolved_name = mallocz( NETDATA_MAX_NETWORK_COMBINED_LENGTH + 1);
         memcpy(ptr->resolved_name, hostname, length);
         ptr->resolved_name[length] = '\0';
     }


### PR DESCRIPTION
##### Summary
Fixes #9647 

The plugin code has a wrong length that was reported only when compiled on `gcc 10.1`. I also used coverity to try catching the error, but it was not shown.

##### Component Name
ebpf.plugin
##### Test Plan

1 - Compile this PR with a `gcc 10.1` or newer redirecting stderr to a file
2 - Verify that the error reported is not more present.

##### Additional Information
