### PR TITLE
Hangout thread

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -374,6 +374,7 @@ IRC_NETWORK=
 
 # hangouts configs
 declare -A HANGOUTS_WEBHOOK_URI
+declare -A HANGOUTS_WEBHOOK_THREAD
 
 # dynatrace configs
 DYNATRACE_SPACE=

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1886,7 +1886,7 @@ send_sms() {
 # hangouts sender
 
 send_hangouts() {
-	local rooms="${1}" httpcode sent=0 room color payload webhook
+	local rooms="${1}" httpcode sent=0 room color payload webhook thread
 
 	[ "${SEND_HANGOUTS}" != "YES" ] && return 1
 
@@ -1901,6 +1901,9 @@ send_hangouts() {
 		if [ -z "${HANGOUTS_WEBHOOK_URI[$room]}" ] ; then
 			info "Can't send Hangouts notification for: ${host} ${chart}.${name} to room ${room}. HANGOUTS_WEBHOOK_URI[$room] not defined"
 		else
+			if [ -n "${HANGOUTS_WEBHOOK_THREAD[$room]}" ]; then
+				thread="\"name\" : \"${HANGOUTS_WEBHOOK_THREAD[$room]}\""
+			fi
 			webhook="${HANGOUTS_WEBHOOK_URI[$room]}"
 			payload="$(
 				cat <<EOF
@@ -1967,7 +1970,10 @@ send_hangouts() {
 								}
 							]
 						}
-					]
+					],
+					"thread": {
+						$thread
+					}
 				}
 EOF
 				)"

--- a/health/notifications/hangouts/README.md
+++ b/health/notifications/hangouts/README.md
@@ -19,6 +19,11 @@ https://developers.google.com/hangouts/chat/how-tos/webhooks
 
 Set the webhook URIs and room names in `health_alarm_notify.conf`. To edit it on your system, run `/etc/netdata/edit-config health_alarm_notify.conf`):
 
+## Threads (optional)
+
+Instead to receive alarms on different threads, Netdata allows you to concentrate them inside an unique thread when
+the variable `HANGOUTS_WEBHOOK_THREAD[NAME]` is set. 
+
 ```
 #------------------------------------------------------------------------------
 # hangouts (google hangouts chat) global notification options
@@ -30,6 +35,8 @@ SEND_HANGOUTS="YES"
 # HANGOUTS_WEBHOOK_URI[ROOM_NAME]="URLforroom1"
 HANGOUTS_WEBHOOK_URI[systems]="https://chat.googleapis.com/v1/spaces/AAAAXXXXXXX/..."
 HANGOUTS_WEBHOOK_URI[development]="https://chat.googleapis.com/v1/spaces/AAAAYYYYY/..."
+# On Hangouts, copy a thread link and change the values for space and thread
+# HANGOUTS_WEBHOOK_THREAD[systems]="spaces/AAAAXXXXXXX/threads/XXXXXXXXXXX"
 # if a DEFAULT_RECIPIENT_HANGOUTS are not configured,
 # notifications wouldn't be send to hangouts rooms.
 # DEFAULT_RECIPIENT_HANGOUTS="systems development|critical"

--- a/health/notifications/hangouts/README.md
+++ b/health/notifications/hangouts/README.md
@@ -7,7 +7,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/health/notificat
 
 # Send notifications to Google Hangouts
 
-[Google Hangouts](https://hangouts.google.com/) is cross-platform messaging app developed by Google. You can configure
+[Google Hangouts](https://hangouts.google.com/) is a cross-platform messaging app developed by Google. You can configure
 Netdata to send alarm notifications to a Hangouts room in order to stay aware of possible health or performance issues
 on your nodes. Here's an example of the notification in action:
 

--- a/health/notifications/hangouts/README.md
+++ b/health/notifications/hangouts/README.md
@@ -1,28 +1,33 @@
 <!--
----
-title: "Hangouts Chat"
+title: "Send notifications to Google Hangouts"
+description: "Send alerts to Send notifications to Google Hangouts any time an anomaly or performance issue strikes a node in your infrastructure."
+sidebar_label: "Google Hangouts"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/health/notifications/hangouts/README.md
----
 -->
 
-# Hangouts Chat
+# Send notifications to Google Hangouts
 
-This is what you will get:
+[Google Hangouts](https://hangouts.google.com/) is cross-platform messaging app developed by Google. You can configure
+Netdata to send alarm notifications to a Hangouts room in order to stay aware of possible health or performance issues
+on your nodes. Here's an example of the notification in action:
+
 ![Netdata on Hangouts](https://user-images.githubusercontent.com/1153921/66427166-47de6900-e9c8-11e9-8322-b4b03f084dc1.png)
+
 To receive notifications in Google Hangouts, you need the following in your Hangouts setup:
 
-1. One or more rooms
-2. An **incoming webhook** for each room
+1.   One or more rooms.
+2.   An **incoming webhook** for each room.
 
-How to create an incoming webhook: 
-https://developers.google.com/hangouts/chat/how-tos/webhooks
+Follow [Google's documentation](https://developers.google.com/hangouts/chat/how-tos/webhooks) to create an incoming
+webhook for each room you want to send Netdata notifications to.
 
-Set the webhook URIs and room names in `health_alarm_notify.conf`. To edit it on your system, run `/etc/netdata/edit-config health_alarm_notify.conf`):
+Set the webhook URIs and room names in `health_alarm_notify.conf`. To edit it on your system, run
+`/etc/netdata/edit-config health_alarm_notify.conf`):
 
 ## Threads (optional)
 
-Instead to receive alarms on different threads, Netdata allows you to concentrate them inside an unique thread when
-the variable `HANGOUTS_WEBHOOK_THREAD[NAME]` is set. 
+Instead to receive alarms on different threads, Netdata allows you to concentrate them inside an unique thread when you
+set the variable `HANGOUTS_WEBHOOK_THREAD[NAME]`.
 
 ```
 #------------------------------------------------------------------------------
