### PR TITLE
Add collect docs to the docsv2 project

### DIFF
--- a/docs/collect/application-metrics.md
+++ b/docs/collect/application-metrics.md
@@ -1,0 +1,16 @@
+<!--
+title: "Collect application metrics with Netdata"
+sidebar_label: "Application metrics"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/application-metrics.md
+-->
+
+# Collect application metrics with Netdata
+
+t/k
+
+## What's next?
+
+t/k
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fapplication-metrics&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/application-metrics.md
+++ b/docs/collect/application-metrics.md
@@ -1,16 +1,76 @@
 <!--
 title: "Collect application metrics with Netdata"
 sidebar_label: "Application metrics"
-description: ""
+description: "Monitor and troubleshoot every application on your infrastructure with per-second metrics, zero configuration, and meaningful charts."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/application-metrics.md
 -->
 
 # Collect application metrics with Netdata
 
-TK
+Netdata instantly collects per-second metrics from many different types of applications running on your systems, such as
+web servers, databases, message brokers, email servers, search platforms, and much more. Metrics collectors are
+pre-installated with every Netdata Agent and usually require zero configuration. Netdata also collects and visualizes
+resource utilization per application on Linux systems using `apps.plugin`.
+
+[**apps.plugin**](/collectors/apps.plugin/README.md) looks at the Linux process tree every second, much like `top` or
+`ps fax`, and collects resource utilization information on every running process. By reading the process tree, Netdata
+shows CPU, disk, networking, processes, and eBPF for every application or Linux user. Unlike `top` or `ps fax`, Netdata
+adds a layer of meaningful visualization on top of the process tree metrics, such as grouping applications into useful
+dimensions, and then creates per-application charts under the **Applications** section of a Netdata dashboard, per-user
+charts under **Users**, and per-user group charts under **User Groups**.
+
+Our most popular application collectors:
+
+-   [Prometheus endpoints](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/prometheus): Gathers
+    metrics from one or more Prometheus endpoints that use the OpenMetrics exposition format. Autodetects more than 600
+    endpoints.
+-   [Web server logs (Apache, NGINX)](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/weblog/):
+    Tail access logs and provide very detailed web server performance statistics. This module is able to parse 200k+
+    rows in less than half a second.
+-   [MySQL](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/mysql/): Collect database global,
+    replication and per user statistics.
+-   [Redis](/collectors/python.d.plugin/redis/): Monitor database status by reading the server's response to the `INFO`
+    command.
+-   [Apache](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/apache/): Collect Apache web
+    server performance metrics via the `server-status?auto` endpoint.
+-   [Nginx](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/nginx/): Monitor web server
+    status information by gathering metrics via `ngx_http_stub_status_module`.
+-   [Postgres](/collectors/python.d.plugin/postgres/README.md): Collect database health and performance metrics. 
+-   [ElasticSearch](/collectors/python.d.plugin/elasticsearch/README.md): Collect search engine performance and health
+    statistics. Optionally collects per-index metrics.
+-   [PHP-FPM](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/phpfpm/): Collect application
+    summary and processes health metrics by scraping the status page (`/status?full`).
+
+Our [supported collectors list](/collectors/COLLECTORS.md#service-and-application-collectors) shows all of Netdata's
+application metrics collectors, including those for containers/k8s clusters.
+
+## Collect metrics from applications running on Windows
+
+Netdata is fully capable of collecting and visualizing metrics from applications running on Windows systems. The only
+caveat is that because there is no native Windows version of the Netdata Agent, you must [install the
+Agent](/packaging/installer/README.md) on a separate system, or a compatible VM.
+
+Once you have the Agent running on that separate system, you can follow the [enable and configure
+doc](/docs/collect/enable-configure.md) to tell the collector to look for exposed metrics on the IP address or hostname
+of the Windows system, plus the applicable port.
+
+For example, let's say you have an MySQL database with a root password of `my-secret-pw` running on a Windows system
+with the IP address 203.0.113.0. you can configure the [MySQL
+collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/mysql) to look at `203.0.113.0:3306`:
+
+```yml
+jobs:
+  - name: local
+    dsn: root:my-secret-pw@tcp(203.0.113.0:3306)/
+```
+
+This same logic applies to any application in our [supported collectors
+list](/collectors/COLLECTORS.md#service-and-application-collectors) list that can run on Windows.
 
 ## What's next?
 
-TK
+Collecting all the available metrics on your nodes, and across your entire infrastructure, is just one piece of the
+puzzle. Next, learn more about Netdata's famous real-time visualizations by [viewing all your nodes at a
+glance](/docs/visualize/view-all-nodes.md).
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fapplication-metrics&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/application-metrics.md
+++ b/docs/collect/application-metrics.md
@@ -7,10 +7,10 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/app
 
 # Collect application metrics with Netdata
 
-t/k
+TK
 
 ## What's next?
 
-t/k
+TK
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fapplication-metrics&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/application-metrics.md
+++ b/docs/collect/application-metrics.md
@@ -9,7 +9,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/app
 
 Netdata instantly collects per-second metrics from many different types of applications running on your systems, such as
 web servers, databases, message brokers, email servers, search platforms, and much more. Metrics collectors are
-pre-installated with every Netdata Agent and usually require zero configuration. Netdata also collects and visualizes
+pre-installed with every Netdata Agent and usually require zero configuration. Netdata also collects and visualizes
 resource utilization per application on Linux systems using `apps.plugin`.
 
 [**apps.plugin**](/collectors/apps.plugin/README.md) looks at the Linux process tree every second, much like `top` or
@@ -28,7 +28,7 @@ Our most popular application collectors:
     Tail access logs and provide very detailed web server performance statistics. This module is able to parse 200k+
     rows in less than half a second.
 -   [MySQL](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/mysql/): Collect database global,
-    replication and per user statistics.
+    replication, and per-user statistics.
 -   [Redis](/collectors/python.d.plugin/redis/): Monitor database status by reading the server's response to the `INFO`
     command.
 -   [Apache](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/apache/): Collect Apache web
@@ -41,21 +41,21 @@ Our most popular application collectors:
 -   [PHP-FPM](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/phpfpm/): Collect application
     summary and processes health metrics by scraping the status page (`/status?full`).
 
-Our [supported collectors list](/collectors/COLLECTORS.md#service-and-application-collectors) shows all of Netdata's
+Our [supported collectors list](/collectors/COLLECTORS.md#service-and-application-collectors) shows all Netdata's
 application metrics collectors, including those for containers/k8s clusters.
 
 ## Collect metrics from applications running on Windows
 
 Netdata is fully capable of collecting and visualizing metrics from applications running on Windows systems. The only
-caveat is that because there is no native Windows version of the Netdata Agent, you must [install the
-Agent](/packaging/installer/README.md) on a separate system, or a compatible VM.
+caveat is that you must [install the Agent](/packaging/installer/README.md) on a separate system or a compatible VM
+because there is no native Windows version of the Netdata Agent.
 
 Once you have the Agent running on that separate system, you can follow the [enable and configure
-doc](/docs/collect/enable-configure.md) to tell the collector to look for exposed metrics on the IP address or hostname
-of the Windows system, plus the applicable port.
+doc](/docs/collect/enable-configure.md) to tell the collector to look for exposed metrics on the Windows system's IP
+address or hostname, plus the applicable port.
 
-For example, let's say you have an MySQL database with a root password of `my-secret-pw` running on a Windows system
-with the IP address 203.0.113.0. you can configure the [MySQL
+For example, you have a MySQL database with a root password of `my-secret-pw` running on a Windows system with the IP
+address 203.0.113.0. you can configure the [MySQL
 collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/mysql) to look at `203.0.113.0:3306`:
 
 ```yml
@@ -65,7 +65,7 @@ jobs:
 ```
 
 This same logic applies to any application in our [supported collectors
-list](/collectors/COLLECTORS.md#service-and-application-collectors) list that can run on Windows.
+list](/collectors/COLLECTORS.md#service-and-application-collectors) that can run on Windows.
 
 ## What's next?
 

--- a/docs/collect/container-metrics.md
+++ b/docs/collect/container-metrics.md
@@ -1,0 +1,20 @@
+<!--
+title: "Collect container metrics with Netdata"
+sidebar_label: "Container metrics"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/container-metrics.md
+-->
+
+# Collect container metrics with Netdata
+
+t/k
+
+## Collect Kubernetes metrics
+
+t/k
+
+## What's next?
+
+t/k
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fcontainer-metrics&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/container-metrics.md
+++ b/docs/collect/container-metrics.md
@@ -1,24 +1,92 @@
 <!--
 title: "Collect container metrics with Netdata"
 sidebar_label: "Container metrics"
-description: ""
+description: "Use Netdata to collect per-second utilization and application-level metrics from Linux/Docker containers and Kubernetes clusters."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/container-metrics.md
 -->
 
 # Collect container metrics with Netdata
 
-TK
+Thanks to close integration with Linux cgroups and the virtual files it maintains under `/sys/fs/cgroup`, Netdata can
+monitor the health, status, and resource utilization of many different types of Linux containers.
+
+Netdata uses [cgroups.plugin](/collectors/cgroups.plugin/README.md) to poll `/sys/fs/cgroup` and convert the raw data
+into human-readable metrics and meaningful visualizations. Through cgroups, Netdata is compatible with **all Linux
+containers**, such as Docker, LXC, LXD, Libvirt, systemd-nspawn, and more. Read more about [Docker-specific
+monitoring](#collect-docker-metrics) below.
+
+Netdata also has robust **Kubernetes monitoring** support thanks to a
+[Helmchart](/packaging/installer/methods/kubernetes.md) to automate deployment, collectors for k8s agent services, and
+robust [service discovery](https://github.com/netdata/agent-service-discovery/#service-discovery) to monitor the
+services running inside of pods in your k8s cluster. Read more about [Kubernetes
+monitoring](#collect-kubernetes-metrics) below.
+
+A handful of additional collectors gather metrics from container-related services, such as
+[dockerd](/collectors/python.d.plugin/dockerd/README.md) or [Docker
+Engine](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/docker_engine/). You can find all
+container collectors in our supported collectors list under the
+[containers/VMs](/collectors/COLLECTORS.md#containers-and-vms) and
+[Kubernetes](/collectors/COLLECTORS.md#containers-and-vms) headings.
 
 ## Collect Docker metrics
 
-TK
+Netdata has robust Docker monitoring thanks to the aforementioned
+[cgroups.plugin](/collectors/cgroups.plugin/README.md). By polling cgroups every second, Netdata can produce meaningful
+visualizations about the CPU, memory, disk, and network utilization of all running containers on the host system with
+zero configuration.
+
+Netdata also collects metrics from applications running inside of Docker containers. Let's say you created a MySQL
+database container using `docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:tag`. By default,
+this container exposes metrics on port 3306. You can configure the [MySQL
+collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/mysql) to look at `127.0.0.0:3306` for
+MySQL metrics:
+
+```yml
+jobs:
+  - name: local
+    dsn: root:my-secret-pw@tcp(127.0.0.1:3306)/
+```
+
+Netdata then collects metrics from the container itself, but also dozens [MySQL-specific
+metrics](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/mysql#charts) as well.
+
+You could use this technique to monitor an entire infrastructure run on Docker containers. The same [enable and
+configure](/docs/collect/enable-configure.md) techniques apply whether an application runs on the host system or inside
+of a container. You just need to configure the exposed endpoint if it's not set to the application's default.
+
+Netdata can even [run in a Docker container](/packaging/docker/README.md) itself, and then collect metrics about the
+host system, its own container with cgroups, and any applications you want to monitor.
 
 ## Collect Kubernetes metrics
 
-TK
+We already have a few complementary tools and collectors for monitoring the many layers of a Kubernetes cluster,
+_entirely for free_. These methods work together to help you troubleshoot performance or availablility issues across
+your k8s infrastructure.
+
+-   A [Helm chart](https://github.com/netdata/helmchart), which bootstraps a Netdata Agent pod on every node in your
+    cluster, plus an additional parent pod for storing metrics and managing alarm notifications.
+-   A [service discovery plugin](https://github.com/netdata/agent-service-discovery), which discovers and immediately
+    monitors 22 different services that might be running inside of your cluster's pods. Service discovery happens
+    without manual intervention as pods are created, destroyed, or moved between nodes. [Compatible
+    services](https://github.com/netdata/helmchart#service-discovery-and-supported-services) include Nginx, Apache,
+    MySQL, CoreDNS, and much more.
+-   A [Kubelet collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/k8s_kubelet), which runs
+    on each node in a k8s cluster to monitor the number of pods/containers, the volume of operations on each container,
+    and more.
+-   A [kube-proxy collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/k8s_kubeproxy), which
+    also runs on each node and monitors latency and the volume of HTTP requests to the proxy.
+-   A [cgroups collector](/collectors/cgroups.plugin/README.md), which collects CPU, memory, and bandwidth metrics for
+    each container running on your k8s cluster.
+
+For a holistic view into Netdata's Kubernetes monitoring capabilities, see our guide: [_Monitor a Kubernetes (k8s)
+cluster with Netdata_](https://learn.netdata.cloud/guides/monitor/kubernetes-k8s-netdata).
 
 ## What's next?
 
-TK
+Netdata is capable of collecting metrics from hundreds of applications, such as web servers, databases, messaging
+brokers, and much more. See more in the [application metrics doc](/docs/collect/application-metrics.md).
+
+If you already have all the information you need about collecting metrics, move into Netdata's meaningful visualizations
+with [viewing all nodes at a glance](/docs/visualize/view-all-nodes.md).
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fcontainer-metrics&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/container-metrics.md
+++ b/docs/collect/container-metrics.md
@@ -35,9 +35,9 @@ Netdata has robust Docker monitoring thanks to the aforementioned
 visualizations about the CPU, memory, disk, and network utilization of all running containers on the host system with
 zero configuration.
 
-Netdata also collects metrics from applications running inside of Docker containers. Let's say you created a MySQL
-database container using `docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:tag`. By default,
-this container exposes metrics on port 3306. You can configure the [MySQL
+Netdata also collects metrics from applications running inside of Docker containers. For example, if you create a MySQL
+database container using `docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:tag`, it exposes
+metrics on port 3306. You can configure the [MySQL
 collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/mysql) to look at `127.0.0.0:3306` for
 MySQL metrics:
 
@@ -50,12 +50,17 @@ jobs:
 Netdata then collects metrics from the container itself, but also dozens [MySQL-specific
 metrics](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/mysql#charts) as well.
 
-You could use this technique to monitor an entire infrastructure run on Docker containers. The same [enable and
-configure](/docs/collect/enable-configure.md) techniques apply whether an application runs on the host system or inside
-of a container. You just need to configure the exposed endpoint if it's not set to the application's default.
+### Collect metrics from applications running in Docker containers
+
+You could use this technique to monitor an entire infrastructure of Docker containers. The same [enable and
+configure](/docs/collect/enable-configure.md) procedures apply whether an application runs on the host system or inside
+a container. You may need to configure the target endpoint if it's not the application's default.
 
 Netdata can even [run in a Docker container](/packaging/docker/README.md) itself, and then collect metrics about the
 host system, its own container with cgroups, and any applications you want to monitor.
+
+See our [application metrics doc](/docs/collect/application-metrics.md) for details about Netdata's application metrics
+collection capabilities.
 
 ## Collect Kubernetes metrics
 
@@ -78,13 +83,13 @@ your k8s infrastructure.
 -   A [cgroups collector](/collectors/cgroups.plugin/README.md), which collects CPU, memory, and bandwidth metrics for
     each container running on your k8s cluster.
 
-For a holistic view into Netdata's Kubernetes monitoring capabilities, see our guide: [_Monitor a Kubernetes (k8s)
-cluster with Netdata_](https://learn.netdata.cloud/guides/monitor/kubernetes-k8s-netdata).
+For a holistic view of Netdata's Kubernetes monitoring capabilities, see our guide: [_Monitor a Kubernetes (k8s) cluster
+with Netdata_](https://learn.netdata.cloud/guides/monitor/kubernetes-k8s-netdata).
 
 ## What's next?
 
 Netdata is capable of collecting metrics from hundreds of applications, such as web servers, databases, messaging
-brokers, and much more. See more in the [application metrics doc](/docs/collect/application-metrics.md).
+brokers, and more. See more in the [application metrics doc](/docs/collect/application-metrics.md).
 
 If you already have all the information you need about collecting metrics, move into Netdata's meaningful visualizations
 with [viewing all nodes at a glance](/docs/visualize/view-all-nodes.md).

--- a/docs/collect/container-metrics.md
+++ b/docs/collect/container-metrics.md
@@ -7,14 +7,18 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/con
 
 # Collect container metrics with Netdata
 
-t/k
+TK
+
+## Collect Docker metrics
+
+TK
 
 ## Collect Kubernetes metrics
 
-t/k
+TK
 
 ## What's next?
 
-t/k
+TK
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fcontainer-metrics&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/enable-configure.md
+++ b/docs/collect/enable-configure.md
@@ -6,9 +6,9 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/ena
 
 # Enable or configure a collector
 
-While collectors start collect metrics right away if they find exposed metrics on their default endpoint, not all
-infrastructures use standard ports, paths, files, or naming conventions. In this case, you may need to enable or
-configure a collector to gather all available metrics from your systems, containers, or applications.
+While collectors start colleting right away if they find exposed metrics on their default endpoint, not all
+infrastructures use standard ports, paths, files, or naming conventions. You may need to enable or configure a collector
+to gather all available metrics from your systems, containers, or applications.
 
 ## Enable a collector or its orchestrator
 
@@ -19,12 +19,13 @@ Use `edit-config` from your [Netdata config directory](/docs/configure/nodes.md#
 the orchestrator's primary configuration file:
 
 ```bash
-./edit-config go.d.conf
+cd /etc/netdata
+sudo ./edit-config go.d.conf
 ```
 
 Within this file, you can either disable the orchestrator entirely (`enabled: yes`), or find a specific collector and
-enable/disable it with `yes` and `no` settings. Uncomment any line you change to ensure it's read by the Netdata deamon
-on start.
+enable/disable it with `yes` and `no` settings. Uncomment any line you change to ensure the Netdata deamon reads it on
+start.
 
 After you make your changes, restart the Agent with `service netdata restart`.
 
@@ -41,9 +42,9 @@ collector's configuration file. For example, edit the Nginx collector with the f
 ```
 
 Each configuration file describes every available option and offers examples to help you tweak Netdata's settings
-according to your needs. In addition, every collector's documentation shows the exact command you need to run in order
-to configure that collector. Uncomment any line you change to ensure it's read by the collector's orchestrator or the
-Netdata daemon itself on start.
+according to your needs. In addition, every collector's documentation shows the exact command you need to run to
+configure that collector. Uncomment any line you change to ensure the collector's orchestrator or the Netdata daemon
+read it on start.
 
 After you make your changes, restart the Agent with `service netdata restart`.
 

--- a/docs/collect/enable-configure.md
+++ b/docs/collect/enable-configure.md
@@ -1,0 +1,15 @@
+<!--
+title: "Enable or configure a collector"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/enable-configure.md
+-->
+
+# Enable or configure a collector
+
+t/k
+
+## What's next?
+
+t/k
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fenable-configure&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/enable-configure.md
+++ b/docs/collect/enable-configure.md
@@ -1,15 +1,59 @@
 <!--
 title: "Enable or configure a collector"
-description: ""
+description: "Every collector is highly configurable, allowing them to collect metrics from any node and any infrastructure."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/enable-configure.md
 -->
 
 # Enable or configure a collector
 
-t/k
+While collectors start collect metrics right away if they find exposed metrics on their default endpoint, not all
+infrastructures use standard ports, paths, files, or naming conventions. In this case, you may need to enable or
+configure a collector to gather all available metrics from your systems, containers, or applications.
+
+## Enable a collector or its orchestrator
+
+You can enable/disable collectors individually, or enable/disable entire orchestrators, using their configuration files.
+For example, you can change the behavior of the Go orchestator, or any of its collectors, by editing `go.d.conf`.
+
+Use `edit-config` from your [Netdata config directory](/docs/configure/nodes.md#the-netdata-config-directory) to open
+the orchestrator's primary configuration file:
+
+```bash
+./edit-config go.d.conf
+```
+
+Within this file, you can either disable the orchestrator entirely (`enabled: yes`), or find a specific collector and
+enable/disable it with `yes` and `no` settings. Uncomment any line you change to ensure it's read by the Netdata deamon
+on start.
+
+After you make your changes, restart the Agent with `service netdata restart`.
+
+## Configure a collector
+
+First, [find the collector](/collectors/COLLECTORS.md) you want to edit and open its documentation. Some software has
+collectors written in multiple languages. In these cases, you should always pick the collector written in Go.
+
+Use `edit-config` from your [Netdata config directory](/docs/configure/nodes.md#the-netdata-config-directory) to open a
+collector's configuration file. For example, edit the Nginx collector with the following:
+
+```bash
+./edit-config go.d/nginx.conf
+```
+
+Each configuration file describes every available option and offers examples to help you tweak Netdata's settings
+according to your needs. In addition, every collector's documentation shows the exact command you need to run in order
+to configure that collector. Uncomment any line you change to ensure it's read by the collector's orchestrator or the
+Netdata daemon itself on start.
+
+After you make your changes, restart the Agent with `service netdata restart`.
 
 ## What's next?
 
-t/k
+Read high-level overviews on how Netdata collects [system metrics](/docs/collect/system-metrics.md), [container
+metrics](/docs/collect/container-metrics.md), and [application metrics](/docs/collect/application-metrics.md).
+
+If you're already collecting all metrics from your systems, containers, and applications, it's time to move into
+Netdata's visualization features. [View all your nodes at a glance](/docs/visualize/view-all-nodes.md) or learn how to
+[interact with dashboards and charts](/docs/visualize/interact-dashboards-charts.md).
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fenable-configure&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/enable-configure.md
+++ b/docs/collect/enable-configure.md
@@ -6,7 +6,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/ena
 
 # Enable or configure a collector
 
-While collectors start colleting right away if they find exposed metrics on their default endpoint, not all
+While collectors start collecting right away if they find exposed metrics on their default endpoint, not all
 infrastructures use standard ports, paths, files, or naming conventions. You may need to enable or configure a collector
 to gather all available metrics from your systems, containers, or applications.
 

--- a/docs/collect/how-collectors-work.md
+++ b/docs/collect/how-collectors-work.md
@@ -12,10 +12,15 @@ collecting per-second metrics.
 Netdata can immediately collect metrics from these endpoints thanks to 300+ **collectors**, which all come pre-installed
 when you [install the Netdata Agent](/docs/get/README.md#).
 
-A collector's primary job to look for exposed metrics at a pre- or user-defined endpoint. If the collector finds
-compatible metrics exposed on that endpoint, it begins a per-second collection job. The Netdata Agent gathers these
-metrics, sends to them to the [database engine for storage](/docs/store/change-metrics-retention.md), and immediately
-[visualizes them meaningfully](/docs/visualize/interact-dashboards-charts.md) on dashboards.
+Every collector has two primary jobs:
+
+-   Look for exposed metrics at a pre- or user-defined endpoint.
+-   Gather exposed metrics and use additional logic to build meaningful, interactive visualizations.
+
+If the collector finds compatible metrics exposed on the configured endpoint, it begins a per-second collection job. The
+Netdata Agent gathers these metrics, sends to them to the [database engine for
+storage](/docs/store/change-metrics-retention.md), and immediately [visualizes them
+meaningfully](/docs/visualize/interact-dashboards-charts.md) on dashboards.
 
 Each collector comes with a pre-defined configuration that matches the default setup for that application. This endpoint
 can be a URL and port, a socket, a file, a web page, and more.
@@ -51,6 +56,14 @@ terms related to collecting metrics.
 -   **Modules** are a type of collector.
 -   **Orchestrators** are external plugins that run and manage one or more modules. They run as independent processes.
     The Go orchestator is in active development.
+    -   [go.d.plugin](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/): An orchestrator for data
+        collection modules written in `go`.
+    -   [python.d.plugin](/collectors/python.d.plugin/README.md): An orchestrator for data collection modules written in
+        `python` v2/v3.
+    -   [charts.d.plugin](/collectors/charts.d.plugin/README.md): An orchestrator for data collection modules written in
+        `bash` v4+.
+    -   [node.d.plugin](/collectors/node.d.plugin/README.md): An orchestrator for data collection modules written in
+        `node.js`.
 -   **External plugins** gather metrics from external processes, such as a webserver or database, and run as independent
     processes that communicate with the Netdata daemon via pipes.
 -   **Internal plugins** gather metrics from `/proc`, `/sys` and other Linux kernel sources. They are written in `C`,

--- a/docs/collect/how-collectors-work.md
+++ b/docs/collect/how-collectors-work.md
@@ -50,7 +50,7 @@ Generally, Netdata's collectors can be grouped into three types:
 
 **Collector** is a catch-all term for any Netdata process that gathers metrics from an endpoint. 
 
-While we use collector most often in documentation, release notes, and educational content, you may encounter other
+While we use _collector_ most often in documentation, release notes, and educational content, you may encounter other
 terms related to collecting metrics.
 
 -   **Modules** are a type of collector.

--- a/docs/collect/how-collectors-work.md
+++ b/docs/collect/how-collectors-work.md
@@ -1,6 +1,6 @@
 <!--
 title: "How Netdata's metrics collectors work"
-description: ""
+description: "When Netdata starts, and with zero configuration, it auto-detects thousands of data sources and immediately begins collecting metrics."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/how-collectors-work.md
 -->
 
@@ -12,10 +12,10 @@ collecting per-second metrics.
 Netdata can immediately collect metrics from these endpoints thanks to 300+ **collectors**, which all come pre-installed
 when you [install the Netdata Agent](/docs/get/README.md#).
 
-A collector's primary job is simple: Look at a pre- or user-defined endpoint to find exposed metrics. If the collector
-finds compatible metrics exposed on that endpoint, it begins a per-second collection job. The Netdata Agent gathers
-these metrics, sends to them to the [database engine for storage](/docs/store/change-metrics-retention.md), and
-immediately [visualizes them meaningfully](/docs/visualize/interact-dashboards-charts.md) on dashboards.
+A collector's primary job to look for exposed metrics at a pre- or user-defined endpoint. If the collector finds
+compatible metrics exposed on that endpoint, it begins a per-second collection job. The Netdata Agent gathers these
+metrics, sends to them to the [database engine for storage](/docs/store/change-metrics-retention.md), and immediately
+[visualizes them meaningfully](/docs/visualize/interact-dashboards-charts.md) on dashboards.
 
 Each collector comes with a pre-defined configuration that matches the default setup for that application. This endpoint
 can be a URL and port, a socket, a file, a web page, and more.
@@ -28,9 +28,38 @@ access log files on Linux systems.
 
 The endpoint is user-configurable, as are many other specifics of what a given collector does.
 
+## What can Netdata collect?
+
+To quickly find your answer, see our [list of supported collectors](/collectors/COLLECTORS.md).
+
+Generally, Netdata's collectors can be grouped into three types:
+
+-   [Systems](/docs/collect/system-metrics.md): Monitor CPU, memory, disk, networking, systemd, eBPF, and much more.
+    Every metric exposed by `/proc`, `/sys` and other Linux kernel sources.
+-   [Containers](/docs/collect/container-metrics.md): Gather metrics from container agents, like `dockerd` or `kubectl`,
+    along with the resource usage of containers and the applications they run.
+-   [Applications](/docs/collect/application-metrics.md): Collect per-second metrics from web servers, databases, logs,
+    message brokers, APM tools, email servers, and much more.
+
+## Collector architecture and terminology
+
+**Collector** is a catch-all term for any Netdata process that gathers metrics from an endpoint. 
+
+While we use collector most often in documentation, release notes, and educational content, you may encounter other
+terms related to collecting metrics.
+
+-   **Modules** are a type of collector.
+-   **Orchestrators** are external plugins that run and manage one or more modules. They run as independent processes.
+    The Go orchestator is in active development.
+-   **External plugins** gather metrics from external processes, such as a webserver or database, and run as independent
+    processes that communicate with the Netdata daemon via pipes.
+-   **Internal plugins** gather metrics from `/proc`, `/sys` and other Linux kernel sources. They are written in `C`,
+    and run as threads within the Netdata daemon.
+
 ## What's next?
 
-[Enable or configure a collector](/docs/collect/enable-configure.md) 
+[Enable or configure a collector](/docs/collect/enable-configure.md) if the default settings are not compatible with
+your infrastructure.
 
 See our [collectors reference](/collectors/REFERENCE.md) for detailed information on Netdata's collector architecture,
 how to troubleshoot a collector, develop a custom collector, and more.

--- a/docs/collect/how-collectors-work.md
+++ b/docs/collect/how-collectors-work.md
@@ -1,13 +1,13 @@
 <!--
 title: "How Netdata's metrics collectors work"
-description: "When Netdata starts, and with zero configuration, it auto-detects thousands of data sources and immediately begins collecting metrics."
+description: "When Netdata starts, and with zero configuration, it auto-detects thousands of data sources and immediately collects per-second metrics."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/how-collectors-work.md
 -->
 
 # How Netdata's metrics collectors work
 
-When Netdata starts, and with zero configuration, it auto-detects thousands of data sources and immediately begins
-collecting per-second metrics.
+When Netdata starts, and with zero configuration, it auto-detects thousands of data sources and immediately collects
+per-second metrics.
 
 Netdata can immediately collect metrics from these endpoints thanks to 300+ **collectors**, which all come pre-installed
 when you [install the Netdata Agent](/docs/get/README.md#).
@@ -18,7 +18,7 @@ Every collector has two primary jobs:
 -   Gather exposed metrics and use additional logic to build meaningful, interactive visualizations.
 
 If the collector finds compatible metrics exposed on the configured endpoint, it begins a per-second collection job. The
-Netdata Agent gathers these metrics, sends to them to the [database engine for
+Netdata Agent gathers these metrics, sends them to the [database engine for
 storage](/docs/store/change-metrics-retention.md), and immediately [visualizes them
 meaningfully](/docs/visualize/interact-dashboards-charts.md) on dashboards.
 
@@ -40,7 +40,7 @@ To quickly find your answer, see our [list of supported collectors](/collectors/
 Generally, Netdata's collectors can be grouped into three types:
 
 -   [Systems](/docs/collect/system-metrics.md): Monitor CPU, memory, disk, networking, systemd, eBPF, and much more.
-    Every metric exposed by `/proc`, `/sys` and other Linux kernel sources.
+    Every metric exposed by `/proc`, `/sys`, and other Linux kernel sources.
 -   [Containers](/docs/collect/container-metrics.md): Gather metrics from container agents, like `dockerd` or `kubectl`,
     along with the resource usage of containers and the applications they run.
 -   [Applications](/docs/collect/application-metrics.md): Collect per-second metrics from web servers, databases, logs,
@@ -66,7 +66,7 @@ terms related to collecting metrics.
         `node.js`.
 -   **External plugins** gather metrics from external processes, such as a webserver or database, and run as independent
     processes that communicate with the Netdata daemon via pipes.
--   **Internal plugins** gather metrics from `/proc`, `/sys` and other Linux kernel sources. They are written in `C`,
+-   **Internal plugins** gather metrics from `/proc`, `/sys`, and other Linux kernel sources. They are written in `C`,
     and run as threads within the Netdata daemon.
 
 ## What's next?
@@ -75,6 +75,6 @@ terms related to collecting metrics.
 your infrastructure.
 
 See our [collectors reference](/collectors/REFERENCE.md) for detailed information on Netdata's collector architecture,
-how to troubleshoot a collector, develop a custom collector, and more.
+troubleshooting a collector, developing a custom collector, and more.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fhow-collectors-work&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/how-collectors-work.md
+++ b/docs/collect/how-collectors-work.md
@@ -1,0 +1,38 @@
+<!--
+title: "How Netdata's metrics collectors work"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/how-collectors-work.md
+-->
+
+# How Netdata's metrics collectors work
+
+When Netdata starts, and with zero configuration, it auto-detects thousands of data sources and immediately begins
+collecting per-second metrics.
+
+Netdata can immediately collect metrics from these endpoints thanks to 300+ **collectors**, which all come pre-installed
+when you [install the Netdata Agent](/docs/get/README.md#).
+
+A collector's primary job is simple: Look at a pre- or user-defined endpoint to find exposed metrics. If the collector
+finds compatible metrics exposed on that endpoint, it begins a per-second collection job. The Netdata Agent gathers
+these metrics, sends to them to the [database engine for storage](/docs/store/change-metrics-retention.md), and
+immediately [visualizes them meaningfully](/docs/visualize/interact-dashboards-charts.md) on dashboards.
+
+Each collector comes with a pre-defined configuration that matches the default setup for that application. This endpoint
+can be a URL and port, a socket, a file, a web page, and more.
+
+For example, the [Nginx collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/nginx) searches
+at `http://127.0.0.1/stub_status`, which is the default endpoint for exposing Nginx metrics. The [web log collector for
+Nginx or Apache](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/weblog) searches at
+`/var/log/nginx/access.log` and `/var/log/apache2/access.log`, respectively, both of which are standard locations for
+access log files on Linux systems.
+
+The endpoint is user-configurable, as are many other specifics of what a given collector does.
+
+## What's next?
+
+[Enable or configure a collector](/docs/collect/enable-configure.md) 
+
+See our [collectors reference](/collectors/REFERENCE.md) for detailed information on Netdata's collector architecture,
+how to troubleshoot a collector, develop a custom collector, and more.
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fhow-collectors-work&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/system-metrics.md
+++ b/docs/collect/system-metrics.md
@@ -1,0 +1,24 @@
+<!--
+title: "Collect system metrics with Netdata"
+sidebar_label: "System metrics"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/system-metrics.md
+-->
+
+# Collect system metrics with Netdata
+
+t/k
+
+## Windows system monitoring
+
+t/k
+
+## Netdata's system collectors
+
+t/k
+
+## What's next?
+
+t/k
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fsystem-metrics&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/system-metrics.md
+++ b/docs/collect/system-metrics.md
@@ -11,7 +11,7 @@ Netdata collects thousands of metrics directly the operating systems of physical
 and [containers](/docs/collect/container-metrics.md) with zero configuration.
 
 To gather system metrics, Netdata uses roughly a dozen plugins, each of which has one or more collectors for very
-specific metrics exposed by the host. Most metrics Netdata users interface with most for health monitoring and
+specific metrics exposed by the host. The system metrics Netdata users interact with most for health monitoring and
 performance troubleshooting are collected and visualized by `proc.plugin`, `cgroups.plugin`, and `ebpf.plugin`.
 
 [**proc.plugin**](/collectors/proc.plugin/README.md) gathers metrics from the `/proc` and `/sys` folders in Linux

--- a/docs/collect/system-metrics.md
+++ b/docs/collect/system-metrics.md
@@ -1,24 +1,62 @@
 <!--
 title: "Collect system metrics with Netdata"
 sidebar_label: "System metrics"
-description: ""
+description: "Netdata collects thousands of metrics from physical and virtual systems, IoT/edge devices, and containers with zero configuration."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/system-metrics.md
 -->
 
 # Collect system metrics with Netdata
 
-TK
+Netdata collects thousands of metrics from physical and virtual systems, IoT/edge devices, and
+[containers](/docs/collect/container-metrics.md) with zero configuration.
 
-## Netdata's system collectors
+To gather system metrics, Netdata uses roughly a dozen plugins, each of which have one or more collectors for very
+specific metrics exposed by the host. A majority of the metrics Netdata users interface with most for health monitoring
+and performance troubleshooting are collected and visualized by `proc.plugin`, `cgroups.plugin`, and `ebpf.plugin`.
 
-t/k
+[**proc.plugin**](/collectors/proc.plugin/README.md) gathers metrics from the `/proc` and `/sys` folders in Linux
+systems, along with a few other endpoints, and is responsible for the bulk of the system metrics collected and
+visualized by Netdata. With zero configuration, it collects CPU, memory, disks, load, networking, mount points, and
+more. It even allows Netdata to monitor its own resource utilization!
 
-## Windows system monitoring
+[**cgroups.plugin**](/collectors/cgroups.plugin/README.md) collects rich metrics about containes and virtual machines
+using the virtual files under `/sys/fs/cgroup`. By reading cgroups, Netdata can instantly collect resource utilization
+metrics for systemd services, all containers (Docker, LXC, LXD, Libvirt, systemd-nspawn), and more. Learn more in the
+[collecting container metrics](/docs/collect/container-metrics.md) doc.
 
-TK
+[**ebpf.plugin**](/collectors/ebpf.plugin/README.md): Netdata's extended Berkeley Packet Filter (eBPF) collector
+monitors kernel-level metrics for file descriptors, virtual filesystem IO, and process management on Linux systems. You
+can use our eBPF collector to analyze how and when a process accesses files, when it makes system calls, whether it
+leaks memory or creating zombie processes, and more.
+
+While the above plugins and associated collectors are the most important for system metrics, there are many others. You
+can find all system collectors in our [supported collectors list](/collectors/COLLECTORS.md#system-metrics).
+
+## Collect Windows system metrics
+
+Netdata is also capable of monitoring Windows systems. The [WMI
+collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/wmi) integrates with
+[windows_exporter](https://github.com/prometheus-community/windows_exporter), which is a small Go-based binary that you
+can run on Windows systems. The WMI collector then gathers metrics from an endpoint created by windows_exporter.
+
+First, [install
+windows_exporter](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/wmi#configuration) and run it:
+`windows_exporter-0.13.0-amd64.exe --collectors.enabled="cpu,memory,net,logical_disk,os,system,logon"`.
+
+Next, [configure the WMI
+collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/wmi#configuration) to point to the URL
+and port of your exposed endpoint. Restart Netdata with `service netdata restart` and you'll start seeing Windows system
+metrics, such as CPU utilization, memory, bandwidth per NIC, number of processes, and much more.
+
+For inforamtion about collecting metrics from applications _running on Windows systems_, see the [application metrics
+doc](/docs/collect/application-metrics.md#collect-metrics-from-applications-running-on-windows).
 
 ## What's next?
 
-TK
+Because there's some overlap between system metrics and [container metrics](/docs/collect/container-metrics.md), you
+should investigate Netdata's container compatibility if you use them heavily in your infrastructure.
+
+If you don't use containers, skip ahead to collecting [application metrics](/docs/collect/application-metrics.md) with
+Netdata.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fsystem-metrics&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/collect/system-metrics.md
+++ b/docs/collect/system-metrics.md
@@ -7,8 +7,8 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/sys
 
 # Collect system metrics with Netdata
 
-Netdata collects thousands of metrics directly the operating systems of physical and virtual systems, IoT/edge devices,
-and [containers](/docs/collect/container-metrics.md) with zero configuration.
+Netdata collects thousands of metrics directly from the operating systems of physical and virtual systems, IoT/edge
+devices, and [containers](/docs/collect/container-metrics.md) with zero configuration.
 
 To gather system metrics, Netdata uses roughly a dozen plugins, each of which has one or more collectors for very
 specific metrics exposed by the host. The system metrics Netdata users interact with most for health monitoring and

--- a/docs/collect/system-metrics.md
+++ b/docs/collect/system-metrics.md
@@ -7,27 +7,27 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/sys
 
 # Collect system metrics with Netdata
 
-Netdata collects thousands of metrics from physical and virtual systems, IoT/edge devices, and
-[containers](/docs/collect/container-metrics.md) with zero configuration.
+Netdata collects thousands of metrics directly the operating systems of physical and virtual systems, IoT/edge devices,
+and [containers](/docs/collect/container-metrics.md) with zero configuration.
 
-To gather system metrics, Netdata uses roughly a dozen plugins, each of which have one or more collectors for very
-specific metrics exposed by the host. A majority of the metrics Netdata users interface with most for health monitoring
-and performance troubleshooting are collected and visualized by `proc.plugin`, `cgroups.plugin`, and `ebpf.plugin`.
+To gather system metrics, Netdata uses roughly a dozen plugins, each of which has one or more collectors for very
+specific metrics exposed by the host. Most metrics Netdata users interface with most for health monitoring and
+performance troubleshooting are collected and visualized by `proc.plugin`, `cgroups.plugin`, and `ebpf.plugin`.
 
 [**proc.plugin**](/collectors/proc.plugin/README.md) gathers metrics from the `/proc` and `/sys` folders in Linux
 systems, along with a few other endpoints, and is responsible for the bulk of the system metrics collected and
-visualized by Netdata. With zero configuration, it collects CPU, memory, disks, load, networking, mount points, and
-more. It even allows Netdata to monitor its own resource utilization!
+visualized by Netdata. It collects CPU, memory, disks, load, networking, mount points, and more with zero configuration.
+It even allows Netdata to monitor its own resource utilization!
 
-[**cgroups.plugin**](/collectors/cgroups.plugin/README.md) collects rich metrics about containes and virtual machines
+[**cgroups.plugin**](/collectors/cgroups.plugin/README.md) collects rich metrics about containers and virtual machines
 using the virtual files under `/sys/fs/cgroup`. By reading cgroups, Netdata can instantly collect resource utilization
 metrics for systemd services, all containers (Docker, LXC, LXD, Libvirt, systemd-nspawn), and more. Learn more in the
 [collecting container metrics](/docs/collect/container-metrics.md) doc.
 
 [**ebpf.plugin**](/collectors/ebpf.plugin/README.md): Netdata's extended Berkeley Packet Filter (eBPF) collector
-monitors kernel-level metrics for file descriptors, virtual filesystem IO, and process management on Linux systems. You
-can use our eBPF collector to analyze how and when a process accesses files, when it makes system calls, whether it
-leaks memory or creating zombie processes, and more.
+monitors Linux kernel-level metrics for file descriptors, virtual filesystem IO, and process management. You can use our
+eBPF collector to analyze how and when a process accesses files, when it makes system calls, whether it leaks memory or
+creating zombie processes, and more.
 
 While the above plugins and associated collectors are the most important for system metrics, there are many others. You
 can find all system collectors in our [supported collectors list](/collectors/COLLECTORS.md#system-metrics).
@@ -36,8 +36,8 @@ can find all system collectors in our [supported collectors list](/collectors/CO
 
 Netdata is also capable of monitoring Windows systems. The [WMI
 collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/wmi) integrates with
-[windows_exporter](https://github.com/prometheus-community/windows_exporter), which is a small Go-based binary that you
-can run on Windows systems. The WMI collector then gathers metrics from an endpoint created by windows_exporter.
+[windows_exporter](https://github.com/prometheus-community/windows_exporter), a small Go-based binary that you can run
+on Windows systems. The WMI collector then gathers metrics from an endpoint created by windows_exporter.
 
 First, [install
 windows_exporter](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/wmi#configuration) and run it:
@@ -48,7 +48,7 @@ collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules
 and port of your exposed endpoint. Restart Netdata with `service netdata restart` and you'll start seeing Windows system
 metrics, such as CPU utilization, memory, bandwidth per NIC, number of processes, and much more.
 
-For inforamtion about collecting metrics from applications _running on Windows systems_, see the [application metrics
+For information about collecting metrics from applications _running on Windows systems_, see the [application metrics
 doc](/docs/collect/application-metrics.md#collect-metrics-from-applications-running-on-windows).
 
 ## What's next?

--- a/docs/collect/system-metrics.md
+++ b/docs/collect/system-metrics.md
@@ -7,18 +7,18 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/collect/sys
 
 # Collect system metrics with Netdata
 
-t/k
-
-## Windows system monitoring
-
-t/k
+TK
 
 ## Netdata's system collectors
 
 t/k
 
+## Windows system monitoring
+
+TK
+
 ## What's next?
 
-t/k
+TK
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fcollect%2Fsystem-metrics&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Five new documents: 

- How Netdata's metrics collectors work
- Enable or configure a collector
- Collect system metrics with Netdata
- Collect container metrics with Netdata
- Collect application metrics with Netdata

> See netdata/netdata-learn-docusaurus#285 for additional context.
>
> This page contains some elements that will only appear on the deployed Learn site, so see the deploy preview for this page for the full picture: https://deploy-preview-285--netdata-docusaurus.netlify.app/docs/get
>
> Some links will not work, as the target docs do not exist yet.
>
> For now, these PRs will get merged into the docsv2 but not go live on Netdata Learn. Once they're all available, or at least a workable majority, we'll merge them into master and deploy the project as a whole.

##### Component Name

area/docs

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
