### PR TITLE
Add check for spurious wakeups

### DIFF
--- a/exporting/aws_kinesis/aws_kinesis.c
+++ b/exporting/aws_kinesis/aws_kinesis.c
@@ -103,7 +103,10 @@ void aws_kinesis_connector_worker(void *instance_p)
         struct stats *stats = &instance->stats;
 
         uv_mutex_lock(&instance->mutex);
-        uv_cond_wait(&instance->cond_var, &instance->mutex);
+        while (!instance->data_is_ready)
+            uv_cond_wait(&instance->cond_var, &instance->mutex);
+        instance->data_is_ready = 0;
+
         if (unlikely(instance->engine->exit)) {
             uv_mutex_unlock(&instance->mutex);
             break;

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -67,6 +67,7 @@ static void exporting_main_cleanup(void *ptr)
             found++;
             info("stopping worker for instance %s", instance->config.name);
             uv_mutex_unlock(&instance->mutex);
+            instance->data_is_ready = 1;
             uv_cond_signal(&instance->cond_var);
         } else
             info("found stopped worker for instance %s", instance->config.name);

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -165,6 +165,7 @@ struct instance {
     uv_thread_t thread;
     uv_mutex_t mutex;
     uv_cond_t cond_var;
+    int data_is_ready;
 
     int (*start_batch_formatting)(struct instance *instance);
     int (*start_host_formatting)(struct instance *instance, RRDHOST *host);

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -284,7 +284,9 @@ void mongodb_connector_worker(void *instance_p)
         struct stats *stats = &instance->stats;
 
         uv_mutex_lock(&instance->mutex);
-        uv_cond_wait(&instance->cond_var, &instance->mutex);
+        while (!instance->data_is_ready)
+            uv_cond_wait(&instance->cond_var, &instance->mutex);
+        instance->data_is_ready = 0;
 
         if (unlikely(instance->engine->exit)) {
             uv_mutex_unlock(&instance->mutex);

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -293,6 +293,7 @@ void end_batch_formatting(struct engine *engine)
                 continue;
             }
             uv_mutex_unlock(&instance->mutex);
+            instance->data_is_ready = 1;
             uv_cond_signal(&instance->cond_var);
 
             instance->scheduled = 0;

--- a/exporting/pubsub/pubsub.c
+++ b/exporting/pubsub/pubsub.c
@@ -103,7 +103,10 @@ void pubsub_connector_worker(void *instance_p)
         char error_message[ERROR_LINE_MAX + 1] = "";
 
         uv_mutex_lock(&instance->mutex);
-        uv_cond_wait(&instance->cond_var, &instance->mutex);
+        while (!instance->data_is_ready)
+            uv_cond_wait(&instance->cond_var, &instance->mutex);
+        instance->data_is_ready = 0;
+
 
         if (unlikely(instance->engine->exit)) {
             uv_mutex_unlock(&instance->mutex);

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -340,7 +340,9 @@ void simple_connector_worker(void *instance_p)
         // if we are connected, send our buffer to the data collecting server
 
         uv_mutex_lock(&instance->mutex);
-        uv_cond_wait(&instance->cond_var, &instance->mutex);
+        while (!instance->data_is_ready)
+            uv_cond_wait(&instance->cond_var, &instance->mutex);
+        instance->data_is_ready = 0;
 
         if (unlikely(instance->engine->exit)) {
             uv_mutex_unlock(&instance->mutex);


### PR DESCRIPTION
##### Summary
@mfundul thanks for pointing this out

http://docs.libuv.org/en/v1.x/threading.html#conditions
> Callers should be prepared to deal with spurious wakeups on uv_cond_wait() and uv_cond_timedwait().

https://linux.die.net/man/3/pthread_cond_wait
> When using condition variables there is always a Boolean predicate involving shared variables associated with each condition wait that is true if the thread should proceed. Spurious wakeups from the pthread_cond_timedwait() or pthread_cond_wait() functions may occur. Since the return from pthread_cond_timedwait() or pthread_cond_wait() does not imply anything about the value of this predicate, the predicate should be re-evaluated upon such return.

##### Component Name
exporting engine