### PR TITLE
Disable chart obsoletion code for archived chart creation.

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -951,7 +951,8 @@ RRDSET *rrdset_create_custom(
     }
 #endif
 
-    rrdhost_cleanup_obsolete_charts(host);
+    if (!is_archived)
+        rrdhost_cleanup_obsolete_charts(host);
 
     rrdhost_unlock(host);
 #ifdef ENABLE_ACLK


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #9595
##### Component Name
database
##### Test Plan
Start an agent that has tens of thousands of charts in the same host, and measure the time before it's up.
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
Creating a chart will trigger obsoletion cleanup code whose time complexity is directly proportional to the number of charts in that host. The metadata log replay will create those charts during start-up and come across this delay. This is not evident when there are multiple child-nodes in the multi-host DB where the number of charts is spread equally among them. The worst-case scenario is a single node (parent or child) where ephemeral charts have been generated over time.