### PR TITLE
Fix Docs GitHub Action with ignore list and update

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run link check
-        uses: gaurav-nelson/github-action-markdown-link-check@1.0.2
+        uses: gaurav-nelson/github-action-markdown-link-check@1.0.7
         with:
           use-quiet-mode: 'no'
           use-verbose-mode: 'yes'

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,7 +1,7 @@
 {
     "ignorePatterns": [
 		{
-			"pattern": "^https://pi-hole.net"
+			"pattern": "^https:\/\/pi-hole.net"
 		}
 	],
     "replacementPatterns": [

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,7 +1,7 @@
 {
     "ignorePatterns": [
 		{
-			"pattern": "^https://pi-hole.net/"
+			"pattern": "^https://pi-hole.net"
 		}
 	],
     "replacementPatterns": [

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,4 +1,9 @@
 {
+    "ignorePatterns": [
+		{
+			"pattern": "^https://pi-hole.net/"
+		}
+	],
     "replacementPatterns": [
         {
             "pattern": "^/",

--- a/claim/README.md
+++ b/claim/README.md
@@ -9,8 +9,6 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/claim/README.md
 
 # Agent claiming
 
-testing the link-checker
-
 Agent claiming allows a Netdata Agent, running on a distributed node, to securely connect to Netdata Cloud. A Space's
 administrator creates a **claiming token**, which is used to add an Agent to their Space via the [Agent-Cloud link
 (ACLK)](/aclk/README.md).

--- a/claim/README.md
+++ b/claim/README.md
@@ -9,6 +9,8 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/claim/README.md
 
 # Agent claiming
 
+testing the link-checker
+
 Agent claiming allows a Netdata Agent, running on a distributed node, to securely connect to Netdata Cloud. A Space's
 administrator creates a **claiming token**, which is used to add an Agent to their Space via the [Agent-Cloud link
 (ACLK)](/aclk/README.md).


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

I've noticed that the Docs GitHub Action always fails due to failing to check the link `https://pi-hole.net`. There's two problems with this. First, it shouldn't always be checking links in the Pi-hole guide—that's a bug. Second, the link is functional, so I'm choosing to ignore the failure.

##### Component Name

area/ci

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