@@ -42,6 +47,9 @@ HANGOUTS_WEBHOOK_URI[development]="https://chat.googleapis.com/v1/spaces/AAAAYYY
 # DEFAULT_RECIPIENT_HANGOUTS="systems development|critical"
 DEFAULT_RECIPIENT_HANGOUTS="sysadmin devops alarms|critical"
 ```
+
 You can define multiple rooms like this: `sysadmin devops alarms|critical`.
 
-The keywords `sysadmin`, `devops` and `alarms` are Hangouts rooms.
+The keywords `sysadmin`, `devops`, and `alarms` are Hangouts rooms.
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fhealth%2Fnotifications%2Fhangouts%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)


### PR DESCRIPTION
##### Summary
Fixes #9784 
Fixes #9785 

This PR brings a new feature for Hangout notification.
##### Component Name
Health
##### Test Plan
1 - Create a room on Hangout.
2 - Create a webhook.
3 - Inside the room, create a specific thread and copy the link
4 - Configure the `healt_alarm_notify.conf` file :

```
SEND_HANGOUTS="YES"
HANGOUTS_WEBHOOK_URI[Alarms]="https://chat.googleapis.com/v1/spaces/AAAAxxxxxxx/messages?key=XXXXX&token=XXXXX"
#HANGOUTS_WEBHOOK_THREAD[Alarms]="spaces/XXXXXXXXX/threads/YYYYYYY"
DEFAULT_RECIPIENT_HANGOUTS="Alarms"
```

for the first test, we will keep the  variable `HANGOUTS_WEBHOOK_THREAD[Alarms]` commented.

4 - Run the following commands:

```
$ cd /usr/libexec/netdata/plugins.d/
$ ./alarm-notfy.sh test
```

the final result will be:

![independent](https://user-images.githubusercontent.com/49162938/97582354-8db00a00-19ed-11eb-866d-3f0a01e13f07.png)

5 - Uncoment the line `HANGOUTS_WEBHOOK_THREAD[Alarms]="spaces/XXXXXXXXX/threads/YYYYYYY"` and run again:

```
$ ./alarm-notfy.sh test
```

The expected result is:

![together](https://user-images.githubusercontent.com/49162938/97582542-cbad2e00-19ed-11eb-9308-55dc35574423.png)

##### Additional Information
