### PR TITLE
health: convert `elasticsearch_last_collected` alarm to template

### DIFF
--- a/health/health.d/elasticsearch.conf
+++ b/health/health.d/elasticsearch.conf
@@ -1,5 +1,8 @@
-   alarm: elasticsearch_last_collected
-      on: elasticsearch_local.cluster_health_status
+
+# make sure elasticsearch is running
+
+template: elasticsearch_last_collected
+      on: elasticsearch.cluster_health_status
     calc: $now - $last_collected_t
    units: seconds ago
    every: 10s


### PR DESCRIPTION
##### Summary

SSIA. Alarm is wrong - `_local` suffix is a job name 😅 

##### Component Name

`health`

##### Test Plan

Changes are pretty straightforward, there is no need in testing them.

##### Additional Information
