### PR TITLE
Removed dependency on libJudy for systems which don't have it.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1125,16 +1125,13 @@ declare -A pkg_openssl=(
 )
 
 declare -A pkg_judy=(
-  ['alpine']="WARNING|" # TODO - need to add code to download and install judy for alpine and clearlinux
-  ['clearlinux']="WARNING|"
-  ['macos']="WARNING|"
   ['debian']="libjudy-dev"
   ['ubuntu']="libjudy-dev"
   ['suse']="judy-devel"
   ['gentoo']="dev-libs/judy"
   ['arch']="judy"
   ['freebsd']="Judy"
-  ['default']="Judy-devel"
+  ['default']="NOTREQUIRED"
 )
 
 declare -A pkg_python3=(


### PR DESCRIPTION
##### Summary

This updates how we handle libJudy in our dependency installation script. Instead of trying to install it everywhere and hoping it works, we now only install it on distros that we know both a system copy available that actually works.

##### Component Name

area/packaging

##### Test Plan

Verified that this behaves correctly in our CI.

##### Additional Information

Followup to: #9776 
Fixes: #9267 
Fixes: #9356 
Fixes: #9605 

This functionally adds CI for #9776 because we test on platforms that will now not have libJudy installed in the testing environment.