### PR TITLE
Fixed handling of offline installs.

### DIFF
--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -268,7 +268,7 @@ if [ -n "$ndpath" ] ; then
 
   if [ -r "${ndprefix}/etc/netdata/.environment" ] ; then
     ndstatic="$(grep IS_NETDATA_STATIC_BINARY "${ndprefix}/etc/netdata/.environment" | cut -d "=" -f 2 | tr -d \")"
-    if [ -z "${NETDATA_REINSTALL}" ] ; then
+    if [ -z "${NETDATA_REINSTALL}" ] && [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE}" ] ; then
       if [ -x "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ] ; then
         progress "Attempting to update existing install instead of creating a new one"
         if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" --not-running-from-cron ; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -372,7 +372,7 @@ if [ -n "$ndpath" ] ; then
 
   if [ -r "${ndprefix}/etc/netdata/.environment" ] ; then
     ndstatic="$(grep IS_NETDATA_STATIC_BINARY "${ndprefix}/etc/netdata/.environment" | cut -d "=" -f 2 | tr -d \")"
-    if [ -z "${NETDATA_REINSTALL}" ] ; then
+    if [ -z "${NETDATA_REINSTALL}" ] && [ -z "${NETDATA_LOCAL_TARBALL_OVERRIDE}" ] ; then
       if [ -x "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" ] ; then
         progress "Attempting to update existing install instead of creating a new one"
         if run ${sudo} "${ndprefix}/usr/libexec/netdata/netdata-updater.sh" --not-running-from-cron ; then

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -78,7 +78,7 @@ To use `md5sum` to verify the intregity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "e06b4ecd791bc50c93d6c71839b53c41" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "4940607945b1b92db96d4674b5bba7b3" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -61,7 +61,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "15420d0d5bd61fe4027c20d9276a696e" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "e08dfbc39c23bf8993861e19c7d32368" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

When updating the handling of duplicate installs in our installers, I unintentionally broke offline install support. This PR fixes this by explicitly bypassing attempts to use the updater script if the user requested an offline installation of Netdata.

##### Component Name

area/packaging

##### Test Plan

Tested locally in Docker containers.

##### Additional Information

Fixes: #9791