### PR TITLE
Fix platform dependent printf format

### DIFF
--- a/collectors/perf.plugin/perf_plugin.c
+++ b/collectors/perf.plugin/perf_plugin.c
@@ -422,7 +422,7 @@ static int perf_collect() {
             }
         }
 
-        if(unlikely(debug)) fprintf(stderr, "perf.plugin: successfully read event id = %u, value = %lu\n", current_event->id, current_event->value);
+        if(unlikely(debug)) fprintf(stderr, "perf.plugin: successfully read event id = %u, value = %"PRIu64"\n", current_event->id, current_event->value);
     }
 
     if(unlikely(perf_events[EV_ID_CPU_CYCLES].value == prev_cpu_cycles_value))

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -191,7 +191,7 @@ struct slabinfo *read_file_slabinfo() {
     slabdebug("   Read %lu lines from procfile", (unsigned long)lines);
     for(l = 2; l < lines; l++) {
         if (unlikely(procfile_linewords(ff, l) < 14)) {
-            slabdebug("    Line %lu has only %lu words, skipping", (unsigned long)l, procfile_linewords(ff,l));
+            slabdebug("    Line %zu has only %lu words, skipping", l, procfile_linewords(ff,l));
             continue;
         }
 
@@ -231,7 +231,7 @@ struct slabinfo *read_file_slabinfo() {
         else
             s->obj_filling = 0;
 
-        slabdebug("    Updated slab %s: %lu %lu %lu %lu %lu / %lu %lu %lu / %lu %lu %lu / %lu %lu %hhu",
+        slabdebug("    Updated slab %s: %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" / %"PRIu64" %"PRIu64" %"PRIu64" / %"PRIu64" %"PRIu64" %"PRIu64" / %"PRIu64" %"PRIu64" %hhu",
             name, s->active_objs, s->num_objs, s->obj_size, s->obj_per_slab, s->pages_per_slab,
             s->tune_limit, s->tune_batchcnt, s->tune_shared_factor,
             s->data_active_slabs, s->data_num_slabs, s->data_shared_avail,
@@ -304,7 +304,7 @@ unsigned int do_slab_stats(int update_every) {
             , "slabmemory"
         );
         for (s = sactive; s; s = s->next) {
-            printf("SET %s = %lu\n"
+            printf("SET %s = %"PRIu64"\n"
                 , s->name
                 , s->mem_usage
             );
@@ -334,7 +334,7 @@ unsigned int do_slab_stats(int update_every) {
             , "slabwaste"
         );
         for (s = sactive; s; s = s->next) {
-            printf("SET %s = %lu\n"
+            printf("SET %s = %"PRIu64"\n"
                 , s->name
                 , s->mem_waste
             );

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -163,12 +163,12 @@ struct slabinfo *read_file_slabinfo() {
     slabdebug("-> Reading procfile %s", PLUGIN_SLABINFO_PROCFILE);
 
     static procfile *ff = NULL;
-	static long slab_pagesize = 0;
+    static long slab_pagesize = 0;
 
-	if (unlikely(!slab_pagesize)) {
-		slab_pagesize = sysconf(_SC_PAGESIZE);
-		slabdebug("   Discovered pagesize: %ld", slab_pagesize);
-	}
+    if (unlikely(!slab_pagesize)) {
+        slab_pagesize = sysconf(_SC_PAGESIZE);
+        slabdebug("   Discovered pagesize: %ld", slab_pagesize);
+    }
 
     if(unlikely(!ff)) {
         ff = procfile_reopen(ff, PLUGIN_SLABINFO_PROCFILE, " ,:" , PROCFILE_FLAG_DEFAULT);

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -191,7 +191,7 @@ struct slabinfo *read_file_slabinfo() {
     slabdebug("   Read %lu lines from procfile", (unsigned long)lines);
     for(l = 2; l < lines; l++) {
         if (unlikely(procfile_linewords(ff, l) < 14)) {
-            slabdebug("    Line %zu has only %"PRIu64" words, skipping", l, procfile_linewords(ff,l));
+            slabdebug("    Line %zu has only %zu words, skipping", l, procfile_linewords(ff,l));
             continue;
         }
 

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -191,7 +191,7 @@ struct slabinfo *read_file_slabinfo() {
     slabdebug("   Read %lu lines from procfile", (unsigned long)lines);
     for(l = 2; l < lines; l++) {
         if (unlikely(procfile_linewords(ff, l) < 14)) {
-            slabdebug("    Line %zu has only %lu words, skipping", l, procfile_linewords(ff,l));
+            slabdebug("    Line %zu has only %"PRIu64" words, skipping", l, procfile_linewords(ff,l));
             continue;
         }
 


### PR DESCRIPTION
##### Summary
When adding debug calls, some printf formats (like uint64_t) are arch-dependent. On a 32bits, a uint64_t is "unsigned long long unsigned int", so expects %llu instead of %lu.
These different formats are set in `<inttypes.h>` and explained here: https://en.cppreference.com/w/cpp/types/integer 

This PR does the following changes:

- `size_t` => `%zu`
- `uint64_t` => `%"PRIu64"`

Fixes #10086 

##### Component Name

slabinfo.plugin

##### Test Plan

Standard compilation flags (-Wformat)

##### Additional Information
