### PR TITLE
Add CAP_SYS_CHROOT for netdata service

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -53,6 +53,7 @@ CapabilityBoundingSet=CAP_SYS_ADMIN       # is required for perf plugin
 CapabilityBoundingSet=CAP_SYS_PTRACE      # is required for apps plugin
 CapabilityBoundingSet=CAP_SYS_RESOURCE    # is required for ebpf plugin
 CapabilityBoundingSet=CAP_NET_RAW         # is required for fping app
+CapabilityBoundingSet=CAP_SYS_CHROOT      # is required for cgroups plugin
 
 # Sandboxing
 ProtectSystem=full


### PR DESCRIPTION
##### Summary
Netdata service doesn't have the ability to change namespaces. As a consequence, cgroups plugin can't read information about network interfaces in LXD 4.x containers. We need to add `CAP_SYS_CHROOT` to the `netdata.service` unit file to fix that.

Fixes #8359
Fixes #9368

##### Component Name
daemon

##### Test Plan
Run Netdata on a machine with LXD 4.x.
Check if there are no errors `Cannot switch to mount namespace` in `error.log`.
Check if virtual network interfaces are displayed under the corresponding container section and not in "Network Interfaces".