### PR TITLE
Added code to release memory used by the global GUID map

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -60,7 +60,9 @@ void netdata_cleanup_and_exit(int ret) {
 #ifdef ENABLE_HTTPS
     security_clean_openssl();
 #endif
-
+#ifdef ENABLE_DBENGINE
+    free_global_guid_map();
+#endif
     info("EXIT: all done - netdata is now exiting - bye bye...");
     exit(ret);
 }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -266,6 +266,10 @@ void cancel_main_threads() {
     }
     else
         info("All threads finished.");
+
+    info("Cleanup global GUID map");
+    destroy_store_map();
+    info("Cleanup global GUID map done");
 }
 
 struct option_def option_definitions[] = {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -266,12 +266,6 @@ void cancel_main_threads() {
     }
     else
         info("All threads finished.");
-
-#ifdef ENABLE_DBENGINE
-    info("Cleanup global GUID map");
-    destroy_store_map();
-    info("Cleanup global GUID map done");
-#endif
 }
 
 struct option_def option_definitions[] = {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -267,9 +267,11 @@ void cancel_main_threads() {
     else
         info("All threads finished.");
 
+#ifdef ENABLE_DBENGINE
     info("Cleanup global GUID map");
     destroy_store_map();
     info("Cleanup global GUID map done");
+#endif
 }
 
 struct option_def option_definitions[] = {

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -10,12 +10,10 @@ static uv_rwlock_t global_lock;
 
 static void free_single_uuid(uuid_t *uuid)
 {
-    char uuid_str[37];
     Pvoid_t *PValue, *PValue1;
     char *existing_object;
     Word_t  size;
 
-    uuid_unparse_lower(*uuid, uuid_str);
     PValue = JudyHSGet(JGUID_map, (void *) uuid, (Word_t) sizeof(uuid_t));
     if (likely(PValue)) {
         existing_object = *PValue;

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -8,6 +8,13 @@ static uv_rwlock_t guid_lock;
 static uv_rwlock_t object_lock;
 static uv_rwlock_t global_lock;
 
+
+void free_global_guid_map()
+{
+    JudyHSFreeArray(&JGUID_map, PJE0);
+    JudyHSFreeArray(&JGUID_object_map, PJE0);
+}
+
 static void free_single_uuid(uuid_t *uuid)
 {
     Pvoid_t *PValue, *PValue1;
@@ -36,11 +43,15 @@ void free_uuid(uuid_t *uuid)
     char object[49];
 
     ret = find_object_by_guid(uuid, object, sizeof(object));
-    if (GUID_TYPE_DIMENSION == ret)
+    if (GUID_TYPE_DIMENSION == ret) {
         free_single_uuid((uuid_t *)(object + 16 + 16));
+        info("FREE DIM");
+    }
 
-    if (GUID_TYPE_CHART == ret)
-        free_single_uuid((uuid_t *)(object + 16));
+    if (GUID_TYPE_CHART == ret) {
+            free_single_uuid((uuid_t *)(object + 16));
+            info("FREE CHART");
+    }
 
     free_single_uuid(uuid);
     return;

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -43,15 +43,11 @@ void free_uuid(uuid_t *uuid)
     char object[49];
 
     ret = find_object_by_guid(uuid, object, sizeof(object));
-    if (GUID_TYPE_DIMENSION == ret) {
+    if (GUID_TYPE_DIMENSION == ret)
         free_single_uuid((uuid_t *)(object + 16 + 16));
-        info("FREE DIM");
-    }
 
-    if (GUID_TYPE_CHART == ret) {
+    if (GUID_TYPE_CHART == ret)
             free_single_uuid((uuid_t *)(object + 16));
-            info("FREE CHART");
-    }
 
     free_single_uuid(uuid);
     return;

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -153,34 +153,6 @@ static inline int guid_store_nolock(uuid_t *uuid, void *object, GUID_TYPE object
 }
 
 
-inline int guid_store(uuid_t *uuid, char *object, GUID_TYPE object_type)
-{
-    uv_rwlock_wrlock(&global_lock);
-    int rc = guid_store_nolock(uuid, object, object_type);
-    uv_rwlock_wrunlock(&global_lock);
-    return rc;
-}
-
-/*
- * This can be used to bulk load entries into the global map
- *
- * A lock must be aquired since it will call guid_store_nolock
- * with a "no lock" parameter.
- *
- * Note: object memory must be allocated by caller and not released
- */
-int guid_bulk_load(char *uuid, char *object)
-{
-    uuid_t target_uuid;
-    if (likely(!uuid_parse(uuid, target_uuid))) {
-#ifdef NETDATA_INTERNAL_CHECKS
-        debug(D_GUIDLOG,"Mapping GUID [%s] on [%s]", uuid, object);
-#endif
-        return guid_store_nolock(&target_uuid, object, GUID_TYPE_CHAR);
-    }
-    return 1;
-}
-
 /*
  * Given a GUID, find if an object is stored
  *   - Optionally return the object
@@ -317,12 +289,6 @@ void init_global_guid_map()
     fatal_assert(0 == uv_rwlock_init(&guid_lock));
     fatal_assert(0 == uv_rwlock_init(&object_lock));
     fatal_assert(0 == uv_rwlock_init(&global_lock));
-
-//    int rc = guid_bulk_load("6fc56a64-05d7-47a7-bc82-7f3235d8cbda","d6b37186-74db-11ea-88b2-0bf5095b1f9e/cgroup_qemu_ubuntu18.04.cpu_per_core/cpu3");
-//    rc = guid_bulk_load("75c6fa02-97cc-40c1-aacd-a0132190472e","d6b37186-74db-11ea-88b2-0bf5095b1f9e/services.throttle_io_ops_write/system.slice_setvtrgb.service");
-//    if (rc == 0)
-//        info("BULK GUID load successful");
-
     return;
 }
 

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -13,15 +13,11 @@ MAP_STORE   *guid_map_store = NULL;
 void add_to_guid_store(uuid_t *uuid)
 {
     MAP_STORE *tmp_guid_map_store;
-    //return;
 
     if (!guid_map_store)
         guid_map_store = callocz(1, sizeof(*guid_map_store));
 
     uuid_copy(guid_map_store->list[guid_map_store->index++], *uuid);
-    char uuid_str[37];
-    uuid_unparse_lower(guid_map_store->list[guid_map_store->index-1], uuid_str);
-    //info("Adding UUID %d = %s", guid_map_store->index-1, uuid_str);
     if (guid_map_store->index == MAP_STORE_SIZE) {
         tmp_guid_map_store = callocz(1, sizeof(*guid_map_store));
         tmp_guid_map_store->next = guid_map_store;

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -168,15 +168,19 @@ GUID_TYPE find_object_by_guid(uuid_t *uuid, char *object, size_t max_bytes)
     if (likely(object && max_bytes)) {
         switch (value_type) {
             case GUID_TYPE_CHAR:
-                if (unlikely(max_bytes - 1 < strlen((char *) *PValue+1)))
+                if (unlikely(max_bytes - 1 < strlen((char *) *PValue+1))) {
+                    uv_rwlock_rdunlock(&global_lock);
                     return GUID_TYPE_NOSPACE;
+                }
                 strncpyz(object, (char *) *PValue+1, max_bytes - 1);
                 break;
             case GUID_TYPE_HOST:
             case GUID_TYPE_CHART:
             case GUID_TYPE_DIMENSION:
-                if (unlikely(max_bytes < (size_t) value_type * 16))
+                if (unlikely(max_bytes < (size_t) value_type * 16)) {
+                    uv_rwlock_rdunlock(&global_lock);
                     return GUID_TYPE_NOSPACE;
+                }
                 memcpy(object, *PValue+1, value_type * 16);
                 break;
             default:

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -19,7 +19,7 @@ void add_to_guid_store(uuid_t *uuid)
 
     uuid_copy(guid_map_store->list[guid_map_store->index++], *uuid);
     if (guid_map_store->index == MAP_STORE_SIZE) {
-        tmp_guid_map_store = callocz(1, sizeof(*guid_map_store));
+        tmp_guid_map_store = callocz(1, sizeof(*tmp_guid_map_store));
         tmp_guid_map_store->next = guid_map_store;
         guid_map_store = tmp_guid_map_store;
     }

--- a/database/engine/global_uuid_map/global_uuid_map.c
+++ b/database/engine/global_uuid_map/global_uuid_map.c
@@ -21,8 +21,8 @@ void add_to_guid_store(uuid_t *uuid)
     uuid_copy(guid_map_store->list[guid_map_store->index++], *uuid);
     char uuid_str[37];
     uuid_unparse_lower(guid_map_store->list[guid_map_store->index-1], uuid_str);
-    info("Adding UUID %d = %s", guid_map_store->index-1, uuid_str);
-    if (guid_map_store->index == 128) {
+    //info("Adding UUID %d = %s", guid_map_store->index-1, uuid_str);
+    if (guid_map_store->index == MAP_STORE_SIZE) {
         tmp_guid_map_store = callocz(1, sizeof(*guid_map_store));
         tmp_guid_map_store->next = guid_map_store;
         guid_map_store = tmp_guid_map_store;

--- a/database/engine/global_uuid_map/global_uuid_map.h
+++ b/database/engine/global_uuid_map/global_uuid_map.h
@@ -21,4 +21,5 @@ extern int find_guid_by_object(char *object, uuid_t *uuid, GUID_TYPE);
 extern void init_global_guid_map();
 extern int find_or_generate_guid(void *object, uuid_t *uuid, GUID_TYPE object_type, int replace_instead_of_generate);
 extern void free_uuid(uuid_t *uuid);
+extern void free_global_guid_map();
 #endif //NETDATA_GLOBAL_UUID_MAP_H

--- a/database/engine/global_uuid_map/global_uuid_map.h
+++ b/database/engine/global_uuid_map/global_uuid_map.h
@@ -7,9 +7,10 @@
 #include <Judy.h>
 #include "../../rrd.h"
 
+#define MAP_STORE_SIZE  256
 typedef struct map_store {
-    uint8_t index;
-    uuid_t  list[128];
+    uint16_t index;
+    uuid_t  list[MAP_STORE_SIZE];
     struct map_store *next;
 } MAP_STORE;
 

--- a/database/engine/global_uuid_map/global_uuid_map.h
+++ b/database/engine/global_uuid_map/global_uuid_map.h
@@ -23,7 +23,6 @@ typedef enum guid_type {
     GUID_TYPE_NOSPACE
 } GUID_TYPE;
 
-extern int guid_store(uuid_t *uuid, char *object, GUID_TYPE);
 extern GUID_TYPE find_object_by_guid(uuid_t *uuid, char *object, size_t max_bytes);
 extern int find_guid_by_object(char *object, uuid_t *uuid, GUID_TYPE);
 extern void init_global_guid_map();

--- a/database/engine/global_uuid_map/global_uuid_map.h
+++ b/database/engine/global_uuid_map/global_uuid_map.h
@@ -7,6 +7,12 @@
 #include <Judy.h>
 #include "../../rrd.h"
 
+typedef struct map_store {
+    uint8_t index;
+    uuid_t  list[128];
+    struct map_store *next;
+} MAP_STORE;
+
 typedef enum guid_type {
     GUID_TYPE_CHAR,
     GUID_TYPE_HOST,
@@ -21,6 +27,6 @@ extern GUID_TYPE find_object_by_guid(uuid_t *uuid, char *object, size_t max_byte
 extern int find_guid_by_object(char *object, uuid_t *uuid, GUID_TYPE);
 extern void init_global_guid_map();
 extern int find_or_generate_guid(void *object, uuid_t *uuid, GUID_TYPE object_type, int replace_instead_of_generate);
-
+extern void destroy_store_map();
 
 #endif //NETDATA_GLOBAL_UUID_MAP_H

--- a/database/engine/global_uuid_map/global_uuid_map.h
+++ b/database/engine/global_uuid_map/global_uuid_map.h
@@ -7,13 +7,6 @@
 #include <Judy.h>
 #include "../../rrd.h"
 
-#define MAP_STORE_SIZE  256
-typedef struct map_store {
-    uint16_t index;
-    uuid_t  list[MAP_STORE_SIZE];
-    struct map_store *next;
-} MAP_STORE;
-
 typedef enum guid_type {
     GUID_TYPE_CHAR,
     GUID_TYPE_HOST,
@@ -27,6 +20,5 @@ extern GUID_TYPE find_object_by_guid(uuid_t *uuid, char *object, size_t max_byte
 extern int find_guid_by_object(char *object, uuid_t *uuid, GUID_TYPE);
 extern void init_global_guid_map();
 extern int find_or_generate_guid(void *object, uuid_t *uuid, GUID_TYPE object_type, int replace_instead_of_generate);
-extern void destroy_store_map();
-
+extern void free_uuid(uuid_t *uuid);
 #endif //NETDATA_GLOBAL_UUID_MAP_H

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -983,9 +983,6 @@ int rrdeng_exit(struct rrdengine_instance *ctx)
         freez(ctx);
     }
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
-    info("Cleanup global GUID map");
-    destroy_store_map();
-    info("Cleanup global GUID map done");
     return 0;
 }
 

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -983,6 +983,9 @@ int rrdeng_exit(struct rrdengine_instance *ctx)
         freez(ctx);
     }
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
+    info("Cleanup global GUID map");
+    destroy_store_map();
+    info("Cleanup global GUID map done");
     return 0;
 }
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -527,7 +527,9 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
             debug(D_RRD_CALLS, "Removing dimension '%s'.", rd->name);
             freez((void *)rd->id);
             freez(rd->cache_filename);
+#ifdef ENABLE_DBENGINE
             freez(rd->state->metric_uuid);
+#endif
             freez(rd->state);
             freez(rd);
             break;

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -487,7 +487,6 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
 #endif
         }
     }
-//    freez(rd->state);
 
     if(rd == st->dimensions)
         st->dimensions = rd->next;

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -487,7 +487,7 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
 #endif
         }
     }
-    freez(rd->state);
+//    freez(rd->state);
 
     if(rd == st->dimensions)
         st->dimensions = rd->next;
@@ -518,6 +518,7 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
             debug(D_RRD_CALLS, "Unmapping dimension '%s'.", rd->name);
             freez((void *)rd->id);
             freez(rd->cache_filename);
+            freez(rd->state);
             munmap(rd, rd->memsize);
             break;
 
@@ -527,6 +528,8 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
             debug(D_RRD_CALLS, "Removing dimension '%s'.", rd->name);
             freez((void *)rd->id);
             freez(rd->cache_filename);
+            freez(rd->state->metric_uuid);
+            freez(rd->state);
             freez(rd);
             break;
     }

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -528,9 +528,8 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
             freez((void *)rd->id);
             freez(rd->cache_filename);
 #ifdef ENABLE_DBENGINE
-            if (rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+            if (rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
                 freez(rd->state->metric_uuid);
-            }
 #endif
             freez(rd->state);
             freez(rd);

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -528,7 +528,9 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
             freez((void *)rd->id);
             freez(rd->cache_filename);
 #ifdef ENABLE_DBENGINE
-            freez(rd->state->metric_uuid);
+            if (rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+                freez(rd->state->metric_uuid);
+            }
 #endif
             freez(rd->state);
             freez(rd);

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -528,8 +528,10 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
             freez((void *)rd->id);
             freez(rd->cache_filename);
 #ifdef ENABLE_DBENGINE
-            if (rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            if (rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+                free_uuid(rd->state->metric_uuid);
                 freez(rd->state->metric_uuid);
+            }
 #endif
             freez(rd->state);
             freez(rd);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -879,7 +879,10 @@ void rrdhost_free(RRDHOST *host) {
     netdata_rwlock_destroy(&host->labels_rwlock);
     netdata_rwlock_destroy(&host->health_log.alarm_log_rwlock);
     netdata_rwlock_destroy(&host->rrdhost_rwlock);
+
+#ifdef ENABLE_DBENGINE
     free_uuid(&host->host_uuid);
+#endif
     freez(host);
 
     rrd_hosts_available--;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -879,6 +879,7 @@ void rrdhost_free(RRDHOST *host) {
     netdata_rwlock_destroy(&host->labels_rwlock);
     netdata_rwlock_destroy(&host->health_log.alarm_log_rwlock);
     netdata_rwlock_destroy(&host->rrdhost_rwlock);
+    free_uuid(&host->host_uuid);
     freez(host);
 
     rrd_hosts_available--;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -388,8 +388,10 @@ void rrdset_free(RRDSET *st) {
         case RRD_MEMORY_MODE_ALLOC:
         case RRD_MEMORY_MODE_NONE:
         case RRD_MEMORY_MODE_DBENGINE:
-            if (st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            if (st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+                free_uuid(st->chart_uuid);
                 freez(st->chart_uuid);
+            }
             freez(st);
             break;
     }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -388,10 +388,12 @@ void rrdset_free(RRDSET *st) {
         case RRD_MEMORY_MODE_ALLOC:
         case RRD_MEMORY_MODE_NONE:
         case RRD_MEMORY_MODE_DBENGINE:
+#ifdef ENABLE_DBENGINE
             if (st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
                 free_uuid(st->chart_uuid);
                 freez(st->chart_uuid);
             }
+#endif
             freez(st);
             break;
     }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -388,6 +388,7 @@ void rrdset_free(RRDSET *st) {
         case RRD_MEMORY_MODE_ALLOC:
         case RRD_MEMORY_MODE_NONE:
         case RRD_MEMORY_MODE_DBENGINE:
+            freez(st->chart_uuid);
             freez(st);
             break;
     }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -388,7 +388,8 @@ void rrdset_free(RRDSET *st) {
         case RRD_MEMORY_MODE_ALLOC:
         case RRD_MEMORY_MODE_NONE:
         case RRD_MEMORY_MODE_DBENGINE:
-            freez(st->chart_uuid);
+            if (st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+                freez(st->chart_uuid);
             freez(st);
             break;
     }


### PR DESCRIPTION
Fixes #9728
##### Summary
Cleanup the memory allocated for the global GUID map and release the associated Judy arrays.

##### Component Name
database

##### Test Plan
- Run with `valgrind` or address sanitizer before and after the cleanup code

##### Additional information
As this uses memory to keep track of the objects we need to release, we may want to enable this with a compile flag so that the code is activated only during debugging.

