### PR TITLE
ebpf memory cleanup

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -115,7 +115,6 @@ ebpf_module_t ebpf_modules[] = {
 };
 
 // Link with apps.plugin
-pid_t *pid_index;
 ebpf_process_stat_t *global_process_stat = NULL;
 
 //Network viewer
@@ -205,7 +204,6 @@ static void ebpf_exit(int sig)
 
     clean_apps_groups_target(apps_groups_root_target);
 
-    freez(pid_index);
     freez(global_process_stat);
 
     int ret = fork();
@@ -830,7 +828,6 @@ int ebpf_start_pthread_variables()
 static void ebpf_allocate_common_vectors()
 {
     all_pids = callocz((size_t)pid_max, sizeof(struct pid_stat *));
-    pid_index = callocz((size_t)pid_max, sizeof(pid_t));
     global_process_stat = callocz((size_t)ebpf_nprocs, sizeof(ebpf_process_stat_t));
 }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -142,6 +142,7 @@ void clean_port_structure(ebpf_network_viewer_port_list_t **clean)
     ebpf_network_viewer_port_list_t *move = *clean;
     while (move) {
         ebpf_network_viewer_port_list_t *next = move->next;
+        freez(move->value);
         freez(move);
 
         move = next;

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -180,13 +180,13 @@ static void change_events()
  * Clean Loaded Events
  *
  * This function cleans the events previous loaded on Linux.
- */
 void clean_loaded_events()
 {
     int event_pid;
     for (event_pid = 0; ebpf_modules[event_pid].probes; event_pid++)
         clean_kprobe_events(NULL, (int)ebpf_modules[event_pid].thread_id, ebpf_modules[event_pid].probes);
 }
+ */
 
 /**
  * Close the collector gracefully
@@ -204,6 +204,7 @@ static void ebpf_exit(int sig)
 
     freez(global_process_stat);
 
+    /*
     int ret = fork();
     if (ret < 0) // error
         error("Cannot fork(), so I won't be able to clean %skprobe_events", NETDATA_DEBUGFS);
@@ -233,6 +234,7 @@ static void ebpf_exit(int sig)
     } else { // parent
         exit(0);
     }
+     */
 
     exit(sig);
 }
@@ -1964,7 +1966,7 @@ int main(int argc, char **argv)
     };
 
     change_events();
-    clean_loaded_events();
+    //clean_loaded_events();
 
     int i;
     for (i = 0; ebpf_threads[i].name != NULL; i++) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -202,8 +202,6 @@ static void ebpf_exit(int sig)
         return;
     }
 
-    clean_apps_groups_target(apps_groups_root_target);
-
     freez(global_process_stat);
 
     int ret = fork();

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -69,6 +69,7 @@ int running_on_kernel = 0;
 char kernel_string[64];
 int ebpf_nprocs;
 static int isrh;
+uint32_t finalized_threads = 1;
 
 pthread_mutex_t lock;
 pthread_mutex_t collect_data_mutex;

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -31,12 +31,6 @@
 
 #include "ebpf_apps.h"
 
-typedef enum {
-    MODE_RETURN = 0, // This attaches kprobe when the function returns
-    MODE_DEVMODE,    // This stores log given description about the errors raised
-    MODE_ENTRY       // This attaches kprobe when the function is called
-} netdata_run_mode_t;
-
 typedef struct netdata_syscall_stat {
     unsigned long bytes;               // total number of bytes
     uint64_t call;                     // total number of calls
@@ -73,20 +67,6 @@ typedef struct netdata_error_report {
     int type;
     int err;
 } netdata_error_report_t;
-
-typedef struct ebpf_module {
-    const char *thread_name;
-    const char *config_name;
-    int enabled;
-    void *(*start_routine)(void *);
-    int update_time;
-    int global_charts;
-    int apps_charts;
-    netdata_run_mode_t mode;
-    netdata_ebpf_events_t *probes;
-    uint32_t thread_id;
-    int optional;
-} ebpf_module_t;
 
 extern ebpf_module_t ebpf_modules[];
 #define EBPF_MODULE_PROCESS_IDX 0

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -198,8 +198,8 @@ extern void write_end_chart();
 // Common variables
 extern char *ebpf_user_config_dir;
 extern char *ebpf_stock_config_dir;
-extern pid_t *pid_index;
 extern int debug_enabled;
+extern struct pid_stat *root_of_pids;
 
 // Socket functions and variables
 // Common functions

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -209,6 +209,7 @@ extern struct pid_stat *root_of_pids;
 extern ebpf_process_stat_t *global_process_stat;
 extern size_t all_pids_count;
 extern int update_every;
+extern uint32_t finalized_threads;
 
 #define EBPF_MAX_SYNCHRONIZATION_TIME 300
 

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -934,9 +934,11 @@ void cleanup_exited_pids()
             prev_apps_data[r] = NULL;
 
             // Clean socket structures
-            freez(socket_bandwidth_curr[r]);
-            socket_bandwidth_curr[r] = NULL;
-            socket_bandwidth_prev[r] = NULL;
+            if (socket_bandwidth_curr) {
+                freez(socket_bandwidth_curr[r]);
+                socket_bandwidth_curr[r] = NULL;
+                socket_bandwidth_prev[r] = NULL;
+            }
         } else {
             if (unlikely(p->keep))
                 p->keeploops++;
@@ -1056,9 +1058,11 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd)
             prev_apps_data[key] = NULL;
 
             // Clean socket structures
