### PR TITLE
Fix race condition with orphan hosts

### DIFF
--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -12,7 +12,6 @@ PARSER_RC metalog_pluginsd_host_action(
 {
     int history = 5;
     RRD_MEMORY_MODE mode = RRD_MEMORY_MODE_DBENGINE;
-    int health_enabled = default_health_enabled;
     int rrdpush_enabled = default_rrdpush_enabled;
     char *rrdpush_destination = default_rrdpush_destination;
     char *rrdpush_api_key = default_rrdpush_api_key;
@@ -49,9 +48,6 @@ PARSER_RC metalog_pluginsd_host_action(
     update_every = (int)appconfig_get_number(&stream_config, machine_guid, "update every", update_every);
     if(update_every < 0) update_every = 1;
 
-    //health_enabled = appconfig_get_boolean_ondemand(&stream_config, rpt->key, "health enabled by default", health_enabled);
-    health_enabled = appconfig_get_boolean_ondemand(&stream_config, machine_guid, "health enabled", health_enabled);
-
     //rrdpush_enabled = appconfig_get_boolean(&stream_config, rpt->key, "default proxy enabled", rrdpush_enabled);
     rrdpush_enabled = appconfig_get_boolean(&stream_config, machine_guid, "proxy enabled", rrdpush_enabled);
 
@@ -77,7 +73,7 @@ PARSER_RC metalog_pluginsd_host_action(
         , update_every
         , history   // entries
         , mode
-        , health_enabled    // health enabled
+        , 0    // health enabled
         , rrdpush_enabled   // Push enabled
         , rrdpush_destination  //destination
         , rrdpush_api_key  // api key

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -573,6 +573,12 @@ RRDHOST *rrdhost_find_or_create(
            , rrdpush_send_charts_matching
            , system_info);
     }
+    if (host) {
+        rrdhost_wrlock(host);
+        rrdhost_flag_clear(host, RRDHOST_FLAG_ORPHAN);
+        host->senders_disconnected_time = 0;
+        rrdhost_unlock(host);
+    }
 
     rrdhost_cleanup_orphan_hosts_nolock(host);
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -421,9 +421,7 @@ static int rrdpush_receive(struct receiver_state *rpt)
     }
 */
 
-    rrdhost_flag_clear(rpt->host, RRDHOST_FLAG_ORPHAN);
 //    rpt->host->connected_senders++;
-    rpt->host->senders_disconnected_time = 0;
     rpt->host->labels_flag = (rpt->stream_version > 0)?LABEL_FLAG_UPDATE_STREAM:LABEL_FLAG_STOP_STREAM;
 
     if(health_enabled != CONFIG_BOOLEAN_NO) {
@@ -455,12 +453,20 @@ static int rrdpush_receive(struct receiver_state *rpt)
     if (!netdata_exit && rpt->host) {
         netdata_mutex_lock(&rpt->host->receiver_lock);
         if (rpt->host->receiver == rpt) {
+            netdata_mutex_unlock(&rpt->host->receiver_lock);
+
+            rrd_wrlock();
             rrdhost_wrlock(rpt->host);
             rpt->host->senders_disconnected_time = now_realtime_sec();
             rrdhost_flag_set(rpt->host, RRDHOST_FLAG_ORPHAN);
             if(health_enabled == CONFIG_BOOLEAN_AUTO)
                 rpt->host->health_enabled = 0;
             rrdhost_unlock(rpt->host);
+            rrd_unlock();
+
+            netdata_mutex_lock(&rpt->host->receiver_lock);
+        }
+        if (rpt->host->receiver == rpt) {
             rrdpush_sender_thread_stop(rpt->host);
         }
         netdata_mutex_unlock(&rpt->host->receiver_lock);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -451,7 +451,7 @@ static int rrdpush_receive(struct receiver_state *rpt)
 
     // During a shutdown there is cleanup code in rrdhost that will cancel the sender thread
     if (!netdata_exit && rpt->host) {
-        rrd_wrlock();
+        rrd_rdlock();
         rrdhost_wrlock(rpt->host);
         netdata_mutex_lock(&rpt->host->receiver_lock);
         if (rpt->host->receiver == rpt) {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #9627
##### Component Name
streaming
##### Test plan
1. Create a 1000 node streaming set-up.
2. Use `dbengine`, disable health for streaming, delete the cache.
2. Use master code, observe crash.
3. Delete the cache again.
4. Use this PR, observe no crash.
5. Restart the agent, observe health is still disabled for all child hosts, no crash.
6. Enable health for streaming.
7. Restart the agent, observe health is enabled for all child hosts.