### PR TITLE
Don't run packaging checks on Travis builds that build packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,6 +162,7 @@ jobs:
       after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Fedora 31"
 
     - name: DEB package test
+      if: commit_message =~ /^((?!\[Package (amd64|arm64|i386) (DEB|RPM)( .*)?\]).)*$/
       git:
         depth: false
       before_install:
@@ -183,6 +184,7 @@ jobs:
         - PACKAGE_TYPE="deb" REPO_TOOL="apt-get"
 
     - name: RPM package test
+      if: commit_message =~ /^((?!\[Package (amd64|arm64|i386) (DEB|RPM)( .*)?\]).)*$/
       git:
         depth: false
       before_install:

--- a/.travis/package_management/create_lxc_for_build.sh
+++ b/.travis/package_management/create_lxc_for_build.sh
@@ -2,7 +2,7 @@
 #
 # This script generates an LXC container and starts it up
 # Once the script completes successfully, a container has become available for usage
-# The container image to be used and the container name to be set, are part of variables
+# The container image to be used and the container name to be set, are part of variables 
 # that must be present for the script to work
 #
 # Copyright: SPDX-License-Identifier: GPL-3.0-or-later
@@ -17,90 +17,85 @@ source .travis/package_management/functions.sh || (echo "Failed to load packagin
 TOP_LEVEL=$(basename "$(git rev-parse --show-toplevel)")
 CWD=$(git rev-parse --show-cdup)
 if [ -n "$CWD" ] || [ ! "${TOP_LEVEL}" == "netdata" ]; then
-  echo "Run as .travis/package_management/$(basename "$0") from top level directory of netdata git repository"
-  echo "LXC Container creation aborted"
-  exit 1
+    echo "Run as .travis/package_management/$(basename "$0") from top level directory of netdata git repository"
+    echo "LXC Container creation aborted"
+    exit 1
 fi
 
 # Check for presence of mandatory environment variables
 if [ -z "${BUILD_STRING}" ]; then
-  echo "No Distribution was defined. Make sure BUILD_STRING is set on the environment before running this script"
-  exit 1
+	echo "No Distribution was defined. Make sure BUILD_STRING is set on the environment before running this script"
+	exit 1
 fi
 
 if [ -z "${BUILDER_NAME}" ]; then
-  echo "No builder account and container name defined. Make sure BUILDER_NAME is set on the environment before running this script"
-  exit 1
+	echo "No builder account and container name defined. Make sure BUILDER_NAME is set on the environment before running this script"
+	exit 1
 fi
 
 if [ -z "${BUILD_DISTRO}" ]; then
-  echo "No build distro information defined. Make sure BUILD_DISTRO is set on the environment before running this script"
-  exit 1
+	echo "No build distro information defined. Make sure BUILD_DISTRO is set on the environment before running this script"
+	exit 1
 fi
 
 if [ -z "${BUILD_RELEASE}" ]; then
-  echo "No build release information defined. Make sure BUILD_RELEASE is set on the environment before running this script"
-  exit 1
+	echo "No build release information defined. Make sure BUILD_RELEASE is set on the environment before running this script"
+	exit 1
 fi
 
 if [ -z "${PACKAGE_TYPE}" ]; then
-  echo "No build release information defined. Make sure PACKAGE_TYPE is set on the environment before running this script"
-  exit 1
+	echo "No build release information defined. Make sure PACKAGE_TYPE is set on the environment before running this script"
+	exit 1
 fi
 
 # Detect architecture and load extra variables needed
 detect_arch_from_commit
 
-if [ x"${BUILDER_NAME}/${BUILD_STRING}/${BUILD_ARCH}" = x"builder/fedora/31/i386" ]; then
-  echo " Skipping Fedora 31 i386 build (non-existent upstream) ..."
-  exit 0
-fi
-
 echo "Creating LXC container ${BUILDER_NAME}/${BUILD_STRING}/${BUILD_ARCH}...."
 
 case "${BUILD_ARCH}" in
-  "all")
-    # i386
-    echo "Creating LXC Container for i386.."
-    export CONTAINER_NAME="${BUILDER_NAME}-${BUILD_DISTRO}${BUILD_RELEASE}-i386"
-    export LXC_CONTAINER_ROOT="/var/lib/lxc/${CONTAINER_NAME}/rootfs"
-    lxc-create -n "${CONTAINER_NAME}" -t "download" -- --dist "${BUILD_DISTRO}" --release "${BUILD_RELEASE}" --arch "i386" --no-validate
+"all")
+	# i386
+	echo "Creating LXC Container for i386.."
+	export CONTAINER_NAME="${BUILDER_NAME}-${BUILD_DISTRO}${BUILD_RELEASE}-i386"
+	export LXC_CONTAINER_ROOT="/var/lib/lxc/${CONTAINER_NAME}/rootfs"
+	lxc-create -n "${CONTAINER_NAME}" -t "download" -- --dist "${BUILD_DISTRO}" --release "${BUILD_RELEASE}" --arch "i386" --no-validate
 
-    echo "Container(s) ready. Configuring container(s).."
-    .travis/package_management/configure_${PACKAGE_TYPE}_lxc_environment.py "${CONTAINER_NAME}"
+	echo "Container(s) ready. Configuring container(s).."
+	.travis/package_management/configure_${PACKAGE_TYPE}_lxc_environment.py "${CONTAINER_NAME}"
 
