### PR TITLE
Fixed bug in installer introduced by #8808

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -272,7 +272,7 @@ export NETDATA_LIB_DIR="${NETDATA_LIB_DIR:-${NETDATA_PREFIX}/var/lib/netdata}"
 [[ -z "${NETDATA_TARBALL_CHECKSUM}" ]] && [[ -f ${NETDATA_LIB_DIR}/netdata.tarball.checksum ]] && NETDATA_TARBALL_CHECKSUM="$(cat "${NETDATA_LIB_DIR}/netdata.tarball.checksum")"
 
 # Grab the nightlies baseurl (defaulting to our Google Storage bucket)
-export NETDATA_NIGHTLIES_BASEURL="${NETDATA_NIGHTLIES_BASEURL:-https://storage.googleapis.com/netdata-nightlies}"
+[ -z "${NETDATA_NIGHTLIES_BASEURL}" ] && export NETDATA_NIGHTLIES_BASEURL="https://storage.googleapis.com/netdata-nightlies"
 
 if [ "${INSTALL_UID}" != "$(id -u)" ]; then
   fatal "You are running this script as user with uid $(id -u). We recommend to run this script as root (user with uid 0)"


### PR DESCRIPTION
##### Summary

In short, you can't do default value substitution in Bash if the default value has parameter expansion meta-characters in it. Simple local test that demonstrates this: `echo ${foo:-http://example.com}` will echo an empty string in Bash.

The result of this is that the updater tries to use a malformed URL for the version check, which in turn always fails.

Users will need to manually handle updates once the next nightly goes out after this is merged.

##### Component Name

area/packaging

##### Test Plan

Verified via local testing.

##### Additional Information

Fixes: #9829 

Originally introduced by #8808 