### PR TITLE
add mirrored_hosts_status into OpenAPI of api/info

### DIFF
--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -1091,6 +1091,35 @@
               "host2.example.com"
             ]
           },
+          "mirrored_hosts_status": {
+            "type": "array",
+            "description": "List of details of hosts mirrored to this served (including self). Indexes corespod to indexes in \"mirrored_hosts\".",
+            "items": {
+              "type": "object",
+              "description": "Host data",
+              "properties": {
+                "guid": {
+                  "type": "string",
+                  "format": "uuid",
+                  "nullable": false,
+                  "description": "Host unique GUID from `netdata.public.unique.id`.",
+                  "example": "245e4bff-3b34-47c1-a6e5-5c535a9abfb2"
+                },
+                "reachable": {
+                  "type": "boolean",
+                  "nullable": false,
+                  "description": "Current state of streaming. Always true for localhost/self."
+                },
+                "claim_id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "nullable": true,
+                  "description": "Cloud GUID/identifier in case the host is claimed. If child status unknown or unclaimed this field is set to `null`",
+                  "example": "c3b2a66a-3052-498c-ac52-7fe9e8cccb0c"
+                }
+              }
+            }
+          },
           "os_name": {
             "type": "string",
             "description": "Operating System Name.",

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -1093,7 +1093,7 @@
           },
           "mirrored_hosts_status": {
             "type": "array",
-            "description": "List of details of hosts mirrored to this served (including self). Indexes corespod to indexes in \"mirrored_hosts\".",
+            "description": "List of details of hosts mirrored to this served (including self). Indexes correspod to indexes in \"mirrored_hosts\".",
             "items": {
               "type": "object",
               "description": "Host data",

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -1093,7 +1093,7 @@
           },
           "mirrored_hosts_status": {
             "type": "array",
-            "description": "List of details of hosts mirrored to this served (including self). Indexes correspod to indexes in \"mirrored_hosts\".",
+            "description": "List of details of hosts mirrored to this served (including self). Indexes correspond to indexes in \"mirrored_hosts\".",
             "items": {
               "type": "object",
               "description": "Host data",

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -883,7 +883,7 @@ components:
             - host2.example.com
         mirrored_hosts_status:
           type: array
-          description: List of details of hosts mirrored to this served (including self). Indexes corespod to indexes in "mirrored_hosts".
+          description: List of details of hosts mirrored to this served (including self). Indexes correspod to indexes in "mirrored_hosts".
           items:
             type: object
             description: Host data

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -883,7 +883,9 @@ components:
             - host2.example.com
         mirrored_hosts_status:
           type: array
-          description: List of details of hosts mirrored to this served (including self). Indexes correspod to indexes in "mirrored_hosts".
+          description: >-
+            List of details of hosts mirrored to this served (including self).
+            Indexes correspod to indexes in "mirrored_hosts".
           items:
             type: object
             description: Host data
@@ -902,7 +904,9 @@ components:
                 type: string
                 format: uuid
                 nullable: true
-                description: Cloud GUID/identifier in case the host is claimed. If child status unknown or unclaimed this field is set to `null`
+                description: >-
+                  Cloud GUID/identifier in case the host is claimed.
+                  If child status unknown or unclaimed this field is set to `null`
                 example: c3b2a66a-3052-498c-ac52-7fe9e8cccb0c
         os_name:
           type: string

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -885,7 +885,7 @@ components:
           type: array
           description: >-
             List of details of hosts mirrored to this served (including self).
-            Indexes correspod to indexes in "mirrored_hosts".
+            Indexes correspond to indexes in "mirrored_hosts".
           items:
             type: object
             description: Host data

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -881,6 +881,29 @@ components:
           example:
             - host1.example.com
             - host2.example.com
+        mirrored_hosts_status:
+          type: array
+          description: List of details of hosts mirrored to this served (including self). Indexes corespod to indexes in "mirrored_hosts".
+          items:
+            type: object
+            description: Host data
+            properties:
+              guid:
+                type: string
+                format: uuid
+                nullable: false
+                description: Host unique GUID from `netdata.public.unique.id`.
+                example: 245e4bff-3b34-47c1-a6e5-5c535a9abfb2
+              reachable:
+                type: boolean
+                nullable: false
+                description: Current state of streaming. Always true for localhost/self.
+              claim_id:
+                type: string
+                format: uuid
+                nullable: true
+                description: Cloud GUID/identifier in case the host is claimed. If child status unknown or unclaimed this field is set to `null`
+                example: c3b2a66a-3052-498c-ac52-7fe9e8cccb0c
         os_name:
           type: string
           description: Operating System Name.


### PR DESCRIPTION
##### Summary
In ab7ff3131f3698710e0bd9fa3c66d31a3a194725 `mirrored_hosts_status` field was added into `/api/v1/info` however this was not reflected in OpenAPI (swagger) documentation. This PR fixes that oversight

##### Component Name
OpenAPI docu

##### Test Plan
Check the description of `mirrored_hosts_status` is valid and matches what gets delivered by `/api/v1/info`. Make sure you check on host that has some children.

##### Additional Information
