### PR TITLE
Add per queue charts in rabbitmq.chart.py

### DIFF
--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -69,6 +69,27 @@ Per Vhost charts:
     -   redeliver
     -   return_unroutable
 
+2. Per Queue charts:
+
+    1. **Queued Messages**
+
+        - messages
+        - paged_out
+        - persistent
+        - ready
+        - unacknowledged
+
+    2. **Queue Messages stats**
+
+        -   ack
+        -   confirm
+        -   deliver
+        -   get
+        -   get_no_ack
+        -   publish
+        -   redeliver
+        -   return_unroutable
+
 ## Configuration
 
 Edit the `python.d/rabbitmq.conf` configuration file using `edit-config` from the your agent's [config

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -308,7 +308,7 @@ class Service(UrlService):
         stats = self.get_queues_stats()
         if stats:
             data.update(stats)
-        
+
         return data or None
 
     def get_overview_stats(self):
@@ -387,7 +387,7 @@ class Service(UrlService):
             if charts_initialized and self.queue.id() not in self.collected_queues:
                 self.collected_queues.add(self.queue.id())
                 self.add_queue_charts(self.queue.id())
-            
+
             data.update(self.queue.queue_stats())
 
         self.debug("number of queues: {0}, metrics: {1}".format(len(queues), len(data)))

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -282,9 +282,12 @@ class Service(UrlService):
         )
         self.node_name = str()
         self.vhost = VhostStatsBuilder()
-        self.queue = QueueStatsBuilder()
         self.collected_vhosts = set()
-        self.collected_queues = set()
+        self.collect_queues_metrics = configuration.get('collect_queues_metrics', False)
+        self.debug("collect_queues_metrics is {0}".format("enabled" if self.collect_queues_metrics else "disabled"))
+        if self.collect_queues_metrics:
+            self.queue = QueueStatsBuilder()
+            self.collected_queues = set()
 
     def _get_data(self):
         data = dict()
@@ -305,9 +308,10 @@ class Service(UrlService):
         if stats:
             data.update(stats)
 
-        stats = self.get_queues_stats()
-        if stats:
-            data.update(stats)
+        if self.collect_queues_metrics:
+            stats = self.get_queues_stats()
+            if stats:
+                data.update(stats)
 
         return data or None
 

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -262,7 +262,7 @@ class QueueStatsBuilder:
         self.stats = raw_stats
 
     def id(self):
-        return (self.stats['vhost'], self.stats['name'])
+        return self.stats['vhost'], self.stats['name']
 
     def queue_stats(self):
         vhost, name = self.id()

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.chart.py
@@ -9,6 +9,7 @@ from bases.FrameworkServices.UrlService import UrlService
 
 API_NODE = 'api/nodes'
 API_OVERVIEW = 'api/overview'
