### PR TITLE
Fix flushing errors

### DIFF
--- a/database/engine/README.md
+++ b/database/engine/README.md
@@ -117,6 +117,13 @@ options.
 You can use our [database engine calculator](https://learn.netdata.cloud/docs/agent/database/calculator) to
 validate the memory requirements for your particular system(s) and configuration (**out-of-date**).
 
+### Disk space requirements
+
+There are explicit disk space requirements **per** DB engine **instance**:
+
+-   The total disk space footprint will be an additional `#dimensions-being-collected x 4096 x 2` bytes over what
+    the user configured with `dbengine multihost disk space` or `dbengine disk space`.
+
 ### File descriptor requirements
 
 The Database Engine may keep a **significant** amount of files open per instance (e.g. per streaming child or

--- a/database/engine/README.md
+++ b/database/engine/README.md
@@ -121,7 +121,7 @@ validate the memory requirements for your particular system(s) and configuration
 
 There are explicit disk space requirements **per** DB engine **instance**:
 
--   The total disk space footprint will be an additional `#dimensions-being-collected x 4096 x 2` bytes over what
+-   The total disk space footprint will be the maximum between `#dimensions-being-collected x 4096 x 2` bytes or what
     the user configured with `dbengine multihost disk space` or `dbengine disk space`.
 
 ### File descriptor requirements

--- a/database/engine/metadata_log/metadatalog.c
+++ b/database/engine/metadata_log/metadatalog.c
@@ -415,3 +415,11 @@ void error_with_guid(uuid_t *uuid, char *reason)
     errno = 0;
     error("%s (GUID = %s)", reason, uuid_str);
 }
+
+void info_with_guid(uuid_t *uuid, char *reason)
+{
+    char  uuid_str[37];
+
+    uuid_unparse_lower(*uuid, uuid_str);
+    info("%s (GUID = %s)", reason, uuid_str);
+}

--- a/database/engine/metadata_log/metadatalog.h
+++ b/database/engine/metadata_log/metadatalog.h
@@ -135,4 +135,5 @@ extern void metalog_worker(void* arg);
 extern void metalog_enq_cmd(struct metalog_worker_config *wc, struct metalog_cmd *cmd);
 extern struct metalog_cmd metalog_deq_cmd(struct metalog_worker_config *wc);
 extern void error_with_guid(uuid_t *uuid, char *reason);
+extern void info_with_guid(uuid_t *uuid, char *reason);
 #endif /* NETDATA_METADATALOG_H */

--- a/database/engine/metadata_log/metadatalogapi.c
+++ b/database/engine/metadata_log/metadatalogapi.c
@@ -392,8 +392,7 @@ void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metr
     uint8_t empty_chart;
 
     rd = metalog_get_dimension_from_uuid(ctx, metric_uuid);
-    if (!rd) { /* in 8the case of legacy UUID convert to multihost and try again */
-        // TODO: Check what to do since we have no host
+    if (!rd) { /* in the case of legacy UUID convert to multihost and try again */
         uuid_t multihost_uuid;
 
         rrdeng_convert_legacy_uuid_to_multihost(ctx->rrdeng_ctx->machine_guid, metric_uuid, &multihost_uuid);
@@ -427,6 +426,36 @@ void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metr
         rrdset_free(st);
         rrdhost_unlock(host);
     }
+}
+
+void metalog_print_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metric_uuid)
+{
+    RRDDIM *rd;
+    RRDSET *st;
+    RRDHOST *host;
+
+    if (!ctx || !ctx->initialized)
+        return;
+
+    rd = metalog_get_dimension_from_uuid(ctx, metric_uuid);
+    if (!rd) { /* in the case of legacy UUID convert to multihost and try again */
+        uuid_t multihost_uuid;
+
+        rrdeng_convert_legacy_uuid_to_multihost(ctx->rrdeng_ctx->machine_guid, metric_uuid, &multihost_uuid);
+        rd = metalog_get_dimension_from_uuid(ctx, &multihost_uuid);
+    }
+    if(!rd) {
+        error_with_guid(metric_uuid, "GUID not found, unknown metric.");
+        return;
+    }
+    st = rd->rrdset;
+    host = st->rrdhost;
+
+    error_with_guid(metric_uuid, "Host - Chart - Dimension are the below:");
+    error("%s %s %s.", host->hostname, st->id, rd->id);
+
+    if (unlikely(host->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE))
+        error_with_guid(metric_uuid, "UUID does not belong to RRD_MEMORY_MODE_DBENGINE.");
 }
 
 /*

--- a/database/engine/metadata_log/metadatalogapi.h
+++ b/database/engine/metadata_log/metadatalogapi.h
@@ -19,6 +19,7 @@ extern RRDSET *metalog_get_chart_from_uuid(struct metalog_instance *ctx, uuid_t 
 extern RRDDIM *metalog_get_dimension_from_uuid(struct metalog_instance *ctx, uuid_t *metric_uuid);
 extern RRDHOST *metalog_get_host_from_uuid(struct metalog_instance *ctx, uuid_t *uuid);
 extern void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metric_uuid);
+extern void metalog_print_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metric_uuid);
 
 /* must call once before using anything */
 extern int metalog_init(struct rrdengine_instance *rrdeng_parent_ctx);

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -444,6 +444,7 @@ uint8_t pg_cache_punch_hole(struct rrdengine_instance *ctx, struct rrdeng_page_d
             if (unlikely(debug_flags & D_RRDENGINE))
                 print_page_cache_descr(descr);
             pg_cache_wait_event_unsafe(descr);
+//metalog_print_dimension_by_uuid(ctx->metalog_ctx, page_index->id);
         }
     }
     if (remove_dirty) {
@@ -455,6 +456,7 @@ uint8_t pg_cache_punch_hole(struct rrdengine_instance *ctx, struct rrdeng_page_d
             if (unlikely(debug_flags & D_RRDENGINE))
                 print_page_cache_descr(descr);
             pg_cache_wait_event_unsafe(descr);
+//metalog_print_dimension_by_uuid(ctx->metalog_ctx, page_index->id);
         }
     }
     rrdeng_page_descr_mutex_unlock(ctx, descr);

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -462,7 +462,6 @@ uint8_t pg_cache_punch_hole(struct rrdengine_instance *ctx, struct rrdeng_page_d
             if (unlikely(debug_flags & D_RRDENGINE))
                 print_page_cache_descr(descr);
             pg_cache_wait_event_unsafe(descr);
-//metalog_print_dimension_by_uuid(ctx->metalog_ctx, page_index->id);
         }
     }
     if (remove_dirty) {
@@ -474,7 +473,6 @@ uint8_t pg_cache_punch_hole(struct rrdengine_instance *ctx, struct rrdeng_page_d
             if (unlikely(debug_flags & D_RRDENGINE))
                 print_page_cache_descr(descr);
             pg_cache_wait_event_unsafe(descr);
-//metalog_print_dimension_by_uuid(ctx->metalog_ctx, page_index->id);
         }
     }
     rrdeng_page_descr_mutex_unlock(ctx, descr);

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -670,7 +670,7 @@ void rrdeng_test_quota(struct rrdengine_worker_config* wc)
 
     out_of_space = 0;
     /* Do not allow the pinned pages to exceed the disk space quota to avoid deadlocks */
