### PR TITLE
Made the update script significantly more robust and user friendly.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -471,12 +471,20 @@ cd netdata-* || fatal "Cannot cd to netdata source tree"
 # ---------------------------------------------------------------------------------------------------------------------
 # install netdata from source
 
-if [ -x netdata-installer.sh ]; then
+install() {
   progress "Installing netdata..."
   run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS} "${@}" || fatal "netdata-installer.sh exited with error"
   if [ -d "${ndtmpdir}" ] && [ ! "${ndtmpdir}" = "/" ]; then
     run ${sudo} rm -rf "${ndtmpdir}" > /dev/null 2>&1
   fi
+}
+
+if [ -x netdata-installer.sh ]; then
+  install "$@"
 else
-  fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${ndtmpdir}"
+  if [ "$(find . -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ] && [ -x "$(find . -mindepth 1 -maxdepth 1 -type d)/netdata-installer.sh" ]; then
+    cd "$(find . -mindepth 1 -maxdepth 1 -type d)" && install "$@"
+  else
+    fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${ndtmpdir}"
+  fi
 fi

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -61,7 +61,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "794498f7009012116aafe466d8f544ae" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "02efc9e5ae084ad3aff072837dbedb1c" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -28,6 +28,8 @@
 
 set -e
 
+script_source="$("$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)/netdata-updater.sh")"
+
 info() {
   echo >&3 "$(date) : INFO: " "${@}"
 }
@@ -87,32 +89,85 @@ _cannot_use_tmpdir() {
 }
 
 create_tmp_directory() {
-  if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
-    if _cannot_use_tmpdir /tmp ; then
-      if _cannot_use_tmpdir "${PWD}" ; then
-        echo >&2
-        echo >&2 "Unable to find a usable temprorary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
-        exit 1
+  if [ -n "${NETDATA_TMPDIR_PATH}" ]; then
+    echo "${NETDATA_TMPDIR_PATH}"
+  else
+    if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
+      if _cannot_use_tmpdir /tmp ; then
+        if _cannot_use_tmpdir "${PWD}" ; then
+          echo >&2
+          echo >&2 "Unable to find a usable temprorary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
+          exit 1
+        else
+          TMPDIR="${PWD}"
+        fi
       else
-        TMPDIR="${PWD}"
+        TMPDIR="/tmp"
       fi
-    else
-      TMPDIR="/tmp"
     fi
-  fi
 
-  mktemp -d -t netdata-updater-XXXXXXXXXX
+    mktemp -d -t netdata-updater-XXXXXXXXXX
+  fi
+}
+
+_safe_download() {
+  url="${1}"
+  dest="${2}"
+  if command -v curl > /dev/null 2>&1; then
+    curl -sSL --connect-timeout 10 --retry 3 "${url}" > "${dest}"
+    return $?
+  elif command -v wget > /dev/null 2>&1; then
+    wget -T 15 -O - "${url}" > "${dest}"
+    return $?
+  else
+    return 255
+  fi
 }
 
 download() {
   url="${1}"
   dest="${2}"
-  if command -v curl > /dev/null 2>&1; then
-    curl -sSL --connect-timeout 10 --retry 3 "${url}" > "${dest}" || fatal "Cannot download ${url}"
-  elif command -v wget > /dev/null 2>&1; then
-    wget -T 15 -O - "${url}" > "${dest}" || fatal "Cannot download ${url}"
-  else
+
+  _safe_download "${url}" "${dest}"
+  ret=$?
+
+  if [ ${ret} -eq 0 ]; then
+    return 0
+  elif [ ${ret} -eq 255 ]; then
     fatal "I need curl or wget to proceed, but neither is available on this system."
+  else
+    fatal "Cannot download ${url}"
+  fi
+}
+
+newer_commit_date() {
+  echo >&3 "Checking if a newer version of the updater script is available."
+
+  if command -v jq > /dev/null 2>&1; then
+    commit_date="$(_safe_download "https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1" /dev/stdout | jq '.[0].commit.committer.date')"
+  elif command -v python > /dev/null 2>&1;then
+    commit_date="$(_safe_download "https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1" /dev/stdout | python -c 'from __future__ import print_function;import sys,json;print(json.load(sys.stdin)["commit"]["committer"]["date"])')"
+  fi
+
+  if [ -z "${commit_date}" ] ; then
+    commit_date="1970-01-01T00:00:00Z"
+  fi
+
+  [ "$(date -d "${commit_date}" +%s)" -ge "$(date -r "${script_source}" +%s)" ]
+}
+
+self_update() {
+  if [ -z "${NETDATA_NO_UPDATER_SELF_UPDATE}" ] && newer_commit_date; then
+    echo >&3 "Downloading newest version of updater script."
+
+    ndtmpdir=$(create_tmp_directory)
+    cd "$ndtmpdir" || exit 1
+
+    if _safe_download "https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/netdata-updater.sh" ./netdata-updater.sh; then
+      exec ./netdata-updater.sh --not-running-from-cron --no-self-update --tmpdir-path "$(pwd)"
+    else
+      echo >&3 "Failed to download newest version of updater script, continuing with current version."
+    fi
   fi
 }
 
