### PR TITLE
python.d/dnsdist: fix latency-avg chart units

### DIFF
--- a/collectors/python.d.plugin/dnsdist/dnsdist.chart.py
+++ b/collectors/python.d.plugin/dnsdist/dnsdist.chart.py
@@ -105,7 +105,7 @@ CHARTS = {
         ]
     },
     'query_latency_avg': {
-        'options': [None, 'Average latency for the last N queries', 'us/query', 'latency',
+        'options': [None, 'Average latency for the last N queries', 'microseconds', 'latency',
                     'dnsdist.query_latency_avg', 'line'],
         'lines': [
             ['latency-avg100', '100', 'absolute'],

--- a/collectors/python.d.plugin/dnsdist/dnsdist.chart.py
+++ b/collectors/python.d.plugin/dnsdist/dnsdist.chart.py
@@ -105,7 +105,7 @@ CHARTS = {
         ]
     },
     'query_latency_avg': {
-        'options': [None, 'Average latency for the last N queries', 'ms/query', 'latency',
+        'options': [None, 'Average latency for the last N queries', 'us/query', 'latency',
                     'dnsdist.query_latency_avg', 'line'],
         'lines': [
             ['latency-avg100', '100', 'absolute'],


### PR DESCRIPTION
The latency-avg values are in microseconds, not milliseconds.
https://dnsdist.org/statistics.html#latency-avg100

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
The latency average graph is currently labeled with ms/query (milliseconds), but it should be us/query (microseconds). I got a little panicy when I was reading that my DNS queries were taking 5 seconds on average. 

##### Component Name
dnsdist collector

