### PR TITLE
Corrected configure option name for bundling libJudy in installer.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -736,7 +736,7 @@ bundle_judy() {
       copy_judy "${tmp}/libjudy-${JUDY_PACKAGE_VERSION}" &&
       rm -rf "${tmp}"; then
       run_ok "libJudy built and prepared."
-      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-libjudy=externaldeps/libJudy"
+      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-libJudy=externaldeps/libJudy"
     else
       run_failed "Failed to build libJudy."
       if [ -n "${NETDATA_BUILD_JUDY}" ]; then


### PR DESCRIPTION
##### Summary

SSIA, not sure how I didn't see this when originally writing this code...

##### Component Name

area/packaging

##### Test Plan

Verified locally that this fixes bundling of libJudy and makes dbengine build correctly.

##### Additional Information

Fixes: #9889