### PR TITLE
minor - removes leading whitespace before JSON in ACLK

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -1214,7 +1214,7 @@ inline void aclk_create_header(BUFFER *dest, char *type, char *msg_id, time_t ts
 
     buffer_sprintf(
         dest,
-        "\t{\"type\": \"%s\",\n"
+        "{\t\"type\": \"%s\",\n"
         "\t\"msg-id\": \"%s\",\n"
         "\t\"timestamp\": %ld,\n"
         "\t\"timestamp-offset-usec\": %llu,\n"


### PR DESCRIPTION
##### Summary
Each message was prepended by the leading tab. This typo causes Cloud to have bothersome additional processing step for agent messages that skips leading whitespace before parsing JSON message.

##### Component Name
ACLK
##### Test Plan
messages should not have leading space anymoar.

Before:
```
       {"type": "hello",
        "msg-id": "32a7e02e-8c68-498c-8f5c-a4e010e3f95c",
        "timestamp": 1601307084,
        "timestamp-offset-usec": 4898,
        "connect": 1601307083,
        "connect-offset-usec": 29813,
        "version": 1,
```
After:
```
{       "type": "hello",
        "msg-id": "32a7e02e-8c68-498c-8f5c-a4e010e3f95c",
        "timestamp": 1601307084,
        "timestamp-offset-usec": 4898,
        "connect": 1601307083,
        "connect-offset-usec": 29813,
        "version": 1,
```

##### Additional Information
