### PR TITLE
Fixed handling of libJudy bundling for RPM packages.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,6 +74,7 @@ dist_noinst_DATA = \
     packaging/mosquitto.checksums \
     packaging/bundle-dashboard.sh \
     packaging/bundle-ebpf.sh \
+    packaging/bundle-judy.sh \
     packaging/bundle-libbpf.sh \
     packaging/bundle-mosquitto.sh \
     packaging/check-kernel-config.sh \

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -132,9 +132,14 @@ BuildRequires: judy-devel
 BuildRequires: liblz4-devel
 BuildRequires: libjson-c-devel
 %else
+%if 0%{?fedora}
 BuildRequires: Judy-devel
 BuildRequires: lz4-devel
 BuildRequires: json-c-devel
+%else
+BuildRequires: lz4-devel
+BuildRequires: json-c-devel
+%endif
 %endif
 
 # Core build requirements for service install
@@ -245,6 +250,10 @@ happened, on your systems and applications.
 %setup -q -n %{name}-%{version}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-lws.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+# Only bundle libJudy if this isn't Fedora or SUSE
+%if 0%{!?fedora:1} && 0%{!?suse_version:1}
+export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-judy.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+%endif
 %if 0%{?have_bpf}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-libbpf.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 %endif
@@ -253,6 +262,9 @@ export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging
 # Conf step
 autoreconf -ivf
 %configure \
+	%if 0%{!?fedora:1} && 0%{!?suse_version:1}
+	--with-libjudy=externaldeps/libJudy
+	%endif
 	--prefix="%{_prefix}" \
 	--sysconfdir="%{_sysconfdir}" \
 	--localstatedir="%{_localstatedir}" \

--- a/packaging/bundle-judy.sh
+++ b/packaging/bundle-judy.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+JUDY_TARBALL="v$(cat "${1}/packaging/judy.version").tar.gz"
+JUDY_BUILD_PATH="${1}/externaldeps/libJudy/libjudy-$(cat "${1}/packaging/judy.version")"
+
+mkdir -p "${1}/externaldeps/libJudy" || exit 1
+curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/libjudy/archive/${JUDY_TARBALL}" > "${JUDY_TARBALL}" || exit 1
+sha256sum -c "${1}/packaging/judy.checksums" || exit 1
+tar -xzf "${JUDY_TARBALL}" -C "${1}/externaldeps/libJudy" || exit 1
+OLDPWD="${PWD}"
+cd "${JUDY_BUILD_PATH}" || exit 1
+libtoolize --force --copy || exit 1
+aclocal || exit 1
+autoheader || exit 1
+automake --add-missing --force --copy --include-deps || exit 1
+autoconf || exit 1
+./configure || exit 1
+make -C src || exit 1
+ar -r src/libJudy.a src/Judy*/*.o || exit 1
+cd "${OLDPWD}" || exit 1
+
+cp -a "${JUDY_BUILD_PATH}/src/libJudy.a" "${1}/externaldeps/libJudy" || exit 1
+cp -a "${JUDY_BUILD_PATH}/src/Judy.h" "${1}/externaldeps/libJudy" || exit 1

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1131,6 +1131,7 @@ declare -A pkg_judy=(
   ['gentoo']="dev-libs/judy"
   ['arch']="judy"
   ['freebsd']="Judy"
+  ['fedora']="Judy-devel"
   ['default']="NOTREQUIRED"
 )
 


### PR DESCRIPTION
##### Summary

When preparing the libJudy bundling code, I forgot to account for the fact that we use `install-required-packages.sh` to set up build environments for our binary packages. Asa result, RPM builds are broken because of libJudy not being installed.

This PR adds the required code to the spec file to fix this, as well as adding Fedora to the list of systems which we will use a system copy of libJudy from (because it actually works there).

##### Component Name

area/packaging

##### Test Plan

Locally verified in Fedora, CentOS and OpenSUSE containers by manually building the packages. The Travis CI failure is expected and is a result of limitations inherent to using LXC through Python (namely, we can't copy files from the 'host' environment, and thus are forced to use the older copy of `install-required-packages.sh` from the master branch of the repo).

##### Additional Information

This will help with getting CentOS 8 packages working.