### PR TITLE
Remove Docker example from update docs and add section to claim troubleshooting

### DIFF
--- a/claim/README.md
+++ b/claim/README.md
@@ -198,9 +198,11 @@ Use these keys and the information below to troubleshoot the ACLK.
 
 If you run the claiming script and see a `command not found` error, you either installed Netdata in a non-standard
 location or are using an unsupported package. If you installed Netdata in a non-standard path using the `--install`
-option, you need to update your `$PATH`, or `cd` to the path and run `netdata-claim.sh` there. If you are using an
-unsupported package, such as a third-party `.deb`/`.rpm` package provided by your distribution, please remove that
-package and reinstall using our [recommended kickstart script](/docs/get#install-the-netdata-agent).
+option, you need to update your `$PATH` or run `netdata-claim.sh` using the full path. For example, if you installed
+Netdata to `/opt/netdata`, use `/opt/netdata/bin/netdata-claim.sh` to run the claiming script.
+
+If you are using an unsupported package, such as a third-party `.deb`/`.rpm` package provided by your distribution,
+please remove that package and reinstall using our [recommended kickstart script](/docs/get#install-the-netdata-agent).
 
 #### Claiming on older distributions (Ubuntu 14.04, Debian 8, CentOS 6)
 

--- a/claim/README.md
+++ b/claim/README.md
@@ -194,6 +194,20 @@ might be having with the ACLK or claiming process.
 
 Use these keys and the information below to troubleshoot the ACLK.
 
+#### bash: netdata-claim.sh: command not found
+
+If you run the claiming script and see a `command not found` error, the claiming script is not in your system's `$PATH`.
+Netdata expects this file at `/usr/sbin/`, but some systems may have installed the script in `/opt/netdata/usr/sbin/` or
+`/opt/netdata/bin/`.
+
+Check those locations for the existence of the `netdata-claim.sh` file. When you find it, run the following commands to
+claim your node.
+
+```bash
+sudo chmod +x netdata-claim.sh
+sudo ./netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud
+```
+
 #### Claiming on older distributions (Ubuntu 14.04, Debian 8, CentOS 6)
 
 If you're running an older Linux distribution or one that has reached EOL, such as Ubuntu 14.04 LTS, Debian 8, or CentOS

--- a/claim/README.md
+++ b/claim/README.md
@@ -196,17 +196,11 @@ Use these keys and the information below to troubleshoot the ACLK.
 
 #### bash: netdata-claim.sh: command not found
 
-If you run the claiming script and see a `command not found` error, the claiming script is not in your system's `$PATH`.
-Netdata expects this file at `/usr/sbin/`, but some systems may have installed the script in `/opt/netdata/usr/sbin/` or
-`/opt/netdata/bin/`.
-
-Check those locations for the existence of the `netdata-claim.sh` file. When you find it, run the following commands to
-claim your node.
-
-```bash
-sudo chmod +x netdata-claim.sh
-sudo ./netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud
-```
+If you run the claiming script and see a `command not found` error, you either installed Netdata in a non-standard
+location or are using an unsupported package. If you installed Netdata in a non-standard path using the `--install`
+option, you need to update your `$PATH`, or `cd` to the path and run `netdata-claim.sh` there. If you are using an
+unsupported package, such as a third-party `.deb`/`.rpm` package provided by your distribution, please remove that
+package and reinstall using our [recommended kickstart script](/docs/get#install-the-netdata-agent).
 
 #### Claiming on older distributions (Ubuntu 14.04, Debian 8, CentOS 6)
 

--- a/packaging/installer/UPDATE.md
+++ b/packaging/installer/UPDATE.md
@@ -126,8 +126,7 @@ docker pull netdata/netdata:latest
 ```
 
 Next, to stop and remove any containers using the `netdata/netdata` image. Replace `netdata` if you changed it from the
-default in our [Docker installation
-instructions](/packaging/docker/README.md#run-the-agent-with-the-docker-command).
+default.
 
 ```bash
 docker stop netdata
@@ -135,21 +134,7 @@ docker rm netdata
 ```
 
 You can now re-create your Netdata container using the `docker` command or a `docker-compose.yml` file. See our [Docker
-installation instructions](/packaging/docker/README.md#run-the-agent-with-the-docker-command) for details. For
-example, using the `docker` command:
-
-```bash
-docker run -d --name=netdata \
-  -p 19999:19999 \
-  -v /etc/passwd:/host/etc/passwd:ro \
-  -v /etc/group:/host/etc/group:ro \
-  -v /proc:/host/proc:ro \
-  -v /sys:/host/sys:ro \
-  -v /etc/os-release:/host/etc/os-release:ro \
-  --cap-add SYS_PTRACE \
-  --security-opt apparmor=unconfined \
-  netdata/netdata
-```
+installation instructions](/packaging/docker/README.md#create-a-new-netdata-agent-container) for details.
 
 ## macOS
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

A mash-up of two small fixes to the docs.

First, a new section to address some [ongoing community feedback](https://github.com/netdata/netdata/issues/9202#issuecomment-712097853) for the `netdata-claim.sh` script not being in the user's PATH.

Second, removing the example `docker run` command from the update page, as it conflicts with the up-to-date examples found in the official Docker installation page. Let's direct users to that page instead of duplicating the command.

##### Component Name

area/docs
area/claim
area/packaging

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
