### PR TITLE
Fix artifact building for dist/static artifacts

### DIFF
--- a/packaging/makeself/jobs/20-openssl.install.sh
+++ b/packaging/makeself/jobs/20-openssl.install.sh
@@ -13,6 +13,7 @@ export PKG_CONFIG="pkg-config --static"
 if [ ! -d "${NETDATA_MAKESELF_PATH}/tmp/openssl" ]; then
   run git clone --branch "${version}" --single-branch git://git.openssl.org/openssl.git "${NETDATA_MAKESELF_PATH}/tmp/openssl"
 fi
+
 cd "${NETDATA_MAKESELF_PATH}/tmp/openssl" || exit 1
 
 run ./config no-shared no-tests --prefix=/openssl-static --openssldir=/opt/netdata/etc/ssl


### PR DESCRIPTION
##### Summary

When you run `.github/scripts/build-artifacts.sh` you get a failure from building/testing on macOS where the build process complianing that the `openssl` directory already exists. I'm not sure why but this condition fixes that.

##### Component Name

- area/ci

##### Test Plan

Tested manually

##### Additional Information