### PR TITLE
Fix cleanup of obsolete charts

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1524,15 +1524,15 @@ restart_after_removal:
                 RRDDIM *rd, *last;
 
                 rrdset_flag_set(st, RRDSET_FLAG_ARCHIVED);
-                while(st->variables)  rrdsetvar_free(st->variables);
-                while(st->alarms)     rrdsetcalc_unlink(st->alarms);
+                while (st->variables)  rrdsetvar_free(st->variables);
+                while (st->alarms)     rrdsetcalc_unlink(st->alarms);
                 rrdset_wrlock(st);
-                for( rd = st->dimensions, last = NULL ; likely(rd) ; ) {
+                for (rd = st->dimensions, last = NULL ; likely(rd) ; ) {
                     if (rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED))
                         continue;
 
                     rrddim_flag_set(rd, RRDDIM_FLAG_ARCHIVED);
-                    while(rd->variables)
+                    while (rd->variables)
                         rrddimvar_free(rd->variables);
 
                     if (rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) {
@@ -1543,7 +1543,7 @@ restart_after_removal:
                             /* This metric has no data and no references */
                             metalog_commit_delete_dimension(rd);
                             rrddim_free(st, rd);
-                            if(unlikely(!last)) {
+                            if (unlikely(!last)) {
                                 rd = st->dimensions;
                             }
                             else {

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1521,9 +1521,41 @@ restart_after_removal:
         )) {
 #ifdef ENABLE_DBENGINE
             if(st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+                RRDDIM *rd, *last;
+
                 rrdset_flag_set(st, RRDSET_FLAG_ARCHIVED);
                 while(st->variables)  rrdsetvar_free(st->variables);
                 while(st->alarms)     rrdsetcalc_unlink(st->alarms);
+                rrdset_wrlock(st);
+                for( rd = st->dimensions, last = NULL ; likely(rd) ; ) {
+                    if (rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED))
+                        continue;
+
+                    rrddim_flag_set(rd, RRDDIM_FLAG_ARCHIVED);
+                    while(rd->variables)
+                        rrddimvar_free(rd->variables);
+
+                    if (rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) {
+                        rrddim_flag_clear(rd, RRDDIM_FLAG_OBSOLETE);
+                        /* only a collector can mark a chart as obsolete, so we must remove the reference */
+                        uint8_t can_delete_metric = rd->state->collect_ops.finalize(rd);
+                        if (can_delete_metric) {
+                            /* This metric has no data and no references */
+                            metalog_commit_delete_dimension(rd);
+                            rrddim_free(st, rd);
+                            if(unlikely(!last)) {
+                                rd = st->dimensions;
+                            }
+                            else {
+                                rd = last->next;
+                            }
+                            continue;
+                        }
+                    }
+                    last = rd;
+                    rd = rd->next;
+                }
+                rrdset_unlock(st);
 
                 debug(D_RRD_CALLS, "RRDSET: Cleaning up remaining chart variables for host '%s', chart '%s'", host->hostname, st->id);
                 rrdvar_free_remaining_variables(host, &st->rrdvar_root_index);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #9363
##### Component Name
database
##### Test Plan
First add a low timeout for cleaning up obsolete charts.
```
[global]
        cleanup obsolete charts after seconds = 10
```

Then make the `/proc/net/dev` collector obsolete the chart itself, without obsoleting its dimensions, as follows:
1. Start a bunch of LXC containers that will create new network devices.
2. Stop those containers so that the collector obsoletes the relevant charts.
3. Start some more containers.
4. Wait for a minute to trigger the cleanup logic.
5. Gracefully shut down the agent.

At this point, the agent will crash with a double-free or use-after-free during shutdown of localhost `RRDHOST`. This PR should fix that situation.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->