### PR TITLE
collect active processes limit feature v2

### DIFF
--- a/collectors/proc.plugin/proc_loadavg.c
+++ b/collectors/proc.plugin/proc_loadavg.c
@@ -47,17 +47,9 @@ int do_proc_loadavg(int update_every, usec_t dt) {
     //unsigned long long running_processes  = str2ull(procfile_lineword(ff, 0, 3));
     unsigned long long active_processes     = str2ull(procfile_lineword(ff, 0, 4));
     
-    //open PID_MAX and get the number
-    FILE *fp;
-    int val;
-    char pid_max [TMP_MAX];
-    fp=fopen("/proc/sys/kernel/pid_max", "r");
-    fscanf(fp,"%d",&val);
-    fclose(fp);
+    //get system pid_max
+    unsigned long long max_processes        = get_system_pid_max();
     //
-
-    unsigned long long max_processes        = (unsigned long long) val;
-   
     //unsigned long long next_pid           = str2ull(procfile_lineword(ff, 0, 5));
 
 

--- a/collectors/proc.plugin/proc_loadavg.c
+++ b/collectors/proc.plugin/proc_loadavg.c
@@ -46,6 +46,18 @@ int do_proc_loadavg(int update_every, usec_t dt) {
 
     //unsigned long long running_processes  = str2ull(procfile_lineword(ff, 0, 3));
     unsigned long long active_processes     = str2ull(procfile_lineword(ff, 0, 4));
+    
+    //open PID_MAX and get the number
+    FILE *fp;
+    int val;
+    char pid_max [TMP_MAX];
+    fp=fopen("/proc/sys/kernel/pid_max", "r");
+    fscanf(fp,"%d",&val);
+    fclose(fp);
+    //
+
+    unsigned long long max_processes        = (unsigned long long) val;
+   
     //unsigned long long next_pid           = str2ull(procfile_lineword(ff, 0, 5));
 
 
@@ -95,6 +107,7 @@ int do_proc_loadavg(int update_every, usec_t dt) {
     if(likely(do_all_processes)) {
         static RRDSET *processes_chart = NULL;
         static RRDDIM *rd_active = NULL;
+        static RRDSETVAR *rd_pidmax;
 
         if(unlikely(!processes_chart)) {
             processes_chart = rrdset_create_localhost(
@@ -113,10 +126,12 @@ int do_proc_loadavg(int update_every, usec_t dt) {
             );
 
             rd_active = rrddim_add(processes_chart, "active", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_pidmax = rrdsetvar_custom_chart_variable_create(processes_chart, "pidmax");
         }
         else rrdset_next(processes_chart);
 
         rrddim_set_by_pointer(processes_chart, rd_active, active_processes);
+        rrdsetvar_custom_chart_variable_set(rd_pidmax, max_processes);
         rrdset_done(processes_chart);
     }
 

--- a/health/health.d/processes.conf
+++ b/health/health.d/processes.conf
@@ -1,21 +1,7 @@
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-   alarm: active_percent_of_limit_freebsd
+   alarm: active_processes
       on: system.active_processes
-      os: freebsd
-   hosts: *
-    calc: $active * 100 / 99999
-   units: %
-   every: 5s
-    warn: $this > 80
-    crit: $this > 90
-   delay: down 5m multiplier 1.5 max 1h
-    info: percentage of processes that are active compared to the limit pid_max
-      to: sysadmin
-
-   alarm: active_percent_of_limit
-      on: system.active_processes
-      os: linux
    hosts: *
     calc: $active * 100 / $pidmax
    units: %
@@ -23,5 +9,5 @@
     warn: $this > 80
     crit: $this > 90
    delay: down 5m multiplier 1.5 max 1h
-    info: percentage of processes that are active compared to the limit pid_max
+    info: the percentage of active processes
       to: sysadmin

--- a/health/health.d/processes.conf
+++ b/health/health.d/processes.conf
@@ -6,8 +6,8 @@
     calc: $active * 100 / $pidmax
    units: %
    every: 5s
-    warn: $this > 80
-    crit: $this > 90
+    warn: $this > (($status >= $WARNING)  ? (75) : (80))
+    crit: $this > (($status == $CRITICAL) ? (85) : (90))
    delay: down 5m multiplier 1.5 max 1h
     info: the percentage of active processes
       to: sysadmin

--- a/health/health.d/processes.conf
+++ b/health/health.d/processes.conf
@@ -1,27 +1,27 @@
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-   alarm: active_processes_limit_freebsd
+   alarm: active_percent_of_limit_freebsd
       on: system.active_processes
       os: freebsd
    hosts: *
-    calc: $active
-   units: processes
+    calc: $active * 100 / 99999
+   units: %
    every: 5s
-    warn: $this > (($status >= $WARNING)  ? (75000) : (80000))
-    crit: $this > (($status == $CRITICAL) ? (85000) : (90000))
+    warn: $this > 80
+    crit: $this > 90
    delay: down 5m multiplier 1.5 max 1h
-    info: the number of active processes
+    info: percentage of processes that are active compared to the limit pid_max
       to: sysadmin
 
-   alarm: active_processes_limit
+   alarm: active_percent_of_limit
       on: system.active_processes
       os: linux
    hosts: *
-    calc: $active
-   units: processes
+    calc: $active * 100 / $pidmax
+   units: %
    every: 5s
-    warn: $this > (($status >= $WARNING)  ? (25000) : (26000))
-    crit: $this > (($status == $CRITICAL) ? (28000) : (30000))
+    warn: $this > 80
+    crit: $this > 90
    delay: down 5m multiplier 1.5 max 1h
-    info: number of active processes
+    info: percentage of processes that are active compared to the limit pid_max
       to: sysadmin


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Added feature mentioned on #6133 and also applied changes mentioned on #9838 
##### Component Name
Collectors and Health


<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
Made it possible so we can read the value of `pid_max` for linux. After that, the notification calculates active processes percentage based on the given limit. The limit was added as a `VARIABLE` to the `active_processes` graph so we can use it in the processes.conf file. On freebsd the limit is static so made it to calculate % based on it