### PR TITLE
Fix redirect with parameters

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1165,7 +1165,7 @@ void web_client_build_http_header(struct web_client *w) {
     if (w->response.code == HTTP_RESP_MOVED_PERM) {
         buffer_sprintf(w->response.header_output,
                        "HTTP/1.1 %d %s\r\n"
-                       "Location: https://%s%s",
+                       "Location: https://%s%s\r\n",
                        w->response.code, code_msg,
                        w->server_host,
                        w->last_url);

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1162,34 +1162,7 @@ void web_client_build_http_header(struct web_client *w) {
         strftime(edate, sizeof(edate), "%a, %d %b %Y %H:%M:%S %Z", tm);
     }
 
-    //char headerlocation[8328];
     if (w->response.code == HTTP_RESP_MOVED_PERM) {
-        /*
-        char *move = headerlocation;
-        memcpy(move, "\r\nLocation: https://", 20);
-        move += 20;
-
-        size_t length = strlen(w->server_host);
-        memcpy(move, w->server_host, length);
-        move += length;
-
-        length = strlen(w->last_url);
-        memcpy(move, w->last_url, length);
-        move += length;
-        if (w->url_search_path && w->separator) {
-            char *s = url_find_protocol(w->url_search_path);
-            if (s)
-                *s = '\0';
-
-            length = strlen(w->url_search_path);
-            memcpy(move, w->url_search_path, length);
-            move += length;
-        }
-
-        memcpy(move, "\r\n",  2);
-        move += 2;
-        *move = '\0';
-    */
         buffer_sprintf(w->response.header_output,
                        "HTTP/1.1 %d %s\r\n"
                        "Location: https://%s%s",
@@ -1213,11 +1186,6 @@ void web_client_build_http_header(struct web_client *w) {
                        w->origin,
                        content_type_string,
                        date);
-
-        /*
-        memcpy(headerlocation,"\r\n",2);
-        headerlocation[2]=0x00;
-         */
     }
 
     if(unlikely(web_x_frame_options))

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1169,7 +1169,6 @@ void web_client_build_http_header(struct web_client *w) {
                        w->response.code, code_msg,
                        w->server_host,
                        w->last_url);
-        buffer_flush(w->response.data);
     }else {
         buffer_sprintf(w->response.header_output,
                        "HTTP/1.1 %d %s\r\n"
@@ -1577,6 +1576,16 @@ void web_client_process_request(struct web_client *w) {
 #ifdef ENABLE_HTTPS
         case HTTP_VALIDATION_REDIRECT:
         {
+            buffer_flush(w->response.data);
+            w->response.data->contenttype = CT_TEXT_HTML;
+            buffer_strcat(w->response.data,
+                          "<!DOCTYPE html><!-- SPDX-License-Identifier: GPL-3.0-or-later --><html>"
+                          "<body onload=\"window.location.href ='https://'+ window.location.hostname +"
+                          " ':' + window.location.port + window.location.pathname + window.location.search\">"
+                          "Redirecting to safety connection, case your browser does not support redirection, please"
+                          " click <a onclick=\"window.location.href ='https://'+ window.location.hostname + ':' "
+                          " + window.location.port + window.location.pathname + window.location.search\">here</a>."
+                          "</body></html>");
             w->response.code = HTTP_RESP_MOVED_PERM;
             break;
         }

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1016,7 +1016,7 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
     encoded_url = s;
 
     //we search for the position where we have " HTTP/", because it finishes the user request
-        s = url_find_protocol(s);
+    s = url_find_protocol(s);
 
     // incomplete requests
     if(unlikely(!*s)) {


### PR DESCRIPTION
##### Summary
While I was testing #9779  I observed that when Netdata was doing redirects from `http` protocol to `https` protocol, it was not adding the query string when it was present.

This PR fixes this wrong redirect.

##### Component Name
Web
##### Test Plan

1 - Create a TLS certificate inside `/etc/netdata/ssl/`
2 - Configure your netdata.conf:

```
[web]
    ssl key = /etc/netdata/ssl/key.pem
   ssl certificate = /etc/netdata/ssl/cert.pem
   bind to = *=dashboard|registry|streaming|management|netdata.conf|badges *:20000=dashboard|registry|streaming|netdata.conf|badges|management^SSL=optional
```

please, pay attention for the fact that the port 19999 will always redirect requests from `HTTP` while 20000 won't do this.

3 - Start Netdata
4 - Access the following URLS, with browser network visible for you see the response received:

```
http://localhost:19999/api/v1/allmetrics?format=prometheus&source=raw&variables=yes&help=yes
http://localhost:19999/api/v1/info
http://localhost:19999

https://localhost:19999
https://localhost:19999/api/v1/alarms?all
```

For the three first URLs, it is expected you receive a `301` and to be redirected for its respective `HTTPS` addresses. For the other two, you will have direct access.

5 - Now repeat the requests, but this time using port 20000 

```
http://localhost:20000/api/v1/allmetrics?format=prometheus&source=raw&variables=yes&help=yes
http://localhost:20000/api/v1/info
http://localhost:20000

https://localhost:20000
https://localhost:20000/api/v1/alarms?all
```

This time you won't be redirected for any request.

If you have some warnings when try to access the URL 4, this is expected due browser cache, please, press CTRL+ SHIFT+R to force the reload after you accept self-signed certificate.
##### Additional Information
