### PR TITLE
Fix buffer overflow in rrdr structure

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -573,6 +573,12 @@ static inline void do_dimension_fixedstep(
 #endif
         db_now = now; // this is needed to set db_now in case the next_metric implementation does not set it
         storage_number n = rd->state->query_ops.next_metric(&handle, &db_now);
+        if(unlikely(db_now > before_wanted)) {
+#ifdef NETDATA_INTERNAL_CHECKS
+            r->internal.log = "stopped, because attempted to access the db after 'wanted before'";
+#endif
+            break;
+        }
         for ( ; now <= db_now ; now += dt) {
             calculated_number value = NAN;
             if(likely(now >= db_now && does_storage_number_exist(n))) {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #9675

##### Component Name
database
##### Test Plan

1. Set-up a parent-child streaming set-up where the parent is using `memory mode = dbengine`.
2. Let the system gather some metrics for 5 minutes.
3. Open the browser tab for localhost and the child host in the parent node's dashboard.
4. Turn off clock synchronization in the child node.
5. Get the current time of the parent node, e.g.:
```
root@Ubuntu-Test:~# date +%T
15:26:32
```
6. Wait 20 seconds and set that time at the child node, e.g.:
```
root@Ubuntu-Test2:~/netdata# date +%T -s "15:26:32"
```
7. This will set the child and the node out of sync.
8. Scroll back and forth, zoom in and out, until the tab crashes.
9. If it doesn't immediately crash move the child node's date forward and backwards until it does.
10. Alternatively you may let the system be idle for some time, until the data are written to disk. Afterwards you can use the dashboard to cause the crash, and capture the exact URL that caused it by utilizing the browser developer tools. This way, you can reproduce the crash 100% of the time by simply restarting the parent agent which loads the database and downloading this specific URL.
11. Using the code of this PR should not cause the agent to crash.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->