### PR TITLE
updated 3rd party static dependencies and use alpine 3.12

### DIFF
--- a/packaging/makeself/build-x86_64-static.sh
+++ b/packaging/makeself/build-x86_64-static.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-DOCKER_CONTAINER_NAME="netdata-package-x86_64-static-alpine37"
+DOCKER_CONTAINER_NAME="netdata-package-x86_64-static-alpine312"
 
 if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
   # To run interactively:

--- a/packaging/makeself/build-x86_64-static.sh
+++ b/packaging/makeself/build-x86_64-static.sh
@@ -23,7 +23,7 @@ if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
   # inside the container and runs the script install-alpine-packages.sh
   # (also inside the container)
   #
-  run docker run -v "$(pwd)":/usr/src/netdata.git:rw alpine:3.7 \
+  run docker run -v "$(pwd)":/usr/src/netdata.git:rw alpine:3.12 \
     /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh
 
   # save the changes made permanently

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -30,6 +30,7 @@ apk add --no-cache -U \
   libmnl-dev \
   libnetfilter_acct-dev \
   libuv-dev \
+  libuv-static \
   lz4-dev \
   snappy-dev \
   protobuf-dev \

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -32,6 +32,7 @@ apk add --no-cache -U \
   libuv-dev \
   libuv-static \
   lz4-dev \
+  lz4-static \
   snappy-dev \
   protobuf-dev \
   binutils \

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -26,6 +26,7 @@ apk add --no-cache -U \
   util-linux-dev \
   gnutls-dev \
   zlib-dev \
+  zlib-static \
   libmnl-dev \
   libnetfilter_acct-dev \
   libuv-dev \

--- a/packaging/makeself/jobs/50-bash-5.0.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.0.install.sh
@@ -4,27 +4,30 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-fetch "fping-4.2" "https://github.com/schweikert/fping/releases/download/v4.2/fping-4.2.tar.gz"
+fetch "bash-5.0" "http://ftp.gnu.org/gnu/bash/bash-5.0.tar.gz"
 
-export CFLAGS="-static -I/openssl-static/include"
-export LDFLAGS="-static -L/openssl-static/lib"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
 run ./configure \
   --prefix="${NETDATA_INSTALL_PATH}" \
-  --enable-ipv4 \
-  --enable-ipv6
+  --without-bash-malloc \
+  --enable-static-link \
+  --enable-net-redirections \
+  --enable-array-variables \
+  --disable-profiling \
+  --disable-nls
 
-cat > doc/Makefile << EOF
+run make clean
+run make -j "$(nproc)"
+
+cat > examples/loadables/Makefile << EOF
 all:
 clean:
 install:
 EOF
 
-run make clean
-run make -j "$(nproc)"
 run make install
 
 if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
-  run strip "${NETDATA_INSTALL_PATH}"/bin/fping
+  run strip "${NETDATA_INSTALL_PATH}"/bin/bash
 fi

--- a/packaging/makeself/jobs/50-curl-7.73.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.73.0.install.sh
@@ -4,14 +4,14 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-fetch "curl-curl-7_60_0" "https://github.com/curl/curl/archive/curl-7_60_0.tar.gz"
+fetch "curl-7.73.0" "https://curl.haxx.se/download/curl-7.73.0.tar.gz"
 
 export CFLAGS="-I/openssl-static/include"
 export LDFLAGS="-static -L/openssl-static/lib"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
-run ./buildconf
+run autoreconf -fi
 
 run ./configure \
   --prefix="${NETDATA_INSTALL_PATH}" \

--- a/packaging/makeself/jobs/50-fping-5.0.install.sh
+++ b/packaging/makeself/jobs/50-fping-5.0.install.sh
@@ -4,30 +4,27 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-fetch "bash-4.4.18" "http://ftp.gnu.org/gnu/bash/bash-4.4.18.tar.gz"
+fetch "fping-5.0" "https://fping.org/dist/fping-5.0.tar.gz"
 
