### PR TITLE
health/portcheck: add `failed` dim to the `connection_fails` alarm

### DIFF
--- a/health/health.d/portcheck.conf
+++ b/health/health.d/portcheck.conf
@@ -36,7 +36,7 @@ families: *
 template: connection_fails
 families: *
       on: portcheck.status
-  lookup: average -5m unaligned percentage of no_connection
+  lookup: average -5m unaligned percentage of no_connection,failed
    every: 10s
    units: %
     warn: $this >= 10 AND $this < 40


### PR DESCRIPTION
##### Summary

Fixes: #10043

go.d portcheck has [`failed`](https://github.com/netdata/go.d.plugin/blob/7959eff02c96b23a994f1d1e532aa43203bb2138/modules/portcheck/charts.go#L26) dimension, py - [`no_connection`](https://github.com/netdata/netdata/blob/04344fda25733c674dd6db6bf59d75586293bbee/collectors/python.d.plugin/portcheck/portcheck.chart.py#L35)

##### Component Name
`health/`

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Tested locally, it works

<img width="959" alt="Screenshot 2020-10-09 at 14 44 46" src="https://user-images.githubusercontent.com/22274335/95579591-9b055480-0a3e-11eb-8629-ac49b30b12f4.png">


##### Additional Information
