### PR TITLE
Don't falsely report that the group was not deleted

### DIFF
--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -187,7 +187,7 @@ portable_del_group() {
       run groupdel "${groupname}" && return 0
     else
       echo >&2 "Group ${groupname} already removed in a previous step."
-      run_ok
+      return 0
     fi
   fi
 
@@ -197,6 +197,7 @@ portable_del_group() {
       run dseditgroup -o delete "${groupname}" && return 0
     else
       echo >&2 "Could not find group ${groupname}, nothing to do"
+      return 0
     fi
   fi
 


### PR DESCRIPTION
The message "Group ${groupname} was not automatically removed, you might have to remove it manually" was displayed even if the group had already been deleted before the invocation of the `portable_del_group` method.
I added the missing return statements to fix this.
