### PR TITLE
Rename NETDATA_PORT to NETDATA_LISTENER_PORT

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -107,8 +107,8 @@ RUN \
 # Install any Python wheels
 RUN pip install /wheels/*
 
-ENV NETDATA_PORT 19999
-EXPOSE $NETDATA_PORT
+ENV NETDATA_LISTENER_PORT 19999
+EXPOSE $NETDATA_LISTENER_PORT
 
 ENTRYPOINT ["/usr/sbin/run.sh"]
 

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -19,6 +19,6 @@ if [ -n "${PGID}" ]; then
   usermod -a -G "${PGID}" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
 fi
 
-exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_PORT}" -W set web "web files group" root -W set web "web files owner" root "$@"
+exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_LISTENER_PORT}" -W set web "web files group" root -W set web "web files owner" root "$@"
 
 echo "Netdata entrypoint script, completed!"


### PR DESCRIPTION
Because it clashes with a kubernetes defined NETDATA_PORT variable: Our Helm
chart creates a service called netdata which in turn makes kubernetes export a
NETDATA_PORT environment variable with a value like tcp://\<ip\>:19999 which is
not parsable by the netdata agent as a value to the `-p` argument.


This PR should resolve the:
```
netdata ERROR : MAIN : LISTENER: Invalid listen port 0 given. Defaulting
to 19999. (errno 22, Invalid argument)
```

errors seen in Helm installations as reported in netdata/helmchart#161.

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information