### PR TITLE
Fix host name when syslog is used

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1833,7 +1833,7 @@ EOF
 
 send_syslog() {
   local facility=${SYSLOG_FACILITY:-"local6"} level='info' targets="${1}"
-  local priority='' message='' host='' port='' prefix=''
+  local priority='' message='' server='' port='' prefix=''
   local temp1='' temp2=''
 
   [ "${SEND_SYSLOG}" = "YES" ] || return 1
@@ -1847,7 +1847,7 @@ send_syslog() {
   for target in ${targets}; do
     priority="${facility}.${level}"
     message=''
-    host=''
+    server=''
     port=''
     prefix=''
     temp1=''
@@ -1859,25 +1859,25 @@ send_syslog() {
     if [ ${prefix} != ${temp1} ]; then
       if (echo ${temp1} | grep -q '@'); then
         temp2=$(echo ${temp1} | cut -d '@' -f 1)
-        host=$(echo ${temp1} | cut -d '@' -f 2)
+        server=$(echo ${temp1} | cut -d '@' -f 2)
 
-        if [ ${temp2} != ${host} ]; then
+        if [ ${temp2} != ${server} ]; then
           priority=${temp2}
         fi
 
-        port=$(echo ${host} | rev | cut -d ':' -f 1 | rev)
+        port=$(echo ${server} | rev | cut -d ':' -f 1 | rev)
 
-        if (echo ${host} | grep -E -q '\[.*\]'); then
+        if (echo ${server} | grep -E -q '\[.*\]'); then
           if (echo ${port} | grep -q ']'); then
             port=''
           else
-            host=$(echo ${host} | rev | cut -d ':' -f 2- | rev)
+            server=$(echo ${server} | rev | cut -d ':' -f 2- | rev)
           fi
         else
-          if [ ${port} = ${host} ]; then
+          if [ ${port} = ${server} ]; then
             port=''
           else
-            host=$(echo ${host} | cut -d ':' -f 1)
+            server=$(echo ${server} | cut -d ':' -f 1)
           fi
         fi
       else
@@ -1885,10 +1885,14 @@ send_syslog() {
       fi
     fi
 
-    message="${prefix} ${status} on ${args_host} at ${date}: ${chart} ${value_string}"
+    if [ -z ${server} ] ; then
+      server="${args_host}"
+    fi
 
-    if [ ${host} ]; then
-      logger_options="${logger_options} -n ${host}"
+    message="${prefix} ${status} on ${server} at ${date}: ${chart} ${value_string}"
+
+    if [ ${server} ]; then
+      logger_options="${logger_options} -n ${server}"
       if [ ${port} ]; then
         logger_options="${logger_options} -P ${port}"
       fi

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1889,7 +1889,7 @@ send_syslog() {
       server="${args_host}"
     fi
 
-    message="${prefix} ${status} on ${server} at ${date}: ${chart} ${value_string}"
+    message="${prefix} ${status} on ${host} at ${date}: ${chart} ${value_string}"
 
     if [ ${server} ] && [ -z $temp1 ]; then
       logger_options="${logger_options} -n ${server}"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1885,10 +1885,6 @@ send_syslog() {
       fi
     fi
 
-    if [ -z ${server} ] ; then
-      server="${args_host}"
-    fi
-
     message="${prefix} ${status} on ${host} at ${date}: ${chart} ${value_string}"
 
     if [ ${server} ] && [ -z $temp1 ]; then

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1885,7 +1885,7 @@ send_syslog() {
       fi
     fi
 
-    message="${prefix} ${status} on ${host} at ${date}: ${chart} ${value_string}"
+    message="${prefix} ${status} on ${args_host} at ${date}: ${chart} ${value_string}"
 
     if [ ${host} ]; then
       logger_options="${logger_options} -n ${host}"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1891,7 +1891,7 @@ send_syslog() {
 
     message="${prefix} ${status} on ${server} at ${date}: ${chart} ${value_string}"
 
-    if [ ${server} ]; then
+    if [ ${server} ] && [ -z $temp1 ]; then
       logger_options="${logger_options} -n ${server}"
       if [ ${port} ]; then
         logger_options="${logger_options} -P ${port}"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1887,7 +1887,7 @@ send_syslog() {
 
     message="${prefix} ${status} on ${host} at ${date}: ${chart} ${value_string}"
 
-    if [ ${server} ] && [ -z $temp1 ]; then
+    if [ ${server} ]; then
       logger_options="${logger_options} -n ${server}"
       if [ ${port} ]; then
         logger_options="${logger_options} -P ${port}"


### PR DESCRIPTION
##### Summary
Fixes #10245 

This PR changes the variable used to reported host inside syslog, previously we were having logs like this:

```
Nov 23 19:56:41 hades thiago: netdata CRITICAL on  at Mon Nov 23 19:56:40 UTC 2020: system.cpu 4.23%
Nov 23 19:56:59 hades thiago: netdata CRITICAL on  at Mon Nov 23 19:56:58 UTC 2020: system.cpu 7.12%
Nov 23 19:56:59 hades thiago: netdata CRITICAL on  at Mon Nov 23 19:56:58 UTC 2020: system.cpu 18.3%
```

After the fix we start to have the expected logs for `parent` and `child`:

```
Nov 23 20:13:26 hades thiago: netdata CRITICAL on zeus at Mon Nov 23 19:55:09 UTC 2020: mem.available 4%
Nov 23 20:13:33 hades thiago: netdata CRITICAL on zeus at Mon Nov 23 20:13:32 UTC 2020: system.cpu 4.78%
Nov 23 20:13:39 hades thiago: netdata CRITICAL on hades at Mon Nov 23 20:13:32 UTC 2020: system.cpu 4.82%
Nov 23 20:14:02 hades thiago: netdata CRITICAL on hades at Mon Nov 23 20:14:01 UTC 2020: system.cpu 4.56%

```

##### Component Name
Health
##### Test Plan
### Simple scenario

I observed that the problem was bigger than reported, so there is another way to test this PR:

1 - Compile this PR on `parent` and set your `health_alarm_notify.conf` with the following variables:

```
SEND_SYSLOG="YES"
SYSLOG_FACILITY='local6'
DEFAULT_RECIPIENT_SYSLOG="netdata" 
```

2 - Go to `/usr/libexec/netdata/plugins.d/` and run:

```
$ ./alarm-notify.sh test
```

And check your syslog messages.

### Scenario reported per user

1 - Compile this PR on `parent` and set your `health_alarm_notify.conf` with the following variables:

```
SEND_SYSLOG="YES"
SYSLOG_FACILITY='local6'
DEFAULT_RECIPIENT_SYSLOG="netdata" 
```

2 - Write an alarm that will be easily raised, for example :

```
   alarm: example_alarm
      on: example.random
   every: 2s
  lookup: sum -1s at 0 every 1 percentage foreach *
    warn: $this > (($status >= $WARNING)  ? (55) : (75))
    crit: $this > (($status == $CRITICAL) ? (75) : (95))
    info: random test
      to: sysadmin
``` 
3 - Enable python `example` module

4 - Start `parent`
5 - You can compile any branch at `child`, because the problem is happening on `parent`.
6 - Also enable python `example` module at slave
7 - Start Netdata with `health` disabled at child.
8 - Take a look at your syslog messages to confirm the `host` is present at parent and child messages.
##### Additional Information
