### PR TITLE
Add BigBlueButton monitoring with a Node.js plugin

### DIFF
--- a/collectors/node.d.plugin/Makefile.am
+++ b/collectors/node.d.plugin/Makefile.am
@@ -36,6 +36,7 @@ dist_nodeconfig_DATA = \
 dist_node_DATA = \
     $(NULL)
 
+include bigbluebutton/Makefile.inc
 include fronius/Makefile.inc
 include named/Makefile.inc
 include sma_webbox/Makefile.inc

--- a/collectors/node.d.plugin/bigbluebutton/Makefile.inc
+++ b/collectors/node.d.plugin/bigbluebutton/Makefile.inc
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_node_DATA       += bigbluebutton/bigbluebutton.node.js
+# dist_nodeconfig_DATA += bigbluebutton/bigbluebutton.conf
+
+# do not install these files, but include them in the distribution
+dist_noinst_DATA       += bigbluebutton/README.md bigbluebutton/Makefile.inc
+

--- a/collectors/node.d.plugin/bigbluebutton/README.md
+++ b/collectors/node.d.plugin/bigbluebutton/README.md
@@ -1,0 +1,29 @@
+<!--
+title: "BigBlueButton monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/node.d.plugin/bigbluebutton/README.md
+sidebar_label: "BigBlueButton"
+-->
+
+# BigBlueButton monitoring with Netdata
+
+Example Netdata configuration for node.d/bigbluebutton.conf
+
+The module supports any number of servers, like this.
+Auto detection is not supported.
+
+```json
+{
+    "enable_autodetect": false,
+    "update_every": 5,
+    "servers": [
+        {
+            "name": "bbb",
+            "url": "https://localhost/api",
+            "update_every": 10,
+            "secret": "Your_BBB_SECRET"
+        }
+    ]
+}
+```
+
+To get the `url` and the `secret` configuration parameter, you can run `bbb-conf --secret` on your BigBlueButton server.

