### PR TITLE
Remove obsoleted libraries from install/uninstall scripts

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -96,9 +96,6 @@ override_dh_installdocs:
 		--target $(TOP)/usr/share/doc/netdata/ \
 		{} \;
 
-override_dh_shlibdeps:
-	dh_shlibdeps -X libnetdata_ebpf
-
 override_dh_fixperms:
 	dh_fixperms
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1432,9 +1432,7 @@ install_ebpf() {
   # chown everything to root:netdata before we start copying out of our package
   run chown -R root:netdata "${tmp}"
 
-  run cp -a -v "${tmp}"/library/* "${NETDATA_PREFIX}"/usr/libexec/netdata/plugins.d
   run cp -a -v "${tmp}"/*netdata_ebpf_*.o "${NETDATA_PREFIX}"/usr/libexec/netdata/plugins.d
-  run cp -a -v "${tmp}"/libnetdata_ebpf.so.* "${NETDATA_PREFIX}"/usr/libexec/netdata/plugins.d
 
   rm -rf "${tmp}"
 

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -440,34 +440,6 @@ stop_all_netdata() {
 
 trap quit_msg EXIT
 
-uninstall_ebpf() {
-  # Removing NetData's libexec directory is taken care of which is where we
-  # installed the rest of the shared libraires for the eBPF Collector.
-
-  echo >&2 " Finding lib directory ..."
-  libdir=
-  libdir="$(ldconfig -v 2> /dev/null | grep ':$' | sed -e 's/://' | sort -r | grep 'usr' | head -n 1)"
-  if [ -z "${libdir}" ]; then
-    libdir="$(ldconfig -v 2> /dev/null | grep ':$' | sed -e 's/://' | sort -r | head -n 1)"
-  fi
-
-  if [ -z "${libdir}" ]; then
-    echo >&2 "Unable to find the system lib directory we installed eBPF ebpf_kernel.so to ..."
-    user_input "Press ENTER to search your system (which may take some time) ..."
-    find / -type f -name 'libbpf_kernel.so' -o -name 'libbpf_kernel.so.0'
-    echo >&2 "Please manually delete these files"
-    return 1
-  fi
-
-  rm_file "${libdir}/libbpf_kernel.so.0"
-  rm_file "${libdir}/libbpf_kernel.so"
-  run ldconfig
-
-  echo >&2 "ePBF uninstall all done!"
-
-  return 0
-}
-
 #shellcheck source=/dev/null
 source "${ENVIRONMENT_FILE}" || exit 1
 
@@ -498,8 +470,6 @@ else
   rm_dir "/var/log/netdata"
   rm_dir "/etc/netdata"
 fi
-
-uninstall_ebpf || echo >&2 "Unable to remove eBPF files automatically"
 
 FILE_REMOVAL_STATUS=1
 


### PR DESCRIPTION
##### Summary
We removed user-side shared libraries from kernel-collector repository https://github.com/netdata/kernel-collector/pull/172. We have to delete them from install/uninstall scripts as well.

##### Component Name
eBPF plugin, packaging

##### Test Plan
Run `netdata-installer.sh` and `netdata-uninstaller-sh`. Check if there are no errors related to `libbpf_kernel.so` or `libnetdata_ebpf.so`.