### PR TITLE
collectors/cgroups: filter pod level cgroups

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -362,9 +362,12 @@ void read_cgroup_plugin_configuration() {
             // ----------------------------------------------------------------
 
                     " /machine.slice/*.service "           // #3367 systemd-nspawn
+                    " /kubepods/pod*/* "                   // k8s containers
+                    " /kubepods/*/pod*/* "                 // k8s containers
 
             // ----------------------------------------------------------------
 
+                    " !/kubepods* "                        // all other k8s cgroups
                     " !*/vcpu* "                           // libvirtd adds these sub-cgroups
                     " !*/emulator "                        // libvirtd adds these sub-cgroups
                     " !*.mount "


### PR DESCRIPTION
##### Summary

This PR updates `enable by default cgroups matching` default value: as agreed in https://github.com/netdata/netdata/issues/10006#issuecomment-707314548 we filter pod level cgroups.

Cgroup tree structure on the GKE and minikube nodes

```cmd
  # GKE /sys/fs/cgroup/*/ tree:
  # |-- kubepods
  # |   |-- burstable
  # |   |   |-- pod98cee708-023b-11eb-933d-42010a800193
  # |   |   |   |-- 922161c98e6ea450bf665226cdc64ca2aa3e889934c2cff0aec4325f8f78ac03
  # |   |       `-- a5d223eec35e00f5a1c6fa3e3a5faac6148cdc1f03a2e762e873b7efede012d7
  # |   `-- pode314bbac-d577-11ea-a171-42010a80013b
  # |       |-- 7d505356b04507de7b710016d540b2759483ed5f9136bb01a80872b08f771930
  # |       `-- 88ab4683b99cfa7cc8c5f503adf7987dd93a3faa7c4ce0d17d419962b3220d50
  #
  # Minikube (v1.8.2) /sys/fs/cgroup/*/ tree:
  # |-- kubepods.slice
  # |   |-- kubepods-besteffort.slice
  # |   |   |-- kubepods-besteffort-pod10fb5647_c724_400c_b9cc_0e6eae3110e7.slice
  # |   |   |   |-- docker-36e5eb5056dfdf6dbb75c0c44a1ecf23217fe2c50d606209d8130fcbb19fb5a7.scope
  # |   |   |   `-- docker-87e18c2323621cf0f635c53c798b926e33e9665c348c60d489eef31ee1bd38d7.scope
```

All `*.slice` cgroups already filtered, so minikube case is ok.

##### Component Name

`collectors/cgroups`

##### Test Plan

Changes are pretty straightforward, but i tested them on GKE - i see only container level cgroups.

##### Additional Information
