### PR TITLE
Don't cache registry responses

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -652,6 +652,9 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
     int redirects = 0;
 */
 
+	// Don't cache registry responses
+    buffer_no_cacheable(w->response.data);
+
     while(url) {
         char *value = mystrsep(&url, "&");
         if (!value || !*value) continue;


### PR DESCRIPTION
##### Summary

Stop caching responses from the registry, in order to correctly record machine and person GUIDs

##### Component Name

web

##### Test Plan

Verify that the registry doesn't cache responses (`expires` header is lower than 1 day in the future).


