### PR TITLE
Set the default value of the home directory to the environment's HOME

### DIFF
--- a/daemon/common.c
+++ b/daemon/common.c
@@ -11,7 +11,7 @@ char *netdata_configured_web_dir             = WEB_DIR;
 char *netdata_configured_cache_dir           = CACHE_DIR;
 char *netdata_configured_varlib_dir          = VARLIB_DIR;
 char *netdata_configured_lock_dir            = NULL;
-char *netdata_configured_home_dir            = CACHE_DIR;
+char *netdata_configured_home_dir            = VARLIB_DIR;
 char *netdata_configured_host_prefix         = NULL;
 char *netdata_configured_timezone            = NULL;
 int netdata_ready;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -541,7 +541,7 @@ static void get_netdata_configured_variables() {
     netdata_configured_web_dir          = config_get(CONFIG_SECTION_GLOBAL, "web files directory",    netdata_configured_web_dir);
     netdata_configured_cache_dir        = config_get(CONFIG_SECTION_GLOBAL, "cache directory",        netdata_configured_cache_dir);
     netdata_configured_varlib_dir       = config_get(CONFIG_SECTION_GLOBAL, "lib directory",          netdata_configured_varlib_dir);
-    netdata_configured_home_dir         = config_get(CONFIG_SECTION_GLOBAL, "home directory",         netdata_configured_home_dir);
+    netdata_configured_home_dir         = config_get(CONFIG_SECTION_GLOBAL, "home directory",         getenv("HOME"));
 
     netdata_configured_lock_dir = initialize_lock_directory_path(netdata_configured_varlib_dir);
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -541,7 +541,8 @@ static void get_netdata_configured_variables() {
     netdata_configured_web_dir          = config_get(CONFIG_SECTION_GLOBAL, "web files directory",    netdata_configured_web_dir);
     netdata_configured_cache_dir        = config_get(CONFIG_SECTION_GLOBAL, "cache directory",        netdata_configured_cache_dir);
     netdata_configured_varlib_dir       = config_get(CONFIG_SECTION_GLOBAL, "lib directory",          netdata_configured_varlib_dir);
-    netdata_configured_home_dir         = config_get(CONFIG_SECTION_GLOBAL, "home directory",         getenv("HOME"));
+    char *env_home=getenv("HOME");
+    netdata_configured_home_dir         = config_get(CONFIG_SECTION_GLOBAL, "home directory",         env_home?env_home:netdata_configured_home_dir);
 
     netdata_configured_lock_dir = initialize_lock_directory_path(netdata_configured_varlib_dir);
 


### PR DESCRIPTION
##### Summary
Fixes #6865 (?)
For the default environment value of "HOME", use the user's "HOME", as defined in the environment.

##### Component Name
daemon

##### Test Plan
Test in various environments, including AWS SNS.

##### Additional Information
I don't know how to properly test this, I'll leave it up to @Ferroin 
