### PR TITLE
Fixed compile error in CENTOS 6

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -13,7 +13,6 @@ typedef struct rrddimvar RRDDIMVAR;
 typedef struct rrdcalc RRDCALC;
 typedef struct rrdcalctemplate RRDCALCTEMPLATE;
 typedef struct alarm_entry ALARM_ENTRY;
-typedef struct context_param CONTEXT_PARAM;
 
 // forward declarations
 struct rrddim_volatile;
@@ -23,6 +22,13 @@ struct rrdeng_page_descr;
 struct rrdengine_instance;
 struct pg_cache_page_index;
 #endif
+
+#include <time.h>
+typedef struct context_param {
+    RRDDIM *rd;
+    time_t first_entry_t;
+    time_t last_entry_t;
+} CONTEXT_PARAM;
 
 #include "../daemon/common.h"
 #include "web/api/queries/query.h"

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -53,12 +53,6 @@
 extern void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
 extern void rrdr_buffer_print_format(BUFFER *wb, uint32_t format);
 
-typedef struct context_param {
-    RRDDIM *rd;
-    time_t first_entry_t;
-    time_t last_entry_t;
-} CONTEXT_PARAM;
-
 extern int rrdset2anything_api_v1(
           RRDSET *st
         , BUFFER *wb


### PR DESCRIPTION
Fixes #10106
##### Summary
Fix the compile error in centos 6 (when trying to use a forward `typedef structure` definition)

##### Component Name
database

##### Test Plan
- Compiling in centos 6 is now successful
