### PR TITLE
Added new data query option "allow_past"

### DIFF
--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -140,6 +140,17 @@
             }
           },
           {
+            "name": "context",
+            "in": "query",
+            "description": "The context of the chart as returned by the /charts call.",
+            "required": false,
+            "allowEmptyValue": false,
+            "schema": {
+              "type": "string",
+              "format": "as returned by /charts"
+            }
+          },
+          {
             "name": "dimension",
             "in": "query",
             "description": "Zero, one or more dimension ids or names, as returned by the /chart call, separated with comma or pipe. Netdata simple patterns are supported.",
@@ -156,7 +167,7 @@
           {
             "name": "after",
             "in": "query",
-            "description": "This parameter can either be an absolute timestamp specifying the starting point of the data to be returned, or a relative number of seconds (negative, relative to parameter: before). Netdata will assume it is a relative number if it is less that 3 years (in seconds). Netdata will adapt this parameter to the boundaries of the round robin database. The default is the beginning of the round robin database (i.e. by default netdata will attempt to return data for the entire database).",
+            "description": "This parameter can either be an absolute timestamp specifying the starting point of the data to be returned, or a relative number of seconds (negative, relative to parameter: before). Netdata will assume it is a relative number if it is less that 3 years (in seconds). If not specified the default is -600 seconds. Netdata will adapt this parameter to the boundaries of the round robin database unless the allow_past option is specified.",
             "required": true,
             "allowEmptyValue": false,
             "schema": {
@@ -273,7 +284,8 @@
                   "unaligned",
                   "match-ids",
                   "match-names",
-                  "showcustomvars"
+                  "showcustomvars",
+                  "allow_past"
                 ]
               },
               "default": [
@@ -478,7 +490,7 @@
               "oneOf": [
                 {
                   "type": "string",
-                  "enum" : [
+                  "enum": [
                     "green",
                     "brightgreen",
                     "yellow",
@@ -520,7 +532,7 @@
               "oneOf": [
                 {
                   "type": "string",
-                  "enum" : [
+                  "enum": [
                     "green",
                     "brightgreen",
                     "yellow",
@@ -551,7 +563,7 @@
               "oneOf": [
                 {
                   "type": "string",
-                  "enum" : [
+                  "enum": [
                     "green",
                     "brightgreen",
                     "yellow",
@@ -812,7 +824,7 @@
     "/alarms": {
       "get": {
         "summary": "Get a list of active or raised alarms on the server",
-        "description": "The alarms endpoint returns the list of all raised or enabled alarms on the Netdata agent. Called without any parameters, the raised alarms in state WARNING or CRITICAL are returned, the same response is delivered when \"?active\" is passed in the URL. By passing \"?all\", all the enabled alarms are returned.",
+        "description": "The alarms endpoint returns the list of all raised or enabled alarms on the netdata server. Called without any parameters, the raised alarms in state WARNING or CRITICAL are returned. By passing \"?all\", all the enabled alarms are returned.",
         "parameters": [
           {
             "name": "all",
@@ -852,7 +864,7 @@
     "/alarms_values": {
       "get": {
         "summary": "Get a list of active or raised alarms on the server",
-        "description": "The alarms endpoint returns the list of all raised or enabled alarms on the Netdata agent. Called without any parameters, the raised alarms in state WARNING or CRITICAL are returned, the same response is delivered when \"?active\" is passed in the URL. By passing \"?all\", all the enabled alarms are returned.",
+        "description": "The alarms_values endpoint returns the list of all raised or enabled alarms on the netdata server. Called without any parameters, the raised alarms in state WARNING or CRITICAL are returned. By passing \"?all\", all the enabled alarms are returned. This option output differs from `/alarms` in the number of variables delivered. This endpoint gives to user `id`, `value` and alarm `status`.",
         "parameters": [
           {
             "name": "all",

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -130,8 +130,8 @@
           {
             "name": "chart",
             "in": "query",
-            "description": "The id of the chart as returned by the /charts call.",
-            "required": true,
+            "description": "The id of the chart as returned by the /charts call. Note chart or context must be specified",
+            "required": false,
             "allowEmptyValue": false,
             "schema": {
               "type": "string",
@@ -142,7 +142,7 @@
           {
             "name": "context",
             "in": "query",
-            "description": "The context of the chart as returned by the /charts call.",
+            "description": "The context of the chart as returned by the /charts call. Note chart or context must be specified",
             "required": false,
             "allowEmptyValue": false,
             "schema": {
@@ -340,7 +340,7 @@
             "description": "Bad request - the body will include a message stating what is wrong."
           },
           "404": {
-            "description": "No chart with the given id is found."
+            "description": "Chart or context is not found. The supplied chart or context will be reported."
           },
           "500": {
             "description": "Internal server error. This usually means the server is out of memory."

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -108,6 +108,14 @@ paths:
             type: string
             format: as returned by /charts
             default: system.cpu
+        - name: context
+          in: query
+          description: The context of the chart as returned by the /charts call.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: string
+            format: as returned by /charts
         - name: dimension
           in: query
           description: Zero, one or more dimension ids or names, as returned by the /chart
@@ -125,11 +133,10 @@ paths:
           description: "This parameter can either be an absolute timestamp specifying the
             starting point of the data to be returned, or a relative number of
             seconds (negative, relative to parameter: before). Netdata will
-            assume it is a relative number if it is less that 3 years (in
-            seconds). Netdata will adapt this parameter to the boundaries of the
-            round robin database. The default is the beginning of the round
-            robin database (i.e. by default netdata will attempt to return data
-            for the entire database)."
+            assume it is a relative number if it is less that 3 years (in seconds).
+            If not specified the default is -600 seconds. Netdata will adapt this
+            parameter to the boundaries of the round robin database unless the allow_past
+            option is specified."
           required: true
           allowEmptyValue: false
           schema:
@@ -243,6 +250,7 @@ paths:
                 - match-ids
                 - match-names
                 - showcustomvars
+                - allow_past
             default:
               - seconds
               - jsonwrap

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -101,8 +101,8 @@ paths:
       parameters:
         - name: chart
           in: query
-          description: The id of the chart as returned by the /charts call.
-          required: true
+          description: The id of the chart as returned by the /charts call. Note chart or context must be specified
+          required: false
           allowEmptyValue: false
           schema:
             type: string
@@ -110,7 +110,7 @@ paths:
             default: system.cpu
         - name: context
           in: query
-          description: The context of the chart as returned by the /charts call.
+          description: The context of the chart as returned by the /charts call. Note chart or context must be specified
           required: false
           allowEmptyValue: false
           schema:
@@ -293,7 +293,7 @@ paths:
         "400":
           description: Bad request - the body will include a message stating what is wrong.
         "404":
-          description: No chart with the given id is found.
+          description: Chart or context is not found. The supplied chart or context will be reported.
         "500":
           description: Internal server error. This usually means the server is out of
             memory.

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1566,8 +1566,6 @@ RRDR *rrd2rrdr(
     int rrd_update_every;
     int absolute_period_requested;
 
-//    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
-
     time_t first_entry_t;
     time_t last_entry_t;
     if (context_param_list) {

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -740,6 +740,7 @@ static int rrdr_convert_before_after_to_absolute(
         , int update_every
         , time_t first_entry_t
         , time_t last_entry_t
+        , RRDR_OPTIONS options
 ) {
     int absolute_period_requested = -1;
     long long after_requested, before_requested;
@@ -785,10 +786,12 @@ static int rrdr_convert_before_after_to_absolute(
 
     // make sure they are within our timeframe
     if(before_requested > last_entry_t)  before_requested = last_entry_t;
-    if(before_requested < first_entry_t) before_requested = first_entry_t;
+    if(before_requested < first_entry_t && !(options & RRDR_OPTION_ALLOW_PAST))
+        before_requested = first_entry_t;
 
     if(after_requested > last_entry_t)  after_requested = last_entry_t;
-    if(after_requested < first_entry_t) after_requested = first_entry_t;
+    if(after_requested < first_entry_t && !(options & RRDR_OPTION_ALLOW_PAST))
+        after_requested = first_entry_t;
 
     // check if they are reversed
     if(after_requested > before_requested) {
@@ -1579,7 +1582,11 @@ RRDR *rrd2rrdr(
     rrd_update_every = st->update_every;
     absolute_period_requested = rrdr_convert_before_after_to_absolute(&after_requested, &before_requested,
                                                                       rrd_update_every, first_entry_t,
-                                                                      last_entry_t);
+                                                                      last_entry_t, options);
+    if (options & RRDR_OPTION_ALLOW_PAST)
+        if (first_entry_t > after_requested)
+            first_entry_t = after_requested;
+
 #ifdef ENABLE_DBENGINE
     if (st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
         struct rrdeng_region_info *region_info_array;
@@ -1595,7 +1602,7 @@ RRDR *rrd2rrdr(
                     /* recalculate query alignment */
                     absolute_period_requested =
                             rrdr_convert_before_after_to_absolute(&after_requested, &before_requested, rrd_update_every,
-                                                                  first_entry_t, last_entry_t);
+                                                                  first_entry_t, last_entry_t, options);
                 }
                 freez(region_info_array);
             }
@@ -1608,7 +1615,7 @@ RRDR *rrd2rrdr(
                 /* recalculate query alignment */
                 absolute_period_requested = rrdr_convert_before_after_to_absolute(&after_requested, &before_requested,
                                                                                   rrd_update_every, first_entry_t,
-                                                                                  last_entry_t);
+                                                                                  last_entry_t, options);
             }
             return rrd2rrdr_variablestep(st, points_requested, after_requested, before_requested, group_method,
                                          resampling_time_requested, options, dimensions, rrd_update_every,

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -23,6 +23,7 @@ typedef enum rrdr_options {
     RRDR_OPTION_MATCH_IDS    = 0x00004000, // when filtering dimensions, match only IDs
     RRDR_OPTION_MATCH_NAMES  = 0x00008000, // when filtering dimensions, match only names
     RRDR_OPTION_CUSTOM_VARS  = 0x00010000, // when wraping response in a JSON, return custom variables in response
+    RRDR_OPTION_ALLOW_PAST   = 0x00020000, // The after parameter can extend in the past before the first entry
 } RRDR_OPTIONS;
 
 typedef enum rrdr_value_flag {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -35,6 +35,7 @@ static struct {
         , {"match_names"     , 0    , RRDR_OPTION_MATCH_NAMES}
         , {"match-names"     , 0    , RRDR_OPTION_MATCH_NAMES}
         , {"showcustomvars"  , 0    , RRDR_OPTION_CUSTOM_VARS}
+        , {"allow_past"      , 0    , RRDR_OPTION_ALLOW_PAST}
         , {                  NULL, 0, 0}
 };
 


### PR DESCRIPTION
##### Summary
Adds a new query option `allow_past` for the data endpoint that will allow the after parameter to extend before the first timestamp stored.  The entries that do not exist will be returned as null

##### Component Name
database

##### Test Plan
- Start agent will no history (e.g. if using dbengine memory mode, delete the dbengine files)
- Run a query such as: 
  `/api/v1/data?chart=system.cpu`
  - This should return just a few entries (the number of seconds the agent is up and running)
- Run the query 
  `/api/v1/data?chart=system.cpu&options=allow_past`
   - You should get 600 entries returned, most of them null
