### PR TITLE
Add store docs to docsv2 project

### DIFF
--- a/docs/store/change-metrics-storage.md
+++ b/docs/store/change-metrics-storage.md
@@ -6,7 +6,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/store/chang
 
 # Change how long Netdata stores metrics
 
-import { Calculator } from '../../../src/components/agent/dbCalc/'
+import { Calculator } from '../../src/components/agent/dbCalc/'
 
 The [database engine](/database/engine/README.md) uses RAM to store recent metrics. When metrics reach a certain age,
 and based on how much system RAM you allocate toward storing metrics in memory, they are compressed and "spilled" to

--- a/docs/store/change-metrics-storage.md
+++ b/docs/store/change-metrics-storage.md
@@ -33,19 +33,23 @@ If you need to store more or less metrics using the database engine, we recommen
 an appropriate value for `dbengine multihost disk space` based on how many metrics your node(s) collect, whether you are
 streaming metrics to a parent node, and more.
 
-> ⚠️ This calculator provides an estimate of disk and RAM usage. Real-life usage may vary based on the accuracy of the
-> values you enter below or due to changes in the compression ratio.
+You do not need to edit the `page cache size` setting to store more metrics using the database engine. However, if you
+want to store more metrics _specifically in memory_, you can increase the cache size.
+
+> ⚠️ This calculator provides an estimate of disk and RAM usage for **metrics storage**, along with its best
+> recommendation for the `dbengine multihost disk space` setting. Real-life usage may vary based on the accuracy of the
+> values you enter below, changes in the compression ratio, and the types of metrics stored.
 
 <Calculator />
 
-## Edit `dbengine multihost disk space` and `page cache size`
+## Edit `netdata.conf` with recommended database engine settings
 
 Now that you have a recommended setting for `dbengine multihost disk space`, open `netdata.conf` with
