### PR TITLE
Change timestamps for global variables in Prometheus output

### DIFF
--- a/backends/prometheus/backend_prometheus.c
+++ b/backends/prometheus/backend_prometheus.c
@@ -205,7 +205,7 @@ static int print_host_variables(RRDVAR *rv, void *data) {
                            , opts->labels
                            , label_post
                            , value
-                           , ((rv->last_updated) ? rv->last_updated : opts->now) * 1000ULL
+                           , opts->now * 1000ULL
             );
         else
             buffer_sprintf(opts->wb, "%s_%s%s%s%s " CALCULATED_NUMBER_FORMAT "\n"

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -364,7 +364,7 @@ static int print_host_variables(RRDVAR *rv, void *data)
                 opts->labels,
                 label_post,
                 value,
-                ((rv->last_updated) ? rv->last_updated : opts->now) * 1000ULL);
+                opts->now * 1000ULL);
         else
             buffer_sprintf(
                 opts->wb,


### PR DESCRIPTION
##### Summary
Prometheus [drops global variables from responses](https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness) by default
> If no sample is found (by default) 5 minutes before a sampling timestamp, no value is returned for that time series at this point in time. 

We will provide current time as a timestamp for the global variables to be sure they are available in Prometheus' responses.

Fixes #6470

##### Component Name
Web API

##### Test Plan
Query Netdata with the following URL
```
http://localhost:19999/api/v1/allmetrics?format=prometheus&source=raw&variables=yes&help=yes
```
Timestamps for global host and chart variables should represent the current time.