### PR TITLE
Don't install eBPF plugin components when they shouldn't be installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,6 +167,12 @@ AC_ARG_ENABLE(
     ,
     [enable_jsonc="detect"]
 )
+AC_ARG_ENABLE(
+    [ebpf],
+    [AS_HELP_STRING([--disable-ebpf], [Disable eBPF support @<:@default autodetect@:>@])],
+    ,
+    [enable_ebpf="detect"]
+)
 
 # -----------------------------------------------------------------------------
 # Check if cloud is enabled and if the functionality is available
@@ -968,6 +974,7 @@ AC_CHECK_FILE(
 
 AC_MSG_CHECKING([if ebpf.plugin should be enabled])
 if test "${build_target}" = "linux" -a \
+        "${enable_ebpf}" != "no" -a \
         "${have_libelf}" = "yes" -a \
         "${have_bpf}" = "yes" -a \
         "${have_libbpf}" = "yes"; then

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -299,7 +299,7 @@ while [ -n "${1}" ]; do
     "--disable-telemetry") NETDATA_DISABLE_TELEMETRY=1 ;;
     "--disable-go") NETDATA_DISABLE_GO=1 ;;
     "--enable-ebpf") NETDATA_DISABLE_EBPF=0 ;;
-    "--disable-ebpf") NETDATA_DISABLE_EBPF=1 ;;
+    "--disable-ebpf") NETDATA_DISABLE_EBPF=1 NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-ebpf/} --disable-ebpf" ;;
     "--disable-cloud")
       if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
         echo "Cloud explicitly enabled, ignoring --disable-cloud."
@@ -1432,6 +1432,12 @@ should_install_ebpf() {
   if [ "${NETDATA_DISABLE_EBPF:=0}" -eq 1 ]; then
     run_failed "eBPF explicitly disabled."
     defer_error "eBPF explicitly disabled."
+    return 1
+  fi
+
+  if [ "$(uname -s)" != Linux ]; then
+    run_failed "Currently eBPF is only supported on Linux."
+    defer_error "Currently eBPF is only supported on Linux."
     return 1
   fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1435,7 +1435,7 @@ should_install_ebpf() {
     return 1
   fi
 
-  if [ "$(uname -s)" != Linux ]; then
+  if [ "$(uname -s)" != "Linux" ]; then
     run_failed "Currently eBPF is only supported on Linux."
     defer_error "Currently eBPF is only supported on Linux."
     return 1


### PR DESCRIPTION
##### Summary
Don't install eBPF components
- when eBPF plugin is explicitly disabled using the `--disable-ebpf` flag.
- on FreeBSD.
- on macOS.

Possibly fixes #9750

##### Component Name
eBPF plugin

##### Test Plan
Check Netdata installation
- With the `--disable-ebpf` flag.
- On FreeBSD.
- On macOS.