### PR TITLE
rpm: Fix rpm build script version issues

### DIFF
--- a/contrib/rhel/build-netdata-rpm.sh
+++ b/contrib/rhel/build-netdata-rpm.sh
@@ -13,24 +13,33 @@ run autoreconf -ivf
 run ./configure --enable-maintainer-mode
 run make dist
 
-version=$(grep PACKAGE_VERSION < config.h | cut -d '"' -f 2)
-if [ -z "${version}" ]
-then
-    echo >&2 "Cannot find netdata version."
-    exit 1
-fi
-
-tgz="netdata-${version}.tar.gz"
-if [ ! -f "${tgz}" ]
-then
-	echo >&2 "Cannot find the generated tar.gz file '${tgz}'"
+typeset version="$(grep PACKAGE_VERSION < config.h | cut -d '"' -f 2)"
+if [[ -z "${version}" ]]; then
+	run_failed "Cannot find netdata version."
 	exit 1
 fi
 
-srpm=$(run rpmbuild -ts "${tgz}" | cut -d ' ' -f 2)
-if [ -z "${srpm}" ] || [ ! -f "${srpm}" ]
-then
-	echo >&2 "Cannot find the generated SRPM file '${srpm}'"
+if [[ "${version//-/}" != "$version" ]]; then
+	# Remove all -* and _* suffixes to be as close as netdata release
+	typeset versionfix="${version%%-*}"; versionfix="${versionfix%%_*}"
+	# Append the current datetime fox a 'unique' build
+	versionfix+="_$(date '+%m%d%H%M%S')"
+	# And issue hints & details on why this failed, and how to fix it
+	run_failed "Current version contains '-' which is fobidden by rpm. You must create a git annotated tag and rerun this script. Exemple:"
+	run_failed "  git tag -a $versionfix -m 'Release by $(id -nu) on $(uname -n)' && $0"
+	exit 1
+fi
+
+
+typeset tgz="netdata-${version}.tar.gz"
+if [[ ! -f "${tgz}" ]]; then
+	run_failed "Cannot find the generated tar.gz file '${tgz}'"
+	exit 1
+fi
+
+typeset srpm="$(run rpmbuild -ts "${tgz}" | cut -d ' ' -f 2)"
+if [[ -z "${srpm}" ]] || ! [[ -f "${srpm}" ]]; then
+	run_failed "Cannot find the generated SRPM file '${srpm}'"
 	exit 1
 fi
 
@@ -44,4 +53,4 @@ fi
 
 run rpmbuild --rebuild "${srpm}"
 
-echo >&2 "All done!"
+run_ok "All done! Packages created in '$(rpm -E '%_rpmdir/%_arch')'"


### PR DESCRIPTION
##### Summary

When creating a package using this script, it's not straighforward that
the version is fetched at the "configure" stage, by "git describe" which
generates a 'lasttag-ncommits-lastcommit' format description. RPM
doesn't allow - in version, so the rpmbuild stage fails.

Add hints of actions to perform to get this script working
Use package standard functions for the message to be seen easily

Example failed message:
```
 FAILED  Current version contains '-' which is fobidden by rpm. You must create a git annotated tag and rerun this script. Exemple: 

 FAILED    git tag -a v1.24.0_0822113117 -m 'Release by adrien on munin' && ./build-netdata-rpm.sh 
```

Example ok message:
```
 OK  All done! Packages created in '/home/adrien/rpmbuild/RPMS/x86_64' 
```

##### Component Name

contrib/rhel/build-netdata-rpm.sh

##### Test Plan

1. Exec: contrib/rhel/build-netdata-rpm.sh
2. The error message should be seen. Copy paste the provided command (or modify it as wanted): 
3. The build should succeed

##### Additional Information

Added a hint on where to find the packages, using `'$(rpm -E '%_rpmdir/%_arch')'`