### PR TITLE
Improved the data query when using the context parameter

### DIFF
--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -376,7 +376,7 @@ static inline uint32_t *pginfo_to_points(struct rrdeng_page_info *page_info)
  * @return number of regions with different data collection intervals.
  */
 unsigned rrdeng_variable_step_boundaries(RRDSET *st, time_t start_time, time_t end_time,
-                                         struct rrdeng_region_info **region_info_arrayp, unsigned *max_intervalp, RRDDIM *temp_rd)
+                                         struct rrdeng_region_info **region_info_arrayp, unsigned *max_intervalp, struct context_param *context_param_list)
 {
     struct pg_cache_page_index *page_index;
     struct rrdengine_instance *ctx;
@@ -396,6 +396,7 @@ unsigned rrdeng_variable_step_boundaries(RRDSET *st, time_t start_time, time_t e
     *region_info_arrayp = NULL;
     page_info_array = NULL;
 
+    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
     rrdset_rdlock(st);
     for(rd_iter = temp_rd?temp_rd:st->dimensions, rd = NULL, min_time = (usec_t)-1 ; rd_iter ; rd_iter = rd_iter->next) {
         /*

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -43,7 +43,7 @@ extern void rrdeng_store_metric_next(RRDDIM *rd, usec_t point_in_time, storage_n
 extern int rrdeng_store_metric_finalize(RRDDIM *rd);
 extern unsigned
     rrdeng_variable_step_boundaries(RRDSET *st, time_t start_time, time_t end_time,
-                                    struct rrdeng_region_info **region_info_arrayp, unsigned *max_intervalp, RRDDIM *temp_rd);
+                                    struct rrdeng_region_info **region_info_arrayp, unsigned *max_intervalp, struct context_param *context_param_list);
 extern void rrdeng_load_metric_init(RRDDIM *rd, struct rrddim_query_handle *rrdimm_handle,
                                     time_t start_time, time_t end_time);
 extern storage_number rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle, time_t *current_time);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -13,6 +13,7 @@ typedef struct rrddimvar RRDDIMVAR;
 typedef struct rrdcalc RRDCALC;
 typedef struct rrdcalctemplate RRDCALCTEMPLATE;
 typedef struct alarm_entry ALARM_ENTRY;
+typedef struct context_param CONTEXT_PARAM;
 
 // forward declarations
 struct rrddim_volatile;

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -24,7 +24,7 @@ static inline void free_temp_rrddim(RRDDIM *temp_rd)
 
 void free_context_param_list(struct context_param **param_list)
 {
-    if (unlikely(!param_list  || !*param_list))
+    if (unlikely(!param_list || !*param_list))
         return;
 
     free_temp_rrddim(((*param_list)->rd));
@@ -34,8 +34,6 @@ void free_context_param_list(struct context_param **param_list)
 
 void build_context_param_list (struct context_param **param_list, RRDSET *st)
 {
-    st->last_accessed_time = now_realtime_sec();
-
     if (unlikely(!param_list || !st))
         return;
 
@@ -49,8 +47,11 @@ void build_context_param_list (struct context_param **param_list, RRDSET *st)
 
     RRDDIM *rd1;
     rrdset_rdlock(st);
+
+    st->last_accessed_time = (*param_list)->last_accessed_time;
     (*param_list)->first_entry_t = MIN((*param_list)->first_entry_t, rrdset_first_entry_t(st));
     (*param_list)->last_entry_t  = MAX((*param_list)->last_entry_t, rrdset_last_entry_t(st));
+
     rrddim_foreach_read(rd1, st) {
         RRDDIM *rd = mallocz(rd1->memsize);
         memcpy(rd, rd1, rd1->memsize);
@@ -68,8 +69,8 @@ void build_context_param_list (struct context_param **param_list, RRDSET *st)
 #endif
         rd->next = (*param_list)->rd;
         (*param_list)->rd = rd;
-        st->last_accessed_time = (*param_list)->last_accessed_time;
     }
+
     rrdset_unlock(st);
 }
 

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -41,14 +41,13 @@ void build_context_param_list (struct context_param **param_list, RRDSET *st)
         *param_list = mallocz(sizeof(struct context_param));
         (*param_list)->first_entry_t = LONG_MAX;
         (*param_list)->last_entry_t = 0;
-        (*param_list)->last_accessed_time = now_realtime_sec();
         (*param_list)->rd = NULL;
     }
 
     RRDDIM *rd1;
     rrdset_rdlock(st);
 
-    st->last_accessed_time = (*param_list)->last_accessed_time;
+    st->last_accessed_time = now_realtime_sec();
     (*param_list)->first_entry_t = MIN((*param_list)->first_entry_t, rrdset_first_entry_t(st));
     (*param_list)->last_entry_t  = MAX((*param_list)->last_entry_t, rrdset_last_entry_t(st));
 

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -32,7 +32,7 @@ void free_context_param_list(struct context_param **param_list)
     *param_list = NULL;
 }
 
-void build_context_param_list (struct context_param **param_list, RRDSET *st)
+void build_context_param_list(struct context_param **param_list, RRDSET *st)
 {
     if (unlikely(!param_list || !st))
         return;
@@ -170,8 +170,6 @@ int rrdset2value_api_v1(
 
     long i = (!(options & RRDR_OPTION_REVERSED))?rrdr_rows(r) - 1:0;
     *n = rrdr2value(r, i, options, value_is_null);
-
-    //free_temp_rrddim(temp_rd);
 
     rrdr_free(r);
     return HTTP_RESP_OK;
@@ -371,8 +369,6 @@ int rrdset2anything_api_v1(
             rrdr_json_wrapper_end(r, wb, format, options, 0);
         break;
     }
-
-    //free_temp_rrddim(temp_rd);
 
     rrdr_free(r);
     return HTTP_RESP_OK;

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -22,6 +22,57 @@ static inline void free_temp_rrddim(RRDDIM *temp_rd)
     }
 }
 
+void free_context_param_list(struct context_param **param_list)
+{
+    if (unlikely(!param_list  || !*param_list))
+        return;
+
+    free_temp_rrddim(((*param_list)->rd));
+    freez((*param_list));
+    *param_list = NULL;
+}
+
+void build_context_param_list (struct context_param **param_list, RRDSET *st)
+{
+    st->last_accessed_time = now_realtime_sec();
+
+    if (unlikely(!param_list || !st))
+        return;
+
+    if (unlikely(!(*param_list))) {
+        *param_list = mallocz(sizeof(struct context_param));
+        (*param_list)->first_entry_t = LONG_MAX;
+        (*param_list)->last_entry_t = 0;
+        (*param_list)->last_accessed_time = now_realtime_sec();
+        (*param_list)->rd = NULL;
+    }
+
+    RRDDIM *rd1;
+    rrdset_rdlock(st);
+    (*param_list)->first_entry_t = MIN((*param_list)->first_entry_t, rrdset_first_entry_t(st));
+    (*param_list)->last_entry_t  = MAX((*param_list)->last_entry_t, rrdset_last_entry_t(st));
+    rrddim_foreach_read(rd1, st) {
+        RRDDIM *rd = mallocz(rd1->memsize);
+        memcpy(rd, rd1, rd1->memsize);
+        rd->id = strdupz(rd1->id);
+        rd->name = strdupz(rd1->name);
+        rd->state = mallocz(sizeof(*rd->state));
+        memcpy(rd->state, rd1->state, sizeof(*rd->state));
+        memcpy(&rd->state->collect_ops, &rd1->state->collect_ops, sizeof(struct rrddim_collect_ops));
+        memcpy(&rd->state->query_ops, &rd1->state->query_ops, sizeof(struct rrddim_query_ops));
+#ifdef ENABLE_DBENGINE
+        if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+            rd->state->metric_uuid = mallocz(sizeof(uuid_t));
+            uuid_copy(*rd->state->metric_uuid, *rd1->state->metric_uuid);
+        }
+#endif
+        rd->next = (*param_list)->rd;
+        (*param_list)->rd = rd;
+        st->last_accessed_time = (*param_list)->last_accessed_time;
+    }
+    rrdset_unlock(st);
+}
+
 void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb) {
     rrdset2json(st, wb, NULL, NULL, 0);
 }
@@ -89,9 +140,8 @@ int rrdset2value_api_v1(
         , time_t *db_before
         , int *value_is_null
 ) {
-    RRDDIM *temp_rd = NULL;
 
-    RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions, temp_rd);
+    RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions, NULL);
 
     if(!r) {
         if(value_is_null) *value_is_null = 1;
@@ -121,7 +171,7 @@ int rrdset2value_api_v1(
     long i = (!(options & RRDR_OPTION_REVERSED))?rrdr_rows(r) - 1:0;
     *n = rrdr2value(r, i, options, value_is_null);
 
-    free_temp_rrddim(temp_rd);
+    //free_temp_rrddim(temp_rd);
 
     rrdr_free(r);
     return HTTP_RESP_OK;
@@ -139,47 +189,14 @@ int rrdset2anything_api_v1(
         , long group_time
         , uint32_t options
         , time_t *latest_timestamp
-        , char *context
+        , struct context_param *context_param_list
 ) {
     time_t last_accessed_time = now_realtime_sec();
     st->last_accessed_time = last_accessed_time;
 
-    RRDDIM *temp_rd = NULL;
+    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
 
-    if (context) {
-        rrdhost_rdlock(st->rrdhost);
-        RRDSET *st1;
-        rrdset_foreach_read(st1, st->rrdhost) {
-            if (strcmp(st1->context, context) == 0) {
-                // Loop the dimensions of the chart
-                RRDDIM  *rd1;
-                rrdset_rdlock(st1);
-                st1->last_accessed_time = last_accessed_time;
-                rrddim_foreach_read(rd1, st1) {
-                    RRDDIM *rd = mallocz(rd1->memsize);
-                    memcpy(rd, rd1, rd1->memsize);
-                    rd->id = strdupz(rd1->id);
-                    rd->name = strdupz(rd1->name);
-                    rd->state = mallocz(sizeof(*rd->state));
-                    memcpy(rd->state, rd1->state, sizeof(*rd->state));
-                    memcpy(&rd->state->collect_ops, &rd1->state->collect_ops, sizeof(struct rrddim_collect_ops));
-                    memcpy(&rd->state->query_ops, &rd1->state->query_ops, sizeof(struct rrddim_query_ops));
-#ifdef ENABLE_DBENGINE
-                    if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-                        rd->state->metric_uuid = mallocz(sizeof(uuid_t));
-                        uuid_copy(*rd->state->metric_uuid, *rd1->state->metric_uuid);
-                    }
-#endif
-                    rd->next = temp_rd;
-                    temp_rd = rd;
-                }
-                rrdset_unlock(st1);
-            }
-        }
-        rrdhost_unlock(st->rrdhost);
-    }
-
-    RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions?buffer_tostring(dimensions):NULL, temp_rd);
+    RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions?buffer_tostring(dimensions):NULL, context_param_list);
     if(!r) {
         buffer_strcat(wb, "Cannot generate output with these parameters on this chart.");
         return HTTP_RESP_INTERNAL_SERVER_ERROR;
@@ -355,7 +372,7 @@ int rrdset2anything_api_v1(
         break;
     }
 
-    free_temp_rrddim(temp_rd);
+    //free_temp_rrddim(temp_rd);
 
     rrdr_free(r);
     return HTTP_RESP_OK;

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -53,6 +53,14 @@
 extern void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
 extern void rrdr_buffer_print_format(BUFFER *wb, uint32_t format);
 
+typedef struct context_param {
+    RRDDIM *rd;
+    time_t first_entry_t;
+    time_t last_entry_t;
+    time_t last_accessed_time;
+
+} CONTEXT_PARAM;
+
 extern int rrdset2anything_api_v1(
           RRDSET *st
         , BUFFER *wb
@@ -65,7 +73,7 @@ extern int rrdset2anything_api_v1(
         , long group_time
         , uint32_t options
         , time_t *latest_timestamp
-        , char *context
+        , struct context_param *context_param_list
 );
 
 extern int rrdset2value_api_v1(
@@ -83,5 +91,8 @@ extern int rrdset2value_api_v1(
         , time_t *db_before
         , int *value_is_null
 );
+
+extern void build_context_param_list(struct context_param **param_list, RRDSET *st);
+extern void free_context_param_list(struct context_param **param_list);
 
 #endif /* NETDATA_RRD2JSON_H */

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -58,7 +58,6 @@ typedef struct context_param {
     time_t first_entry_t;
     time_t last_entry_t;
     time_t last_accessed_time;
-
 } CONTEXT_PARAM;
 
 extern int rrdset2anything_api_v1(

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -57,7 +57,6 @@ typedef struct context_param {
     RRDDIM *rd;
     time_t first_entry_t;
     time_t last_entry_t;
-    time_t last_accessed_time;
 } CONTEXT_PARAM;
 
 extern int rrdset2anything_api_v1(

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -98,7 +98,7 @@ inline void rrdr_free(RRDR *r)
     freez(r);
 }
 
-RRDR *rrdr_create(struct rrdset *st, long n, struct rrddim *temp_rd)
+RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param_list)
 {
     if(unlikely(!st)) {
         error("NULL value given!");
@@ -110,6 +110,7 @@ RRDR *rrdr_create(struct rrdset *st, long n, struct rrddim *temp_rd)
 
     rrdr_lock_rrdset(r);
 
+    RRDDIM *temp_rd =  context_param_list ? context_param_list->rd : NULL;
     RRDDIM *rd;
     if (temp_rd) {
         RRDDIM *t = temp_rd;

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -99,12 +99,15 @@ typedef struct rrdresult {
 
 #include "../../../database/rrd.h"
 extern void rrdr_free(RRDR *r);
-extern RRDR *rrdr_create(struct rrdset *st, long n, struct rrddim *id);
+extern RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param_list);
 
 #include "../web_api_v1.h"
 #include "web/api/queries/query.h"
 
-extern RRDR *rrd2rrdr(RRDSET *st, long points_requested, long long after_requested, long long before_requested, RRDR_GROUPING group_method, long resampling_time_requested, RRDR_OPTIONS options, const char *dimensions, RRDDIM *temp_rd);
+extern RRDR *rrd2rrdr(
+    RRDSET *st, long points_requested, long long after_requested, long long before_requested,
+    RRDR_GROUPING group_method, long resampling_time_requested, RRDR_OPTIONS options, const char *dimensions,
+    struct context_param *context_param_list);
 
 #include "query.h"
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -515,7 +515,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     if (!st && !context_param_list) {
         if (context) {
             buffer_strcat(w->response.data, "Context is not found: ");
-            buffer_strcat_htmlescape(w->response.data, chart);
+            buffer_strcat_htmlescape(w->response.data, context);
         }
         else {
             buffer_strcat(w->response.data, "Chart is not found: ");

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -491,35 +491,38 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         goto cleanup;
     }
 
+    struct context_param  *context_param_list = NULL;
     if (context) {
-        st = NULL;
-        // TODO: Scan all charts of host
-        rrdhost_rdlock(localhost);
         RRDSET *st1;
+        uint32_t context_hash = simple_hash(context);
+        rrdhost_rdlock(localhost);
         rrdset_foreach_read(st1, localhost) {
-            if (strcmp(st1->context, context) == 0) {
-                st = st1;
-                break;
-            }
+            if (st1->hash_context == context_hash && !strcmp(st1->context, context))
+                build_context_param_list(&context_param_list, st1);
         }
         rrdhost_unlock(localhost);
+        if (context_param_list)
+            st = context_param_list->rd->rrdset;
     }
-
-    if (!st) {
-        if (!chart || !*chart) {
-            buffer_sprintf(w->response.data, "No chart id is given at the request.");
-            goto cleanup;
-        }
+    else {
         st = rrdset_find(host, chart);
         if (!st)
             st = rrdset_find_byname(host, chart);
-        if (!st) {
+    }
+
+    if (!st && !context_param_list) {
+        if (context) {
+            buffer_strcat(w->response.data, "Context is not found: ");
+            buffer_strcat_htmlescape(w->response.data, chart);
+        }
+        else {
             buffer_strcat(w->response.data, "Chart is not found: ");
             buffer_strcat_htmlescape(w->response.data, chart);
-            ret = HTTP_RESP_NOT_FOUND;
-            goto cleanup;
         }
+        ret = HTTP_RESP_NOT_FOUND;
+        goto cleanup;
     }
+
     st->last_accessed_time = now_realtime_sec();
 
     long long before = (before_str && *before_str)?str2l(before_str):0;
@@ -565,7 +568,9 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     }
 
     ret = rrdset2anything_api_v1(st, w->response.data, dimensions, format, points, after, before, group, group_time
-                                 , options, &last_timestamp_in_data, context);
+                                 , options, &last_timestamp_in_data, context_param_list);
+
+    free_context_param_list(&context_param_list);
 
     if(format == DATASOURCE_DATATABLE_JSONP) {
         if(google_timestamp < last_timestamp_in_data)


### PR DESCRIPTION
##### Summary
Improved the processing of the data query when data for a `context` is requested

- Define a generic structure to pass along to functions (instead of RRDDIM linked list) to allow for easy changes in the future
- Collect the matching charts, dimensions and calculate first_entry_t / last_entry_t at the same time
- Speedup context match by using the context hash in RRDSET
- Add correct response `Chart is not found:` or `Context is not found:`

##### Component Name
database

##### Test Plan
Example context call

```
http://127.0.0.1:19999/api/v1/data?context=cpu.cpu&options=jsonwrap
```

##### Additional Information
