### PR TITLE
Improved archivedcharts endpoint

### DIFF
--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -68,17 +68,6 @@ void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid)
     pg_cache = &ctx->pg_cache;
 
     rrdeng_generate_legacy_uuid(rd->id, rd->rrdset->id, &legacy_uuid);
-    {
-        uuid_t multihost_legacy_uuid1;
-        char uuid_str[37];
-        char uuid_str1[37];
-        uuid_unparse_lower(legacy_uuid, uuid_str);
-        info("Computing legacy id on %s [%s] [%s]  --> %s",rd->rrdset->rrdhost->machine_guid, rd->id, rd->rrdset->id, uuid_str);
-        rrdeng_convert_legacy_uuid_to_multihost(rd->rrdset->rrdhost->machine_guid, &legacy_uuid,
-                                                &multihost_legacy_uuid1);
-        uuid_unparse_lower(multihost_legacy_uuid1, uuid_str1);
-        info("Computing multihost legacy id on %s [%s] [%s]  --> %s    multi = [%s]",rd->rrdset->rrdhost->machine_guid, rd->id, rd->rrdset->id, uuid_str, uuid_str1);
-    }
     rd->state->metric_uuid = dim_uuid;
     if (host != localhost && host->rrdeng_ctx == &multidb_ctx)
         is_multihost_child = 1;
