### PR TITLE
Fix lock order reversal. (Coverity defect CID 361629)

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -460,11 +460,11 @@ static int rrdpush_receive(struct receiver_state *rpt)
             if(health_enabled == CONFIG_BOOLEAN_AUTO)
                 rpt->host->health_enabled = 0;
         }
+        rrdhost_unlock(rpt->host);
         if (rpt->host->receiver == rpt) {
             rrdpush_sender_thread_stop(rpt->host);
         }
         netdata_mutex_unlock(&rpt->host->receiver_lock);
-        rrdhost_unlock(rpt->host);
         rrd_unlock();
     }
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fix the following coverity defect:

** CID 361629:  Program hangs  (ORDER_REVERSAL)

```
________________________________________________________________________________________________________
*** CID 361629:  Program hangs  (ORDER_REVERSAL)
/streaming/receiver.c: 464 in rrdpush_receive()
458                 rpt->host->senders_disconnected_time = now_realtime_sec();
459                 rrdhost_flag_set(rpt->host, RRDHOST_FLAG_ORPHAN);
460                 if(health_enabled == CONFIG_BOOLEAN_AUTO)
461                     rpt->host->health_enabled = 0;
462             }
463             if (rpt->host->receiver == rpt) {
>>>     CID 361629:  Program hangs  (ORDER_REVERSAL)
>>>     Calling "rrdpush_sender_thread_stop" acquires lock "sender_state.mutex" while holding lock "rrdhost.rrdhost_rwlock" (count: 1 / 2).
464                 rrdpush_sender_thread_stop(rpt->host);
465             }
466             netdata_mutex_unlock(&rpt->host->receiver_lock);
467             rrdhost_unlock(rpt->host);
468             rrd_unlock();
469         }
```

##### Component Name
Streaming
##### Test Plan
Start and Stop 1000 child nodes in a streaming set-up. Restart the agent.