### PR TITLE
Remove possibility wait for a command not enqueued

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -367,6 +367,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
     debug(D_HEALTH, "executing command '%s'", command_to_run);
     ae->flags |= HEALTH_ENTRY_FLAG_EXEC_IN_PROGRESS;
     ae->exec_spawn_serial = spawn_enq_cmd(command_to_run);
+    debug(D_HEALTH, "enqueue the alarm '%s' with the serial '%lu'", ae->name, ae->exec_spawn_serial);
     enqueue_alarm_notify_in_progress(ae);
 
     return; //health_alarm_wait_for_execution
@@ -375,7 +376,7 @@ done:
 }
 
 static inline void health_alarm_wait_for_execution(ALARM_ENTRY *ae) {
-    if (!(ae->flags & HEALTH_ENTRY_FLAG_EXEC_IN_PROGRESS))
+    if ((!(ae->flags & HEALTH_ENTRY_FLAG_EXEC_IN_PROGRESS)) || !ae->exec_spawn_serial)
         return;
 
     spawn_wait_cmd(ae->exec_spawn_serial, &ae->exec_code, &ae->exec_run_timestamp);


### PR DESCRIPTION
##### Summary
Fixes #9743 

Health is trying to execute commands that was not enqueue, as described in the comment https://github.com/netdata/netdata/issues/9743#issuecomment-675229537, and this was crashing the spawn server and the whole Netdata. This PR is bringing the missing test that keeps spawn server running.

I am also adding a debug message to help debug health.

##### Component Name
Health
Spawn
##### Test Plan

1 - Create "high frequency alarms" alarm that will generate a good sample in your alarm log, for example:

```
 alarm: dev_dim_template
    on: system.cpu
    os: linux
lookup: sum -3s at 0 every 3 percentage foreach *
 units: %
 every: 1s
  warn: $this > 1
  crit:  $this > 4
```
and

```
alarm: example_alarm1
      on: example.random
   every: 2s
    warn: $random1 > (($status >= $WARNING)  ? (55) : (75))
    crit: $random1 > (($status == $CRITICAL) ? (75) : (95))
    info: random
      to: sysadmin

alarm: example_alarm2
      on: example.random
   every: 2s
    warn: $random2 > (($status >= $WARNING)  ? (55) : (75))
    crit: $random2 > (($status == $CRITICAL) ? (75) : (95))
    info: random
      to: sysadmin
```

2 - Change your health log to this [file](https://github.com/netdata/netdata/files/5105366/db.zip)
3 - If you do not have alarm log before this PR, reduce the number of alarms that is kept in memory ( `in memory max health log entries`)
4 - Start Netdata
5 - Run on terminal:

```
for i in `seq 1 15`; do sleep 60; echo $i;  killall -USR2 netdata ; done
```

6 - After this period of time, you should have Netdata running and the alarm log completely filled.

##### Additional Information
