### PR TITLE
Fixed the data endpoint to prioritize chart over context if both are present

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -492,7 +492,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     }
 
     struct context_param  *context_param_list = NULL;
-    if (context) {
+    if (context && !chart) {
         RRDSET *st1;
         uint32_t context_hash = simple_hash(context);
         rrdhost_rdlock(localhost);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -513,7 +513,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     }
 
     if (!st && !context_param_list) {
-        if (context) {
+        if (context && !chart) {
             buffer_strcat(w->response.data, "Context is not found: ");
             buffer_strcat_htmlescape(w->response.data, context);
         }


### PR DESCRIPTION
##### Summary
When a chart and context is specified in a data query give priority to the chart

##### Component Name
database

##### Test Plan

Before the PR
`http://127.0.0.1:19999/api/v1/data?chart=system.cpu&options=jsonwrap&format=array&after=-10&context=cpu.cpu`

will return a response for the **cpu.cpu**

With the change in this PR the `context=cpu.cpu` will be ignored and return information for the **system.cpu** chart

