### PR TITLE
Fix systemd comment syntax

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -45,15 +45,24 @@ CPUSchedulingPolicy=idle
 #Nice=0
 
 # Capabilities
-CapabilityBoundingSet=CAP_DAC_OVERRIDE    # is required for freeipmi and slabinfo plugins
-CapabilityBoundingSet=CAP_DAC_READ_SEARCH # is required for apps plugin
-CapabilityBoundingSet=CAP_FOWNER          # is required for freeipmi plugin
-CapabilityBoundingSet=CAP_SETPCAP         # is required for apps, perf and slabinfo plugins
-CapabilityBoundingSet=CAP_SYS_ADMIN       # is required for perf plugin
-CapabilityBoundingSet=CAP_SYS_PTRACE      # is required for apps plugin
-CapabilityBoundingSet=CAP_SYS_RESOURCE    # is required for ebpf plugin
-CapabilityBoundingSet=CAP_NET_RAW         # is required for fping app
-CapabilityBoundingSet=CAP_SYS_CHROOT      # is required for cgroups plugin
+# is required for freeipmi and slabinfo plugins
+CapabilityBoundingSet=CAP_DAC_OVERRIDE    
+# is required for apps plugin
+CapabilityBoundingSet=CAP_DAC_READ_SEARCH
+# is required for freeipmi plugin
+CapabilityBoundingSet=CAP_FOWNER          
+# is required for apps, perf and slabinfo plugins
+CapabilityBoundingSet=CAP_SETPCAP         
+# is required for perf plugin
+CapabilityBoundingSet=CAP_SYS_ADMIN      
+# is required for apps plugin
+CapabilityBoundingSet=CAP_SYS_PTRACE      
+# is required for ebpf plugin
+CapabilityBoundingSet=CAP_SYS_RESOURCE    
+# is required for fping app
+CapabilityBoundingSet=CAP_NET_RAW         
+# is required for cgroups plugin
+CapabilityBoundingSet=CAP_SYS_CHROOT      
 
 # Sandboxing
 ProtectSystem=full

--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -46,23 +46,23 @@ CPUSchedulingPolicy=idle
 
 # Capabilities
 # is required for freeipmi and slabinfo plugins
-CapabilityBoundingSet=CAP_DAC_OVERRIDE    
+CapabilityBoundingSet=CAP_DAC_OVERRIDE
 # is required for apps plugin
 CapabilityBoundingSet=CAP_DAC_READ_SEARCH
 # is required for freeipmi plugin
-CapabilityBoundingSet=CAP_FOWNER          
+CapabilityBoundingSet=CAP_FOWNER
 # is required for apps, perf and slabinfo plugins
-CapabilityBoundingSet=CAP_SETPCAP         
+CapabilityBoundingSet=CAP_SETPCAP
 # is required for perf plugin
-CapabilityBoundingSet=CAP_SYS_ADMIN      
+CapabilityBoundingSet=CAP_SYS_ADMIN
 # is required for apps plugin
-CapabilityBoundingSet=CAP_SYS_PTRACE      
+CapabilityBoundingSet=CAP_SYS_PTRACE
 # is required for ebpf plugin
-CapabilityBoundingSet=CAP_SYS_RESOURCE    
+CapabilityBoundingSet=CAP_SYS_RESOURCE
 # is required for fping app
-CapabilityBoundingSet=CAP_NET_RAW         
+CapabilityBoundingSet=CAP_NET_RAW
 # is required for cgroups plugin
-CapabilityBoundingSet=CAP_SYS_CHROOT      
+CapabilityBoundingSet=CAP_SYS_CHROOT
 
 # Sandboxing
 ProtectSystem=full


### PR DESCRIPTION
comments for systemd service files are only allowed in the beginning of a new line
https://www.freedesktop.org/software/systemd/man/systemd.syntax.html

otherwise you get error messages like
```
/usr/lib/systemd/system/netdata.service:48: Failed to parse capability in bounding/ambient set, ignoring: #
```

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
