### PR TITLE
Opsgenie integration

### DIFF
--- a/health/notifications/Makefile.am
+++ b/health/notifications/Makefile.am
@@ -35,6 +35,7 @@ include hangouts/Makefile.inc
 include irc/Makefile.inc
 include kavenegar/Makefile.inc
 include messagebird/Makefile.inc
+include opsgenie/Makefile.inc
 include pagerduty/Makefile.inc
 include pushbullet/Makefile.inc
 include pushover/Makefile.inc

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -536,7 +536,7 @@ filter_recipient_by_criticality() {
   [ -z "${DYNATRACE_TAG_VALUE}" ] ||
   [ -z "${DYNATRACE_EVENT}" ]; } && SEND_DYNATRACE="NO"
 
-# check irc
+# check opsgenie
 [ -z "${OPSGENIE_API_KEY}" ] && SEND_OPSGENIE="NO"
 
 # check matrix
@@ -2770,7 +2770,7 @@ SENT_STACKPULSE=$?
 
 # -----------------------------------------------------------------------------
 # send messages to Opsgenie
-send_opsgenie "${host}" "${chart}" "${name}"  "${status_message}"
+send_opsgenie
 SENT_OPSGENIE=$?
 
 # -----------------------------------------------------------------------------

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -37,6 +37,7 @@
 #  - Google Hangouts Chat notifications by @EnzoAkira and @hendrikhofstadt
 #  - Dynatrace Event by @illumine
 #  - Stackpulse Event by @thiagoftsm
+#  - Opsgenie by @thiaoftsm #9858
 
 # -----------------------------------------------------------------------------
 # testing notifications
@@ -386,6 +387,9 @@ SEND_DYNATRACE=
 # stackpulse configs
 STACKPULSE_WEBHOOK=
 
+# opsgenie configs
+OPSGENIE_API_KEY=
+
 # load the stock and user configuration files
 # these will overwrite the variables above
 
@@ -532,6 +536,9 @@ filter_recipient_by_criticality() {
   [ -z "${DYNATRACE_TAG_VALUE}" ] ||
   [ -z "${DYNATRACE_EVENT}" ]; } && SEND_DYNATRACE="NO"
 
+# check irc
+[ -z "${OPSGENIE_API_KEY}" ] && SEND_OPSGENIE="NO"
+
 # check matrix
 { [ -z "${MATRIX_HOMESERVER}" ] || [ -z "${MATRIX_ACCESSTOKEN}" ]; } && SEND_MATRIX="NO"
 
@@ -559,7 +566,8 @@ if [ "${SEND_PUSHOVER}" = "YES" ] ||
 	[ "${SEND_CUSTOM}" = "YES" ] ||
 	[ "${SEND_MSTEAM}" = "YES" ] ||
 	[ "${SEND_DYNATRACE}" = "YES" ] ||
-	[ "${SEND_STACKPULSE}" = "YES" ]; then
+	[ "${SEND_STACKPULSE}" = "YES" ] ||
+	[ "${SEND_OPSGENIE}" = "YES" ]; then
 	# if we need curl, check for the curl command
 	if [ -z "${curl}" ]; then
 		curl="$(command -v curl 2>/dev/null)"
@@ -588,6 +596,7 @@ if [ "${SEND_PUSHOVER}" = "YES" ] ||
 		SEND_CUSTOM="NO"
 		SEND_DYNATRACE="NO"
 		SEND_STACKPULSE="NO"
+		SEND_OPSGENIE="NO"
 	fi
 fi
 
@@ -717,8 +726,9 @@ for method in "${SEND_EMAIL}" \
 	"${SEND_SMS}" \
 	"${SEND_MSTEAM}" \
 	"${SEND_DYNATRACE}" \
-	"${SEND_STACKPULSE}" ; do
-	
+	"${SEND_STACKPULSE}" \
+	"${SEND_OPSGENIE}" ; do
+
 	if [ "${method}" == "YES" ]; then
 		proceed=1
 		break
@@ -2073,6 +2083,170 @@ EOF
   return 0
 }
 # -----------------------------------------------------------------------------
