### PR TITLE
Switched to our installer's bundling code for libJudy in static installs.

### DIFF
--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -46,13 +46,3 @@ mkdir build
 cd build || exit 1
 cmake -DCMAKE_BUILD_SHARED_LIBS=true -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR=lib ../
 make && make install
-
-# Judy doesnt seem to be available on the repositories, download manually and install it
-export JUDY_VER="1.0.5"
-wget -O /judy.tar.gz http://downloads.sourceforge.net/project/judy/judy/Judy-${JUDY_VER}/Judy-${JUDY_VER}.tar.gz
-tar -C / -xf /judy.tar.gz
-rm /judy.tar.gz
-cd /judy-${JUDY_VER} || exit 1
-CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure
-make
-make install


### PR DESCRIPTION
##### Summary

This removes the old code from our static build process for bundling libJudy in favor of leveraging the new bundling code in `netdata-installer.sh`. There is no net change from an end-user perspective, but this will make our static build more consistent with our other installation methods, simplifying maintenance for us and also marginally reducing the disk space needed for the static build process.

##### Component Name

area/packaging

##### Test Plan

Verified that libJudy gets linked in using `netdata -W buildinfo` and checked that the dbengine stress testing works correctly.

##### Additional Information

I intended to do this as part of the changes that came shortly after adding the libJudy bundling code, but unfortunately forgot about it then.