@@ -706,24 +695,15 @@ int rrdeng_metric_latest_time_by_uuid(uuid_t *dim_uuid, time_t *first_entry_t, t
 {
     struct page_cache *pg_cache;
     struct rrdengine_instance *ctx;
-//    uuid_t legacy_uuid;
-//    uuid_t multihost_legacy_uuid;
     Pvoid_t *PValue;
     struct pg_cache_page_index *page_index = NULL;
-    int is_multihost_child = 0;
-    //RRDHOST *host = rd->rrdset->rrdhost;
 
     ctx = get_rrdeng_ctx_from_host(localhost);
     if (unlikely(!ctx)) {
         error("Failed to fetch multidb context");
-        return;
+        return 1;
     }
     pg_cache = &ctx->pg_cache;
-
-//    rrdeng_generate_legacy_uuid(rd->id, rd->rrdset->id, &legacy_uuid);
-//    rd->state->metric_uuid = dim_uuid;
-//    if (host != localhost && host->rrdeng_ctx == &multidb_ctx)
-//        is_multihost_child = 1;
 
     uv_rwlock_rdlock(&pg_cache->metrics_index.lock);
     PValue = JudyHSGet(pg_cache->metrics_index.JudyHS_array, dim_uuid, sizeof(uuid_t));

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -12,6 +12,8 @@ uint8_t rrdeng_drop_metrics_under_page_cache_pressure = 1;
 
 static inline struct rrdengine_instance *get_rrdeng_ctx_from_host(RRDHOST *host)
 {
+    if (!host)
+        return &multidb_ctx;
     return host->rrdeng_ctx;
 }
 

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -59,5 +59,6 @@ extern int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *db
 
 extern int rrdeng_exit(struct rrdengine_instance *ctx);
 extern void rrdeng_prepare_exit(struct rrdengine_instance *ctx);
+extern int rrdeng_metric_latest_time_by_uuid(uuid_t *dim_uuid, time_t *first_entry_t, time_t *last_entry_t);
 
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -40,6 +40,7 @@ struct context_param {
     RRDDIM *rd;
     time_t first_entry_t;
     time_t last_entry_t;
+    int archive_mode;
 };
 
 #define META_CHART_UPDATED 1

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -947,24 +947,40 @@ failed:
 }
 
 #define SELECT_HOST "select host_id, registry_hostname, update_every, os, timezone, tags from host where hostname = @hostname order by rowid desc;"
+#define SELECT_HOST_BY_UUID "select host_id, registry_hostname, update_every, os, timezone, tags from host where host_id = @host_id ;"
 
 RRDHOST *sql_create_host_by_uuid(char *hostname)
 {
     int rc;
     RRDHOST *host = NULL;
+    uuid_t host_uuid;
 
     sqlite3_stmt *res = NULL;
 
-    rc = sqlite3_prepare_v2(db_meta, SELECT_HOST, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to prepare statement to fetch host");
-        return NULL;
+    rc = uuid_parse(hostname, host_uuid);
+    if (!rc) {
+        rc = sqlite3_prepare_v2(db_meta, SELECT_HOST_BY_UUID, -1, &res, 0);
+        if (unlikely(rc != SQLITE_OK)) {
+            error_report("Failed to prepare statement to fetch host");
+            return NULL;
+        }
+        rc = sqlite3_bind_blob(res, 1, &host_uuid, sizeof(host_uuid), SQLITE_STATIC);
+        if (unlikely(rc != SQLITE_OK)) {
+            error_report("Failed to bind host_id parameter to fetch host information");
+            return NULL;
+        }
     }
-
-    rc = sqlite3_bind_text(res, 1, hostname, -1, SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind hostname parameter to fetch host information");
-        return NULL;
+    else {
+        rc = sqlite3_prepare_v2(db_meta, SELECT_HOST, -1, &res, 0);
+        if (unlikely(rc != SQLITE_OK)) {
+            error_report("Failed to prepare statement to fetch host");
+            return NULL;
+        }
+        rc = sqlite3_bind_text(res, 1, hostname, -1, SQLITE_STATIC);
+        if (unlikely(rc != SQLITE_OK)) {
+            error_report("Failed to bind hostname parameter to fetch host information");
+            return NULL;
+        }
     }
 
     rc = sqlite3_step(res);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -703,14 +703,13 @@ void sql_rrdim2json(sqlite3_stmt *res_dim, uuid_t *chart_uuid, char *chart_id, c
         time_t dim_first_entry_t, dim_last_entry_t;
 
         rrdeng_generate_legacy_uuid((const char *) sqlite3_column_text(res_dim, 0), chart_id, &legacy_uuid);
-        rrdeng_convert_legacy_uuid_to_multihost(machine_guid, &legacy_uuid,
-                                                &multihost_legacy_uuid);
+        rrdeng_convert_legacy_uuid_to_multihost(machine_guid, &legacy_uuid, &multihost_legacy_uuid);
 
         char uuid_str[37];
         uuid_unparse_lower(*(uuid_t *) sqlite3_column_text(res_dim, 2), uuid_str);
         info("LOOKING UUID %s", uuid_str);
         uuid_unparse_lower(legacy_uuid, uuid_str);
-        info("  LEGACY UUID %s", uuid_str);
+        info("  LEGACY UUID on %s [%s] [%s] --> %s", machine_guid, (char *) sqlite3_column_text(res_dim, 0), chart_id, uuid_str);
         uuid_unparse_lower(multihost_legacy_uuid, uuid_str);
         info("  MULTIHOST LEGACY UUID %s", uuid_str);
 
@@ -947,7 +946,7 @@ failed:
     return;
 }
 
-#define SELECT_HOST "select host_id, registry_hostname, update_every, os, timezone, tags from host where hostname = @hostname;"
+#define SELECT_HOST "select host_id, registry_hostname, update_every, os, timezone, tags from host where hostname = @hostname order by rowid desc;"
 
 RRDHOST *sql_create_host_by_uuid(char *hostname)
 {

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -731,6 +731,39 @@ void sql_rrdim2json(sqlite3_stmt *res_dim, uuid_t *chart_uuid, char *chart_id, c
     buffer_sprintf(wb, "\n\t\t\t}");
 }
 
+#define SELECT_ARCHIVED_HOSTS "select host_id, hostname from host where host_id not in (select host_id from chart where chart_id in (select chart_id from chart_active));"
+
+void sql_archived_database_hosts(BUFFER *wb, int count)
+{
+    int rc;
+
+    sqlite3_stmt *res = NULL;
+
+    rc = sqlite3_prepare_v2(db_meta, SELECT_ARCHIVED_HOSTS, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement to fetch archived hosts");
+        return;
+    }
+
+    char machine_guid[GUID_LEN + 1];
+
+    while (sqlite3_step(res) == SQLITE_ROW) {
+        uuid_unparse_lower(*(uuid_t *) sqlite3_column_blob(res, 0), machine_guid);
+        if (count > 0)
+            buffer_strcat(wb, ",\n");
+        buffer_sprintf(
+            wb, "\t\t{ \"guid\": \"%s\", \"hostname\": \"%s\" }", machine_guid, sqlite3_column_text(res, 1));
+
+        count++;
+    }
+
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when reading archived hosts");
+
+    return;
+}
+
 #define SELECT_CHART "select chart_id, id, name, type, family, context, title, priority, plugin, " \
     "module, unit, chart_type, update_every from chart " \
     "where host_id = @host_uuid and chart_id not in (select chart_id from chart_active) order by chart_id asc;"

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -811,8 +811,9 @@ void sql_rrdset2json(RRDHOST *host, BUFFER *wb)
     BUFFER *dimension_buffer = buffer_create(16384);
 
     while (sqlite3_step(res_chart) == SQLITE_ROW) {
-        char id[512];
-        sprintf(id, "%s.%s", sqlite3_column_text(res_chart, 3), sqlite3_column_text(res_chart, 1));
+        char id[RRD_ID_LENGTH_MAX + 1];
+
+        snprintfz(id, RRD_ID_LENGTH_MAX, "%s.%s", sqlite3_column_text(res_chart, 3), sqlite3_column_text(res_chart, 1));
         RRDSET *st = rrdset_find(host, id);
         if (st && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED))
             continue;
@@ -869,13 +870,8 @@ void sql_rrdset2json(RRDHOST *host, BUFFER *wb)
             last_entry_t - first_entry_t, // duration
             first_entry_t, // first_entry
             last_entry_t, // last_entry
-            1  // update every
+            sqlite3_column_int(res_chart, 12)  // update every
             );
-
-//        buffer_reset(dimension_buffer);
-//
-//        sql_rrdim2json(res_dim, (uuid_t *) sqlite3_column_blob(res_chart, 0), dimension_buffer,
-//                       &dimensions, &first_entry_t, &last_entry_t);
 
         buffer_strcat(wb, buffer_tostring(dimension_buffer));
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1146,7 +1146,8 @@ void add_migrated_file(char *path, uint64_t file_size)
 }
 
 
-#define SELECT_CHART_CONTEXT  "select d.dim_id, d.id, d.name, c.id, c.type, c.name from chart c, dimension d, host h " \
+#define SELECT_CHART_CONTEXT  "select d.dim_id, d.id, d.name, c.id, c.type, c.name, c.update_every from chart c, " \
+    "dimension d, host h " \
     "where d.chart_id = c.chart_id and c.host_id = h.host_id and c.host_id = @host_id and c.context = @context " \
     "order by c.type||c.id desc;"
 
@@ -1201,7 +1202,7 @@ void sql_build_context_param_list(struct context_param **param_list, uuid_t *hos
             snprintfz(n, RRD_ID_LENGTH_MAX, "%s.%s", (char *) sqlite3_column_text(res, 4), (char *) sqlite3_column_text(res, 3));
             st->name = strdupz(n);
 //            st->context = strdupz(context);
-            st->update_every = 1;
+            st->update_every = sqlite3_column_int(res, 6);
 //            if((char *) sqlite3_column_text(res, 5) && *(char *) sqlite3_column_text(res, 5) && rrdset_set_name(st, (char *) sqlite3_column_text(res, 5)))
 //                ;
 //            else

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -677,27 +677,37 @@ bind_fail:
     return 1;
 }
 
-int find_dimension_first_last_t(char *machine_uid, uuid_t *uuid, time_t *first_entry_t, time_t *last_entry_t)
+int find_dimension_first_last_t(char *machine_guid, char *chart_id, char *dim_id,
+                                uuid_t *uuid, time_t *first_entry_t, time_t *last_entry_t, uuid_t *rrdeng_uuid)
 {
     int rc;
+    uuid_t  legacy_uuid;
+    uuid_t  multihost_legacy_uuid;
+
 
     time_t dim_first_entry_t, dim_last_entry_t;
 
-    rc = rrdeng_metric_latest_time_by_uuid(
-        (uuid_t *)sqlite3_column_text(res_dim, 2), &dim_first_entry_t, &dim_last_entry_t);
+    rc = rrdeng_metric_latest_time_by_uuid(uuid, &dim_first_entry_t, &dim_last_entry_t);
     if (unlikely(rc)) {
-        rrdeng_generate_legacy_uuid((const char *)sqlite3_column_text(res_dim, 0), chart_id, &legacy_uuid);
+        rrdeng_generate_legacy_uuid(dim_id, chart_id, &legacy_uuid);
         rc = rrdeng_metric_latest_time_by_uuid(&legacy_uuid, &dim_first_entry_t, &dim_last_entry_t);
         if (likely(rc)) {
             rrdeng_convert_legacy_uuid_to_multihost(machine_guid, &legacy_uuid, &multihost_legacy_uuid);
             rc = rrdeng_metric_latest_time_by_uuid(&multihost_legacy_uuid, &dim_first_entry_t, &dim_last_entry_t);
+            if (likely(!rc))
+                uuid_copy(*rrdeng_uuid, multihost_legacy_uuid);
         }
+        else
+            uuid_copy(*rrdeng_uuid, legacy_uuid);
     }
+    else
+        uuid_copy(*rrdeng_uuid, *uuid);
 
     if (likely(!rc)) {
         *first_entry_t = MIN(*first_entry_t, dim_first_entry_t);
         *last_entry_t = MAX(*last_entry_t, dim_last_entry_t);
     }
+    return rc;
 }
 
 //
@@ -1137,7 +1147,8 @@ void add_migrated_file(char *path, uint64_t file_size)
 
 
 #define SELECT_CHART_CONTEXT  "select d.dim_id, d.id, d.name, c.id, c.type, c.name from chart c, dimension d, host h " \
-    "where d.chart_id = c.chart_id and c.host_id = h.host_id and c.host_id = @host_id and c.context = @context;"
+    "where d.chart_id = c.chart_id and c.host_id = h.host_id and c.host_id = @host_id and c.context = @context " \
+    "order by c.type||c.id desc;"
 
 void sql_build_context_param_list(struct context_param **param_list, uuid_t *host_uuid, char *context)
 {
@@ -1151,6 +1162,7 @@ void sql_build_context_param_list(struct context_param **param_list, uuid_t *hos
         (*param_list)->first_entry_t = LONG_MAX;
         (*param_list)->last_entry_t = 0;
         (*param_list)->rd = NULL;
+        (*param_list)->archive_mode = 1;
     }
 
     sqlite3_stmt *res = NULL;
@@ -1174,58 +1186,72 @@ void sql_build_context_param_list(struct context_param **param_list, uuid_t *hos
     }
 
     RRDSET *st = NULL;
+    char machine_guid[GUID_LEN + 1];
+    uuid_unparse_lower(*host_uuid, machine_guid);
+    uuid_t rrdeng_uuid;
 
     while (sqlite3_step(res) == SQLITE_ROW) {
         char id[512];
         sprintf(id, "%s.%s", sqlite3_column_text(res, 3), sqlite3_column_text(res, 1));
 
-        if (!st) {
+        if (1 || !st) {
             st = callocz(1, sizeof(*st));
             char n[RRD_ID_LENGTH_MAX + 1];
 
             snprintfz(n, RRD_ID_LENGTH_MAX, "%s.%s", (char *) sqlite3_column_text(res, 4), (char *) sqlite3_column_text(res, 3));
             st->name = strdupz(n);
+//            st->context = strdupz(context);
+            st->update_every = 1;
 //            if((char *) sqlite3_column_text(res, 5) && *(char *) sqlite3_column_text(res, 5) && rrdset_set_name(st, (char *) sqlite3_column_text(res, 5)))
 //                ;
 //            else
 //                rrdset_set_name(st, (char *) sqlite3_column_text(res, 3));
         }
 
+        //find_dimension_first_last_t(char *machine_guid, char *chart_id, char *dim_id, uuid_t *uuid, time_t *first_entry_t, time_t *last_entry_t)
+        find_dimension_first_last_t(machine_guid, (char *) st->name, (char *) sqlite3_column_text(res, 1),
+                                    (uuid_t *) sqlite3_column_blob(res, 0), &(*param_list)->first_entry_t, &(*param_list)->last_entry_t, &rrdeng_uuid);
+
         // d.id, d.name, c.id, c.type, c.name
-        info("Dimension [%s / %s] Chart [%s %s %s]",
-                sqlite3_column_text(res, 1),   // dim id
-                sqlite3_column_text(res, 2),    // dim
-             sqlite3_column_text(res, 3),
-             sqlite3_column_text(res, 4),
-             sqlite3_column_text(res, 5));
+//        char uuid_str[GUID_LEN + 1];
+//        uuid_unparse_lower(rrdeng_uuid, uuid_str);
+//        info("Dimension [%s / %s] Chart [%s %s %s] --> %s",
+//             sqlite3_column_text(res, 1),   // dim id
+//             sqlite3_column_text(res, 2),    // dim
+//             sqlite3_column_text(res, 3),
+//             sqlite3_column_text(res, 4),
+//             sqlite3_column_text(res, 5), uuid_str);
 
             RRDDIM *rd = mallocz(sizeof(*rd));
             rd->rrdset = st;
             rd->id = strdupz((char *) sqlite3_column_text(res, 1));
             rd->name = strdupz((char *) sqlite3_column_text(res, 2));
             rd->state = mallocz(sizeof(*rd->state));
-            //memcpy(rd->state, rd1->state, sizeof(*rd->state));
-            //memcpy(&rd->state->collect_ops, &rd1->state->collect_ops, sizeof(struct rrddim_collect_ops));
-            //memcpy(&rd->state->query_ops, &rd1->state->query_ops, sizeof(struct rrddim_query_ops));
-            {
-                rd->state->collect_ops.init = rrdeng_store_metric_init;
-                rd->state->collect_ops.store_metric = rrdeng_store_metric_next;
-                rd->state->collect_ops.finalize = rrdeng_store_metric_finalize;
-                rd->state->query_ops.init = rrdeng_load_metric_init;
-                rd->state->query_ops.next_metric = rrdeng_load_metric_next;
-                rd->state->query_ops.is_finished = rrdeng_load_metric_is_finished;
-                rd->state->query_ops.finalize = rrdeng_load_metric_finalize;
-                rd->state->query_ops.latest_time = rrdeng_metric_latest_time;
-                rd->state->query_ops.oldest_time = rrdeng_metric_oldest_time;
-            }
+
+            rd->state->collect_ops.init = rrdeng_store_metric_init;
+            rd->state->collect_ops.store_metric = rrdeng_store_metric_next;
+            rd->state->collect_ops.finalize = rrdeng_store_metric_finalize;
+            rd->state->query_ops.init = rrdeng_load_metric_init;
+            rd->state->query_ops.next_metric = rrdeng_load_metric_next;
+            rd->state->query_ops.is_finished = rrdeng_load_metric_is_finished;
+            rd->state->query_ops.finalize = rrdeng_load_metric_finalize;
+            rd->state->query_ops.latest_time = rrdeng_metric_latest_time;
+            rd->state->query_ops.oldest_time = rrdeng_metric_oldest_time;
     #ifdef ENABLE_DBENGINE
-            if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-                rd->state->metric_uuid = mallocz(sizeof(uuid_t));
-                uuid_copy(*rd->state->metric_uuid, *(uuid_t *) sqlite3_column_blob(res, 0));
-            }
+            //if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+                //rd->state->metric_uuid = mallocz(sizeof(uuid_t));
+                rd->state->metric_uuid = NULL;
+                rd->state->rrdeng_uuid = mallocz(sizeof(uuid_t));
+                uuid_copy(*rd->state->rrdeng_uuid, rrdeng_uuid);
+                rd->state->metric_uuid = rd->state->rrdeng_uuid;
+                //uuid_copy(*rd->state->metric_uuid, *(uuid_t *) sqlite3_column_blob(res, 0));
+            //}
     #endif
             rd->next = (*param_list)->rd;
             (*param_list)->rd = rd;
+    }
+    if (likely(st)) {
+        st->context = strdupz(context);
     }
 
     rc = sqlite3_finalize(res);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -677,6 +677,28 @@ bind_fail:
     return 1;
 }
 
+int find_dimension_first_last_t(char *machine_uid, uuid_t *uuid, time_t *first_entry_t, time_t *last_entry_t)
+{
+    int rc;
+
+    time_t dim_first_entry_t, dim_last_entry_t;
+
+    rc = rrdeng_metric_latest_time_by_uuid(
+        (uuid_t *)sqlite3_column_text(res_dim, 2), &dim_first_entry_t, &dim_last_entry_t);
+    if (unlikely(rc)) {
+        rrdeng_generate_legacy_uuid((const char *)sqlite3_column_text(res_dim, 0), chart_id, &legacy_uuid);
+        rc = rrdeng_metric_latest_time_by_uuid(&legacy_uuid, &dim_first_entry_t, &dim_last_entry_t);
+        if (likely(rc)) {
+            rrdeng_convert_legacy_uuid_to_multihost(machine_guid, &legacy_uuid, &multihost_legacy_uuid);
+            rc = rrdeng_metric_latest_time_by_uuid(&multihost_legacy_uuid, &dim_first_entry_t, &dim_last_entry_t);
+        }
+    }
+
+    if (likely(!rc)) {
+        *first_entry_t = MIN(*first_entry_t, dim_first_entry_t);
+        *last_entry_t = MAX(*last_entry_t, dim_last_entry_t);
+    }
+}
 
 //
 // Support for archived charts
@@ -1111,4 +1133,133 @@ void add_migrated_file(char *path, uint64_t file_size)
         error_report("Failed to finalize the prepared statement when checking if metadata file is migrated");
 
     return;
+}
+
+
+#define SELECT_CHART_CONTEXT  "select d.dim_id, d.id, d.name, c.id, c.type, c.name from chart c, dimension d, host h " \
+    "where d.chart_id = c.chart_id and c.host_id = h.host_id and c.host_id = @host_id and c.context = @context;"
+
+void sql_build_context_param_list(struct context_param **param_list, uuid_t *host_uuid, char *context)
+{
+    int rc;
+
+    if (unlikely(!param_list))
+        return;
+
+    if (unlikely(!(*param_list))) {
+        *param_list = mallocz(sizeof(struct context_param));
+        (*param_list)->first_entry_t = LONG_MAX;
+        (*param_list)->last_entry_t = 0;
+        (*param_list)->rd = NULL;
+    }
+
+    sqlite3_stmt *res = NULL;
+
+    rc = sqlite3_prepare_v2(db_meta, SELECT_CHART_CONTEXT, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement to fetch host archived charts");
+        return;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, host_uuid, sizeof(*host_uuid), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host parameter to fetch archived charts");
+        return;
+    }
+
+    rc = sqlite3_bind_text(res, 2, context, -1, SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host parameter to fetch archived charts");
+        return;
+    }
+
+    RRDSET *st = NULL;
+
+    while (sqlite3_step(res) == SQLITE_ROW) {
+        char id[512];
+        sprintf(id, "%s.%s", sqlite3_column_text(res, 3), sqlite3_column_text(res, 1));
+
+        if (!st) {
+            st = callocz(1, sizeof(*st));
+            char n[RRD_ID_LENGTH_MAX + 1];
+
+            snprintfz(n, RRD_ID_LENGTH_MAX, "%s.%s", (char *) sqlite3_column_text(res, 4), (char *) sqlite3_column_text(res, 3));
+            st->name = strdupz(n);
+//            if((char *) sqlite3_column_text(res, 5) && *(char *) sqlite3_column_text(res, 5) && rrdset_set_name(st, (char *) sqlite3_column_text(res, 5)))
+//                ;
+//            else
+//                rrdset_set_name(st, (char *) sqlite3_column_text(res, 3));
+        }
+
+        // d.id, d.name, c.id, c.type, c.name
+        info("Dimension [%s / %s] Chart [%s %s %s]",
+                sqlite3_column_text(res, 1),   // dim id
+                sqlite3_column_text(res, 2),    // dim
+             sqlite3_column_text(res, 3),
+             sqlite3_column_text(res, 4),
+             sqlite3_column_text(res, 5));
+
+            RRDDIM *rd = mallocz(sizeof(*rd));
+            rd->rrdset = st;
+            rd->id = strdupz((char *) sqlite3_column_text(res, 1));
+            rd->name = strdupz((char *) sqlite3_column_text(res, 2));
+            rd->state = mallocz(sizeof(*rd->state));
+            //memcpy(rd->state, rd1->state, sizeof(*rd->state));
+            //memcpy(&rd->state->collect_ops, &rd1->state->collect_ops, sizeof(struct rrddim_collect_ops));
+            //memcpy(&rd->state->query_ops, &rd1->state->query_ops, sizeof(struct rrddim_query_ops));
+            {
+                rd->state->collect_ops.init = rrdeng_store_metric_init;
+                rd->state->collect_ops.store_metric = rrdeng_store_metric_next;
+                rd->state->collect_ops.finalize = rrdeng_store_metric_finalize;
+                rd->state->query_ops.init = rrdeng_load_metric_init;
+                rd->state->query_ops.next_metric = rrdeng_load_metric_next;
+                rd->state->query_ops.is_finished = rrdeng_load_metric_is_finished;
+                rd->state->query_ops.finalize = rrdeng_load_metric_finalize;
+                rd->state->query_ops.latest_time = rrdeng_metric_latest_time;
+                rd->state->query_ops.oldest_time = rrdeng_metric_oldest_time;
+            }
+    #ifdef ENABLE_DBENGINE
+            if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+                rd->state->metric_uuid = mallocz(sizeof(uuid_t));
+                uuid_copy(*rd->state->metric_uuid, *(uuid_t *) sqlite3_column_blob(res, 0));
+            }
+    #endif
+            rd->next = (*param_list)->rd;
+            (*param_list)->rd = rd;
+    }
+
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when reading archived charts");
+
+    return;
+
+//
+//    RRDDIM *rd1;
+//    (*param_list)->first_entry_t = MIN((*param_list)->first_entry_t, rrdset_first_entry_t(st));
+//    (*param_list)->last_entry_t  = MAX((*param_list)->last_entry_t, rrdset_last_entry_t(st));
+//
+//    st->last_accessed_time = now_realtime_sec();
+//    rrdset_rdlock(st);
+//
+//    rrddim_foreach_read(rd1, st) {
+//        RRDDIM *rd = mallocz(rd1->memsize);
+//        memcpy(rd, rd1, rd1->memsize);
+//        rd->id = strdupz(rd1->id);
+//        rd->name = strdupz(rd1->name);
+//        rd->state = mallocz(sizeof(*rd->state));
+//        memcpy(rd->state, rd1->state, sizeof(*rd->state));
+//        memcpy(&rd->state->collect_ops, &rd1->state->collect_ops, sizeof(struct rrddim_collect_ops));
+//        memcpy(&rd->state->query_ops, &rd1->state->query_ops, sizeof(struct rrddim_query_ops));
+//#ifdef ENABLE_DBENGINE
+//        if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+//            rd->state->metric_uuid = mallocz(sizeof(uuid_t));
+//            uuid_copy(*rd->state->metric_uuid, *rd1->state->metric_uuid);
+//        }
+//#endif
+//        rd->next = (*param_list)->rd;
+//        (*param_list)->rd = rd;
+//    }
+//
+//    rrdset_unlock(st);
 }

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -58,5 +58,6 @@ extern void add_migrated_file(char *path, uint64_t file_size);
 extern void db_unlock(void);
 extern void db_lock(void);
 extern void delete_dimension_uuid(uuid_t *dimension_uuid);
+extern void sql_archived_database_hosts(BUFFER *wb, int count);
 
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -60,4 +60,6 @@ extern void db_lock(void);
 extern void delete_dimension_uuid(uuid_t *dimension_uuid);
 extern void sql_archived_database_hosts(BUFFER *wb, int count);
 
+extern void sql_build_context_param_list(struct context_param **param_list, uuid_t *host_uuid, char *context);
+
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -5,8 +5,13 @@
 #define JSON_DATES_JS 1
 #define JSON_DATES_TIMESTAMP 2
 
-void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, RRDDIM *temp_rd) {
-    rrdset_check_rdlock(r->st);
+void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, struct context_param *context_param_list)
+{
+    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
+    int should_lock = (!context_param_list || (context_param_list && !context_param_list->archive_mode));
+
+    if (should_lock)
+        rrdset_check_rdlock(r->st);
 
     //info("RRD2JSON(): %s: BEGIN", r->st->id);
     int row_annotations = 0, dates, dates_with_new = 0;
@@ -100,8 +105,6 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, RRDDIM 
 
         buffer_strcat(wb, pre_label);
         buffer_strcat(wb, rd->name);
-//        buffer_strcat(wb, ".");
-//        buffer_strcat(wb, rd->rrdset->name);
         buffer_strcat(wb, post_label);
         i++;
     }

