### PR TITLE
Fix UNIX socket access with kickstart-static64

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -118,6 +118,7 @@ int make_dns_decision(const char *section_name, const char *config_name, const c
     if(strcmp("heuristic",value))
         error("Invalid configuration option '%s' for '%s'/'%s'. Valid options are 'yes', 'no' and 'heuristic'. Proceeding with 'heuristic'",
               value, section_name, config_name);
+
     return simple_pattern_is_potential_name(p);
 }
 
@@ -163,9 +164,9 @@ void web_server_config_options(void)
                                                        "localhost fd* 10.* 192.168.* 172.16.* 172.17.* 172.18.*"
                                                        " 172.19.* 172.20.* 172.21.* 172.22.* 172.23.* 172.24.*"
                                                        " 172.25.* 172.26.* 172.27.* 172.28.* 172.29.* 172.30.*"
-                                                       " 172.31.*"), NULL, SIMPLE_PATTERN_EXACT);
+                                                       " 172.31.* UNKNOWN"), NULL, SIMPLE_PATTERN_EXACT);
     web_allow_netdataconf_dns  =
-        make_dns_decision(CONFIG_SECTION_WEB, "allow netdata.conf by dns", "no", web_allow_mgmt_from);
+        make_dns_decision(CONFIG_SECTION_WEB, "allow netdata.conf by dns", "no", web_allow_netdataconf_from);
     web_allow_mgmt_from        =
         simple_pattern_create(config_get(CONFIG_SECTION_WEB, "allow management from", "localhost"),
                               NULL, SIMPLE_PATTERN_EXACT);

--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -248,8 +248,6 @@ static int web_server_rcv_callback(POLLINFO *pi, short int *events) {
     struct web_client *w = (struct web_client *)pi->data;
     int fd = pi->fd;
 
-    //BRING IT TO HERE
-
     if(unlikely(web_client_receive(w) < 0))
         return -1;
 


### PR DESCRIPTION
##### Summary
Fixes #8962 

During the tests I made, I observed that Unix socket is presented with UNKNOWN client_ip, this value was not present in the default list of simple patterns associated to the variable `web_allow_netdataconf_from`.

I have to call attention for an important thing in this PR, I could never recreate the problem using nginx and doing normal compilation, this is one of the various problems that are appearing only on kickstart-static64.

I am also using this PR to remove an old comment that is not doing any contribution for the code.

##### Component Name
Web
kickstart-static64
##### Test Plan

First test, check if nothing was breaking:

1 - Compile this branch
2 - Start Netdata
3 - Access  http://localhost:19999/netdata.conf

Stop Netdata and do the next steps to confirm the problem was really fixed.

1 - Install docker on your host and start it.
2 - Clone this PR.
3 - Run  sh ./packaging/makeself/build-x86_64-static.sh
4 - Install the final binary that will be stored inside `./artifacts`.
5 - Stop Netdata
6  - Edit `/opt/netdata/etc/netdata/netdata.conf` and change the following option:
```
[web]
  bind to = unix:/tmp/fd1.sock
```
7  - Start Netdata
8 - Configure a nginx to use the unix socket:

```
    server {
        listen       8082;
        server_name  localhost;

        location / {
            proxy_redirect off;
            proxy_set_header Host $host;
            proxy_set_header X-Forwarded-Host $host:$server_port;
            proxy_set_header X-Forwarded-Server $host;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto https; #New
            proxy_http_version 1.1;
            proxy_pass_request_headers on;
            proxy_set_header Connection "keep-alive";
            proxy_store off;
            gzip on;
            gzip_proxied any;
            gzip_types *;
            rewrite ^/netdata(/.*)$ $1 break;
            proxy_pass http://unix:/tmp/fd1.sock;
         }

        location = /50x.html {
            root   /var/www/html;
        }
    }
```
9 - Start Nginx
10  - Access `http://localhost:8082/netdata.conf`, If you could access, this PR fixed the problem.

##### Additional Information
