### PR TITLE
Added proper certificate handling cURL in our static build.

### DIFF
--- a/packaging/makeself/jobs/50-curl-7.60.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.60.0.install.sh
@@ -21,7 +21,9 @@ run ./configure \
   --enable-http \
   --enable-proxy \
   --enable-ipv6 \
-  --enable-cookies
+  --enable-cookies \
+  --with-ca-fallback \
+  --with-ca-bundle=/opt/netdata/etc/ssl/certs/ca-bundle.crt
 
 # Curl autoconf does not honour the curl_LDFLAGS environment variable
 run sed -i -e "s/curl_LDFLAGS =/curl_LDFLAGS = -all-static/" src/Makefile


### PR DESCRIPTION
##### Summary

The default behavior of cURL when validating TLS certificates is to use a CA certificate bundle located at a path either specified on the command line or at a default location detected at build time, and then fail if it cannot find this file.

This causes failures when the system on which cURL was built had different paths for the CA certificate bundle than those used on the system it's being run on.

This adds configure options to the build of cURL during our static build which will cause it to use the same central dispatch that we are configuring OpenSSL to use to find the CA certificate bundle and to make it fall back to asking OpenSSL to do the validation if it cannot find the CA bundle.

##### Component Name

area/packaging

##### Test Plan

Build verified locally.

Actual runtime behavior verified using a local install of the locally created static build and manually invoking cURL.

##### Additional Information

Fixes: #9494 