### PR TITLE
Fixed bugs in handling of Python 3 dependencies on install.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -954,6 +954,10 @@ declare -A pkg_python3_mysqldb=(
   ['ubuntu-14.10']="WARNING|"
   ['ubuntu-15.04']="WARNING|"
   ['ubuntu-15.10']="WARNING|"
+  ['centos-7']="python36-mysql"
+  ['centos-8']="python38-mysql"
+  ['rhel-7']="python36-mysql"
+  ['rhel-8']="python38-mysql"
 )
 
 declare -A pkg_python_psycopg2=(
@@ -982,6 +986,11 @@ declare -A pkg_python3_psycopg2=(
   ['clearlinux']="WARNING|"
   ['macos']="WARNING|"
   ['default']="WARNING|"
+
+  ['centos-7']="python3-psycopg2"
+  ['centos-8']="python38-psycopg2"
+  ['rhel-7']="python3-psycopg2"
+  ['rhel-8']="python38-psycopg2"
 )
 
 declare -A pkg_python_pip=(
@@ -996,10 +1005,8 @@ declare -A pkg_python_pip=(
 declare -A pkg_python3_pip=(
   ['alpine']="py3-pip"
   ['arch']="python-pip"
-  ['centos']="WARNING|"
   ['gentoo']="dev-python/pip"
   ['sabayon']="dev-python/pip"
-  ['rhel']="WARNING|"
   ['clearlinux']="python3-basic"
   ['macos']="NOTREQUIRED"
   ['default']="python3-pip"
@@ -1013,6 +1020,7 @@ declare -A pkg_python_pymongo=(
   ['gentoo']="dev-python/pymongo"
   ['suse']="python-pymongo"
   ['clearlinux']="WARNING|"
+  ['rhel']="WARNING|"
   ['macos']="WARNING|"
   ['default']="python-pymongo"
 )
@@ -1025,9 +1033,15 @@ declare -A pkg_python3_pymongo=(
   ['gentoo']="dev-python/pymongo"
   ['suse']="python3-pymongo"
   ['clearlinux']="WARNING|"
+  ['rhel']="WARNING|"
   ['freebsd']="py37-pymongo"
   ['macos']="WARNING|"
   ['default']="python3-pymongo"
+
+  ['centos-7']="python36-pymongo"
+  ['centos-8']="python3-pymongo"
+  ['rhel-7']="python36-pymongo"
+  ['rhel-8']="python3-pymongo"
 )
 
 declare -A pkg_python_requests=(
@@ -1058,6 +1072,11 @@ declare -A pkg_python3_requests=(
   ['clearlinux']="python-extras"
   ['macos']="WARNING|"
   ['default']="WARNING|"
+
+  ['centos-7']="python36-requests"
+  ['centos-8']="python3-requests"
+  ['rhel-7']="python36-requests"
+  ['rhel-8']="python3-requests"
 )
 
 declare -A pkg_lz4=(

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1379,7 +1379,6 @@ packages() {
   if [ "${PACKAGES_NETDATA_PYTHON3}" -ne 0 ]; then
     require_cmd python3 || suitable_package python3
 
-    suitable_package python3-pymongo
     [ "${PACKAGES_NETDATA_PYTHON_MONGO}" -ne 0 ] && suitable_package python3-pymongo
     # suitable_package python3-requests
     # suitable_package python3-pip


### PR DESCRIPTION
##### Summary

This fixes two bugs present in our current handling of Python 3 dependencies:

1. We unconditionally try to install the Python 3 MongoDB module whenever we have been told to install Python 3, instead of it being dependent on whether the user has asked us to install MongoDB deps or not. This PR removes the duplicate install line that was causing this.
2. We incorrectly claim alack of Python 3 packages on CentOS and RHEL systems (and their derivatives), as well as not having proper entries for these packges for some system types. This leads to installation failures in some cases. This PR fixes this by adding appropriate overrides for the relevant packages for specific versions of CentOS/RHEL based on what is actually available.

##### Component Name

area/packaging

##### Test Plan

Verified locally on CentOS 7 and 8 systems.

##### Additional Information

Fixes: #9168 