### PR TITLE
collectors/cgroups: fix resolving container names in k8s

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -98,9 +98,9 @@ function get_lbl_val() {
   return 1
 }
 
-# k8s_get_kubepod_name gets pod or container level cgroup name from the k8s API server.
-# pod name format: 'pod_<namespace>_<pod_name>'
-# container name format: 'cntr_<namespace>_<pod_name>_<container_name>'
+# k8s_get_kubepod_name resolves */kubepods/* cgroup name.
+# pod level cgroup name format: 'pod_<namespace>_<pod_name>'
+# container level cgroup name format: 'cntr_<namespace>_<pod_name>_<container_name>'
 function k8s_get_kubepod_name() {
   # GKE /sys/fs/cgroup/*/ tree:
   # |-- kubepods
@@ -137,13 +137,18 @@ function k8s_get_kubepod_name() {
   if [[ $clean_id == "kubepods" ]]; then
     name="$clean_id"
   elif [[ $clean_id =~ .+(besteffort|burstable|guaranteed)$ ]]; then
+    # kubepods_<QOS_CLASS>
+    # kubepods_kubepods-<QOS_CLASS>
     name=${clean_id//-/_}
     name=${NAME/#kubepods_kubepods/kubepods}
   elif [[ $clean_id =~ .+pod[a-f0-9_-]+_docker-([a-f0-9]+)$ ]]; then
+    # ...pod<POD_UID>_docker-<CONTAINER_ID> (POD_UID w/ "_")
     cntr_id=${BASH_REMATCH[1]}
   elif [[ $clean_id =~ .+pod[a-f0-9-]+_([a-f0-9]+)$ ]]; then
+    # ...pod<POD_UID>_<CONTAINER_ID>
     cntr_id=${BASH_REMATCH[1]}
   elif [[ $clean_id =~ .+pod([a-f0-9_-]+)$ ]]; then
+    # ...pod<POD_UID> (POD_UID w/ and w/o "_")
     pod_uid=${BASH_REMATCH[1]}
     pod_uid=${pod_uid//_/-}
   fi
@@ -189,6 +194,8 @@ function k8s_get_kubepod_name() {
 
   local containers
   local jq_pod jq_cntr jq_filter
+  # 'namespace="<NAMESPACE>",pod_name="<NAME>",pod_uid="<UID>",container_name="<NAME>",container_ID="<ID>"'
+  # wrong field value is 'null'
   jq_pod='namespace=\"\(.metadata.namespace)\",pod_name=\"\(.metadata.name)\",pod_uid=\"\(.metadata.uid)\"'
   jq_cntr=',container_name=\"\(.name)\",container_id=\"\(.containerID)\"'
   jq_filter=".items[] | \"${jq_pod}\" + (.status.containerStatuses[]? | \"${jq_cntr}\") | sub(\"docker://\";\"\")"
@@ -198,6 +205,9 @@ function k8s_get_kubepod_name() {
     return 1
   fi
 
+  # available labels:
+  # namespace, pod_name, pod_uid, container_name, container_id
+  # TODO: check 'null' values after 'jq' and missing values after 'get_lbl_val'
   local labels
   if [ -n "$cntr_id" ]; then
     if labels=$(grep "$cntr_id" <<< "$containers" 2> /dev/null); then
@@ -209,8 +219,6 @@ function k8s_get_kubepod_name() {
       name="pod_$(get_lbl_val "$labels" namespace)_$(get_lbl_val "$labels" pod_name)"
     fi
   fi
-
-  [ -z "$name" ] && warning "can't"
 
   echo "$name"
   [ -n "$name" ]

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -140,7 +140,7 @@ function k8s_get_kubepod_name() {
     # kubepods_<QOS_CLASS>
     # kubepods_kubepods-<QOS_CLASS>
     name=${clean_id//-/_}
-    name=${NAME/#kubepods_kubepods/kubepods}
+    name=${name/#kubepods_kubepods/kubepods}
   elif [[ $clean_id =~ .+pod[a-f0-9_-]+_docker-([a-f0-9]+)$ ]]; then
     # ...pod<POD_UID>_docker-<CONTAINER_ID> (POD_UID w/ "_")
     cntr_id=${BASH_REMATCH[1]}
@@ -293,8 +293,10 @@ function podman_validate_id() {
 
 # -----------------------------------------------------------------------------
 
-[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="@configdir_POST@"
-[ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
+#[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="@configdir_POST@"
+#[ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
+[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="/etc/netdata"
+[ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="/usr/lib/netdata/conf.d"
 
 DOCKER_HOST="${DOCKER_HOST:=/var/run/docker.sock}"
 PODMAN_HOST="${PODMAN_HOST:=/run/podman/podman.sock}"

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -293,10 +293,8 @@ function podman_validate_id() {
 
 # -----------------------------------------------------------------------------
 
-#[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="@configdir_POST@"
-#[ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
-[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="/etc/netdata"
-[ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="/usr/lib/netdata/conf.d"
+[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="@configdir_POST@"
+[ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
 
 DOCKER_HOST="${DOCKER_HOST:=/var/run/docker.sock}"
 PODMAN_HOST="${PODMAN_HOST:=/run/podman/podman.sock}"

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -192,14 +192,17 @@ function k8s_get_kubepod_name() {
     return 1
   fi
 
-  local containers
-  local jq_pod jq_cntr jq_filter
+  local jq_filter
   # 'namespace="<NAMESPACE>",pod_name="<NAME>",pod_uid="<UID>",container_name="<NAME>",container_ID="<ID>"'
   # wrong field value is 'null'
-  jq_pod='namespace=\"\(.metadata.namespace)\",pod_name=\"\(.metadata.name)\",pod_uid=\"\(.metadata.uid)\"'
-  jq_cntr=',container_name=\"\(.name)\",container_id=\"\(.containerID)\"'
-  jq_filter=".items[] | \"${jq_pod}\" + (.status.containerStatuses[]? | \"${jq_cntr}\") | sub(\"docker://\";\"\")"
+  jq_filter+='.items[] | '
+  jq_filter+='"namespace=\"\(.metadata.namespace)\",pod_name=\"\(.metadata.name)\",pod_uid=\"\(.metadata.uid)\"" + '
+  jq_filter+='(.status.containerStatuses[]? | '
+  jq_filter+='",container_name=\"\(.name)\",container_id=\"\(.containerID)\""'
+  jq_filter+=') | '
+  jq_filter+='sub("docker://";"")'
 
+  local containers
   if ! containers=$(jq -r "${jq_filter}" <<< "$pods" 2>&1); then
     warning "${funcname}: error on 'jq' parse: ${containers}."
     return 1

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -77,7 +77,7 @@ function docker_like_get_name_api() {
 }
 
 # get_lbl_val returns the value for the label with the given name.
-# Returns an empty string if the label doesn't exist.
+# Returns "null" string if the label doesn't exist.
 # Expected labels format: 'name="value",...'.
 function get_lbl_val() {
   local labels want_name
@@ -95,6 +95,7 @@ function get_lbl_val() {
     fi
   done
 
+  echo "null"
   return 1
 }
 
@@ -210,7 +211,6 @@ function k8s_get_kubepod_name() {
 
   # available labels:
   # namespace, pod_name, pod_uid, container_name, container_id
-  # TODO: check 'null' values after 'jq' and missing values after 'get_lbl_val'
   local labels
   if [ -n "$cntr_id" ]; then
     if labels=$(grep "$cntr_id" <<< "$containers" 2> /dev/null); then
@@ -221,6 +221,12 @@ function k8s_get_kubepod_name() {
       labels="${labels%%,cont*}"
       name="pod_$(get_lbl_val "$labels" namespace)_$(get_lbl_val "$labels" pod_name)"
     fi
+  fi
+
+  # jq filter nonexistent field and nonexistent label value is 'null'
+  if [[ $name =~ _null(_|$) ]]; then
+    warning "${funcname}: invalid name: $name (cgroup '$id')"
+    name=""
   fi
 
   echo "$name"

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -102,36 +102,84 @@ function get_lbl_val() {
 # pod name format: 'pod_<namespace>_<pod_name>'
 # container name format: 'cntr_<namespace>_<pod_name>_<container_name>'
 function k8s_get_kubepod_name() {
+  # GKE /sys/fs/cgroup/*/ tree:
+  # |-- kubepods
+  # |   |-- burstable
+  # |   |   |-- pod98cee708-023b-11eb-933d-42010a800193
+  # |   |   |   |-- 922161c98e6ea450bf665226cdc64ca2aa3e889934c2cff0aec4325f8f78ac03
+  # |   |       `-- a5d223eec35e00f5a1c6fa3e3a5faac6148cdc1f03a2e762e873b7efede012d7
+  # |   `-- pode314bbac-d577-11ea-a171-42010a80013b
+  # |       |-- 7d505356b04507de7b710016d540b2759483ed5f9136bb01a80872b08f771930
+  # |       `-- 88ab4683b99cfa7cc8c5f503adf7987dd93a3faa7c4ce0d17d419962b3220d50
+  #
+  # Minikube (v1.8.2) /sys/fs/cgroup/*/ tree:
+  # |-- kubepods.slice
+  # |   |-- kubepods-besteffort.slice
+  # |   |   |-- kubepods-besteffort-pod10fb5647_c724_400c_b9cc_0e6eae3110e7.slice
+  # |   |   |   |-- docker-36e5eb5056dfdf6dbb75c0c44a1ecf23217fe2c50d606209d8130fcbb19fb5a7.scope
+  # |   |   |   `-- docker-87e18c2323621cf0f635c53c798b926e33e9665c348c60d489eef31ee1bd38d7.scope
+  #
+  # NOTE: cgroups plugin uses '_' to join dir names, so it is <parent>_<child>_<child>_...
+
   local funcname="${FUNCNAME[0]}"
   local id="${1}"
 
-  if [[ ! "${id}" =~ ^kube.*_pod.*$ ]]; then
-    warning "${funcname}: '${id}' is not kubepod."
+  if [[ ! $id =~ ^kubepods ]]; then
+    warning "${funcname}: '${id}' is not kubepod cgroup."
     return 1
   fi
 
-  local pod_uid cntr_id
-  IFS=_ read -r pod_uid cntr_id <<< "${id##*_pod}"
+  local clean_id="$id"
+  clean_id=${clean_id//.slice/}
+  clean_id=${clean_id//.scope/}
+
+  local name pod_uid cntr_id
+  if [[ $clean_id == "kubepods" ]]; then
+    name="$clean_id"
+  elif [[ $clean_id =~ .+(besteffort|burstable|guaranteed)$ ]]; then
+    name=${clean_id//-/_}
+    name=${NAME/#kubepods_kubepods/kubepods}
+  elif [[ $clean_id =~ .+pod[a-f0-9_-]+_docker-([a-f0-9]+)$ ]]; then
+    cntr_id=${BASH_REMATCH[1]}
+  elif [[ $clean_id =~ .+pod[a-f0-9-]+_([a-f0-9]+)$ ]]; then
+    cntr_id=${BASH_REMATCH[1]}
+  elif [[ $clean_id =~ .+pod([a-f0-9_-]+)$ ]]; then
+    pod_uid=${BASH_REMATCH[1]}
+    pod_uid=${pod_uid//_/-}
+  fi
+
+  if [ -n "$name" ]; then
+    echo "$name"
+    return 0
+  fi
 
   if [ -z "$pod_uid" ] && [ -z "$cntr_id" ]; then
-    warning "${funcname}: can't extract pod_uid or container_id from '${id}'."
+    warning "${funcname}: can't extract pod_uid or container_id from the cgroup '$id'."
     return 1
   fi
 
-  local data
+  [ -n "$pod_uid" ] && info "${funcname}: cgroup '$id' is a pod(uid:$pod_uid)"
+  [ -n "$cntr_id" ] && info "${funcname}: cgroup '$id' is a container(id:$cntr_id)"
+
+  if ! command -v jq > /dev/null 2>&1; then
+    warning "${funcname}: 'jq' command not available."
+    return 1
+  fi
+
+  local pods
   if [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}" ]; then
     local token header url
     token="$(< /var/run/secrets/kubernetes.io/serviceaccount/token)"
     header="Authorization: Bearer $token"
     url="https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/pods"
-    if ! data=$(curl -sSk -H "$header" "$url" 2>&1); then
-      warning "${funcname}: error on curl '${url}': ${data}."
+    if ! pods=$(curl -sSk -H "$header" "$url" 2>&1); then
+      warning "${funcname}: error on curl '${url}': ${pods}."
       return 1
     fi
   elif ps -C kubelet > /dev/null 2>&1 && command -v kubectl > /dev/null 2>&1; then
     [[ -z ${KUBE_CONFIG+x} ]] && KUBE_CONFIG="/etc/kubernetes/admin.conf"
-    if ! data=$(kubectl --kubeconfig="$KUBE_CONFIG" get pods --all-namespaces -o json 2>&1); then
-      warning "${funcname}: error on 'kubectl get pods --all-namespaces -o json': ${data}."
+    if ! pods=$(kubectl --kubeconfig="$KUBE_CONFIG" get pods --all-namespaces -o json 2>&1); then
+      warning "${funcname}: error on 'kubectl': ${pods}."
       return 1
     fi
   else
@@ -139,47 +187,41 @@ function k8s_get_kubepod_name() {
     return 1
   fi
 
-  local jq_pod jq_cont jq_filter
+  local containers
+  local jq_pod jq_cntr jq_filter
   jq_pod='namespace=\"\(.metadata.namespace)\",pod_name=\"\(.metadata.name)\",pod_uid=\"\(.metadata.uid)\"'
-  jq_cont=',container_name=\"\(.name)\",container_id=\"\(.containerID)\"'
-  jq_filter=".items[] | \"${jq_pod}\" + (.status.containerStatuses[]? | \"${jq_cont}\") | sub(\"docker://\";\"\")"
+  jq_cntr=',container_name=\"\(.name)\",container_id=\"\(.containerID)\"'
+  jq_filter=".items[] | \"${jq_pod}\" + (.status.containerStatuses[]? | \"${jq_cntr}\") | sub(\"docker://\";\"\")"
 
-  if ! data=$(jq -r "${jq_filter}" <<< "$data" 2>&1); then
-    warning "${funcname}: error on 'jq -r '${jq_filter}'': ${data}."
+  if ! containers=$(jq -r "${jq_filter}" <<< "$pods" 2>&1); then
+    warning "${funcname}: error on 'jq' parse: ${containers}."
     return 1
   fi
 
-  local labels name
+  local labels
   if [ -n "$cntr_id" ]; then
-    if labels=$(grep "$cntr_id" <<< "$data" 2> /dev/null); then
+    if labels=$(grep "$cntr_id" <<< "$containers" 2> /dev/null); then
       name="cntr_$(get_lbl_val "$labels" namespace)_$(get_lbl_val "$labels" pod_name)_$(get_lbl_val "$labels" container_name)"
     fi
   elif [ -n "$pod_uid" ]; then
-    if labels=$(grep "$pod_uid" -m 1 <<< "$data" 2> /dev/null); then
+    if labels=$(grep "$pod_uid" -m 1 <<< "$containers" 2> /dev/null); then
       labels="${labels%%,cont*}"
       name="pod_$(get_lbl_val "$labels" namespace)_$(get_lbl_val "$labels" pod_name)"
     fi
   fi
 
+  [ -z "$name" ] && warning "can't"
+
   echo "$name"
-  [[ -n "$name" ]]
+  [ -n "$name" ]
   return
 }
 
 function k8s_get_name() {
   local funcname="${FUNCNAME[0]}"
-  local orig_id="${1}"
-  local id=${orig_id//.slice/} # minikube ids sanitizing
+  local id="${1}"
 
-  case "$id" in
-    "kubepods" | "kubepods_guaranteed" | "kubepods_burstable" | "kubepods_besteffort")
-      NAME="${id}"
-      ;;
-  esac
-
-  if [ -z "$NAME" ]; then
-    NAME=$(k8s_get_kubepod_name "$id")
-  fi
+  NAME=$(k8s_get_kubepod_name "$id")
 
   if [ -z "${NAME}" ]; then
     warning "${funcname}: cannot find the name of cgroup with id '${id}'. Setting name to ${id} and disabling it."

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -76,51 +76,119 @@ function docker_like_get_name_api() {
 	return 0
 }
 
-function k8s_get_name() {
-	if [[ "${1}" =~ ^kube.*_pod.*$ ]]; then
-		local id="${1##*_pod}"
-	else
-		# Take the last part of the delimited path identifier (expecting either _ or / as a delimiter).
-		local id="${1##*_}"
-		if [ "${id}" == "${1}" ]; then
-			id="${1##*/}"
-		fi
-	fi
-	if command -v jq >/dev/null 2>&1; then
-		if [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}" ]; then
-			KUBE_TOKEN="$(</var/run/secrets/kubernetes.io/serviceaccount/token)"
-			NAME="$(
-			curl -sSk -H "Authorization: Bearer $KUBE_TOKEN"  "https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/pods" |
-			jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_" + (.status.containerStatuses[]? | "\(.name) \(.containerID)")' |
-			grep "$id" |
-			cut -d' ' -f1
-			)"
-		elif ps -C kubelet >/dev/null 2>&1 && command -v kubectl >/dev/null 2>&1; then
-			if [[ -z ${KUBE_CONFIG+x} ]]; then
-				KUBE_CONFIG="/etc/kubernetes/admin.conf"
-			fi
-			if kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces >/dev/null 2>&1; then
-				#shellcheck disable=SC2086
-				NAME="$(kubectl --kubeconfig=$KUBE_CONFIG get pod --all-namespaces --output='json' |
-				jq -r '.items[] | "k8s_\(.metadata.namespace)_\(.metadata.name)_\(.metadata.uid)_" + (.status.containerStatuses[]? | "\(.name) \(.containerID)")' |
-				grep "$id" |
-				cut -d' ' -f1
-				)"
-			else
-				warning "kubectl cannot get pod list, check for configuration file in $KUBE_CONFIG, or set this path to env \$KUBE_CONFIG"
-			fi
-		fi
-	else
-		warning "jq command not available, k8s_get_name() cannot execute. Please install jq should you wish for k8s to be fully functional"
-	fi
+# get_lbl_val returns the value for the label with the given name.
+# Returns an empty string if the label doesn't exist.
+# Expected labels format: 'name="value",...'.
+function get_lbl_val() {
+  local labels want_name
+  labels="${1}"
+  want_name="${2}"
 
-	if [ -z "${NAME}" ]; then
-		warning "cannot find the name of k8s pod with containerID '${id}'. Setting name to ${id} and disabling it"
-		NAME="${id}"
-		NAME_NOT_FOUND=3
-	else
-		info "k8s containerID '${id}' has chart name (namespace_podname_poduid_containername) '${NAME}'"
-	fi
+  IFS=, read -ra labels <<< "$labels"
+
+  local lname lval
+  for l in "${labels[@]}"; do
+    IFS="=" read -r lname lval <<< "$l"
+    if [ "$want_name" = "$lname" ] && [ -n "$lval" ]; then
+      echo "${lval:1:-1}" # trim "
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# k8s_get_kubepod_name gets pod or container level cgroup name from the k8s API server.
+# pod name format: 'pod_<namespace>_<pod_name>'
+# container name format: 'cntr_<namespace>_<pod_name>_<container_name>'
+function k8s_get_kubepod_name() {
+  local funcname="${FUNCNAME[0]}"
+  local id="${1}"
+
+  if [[ ! "${id}" =~ ^kube.*_pod.*$ ]]; then
+    warning "${funcname}: '${id}' is not kubepod."
+    return 1
+  fi
+
+  local pod_uid cntr_id
+  IFS=_ read -r pod_uid cntr_id <<< "${id##*_pod}"
+
+  if [ -z "$pod_uid" ] && [ -z "$cntr_id" ]; then
+    warning "${funcname}: can't extract pod_uid or container_id from '${id}'."
+    return 1
+  fi
+
+  local data
+  if [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}" ]; then
+    local token header url
+    token="$(< /var/run/secrets/kubernetes.io/serviceaccount/token)"
+    header="Authorization: Bearer $token"
+    url="https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/pods"
+    if ! data=$(curl -sSk -H "$header" "$url" 2>&1); then
+      warning "${funcname}: error on curl '${url}': ${data}."
+      return 1
+    fi
+  elif ps -C kubelet > /dev/null 2>&1 && command -v kubectl > /dev/null 2>&1; then
+    [[ -z ${KUBE_CONFIG+x} ]] && KUBE_CONFIG="/etc/kubernetes/admin.conf"
+    if ! data=$(kubectl --kubeconfig="$KUBE_CONFIG" get pods --all-namespaces -o json 2>&1); then
+      warning "${funcname}: error on 'kubectl get pods --all-namespaces -o json': ${data}."
+      return 1
+    fi
+  else
+    warning "${funcname}: not inside the k8s cluster and 'kubectl' command not available."
+    return 1
+  fi
+
+  local jq_pod jq_cont jq_filter
+  jq_pod='namespace=\"\(.metadata.namespace)\",pod_name=\"\(.metadata.name)\",pod_uid=\"\(.metadata.uid)\"'
+  jq_cont=',container_name=\"\(.name)\",container_id=\"\(.containerID)\"'
+  jq_filter=".items[] | \"${jq_pod}\" + (.status.containerStatuses[]? | \"${jq_cont}\") | sub(\"docker://\";\"\")"
+
+  if ! data=$(jq -r "${jq_filter}" <<< "$data" 2>&1); then
+    warning "${funcname}: error on 'jq -r '${jq_filter}'': ${data}."
+    return 1
+  fi
+
+  local labels name
+  if [ -n "$cntr_id" ]; then
+    if labels=$(grep "$cntr_id" <<< "$data" 2> /dev/null); then
+      name="cntr_$(get_lbl_val "$labels" namespace)_$(get_lbl_val "$labels" pod_name)_$(get_lbl_val "$labels" container_name)"
+    fi
+  elif [ -n "$pod_uid" ]; then
+    if labels=$(grep "$pod_uid" -m 1 <<< "$data" 2> /dev/null); then
+      labels="${labels%%,cont*}"
+      name="pod_$(get_lbl_val "$labels" namespace)_$(get_lbl_val "$labels" pod_name)"
+    fi
+  fi
+
+  echo "$name"
+  [[ -n "$name" ]]
+  return
+}
+
+function k8s_get_name() {
+  local funcname="${FUNCNAME[0]}"
+  local orig_id="${1}"
+  local id=${orig_id//.slice/} # minikube ids sanitizing
+
+  case "$id" in
+    "kubepods" | "kubepods_guaranteed" | "kubepods_burstable" | "kubepods_besteffort")
+      NAME="${id}"
+      ;;
+  esac
+
+  if [ -z "$NAME" ]; then
+    NAME=$(k8s_get_kubepod_name "$id")
+  fi
+
+  if [ -z "${NAME}" ]; then
+    warning "${funcname}: cannot find the name of cgroup with id '${id}'. Setting name to ${id} and disabling it."
+    NAME="${id}"
+    NAME_NOT_FOUND=3
+  else
+    NAME="k8s_${NAME}"
+    info "${funcname}: cgroup '${id}' has chart name '${NAME}'"
+  fi
 }
 
 function docker_get_name() {


### PR DESCRIPTION
##### Summary

Fixes: #10006

Correctly resolve all `kubepods/*` cgroups names when running inside the k8s cluster (http req to the API server) or installed on a k8 node (via `kubectl`).

New naming format (**breaking change**):
- pod level cgroup name format: `k8s_pod_<NAMESPACE>_<POD_NAME>`
- container level cgroup name format: `k8s_cntr_<NAMESPACE>_<POD_NAME>_<CONTAINER_NAME>`

**I don't add filtering to the cgroup-name.sh script**, so all level cgroup are collected. I think it is better to have filtering in the cgroups collector configuration options (`enable by default cgroups matching`).

**This PR doesn't contain** `enable by default cgroups matching` option updates, i plan to add them in a separet PR (added in https://github.com/netdata/netdata/pull/10095).

Cgroup tree structure on the GKE and minikube nodes

```cmd
  # GKE /sys/fs/cgroup/*/ tree:
  # |-- kubepods
  # |   |-- burstable
  # |   |   |-- pod98cee708-023b-11eb-933d-42010a800193
  # |   |   |   |-- 922161c98e6ea450bf665226cdc64ca2aa3e889934c2cff0aec4325f8f78ac03
  # |   |       `-- a5d223eec35e00f5a1c6fa3e3a5faac6148cdc1f03a2e762e873b7efede012d7
  # |   `-- pode314bbac-d577-11ea-a171-42010a80013b
  # |       |-- 7d505356b04507de7b710016d540b2759483ed5f9136bb01a80872b08f771930
  # |       `-- 88ab4683b99cfa7cc8c5f503adf7987dd93a3faa7c4ce0d17d419962b3220d50
  #
  # Minikube (v1.8.2) /sys/fs/cgroup/*/ tree:
  # |-- kubepods.slice
  # |   |-- kubepods-besteffort.slice
  # |   |   |-- kubepods-besteffort-pod10fb5647_c724_400c_b9cc_0e6eae3110e7.slice
  # |   |   |   |-- docker-36e5eb5056dfdf6dbb75c0c44a1ecf23217fe2c50d606209d8130fcbb19fb5a7.scope
  # |   |   |   `-- docker-87e18c2323621cf0f635c53c798b926e33e9665c348c60d489eef31ee1bd38d7.scope
```

This PR handles both cases, if there are other dir names _formats_ it is likely it fails to extract `podUID` or `containerID`.

It is kind of difficult because `cgroups` collector passes a chart.id as an argument => all `/` changed to `_` (`_` is field delimiter...).

##### Component Name

`collectors/cgroups`

##### Test Plan
- [x] test in GKE
  - copy modified `cgroup-name.sh` script to the children nodes
  - restart children netdata containers (`docker restart <CONTAINER_ID>`)
  - `kubectl exec ...` into the parent node, `rm -rf *` db cache
  - restart parent netdata container

I see all the `kubepods/*` cgroups on the dashboard.

- [x] test in minikube (one agent setup)
  - copy modified `cgroup-name.sh` script to the agent
  - restart the agent container

I see all containers level cgroups on the dashboard. Pod and higher level cgroups filtered because of `.slice` suffix which doesn't match default _match cgroup name_ simple pattern.

##### Additional Information

