### PR TITLE
Fix coverity issues

### DIFF
--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -118,6 +118,9 @@ void simple_connector_init(struct instance *instance)
     if (connector_specific_data->first_buffer)
         return;
 
+    connector_specific_data->header = buffer_create(0);
+    connector_specific_data->buffer = buffer_create(0);
+
     // create a ring buffer
     struct simple_connector_buffer *first_buffer = NULL;
 

--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -115,6 +115,9 @@ void simple_connector_init(struct instance *instance)
     struct simple_connector_data *connector_specific_data =
         (struct simple_connector_data *)instance->connector_specific_data;
 
+    if (connector_specific_data->first_buffer)
+        return;
+
     // create a ring buffer
     struct simple_connector_buffer *first_buffer = NULL;
 

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -609,6 +609,8 @@ static void test_simple_connector_worker(void **state)
     instance->connector_specific_data = simple_connector_data;
     simple_connector_data->last_buffer = callocz(1, sizeof(struct simple_connector_buffer));
     simple_connector_data->first_buffer = simple_connector_data->last_buffer;
+    simple_connector_data->header = buffer_create(0);
+    simple_connector_data->buffer = buffer_create(0);
     simple_connector_data->last_buffer->header = buffer_create(0);
     simple_connector_data->last_buffer->buffer = buffer_create(0);
 


### PR DESCRIPTION
##### Summary
```
** CID 363765:  Null pointer dereferences  (FORWARD_NULL)
/exporting/init_connectors.c: 135 in simple_connector_init()


________________________________________________________________________________________________________
*** CID 363765:  Null pointer dereferences  (FORWARD_NULL)
/exporting/init_connectors.c: 135 in simple_connector_init()
129             else
130                 current_buffer->next = connector_specific_data->first_buffer;
131     
132             connector_specific_data->first_buffer = current_buffer;
133         }
134     
>>>     CID 363765:  Null pointer dereferences  (FORWARD_NULL)
>>>     Dereferencing null pointer "first_buffer".
135         first_buffer->next = connector_specific_data->first_buffer;
136         connector_specific_data->last_buffer = connector_specific_data->first_buffer;
137     
138         return;

** CID 363764:  Resource leaks  (RESOURCE_LEAK)
/exporting/send_data.c: 443 in simple_connector_worker()


________________________________________________________________________________________________________
*** CID 363764:  Resource leaks  (RESOURCE_LEAK)
/exporting/send_data.c: 443 in simple_connector_worker()
437     #if ENABLE_PROMETHEUS_REMOTE_WRITE
438         if (instance->config.type == EXPORTING_CONNECTOR_TYPE_PROMETHEUS_REMOTE_WRITE)
439             clean_prometheus_remote_write(instance);
440     #endif
441     
442         simple_connector_cleanup(instance);
>>>     CID 363764:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "spare_header" going out of scope leaks the storage it points to.

** CID 363763:  Resource leaks  (RESOURCE_LEAK)
/exporting/send_data.c: 443 in simple_connector_worker()


________________________________________________________________________________________________________
*** CID 363763:  Resource leaks  (RESOURCE_LEAK)
/exporting/send_data.c: 443 in simple_connector_worker()
437     #if ENABLE_PROMETHEUS_REMOTE_WRITE
438         if (instance->config.type == EXPORTING_CONNECTOR_TYPE_PROMETHEUS_REMOTE_WRITE)
439             clean_prometheus_remote_write(instance);
440     #endif
441     
442         simple_connector_cleanup(instance);
>>>     CID 363763:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "spare_buffer" going out of scope leaks the storage it points to.
```

##### Component Name
exporting engine