### PR TITLE
Send follow up alarms when the initial status matches the notification

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -452,6 +452,7 @@ filter_recipient_by_criticality() {
 		if [ -f "${NETDATA_CACHE_DIR}/alarm-notify/${method}/${r}/${alarm_id}" ]; then
 			# we do not remove the file, so that he will get future notifications of this alarm
 			debug "SEVERITY FILTERING for ${x} VIA ${method}: ALLOW: recipient has been notified for this alarm in the past (will still receive next status change)"
+			return 0
 		fi
 		;;
 
@@ -460,6 +461,7 @@ filter_recipient_by_criticality() {
 			# remove the file, so that he will only receive notifications for CRITICAL states for this alarm
 			rm "${NETDATA_CACHE_DIR}/alarm-notify/${method}/${r}/${alarm_id}"
 			debug "SEVERITY FILTERING for ${x} VIA ${method}: ALLOW: recipient has been notified for this alarm (will only receive CRITICAL notifications from now on)"
+			return 0
 		fi
 		;;
 	esac


### PR DESCRIPTION
##### Summary
Fixes #8739 

When Netdata sends an alarm notification that matches the configured filters, it's supposed to send follow-up notifications, until the alarm is cleared. This feature was erroneously broken by #7769, due to an incorrect handling of #7756.
Returning the previous functionality.

##### Component Name
health/notifications

##### Test Plan
Run the notifications test, to verify that the initial WARNING alarm is not sent, but the CRITICAL and CLEAR alarms are sent, when a recipient has the `|CRITICAL` filter.

More detailed tests:
- Run `bash -x /usr/libexec/netdata/plugins.d/alarm-notify.sh test`, with debug enabled (https://learn.netdata.cloud/docs/agent/health/notifications#testing-notifications)
- Look in the output for the alarm-notify.sh calls. There are three of them. 
- Run them one by one and after each execution look at the debug output and also check for the existence of /var/cache/netdata/alarm-notify/xxx/zzz

You'll see that CRITICAL creates a file there, CLEAR deletes it. Depending on the existence of that file, other notifications are sent (including ones for WARNING). 
