### PR TITLE
Allow connecting to arbitrary MQTT WSS broker for devs

### DIFF
--- a/aclk/aclk_common.c
+++ b/aclk/aclk_common.c
@@ -199,7 +199,7 @@ const char *aclk_get_proxy(ACLK_PROXY_TYPE *type)
     return proxy;
 }
 
-int aclk_decode_base_url(char *url, char **aclk_hostname, char **aclk_port)
+int aclk_decode_base_url(char *url, char **aclk_hostname, int *aclk_port)
 {
     int pos = 0;
     if (!strncmp("https://", url, 8)) {
@@ -213,8 +213,8 @@ int aclk_decode_base_url(char *url, char **aclk_hostname, char **aclk_port)
         host_end++;
     if (url[host_end] == 0) {
         *aclk_hostname = strdupz(url + pos);
-        *aclk_port = strdupz("443");
-        info("Setting ACLK target host=%s port=%s from %s", *aclk_hostname, *aclk_port, url);
+        *aclk_port = 443;
+        info("Setting ACLK target host=%s port=%d from %s", *aclk_hostname, *aclk_port, url);
         return 0;
     }
     if (url[host_end] == ':') {
@@ -227,15 +227,13 @@ int aclk_decode_base_url(char *url, char **aclk_hostname, char **aclk_port)
             error("Port specified in %s is invalid", url);
             return 0;
         }
-        *aclk_port = callocz(port_end - host_end + 1, 1);
-        for (int i = host_end + 1; i < port_end; i++)
-            (*aclk_port)[i - host_end - 1] = url[i];
+        *aclk_port = atoi(&url[host_end+1]);
     }
     if (url[host_end] == '/') {
-        *aclk_port = strdupz("443");
+        *aclk_port = 443;
         *aclk_hostname = callocz(1, host_end - pos + 1);
         strncpy(*aclk_hostname, url+pos, host_end - pos);
     }
-    info("Setting ACLK target host=%s port=%s from %s", *aclk_hostname, *aclk_port, url);
+    info("Setting ACLK target host=%s port=%d from %s", *aclk_hostname, *aclk_port, url);
     return 0;
 }

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -81,7 +81,7 @@ const char *aclk_proxy_type_to_s(ACLK_PROXY_TYPE *type);
 ACLK_PROXY_TYPE aclk_verify_proxy(const char *string);
 const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type);
 void safe_log_proxy_censor(char *proxy);
-int aclk_decode_base_url(char *url, char **aclk_hostname, char **aclk_port);
+int aclk_decode_base_url(char *url, char **aclk_hostname, int *aclk_port);
 const char *aclk_get_proxy(ACLK_PROXY_TYPE *type);
 
 #endif //ACLK_COMMON_H

--- a/aclk/aclk_lws_https_client.c
+++ b/aclk/aclk_lws_https_client.c
@@ -147,7 +147,7 @@ static void simple_hcc_log_divert(int level, const char *line)
     error("Libwebsockets: %s", line);
 }
 
