### PR TITLE
database: avoid endless loop when cleaning obsolete charts

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1528,8 +1528,11 @@ restart_after_removal:
                 while (st->alarms)     rrdsetcalc_unlink(st->alarms);
                 rrdset_wrlock(st);
                 for (rd = st->dimensions, last = NULL ; likely(rd) ; ) {
-                    if (rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED))
+                    if (rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
+                        last = rd;
+                        rd = rd->next;
                         continue;
+                    }
 
                     rrddim_flag_set(rd, RRDDIM_FLAG_ARCHIVED);
                     while (rd->variables)


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes a possible endless loop in `rrdhost_cleanup_obsolete_charts`. Should fix #10234.

##### Component Name
database

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information