### PR TITLE
collector infiniband: fix file descriptor leak

### DIFF
--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -375,12 +375,12 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                 // Standard counters are mandatory
                 if (!counters_dir)
                     continue;
+                closedir(counters_dir);
 
-                // Nearly same with hardware counters
+                // Hardware Counters are optionnal, used later
                 char hwcounters_dirname[FILENAME_MAX + 1];
                 snprintfz(
                     hwcounters_dirname, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "hw_counters");
-                DIR *hwcounters_dir = opendir(hwcounters_dirname);
 
                 // Get new or existing ibport
                 struct ibport *p = get_ibport(dev_dent->d_name, port_dent->d_name);
@@ -412,6 +412,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                     FOREACH_COUNTER(GEN_DO_COUNTER_NAME, p)
 
                     // Check HW Counters vendor dependent
+                    DIR *hwcounters_dir = opendir(hwcounters_dirname);
                     if (hwcounters_dir) {
                         // By default set standard
                         p->do_hwpackets = config_get_boolean_ondemand(buffer, "hwpackets", do_hwpackets);
@@ -442,6 +443,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                             p->do_hwpackets = CONFIG_BOOLEAN_NO;
                             p->do_hwerrors = CONFIG_BOOLEAN_NO;
                         }
+                        closedir(hwcounters_dir);
                     }
                 }
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fix a missing file-descriptor leak due to missing closedir() during discovery, reported by #10012 


##### Component Name
proc.plugin

##### Test Plan

##### Additional Information
