### PR TITLE
Package ebpf plugin only if enabled in config.h

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -5,6 +5,12 @@
 #TODO: Temporary fix for the build-id error during go.d plugin set up
 %global _missing_build_ids_terminate_build 0
 
+%if "@HAVE_LIBBPF@" == "1"
+%global have_bpf 1
+%else
+%global have_bpf 0
+%endif
+
 # This is temporary and should eventually be resolved. This bypasses
 # the default rhel __os_install_post which throws a python compile
 # error.
@@ -239,7 +245,9 @@ happened, on your systems and applications.
 %setup -q -n %{name}-%{version}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-lws.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+%if 0%{?have_bpf}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-libbpf.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+%endif
 
 %build
 # Conf step
@@ -285,7 +293,9 @@ install -m 4750 -p perf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.
 
 # ###########################################################
 # Install ebpf.plugin
+%if 0%{?have_bpf}
 install -m 4750 -p ebpf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/ebpf.plugin"
+%endif
 
 # ###########################################################
 # Install cups.plugin
@@ -413,7 +423,9 @@ install_go
 install -m 0640 -p go.d.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/go.d.plugin"
 
 ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-dashboard.sh ${RPM_BUILD_DIR}/%{name}-%{version} ${RPM_BUILD_ROOT}%{_datadir}/%{name}/web
+%if 0%{?have_bpf}
 ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-ebpf.sh ${RPM_BUILD_DIR}/%{name}-%{version} ${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d
+%endif
 
 %pre
 


### PR DESCRIPTION
##### Summary

If `@HAVE_LIBBPF@` is not enabled from `config.h` do not try to embed libbpf plugin.
This is required for work with CentOS6, as libbpf is not available on 2.6.32 kernels. So bpf doesn't work, but the `bundle-libbpf.sh` is still executed, making the packaging fail.
 
Fixes #9705 

##### Component Name

netdata.spec.in 

##### Test Plan

```.
# Make libbpf unavailable on the building machine (remove the elfutils-libelf or kernel-devel package)
# Build the package
./contrib/rhel/build-netdata-rpm.sh
# Check the package does not have the libbpf plugin:
rpm -qvp ~/rpmbuild/RPMS/x86_64/netdata-*.rpm | grep bpf
```

##### Additional Information
