### PR TITLE
Added improved auto-update support.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -280,7 +280,7 @@ while [ -n "${1}" ]; do
     "--dont-wait") DONOTWAIT=1 ;;
     "--auto-update" | "-u") AUTOUPDATE=1 ;;
     "--auto-update-type")
-      AUTO_UPDATE_TYPE="${2}"
+      AUTO_UPDATE_TYPE="$(echo "${2}" | tr '[:upper:]' '[:lower:]')"
       case "${AUTO_UPDATE_TYPE}" in
         systemd|interval|crontab)
           shift 1

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -205,6 +205,8 @@ USAGE: ${PROGRAM} [options]
   --dont-start-it            Do not (re)start netdata after installation
   --dont-wait                Run installation in non-interactive mode
   --auto-update or -u        Install netdata-updater in cron to update netdata automatically once per day
+  --auto-update-type         Override the auto-update scheduling mechanism detection, currently supported types
+                             are: systemd, interval, crontab
   --stable-channel           Use packages from GitHub release pages instead of GCS (nightly updates).
                              This results in less frequent updates.
   --nightly-channel          Use most recent nightly udpates instead of GitHub releases.
@@ -277,6 +279,18 @@ while [ -n "${1}" ]; do
     "--dont-start-it") DONOTSTART=1 ;;
     "--dont-wait") DONOTWAIT=1 ;;
     "--auto-update" | "-u") AUTOUPDATE=1 ;;
+    "--auto-update-type")
+      AUTO_UPDATE_TYPE="${2}"
+      case "${AUTO_UPDATE_TYPE}" in
+        systemd|interval|crontab)
+          shift 1
+          ;;
+        *)
+          echo "Unrecognized value for --auto-update-type. Valid values are: systemd, interval, crontab"
+          exit 1
+          ;;
+      esac
+      ;;
     "--stable-channel") RELEASE_CHANNEL="stable" ;;
     "--nightly-channel") RELEASE_CHANNEL="nightly" ;;
     "--enable-plugin-freeipmi") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-freeipmi/} --enable-plugin-freeipmi" ;;
@@ -1796,7 +1810,7 @@ install_netdata_updater || run_failed "Cannot install netdata updater tool."
 
 progress "Check if we must enable/disable the netdata updater tool"
 if [ "${AUTOUPDATE}" = "1" ]; then
