### PR TITLE
Fixed two bugs related to version handling in install and update code.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -917,6 +917,18 @@ if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata-switch-dashboard.sh" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# By default, `git` does not update local tags based on remotes. Because
+# we use the most recent tag as part of our version determination in
+# our build, this can lead to strange versions that look ancient but are
+# actually really recent. To avoid this, try and fetch tags if we're
+# working in a git checkout.
+if [ -d ./.git ] ; then
+  echo >&2
+  progress "Updating tags in git to ensure a consistent version number"
+  run git fetch <remote> 'refs/tags/*:refs/tags/*' || true
+fi
+
+# -----------------------------------------------------------------------------
 echo >&2
 progress "Run autotools to configure the build environment"
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -133,7 +133,7 @@ parse_version() {
   fi
 
   read -r -a pp <<< "$(echo "${v}" | tr '.' ' ')"
-  printf "%03d%03d%03d%03d" "${pp[0]}" "${pp[1]}" "${pp[2]}" "${b}"
+  printf "%03d%03d%03d%05d" "${pp[0]}" "${pp[1]}" "${pp[2]}" "${b}"
 }
 
 get_latest_version() {


### PR DESCRIPTION
##### Summary

This fixes two issues with our version handling code:

* Due to how `git` handles tags, we can end up with ancient looking version numbers like `v1.11.1-2915-g6106dd7` that are actually quite recent copies of the code (the above example is actually from shortly before the v1.22.0 release). This can be mitigated by ensuring we have up-to-date tags in the local git repository we are building from, and this PR updates `netdata-installer.sh` to do this if it detects that it is running in a `git` repo.
* The version comparison code in the `netdata-updater.sh` script only allows for 3 digits worth of commits in the version string. This works fine, until the installed version is at least 1000 commits beyond the reference tag for the version, at which point it causes the user to get stuck on the older version. This PR increases the number of digits used for commit counts from 3 to 5, allowing for 9999 commits before the same issue happens again. It’s essentially a stopgap (a proper fix would require redesigning the version comparison code to compare individual version components, which would result in a far more complex and harder to maintain script), but it should be sufficient to reduce the possibility of the bug happening to a statistical impossibility.

##### Component Name

area/packaging

##### Test Plan

Confirmed the git tag handling fix locally by wiping out tags in a checked out repo and verifying that running `netdata-installer.sh` still produces a build with a correct version number.

Confirmed the updater version check fix by manually manipulating version numbers to produce the condition required to trigger the bug.

##### Additional Information

Credit to @ktsaou for uncovering both of these bugs.

@cakrit, @OdysLam The combination of these two bugs may be a partial cause of users stuck on older versions. The thing to look for to check is older base versions combined with 4-digit or larger number after the first dash in the version string. I suspect it will only be a handful of cases though, as the installation workflow that leads to this situation is relatively uncommon for users who are not developers. Once this PR is merged, they should end up with the newest version next time they run the updater.