### PR TITLE
Fix netdata/netdata Docker image size

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -60,6 +60,7 @@ FROM netdata/base:${ARCH}
 # Copy files over
 RUN mkdir -p /opt/src
 COPY --from=builder /app /
+COPY --from=builder /wheels /wheels
 COPY packaging/docker/health.sh /health.sh
 
 # Configure system
@@ -102,6 +103,9 @@ RUN \
     ln -sf /dev/stdout /var/log/netdata/access.log && \
     ln -sf /dev/stdout /var/log/netdata/debug.log && \
     ln -sf /dev/stderr /var/log/netdata/error.log
+
+# Install any Python wheels
+RUN pip install /wheels/*
 
 ENV NETDATA_PORT 19999
 EXPOSE $NETDATA_PORT


### PR DESCRIPTION
##### Summary

Fixes the `netdata/netdata` Docker image size by ensuring that we
install Python dependencies in pre-built (_wheels_) form and only
install/build things in the `netdata/buidler` image and only include
runtim dependencies in the `netdata/base` runtime image.

Depends on:

- netdata/helper-images#84

Fixes:

- #9664 

##### Component Name

- area/packacing

##### Test Plan

```#!sh
$ dki -t --rm --entrypoint /bin/sh netdata/netdata:amd64
/ # python3
Python 3.8.5 (default, Jul 20 2020, 23:11:29)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pymongo
>>> import psycopg2
>>>
```

```#!sh
$ docker images netdata/netdata:amd64
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
netdata/netdata     amd64               37fe4941b674        7 minutes ago       314MB
```

##### Additional Information