### PR TITLE
Fix unit tests for exporting engine

### DIFF
--- a/exporting/tests/exporting_fixtures.c
+++ b/exporting/tests/exporting_fixtures.c
@@ -5,6 +5,7 @@
 int setup_configured_engine(void **state)
 {
     struct engine *engine = __mock_read_exporting_config();
+    engine->instance_root->data_is_ready = 1;
 
     *state = engine;
 


### PR DESCRIPTION
##### Summary
After applying #9751 unit tests for the exporting engine were broken.

##### Component Name
exporting engine

##### Test Plan
Run `sudo make check`. Unit tests for the exporting engine should pass.