### PR TITLE
allows use of system libwebsockets instead of bundled one

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -716,11 +716,6 @@ netdata_LDADD = \
     $(OPTIONAL_LWS_LIBS) \
     $(NETDATA_COMMON_LIBS) \
     $(NULL)
-if HAVE_STATIC_LWS
-netdata_LDADD += \
-    externaldeps/libwebsockets/libwebsockets.a \
-    $(NULL)
-endif
 else
 netdata_LDADD = \
     $(NETDATA_COMMON_LIBS) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -712,10 +712,15 @@ netdata_SOURCES = $(NETDATA_FILES)
 if ENABLE_ACLK
 netdata_LDADD = \
     externaldeps/mosquitto/libmosquitto.a \
-    externaldeps/libwebsockets/libwebsockets.a \
     $(OPTIONAL_LIBCAP_LIBS) \
+    $(OPTIONAL_LWS_LIBS) \
     $(NETDATA_COMMON_LIBS) \
     $(NULL)
+if HAVE_STATIC_LWS
+netdata_LDADD += \
+    externaldeps/libwebsockets/libwebsockets.a \
+    $(NULL)
+endif
 else
 netdata_LDADD = \
     $(NETDATA_COMMON_LIBS) \

--- a/configure.ac
+++ b/configure.ac
@@ -666,6 +666,7 @@ if test "$enable_cloud" != "no"; then
             LWS_CFLAGS="-I ${bundled_lws_dir}/include"
             OPTIONAL_LWS_LIBS="${bundled_lws_dir}/libwebsockets.a"
             AC_MSG_RESULT([yes])
+            AC_DEFINE([BUNDLED_LWS], [1], [using statically linked libwebsockets])
         else
             AC_DEFINE([ACLK_NO_LWS], [1], [libwebsockets.a was not found during build.])
             # this should be error if installer ever changes default to system

--- a/configure.ac
+++ b/configure.ac
@@ -172,6 +172,12 @@ AC_ARG_ENABLE(
     ,
     [enable_ebpf="detect"]
 )
+AC_ARG_WITH(
+    [bundled-lws],
+    [AS_HELP_STRING([--without-bundled-lws], [use system Libwebsockets instead of version bundled by netdata installer @<:@default use bundled@:>@])],
+    ,
+    [with_bundled_lws="yes"]
+)
 
 # -----------------------------------------------------------------------------
 # Enforce building with C99, bail early if we can't.
@@ -651,15 +657,29 @@ if test "$enable_cloud" != "no"; then
     fi
     AC_MSG_RESULT([${HAVE_libmosquitto_a}])
 
-    AC_MSG_CHECKING([if libwebsockets static lib is present])
-    if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
-        LWS_CFLAGS="-I externaldeps/libwebsockets/include"
-        HAVE_libwebsockets_a="yes"
+    if test "${with_bundled_lws}" = "yes"; then
+        AC_MSG_CHECKING([if libwebsockets static lib is present])
+        if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
+            LWS_CFLAGS="-I externaldeps/libwebsockets/include"
+            HAVE_libwebsockets="yes"
+            HAVE_STATIC_LWS="yes"
+        else
+            HAVE_libwebsockets="no"
+            AC_DEFINE([ACLK_NO_LWS], [1], [libwebsockets.a was not found during build.])
+        fi
+        AC_MSG_RESULT([${HAVE_libwebsockets}])
     else
