### PR TITLE
Make internal Travis CI notifications behave better.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,12 @@ install:
 # Setup notification system
 #
 notifications:
-  webhooks: https://app.fossa.io/hooks/travisci
-
+  webhooks:
+    urls:
+      - https://app.fossa.io/hooks/travisci
+    if: branch = master
+  slack:
+    if: branch = master
 
 # Define the stage sequence and conditionals
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -182,6 +182,7 @@ jobs:
       env:
         - BUILDER_NAME="builder" BUILD_DISTRO="debian" BUILD_RELEASE="buster" BUILD_STRING="debian/buster"
         - PACKAGE_TYPE="deb" REPO_TOOL="apt-get"
+      after_failure: post_message "TRAVIS_MESSAGE" "Netdata DEB package build check failed."
 
     - name: RPM package test
       if: commit_message =~ /^((?!\[Package (amd64|arm64|i386) (DEB|RPM)( .*)?\]).)*$/
@@ -203,6 +204,7 @@ jobs:
       env:
         - BUILDER_NAME="builder" BUILD_DISTRO="fedora" BUILD_RELEASE="31" BUILD_STRING="fedora/31"
         - PACKAGE_TYPE="rpm" REPO_TOOL="dnf"
+      after_failure: post_message "TRAVIS_MESSAGE" "Netdata RPM package build check failed."
 
     - stage: Support activities on main branch
       name: Generate changelog for release (only on special and tagged commit msg)


### PR DESCRIPTION
##### Summary

This stops Travis CI from sending internal notifications Slack/FOSSA notifications on branches other than `master`.

It also adds failure notifications to the DEB and RPM build checks.

##### Component Name

area/ci

##### Test Plan

Validated the YAML for the config and checked the config itself on Travis for my own branch. Exact changes are not trivially testable, but match up with official documentation.