### PR TITLE
Remove knatsakis from makefile code ownership.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,7 +43,7 @@ web/ @thiagoftsm @mfundul @vlvkobal
 web/gui/ @jacekkolasa
 
 # Ownership by filetype (overwrites ownership by directory)
-*.am @Ferroin @knatsakis
+*.am @Ferroin
 *.md @joelhans
 Dockerfile* @Ferroin @knatsakis
 


### PR DESCRIPTION
##### Summary

Based on discussion with him, he’s not readily able to review changes here, and the only changes I would be doing can be reviewed by the agent team (or would involve other changes that would pull him in anyway), so there’s not point in having him listed for review on them.

##### Component Name

area/ci

##### Test Plan

n/a