+# Opsgenie sender
+
+create_opsgenie_array() {
+  local counter=0 values="$1" max=$2 message
+
+  message="[ "
+  for value in ${values} ; do
+    if [ "$counter" != "0" ] ; then
+      message+=", "
+    fi
+
+    message+=" \"${value:0:49}\""
+    counter=$((counter + 1))
+
+    if [ "$counter" == "$max" ] ; then
+      break;
+    fi
+  done
+  message+=" ]"$'\n'
+
+  echo "$message"
+}
+
+create_opsgenie_list() {
+  local counter=0 values types="$2" field=$3 max=$4
+
+  # Convert values to array
+  separator=' ' read -r -a values <<< "$1"
+
+  message=" "
+  # The type is a mandatory field, so we are using it to main loop
+  for t in ${types} ; do
+    if [ "$counter" != "0" ] ; then
+      message+=", "
+    fi
+
+    if [ -n "${values[$counter]}" ] ; then
+      message+="{ \"${field}\": \"${values[$counter]}\", \"type\": \"${t}\" }"
+    fi
+
+    counter=$((counter + 1))
+    if [ "$counter" == "$max" ] ; then
+      break;
+    fi
+  done
+
+  echo "$message"
+}
+
+create_opsgenie_lists() {
+  local message=""
+
+  if [ -n "${1}" ] &&  [ -n "${2}" ] ; then
+    message+="$(create_opsgenie_list "${1}" "${2}" "id" 50)"
+  fi
+
+  if [ -n "${3}" ] &&  [ -n "${4}" ] ; then
+    if [ -n "${message}" ]; then
+      message+=", "
+    fi
+
+    message+="$(create_opsgenie_list "${3}" "${4}" "username" 50)"
+  fi
+
+  if [ -n "${5}" ] &&  [ -n "${6}" ] ; then
+    if [ -n "${message}" ]; then
+      message+=", "
+    fi
+
+    message+="$(create_opsgenie_list "${5}" "${6}" "name" 50)"
+  fi
+
+  echo "$message"
+}
+
+send_opsgenie() {
+  local opts=() message idx priority
+  [ "${SEND_OPSGENIE}" != "YES" ] && return 1
+
+  if [ -z "${OPSGENIE_API_KEY}" ] ; then
+    info "Can't send Opsgenie notification, because OPSGENIE_API_KEY is not defined"
+    return 1
+  fi
+
+  case "${status}" in
+    WARNING) priority="P3" ;;
+    CRITICAL) priority="P1" ;;
+    CLEAR) priority="P4" ;;
+    *) priority="P5" ;;
+  esac
+
+  # The restrictions applied for each variable was defined according
+  # the URL https://docs.opsgenie.com/docs/alert-api#create-alert on September 2nd, 2020.
+
+  opts+=("\"message\": \"netdata on ${host:0:129}\","$'\n')
+
+  # Add Optional fields
+  opts+=($'\t'"\"description\": \"${chart}.${name} ${status_message}, ${info}\","$'\n')
+  opts+=($'\t'"\"priority\": \"${priority}\"")
+
+  # Commas are added to previous array element every time another optional value is necessary
+  # Add Optional fields if user specified them
+  idx=2
+  [ -n "${OPSGENIE_ENTITY}" ] && opts[2]="${opts[2]},"$'\n' && idx=3 && opts+=($'\t'"\"entity\": \"${OPSGENIE_ENTITY}\"")
+
+  if [ -n "${OPSGENIE_ACTIONS}" ] ; then
+    opts[${idx}]="${opts[${idx}]},"$'\n'
+    idx=$((idx + 1))
+
+    message="$(create_opsgenie_array "${OPSGENIE_ACTIONS}" 10)"
+
+    opts+=($'\t'"\"actions\": ${message}")
+  fi
+
+  if [ -n "${OPSGENIE_TAGS}" ] ; then
+    opts[${idx}]="${opts[${idx}]},"$'\n'
+    idx=$((idx + 1))
+
+    message="$(create_opsgenie_array "${OPSGENIE_TAGS}" 20)"
+
+    opts+=($'\t'"\"tags\": ${message}")
+  fi
+
+  message="$(create_opsgenie_lists "${OPSGENIE_RESPONDERS_IDS}" "${OPSGENIE_RESPONDERS_IDS_TYPES}"\
+   "${OPSGENIE_RESPONDERS_USERNAMES}" "${OPSGENIE_RESPONDERS_USERNAMES_TYPES}"\
+    "${OPSGENIE_RESPONDERS_NAMES}" "${OPSGENIE_RESPONDERS_NAMES_TYPES}")"
+  if [ -n "${message}" ] ; then
+    opts[${idx}]="${opts[${idx}]},"$'\n'
+    idx=$((idx + 1))
+
+    opts+=($'\t'"\"responders\": [ ${message} ]")
+  fi
+
+  message="$(create_opsgenie_lists "${OPSGENIE_VISIBLE_IDS}" "${OPSGENIE_VISIBLE_IDS_TYPES}"\
+   "${OPSGENIE_VISIBLE_USERNAMES}" "${OPSGENIE_VISIBLE_USERNAMES_TYPES}"\
+    "${OPSGENIE_VISIBLE_NAMES}" "${OPSGENIE_VISIBLE_NAMES_TYPES}")"
+  if [ -n "${message}" ] ; then
+    opts[${idx}]="${opts[${idx}]},"$'\n'
+
+    opts+=($'\t'"\"visibleTo\": [ ${message} ]")
+  fi
+
+  # Fill payload with obligatory fields
+  payload="$(
+    cat <<EOF
+    {
+      ${opts[@]}
+    }
+EOF
+    )"
+
+  httpcode=$(docurl -X POST  -H "Authorization: GenieKey ${OPSGENIE_API_KEY}"  -H "Content-Type: application/json" -d "${payload}" "https://api.opsgenie.com/v2/alerts")
+  # https://docs.opsgenie.com/docs/alert-api#create-alert
+  if [ "${httpcode}" = "202" ]; then
+    info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
+  else
+    error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP error code ${httpcode}."
+  fi
+  ret=$?
+
+  return 0
+}
+
+# -----------------------------------------------------------------------------
 # prepare the content of the notification
 
 # the url to send the user on click
@@ -2589,11 +2763,15 @@ SENT_EMAIL=$?
 send_dynatrace "${host}" "${chart}" "${name}"  "${status}"
 SENT_DYNATRACE=$?
 
-
 # -----------------------------------------------------------------------------
-# send the EVENT to Dynatrace
+# send the EVENT to Stackpulse
 send_stackpulse
 SENT_STACKPULSE=$?
+
+# -----------------------------------------------------------------------------
+# send messages to Opsgenie
+send_opsgenie "${host}" "${chart}" "${name}"  "${status_message}"
+SENT_OPSGENIE=$?
 
 # -----------------------------------------------------------------------------
 # let netdata know
@@ -2623,7 +2801,8 @@ for state in "${SENT_EMAIL}" \
 	"${SENT_SMS}" \
 	"${SENT_MSTEAM}" \
 	"${SENT_DYNATRACE}" \
-	"${SENT_STACKPULSE}" ; do
+	"${SENT_STACKPULSE}" \
+  "${SENT_OPSGENIE}"; do
 	if [ "${state}" -eq 0 ]; then
 		# we sent something
 		exit 0

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2158,22 +2158,8 @@ create_opsgenie_lists() {
   echo "$message"
 }
 
