### PR TITLE
Fixed global GUID map memory leak

### DIFF
--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -244,10 +244,12 @@ int find_or_generate_guid(void *object, uuid_t *uuid, GUID_TYPE object_type, int
         uv_rwlock_wrunlock(&global_lock);
         return rc;
     }
-    //uv_rwlock_wrunlock(&global_lock);
+    else {
 #ifdef NETDATA_INTERNAL_CHECKS
-    dump_object(uuid, target_object);
+        dump_object(uuid, target_object);
 #endif
+        freez(target_object);
+    }
     return 0;
 }
 

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -240,16 +240,16 @@ int find_or_generate_guid(void *object, uuid_t *uuid, GUID_TYPE object_type, int
         if (!replace_instead_of_generate) /* else take *uuid as user input */
             uuid_generate(*uuid);
         uv_rwlock_wrlock(&global_lock);
-        int rc = guid_store_nolock(uuid, target_object, object_type);
+        rc = guid_store_nolock(uuid, target_object, object_type);
         uv_rwlock_wrunlock(&global_lock);
+        if (rc)
+            freez(target_object);
         return rc;
     }
-    else {
 #ifdef NETDATA_INTERNAL_CHECKS
-        dump_object(uuid, target_object);
+    dump_object(uuid, target_object);
 #endif
-        freez(target_object);
-    }
+    freez(target_object);
     return 0;
 }
 


### PR DESCRIPTION
Fixes #9724

##### Summary
The object memory is now released if the object already exists in the map.

The memory leak only affects the `GUID_TYPE_CHAR` objects. 

##### Component Name
database

##### Test Plan
- Run valgrind to track the  `GUID_TYPE_CHAR` object creation during the creation of `GUID_TYPE_DIMENSION` or `GUID_TYPE_CHART` object in `find_or_generate_guid`


