### PR TITLE
allow using LWS without SOCKS5

### DIFF
--- a/aclk/aclk_common.c
+++ b/aclk/aclk_common.c
@@ -149,7 +149,7 @@ const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type)
 
     if (strcmp(proxy, ACLK_PROXY_ENV) == 0) {
         if (check_socks_enviroment(&proxy) == 0) {
-#ifdef LWS_WITH_SOCKS
+#ifdef LWS_WITH_SOCKS5
             *type = PROXY_TYPE_SOCKS5;
             return proxy;
 #else

--- a/aclk/aclk_common.c
+++ b/aclk/aclk_common.c
@@ -2,6 +2,10 @@
 
 #include "../daemon/common.h"
 
+#ifdef ENABLE_ACLK
+#include <libwebsockets.h>
+#endif
+
 netdata_mutex_t aclk_shared_state_mutex = NETDATA_MUTEX_INITIALIZER;
 
 int aclk_disable_runtime = 0;
@@ -144,14 +148,31 @@ const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type)
         return proxy;
 
     if (strcmp(proxy, ACLK_PROXY_ENV) == 0) {
-        if (check_socks_enviroment(&proxy) == 0)
+        if (check_socks_enviroment(&proxy) == 0) {
+#ifdef LWS_WITH_SOCKS
             *type = PROXY_TYPE_SOCKS5;
-        else if (check_http_enviroment(&proxy) == 0)
+            return proxy;
+#else
+            safe_log_proxy_error("socks_proxy environment variable set to use SOCKS5 proxy "
+                "but Libwebsockets used doesn't have SOCKS5 support built in. "
+                "Ignoring and checking for other options.",
+                proxy);
+#endif
+        }
+        if (check_http_enviroment(&proxy) == 0)
             *type = PROXY_TYPE_HTTP;
         return proxy;
     }
 
     *type = aclk_verify_proxy(proxy);
+#ifndef LWS_WITH_SOCKS5
+    if (*type == PROXY_TYPE_SOCKS5) {
+        safe_log_proxy_error(
+            "Config var \"" ACLK_PROXY_CONFIG_VAR
+            "\" set to use SOCKS5 proxy but Libwebsockets used is built without support for SOCKS proxy. ACLK will be disabled.",
+            proxy);
+    }
+#endif
     if (*type == PROXY_TYPE_UNKNOWN) {
         *type = PROXY_DISABLED;
         safe_log_proxy_error(

--- a/aclk/aclk_lws_wss_client.c
+++ b/aclk/aclk_lws_wss_client.c
@@ -209,6 +209,7 @@ void aclk_lws_wss_client_destroy()
 #endif
 }
 
+#ifdef LWS_WITH_SOCKS5
 static int aclk_wss_set_socks(struct lws_vhost *vhost, const char *socks)
 {
     char *proxy = strstr(socks, ACLK_PROXY_PROTO_ADDR_SEPARATOR);
@@ -223,6 +224,7 @@ static int aclk_wss_set_socks(struct lws_vhost *vhost, const char *socks)
 
     return lws_set_socks(vhost, proxy);
 }
+#endif
 
 void aclk_wss_set_proxy(struct lws_vhost *vhost)
 {
@@ -232,7 +234,9 @@ void aclk_wss_set_proxy(struct lws_vhost *vhost)
 
     proxy = aclk_get_proxy(&proxy_type);
 
+#ifdef LWS_WITH_SOCKS5
     lws_set_socks(vhost, ":");
+#endif
     lws_set_proxy(vhost, ":");
 
     if (proxy_type == PROXY_TYPE_UNKNOWN) {
@@ -247,9 +251,13 @@ void aclk_wss_set_proxy(struct lws_vhost *vhost)
         freez(log);
     }
     if (proxy_type == PROXY_TYPE_SOCKS5) {
+#ifdef LWS_WITH_SOCKS5
         if (aclk_wss_set_socks(vhost, proxy))
             error("LWS failed to accept socks proxy.");
         return;
+#else
+        fatal("We have no SOCKS5 support but we made it here. Programming error!");
+#endif
     }
     if (proxy_type == PROXY_TYPE_HTTP) {
         if (lws_set_proxy(vhost, proxy))

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -7,6 +7,10 @@
 #include "aclk_common.h"
 #include "aclk_stats.h"
 
+#ifdef ENABLE_ACLK
+#include <libwebsockets.h>
+#endif
+
 int aclk_shutting_down = 0;
 
 // Other global state
@@ -884,6 +888,16 @@ void *aclk_main(void *ptr)
     info("Killing ACLK thread -> cloud functionality has been disabled");
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
     return NULL;
+#endif
+
+#ifndef LWS_WITH_SOCKS5
+    ACLK_PROXY_TYPE proxy_type;
+    aclk_get_proxy(&proxy_type);
+    if(proxy_type == PROXY_TYPE_SOCKS5) {
+        error("Disabling ACLK due to requested SOCKS5 proxy.");
+        static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
+        return NULL;
+    }
 #endif
 
     info("Waiting for netdata to be ready");


### PR DESCRIPTION
##### Summary
As a first step towards allowing usage of system LWS we allow building Netdata with LWS that was built without SOCKS5.
In case the user tries to use SOCKS5 we will log appropriate error into the logfile and ignore the setting.

More detailed discussion #8961 

##### Component Name
ACLK

##### Test Plan
Build with LWS without SOCKS 5 support. Should build without error. Example how to do that: Cripple installer.sh (remove `LWS_WITH_SOCKS5:bool=ON`) here (in else branch):
```
build_libwebsockets() {
  local env_cmd=''

  if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
    env_cmd="env CFLAGS= CXXFLAGS= LDFLAGS="
  fi

  pushd "${1}" > /dev/null || exit 1
  if [ "$(uname)" = "Darwin" ] && [ -d /usr/local/opt/openssl ]; then
    run ${env_cmd} cmake \
      -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
      -D OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib \
      -D LWS_WITH_SOCKS5:bool=ON \
      $CMAKE_FLAGS \
      .
  else
    run ${env_cmd} cmake -D LWS_WITH_SOCKS5:bool=ON $CMAKE_FLAGS .
```
Attempting to use SOCKS5 proxy will result in error message and such setting to be ignored.

##### Additional Information