-send_opsgenie() {
-  local opts=() message idx priority
-  [ "${SEND_OPSGENIE}" != "YES" ] && return 1
-
-  if [ -z "${OPSGENIE_API_KEY}" ] ; then
-    info "Can't send Opsgenie notification, because OPSGENIE_API_KEY is not defined"
-    return 1
-  fi
-
-  case "${status}" in
-    WARNING) priority="P3" ;;
-    CRITICAL) priority="P1" ;;
-    CLEAR) priority="P4" ;;
-    *) priority="P5" ;;
-  esac
-
+opsgenie_create_alarm() {
+  local opts=() message idx priority=$1
   # The restrictions applied for each variable was defined according
   # the URL https://docs.opsgenie.com/docs/alert-api#create-alert on September 2nd, 2020.
 
@@ -2181,12 +2167,13 @@ send_opsgenie() {
 
   # Add Optional fields
   opts+=($'\t'"\"description\": \"${chart}.${name} ${status_message}, ${info}\","$'\n')
-  opts+=($'\t'"\"priority\": \"${priority}\"")
+  opts+=($'\t'"\"priority\": \"${priority}\","$'\n')
+  opts+=($'\t'"\"alias\": \"${alarm_id}\"")
 
   # Commas are added to previous array element every time another optional value is necessary
   # Add Optional fields if user specified them
-  idx=2
-  [ -n "${OPSGENIE_ENTITY}" ] && opts[2]="${opts[2]},"$'\n' && idx=3 && opts+=($'\t'"\"entity\": \"${OPSGENIE_ENTITY}\"")
+  idx=3
+  [ -n "${OPSGENIE_ENTITY}" ] && opts[2]="${opts[2]},"$'\n' && idx=4 && opts+=($'\t'"\"entity\": \"${OPSGENIE_ENTITY}\"")
 
   if [ -n "${OPSGENIE_ACTIONS}" ] ; then
     opts[${idx}]="${opts[${idx}]},"$'\n'
@@ -2234,16 +2221,50 @@ send_opsgenie() {
 EOF
     )"
 
-  httpcode=$(docurl -X POST  -H "Authorization: GenieKey ${OPSGENIE_API_KEY}"  -H "Content-Type: application/json" -d "${payload}" "https://api.opsgenie.com/v2/alerts")
+  httpcode=$(docurl -X POST -H "Authorization: GenieKey ${OPSGENIE_API_KEY}" -H "Content-Type: application/json" -d "${payload}" "https://api.opsgenie.com/v2/alerts")
   # https://docs.opsgenie.com/docs/alert-api#create-alert
   if [ "${httpcode}" = "202" ]; then
     info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
   else
     error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP error code ${httpcode}."
   fi
-  ret=$?
 
-  return 0
+  return 0;
+}
+
+opsgenie_close_alarm() {
+  # https://docs.opsgenie.com/docs/alert-api#close-alert
+  httpcode=$(docurl -X POST -H "Authorization: GenieKey ${OPSGENIE_API_KEY}" -H "Content-Type: application/json" -d "{ }" "https://api.opsgenie.com/v2/alerts/${alarm_id}/close?type=alias")
+  if [ "${httpcode}" = "202" ]; then
+    info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
+  else
+    error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP error code ${httpcode}."
+  fi
+}
+
+send_opsgenie() {
+  local priority
+  [ "${SEND_OPSGENIE}" != "YES" ] && return 1
+
+  if [ -z "${OPSGENIE_API_KEY}" ] ; then
+    info "Can't send Opsgenie notification, because OPSGENIE_API_KEY is not defined"
+    return 1
+  fi
+
+  case "${status}" in
+    WARNING) priority="P3" ;;
+    CRITICAL) priority="P1" ;;
+    CLEAR) priority="P4" ;;
+    *) priority="P5" ;;
+  esac
+
+  if [ "${status}" != CLEAR ] ; then
+    ret=$(opsgenie_create_alarm "${priority}")
+  else
+    opsgenie_close_alarm
+  fi
+
+  return $ret
 }
 
 # -----------------------------------------------------------------------------

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2163,17 +2163,17 @@ opsgenie_create_alarm() {
   # The restrictions applied for each variable was defined according
   # the URL https://docs.opsgenie.com/docs/alert-api#create-alert on September 2nd, 2020.
 
-  opts+=("\"message\": \"netdata on ${host:0:129}\","$'\n')
+  opts+=("\"message\": \"Netdata on ${host:0:117}\","$'\n')
 
   # Add Optional fields
-  opts+=($'\t'"\"description\": \"${chart}.${name} ${status_message}, ${info}\","$'\n')
+  opts+=($'\t'"\"description\": \"${chart:0:1023}.${name:0:1023} ${status_message}, ${info:0:8192}\","$'\n')
   opts+=($'\t'"\"priority\": \"${priority}\","$'\n')
   opts+=($'\t'"\"alias\": \"${alarm_id}\"")
 
   # Commas are added to previous array element every time another optional value is necessary
   # Add Optional fields if user specified them
   idx=3
-  [ -n "${OPSGENIE_ENTITY}" ] && opts[2]="${opts[2]},"$'\n' && idx=4 && opts+=($'\t'"\"entity\": \"${OPSGENIE_ENTITY}\"")
+  [ -n "${OPSGENIE_ENTITY}" ] && opts[2]="${opts[2]},"$'\n' && idx=4 && opts+=($'\t'"\"entity\": \"${OPSGENIE_ENTITY:0:511}\"")
 
   if [ -n "${OPSGENIE_ACTIONS}" ] ; then
     opts[${idx}]="${opts[${idx}]},"$'\n'

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2124,6 +2124,15 @@ send_opsgenie() {
 EOF
 )
 
+  httpcode=$(docurl -X POST  -H "Authorization: GenieKey ${OPSGENIE_API_KEY}"  -H "Content-Type: application/json" -d "${payload}" "https://api.opsgenie.com/v2/alerts")
+  # https://docs.opsgenie.com/docs/alert-api#create-alert
+  if [ "${httpcode}" = "202" ]; then
+    info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
+  else
+    error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP error code ${httpcode}."
+    return 1
+  fi
+
   return 0
 }
 

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2226,7 +2226,7 @@ EOF
   if [ "${httpcode}" = "202" ]; then
     info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
   else
-    error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP error code ${httpcode}."
+    error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP response code ${httpcode}."
   fi
 
   return 0;
@@ -2238,7 +2238,7 @@ opsgenie_close_alarm() {
   if [ "${httpcode}" = "202" ]; then
     info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
   else
-    error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP error code ${httpcode}."
+    error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP response code ${httpcode}."
   fi
 }
 

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2227,6 +2227,7 @@ EOF
     info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
   else
     error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP response code ${httpcode}."
+    return 1
   fi
 
   return 0;
