### PR TITLE
python.d/nvidia_smi: use `pwd` lib to get username if not inside a container

### DIFF
--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -248,11 +248,12 @@ HOST_PREFIX = os.getenv('NETDATA_HOST_PREFIX')
 ETC_PASSWD_PATH = '/etc/passwd'
 PROC_PATH = '/proc'
 
-IS_INSIDE_DOCKER = HOST_PREFIX is not None
+IS_INSIDE_DOCKER = False
 
 if HOST_PREFIX:
     ETC_PASSWD_PATH = os.path.join(HOST_PREFIX, ETC_PASSWD_PATH[1:])
     PROC_PATH = os.path.join(HOST_PREFIX, PROC_PATH[1:])
+    IS_INSIDE_DOCKER = True
 
 
 def read_passwd_file():
@@ -294,7 +295,7 @@ def get_username_by_pid_safe(pid, passwd_file):
     try:
         return passwd_file[uid][0]
     except KeyError:
-        return uid
+        return str(uid)
 
 
 class GPU:

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -277,15 +277,12 @@ def read_passwd_file_safe():
     try:
         if IS_INSIDE_DOCKER:
             return read_passwd_file()
-        else:
-            return dict((k[2], k) for k in pwd.getpwall())
+        return dict((k[2], k) for k in pwd.getpwall())
     except (OSError, IOError):
         return dict()
 
 
 def get_username_by_pid_safe(pid, passwd_file):
-    if not passwd_file:
-        return ''
     path = os.path.join(PROC_PATH, pid)
     try:
         uid = os.stat(path).st_uid

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -7,6 +7,7 @@
 import subprocess
 import threading
 import os
+import pwd
 
 import xml.etree.ElementTree as et
 
@@ -247,6 +248,8 @@ HOST_PREFIX = os.getenv('NETDATA_HOST_PREFIX')
 ETC_PASSWD_PATH = '/etc/passwd'
 PROC_PATH = '/proc'
 
+IS_INSIDE_DOCKER = HOST_PREFIX is not None
+
 if HOST_PREFIX:
     ETC_PASSWD_PATH = os.path.join(HOST_PREFIX, ETC_PASSWD_PATH[1:])
     PROC_PATH = os.path.join(HOST_PREFIX, PROC_PATH[1:])
@@ -271,7 +274,10 @@ def read_passwd_file():
 
 def read_passwd_file_safe():
     try:
-        return read_passwd_file()
+        if IS_INSIDE_DOCKER:
+            return read_passwd_file()
+        else:
+            return dict((k[2], k) for k in pwd.getpwall())
     except (OSError, IOError):
         return dict()
 
@@ -282,9 +288,13 @@ def get_username_by_pid_safe(pid, passwd_file):
     path = os.path.join(PROC_PATH, pid)
     try:
         uid = os.stat(path).st_uid
-        return passwd_file[uid][0]
-    except (OSError, IOError, KeyError):
+    except (OSError, IOError):
         return ''
+
+    try:
+        return passwd_file[uid][0]
+    except KeyError:
+        return uid
 
 
 class GPU:


### PR DESCRIPTION
##### Summary

Fixes: #10264

[`pwd`](https://docs.python.org/3/library/pwd.html) is python standard library. But it doesn't allow to set _host_ prefix - that is why we don't want to use it inside a docker container.


This PR changes find username by uid logic to:
 - if installed directly on host (env var `NETDATA_HOST_PREFIX` not set): use `pwd`.
 - if not: `/etc/passwd` file using custom function that respects `NETDATA_HOST_PREFIX`.

If we fail (both cases): use process `st_uid` (User ID of owner) as username.

##### Component Name

`collectors/python.d/nvidia_smi`

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information

- [x] test PR locally, ensure name resolution works.
- [x] test PR with LDAP users (LDAP is configured by sssd), ensure name resolution works (@scatenag )
