### PR TITLE
Fix an infinite loop in the statsd plugin

### DIFF
--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -698,7 +698,10 @@ static inline size_t statsd_process(char *buffer, size_t size, int require_newli
 
         s = name_end = (char *)statsd_parse_skip_up_to(name = s, ':', '|');
         if(name == name_end) {
-            s = statsd_parse_skip_spaces(s);
+            if (*s) {
+                s++;
+                s = statsd_parse_skip_spaces(s);
+            }
             continue;
         }
 


### PR DESCRIPTION
##### Summary
Fixes #10176

##### Component Name
statsd plugin

##### Test Plan
1) Insert `strcpy(buffer, ":");` in https://github.com/netdata/netdata/blob/master/collectors/statsd.plugin/statsd.c#L693
2) Run `echo "test:1|c" | nc -u localhost 8125`
3) Check if there is no infinite loop.