--- a/web/api/formatters/json/json.h
+++ b/web/api/formatters/json/json.h
@@ -5,6 +5,6 @@
 
 #include "../rrd2json.h"
 
-extern void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, RRDDIM *temp_rd);
+extern void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, struct context_param *context_param_list);
 
 #endif //NETDATA_API_FORMATTER_JSON_H

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -3,7 +3,7 @@
 #include "json_wrapper.h"
 
 void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value,
-                             struct context_param *context_param_list, char *chart_label_key) {
+                             struct context_param *context_param_list, char *chart_label_key)
 {
 
     RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -2,8 +2,14 @@
 
 #include "json_wrapper.h"
 
-void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value, RRDDIM *temp_rd, char *chart_label_key) {
-    rrdset_check_rdlock(r->st);
+void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value,
+                             struct context_param *context_param_list, char *chart_label_key) {
+{
+
+    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
+
+    if (context_param_list && !context_param_list->archive_mode)
+        rrdset_check_rdlock(r->st);
 
     long rows = rrdr_rows(r);
     long c, i;
@@ -39,8 +45,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                    , kq, kq, sq, temp_rd?r->st->context:r->st->name, sq
                    , kq, kq, r->update_every
                    , kq, kq, r->st->update_every
-                   , kq, kq, (uint32_t)rrdset_first_entry_t_nolock(r->st)
-                   , kq, kq, (uint32_t)rrdset_last_entry_t_nolock(r->st)
+                   , kq, kq, context_param_list ? (uint32_t) context_param_list->first_entry_t : (uint32_t)rrdset_first_entry_t(r->st)
+                   , kq, kq, context_param_list ? (uint32_t) context_param_list->last_entry_t : (uint32_t)rrdset_last_entry_t(r->st)
                    , kq, kq, (uint32_t)r->before
                    , kq, kq, (uint32_t)r->after
                    , kq, kq);

--- a/web/api/formatters/json_wrapper.h
+++ b/web/api/formatters/json_wrapper.h
@@ -5,7 +5,7 @@
 
 #include "rrd2json.h"
 
-extern void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value, RRDDIM *temp_rd, char *chart_key);
+extern void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value, struct context_param *context_param_list, char *chart_key);
 extern void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
 
 #endif //NETDATA_API_FORMATTER_JSON_WRAPPER_H

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -334,7 +334,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 1, temp_rd);
+        rrdr2json(r, wb, options, 1, context_param_list);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);
@@ -346,7 +346,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 1, temp_rd);
+        rrdr2json(r, wb, options, 1, context_param_list);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);
@@ -357,7 +357,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 0, temp_rd);
+        rrdr2json(r, wb, options, 0, context_param_list);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);
@@ -370,7 +370,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 0, temp_rd);
+        rrdr2json(r, wb, options, 0, context_param_list);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -13,9 +13,12 @@ static inline void free_temp_rrddim(RRDDIM *temp_rd, int archive_mode)
         freez((char *)temp_rd->id);
         freez((char *)temp_rd->name);
         if (unlikely(archive_mode)) {
-            freez((char *) temp_rd->rrdset->name);
-            freez(temp_rd->rrdset->context);
-            freez(temp_rd->rrdset);
+            temp_rd->rrdset->counter--;
+            if (!temp_rd->rrdset->counter) {
+                freez((char *)temp_rd->rrdset->name);
+                freez(temp_rd->rrdset->context);
+                freez(temp_rd->rrdset);
+            }
         }
 #ifdef ENABLE_DBENGINE
         if (temp_rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -219,7 +219,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_SSV:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2ssv(r, wb, options, "", " ", "");
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -232,7 +232,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_SSV_COMMA:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2ssv(r, wb, options, "", ",", "");
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -245,7 +245,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_JS_ARRAY:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
             rrdr2ssv(r, wb, options, "[", ",", "]");
             rrdr_json_wrapper_end(r, wb, format, options, 0);
         }
