### PR TITLE
Fix long stats.d chart names (suggested by @vince-lessbits)

### DIFF
--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -81,7 +81,7 @@ struct receiver_state {
     int update_every;
     uint32_t stream_version;
     time_t last_msg_t;
-    char read_buffer[512];
+    char read_buffer[1024];     // Need to allow RRD_ID_LENGTH_MAX * 4 + the other fields
     int read_len;
 #ifdef ENABLE_HTTPS
     struct netdata_ssl ssl;


### PR DESCRIPTION
### Summary
Fixes #9768 
The read buffer in the streaming receiver was too small to allow the longest lines in the protocol.

##### Component Name
streaming

##### Test Plan
https://github.com/vince-lessbits/netdata-test

##### Additional Information
