### PR TITLE
Fix chart filtering

### DIFF
--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -8,7 +8,7 @@
 // /api/v1/allmetrics?format=prometheus and /api/v1/allmetrics?format=prometheus_all_hosts
 
 /**
- * Check if a chart can be sent to an external databese
+ * Check if a chart can be sent to Prometheus
  *
  * @param instance an instance data structure.
  * @param st a chart.

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -191,19 +191,17 @@ int format_chart_prometheus_remote_write(struct instance *instance, RRDSET *st)
     prometheus_label_copy(family, st->family, PROMETHEUS_ELEMENT_MAX);
     prometheus_name_copy(context, st->context, PROMETHEUS_ELEMENT_MAX);
 
-    if (likely(can_send_rrdset(instance, st))) {
-        as_collected = (EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_AS_COLLECTED);
-        homogeneous = 1;
-        if (as_collected) {
-            if (rrdset_flag_check(st, RRDSET_FLAG_HOMOGENEOUS_CHECK))
-                rrdset_update_heterogeneous_flag(st);
+    as_collected = (EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_AS_COLLECTED);
+    homogeneous = 1;
+    if (as_collected) {
+        if (rrdset_flag_check(st, RRDSET_FLAG_HOMOGENEOUS_CHECK))
+            rrdset_update_heterogeneous_flag(st);
 
-            if (rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS))
-                homogeneous = 0;
-        } else {
-            if (EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_AVERAGE)
-                prometheus_units_copy(units, st->units, PROMETHEUS_ELEMENT_MAX, 0);
-        }
+        if (rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS))
+            homogeneous = 0;
+    } else {
+        if (EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_AVERAGE)
+            prometheus_units_copy(units, st->units, PROMETHEUS_ELEMENT_MAX, 0);
     }
 
     return 0;

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -64,7 +64,7 @@ void simple_connector_receive_response(int *sock, struct instance *instance)
 {
     static BUFFER *response = NULL;
     if (!response)
-        response = buffer_create(1);
+        response = buffer_create(4096);
 
     struct stats *stats = &instance->stats;
 #ifdef ENABLE_HTTPS
@@ -79,8 +79,6 @@ void simple_connector_receive_response(int *sock, struct instance *instance)
 
     // loop through to collect all data
     while (*sock != -1 && errno != EWOULDBLOCK) {
-        buffer_need_bytes(response, 4096);
-
         ssize_t r;
 #ifdef ENABLE_HTTPS
         if (exporting_tls_is_enabled(instance->config.type, options) &&


### PR DESCRIPTION
##### Summary
When chart filtering is configured for both, the Prometheus Web API and a Prometheus remote write connector instance, the Web API adds charts that are configured in a `prometheus_remote_write` section to its own filter.

Related: #10057

##### Component Name
exporting engine

##### Test Plan
Configure chart filtering for the Prometheus Web API and for a Prometheus remote write connector instance. Check that `http://localhost:19999/api/v1/allmetrics?format=prometheus` doesn't return charts, configured for the Prometheus remote write instance.