### PR TITLE
Add overview docs to docsv2 project

### DIFF
--- a/docs/overview/netdata-monitoring-stack.md
+++ b/docs/overview/netdata-monitoring-stack.md
@@ -1,9 +1,61 @@
 <!--
-title: "Using Netdata with your existing monitoring stack"
-description: ""
+title: "Use Netdata standalone or as part of your monitoring stack"
+description: "Netdata can run independently or as part of a larger monitoring stack thanks to its flexibility, interoperable core, and exporting features."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/netdata-monitoring-stack.md
 -->
 
-# Using Netdata with your existing monitoring stack
+# Use Netdata standalone or as part of your monitoring stack
 
-t/k
+Netdata is an extremely powerful monitoring, visualization, and troubleshooting platform, and while it can be used as a
+standalone tool, it's also designed with openness in mind. 
+
+Netdata helps you collect everything and scales to infrastructure of any size, but it doesn't lock-in data or force you
+to use specific tools or methodologies. Each feature is extensible and interoperable so they can work in parallel with
+other tools. For example, you can use Netdata to collect metrics, visualize metrics with a second open-source program,
+and centalize your metrics in a cloud-based time-series database solution for long-term storage or further analysis.
+
+You can build a new monitoring stack including Netdata, or you can integrate Netdata's metrics with your existing
+monitoring stack. No matter which route you take, Netdata helps you monitor infrastructure of any size.
+
+Here are a few ways to enrich your existing monitoring and troubleshooting stack with Netdata:
+
+## Collect metrics from Prometheus endpoints
+
+Netdata automatically detects 600 popular endpoints and collects per-second metrics from them via the [generic
+Prometheus collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/prometheus). This even
+includes support for Windows 10 via [`windows_exporter`](https://github.com/prometheus-community/windows_exporter).
+
+This collector is installed and enabled on all Agent installations by default, so you don't need to waste time
+configuring Netdata. Netdata will detect these Prometheus metrics endpoints and collect even more granular metrics than
+your existing solutions. You can now use all of Netdata's charts, which are meaningfully visualized, to help you
+diagnose issues and troubleshoot anomalies.
+
+## Export metrics to external time-series databases
+
+Netdata is capable of sending its per-second metrics to external time-series databases, such as InfluxDB, Prometheus,
+Graphite, TimescaleDB, ElasticSearch, AWS Kinesis Data Streams, Google Cloud Pub/Sub Service, and many others.
+
+To enable exporting, you configure an _exporting connector_. These connectors support filtering and resampling for
+granular control over which metrics you export, and at what volume. You can export resampled metrics as collected, as
+averages, or the sum of interpolated values based on your needs and your other monitoring tools.
+
+Once you have Netdata's metrics in a secondary time-series database, you can use them however you'd like, such as
+additional visualization/dashboarding tools or aggregation of data from multiple sources.
+
+## Visualize metrics with Grafana
+
+One popular monitoring stack is Netdata, Graphite, and Grafana. Netdata acts as the stack's metrics collection
+powerhouse, Graphite the time-series database, and Grafana the visualization platform. With Netdata at the core, you can
+be confident that your monitoring stack is powered by all possible metrics, from all possible sources, from every node
+in your infrastrucutre.
+
+Of course, just because you export or visualize metrics elsewhere, it doesn't mean Netdata's equivalent features
+disappear. You can always use build new dashboards in Netdata Cloud, drill down into per-second metrics using Netdata's
+charts, or use Netdata's health watchdog to send notifications whenever an anomaly strikes.
+
+## What's next?
+
+Whether you're using Netdata standalone or as part of a larger monitoring stack, the next step is the same: [**Get
+Netdata**](/packaging/installer/README.md).
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Foverview%2Fnetdata-monitoring-stacka&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/overview/netdata-monitoring-stack.md
+++ b/docs/overview/netdata-monitoring-stack.md
@@ -6,16 +6,16 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/ne
 
 # Use Netdata standalone or as part of your monitoring stack
 
