### PR TITLE
Create clean

### DIFF
--- a/contrib/debian/clean
+++ b/contrib/debian/clean
@@ -1,0 +1,8 @@
+*/*/*/*/*/*.o
+*/*/*/*/*.o
+*/*/*/*.o
+*/*/*.o
+*/*.o
+tmp/
+externaldeps/
+daemon/get-kubernetes-labels.sh


### PR DESCRIPTION
allow double builds...
fails otherwise as the clean target of upstream is not clean

##### Summary

##### Component Name

##### Test Plan

run debuild, and then run it again

##### Additional Information
