### PR TITLE
Added more stringent check for C99 support in configure script.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,10 @@ AC_ARG_ENABLE(
 )
 
 # -----------------------------------------------------------------------------
+# Enforce building with C99, bail early if we can't.
+test "${ac_cv_prog_cc_c99}" = "no" && AC_MSG_ERROR([Netdata rquires a compiler that supports C99 to build])
+
+# -----------------------------------------------------------------------------
 # Check if cloud is enabled and if the functionality is available
 
 AC_ARG_ENABLE(


### PR DESCRIPTION
##### Summary

This will help ensure that people who are building on a compiler that does not support C99 get a more useful message about needing C99 and also avoid wasting time getting into the build itself.

##### Component Name

area/build

##### Test Plan

Locally checked using a special wrapper for GCC that unconditionally passes `-std=c89` to fail the C99 check.

##### Additional Information

This is largely proactively preventing an issue we do not currently have. Linux, BSD, and macOS largely universally have working C99 support.  However, when we eventually branch out into IoT usage, we will likely have to deal with significantly more exotic build environments, and there are a surprising number of systems out there that only support ANSI C (C89), not C99.