-            freez(socket_bandwidth_curr[key]);
-            socket_bandwidth_curr[key] = NULL;
-            socket_bandwidth_prev[key] = NULL;
+            if (socket_bandwidth_curr) {
+                freez(socket_bandwidth_curr[key]);
+                socket_bandwidth_curr[key] = NULL;
+                socket_bandwidth_prev[key] = NULL;
+            }
 
             pids = pids->next;
             continue;

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -14,6 +14,8 @@
 #define NETDATA_APPS_SYSCALL_GROUP "ebpf syscall"
 #define NETDATA_APPS_NET_GROUP "ebpf net"
 
+#include "ebpf_process.h"
+
 #define MAX_COMPARE_NAME 100
 #define MAX_NAME 100
 
@@ -404,7 +406,7 @@ extern size_t zero_all_targets(struct target *root);
 
 extern int am_i_running_as_root();
 
-extern void cleanup_exited_pids(ebpf_process_stat_t **out);
+extern void cleanup_exited_pids();
 
 extern int ebpf_read_hash_table(void *ep, int fd, uint32_t pid);
 
@@ -417,5 +419,7 @@ extern size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep
 extern void collect_data_for_all_processes(int tbl_pid_stats_fd);
 
 extern ebpf_process_stat_t **global_process_stats;
+extern ebpf_process_publish_apps_t **current_apps_data;
+extern ebpf_process_publish_apps_t **prev_apps_data;
 
 #endif /* NETDATA_EBPF_APPS_H */

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -414,7 +414,7 @@ extern size_t read_processes_statistic_using_pid_on_target(ebpf_process_stat_t *
 
 extern size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep, int fd, struct pid_on_target *pids);
 
-extern void collect_data_for_all_processes(pid_t *index, int tbl_pid_stats_fd);
+extern void collect_data_for_all_processes(int tbl_pid_stats_fd);
 
 extern ebpf_process_stat_t **global_process_stats;
 

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -414,6 +414,8 @@ extern size_t read_processes_statistic_using_pid_on_target(ebpf_process_stat_t *
 
 extern size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep, int fd, struct pid_on_target *pids);
 