-        HAVE_libwebsockets_a="no"
-        AC_DEFINE([ACLK_NO_LWS], [1], [libwebsockets.a was not found during build.])
+        AC_CHECK_LIB([websockets],
+            [lws_ring_create],
+            [
+                HAVE_libwebsockets="yes"
+                OPTIONAL_LWS_LIBS="-lwebsockets"
+            ],
+            [
+                AC_DEFINE([ACLK_NO_LWS], [1], [usable system libwebsockets was not found during build.])
+                AC_MSG_WARN([You have chosen to use systeb libwebsockets instead of bundled one. We can't find or use the system library. ACLK will be disabled.l])
+            ])
     fi
-    AC_MSG_RESULT([${HAVE_libwebsockets_a}])
 
     if test "${build_target}" = "linux" -a "${enable_cloud}" != "no"; then
         if test "${have_libcap}" = "yes" -a "${with_libcap}" = "no"; then
@@ -678,7 +698,7 @@ if test "$enable_cloud" != "no"; then
         AC_MSG_ERROR([You have asked for ACLK to be built but no json-c available. ACLK requires json-c])
 
     AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
-    if test "${HAVE_libmosquitto_a}" = "yes" -a "${HAVE_libwebsockets_a}" = "yes" -a -n "${SSL_LIBS}" -a "${enable_jsonc}" = "yes"; then
+    if test "${HAVE_libmosquitto_a}" = "yes" -a "${HAVE_libwebsockets}" = "yes" -a -n "${SSL_LIBS}" -a "${enable_jsonc}" = "yes"; then
         can_enable_aclk="yes"
     else
         can_enable_aclk="no"
@@ -704,6 +724,7 @@ if test "$enable_cloud" != "no"; then
 fi
 AC_SUBST([enable_cloud])
 AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
+AM_CONDITIONAL([HAVE_STATIC_LWS], [test "${HAVE_STATIC_LWS}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # apps.plugin
@@ -1452,6 +1473,7 @@ AC_SUBST([OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS])
 AC_SUBST([OPTIONAL_PROMETHEUS_REMOTE_WRITE_LIBS])
 AC_SUBST([OPTIONAL_MONGOC_CFLAGS])
 AC_SUBST([OPTIONAL_MONGOC_LIBS])
+AC_SUBST([OPTIONAL_LWS_LIBS])
 
 # -----------------------------------------------------------------------------
 # Check if cmocka is available - needed for unit testing

--- a/configure.ac
+++ b/configure.ac
@@ -677,7 +677,7 @@ if test "$enable_cloud" != "no"; then
             ],
             [
                 AC_DEFINE([ACLK_NO_LWS], [1], [usable system libwebsockets was not found during build.])
-                AC_MSG_WARN([You have chosen to use systeb libwebsockets instead of bundled one. We can't find or use the system library. ACLK will be disabled.l])
+                AC_MSG_WARN([You have chosen to use system libwebsockets instead of bundled one. We can't find or use the system library. ACLK will be disabled.l])
             ])
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -174,9 +174,12 @@ AC_ARG_ENABLE(
 )
 AC_ARG_WITH(
     [bundled-lws],
-    [AS_HELP_STRING([--without-bundled-lws], [use system Libwebsockets instead of version bundled by netdata installer @<:@default use bundled@:>@])],
-    ,
-    [with_bundled_lws="yes"]
+    [AS_HELP_STRING([--with-bundled-lws=DIR], [Use a specific Libwebsockets static library @<:@default use system library@:>@])],
+    [
+        with_bundled_lws="yes"
+        bundled_lws_dir="${withval}"
+    ],
+    [with_bundled_lws="no"]
 )
 
 # -----------------------------------------------------------------------------
@@ -659,26 +662,23 @@ if test "$enable_cloud" != "no"; then
 
     if test "${with_bundled_lws}" = "yes"; then
         AC_MSG_CHECKING([if libwebsockets static lib is present])
-        if test -f "externaldeps/libwebsockets/libwebsockets.a"; then
-            LWS_CFLAGS="-I externaldeps/libwebsockets/include"
-            HAVE_libwebsockets="yes"
-            HAVE_STATIC_LWS="yes"
+        if test -f "${bundled_lws_dir}/libwebsockets.a"; then
+            LWS_CFLAGS="-I ${bundled_lws_dir}/include"
+            OPTIONAL_LWS_LIBS="${bundled_lws_dir}/libwebsockets.a"
+            AC_MSG_RESULT([yes])
         else
-            HAVE_libwebsockets="no"
             AC_DEFINE([ACLK_NO_LWS], [1], [libwebsockets.a was not found during build.])
+            # this should be error if installer ever changes default to system
+            # as currently this is default we prefer building netdata without ACLK
+            # instead of error fail
+            AC_MSG_RESULT([no])
+            AC_MSG_WARN([You required static libwebsockets to be used but we can't use it. Disabling ACLK])
         fi
-        AC_MSG_RESULT([${HAVE_libwebsockets}])
     else
         AC_CHECK_LIB([websockets],
             [lws_ring_create],
-            [
-                HAVE_libwebsockets="yes"
-                OPTIONAL_LWS_LIBS="-lwebsockets"
-            ],
-            [
-                AC_DEFINE([ACLK_NO_LWS], [1], [usable system libwebsockets was not found during build.])
-                AC_MSG_WARN([You have chosen to use system libwebsockets instead of bundled one. We can't find or use the system library. ACLK will be disabled.l])
-            ])
+            [OPTIONAL_LWS_LIBS="-lwebsockets"],
+            [AC_DEFINE([ACLK_NO_LWS], [1], [usable system libwebsockets was not found during build.])])
     fi
 
     if test "${build_target}" = "linux" -a "${enable_cloud}" != "no"; then
@@ -698,7 +698,7 @@ if test "$enable_cloud" != "no"; then
         AC_MSG_ERROR([You have asked for ACLK to be built but no json-c available. ACLK requires json-c])
 
     AC_MSG_CHECKING([if netdata agent-cloud-link can be enabled])
-    if test "${HAVE_libmosquitto_a}" = "yes" -a "${HAVE_libwebsockets}" = "yes" -a -n "${SSL_LIBS}" -a "${enable_jsonc}" = "yes"; then
+    if test "${HAVE_libmosquitto_a}" = "yes" -a -n "${OPTIONAL_LWS_LIBS}" -a -n "${SSL_LIBS}" -a "${enable_jsonc}" = "yes"; then
         can_enable_aclk="yes"
     else
         can_enable_aclk="no"
@@ -724,7 +724,6 @@ if test "$enable_cloud" != "no"; then
 fi
 AC_SUBST([enable_cloud])
 AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
-AM_CONDITIONAL([HAVE_STATIC_LWS], [test "${HAVE_STATIC_LWS}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # apps.plugin

--- a/configure.ac
+++ b/configure.ac
@@ -676,7 +676,7 @@ if test "$enable_cloud" != "no"; then
         fi
     else
         AC_CHECK_LIB([websockets],
-            [lws_ring_create],
+            [lws_get_vhost_by_name],
             [OPTIONAL_LWS_LIBS="-lwebsockets"],
             [AC_DEFINE([ACLK_NO_LWS], [1], [usable system libwebsockets was not found during build.])])
     fi

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -200,7 +200,7 @@ void print_build_info(void) {
     printf("    libcap:                  %s\n", FEAT_LIBCAP);
     printf("    libcrypto:               %s\n", FEAT_CRYPTO);
     printf("    libm:                    %s\n", FEAT_LIBM);
-#if defined(ENABLE_ACLK) && !defined(ACLK_NO_LWS)
+#if defined(ENABLE_ACLK)
     printf("    LWS:                     %s v%d.%d.%d\n", FEAT_LWS, LWS_LIBRARY_VERSION_MAJOR, LWS_LIBRARY_VERSION_MINOR, LWS_LIBRARY_VERSION_PATCH);
 #else
     printf("    LWS:                     %s\n", FEAT_LWS);

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -68,7 +68,12 @@
 #ifdef ACLK_NO_LWS
 #define FEAT_LWS "NO"
 #else
-#define FEAT_LWS "YES"
+#include <libwebsockets.h>
+#ifdef BUNDLED_LWS
+#define FEAT_LWS "YES static"
+#else
+#define FEAT_LWS "YES shared-lib"
+#endif
 #endif
 
 #ifdef NETDATA_WITH_ZLIB
@@ -193,7 +198,11 @@ void print_build_info(void) {
     printf("    libcap:                  %s\n", FEAT_LIBCAP);
     printf("    libcrypto:               %s\n", FEAT_CRYPTO);
     printf("    libm:                    %s\n", FEAT_LIBM);
+#if defined(ENABLE_ACLK) && !defined(ACLK_NO_LWS)
+    printf("    LWS:                     %s v%d.%d.%d\n", FEAT_LWS, LWS_LIBRARY_VERSION_MAJOR, LWS_LIBRARY_VERSION_MINOR, LWS_LIBRARY_VERSION_PATCH);
+#else
     printf("    LWS:                     %s\n", FEAT_LWS);
+#endif
     printf("    mosquitto:               %s\n", FEAT_MOSQUITTO);
     printf("    tcalloc:                 %s\n", FEAT_TCMALLOC);
     printf("    zlib:                    %s\n", FEAT_ZLIB);

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -68,7 +68,9 @@
 #ifdef ACLK_NO_LWS
 #define FEAT_LWS "NO"
 #else
+#ifdef ENABLE_ACLK
 #include <libwebsockets.h>
+#endif
 #ifdef BUNDLED_LWS
 #define FEAT_LWS "YES static"
 #else

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -234,6 +234,7 @@ USAGE: ${PROGRAM} [options]
   --enable-lto               Enable Link-Time-Optimization. Default: enabled
   --disable-lto
   --disable-x86-sse          Disable SSE instructions. By default SSE optimizations are enabled.
+  --use-system-lws           Use a system copy of libwebsockets instead of bundling our own (default is to use the bundled copy).
   --zlib-is-really-here or
   --libs-are-really-here     If you get errors about missing zlib or libuuid but you know it is available, you might
                              have a broken pkg-config. Use this option to proceed without checking pkg-config.
@@ -275,6 +276,7 @@ while [ -n "${1}" ]; do
   case "${1}" in
     "--zlib-is-really-here") LIBS_ARE_HERE=1 ;;
     "--libs-are-really-here") LIBS_ARE_HERE=1 ;;
+    "--use-system-lws") USE_SYSTEM_LWS=1 ;;
     "--dont-scrub-cflags-even-though-it-may-break-things") DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS=1 ;;
     "--dont-start-it") DONOTSTART=1 ;;
     "--dont-wait") DONOTWAIT=1 ;;
@@ -641,7 +643,7 @@ copy_libwebsockets() {
 }
 
 bundle_libwebsockets() {
-  if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
+  if [ -n "${NETDATA_DISABLE_CLOUD}" ] || [ -n "${USE_SYSTEM_LWS}" ]; then
     return 0
   fi
 
@@ -668,6 +670,7 @@ bundle_libwebsockets() {
       copy_libwebsockets "${tmp}/libwebsockets-${LIBWEBSOCKETS_PACKAGE_VERSION}" &&
       rm -rf "${tmp}"; then
       run_ok "libwebsockets built and prepared."
+      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-bundled-lws=externaldeps/libwebsockets"
     else
       run_failed "Failed to build libwebsockets."
       if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then


### PR DESCRIPTION
##### Summary
Allows using system `libwebsockets` instead of one bundled by the installer.

More detailed discussion #8961

If system LWS is used configure will check if the version is recent enough (min `3.2`)
Code has been updated to support up to the latest released LWS at the point of this PR creation (`4.1.4`)

##### Component Name

##### Test Plan
Use configure with `--without-bundled-lws` on system with libwebsockets.
Use configure as normal on system without libwebsockets.
Everything should work as expected and/or appropriate error message should be printed.
Check with `ldd netdata` if output is correct.

##### Additional Information