+API_QUEUES = 'api/queues'
 API_VHOSTS = 'api/vhosts'
 
 NODE_STATS = [
@@ -39,6 +40,22 @@ OVERVIEW_STATS = [
     'churn_rates.queue_created_details.rate',
     'churn_rates.queue_declared_details.rate',
     'churn_rates.queue_deleted_details.rate'
+]
+
+QUEUE_STATS = [
+    'messages',
+    'messages_paged_out',
+    'messages_persistent',
+    'messages_ready',
+    'messages_unacknowledged',
+    'message_stats.ack',
+    'message_stats.confirm',
+    'message_stats.deliver',
+    'message_stats.get',
+    'message_stats.get_no_ack',
+    'message_stats.publish',
+    'message_stats.redeliver',
+    'message_stats.return_unroutable',
 ]
 
 VHOST_MESSAGE_STATS = [
@@ -180,6 +197,44 @@ def vhost_chart_template(name):
 
     return order, charts
 
+def queue_chart_template(queue_id):
+    vhost, name = queue_id
+    order = [
+        'vhost_{0}_queue_{1}_queued_message'.format(vhost, name),
+        'vhost_{0}_queue_{1}_messages_stats'.format(vhost, name),
+    ]
+    family = 'vhost {0}'.format(vhost)
+
+    charts = {
+        order[0]: {
+            'options': [
+                None, 'Queue "{0}" in "{1}" queued messages'.format(name, vhost), 'messages', family, 'rabbitmq.queue_messages', 'line'],
+            'lines': [
+                ['vhost_{0}_queue_{1}_messages'.format(vhost, name), 'messages', 'absolute'],
+                ['vhost_{0}_queue_{1}_messages_paged_out'.format(vhost, name), 'paged_out', 'absolute'],
+                ['vhost_{0}_queue_{1}_messages_persistent'.format(vhost, name), 'persistent', 'absolute'],
+                ['vhost_{0}_queue_{1}_messages_ready'.format(vhost, name), 'ready', 'absolute'],
+                ['vhost_{0}_queue_{1}_messages_unacknowledged'.format(vhost, name), 'unack', 'absolute'],
+            ]
+        },
+        order[1]: {
+            'options': [
+                None, 'Queue "{0}" in "{1}" messages stats'.format(name, vhost), 'messages/s', family, 'rabbitmq.queue_messages_stats', 'line'],
+            'lines': [
+                ['vhost_{0}_queue_{1}_message_stats_ack'.format(vhost, name), 'ack', 'incremental'],
+                ['vhost_{0}_queue_{1}_message_stats_confirm'.format(vhost, name), 'confirm', 'incremental'],
+                ['vhost_{0}_queue_{1}_message_stats_deliver'.format(vhost, name), 'deliver', 'incremental'],
+                ['vhost_{0}_queue_{1}_message_stats_get'.format(vhost, name), 'get', 'incremental'],
+                ['vhost_{0}_queue_{1}_message_stats_get_no_ack'.format(vhost, name), 'get_no_ack', 'incremental'],
+                ['vhost_{0}_queue_{1}_message_stats_publish'.format(vhost, name), 'publish', 'incremental'],
+                ['vhost_{0}_queue_{1}_message_stats_redeliver'.format(vhost, name), 'redeliver', 'incremental'],
+                ['vhost_{0}_queue_{1}_message_stats_return_unroutable'.format(vhost, name), 'return_unroutable', 'incremental'],
+            ]
+        },
+    }
+
+    return order, charts
+
 
 class VhostStatsBuilder:
     def __init__(self):
@@ -199,6 +254,21 @@ class VhostStatsBuilder:
         stats = fetch_data(raw_data=self.stats, metrics=VHOST_MESSAGE_STATS)
         return dict(('vhost_{0}_{1}'.format(name, k), v) for k, v in stats.items())
 
+class QueueStatsBuilder:
+    def __init__(self):
+        self.stats = None
+
+    def set(self, raw_stats):
+        self.stats = raw_stats
+
+    def id(self):
+        return (self.stats['vhost'], self.stats['name'])
+
+    def queue_stats(self):
+        vhost, name = self.id()
+        stats = fetch_data(raw_data=self.stats, metrics=QUEUE_STATS)
+        return dict(('vhost_{0}_queue_{1}_{2}'.format(vhost, name, k), v) for k, v in stats.items())
+
 
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
@@ -212,7 +282,9 @@ class Service(UrlService):
         )
         self.node_name = str()
         self.vhost = VhostStatsBuilder()
+        self.queue = QueueStatsBuilder()
         self.collected_vhosts = set()
+        self.collected_queues = set()
 
     def _get_data(self):
         data = dict()
@@ -233,6 +305,10 @@ class Service(UrlService):
         if stats:
             data.update(stats)
 
+        stats = self.get_queues_stats()
+        if stats:
+            data.update(stats)
+        
         return data or None
 
     def get_overview_stats(self):
@@ -292,8 +368,44 @@ class Service(UrlService):
         self.debug("number of vhosts: {0}, metrics: {1}".format(len(vhosts), len(data)))
         return data
 
+    def get_queues_stats(self):
+        url = '{0}/{1}'.format(self.url, API_QUEUES)
+        self.debug("doing http request to '{0}'".format(url))
+        raw = self._get_raw_data(url)
+        if not raw:
+            return None
+
+        data = dict()
+        queues = loads(raw)
+        charts_initialized = len(self.charts) > 0
+
+        for queue in queues:
+            self.queue.set(queue)
+            if self.queue.id()[0] not in self.collected_vhosts:
+                continue
+
+            if charts_initialized and self.queue.id() not in self.collected_queues:
+                self.collected_queues.add(self.queue.id())
+                self.add_queue_charts(self.queue.id())
+            
+            data.update(self.queue.queue_stats())
+
+        self.debug("number of queues: {0}, metrics: {1}".format(len(queues), len(data)))
+        return data
+
     def add_vhost_charts(self, vhost_name):
         order, charts = vhost_chart_template(vhost_name)
+
+        for chart_name in order:
+            params = [chart_name] + charts[chart_name]['options']
+            dimensions = charts[chart_name]['lines']
+
+            new_chart = self.charts.add_chart(params)
+            for dimension in dimensions:
+                new_chart.add_dimension(dimension)
+
+    def add_queue_charts(self, queue_id):
+        order, charts = queue_chart_template(queue_id)
 
         for chart_name in order:
             params = [chart_name] + charts[chart_name]['options']

--- a/collectors/python.d.plugin/rabbitmq/rabbitmq.conf
+++ b/collectors/python.d.plugin/rabbitmq/rabbitmq.conf
@@ -70,6 +70,12 @@
 #     user: 'username'
 #     pass: 'password'
 #
+# Rabbitmq plugin can also collect stats per vhost per queues, which is disabled
+# by default. Please note that enabling this can induced a serious overhead on
+# both netdata and rabbitmq if a look of queues are configured and used.
+#
+#    collect_queues_metrics: 'yes/no'
+#
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
 # only one of them will run (they have the same name)

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -2539,6 +2539,16 @@ netdataDashboard.context = {
         colors: NETDATA.colors[3]
     },
 
+    'rabbitmq.queue_messages': {
+        info: 'Total amount of messages and their states in this queue.',
+        colors: NETDATA.colors[3]
+    },
+
+    'rabbitmq.queue_messages_stats': {
+        info: 'Overall messaging rates including acknowledgements, delieveries, redeliveries, and publishes.',
+        colors: NETDATA.colors[3]
+    },
+
     // ------------------------------------------------------------------------
     // ntpd
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds new metrics to be collected and their associated charts to the rabbitmq python.d plugin.
Those metrics are per-queue stats, where metrics were global or per-vhost before.

##### Component Name

collector / python.d / rabbitmq.chart.py

##### Test Plan

Using a local rabbitmq, configured to have multiple vhosts, multiple queues within those vhosts, I generated traffic to see the impact on Netdata

##### Additional Information

This is my first PR, I'm not sure everything's fine and I'd love guidance to make it work