### PR TITLE
Remove usage of deprecated GHA syntax.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Verify & Set distfile
         run: |
           ls -lah netdata-*.tar.gz
-          echo "::set-env name=DISTFILE::$(ls netdata-*.tar.gz)"
+          echo "DISTFILE=$(ls netdata-*.tar.gz)" >> $GITHUB_ENV
       - name: Run run_install_with_dist_file.sh
         run: |
           ./.github/scripts/run_install_with_dist_file.sh "${DISTFILE}"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check files
         run: |
           if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '*\.js|node\.d\.plugin\.in' ; then
-            echo ::set-env name=run_eslint::1
+            echo 'run_eslint=1' >> $GITHUB_ENV
           fi
       - name: Run eslint
         if: env.run_eslint == 1
@@ -40,7 +40,7 @@ jobs:
       - name: Check files
         run: |
           if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '*\.sh.*' ; then
-            echo ::set-env name=run_shellcheck::1
+            echo 'run_shellcheck=1' >> $GITHUB_ENV
           fi
       - name: Run shellcheck
         if: env.run_shellcheck == 1
@@ -63,7 +63,7 @@ jobs:
       - name: Check files
         run: |
           if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '*\.ya?ml|python\.d/.*\.conf' ; then
-            echo ::set-env name=run_yamllint::1
+            echo 'run_yamllint=1' >> $GITHUB_ENV
           fi
       - name: Run yamllint
         if: env.run_yamllint == 1


### PR DESCRIPTION
##### Summary

See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ for details on the change.

##### Component Name

area/ci

##### Test Plan

CI checks still pass correctly.