-[`edit-config`](/docs/configure/nodes.md#use-edit-config-to-edit-netdataconf) and 
+[`edit-config`](/docs/configure/nodes.md#use-edit-config-to-edit-netdataconf) and look for the `dbengine multihost disk
+space` setting. Change it to the value recommended above. For example:
 
 ```conf
 [global]
-    page cache size = 32
     dbengine multihost disk space = 1024
 ```
 

--- a/docs/store/change-metrics-storage.md
+++ b/docs/store/change-metrics-storage.md
@@ -10,9 +10,9 @@ import { Calculator } from '../../src/components/agent/dbCalc/'
 
 The [database engine](/database/engine/README.md) uses RAM to store recent metrics. When metrics reach a certain age,
 and based on how much system RAM you allocate toward storing metrics in memory, they are compressed and "spilled" to
-disk for long-term storage. 
+disk for long-term storage.
 
-The default settings retain about two day's worth of metris on a system collecting 2,000 metrics every second, but the
+The default settings retain about two day's worth of metrics on a system collecting 2,000 metrics every second, but the
 Netdata Agent is highly configurable if you want your nodes to store days, weeks, or months worth of per-second data.
 
 The Netdata Agent uses two settings in `netdata.conf` to change the behavior of the database engine:
@@ -25,13 +25,14 @@ The Netdata Agent uses two settings in `netdata.conf` to change the behavior of 
 
 `page cache size` sets the maximum amount of RAM (in MiB) the database engine uses to cache and index recent metrics.
 `dbengine multihost disk space` sets the maximum disk space (again, in MiB) the database engine uses to store
-historical, compressed metrics.
+historical, compressed metrics. When the size of stored metrics exceeds the allocated disk space, the database engine
+removes the oldest metrics on a rolling basis.
 
 ## Calculate the system resources (RAM, disk space) needed to store metrics
 
-If you need to store more or less metrics using the database engine, we recommend you use the below calculator to find
-an appropriate value for `dbengine multihost disk space` based on how many metrics your node(s) collect, whether you are
-streaming metrics to a parent node, and more.
+You can store more or less metrics using the database engine by changing the allocated disk space. Use the calculator
+below to find an appropriate value for `dbengine multihost disk space` based on how many metrics your node(s) collect,
+whether you are streaming metrics to a parent node, and more.
 
 You do not need to edit the `page cache size` setting to store more metrics using the database engine. However, if you
 want to store more metrics _specifically in memory_, you can increase the cache size.
@@ -61,10 +62,10 @@ For more information about the database engine, see our [database reference doc]
 
 Storing metrics with the database engine is completely interoperable with [exporting to other time-series
 databases](/docs/export/integrate-exporting.md). With exporting, you can use the node's resources to surface metrics
-when [viewing dashboards](/docs/visualize/interact-dashboards-charts.md), while also archiving and preserving metrics
-elsewhere for further analysis, visualization, or correlation with other tools. 
+when [viewing dashboards](/docs/visualize/interact-dashboards-charts.md), while also archiving metrics elsewhere for
+further analysis, visualization, or correlation with other tools. 
 
-If you don't want to always store metrics on the node that collects them, or you run ephemeral nodes without dedicated
+If you don't want to always store metrics on the node that collects them or run ephemeral nodes without dedicated
 storage, you can use [streaming](/docs/stream/README.md). Streaming allows you to centralize your data, run Agents as
 headless collectors, replicate data, and more.
 

--- a/docs/store/change-metrics-storage.md
+++ b/docs/store/change-metrics-storage.md
@@ -1,0 +1,67 @@
+<!--
+title: "Change how long Netdata stores metrics"
+description: "With a single configuration change, the Netdata Agent can store days, weeks, or months of metrics at its famous per-second granularity."
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/store/change-metrics-storage.md
+-->
+
+# Change how long Netdata stores metrics
+
+import { Calculator } from '../../../src/components/agent/dbCalc/'
+
+The [database engine](/database/engine/README.md) uses RAM to store recent metrics. When metrics reach a certain age,
+and based on how much system RAM you allocate toward storing metrics in memory, they are compressed and "spilled" to
+disk for long-term storage. 
+
+The default settings retain about two day's worth of metris on a system collecting 2,000 metrics every second, but the
+Netdata Agent is highly configurable if you want your nodes to store days, weeks, or months worth of per-second data.
+
+The Netdata Agent uses two settings in `netdata.conf` to change the behavior of the database engine:
+
+```conf
+[global]
+    page cache size = 32
+    dbengine multihost disk space = 256
+```
+
+`page cache size` sets the maximum amount of RAM (in MiB) the database engine uses to cache and index recent metrics.
+`dbengine multihost disk space` sets the maximum disk space (again, in MiB) the database engine uses to store
+historical, compressed metrics.
+
+## Calculate the system resources (RAM, disk space) needed to store metrics
+
+If you need to store more or less metrics using the database engine, we recommend you use the below calculator to find
+an appropriate value for `dbengine multihost disk space` based on how many metrics your node(s) collect, whether you are
+streaming metrics to a parent node, and more.
+
+> ⚠️ This calculator provides an estimate of disk and RAM usage. Real-life usage may vary based on the accuracy of the
+> values you enter below or due to changes in the compression ratio.
+
+<Calculator />
+
+## Edit `dbengine multihost disk space` and `page cache size`
+
+Now that you have a recommended setting for `dbengine multihost disk space`, open `netdata.conf` with
+[`edit-config`](/docs/configure/nodes.md#use-edit-config-to-edit-netdataconf) and 
+
+```conf
+[global]
+    page cache size = 32
+    dbengine multihost disk space = 1024
+```
+
+Save the file and restart the Agent with `service netdata restart` to change the database engine's size.
+
+## What's next?
+
+For more information about the database engine, see our [database reference doc](/database/engine/README.md).
+
+Storing metrics with the database engine is completely interoperable with [exporting to other time-series
+databases](/docs/export/integrate-exporting.md). With exporting, you can use the node's resources to surface metrics
+when [viewing dashboards](/docs/visualize/interact-dashboards-charts.md), while also archiving and preserving metrics
+elsewhere for further analysis, visualization, or correlation with other tools. 
+
+If you don't want to always store metrics on the node that collects them, or you run ephemeral nodes without dedicated
+storage, you can use [streaming](/docs/stream/README.md). Streaming allows you to centralize your data, run Agents as
+headless collectors, replicate data, and more.
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fstore%2Fchange-metrics-storage&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/store/distributed-data-architecture.md
+++ b/docs/store/distributed-data-architecture.md
@@ -1,0 +1,76 @@
+<!--
+title: "Distributed data architecture"
+description: ""
+custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/store/distributed-data.md
+-->
+
+# Distributed data architecture
+
+Netdata uses a distributed data architecture to help you collect and store per-second metrics from any number of nodes.
+Every node in your infrastructure, whether it's one or a thousand, stores its own metrics. By storing metrics at the
+point where they are collected, or as close as possible, Netdata helps you maintain control of your data and control the
+costs of deploying infrastructure monitoring.
+
+Netdata Cloud bridges the gap between many distributed databases by centralizing the interface you use to query and
+visualize metrics from your nodes. When you look at charts in [Netdata
+Cloud](/docs/visualize/interact-dashboards-charts.md), the metrics values are queried directly from that node's database
+and securely streamed to Netdata Cloud, where they are in turn proxied to your browser.
+
+Netdata's distributed data architecture has a number of benefits:
+
+-   **Performance**: Every query to a node's database takes only a few milliseconds to complete for responsiveness when
+    viewing dashboards or using features like [Metric
+    Correlations](https://learn.netdata.cloud/docs/cloud/insights/metric-correlations).
+-   **Scalability**: As your infrastructure scales, install the Netdata Agent on every new node to immediately add it to
+    your monitoring solution without adding cost or complexity.
+-   **1-second granularity**: Without an expensive centralized data lake, you don't need to reduce the granularity of
+    retained metrics to keep costs down.
+-   **No filtering or selecting of metrics**: Because Netdata's distributed data architecture allows you to store all
+    metrics, you don't have to configure which metrics you retain. Keep everything for full visibility during
+    troubleshooting and root cause analysis.
+-   **Easy maintenance**: There is no centralized data lake to purchase, allocate, monitor, and update, removing
+    complexity from your monitoring infrastructure.
+
+## Does Netdata Cloud store my metrics?
+
+Netdata Cloud does not store metrics values. To enable certain features, such as [viewing active
+alarms](/docs/monitor/view-active-alarms.md) or [filtering by
+service](/docs/visualize/view-all-nodes.md#filter-and-group-your-infrastructure), Netdata Cloud does store configured
+alarms, their status, and a list of active collectors.
+
+The benefits of Netdata's distributed data architecture are also explanations as to why Netdata Cloud does not store
+metrics values. If Netdata Cloud stored every metric from every node in a data lake, it would not be able to visualize
+those metrics efficiently and for free.
+
+Netdata does not and never will sell your personal data or data about your deployment.
+
+## Long-term metrics storage with Netdata
+
+Any node running the Netdata Agent can store its own long-term metrics for any retention period, given you allocate the
+appropriate amount of RAM and disk space.
+
+Read our document on changing [how long Netdata stores metrics](/docs/store/change-metrics-storage.md) on your nodes for
+details.
+
+## Other options for your metrics data
+
+While a distributed data architecture is the default when monitoring an infrastructure with Netdata, you can also
+configure its behavior based on your needs or the type of infrastructure you manage.
+
+To archive metrics to an external time-series database, such as InfluxDB, Graphite, OpenTSDB, Elasticsearch,
+TimescaleDB, and many others, see details on [integrating Netdata via exporting](/docs/export/integrate-exporting.md).
+
+You can also stream between nodes using [streaming](/docs/stream/README.md), which also allows you to replicate
+databases and create your own centralized data lake of metrics, if you choose to do so.
+
+When you use the database engine to store your metrics, you can always perform a quick backup of a node's
+`/var/cache/netdata/dbengine/` folder using the tool of your choice.
+
+## What's next?
+
+You can configure the Netdata Agent to store days, weeks, or months worth of distributed, per-second data by
+[configuring the database engine](/docs/store/change-metrics-storage.md). Use our calculator to determine the system
+resources required to retain your desired amount of metrics, and expand or contract the database by editing a single
+setting.
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fstore%2Fdistributed-data&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/store/distributed-data-architecture.md
+++ b/docs/store/distributed-data-architecture.md
@@ -7,14 +7,12 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/store/distr
 # Distributed data architecture
 
 Netdata uses a distributed data architecture to help you collect and store per-second metrics from any number of nodes.
-Every node in your infrastructure, whether it's one or a thousand, stores its own metrics. By storing metrics at the
-point where they are collected, or as close as possible, Netdata helps you maintain control of your data and control the
-costs of deploying infrastructure monitoring.
+Every node in your infrastructure, whether it's one or a thousand, stores the metrics it collects.
 
-Netdata Cloud bridges the gap between many distributed databases by centralizing the interface you use to query and
-visualize metrics from your nodes. When you look at charts in [Netdata
+Netdata Cloud bridges the gap between many distributed databases by _centralizing the interface you use_ to query and
+visualize your nodes' metrics. When you [look at charts in Netdata
 Cloud](/docs/visualize/interact-dashboards-charts.md), the metrics values are queried directly from that node's database
-and securely streamed to Netdata Cloud, where they are in turn proxied to your browser.
+and securely streamed to Netdata Cloud, which proxies them to your browser.
 
 Netdata's distributed data architecture has a number of benefits:
 
@@ -23,8 +21,8 @@ Netdata's distributed data architecture has a number of benefits:
     Correlations](https://learn.netdata.cloud/docs/cloud/insights/metric-correlations).
 -   **Scalability**: As your infrastructure scales, install the Netdata Agent on every new node to immediately add it to
     your monitoring solution without adding cost or complexity.
--   **1-second granularity**: Without an expensive centralized data lake, you don't need to reduce the granularity of
-    retained metrics to keep costs down.
+-   **1-second granularity**: Without an expensive centralized data lake, you can store all of your nodes' per-second
+    metrics, for any period of time, while keeping costs down.
 -   **No filtering or selecting of metrics**: Because Netdata's distributed data architecture allows you to store all
     metrics, you don't have to configure which metrics you retain. Keep everything for full visibility during
     troubleshooting and root cause analysis.
@@ -33,20 +31,17 @@ Netdata's distributed data architecture has a number of benefits:
 
 ## Does Netdata Cloud store my metrics?
 
-Netdata Cloud does not store metrics values. To enable certain features, such as [viewing active
-alarms](/docs/monitor/view-active-alarms.md) or [filtering by
+Netdata Cloud does not store metric values. 
+
+To enable certain features, such as [viewing active alarms](/docs/monitor/view-active-alarms.md) or [filtering by
 service](/docs/visualize/view-all-nodes.md#filter-and-group-your-infrastructure), Netdata Cloud does store configured
 alarms, their status, and a list of active collectors.
-
-The benefits of Netdata's distributed data architecture are also explanations as to why Netdata Cloud does not store
-metrics values. If Netdata Cloud stored every metric from every node in a data lake, it would not be able to visualize
-those metrics efficiently and for free.
 
 Netdata does not and never will sell your personal data or data about your deployment.
 
 ## Long-term metrics storage with Netdata
 
-Any node running the Netdata Agent can store its own long-term metrics for any retention period, given you allocate the
+Any node running the Netdata Agent can store long-term metrics for any retention period, given you allocate the
 appropriate amount of RAM and disk space.
 
 Read our document on changing [how long Netdata stores metrics](/docs/store/change-metrics-storage.md) on your nodes for
@@ -54,14 +49,14 @@ details.
 
 ## Other options for your metrics data
 
-While a distributed data architecture is the default when monitoring an infrastructure with Netdata, you can also
-configure its behavior based on your needs or the type of infrastructure you manage.
+While a distributed data architecture is the default when monitoring infrastructure with Netdata, you can also configure
+its behavior based on your needs or the type of infrastructure you manage.
 
 To archive metrics to an external time-series database, such as InfluxDB, Graphite, OpenTSDB, Elasticsearch,
 TimescaleDB, and many others, see details on [integrating Netdata via exporting](/docs/export/integrate-exporting.md).
 
-You can also stream between nodes using [streaming](/docs/stream/README.md), which also allows you to replicate
-databases and create your own centralized data lake of metrics, if you choose to do so.
+You can also stream between nodes using [streaming](/docs/stream/README.md), allowing to replicate databases and create
+your own centralized data lake of metrics, if you choose to do so.
 
 When you use the database engine to store your metrics, you can always perform a quick backup of a node's
 `/var/cache/netdata/dbengine/` folder using the tool of your choice.

--- a/docs/store/distributed-data-architecture.md
+++ b/docs/store/distributed-data-architecture.md
@@ -1,6 +1,6 @@
 <!--
 title: "Distributed data architecture"
-description: ""
+description: "Netdata's distributed data architecture stores metrics on individual nodes for high performance and scalability using all your granular metrics."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/store/distributed-data.md
 -->
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

One high-level document about the distributed data architecture, and another for changing metrics retention.

See [a preview of the inline calculator](https://deploy-preview-285--netdata-docusaurus.netlify.app/docs/store/change-metrics-storage#calculate-the-system-resources-ram-disk-space-needed-to-store-metrics).

> See netdata/netdata-learn-docusaurus#285 for additional context.
>
> This page contains some elements that will only appear on the deployed Learn site, so see the deploy preview for this page for the full picture: https://deploy-preview-285--netdata-docusaurus.netlify.app/docs/get
>
> Some links will not work, as the target docs do not exist yet.
>
> For now, these PRs will get merged into the docsv2 but not go live on Netdata Learn. Once they're all available, or at least a workable majority, we'll merge them into master and deploy the project as a whole.

##### Component Name

area/docs

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
