### PR TITLE
Fix empty dbengine files

### DIFF
--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -75,6 +75,27 @@ int close_data_file(struct rrdengine_datafile *datafile)
     return ret;
 }
 
+int unlink_data_file(struct rrdengine_datafile *datafile)
+{
+    struct rrdengine_instance *ctx = datafile->ctx;
+    uv_fs_t req;
+    int ret;
+    char path[RRDENG_PATH_MAX];
+
+    generate_datafilepath(datafile, path, sizeof(path));
+
+    ret = uv_fs_unlink(NULL, &req, path, NULL);
+    if (ret < 0) {
+        error("uv_fs_fsunlink(%s): %s", path, uv_strerror(ret));
+        ++ctx->stats.fs_errors;
+        rrd_stat_atomic_add(&global_fs_errors, 1);
+    }
+    uv_fs_req_cleanup(&req);
+
+    ++ctx->stats.datafile_deletions;
+
+    return ret;
+}
 
 int destroy_data_file(struct rrdengine_datafile *datafile)
 {
@@ -305,33 +326,45 @@ static int scan_data_files(struct rrdengine_instance *ctx)
     ctx->last_fileno = datafiles[matched_files - 1]->fileno;
 
     for (failed_to_load = 0, i = 0 ; i < matched_files ; ++i) {
+        uint8_t must_delete_pair = 0;
+
         datafile = datafiles[i];
         ret = load_data_file(datafile);
         if (0 != ret) {
-            freez(datafile);
-            ++failed_to_load;
-            break;
+            must_delete_pair = 1;
         }
         journalfile = mallocz(sizeof(*journalfile));
         datafile->journalfile = journalfile;
         journalfile_init(journalfile, datafile);
         ret = load_journal_file(ctx, journalfile, datafile);
         if (0 != ret) {
-            close_data_file(datafile);
-            freez(datafile);
-            freez(journalfile);
-            ++failed_to_load;
-            break;
+            must_delete_pair = 1;
         }
+        if (must_delete_pair) {
+            char path[RRDENG_PATH_MAX];
+
+            error("Deleting invalid data and journal file pair.");
+            ret = unlink_journal_file(journalfile);
+            if (!ret) {
+                generate_journalfilepath(datafile, path, sizeof(path));
+                info("Deleted journal file \"%s\".", path);
+            }
+            ret = unlink_data_file(datafile);
+            if (!ret) {
+                generate_datafilepath(datafile, path, sizeof(path));
+                info("Deleted data file \"%s\".", path);
+            }
+            freez(journalfile);
+            freez(datafile);
+            ++failed_to_load;
+            continue;
+        }
+
         datafile_list_insert(ctx, datafile);
         ctx->disk_space += datafile->pos + journalfile->pos;
     }
+    matched_files -= failed_to_load;
     freez(datafiles);
-    if (failed_to_load) {
-        error("%u datafiles failed to load.", failed_to_load);
-        finalize_data_files(ctx);
-        return UV_EIO;
-    }
 
     return matched_files;
 }

--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -338,6 +338,8 @@ static int scan_data_files(struct rrdengine_instance *ctx)
         journalfile_init(journalfile, datafile);
         ret = load_journal_file(ctx, journalfile, datafile);
         if (0 != ret) {
+            if (!must_delete_pair) /* If datafile is still open close it */
+                close_data_file(datafile);
             must_delete_pair = 1;
         }
         if (must_delete_pair) {

--- a/database/engine/datafile.h
+++ b/database/engine/datafile.h
@@ -57,6 +57,7 @@ extern void datafile_list_insert(struct rrdengine_instance *ctx, struct rrdengin
 extern void datafile_list_delete(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile);
 extern void generate_datafilepath(struct rrdengine_datafile *datafile, char *str, size_t maxlen);
 extern int close_data_file(struct rrdengine_datafile *datafile);
+extern int unlink_data_file(struct rrdengine_datafile *datafile);
 extern int destroy_data_file(struct rrdengine_datafile *datafile);
 extern int create_data_file(struct rrdengine_datafile *datafile);
 extern int create_new_datafile_pair(struct rrdengine_instance *ctx, unsigned tier, unsigned fileno);

--- a/database/engine/journalfile.h
+++ b/database/engine/journalfile.h
@@ -38,6 +38,7 @@ extern void journalfile_init(struct rrdengine_journalfile *journalfile, struct r
 extern void *wal_get_transaction_buffer(struct rrdengine_worker_config* wc, unsigned size);
 extern void wal_flush_transaction_buffer(struct rrdengine_worker_config* wc);
 extern int close_journal_file(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
+extern int unlink_journal_file(struct rrdengine_journalfile *journalfile);
 extern int destroy_journal_file(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
 extern int create_journal_file(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
 extern int load_journal_file(struct rrdengine_instance *ctx, struct rrdengine_journalfile *journalfile,

--- a/database/engine/metadata_log/logfile.h
+++ b/database/engine/metadata_log/logfile.h
@@ -83,6 +83,7 @@ extern void metadata_logfile_init(struct metadata_logfile *metadatalog, struct m
 extern int rename_metadata_logfile(struct metadata_logfile *metalogfile, unsigned new_starting_fileno,
                                    unsigned new_fileno);
 extern int close_metadata_logfile(struct metadata_logfile *metadatalog);
+extern int fsync_metadata_logfile(struct metadata_logfile *metalogfile);
 extern int unlink_metadata_logfile(struct metadata_logfile *metalogfile);
 extern int destroy_metadata_logfile(struct metadata_logfile *metalogfile);
 extern int create_metadata_logfile(struct metadata_logfile *metalogfile);

--- a/database/engine/metadata_log/metadatalog.c
+++ b/database/engine/metadata_log/metadatalog.c
@@ -134,6 +134,7 @@ void metalog_try_link_new_metadata_logfile(struct metalog_worker_config *wc)
     if (metalogfile->records.first) { /* it has records */
         /* Finalize metadata log file and create a new one */
         mlf_flush_records_buffer(wc, &ctx->records_log, &ctx->metadata_logfiles);
+        fsync_metadata_logfile(ctx->metadata_logfiles.last);
         ret = add_new_metadata_logfile(ctx, &ctx->metadata_logfiles, 0, ctx->last_fileno + 1);
         if (likely(!ret)) {
             ++ctx->last_fileno;
@@ -364,6 +365,7 @@ void metalog_worker(void* arg)
             case METALOG_COMPACTION_FLUSH:
                 mlf_flush_records_buffer(wc, &ctx->compaction_state.records_log,
                                          &ctx->compaction_state.new_metadata_logfiles);
+                fsync_metadata_logfile(ctx->compaction_state.new_metadata_logfiles.last);
                 complete(cmd.record_io_descr.completion);
                 break;
                 default:


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #9521
##### Component Name
database
##### Test Plan
1. Stop the agent.
2. Go to the cache folder:
```
cd /var/cache/netdata/dbengine
```
3. Create an empty file for the metadata log:
```
touch metadatalog-00000-00013.mlf
```
4. Create empty files for dbgengine:
```
touch datafile-1-0000000333.ndf
touch journalfile-1-0000000333.njf
```
5. Start the agent.
6. The agent should operate normally from now on.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
This PR changes the handling of empty dbengine and metadata-log files. Previously the dbengine instance would abort. Now it deletes the corrupted files and continues.