### PR TITLE
Fix formatting source code blocks in custom dashboard page

### DIFF
--- a/web/gui/custom/README.md
+++ b/web/gui/custom/README.md
@@ -183,14 +183,14 @@ by adding this fragment before loading it:
 
 ```html
 <script>var netdataDontStart = true;</script>
-`"
+```
 
 The above, will inform the `dashboard.js` to load everything, but not process the web page until you tell it to.
 You can tell it to start processing the page, by running this javascript code:
 
 ```js
 NETDATA.start();
-`"
+```
 
 Be careful not to call the `NETDATA.start()` multiple times. Each call to this
 function will spawn a new thread that will start refreshing the charts.


### PR DESCRIPTION
##### Summary

Fixed a typo in formatting source code in Custom Dashboard page in "Prevent dashboard.js from starting chart refreshes" section.

##### Component Name

Documentation about custom dashboards.

URL: https://learn.netdata.cloud/docs/agent/web/gui/custom#what-does-dashboardjs-do

##### Test Plan

1. Need to open page https://learn.netdata.cloud/docs/agent/web/gui/custom#what-does-dashboardjs-do
2. Check "Prevent dashboard.js from starting chart refreshes" section
3. Code blocks should not leak to text.

**Actual behavior:**

![image](https://user-images.githubusercontent.com/5189110/95592183-f5a7ac00-0a50-11eb-86b4-160c84a7384d.png)

**Fixed behavior there is in "Files changed" tab.**
