### PR TITLE
Change a log level in cgroup-network helper

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -689,8 +689,10 @@ int main(int argc, char **argv) {
     }
     else if(!strcmp(argv[1], "--cgroup")) {
         char *cgroup = argv[2];
-        if(verify_path(cgroup) == -1)
-            fatal("cgroup '%s' does not exist or is not valid.", cgroup);
+        if(verify_path(cgroup) == -1) {
+            error("cgroup '%s' does not exist or is not valid.", cgroup);
+            return 1;
+        }
 
         pid = read_pid_from_cgroup(cgroup);
         call_the_helper(pid, cgroup);


### PR DESCRIPTION
##### Summary
Change a log level reported by the `cgroup-network` helper from `FATAL` to `ERROR`.

Fixes #7202

##### Component Name
cgroups plugin

##### Test Plan
Install `canonical-livepatch` using `snap` on Ubuntu 18.04. Check if there are no fatal errors emitted by the `cgroup-network` helper.