@@ -2239,6 +2240,7 @@ opsgenie_close_alarm() {
     info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
   else
     error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP response code ${httpcode}."
+    return 1
   fi
 }
 

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2085,167 +2085,8 @@ EOF
 # -----------------------------------------------------------------------------
 # Opsgenie sender
 
-create_opsgenie_array() {
-  local counter=0 values="$1" max=$2 message
-
-  message="[ "
-  for value in ${values} ; do
-    if [ "$counter" != "0" ] ; then
-      message+=", "
-    fi
-
-    message+=" \"${value:0:49}\""
-    counter=$((counter + 1))
-
-    if [ "$counter" == "$max" ] ; then
-      break;
-    fi
-  done
-  message+=" ]"$'\n'
-
-  echo "$message"
-}
-
-create_opsgenie_list() {
-  local counter=0 values types="$2" field=$3 max=$4
-
-  # Convert values to array
-  separator=' ' read -r -a values <<< "$1"
-
-  message=" "
-  # The type is a mandatory field, so we are using it to main loop
-  for t in ${types} ; do
-    if [ "$counter" != "0" ] ; then
-      message+=", "
-    fi
-
-    if [ -n "${values[$counter]}" ] ; then
-      message+="{ \"${field}\": \"${values[$counter]}\", \"type\": \"${t}\" }"
-    fi
-
-    counter=$((counter + 1))
-    if [ "$counter" == "$max" ] ; then
-      break;
-    fi
-  done
-
-  echo "$message"
-}
-
-create_opsgenie_lists() {
-  local message=""
-
-  if [ -n "${1}" ] &&  [ -n "${2}" ] ; then
-    message+="$(create_opsgenie_list "${1}" "${2}" "id" 50)"
-  fi
-
-  if [ -n "${3}" ] &&  [ -n "${4}" ] ; then
-    if [ -n "${message}" ]; then
-      message+=", "
-    fi
-
-    message+="$(create_opsgenie_list "${3}" "${4}" "username" 50)"
-  fi
-
-  if [ -n "${5}" ] &&  [ -n "${6}" ] ; then
-    if [ -n "${message}" ]; then
-      message+=", "
-    fi
-
-    message+="$(create_opsgenie_list "${5}" "${6}" "name" 50)"
-  fi
-
-  echo "$message"
-}
-
-opsgenie_create_alarm() {
-  local opts=() message idx priority=$1
-  # The restrictions applied for each variable was defined according
-  # the URL https://docs.opsgenie.com/docs/alert-api#create-alert on September 2nd, 2020.
-
-  opts+=("\"message\": \"Netdata on ${host:0:117}\","$'\n')
-
-  # Add Optional fields
-  opts+=($'\t'"\"description\": \"${chart:0:1023}.${name:0:1023} ${status_message}, ${info:0:8192}\","$'\n')
-  opts+=($'\t'"\"priority\": \"${priority}\","$'\n')
-  opts+=($'\t'"\"alias\": \"${alarm_id}\"")
-
-  # Commas are added to previous array element every time another optional value is necessary
-  # Add Optional fields if user specified them
-  idx=3
-  [ -n "${OPSGENIE_ENTITY}" ] && opts[2]="${opts[2]},"$'\n' && idx=4 && opts+=($'\t'"\"entity\": \"${OPSGENIE_ENTITY:0:511}\"")
-
-  if [ -n "${OPSGENIE_ACTIONS}" ] ; then
-    opts[${idx}]="${opts[${idx}]},"$'\n'
-    idx=$((idx + 1))
-
-    message="$(create_opsgenie_array "${OPSGENIE_ACTIONS}" 10)"
-
-    opts+=($'\t'"\"actions\": ${message}")
-  fi
-
-  if [ -n "${OPSGENIE_TAGS}" ] ; then
-    opts[${idx}]="${opts[${idx}]},"$'\n'
-    idx=$((idx + 1))
-
-    message="$(create_opsgenie_array "${OPSGENIE_TAGS}" 20)"
-
-    opts+=($'\t'"\"tags\": ${message}")
-  fi
-
-  message="$(create_opsgenie_lists "${OPSGENIE_RESPONDERS_IDS}" "${OPSGENIE_RESPONDERS_IDS_TYPES}"\
-   "${OPSGENIE_RESPONDERS_USERNAMES}" "${OPSGENIE_RESPONDERS_USERNAMES_TYPES}"\
-    "${OPSGENIE_RESPONDERS_NAMES}" "${OPSGENIE_RESPONDERS_NAMES_TYPES}")"
-  if [ -n "${message}" ] ; then
-    opts[${idx}]="${opts[${idx}]},"$'\n'
-    idx=$((idx + 1))
-
-    opts+=($'\t'"\"responders\": [ ${message} ]")
-  fi
-
-  message="$(create_opsgenie_lists "${OPSGENIE_VISIBLE_IDS}" "${OPSGENIE_VISIBLE_IDS_TYPES}"\
-   "${OPSGENIE_VISIBLE_USERNAMES}" "${OPSGENIE_VISIBLE_USERNAMES_TYPES}"\
-    "${OPSGENIE_VISIBLE_NAMES}" "${OPSGENIE_VISIBLE_NAMES_TYPES}")"
-  if [ -n "${message}" ] ; then
-    opts[${idx}]="${opts[${idx}]},"$'\n'
-
-    opts+=($'\t'"\"visibleTo\": [ ${message} ]")
-  fi
-
-  # Fill payload with obligatory fields
-  payload="$(
-    cat <<EOF
-    {
-      ${opts[@]}
-    }
-EOF
-    )"
-
-  httpcode=$(docurl -X POST -H "Authorization: GenieKey ${OPSGENIE_API_KEY}" -H "Content-Type: application/json" -d "${payload}" "https://api.opsgenie.com/v2/alerts")
-  # https://docs.opsgenie.com/docs/alert-api#create-alert
-  if [ "${httpcode}" = "202" ]; then
-    info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
-  else
-    error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP response code ${httpcode}."
-    return 1
-  fi
-
-  return 0;
-}
-
-opsgenie_close_alarm() {
-  # https://docs.opsgenie.com/docs/alert-api#close-alert
-  httpcode=$(docurl -X POST -H "Authorization: GenieKey ${OPSGENIE_API_KEY}" -H "Content-Type: application/json" -d "{ }" "https://api.opsgenie.com/v2/alerts/${alarm_id}/close?type=alias")
-  if [ "${httpcode}" = "202" ]; then
-    info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
-  else
-    error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP response code ${httpcode}."
-    return 1
-  fi
-}
-
 send_opsgenie() {
-  local priority
+  local payload httpcode oldv currv
   [ "${SEND_OPSGENIE}" != "YES" ] && return 1
 
   if [ -z "${OPSGENIE_API_KEY}" ] ; then
@@ -2253,20 +2094,37 @@ send_opsgenie() {
     return 1
   fi
 
-  case "${status}" in
-    WARNING) priority="P3" ;;
-    CRITICAL) priority="P1" ;;
-    CLEAR) priority="P4" ;;
-    *) priority="P5" ;;
-  esac
+  # We are sending null when values are nan to avoid errors while JSON message is parsed
+  [ "${old_value}" != "nan" ] && oldv="${old_value}" ||  oldv="null"
+  [ "${value}" != "nan" ] && currv="${value}" || currv="null"
 
