### PR TITLE
Fixed locking order to address CID_362348

### DIFF
--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -45,11 +45,11 @@ void build_context_param_list(struct context_param **param_list, RRDSET *st)
     }
 
     RRDDIM *rd1;
-    rrdset_rdlock(st);
-
-    st->last_accessed_time = now_realtime_sec();
     (*param_list)->first_entry_t = MIN((*param_list)->first_entry_t, rrdset_first_entry_t(st));
     (*param_list)->last_entry_t  = MAX((*param_list)->last_entry_t, rrdset_last_entry_t(st));
+
+    rrdset_rdlock(st);
+    st->last_accessed_time = now_realtime_sec();
 
     rrddim_foreach_read(rd1, st) {
         RRDDIM *rd = mallocz(rd1->memsize);

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -48,8 +48,8 @@ void build_context_param_list(struct context_param **param_list, RRDSET *st)
     (*param_list)->first_entry_t = MIN((*param_list)->first_entry_t, rrdset_first_entry_t(st));
     (*param_list)->last_entry_t  = MAX((*param_list)->last_entry_t, rrdset_last_entry_t(st));
 
-    rrdset_rdlock(st);
     st->last_accessed_time = now_realtime_sec();
+    rrdset_rdlock(st);
 
     rrddim_foreach_read(rd1, st) {
         RRDDIM *rd = mallocz(rd1->memsize);


### PR DESCRIPTION

##### Summary
```
7             }
68     #endif
69             rd->next = (*param_list)->rd;
70             (*param_list)->rd = rd;
71         }
72     
>>>     CID 362348:  API usage errors  (LOCK)
>>>     "__netdata_rwlock_unlock" unlocks "st->rrdset_rwlock" while it is unlocked.
73         rrdset_unlock(st);
74     }
75     
76     void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb) {
77         rrdset2json(st, wb, NULL, NULL, 0);
78     }
```

Change the locking order to handle CID_362348. The lock may be acquired and released by the functions
that calculate the first_entry_t and last_entry_t.

##### Component Name
database

##### Test Plan
- Submit a build to coverity