### PR TITLE
collect active processes limit feature #6133

### DIFF
--- a/health/health.d/processes.conf
+++ b/health/health.d/processes.conf
@@ -1,27 +1,27 @@
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-   alarm: active_processes_limit_freebsd
+   alarm: active_percent_of_limit_freebsd
       on: system.active_processes
       os: freebsd
    hosts: *
-    calc: $active
-   units: processes
+    calc: $active * 100 / 99999
+   units: %
    every: 5s
-    warn: $this > (($status >= $WARNING)  ? (75000) : (80000))
-    crit: $this > (($status == $CRITICAL) ? (85000) : (90000))
+    warn: $this > 80
+    crit: $this > 90
    delay: down 5m multiplier 1.5 max 1h
-    info: the number of active processes
+    info: percentage of processes that are active compared to the limit pid_max
       to: sysadmin
 
-   alarm: active_processes_limit
+   alarm: active_percent_of_limit
       on: system.active_processes
       os: linux
    hosts: *
-    calc: $active
-   units: processes
+    calc: $active * 100 / $pidmax
+   units: %
    every: 5s
-    warn: $this > (($status >= $WARNING)  ? (25000) : (26000))
-    crit: $this > (($status == $CRITICAL) ? (28000) : (30000))
+    warn: $this > 80
+    crit: $this > 90
    delay: down 5m multiplier 1.5 max 1h
-    info: number of active processes
+    info: percentage of processes that are active compared to the limit pid_max
       to: sysadmin


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Added feature mentioned on #6133 
##### Component Name
Collectors and Health
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
**Made it possible so we can read the value of `pid_max` for linux. After that, the notification calculates active processes percentage based on the given limit.** The limit was added as a parameter to the `active_processes` graph but then hidden so we can use it in the `processes.conf` file _(I hid it so we dont get a line pointing to a static 4 million value f.e)_. On freebsd the limit is static so made it to calculate % based on it