### PR TITLE
Fix installer to not install eBPF plugin/collector if installed as non-root (euid=0)

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1367,6 +1367,12 @@ detect_libc() {
 }
 
 should_install_ebpf() {
+  if [ -n "$EUID" ] && [ $EUID -ne 0 ]; then
+    run_failed "Not running as root (euid=0), not installing eBPF..."
+    defer_error "eBPF disabled in non-root (euid=0) installation"
+    return 1
+  fi
+
   if [ "${NETDATA_DISABLE_EBPF:=0}" -eq 1 ]; then
     run_failed "eBPF explicitly disabled."
     defer_error "eBPF explicitly disabled."


### PR DESCRIPTION
##### Summary

ssia

##### Component Name

- packaging

##### Test Plan

Ran the installer as non-root:

```#!sh
The following non-fatal errors were encountered during the installation process:

* eBPF disabled in non-root (euid=0) installation

 --- We are done! ---
```

##### Additional Information