-int aclk_send_https_request(char *method, char *host, char *port, char *url, char *b, size_t b_size, char *payload)
+int aclk_send_https_request(char *method, char *host, int port, char *url, char *b, size_t b_size, char *payload)
 {
     info("%s %s", __func__, method);
 
@@ -198,7 +198,7 @@ int aclk_send_https_request(char *method, char *host, char *port, char *url, cha
     i.ssl_connection |= LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK;
 #endif
 
-    i.port = atoi(port);
+    i.port = port;
     i.address = host;
     i.path = url;
 

--- a/aclk/aclk_lws_https_client.h
+++ b/aclk/aclk_lws_https_client.h
@@ -13,6 +13,6 @@
 #define SEND_HTTPS_REQUEST_TIMEOUT 30
 #endif
 
-int aclk_send_https_request(char *method, char *host, char *port, char *url, char *b, size_t b_size, char *payload);
+int aclk_send_https_request(char *method, char *host, int port, char *url, char *b, size_t b_size, char *payload);
 
 #endif /* NETDATA_LWS_HTTPS_CLIENT_H */

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -723,7 +723,7 @@ int private_decrypt(unsigned char * enc_data, int data_len, unsigned char *decry
     return result;
 }
 
-void aclk_get_challenge(char *aclk_hostname, char *aclk_port)
+void aclk_get_challenge(char *aclk_hostname, int port)
 {
     char *data_buffer = mallocz(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
     debug(D_ACLK, "Performing challenge-response sequence");
@@ -742,8 +742,8 @@ void aclk_get_challenge(char *aclk_hostname, char *aclk_port)
     }
     char url[1024];
     sprintf(url, "/api/v1/auth/node/%s/challenge", agent_id);
-    info("Retrieving challenge from cloud: %s %s %s", aclk_hostname, aclk_port, url);
-    if(aclk_send_https_request("GET", aclk_hostname, aclk_port, url, data_buffer, NETDATA_WEB_RESPONSE_INITIAL_SIZE, NULL))
+    info("Retrieving challenge from cloud: %s %d %s", aclk_hostname, port, url);
+    if(aclk_send_https_request("GET", aclk_hostname, port, url, data_buffer, NETDATA_WEB_RESPONSE_INITIAL_SIZE, NULL))
     {
         error("Challenge failed: %s", data_buffer);
         goto CLEANUP;
@@ -780,7 +780,7 @@ void aclk_get_challenge(char *aclk_hostname, char *aclk_port)
     debug(D_ACLK, "Password phase: %s",response_json);
     // TODO - host
     sprintf(url, "/api/v1/auth/node/%s/password", agent_id);
-    if(aclk_send_https_request("POST", aclk_hostname, aclk_port, url, data_buffer, NETDATA_WEB_RESPONSE_INITIAL_SIZE, response_json))
+    if(aclk_send_https_request("POST", aclk_hostname, port, url, data_buffer, NETDATA_WEB_RESPONSE_INITIAL_SIZE, response_json))
     {
         error("Challenge-response failed: %s", data_buffer);
         goto CLEANUP;
@@ -819,7 +819,7 @@ CLEANUP:
 #pragma endregion
 #endif
 
-static void aclk_try_to_connect(char *hostname, char *port, int port_num)
+static void aclk_try_to_connect(char *hostname, int port)
 {
     if (!aclk_private_key) {
             error("Cannot try to establish the agent cloud link - no private key available!");
@@ -836,7 +836,7 @@ static void aclk_try_to_connect(char *hostname, char *port, int port_num)
     aclk_shared_state.version_neg = 0;
     aclk_shared_state.version_neg_wait_till = 0;
     ACLK_SHARED_STATE_UNLOCK;
-    rc = mqtt_attempt_connection(hostname, port_num, aclk_username, aclk_password);
+    rc = mqtt_attempt_connection(hostname, port, aclk_username, aclk_password);
     if (unlikely(rc)) {
         error("Failed to initialize the agent cloud link library");
     }
@@ -934,8 +934,7 @@ void *aclk_main(void *ptr)
     }
 
     char *aclk_hostname = NULL; // Initializers are over-written but prevent gcc complaining about clobbering.
-    char *aclk_port = NULL;
-    uint32_t port_num = 0;
+    int port_num = 0;
     info("Waiting for netdata to be claimed");
     while(1) {
         char *agent_id = is_agent_claimed();
@@ -953,15 +952,10 @@ void *aclk_main(void *ptr)
             error("Do not move the cloud base url out of post_conf_load!!");
             goto exited;
         }
-        if (aclk_decode_base_url(cloud_base_url, &aclk_hostname, &aclk_port)) {
+        if (aclk_decode_base_url(cloud_base_url, &aclk_hostname, &port_num))
             error("Agent is claimed but the configuration is invalid, please fix");
-        }
-        else
-        {
-            port_num = atoi(aclk_port);     // SSL library uses the string, MQTT uses the numeric value
-            if (!create_private_key() && !_mqtt_lib_init())
+        else if (!create_private_key() && !_mqtt_lib_init())
                 break;
-        }
 
         for (int i=0; i<60; i++) {
             if (netdata_exit)
@@ -996,7 +990,7 @@ void *aclk_main(void *ptr)
         }
         if (unlikely(!netdata_exit && !aclk_connected && !aclk_force_reconnect)) {
             if (unlikely(!first_init)) {
-                aclk_try_to_connect(aclk_hostname, aclk_port, port_num);
+                aclk_try_to_connect(aclk_hostname, port_num);
                 first_init = 1;
             } else {
                 if (aclk_connecting == 0) {
@@ -1007,7 +1001,7 @@ void *aclk_main(void *ptr)
                     }
                     if (now_realtime_usec() >= reconnect_expiry) {
                         reconnect_expiry = 0;
-                        aclk_try_to_connect(aclk_hostname, aclk_port, port_num);
+                        aclk_try_to_connect(aclk_hostname, port_num);
                     }
                     sleep_usec(USEC_PER_MS * 100);
                 }
@@ -1045,7 +1039,6 @@ exited:
     freez(aclk_username);
     freez(aclk_password);
     freez(aclk_hostname);
-    freez(aclk_port);
     if (aclk_private_key != NULL)
         RSA_free(aclk_private_key);
 

--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -835,6 +835,9 @@ static void aclk_try_to_connect(char *hostname, int port)
 
     info("Attempting to establish the agent cloud link");
 #ifdef ACLK_DISABLE_CHALLENGE
+    error("Agent built with ACLK_DISABLE_CHALLENGE. This is for testing "
+          "and development purposes only. Warranty void. Won't be able "
+          "to connect to Netdata Cloud.");
     if (aclk_password == NULL)
         aclk_password = strdupz("anon");
 #else


### PR DESCRIPTION
##### Summary
For easier testing of ACLK, it is useful to connect to an arbitrary MQTT WSS brokers. This allows doing that easily by adding `-DACLK_DISABLE_CHALLENGE` to the compiler.
This will disable challenge-response functionality which is supported and specific only to netdata cloud.

During the implementation, I noticed we are unnecessarily passing the port as both string and integer and carrying that around the code. This fixes also that problem.

Review the 2 commits separately for a clearer picture as one does code cleanup and the second one actually implements the feature,

##### Component Name
ACLK

##### Test Plan
compile with `-DACLK_SSL_ALLOW_SELF_SIGNED -DACLK_DISABLE_CHALLENGE`, set up `cloud base url = 127.0.0.1:9002` in `cloud.conf`. Set mosquito broker (compiled with WSS support) to listen with WSS listener on port `9002`. Example mosquito config:
```
port 1883
listener 9002
protocol websockets
certfile server.crt
keyfile server.key
log_dest stdout
log_type all
websockets_log_level 9999
```

Agent should skip challenge-response and connect to the broker successfully.

##### Additional Information