@@ -254,6 +309,12 @@ while [ -n "${1}" ]; do
   if [ "${1}" = "--not-running-from-cron" ]; then
     NETDATA_NOT_RUNNING_FROM_CRON=1
     shift 1
+  elif [ "${1}" = "--no-updater-self-update" ]; then
+    NETDATA_NO_UPDATER_SELF_UPDATE=1
+    shift 1
+  elif [ "${1}" = "--tempdir-path" ]; then
+    NETDATA_TMPDIR_PATH="${2}"
+    shift 2
   else
     break
   fi
@@ -297,6 +358,8 @@ else
   # open fd 3 and send it to logfile
   exec 3> "${logfile}"
 fi
+
+self_update
 
 set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -19,10 +19,12 @@
 #  - TMPDIR (set to a usable temporary directory)
 #  - NETDATA_NIGHTLIES_BASEURL (set the base url for downloading the dist tarball)
 #
-# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright: 2018-2020 Netdata Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Author: Paweł Krupa <paulfantom@gmail.com>
 # Author: Pavlos Emm. Katsoulakis <paul@netdata.cloud>
+# Author: Austin S. Hemmelgarn <austin@netdata.cloud>
 
 set -e
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -223,6 +223,12 @@ update() {
       env="NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
     fi
 
+    if [ ! -x ./netdata-installer.sh ]; then
+      if [ "$(find . -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ] && [ -x "$(find . -mindepth 1 -maxdepth 1 -type d)/netdata-installer.sh" ]; then
+        cd "$(find . -mindepth 1 -maxdepth 1 -type d)" || exit 1
+      fi
+    fi
+
     info "Re-installing netdata..."
     eval "${env} ./netdata-installer.sh ${REINSTALL_OPTIONS} --dont-wait ${do_not_start}" >&3 2>&3 || fatal "FAILED TO COMPILE/INSTALL NETDATA"
 


### PR DESCRIPTION
##### Summary

This makes a number of changes to the updater to make it more user-friendly and more generally robust, including:

* If the installer is not where we expect it to be and there is _exactly_ one directory in the location we expected the installer to be, try changing to that directory and running it from there. This should fix #9863, as well as related issues with new installs.
* Each time the updater is run, check if a newer version exists in the repo, and if so download that and run it instead of using the current updater code. This will allow automatic recovery from a wide variety of bugs that may show up in the updater (especially since it runs very early in the update process). The actual check involves making a call to GitHub’s API to check the commit date on the master branch for the updater code, and only downloads it if the commit date is newer than the timestamp on the local copy. This intentionally _does not_ overwrite the local copy of the updater script, as that would actually make it easier to break things.

It also properly updates the copyright notice in the updater, which has gotten severely out of date.

##### Component Name

area/packaging

##### Test Plan

Behavior verified locally.

Testing of the auto-updating of the updater script can be verified by installing a local copy of Netdata from this branch, using `touch` to set the timestamp on the installed copy of the updater script to 1970-01-01 00:00:00 and adding a line just after line 362 to print something recognizable to the console, and then running the updater script. You should _not_ see output from the line added after 362 on the console if it works correctly.

##### Additional Information

Fixes: #9863 
Fixes: #10249