### PR TITLE
ACLK Version Negotiation

### DIFF
--- a/aclk/aclk_common.c
+++ b/aclk/aclk_common.c
@@ -4,6 +4,8 @@
 
 netdata_mutex_t aclk_shared_state_mutex = NETDATA_MUTEX_INITIALIZER;
 
+int aclk_disable_runtime = 0;
+
 struct aclk_shared_state aclk_shared_state = {
     .metadata_submitted = ACLK_METADATA_REQUIRED,
     .agent_state = AGENT_INITIALIZING,

--- a/aclk/aclk_common.c
+++ b/aclk/aclk_common.c
@@ -7,7 +7,9 @@ netdata_mutex_t aclk_shared_state_mutex = NETDATA_MUTEX_INITIALIZER;
 struct aclk_shared_state aclk_shared_state = {
     .metadata_submitted = ACLK_METADATA_REQUIRED,
     .agent_state = AGENT_INITIALIZING,
-    .last_popcorn_interrupt = 0
+    .last_popcorn_interrupt = 0,
+    .version_neg = 0,
+    .version_neg_wait_till = 0
 };
 
 struct {

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -12,6 +12,11 @@ extern netdata_mutex_t aclk_shared_state_mutex;
 #define ACLK_VERSION_MIN 1
 #define ACLK_VERSION_MAX 1
 
+// Version negotiation messages have they own versioning
+// this is also used for LWT message as we set that up
+// before version negotiation
+#define ACLK_VERSION_NEG_VERSION 1
+
 // Maximum time to wait for version negotiation before aborting
 // and defaulting to oldest supported version
 #define VERSION_NEG_TIMEOUT 3

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -7,6 +7,11 @@ extern netdata_mutex_t aclk_shared_state_mutex;
 #define ACLK_SHARED_STATE_LOCK netdata_mutex_lock(&aclk_shared_state_mutex)
 #define ACLK_SHARED_STATE_UNLOCK netdata_mutex_unlock(&aclk_shared_state_mutex)
 
+// minimum and maximum supported version of ACLK
+// in this version of agent
+#define ACLK_VERSION_MIN 1
+#define ACLK_VERSION_MAX 1
+
 typedef enum aclk_cmd {
     ACLK_CMD_CLOUD,
     ACLK_CMD_ONCONNECT,
@@ -31,6 +36,7 @@ extern struct aclk_shared_state {
     ACLK_METADATA_STATE metadata_submitted;
     ACLK_AGENT_STATE agent_state;
     time_t last_popcorn_interrupt;
+    int negotiated_version;
 } aclk_shared_state;
 
 typedef enum aclk_proxy_type {

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -76,4 +76,6 @@ void safe_log_proxy_censor(char *proxy);
 int aclk_decode_base_url(char *url, char **aclk_hostname, char **aclk_port);
 const char *aclk_get_proxy(ACLK_PROXY_TYPE *type);
 
+extern int aclk_disable_runtime;
+
 #endif //ACLK_COMMON_H

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -12,6 +12,19 @@ extern netdata_mutex_t aclk_shared_state_mutex;
 #define ACLK_VERSION_MIN 1
 #define ACLK_VERSION_MAX 1
 
+// Version negotiation messages have they own versioning
+// this is also used for LWT message as we set that up
+// before version negotiation
+#define ACLK_VERSION_NEG_VERSION 1
+
+// Maximum time to wait for version negotiation before aborting
+// and defaulting to oldest supported version
+#define VERSION_NEG_TIMEOUT 3
+
+#if ACLK_VERSION_MIN > ACLK_VERSION_MAX
+#error "ACLK_VERSION_MAX must be >= than ACLK_VERSION_MIN"
+#endif
+
 typedef enum aclk_cmd {
     ACLK_CMD_CLOUD,
     ACLK_CMD_ONCONNECT,
@@ -36,7 +49,11 @@ extern struct aclk_shared_state {
     ACLK_METADATA_STATE metadata_submitted;
     ACLK_AGENT_STATE agent_state;
     time_t last_popcorn_interrupt;
-    int negotiated_version;
+
+    // read only while ACLK connected
+    // protect by lock otherwise
+    volatile int version_neg;
+    usec_t version_neg_wait_till;
 } aclk_shared_state;
 
 typedef enum aclk_proxy_type {

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -12,11 +12,6 @@ extern netdata_mutex_t aclk_shared_state_mutex;
 #define ACLK_VERSION_MIN 1
 #define ACLK_VERSION_MAX 1
 
-// Version negotiation messages have they own versioning
-// this is also used for LWT message as we set that up
-// before version negotiation
-#define ACLK_VERSION_NEG_VERSION 1
-
 // Maximum time to wait for version negotiation before aborting
 // and defaulting to oldest supported version
 #define VERSION_NEG_TIMEOUT 3

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -52,7 +52,7 @@ extern struct aclk_shared_state {
 
     // read only while ACLK connected
     // protect by lock otherwise
-    volatile int version_neg;
+    int version_neg;
     usec_t version_neg_wait_till;
 } aclk_shared_state;
 

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -553,15 +553,14 @@ void *aclk_query_main_thread(void *ptr)
                 " Reverting to default ACLK version of %d.", VERSION_NEG_TIMEOUT, ACLK_VERSION_MIN);
             aclk_shared_state.version_neg = ACLK_VERSION_MIN;
         }
-        if (unlikely(!aclk_shared_state.metadata_submitted)) {
-            ACLK_SHARED_STATE_UNLOCK;
+        if (unlikely(aclk_shared_state.metadata_submitted == ACLK_METADATA_REQUIRED)) {
             if (unlikely(aclk_queue_query("on_connect", NULL, NULL, NULL, 0, 1, ACLK_CMD_ONCONNECT))) {
+                ACLK_SHARED_STATE_UNLOCK;
                 errno = 0;
                 error("ACLK failed to queue on_connect command");
                 sleep(1);
                 continue;
             }
-            ACLK_SHARED_STATE_LOCK;
             aclk_shared_state.metadata_submitted = ACLK_METADATA_CMD_QUEUED;
         }
         ACLK_SHARED_STATE_UNLOCK;

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -549,7 +549,8 @@ void *aclk_query_main_thread(void *ptr)
                 sleep(1);
                 continue;
             }
-            error("ACLK version negotiation failed. No reply to \"hello\" with \"version\" from cloud in time of %ds. "
+            errno = 0;
+            error("ACLK version negotiation failed. No reply to \"hello\" with \"version\" from cloud in time of %ds."
                 " Reverting to default ACLK version of %d.", VERSION_NEG_TIMEOUT, ACLK_VERSION_MIN);
             aclk_shared_state.version_neg = ACLK_VERSION_MIN;
         }

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -348,7 +348,7 @@ static int aclk_execute_query(struct aclk_query *this_query)
         buffer_flush(local_buffer);
         local_buffer->contenttype = CT_APPLICATION_JSON;
 
-        aclk_create_header(local_buffer, "http", this_query->msg_id, 0, 0);
+        aclk_create_header(local_buffer, "http", this_query->msg_id, 0, 0, ACLK_VERSION);
         buffer_strcat(local_buffer, ",\n\t\"payload\": ");
         char *encoded_response = aclk_encode_response(w->response.data->buffer, w->response.data->len, 0);
         char *encoded_header = aclk_encode_response(w->response.header_output->buffer, w->response.header_output->len, 1);

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -537,6 +537,10 @@ void *aclk_query_main_thread(void *ptr)
     }
 
     while (!netdata_exit) {
+        if(aclk_disable_runtime) {
+            sleep(1);
+            continue;
+        }
         ACLK_SHARED_STATE_LOCK;
         if (unlikely(!aclk_shared_state.version_neg)) {
             if (!aclk_shared_state.version_neg_wait_till || aclk_shared_state.version_neg_wait_till > now_monotonic_usec()) {

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -549,6 +549,8 @@ void *aclk_query_main_thread(void *ptr)
                 sleep(1);
                 continue;
             }
+            error("ACLK version negotiation failed. No reply to \"hello\" with \"version\" from cloud in time of %ds. "
+                " Reverting to default ACLK version of %d.", VERSION_NEG_TIMEOUT, ACLK_VERSION_MIN);
             aclk_shared_state.version_neg = ACLK_VERSION_MIN;
         }
         if (unlikely(!aclk_shared_state.metadata_submitted)) {

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -851,8 +851,7 @@ static inline void aclk_hello_msg()
     aclk_shared_state.version_neg_wait_till = now_monotonic_usec() + USEC_PER_SEC * VERSION_NEG_TIMEOUT;
     ACLK_SHARED_STATE_UNLOCK;
 
-    //Hello message is versioned separatelly from the rest of the protocol
-    aclk_create_header(buf, "hello", msg_id, 0, 0, ACLK_VERSION_NEG_VERSION);
+    aclk_create_header(buf, "hello", msg_id, 0, 0, ACLK_VERSION_MIN);
     buffer_sprintf(buf, ",\"min-version\":%d,\"max-version\":%d}", ACLK_VERSION_MIN, ACLK_VERSION_MAX);
     aclk_send_message(ACLK_METADATA_TOPIC, buf->buffer, msg_id);
     freez(msg_id);
@@ -1524,8 +1523,8 @@ static int aclk_handle_version_response(struct aclk_request *cloud_to_agent)
 {
     int version = -1;
 
-    if(unlikely(cloud_to_agent->version != ACLK_VERSION_NEG_VERSION)) {
-        error("Unsuported version of \"version\" message from cloud. Expected %d, Got %d", ACLK_VERSION_NEG_VERSION, cloud_to_agent->version);
+    if(unlikely(cloud_to_agent->version != ACLK_VERSION_MIN)) {
+        error("Unsuported version of \"version\" message from cloud. Expected %d, Got %d", ACLK_VERSION_MIN, cloud_to_agent->version);
         return 1;
     }
     if(unlikely(!cloud_to_agent->min_version)) {

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -945,6 +945,11 @@ void *aclk_main(void *ptr)
  /*       size_t write_q, write_q_bytes, read_q;
         lws_wss_check_queues(&write_q, &write_q_bytes, &read_q);*/
 
+        if (aclk_disable_runtime && !aclk_connected) {
+            sleep(1);
+            continue;
+        }
+
         if (aclk_kill_link) {                       // User has reloaded the claiming state
             aclk_kill_link = 0;
             aclk_graceful_disconnect();
@@ -1527,7 +1532,8 @@ static int aclk_handle_version_response(struct aclk_request *cloud_to_agent)
 
     if(unlikely(cloud_to_agent->min_version > ACLK_VERSION_MAX)) {
         error("Agent too old for this cloud. Minimum version required by cloud %d. Maximum version supported by this agent %d.", cloud_to_agent->min_version, ACLK_VERSION_MAX);
-        //TODO Disconnect ACLK permanently until restart of agent
+        aclk_kill_link = 1;
+        aclk_disable_runtime = 1;
         return 1;
     }
     if(unlikely(cloud_to_agent->max_version < ACLK_VERSION_MIN)) {

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1483,6 +1483,7 @@ int aclk_update_alarm(RRDHOST *host, ALARM_ENTRY *ae)
  */
 static int aclk_handle_cloud_request(struct aclk_request *cloud_to_agent)
 {
+    errno = 0;
     ACLK_SHARED_STATE_LOCK;
     if (unlikely(aclk_shared_state.agent_state == AGENT_INITIALIZING)) {
         debug(D_ACLK, "Ignoring \"http\" cloud request; agent not in stable state");
@@ -1523,6 +1524,7 @@ static int aclk_handle_cloud_request(struct aclk_request *cloud_to_agent)
 static int aclk_handle_version_response(struct aclk_request *cloud_to_agent)
 {
     int version = -1;
+    errno = 0;
 
     if(unlikely(cloud_to_agent->version != ACLK_VERSION_NEG_VERSION)) {
         error("Unsuported version of \"version\" message from cloud. Expected %d, Got %d", ACLK_VERSION_NEG_VERSION, cloud_to_agent->version);
@@ -1557,10 +1559,12 @@ static int aclk_handle_version_response(struct aclk_request *cloud_to_agent)
 
     ACLK_SHARED_STATE_LOCK;
     if (unlikely(now_monotonic_usec() > aclk_shared_state.version_neg_wait_till)) {
+        errno = 0;
         error("The \"version\" message came too late ignoring.");
         goto err_cleanup;
     }
     if (unlikely(aclk_shared_state.version_neg)) {
+        errno = 0;
         error("Version has already been set to %d", aclk_shared_state.version_neg);
         goto err_cleanup;
     }
@@ -1606,11 +1610,13 @@ int aclk_handle_cloud_message(char *payload)
     int rc = json_parse(payload, &cloud_to_agent, cloud_to_agent_parse);
 
     if (unlikely(rc != JSON_OK)) {
+        errno = 0;
         error("Malformed json request (%s)", payload);
         goto err_cleanup;
     }
 
     if (!cloud_to_agent.type_id) {
+        errno = 0;
         error("Cloud message is missing compulsory key \"type\"");
         goto err_cleanup;
     }
@@ -1625,6 +1631,7 @@ int aclk_handle_cloud_message(char *payload)
         }
     }
 
+    errno = 0;
     error("Unknown message type from Cloud \"%s\"", cloud_to_agent.type_id);
 
 err_cleanup:

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1015,7 +1015,6 @@ void *aclk_main(void *ptr)
             stress_counter = 0;
         }*/
 
-        // TODO: Move to on-connect
         if (unlikely(!aclk_subscribed)) {
             aclk_subscribed = !aclk_subscribe(ACLK_COMMAND_TOPIC, 1);
             aclk_hello_msg();

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1492,11 +1492,23 @@ static int aclk_handle_cloud_request(struct aclk_request *cloud_to_agent)
     }
     ACLK_SHARED_STATE_UNLOCK;
 
-    if (unlikely(!cloud_to_agent->payload || !cloud_to_agent->callback_topic || !cloud_to_agent->msg_id)) {
-        //TODO VERSION CHECK
-        /*        if (cloud_to_agent.version > ACLK_VERSION)
-            error("Unsupported version in JSON request %d", cloud_to_agent.version);*/
+    if (unlikely(cloud_to_agent->version != aclk_shared_state.version_neg)) {
+        error("Received \"http\" message from Cloud with version %d, but ACLK version %d is used", cloud_to_agent->version, aclk_shared_state.version_neg);
+        return 1;
+    }
 
+    if (unlikely(!cloud_to_agent->payload)) {
+        error("payload missing");
+        return 1;
+    }
+    
+    if (unlikely(!cloud_to_agent->callback_topic)) {
+        error("callback_topic missing");
+        return 1;
+    }
+    
+    if (unlikely(!cloud_to_agent->msg_id)) {
+        error("msg_id missing");
         return 1;
     }
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -851,7 +851,8 @@ static inline void aclk_hello_msg()
     aclk_shared_state.version_neg_wait_till = now_monotonic_usec() + USEC_PER_SEC * VERSION_NEG_TIMEOUT;
     ACLK_SHARED_STATE_UNLOCK;
 
-    aclk_create_header(buf, "hello", msg_id, 0, 0, ACLK_VERSION_MIN);
+    //Hello message is versioned separatelly from the rest of the protocol
+    aclk_create_header(buf, "hello", msg_id, 0, 0, ACLK_VERSION_NEG_VERSION);
     buffer_sprintf(buf, ",\"min-version\":%d,\"max-version\":%d}", ACLK_VERSION_MIN, ACLK_VERSION_MAX);
     aclk_send_message(ACLK_METADATA_TOPIC, buf->buffer, msg_id);
     freez(msg_id);
@@ -1523,8 +1524,8 @@ static int aclk_handle_version_response(struct aclk_request *cloud_to_agent)
 {
     int version = -1;
 
-    if(unlikely(cloud_to_agent->version != ACLK_VERSION_MIN)) {
-        error("Unsuported version of \"version\" message from cloud. Expected %d, Got %d", ACLK_VERSION_MIN, cloud_to_agent->version);
+    if(unlikely(cloud_to_agent->version != ACLK_VERSION_NEG_VERSION)) {
+        error("Unsuported version of \"version\" message from cloud. Expected %d, Got %d", ACLK_VERSION_NEG_VERSION, cloud_to_agent->version);
         return 1;
     }
     if(unlikely(!cloud_to_agent->min_version)) {

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1626,6 +1626,10 @@ int aclk_handle_cloud_message(char *payload)
     for (int i = 0; aclk_incoming_msg_types[i].name; i++) {
         if (strcmp(cloud_to_agent.type_id, aclk_incoming_msg_types[i].name) == 0) {
             if (likely(!aclk_incoming_msg_types[i].fnc(&cloud_to_agent))) {
+                // in case of success handler is supposed to clean up after itself
+                // or as in the case of aclk_handle_cloud_request take
+                // ownership of the pointers (done to avoid copying)
+                // see what `aclk_queue_query` parameter `internal` does
                 freez(cloud_to_agent.type_id);
                 return 0;
             }

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -856,6 +856,7 @@ static inline void aclk_hello_msg()
     buffer_sprintf(buf, ",\"min-version\":%d,\"max-version\":%d}", ACLK_VERSION_MIN, ACLK_VERSION_MAX);
     aclk_send_message(ACLK_METADATA_TOPIC, buf->buffer, msg_id);
     freez(msg_id);
+    buffer_free(buf);
 }
 
 /**

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1602,8 +1602,9 @@ int aclk_handle_cloud_message(char *payload)
     }
 
     if (unlikely(!payload)) {
-        debug(D_ACLK, "ACLK incoming message is empty");
-        goto err_cleanup;
+        errno = 0;
+        error("ACLK incoming message is empty");
+        goto err_cleanup_nojson;
     }
 
     debug(D_ACLK, "ACLK incoming message (%s)", payload);
@@ -1645,6 +1646,7 @@ err_cleanup:
     if (cloud_to_agent.callback_topic)
         freez(cloud_to_agent.callback_topic);
 
+err_cleanup_nojson:
     if (aclk_stats_enabled) {
         ACLK_STATS_LOCK;
         aclk_metrics_per_sample.cloud_req_err++;

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1539,7 +1539,7 @@ static int aclk_handle_version_response(struct aclk_request *cloud_to_agent)
         error("Max version missing or 0");
         return 1;
     }
-    if(unlikely(cloud_to_agent->max_version < cloud_to_agent->max_version)) {
+    if(unlikely(cloud_to_agent->max_version < cloud_to_agent->min_version)) {
         error("Max version (%d) must be >= than min version (%d)", cloud_to_agent->max_version, cloud_to_agent->min_version);
         return 1;
     }

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -7,7 +7,6 @@
 #include "mqtt.h"
 #include "aclk_common.h"
 
-#define ACLK_VERSION 1
 #define ACLK_THREAD_NAME "ACLK_Query"
 #define ACLK_CHART_TOPIC "outbound/meta"
 #define ACLK_ALARMS_TOPIC "outbound/alarms"
@@ -35,6 +34,8 @@ struct aclk_request {
     char *callback_topic;
     char *payload;
     int version;
+    int min_version;
+    int max_version;
 };
 
 typedef enum aclk_init_action { ACLK_INIT, ACLK_REINIT } ACLK_INIT_ACTION;
@@ -73,7 +74,7 @@ int aclk_send_single_chart(char *host, char *chart);
 int aclk_update_chart(RRDHOST *host, char *chart_name, ACLK_CMD aclk_cmd);
 int aclk_update_alarm(RRDHOST *host, ALARM_ENTRY *ae);
 void aclk_create_header(BUFFER *dest, char *type, char *msg_id, time_t ts_secs, usec_t ts_us, int version);
-int aclk_handle_cloud_request(char *payload);
+int aclk_handle_cloud_message(char *payload);
 void aclk_add_collector(const char *hostname, const char *plugin_name, const char *module_name);
 void aclk_del_collector(const char *hostname, const char *plugin_name, const char *module_name);
 void aclk_alarm_reload();

--- a/aclk/agent_cloud_link.h
+++ b/aclk/agent_cloud_link.h
@@ -72,7 +72,7 @@ char *create_publish_base_topic();
 int aclk_send_single_chart(char *host, char *chart);
 int aclk_update_chart(RRDHOST *host, char *chart_name, ACLK_CMD aclk_cmd);
 int aclk_update_alarm(RRDHOST *host, ALARM_ENTRY *ae);
-void aclk_create_header(BUFFER *dest, char *type, char *msg_id, time_t ts_secs, usec_t ts_us);
+void aclk_create_header(BUFFER *dest, char *type, char *msg_id, time_t ts_secs, usec_t ts_us, int version);
 int aclk_handle_cloud_request(char *payload);
 void aclk_add_collector(const char *hostname, const char *plugin_name, const char *module_name);
 void aclk_del_collector(const char *hostname, const char *plugin_name, const char *module_name);

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -26,7 +26,7 @@ void mqtt_message_callback(struct mosquitto *mosq, void *obj, const struct mosqu
     UNUSED(mosq);
     UNUSED(obj);
 
-    aclk_handle_cloud_request(msg->payload);
+    aclk_handle_cloud_message(msg->payload);
 }
 
 void publish_callback(struct mosquitto *mosq, void *obj, int rc)
@@ -306,7 +306,7 @@ int _link_set_lwt(char *sub_topic, int qos)
 
     usec_t lwt_time = aclk_session_sec * USEC_PER_SEC + aclk_session_us + 1;
     BUFFER *b = buffer_create(512);
-    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC, ACLK_VERSION);
+    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC, ACLK_VERSION_NEG_VERSION);
     buffer_strcat(b, ", \"payload\": \"unexpected\" }");
     rc = mosquitto_will_set(mosq, topic, buffer_strlen(b), buffer_tostring(b), qos, 0);
     buffer_free(b);

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -306,7 +306,7 @@ int _link_set_lwt(char *sub_topic, int qos)
 
     usec_t lwt_time = aclk_session_sec * USEC_PER_SEC + aclk_session_us + 1;
     BUFFER *b = buffer_create(512);
-    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC, ACLK_VERSION_MIN);
+    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC, ACLK_VERSION_NEG_VERSION);
     buffer_strcat(b, ", \"payload\": \"unexpected\" }");
     rc = mosquitto_will_set(mosq, topic, buffer_strlen(b), buffer_tostring(b), qos, 0);
     buffer_free(b);

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -306,7 +306,7 @@ int _link_set_lwt(char *sub_topic, int qos)
 
     usec_t lwt_time = aclk_session_sec * USEC_PER_SEC + aclk_session_us + 1;
     BUFFER *b = buffer_create(512);
-    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC, ACLK_VERSION_NEG_VERSION);
+    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC, ACLK_VERSION_MIN);
     buffer_strcat(b, ", \"payload\": \"unexpected\" }");
     rc = mosquitto_will_set(mosq, topic, buffer_strlen(b), buffer_tostring(b), qos, 0);
     buffer_free(b);

--- a/aclk/mqtt.c
+++ b/aclk/mqtt.c
@@ -306,7 +306,7 @@ int _link_set_lwt(char *sub_topic, int qos)
 
     usec_t lwt_time = aclk_session_sec * USEC_PER_SEC + aclk_session_us + 1;
     BUFFER *b = buffer_create(512);
-    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC);
+    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC, ACLK_VERSION);
     buffer_strcat(b, ", \"payload\": \"unexpected\" }");
     rc = mosquitto_will_set(mosq, topic, buffer_strlen(b), buffer_tostring(b), qos, 0);
     buffer_free(b);

--- a/aclk/mqtt.h
+++ b/aclk/mqtt.h
@@ -19,7 +19,7 @@ const char *_link_strerror(int rc);
 int _link_set_lwt(char *topic, int qos);
 
 
-int aclk_handle_cloud_request(char *);
+int aclk_handle_cloud_message(char *);
 extern char *get_topic(char *sub_topic, char *final_topic, int max_size);
 
 #endif //NETDATA_MQTT_H

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -116,7 +116,7 @@ void claim_agent(char *claiming_arguments)
 }
 
 #ifdef ENABLE_ACLK
-extern int aclk_connected, aclk_kill_link;
+extern int aclk_connected, aclk_kill_link, aclk_disable_runtime;
 #endif
 
 /* Change the claimed state of the agent.
@@ -144,6 +144,7 @@ void load_claiming_state(void)
         info("Agent was already connected to Cloud - forcing reconnection under new credentials");
         aclk_kill_link = 1;
     }
+    aclk_disable_runtime = 0;
 
     // Propagate into aclk and registry. Be kind of atomic...
     appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "cloud base url", DEFAULT_CLOUD_BASE_URL);


### PR DESCRIPTION
##### Summary

Merge is possible after following cloud PRs are released to production:
- [x] https://github.com/netdata/cloud-agent-metadata-ctrl-service/pull/72
- [x] https://github.com/netdata/cloud-agent-metadata-ctrl-service/pull/74
- [x] Final Test With Staging environment together with Cloud
- [x] Wait for Leonidas confirms https://github.com/netdata/product/issues/1382 is not caused by recent changes/unrelated or until it is fixed
- [x] Previous step result. Following bugfixes have to be merged to Cloud https://github.com/netdata/cloud-agent-metadata-ctrl-service/pull/73/files
- [x] Tested on Staging with Leonidas
- [x] Confirmed with Cloud Team agents with these modifications can connect to Cloud


The agent will send a `hello` message to the cloud as soon as the MQTT connection is made and the agent is subscribed.
The agent will wait up to 3 seconds for a reply from the cloud and if none arrives default to an oldest supported version _(this is done so we can merge this before cloud implements support for this messages)_.
If reply arrives _(in form of `version` message)_ the highest version supported by both Agent and Cloud is selected for communication.

Messages `hello`, `version`, and LWT are versioned separately as they are sent (in case of LWT set) before the negotiation was finished.

##### Component Name

##### Test Plan
The first test is easy. Connect agent to staging and as it doesn't reply to `hello` message you should see it to revert to version 1 (oldest supported) of ACLK after the timeout. You should see a log like this: `ACLK version negotiation failed. No reply to "hello" with "version" from the cloud in time of 3s.  Reverting to the default version of 1.`

Other tests are a bit harder but I tried to make it easier by providing some helper script that emulates Cloud with support of version negotiation.

To test this you will have to temporarily disable challenge/response to allow the agent to connect to your local MQTT broker as follows:
```
static void aclk_try_to_connect(char *hostname, char *port, int port_num)
{
    UNUSED(port);
    if (!aclk_private_key) {
            error("Cannot try to establish the agent cloud link - no private key available!");
            return;
    }
    info("Attempting to establish the agent cloud link");
    /*aclk_get_challenge(hostname, port);
    if (aclk_password == NULL)
        return;*/
    aclk_password = strdupz("anon");
    int rc;
    aclk_connecting = 1;
...
```
Then set `cloud.conf` to connect to your local mosquito broker as follows:
```
[global]
  enabled = yes
  cloud base url = 127.0.0.1:9002
```
This will work with broker started as `mosquitto -c mosquitto.conf` with `mosquito.conf` contents:
```
port 1883
listener 9002
protocol websockets
certfile server.crt
keyfile server.key
log_dest stdout
log_type all
websockets_log_level 9999
```
you will of course need your own self-signed certificate `server.crt` and `server.key` and agent compiled with `-DACLK_SSL_ALLOW_SELF_SIGNED` _(unfortunately the flag `-DACLK_DISABLE_SSL` was removed from agent, this would be useful for testing)_

Then you can use my script from repo `https://github.com/netdata/internal/` path `underhood/cloud_helpers/aclk_reply_hello.rb`. You will need `ruby` interpreter and following ruby gems (packages/libraries):
```
gem install mqtt
gem install colorize
```

Then you can start it as follows: `./aclk_reply_hello.rb [MIN_VER] [MAX_VER]`. This will wait for agent to start and reply to `hello` message with minimum and maximum ACLK version specified by parameters. This allows to test this PR while cloud doesn't reply anything yet.

As currently there is `ACLK_VERSION_MIN == ACLK_VERSION_MAX == 1` only 1 version you will have to play with these defines in `aclk_common.h` to pretend there are other versions already.

Test following cases:
- Cloud doesn't reply to message. Agent should revert to default version
- Cloud min & max version are both > than agent max version -> Agent is way too old for the cloud
- Agent min & max version are both > than max version of cloud -> Cloud is way too old for the agent
- min & max of agent and cloud partially or fully overlap

##### Additional Information
