### PR TITLE
New alarm entities

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -109,9 +109,13 @@ static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
 }
 
 static inline int rrdcalc_is_matching_this_rrdset(RRDCALC *rc, RRDSET *st) {
-    if(     (rc->hash_chart == st->hash      && !strcmp(rc->chart, st->id)) ||
-            (rc->hash_chart == st->hash_name && !strcmp(rc->chart, st->name)))
-        return 1;
+    if((rc->hash_chart == st->hash      && !strcmp(rc->chart, st->id)) ||
+        (rc->hash_chart == st->hash_name && !strcmp(rc->chart, st->name))) {
+        if ((!rc->module_match && !rc->plugin_match) ||
+            (rc->module_match && simple_pattern_matches(rc->module_pattern, st->module_name)) ||
+            (rc->plugin_match && simple_pattern_matches(rc->plugin_pattern, st->plugin_name)))
+            return 1;
+    }
 
     return 0;
 }
@@ -564,6 +568,10 @@ void rrdcalc_free(RRDCALC *rc) {
     simple_pattern_free(rc->spdim);
     freez(rc->labels);
     simple_pattern_free(rc->splabels);
+    freez(rc->module_match);
+    simple_pattern_free(rc->module_pattern);
+    freez(rc->plugin_match);
+    simple_pattern_free(rc->plugin_pattern);
     freez(rc);
 }
 

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -109,17 +109,13 @@ static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
 }
 
 static inline int rrdcalc_test_additional_restriction(RRDCALC *rc, RRDSET *st){
-    if (!rc->module_match && !rc->plugin_match)
-        return 1;
+    if (rc->module_match && !simple_pattern_matches(rc->module_pattern, st->module_name))
+        return 0;
 
-    if (rc->module_match && rc->plugin_match)
-        return (rc->module_match && simple_pattern_matches(rc->module_pattern, st->module_name) &&
-         rc->plugin_match && simple_pattern_matches(rc->plugin_pattern, st->plugin_name));
+    if (rc->plugin_match && !simple_pattern_matches(rc->plugin_pattern, st->plugin_name))
+        return 0;
 
-    if (rc->module_match)
-        return simple_pattern_matches(rc->module_pattern, st->module_name);
-
-    return simple_pattern_matches(rc->plugin_pattern, st->plugin_name);
+    return 1;
 }
 
 static inline int rrdcalc_is_matching_this_rrdset(RRDCALC *rc, RRDSET *st) {

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -112,8 +112,8 @@ static inline int rrdcalc_is_matching_this_rrdset(RRDCALC *rc, RRDSET *st) {
     if((rc->hash_chart == st->hash      && !strcmp(rc->chart, st->id)) ||
         (rc->hash_chart == st->hash_name && !strcmp(rc->chart, st->name))) {
         if ((!rc->module_match && !rc->plugin_match) ||
-            (rc->module_match && simple_pattern_matches(rc->module_pattern, st->module_name)) ||
-            (rc->plugin_match && simple_pattern_matches(rc->plugin_pattern, st->plugin_name)))
+            (rc->module_match && simple_pattern_matches(rc->module_pattern, st->module_name) &&
+            rc->plugin_match && simple_pattern_matches(rc->plugin_pattern, st->plugin_name)) )
             return 1;
     }
 

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -45,6 +45,13 @@ struct rrdcalc {
     char *chart;                    // the chart id this should be linked to
     uint32_t hash_chart;
 
+
+    char *plugin_match;             //the plugin name that should be linked to
+    SIMPLE_PATTERN *plugin_pattern;
+
+    char *module_match;             //the module name that should be linked to
+    SIMPLE_PATTERN *module_pattern;
+
     char *source;                   // the source of this alarm
     char *units;                    // the units of the alarm
     char *info;                     // a short description of the alarm

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -45,19 +45,15 @@ static int rrdcalctemplate_is_there_label_restriction(RRDCALCTEMPLATE *rt,  RRDH
 }
 
 static inline int rrdcalctemplate_test_additional_restriction(RRDCALCTEMPLATE *rt, RRDSET *st) {
-    error("KILLME %s: %s %s %s", st->name, rt->family_match, rt->module_match, rt->plugin_match);
     if (rt->family_pattern && !simple_pattern_matches(rt->family_pattern, st->family))
         return 0;
 
-    error("KILLME 1 %s: %s %s %s", st->name, rt->family_match, rt->module_match, rt->plugin_match);
     if (rt->module_pattern && !simple_pattern_matches(rt->module_pattern, st->module_name))
         return 0;
 
-    error("KILLME 2 %s: %s %s %s", st->name, rt->family_match, rt->module_match, rt->plugin_match);
     if (rt->plugin_pattern && !simple_pattern_matches(rt->plugin_pattern, st->plugin_name))
         return 0;
 
-    error("KILLME 3 %s: %s %s %s", st->name, rt->family_match, rt->module_match, rt->plugin_match);
     return 1;
 }
 

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -53,9 +53,10 @@ static int rrdcalctemplate_is_there_label_restriction(RRDCALCTEMPLATE *rt,  RRDH
  */
 void rrdcalctemplate_link_matching_test(RRDCALCTEMPLATE *rt, RRDSET *st, RRDHOST *host ) {
     if(rt->hash_context == st->hash_context && !strcmp(rt->context, st->context) &&
-       ((!rt->family_pattern || (rt->family_pattern && simple_pattern_matches(rt->family_pattern, st->family))) ||
-       (!rt->module_pattern || (rt->module_pattern && simple_pattern_matches(rt->module_pattern, st->module_name))) ||
-       (!rt->plugin_pattern || (rt->plugin_pattern && simple_pattern_matches(rt->plugin_pattern, st->plugin_name)) )
+       ((!rt->family_pattern && !rt->module_pattern && !rt->plugin_pattern) ||
+       ((rt->family_pattern && simple_pattern_matches(rt->family_pattern, st->family)) ||
+       (rt->module_pattern && simple_pattern_matches(rt->module_pattern, st->module_name)) ||
+       (rt->plugin_pattern && simple_pattern_matches(rt->plugin_pattern, st->plugin_name)) )
                                                          )) {
         if (!rrdcalctemplate_is_there_label_restriction(rt, host)) {
             RRDCALC *rc = rrdcalc_create_from_template(host, rt, st->id);

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -55,9 +55,10 @@ void rrdcalctemplate_link_matching_test(RRDCALCTEMPLATE *rt, RRDSET *st, RRDHOST
     if(rt->hash_context == st->hash_context && !strcmp(rt->context, st->context) &&
        ((!rt->family_pattern && !rt->module_pattern && !rt->plugin_pattern) ||
        ((rt->family_pattern && simple_pattern_matches(rt->family_pattern, st->family)) ||
-       (rt->module_pattern && simple_pattern_matches(rt->module_pattern, st->module_name)) ||
-       (rt->plugin_pattern && simple_pattern_matches(rt->plugin_pattern, st->plugin_name)) )
-                                                         )) {
+       (rt->module_pattern && !rt->plugin_pattern && simple_pattern_matches(rt->module_pattern, st->module_name)) ||
+       (rt->plugin_pattern && !rt->module_pattern && simple_pattern_matches(rt->plugin_pattern, st->plugin_name)) ||
+       (rt->plugin_pattern && simple_pattern_matches(rt->module_pattern, st->module_name) &&
+        rt->module_pattern && simple_pattern_matches(rt->plugin_pattern, st->plugin_name)))) ) {
         if (!rrdcalctemplate_is_there_label_restriction(rt, host)) {
             RRDCALC *rc = rrdcalc_create_from_template(host, rt, st->id);
             if (unlikely(!rc))

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -55,10 +55,8 @@ void rrdcalctemplate_link_matching_test(RRDCALCTEMPLATE *rt, RRDSET *st, RRDHOST
     if(rt->hash_context == st->hash_context && !strcmp(rt->context, st->context) &&
        ((!rt->family_pattern && !rt->module_pattern && !rt->plugin_pattern) ||
        ((rt->family_pattern && simple_pattern_matches(rt->family_pattern, st->family)) ||
-       (rt->module_pattern && !rt->plugin_pattern && simple_pattern_matches(rt->module_pattern, st->module_name)) ||
-       (rt->plugin_pattern && !rt->module_pattern && simple_pattern_matches(rt->plugin_pattern, st->plugin_name)) ||
-       (rt->plugin_pattern && simple_pattern_matches(rt->module_pattern, st->module_name) &&
-        rt->module_pattern && simple_pattern_matches(rt->plugin_pattern, st->plugin_name)))) ) {
+       (rt->module_pattern && simple_pattern_matches(rt->module_pattern, st->module_name) &&
+        rt->plugin_pattern && simple_pattern_matches(rt->plugin_pattern, st->plugin_name)))) ) {
         if (!rrdcalctemplate_is_there_label_restriction(rt, host)) {
             RRDCALC *rc = rrdcalc_create_from_template(host, rt, st->id);
             if (unlikely(!rc))

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -52,8 +52,11 @@ static int rrdcalctemplate_is_there_label_restriction(RRDCALCTEMPLATE *rt,  RRDH
  * @param st is the chart where the alarm will be attached.
  */
 void rrdcalctemplate_link_matching_test(RRDCALCTEMPLATE *rt, RRDSET *st, RRDHOST *host ) {
-    if(rt->hash_context == st->hash_context && !strcmp(rt->context, st->context)
-       && (!rt->family_pattern || simple_pattern_matches(rt->family_pattern, st->family))) {
+    if(rt->hash_context == st->hash_context && !strcmp(rt->context, st->context) &&
+       ((!rt->family_pattern || (rt->family_pattern && simple_pattern_matches(rt->family_pattern, st->family))) ||
+       (!rt->module_pattern || (rt->module_pattern && simple_pattern_matches(rt->module_pattern, st->module_name))) ||
+       (!rt->plugin_pattern || (rt->plugin_pattern && simple_pattern_matches(rt->plugin_pattern, st->plugin_name)) )
+                                                         )) {
         if (!rrdcalctemplate_is_there_label_restriction(rt, host)) {
             RRDCALC *rc = rrdcalc_create_from_template(host, rt, st->id);
             if (unlikely(!rc))
@@ -91,6 +94,12 @@ inline void rrdcalctemplate_free(RRDCALCTEMPLATE *rt) {
 
     freez(rt->family_match);
     simple_pattern_free(rt->family_pattern);
+
+    freez(rt->plugin_match);
+    simple_pattern_free(rt->plugin_pattern);
+
+    freez(rt->module_match);
+    simple_pattern_free(rt->module_pattern);
 
     freez(rt->name);
     freez(rt->exec);

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -45,33 +45,20 @@ static int rrdcalctemplate_is_there_label_restriction(RRDCALCTEMPLATE *rt,  RRDH
 }
 
 static inline int rrdcalctemplate_test_additional_restriction(RRDCALCTEMPLATE *rt, RRDSET *st) {
-    if (!rt->family_pattern && !rt->module_pattern && !rt->plugin_pattern)
-        return 1;
+    error("KILLME %s: %s %s %s", st->name, rt->family_match, rt->module_match, rt->plugin_match);
+    if (rt->family_pattern && !simple_pattern_matches(rt->family_pattern, st->family))
+        return 0;
 
-    int test_family, test_module, test_plugin;
+    error("KILLME 1 %s: %s %s %s", st->name, rt->family_match, rt->module_match, rt->plugin_match);
+    if (rt->module_pattern && !simple_pattern_matches(rt->module_pattern, st->module_name))
+        return 0;
 
-    if (rt->family_pattern)
-        test_family = simple_pattern_matches(rt->family_pattern, st->family);
-    else
-        test_family = 1;
+    error("KILLME 2 %s: %s %s %s", st->name, rt->family_match, rt->module_match, rt->plugin_match);
+    if (rt->plugin_pattern && !simple_pattern_matches(rt->plugin_pattern, st->plugin_name))
+        return 0;
 
-    if (rt->module_match && rt->plugin_match) {
-        test_module = (simple_pattern_matches(rt->module_pattern, st->module_name) &&
-                           simple_pattern_matches(rt->plugin_pattern, st->plugin_name));
-        test_plugin = test_module;
-    } else {
-        if (rt->module_pattern)
-            test_module = simple_pattern_matches(rt->module_pattern, st->module_name);
-        else
-            test_module = 1;
-
-        if (rt->plugin_pattern)
-            test_plugin = simple_pattern_matches(rt->plugin_pattern, st->plugin_name);
-        else
-            test_plugin = 1;
-    }
-
-    return (test_module && test_family && test_plugin);
+    error("KILLME 3 %s: %s %s %s", st->name, rt->family_match, rt->module_match, rt->plugin_match);
+    return 1;
 }
 
 // RRDCALCTEMPLATE management

--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -21,6 +21,12 @@ struct rrdcalctemplate {
     char *family_match;
     SIMPLE_PATTERN *family_pattern;
 
+    char *plugin_match;
+    SIMPLE_PATTERN *plugin_pattern;
+
+    char *module_match;
+    SIMPLE_PATTERN *module_pattern;
+
     char *source;                   // the source of this alarm
     char *units;                    // the units of the alarm
     char *info;                     // a short description of the alarm

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -169,7 +169,7 @@ comprehensive example using both.
 #### Alarm line `module`
 
 The `module` line filters which module within the context this alarm should apply to. The value is a space-separated
-list of simple patterns. See our [simple patterns docs](/libnetdata/simple_pattern/README.md) for some examples. For
+list of [simple patterns](/libnetdata/simple_pattern/README.md). For
 example, you can create an alarm that applies only on the `isc_dhcpd` module started by `python.d.plugin`:
 
 ```yaml

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -157,12 +157,7 @@ hosts: server1 server2 database* !redis3 redis*
 The `plugin` line, filters which plugin within the context this alarm should apply to. The value is a space-separated 
 list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for some examples.
 
-For example, you can create a template on the `isc_dhcpd.utilization` chart, but filter it to only the `python.d.plugin` 
-plugin:
-
-```yaml
-plugin: python.d.plugin
-```
+This value is not applied independent of the option `module`, for more details see next option.
 
 #### Alarm line `module`
 
@@ -173,6 +168,7 @@ For example, you can create a template on the `isc_dhcpd.utilization` chart, but
 module:
 
 ```yaml
+plugin: python.d.plugin
 module: isc_dhcpd
 ```
 

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -187,7 +187,7 @@ For example, you can create a template on the `isc_dhcpd.utilization` chart, but
 plugin:
 
 ```yaml
-plugin: isc_dhcpd
+plugin: python.d.plugin
 ```
 
 #### Alarm line `lookup`

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -155,7 +155,7 @@ hosts: server1 server2 database* !redis3 redis*
 #### Alarm line `plugin`
 
 The `plugin` line filters which plugin within the context this alarm should apply to. The value is a space-separated
-list of simple patterns. See our [simple patterns docs](/libnetdata/simple_pattern/README.md) for details. For example,
+list of [simple patterns](/libnetdata/simple_pattern/README.md). For example,
 you can create a filter for an alarm that applies specifically to `python.d.plugin`:
 
 ```yaml

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -60,9 +60,9 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`on`](#alarm-line-on)                              | yes             | The chart this alarm should attach to.                                                |
 | [`os`](#alarm-line-os)                              | no              | Which operating systems to run this chart.                                            |
 | [`hosts`](#alarm-line-hosts)                        | no              | Which hostnames will run this alarm.                                                  |
-| [`families`](#alarm-line-families)                  | no              | Restrict a template to only certain families.                                         |
-| [`module`](#alarm-line-module)                      | no              | Restrict alarm to only certain module.                                                |
 | [`plugin`](#alarm-line-plugin)                      | no              | Restrict alarm to only certain plugin.                                                |
+| [`module`](#alarm-line-module)                      | no              | Restrict alarm to only certain module.                                                |
+| [`families`](#alarm-line-families)                  | no              | Restrict a template to only certain families.                                         |
 | [`lookup`](#alarm-line-lookup)                      | yes             | The database lookup to find and process metrics for the chart specified through `on`. |
 | [`calc`](#alarm-line-calc)                          | yes (see above) | A calculation to apply to the value found via `lookup` or another variable.           |
 | [`every`](#alarm-line-every)                        | no              | The frequency of the alarm.                                                           |
@@ -152,18 +152,16 @@ begin with `redis`.
 hosts: server1 server2 database* !redis3 redis*
 ```
 
-#### Alarm line `families`
+#### Alarm line `plugin`
 
-The `families` line, used only alongside templates, filters which families within the context this alarm should apply
-to. The value is a space-separated list.
+The `plugin` line, filters which plugin within the context this alarm should apply to. The value is a space-separated 
+list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for some examples.
 
-The value is a space-separate list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for
-some examples.
-
-For example, you can create a template on the `disk.io` context, but filter it to only the `sda` and `sdb` families:
+For example, you can create a template on the `isc_dhcpd.utilization` chart, but filter it to only the `python.d.plugin` 
+plugin:
 
 ```yaml
-families: sda sdb
+plugin: python.d.plugin
 ```
 
 #### Alarm line `module`
@@ -178,16 +176,18 @@ module:
 module: isc_dhcpd
 ```
 
-#### Alarm line `plugin`
+#### Alarm line `families`
 
-The `plugin` line, filters which plugin within the context this alarm should apply to. The value is a space-separated 
-list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for some examples.
+The `families` line, used only alongside templates, filters which families within the context this alarm should apply
+to. The value is a space-separated list.
 
-For example, you can create a template on the `isc_dhcpd.utilization` chart, but filter it to only the `python.d.plugin` 
-plugin:
+The value is a space-separate list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for
+some examples.
+
+For example, you can create a template on the `disk.io` context, but filter it to only the `sda` and `sdb` families:
 
 ```yaml
-plugin: python.d.plugin
+families: sda sdb
 ```
 
 #### Alarm line `lookup`

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -61,7 +61,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`os`](#alarm-line-os)                              | no              | Which operating systems to run this chart.                                            |
 | [`hosts`](#alarm-line-hosts)                        | no              | Which hostnames will run this alarm.                                                  |
 | [`plugin`](#alarm-line-plugin)                      | no              | Restrict alarm to only certain plugin.                                                |
-| [`module`](#alarm-line-module)                      | no              | Restrict alarm to only certain module.                                                |
+| [`module`](#alarm-line-module)                      | no              | Restrict an alarm or template to only a certain module.                                             |
 | [`families`](#alarm-line-families)                  | no              | Restrict a template to only certain families.                                         |
 | [`lookup`](#alarm-line-lookup)                      | yes             | The database lookup to find and process metrics for the chart specified through `on`. |
 | [`calc`](#alarm-line-calc)                          | yes (see above) | A calculation to apply to the value found via `lookup` or another variable.           |

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -61,6 +61,8 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`os`](#alarm-line-os)                              | no              | Which operating systems to run this chart.                                            |
 | [`hosts`](#alarm-line-hosts)                        | no              | Which hostnames will run this alarm.                                                  |
 | [`families`](#alarm-line-families)                  | no              | Restrict a template to only certain families.                                         |
+| [`module`](#alarm-line-module)                      | no              | Restrict alarm to only certain module.                                                |
+| [`plugin`](#alarm-line-plugin)                      | no              | Restrict alarm to only certain plugin.                                                |
 | [`lookup`](#alarm-line-lookup)                      | yes             | The database lookup to find and process metrics for the chart specified through `on`. |
 | [`calc`](#alarm-line-calc)                          | yes (see above) | A calculation to apply to the value found via `lookup` or another variable.           |
 | [`every`](#alarm-line-every)                        | no              | The frequency of the alarm.                                                           |
@@ -162,6 +164,29 @@ For example, you can create a template on the `disk.io` context, but filter it t
 
 ```yaml
 families: sda sdb
+```
+
+#### Alarm line `module`
+
+The `module` line, filters which module within the context this alarm should apply to. The value is a space-separated 
+list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for some examples.
+
+For example, you can create an alarm on the `isc_dhcpd.utilization` chart, but filter it to only the `isc_dhcpd` module:
+
+```yaml
+module: isc_dhcpd
+```
+
+#### Alarm line `plugin`
+
+The `plugin` line, filters which plugin within the context this alarm should apply to. The value is a space-separated 
+list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for some examples.
+
+For example, you can create an alarm on the `isc_dhcpd.utilization` chart, but filter it to only the `python.d.plugin` 
+plugin:
+
+```yaml
+plugin: isc_dhcpd
 ```
 
 #### Alarm line `lookup`

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -171,7 +171,8 @@ families: sda sdb
 The `module` line, filters which module within the context this alarm should apply to. The value is a space-separated 
 list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for some examples.
 
-For example, you can create an alarm on the `isc_dhcpd.utilization` chart, but filter it to only the `isc_dhcpd` module:
+For example, you can create a template on the `isc_dhcpd.utilization` chart, but filter it to only the `isc_dhcpd` 
+module:
 
 ```yaml
 module: isc_dhcpd
@@ -182,7 +183,7 @@ module: isc_dhcpd
 The `plugin` line, filters which plugin within the context this alarm should apply to. The value is a space-separated 
 list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for some examples.
 
-For example, you can create an alarm on the `isc_dhcpd.utilization` chart, but filter it to only the `python.d.plugin` 
+For example, you can create a template on the `isc_dhcpd.utilization` chart, but filter it to only the `python.d.plugin` 
 plugin:
 
 ```yaml

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -154,18 +154,23 @@ hosts: server1 server2 database* !redis3 redis*
 
 #### Alarm line `plugin`
 
-The `plugin` line, filters which plugin within the context this alarm should apply to. The value is a space-separated 
-list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for some examples.
+The `plugin` line filters which plugin within the context this alarm should apply to. The value is a space-separated
+list of simple patterns. See our [simple patterns docs](/libnetdata/simple_pattern/README.md) for details. For example,
+you can create a filter for an alarm that applies specifically to `python.d.plugin`:
 
-This value is not applied independent of the option `module`, for more details see next option.
+```yaml
+plugin: python.d.plugin
+```
+
+The `plugin` line is best used with other options like `module`. When used alone, the `plugin` line creates a very
+inclusive filter that is unlikely to be of much use in production. See [`module`](#alarm-line-module) for a
+comprehensive example using both.
 
 #### Alarm line `module`
 
-The `module` line, filters which module within the context this alarm should apply to. The value is a space-separated 
-list of simple patterns. See our [simple patterns docs](../libnetdata/simple_pattern/) for some examples.
-
-For example, you can create a template on the `isc_dhcpd.utilization` chart, but filter it to only the `isc_dhcpd` 
-module:
+The `module` line filters which module within the context this alarm should apply to. The value is a space-separated
+list of simple patterns. See our [simple patterns docs](/libnetdata/simple_pattern/README.md) for some examples. For
+example, you can create an alarm that applies only on the `isc_dhcpd` module started by `python.d.plugin`:
 
 ```yaml
 plugin: python.d.plugin

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -60,7 +60,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`on`](#alarm-line-on)                              | yes             | The chart this alarm should attach to.                                                |
 | [`os`](#alarm-line-os)                              | no              | Which operating systems to run this chart.                                            |
 | [`hosts`](#alarm-line-hosts)                        | no              | Which hostnames will run this alarm.                                                  |
-| [`plugin`](#alarm-line-plugin)                      | no              | Restrict alarm to only certain plugin.                                                |
+| [`plugin`](#alarm-line-plugin)                      | no              | Restrict an alarm or template to only a certain plugin.                                             |
 | [`module`](#alarm-line-module)                      | no              | Restrict an alarm or template to only a certain module.                                             |
 | [`families`](#alarm-line-families)                  | no              | Restrict a template to only certain families.                                         |
 | [`lookup`](#alarm-line-lookup)                      | yes             | The database lookup to find and process metrics for the chart specified through `on`. |

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -10,6 +10,8 @@
 #define HEALTH_HOST_KEY "hosts"
 #define HEALTH_OS_KEY "os"
 #define HEALTH_FAMILIES_KEY "families"
+#define HEALTH_PLUGIN_KEY "plugin"
+#define HEALTH_MODULE_KEY "module"
 #define HEALTH_LOOKUP_KEY "lookup"
 #define HEALTH_CALC_KEY "calc"
 #define HEALTH_EVERY_KEY "every"
@@ -485,6 +487,8 @@ static int health_readfile(const char *filename, void *data) {
             hash_on = 0,
             hash_host = 0,
             hash_families = 0,
+            hash_plugin = 0,
+            hash_module = 0,
             hash_calc = 0,
             hash_green = 0,
             hash_red = 0,
@@ -510,6 +514,8 @@ static int health_readfile(const char *filename, void *data) {
         hash_os = simple_uhash(HEALTH_OS_KEY);
         hash_host = simple_uhash(HEALTH_HOST_KEY);
         hash_families = simple_uhash(HEALTH_FAMILIES_KEY);
+        hash_plugin = simple_uhash(HEALTH_PLUGIN_KEY);
+        hash_module = simple_uhash(HEALTH_MODULE_KEY);
         hash_calc = simple_uhash(HEALTH_CALC_KEY);
         hash_lookup = simple_uhash(HEALTH_LOOKUP_KEY);
         hash_green = simple_uhash(HEALTH_GREEN_KEY);
@@ -811,6 +817,20 @@ static int health_readfile(const char *filename, void *data) {
                 rc->labels = simple_pattern_trim_around_equal(value);
                 rc->splabels = simple_pattern_create(rc->labels, NULL, SIMPLE_PATTERN_EXACT);
             }
+            else if(hash == hash_plugin && !strcasecmp(key, HEALTH_PLUGIN_KEY)) {
+                freez(rc->plugin_match);
+                simple_pattern_free(rc->plugin_pattern);
+
+                rc->plugin_match = strdupz(value);
+                rc->plugin_pattern = simple_pattern_create(rc->plugin_match, NULL, SIMPLE_PATTERN_EXACT);
+            }
+            else if(hash == hash_module && !strcasecmp(key, HEALTH_MODULE_KEY)) {
+                freez(rc->module_match);
+                simple_pattern_free(rc->module_pattern);
+
+                rc->module_match = strdupz(value);
+                rc->module_pattern = simple_pattern_create(rc->module_match, NULL, SIMPLE_PATTERN_EXACT);
+            }
             else {
                 error("Health configuration at line %zu of file '%s' for alarm '%s' has unknown key '%s'.",
                         line, filename, rc->name, key);
@@ -834,6 +854,20 @@ static int health_readfile(const char *filename, void *data) {
 
                 rt->family_match = strdupz(value);
                 rt->family_pattern = simple_pattern_create(rt->family_match, NULL, SIMPLE_PATTERN_EXACT);
+            }
+            else if(hash == hash_plugin && !strcasecmp(key, HEALTH_PLUGIN_KEY)) {
+                freez(rt->plugin_match);
+                simple_pattern_free(rt->plugin_pattern);
+
+                rt->plugin_match = strdupz(value);
+                rt->plugin_pattern = simple_pattern_create(rt->plugin_match, NULL, SIMPLE_PATTERN_EXACT);
+            }
+            else if(hash == hash_module && !strcasecmp(key, HEALTH_MODULE_KEY)) {
+                freez(rt->module_match);
+                simple_pattern_free(rt->module_pattern);
+
+                rt->module_match = strdupz(value);
+                rt->module_pattern = simple_pattern_create(rt->module_match, NULL, SIMPLE_PATTERN_EXACT);
             }
             else if(hash == hash_lookup && !strcasecmp(key, HEALTH_LOOKUP_KEY)) {
                 health_parse_db_lookup(line, filename, value, &rt->group, &rt->after, &rt->before,

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -47,11 +47,6 @@ static inline int rrdcalc_add_alarm_from_config(RRDHOST *host, RRDCALC *rc) {
     if (rrdcalc_exists(host, rc->chart, rc->name, rc->hash_chart, rc->hash))
         return 0;
 
-    if ( (!rc->module_match && rc->plugin_match) || (rc->module_match && !rc->plugin_match)) {
-        error("Health configuration for alarm '%s.%s' has neither \"module\" nor \"plugin\", but it is necessary to define both. Ignoring it.", rc->chart, rc->name);
-        return 0;
-    }
-
     rc->id = rrdcalc_get_unique_id(host, rc->chart, rc->name, &rc->next_event_id);
 
     debug(D_HEALTH, "Health configuration adding alarm '%s.%s' (%u): exec '%s', recipient '%s', green " CALCULATED_NUMBER_FORMAT_AUTO ", red " CALCULATED_NUMBER_FORMAT_AUTO ", lookup: group %d, after %d, before %d, options %u, dimensions '%s', for each dimension '%s', update every %d, calculation '%s', warning '%s', critical '%s', source '%s', delay up %d, delay down %d, delay max %d, delay_multiplier %f, warn_repeat_every %u, crit_repeat_every %u",
@@ -99,11 +94,6 @@ static inline int rrdcalctemplate_add_template_from_config(RRDHOST *host, RRDCAL
 
     if(unlikely(!RRDCALCTEMPLATE_HAS_DB_LOOKUP(rt) && !rt->calculation && !rt->warning && !rt->critical)) {
         error("Health configuration for template '%s' is useless (no calculation, no warning and no critical evaluation)", rt->name);
-        return 0;
-    }
-
-    if ( (!rt->module_match && rt->plugin_match) || (rt->module_match && !rt->plugin_match)) {
-        error("Health configuration for template '%s' has neither \"module\" or \"plugin\", but it is necessary to define both. Ignoring it.", rt->name);
         return 0;
     }
 

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -47,6 +47,11 @@ static inline int rrdcalc_add_alarm_from_config(RRDHOST *host, RRDCALC *rc) {
     if (rrdcalc_exists(host, rc->chart, rc->name, rc->hash_chart, rc->hash))
         return 0;
 
+    if ( (!rc->module_match && rc->plugin_match) || (rc->module_match && !rc->plugin_match)) {
+        error("Health configuration for alarm '%s.%s' has neither \"module\" nor \"plugin\", but it is necessary to define both. Ignoring it.", rc->chart, rc->name);
+        return 0;
+    }
+
     rc->id = rrdcalc_get_unique_id(host, rc->chart, rc->name, &rc->next_event_id);
 
     debug(D_HEALTH, "Health configuration adding alarm '%s.%s' (%u): exec '%s', recipient '%s', green " CALCULATED_NUMBER_FORMAT_AUTO ", red " CALCULATED_NUMBER_FORMAT_AUTO ", lookup: group %d, after %d, before %d, options %u, dimensions '%s', for each dimension '%s', update every %d, calculation '%s', warning '%s', critical '%s', source '%s', delay up %d, delay down %d, delay max %d, delay_multiplier %f, warn_repeat_every %u, crit_repeat_every %u",
@@ -94,6 +99,11 @@ static inline int rrdcalctemplate_add_template_from_config(RRDHOST *host, RRDCAL
 
     if(unlikely(!RRDCALCTEMPLATE_HAS_DB_LOOKUP(rt) && !rt->calculation && !rt->warning && !rt->critical)) {
         error("Health configuration for template '%s' is useless (no calculation, no warning and no critical evaluation)", rt->name);
+        return 0;
+    }
+
+    if ( (!rt->module_match && rt->plugin_match) || (rt->module_match && !rt->plugin_match)) {
+        error("Health configuration for template '%s' has neither \"module\" or \"plugin\", but it is necessary to define both. Ignoring it.", rt->name);
         return 0;
     }
 


### PR DESCRIPTION
##### Summary
Fixes #10014 

This PR is bringing new entities for alarms that will help us to notify users that a specific module is deprecated for a plugin and we are using another plugin with the same features.
##### Component Name
Health
##### Test Plan
The suggestion here is to simulate something near the next steps (the  alarm creation):

<details>
<summary>test setup click click!</summary>

1 - Configure the python example plugin

```bash
# cd /etc/netdata
# ./edit-config python.d.conf
```

and uncommenting the following line:

```
example: yes
```

2 - Compile this PR.
3 - Now test this PR with the following alarms:

- Test if nothing was breaking:

```
 alarm: dev_dim_template
    on: example.random
    os: linux
lookup: sum -3s at 0 every 3 percentage foreach *
 units: %
 every: 1s
  warn: $this > 1
  crit: $this > 4
```

- Test a template with module:

```
template: disable_example_plugin
      on: random
   units: boolean
    calc: $last_collected_t
   every: 1m
    warn: $now != nan
  module: example
   delay: down 5m multiplier 1.5 max 1h
    info: The example python module is deprecated and will be removed soon. Migrate your configuration to example go.d module.
      to: sysadmin
```

- Test a template with plugin:

```
template: disable_example_plugin
      on: random
   units: boolean
    calc: $last_collected_t
   every: 1m
    warn: $now != nan
  plugin: python.d.plugin
   delay: down 5m multiplier 1.5 max 1h
    info: The example python module is deprecated and will be removed soon. Migrate your configuration to example go.d module.
      to: sysadmin
```

- Test an alarm with module:

``` 
   alarm: disable_example_plugin
      on: example.random
   units: boolean
    calc: $last_collected_t
   every: 1m
    warn: $now != nan
  module: example
   delay: down 5m multiplier 1.5 max 1h
    info: The example python module is deprecated and will be removed soon. Migrate your configuration to example go.d module.
      to: sysadmin
```

- Test an alarm with plugin:

```
   alarm: disable_example_plugin
      on: example.random
   units: boolean
    calc: $last_collected_t
   every: 1m
    warn: $now != nan
  plugin: python.d.plugin
   delay: down 5m multiplier 1.5 max 1h
    info: The example python module is deprecated and will be removed soon. Migrate your configuration to example go.d module.
      to: sysadmin
```

</details>

##### Additional Information
During the development I also used the environment that @ilyam8 gave us [here](https://github.com/netdata/netdata/pull/10041#issuecomment-705138975), firstly to fix the problem and after this to confirm that everything was working as expected. With the given templates I got the following expected results:

|  Type | Case | Alarms | 
| ------ | --------- |--------- |
| Template | plugin(-)/module(-) | 4 |
| Template |plugin(-)/module(+) | 2 |
| Template | plugin(+)/module(-) | 2 |
| Alarm | plugin(-)/module(-) | 1 |
| Alarm | plugin(+)/module(-) | 1 |
| Alarm | plugin(-)/module(+) | 1 |