### PR TITLE
Fixed bug in auto-updater for FreeBSD (#10198)

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -256,7 +256,7 @@ done
 # But only we're not a controlling terminal (tty)
 # Randomly sleep between 1s and 60m
 if [ ! -t 1 ] && [ -z "${NETDATA_NOT_RUNNING_FROM_CRON}" ]; then
-  sleep $(((RANDOM % 3600) + 1))s
+    sleep $(((RANDOM % 3600) + 1))
 fi
 
 # Usually stored in /etc/netdata/.environment


### PR DESCRIPTION
**Summary**

Fixes bug in auto-updater for FreeBSD systems (like FreeNAS/TrueNAS) #10198 

The netdata-updater.sh script which is used to automatically check for new versions of Netdata and install them if necessary
did not work in my TrueNAS jail (based on FreeBSD).

Problem is the RANDOM function which does not work in FreeBSD.
Build an extra check if running on FreeBSD system to use another method for the RANDOM function on FreeBSD.

**Component Name**

area/packaging

**Test plan**

Installed an older version of Netdata (v1.25) and ran the 'periodic daily' command to force the daily cron jobs to execute and checked if Netdata was automatically upgraded to latest version (v1.26 at time of writing).
All seemed to work fine.

**Additional Information**

@Ferroin  This is my first PR ever on Github so if i did anything wrong please let me know.

Fixes: #10198 