-  enable_netdata_updater || run_failed "Cannot enable netdata updater tool"
+  enable_netdata_updater ${AUTO_UPDATE_TYPE} || run_failed "Cannot enable netdata updater tool"
 else
   disable_netdata_updater || run_failed "Cannot disable netdata updater tool"
 fi

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -972,7 +972,7 @@ cleanup_old_netdata_updater() {
   fi
 
   if [ -d /etc/cron.d ]; then
-    rm -f /etc/cron.d/netdata
+    rm -f /etc/cron.d/netdata-updater
   fi
 
   return 0
@@ -1009,7 +1009,7 @@ enable_netdata_updater() {
     "crontab")
       cat "${NETDATA_SOURCE_DIR}/system/netdata.crontab" > "/etc/cron.d/netdata-updater"
 
-      echo >&2 "Auto-updating has been enabled through cron, using a crontab at ${TPUT_RED}${TPUT_BOLD}/etc/cron.d/netdata${TPUT_RESET}"
+      echo >&2 "Auto-updating has been enabled through cron, using a crontab at ${TPUT_RED}${TPUT_BOLD}/etc/cron.d/netdata-updater${TPUT_RESET}"
       echo >&2
       echo >&2 "If the update process fails and you have email notifications set up correctly for cron on this system, you should receive an email notification of the failure."
       echo >&2 "Successful updates will not send an email."

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -392,7 +392,7 @@ issystemd() {
   return 1
 }
 
-systemd_unit_dir() {
+get_systemd_service_dir() {
   local SYSTEMD_DIRECTORY=""
   local key
   key="$(get_os_key)"
@@ -502,7 +502,7 @@ install_netdata_service() {
       NETDATA_STOP_CMD="systemctl stop netdata"
       NETDATA_INSTALLER_START_CMD="${NETDATA_START_CMD}"
 
-      SYSTEMD_DIRECTORY="$(systemd_service_path)"
+      SYSTEMD_DIRECTORY="$(get_systemd_service_dir)"
 
       if [ "${SYSTEMD_DIRECTORY}x" != "x" ]; then
         ENABLE_NETDATA_IF_PREVIOUSLY_ENABLED="run systemctl enable netdata"
@@ -935,9 +935,9 @@ install_netdata_updater() {
     cat "${NETDATA_SOURCE_DIR}/packaging/installer/netdata-updater.sh" > "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || return 1
   fi
 
-  if issystemd && [ -n "$(systemd_service_dir)" ]; then
-    cat "${NETDATA_SOURCE_DIR}/system/netdata-updater.timer" > "$(systemd_service_dir)/netdata-updater.timer"
-    cat "${NETDATA_SOURCE_DIR}/system/netdata-updater.service" > "$(systemd_service_dir)/netdata-updater.service"
+  if issystemd && [ -n "$(get_systemd_service_dir)" ]; then
+    cat "${NETDATA_SOURCE_DIR}/system/netdata-updater.timer" > "$(get_systemd_service_dir)/netdata-updater.timer"
+    cat "${NETDATA_SOURCE_DIR}/system/netdata-updater.service" > "$(get_systemd_service_dir)/netdata-updater.service"
   fi
 
   sed -i -e "s|THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT|${NETDATA_USER_CONFIG_DIR}/.environment|" "${NETDATA_PREFIX}/usr/libexec/netdata/netdata-updater.sh" || return 1
@@ -955,10 +955,10 @@ cleanup_old_netdata_updater() {
     rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh
   fi
 
-  if issystemd && [ -n "$(systemd_service_dir)" ] ; then
+  if issystemd && [ -n "$(get_systemd_service_dir)" ] ; then
     systemctl disable netdata-updater.timer
-    rm -f "$(systemd_service_dir)/netdata-updater.timer"
-    rm -f "$(systemd_service_dir)/netdata-updater.service"
+    rm -f "$(get_systemd_service_dir)/netdata-updater.timer"
+    rm -f "$(get_systemd_service_dir)/netdata-updater.service"
   fi
 
   if [ -d /etc/cron.daily ]; then
@@ -1028,7 +1028,7 @@ disable_netdata_updater() {
   echo >&2 "You chose *NOT* to enable auto-update, removing any links to the updater from cron (it may have happened if you are reinstalling)"
   echo >&2
 
-  if issystemd && [ -n "$(systemd_service_dir)" ] ; then
+  if issystemd && [ -n "$(get_systemd_service_dir)" ] ; then
     systemctl disable netdata-updater.timer
   fi
 

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -903,10 +903,10 @@ safe_sha256sum() {
 }
 
 _get_scheduler_type() {
-  if issystemd ; then
-    echo 'systemd'
-  elif _get_intervaldir > /dev/null ; then
+  if _get_intervaldir > /dev/null ; then
     echo 'interval'
+  elif issystemd ; then
+    echo 'systemd'
   elif [ -d /etc/cron.d ] ; then
     echo 'crontab'
   else

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -979,7 +979,15 @@ cleanup_old_netdata_updater() {
 }
 
 enable_netdata_updater() {
-  case "$(_get_scheduler_type)" in
+  local updater_type
+
+  if [ -z "${1}" ] ; then
+    updater_type="${1}"
+  else
+    updater_type="$(_get_scheduler_type)"
+  fi
+
+  case "${updater_type}" in
     "systemd")
       systemctl enable netdata-updater.timer
 

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -453,6 +453,12 @@ rm_file /etc/logrotate.d/netdata
 rm_file /etc/systemd/system/netdata.service
 rm_file /lib/systemd/system/netdata.service
 rm_file /usr/lib/systemd/system/netdata.service
+rm_file /etc/systemd/system/netdata-updater.service
+rm_file /lib/systemd/system/netdata-updater.service
+rm_file /usr/lib/systemd/system/netdata-updater.service
+rm_file /etc/systemd/system/netdata-updater.timer
+rm_file /lib/systemd/system/netdata-updater.timer
+rm_file /usr/lib/systemd/system/netdata-updater.timer
 rm_file /etc/init.d/netdata
 rm_file /etc/periodic/daily/netdata-updater
 rm_file /etc/cron.daily/netdata-updater

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -13,6 +13,7 @@ CLEANFILES = \
     netdata-freebsd \
     netdata.plist \
     netdata.crontab \
+    netdata-updater.service \
     $(NULL)
 
 include $(top_srcdir)/build/subst.inc
@@ -36,6 +37,7 @@ nodist_noinst_DATA = \
     netdata-freebsd \
     netdata.plist \
     netdata.crontab \
+    netdata-updater.service \
     $(NULL)
 
 dist_noinst_DATA = \
@@ -50,4 +52,6 @@ dist_noinst_DATA = \
     netdata.plist.in \
     netdata.conf \
     netdata.crontab.in \
+    netdata-updater.service.in \
+    netdata-updater.timer \
     $(NULL)

--- a/system/netdata-updater.service.in
+++ b/system/netdata-updater.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Daily auto-updates for Netdata
+RefuseManualStart=no
+RefuseManualStop=yes
+
+[Service]
+Type=oneshot
+ExecStart=@pkglibexecdir_POST@/netdata-updater.sh

--- a/system/netdata-updater.timer
+++ b/system/netdata-updater.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daily auto-updates for Netdata
+RefuseManualStart=no
+RefuseManualStop=no
+
+[Timer]
+Persistent=false
+OnCalendar=daily
+Unit=netdata-updater.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
##### Summary

This adds two new features around auto-updates:

* Support for using  systemd timer unit and associated service to handle updates. This removes the need to have either a working cron daemon or a special shim on systemd systems if the user wants auto-updates. This will be used only if the `/etc/cron.daily` or `/etc/periodic/daily` methods don't work, as it does not provide email notifications for failures.
* Add the ability to override the auto-detection of the auto-update mechanism using a new `--auto-update-type` option. Takes one of `systemd`, `interval`, or `crontab` to select that type of auto-update scheduling. This should improve testability as well as allowing users who want something other than the default to actually use it.

##### Component Name

area/packaging

##### Test Plan

Verified locally on a variety of distributions.

##### Additional Information

Fixes: #9077 (together with the changes from #9598).