### PR TITLE
Fix compilation with https disabled. Fixes #10278

### DIFF
--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -236,10 +236,10 @@ void simple_connector_send_buffer(
 void simple_connector_worker(void *instance_p)
 {
     struct instance *instance = (struct instance*)instance_p;
+    struct simple_connector_data *connector_specific_data = instance->connector_specific_data;
 
 #ifdef ENABLE_HTTPS
     uint32_t options = (uint32_t)instance->config.options;
-    struct simple_connector_data *connector_specific_data = instance->connector_specific_data;
 
     if (options & EXPORTING_OPTION_USE_TLS)
         ERR_clear_error();


### PR DESCRIPTION
##### Summary

Move variable declaration out of ifdef, it is not https specific.

Fixes #10278

##### Component Name
Core

##### Test Plan
Compile with https disabled (--enable-https=no)