-  if [ "${status}" != CLEAR ] ; then
-    ret=$(opsgenie_create_alarm "${priority}")
-  else
-    opsgenie_close_alarm
-  fi
+  payload=$(cat <<EOF
+  {
+    "host" : "${host}",
+    "unique_id" : "${unique_id}",
+    "alarmId" : ${alarm_id},
+    "eventId" : ${event_id},
+    "chart" : "${chart}",
+    "when": ${when},
+    "name" : "${name}",
+    "family" : "${family}",
+    "status" : "${status}",
+    "old_status" : "${old_status}",
+    "value" : ${currv},
+    "old_value" : ${oldv},
+    "duration": ${duration},
+    "non_clear_duration": ${non_clear_duration},
+    "units" : "${units}",
+    "info" : "${status_message}, ${info}",
+    "calc_expression" : "${calc_expression}",
+    "total_warnings" : "${total_warnings}",
+    "total_critical" : "${total_critical}",
+    "src" : "${src}"
+  }
+EOF
+)
 
-  return $ret
+  return 0
 }
 
 # -----------------------------------------------------------------------------

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2126,7 +2126,7 @@ EOF
 
   httpcode=$(docurl -X POST -H "Content-Type: application/json" -d "${payload}" "https://api.opsgenie.com/v1/json/integrations/webhooks/netdata?apiKey=${OPSGENIE_API_KEY}")
   # https://docs.opsgenie.com/docs/alert-api#create-alert
-  if [ "${httpcode}" = "202" ]; then
+  if [ "${httpcode}" = "200" ]; then
     info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"
   else
     error "failed to send opsgenie notification for: ${host} ${chart}.${name} is ${status}, with HTTP error code ${httpcode}."

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2124,7 +2124,7 @@ send_opsgenie() {
 EOF
 )
 
-  httpcode=$(docurl -X POST  -H "Authorization: GenieKey ${OPSGENIE_API_KEY}"  -H "Content-Type: application/json" -d "${payload}" "https://api.opsgenie.com/v2/alerts")
+  httpcode=$(docurl -X POST -H "Content-Type: application/json" -d "${payload}" "https://api.opsgenie.com/v1/json/integrations/webhooks/netdata?apiKey=${OPSGENIE_API_KEY}")
   # https://docs.opsgenie.com/docs/alert-api#create-alert
   if [ "${httpcode}" = "202" ]; then
     info "sent opsgenie notification for: ${host} ${chart}.${name} is ${status}"

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -279,6 +279,13 @@ STACKPULSE_WEBHOOK=""
 DEFAULT_RECIPIENT_STACKPULSE=""
 
 #------------------------------------------------------------------------------
+# opsgenie global notification options
+SEND_OPSGENIE="YES"
+
+# Api key
+OPSGENIE_API_KEY=""
+
+#------------------------------------------------------------------------------
 # hangouts (google hangouts chat) global notification options
 
 # enable/disable sending hangouts notifications
