### PR TITLE
Fix ram level alarms

### DIFF
--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -13,8 +13,7 @@
       on: system.ram
       os: linux
    hosts: *
-#   calc: $used * 100 / ($used + $cached + $free)
-    calc: ($used - $used_ram_to_ignore) * 100 / ($used  + $cached + $free)
+    calc: ($used - $used_ram_to_ignore) * 100 / ($used  + $cached + $free + $buffers)
    units: %
    every: 10s
     warn: $this > (($status >= $WARNING)  ? (80) : (90))
@@ -27,7 +26,7 @@
       on: mem.available
       os: linux
    hosts: *
-    calc: ($avail + $system.ram.used_ram_to_ignore) * 100 / ($system.ram.used + $system.ram.cached + $system.ram.free + $system.ram.buffers)
+    calc: $avail * 100 / ($system.ram.used + $system.ram.cached + $system.ram.free + $system.ram.buffers)
    units: %
    every: 10s
     warn: $this < (($status >= $WARNING)  ? (15) : (10))


### PR DESCRIPTION
##### Summary
Fixes #9059 

##### Component Name
health

##### Test Plan

* Trigger a scenario with high usage of buffers, where the buffers are counted as available by the kernel. 

##### Additional Information
