### PR TITLE
fix loading custom dashboard_info in /old dashboard

### DIFF
--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -1929,7 +1929,7 @@ function renderChartsAndMenu(data) {
 
 function loadJs(url, callback) {
     $.ajax({
-        url: `../${url}`,
+        url: url.startsWith("http") ? url : `../${url}`,
         cache: true,
         dataType: "script",
         xhrFields: { withCredentials: true } // required for the cookie


### PR DESCRIPTION
### Summary
fixes https://github.com/netdata/netdata/issues/9787
Old dashboard accessed with /old suffix was not loading custom dashboard_info.js files.

##### Component Name
web

##### Test Plan
In /etc/netdata.conf

```
[web]
   custom dashboard_info.js = dashboard_info_custom.js
```
dashboard should not show error, and the dashboard_info_custom.js file should be loaded by browser.
