### PR TITLE
health/web_log: remove `crit` from unmatched alarms

### DIFF
--- a/health/health.d/web_log.conf
+++ b/health/health.d/web_log.conf
@@ -111,7 +111,6 @@ families: *
    units: %
    every: 10s
     warn: ($1m_total_requests > 120) ? ($this > 1) : ( 0 )
-    crit: ($1m_total_requests > 120) ? ($this > 5) : ( 0 )
    delay: up 1m down 5m multiplier 1.5 max 1h
     info: the ratio of unmatched lines, over the last minute
       to: webmaster
@@ -235,7 +234,6 @@ families: *
    units: %
    every: 10s
     warn: ($web_log_1m_total_requests > 120) ? ($this > 1) : ( 0 )
-    crit: ($web_log_1m_total_requests > 120) ? ($this > 5) : ( 0 )
    delay: up 1m down 5m multiplier 1.5 max 1h
     info: the ratio of unmatched lines, over the last minute
       to: webmaster


### PR DESCRIPTION
##### Summary

Not really a critical event, warning is enough. [Critical scares people](https://community.netdata.cloud/t/web-log-nginx-excluded-requests-web-log-1m-unmatched/504), should use it only if it is really a critical event.

##### Component Name

`health/`

##### Test Plan

Not needed.

##### Additional Information