-Netdata is an extremely powerful monitoring, visualization, and troubleshooting platform, and while it can be used as a
-standalone tool, it's also designed with openness in mind. 
+Netdata is an extremely powerful monitoring, visualization, and troubleshooting platform. While you can use it as an
+effective standalone tool, we also designed it to be open and interoperable with other tools you might already be using.
 
 Netdata helps you collect everything and scales to infrastructure of any size, but it doesn't lock-in data or force you
 to use specific tools or methodologies. Each feature is extensible and interoperable so they can work in parallel with
 other tools. For example, you can use Netdata to collect metrics, visualize metrics with a second open-source program,
-and centalize your metrics in a cloud-based time-series database solution for long-term storage or further analysis.
+and centralize your metrics in a cloud-based time-series database solution for long-term storage or further analysis.
 
-You can build a new monitoring stack including Netdata, or you can integrate Netdata's metrics with your existing
-monitoring stack. No matter which route you take, Netdata helps you monitor infrastructure of any size.
+You can build a new monitoring stack, including Netdata, or integrate Netdata's metrics with your existing monitoring
+stack. No matter which route you take, Netdata helps you monitor infrastructure of any size.
 
 Here are a few ways to enrich your existing monitoring and troubleshooting stack with Netdata:
 
@@ -27,17 +27,18 @@ includes support for Windows 10 via [`windows_exporter`](https://github.com/prom
 
 This collector is installed and enabled on all Agent installations by default, so you don't need to waste time
 configuring Netdata. Netdata will detect these Prometheus metrics endpoints and collect even more granular metrics than
-your existing solutions. You can now use all of Netdata's charts, which are meaningfully visualized, to help you
-diagnose issues and troubleshoot anomalies.
+your existing solutions. You can now use all of Netdata's meaningfully-visualized charts to diagnose issues and
+troubleshoot anomalies.
 
 ## Export metrics to external time-series databases
 
-Netdata is capable of sending its per-second metrics to external time-series databases, such as InfluxDB, Prometheus,
-Graphite, TimescaleDB, ElasticSearch, AWS Kinesis Data Streams, Google Cloud Pub/Sub Service, and many others.
+Netdata can send its per-second metrics to external time-series databases, such as InfluxDB, Prometheus, Graphite,
+TimescaleDB, ElasticSearch, AWS Kinesis Data Streams, Google Cloud Pub/Sub Service, and many others.
 
-To enable exporting, you configure an _exporting connector_. These connectors support filtering and resampling for
-granular control over which metrics you export, and at what volume. You can export resampled metrics as collected, as
-averages, or the sum of interpolated values based on your needs and your other monitoring tools.
+To [enable exporting](/docs/export/enable-exporting.md), you configure an _exporting connector_. These connectors
+support filtering and resampling for granular control over which metrics you export, and at what volume. You can export
+resampled metrics as collected, as averages, or the sum of interpolated values based on your needs and other monitoring
+tools.
 
 Once you have Netdata's metrics in a secondary time-series database, you can use them however you'd like, such as
 additional visualization/dashboarding tools or aggregation of data from multiple sources.
@@ -47,15 +48,15 @@ additional visualization/dashboarding tools or aggregation of data from multiple
 One popular monitoring stack is Netdata, Graphite, and Grafana. Netdata acts as the stack's metrics collection
 powerhouse, Graphite the time-series database, and Grafana the visualization platform. With Netdata at the core, you can
 be confident that your monitoring stack is powered by all possible metrics, from all possible sources, from every node
-in your infrastrucutre.
+in your infrastructure.
 
 Of course, just because you export or visualize metrics elsewhere, it doesn't mean Netdata's equivalent features
-disappear. You can always use build new dashboards in Netdata Cloud, drill down into per-second metrics using Netdata's
+disappear. You can always build new dashboards in Netdata Cloud, drill down into per-second metrics using Netdata's
 charts, or use Netdata's health watchdog to send notifications whenever an anomaly strikes.
 
 ## What's next?
 
 Whether you're using Netdata standalone or as part of a larger monitoring stack, the next step is the same: [**Get
-Netdata**](/packaging/installer/README.md).
+Netdata**](/docs/get/README.md).
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Foverview%2Fnetdata-monitoring-stacka&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/overview/netdata-monitoring-stack.md
+++ b/docs/overview/netdata-monitoring-stack.md
@@ -4,6 +4,6 @@ description: ""
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/netdata-monitoring-stack.md
 -->
 