@@ -258,7 +258,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_CSV:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2csv(r, wb, format, options, "", ",", "\\n", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -271,7 +271,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_CSV_MARKDOWN:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2csv(r, wb, format, options, "", "|", "\\n", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -284,7 +284,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_CSV_JSON_ARRAY:
         wb->contenttype = CT_APPLICATION_JSON;
         if(options & RRDR_OPTION_JSON_WRAP) {
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
             buffer_strcat(wb, "[\n");
             rrdr2csv(r, wb, format, options + RRDR_OPTION_LABEL_QUOTES, "[", ",", "]", ",\n", temp_rd);
             buffer_strcat(wb, "\n]");
@@ -301,7 +301,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_TSV:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2csv(r, wb, format, options, "", "\t", "\\n", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -314,7 +314,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_HTML:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             buffer_strcat(wb, "<html>\\n<center>\\n<table border=\\\"0\\\" cellpadding=\\\"5\\\" cellspacing=\\\"5\\\">\\n");
             rrdr2csv(r, wb, format, options, "<tr><td>", "</td><td>", "</td></tr>\\n", "", temp_rd);
             buffer_strcat(wb, "</table>\\n</center>\\n</html>\\n");
@@ -332,7 +332,7 @@ int rrdset2anything_api_v1(
         wb->contenttype = CT_APPLICATION_X_JAVASCRIPT;
 
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
         rrdr2json(r, wb, options, 1, temp_rd);
 
@@ -344,7 +344,7 @@ int rrdset2anything_api_v1(
         wb->contenttype = CT_APPLICATION_JSON;
 
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
         rrdr2json(r, wb, options, 1, temp_rd);
 
@@ -355,7 +355,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_JSONP:
         wb->contenttype = CT_APPLICATION_X_JAVASCRIPT;
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
         rrdr2json(r, wb, options, 0, temp_rd);
 
@@ -368,7 +368,7 @@ int rrdset2anything_api_v1(
         wb->contenttype = CT_APPLICATION_JSON;
 
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
         rrdr2json(r, wb, options, 0, temp_rd);
 

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -281,8 +281,14 @@ RRDR_GROUPING web_client_api_request_v1_data_group(const char *name, RRDR_GROUPI
 
 // ----------------------------------------------------------------------------
 
-static void rrdr_disable_not_selected_dimensions(RRDR *r, RRDR_OPTIONS options, const char *dims, RRDDIM *temp_rd) {
-    rrdset_check_rdlock(r->st);
+static void rrdr_disable_not_selected_dimensions(RRDR *r, RRDR_OPTIONS options, const char *dims,
+                                                 struct context_param *context_param_list)
+{
+    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
+    int should_lock = (!context_param_list || (context_param_list && !context_param_list->archive_mode));
+
+    if (should_lock)
+        rrdset_check_rdlock(r->st);
 
     if(unlikely(!dims || !*dims || (dims[0] == '*' && dims[1] == '\0'))) return;
 
@@ -1064,7 +1070,7 @@ static RRDR *rrd2rrdr_fixedstep(
         rrdset_check_rdlock(st);
 
     if(dimensions)
-        rrdr_disable_not_selected_dimensions(r, options, dimensions, temp_rd);
+        rrdr_disable_not_selected_dimensions(r, options, dimensions, context_param_list);
 
 
     // -------------------------------------------------------------------------
@@ -1441,7 +1447,7 @@ static RRDR *rrd2rrdr_variablestep(
         rrdset_check_rdlock(st);
 
     if(dimensions)
-        rrdr_disable_not_selected_dimensions(r, options, dimensions, temp_rd);
+        rrdr_disable_not_selected_dimensions(r, options, dimensions, context_param_list);
 
 
     // -------------------------------------------------------------------------

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1060,7 +1060,8 @@ static RRDR *rrd2rrdr_fixedstep(
     // -------------------------------------------------------------------------
     // disable the not-wanted dimensions
 
-    rrdset_check_rdlock(st);
+    if (context_param_list && !context_param_list->archive_mode)
+        rrdset_check_rdlock(st);
 
     if(dimensions)
         rrdr_disable_not_selected_dimensions(r, options, dimensions, temp_rd);
@@ -1436,7 +1437,8 @@ static RRDR *rrd2rrdr_variablestep(
     // -------------------------------------------------------------------------
     // disable the not-wanted dimensions
 
-    rrdset_check_rdlock(st);
+    if (context_param_list && !context_param_list->archive_mode)
+        rrdset_check_rdlock(st);
 
     if(dimensions)
         rrdr_disable_not_selected_dimensions(r, options, dimensions, temp_rd);

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -108,7 +108,7 @@ RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param
     RRDR *r = callocz(1, sizeof(RRDR));
     r->st = st;
 
-    if (context_param_list && !context_param_list->archive_mode)
+    if (!context_param_list || (context_param_list && !context_param_list->archive_mode))
         rrdr_lock_rrdset(r);
 
     RRDDIM *temp_rd =  context_param_list ? context_param_list->rd : NULL;

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -108,7 +108,8 @@ RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param
     RRDR *r = callocz(1, sizeof(RRDR));
     r->st = st;
 
-    rrdr_lock_rrdset(r);
+    if (context_param_list && !context_param_list->archive_mode)
+        rrdr_lock_rrdset(r);
 
     RRDDIM *temp_rd =  context_param_list ? context_param_list->rd : NULL;
     RRDDIM *rd;

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -797,7 +797,7 @@ inline int web_client_api_request_v1_archived_data(RRDHOST *host, struct web_cli
     }
 
     ret = rrdset2anything_api_v1(st, w->response.data, dimensions, format, points, after, before, group, group_time
-        , options, &last_timestamp_in_data, context_param_list);
+        , options, &last_timestamp_in_data, context_param_list, NULL);
 
     free_context_param_list(&context_param_list);
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -608,6 +608,222 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     return ret;
 }
 
+inline int web_client_api_request_v1_archived_data(RRDHOST *host, struct web_client *w, char *url) {
+    debug(D_WEB_CLIENT, "%llu: API v1 data with URL '%s'", w->id, url);
+
+    int ret = HTTP_RESP_BAD_REQUEST;
+    BUFFER *dimensions = NULL;
+
+    buffer_flush(w->response.data);
+
+    char    *google_version = "0.6",
+        *google_reqId = "0",
+        *google_sig = "0",
+        *google_out = "json",
+        *responseHandler = NULL,
+        *outFileName = NULL;
+
+    time_t last_timestamp_in_data = 0, google_timestamp = 0;
+
+    char *chart = NULL
+    , *before_str = NULL
+    , *after_str = NULL
+    , *group_time_str = NULL
+    , *points_str = NULL
+    , *context = NULL;
+
+    int group = RRDR_GROUPING_AVERAGE;
+    uint32_t format = DATASOURCE_JSON;
+    uint32_t options = 0x00000000;
+
+    while(url) {
+        char *value = mystrsep(&url, "&");
+        if(!value || !*value) continue;
+
+        char *name = mystrsep(&value, "=");
+        if(!name || !*name) continue;
+        if(!value || !*value) continue;
+
+        debug(D_WEB_CLIENT, "%llu: API v1 data query param '%s' with value '%s'", w->id, name, value);
+
+        // name and value are now the parameters
+        // they are not null and not empty
+
+        if(!strcmp(name, "context")) context = value;
+        else if(!strcmp(name, "chart")) chart = value;
+        else if(!strcmp(name, "dimension") || !strcmp(name, "dim") || !strcmp(name, "dimensions") || !strcmp(name, "dims")) {
+            if(!dimensions) dimensions = buffer_create(100);
+            buffer_strcat(dimensions, "|");
+            buffer_strcat(dimensions, value);
+        }
+        else if(!strcmp(name, "after")) after_str = value;
+        else if(!strcmp(name, "before")) before_str = value;
+        else if(!strcmp(name, "points")) points_str = value;
+        else if(!strcmp(name, "gtime")) group_time_str = value;
+        else if(!strcmp(name, "group")) {
+            group = web_client_api_request_v1_data_group(value, RRDR_GROUPING_AVERAGE);
+        }
+        else if(!strcmp(name, "format")) {
+            format = web_client_api_request_v1_data_format(value);
+        }
+        else if(!strcmp(name, "options")) {
+            options |= web_client_api_request_v1_data_options(value);
+        }
+        else if(!strcmp(name, "callback")) {
+            responseHandler = value;
+        }
+        else if(!strcmp(name, "filename")) {
+            outFileName = value;
+        }
+        else if(!strcmp(name, "tqx")) {
+            // parse Google Visualization API options
+            // https://developers.google.com/chart/interactive/docs/dev/implementing_data_source
+            char *tqx_name, *tqx_value;
+
+            while(value) {
+                tqx_value = mystrsep(&value, ";");
+                if(!tqx_value || !*tqx_value) continue;
+
+                tqx_name = mystrsep(&tqx_value, ":");
+                if(!tqx_name || !*tqx_name) continue;
+                if(!tqx_value || !*tqx_value) continue;
+
+                if(!strcmp(tqx_name, "version"))
+                    google_version = tqx_value;
+                else if(!strcmp(tqx_name, "reqId"))
+                    google_reqId = tqx_value;
+                else if(!strcmp(tqx_name, "sig")) {
+                    google_sig = tqx_value;
+                    google_timestamp = strtoul(google_sig, NULL, 0);
+                }
+                else if(!strcmp(tqx_name, "out")) {
+                    google_out = tqx_value;
+                    format = web_client_api_request_v1_data_google_format(google_out);
+                }
+                else if(!strcmp(tqx_name, "responseHandler"))
+                    responseHandler = tqx_value;
+                else if(!strcmp(tqx_name, "outFileName"))
+                    outFileName = tqx_value;
+            }
+        }
+    }
+
+    // validate the google parameters given
+    fix_google_param(google_out);
+    fix_google_param(google_sig);
+    fix_google_param(google_reqId);
+    fix_google_param(google_version);
+    fix_google_param(responseHandler);
+    fix_google_param(outFileName);
+
+    RRDSET *st = NULL;
+
+    if((!chart || !*chart) && (!context)) {
+        buffer_sprintf(w->response.data, "No chart id is given at the request.");
+        goto cleanup;
+    }
+
+    struct context_param  *context_param_list = NULL;
+    if (context && !chart) {
+        RRDSET *st1;
+        uint32_t context_hash = simple_hash(context);
+        rrdhost_rdlock(localhost);
+        rrdset_foreach_read(st1, localhost) {
+            if (st1->hash_context == context_hash && !strcmp(st1->context, context))
+                build_context_param_list(&context_param_list, st1);
+        }
+        rrdhost_unlock(localhost);
+        if (likely(context_param_list && context_param_list->rd))  // Just set the first one
+            st = context_param_list->rd->rrdset;
+    }
+    else {
+        st = rrdset_find(host, chart);
+        if (!st)
+            st = rrdset_find_byname(host, chart);
+        if (likely(st))
+            st->last_accessed_time = now_realtime_sec();
+    }
+
+    if (!st && !context_param_list) {
+        if (context && !chart) {
+            buffer_strcat(w->response.data, "Context is not found: ");
+            buffer_strcat_htmlescape(w->response.data, context);
+        }
+        else {
+            buffer_strcat(w->response.data, "Chart is not found: ");
+            buffer_strcat_htmlescape(w->response.data, chart);
+        }
+        ret = HTTP_RESP_NOT_FOUND;
+        goto cleanup;
+    }
+
+    long long before = (before_str && *before_str)?str2l(before_str):0;
+    long long after  = (after_str  && *after_str) ?str2l(after_str):-600;
+    int       points = (points_str && *points_str)?str2i(points_str):0;
+    long      group_time = (group_time_str && *group_time_str)?str2l(group_time_str):0;
+
+    debug(D_WEB_CLIENT, "%llu: API command 'data' for chart '%s', dimensions '%s', after '%lld', before '%lld', points '%d', group '%d', format '%u', options '0x%08x'"
+    , w->id
+    , chart
+    , (dimensions)?buffer_tostring(dimensions):""
+    , after
+    , before
+    , points
+    , group
+    , format
+    , options
+    );
+
+    if(outFileName && *outFileName) {
+        buffer_sprintf(w->response.header, "Content-Disposition: attachment; filename=\"%s\"\r\n", outFileName);
+        debug(D_WEB_CLIENT, "%llu: generating outfilename header: '%s'", w->id, outFileName);
+    }
+
+    if(format == DATASOURCE_DATATABLE_JSONP) {
+        if(responseHandler == NULL)
+            responseHandler = "google.visualization.Query.setResponse";
+
+        debug(D_WEB_CLIENT_ACCESS, "%llu: GOOGLE JSON/JSONP: version = '%s', reqId = '%s', sig = '%s', out = '%s', responseHandler = '%s', outFileName = '%s'",
+              w->id, google_version, google_reqId, google_sig, google_out, responseHandler, outFileName
+        );
+
+        buffer_sprintf(w->response.data,
+                       "%s({version:'%s',reqId:'%s',status:'ok',sig:'%ld',table:",
+                       responseHandler, google_version, google_reqId, st->last_updated.tv_sec);
+    }
+    else if(format == DATASOURCE_JSONP) {
+        if(responseHandler == NULL)
+            responseHandler = "callback";
+
+        buffer_strcat(w->response.data, responseHandler);
+        buffer_strcat(w->response.data, "(");
+    }
+
+    ret = rrdset2anything_api_v1(st, w->response.data, dimensions, format, points, after, before, group, group_time
+        , options, &last_timestamp_in_data, context_param_list);
+
+    free_context_param_list(&context_param_list);
+
+    if(format == DATASOURCE_DATATABLE_JSONP) {
+        if(google_timestamp < last_timestamp_in_data)
+            buffer_strcat(w->response.data, "});");
+
+        else {
+            // the client already has the latest data
+            buffer_flush(w->response.data);
+            buffer_sprintf(w->response.data,
+                           "%s({version:'%s',reqId:'%s',status:'error',errors:[{reason:'not_modified',message:'Data not modified'}]});",
+                           responseHandler, google_version, google_reqId);
+        }
+    }
+    else if(format == DATASOURCE_JSONP)
+        buffer_strcat(w->response.data, ");");
+
+    cleanup:
+    buffer_free(dimensions);
+    return ret;
+}
+
 // Pings a netdata server:
 // /api/v1/registry?action=hello
 //
@@ -864,6 +1080,23 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
     }
     rrd_unlock();
 
+    buffer_strcat(wb, "\n\t],\n\t\"archived_hosts\": [\n");
+    count = 0;
+    rrdhost_foreach_read(host)
+    {
+        if (!rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))
+            continue;
+        if (count > 0)
+            buffer_strcat(wb, ",\n");
+
+        buffer_sprintf(
+            wb, "\t\t{ \"guid\": \"%s\", \"hostname\": \"%s\"", host->machine_guid, host->hostname);
+
+        count++;
+    }
+
+    sql_archived_database_hosts(wb, count);
+
     buffer_strcat(wb, "\n\t],\n");
 }
 
@@ -1003,6 +1236,7 @@ static struct api_command {
 } api_commands[] = {
         { "info",            0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_info            },
         { "data",            0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_data            },
+        { "archived_data",   0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_archived_data    },
         { "chart",           0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_chart           },
         { "charts",          0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_charts          },
         { "archivedcharts",  0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_archivedcharts  },

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -727,12 +727,7 @@ inline int web_client_api_request_v1_archived_data(RRDHOST *host, struct web_cli
     if (context && !chart) {
         RRDSET *st1;
         uint32_t context_hash = simple_hash(context);
-        rrdhost_rdlock(localhost);
-        rrdset_foreach_read(st1, localhost) {
-            if (st1->hash_context == context_hash && !strcmp(st1->context, context))
-                build_context_param_list(&context_param_list, st1);
-        }
-        rrdhost_unlock(localhost);
+        sql_build_context_param_list(&context_param_list, &host->host_uuid, context);
         if (likely(context_param_list && context_param_list->rd))  // Just set the first one
             st = context_param_list->rd->rrdset;
     }

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1073,7 +1073,6 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 
         count++;
     }
-    rrd_unlock();
 
     buffer_strcat(wb, "\n\t],\n\t\"archived_hosts\": [\n");
     count = 0;
@@ -1089,6 +1088,7 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 
         count++;
     }
+    rrd_unlock();
 
     sql_archived_database_hosts(wb, count);
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -725,8 +725,8 @@ inline int web_client_api_request_v1_archived_data(RRDHOST *host, struct web_cli
 
     struct context_param  *context_param_list = NULL;
     if (context && !chart) {
-        RRDSET *st1;
-        uint32_t context_hash = simple_hash(context);
+//        RRDSET *st1;
+//        uint32_t context_hash = simple_hash(context);
         sql_build_context_param_list(&context_param_list, &host->host_uuid, context);
         if (likely(context_param_list && context_param_list->rd))  // Just set the first one
             st = context_param_list->rd->rrdset;

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -27,6 +27,9 @@ extern int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, c
 extern int web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *url);
 extern int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb);
 extern void host_labels2json(RRDHOST *host, BUFFER *wb, size_t indentation);
+extern int web_client_api_request_v1_archived_data(RRDHOST *host, struct web_client *w, char *url);
+extern int web_client_api_request_v1_archived_hosts(RRDHOST *host, struct web_client *w, char *url);
+
 
 extern void web_client_api_v1_init(void);
 extern void web_client_api_v1_management_init(void);


### PR DESCRIPTION
##### Summary
Add missing entries to the archivedcharts endpoint

- duration
- first_entry
- last_entry
- updated_every

Archived charts are fetched from the database. The dimension uuid is used to query the database for first and last entry in the
following order: 

- Dimension uuid as stored in the database
- if not found the legacy uuid is computed and is used to search
- if not found the multihost uuid is computed and used to search

##### Component Name
database

##### Test Plan
