### PR TITLE
Fix HTTP header for the remote write exporting connector

### DIFF
--- a/backends/backends.c
+++ b/backends/backends.c
@@ -1073,7 +1073,7 @@ void *backends_main(void *ptr) {
                                     "Content-Length: %zu\r\n"
                                     "Content-Type: application/x-www-form-urlencoded\r\n\r\n",
                                     remote_write_path,
-                                    hostname,
+                                    destination,
                                     data_size
                     );
 

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -39,7 +39,7 @@ int prometheus_remote_write_send_header(int *sock, struct instance *instance)
         "Content-Length: %zu\r\n"
         "Content-Type: application/x-www-form-urlencoded\r\n\r\n",
         connector_specific_config->remote_write_path,
-        instance->engine->config.hostname,
+        instance->config.destination,
         buffer_strlen((BUFFER *)instance->buffer));
 
     size_t header_len = buffer_strlen(header);

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -1192,7 +1192,7 @@ static void test_prometheus_remote_write_send_header(void **state)
     expect_string(
         __wrap_send, buf,
         "POST /receive HTTP/1.1\r\n"
-        "Host: test-host\r\n"
+        "Host: localhost\r\n"
         "Accept: */*\r\n"
         "X-Prometheus-Remote-Write-Version: 0.1.0\r\n"
         "Content-Length: 11\r\n"


### PR DESCRIPTION
##### Summary
Fixes #7676

##### Component Name
exporting engine, backends

##### Test Plan
1. Configure an exporting connector
```
[prometheus_remote_write:test_instance]
enabled = yes
destination = localhost:1234
remote write URL path = /receive
data source = as collected
update every = 2
send charts matching = system.processes
```
Check the HTTP Host filed using `nc -l -p 1234`, it should be set to `localhost:1234`.

2. Configure the backends subsytem
```
[backend]
  enabled = yes
  type = prometheus_remote_write
  data source = as collected
  destination = localhost:1234
  send charts matching = system.processes
```
Check the HTTP Host filed using `nc -l -p 1234`, it should be set to `localhost:1234`.