### PR TITLE
Use non-interactive backend for debconf in Kinesis CI setup.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -151,8 +151,8 @@ jobs:
           - distro: 'debian:buster'
             pre: >-
               apt-get update &&
-              apt-get install -y build-essential &&
-              apt-get install -y libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev
+              DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential &&
+              DEBIAN_FRONTEND=noninteractive apt-get install -y libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev
             build_kinesis: >-
               git clone https://github.com/aws/aws-sdk-cpp.git &&
               cmake -DCMAKE_INSTALL_PREFIX=/usr
@@ -175,8 +175,8 @@ jobs:
           - distro: 'ubuntu:20.04'
             pre: >-
               apt-get update &&
-              apt-get install -y build-essential &&
-              apt-get install -y libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev
+              DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential &&
+              DEBIAN_FRONTEND=noninteractive apt-get install -y libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev
             build_kinesis: >-
               git clone https://github.com/aws/aws-sdk-cpp.git &&
               cmake -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
##### Summary

This prevents us from hanging in debconf prompts during the setup process, which in turn prevents us from hanging until the job gets auto-cancelled.

##### Component Name

area/ci

##### Test Plan

The CI checks pass without being cancelled due to hanging.