### PR TITLE
python.d/redis: collect `maxmemory`

### DIFF
--- a/collectors/python.d.plugin/redis/redis.chart.py
+++ b/collectors/python.d.plugin/redis/redis.chart.py
@@ -51,8 +51,9 @@ CHARTS = {
         ]
     },
     'memory': {
-        'options': [None, 'Memory utilization', 'KiB', 'memory', 'redis.memory', 'line'],
+        'options': [None, 'Memory utilization', 'KiB', 'memory', 'redis.memory', 'area'],
         'lines': [
+            ['maxmemory', 'max', 'absolute', 1, 1024],
             ['used_memory', 'total', 'absolute', 1, 1024],
             ['used_memory_lua', 'lua', 'absolute', 1, 1024]
         ]


### PR DESCRIPTION
##### Summary

Fixes: #9764

Collect [`maxmemory`](https://redis.io/commands/info#notes) metric

> maxmemory: The value of the maxmemory configuration directive

##### Component Name

`/collectors/python.d/redis`

##### Test Plan

Tested by @TheOldMan2000

> https://github.com/netdata/netdata/issues/9764#issuecomment-674788164


##### Additional Information
