### PR TITLE
python.d/openldap: fix tls over ldap

### DIFF
--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -150,10 +150,7 @@ class Service(SimpleService):
 
     def disconnect(self):
         if self.conn:
-            if self.use_start_tls or self.use_tls:
-                self.conn.unbind_s()
-            else:
-                self.conn.unbind()
+            self.conn.unbind()
             self.conn = None
             self.alive = False
 
@@ -172,10 +169,7 @@ class Service(SimpleService):
                 self.conn.protocol_version = ldap.VERSION3
                 self.conn.start_tls_s()
             if self.username and self.password:
-                if self.use_start_tls or self.use_tls:
-                    self.conn.simple_bind_s(self.username, self.password)
-                else:
-                    self.conn.simple_bind(self.username, self.password)
+                self.conn.simple_bind(self.username, self.password)
         except ldap.LDAPError as error:
             self.error(error)
             return False

--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -150,7 +150,7 @@ class Service(SimpleService):
 
     def disconnect(self):
         if self.conn:
-            self.conn.unbind()
+            self.conn.unbind_s()
             self.conn = None
             self.alive = False
 

--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -145,7 +145,7 @@ class Service(SimpleService):
         self.use_tls = configuration.get('use_tls', DEFAULT_TLS)
         self.cert_check = configuration.get('cert_check', DEFAULT_CERT_CHECK)
         self.use_start_tls = configuration.get('use_start_tls', DEFAULT_START_TLS)
-	self.alive = False
+        self.alive = False
         self.conn = None
 
     def disconnect(self):
@@ -163,13 +163,12 @@ class Service(SimpleService):
             self.conn.set_option(ldap.OPT_NETWORK_TIMEOUT, self.timeout)
             if (self.use_tls or self.use_start_tls) and not self.cert_check:
                 self.conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
-            if self.use_start_tls: 
-		        self.conn.protocol_version=ldap.VERSION3
-		        self.conn.set_option(ldap.OPT_X_TLS_NEWCTX,0)
-		        self.conn.start_tls_s()
-	    if self.username and self.password:
+            if self.use_start_tls:
+                self.conn.protocol_version=ldap.VERSION3
+                self.conn.set_option(ldap.OPT_X_TLS_NEWCTX,0)
+                self.conn.start_tls_s()
+            if self.username and self.password:
                 self.conn.simple_bind_s(self.username, self.password)
-	
         except ldap.LDAPError as error:
             self.error(error)
             return False

--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -206,10 +206,10 @@ class Service(SimpleService):
             if result_type != 101:
                 continue
 
-            try: 
-                data[key] = int(list(result_data[0][1].values())[0][0]) 
-            except (ValueError, IndexError) as error: 
-                self.debug(error) 
-                continue 
+            try:
+                data[key] = int(list(result_data[0][1].values())[0][0])
+            except (ValueError, IndexError) as error:
+                self.debug(error)
+                continue
 
         return data

--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -163,10 +163,12 @@ class Service(SimpleService):
             self.conn.set_option(ldap.OPT_NETWORK_TIMEOUT, self.timeout)
             if (self.use_tls or self.use_start_tls) and not self.cert_check:
                 self.conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+            if self.use_start_tls or self.use_tls:
+                self.conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
             if self.use_start_tls:
                 self.conn.protocol_version = ldap.VERSION3
-                self.conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
                 self.conn.start_tls_s()
+
             if self.username and self.password:
                 self.conn.simple_bind_s(self.username, self.password)
         except ldap.LDAPError as error:

--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -150,7 +150,10 @@ class Service(SimpleService):
 
     def disconnect(self):
         if self.conn:
-            self.conn.unbind_s()
+            if self.use_start_tls or self.use_tls:
+                self.conn.unbind_s()
+            else:
+                self.conn.unbind()
             self.conn = None
             self.alive = False
 
