### PR TITLE
Stop multi-host DB statistics from being counted multiple times.

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -537,12 +537,17 @@ void global_statistics_charts(void) {
     RRDHOST *host;
     unsigned long long stats_array[RRDENG_NR_STATS] = {0};
     unsigned long long local_stats_array[RRDENG_NR_STATS];
-    unsigned hosts_with_dbengine = 0, i;
+    unsigned dbengine_contexts = 0, counted_multihost_db = 0, i;
 
     rrd_rdlock();
     rrdhost_foreach_read(host) {
-        if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-            ++hosts_with_dbengine;
+        if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && !rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
+            if (&multidb_ctx == host->rrdeng_ctx) {
+                if (counted_multihost_db)
+                    continue; /* Only count multi-host DB once */
+                counted_multihost_db = 1;
+            }
+            ++dbengine_contexts;
             /* get localhost's DB engine's statistics */
             rrdeng_get_37_statistics(host->rrdeng_ctx, local_stats_array);
             for (i = 0 ; i < RRDENG_NR_STATS ; ++i) {
@@ -553,8 +558,8 @@ void global_statistics_charts(void) {
     }
     rrd_unlock();
 
-    if (hosts_with_dbengine) {
-        /* deduplicate global statistics by getting the ones from the last host */
+    if (dbengine_contexts) {
+        /* deduplicate global statistics by getting the ones from the last context */
         stats_array[30] = local_stats_array[30];
         stats_array[31] = local_stats_array[31];
         stats_array[32] = local_stats_array[32];


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fix multi-host DB statistics.
##### Component Name
dbengine
##### Test Plan
Connect multiple hosts to multihost DB. Observe dbengine statistics not being magnified contrary to what it was before.
