### PR TITLE
Removed Ubuntu 20.04 32-bit x86 package builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -280,7 +280,7 @@ jobs:
 
     - name: "Build & Publish DEB package for ubuntu/focal"
       <<: *DEB_TEMPLATE
-      if: commit_message =~ /\[Package (amd64|arm64|i386) DEB( Ubuntu)?\]/
+      if: commit_message =~ /\[Package (amd64|arm64) DEB( Ubuntu)?\]/
       env:
         - BUILDER_NAME="builder" BUILD_DISTRO="ubuntu" BUILD_RELEASE="focal" BUILD_STRING="ubuntu/focal"
         - PACKAGE_TYPE="deb" REPO_TOOL="apt-get"


### PR DESCRIPTION
##### Summary

Our current infrastructure depends on availability of appropriate architecture LXC containers for the distros we're building for, and
there are no 32-bit x86 LXC images for Ubuntu 20.04, so we cannot build these packages.

##### Component Name

area/ci
area/packaging

##### Test Plan

Verified the new commit message regex locally.