### PR TITLE
Fixed the data endpoint so that the context param is correctly applied to children

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -499,12 +499,12 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     if (context && !chart) {
         RRDSET *st1;
         uint32_t context_hash = simple_hash(context);
-        rrdhost_rdlock(localhost);
-        rrdset_foreach_read(st1, localhost) {
+        rrdhost_rdlock(host);
+        rrdset_foreach_read(st1, host) {
             if (st1->hash_context == context_hash && !strcmp(st1->context, context))
                 build_context_param_list(&context_param_list, st1);
         }
-        rrdhost_unlock(localhost);
+        rrdhost_unlock(host);
         if (likely(context_param_list && context_param_list->rd))  // Just set the first one
             st = context_param_list->rd->rrdset;
     }


### PR DESCRIPTION
##### Summary
When the context param is supplied to the data endpoint the context matched charts available to the localhost. 
This would return results for the parent even if a data query in the form 

`/host/<host>/api/v1/data?context=xxx` 

query was given. 

##### Component Name
database

##### Test Plan
To make the difference stand out select a parent and child that have different cpu core count

- Execute a query for a parent as
  - localhost:19999/api/v1/data?context=cpu.cpu&dimension=system
- Execute a query for a child **XX** as
  - localhost:19999/host/XX/api/v1/data?context=cpu.cpu&dimension=system

Repeat after applying this PR to notice the difference in the child data query results


##### Additional Information
