### PR TITLE
python.d/ipfs: disable call to the `/api/v0/stats/repo` endpoint by default

### DIFF
--- a/collectors/python.d.plugin/ipfs/README.md
+++ b/collectors/python.d.plugin/ipfs/README.md
@@ -34,7 +34,7 @@ Calls to the following endpoints are disabled due to `IPFS` bugs:
 -   `/api/v0/stats/repo` (https://github.com/ipfs/go-ipfs/issues/3874)
 -   `/api/v0/pin/ls` (https://github.com/ipfs/go-ipfs/issues/7528)
 
-Can enabled in the collector configuration file.
+Can be enabled in the collector configuration file.
 
 The configuration needs only `url` to `IPFS` server, here is an example for 2 `IPFS` instances:
 

--- a/collectors/python.d.plugin/ipfs/README.md
+++ b/collectors/python.d.plugin/ipfs/README.md
@@ -6,16 +6,16 @@ sidebar_label: "IPFS"
 
 # IPFS monitoring with Netdata
 
-Collects [IPFS](https://ipfs.io) basic information like file system bandwidth, peers and repo metrics. 
+Collects [`IPFS`](https://ipfs.io) basic information like file system bandwidth, peers and repo metrics.
 
-1.  **Bandwidth** in kbits/s
+## Charts
 
-    -   in
-    -   out
+It produces the following charts:
 
-2.  **Peers**
-
-    -   peers
+-   Bandwidth in `kilobits/s`
+-   Peers in `peers`
+-   Repo Size in `GiB`
+-   Repo Objects in `objects`
 
 ## Configuration
 
@@ -27,14 +27,23 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d/ipfs.conf
 ```
 
-Only url to IPFS server is needed.
+---
 
-Sample:
+Calls to the following endpoints are disabled due to `IPFS` bugs:
+
+-   `/api/v0/stats/repo` (https://github.com/ipfs/go-ipfs/issues/3874)
+-   `/api/v0/pin/ls` (https://github.com/ipfs/go-ipfs/issues/7528)
+
+Can enabled in the collector configuration file.
+
+The configuration needs only `url` to `IPFS` server, here is an example for 2 `IPFS` instances:
 
 ```yaml
 localhost:
-  name : 'local'
-  url  : 'http://localhost:5001'
+  url: 'http://localhost:5001'
+
+remote:
+  url: 'http://203.0.113.10::5001'
 ```
 
 ---

--- a/collectors/python.d.plugin/ipfs/ipfs.chart.py
+++ b/collectors/python.d.plugin/ipfs/ipfs.chart.py
@@ -65,6 +65,7 @@ class Service(UrlService):
         self.baseurl = self.configuration.get('url', 'http://localhost:5001')
         self.method = "POST"
         self.do_pinapi = self.configuration.get('pinapi')
+        self.do_repoapi = self.configuration.get('repoapi')
         self.__storage_max = None
 
     def _get_json(self, sub_url):
@@ -110,16 +111,32 @@ class Service(UrlService):
         # suburl : List of (result-key, original-key, transform-func)
         cfg = {
             '/api/v0/stats/bw':
-                [('in', 'RateIn', int), ('out', 'RateOut', int)],
+                [
+                    ('in', 'RateIn', int),
+                    ('out', 'RateOut', int),
+                ],
             '/api/v0/swarm/peers':
-                [('peers', 'Peers', len)],
-            '/api/v0/stats/repo':
-                [('size', 'RepoSize', int), ('objects', 'NumObjects', int), ('avail', 'StorageMax', self._storagemax)],
+                [
+                    ('peers', 'Peers', len),
+                ],
         }
+        if self.do_repoapi:
+            cfg.update({
+                '/api/v0/stats/repo':
+                    [
+                        ('size', 'RepoSize', int),
+                        ('objects', 'NumObjects', int),
+                        ('avail', 'StorageMax', self._storagemax),
+                    ],
+            })
+
         if self.do_pinapi:
             cfg.update({
                 '/api/v0/pin/ls':
-                    [('pinned', 'Keys', len), ('recursive_pins', 'Keys', self._recursive_pins)]
+                    [
+                        ('pinned', 'Keys', len),
+                        ('recursive_pins', 'Keys', self._recursive_pins),
+                    ]
             })
         r = dict()
         for suburl in cfg:

--- a/collectors/python.d.plugin/ipfs/ipfs.conf
+++ b/collectors/python.d.plugin/ipfs/ipfs.conf
@@ -62,6 +62,10 @@
 # Additionally to the above, ipfs also supports the following:
 #
 #     url: 'URL'       # URL to the IPFS API
+#     repoapi: no      # Collect repo metrics
+#                      # Currently defaults to disabled due to IPFS Bug
+#                      # https://github.com/ipfs/go-ipfs/issues/7528
+#                      # resulting in very high CPU Usage
 #     pinapi: no       # Set status of IPFS pinned object polling
 #                      # Currently defaults to disabled due to IPFS Bug
 #                      # https://github.com/ipfs/go-ipfs/issues/3874
@@ -72,6 +76,7 @@
 # only one of them will run (they have the same name)
 
 localhost:
-  name   : 'local'
-  url    : 'http://localhost:5001'
-  pinapi : no
+  name: 'local'
+  url: 'http://localhost:5001'
+  repoapi: no
+  pinapi: no


### PR DESCRIPTION
##### Summary

Fixes: #9505

Using python ipfs collector results in [high CPU load of IPFS](https://user-images.githubusercontent.com/614929/86942195-27a12d80-c145-11ea-8ffd-9084dfcacfd7.png).

There is an open bug in the IPFS repo

> https://github.com/ipfs/go-ipfs/issues/7528


This PR disables call to the `/api/v0/stats/repo` endpoint by default. Can be enabled in the module config file.

Same as we did in https://github.com/netdata/netdata/pull/4224


##### Component Name

`python.d/ipfs`

##### Test Plan

- [ ] Ask @RubenKelevra to test it 😄 

##### Additional Information
