### PR TITLE
Fixed numerous bugs in duplicate install handling.

### DIFF
--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -31,8 +31,7 @@ bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh)
 
 The `kickstart.sh` script does the following after being downloaded and run:
 
--   Detects the Linux distribution and **installs the required system packages** for building Netdata. Unless you added
-    the `--dont-wait` option, it will ask for your permission first.
+-   Checks to see if there is an existing installation, and if there is updates that in preference to reinstalling.
 -   Downloads the latest Netdata binary from the [binary-packages](https://github.com/netdata/binary-packages)
     repository. You can also run any of these `.run` files with [makeself](https://github.com/megastep/makeself).
 -   Installs Netdata by running `./netdata-installer.sh` from the source tree, including any options you might have
@@ -66,6 +65,8 @@ your installation. Here are a few important parameters:
 -   `--disable-telemetry`: Opt-out of [anonymous statistics](/docs/anonymous-statistics.md) we use to make
     Netdata better.
 -   `--no-updates`: Prevent automatic updates of any kind.
+-   `--reinstall`: If an existing installation is detected, reinstall instead of attempting to update it. Note
+    that this cannot be used to switch betwen installation types.
 -   `--local-files`: Used for [offline installations](/packaging/installer/methods/offline.md). Pass four file paths:
     the Netdata tarball, the checksum file, the go.d plugin tarball, and the go.d plugin config tarball, to force
     kickstart run the process using those files. This option conflicts with the `--stable-channel` option. If you set
@@ -77,7 +78,7 @@ To use `md5sum` to verify the intregity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "6c3c2957caeeeb1decaf6b6178a3a3cd" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "e06b4ecd791bc50c93d6c71839b53c41" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -28,6 +28,7 @@ The `kickstart.sh` script does the following after being downloaded and run usin
 
 -   Detects the Linux distribution and **installs the required system packages** for building Netdata. Unless you added
     the `--dont-wait` option, it will ask for your permission first.
+-   Checks for an existing installation, and if found updates that instead of creating a new install.
 -   Downloads the latest Netdata source tree to `/usr/src/netdata.git`.
 -   Installs Netdata by running `./netdata-installer.sh` from the source tree, using any [optional
     parameters](#optional-parameters-to-alter-your-installation) you have specified.
@@ -47,6 +48,8 @@ installation. Here are a few important parameters:
 -   `--disable-telemetry`: Opt-out of [anonymous statistics](/docs/anonymous-statistics.md) we use to make
     Netdata better.
 -   `--no-updates`: Prevent automatic updates of any kind.
+-   `--reinstall`: If an existing install is detected, reinstall instead of trying to update it. Note that this
+    cannot be used to change installation types.
 -   `--local-files`: Used for [offline installations](offline.md). Pass four file paths: the Netdata
     tarball, the checksum file, the go.d plugin tarball, and the go.d plugin config tarball, to force kickstart run the
     process using those files. This option conflicts with the `--stable-channel` option. If you set this _and_
@@ -58,7 +61,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "86abaea95a24df12fe444c1b3e5cfa33" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "15420d0d5bd61fe4027c20d9276a696e" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

This fixes three bugs in the installer relating to the handling of duplicate installs:

* The existing checks for duplicate installs were being run before we parsed options, but trying to use variables assigned by the option parsing code. As a result, some of the cases they were supposed to handle did not work correctly. This PR moves the checks to the correct place so these cases work properly.
* In the specific case of trying to reinstall over top of an existing installation that had a functioning 'netdata-updater' script, there was no easy way to make the script explicitly reinstall instead of just attempting to update the existing install. This adds a new option (`--reinstall`) that explicitly requests a reinstall if the script would normally update an existing install.
* For the specific case of attempting to reinstall over top of an existing install that was of a different type, we were not checking and blocking the installation attempt as rigorously as we should have been. This fixes that.

Additionally, this updates the installer documentation to properly reflect current behaviors and options.

##### Component Name

area/packaging

##### Test Plan

New and changed behaviors tested locally using installations in VMs and Docker containers.

##### Additional Information

Fixes: #9758 