### PR TITLE
Fix typo inside netdata-installer.sh

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1619,7 +1619,7 @@ progress "Install netdata at system init"
 # By default we assume the shutdown/startup of the Netdata Agent are effectively
 # without any system supervisor/init like SystemD or SysV. So we assume the most
 # basic startup/shutdown commands...
-NETDATA_STOP_CMD="${NETDATA_PREFIX}/usr/bin/netdatacli shutdown-agent"
+NETDATA_STOP_CMD="${NETDATA_PREFIX}/usr/sbin/netdatacli shutdown-agent"
 NETDATA_START_CMD="${NETDATA_PREFIX}/usr/sbin/netdata"
 
 if grep -q docker /proc/1/cgroup > /dev/null 2>&1; then


### PR DESCRIPTION
##### Summary
Fixes #9961 

As discussed in the specified issue, this PR is fixing the typo that we have inside `netdata-installer.sh`
##### Component Name
Installer.

##### Test Plan
Install Netdata on an environment that has Netdata is already running and verify that the error is fixed

##### Additional Information
