### PR TITLE
Fixed issue with missing alarms

### DIFF
--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -19,7 +19,7 @@ static inline void calc_link_to_rrddim(RRDDIM *rd)
             } else if (hostlocked != EBUSY) {
                 error("Cannot lock host to create an alarm for the dimension.");
             }
-            usleep(200000);
+            sleep_usec(USEC_PER_MS * 200);
         }
 
         if (count == 5) {

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -452,7 +452,6 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     if(unlikely(rrddim_index_add(st, rd) != rd))
         error("RRDDIM: INTERNAL ERROR: attempt to index duplicate dimension '%s' on chart '%s'", rd->id, st->id);
 
-
     if (!is_archived)
         calc_link_to_rrddim(rd);
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -3,6 +3,32 @@
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
 
+static inline void calc_link_to_rrddim(RRDDIM *rd)
+{
+    RRDHOST *host = rd->rrdset->rrdhost;
+    RRDSET  *st = rd->rrdset;
+    if (host->alarms_with_foreach || host->alarms_template_with_foreach) {
+        int count = 0;
+        int hostlocked;
+        for (count = 0; count < 5; count++) {
+            hostlocked = netdata_rwlock_trywrlock(&host->rrdhost_rwlock);
+            if (!hostlocked) {
+                rrdcalc_link_to_rrddim(rd, st, host);
+                rrdhost_unlock(host);
+                break;
+            } else if (hostlocked != EBUSY) {
+                error("Cannot lock host to create an alarm for the dimension.");
+            }
+            usleep(200000);
+        }
+
+        if (count == 5) {
+            error(
+                "Failed to create an alarm for dimension %s of chart %s 5 times. Skipping alarm.", rd->name, st->name);
+        }
+    }
+}
+
 // ----------------------------------------------------------------------------
 // RRDDIM index
 
@@ -212,6 +238,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
             rrddimvar_create(rd, RRDVAR_TYPE_CALCULATED, NULL, NULL, &rd->last_stored_value, RRDVAR_OPTION_DEFAULT);
             rrddimvar_create(rd, RRDVAR_TYPE_COLLECTED, NULL, "_raw", &rd->last_collected_value, RRDVAR_OPTION_DEFAULT);
             rrddimvar_create(rd, RRDVAR_TYPE_TIME_T, NULL, "_last_collected_t", &rd->last_collected_time.tv_sec, RRDVAR_OPTION_DEFAULT);
+            calc_link_to_rrddim(rd);
         }
         // DBENGINE available and activated?
 #ifdef ENABLE_DBENGINE
@@ -425,26 +452,10 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     if(unlikely(rrddim_index_add(st, rd) != rd))
         error("RRDDIM: INTERNAL ERROR: attempt to index duplicate dimension '%s' on chart '%s'", rd->id, st->id);
 
-    if (host->alarms_with_foreach || host->alarms_template_with_foreach) {
-        int count = 0;
-        int hostlocked;
-        for (count = 0 ; count < 5 ; count++) {
-            hostlocked = netdata_rwlock_trywrlock(&host->rrdhost_rwlock);
-            if (!hostlocked) {
-                rrdcalc_link_to_rrddim(rd, st, host);
-                rrdhost_unlock(host);
-                break;
-            } else if (hostlocked != EBUSY) {
-                error("Cannot lock host to create an alarm for the dimension.");
-            }
-            usleep(200000);
-        }
 
-        if (count == 5) {
-            error("Failed to create an alarm for dimension %s of chart %s 5 times. Skipping alarm."
-            , rd->name, st->name);
-        }
-    }
+    if (!is_archived)
+        calc_link_to_rrddim(rd);
+
     rrdset_unlock(st);
 #ifdef ENABLE_ACLK
     if (netdata_cloud_setting)

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -679,6 +679,11 @@ RRDSET *rrdset_create_custom(
             rrdsetvar_create(st, "update_every",        RRDVAR_TYPE_INT,        &st->update_every,               RRDVAR_OPTION_DEFAULT);
             rrdsetcalc_link_matching(st);
             rrdcalctemplate_link_matching(st);
+
+            RRDDIM *rd;
+            rrddim_foreach_read(rd, st) {
+                rrdcalc_link_to_rrddim(rd, st, host);
+            }
         }
         rrdhost_unlock(host);
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -679,11 +679,6 @@ RRDSET *rrdset_create_custom(
             rrdsetvar_create(st, "update_every",        RRDVAR_TYPE_INT,        &st->update_every,               RRDVAR_OPTION_DEFAULT);
             rrdsetcalc_link_matching(st);
             rrdcalctemplate_link_matching(st);
-
-            RRDDIM *rd;
-            rrddim_foreach_read(rd, st) {
-                rrdcalc_link_to_rrddim(rd, st, host);
-            }
         }
         rrdhost_unlock(host);
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);


### PR DESCRIPTION
Fixes #9706
##### Summary
When the health subsystem is configured, archived charts are skipped to avoid unnecessary configuration that slows
down the metadata log replay. 

Health related configuration for those charts is performed when a chart switches from archived to active by having a collector gather metrics for any dimension of that chart.

The following init code (found in the health configuration initialization) did not run in that case

```
rrddim_foreach_read(rd, st) {
    rrdcalc_link_to_rrddim(rd, st, host);
}
```

##### Component Name
database
health

##### Test Plan
- Before the PR
- Configure an alarm as described in #9706 
- Restart the agent 
   - The alarm is not raised
- Perform health reload
- Alarm is now raised
  - Note that during health reload the init process is done properly because the chart is not archived anymore

- Apply the PR    
- Restart agent
- Alarm is now immediately raised
