### PR TITLE
Updated RPM spec file to use automatic dependency list generation.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -5,6 +5,11 @@
 #TODO: Temporary fix for the build-id error during go.d plugin set up
 %global _missing_build_ids_terminate_build 0
 
+# XXX: We are using automatic `Requires:` generation for libraries
+# whenever possible, DO NOT LIST LIBRARY DEPENDENCIES UNLESS THE RESULTANT
+# PACKAGE IS BROKEN WITHOUT THEM.
+AutoReqProv: yes
+
 %if "@HAVE_LIBBPF@" == "1"
 %global have_bpf 1
 %else
@@ -148,31 +153,10 @@ BuildRequires: json-c-devel
 # Runtime dependencies
 #
 Requires:      python
-Requires:      zlib
-%if 0%{?suse_version}
-# for libuv, Requires version >= 1
-Requires:      libuv1
-Requires:      libJudy1
-Requires:      libjson-c4
-Requires:      libuuid1
-%else
-# for libuv, Requires version >= 1
-Requires:      libuv >= 1
-Requires:      Judy
-Requires:      json-c
-Requires:      libuuid
-%endif
-Requires:      openssl
-Requires:      lz4
 
 # Core requirements for the install to succeed
 Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd
-%if 0%{?suse_version} >= 1140
-Requires(post): libcap1
-%else
-Requires(post): libcap
-%endif
 
 %{netdata_initd_requires}
 
@@ -188,19 +172,6 @@ BuildRequires:  libmnl-devel
 BuildRequires:  libnetfilter_acct-devel
 %endif
 
-%if 0%{?suse_version}
-Requires: libmnl0
-%else
-Requires: libmnl
-%endif
-
-%if 0%{?fedora}
-Requires: libnetfilter_acct
-%else
-%if 0%{?suse_version} >= 1140
-Requires: libnetfilter_acct1
-%endif
-%endif
 # end nfacct plugin dependencies
 
 # freeipmi plugin dependencies
@@ -220,16 +191,6 @@ BuildRequires: protobuf-devel
 BuildRequires: libprotobuf-c-devel
 %else
 BuildRequires: protobuf-c-devel
-%endif
-
-%if 0%{?suse_version}
-Requires: libsnappy1
-Requires: protobuf-c
-Requires: libprotobuf15
-%else
-Requires: snappy
-Requires: protobuf-c
-Requires: protobuf
 %endif
 # end - prometheus remote write dependencies
 
@@ -559,6 +520,8 @@ are sensor monitoring, system event monitoring, power control, and serial-over-L
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 
 %changelog
+* Wed Sep 16 2020 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-14
+- Convert to using 'AutoReq: yes' for library dependencies.
 * Thu Feb 13 2020 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-13
 - Add handling for custom libmosquitto fork
 * Wed Jan 01 2020 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-12


### PR DESCRIPTION
##### Summary

Our current RPM spec file includes _all_ of our library dependencies as statically listed `Requires:` lines. This, in turn, requires a very large number of conditionals in the dependencies to account for package naming differences between RPM distros, and also makes it a pain in the arse to port the spec file to work with new releases of existing distros.

This changes the spec file to just use the automatic `Requires:` generation functionality that's already included in the RPM build process. The net effect is that the spec file ends up much cleaner, and it works just about anywhere with minimal modification., as well as us not having to track anything but build dependencies manually. It also results in a more accurate representation of our dependencies, because the resulting RPM depends directly on the exact libraries that we're linked to instead of package names that may or may not match on any given distro.

##### Component Name

area/packaging

##### Test Plan

Tested locally by verifying the packages generated using the modified spec file properly list all of the libraries linked into the executables in the package itself. Relevant `rpm` command to get the list of required libraries/packages from the built package files is `rpm -qp --requires`.

##### Additional Information

See http://ftp.rpm.org/max-rpm/s1-rpm-depend-auto-depend.html for documentation about this RPM feature.

This is functionally required for #8065.