### PR TITLE
Fix proxy redirect

### DIFF
--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -10,6 +10,7 @@
 # define NETDATA_SSL_FORCE 32                //We only accepts HTTPS request
 # define NETDATA_SSL_INVALID_CERTIFICATE 64  //Accepts invalid certificate
 # define NETDATA_SSL_VALID_CERTIFICATE 128  //Accepts invalid certificate
+# define NETDATA_SSL_PROXY_HTTPS 256        //Proxy is using HTTPS
 
 #define NETDATA_SSL_CONTEXT_SERVER 0
 #define NETDATA_SSL_CONTEXT_STREAMING 1
@@ -30,7 +31,7 @@
 
 struct netdata_ssl{
     SSL *conn; //SSL connection
-    int flags; //The flags for SSL connection
+    uint32_t flags; //The flags for SSL connection
 };
 
 extern SSL_CTX *netdata_opentsdb_ctx;

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -155,6 +155,7 @@ struct web_client {
     char client_port[NI_MAXSERV];
     char server_host[NI_MAXHOST];
     char client_host[NI_MAXHOST];
+    char forwarded_host[NI_MAXHOST]; //Used with proxy
 
     char decoded_url[NETDATA_WEB_REQUEST_URL_SIZE + 1];          // we decode the URL in this buffer
     char decoded_query_string[NETDATA_WEB_REQUEST_URL_SIZE + 1]; // we decode the Query String in this buffer

--- a/web/server/web_client_cache.c
+++ b/web/server/web_client_cache.c
@@ -188,7 +188,7 @@ struct web_client *web_client_get_from_cache_or_allocate() {
 #ifdef ENABLE_HTTPS
         w->ssl.conn = ssl;
         w->ssl.flags = NETDATA_SSL_START;
-        debug(D_WEB_CLIENT_ACCESS,"Reusing SSL structure with (w->ssl = NULL, w->accepted = %d)",w->ssl.flags);
+        debug(D_WEB_CLIENT_ACCESS,"Reusing SSL structure with (w->ssl = NULL, w->accepted = %u)", w->ssl.flags);
 #endif
     }
     else {
@@ -196,7 +196,7 @@ struct web_client *web_client_get_from_cache_or_allocate() {
         w = web_client_alloc();
 #ifdef ENABLE_HTTPS
         w->ssl.flags = NETDATA_SSL_START;
-        debug(D_WEB_CLIENT_ACCESS,"Starting SSL structure with (w->ssl = NULL, w->accepted = %d)",w->ssl.flags);
+        debug(D_WEB_CLIENT_ACCESS,"Starting SSL structure with (w->ssl = NULL, w->accepted = %u)", w->ssl.flags);
 #endif
         web_clients_cache.allocated++;
     }


### PR DESCRIPTION
##### Summary
Fixes #9065 

This PR fixes the wrong Location returned by Netdata. Previously Netdata was considering only direct access to dashboard, but when a proxy is put between the browser and Netdata, it is necessary to parse more headers to build the correct URL that proxy has condition to redirect.

##### Component Name
Web

##### Test Plan
The user reported the error while he was using GCP HTTPS, but this test plan is based on Nginx proxy.

1 - Configure your Netdata `parent` to support a port with SSL and another port without it:

```
[web]
        ssl key = /etc/netdata/ssl/key.pem
        ssl certificate = /etc/netdata/ssl/cert.pem
        bind to = *=dashboard|registry|streaming|management|netdata.conf|badges *:20000=dashboard|registry|streaming|netdata.conf|badges|management^SSL=optional
```

please, do not forget to create the SSL certificate inside `/etc/netdata/ssl/`.

2 - Configure the `child` to connect either using SSL or with plan text, this does not affect the tests, but it is good to verify that nothing is broken.
3 - Start `parent` and after this start `child`
4 - Configure Nginx to work as a proxy:

```
server {
        listen       8081;
        server_name  localhost;

        #charset koi8-r;

        #access_log  logs/host.access.log  main;

        #location / {
        #    root   /var/www/html;
        #    index  index.html index.htm;
        #}

                #auth_basic           "Administrator’s Area";
        #auth_basic_user_file /etc/nginx/.htpasswd;
        location / {
            proxy_redirect off;
            proxy_set_header Host $host;
            proxy_set_header X-Forwarded-Host $host:$server_port;
            proxy_set_header X-Forwarded-Server $host;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto https; #New
            proxy_http_version 1.1;
            proxy_pass_request_headers on;
            proxy_set_header Connection "keep-alive";
            proxy_store off;
            gzip on;
            gzip_proxied any;
            gzip_types *;
            rewrite ^/netdata(/.*)$ $1 break;
            proxy_pass http://localhost:20000;
         }

         ssl on;
         ssl_certificate /etc/nginx/cert.pem;
         ssl_certificate_key /etc/nginx/key.pem;

        #error_page  404              /404.html;
        location = /50x.html {
            root   /var/www/html;
        }
    }
```

This nginx is replicating the user configuration, the SSL certificates are on nginx and the redirect is done for a Netdata using the port without TLS certificate associated.

5 - Create other tls certificates inside `/etc/nginx'
6 - Start nginx
7 - Now we will confirm that nothing was broken, please access these URLs pairs:

```
https://localhost:19999 , https://localhost:19999/host/child_name
http://localhost:20000 , http://localhost:20000/host/child_name
https://localhost:8081 , https://localhost:20000/host/child_name/8081/
```

please, pay attention that the last URL has a bar at the end.

8 - Finally we will access the URL that was creating problems `https://localhost:20000/host/child_name/8081`.

If somehow GCP is using a different proxy headers, this PR will need another small change.

##### Additional Information