+export CFLAGS="-static -I/openssl-static/include"
+export LDFLAGS="-static -L/openssl-static/lib"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
 run ./configure \
   --prefix="${NETDATA_INSTALL_PATH}" \
-  --without-bash-malloc \
-  --enable-static-link \
-  --enable-net-redirections \
-  --enable-array-variables \
-  --disable-profiling \
-  --disable-nls
+  --enable-ipv4 \
+  --enable-ipv6
 
-run make clean
-run make -j "$(nproc)"
-
-cat > examples/loadables/Makefile << EOF
+cat > doc/Makefile << EOF
 all:
 clean:
 install:
 EOF
 
+run make clean
+run make -j "$(nproc)"
 run make install
 
 if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
-  run strip "${NETDATA_INSTALL_PATH}"/bin/bash
+  run strip "${NETDATA_INSTALL_PATH}"/bin/fping
 fi

--- a/packaging/makeself/jobs/50-ioping-1.2.install.sh
+++ b/packaging/makeself/jobs/50-ioping-1.2.install.sh
@@ -4,7 +4,7 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-fetch "netdata-ioping-43d15a5" "https://github.com/netdata/ioping/tarball/master"
+fetch "ioping-1.2" "https://github.com/koct9i/ioping/archive/v1.2.tar.gz"
 
 export CFLAGS="-static"
 

--- a/packaging/makeself/openssl.version
+++ b/packaging/makeself/openssl.version
@@ -1,1 +1,1 @@
-OpenSSL_1_1_1g
+OpenSSL_1_1_1h


### PR DESCRIPTION
##### Summary

Update netdata static builds to latest 3rd party versions:

component|old version|new version
---:|:---:|:---:
bash|4.4.18|5.0
openssl|1.1.1g|1.1.1h
curl|7.60.0|7.73.0
fping|4.2|5.0
ioping|1.1|1.2

This version uses latest `alpine` release `3.12`. This version of alpine provides a static version of zlib with the package `zlib-static`, libuv with `libuv-static` and `lz4` with `lz4-static`.

##### Test Plan

Tested once. It works (dbengine and ACLK).

```
# /opt/netdata/bin/netdata -W buildinfo
Version: netdata v1.26.0-204-g17db1415a
Configure options:  '--prefix=/opt/netdata/usr' '--sysconfdir=/opt/netdata/etc' '--localstatedir=/opt/netdata/var' '--libexecdir=/opt/netdata/usr/libexec' '--libdir=/opt/netdata/usr/lib' '--with-zlib' '--with-math' '--with-user=netdata' '--enable-cloud' '--with-bundled-lws=externaldeps/libwebsockets' '--with-libJudy=externaldeps/libJudy' 'CFLAGS=-static -O3 -I/openssl-static/include' 'LDFLAGS=-static -L/openssl-static/lib' 'PKG_CONFIG_PATH=/openssl-static/lib/pkgconfig'
Features:
    dbengine:                YES
    Native HTTPS:            YES
    Netdata Cloud:           YES
    TLS Host Verification:   YES
Libraries:
    jemalloc:                NO
    JSON-C:                  YES
    libcap:                  NO
    libcrypto:               YES
    libm:                    YES
    LWS:                     YES static v3.2.2
    mosquitto:               YES
    tcalloc:                 NO
    zlib:                    YES
Plugins:
    apps:                    YES
    cgroup Network Tracking: YES
    CUPS:                    NO
    EBPF:                    NO
    IPMI:                    NO
    NFACCT:                  NO
    perf:                    YES
    slabinfo:                YES
    Xen:                     NO
    Xen VBD Error Tracking:  NO
Exporters:
    AWS Kinesis:             NO
    GCP PubSub:              NO
    MongoDB:                 NO
    Prometheus Remote Write: YES
```

- [x] builds on alpine 3.12, with latest versions of all 3rd party packages
- [x] dbengine available
- [x] aclk available
- [x] https available
- [x] tested on `ubuntu-12.04`
- [ ] tested alarm notifications (curl)
- [ ] tested fping
- [ ] tested ioping

##### Additional Information
