### PR TITLE
Stream Claim Id

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -35,7 +35,7 @@ char *is_agent_claimed()
 {
     char *result;
     netdata_mutex_lock(&localhost->claimed_id_lock);
-    result = (localhost->claimed_id == NULL) ? NULL : strdup(localhost->claimed_id);
+    result = (localhost->claimed_id == NULL) ? NULL : strdupz(localhost->claimed_id);
     netdata_mutex_unlock(&localhost->claimed_id_lock);
     return result;
 }

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -154,6 +154,8 @@ void load_claiming_state(void)
 
     long bytes_read;
     claimed_id = read_by_filename(filename, &bytes_read);
+    //TODO: remove claimed_id global variable and cleanup
+    rrdhost_set_claimed_id(localhost, claimed_id);
     netdata_mutex_unlock(&claim_mutex);   // Only the main thread can call this function, safe to release and then read
     if (!claimed_id) {
         info("Unable to load '%s', setting state to AGENT_UNCLAIMED", filename);
@@ -162,6 +164,7 @@ void load_claiming_state(void)
 
     info("File '%s' was found. Setting state to AGENT_CLAIMED.", filename);
     netdata_cloud_setting = appconfig_get_boolean(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", 1);
+
 #endif
 }
 

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -154,7 +154,7 @@ void load_claiming_state(void)
     long bytes_read;
     char *claimed_id = read_by_filename(filename, &bytes_read);
     if(claimed_id && uuid_parse(claimed_id, uuid)) {
-        error("claimed_id doesn't look like valid UUID");
+        error("claimed_id \"%s\" doesn't look like valid UUID", claimed_id);
         freez(claimed_id);
         claimed_id = NULL;
     }

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -133,6 +133,7 @@ void load_claiming_state(void)
 #if defined( DISABLE_CLOUD ) || !defined( ENABLE_ACLK )
     netdata_cloud_setting = 0;
 #else
+    uuid_t uuid;
     netdata_mutex_lock(&localhost->claimed_id_lock);
     if (localhost->claimed_id) {
         freez(localhost->claimed_id);
@@ -152,6 +153,11 @@ void load_claiming_state(void)
 
     long bytes_read;
     char *claimed_id = read_by_filename(filename, &bytes_read);
+    if(claimed_id && uuid_parse(claimed_id, uuid)) {
+        error("claimed_id doesn't look like valid UUID");
+        freez(claimed_id);
+        claimed_id = NULL;
+    }
     localhost->claimed_id = claimed_id;
     netdata_mutex_unlock(&localhost->claimed_id_lock);
     if (!claimed_id) {

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -27,8 +27,6 @@ static char *claiming_errors[] = {
         "Service Unavailable",                          // 17
         "Agent Unique Id Not Readable"                  // 18
 };
-static netdata_mutex_t claim_mutex = NETDATA_MUTEX_INITIALIZER;
-static char *claimed_id = NULL;
 
 /* Retrieve the claim id for the agent.
  * Caller owns the string.
@@ -36,9 +34,9 @@ static char *claimed_id = NULL;
 char *is_agent_claimed()
 {
     char *result;
-    netdata_mutex_lock(&claim_mutex);
-    result = (claimed_id == NULL) ? NULL : strdup(claimed_id);
-    netdata_mutex_unlock(&claim_mutex);
+    netdata_mutex_lock(&localhost->claimed_id_lock);
+    result = (localhost->claimed_id == NULL) ? NULL : strdup(localhost->claimed_id);
+    netdata_mutex_unlock(&localhost->claimed_id_lock);
     return result;
 }
 
@@ -135,10 +133,10 @@ void load_claiming_state(void)
 #if defined( DISABLE_CLOUD ) || !defined( ENABLE_ACLK )
     netdata_cloud_setting = 0;
 #else
-    netdata_mutex_lock(&claim_mutex);
-    if (claimed_id != NULL) {
-        freez(claimed_id);
-        claimed_id = NULL;
+    netdata_mutex_lock(&localhost->claimed_id_lock);
+    if (localhost->claimed_id) {
+        freez(localhost->claimed_id);
+        localhost->claimed_id = NULL;
     }
     if (aclk_connected)
     {
@@ -153,10 +151,9 @@ void load_claiming_state(void)
     snprintfz(filename, FILENAME_MAX, "%s/cloud.d/claimed_id", netdata_configured_varlib_dir);
 
     long bytes_read;
-    claimed_id = read_by_filename(filename, &bytes_read);
-    //TODO: remove claimed_id global variable and cleanup
-    rrdhost_set_claimed_id(localhost, claimed_id);
-    netdata_mutex_unlock(&claim_mutex);   // Only the main thread can call this function, safe to release and then read
+    char *claimed_id = read_by_filename(filename, &bytes_read);
+    localhost->claimed_id = claimed_id;
+    netdata_mutex_unlock(&localhost->claimed_id_lock);
     if (!claimed_id) {
         info("Unable to load '%s', setting state to AGENT_UNCLAIMED", filename);
         return;
@@ -164,7 +161,6 @@ void load_claiming_state(void)
 
     info("File '%s' was found. Setting state to AGENT_CLAIMED.", filename);
     netdata_cloud_setting = appconfig_get_boolean(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", 1);
-
 #endif
 }
 

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -202,7 +202,7 @@ static cmd_status_t cmd_reload_claiming_state_execute(char *args, char **message
     info("COMMAND: Reloading Agent Claiming configuration.");
     load_claiming_state();
     registry_update_cloud_base_url();
-    rrdpush_was_runtime_claimed(localhost);
+    rrdpush_claimed_id(localhost);
     error_log_limit_reset();
     return CMD_STATUS_SUCCESS;
 }

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -202,6 +202,7 @@ static cmd_status_t cmd_reload_claiming_state_execute(char *args, char **message
     info("COMMAND: Reloading Agent Claiming configuration.");
     load_claiming_state();
     registry_update_cloud_base_url();
+    rrdpush_was_runtime_claimed(localhost);
     error_log_limit_reset();
     return CMD_STATUS_SUCCESS;
 }

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -817,6 +817,7 @@ struct rrdhost {
     struct netdata_ssl stream_ssl;                         //Structure used to encrypt the stream
 #endif
 
+    netdata_mutex_t claimed_id_lock;
     char *claimed_id;                               // Claimed ID if host has one otherwise NULL
 
     struct rrdhost *next;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -817,6 +817,8 @@ struct rrdhost {
     struct netdata_ssl stream_ssl;                         //Structure used to encrypt the stream
 #endif
 
+    char *claimed_id;                               // Claimed ID if host has one otherwise NULL
+
     struct rrdhost *next;
 };
 extern RRDHOST *localhost;
@@ -1174,6 +1176,8 @@ extern long align_entries_to_pagesize(RRD_MEMORY_MODE mode, long entries);
 
 extern int alarm_compare_id(void *a, void *b);
 extern int alarm_compare_name(void *a, void *b);
+
+extern void rrdhost_set_claimed_id(RRDHOST *host, const char *new_id);
 
 // ----------------------------------------------------------------------------
 // RRD internal functions

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -817,6 +817,7 @@ struct rrdhost {
     struct netdata_ssl stream_ssl;                         //Structure used to encrypt the stream
 #endif
 
+    // if held together with receiver_lock. Order is receiver_lock then claimed_id_lock
     netdata_mutex_t claimed_id_lock;
     char *claimed_id;                               // Claimed ID if host has one otherwise NULL
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1178,8 +1178,6 @@ extern long align_entries_to_pagesize(RRD_MEMORY_MODE mode, long entries);
 extern int alarm_compare_id(void *a, void *b);
 extern int alarm_compare_name(void *a, void *b);
 
-extern void rrdhost_set_claimed_id(RRDHOST *host, const char *new_id);
-
 // ----------------------------------------------------------------------------
 // RRD internal functions
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -817,7 +817,6 @@ struct rrdhost {
     struct netdata_ssl stream_ssl;                         //Structure used to encrypt the stream
 #endif
 
-    // if held together with receiver_lock. Order is receiver_lock then claimed_id_lock
     netdata_mutex_t claimed_id_lock;
     char *claimed_id;                               // Claimed ID if host has one otherwise NULL
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1712,12 +1712,3 @@ time_t rrdhost_last_entry_t(RRDHOST *h) {
     rrdhost_unlock(h);
     return result;
 }
-
-void rrdhost_set_claimed_id(RRDHOST *host, const char *new_id)
-{
-    netdata_mutex_lock(&host->claimed_id_lock);
-    if (unlikely(host->claimed_id))
-        freez(host->claimed_id);
-    host->claimed_id = new_id ? strdupz(new_id) : NULL;
-    netdata_mutex_unlock(&host->claimed_id_lock);
-}

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -858,6 +858,7 @@ void rrdhost_free(RRDHOST *host) {
     // ------------------------------------------------------------------------
     // free it
 
+    freez(host->claimed_id);
     freez((void *)host->tags);
     free_host_labels(host->labels);
     freez((void *)host->os);
@@ -1707,4 +1708,13 @@ time_t rrdhost_last_entry_t(RRDHOST *h) {
     }
     rrdhost_unlock(h);
     return result;
+}
+
+void rrdhost_set_claimed_id(RRDHOST *host, const char *new_id)
+{
+    rrdhost_wrlock(host);
+    if (unlikely(host->claimed_id))
+        freez(host->claimed_id);
+    host->claimed_id = new_id ? strdupz(new_id) : NULL;
+    rrdhost_unlock(localhost);
 }

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -116,7 +116,7 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
         error("The host GUID received doesn't have format of valid UUID!");
         return PARSER_RC_ERROR;
     }
-    if(uuid_parse(words[2], uuid)) {
+    if(uuid_parse(words[2], uuid) && strcmp(words[2], "NULL")) {
         error("The Claim ID received doesn't have format of valid UUID!");
         return PARSER_RC_ERROR;
     }

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -106,24 +106,24 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
 
     for (i = 0; words[i]; i++) ;
     if (i != CLAIMED_ID_MIN_WORDS) {
-        error("Command CLAIMED_ID came malformed %d parameters are compulsory", CLAIMED_ID_MIN_WORDS - 1);
+        error("Command CLAIMED_ID came malformed %d parameters are expected but %d received", CLAIMED_ID_MIN_WORDS - 1, i - 1);
         return PARSER_RC_ERROR;
     }
 
     // We don't need to parsed UUID
     // just do it to check the format
     if(uuid_parse(words[1], uuid)) {
-        error("The host GUID received doesn't have format of valid UUID!");
+        error("1st parameter (host GUID) to CLAIMED_ID command is not valid GUID. Received: \"%s\".", words[1]);
         return PARSER_RC_ERROR;
     }
     if(uuid_parse(words[2], uuid) && strcmp(words[2], "NULL")) {
-        error("The Claim ID received doesn't have format of valid UUID!");
+        error("2nd parameter (Claim ID) to CLAIMED_ID command is not valid GUID. Received: \"%s\".", words[2]);
         return PARSER_RC_ERROR;
     }
 
     RRDHOST *host = rrdhost_find_by_guid(words[1], 0);
     if (!host) {
-        error("Host with GUID %s not found. Ignoring", words[1]);
+        error("Host with GUID \"%s\" not found. Ignoring", words[1]);
         return PARSER_RC_OK; //the message is OK problem must be somewehere else
     }
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -120,7 +120,11 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
         return PARSER_RC_OK;
     }
 
-    rrdhost_set_claimed_id(host, words[2]);
+    netdata_mutex_lock(&host->claimed_id_lock);
+    if (host->claimed_id)
+        freez(host->claimed_id);
+    host->claimed_id = strcmp(words[2], "NULL") ? strdupz(words[2]) : NULL;
+    netdata_mutex_unlock(&host->claimed_id_lock);
 
     rrdpush_was_runtime_claimed(host);
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -110,7 +110,7 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
         return PARSER_RC_ERROR;
     }
 
-    // We don't need to parsed UUID
+    // We don't need the parsed UUID
     // just do it to check the format
     if(uuid_parse(words[1], uuid)) {
         error("1st parameter (host GUID) to CLAIMED_ID command is not valid GUID. Received: \"%s\".", words[1]);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -126,7 +126,7 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
     host->claimed_id = strcmp(words[2], "NULL") ? strdupz(words[2]) : NULL;
     netdata_mutex_unlock(&host->claimed_id_lock);
 
-    rrdpush_was_runtime_claimed(host);
+    rrdpush_claimed_id(host);
 
     return PARSER_RC_OK;
 }

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -98,11 +98,11 @@ PARSER_RC streaming_timestamp(char **words, void *user, PLUGINSD_ACTION *plugins
 #define CLAIMED_ID_MIN_WORDS 3
 PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugins_action)
 {
-    UNUSED(user);
     UNUSED(plugins_action);
 
     int i;
     uuid_t uuid;
+    RRDHOST *host = ((PARSER_USER_OBJECT *)user)->host;
 
     for (i = 0; words[i]; i++) ;
     if (i != CLAIMED_ID_MIN_WORDS) {
@@ -121,9 +121,8 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
         return PARSER_RC_ERROR;
     }
 
-    RRDHOST *host = rrdhost_find_by_guid(words[1], 0);
-    if (!host) {
-        error("Host with GUID \"%s\" not found. Ignoring", words[1]);
+    if(strcmp(words[1], host->machine_guid)) {
+        error("Claim ID is for host \"%s\" but it came over connection for \"%s\"", words[1], host->machine_guid);
         return PARSER_RC_OK; //the message is OK problem must be somewehere else
     }
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -102,10 +102,22 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
     UNUSED(plugins_action);
 
     int i;
+    uuid_t uuid;
 
     for (i = 0; words[i]; i++) ;
     if (i != CLAIMED_ID_MIN_WORDS) {
         error("Command CLAIMED_ID came malformed %d parameters are compulsory", CLAIMED_ID_MIN_WORDS - 1);
+        return PARSER_RC_ERROR;
+    }
+
+    // We don't need to parsed UUID
+    // just do it to check the format
+    if(uuid_parse(words[1], uuid)) {
+        error("The host GUID received doesn't have format of valid UUID!");
+        return PARSER_RC_ERROR;
+    }
+    if(uuid_parse(words[2], uuid)) {
+        error("The Claim ID received doesn't have format of valid UUID!");
         return PARSER_RC_ERROR;
     }
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -126,11 +126,6 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
         return PARSER_RC_OK; //the message is OK problem must be somewehere else
     }
 
-    if (host == localhost) {
-        error("Streaming Child attempted to change claiming id of parent (me). This is not allowed.");
-        return PARSER_RC_OK;
-    }
-
     netdata_mutex_lock(&host->claimed_id_lock);
     if (host->claimed_id)
         freez(host->claimed_id);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -371,11 +371,11 @@ void rrdpush_was_runtime_claimed(RRDHOST *host)
         return;
 
     sender_start(host->sender);
-    rrdhost_rdlock(host);
+    netdata_mutex_lock(&host->receiver_lock);
 
     buffer_sprintf(host->sender->build, "CLAIMED_ID %s %s\n", host->machine_guid, (host->claimed_id ? host->claimed_id : "NULL") );
 
-    rrdhost_unlock(host);
+    netdata_mutex_unlock(&host->receiver_lock);
     sender_commit(host->sender);
 }
 

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -371,11 +371,11 @@ void rrdpush_claimed_id(RRDHOST *host)
         return;
 
     sender_start(host->sender);
-    netdata_mutex_lock(&host->receiver_lock);
+    netdata_mutex_lock(&host->claimed_id_lock);
 
     buffer_sprintf(host->sender->build, "CLAIMED_ID %s %s\n", host->machine_guid, (host->claimed_id ? host->claimed_id : "NULL") );
 
-    netdata_mutex_unlock(&host->receiver_lock);
+    netdata_mutex_unlock(&host->claimed_id_lock);
     sender_commit(host->sender);
 }
 

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -364,6 +364,21 @@ void rrdpush_send_labels(RRDHOST *host) {
 
     host->labels_flag &= ~LABEL_FLAG_UPDATE_STREAM;
 }
+
+void rrdpush_was_runtime_claimed(RRDHOST *host)
+{
+    if(unlikely(!host->rrdpush_send_enabled))
+        return;
+
+    sender_start(host->sender);
+    rrdhost_rdlock(host);
+
+    buffer_sprintf(host->sender->build, "CLAIMED_ID %s %s\n", host->machine_guid, (host->claimed_id ? host->claimed_id : "NULL") );
+
+    rrdhost_unlock(host);
+    sender_commit(host->sender);
+}
+
 // ----------------------------------------------------------------------------
 // rrdpush sender thread
 

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -365,7 +365,7 @@ void rrdpush_send_labels(RRDHOST *host) {
     host->labels_flag &= ~LABEL_FLAG_UPDATE_STREAM;
 }
 
-void rrdpush_was_runtime_claimed(RRDHOST *host)
+void rrdpush_claimed_id(RRDHOST *host)
 {
     if(unlikely(!host->rrdpush_send_enabled))
         return;

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -377,6 +377,10 @@ void rrdpush_claimed_id(RRDHOST *host)
 
     netdata_mutex_unlock(&host->claimed_id_lock);
     sender_commit(host->sender);
+
+    // signal the sender there are more data
+    if(host->rrdpush_sender_pipe[PIPE_WRITE] != -1 && write(host->rrdpush_sender_pipe[PIPE_WRITE], " ", 1) == -1)
+        error("STREAM %s [send]: cannot write to internal pipe", host->hostname);
 }
 
 // ----------------------------------------------------------------------------

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -367,7 +367,7 @@ void rrdpush_send_labels(RRDHOST *host) {
 
 void rrdpush_claimed_id(RRDHOST *host)
 {
-    if(unlikely(!host->rrdpush_send_enabled))
+    if(unlikely(!host->rrdpush_send_enabled || !host->rrdpush_sender_connected))
         return;
 
     sender_start(host->sender);

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -10,9 +10,9 @@
 
 #define CONNECTED_TO_SIZE 100
 
-// #define STREAMING_PROTOCOL_CURRENT_VERSION (uint32_t)3       Gap-filling
-#define STREAMING_PROTOCOL_CURRENT_VERSION (uint32_t)2
-#define VERSION_GAP_FILLING 3
+// #define STREAMING_PROTOCOL_CURRENT_VERSION (uint32_t)4       Gap-filling
+#define STREAMING_PROTOCOL_CURRENT_VERSION (uint32_t)3
+#define VERSION_GAP_FILLING 4
 
 #define STREAMING_PROTOCOL_VERSION "1.1"
 #define START_STREAMING_PROMPT "Hit me baby, push them over..."

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -13,6 +13,7 @@
 // #define STREAMING_PROTOCOL_CURRENT_VERSION (uint32_t)4       Gap-filling
 #define STREAMING_PROTOCOL_CURRENT_VERSION (uint32_t)3
 #define VERSION_GAP_FILLING 4
+#define STREAM_VERSION_CLAIM 3
 
 #define STREAMING_PROTOCOL_VERSION "1.1"
 #define START_STREAMING_PROMPT "Hit me baby, push them over..."
@@ -106,6 +107,7 @@ extern void rrdset_done_push(RRDSET *st);
 extern void rrdset_push_chart_definition_now(RRDSET *st);
 extern void *rrdpush_sender_thread(void *ptr);
 extern void rrdpush_send_labels(RRDHOST *host);
+extern void rrdpush_was_runtime_claimed(RRDHOST *host);
 
 extern int rrdpush_receiver_thread_spawn(struct web_client *w, char *url);
 extern void rrdpush_sender_thread_stop(RRDHOST *host);

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -107,7 +107,7 @@ extern void rrdset_done_push(RRDSET *st);
 extern void rrdset_push_chart_definition_now(RRDSET *st);
 extern void *rrdpush_sender_thread(void *ptr);
 extern void rrdpush_send_labels(RRDHOST *host);
-extern void rrdpush_was_runtime_claimed(RRDHOST *host);
+extern void rrdpush_claimed_id(RRDHOST *host);
 
 extern int rrdpush_receiver_thread_spawn(struct web_client *w, char *url);
 extern void rrdpush_sender_thread_stop(RRDHOST *host);

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -627,7 +627,7 @@ void *rrdpush_sender_thread(void *ptr) {
                 RRDHOST *h;
                 rrdhost_foreach_read(h) {
                     if(h->claimed_id)
-                        rrdpush_was_runtime_claimed(h);
+                        rrdpush_claimed_id(h);
                 }
                 rrd_unlock();
             }

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -622,15 +622,8 @@ void *rrdpush_sender_thread(void *ptr) {
                 buffer_sprintf(s->build, "TIMESTAMP %ld", now);
                 sender_commit(s);
             }
-            if (s->version >= STREAM_VERSION_CLAIM) {
-                rrd_rdlock();
-                RRDHOST *h;
-                rrdhost_foreach_read(h) {
-                    if(h->claimed_id)
-                        rrdpush_claimed_id(h);
-                }
-                rrd_unlock();
-            }
+            if (s->version >= STREAM_VERSION_CLAIM)
+                rrdpush_claimed_id(s->host);
             continue;
         }
 

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -622,6 +622,15 @@ void *rrdpush_sender_thread(void *ptr) {
                 buffer_sprintf(s->build, "TIMESTAMP %ld", now);
                 sender_commit(s);
             }
+            if (s->version >= STREAM_VERSION_CLAIM) {
+                rrd_rdlock();
+                RRDHOST *h;
+                rrdhost_foreach_read(h) {
+                    if(h->claimed_id)
+                        rrdpush_was_runtime_claimed(h);
+                }
+                rrd_unlock();
+            }
             continue;
         }
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -799,11 +799,16 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 
         netdata_mutex_lock(&rc->receiver_lock);
         netdata_mutex_lock(&rc->claimed_id_lock);
-        buffer_sprintf(wb, "\t\t{ \"guid\": \"%s\", \"reachable\": \"%s\", \"claim_id\": \"%s\" }"
+        buffer_sprintf(wb, "\t\t{ \"guid\": \"%s\", \"reachable\": %s, \"claim_id\": "
                        , rc->machine_guid
                        , (rc->receiver || rc == localhost) ? "true" : "false"
-                       , rc->claimed_id ? rc->claimed_id : "null"
         );
+
+        if(rc->claimed_id)
+            buffer_sprintf(wb, "\"%s\" }", rc->claimed_id);
+        else
+            buffer_strcat(wb, "null }");
+
         netdata_mutex_unlock(&rc->claimed_id_lock);
         netdata_mutex_unlock(&rc->receiver_lock);
         count++;

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -775,13 +775,44 @@ static inline void web_client_api_request_v1_info_summary_alarm_statuses(RRDHOST
 
 static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
     RRDHOST *rc;
+    BUFFER *guids = buffer_create(2048);
     int count = 0;
+
+    buffer_strcat(wb, "\t\"mirrored_hosts\": [\n");
+    buffer_strcat(guids, "\t\"mirrored_hosts_status\": [\n");
     rrd_rdlock();
     rrdhost_foreach_read(rc) {
         if (rrdhost_flag_check(rc, RRDHOST_FLAG_ARCHIVED))
             continue;
-        if(count > 0) buffer_strcat(wb, ",\n");
+        if(count > 0) {
+            buffer_strcat(wb, ",\n");
+            buffer_strcat(guids, ",\n");
+        }
         buffer_sprintf(wb, "\t\t\"%s\"", rc->hostname);
+        netdata_mutex_lock(&rc->receiver_lock);
+        netdata_mutex_lock(&rc->claimed_id_lock);
+        buffer_sprintf(guids, "\t\t{ \"guid\": \"%s\", \"reachable\": \"%s\", \"claim_id\": \"%s\" }"
+                       , rc->machine_guid
+                       , (rc->receiver || rc == localhost) ? "true" : "false"
+                       , rc->claimed_id ? rc->claimed_id : "null"
+        );
+        netdata_mutex_unlock(&rc->claimed_id_lock);
+        netdata_mutex_unlock(&rc->receiver_lock);
+        count++;
+    }
+    rrd_unlock();
+    buffer_strcat(wb, "\n\t],\n");
+    buffer_sprintf(wb, "%s\n\t],\n", buffer_tostring(guids));
+    buffer_free(guids);
+}
+
+static inline void web_client_api_request_v1_info_mirrored_hosts_uids(BUFFER *wb) {
+    RRDHOST *rc;
+    int count = 0;
+    rrd_rdlock();
+    rrdhost_foreach_read(rc) {
+        if(count > 0) buffer_strcat(wb, ",\n");
+        buffer_sprintf(wb, "\t\t\"%s\"", rc->machine_guid);
         count++;
     }
     buffer_strcat(wb, "\n");
@@ -825,9 +856,7 @@ inline int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb)
     buffer_sprintf(wb, "\t\"version\": \"%s\",\n", host->program_version);
     buffer_sprintf(wb, "\t\"uid\": \"%s\",\n", host->machine_guid);
 
-    buffer_strcat(wb, "\t\"mirrored_hosts\": [\n");
     web_client_api_request_v1_info_mirrored_hosts(wb);
-    buffer_strcat(wb, "\t],\n");
 
     buffer_strcat(wb, "\t\"alarms\": {\n");
     web_client_api_request_v1_info_summary_alarm_statuses(host, wb);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -774,42 +774,42 @@ static inline void web_client_api_request_v1_info_summary_alarm_statuses(RRDHOST
 }
 
 static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
-    RRDHOST *rc;
+    RRDHOST *host;
     int count = 0;
 
     buffer_strcat(wb, "\t\"mirrored_hosts\": [\n");
     rrd_rdlock();
-    rrdhost_foreach_read(rc) {
-        if (rrdhost_flag_check(rc, RRDHOST_FLAG_ARCHIVED))
+    rrdhost_foreach_read(host) {
+        if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))
             continue;
         if (count > 0)
             buffer_strcat(wb, ",\n");
 
-        buffer_sprintf(wb, "\t\t\"%s\"", rc->hostname);
+        buffer_sprintf(wb, "\t\t\"%s\"", host->hostname);
         count++;
     }
 
     buffer_strcat(wb, "\n\t],\n\t\"mirrored_hosts_status\": [\n");
     count = 0;
-    rrdhost_foreach_read(rc)
+    rrdhost_foreach_read(host)
     {
-        if (rrdhost_flag_check(rc, RRDHOST_FLAG_ARCHIVED))
+        if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))
             continue;
         if (count > 0)
             buffer_strcat(wb, ",\n");
 
-        netdata_mutex_lock(&rc->receiver_lock);
+        netdata_mutex_lock(&host->receiver_lock);
         buffer_sprintf(
-            wb, "\t\t{ \"guid\": \"%s\", \"reachable\": %s, \"claim_id\": ", rc->machine_guid,
-            (rc->receiver || rc == localhost) ? "true" : "false");
-        netdata_mutex_unlock(&rc->receiver_lock);
+            wb, "\t\t{ \"guid\": \"%s\", \"reachable\": %s, \"claim_id\": ", host->machine_guid,
+            (host->receiver || host == localhost) ? "true" : "false");
+        netdata_mutex_unlock(&host->receiver_lock);
 
-        netdata_mutex_lock(&rc->claimed_id_lock);
-        if (rc->claimed_id)
-            buffer_sprintf(wb, "\"%s\" }", rc->claimed_id);
+        netdata_mutex_lock(&host->claimed_id_lock);
+        if (host->claimed_id)
+            buffer_sprintf(wb, "\"%s\" }", host->claimed_id);
         else
             buffer_strcat(wb, "null }");
-        netdata_mutex_unlock(&rc->claimed_id_lock);
+        netdata_mutex_unlock(&host->claimed_id_lock);
 
         count++;
     }

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -818,19 +818,6 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
     buffer_strcat(wb, "\n\t],\n");
 }
 
-static inline void web_client_api_request_v1_info_mirrored_hosts_uids(BUFFER *wb) {
-    RRDHOST *rc;
-    int count = 0;
-    rrd_rdlock();
-    rrdhost_foreach_read(rc) {
-        if(count > 0) buffer_strcat(wb, ",\n");
-        buffer_sprintf(wb, "\t\t\"%s\"", rc->machine_guid);
-        count++;
-    }
-    buffer_strcat(wb, "\n");
-    rrd_unlock();
-}
-
 inline void host_labels2json(RRDHOST *host, BUFFER *wb, size_t indentation) {
     char tabs[11];
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -791,26 +791,26 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 
     buffer_strcat(wb, "\n\t],\n\t\"mirrored_hosts_status\": [\n");
     count = 0;
-    rrdhost_foreach_read(rc) {
+    rrdhost_foreach_read(rc)
+    {
         if (rrdhost_flag_check(rc, RRDHOST_FLAG_ARCHIVED))
             continue;
         if (count > 0)
             buffer_strcat(wb, ",\n");
 
         netdata_mutex_lock(&rc->receiver_lock);
-        netdata_mutex_lock(&rc->claimed_id_lock);
-        buffer_sprintf(wb, "\t\t{ \"guid\": \"%s\", \"reachable\": %s, \"claim_id\": "
-                       , rc->machine_guid
-                       , (rc->receiver || rc == localhost) ? "true" : "false"
-        );
+        buffer_sprintf(
+            wb, "\t\t{ \"guid\": \"%s\", \"reachable\": %s, \"claim_id\": ", rc->machine_guid,
+            (rc->receiver || rc == localhost) ? "true" : "false");
+        netdata_mutex_unlock(&rc->receiver_lock);
 
-        if(rc->claimed_id)
+        netdata_mutex_lock(&rc->claimed_id_lock);
+        if (rc->claimed_id)
             buffer_sprintf(wb, "\"%s\" }", rc->claimed_id);
         else
             buffer_strcat(wb, "null }");
-
         netdata_mutex_unlock(&rc->claimed_id_lock);
-        netdata_mutex_unlock(&rc->receiver_lock);
+
         count++;
     }
     rrd_unlock();


### PR DESCRIPTION
##### Summary
claimed_id of nodes is streamed to parents. For easy testing also added to `/api/v1/info` (where cloud will need it anyway sooner or later)
Example of 3-level streaming from the view of top-level parent:
![Screenshot from 2020-08-25 11-38-41](https://user-images.githubusercontent.com/6674623/91158903-9a4f7380-e6c7-11ea-8c7d-07491b08c330.png)


##### Component Name
Streaming
##### Test Plan
Have some streaming setup and look at `/api/v1/info`. Check nothing breaks with Cloud by connecting this node to `staging.netdata.cloud`. Claim nodes and see if their claiming Id propagates up the network by checking `/api/v1/info` of the topmost node. All nodes have to be running this PR for it to work.

What was tested together with the cloud team:
1. Claim node to Staging and connect it. Node had 2 children.
1. Message as per screenshot above (with new `mirrored_hosts_status` field) is send to cloud as part of `onconnect` payload over ACLK
1. Checked Cloud GUI still works as expected with this new fields
1. Cloud team checked there are no errors in the background (not visible to us from GUI)

What was tested additionally:
- node that is claimed during runtime and then `netdatacli reload-claiming-state`
- up to 4 level hierarchy of streaming
    - `TopLevelMaster` (VM,not claimed)
    - `timowss` (real machine,claimed) -> `TopLevelMaster` (VM)
    - `Fed32-Layer1Host1` (VM,claimed) -> `timowss` (real machine, claimed)
    - `Fed32-Layer1Host2` (VM,not claimed) -> `timowss` (real machine, claimed)
    - `Fed32-Layer2Host1` (VM,not claimed) -> `Fed21-Layer1Host1` (VM, claimed)
    - this represents final test with biggest amount of hosts tested, during development and testing different combination of nodes and claiming states were used
- both claimed and unclaimed nodes have correct status reported

##### Additional Information
Codacy false triggers here. It doesn't seem to recognize `rrdhost_foreach_read` macro is a loop and as a result, thinks `if(count > 0) {` is always false (which is not true).
