### PR TITLE
fixes compilation warnings

### DIFF
--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -201,7 +201,7 @@ void aclk_lws_wss_client_destroy()
     aclk_lws_wss_destroy_context();
     engine_instance->lws_wsi = NULL;
 
-    aclk_lws_wss_clear_io_buffers(engine_instance);
+    aclk_lws_wss_clear_io_buffers();
 
 #ifdef ACLK_LWS_MOSQUITTO_IO_CALLS_MULTITHREADED
     pthread_mutex_destroy(&engine_instance->write_buf_mutex);
@@ -510,7 +510,7 @@ static int aclk_lws_wss_callback(struct lws *wsi, enum lws_callback_reasons reas
             aclk_lws_connection_closed();
             return -1;                       // the callback response is ignored, hope the above remains true
         case LWS_CALLBACK_WSI_DESTROY:
-            aclk_lws_wss_clear_io_buffers(engine_instance);
+            aclk_lws_wss_clear_io_buffers();
             if (!engine_instance->websocket_connection_up)
                 aclk_lws_wss_fail_report();
             engine_instance->lws_wsi = NULL;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -187,7 +187,7 @@ void rrdeng_store_metric_flush_current_page(RRDDIM *rd)
         return;
     }
     if (likely(descr->page_length)) {
-        int ret, page_is_empty;
+        int page_is_empty;
 
         rrd_stat_atomic_add(&ctx->stats.metric_API_producers, -1);
 


### PR DESCRIPTION

##### Summary

Fixes compilation warning on FreeBSD:
```
aclk/aclk_lws_wss_client.c:204:50: warning: too many arguments in call to 'aclk_lws_wss_clear_io_buffers'
    aclk_lws_wss_clear_io_buffers(engine_instance);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                ^
aclk/aclk_lws_wss_client.c:513:58: warning: too many arguments in call to 'aclk_lws_wss_clear_io_buffers'
            aclk_lws_wss_clear_io_buffers(engine_instance);
```

and on Linux:
```
  CC       database/engine/metadata_log/metalogpluginsd.o
database/engine/rrdengineapi.c: In function ‘rrdeng_store_metric_flush_current_page’:
database/engine/rrdengineapi.c:190:13: warning: unused variable ‘ret’ [-Wunused-variable]
  190 |         int ret, page_is_empty;
      |             ^~~
  CC       database/engine/metadata_log/compaction.o
```
##### Component Name
Netdata

##### Test Plan
Compilation should not show these 2 warnings anymore

##### Additional Information