@@ -168,9 +171,11 @@ class Service(SimpleService):
             if self.use_start_tls:
                 self.conn.protocol_version = ldap.VERSION3
                 self.conn.start_tls_s()
-
             if self.username and self.password:
-                self.conn.simple_bind_s(self.username, self.password)
+                if self.use_start_tls or self.use_tls:
+                    self.conn.simple_bind_s(self.username, self.password)
+                else:
+                    self.conn.simple_bind(self.username, self.password)
         except ldap.LDAPError as error:
             self.error(error)
             return False

--- a/collectors/python.d.plugin/openldap/openldap.chart.py
+++ b/collectors/python.d.plugin/openldap/openldap.chart.py
@@ -164,8 +164,8 @@ class Service(SimpleService):
             if (self.use_tls or self.use_start_tls) and not self.cert_check:
                 self.conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
             if self.use_start_tls:
-                self.conn.protocol_version=ldap.VERSION3
-                self.conn.set_option(ldap.OPT_X_TLS_NEWCTX,0)
+                self.conn.protocol_version = ldap.VERSION3
+                self.conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
                 self.conn.start_tls_s()
             if self.username and self.password:
                 self.conn.simple_bind_s(self.username, self.password)
@@ -203,13 +203,13 @@ class Service(SimpleService):
                 self.alive = False
                 return None
 
-            try:
-                if result_type == 101:
-                    val = int(list(result_data[0][1].values())[0][0])
-            except (ValueError, IndexError) as error:
-                self.debug(error)
+            if result_type != 101:
                 continue
 
-            data[key] = val
+            try: 
+                data[key] = int(list(result_data[0][1].values())[0][0]) 
+            except (ValueError, IndexError) as error: 
+                self.debug(error) 
+                continue 
 
         return data

--- a/collectors/python.d.plugin/openldap/openldap.conf
+++ b/collectors/python.d.plugin/openldap/openldap.conf
@@ -65,10 +65,11 @@ update_every: 10
 
 # Set here your LDAP connection settings
 
-#username : "cn=admin,dc=example,dc=com"   # The bind user with right to access monitor statistics
-#password : "yourpass"                     # The password for the binded user
-#server   : 'localhost'                    # The listening address of the LDAP server. In case of TLS, use the hostname which the certificate is published for.
-#port     : 389                            # The listening port of the LDAP server. Change to 636 port in case of TLS connection
-#use_tls  : False                          # Make True if a TLS connection is used
-#cert_check : True                         # False if you want to ignore certificate check
-#timeout  : 1                              # Seconds to timeout if no connection exi
+#username     : "cn=admin,dc=example,dc=com"   # The bind user with right to access monitor statistics
+#password     : "yourpass"                     # The password for the binded user
+#server       : 'localhost'                    # The listening address of the LDAP server. In case of TLS, use the hostname which the certificate is published for.
+#port         : 389                            # The listening port of the LDAP server. Change to 636 port in case of TLS connection
+#use_tls      : False                          # Make True if a TLS connection is used over ldaps://
+#use_start_tls: False                          # Make True if a TLS connection is used over ldap://
+#cert_check   : True                           # False if you want to ignore certificate check
+#timeout      : 1                              # Seconds to timeout if no connection exi


### PR DESCRIPTION
##### Summary

Since [`ldaps:// `is deprecated](https://www.openldap.org/faq/data/cache/605.html), we use TSL over `ldap://` with `start_tsl` on our LDAP server; that case is not covered by the code.

I added the option `use_start_tls` by `sudo ./edit-config python.d/openldap.conf` and managed them in  `/usr/libexec/netdata/python.d/openldap.chart.py` .

##### Component Name

python.d/openldap

##### Test Plan

I tested it for TSL over `ldap://` with `start_tls`;
we should test if TSL over `ldaps://` is not broken.

##### Additional Information

Related to [issue 9004](https://github.com/netdata/netdata/issues/9004).