--- a/collectors/node.d.plugin/bigbluebutton/bigbluebutton.node.js
+++ b/collectors/node.d.plugin/bigbluebutton/bigbluebutton.node.js
@@ -1,0 +1,196 @@
+// this is the mymodule definition
+var crypto = require("crypto");
+var https = require("https");
+var netdata = require("netdata");
+var url = require("url");
+
+var bigbluebutton = {
+  charts: {},
+
+  base_priority: 60000,
+
+  processResponse: function(service, data) {
+    /* send information to the Netdata server here */
+    if (data !== null) {
+      if (service.added !== true) {
+        service.commit();
+      }
+
+      var conferences = (data.match(/<meetingID>/g) || []).length;
+
+      var id = "bbb_" + service.name + ".conferences";
+      var chart = bigbluebutton.charts[id];
+
+      if (typeof chart === "undefined") {
+        chart = {
+          id: "bbb_conferences", // the unique id of the chart
+          name: "BBB conferences", // the unique name of the chart
+          title: "BBB Current conferences", // the title of the chart
+          units: "conferences", // the units of the chart dimensions
+          family: "conferences", // the family of the chart
+          context: "bigbluebutton.conferences", // the context of the chart
+          type: netdata.chartTypes.line, // the type of the chart
+          priority: bigbluebutton.base_priority + 1, // the priority relative to others in the same family
+          update_every: service.update_every, // the expected update frequency of the chart
+          dimensions: {
+            conferences: {
+              id: "conferences", // the unique id of the dimension
+              name: "", // the name of the dimension
+              algorithm: netdata.chartAlgorithms.absolute, // the id of the netdata algorithm
+              multiplier: 1, // the multiplier
+              divisor: 1, // the divisor
+              hidden: false // is hidden (boolean)
+            }
+          }
+        };
+        chart = service.chart(id, chart);
+        bigbluebutton.charts[id] = chart;
+      }
+
+      service.begin(chart);
+      service.set("conferences", conferences);
+      service.end();
+
+      var sumXmlAttr = function(name) {
+        var sum = 0;
+        var r = new RegExp("<" + name + ">([0-9]+)</" + name + ">", "g");
+        var match = r.exec(data);
+        while (match !== null) {
+          sum += parseInt(match[1], 10);
+          match = r.exec(data);
+        }
+        return sum;
+      };
+
+      var participantCount = sumXmlAttr("participantCount");
+      var listenerCount = sumXmlAttr("listenerCount");
+      var voiceParticipantCount = sumXmlAttr("voiceParticipantCount");
+      var videoCount = sumXmlAttr("videoCount");
+
+      id = "bbb_" + service.name + ".users";
+      chart = bigbluebutton.charts[id];
+
+      if (typeof chart === "undefined") {
+        chart = {
+          id: "bbb_users", // the unique id of the chart
+          name: "BBB users", // the unique name of the chart
+          title: "BBB Current users", // the title of the chart
+          units: "users", // the units of the chart dimensions
+          family: "users", // the family of the chart
+          context: "bigbluebutton.users", // the context of the chart
+          type: netdata.chartTypes.line, // the type of the chart
+          priority: bigbluebutton.base_priority + 1, // the priority relative to others in the same family
+          update_every: service.update_every, // the expected update frequency of the chart
+          dimensions: {
+            participants: {
+              id: "participants", // the unique id of the dimension
+              name: "", // the name of the dimension
+              algorithm: netdata.chartAlgorithms.absolute, // the id of the netdata algorithm
+              multiplier: 1, // the multiplier
+              divisor: 1, // the divisor
+              hidden: false // is hidden (boolean)
+            },
+            listeners: {
+              id: "listeners", // the unique id of the dimension
+              name: "", // the name of the dimension
+              algorithm: netdata.chartAlgorithms.absolute, // the id of the netdata algorithm
+              multiplier: 1, // the multiplier
+              divisor: 1, // the divisor
+              hidden: false // is hidden (boolean)
+            },
+            voiceParticipants: {
+              id: "voiceParticipants", // the unique id of the dimension
+              name: "", // the name of the dimension
+              algorithm: netdata.chartAlgorithms.absolute, // the id of the netdata algorithm
+              multiplier: 1, // the multiplier
+              divisor: 1, // the divisor
+              hidden: false // is hidden (boolean)
+            },
+            videos: {
+              id: "videos", // the unique id of the dimension
+              name: "", // the name of the dimension
+              algorithm: netdata.chartAlgorithms.absolute, // the id of the netdata algorithm
+              multiplier: 1, // the multiplier
+              divisor: 1, // the divisor
+              hidden: false // is hidden (boolean)
+            }
+          }
+        };
+        chart = service.chart(id, chart);
+        bigbluebutton.charts[id] = chart;
+      }
+
+      service.begin(chart);
+      service.set("participants", participantCount);
+      service.set("listeners", listenerCount);
+      service.set("voiceParticipants", voiceParticipantCount);
+      service.set("videos", videoCount);
+      service.end();
+    }
+  },
+
+  configure: function(config) {
+    var eligible_services = 0;
+
+    if (typeof config.servers !== "undefined" || config.servers.length !== 0) {
+      var len = config.servers.length;
+      while (len--) {
+        var server = config.servers[len];
+
+        // See https://docs.bigbluebutton.org/dev/api.html#usage
+        var checksum = crypto
+          .createHash("sha1")
+          .update("getMeetings" + server.secret)
+          .digest("hex");
+        var serverUrl = server.url + "api/getMeetings?checksum=" + checksum;
+        var u = url.parse(serverUrl);
+
+        netdata
+          .service({
+            name: server.name,
+            update_every: server.update_every,
+            module: this,
+            request: {
+              protocol: u.protocol,
+              hostname: u.hostname,
+              port: u.port,
+              path: u.path,
+              //family: 4,
+              method: u.method,
+              headers: {
+                Connection: "keep-alive"
+              },
+              agent: new https.Agent({
+                keepAlive: true,
+                keepAliveMsecs: netdata.options.update_every * 1000,
+                maxSockets: 2, // it must be 2 to work
+                maxFreeSockets: 1
+              })
+            }
+          })
+          .execute(this.processResponse);
+
+        eligible_services++;
+      }
+    }
+
+    return eligible_services;
+  },
+
+  update: function(service, callback) {
+    /*
+     * this function is called when each service
+     * created by the configure function, needs to
+     * collect updated values.
+     *
+     * You normally will not need to change it.
+     */
+
+    service.execute(function(service, data) {
+      bigbluebutton.processResponse(service, data);
+      callback();
+    });
+  }
+};
+
+module.exports = bigbluebutton;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Add a Node.js plugin to monitor [BigBlueButton](https://bigbluebutton.org/).


##### Component Name

`node.d.plugin/bigbluebutton`

##### Test Plan

- I installed this plugin on my own netdata instance. BigBlueButton was running on the same server.
- I followed the instructions documented in the [README.md](https://github.com/madmatah/netdata/blob/98a6f7747258674fe23e8011fc66b83c2843d265/collectors/node.d.plugin/bigbluebutton/README.md) (add configuration file + set `url` and `secret`  options)

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information

[Link to BigBlueButton API documentation](https://docs.bigbluebutton.org/dev/api.html).

The following charts and dimensions are added (see screenshot below) :

###### bbb_conferences
- **conferences** : the number of active conferences running on the server.

###### bbb_users
- **participants** : the total number of participants connected to a conference on the BigBlueButton server
- **listeners** : the number of participants connected in «Listen only» mode
- **voiceParticipants** : the number of participants connected in «Microphone» mode
- **videos** : the number of active video streams (webcam + screen sharing)


Here is a demo screenshot : 

![bbb-netdata-plugin](https://user-images.githubusercontent.com/2926/89787475-d1495500-db1d-11ea-9664-2a79c28e41b4.png)


This is my first contribution to the netdata project, so I'm interested by your feedbacks and help to improve this plugin.