-extern void collect_data_for_all_processes(ebpf_process_stat_t **out, pid_t *index, int tbl_pid_stats_fd);
+extern void collect_data_for_all_processes(pid_t *index, int tbl_pid_stats_fd);
+
+extern ebpf_process_stat_t **global_process_stats;
 
 #endif /* NETDATA_EBPF_APPS_H */

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -877,8 +877,7 @@ void clean_global_memory() {
     struct pid_stat *pids = root_of_pids;
     while (pids) {
         uint32_t pid = pids->pid;
-        ebpf_process_stat_t *w = global_process_stats[pid];
-        freez(w);
+        freez(global_process_stats[pid]);
 
         bpf_map_delete_elem(pid_fd, &pid);
         freez(current_apps_data[pid]);

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -923,7 +923,6 @@ static void ebpf_process_cleanup(void *ptr)
     freez(current_apps_data);
     freez(prev_apps_data);
 
-    //clean_apps_structures(apps_groups_default_target);
     clean_apps_structures(apps_groups_root_target);
     freez(process_data.map_fd);
 }

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -912,7 +912,15 @@ void clean_apps_structures(struct target *ptr) {
  */
 static void ebpf_process_cleanup(void *ptr)
 {
-    (void)ptr;
+    UNUSED(ptr);
+
+    heartbeat_t hb;
+    heartbeat_init(&hb);
+    uint32_t tick = 200*USEC_PER_MS;
+    while (!finalized_threads) {
+        usec_t dt = heartbeat_next(&hb, tick);
+        UNUSED(dt);
+    }
 
     freez(process_aggregated_data);
     freez(process_publish_aggregated);

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -885,6 +885,26 @@ void clean_global_memory() {
     }
 }
 
+void clean_pid_on_target(struct pid_on_target *ptr) {
+    while (ptr) {
+        struct pid_on_target *next = ptr->next;
+        freez(ptr);
+
+        ptr = next;
+    }
+}
+
+void clean_apps_structures(struct target *ptr) {
+    struct target *agdt = ptr;
+    while (agdt) {
+        struct target *next = agdt->next;
+        clean_pid_on_target(agdt->root_pid);
+        freez(agdt);
+
+        agdt = next;
+    }
+}
+
 /**
  * Clean up the main thread.
  *
@@ -903,6 +923,8 @@ static void ebpf_process_cleanup(void *ptr)
     freez(current_apps_data);
     freez(prev_apps_data);
 
+    //clean_apps_structures(apps_groups_default_target);
+    clean_apps_structures(apps_groups_root_target);
     freez(process_data.map_fd);
 }
 

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1686,6 +1686,7 @@ static void ebpf_socket_cleanup(void *ptr)
     clean_hostnames(network_viewer_opt.excluded_hostnames);
 
     pthread_mutex_destroy(&nv_mutex);
+    finalized_threads = 1;
 }
 
 /*****************************************************************
@@ -1804,6 +1805,7 @@ void *ebpf_socket_thread(void *ptr)
 
     ebpf_create_global_charts(em);
 
+    finalized_threads = 0;
     pthread_mutex_unlock(&lock);
 
     socket_collector((usec_t)(em->update_time * USEC_PER_SEC), em);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1657,7 +1657,10 @@ static void clean_hostnames(ebpf_network_viewer_hostname_list_t *hostnames)
  */
 static void ebpf_socket_cleanup(void *ptr)
 {
-    UNUSED(ptr);
+    ebpf_module_t *em = (ebpf_module_t *)ptr;
+    if (!em->enabled)
+        return;
+
     freez(socket_aggregated_data);
     freez(socket_publish_aggregated);
     freez(socket_hash_values);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1650,6 +1650,15 @@ static void clean_hostnames(ebpf_network_viewer_hostname_list_t *hostnames)
     }
 }
 
+void clean_thread_structures() {
+    struct pid_stat *pids = root_of_pids;
+    while (pids) {
+        freez(socket_bandwidth_curr[pids->pid]);
+
+        pids = pids->next;
+    }
+}
+
 /**
  * Clean up the main thread.
  *
@@ -1665,7 +1674,7 @@ static void ebpf_socket_cleanup(void *ptr)
     freez(socket_publish_aggregated);
     freez(socket_hash_values);
 
-    freez(socket_data.map_fd);
+    clean_thread_structures();
     freez(socket_bandwidth_curr);
     freez(socket_bandwidth_prev);
     freez(bandwidth_vector);
@@ -1686,6 +1695,7 @@ static void ebpf_socket_cleanup(void *ptr)
     clean_hostnames(network_viewer_opt.excluded_hostnames);
 
     pthread_mutex_destroy(&nv_mutex);
+    freez(socket_data.map_fd);
     finalized_threads = 1;
 }
 

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -255,4 +255,7 @@ extern void clean_port_structure(ebpf_network_viewer_port_list_t **clean);
 extern ebpf_network_viewer_port_list_t *listen_ports;
 extern void update_listen_table(uint16_t value, uint8_t proto);
 
+extern ebpf_socket_publish_apps_t **socket_bandwidth_curr;
+extern ebpf_socket_publish_apps_t **socket_bandwidth_prev;
+
 #endif

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -282,7 +282,6 @@ static int select_file(char *name, const char *program, size_t length, int mode,
     return ret;
 }
 
-//give ojs as arg and get link as result
 struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, char *kernel_string, struct bpf_object **obj, int *map_fd)
 {
     char lpath[4096];
@@ -298,7 +297,7 @@ struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, char *
         info("Cannot load program: %s", lpath);
         return NULL;
     } else {
-        info("The eBPF program %s was loaded with success.",em->thread_name);
+        info("The eBPF program %s was loaded with success.", em->thread_name);
     }
 
     struct bpf_map *map;

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -8,6 +8,7 @@
 
 #include "../libnetdata.h"
 
+/*
 static int clean_kprobe_event(FILE *out, char *filename, char *father_pid, netdata_ebpf_events_t *ptr)
 {
     int fd = open(filename, O_WRONLY | O_APPEND, 0);
@@ -56,6 +57,7 @@ int clean_kprobe_events(FILE *out, int pid, netdata_ebpf_events_t *ptr)
 
     return 0;
 }
+*/
 
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -282,40 +282,41 @@ static int select_file(char *name, const char *program, size_t length, int mode,
     return ret;
 }
 
-int ebpf_load_program(char *plugins_dir, int event_id, int mode, char *kernel_string, const char *name, int *map_fd)
+//give ojs as arg and get link as result
+struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, char *kernel_string, struct bpf_object **obj, int *map_fd)
 {
-    UNUSED(event_id);
-
     char lpath[4096];
     char lname[128];
-    struct bpf_object *obj;
     int prog_fd;
 
-    int test = select_file(lname, name, (size_t)127, mode, kernel_string);
+    int test = select_file(lname, em->thread_name, (size_t)127, em->mode, kernel_string);
     if (test < 0 || test > 127)
-        return -1;
+        return NULL;
 
     snprintf(lpath, 4096, "%s/%s", plugins_dir, lname);
-    if (bpf_prog_load(lpath, BPF_PROG_TYPE_KPROBE, &obj, &prog_fd)) {
+    if (bpf_prog_load(lpath, BPF_PROG_TYPE_KPROBE, obj, &prog_fd)) {
         info("Cannot load program: %s", lpath);
-        return -1;
+        return NULL;
     } else {
-        info("The eBPF program %s was loaded with success.", name);
+        info("The eBPF program %s was loaded with success.",em->thread_name);
     }
 
     struct bpf_map *map;
     size_t i = 0;
-    bpf_map__for_each(map, obj)
+    bpf_map__for_each(map, *obj)
     {
         map_fd[i] = bpf_map__fd(map);
         i++;
     }
 
     struct bpf_program *prog;
-    bpf_object__for_each_program(prog, obj)
+    struct bpf_link **links = callocz(NETDATA_MAX_PROBES , sizeof(struct bpf_link *));
+    i = 0;
+    bpf_object__for_each_program(prog, *obj)
     {
-        bpf_program__attach(prog);
+        links[i] = bpf_program__attach(prog);
+        i++;
     }
 
-    return 0;
+    return links;
 }

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -68,16 +68,38 @@ typedef struct ebpf_data {
     int isrh;
 } ebpf_data_t;
 
+typedef enum {
+    MODE_RETURN = 0, // This attaches kprobe when the function returns
+    MODE_DEVMODE,    // This stores log given description about the errors raised
+    MODE_ENTRY       // This attaches kprobe when the function is called
+} netdata_run_mode_t;
+
+typedef struct ebpf_module {
+    const char *thread_name;
+    const char *config_name;
+    int enabled;
+    void *(*start_routine)(void *);
+    int update_time;
+    int global_charts;
+    int apps_charts;
+    netdata_run_mode_t mode;
+    netdata_ebpf_events_t *probes;
+    uint32_t thread_id;
+    int optional;
+} ebpf_module_t;
+
+#define NETDATA_MAX_PROBES 64
+
 extern int clean_kprobe_events(FILE *out, int pid, netdata_ebpf_events_t *ptr);
 extern int get_kernel_version(char *out, int size);
 extern int get_redhat_release();
 extern int has_condition_to_run(int version);
 extern char *ebpf_kernel_suffix(int version, int isrh);
 extern int ebpf_update_kernel(ebpf_data_t *ef);
-extern int ebpf_load_program(char *plugins_dir,
-                             int event_id, int mode,
+extern struct bpf_link **ebpf_load_program(char *plugins_dir,
+                             ebpf_module_t *em,
                              char *kernel_string,
-                             const char *name,
+                             struct bpf_object **obj,
                              int *map_fd);
 
 #endif /* NETDATA_EBPF_H */


### PR DESCRIPTION
##### Summary
This PR fixes the memory cleanup when `ebpf.plugin` is closed.

I am also using this PR to remove some unnecessary code, because we are using `libbpf` now, but instead to remove the old code, I decided to comment it, because it can be useful where `libbpf` cannot be used.

##### Component Name
Ebpf plugin
##### Test Plan

1 - Install `libasan` on your environment. 
2 - Compile this branch with the following flags: 

```
CFLAGS="-O1 -ggdb -Wall -Wextra -fsanitize=address -static-libasan -fno-omit-frame-pointer -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1" ./netdata-installer.sh --disable-lto --dont-wait --dont-start-it
```

If you prefer you can use the dynamic `libasan`.

3 - Go to directory `/usr/libexec/netdata/plugins.d`
4 - Run `ebpf.plugin` redirecting `STDERR` and `STDOUT` for files:

```
./ebpf.pluging 2> stderr > stdout
```

5 - After few minutes, kill the process and investigate your `stderr` file, you cannot have any memory leak reported.
6 - Start Netdata and take a look on `ebpf.plugin` charts.
7 - Access `apps.plugin` and also take a look on the ebpf section to confirm that charts are ok.

##### Additional Information

I tested this PR with the the kernels `5.9.1`, `5.8.12`, `5.4.72`, `4.19.144`, `4.17.19`, `4.15.0`, `4.14.197`. I observed that the network monitoring is not working fine for kernels older than `4.17`, but this is a known problem that will be fixed next days, for the newest kernels everything is working as expected.