### PR TITLE
add explicit example of how to get to netdata.conf and open it in edi…

### DIFF
--- a/docs/guides/longer-metrics-storage.md
+++ b/docs/guides/longer-metrics-storage.md
@@ -27,6 +27,12 @@ larger dataset than your system's available RAM.
 The database engine is currently the default method of storing metrics, but if you're not sure which database you're
 using, check out your `netdata.conf` file and look for the `memory mode` setting:
 
+```bash
+# navigate to and open your netdata.conf file to make changes if needed
+cd /etc/netdata/
+sudo ./edit-config netdata.conf
+```
+
 ```conf
 [global]
     memory mode = dbengine


### PR DESCRIPTION
…t mode

This may be overkill but assuming this is one place a lot of new people will look i was wondering if worth explicitly adding step of how to get in and open netdata.conf in edit mode. 

Totally ok if you think this add's more noise than is worth. Just that one thing always struck me was everywhere we say "just edit netdata.conf" but for like the first few months that basically meant me opening up another chrome tab and searching for "edit netdata.conf" until it just came naturally for me to just do:

```bash
cd /etc/netdata/
sudo ./edit-config netdata.conf
```

##### Summary

##### Component Name

docs

##### Test Plan

##### Additional Information