@@ -944,6 +951,8 @@ role_recipients_rocketchat[sysadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
 role_recipients_dynatrace[sysadmin]="${DEFAULT_RECIPIENT_DYNATRACE}"
 
+role_recipients_opsgenie[sysadmin]="${DEFAULT_RECIPIENT_OPSGENIE}"
+
 role_recipients_matrix[sysadmin]="${DEFAULT_RECIPIENT_MATRIX}"
 
 role_recipients_stackpulse[sysadmin]="${DEFAULT_RECIPIENT_STACKPULSE}"
@@ -998,6 +1007,8 @@ role_recipients_rocketchat[domainadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 role_recipients_sms[domainadmin]="${DEFAULT_RECIPIENT_SMS}"
 
 role_recipients_dynatrace[domainadmin]="${DEFAULT_RECIPIENT_DYNATRACE}"
+
+role_recipients_opsgenie[domainadmin]="${DEFAULT_RECIPIENT_OPSGENIE}"
 
 role_recipients_matrix[domainadmin]="${DEFAULT_RECIPIENT_MATRIX}"
 
@@ -1055,6 +1066,8 @@ role_recipients_sms[dba]="${DEFAULT_RECIPIENT_SMS}"
 
 role_recipients_dynatrace[dba]="${DEFAULT_RECIPIENT_DYNATRACE}"
 
+role_recipients_opsgenie[dba]="${DEFAULT_RECIPIENT_OPSGENIE}"
+
 role_recipients_matrix[dba]="${DEFAULT_RECIPIENT_MATRIX}"
 
 role_recipients_stackpulse[dba]="${DEFAULT_RECIPIENT_STACKPULSE}"
@@ -1110,6 +1123,8 @@ role_recipients_rocketchat[webmaster]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 role_recipients_sms[webmaster]="${DEFAULT_RECIPIENT_SMS}"
 
 role_recipients_dynatrace[webmaster]="${DEFAULT_RECIPIENT_DYNATRACE}"
+
+role_recipients_opsgenie[webmaster]="${DEFAULT_RECIPIENT_OPSGENIE}"
 
 role_recipients_matrix[webmaster]="${DEFAULT_RECIPIENT_MATRIX}"
 
@@ -1167,6 +1182,8 @@ role_recipients_sms[proxyadmin]="${DEFAULT_RECIPIENT_SMS}"
 
 role_recipients_dynatrace[proxyadmin]="${DEFAULT_RECIPIENT_DYNATRACE}"
 
+role_recipients_opsgenie[proxyadmin]="${DEFAULT_RECIPIENT_OPSGENIE}"
+
 role_recipients_matrix[proxyadmin]="${DEFAULT_RECIPIENT_MATRIX}"
 
 role_recipients_stackpulse[proxyadmin]="${DEFAULT_RECIPIENT_STACKPULSE}"
@@ -1220,6 +1237,8 @@ role_recipients_rocketchat[sitemgr]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 role_recipients_sms[sitemgr]="${DEFAULT_RECIPIENT_SMS}"
 
 role_recipients_dynatrace[sitemgr]="${DEFAULT_RECIPIENT_DYNATRACE}"
+
+role_recipients_opsgenie[sitemgr]="${DEFAULT_RECIPIENT_OPSGENIE}"
 
 role_recipients_matrix[sitemgr]="${DEFAULT_RECIPIENT_MATRIX}"
 

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -285,6 +285,8 @@ SEND_OPSGENIE="YES"
 # Api key
 OPSGENIE_API_KEY=""
 
+DEFAULT_RECIPIENT_OPSGENIE=""
+
 #------------------------------------------------------------------------------
 # hangouts (google hangouts chat) global notification options
 

--- a/health/notifications/opsgenie/Makefile.inc
+++ b/health/notifications/opsgenie/Makefile.inc
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_noinst_DATA += \
+    opsgenie/README.md \
+    opsgenie/Makefile.inc \
+    $(NULL)
+

--- a/health/notifications/opsgenie/README.md
+++ b/health/notifications/opsgenie/README.md
@@ -6,3 +6,46 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/health/notificat
 -->
 
 # Opsgenie
+
+You will need an [API integration key](https://docs.opsgenie.com/docs/api-integration) to send your alarms for Opsgenie.
+
+## configuration
+
+To edit `health_alarm_notify.conf` on your system run `/etc/netdata/edit-config health_alarm_notify.conf`.
+
+Opsgenie has sixteen different possible configuration [options](https://docs.opsgenie.com/docs/alert-api), but only the
+option `OPSGENIE_API_KEY` is obligatory, the other options are used to improve information delivered with alarm.
+
+Opsgenie has two kind of options:
+
+-   independent: Variables that are treated without to consider other variables, they are `OPSGENIE_API_KEY`,
+ `OPSGENIE_ENTITY`, `OPSGENIE_ACTIONS` and `OPSGENIE_TAGS`.
+-   types: Variables that have values analysed in pairs, where the first value is stored in a variable named `NAME` and
+the respective pair is stored in the same position in another variable named `NAME_TYPES.`. The types variables are
+`OPSGENIE_RESPONDERS_NAMES` and `OPSGENIE_RESPONDERS_NAMES_TYPES`, `OPSGENIE_RESPONDERS_USERNAMES` and
+`OPSGENIE_RESPONDERS_USERNAMES_TYPES`, `OPSGENIE_RESPONDERS_IDS` and `OPSGENIE_RESPONDERS_IDS_TYPES`, 
+`OPSGENIE_VISIBLE_NAMES` and `OPSGENIE_VISIBLE_NAMES_TYPES`, `OPSGENIE_VISIBLE_USERNAMES` and
+`OPSGENIE_VISIBLE_USERNAMES_TYPES`, `OPSGENIE_VISIBLE_IDS` and `OPSGENIE_VISIBLE_IDS_TYPES`.
+
+Changes to this file do not require a Netdata restart.
+
+You can test your configuration by issuing the commands:
+
+```sh
+# become user netdata
+sudo su -s /bin/bash netdata
+
+# send a test alarm
+/usr/libexec/netdata/plugins.d/alarm-notify.sh test [ROLE]
+```
+
+On success you will have alarms in your Opsgenie platform
+
+
+, but if Netdata receives an error message, it will print a message like 
+
+```
+2020-09-03 23:07:00: alarm-notify.sh: ERROR: failed to send opsgenie notification for: hades test.chart.test_alarm is CRITICAL, with HTTP error code 403.
+```
+
+and you can obtain more details in this [link](https://docs.opsgenie.com/docs/response).

--- a/health/notifications/opsgenie/README.md
+++ b/health/notifications/opsgenie/README.md
@@ -1,35 +1,36 @@
 <!--
----
-title: "Opsgenie"
+title: "Send notifications to Opsgenie"
+description: "Send alerts to your Opsgenie incident response account any time an anomaly or performance issue strikes a node in your infrastructure."
+sidebar_label: "Opsgenie"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/health/notifications/opsgenie/README.md
----
 -->
 
-# Opsgenie
+# Send notifications to Opsgenie
 
-You will need an [API integration key](https://docs.opsgenie.com/docs/api-integration) to send your alarms for Opsgenie.
+You will need an [API integration key](https://docs.opsgenie.com/docs/api-integration) to send your alarms to
+[Opsgenie](https://www.atlassian.com/software/opsgenie).
 
-## configuration
+## Configuration
 
-To edit `health_alarm_notify.conf` on your system run `/etc/netdata/edit-config health_alarm_notify.conf`.
+To edit `health_alarm_notify.conf` on your system, run `/etc/netdata/edit-config health_alarm_notify.conf`.
 
-Opsgenie has sixteen different possible configuration [options](https://docs.opsgenie.com/docs/alert-api), but only the
-option `OPSGENIE_API_KEY` is obligatory, the other options are used to improve information delivered with alarm.
+Opsgenie has sixteen different possible [configuration options](https://docs.opsgenie.com/docs/alert-api), but only the
+option `OPSGENIE_API_KEY` is required. The other options are used to improve the alarm information sent to Opsgenie.
 
 Opsgenie has two kind of options:
 
--   independent: Variables that are treated without to consider other variables, they are `OPSGENIE_API_KEY`,
- `OPSGENIE_ENTITY`, `OPSGENIE_ACTIONS` and `OPSGENIE_TAGS`.
--   types: Variables that have values analysed in pairs, where the first value is stored in a variable named `NAME` and
-the respective pair is stored in the same position in another variable named `NAME_TYPES.`. The types variables are
-`OPSGENIE_RESPONDERS_NAMES` and `OPSGENIE_RESPONDERS_NAMES_TYPES`, `OPSGENIE_RESPONDERS_USERNAMES` and
-`OPSGENIE_RESPONDERS_USERNAMES_TYPES`, `OPSGENIE_RESPONDERS_IDS` and `OPSGENIE_RESPONDERS_IDS_TYPES`, 
-`OPSGENIE_VISIBLE_NAMES` and `OPSGENIE_VISIBLE_NAMES_TYPES`, `OPSGENIE_VISIBLE_USERNAMES` and
-`OPSGENIE_VISIBLE_USERNAMES_TYPES`, `OPSGENIE_VISIBLE_IDS` and `OPSGENIE_VISIBLE_IDS_TYPES`.
+-   **independent**: Variables that are not affected by the state of other variables. These are `OPSGENIE_API_KEY`,
+    `OPSGENIE_ENTITY`, `OPSGENIE_ACTIONS`, and `OPSGENIE_TAGS`.
+-   **types**: Variables that have values analysed in pairs, where the first value is stored in a variable named `NAME`
+    and the respective pair is stored in the same position in another variable named `NAME_TYPES.`. The types variables
+    are `OPSGENIE_RESPONDERS_NAMES`/`OPSGENIE_RESPONDERS_NAMES_TYPES`, `OPSGENIE_RESPONDERS_USERNAMES`/
+    `OPSGENIE_RESPONDERS_USERNAMES_TYPES`, `OPSGENIE_RESPONDERS_IDS`/`OPSGENIE_RESPONDERS_IDS_TYPES`,
+    `OPSGENIE_VISIBLE_NAMES`/`OPSGENIE_VISIBLE_NAMES_TYPES`, `OPSGENIE_VISIBLE_USERNAMES`/
+    `OPSGENIE_VISIBLE_USERNAMES_TYPES`, and `OPSGENIE_VISIBLE_IDS`/`OPSGENIE_VISIBLE_IDS_TYPES`.
 
-Changes to this file do not require a Netdata restart.
+Changes to `health_alarm_notify.conf` do not require a Netdata restart.
 
-You can test your configuration by issuing the commands:
+You can test your Opsgenie notifications configuration by issuing the commands:
 
 ```sh
 # become user netdata
@@ -39,14 +40,19 @@ sudo su -s /bin/bash netdata
 /usr/libexec/netdata/plugins.d/alarm-notify.sh test [ROLE]
 ```
 
-On success you will have alarms in your Opsgenie platform
+If everything works, you'll see alarms in your Opsgenie platform:
 
-![image](https://user-images.githubusercontent.com/49162938/92184518-f725f900-ee40-11ea-9afa-e7c639c72206.png)
+![Example alarm notifications in
+Opsgenie](https://user-images.githubusercontent.com/49162938/92184518-f725f900-ee40-11ea-9afa-e7c639c72206.png)
 
-, but if Netdata receives an error message, it will print a message like 
+If sending the test notifications fails, you can look in `/var/log/netdata/error.log` to find the relevant error
+message:
 
-```
+```log
 2020-09-03 23:07:00: alarm-notify.sh: ERROR: failed to send opsgenie notification for: hades test.chart.test_alarm is CRITICAL, with HTTP error code 403.
 ```
 
-and you can obtain more details in this [link](https://docs.opsgenie.com/docs/response).
+You can find more details about the Opsgenie error codes in their [response
+docs](https://docs.opsgenie.com/docs/response).
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fhealth%2Fnotifications%2Fopsgenie%2FREADME%2FDonations-netdata-has-received&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/health/notifications/opsgenie/README.md
+++ b/health/notifications/opsgenie/README.md
@@ -7,26 +7,24 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/health/notificat
 
 # Send notifications to Opsgenie
 
-You will need an [API integration key](https://docs.opsgenie.com/docs/api-integration) to send your alarms to
-[Opsgenie](https://www.atlassian.com/software/opsgenie).
+The first step is to create a [Netdata integration](https://docs.opsgenie.com/docs/api-integration) on
+[Opsgenie](https://www.atlassian.com/software/opsgenie) dashboard. After this it is necessary to edit 
+ `health_alarm_notify.conf` on your system, run the command 
+ 
+```bash
+# /etc/netdata/edit-config health_alarm_notify.conf`
+```
 
-## Configuration
+and change the variable `OPSGENIE_API_KEY`:
 
-To edit `health_alarm_notify.conf` on your system, run `/etc/netdata/edit-config health_alarm_notify.conf`.
+```
+SEND_OPSGENIE="YES"
 
-Opsgenie has sixteen different possible [configuration options](https://docs.opsgenie.com/docs/alert-api), but only the
-option `OPSGENIE_API_KEY` is required. The other options are used to improve the alarm information sent to Opsgenie.
+# Api key
+# Default Opsgenie APi
+OPSGENIE_API_KEY="11111111-2222-3333-4444-555555555555"
 
-Opsgenie has two kind of options:
-
--   **independent**: Variables that are not affected by the state of other variables. These are `OPSGENIE_API_KEY`,
-    `OPSGENIE_ENTITY`, `OPSGENIE_ACTIONS`, and `OPSGENIE_TAGS`.
--   **types**: Variables that have values analysed in pairs, where the first value is stored in a variable named `NAME`
-    and the respective pair is stored in the same position in another variable named `NAME_TYPES.`. The types variables
-    are `OPSGENIE_RESPONDERS_NAMES`/`OPSGENIE_RESPONDERS_NAMES_TYPES`, `OPSGENIE_RESPONDERS_USERNAMES`/
-    `OPSGENIE_RESPONDERS_USERNAMES_TYPES`, `OPSGENIE_RESPONDERS_IDS`/`OPSGENIE_RESPONDERS_IDS_TYPES`,
-    `OPSGENIE_VISIBLE_NAMES`/`OPSGENIE_VISIBLE_NAMES_TYPES`, `OPSGENIE_VISIBLE_USERNAMES`/
-    `OPSGENIE_VISIBLE_USERNAMES_TYPES`, and `OPSGENIE_VISIBLE_IDS`/`OPSGENIE_VISIBLE_IDS_TYPES`.
+```
 
 Changes to `health_alarm_notify.conf` do not require a Netdata restart.
 
@@ -49,10 +47,9 @@ If sending the test notifications fails, you can look in `/var/log/netdata/error
 message:
 
 ```log
-2020-09-03 23:07:00: alarm-notify.sh: ERROR: failed to send opsgenie notification for: hades test.chart.test_alarm is CRITICAL, with HTTP error code 403.
+2020-09-03 23:07:00: alarm-notify.sh: ERROR: failed to send opsgenie notification for: hades test.chart.test_alarm is CRITICAL, with HTTP error code 401.
 ```
 
-You can find more details about the Opsgenie error codes in their [response
-docs](https://docs.opsgenie.com/docs/response).
+You can find more details about the Opsgenie error codes in their [response docs](https://docs.opsgenie.com/docs/response).
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fhealth%2Fnotifications%2Fopsgenie%2FREADME%2FDonations-netdata-has-received&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/health/notifications/opsgenie/README.md
+++ b/health/notifications/opsgenie/README.md
@@ -1,0 +1,8 @@
+<!--
+---
+title: "Opsgenie"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/health/notifications/opsgenie/README.md
+---
+-->
+
+# Opsgenie

--- a/health/notifications/opsgenie/README.md
+++ b/health/notifications/opsgenie/README.md
@@ -41,6 +41,7 @@ sudo su -s /bin/bash netdata
 
 On success you will have alarms in your Opsgenie platform
 
+![image](https://user-images.githubusercontent.com/49162938/92184518-f725f900-ee40-11ea-9afa-e7c639c72206.png)
 
 , but if Netdata receives an error message, it will print a message like 
 

--- a/health/notifications/opsgenie/README.md
+++ b/health/notifications/opsgenie/README.md
@@ -7,15 +7,20 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/health/notificat
 
 # Send notifications to Opsgenie
 
-The first step is to create a [Netdata integration](https://docs.opsgenie.com/docs/api-integration) on
-[Opsgenie](https://www.atlassian.com/software/opsgenie) dashboard. After this it is necessary to edit 
- `health_alarm_notify.conf` on your system, run the command 
+[Opsgenie](https://www.atlassian.com/software/opsgenie) is an alerting and incident response tool. It is designed to
+group and filter alarms, build custom routing rules for on-call teams, and correlate deployments and commits to
+incidents.
+
+The first step is to create a [Netdata integration](https://docs.opsgenie.com/docs/api-integration) in the
+[Opsgenie](https://www.atlassian.com/software/opsgenie) dashboard. After this, you need to edit
+`health_alarm_notify.conf` on your system, by running the following from your [config
+directory](/docs/configure/nodes.md):
  
 ```bash
-# /etc/netdata/edit-config health_alarm_notify.conf`
+./edit-config health_alarm_notify.conf
 ```
 
-and change the variable `OPSGENIE_API_KEY`:
+Change the variable `OPSGENIE_API_KEY` with the API key you got from Opsgenie.
 
 ```
 SEND_OPSGENIE="YES"
@@ -23,19 +28,17 @@ SEND_OPSGENIE="YES"
 # Api key
 # Default Opsgenie APi
 OPSGENIE_API_KEY="11111111-2222-3333-4444-555555555555"
-
 ```
 
-Changes to `health_alarm_notify.conf` do not require a Netdata restart.
-
-You can test your Opsgenie notifications configuration by issuing the commands:
+Changes to `health_alarm_notify.conf` do not require a Netdata restart. You can test your Opsgenie notifications
+configuration by issuing the commands, replacing `ROLE` with your preferred role:
 
 ```sh
 # become user netdata
 sudo su -s /bin/bash netdata
 
 # send a test alarm
-/usr/libexec/netdata/plugins.d/alarm-notify.sh test [ROLE]
+/usr/libexec/netdata/plugins.d/alarm-notify.sh test ROLE
 ```
 
 If everything works, you'll see alarms in your Opsgenie platform:
@@ -50,6 +53,7 @@ message:
 2020-09-03 23:07:00: alarm-notify.sh: ERROR: failed to send opsgenie notification for: hades test.chart.test_alarm is CRITICAL, with HTTP error code 401.
 ```
 
-You can find more details about the Opsgenie error codes in their [response docs](https://docs.opsgenie.com/docs/response).
+You can find more details about the Opsgenie error codes in their [response
+docs](https://docs.opsgenie.com/docs/response).
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fhealth%2Fnotifications%2Fopsgenie%2FREADME%2FDonations-netdata-has-received&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)


### PR DESCRIPTION
##### Summary
Fixes #9858 

This PR brings the integration between Netdata and Opsgenie.

##### Component Name
Health
##### Test Plan
1 - Require @cakrit access to Opsgenie platform ( I am sorry Chris, but this is the simplest way I know to test this PR).
2 - Access the Opsgenie platform and get the integration key in the following the path: Settings -> Integrations -> Configured Integrations -> API.
3 - Set inside your `health_alarm_notify.conf` the following variables:

```
SEND_OPSGENIE="YES"

# Api key
OPSGENIE_API_KEY=""
```

4 - Go to directory `/usr/libexec/netdata/plugins.d` and run the following test:

```
./alarm-notify.sh test
```

5 - Access Opsgine platform and click on link `Alerts` you will have alarms like the image

![opsgenie](https://user-images.githubusercontent.com/49162938/97355380-bcfc3500-188e-11eb-9599-f2b747ccf81e.png)


##### Additional Information