-    # amd64
-    echo "Creating LXC Container for amd64.."
-    export CONTAINER_NAME="${BUILDER_NAME}-${BUILD_DISTRO}${BUILD_RELEASE}-amd64"
-    export LXC_CONTAINER_ROOT="/var/lib/lxc/${CONTAINER_NAME}/rootfs"
-    lxc-create -n "${CONTAINER_NAME}" -t "download" -- --dist "${BUILD_DISTRO}" --release "${BUILD_RELEASE}" --arch "amd64" --no-validate
+	# amd64
+	echo "Creating LXC Container for amd64.."
+	export CONTAINER_NAME="${BUILDER_NAME}-${BUILD_DISTRO}${BUILD_RELEASE}-amd64"
+	export LXC_CONTAINER_ROOT="/var/lib/lxc/${CONTAINER_NAME}/rootfs"
+	lxc-create -n "${CONTAINER_NAME}" -t "download" -- --dist "${BUILD_DISTRO}" --release "${BUILD_RELEASE}" --arch "amd64" --no-validate
 
-    echo "Container(s) ready. Configuring container(s).."
-    .travis/package_management/configure_${PACKAGE_TYPE}_lxc_environment.py "${CONTAINER_NAME}"
+	echo "Container(s) ready. Configuring container(s).."
+	.travis/package_management/configure_${PACKAGE_TYPE}_lxc_environment.py "${CONTAINER_NAME}"
 
-    # arm64
-    echo "Creating LXC Container for arm64.."
-    export CONTAINER_NAME="${BUILDER_NAME}-${BUILD_DISTRO}${BUILD_RELEASE}-arm64"
-    export LXC_CONTAINER_ROOT="/var/lib/lxc/${CONTAINER_NAME}/rootfs"
-    lxc-create -n "${CONTAINER_NAME}" -t "download" -- --dist "${BUILD_DISTRO}" --release "${BUILD_RELEASE}" --arch "arm64" --no-validate
+	# arm64
+	echo "Creating LXC Container for arm64.."
+	export CONTAINER_NAME="${BUILDER_NAME}-${BUILD_DISTRO}${BUILD_RELEASE}-arm64"
+	export LXC_CONTAINER_ROOT="/var/lib/lxc/${CONTAINER_NAME}/rootfs"
+	lxc-create -n "${CONTAINER_NAME}" -t "download" -- --dist "${BUILD_DISTRO}" --release "${BUILD_RELEASE}" --arch "arm64" --no-validate
 
-    echo "Container(s) ready. Configuring container(s).."
-    .travis/package_management/configure_${PACKAGE_TYPE}_lxc_environment.py "${CONTAINER_NAME}"
-    ;;
-  "i386" | "amd64" | "arm64")
-    # amd64 or i386
-    echo "Creating LXC Container for ${BUILD_ARCH}.."
-    export CONTAINER_NAME="${BUILDER_NAME}-${BUILD_DISTRO}${BUILD_RELEASE}-${BUILD_ARCH}"
-    export LXC_CONTAINER_ROOT="/var/lib/lxc/${CONTAINER_NAME}/rootfs"
-    lxc-create -n "${CONTAINER_NAME}" -t "download" -- --dist "${BUILD_DISTRO}" --release "${BUILD_RELEASE}" --arch "${BUILD_ARCH}" --no-validate
+	echo "Container(s) ready. Configuring container(s).."
+	.travis/package_management/configure_${PACKAGE_TYPE}_lxc_environment.py "${CONTAINER_NAME}"
+	;;
+"i386"|"amd64"|"arm64")
+	# amd64 or i386
+	echo "Creating LXC Container for ${BUILD_ARCH}.."
+	export CONTAINER_NAME="${BUILDER_NAME}-${BUILD_DISTRO}${BUILD_RELEASE}-${BUILD_ARCH}"
+	export LXC_CONTAINER_ROOT="/var/lib/lxc/${CONTAINER_NAME}/rootfs"
+	lxc-create -n "${CONTAINER_NAME}" -t "download" -- --dist "${BUILD_DISTRO}" --release "${BUILD_RELEASE}" --arch "${BUILD_ARCH}" --no-validate
 
-    echo "Container(s) ready. Configuring container(s).."
-    .travis/package_management/configure_${PACKAGE_TYPE}_lxc_environment.py "${CONTAINER_NAME}"
-    ;;
-  *)
-    echo "Unknown BUILD_ARCH value '${BUILD_ARCH}' given, process failed"
-    exit 1
-    ;;
+	echo "Container(s) ready. Configuring container(s).."
+	.travis/package_management/configure_${PACKAGE_TYPE}_lxc_environment.py "${CONTAINER_NAME}"
+	;;
+*)
+	echo "Unknown BUILD_ARCH value '${BUILD_ARCH}' given, process failed"
+	exit 1
+	;;
 esac
 
 echo "..LXC creation complete!"


### PR DESCRIPTION
##### Summary

Testing that the package builds work prior to actually building the packages is a waste of time and is causing issues for certain package builds. Just skip our packaging CI checks on those builds instead.

##### Component Name

area/ci

##### Test Plan

Verified using Travis on my fork with dummy packaging commits.

##### Additional Information

Sample test build that demonstrates this working: https://travis-ci.org/github/Ferroin/netdata/builds/719593095