### PR TITLE
Fixed tmpdir handling failure on macOS/FreeBSD.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -52,7 +52,7 @@ _cannot_use_tmpdir() {
     return "${ret}"
   fi
 
-  if /bin/echo -e '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
+  if printf '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
     if chmod +x "${testfile}" ; then
       if [ "$("${testfile}")" = "SUCCESS" ] ; then
         ret=1

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -130,7 +130,7 @@ _cannot_use_tmpdir() {
     return "${ret}"
   fi
 
-  if /bin/echo -e '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
+  if printf '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
     if chmod +x "${testfile}" ; then
       if [ "$("${testfile}")" = "SUCCESS" ] ; then
         ret=1

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -162,7 +162,7 @@ _cannot_use_tmpdir() {
     return "${ret}"
   fi
 
-  if /bin/echo -e '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
+  if printf '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
     if chmod +x "${testfile}" ; then
       if [ "$("${testfile}")" = "SUCCESS" ] ; then
         ret=1

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -78,7 +78,7 @@ To use `md5sum` to verify the intregity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "2b0219a71a070853e9109eecebb4be92" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "efddf41d3c19c4988601aecf5b483e3a" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -61,7 +61,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "0bfd0e5d8ac868ff09957f1d43e8a35a" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "794498f7009012116aafe466d8f544ae" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -72,7 +72,7 @@ _cannot_use_tmpdir() {
     return "${ret}"
   fi
 
-  if /bin/echo -e '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
+  if printf '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
     if chmod +x "${testfile}" ; then
       if [ "$("${testfile}")" = "SUCCESS" ] ; then
         ret=1


### PR DESCRIPTION
##### Summary

When writing the new temporary directory handling code, I forgot that POSIX versions of the `echo` command don't take any options, and as a result ended up breaking the installer and updater for systems that use a POSIX version of `echo`. This fixes the issue by just using `printf` instead.

##### Component Name

area/packaging

##### Test Plan

Relevant code manually tested on macOS and FreeBSD.

##### Additional Information

Fixes: #9840 