### PR TITLE
Completely hide SSO iframe

### DIFF
--- a/web/gui/index.html
+++ b/web/gui/index.html
@@ -1315,7 +1315,7 @@
             </div>
         </div>
     </div>
-    <iframe id="ssoifrm" width="0" height="0"></iframe>
+    <iframe id="ssoifrm" width="0" height="0" style="border: none;"></iframe>
     <div id="hiddenDownloadLinks" style="display: none;" hidden></div>
     <script type="text/javascript" src="dashboard.js?v20190902-0"></script>
 </body>


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

The SSO `iframe` is not completely hidden and it appears as a small visible square.

##### Component Name

Web / Gui

##### Test Plan

Add / Remove `style="border: none;"` on the `iframe` with the web console

##### Additional Information

You can see the issue with the picture below:

![image](https://user-images.githubusercontent.com/9881407/95072517-94f43880-070b-11eb-9301-50bb1b303e1f.png)

After patch:

![image](https://user-images.githubusercontent.com/9881407/95072798-1055ea00-070c-11eb-923a-d2d030cd7acc.png)


I've spotted the issue on the stable and nightly versions.
