### PR TITLE
netdata.service: unbreak Samba plugin

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -64,6 +64,8 @@ CapabilityBoundingSet=CAP_NET_RAW
 CapabilityBoundingSet=CAP_SYS_CHROOT
 # is required for nfacct plugin (bandwidth accounting)
 CapabilityBoundingSet=CAP_NET_ADMIN
+# is required for plugins that use sudo
+CapabilityBoundingSet=CAP_SETGID CAP_SETUID
 
 # Sandboxing
 ProtectSystem=full


### PR DESCRIPTION
This is related to #9640. The samba plugin fails its check, being unable to run `/usr/bin/sudo /usr/bin/smbstatus -P`. 

I modified `ExecutableService.py` to print the stdout/stderr from the command:
> 2020-11-04 23:36:54: python.d ERROR: samba[samba] : cmd: '['/usr/bin/sudo', '-n', '-l', '/usr/bin/smbstatus', '-P']', stdout: '', stderr: 'sudo: unable to change to root gid: Operation not permitted'

Note that I can run this manually as the netdata user:
```
# su -s /bin/bash - netdata
[netdata@elbereth /]$ /usr/bin/sudo -n -l /usr/bin/smbstatus -P
/usr/bin/smbstatus -P
```

The `CapabilityBoundingSet` in the systemd service doesn't have sufficient capabilities for sudo:
```
# Capabilities
# is required for freeipmi and slabinfo plugins
CapabilityBoundingSet=CAP_DAC_OVERRIDE
# is required for apps plugin
CapabilityBoundingSet=CAP_DAC_READ_SEARCH
# is required for freeipmi plugin
CapabilityBoundingSet=CAP_FOWNER
# is required for apps, perf and slabinfo plugins
CapabilityBoundingSet=CAP_SETPCAP
# is required for perf plugin
CapabilityBoundingSet=CAP_SYS_ADMIN
# is required for apps plugin
CapabilityBoundingSet=CAP_SYS_PTRACE
# is required for ebpf plugin
CapabilityBoundingSet=CAP_SYS_RESOURCE
# is required for fping app
CapabilityBoundingSet=CAP_NET_RAW
# is required for cgroups plugin
CapabilityBoundingSet=CAP_SYS_CHROOT
```
If I add this, it starts working:
```
# is required for samba plugin
CapabilityBoundingSet=CAP_SETGID CAP_SETUID  
```
