### PR TITLE
Fix setting for disabling eBPF-apps.plugin integration

### DIFF
--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -175,11 +175,12 @@ When the integration is enabled, your dashboard will also show the following cha
 -   eBPF net
     -   Number of bytes transmited per seconds.   
 
-If you want to disable these charts, change the setting `disable apps` to `no`.
+If you want to _disable_ the integration with `apps.plugin` along with the above charts, change the setting `disable
+apps` to `yes`.
 
 ```conf
 [global]
-   disable apps = no
+   disable apps = yes
 ```
 
 ### `[ebpf programs]`


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

We had our `yes` and `no` mixed up for this setting. This PR is a quick fix to flip the logic.

cc @OdysLam 

##### Component Name

area/docs

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Verified on my local system that setting `disable apps = yes` removed the eBPF charts from the **Applications** section. They were enabled and visible by default.

##### Additional Information
