### PR TITLE
changes default query thread count

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -914,7 +914,9 @@ void *aclk_main(void *ptr)
         }
     }
 
-    query_threads.count = config_get_number(CONFIG_SECTION_CLOUD, "query thread count", 2);
+    query_threads.count = MIN(processors/2, 6);
+    query_threads.count = MAX(query_threads.count, 2);
+    query_threads.count = config_get_number(CONFIG_SECTION_CLOUD, "query thread count", query_threads.count);
     if(query_threads.count < 1) {
         error("You need at least one query thread. Overriding configured setting of \"%d\"", query_threads.count);
         query_threads.count = 1;


### PR DESCRIPTION
##### Summary
After meeting with Costa we had agreed to change the default ACLK Query Thread count to be following:
1. `available cores / 2`
1. but `max of 6`
1. and `min of 2`

This applies only for default value. User might configure more than 6 threads.

##### Component Name
ACLK

##### Test Plan

##### Additional Information
