### PR TITLE
Clarify which notifications are received when the "|critical" limit is set

### DIFF
--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -163,7 +163,10 @@ sendsms=""
 # You can append |critical to limit the notifications to be sent.
 #
 # In these examples, the first recipient receives all the alarms
-# while the second one receives only the critical ones:
+# while the second one receives only notifications for alarms that 
+# have at some point become critical. The second user may still receive
+# warning and clear notifications, but only for the event that previously 
+# caused a critical alarm.
 #
 #  email      : "user1@example.com user2@example.com|critical"
 #  pushover   : "2987343...9437837 8756278...2362736|critical"


### PR DESCRIPTION
#### Summary
Explain that with the recipient "|critical" option, a user will receive warnings only if an alarm goes to critical first.
Covers the comment in https://github.com/netdata/netdata/pull/9698#discussion_r468592201

##### Component Name
health/notifications

@thiagoftsm I lost my laptop and don't have everything set up on this one, so this is a different PR.