### PR TITLE
Skip all build checks on CI packaging builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ notifications:
 stages:
   # Mandatory runs, we always want these executed
   - name: Build process
+    if: commit_message =~ /^((?!\[Package (amd64|arm64|i386) (DEB|RPM)( .*)?\]).)*$/
 
     # Nightly operations
   - name: Nightly operations
@@ -163,7 +164,6 @@ jobs:
       after_failure: post_message "TRAVIS_MESSAGE" "Netdata updater process failed on bare Fedora 31"
 
     - name: DEB package test
-      if: commit_message =~ /^((?!\[Package (amd64|arm64|i386) (DEB|RPM)( .*)?\]).)*$/
       git:
         depth: false
       before_install:
@@ -186,7 +186,6 @@ jobs:
       after_failure: post_message "TRAVIS_MESSAGE" "Netdata DEB package build check failed."
 
     - name: RPM package test
-      if: commit_message =~ /^((?!\[Package (amd64|arm64|i386) (DEB|RPM)( .*)?\]).)*$/
       git:
         depth: false
       before_install:


### PR DESCRIPTION
##### Summary

Package build runs on Travis only happen as part of release builds. Because they happen _after_ the rest of the release, the build checks have already run at least once because they're run as part of the initial release build. As such, there’s no point in running them again on the packaging builds, especially since they are the primary reason that the packaging builds experience transient errors.

This will both speed up the overall release process (quite a bit in fact, the redundant build checks account or more than half the time it currently takes to cut a release) and also reduce the false failure rate on package builds to near zero.

##### Component Name

area/ci

##### Test Plan

Behavior of the conditional itself verified through prior usage in other parts of the Travis CI configuration.