### PR TITLE
Fixes proxy forwarding claim_id to old parent

### DIFF
--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -369,6 +369,9 @@ void rrdpush_claimed_id(RRDHOST *host)
 {
     if(unlikely(!host->rrdpush_send_enabled || !host->rrdpush_sender_connected))
         return;
+    
+    if(host->sender->version < STREAM_VERSION_CLAIM)
+        return;
 
     sender_start(host->sender);
     netdata_mutex_lock(&host->claimed_id_lock);

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -622,8 +622,7 @@ void *rrdpush_sender_thread(void *ptr) {
                 buffer_sprintf(s->build, "TIMESTAMP %ld", now);
                 sender_commit(s);
             }
-            if (s->version >= STREAM_VERSION_CLAIM)
-                rrdpush_claimed_id(s->host);
+            rrdpush_claimed_id(s->host);
             continue;
         }
 


### PR DESCRIPTION
##### Summary

Imagine 3 level streaming setup child->proxy->parent where parent is v2 streaming (older version of agent) but proxy and child are latest v3 version.

When proxy connects to parent it checked the parent streaming version is at least v3 before sending `claim_id`:
```
if (s->version >= STREAM_VERSION_CLAIM)
                rrdpush_claimed_id(s->host);
```

but when already connected and child sends the `claim_id` update (by `netdatacli reload-claiming-state`) the proxy forwarded it without checking version of parent trough following call chain `streaming_claimed_id->rrdpush_claimed_id`. This leads to parent disconnecting proxy with error. Then proxy reconnects to parent and continues working normally.
Therefore this is low impact bug (only happens when parent is old version while proxy is new version and user reloads child claiming state on runtime and causes only temporary disconnection of proxy from parent).

This PR moves the version check into function `rrdpush_claimed_id` and thus ensures that parent version is always checked before sending `CLAIMED_ID` command

##### Component Name

Agent/Streaming

##### Test Plan

Maximum tested with 4 level streaming setup:
![ZO_12i8m38RlVOgm-mwjDr7OIJpCcoyGjuYJr4gJAO8FhyLDN57myfU4VlnVAb6CsdisONUaHc4RpZLTY3SeIj5CHvX3mzXvQc49UsIX4IjMrCvSMUEDebq7KLi02h0zM9DYGchitw1sFbn5pF3c_tuNkB70cHJ_gRaFDVTKI_65pCzUtCioDtqjqstPPZ2omvXgAZgrlUS7](https://user-images.githubusercontent.com/6674623/91409777-2f787680-e846-11ea-8364-b0cf9f55112a.png)

1st test - (with top level node being old version and children/proxies being latest) and by changing claiming state of children during runtime with `netdatacli reload-claiming-state` the `claimed_id` is not sent to parent who is old
2nd test - with all nodes being newest version and reloading claiming state of children during runtime - claimed_id still propagates up the network as expected

##### Additional Information
