### PR TITLE
Fix install if system does not have ebpf.plugin

### DIFF
--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -59,7 +59,9 @@ case "$1" in
     chmod 4750 /usr/libexec/netdata/plugins.d/slabinfo.plugin
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network
     chmod 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin
-    chmod 4750 /usr/libexec/netdata/plugins.d/ebpf.plugin
+
+    # Workaround if system does not have ebpf.plugin
+    chmod -f 4750 /usr/libexec/netdata/plugins.d/ebpf.plugin || true
 
     # Workaround for other plugins not installed directly by this package
     chmod -f 4750 /usr/libexec/netdata/plugins.d/freeipmi.plugin || true


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
When the ebpf.plugin is not available for a debian/ubuntu based system, the install fails. This fixes just that.

##### Component Name
Debian package

##### Test Plan
Did not test. The idea is to just give a correct exit status when the chmod fails.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
Fixes #9707 
