### PR TITLE
web/gui: Added support for dynamic shading on dygraphs

### DIFF
--- a/web/gui/dashboard.js
+++ b/web/gui/dashboard.js
@@ -3596,7 +3596,7 @@ NETDATA.gaugeChartCreate = function (state, data) {
         colorStart: startColor,     // Colors
         colorStop: stopColor,       // just experiment with them
         strokeColor: strokeColor,   // to see which ones work best for you
-        generateGradient: (generateGradient === true), // gmosx:
+        generateGradient: (generateGradient === true), // gmosx: 
         gradientType: 0,
         highDpiSupport: true        // High resolution support
     };
@@ -10104,7 +10104,7 @@ NETDATA.registry = {
                 }
                 NETDATA.registry.access(2, function (person_urls) {
                     NETDATA.registry.parsePersonUrls(person_urls);
-                });
+                });    
             }
         });
     },
@@ -10155,7 +10155,7 @@ NETDATA.registry = {
             // data.
             name = NETDATA.registry.hostname;
             url = NETDATA.serverDefault;
-        }
+        } 
 
         console.log("ACCESS", name, url);
 

--- a/web/gui/src/dashboard.js/charting/dygraph.js
+++ b/web/gui/src/dashboard.js/charting/dygraph.js
@@ -317,6 +317,18 @@ NETDATA.dygraphChartCreate = function (state, data) {
         // Expects a string in the format "<series name>: <style>" where each series is separated by a |
         perSeriesStyle: NETDATA.dataAttribute(state.element, 'dygraph-per-series-style', ''),
 
+        // Applies shading to the graph based on the value of this (reference) dimension
+        dyShadeReferenceDimension: NETDATA.dataAttribute(state.element, 'dygraph-shaderefdimension', undefined),
+
+        // The threshold value of the reference dimension to apply shading
+        dyShadeReferenceThreshold: NETDATA.dataAttribute(state.element, 'dygraph-shaderefthreshold', undefined),
+
+        // Tells the algorithm how to compare against the reference dimension. Accepts '<', '<=', '>', '>=', '=', '!='
+        dyShadeCompareWith: NETDATA.dataAttribute(state.element, 'dygraph-shaderefcomparewith', '<'),
+
+        // The color of the shaded area
+        dyShadeColor: NETDATA.dataAttribute(state.element, 'dygraph-shadecolor', NETDATA.themes.current.highlight),
+
         axes: {
             x: {
                 pixelsPerLabel: NETDATA.dataAttribute(state.element, 'dygraph-xpixelsperlabel', 50),
@@ -487,6 +499,78 @@ NETDATA.dygraphChartCreate = function (state, data) {
         },
         underlayCallback: function (canvas, area, g) {
             // the chart is about to be drawn
+
+            if (g.attributes_.user_.dyShadeReferenceDimension && g.attributes_.user_.dyShadeReferenceThreshold) {
+                // Compares a left hand value to a right hand value using an operator.
+                // Treats '===', '==' and '=' as ===, '!==', '!=' and '!' as '!==' to make the input syntax more lenient.
+                // Defaults to '<'.
+                const compareValues = function(operator, lhValue, rhValue) {
+                    switch (operator) {
+                        case '=':
+                        case '==':
+                        case '===':
+                            return lhValue === rhValue;
+                        case '!==':
+                        case '!=':
+                        case '!':
+                            return lhValue !== rhValue;
+                        case '>':
+                            return lhValue > rhValue;
+                        case '>=':
+                            return lhValue >= rhValue;
+                        case '<=':
+                            return lhValue <= rhValue;
+                        default:
+                            return lhValue < rhValue;
+                    }
+                };
+
+                const findSectionsToShade = function (dygraph, dimension, threshold, operator) {
+                    const shadeSections = [];
+                    // Stores the current processed section in the format of { 'start': <timestamp>, 'stop': <timestamp> }
+                    let currentSection;
+
+                    const dimensionIndex = dygraph.attributes_.labels_.indexOf(dimension) + 1;
+                    if (!dimensionIndex) {
+                        return shadeSections;
+                    }
+
+                    dygraph.rawData_.forEach(function (dataPoint, i, series) {
+                        if (compareValues(operator, dataPoint[dimensionIndex], threshold)) {
+                            currentSection = currentSection || { 'start': dataPoint[0] };
+                            currentSection.stop = dataPoint[0];
+                            // Keep processing unless we are at the last data point
+                            if (i < (series.length - 1)) {
+                                return;
+                            }
+                        }
+                        if (currentSection) {
+                            shadeSections.push(currentSection);
+                            currentSection = undefined;
+                        }
+                    });
+
+                    return shadeSections;
+                };
+
+                const dygraphShading = function (dygraph, canvas, area, start, stop, color) {
+                    const fillStart = dygraph.toDomXCoord(start);
+                    const fillStop = dygraph.toDomXCoord(stop);
+                    canvas.fillStyle = color;
+
+                    const width = fillStop - fillStart || 1; // Always shade at least one pixel
+                    canvas.fillRect(fillStart, area.y, width, area.h);
+                };
+
+                const refDimension = g.attributes_.user_.dyShadeReferenceDimension;
+                const threshold = g.attributes_.user_.dyShadeReferenceThreshold;
+                const operator = g.attributes_.user_.dyShadeCompareWith;
+
+                const sections = findSectionsToShade(g, refDimension, threshold, operator);
+                sections.forEach(function (section) {
+                    dygraphShading(g, canvas, area, section.start, section.stop, g.attributes_.user_.dyShadeColor);
+                });
+            }
 
             // update history_tip_element
             if (state.tmp.dygraph_history_tip_element) {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
This change adds support for dynamic shading on a dygraph, based on the value of a dimension. The rationale for this change was to shade the area of a graph based on a dimension value, i.e. highlight when a value is below some target. 

To achieve this, the following new attributes are exposed on the graph component:
* `dygraph-shaderefdimension`: the reference dimension to apply shading
* `dygraph-shaderefthreshold`: a threshold value of the reference dimension to begin shading
* `dygraph-shaderefcomparewith`: the operation used to compare against the threshold. It accepts '<', '<=', '>', '>=', '=', '!=' and defaults to '<'
* `dygraph-shadecolor`: a color hex code for the shading

This works by hooking into the `underlayCallback` that is called before every re-draw of the graph. It checks to see if the reference dimension is defined in the dataset and compares that value to a defined threshold. If the comparison of the value and the threshold is truthy, it adds it to a record of shaded areas. Once all the data on the graph has been checked, it then draws a rectangle on the underlying canvas for each of the shaded regions that it collected earlier.

##### Component Name
web/gui
 
##### Test Plan
I created a graph with the following attributes set.
```
data-dygraph-shaderefdimension="actual"
data-dygraph-shaderefthreshold=2
data-dygraph-shaderefcomparewith=">"
data-dygraph-shadecolor="#0000FF1F"
```
I confirmed that the shading was applied when expected. I tried dragging the graphs back through time and confirmed that the shading was applied. Zooming in and out also scaled the shading appropriately. All other graphs on the page continued to be in in time sync with the graph.

Afterwards I tried the other comparison methods:  '<', '<=', '>', '>=', '=', '==', '===' , '!==',  '!=', '!' and confirmed that the shading applied as desired.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
The comparison methods of '=', '==', '==='  are all compared using `===` and '!==',  '!=', '!' are all compared using `!==` under the hood. The additional formats were added to provide more flexibility to the input interface. 