-    if (unlikely(ctx->disk_space > ctx->max_disk_space + 2 * ctx->metric_API_max_producers * RRDENG_BLOCK_SIZE)) {
+    if (unlikely(ctx->disk_space > MAX(ctx->max_disk_space, 2 * ctx->metric_API_max_producers * RRDENG_BLOCK_SIZE))) {
         out_of_space = 1;
     }
     datafile = ctx->datafiles.last;

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -669,7 +669,8 @@ void rrdeng_test_quota(struct rrdengine_worker_config* wc)
     int ret, error;
 
     out_of_space = 0;
-    if (unlikely(ctx->disk_space > ctx->max_disk_space)) {
+    /* Do not allow the pinned pages to exceed the disk space quota to avoid deadlocks */
+    if (unlikely(ctx->disk_space > ctx->max_disk_space + 2 * ctx->metric_API_max_producers * RRDENG_BLOCK_SIZE)) {
         out_of_space = 1;
     }
     datafile = ctx->datafiles.last;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -204,17 +204,17 @@ void rrdeng_store_metric_flush_current_page(RRDDIM *rd)
             pg_cache_punch_hole(ctx, descr, 1, 0, NULL);
             handle->prev_descr = NULL;
         } else {
-            /* added 1 extra reference to keep 2 dirty pages pinned per metric, expected refcnt = 2 */
-            rrdeng_page_descr_mutex_lock(ctx, descr);
-            ret = pg_cache_try_get_unsafe(descr, 0);
-            rrdeng_page_descr_mutex_unlock(ctx, descr);
-            fatal_assert(1 == ret);
-
-            rrdeng_commit_page(ctx, descr, handle->page_correlation_id);
             /*
              * Disable pinning for now as it leads to deadlocks. When a collector stops collecting the extra pinned page
              * eventually gets rotated but it cannot be destroyed due to the extra reference.
              */
+            /* added 1 extra reference to keep 2 dirty pages pinned per metric, expected refcnt = 2 */
+/*          rrdeng_page_descr_mutex_lock(ctx, descr);
+            ret = pg_cache_try_get_unsafe(descr, 0);
+            rrdeng_page_descr_mutex_unlock(ctx, descr);
+            fatal_assert(1 == ret);*/
+
+            rrdeng_commit_page(ctx, descr, handle->page_correlation_id);
             /* handle->prev_descr = descr;*/
         }
     } else {

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -211,7 +211,11 @@ void rrdeng_store_metric_flush_current_page(RRDDIM *rd)
             fatal_assert(1 == ret);
 
             rrdeng_commit_page(ctx, descr, handle->page_correlation_id);
-            handle->prev_descr = descr;
+            /*
+             * Disable pinning for now as it leads to deadlocks. When a collector stops collecting the extra pinned page
+             * eventually gets rotated but it cannot be destroyed due to the extra reference.
+             */
+            /* handle->prev_descr = descr;*/
         }
     } else {
         freez(descr->pg_cache_descr->page);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes  #8384
Fixes  #9730
##### Component Name
database
##### Test Plan

1. Make sure that `2 * 4096 * number-of-metrics-being-collected` bytes is more than the disk space quota. This should trigger the `Failed to flush dirty buffers quickly enough in dbengine instance` error message in the old code.
2. Make sure that a collector that has collected at least 34 minutes worth of metric data points stops collecting a specific metric (2 4K pages of metrics with 1 second collection interval). After a full database rotation you should start seeing the aforementioned error message.