### PR TITLE
Docs: Point users to proper configure doc

### DIFF
--- a/collectors/QUICKSTART.md
+++ b/collectors/QUICKSTART.md
@@ -83,9 +83,8 @@ auto-detect almost all local Nginx web servers.
 Despite Netdata's auto-detection capabilities, it's important to know how to edit collector configuration files.
 
 You should always edit configuration files with the `edit-config` script that comes with every installation of Netdata.
-To edit a collector configuration file, navigate to your [Netdata configuration
-directory](/docs/guides/step-by-step/step-04.md#find-your-netdataconf-file). Launch `edit-config` with the path to the
-collector's configuration file.
+To edit a collector configuration file, navigate to your [Netdata configuration directory](/docs/configure/nodes.md).
+Launch `edit-config` with the path to the collector's configuration file.
 
 How do you find that path to the collector's configuration file? Look under the **Configuration** heading in the
 collector's documentation. Each file contains a short code block with the relevant command.

--- a/collectors/charts.d.plugin/ap/README.md
+++ b/collectors/charts.d.plugin/ap/README.md
@@ -82,8 +82,8 @@ Station 40:b8:37:5a:ed:5e (on wlan0)
 
 ## Configuration
 
-Edit the `charts.d/ap.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `charts.d/ap.conf` configuration file using `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/charts.d.plugin/apcupsd/README.md
+++ b/collectors/charts.d.plugin/apcupsd/README.md
@@ -10,8 +10,8 @@ Monitors different APC UPS models and retrieves status information using `apcacc
 
 ## Configuration
 
-Edit the `charts.d/apcupsd.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `charts.d/apcupsd.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/charts.d.plugin/apcupsd/README.md
+++ b/collectors/charts.d.plugin/apcupsd/README.md
@@ -10,7 +10,7 @@ Monitors different APC UPS models and retrieves status information using `apcacc
 
 ## Configuration
 
-Edit the `charts.d/apcupsd.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `charts.d/apcupsd.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/charts.d.plugin/libreswan/README.md
+++ b/collectors/charts.d.plugin/libreswan/README.md
@@ -21,7 +21,7 @@ The following charts are created, **per tunnel**:
 
 ## Configuration
 
-Edit the `charts.d/libreswan.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `charts.d/libreswan.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/charts.d.plugin/libreswan/README.md
+++ b/collectors/charts.d.plugin/libreswan/README.md
@@ -21,8 +21,8 @@ The following charts are created, **per tunnel**:
 
 ## Configuration
 
-Edit the `charts.d/libreswan.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `charts.d/libreswan.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/charts.d.plugin/nut/README.md
+++ b/collectors/charts.d.plugin/nut/README.md
@@ -50,8 +50,8 @@ The following charts will be created:
 
 ## Configuration
 
-Edit the `charts.d/nut.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `charts.d/nut.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/charts.d.plugin/nut/README.md
+++ b/collectors/charts.d.plugin/nut/README.md
@@ -50,7 +50,7 @@ The following charts will be created:
 
 ## Configuration
 
-Edit the `charts.d/nut.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `charts.d/nut.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/charts.d.plugin/opensips/README.md
+++ b/collectors/charts.d.plugin/opensips/README.md
@@ -8,8 +8,8 @@ sidebar_label: "OpenSIPS"
 
 ## Configuration
 
-Edit the `charts.d/opensips.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `charts.d/opensips.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/charts.d.plugin/opensips/README.md
+++ b/collectors/charts.d.plugin/opensips/README.md
@@ -8,7 +8,7 @@ sidebar_label: "OpenSIPS"
 
 ## Configuration
 
-Edit the `charts.d/opensips.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `charts.d/opensips.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/charts.d.plugin/sensors/README.md
+++ b/collectors/charts.d.plugin/sensors/README.md
@@ -31,7 +31,7 @@ One chart for every sensor chip found and each of the above will be created.
 
 ## Configuration
 
-Edit the `charts.d/sensors.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `charts.d/sensors.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/charts.d.plugin/sensors/README.md
+++ b/collectors/charts.d.plugin/sensors/README.md
@@ -31,8 +31,8 @@ One chart for every sensor chip found and each of the above will be created.
 
 ## Configuration
 
-Edit the `charts.d/sensors.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `charts.d/sensors.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -43,8 +43,8 @@ It produces:
 adaptec_raid: yes
 ```
 
-Edit the `python.d/adaptec_raid.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/adaptec_raid.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -43,7 +43,7 @@ It produces:
 adaptec_raid: yes
 ```
 
-Edit the `python.d/adaptec_raid.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/adaptec_raid.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/am2320/README.md
+++ b/collectors/python.d.plugin/am2320/README.md
@@ -20,7 +20,7 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/am2320.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/am2320.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/am2320/README.md
+++ b/collectors/python.d.plugin/am2320/README.md
@@ -20,8 +20,8 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/am2320.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/am2320.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/apache/README.md
+++ b/collectors/python.d.plugin/apache/README.md
@@ -51,7 +51,7 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/apache.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/apache.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/apache/README.md
+++ b/collectors/python.d.plugin/apache/README.md
@@ -51,8 +51,8 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/apache.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/apache.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/beanstalk/README.md
+++ b/collectors/python.d.plugin/beanstalk/README.md
@@ -111,8 +111,8 @@ Provides server and tube-level statistics.
 
 ## Configuration
 
-Edit the `python.d/beanstalk.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/beanstalk.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/beanstalk/README.md
+++ b/collectors/python.d.plugin/beanstalk/README.md
@@ -111,7 +111,7 @@ Provides server and tube-level statistics.
 
 ## Configuration
 
-Edit the `python.d/beanstalk.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/beanstalk.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/bind_rndc/README.md
+++ b/collectors/python.d.plugin/bind_rndc/README.md
@@ -57,8 +57,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/bind_rndc.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/bind_rndc.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/bind_rndc/README.md
+++ b/collectors/python.d.plugin/bind_rndc/README.md
@@ -57,7 +57,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/bind_rndc.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/bind_rndc.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/boinc/README.md
+++ b/collectors/python.d.plugin/boinc/README.md
@@ -12,8 +12,8 @@ It provides charts tracking the total number of tasks and active tasks, as well 
 
 ## Configuration
 
-Edit the `python.d/boinc.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/boinc.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/boinc/README.md
+++ b/collectors/python.d.plugin/boinc/README.md
@@ -12,7 +12,7 @@ It provides charts tracking the total number of tasks and active tasks, as well 
 
 ## Configuration
 
-Edit the `python.d/boinc.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/boinc.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/ceph/README.md
+++ b/collectors/python.d.plugin/ceph/README.md
@@ -27,7 +27,7 @@ Monitors the ceph cluster usage and consumption data of a server, and produces:
 
 ## Configuration
 
-Edit the `python.d/ceph.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/ceph.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/ceph/README.md
+++ b/collectors/python.d.plugin/ceph/README.md
@@ -27,8 +27,8 @@ Monitors the ceph cluster usage and consumption data of a server, and produces:
 
 ## Configuration
 
-Edit the `python.d/ceph.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/ceph.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/chrony/README.md
+++ b/collectors/python.d.plugin/chrony/README.md
@@ -22,8 +22,8 @@ Verify that user Netdata can execute `chronyc tracking`. If necessary, update `/
 
 ## Configuration
 
-Edit the `python.d/chrony.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/chrony.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different

--- a/collectors/python.d.plugin/chrony/README.md
+++ b/collectors/python.d.plugin/chrony/README.md
@@ -22,7 +22,7 @@ Verify that user Netdata can execute `chronyc tracking`. If necessary, update `/
 
 ## Configuration
 
-Edit the `python.d/chrony.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/chrony.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/couchdb/README.md
+++ b/collectors/python.d.plugin/couchdb/README.md
@@ -19,8 +19,8 @@ Monitors vital statistics of a local Apache CouchDB 2.x server, including:
 
 ## Configuration
 
-Edit the `python.d/couchdb.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/couchdb.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/couchdb/README.md
+++ b/collectors/python.d.plugin/couchdb/README.md
@@ -19,7 +19,7 @@ Monitors vital statistics of a local Apache CouchDB 2.x server, including:
 
 ## Configuration
 
-Edit the `python.d/couchdb.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/couchdb.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/dns_query_time/README.md
+++ b/collectors/python.d.plugin/dns_query_time/README.md
@@ -16,8 +16,8 @@ It produces one aggregate chart or one chart per DNS server, showing the query t
 
 ## Configuration
 
-Edit the `python.d/dns_query_time.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/dns_query_time.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different

--- a/collectors/python.d.plugin/dns_query_time/README.md
+++ b/collectors/python.d.plugin/dns_query_time/README.md
@@ -16,7 +16,7 @@ It produces one aggregate chart or one chart per DNS server, showing the query t
 
 ## Configuration
 
-Edit the `python.d/dns_query_time.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/dns_query_time.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/dnsdist/README.md
+++ b/collectors/python.d.plugin/dnsdist/README.md
@@ -51,8 +51,8 @@ Collects load-balancer performance and health metrics, and draws the following c
 
 ## Configuration
 
-Edit the `python.d/dnsdist.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/dnsdist.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different

--- a/collectors/python.d.plugin/dnsdist/README.md
+++ b/collectors/python.d.plugin/dnsdist/README.md
@@ -51,7 +51,7 @@ Collects load-balancer performance and health metrics, and draws the following c
 
 ## Configuration
 
-Edit the `python.d/dnsdist.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/dnsdist.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/dockerd/README.md
+++ b/collectors/python.d.plugin/dockerd/README.md
@@ -28,7 +28,7 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/dockerd.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/dockerd.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/dockerd/README.md
+++ b/collectors/python.d.plugin/dockerd/README.md
@@ -28,8 +28,8 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/dockerd.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/dockerd.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different

--- a/collectors/python.d.plugin/dovecot/README.md
+++ b/collectors/python.d.plugin/dovecot/README.md
@@ -77,7 +77,7 @@ Module gives information with following charts:
 
 ## Configuration
 
-Edit the `python.d/dovecot.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/dovecot.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/dovecot/README.md
+++ b/collectors/python.d.plugin/dovecot/README.md
@@ -77,8 +77,8 @@ Module gives information with following charts:
 
 ## Configuration
 
-Edit the `python.d/dovecot.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/dovecot.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different

--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -66,7 +66,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/elasticsearch.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/elasticsearch.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -66,8 +66,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/elasticsearch.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/elasticsearch.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different

--- a/collectors/python.d.plugin/energid/README.md
+++ b/collectors/python.d.plugin/energid/README.md
@@ -48,8 +48,8 @@ long daemon startup.
 
 ## Configuration
 
-Edit the `python.d/energid.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/energid.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different

--- a/collectors/python.d.plugin/energid/README.md
+++ b/collectors/python.d.plugin/energid/README.md
@@ -48,7 +48,7 @@ long daemon startup.
 
 ## Configuration
 
-Edit the `python.d/energid.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/energid.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -16,7 +16,7 @@ It produces one chart with multiple lines (one line per jail)
 
 ## Configuration
 
-Edit the `python.d/fail2ban.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/fail2ban.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -16,8 +16,8 @@ It produces one chart with multiple lines (one line per jail)
 
 ## Configuration
 
-Edit the `python.d/fail2ban.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/fail2ban.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/freeradius/README.md
+++ b/collectors/python.d.plugin/freeradius/README.md
@@ -52,8 +52,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/freeradius.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/freeradius.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/freeradius/README.md
+++ b/collectors/python.d.plugin/freeradius/README.md
@@ -52,7 +52,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/freeradius.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/freeradius.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/gearman/README.md
+++ b/collectors/python.d.plugin/gearman/README.md
@@ -26,8 +26,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/gearman.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/gearman.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/gearman/README.md
+++ b/collectors/python.d.plugin/gearman/README.md
@@ -26,7 +26,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/gearman.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/gearman.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/go_expvar/README.md
+++ b/collectors/python.d.plugin/go_expvar/README.md
@@ -254,8 +254,8 @@ the first defined key wins and all subsequent keys with the same name are ignore
 
 ## Configuration
 
-Edit the `python.d/go_expvar.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/go_expvar.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/go_expvar/README.md
+++ b/collectors/python.d.plugin/go_expvar/README.md
@@ -254,7 +254,7 @@ the first defined key wins and all subsequent keys with the same name are ignore
 
 ## Configuration
 
-Edit the `python.d/go_expvar.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/go_expvar.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/haproxy/README.md
+++ b/collectors/python.d.plugin/haproxy/README.md
@@ -36,8 +36,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/hapxory.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/hapxory.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/haproxy/README.md
+++ b/collectors/python.d.plugin/haproxy/README.md
@@ -36,7 +36,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/hapxory.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/hapxory.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/hddtemp/README.md
+++ b/collectors/python.d.plugin/hddtemp/README.md
@@ -15,7 +15,7 @@ It produces one chart **Temperature** with dynamic number of dimensions (one per
 
 ## Configuration
 
-Edit the `python.d/hddtemp.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/hddtemp.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/hddtemp/README.md
+++ b/collectors/python.d.plugin/hddtemp/README.md
@@ -15,8 +15,8 @@ It produces one chart **Temperature** with dynamic number of dimensions (one per
 
 ## Configuration
 
-Edit the `python.d/hddtemp.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/hddtemp.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -38,7 +38,7 @@ This module produces:
 hpssa: yes
 ```
 
-Edit the `python.d/hpssa.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/hpssa.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -38,8 +38,8 @@ This module produces:
 hpssa: yes
 ```
 
-Edit the `python.d/hpssa.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/hpssa.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/httpcheck/README.md
+++ b/collectors/python.d.plugin/httpcheck/README.md
@@ -25,8 +25,8 @@ Following charts are drawn per job:
 
 ## Configuration
 
-Edit the `python.d/httpcheck.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/httpcheck.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/httpcheck/README.md
+++ b/collectors/python.d.plugin/httpcheck/README.md
@@ -25,7 +25,7 @@ Following charts are drawn per job:
 
 ## Configuration
 
-Edit the `python.d/httpcheck.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/httpcheck.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/icecast/README.md
+++ b/collectors/python.d.plugin/icecast/README.md
@@ -20,7 +20,7 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/icecast.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/icecast.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/icecast/README.md
+++ b/collectors/python.d.plugin/icecast/README.md
@@ -20,8 +20,8 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/icecast.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/icecast.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/ipfs/README.md
+++ b/collectors/python.d.plugin/ipfs/README.md
@@ -19,8 +19,8 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/ipfs.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/ipfs.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/ipfs/README.md
+++ b/collectors/python.d.plugin/ipfs/README.md
@@ -19,7 +19,7 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/ipfs.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/ipfs.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/isc_dhcpd/README.md
+++ b/collectors/python.d.plugin/isc_dhcpd/README.md
@@ -30,8 +30,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/isc_dhcpd.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/isc_dhcpd.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/isc_dhcpd/README.md
+++ b/collectors/python.d.plugin/isc_dhcpd/README.md
@@ -30,7 +30,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/isc_dhcpd.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/isc_dhcpd.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/litespeed/README.md
+++ b/collectors/python.d.plugin/litespeed/README.md
@@ -52,8 +52,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/litespeed.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/litespeed.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/litespeed/README.md
+++ b/collectors/python.d.plugin/litespeed/README.md
@@ -52,7 +52,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/litespeed.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/litespeed.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/logind/README.md
+++ b/collectors/python.d.plugin/logind/README.md
@@ -41,8 +41,8 @@ specify it using the `command` key like so:
 command: '/path/to/other/command'
 ```
 
-Edit the `python.d/logind.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/logind.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/logind/README.md
+++ b/collectors/python.d.plugin/logind/README.md
@@ -41,7 +41,7 @@ specify it using the `command` key like so:
 command: '/path/to/other/command'
 ```
 
-Edit the `python.d/logind.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/logind.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -48,8 +48,8 @@ It produces:
 megacli: yes
 ```
 
-Edit the `python.d/megacli.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/megacli.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -48,7 +48,7 @@ It produces:
 megacli: yes
 ```
 
-Edit the `python.d/megacli.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/megacli.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/memcached/README.md
+++ b/collectors/python.d.plugin/memcached/README.md
@@ -75,8 +75,8 @@ Collects memory-caching system performance metrics. It reads server response to 
 
 ## Configuration
 
-Edit the `python.d/memcached.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/memcached.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/memcached/README.md
+++ b/collectors/python.d.plugin/memcached/README.md
@@ -75,7 +75,7 @@ Collects memory-caching system performance metrics. It reads server response to 
 
 ## Configuration
 
-Edit the `python.d/memcached.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/memcached.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/mongodb/README.md
+++ b/collectors/python.d.plugin/mongodb/README.md
@@ -183,7 +183,7 @@ db.createUser({
 
 ## Configuration
 
-Edit the `python.d/mongodb.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/mongodb.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/mongodb/README.md
+++ b/collectors/python.d.plugin/mongodb/README.md
@@ -183,8 +183,8 @@ db.createUser({
 
 ## Configuration
 
-Edit the `python.d/mongodb.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/mongodb.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/monit/README.md
+++ b/collectors/python.d.plugin/monit/README.md
@@ -27,7 +27,7 @@ Monit monitoring module. Data is grabbed from stats XML interface (exists for a 
 
 ## Configuration
 
-Edit the `python.d/monit.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/monit.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/monit/README.md
+++ b/collectors/python.d.plugin/monit/README.md
@@ -27,8 +27,8 @@ Monit monitoring module. Data is grabbed from stats XML interface (exists for a 
 
 ## Configuration
 
-Edit the `python.d/monit.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/monit.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -336,7 +336,7 @@ This module will produce following charts (if data is available):
 
 ## Configuration
 
-Edit the `python.d/mysql.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/mysql.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -336,8 +336,8 @@ This module will produce following charts (if data is available):
 
 ## Configuration
 
-Edit the `python.d/mysql.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/mysql.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/nginx/README.md
+++ b/collectors/python.d.plugin/nginx/README.md
@@ -38,7 +38,7 @@ It produces following charts:
 
 ## Configuration
 
-Edit the `python.d/nginx.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/nginx.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/nginx/README.md
+++ b/collectors/python.d.plugin/nginx/README.md
@@ -38,8 +38,8 @@ It produces following charts:
 
 ## Configuration
 
-Edit the `python.d/nginx.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/nginx.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/nginx_plus/README.md
+++ b/collectors/python.d.plugin/nginx_plus/README.md
@@ -141,8 +141,8 @@ For every cache:
 
 ## Configuration
 
-Edit the `python.d/nginx_plus.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/nginx_plus.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/nginx_plus/README.md
+++ b/collectors/python.d.plugin/nginx_plus/README.md
@@ -141,7 +141,7 @@ For every cache:
 
 ## Configuration
 
-Edit the `python.d/nginx_plus.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/nginx_plus.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/ntpd/README.md
+++ b/collectors/python.d.plugin/ntpd/README.md
@@ -49,7 +49,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/ntpd.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/ntpd.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/ntpd/README.md
+++ b/collectors/python.d.plugin/ntpd/README.md
@@ -49,8 +49,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/ntpd.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/ntpd.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -39,7 +39,7 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/nvidia_smi.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/nvidia_smi.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -39,8 +39,8 @@ It produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/nvidia_smi.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/nvidia_smi.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/openldap/README.md
+++ b/collectors/python.d.plugin/openldap/README.md
@@ -55,8 +55,8 @@ Statistics are taken from LDAP monitoring interface. Manual page, slapd-monitor(
 
 ## Configuration
 
-Edit the `python.d/openldap.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/openldap.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/openldap/README.md
+++ b/collectors/python.d.plugin/openldap/README.md
@@ -55,7 +55,7 @@ Statistics are taken from LDAP monitoring interface. Manual page, slapd-monitor(
 
 ## Configuration
 
-Edit the `python.d/openldap.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/openldap.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -70,8 +70,8 @@ GRANT SELECT_CATALOG_ROLE TO netdata;
 
 ## Configuration
 
-Edit the `python.d/oracledb.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/oracledb.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -70,7 +70,7 @@ GRANT SELECT_CATALOG_ROLE TO netdata;
 
 ## Configuration
 
-Edit the `python.d/oracledb.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/oracledb.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/ovpn_status_log/README.md
+++ b/collectors/python.d.plugin/ovpn_status_log/README.md
@@ -30,8 +30,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/ovpn_status_log.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/ovpn_status_log.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/ovpn_status_log/README.md
+++ b/collectors/python.d.plugin/ovpn_status_log/README.md
@@ -30,7 +30,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/ovpn_status_log.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/ovpn_status_log.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/phpfpm/README.md
+++ b/collectors/python.d.plugin/phpfpm/README.md
@@ -26,7 +26,7 @@ It produces following charts:
 
 ## Configuration
 
-Edit the `python.d/phpfpm.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/phpfpm.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/phpfpm/README.md
+++ b/collectors/python.d.plugin/phpfpm/README.md
@@ -26,8 +26,8 @@ It produces following charts:
 
 ## Configuration
 
-Edit the `python.d/phpfpm.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/phpfpm.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/portcheck/README.md
+++ b/collectors/python.d.plugin/portcheck/README.md
@@ -24,8 +24,8 @@ Following charts are drawn per host:
 
 ## Configuration
 
-Edit the `python.d/portcheck.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/portcheck.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/portcheck/README.md
+++ b/collectors/python.d.plugin/portcheck/README.md
@@ -24,7 +24,7 @@ Following charts are drawn per host:
 
 ## Configuration
 
-Edit the `python.d/portcheck.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/portcheck.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/postgres/README.md
+++ b/collectors/python.d.plugin/postgres/README.md
@@ -70,8 +70,8 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/postgres.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/postgres.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/postgres/README.md
+++ b/collectors/python.d.plugin/postgres/README.md
@@ -70,7 +70,7 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/postgres.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/postgres.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/powerdns/README.md
+++ b/collectors/python.d.plugin/powerdns/README.md
@@ -83,7 +83,7 @@ Powerdns charts:
 
 ## Configuration
 
-Edit the `python.d/powerdns.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/powerdns.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/powerdns/README.md
+++ b/collectors/python.d.plugin/powerdns/README.md
@@ -83,8 +83,8 @@ Powerdns charts:
 
 ## Configuration
 
-Edit the `python.d/powerdns.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/powerdns.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/proxysql/README.md
+++ b/collectors/python.d.plugin/proxysql/README.md
@@ -82,7 +82,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/proxysql.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/proxysql.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/proxysql/README.md
+++ b/collectors/python.d.plugin/proxysql/README.md
@@ -82,8 +82,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/proxysql.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/proxysql.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/puppet/README.md
+++ b/collectors/python.d.plugin/puppet/README.md
@@ -32,7 +32,7 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/puppet.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/puppet.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/puppet/README.md
+++ b/collectors/python.d.plugin/puppet/README.md
@@ -32,8 +32,8 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/puppet.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/puppet.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -92,8 +92,8 @@ Per Vhost charts:
 
 ## Configuration
 
-Edit the `python.d/rabbitmq.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/rabbitmq.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -92,7 +92,7 @@ Per Vhost charts:
 
 ## Configuration
 
-Edit the `python.d/rabbitmq.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/rabbitmq.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/redis/README.md
+++ b/collectors/python.d.plugin/redis/README.md
@@ -38,7 +38,7 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/redis.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/redis.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/redis/README.md
+++ b/collectors/python.d.plugin/redis/README.md
@@ -38,8 +38,8 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/redis.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/redis.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/rethinkdbs/README.md
+++ b/collectors/python.d.plugin/rethinkdbs/README.md
@@ -29,7 +29,7 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/rethinkdbs.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/rethinkdbs.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/rethinkdbs/README.md
+++ b/collectors/python.d.plugin/rethinkdbs/README.md
@@ -29,8 +29,8 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/rethinkdbs.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/rethinkdbs.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/retroshare/README.md
+++ b/collectors/python.d.plugin/retroshare/README.md
@@ -21,7 +21,7 @@ This module produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/retroshare.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/retroshare.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/retroshare/README.md
+++ b/collectors/python.d.plugin/retroshare/README.md
@@ -21,8 +21,8 @@ This module produces the following charts:
 
 ## Configuration
 
-Edit the `python.d/retroshare.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/retroshare.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/riakkv/README.md
+++ b/collectors/python.d.plugin/riakkv/README.md
@@ -102,7 +102,7 @@ listed
 
 ## Configuration
 
-Edit the `python.d/riakkv.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/riakkv.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/riakkv/README.md
+++ b/collectors/python.d.plugin/riakkv/README.md
@@ -102,8 +102,8 @@ listed
 
 ## Configuration
 
-Edit the `python.d/riakkv.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/riakkv.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -81,7 +81,7 @@ netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
 samba: yes
 ```
 
-Edit the `python.d/samba.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/samba.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -81,8 +81,8 @@ netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
 samba: yes
 ```
 
-Edit the `python.d/samba.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/samba.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/sensors/README.md
+++ b/collectors/python.d.plugin/sensors/README.md
@@ -12,7 +12,7 @@ Charts are created dynamically.
 
 ## Configuration
 
-Edit the `python.d/sensors.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/sensors.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/sensors/README.md
+++ b/collectors/python.d.plugin/sensors/README.md
@@ -12,8 +12,8 @@ Charts are created dynamically.
 
 ## Configuration
 
-Edit the `python.d/sensors.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/sensors.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/smartd_log/README.md
+++ b/collectors/python.d.plugin/smartd_log/README.md
@@ -105,8 +105,8 @@ Otherwise, all the smartd `.csv` files may get written to `/var/lib/smartmontool
 
 ## Configuration
 
-Edit the `python.d/smartd_log.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/smartd_log.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/smartd_log/README.md
+++ b/collectors/python.d.plugin/smartd_log/README.md
@@ -105,7 +105,7 @@ Otherwise, all the smartd `.csv` files may get written to `/var/lib/smartmontool
 
 ## Configuration
 
-Edit the `python.d/smartd_log.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/smartd_log.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/spigotmc/README.md
+++ b/collectors/python.d.plugin/spigotmc/README.md
@@ -17,7 +17,7 @@ the data returned by the `tps` or `list` console commands.
 
 ## Configuration
 
-Edit the `python.d/spigotmc.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/spigotmc.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/spigotmc/README.md
+++ b/collectors/python.d.plugin/spigotmc/README.md
@@ -17,8 +17,8 @@ the data returned by the `tps` or `list` console commands.
 
 ## Configuration
 
-Edit the `python.d/spigotmc.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/spigotmc.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/springboot/README.md
+++ b/collectors/python.d.plugin/springboot/README.md
@@ -100,8 +100,8 @@ Please refer [Spring Boot Actuator: Production-ready Features](https://docs.spri
 
 ## Usage
 
-Edit the `python.d/springboot.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/springboot.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/springboot/README.md
+++ b/collectors/python.d.plugin/springboot/README.md
@@ -100,7 +100,7 @@ Please refer [Spring Boot Actuator: Production-ready Features](https://docs.spri
 
 ## Usage
 
-Edit the `python.d/springboot.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/springboot.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/squid/README.md
+++ b/collectors/python.d.plugin/squid/README.md
@@ -34,7 +34,7 @@ It produces following charts:
 
 ## Configuration
 
-Edit the `python.d/squid.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/squid.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/squid/README.md
+++ b/collectors/python.d.plugin/squid/README.md
@@ -34,8 +34,8 @@ It produces following charts:
 
 ## Configuration
 
-Edit the `python.d/squid.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/squid.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/tomcat/README.md
+++ b/collectors/python.d.plugin/tomcat/README.md
@@ -29,8 +29,8 @@ Charts:
 
 ## Configuration
 
-Edit the `python.d/tomcat.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/tomcat.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/tomcat/README.md
+++ b/collectors/python.d.plugin/tomcat/README.md
@@ -29,7 +29,7 @@ Charts:
 
 ## Configuration
 
-Edit the `python.d/tomcat.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/tomcat.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/tor/README.md
+++ b/collectors/python.d.plugin/tor/README.md
@@ -22,7 +22,7 @@ It produces only one chart:
 
 ## Configuration
 
-Edit the `python.d/tor.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/tor.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/tor/README.md
+++ b/collectors/python.d.plugin/tor/README.md
@@ -22,8 +22,8 @@ It produces only one chart:
 
 ## Configuration
 
-Edit the `python.d/tor.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/tor.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/traefik/README.md
+++ b/collectors/python.d.plugin/traefik/README.md
@@ -47,7 +47,7 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/traefik.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/traefik.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/traefik/README.md
+++ b/collectors/python.d.plugin/traefik/README.md
@@ -47,8 +47,8 @@ It produces:
 
 ## Configuration
 
-Edit the `python.d/traefik.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/traefik.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/uwsgi/README.md
+++ b/collectors/python.d.plugin/uwsgi/README.md
@@ -28,7 +28,7 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/uwsgi.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/uwsgi.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/uwsgi/README.md
+++ b/collectors/python.d.plugin/uwsgi/README.md
@@ -28,8 +28,8 @@ Following charts are drawn:
 
 ## Configuration
 
-Edit the `python.d/uwsgi.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/uwsgi.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -42,7 +42,7 @@ For every disk (SMF):
 
 ## Configuration
 
-Edit the `python.d/varnish.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/varnish.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -42,8 +42,8 @@ For every disk (SMF):
 
 ## Configuration
 
-Edit the `python.d/varnish.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/varnish.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/w1sensor/README.md
+++ b/collectors/python.d.plugin/w1sensor/README.md
@@ -15,7 +15,7 @@ Charts are created dynamically based on the number of detected sensors.
 
 ## Configuration
 
-Edit the `python.d/w1sensor.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/w1sensor.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/collectors/python.d.plugin/w1sensor/README.md
+++ b/collectors/python.d.plugin/w1sensor/README.md
@@ -15,8 +15,8 @@ Charts are created dynamically based on the number of detected sensors.
 
 ## Configuration
 
-Edit the `python.d/w1sensor.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/w1sensor.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/web_log/README.md
+++ b/collectors/python.d.plugin/web_log/README.md
@@ -35,8 +35,8 @@ If Netdata is installed on a system running a web server, it will detect it and 
 
 ## Configuration
 
-Edit the `python.d/web_log.conf` configuration file using `edit-config` from the your agent's [config
-directory](/docs/step-by-step/step-04.md#find-your-netdataconf-file), which is typically at `/etc/netdata`.
+Edit the `python.d/web_log.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/web_log/README.md
+++ b/collectors/python.d.plugin/web_log/README.md
@@ -35,7 +35,7 @@ If Netdata is installed on a system running a web server, it will detect it and 
 
 ## Configuration
 
-Edit the `python.d/web_log.conf` configuration file using `edit-config` from the `edit-config` from the Netdata [config
+Edit the `python.d/web_log.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash

--- a/health/QUICKSTART.md
+++ b/health/QUICKSTART.md
@@ -13,10 +13,10 @@ To learn about more advanced health configurations, visit the [health reference 
 
 ## Edit health configuration files
 
-You should use `edit-config` to edit Netdata's health configuration files. `edit-config` will open your system's default
-terminal editor for you to make your changes. Once you've saved and closed the editor, `edit-config` will copy your
-edited file into `/etc/netdata/health.d/`, which will override the stock file in `/usr/lib/netdata/conf.d/health.d/` and
-ensure your customizations are persistent between updates.
+You should [use `edit-config`](/docs/configure/nodes.md) to edit Netdata's health configuration files. `edit-config`
+will open your system's default terminal editor for you to make your changes. Once you've saved and closed the editor,
+`edit-config` will copy your edited file into `/etc/netdata/health.d/`, which will override the stock file in
+`/usr/lib/netdata/conf.d/health.d/` and ensure your customizations are persistent between updates.
 
 For example, to edit the `cpu.conf` health configuration file, you would run:
 
@@ -24,11 +24,6 @@ For example, to edit the `cpu.conf` health configuration file, you would run:
 cd /etc/netdata/ # Replace with your Netdata configuration directory, if not /etc/netdata/
 ./edit-config health.d/cpu.conf
 ```
-
-> You may need to use `sudo` or another method of elevating your privileges: `sudo ./edit-config health.d/cpu.conf`.
->
-> You can also use the `$EDITOR` environment variable to use your preferred terminal editor with `edit-config`. See 
-> [this page](/docs/guides/step-by-step/step-04.md#use-edit-config-to-open-netdataconf) for details.
 
 Each health configuration file contains one or more health entities, which always begin with an `alarm:` or `template:`
 line. You can edit these entities based on your needs. To make any changes live, be sure to [reload your health


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

During the great "docsv2" project, I created a new core document that explains `edit-config` and the Netdata config directory at `/docs/configure/nodes.md`. This PR changes many links to point to this core doc to emphasize that it is the source of truth about configuration, and make further navigation easier.

##### Component Name

area/docs
area/collectors

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
