### PR TITLE
nvidia_smi: Not count users with zero memory allocated

### DIFF
--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -52,7 +52,7 @@ Sample:
 ```yaml
 loop_mode    : yes
 poll_seconds : 1
-exclude_zero_memory_allocated_users : yes
+exclude_zero_memory_users : yes
 ```
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fnvidia_smi%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -52,6 +52,7 @@ Sample:
 ```yaml
 loop_mode    : yes
 poll_seconds : 1
+exclude_zero_memory_allocated_users : yes
 ```
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fnvidia_smi%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -407,6 +407,7 @@ class GPU:
             if p['username']:
                 if self.exclude_zero_memory_users and p['used_memory'] == 0:
                     continue
+                users.add(p['username'])
                 key = 'user_mem_{0}'.format(p['username'])
                 if key in data:
                     data[key] += p['used_memory']

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -405,13 +405,13 @@ class GPU:
         for p in processes:
             data['process_mem_{0}'.format(p['pid'])] = p['used_memory']
             if p['username']:
-                if p['used_memory'] > 0 or not self.exclude_zero_memory_users:
-                    users.add(p['username'])
-            key = 'user_mem_{0}'.format(p['username'])
-            if key in data:
-                data[key] += p['used_memory']
-            else:
-                data[key] = p['used_memory']
+                if self.exclude_zero_memory_users and p['used_memory'] == 0:
+                    continue
+                key = 'user_mem_{0}'.format(p['username'])
+                if key in data:
+                    data[key] += p['used_memory']
+                else:
+                    data[key] = p['used_memory']
         data['user_num'] = len(users)
 
         return dict(

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -404,7 +404,7 @@ class GPU:
         for p in processes:
             data['process_mem_{0}'.format(p['pid'])] = p['used_memory']
             if p['username']:
-                if not(self.exclude_zero_memory_allocated_users) or p['used_memory'] > 0: 
+                if not(self.exclude_zero_memory_allocated_users) or p['used_memory'] > 0:
                     users.add(p['username'])
                 key = 'user_mem_{0}'.format(p['username'])
                 if key in data:

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -404,7 +404,8 @@ class GPU:
         for p in processes:
             data['process_mem_{0}'.format(p['pid'])] = p['used_memory']
             if p['username']:
-                if p['used_memory'] > 0 : users.add(p['username'])
+                if not(self.exclude_zero_memory_allocated_users) or p['used_memory'] > 0: 
+                    users.add(p['username'])
                 key = 'user_mem_{0}'.format(p['username'])
                 if key in data:
                     data[key] += p['used_memory']
@@ -424,6 +425,7 @@ class Service(SimpleService):
         self.definitions = dict()
         self.loop_mode = configuration.get('loop_mode', True)
         poll = int(configuration.get('poll_seconds', 1))
+        self.exclude_zero_memory_allocated_users = configuration.get('exclude_zero_memory_allocated_users', False)
         self.poller = NvidiaSMIPoller(poll)
 
     def get_data_loop_mode(self):

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -404,7 +404,7 @@ class GPU:
         for p in processes:
             data['process_mem_{0}'.format(p['pid'])] = p['used_memory']
             if p['username']:
-                users.add(p['username'])
+                if p['used_memory'] > 0 : users.add(p['username'])
                 key = 'user_mem_{0}'.format(p['username'])
                 if key in data:
                     data[key] += p['used_memory']

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -288,9 +288,10 @@ def get_username_by_pid_safe(pid, passwd_file):
 
 
 class GPU:
-    def __init__(self, num, root):
+    def __init__(self, num, root, exclude_zero_memory_users=False):
         self.num = num
         self.root = root
+        self.exclude_zero_memory_users = exclude_zero_memory_users
 
     def id(self):
         return self.root.get('id')
@@ -404,13 +405,13 @@ class GPU:
         for p in processes:
             data['process_mem_{0}'.format(p['pid'])] = p['used_memory']
             if p['username']:
-                if not(self.exclude_zero_memory_allocated_users) or p['used_memory'] > 0:
+                if p['used_memory'] > 0 or not self.exclude_zero_memory_users:
                     users.add(p['username'])
-                key = 'user_mem_{0}'.format(p['username'])
-                if key in data:
-                    data[key] += p['used_memory']
-                else:
-                    data[key] = p['used_memory']
+            key = 'user_mem_{0}'.format(p['username'])
+            if key in data:
+                data[key] += p['used_memory']
+            else:
+                data[key] = p['used_memory']
         data['user_num'] = len(users)
 
         return dict(
@@ -425,7 +426,7 @@ class Service(SimpleService):
         self.definitions = dict()
         self.loop_mode = configuration.get('loop_mode', True)
         poll = int(configuration.get('poll_seconds', 1))
-        self.exclude_zero_memory_allocated_users = configuration.get('exclude_zero_memory_allocated_users', False)
+        self.exclude_zero_memory_users = configuration.get('exclude_zero_memory_users', False)
         self.poller = NvidiaSMIPoller(poll)
 
     def get_data_loop_mode(self):
@@ -456,7 +457,7 @@ class Service(SimpleService):
 
         data = dict()
         for idx, root in enumerate(parsed.findall('gpu')):
-            gpu = GPU(idx, root)
+            gpu = GPU(idx, root, self.exclude_zero_memory_users)
             data.update(gpu.data())
             self.update_processes_mem_chart(gpu)
             self.update_processes_user_mem_chart(gpu)

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.conf
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.conf
@@ -61,8 +61,8 @@
 #
 # Additionally to the above, example also supports the following:
 #
-# loop_mode: yes/no           # default is yes. If set to yes `nvidia-smi` is executed in a separate thread using `-l` option.
-# poll_seconds: SECONDS       # default is 1. Sets the frequency of seconds the nvidia-smi tool is polled in loop mode.
-# exclude_zero_memory_allocated_users: yes/no # default is no. If set to yes nr_users (users) doesn't count user with only processes with 0Mb memory allocation
+# loop_mode: yes/no                 # default is yes. If set to yes `nvidia-smi` is executed in a separate thread using `-l` option.
+# poll_seconds: SECONDS             # default is 1. Sets the frequency of seconds the nvidia-smi tool is polled in loop mode.
+# exclude_zero_memory_users: yes/no # default is no. Whether to collect users metrics with 0Mb memory allocation.
 #
 # ----------------------------------------------------------------------

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.conf
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.conf
@@ -63,5 +63,6 @@
 #
 # loop_mode: yes/no           # default is yes. If set to yes `nvidia-smi` is executed in a separate thread using `-l` option.
 # poll_seconds: SECONDS       # default is 1. Sets the frequency of seconds the nvidia-smi tool is polled in loop mode.
+# exclude_zero_memory_allocated_users: yes/no # default is no. If set to yes nr_users (users) doesn't count user with only processes with 0Mb memory allocation
 #
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Exclude from nr_user count users with zero memory allocated

##### Summary
Really small change;
just to avoid counting users with actually no memory allocated.

##### Component Name
nvidia-smi python collector
