### PR TITLE
Update proc_net_snmp.c

### DIFF
--- a/collectors/proc.plugin/proc_net_snmp.c
+++ b/collectors/proc.plugin/proc_net_snmp.c
@@ -998,7 +998,7 @@ int do_proc_net_snmp(int update_every, usec_t dt) {
                     rrdset_flag_set(st, RRDSET_FLAG_DETAIL);
 
                     rd_RcvbufErrors = rrddim_add(st, "RcvbufErrors", NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
-                    rd_SndbufErrors = rrddim_add(st, "SndbufErrors", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+                    rd_SndbufErrors = rrddim_add(st, "SndbufErrors", NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
                     rd_InErrors     = rrddim_add(st, "InErrors",     NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
                     rd_NoPorts      = rrddim_add(st, "NoPorts",      NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
                     rd_InCsumErrors = rrddim_add(st, "InCsumErrors", NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);


### PR DESCRIPTION
I believe the -1 was the wrong multiplier. Also as the dimensions represent different errors the default chart type should be changed to stacked.

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
