### PR TITLE
Remove debug messages from ebpf.

### DIFF
--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1158,7 +1158,6 @@ static void hash_accumulator(netdata_socket_t *values, netdata_socket_idx_t *key
     int i;
     uint8_t protocol = values[0].protocol;
     uint64_t ct = values[0].ct;
-    error("KILLME_FIRST %u (%u)", protocol, ntohs(key->sport));
     for (i = 1; i < end; i++) {
         netdata_socket_t *w = &values[i];
 
@@ -1177,7 +1176,6 @@ static void hash_accumulator(netdata_socket_t *values, netdata_socket_idx_t *key
         *removesock += (int)w->removeme;
     }
 
-    error("KILLME_LAST %u (%u)", protocol, ntohs(key->sport));
     values[0].recv_packets += precv;
     values[0].sent_packets += psent;
     values[0].recv_bytes   += brecv;
@@ -1223,7 +1221,6 @@ static void read_socket_hash_table(int fd, int family, int network_connection)
         // values for specific processor unless it is used to store data. As result of this behavior one the next socket
         // can have values from the previous one.
         memset(values, 0, length);
-        error("KILLME_READ %u %u %u %u (%u)", values[0].protocol, values[1].protocol, values[2].protocol, values[3].protocol, ntohs(key.sport));
         test = bpf_map_lookup_elem(fd, &key, values);
         if (test < 0) {
             key = next_key;


### PR DESCRIPTION
##### Summary
The merge of 9591 probably fixed some problems that users were having, but it also brings unnecessary debug messages, this PR fixed this problem.

##### Component Name
ebpf.plugin
##### Test Plan

1 - Compile this branch
2 - Enable network viewer.
3 - Take a look on logs, the messages should not be there.

##### Additional Information
