### PR TITLE
Add a few changes that were missed by the systemd updater support.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -83,3 +83,15 @@ jobs:
       - name: Run run_install_with_dist_file.sh
         run: |
           ./.github/scripts/run_install_with_dist_file.sh "${DISTFILE}"
+  gitignore-check:
+    name: .gitignore
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Prepare environment
+        run: ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata
+      - name: Build netdata
+        run: ./netdata-installer.sh --dont-start-it --disable-telemetry --dont-wait --install /tmp/install
+      - name: Check that repo is clean
+        run: if [ "$(git status --porcelain=v1 | wc -l)" -gt 0 ] ; then exit 1 ; fi

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ system/netdata-init-d
 system/netdata.logrotate
 system/netdata.service
 system/netdata.service.*
+system/netdata-updater.service
 !system/netdata.service.in
 !system/netdata.service.*.in
 system/netdata.plist

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1059,7 +1059,7 @@ run $make install || exit 1
 # -----------------------------------------------------------------------------
 progress "Fix generated files permissions"
 
-run find ./system/ -type f -a \! -name \*.in -a \! -name Makefile\* -a \! -name \*.conf -a \! -name \*.service -a \! -name \*.logrotate -exec chmod 755 {} \;
+run find ./system/ -type f -a \! -name \*.in -a \! -name Makefile\* -a \! -name \*.conf -a \! -name \*.service -a \! -name \*.timer -a \! -name \*.logrotate -exec chmod 755 {} \;
 
 # -----------------------------------------------------------------------------
 progress "Creating standard user and groups for netdata"


### PR DESCRIPTION
##### Summary

When adding systemd timer unit support for the updater, I unintentionally missed a few places that needed changed to avoid leaving the repo dirty after a build and install.

This also adds a CI check to help ensure this doesn't happen again.

##### Component Name

area/packaging
area/ci

##### Test Plan

Newly added CI check passes correctly, but ails if run against the current `master` branch.