### PR TITLE
Removed redundant dependencies from Debian control file.

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -24,8 +24,6 @@ Build-Depends: debhelper (>= 9),
                automake,
                pkg-config,
                curl,
-               gcc,
-               g++,
                protobuf-compiler
 Section: net
 Priority: optional


### PR DESCRIPTION
https://lintian.debian.org/tags/build-depends-on-build-essential-package-without-using-version.html