-# How to use Netdata
+# Using Netdata with your existing monitoring stack
 
 t/k

--- a/docs/overview/netdata-monitoring-stack.md
+++ b/docs/overview/netdata-monitoring-stack.md
@@ -1,0 +1,9 @@
+<!--
+title: "Using Netdata with your existing monitoring stack"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/netdata-monitoring-stack.md
+-->
+
+# How to use Netdata
+
+t/k

--- a/docs/overview/what-is-netdata.md
+++ b/docs/overview/what-is-netdata.md
@@ -1,41 +1,68 @@
 <!--
 title: "What is Netdata?"
-description: ""
+description: "Netdata is distributed, real-time performance and health monitoring for systems and applications on a single node or an entire infrastructure."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/what-is-netdata.md
 -->
 
 # What is Netdata?
 
-t/k
-
-## Two integrated components: Agent and Cloud
-
-The Netdata solution is composed of two 
+Netdata is distributed, real-time performance and health monitoring for systems and applications. This solution uses two
+primary components, the Netdata Agent and Netdata Cloud, to offer powerful monitoring, visualization, and
+troubleshooting for both single nodes and entire infrastructures.
 
 ## Netdata Agent
 
-t/k
+Netdata's distributed monitoring Agent collects thousands of metrics from systems, hardware, and applications with zero
+configuration. It runs permanently on all your physical/virtual servers, containers, cloud deployments, and edge/IoT
+devices.
+
+You can install Netdata on most Linux distributions (Ubuntu, Debian, CentOS, and more), container platforms (Kubernetes
+clusters, Docker), and many other operating systems (FreeBSD, macOS). No `sudo` required.
+
+![agent-hero-overview](https://user-images.githubusercontent.com/1153921/91363069-9e0af500-e7b0-11ea-82f1-8cba692ca118.png)
 
 ## Netdata Cloud
 
-Netdata Cloud gives you real-time visibility for your entire infrastructure. With Netdata Cloud, you can view key
-metrics, insightful charts, and active alarms from all your nodes in a single web interface. When an anomaly strikes,
-seamlessly navigate to any node to troubleshoot and discover the root cause with the familiar Netdata dashboard.
-
-![Animated GIF of Netdata
-Cloud](https://user-images.githubusercontent.com/1153921/80828986-1ebb3b00-8b9b-11ea-957f-2c8d0d009e44.gif)
+Netdata Cloud is a web application that gives you real-time visibility for your entire infrastructure. With Netdata
+Cloud, you can view key metrics, insightful charts, and active alarms from all your nodes in a single web interface.
+When an anomaly strikes, seamlessly navigate to any node to troubleshoot and discover the root cause with the familiar
+Netdata dashboard.
 
 **[Netdata Cloud is free](/docs/cloud/faq-glossary#how-much-does-netdata-cost-how-and-why-is-it-free)**! You can add an
 entire infrastructure of nodes, invite all your colleagues, and visualize any number of metrics, charts, and alarms
 entirely for free.
 
 While Netdata Cloud offers a centralized method of monitoring your Agents, your metrics data is not stored or
-centralized in any way. Metrics data remains with your nodes and is only streamed to your browser through Cloud. 
+centralized in any way. Metrics data remains with your nodes and is only streamed to your browser through Cloud.
 
-In addition, Cloud only expands on the functionality of the wildly popular [free and open source Agent](/docs/agent/).
-We will never make any of our open source Agent features cloud-exclusive, and we will actively continue to develop the
-Agent so that we can integrate new features with Netdata Cloud.
+![cloud-hero-overview](https://user-images.githubusercontent.com/1153921/91363071-9ea38b80-e7b0-11ea-87d9-28b91b360cd1.png)
 
-## Features
+## What you can do with Netdata
 
-t/k
+Netdata is designed to collect everything, help you visualize metrics, troubleshoot complex performance problems, and
+make data interoperable with the rest of your monitoring stack:
+
+-   **Collect**: Netdata collects all available metrics from your system and applications. It uses 300+ collectors,
+    Kubernetes service discovery, in-depth container monitoring, while using only 1% CPU and a few MB of RAM. It even
+    collects metrics from Windows machines.
+-   **Visualize**: The dashboard meaningfully presents charts to to help you understand the relationships between your
+    hardware, operating system, running apps/services, and the rest of your infrastructure. Add nodes to Netdata Cloud
+    for a complete view of your infrastructure from a single pane of glass.
+-   **Monitor**: Netdata's health watchdog uses uses hundreds of preconfigured alarms to notify you via Slack, email,
+    PagerDuty and more when an anomaly strikes. Customize with dynamic thresholds, hysteresis, alarm templates, and
+    role-based notifications.
+-   **Troubleshoot**: 1s granularity helps you detect analyze anomalies other monitoring platforms might have missed.
+    Interactive visualizations reduce your reliance on the console and historical metrics help you trace issues back to
+    their root cause.
+-   **Store**: Netdata's efficient database engine efficiently stores per-second metrics for days, weeks, or even
+    months. Every distributed node stores metrics locally, which simplifies deployment, slashes costs, and enriches
+    Netdata's interactive dashboards.
+-   **Export**: Integrate per-second metrics with other time-series databases like Graphite, Prometheus, InfluxDB,
+    TimescaleDB, and more with Netdata's interoperable and extensible core.
+-   **Stream**: Aggregate metrics from any number of distributed nodes in one place for in-depth analysis, including
+    ephemeral nodes in a Kubernetes cluster.
+
+## What's next?
+
+Learn more about [why you should use Netdata](/docs/overview/why-netdata), or [how Netdata works with your existing
+monitoring stack](/docs/overview/netdata-monitoring-stack).

--- a/docs/overview/what-is-netdata.md
+++ b/docs/overview/what-is-netdata.md
@@ -6,12 +6,11 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/wh
 
 # What is Netdata?
 
-Netdata is distributed, real-time performance and health monitoring for systems and applications. It's designed to help
-sysadmins, SREs, DevOps engineers, and IT professionals collect all metrics, visualize the health of their systems, and
-troubleshoot complex performance problems.
+Netdata helps sysadmins, SREs, DevOps engineers, and IT professionals collect all possible metrics from systems and
+applications, visualize these metrics in real-time, and troubleshoot complex performance problems.
 
-Netdata's solution uses two components, the Netdata Agent and Netdata Cloud, to deliver performance and health
-monitoring for both single and entire infrastructures.
+Netdata's solution uses two components, the Netdata Agent and Netdata Cloud, to deliver real-time performance and health
+monitoring for both single nodes and entire infrastructures.
 
 ## Netdata Agent
 
@@ -36,7 +35,8 @@ entire infrastructure of nodes, invite all your colleagues, and visualize any nu
 entirely for free.
 
 While Netdata Cloud offers a centralized method of monitoring your Agents, your metrics data is not stored or
-centralized in any way. Metrics data remains with your nodes and is only streamed to your browser through Cloud.
+centralized in any way. Metrics data remains with your nodes and is only streamed to your browser, through Cloud, when
+you're viewing the Netdata Cloud interface.
 
 ![cloud-hero-overview](https://user-images.githubusercontent.com/1153921/91363071-9ea38b80-e7b0-11ea-87d9-28b91b360cd1.png)
 
@@ -45,20 +45,20 @@ centralized in any way. Metrics data remains with your nodes and is only streame
 Netdata is designed to be both simple to use and flexible for every monitoring, visualization, and troubleshooting use
 case:
 
--   **Collect**: Netdata collects all available metrics from your system and applications. It uses 300+ collectors,
-    Kubernetes service discovery, in-depth container monitoring, while using only 1% CPU and a few MB of RAM. It even
-    collects metrics from Windows machines.
--   **Visualize**: The dashboard meaningfully presents charts to to help you understand the relationships between your
+-   **Collect**: Netdata collects all available metrics from your system and applications with 300+ collectors,
+    Kubernetes service discovery, and in-depth container monitoring, all while using only 1% CPU and a few MB of RAM. It
+    even collects metrics from Windows machines.
+-   **Visualize**: The dashboard meaningfully presents charts to help you understand the relationships between your
     hardware, operating system, running apps/services, and the rest of your infrastructure. Add nodes to Netdata Cloud
     for a complete view of your infrastructure from a single pane of glass.
--   **Monitor**: Netdata's health watchdog uses uses hundreds of preconfigured alarms to notify you via Slack, email,
+-   **Monitor**: Netdata's health watchdog uses hundreds of preconfigured alarms to notify you via Slack, email,
     PagerDuty and more when an anomaly strikes. Customize with dynamic thresholds, hysteresis, alarm templates, and
     role-based notifications.
 -   **Troubleshoot**: 1s granularity helps you detect analyze anomalies other monitoring platforms might have missed.
-    Interactive visualizations reduce your reliance on the console and historical metrics help you trace issues back to
+    Interactive visualizations reduce your reliance on the console, and historical metrics help you trace issues back to
     their root cause.
 -   **Store**: Netdata's efficient database engine efficiently stores per-second metrics for days, weeks, or even
-    months. Every distributed node stores metrics locally, which simplifies deployment, slashes costs, and enriches
+    months. Every distributed node stores metrics locally, simplifying deployment, slashing costs, and enriching
     Netdata's interactive dashboards.
 -   **Export**: Integrate per-second metrics with other time-series databases like Graphite, Prometheus, InfluxDB,
     TimescaleDB, and more with Netdata's interoperable and extensible core.

--- a/docs/overview/what-is-netdata.md
+++ b/docs/overview/what-is-netdata.md
@@ -6,9 +6,12 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/wh
 
 # What is Netdata?
 
-Netdata is distributed, real-time performance and health monitoring for systems and applications. This solution uses two
-primary components, the Netdata Agent and Netdata Cloud, to offer powerful monitoring, visualization, and
-troubleshooting for both single nodes and entire infrastructures.
+Netdata is distributed, real-time performance and health monitoring for systems and applications. It's designed to help
+sysadmins, SREs, DevOps engineers, and IT professionals collect all metrics, visualize the health of their systems, and
+troubleshoot complex performance problems.
+
+Netdata's solution uses two components, the Netdata Agent and Netdata Cloud, to deliver performance and health
+monitoring for both single and entire infrastructures.
 
 ## Netdata Agent
 
@@ -16,8 +19,8 @@ Netdata's distributed monitoring Agent collects thousands of metrics from system
 configuration. It runs permanently on all your physical/virtual servers, containers, cloud deployments, and edge/IoT
 devices.
 
-You can install Netdata on most Linux distributions (Ubuntu, Debian, CentOS, and more), container platforms (Kubernetes
-clusters, Docker), and many other operating systems (FreeBSD, macOS). No `sudo` required.
+You can install Netdata on most Linux distributions (Ubuntu, Debian, CentOS, and more), container/microservice platforms
+(Kubernetes clusters, Docker), and many other operating systems (FreeBSD, macOS), with no `sudo` required.
 
 ![agent-hero-overview](https://user-images.githubusercontent.com/1153921/91363069-9e0af500-e7b0-11ea-82f1-8cba692ca118.png)
 
@@ -39,8 +42,8 @@ centralized in any way. Metrics data remains with your nodes and is only streame
 
 ## What you can do with Netdata
 
-Netdata is designed to collect everything, help you visualize metrics, troubleshoot complex performance problems, and
-make data interoperable with the rest of your monitoring stack:
+Netdata is designed to be both simple to use and flexible for every monitoring, visualization, and troubleshooting use
+case:
 
 -   **Collect**: Netdata collects all available metrics from your system and applications. It uses 300+ collectors,
     Kubernetes service discovery, in-depth container monitoring, while using only 1% CPU and a few MB of RAM. It even
@@ -66,3 +69,5 @@ make data interoperable with the rest of your monitoring stack:
 
 Learn more about [why you should use Netdata](/docs/overview/why-netdata), or [how Netdata works with your existing
 monitoring stack](/docs/overview/netdata-monitoring-stack).
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Foverview%2Fwhat-is-netdata&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/overview/what-is-netdata.md
+++ b/docs/overview/what-is-netdata.md
@@ -1,0 +1,41 @@
+<!--
+title: "What is Netdata?"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/what-is-netdata.md
+-->
+
+# What is Netdata?
+
+t/k
+
+## Two integrated components: Agent and Cloud
+
+The Netdata solution is composed of two 
+
+## Netdata Agent
+
+t/k
+
+## Netdata Cloud
+
+Netdata Cloud gives you real-time visibility for your entire infrastructure. With Netdata Cloud, you can view key
+metrics, insightful charts, and active alarms from all your nodes in a single web interface. When an anomaly strikes,
+seamlessly navigate to any node to troubleshoot and discover the root cause with the familiar Netdata dashboard.
+
+![Animated GIF of Netdata
+Cloud](https://user-images.githubusercontent.com/1153921/80828986-1ebb3b00-8b9b-11ea-957f-2c8d0d009e44.gif)
+
+**[Netdata Cloud is free](/docs/cloud/faq-glossary#how-much-does-netdata-cost-how-and-why-is-it-free)**! You can add an
+entire infrastructure of nodes, invite all your colleagues, and visualize any number of metrics, charts, and alarms
+entirely for free.
+
+While Netdata Cloud offers a centralized method of monitoring your Agents, your metrics data is not stored or
+centralized in any way. Metrics data remains with your nodes and is only streamed to your browser through Cloud. 
+
+In addition, Cloud only expands on the functionality of the wildly popular [free and open source Agent](/docs/agent/).
+We will never make any of our open source Agent features cloud-exclusive, and we will actively continue to develop the
+Agent so that we can integrate new features with Netdata Cloud.
+
+## Features
+
+t/k

--- a/docs/overview/why-netdata.md
+++ b/docs/overview/why-netdata.md
@@ -6,9 +6,9 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/wh
 
 # Why use Netdata?
 
-Netdata takes a different approach to helping people build extraordinary infrastructure. It was born out of a
-frustration with existing monitoring tools that are too complex, too expensive, and don't help their users actually
-troubleshoot issues. 
+Netdata takes a different approach to helping people build extraordinary infrastructure. It was built out of frustration
+with existing monitoring tools that are too complex, too expensive, and don't help their users actually troubleshoot
+complex performance and health issues.
 
 Netdata is:
 
@@ -34,7 +34,7 @@ Netdata is:
 -   **Visual anomaly detection** with a UI/UX that emphasizes the relationships between charts.
 -   **Customizable dashboards** to pinpoint correlated metrics, respond to incidents, and help you streamline your
     workflows.
--   **Distributed metrics in a centralized interface** to help users or teams trace complex issues between distributed
+-   **Distributed metrics in a centralized interface** to assist users or teams trace complex issues between distributed
     nodes.
 
 ## Comparison with other monitoring solutions

--- a/docs/overview/why-netdata.md
+++ b/docs/overview/why-netdata.md
@@ -1,6 +1,6 @@
 <!--
 title: "Why use Netdata?"
-description: ""
+description: "Netdata is simple to deploy, scalable, and optimized for troubleshooting. Cut the complexity and expense out of your monitoring stack."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/why-use-netdata.md
 -->
 
@@ -56,5 +56,8 @@ open-source tools.
 
 ## What's next?
 
-If you already have a monitoring stack, you may want to read more on [Netdata's
-interoperability](/docs/overview/netdata-monitoring-stack). 
+Whether you already have a monitoring stack you want to integrate Netdata into, or are building something from the
+ground-up, you should read more on how Netdata can work either [standalone or as an interoperable part of a monitoring
+stack](/docs/overview/netdata-monitoring-stack).
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Foverview%2Fwhy-netdata&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/overview/why-netdata.md
+++ b/docs/overview/why-netdata.md
@@ -1,0 +1,9 @@
+<!--
+title: "Why use Netdata?"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/why-use-netdata.md
+-->
+
+# Why use Netdata?
+
+t/k

--- a/docs/overview/why-netdata.md
+++ b/docs/overview/why-netdata.md
@@ -1,7 +1,7 @@
 <!--
 title: "Why use Netdata?"
 description: "Netdata is simple to deploy, scalable, and optimized for troubleshooting. Cut the complexity and expense out of your monitoring stack."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/why-use-netdata.md
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/why-netdata.md
 -->
 
 # Why use Netdata?

--- a/docs/overview/why-netdata.md
+++ b/docs/overview/why-netdata.md
@@ -6,4 +6,55 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/overview/wh
 
 # Why use Netdata?
 
-t/k
+Netdata takes a different approach to helping people build extraordinary infrastructure. It was born out of a
+frustration with existing monitoring tools that are too complex, too expensive, and don't help their users actually
+troubleshoot issues. 
+
+Netdata is:
+
+## Simple to deploy
+
+-   **One-line deployment** for Linux distributions, plus support for Kubernetes/Docker infrastructures
+-   **Zero configuration and maintenance** required to collect thousands of metrics, every second, from the underlying
+    OS and running applications.
+-   **Prebuilt charts and alarms** alert you to common anomalies and performance issues without manual configuration.
+-   **Distributed storage** to simplify the cost and complexity of storing metrics data from any number of nodes.
+
+## Powerful and scalable
+
+-   **1% CPU utilization, a few MB of RAM, and minimal disk I/O** to run the monitoring Agent on bare metal, virtual
+    machines, containers, and even IoT devices.
+-   **Per-second granularity** for an unlimited number of metrics based on the hardware and applications you're running
+    on your nodes.
+-   **Interoperable exporters** let you connect Netdata's per-second metrics with an existing monitoring stack and other
+    time-series databases.
+
+## Optimized for troubleshooting
+
+-   **Visual anomaly detection** with a UI/UX that emphasizes the relationships between charts.
+-   **Customizable dashboards** to pinpoint correlated metrics, respond to incidents, and help you streamline your
+    workflows.
+-   **Distributed metrics in a centralized interface** to help users or teams trace complex issues between distributed
+    nodes.
+
+## Comparison with other monitoring solutions
+
+Netdata offers many benefits over the existing monitoring landscape, whether they're expensive SaaS products or other
+open-source tools.
+
+| Netdata                                                         | Others (open-source and commercial)                              |
+| :-------------------------------------------------------------- | :--------------------------------------------------------------- |
+| **High resolution metrics** (1s granularity)                    | Low resolution metrics (10s granularity at best)                 |
+| Collects **thousands of metrics per node**                      | Collects just a few metrics                                      |
+| Fast UI optimized for **anomaly detection**                     | UI is good for just an abstract view                             |
+| **Long-term, autonomous storage** at one-second granularity     | Centralized metrics in an expensive data lake at 10s granularity |
+| **Meaningful presentation**, to help you understand the metrics | You have to know the metrics before you start                    |
+| Install and get results **immediately**                         | Long sales process and complex installation process              |
+| Use it for **troubleshooting** performance problems             | Only gathers _statistics of past performance_                    |
+| **Kills the console** for tracing performance issues            | The console is always required for troubleshooting               |
+| Requires **zero dedicated resources**                           | Require large dedicated resources                                |
+
+## What's next?
+
+If you already have a monitoring stack, you may want to read more on [Netdata's
+interoperability](/docs/overview/netdata-monitoring-stack). 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This is the first of many PRs for the project on rearchitecting Netdata's documentation. See netdata/netdata-learn-docusaurus#285 for additional context.

Starting with overview content of what Netdata is.

**Some links will not work, as the target docs do not exist yet.**

For now, these PRs will get merged into the `docsv2` but not go live on [Netdata Learn](https://learn.netdata.cloud). Once they're all available, or at least a workable majority, we'll merge them into `master` and deploy the project as a whole.

##### Component Name

area/docs

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
