### PR TITLE
Don't stop Prometheus remote write collector when data is not available for dimension formatting

### DIFF
--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -242,7 +242,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                     (unsigned long)rd->last_collected_time.tv_sec,
                     (unsigned long)instance->after,
                     (unsigned long)instance->before);
-                return 1;
+                return 0;
             }
 
             if (homogeneous) {


### PR DESCRIPTION
##### Summary
If `data source = as collected` and there is no data available, Prometheus remote write collector stops with the following error
```
/var/log/netdata/error.log:2020-10-29 13:58:54: netdata ERROR : EXPORTING : EXPORTING: cannot format metric for victoria_metrics
```
The connector should continue processing data instead of exiting.

Fixes #10152

##### Component Name
exporting engine