### PR TITLE
Add quickstart docs to docsv2 project

### DIFF
--- a/docs/quickstart/infrastructure.md
+++ b/docs/quickstart/infrastructure.md
@@ -5,6 +5,8 @@ description: "Build a robust, infinitely-scalable infrastructure monitoring solu
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/infrastructure.md
 -->
 
+# Infrastructure monitoring with Netdata
+
 Together, the Netdata Agent and Netdata Cloud create a powerful, infinitely-scalable infrastructure monitoring solution.
 
 The Netdata Agent uses zero-configuration collectors to instantly gather metrics from every application and container,

--- a/docs/quickstart/infrastructure.md
+++ b/docs/quickstart/infrastructure.md
@@ -5,6 +5,93 @@ description: "."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/infrastructure.md
 -->
 
-t/k
+While the free, open-source Netdata Agent is a surpurb single-node monitoring tool, it also works in parallel with
+Netdata Cloud to create a unified infrastructure monitoring tool.
+
+The Netdata Agent turns each node in your infrastructure into a distributed metrics collection and storage system, and then Netdat Cloud puts real-time metrics from every node into a single interface.
+
+In this quickstart guide, you'll learn how to see key metrics from all your nodes in one interface, and build your first
+dashboard for aggregating like metrics from many distributed nodes. You'll then take a peek into configuring individual
+nodes and tweaking collectors to gather metrics on every critical application.
+
+> This quickstart assumes you've installed the Netdata Agent on more than one node in your infrastructure, and claimed
+> that node to your Space in Netdata Cloud. If you haven't yet, see the [_Get Netdata_ doc](/docs/get/README.md) for
+> details on installation and claiming.
+
+## See your infrastructure's metrics
+
+To see all your nodes from a single pane of glass, first [sign in](https://app.netdata.cloud) to Netdata Cloud. You
+should immediately see all your nodes on a single interface inside of your Space.
+
+![Animated GIF of Netdata
+Cloud](https://user-images.githubusercontent.com/1153921/80828986-1ebb3b00-8b9b-11ea-957f-2c8d0d009e44.gif)
+
+You can [organize your nodes](/docs/configure/spaces-war-rooms.md) into **War Rooms** based on your preferred strategy.
+Most Netdata Cloud users set up War Rooms based on the node's purpose or the primary application it's responsible for
+running.
+
+Once you've properly set up your Space, you can [invite your team](/docs/configure/invite-collaborate.md) and
+collaborate on identifying anomalies or troubleshooting complex performance problems.
+
+> If you want to monitor a Kubernetes cluster with Netdata, see our [k8s installation
+> doc](/packaging/installer/methods/kubernetes.md) and read our guide, [_Monitor a Kubernetes cluster with
+> Netdata_](/docs/guides/kubernetes-k8s-netdata.md).
+
+## Build new dashboards for your infrastructure
+
+
+
+## Configure your nodes
+
+You can configure any node in your infrastructure based on its unique needs, whether that's to store more metrics
+locally, reduce the frequency of data collection, or reduce resource usage.
+
+Each node has a configuration file called `netdata.conf`, which is typically at `/etc/netdata/netdata.conf`. The best
+way to edit this file is using the `edit-config` script, which ensures the configuration changes you make are not
+overwritten by updates to the Netdata Agent. For example:
+
+```bash
+cd /etc/netdata
+sudo ./edit-config netdata.conf
+```
+
+Our [configuration basics doc](/docs/configure/nodes.md) contains more information about `netdata.conf`, `edit-config`,
+along with simple examples to get you familiar with editing your node's configuration.
+
+After you've learned the basics, you should [secure your infrastructure's nodes](/docs/configure/secure-nodes.md) using
+one of our recommended methods. These security best practices ensure no untrusted parties gain access to the metrics
+collected on any of your nodes.
+
+## Collect metrics from your system and applications
+
+Netdata has [300+ pre-installed collectors](/docs/collectors/COLLECTORS.md) that gather thousands of metrics with zero
+configuration. In fact, Netdata is already collecting thousands of metrics per second on your single node, all without
+you setting it up first.
+
+These collectors search your system in default locations and ports to find the applications running on your node and
+gather as many metrics. The dashboard presents them meaningfully in charts to help you understand the baseline and
+identify anomalies.
+
+You may need to set up specific collectors for them to work, or you might want to configure a specific collector's
+behavior. Read more about [collector configuration](/docs/collect/configuration.md), or find detailed information about
+which [system](/docs/collect/system-metrics.md), [container](/docs/collect/container-metrics.md), and
+[application](/docs/collect/application-metrics.md) metrics you can collect with Netdata.
+
+## What's next?
+
+Netdata has many features that help you monitor the health of your node and troubleshoot complex performance problems.
+Once you have a handle on configuration and are collecting all the right metrics, try out some of Netdata's other
+features:
+
+-   [Build new dashboards](/docs/visualize/create-dashboards.md) to put disparate-but-relevant metrics onto a single
+    interface.
+-   [Create new alarms](/docs/monitor/configure-alarms.md), or tweak some of the pre-configured alarms, to stay on top
+    of anomalies.
+-   [Enable notifications](/docs/monitor/enable-notifications.md) to Slack, PagerDuty, email, and 30+ other services.
+-   [Change how long your node stores metrics](/docs/store/change-metrics-retention.md) based on how many metrics it
+    collects, your preferred retention period, and the resources you want to dedicate toward long-term metrics
+    retention.
+-   [Export metrics](/docs/export/enable-exporting.md) to an external time-series database to use Netdata alongside
+    other monitoring and troubleshooting tools.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fquickstart%2Finfrastructure&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/quickstart/infrastructure.md
+++ b/docs/quickstart/infrastructure.md
@@ -1,7 +1,7 @@
 <!--
 title: "Infrastructure monitoring with Netdata"
 sidebar_label: "Infrastructure monitoring"
-description: "Build a robust, infinitely-scalable infrastructure monitoring solution with Netdata. "
+description: "Build a robust, infinitely scalable infrastructure monitoring solution with Netdata. Any number of nodes and every available metric."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/infrastructure.md
 -->
 
@@ -10,14 +10,13 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/
 Together, the Netdata Agent and Netdata Cloud create a powerful, infinitely-scalable infrastructure monitoring solution.
 
 The Netdata Agent uses zero-configuration collectors to gather metrics from every application and container instantly.
-The distributed data model lets you monitor everything at a fraction of the cost compared to centralized metrics
-databases. Netdata Cloud unifies all the metrics from these distributed nodes on customizable, interactive, and
-real-time visualizations.
+The distributed data model lets you monitor everything without a slow and troublesome centralized data lake for your
+infrastructure's metrics, reducing the resources you need to invest in metrics retention. Netdata Cloud unifies all the
+metrics from these distributed nodes on customizable, interactive, and real-time visualizations.
 
 In this quickstart guide, you'll learn how to see key metrics from all your nodes in one interface and build your first
 dashboard for aggregating like metrics from many distributed nodes. You'll then take a peek into configuring individual
-nodes, in addition to helpful pointers about collecting all the metrics from every critical application in your
-infrastructure.
+nodes and get helpful pointers about collecting all the metrics from every critical application in your infrastructure.
 
 > This quickstart assumes you've installed the Netdata Agent on more than one node in your infrastructure, and claimed
 > that node to your Space in Netdata Cloud. If you haven't yet, see the [_Get Netdata_ doc](/docs/get/README.md) for
@@ -28,7 +27,7 @@ infrastructure.
 To see all your nodes from a single pane of glass, first [sign in](https://app.netdata.cloud) to Netdata Cloud. As you
 sign in, Netdata Cloud pings each claimed node to start on-demand streaming from your nodes to your browser. When
 Netdata Cloud loads your War Room's **Nodes** view, you'll immediately see key metrics from your nodes, streamed in
-real-time, in a single interface.
+real time, in a single interface.
 
 ![Animated GIF of Netdata
 Cloud](https://user-images.githubusercontent.com/1153921/80828986-1ebb3b00-8b9b-11ea-957f-2c8d0d009e44.gif)
@@ -54,7 +53,7 @@ issues by aggregating correlated charts from any number of nodes.
 
 To build your first dashboard, click on the **Nodes** dropdown, then select **+ Add**. Enter a name to assign to this
 dashboard. Click on either of the **Add chart** buttons, then select the node you want to add a chart from. Select the
-context, which are Netdata's way to organize charts, and then click **Add chart**.
+context, which os Netdata's way to organize charts, and then click **Add chart**.
 
 Once you added a few charts, you can move them around, resize them, and add text. Make sure you click the **Save**
 button before you navigate away.
@@ -83,7 +82,7 @@ After you've learned the basics, you should [secure your infrastructure's nodes]
 one of our recommended methods. These security best practices ensure no untrusted parties gain access to the metrics
 collected on any of your nodes.
 
-## Collect metrics from your system and applications
+## Collect metrics from your systems and applications
 
 Netdata has [300+ pre-installed collectors](/docs/collectors/COLLECTORS.md) that gather thousands of metrics with zero
 configuration. Collectors search each of your nodes in default locations and ports to find running applications and
@@ -105,7 +104,7 @@ collect from across your infrastructure with Netdata.
 
 ## What's next?
 
-Netdata has many features that help you monitor the health of your node and troubleshoot complex performance problems.
+Netdata has many features that help you monitor the health of your nodes and troubleshoot complex performance problems.
 Once you have a handle on configuration and are collecting all the right metrics, try out some of Netdata's other
 infrastructure-focused features:
 

--- a/docs/quickstart/infrastructure.md
+++ b/docs/quickstart/infrastructure.md
@@ -9,12 +9,12 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/
 
 Together, the Netdata Agent and Netdata Cloud create a powerful, infinitely-scalable infrastructure monitoring solution.
 
-The Netdata Agent uses zero-configuration collectors to instantly gather metrics from every application and container,
-and the distributed data model lets you monitor everything at a fraction of the cost compared to centralized metrics
+The Netdata Agent uses zero-configuration collectors to gather metrics from every application and container instantly.
+The distributed data model lets you monitor everything at a fraction of the cost compared to centralized metrics
 databases. Netdata Cloud unifies all the metrics from these distributed nodes on customizable, interactive, and
 real-time visualizations.
 
-In this quickstart guide, you'll learn how to see key metrics from all your nodes in one interface, and build your first
+In this quickstart guide, you'll learn how to see key metrics from all your nodes in one interface and build your first
 dashboard for aggregating like metrics from many distributed nodes. You'll then take a peek into configuring individual
 nodes, in addition to helpful pointers about collecting all the metrics from every critical application in your
 infrastructure.
@@ -26,7 +26,7 @@ infrastructure.
 ## See your infrastructure's metrics
 
 To see all your nodes from a single pane of glass, first [sign in](https://app.netdata.cloud) to Netdata Cloud. As you
-sign in, Netdata Cloud pings each of claimed node to start on-demand streaming from your nodes to your browser. When
+sign in, Netdata Cloud pings each claimed node to start on-demand streaming from your nodes to your browser. When
 Netdata Cloud loads your War Room's **Nodes** view, you'll immediately see key metrics from your nodes, streamed in
 real-time, in a single interface.
 
@@ -38,8 +38,8 @@ You can drill down into any node's full dashboard by clicking on that node's hos
 ![Screenshot of an embedded node
 dashboard](https://user-images.githubusercontent.com/1153921/87457036-9b678e00-c5bc-11ea-977d-ad561a73beef.png)
 
-You can use node dashboards to drill down on specific issues, scrub backwards in time to investigate historical data,
-and see like metrics presented meaningfully to help you in [visual anomaly
+You can use node dashboards to drill down on specific issues, scrub backward in time to investigate historical data, and
+see like metrics presented meaningfully to help you in [visual anomaly
 detection](/docs/troubleshoot/visual-anomaly-detection.md). Learn about [interacting with dashboards and
 charts](/docs/visualize/interact-dashboards-charts.md) to get the most from all of Netdata's real-time metrics.
 
@@ -49,8 +49,8 @@ charts](/docs/visualize/interact-dashboards-charts.md) to get the most from all 
 
 ## Build new dashboards for your infrastructure
 
-You can use Netdata Cloud to build new dashboards that match the topology of your infrastructure or assist you in
-diagnosing very specific issues by aggregating correlated charts from any number of nodes.
+You can use Netdata Cloud to build new dashboards that match your infrastructure's topology or help you diagnose complex
+issues by aggregating correlated charts from any number of nodes.
 
 To build your first dashboard, click on the **Nodes** dropdown, then select **+ Add**. Enter a name to assign to this
 dashboard. Click on either of the **Add chart** buttons, then select the node you want to add a chart from. Select the
@@ -68,8 +68,8 @@ You can configure any node in your infrastructure if you need to, although most 
 work extremely well for monitoring their infrastructures.
 
 Each node has a configuration file called `netdata.conf`, which is typically at `/etc/netdata/netdata.conf`. The best
-way to edit this file is using the `edit-config` script, which ensures the configuration changes you make are not
-overwritten by updates to the Netdata Agent. For example:
+way to edit this file is using the `edit-config` script, which ensures updates to the Netdata Agent do not overwrite
+your changes. For example:
 
 ```bash
 cd /etc/netdata

--- a/docs/quickstart/infrastructure.md
+++ b/docs/quickstart/infrastructure.md
@@ -1,0 +1,10 @@
+<!--
+title: "Infrastructure monitoring with Netdata"
+sidebar_label: "Infrastructure monitoring"
+description: "."
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/infrastructure.md
+-->
+
+t/k
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fquickstart%2Finfrastructure&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/quickstart/infrastructure.md
+++ b/docs/quickstart/infrastructure.md
@@ -1,19 +1,21 @@
 <!--
 title: "Infrastructure monitoring with Netdata"
 sidebar_label: "Infrastructure monitoring"
-description: "."
+description: "Build a robust, infinitely-scalable infrastructure monitoring solution with Netdata. "
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/infrastructure.md
 -->
 
-While the free, open-source Netdata Agent is a surpurb single-node monitoring tool, it also works in parallel with
-Netdata Cloud to create a unified infrastructure monitoring tool.
+Together, the Netdata Agent and Netdata Cloud create a powerful, infinitely-scalable infrastructure monitoring solution.
 
-The Netdata Agent turns each node in your infrastructure into a distributed metrics collection and storage system, and
-then Netdat Cloud puts real-time metrics from every node into a single interface.
+The Netdata Agent uses zero-configuration collectors to instantly gather metrics from every application and container,
+and the distributed data model lets you monitor everything at a fraction of the cost compared to centralized metrics
+databases. Netdata Cloud unifies all the metrics from these distributed nodes on customizable, interactive, and
+real-time visualizations.
 
 In this quickstart guide, you'll learn how to see key metrics from all your nodes in one interface, and build your first
 dashboard for aggregating like metrics from many distributed nodes. You'll then take a peek into configuring individual
-nodes and tweaking collectors to gather metrics on every critical application.
+nodes, in addition to helpful pointers about collecting all the metrics from every critical application in your
+infrastructure.
 
 > This quickstart assumes you've installed the Netdata Agent on more than one node in your infrastructure, and claimed
 > that node to your Space in Netdata Cloud. If you haven't yet, see the [_Get Netdata_ doc](/docs/get/README.md) for
@@ -111,7 +113,7 @@ infrastructure-focused features:
 -   [Export metrics](/docs/export/enable-exporting.md) to an external time-series database to use Netdata alongside
     other monitoring and troubleshooting tools.
 
-If you want to get granular with 
+To change how the Netdata Agent runs on each node, dig in to configuration files:
 
 -   [Change how long nodes in your infrastructure retain metrics](/docs/store/change-metrics-retention.md) based on how
     many metrics each node collects, your preferred retention period, and the resources you want to dedicate toward

--- a/docs/quickstart/infrastructure.md
+++ b/docs/quickstart/infrastructure.md
@@ -8,7 +8,8 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/
 While the free, open-source Netdata Agent is a surpurb single-node monitoring tool, it also works in parallel with
 Netdata Cloud to create a unified infrastructure monitoring tool.
 
-The Netdata Agent turns each node in your infrastructure into a distributed metrics collection and storage system, and then Netdat Cloud puts real-time metrics from every node into a single interface.
+The Netdata Agent turns each node in your infrastructure into a distributed metrics collection and storage system, and
+then Netdat Cloud puts real-time metrics from every node into a single interface.
 
 In this quickstart guide, you'll learn how to see key metrics from all your nodes in one interface, and build your first
 dashboard for aggregating like metrics from many distributed nodes. You'll then take a peek into configuring individual
@@ -20,31 +21,47 @@ nodes and tweaking collectors to gather metrics on every critical application.
 
 ## See your infrastructure's metrics
 
-To see all your nodes from a single pane of glass, first [sign in](https://app.netdata.cloud) to Netdata Cloud. You
-should immediately see all your nodes on a single interface inside of your Space.
+To see all your nodes from a single pane of glass, first [sign in](https://app.netdata.cloud) to Netdata Cloud. As you
+sign in, Netdata Cloud pings each of claimed node to start on-demand streaming from your nodes to your browser. When
+Netdata Cloud loads your War Room's **Nodes** view, you'll immediately see key metrics from your nodes, streamed in
+real-time, in a single interface.
 
 ![Animated GIF of Netdata
 Cloud](https://user-images.githubusercontent.com/1153921/80828986-1ebb3b00-8b9b-11ea-957f-2c8d0d009e44.gif)
 
-You can [organize your nodes](/docs/configure/spaces-war-rooms.md) into **War Rooms** based on your preferred strategy.
-Most Netdata Cloud users set up War Rooms based on the node's purpose or the primary application it's responsible for
-running.
+You can drill down into any node's full dashboard by clicking on that node's hostname in the Nodes view.
 
-Once you've properly set up your Space, you can [invite your team](/docs/configure/invite-collaborate.md) and
-collaborate on identifying anomalies or troubleshooting complex performance problems.
+![Screenshot of an embedded node
+dashboard](https://user-images.githubusercontent.com/1153921/87457036-9b678e00-c5bc-11ea-977d-ad561a73beef.png)
+
+You can use node dashboards to drill down on specific issues, scrub backwards in time to investigate historical data,
+and see like metrics presented meaningfully to help you in [visual anomaly
+detection](/docs/troubleshoot/visual-anomaly-detection.md). Learn about [interacting with dashboards and
+charts](/docs/visualize/interact-dashboards-charts.md) to get the most from all of Netdata's real-time metrics.
 
 > If you want to monitor a Kubernetes cluster with Netdata, see our [k8s installation
-> doc](/packaging/installer/methods/kubernetes.md) and read our guide, [_Monitor a Kubernetes cluster with
-> Netdata_](/docs/guides/kubernetes-k8s-netdata.md).
+> doc](/packaging/installer/methods/kubernetes.md) for setup details, and then read our guide, [_Monitor a Kubernetes
+> cluster with Netdata_](/docs/guides/kubernetes-k8s-netdata.md).
 
 ## Build new dashboards for your infrastructure
 
+You can use Netdata Cloud to build new dashboards that match the topology of your infrastructure or assist you in
+diagnosing very specific issues by aggregating correlated charts from any number of nodes.
 
+To build your first dashboard, click on the **Nodes** dropdown, then select **+ Add**. Enter a name to assign to this
+dashboard. Click on either of the **Add chart** buttons, then select the node you want to add a chart from. Select the
+context, which are Netdata's way to organize charts, and then click **Add chart**.
+
+Once you added a few charts, you can move them around, resize them, and add text. Make sure you click the **Save**
+button before you navigate away.
+
+Read more about [creating new dashboards](/docs/visualize/create-dashboard.md) for more details about the process and
+additional tips on best leveraging the feature to help you troubleshoot complex performance problems.
 
 ## Configure your nodes
 
-You can configure any node in your infrastructure based on its unique needs, whether that's to store more metrics
-locally, reduce the frequency of data collection, or reduce resource usage.
+You can configure any node in your infrastructure if you need to, although most users will find the default settings
+work extremely well for monitoring their infrastructures.
 
 Each node has a configuration file called `netdata.conf`, which is typically at `/etc/netdata/netdata.conf`. The best
 way to edit this file is using the `edit-config` script, which ensures the configuration changes you make are not
@@ -65,33 +82,42 @@ collected on any of your nodes.
 ## Collect metrics from your system and applications
 
 Netdata has [300+ pre-installed collectors](/docs/collectors/COLLECTORS.md) that gather thousands of metrics with zero
-configuration. In fact, Netdata is already collecting thousands of metrics per second on your single node, all without
-you setting it up first.
+configuration. Collectors search each of your nodes in default locations and ports to find running applications and
+gather as many metrics as they can without you having to configure them individually.
 
-These collectors search your system in default locations and ports to find the applications running on your node and
-gather as many metrics. The dashboard presents them meaningfully in charts to help you understand the baseline and
-identify anomalies.
+In fact, Netdata is already collecting thousands of metrics per second from your webservers, databases, containers, and
+much more, on each node in your infrastructure.
 
-You may need to set up specific collectors for them to work, or you might want to configure a specific collector's
-behavior. Read more about [collector configuration](/docs/collect/configuration.md), or find detailed information about
-which [system](/docs/collect/system-metrics.md), [container](/docs/collect/container-metrics.md), and
-[application](/docs/collect/application-metrics.md) metrics you can collect with Netdata.
+These metrics enrich your Netdata Cloud experience. You can see metrics from systems, containers, and applications in
+the individual node dashboards, and you can create new dashboards around very specific charts, such as the real-time
+volume of 503 responses from each of your webserver nodes.
+
+Most collectors work without configuring them, but you should read up on how [collector
+configuration](/docs/collect/configure.md) works.
+
+In addition, find detailed information about which [system](/docs/collect/system-metrics.md),
+[container](/docs/collect/container-metrics.md), and [application](/docs/collect/application-metrics.md) metrics you can
+collect from across your infrastructure with Netdata.
 
 ## What's next?
 
 Netdata has many features that help you monitor the health of your node and troubleshoot complex performance problems.
 Once you have a handle on configuration and are collecting all the right metrics, try out some of Netdata's other
-features:
+infrastructure-focused features:
 
--   [Build new dashboards](/docs/visualize/create-dashboards.md) to put disparate-but-relevant metrics onto a single
-    interface.
+-   [Organize your nodes](/docs/configure/spaces-war-rooms.md) into **War Rooms** based on your preferred strategy.
+-   [Invite your team](/docs/configure/invite-collaborate.md) to collaborate on identifying anomalies or troubleshooting
+    complex performance problems.
+-   [Export metrics](/docs/export/enable-exporting.md) to an external time-series database to use Netdata alongside
+    other monitoring and troubleshooting tools.
+
+If you want to get granular with 
+
+-   [Change how long nodes in your infrastructure retain metrics](/docs/store/change-metrics-retention.md) based on how
+    many metrics each node collects, your preferred retention period, and the resources you want to dedicate toward
+    long-term metrics retention.
 -   [Create new alarms](/docs/monitor/configure-alarms.md), or tweak some of the pre-configured alarms, to stay on top
     of anomalies.
 -   [Enable notifications](/docs/monitor/enable-notifications.md) to Slack, PagerDuty, email, and 30+ other services.
--   [Change how long your node stores metrics](/docs/store/change-metrics-retention.md) based on how many metrics it
-    collects, your preferred retention period, and the resources you want to dedicate toward long-term metrics
-    retention.
--   [Export metrics](/docs/export/enable-exporting.md) to an external time-series database to use Netdata alongside
-    other monitoring and troubleshooting tools.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fquickstart%2Finfrastructure&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/quickstart/single-node.md
+++ b/docs/quickstart/single-node.md
@@ -8,7 +8,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/
 # Single-node monitoring with Netdata
 
 Because it's free, open-source, and requires only 1% CPU utilization to collect thousands of metrics every second,
-Netdata is a surpurb single-node monitoring tool.
+Netdata is a superb single-node monitoring tool.
 
 In this quickstart guide, you'll learn how to access your single node's metrics through dashboards, configure your node
 to your liking, and make sure the Netdata Agent is collecting metrics from the applications or containers you're running
@@ -20,12 +20,12 @@ on your node.
 
 ## See your node's metrics
 
-To see your node's real-time metrics, you can either access the node's local dashboard or through Netdata Cloud. The
-navigation, charts, and metrics are identical with both methods. In addition, both dashboards update with new metrics in
-real-time, with fully interactive and synchronized charts.
+To see your node's real-time metric, you need to access its dashboard. You can either view the local dashboard, which
+runs on the node itself, or see the dashboard through Netdata Cloud. Both methods feature real-time, interactive, and
+synchronized charts, with the same metrics, and use the same UI.
 
-The primary difference is that Netdata Cloud also has a few extra features, like creating new dashboards, that you might
-want to use for monitoring your node.
+The primary difference is that Netdata Cloud also has a few extra features, like creating new dashboards using a
+drag-and-drop editor, that enhance your monitoring and troubleshooting experience.
 
 To see your node's local dashboard, open up your web browser of choice and navigate to `http://NODE:19999`, replacing
 `NODE` with the IP address or hostname of your Agent. Hit `Enter`. 
@@ -34,20 +34,20 @@ To see your node's local dashboard, open up your web browser of choice and navig
 dashboard](https://user-images.githubusercontent.com/1153921/80825153-abaec600-8b94-11ea-8b17-1b770a2abaa9.gif)
 
 To see a node's dashboard in Netdata Cloud, [sign in](https://app.netdata.cloud). From the **Nodes** view in your
-**General** War Room, click on the hostname of your node to access its dashboard.
+**General** War Room, click on the hostname of your node to access its dashboard through Netdata Cloud.
 
 ![Screenshot of an embedded node
 dashboard](https://user-images.githubusercontent.com/1153921/87457036-9b678e00-c5bc-11ea-977d-ad561a73beef.png)
 
 Once you've decided which dashboard you prefer, learn about [interacting with dashboards and
-charts](/docs/visualize/interact-dashboards-charts.md) to get the most from all of Netdata's real-time metrics.
+charts](/docs/visualize/interact-dashboards-charts.md) to get the most from Netdata's real-time metrics.
 
 ## Configure your node
 
 The Netdata Agent is highly configurable so that you can match its behavior to your node. You will find most
 configuration options in the `netdata.conf` file, which is typically at `/etc/netdata/netdata.conf`. The best way to
-edit this file is using the `edit-config` script, which ensures the configuration changes you make are not overwritten
-by updates to the Netdata Agent yourself. For example:
+edit this file is using the `edit-config` script, which ensures updates to the Netdata Agent do not overwrite your
+changes. For example:
 
 ```bash
 cd /etc/netdata
@@ -65,7 +65,7 @@ metrics.
 
 Netdata has [300+ pre-installed collectors](/docs/collectors/COLLECTORS.md) that gather thousands of metrics with zero
 configuration. Collectors search your node in default locations and ports to find running applications and gather as
-many metrics as they can without you having to configure them individually.
+many metrics as possible without you having to configure them individually.
 
 These metrics enrich both the local and Netdata Cloud dashboards.
 
@@ -79,8 +79,8 @@ collect from across your infrastructure with Netdata.
 ## What's next?
 
 Netdata has many features that help you monitor the health of your node and troubleshoot complex performance problems.
-Once you have a handle on configuration and are collecting all the right metrics, try out some of Netdata's other
-features:
+Once you understand configuration, and are certain Netdata is collecting all the important metrics from your node, try
+out some of Netdata's other visualization and health monitoring features:
 
 -   [Build new dashboards](/docs/visualize/create-dashboards.md) to put disparate-but-relevant metrics onto a single
     interface.

--- a/docs/quickstart/single-node.md
+++ b/docs/quickstart/single-node.md
@@ -5,6 +5,8 @@ description: "Learn dashboard basics, configuring your nodes, and collecting met
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/single-node.md
 -->
 
+# Single-node monitoring with Netdata
+
 Because it's free, open-source, and requires only 1% CPU utilization to collect thousands of metrics every second,
 Netdata is a surpurb single-node monitoring tool.
 

--- a/docs/quickstart/single-node.md
+++ b/docs/quickstart/single-node.md
@@ -1,10 +1,94 @@
 <!--
 title: "Single-node monitoring with Netdata"
 sidebar_label: "Single-node monitoring"
-description: "."
+description: "Learn dashboard basics, configuring your nodes, and collecting metrics from applications to create a powerful single-node monitoring tool."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/single-node.md
 -->
 
-t/k
+Because it's free, open-source, and requires only 1% CPU utilization to collect thousands of metrics every second,
+Netdata is a surpurb single-node monitoring tool.
+
+In this quickstart guide, you'll learn how to access your single node's metrics through dashboards, configure your node
+to your liking, and make sure the Netdata Agent is collecting metrics from the applications or containers you're running
+on your node.
+
+> This quickstart assumes you installed the Netdaat Agent on your node. If you haven't yet, see the [_Get Netdata_
+> doc](/docs/get/README.md) for details on installation. In addition, this quickstart mentions features available only
+> through Netdata Cloud, which requires you to [claim your node](/docs/get/README.md#claim-your-node-on-netdata-cloud).
+
+## See your node's metrics
+
+To see your node's real-time metrics, you can either access the node's dashboard directly or through Netdata Cloud. The
+navigation, charts, and metrics are identical with both methods. In addition, both dashboards update with new metrics in
+real-time, with fully interactive and synchronized charts.
+
+The primary difference is thatNetdata Cloud also has a few extra features, like creating new dashboards, that you might
+want to use for monitoring your node.
+
+To see your node's dashboard directly, open up your web browser of choice and navigate to `http://NODE:19999`, replacing
+`NODE` with the IP address or hostname of your Agent. Hit `Enter`. 
+
+![Animated GIF of navigating to the
+dashboard](https://user-images.githubusercontent.com/1153921/80825153-abaec600-8b94-11ea-8b17-1b770a2abaa9.gif)
+
+To see a node's dashboard in Netdata Cloud, [sign in](https://app.netdata.cloud). From the **Nodes** view in your
+**General** War Room, click on the hostname of your node to access its dashboard.
+
+![Screenshot of an embedded node
+dashboard](https://user-images.githubusercontent.com/1153921/87457036-9b678e00-c5bc-11ea-977d-ad561a73beef.png)
+
+Once you've decided which dashboard you prefer, learn about [interacting with dashboards and
+charts](/docs/visualize/interact-dashboards-charts.md) to get the most from all of Netdata's real-time metrics.
+
+## Configure your node
+
+The Netdata Agent is highly configurable so that you can match its behavior to your node. You will find most
+configuration options in the `netdata.conf` file, which is typically at `/etc/netdata/netdata.conf`. The best way to
+edit this file is using the `edit-config` script, which ensures the configuration changes you make are not overwritten
+by updates to the Netdata Agent yourself. For example:
+
+```bash
+cd /etc/netdata
+sudo ./edit-config netdata.conf
+```
+
+Our [configuration basics doc](/docs/configure/nodes.md) contains more information about `netdata.conf`, `edit-config`,
+along with simple examples to get you familiar with editing your node's configuration.
+
+After you've learned the basics, you should [secure your node](/docs/configure/secure-nodes.md) using one of our
+recommended methods. These security best practices ensure no untrusted parties gain access to your dashboard or its
+metrics.
+
+## Collect metrics from your system and applications
+
+Netdata has [300+ pre-installed collectors](/docs/collectors/COLLECTORS.md) that gather thousands of metrics with zero
+configuration. In fact, Netdata is already collecting thousands of metrics per second on your single node, all without
+you setting it up first.
+
+These collectors search your system in default locations and ports to find the applications running on your node and
+gather as many metrics. The dashboard presents them meaningfully in charts to help you understand the baseline and
+identify anomalies.
+
+You may need to set up specific collectors for them to work, or you might want to configure a specific collector's
+behavior. Read more about [collector configuration](/docs/collect/configuration.md), or find detailed information about
+which [system](/docs/collect/system-metrics.md), [container](/docs/collect/container-metrics.md), and
+[application](/docs/collect/application-metrics.md) metrics you can collect with Netdata.
+
+## What's next?
+
+Netdata has many features that help you monitor the health of your node and troubleshoot complex performance problems.
+Once you have a handle on configuration and are collecting all the right metrics, try out some of Netdata's other
+features:
+
+-   [Build new dashboards](/docs/visualize/create-dashboards.md) to put disparate-but-relevant metrics onto a single
+    interface.
+-   [Create new alarms](/docs/monitor/configure-alarms.md), or tweak some of the pre-configured alarms, to stay on top
+    of anomalies.
+-   [Enable notifications](/docs/monitor/enable-notifications.md) to Slack, PagerDuty, email, and 30+ other services.
+-   [Change how long your node stores metrics](/docs/store/change-metrics-retention.md) based on how many metrics it
+    collects, your preferred retention period, and the resources you want to dedicate toward long-term metrics
+    retention.
+-   [Export metrics](/docs/export/enable-exporting.md) to an external time-series database to use Netdata alongside
+    other monitoring and troubleshooting tools.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fquickstart%2Fsingle-node&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/quickstart/single-node.md
+++ b/docs/quickstart/single-node.md
@@ -1,0 +1,10 @@
+<!--
+title: "Single-node monitoring with Netdata"
+sidebar_label: "Single-node monitoring"
+description: "."
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/quickstart/single-node.md
+-->
+
+t/k
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fquickstart%2Fsingle-node&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/quickstart/single-node.md
+++ b/docs/quickstart/single-node.md
@@ -18,14 +18,14 @@ on your node.
 
 ## See your node's metrics
 
-To see your node's real-time metrics, you can either access the node's dashboard directly or through Netdata Cloud. The
+To see your node's real-time metrics, you can either access the node's local dashboard or through Netdata Cloud. The
 navigation, charts, and metrics are identical with both methods. In addition, both dashboards update with new metrics in
 real-time, with fully interactive and synchronized charts.
 
-The primary difference is thatNetdata Cloud also has a few extra features, like creating new dashboards, that you might
+The primary difference is that Netdata Cloud also has a few extra features, like creating new dashboards, that you might
 want to use for monitoring your node.
 
-To see your node's dashboard directly, open up your web browser of choice and navigate to `http://NODE:19999`, replacing
+To see your node's local dashboard, open up your web browser of choice and navigate to `http://NODE:19999`, replacing
 `NODE` with the IP address or hostname of your Agent. Hit `Enter`. 
 
 ![Animated GIF of navigating to the
@@ -62,17 +62,17 @@ metrics.
 ## Collect metrics from your system and applications
 
 Netdata has [300+ pre-installed collectors](/docs/collectors/COLLECTORS.md) that gather thousands of metrics with zero
-configuration. In fact, Netdata is already collecting thousands of metrics per second on your single node, all without
-you setting it up first.
+configuration. Collectors search your node in default locations and ports to find running applications and gather as
+many metrics as they can without you having to configure them individually.
 
-These collectors search your system in default locations and ports to find the applications running on your node and
-gather as many metrics. The dashboard presents them meaningfully in charts to help you understand the baseline and
-identify anomalies.
+These metrics enrich both the local and Netdata Cloud dashboards.
 
-You may need to set up specific collectors for them to work, or you might want to configure a specific collector's
-behavior. Read more about [collector configuration](/docs/collect/configuration.md), or find detailed information about
-which [system](/docs/collect/system-metrics.md), [container](/docs/collect/container-metrics.md), and
-[application](/docs/collect/application-metrics.md) metrics you can collect with Netdata.
+Most collectors work without configuring them, but you should read up on how [collector
+configuration](/docs/collect/configure.md) works.
+
+In addition, find detailed information about which [system](/docs/collect/system-metrics.md),
+[container](/docs/collect/container-metrics.md), and [application](/docs/collect/application-metrics.md) metrics you can
+collect from across your infrastructure with Netdata.
 
 ## What's next?
 

--- a/docs/quickstart/single-node.md
+++ b/docs/quickstart/single-node.md
@@ -14,13 +14,13 @@ In this quickstart guide, you'll learn how to access your single node's metrics 
 to your liking, and make sure the Netdata Agent is collecting metrics from the applications or containers you're running
 on your node.
 
-> This quickstart assumes you installed the Netdaat Agent on your node. If you haven't yet, see the [_Get Netdata_
+> This quickstart assumes you have installed the Netdata Agent on your node. If you haven't yet, see the [_Get Netdata_
 > doc](/docs/get/README.md) for details on installation. In addition, this quickstart mentions features available only
 > through Netdata Cloud, which requires you to [claim your node](/docs/get/README.md#claim-your-node-on-netdata-cloud).
 
 ## See your node's metrics
 
-To see your node's real-time metric, you need to access its dashboard. You can either view the local dashboard, which
+To see your node's real-time metrics, you need to access its dashboard. You can either view the local dashboard, which
 runs on the node itself, or see the dashboard through Netdata Cloud. Both methods feature real-time, interactive, and
 synchronized charts, with the same metrics, and use the same UI.
 
@@ -82,7 +82,7 @@ Netdata has many features that help you monitor the health of your node and trou
 Once you understand configuration, and are certain Netdata is collecting all the important metrics from your node, try
 out some of Netdata's other visualization and health monitoring features:
 
--   [Build new dashboards](/docs/visualize/create-dashboards.md) to put disparate-but-relevant metrics onto a single
+-   [Build new dashboards](/docs/visualize/create-dashboards.md) to put disparate but relevant metrics onto a single
     interface.
 -   [Create new alarms](/docs/monitor/configure-alarms.md), or tweak some of the pre-configured alarms, to stay on top
     of anomalies.


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

The two quickstart documents—single-node vs. infrastructure—that aim to help users find the most important features of Netdata based on their need and the features available to them. 

And the context:

> See netdata/netdata-learn-docusaurus#285 for additional context.
>
> This page contains some elements that will only appear on the deployed Learn site, so see the deploy preview for this page for the full picture: https://deploy-preview-285--netdata-docusaurus.netlify.app/docs/get
>
> Some links will not work, as the target docs do not exist yet.
>
> For now, these PRs will get merged into the docsv2 but not go live on Netdata Learn. Once they're all available, or at least a workable majority, we'll merge them into master and deploy the project as a whole.

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
