### PR TITLE
Improved temporary directory checking in installer and updater.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -78,8 +78,6 @@ if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
   fi
 fi
 
-echo >&2 "Using ${TMPDIR} as a temporary directory."
-
 # -----------------------------------------------------------------------------
 # set up handling for deferred error messages
 NETDATA_DEFERRED_ERRORS=""
@@ -362,6 +360,10 @@ netdata_banner "real-time performance monitoring, done right!"
 cat << BANNER1
 
   You are about to build and install netdata to your system.
+
+  The build process will use ${TPUT_CYAN}${TMPDIR}${TPUT_RESET} for
+  any temporary files. You can override this by setting \$TMPDIR to a
+  writable directory where you can execute files.
 
   It will be installed at these locations:
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -42,6 +42,45 @@ fi
 cd "${NETDATA_SOURCE_DIR}" || exit 1
 
 # -----------------------------------------------------------------------------
+# figure out an appropriate temporary directory
+_cannot_use_tmpdir() {
+  local testfile ret
+  testfile="$(TMPDIR="${1}" mktemp -q -t netdata-test.XXXXXXXXXX)"
+  ret=0
+
+  if [ -z "${testfile}" ] ; then
+    return "${ret}"
+  fi
+
+  if /bin/echo -e "#!/bin/sh\necho SUCCESS\n" > "${testfile}" ; then
+    if chmod +x "${testfile}" ; then
+      if [ "$("${testfile}")" = "SUCCESS" ] ; then
+        ret=1
+      fi
+    fi
+  fi
+
+  rm -f "${testfile}"
+  return "${ret}"
+}
+
+if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
+  if _cannot_use_tmpdir /tmp ; then
+    if _cannot_use_tmpdir "${PWD}" ; then
+      echo >&2
+      echo >&2 "Unable to find a usable temprorary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
+      exit 1
+    else
+      TMPDIR="${PWD}"
+    fi
+  else
+    TMPDIR="/tmp"
+  fi
+fi
+
+echo >&2 "Using ${TMPDIR} as a temporary directory."
+
+# -----------------------------------------------------------------------------
 # set up handling for deferred error messages
 NETDATA_DEFERRED_ERRORS=""
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -52,7 +52,7 @@ _cannot_use_tmpdir() {
     return "${ret}"
   fi
 
-  if /bin/echo -e "#!/bin/sh\necho SUCCESS\n" > "${testfile}" ; then
+  if /bin/echo -e '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
     if chmod +x "${testfile}" ; then
       if [ "$("${testfile}")" = "SUCCESS" ] ; then
         ret=1

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -121,15 +121,43 @@ fatal() {
   exit 1
 }
 
-create_tmp_directory() {
-  # Check if tmp is mounted as noexec
-  if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts; then
-    pattern="$(pwd)/netdata-kickstart-XXXXXX"
-  else
-    pattern="/tmp/netdata-kickstart-XXXXXX"
+_cannot_use_tmpdir() {
+  local testfile ret
+  testfile="$(TMPDIR="${1}" mktemp -q -t netdata-test.XXXXXXXXXX)"
+  ret=0
+
+  if [ -z "${testfile}" ] ; then
+    return "${ret}"
   fi
 
-  mktemp -d $pattern
+  if /bin/echo -e "#!/bin/sh\necho SUCCESS\n" > "${testfile}" ; then
+    if chmod +x "${testfile}" ; then
+      if [ "$("${testfile}")" = "SUCCESS" ] ; then
+        ret=1
+      fi
+    fi
+  fi
+
+  rm -f "${testfile}"
+  return "${ret}"
+}
+
+create_tmp_directory() {
+  if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
+    if _cannot_use_tmpdir /tmp ; then
+      if _cannot_use_tmpdir "${PWD}" ; then
+        echo >&2
+        echo >&2 "Unable to find a usable temprorary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
+        exit 1
+      else
+        TMPDIR="${PWD}"
+      fi
+    else
+      TMPDIR="/tmp"
+    fi
+  fi
+
+  mktemp -d -t netdata-kickstart-XXXXXXXXXX
 }
 
 download() {

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -130,7 +130,7 @@ _cannot_use_tmpdir() {
     return "${ret}"
   fi
 
-  if /bin/echo -e "#!/bin/sh\necho SUCCESS\n" > "${testfile}" ; then
+  if /bin/echo -e '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
     if chmod +x "${testfile}" ; then
       if [ "$("${testfile}")" = "SUCCESS" ] ; then
         ret=1

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -19,6 +19,7 @@
 #
 # Environment options:
 #
+#  TMPDIR                     specify where to save temporary files
 #  NETDATA_TARBALL_BASEURL    set the base url for downloading the dist tarball
 #
 # This script will:
@@ -152,15 +153,43 @@ warning() {
   fi
 }
 
-create_tmp_directory() {
-  # Check if tmp is mounted as noexec
-  if grep -Eq '^[^ ]+ /tmp [^ ]+ ([^ ]*,)?noexec[, ]' /proc/mounts > /dev/null 2>&1; then
-    pattern="$(pwd)/netdata-kickstart-XXXXXX"
-  else
-    pattern="/tmp/netdata-kickstart-XXXXXX"
+_cannot_use_tmpdir() {
+  local testfile ret
+  testfile="$(TMPDIR="${1}" mktemp -q -t netdata-test.XXXXXXXXXX)"
+  ret=0
+
+  if [ -z "${testfile}" ] ; then
+    return "${ret}"
   fi
 
-  mktemp -d $pattern
+  if /bin/echo -e "#!/bin/sh\necho SUCCESS\n" > "${testfile}" ; then
+    if chmod +x "${testfile}" ; then
+      if [ "$("${testfile}")" = "SUCCESS" ] ; then
+        ret=1
+      fi
+    fi
+  fi
+
+  rm -f "${testfile}"
+  return "${ret}"
+}
+
+create_tmp_directory() {
+  if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
+    if _cannot_use_tmpdir /tmp ; then
+      if _cannot_use_tmpdir "${PWD}" ; then
+        echo >&2
+        echo >&2 "Unable to find a usable temprorary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
+        exit 1
+      else
+        TMPDIR="${PWD}"
+      fi
+    else
+      TMPDIR="/tmp"
+    fi
+  fi
+
+  mktemp -d -t netdata-kickstart-XXXXXXXXXX
 }
 
 download() {
@@ -236,19 +265,19 @@ dependencies() {
       progress "Fetching script to detect required packages..."
       if [ -n "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" ]; then
         if [ -f "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" ]; then
-          run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" "${TMPDIR}/install-required-packages.sh"
+          run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" "${tmpdir}/install-required-packages.sh"
         else
           fatal "Invalid given dependency file, please check your --local-files parameter options and try again"
         fi
       else
-        download "${PACKAGES_SCRIPT}" "${TMPDIR}/install-required-packages.sh"
+        download "${PACKAGES_SCRIPT}" "${tmpdir}/install-required-packages.sh"
       fi
 
-      if [ ! -s "${TMPDIR}/install-required-packages.sh" ]; then
+      if [ ! -s "${tmpdir}/install-required-packages.sh" ]; then
         warning "Downloaded dependency installation script is empty."
       else
         progress "Running downloaded script to detect required packages..."
-        run ${sudo} "${bash}" "${TMPDIR}/install-required-packages.sh" ${PACKAGES_INSTALLER_OPTIONS}
+        run ${sudo} "${bash}" "${tmpdir}/install-required-packages.sh" ${PACKAGES_INSTALLER_OPTIONS}
         # shellcheck disable=SC2181
         if [ $? -ne 0 ]; then
           warning "It failed to install all the required packages, but installation might still be possible."
@@ -278,6 +307,7 @@ sudo=""
 [ -z "${UID}" ] && UID="$(id -u)"
 [ "${UID}" -ne "0" ] && sudo="sudo"
 export PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
+
 
 # ---------------------------------------------------------------------------------------------------------------------
 
@@ -412,8 +442,8 @@ fi
 # ---------------------------------------------------------------------------------------------------------------------
 # install required system packages
 
-TMPDIR=$(create_tmp_directory)
-cd "${TMPDIR}" || exit 1
+tmpdir=$(create_tmp_directory)
+cd "${tmpdir}" || exit 1
 
 dependencies
 
@@ -423,16 +453,16 @@ dependencies
 if [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE}" ]; then
   set_tarball_urls "${RELEASE_CHANNEL}"
 
-  download "${NETDATA_TARBALL_CHECKSUM_URL}" "${TMPDIR}/sha256sum.txt"
-  download "${NETDATA_TARBALL_URL}" "${TMPDIR}/netdata-latest.tar.gz"
+  download "${NETDATA_TARBALL_CHECKSUM_URL}" "${tmpdir}/sha256sum.txt"
+  download "${NETDATA_TARBALL_URL}" "${tmpdir}/netdata-latest.tar.gz"
 else
   progress "Installation sources were given as input, running installation using \"${NETDATA_LOCAL_TARBALL_OVERRIDE}\""
-  run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM}" "${TMPDIR}/sha256sum.txt"
-  run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE}" "${TMPDIR}/netdata-latest.tar.gz"
+  run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM}" "${tmpdir}/sha256sum.txt"
+  run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE}" "${tmpdir}/netdata-latest.tar.gz"
 fi
 
-if ! grep netdata-latest.tar.gz "${TMPDIR}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-  fatal "Tarball checksum validation failed. Stopping netdata installation and leaving tarball in ${TMPDIR}"
+if ! grep netdata-latest.tar.gz "${tmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
+  fatal "Tarball checksum validation failed. Stopping netdata installation and leaving tarball in ${tmpdir}"
 fi
 run tar -xf netdata-latest.tar.gz
 rm -rf netdata-latest.tar.gz > /dev/null 2>&1
@@ -444,9 +474,9 @@ cd netdata-* || fatal "Cannot cd to netdata source tree"
 if [ -x netdata-installer.sh ]; then
   progress "Installing netdata..."
   run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS} "${@}" || fatal "netdata-installer.sh exited with error"
-  if [ -d "${TMPDIR}" ] && [ ! "${TMPDIR}" = "/" ]; then
-    run ${sudo} rm -rf "${TMPDIR}" > /dev/null 2>&1
+  if [ -d "${tmpdir}" ] && [ ! "${tmpdir}" = "/" ]; then
+    run ${sudo} rm -rf "${tmpdir}" > /dev/null 2>&1
   fi
 else
-  fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${TMPDIR}"
+  fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${tmpdir}"
 fi

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -78,7 +78,7 @@ To use `md5sum` to verify the intregity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "459d0855154657ece8dce6d20b4cbfc8" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "2b0219a71a070853e9109eecebb4be92" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -78,7 +78,7 @@ To use `md5sum` to verify the intregity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "4940607945b1b92db96d4674b5bba7b3" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "459d0855154657ece8dce6d20b4cbfc8" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -61,7 +61,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "dd940481d677c463d6ed96f46eb16576" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "0bfd0e5d8ac868ff09957f1d43e8a35a" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -61,7 +61,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "e08dfbc39c23bf8993861e19c7d32368" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "dd940481d677c463d6ed96f46eb16576" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -58,8 +58,8 @@ cleanup() {
     rm "${logfile}"
   fi
 
-  if [ -n "$tmpdir" ] && [ -d "$tmpdir" ]; then
-    rm -rf "$tmpdir"
+  if [ -n "$ndtmpdir" ] && [ -d "$ndtmpdir" ]; then
+    rm -rf "$ndtmpdir"
   fi
 }
 
@@ -72,7 +72,7 @@ _cannot_use_tmpdir() {
     return "${ret}"
   fi
 
-  if /bin/echo -e "#!/bin/sh\necho SUCCESS\n" > "${testfile}" ; then
+  if /bin/echo -e '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
     if chmod +x "${testfile}" ; then
       if [ "$("${testfile}")" = "SUCCESS" ] ; then
         ret=1
@@ -169,10 +169,10 @@ update() {
   [ -z "${logfile}" ] && info "Running on a terminal - (this script also supports running headless from crontab)"
 
   RUN_INSTALLER=0
-  tmpdir=$(create_tmp_directory)
-  cd "$tmpdir" || exit 1
+  ndtmpdir=$(create_tmp_directory)
+  cd "$ndtmpdir" || exit 1
 
-  download "${NETDATA_TARBALL_CHECKSUM_URL}" "${tmpdir}/sha256sum.txt" >&3 2>&3
+  download "${NETDATA_TARBALL_CHECKSUM_URL}" "${ndtmpdir}/sha256sum.txt" >&3 2>&3
 
   current_version="$(command -v netdata > /dev/null && parse_version "$(netdata -v | cut -f 2 -d ' ')")"
   latest_version="$(get_latest_version)"
@@ -191,9 +191,9 @@ update() {
   elif [ -n "${NETDATA_TARBALL_CHECKSUM}" ] && grep "${NETDATA_TARBALL_CHECKSUM}" sha256sum.txt >&3 2>&3; then
     info "Newest version is already installed"
   else
-    download "${NETDATA_TARBALL_URL}" "${tmpdir}/netdata-latest.tar.gz"
+    download "${NETDATA_TARBALL_URL}" "${ndtmpdir}/netdata-latest.tar.gz"
     if ! grep netdata-latest.tar.gz sha256sum.txt | safe_sha256sum -c - >&3 2>&3; then
-      fatal "Tarball checksum validation failed. Stopping netdata upgrade and leaving tarball in ${tmpdir}"
+      fatal "Tarball checksum validation failed. Stopping netdata upgrade and leaving tarball in ${ndtmpdir}"
     fi
     NEW_CHECKSUM="$(safe_sha256sum netdata-latest.tar.gz 2> /dev/null | cut -d' ' -f1)"
     tar -xf netdata-latest.tar.gz >&3 2>&3
@@ -231,14 +231,14 @@ update() {
     echo "${NEW_CHECKSUM}" > "${NETDATA_LIB_DIR}/netdata.tarball.checksum"
   fi
 
-  rm -rf "${tmpdir}" >&3 2>&3
+  rm -rf "${ndtmpdir}" >&3 2>&3
   [ -n "${logfile}" ] && rm "${logfile}" && logfile=
 
   return 0
 }
 
 logfile=
-tmpdir=
+ndtmpdir=
 
 trap cleanup EXIT
 
@@ -293,24 +293,24 @@ fi
 set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
 
 if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
-  tmpdir="$(create_tmp_directory)"
+  ndtmpdir="$(create_tmp_directory)"
   PREVDIR="$(pwd)"
 
-  echo >&2 "Entering ${tmpdir}"
-  cd "${tmpdir}" || exit 1
+  echo >&2 "Entering ${ndtmpdir}"
+  cd "${ndtmpdir}" || exit 1
 
-  download "${NETDATA_TARBALL_CHECKSUM_URL}" "${tmpdir}/sha256sum.txt"
-  download "${NETDATA_TARBALL_URL}" "${tmpdir}/netdata-latest.gz.run"
-  if ! grep netdata-latest.gz.run "${tmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-    fatal "Static binary checksum validation failed. Stopping netdata installation and leaving binary in ${tmpdir}"
+  download "${NETDATA_TARBALL_CHECKSUM_URL}" "${ndtmpdir}/sha256sum.txt"
+  download "${NETDATA_TARBALL_URL}" "${ndtmpdir}/netdata-latest.gz.run"
+  if ! grep netdata-latest.gz.run "${ndtmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
+    fatal "Static binary checksum validation failed. Stopping netdata installation and leaving binary in ${ndtmpdir}"
   fi
 
   # Do not pass any options other than the accept, for now
   # shellcheck disable=SC2086
-  if sh "${tmpdir}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS}; then
-    rm -r "${tmpdir}"
+  if sh "${ndtmpdir}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS}; then
+    rm -r "${ndtmpdir}"
   else
-    echo >&2 "NOTE: did not remove: ${tmpdir}"
+    echo >&2 "NOTE: did not remove: ${ndtmpdir}"
   fi
   echo >&2 "Switching back to ${PREVDIR}"
   cd "${PREVDIR}" || exit 1


### PR DESCRIPTION
##### Summary

This updates the checks that our installer and updater make to choose what to use for a temporary directory to be both more robust and more portable.

The original logic directly checked the mount options for `/tmp`, which is unfortunately unreliable as it doesn't work at all on FreeBSD (no procfs), probably doesn't work on macOS (different paths), and fails in some configurations on Linux (rare cases where `/tmp` is not actually a mount point, such as systems where `/` is inherently on tmpfs). The new check instead explicitly writes a temporary file at the location under test, marks it executable, and tries to run it (similar to how Autoconf generated configure scripts handle this type of thing), which will always tell us if that location is usable.

The new checks use the following logic for deciding where to place temporary files:

* For each directory to be checked, verify that it is both writable by the current user, and that the current user can execute files they write there.
* If `$TMPDIR` is set, preferentially use that.
* If that fials, try `/tmp`.
* If that also fails, fall back to `$PWD`.
* If all checks fail, bail early with an explanation instead of failing when we first try to do things with the directory.

It also adds the same checks to the `netdata-installer.sh` script, which was previously completely missing them.

##### Component Name

area/packaging

##### Test Plan

Tested using local installs in Docker containers with various temporary directory setups.

##### Additional Information

Fixes: #9626 