### PR TITLE
dbengine extent cache

### DIFF
--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -92,11 +92,11 @@ static int try_insert_into_xt_cache(struct rrdengine_worker_config* wc, struct e
     unsigned idx;
     int ret;
 
-    ret = find_first_zero(wc->xt_cache.allocation_bitmap);
+    ret = find_first_zero(xt_cache->allocation_bitmap);
     if (-1 == ret || ret >= MAX_CACHED_EXTENTS) {
         for (xt_cache_elem = xt_cache->replaceQ_head ; NULL != xt_cache_elem ; xt_cache_elem = xt_cache_elem->next) {
             idx = xt_cache_elem - xt_cache->extent_array;
-            if (!check_bit(wc->xt_cache.inflight_bitmap, idx)) {
+            if (!check_bit(xt_cache->inflight_bitmap, idx)) {
                 xt_cache_replaceQ_delete(wc, xt_cache_elem);
                 break;
             }
@@ -110,7 +110,7 @@ static int try_insert_into_xt_cache(struct rrdengine_worker_config* wc, struct e
     xt_cache_elem->extent = extent;
     xt_cache_elem->inflight_io_descr = NULL;
     xt_cache_replaceQ_insert(wc, xt_cache_elem);
-    modify_bit(&wc->xt_cache.allocation_bitmap, idx, 1);
+    modify_bit(&xt_cache->allocation_bitmap, idx, 1);
 
     return (int)idx;
 }
@@ -127,7 +127,7 @@ static uint8_t lookup_in_xt_cache(struct rrdengine_worker_config* wc, struct ext
 
     for (i = 0 ; i < MAX_CACHED_EXTENTS ; ++i) {
         xt_cache_elem = &xt_cache->extent_array[i];
-        if (xt_cache_elem->extent == extent) {
+        if (check_bit(xt_cache->allocation_bitmap, i) && xt_cache_elem->extent == extent) {
             *idx = i;
             return 0;
         }

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -283,7 +283,7 @@ after_crc_check:
         if (xt_is_cached && xt_is_inflight) {
             struct extent_cache *xt_cache = &wc->xt_cache;
             struct extent_cache_element *xt_cache_elem = &xt_cache->extent_array[xt_idx];
-            struct extent_io_descriptor *curr;
+            struct extent_io_descriptor *curr, *next;
 
             if (have_read_error) {
                 memset(xt_cache_elem->pages, 0, sizeof(xt_cache_elem->pages));
@@ -293,7 +293,8 @@ after_crc_check:
                 (void)memcpy(xt_cache_elem->pages, uncompressed_buf, uncompressed_payload_length);
             }
             /* complete all connected in-flight read requests */
-            for (curr = xt_cache_elem->inflight_io_descr->next ; curr ; curr = curr->next) {
+            for (curr = xt_cache_elem->inflight_io_descr->next ; curr ; curr = next) {
+                next = curr->next;
                 read_cached_extent_cb(wc, xt_idx, curr);
             }
             xt_cache_elem->inflight_io_descr = NULL;

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -40,6 +40,9 @@ static inline void xt_cache_replaceQ_insert(struct rrdengine_worker_config* wc,
 {
     struct extent_cache *xt_cache = &wc->xt_cache;
 
+    xt_cache_elem->prev = NULL;
+    xt_cache_elem->next = NULL;
+
     if (likely(NULL != xt_cache->replaceQ_tail)) {
         xt_cache_elem->prev = xt_cache->replaceQ_tail;
         xt_cache->replaceQ_tail->next = xt_cache_elem;
@@ -81,23 +84,35 @@ static inline void xt_cache_replaceQ_set_hot(struct rrdengine_worker_config* wc,
     xt_cache_replaceQ_insert(wc, xt_cache_elem);
 }
 
-/* Returns 0 if the index of the cached extent if it was successfully inserted in the extent cache. */
-static uint8_t try_insert_into_xt_cache(struct rrdengine_worker_config* wc, struct extent_info *extent)
+/* Returns the index of the cached extent if it was successfully inserted in the extent cache, otherwise -1 */
+static int try_insert_into_xt_cache(struct rrdengine_worker_config* wc, struct extent_info *extent)
 {
     struct extent_cache *xt_cache = &wc->xt_cache;
     struct extent_cache_element *xt_cache_elem;
     unsigned idx;
     int ret;
 
-    ret = find_first_bit(wc->xt_cache.allocation_bitmap);
-    if (-1 == ret)
-        return 1;
-
-    idx = (unsigned)ret;
-    xt_cache_elem = &xt_cache->extent_array[idx];
+    ret = find_first_zero(wc->xt_cache.allocation_bitmap);
+    if (-1 == ret || ret >= MAX_CACHED_EXTENTS) {
+        for (xt_cache_elem = xt_cache->replaceQ_head ; NULL != xt_cache_elem ; xt_cache_elem = xt_cache_elem->next) {
+            idx = xt_cache_elem - xt_cache->extent_array;
+            if (!check_bit(wc->xt_cache.inflight_bitmap, idx)) {
+                xt_cache_replaceQ_delete(wc, xt_cache_elem);
+                break;
+            }
+        }
+        if (NULL == xt_cache_elem)
+            return -1;
+    } else {
+        idx = (unsigned)ret;
+        xt_cache_elem = &xt_cache->extent_array[idx];
+    }
     xt_cache_elem->extent = extent;
+    xt_cache_elem->inflight_io_descr = NULL;
     xt_cache_replaceQ_insert(wc, xt_cache_elem);
-    modify_bit(wc->xt_cache.allocation_bitmap, idx, 1);
+    modify_bit(&wc->xt_cache.allocation_bitmap, idx, 1);
+
+    return (int)idx;
 }
 
 /**
@@ -128,8 +143,67 @@ static void delete_from_xt_cache(struct rrdengine_worker_config* wc, unsigned id
     xt_cache_elem = &xt_cache->extent_array[idx];
     xt_cache_replaceQ_delete(wc, xt_cache_elem);
     xt_cache_elem->extent = NULL;
-    modify_bit(wc->xt_cache.allocation_bitmap, idx, 0); /* invalidate it */
-    modify_bit(wc->xt_cache.inflight_bitmap, idx, 0); /* not in-flight anymore */
+    modify_bit(&wc->xt_cache.allocation_bitmap, idx, 0); /* invalidate it */
+    modify_bit(&wc->xt_cache.inflight_bitmap, idx, 0); /* not in-flight anymore */
+}
+
+void enqueue_inflight_read_to_xt_cache(struct rrdengine_worker_config* wc, unsigned idx,
+                                       struct extent_io_descriptor *xt_io_descr)
+{
+    struct extent_cache *xt_cache = &wc->xt_cache;
+    struct extent_cache_element *xt_cache_elem;
+    struct extent_io_descriptor *curr;
+
+    xt_cache_elem = &xt_cache->extent_array[idx];
+    for (curr = xt_cache_elem->inflight_io_descr ; curr->next != NULL ; curr = curr->next) {
+        ;
+    }
+    curr->next = xt_io_descr;
+}
+
+void read_cached_extent_cb(struct rrdengine_worker_config* wc, unsigned idx, struct extent_io_descriptor *xt_io_descr)
+{
+    unsigned i, j, page_offset;
+    struct rrdengine_instance *ctx = wc->ctx;
+    struct rrdeng_page_descr *descr;
+    struct page_cache_descr *pg_cache_descr;
+    void *page;
+    struct extent_info *extent = xt_io_descr->descr_array[0]->extent;
+
+    for (i = 0 ; i < xt_io_descr->descr_count; ++i) {
+        page = mallocz(RRDENG_BLOCK_SIZE);
+        descr = xt_io_descr->descr_array[i];
+        for (j = 0, page_offset = 0 ; j < extent->number_of_pages ; ++j) {
+            /* care, we don't hold the descriptor mutex */
+            if (!uuid_compare(*extent->pages[j]->id, *descr->id) &&
+                extent->pages[j]->page_length == descr->page_length &&
+                extent->pages[j]->start_time == descr->start_time &&
+                extent->pages[j]->end_time == descr->end_time) {
+                break;
+            }
+            page_offset += extent->pages[j]->page_length;
+
+        }
+        /* care, we don't hold the descriptor mutex */
+       (void) memcpy(page, wc->xt_cache.extent_array[idx].pages + page_offset, descr->page_length);
+
+        rrdeng_page_descr_mutex_lock(ctx, descr);
+        pg_cache_descr = descr->pg_cache_descr;
+        pg_cache_descr->page = page;
+        pg_cache_descr->flags |= RRD_PAGE_POPULATED;
+        pg_cache_descr->flags &= ~RRD_PAGE_READ_PENDING;
+        rrdeng_page_descr_mutex_unlock(ctx, descr);
+        pg_cache_replaceQ_insert(ctx, descr);
+        if (xt_io_descr->release_descr) {
+            pg_cache_put(ctx, descr);
+        } else {
+            debug(D_RRDENGINE, "%s: Waking up waiters.", __func__);
+            pg_cache_wake_up_waiters(ctx, descr);
+        }
+    }
+    if (xt_io_descr->completion)
+        complete(xt_io_descr->completion);
+    freez(xt_io_descr);
 }
 
 void read_extent_cb(uv_fs_t* req)
@@ -208,22 +282,27 @@ after_crc_check:
         xt_is_cached = !lookup_in_xt_cache(wc, extent, &xt_idx);
         xt_is_inflight = check_bit(wc->xt_cache.inflight_bitmap, xt_idx);
         if (xt_is_cached && xt_is_inflight) {
+            struct extent_cache *xt_cache = &wc->xt_cache;
+            struct extent_cache_element *xt_cache_elem = &xt_cache->extent_array[xt_idx];
+            struct extent_io_descriptor *curr;
+
             if (have_read_error) {
-                delete_from_xt_cache(wc, xt_idx);
+                memset(xt_cache_elem->pages, 0, payload_length);
             }
             else {
-                for (j = 0, page_offset = 0; j < count; ++j) {
+                for (j = 0 ; j < count ; ++j) {
                     if (RRD_NO_COMPRESSION == header->compression_algorithm)
-                        (void)memcpy(
-                            wc->xt_cache.extent_array[xt_idx].pages, xt_io_descr->buf + payload_offset + page_offset,
-                            header->descr[j].page_length);
+                        (void)memcpy(xt_cache_elem->pages, xt_io_descr->buf + payload_offset, payload_length);
                     else
-                        (void)memcpy(
-                            wc->xt_cache.extent_array[xt_idx].pages, uncompressed_buf + page_offset,
-                            header->descr[j].page_length);
+                        (void)memcpy(xt_cache_elem->pages, uncompressed_buf, payload_length);
                 }
-                modify_bit(wc->xt_cache.inflight_bitmap, xt_idx, 0); /* not in-flight anymore */
             }
+            /* complete all connected in-flight read requests */
+            for (curr = xt_cache_elem->inflight_io_descr->next ; curr ; curr = curr->next) {
+                read_cached_extent_cb(wc, xt_idx, curr);
+            }
+            xt_cache_elem->inflight_io_descr = NULL;
+            modify_bit(&xt_cache->inflight_bitmap, xt_idx, 0); /* not in-flight anymore */
         }
     }
 
@@ -286,18 +365,15 @@ static void do_read_extent(struct rrdengine_worker_config* wc,
 //    uint32_t payload_length;
     struct extent_io_descriptor *xt_io_descr;
     struct rrdengine_datafile *datafile;
+    struct extent_info *extent = descr[0]->extent;
+    uint8_t xt_is_cached = 0, xt_is_inflight = 0;
+    unsigned xt_idx;
 
-    datafile = descr[0]->extent->datafile;
-    pos = descr[0]->extent->offset;
-    size_bytes = descr[0]->extent->size;
+    datafile = extent->datafile;
+    pos = extent->offset;
+    size_bytes = extent->size;
 
-    xt_io_descr = mallocz(sizeof(*xt_io_descr));
-    ret = posix_memalign((void *)&xt_io_descr->buf, RRDFILE_ALIGNMENT, ALIGN_BYTES_CEILING(size_bytes));
-    if (unlikely(ret)) {
-        fatal("posix_memalign:%s", strerror(ret));
-        /* freez(xt_io_descr);
-        return;*/
-    }
+    xt_io_descr = callocz(1, sizeof(*xt_io_descr));
     for (i = 0 ; i < count; ++i) {
         rrdeng_page_descr_mutex_lock(ctx, descr[i]);
         pg_cache_descr = descr[i]->pg_cache_descr;
@@ -315,6 +391,30 @@ static void do_read_extent(struct rrdengine_worker_config* wc,
     /* xt_io_descr->descr_commit_idx_array[0] */
     xt_io_descr->release_descr = release_descr;
 
+    xt_is_cached = !lookup_in_xt_cache(wc, extent, &xt_idx);
+    if (xt_is_cached) {
+        xt_cache_replaceQ_set_hot(wc, &wc->xt_cache.extent_array[xt_idx]);
+        xt_is_inflight = check_bit(wc->xt_cache.inflight_bitmap, xt_idx);
+        if (xt_is_inflight) {
+            enqueue_inflight_read_to_xt_cache(wc, xt_idx, xt_io_descr);
+            return;
+        }
+        return read_cached_extent_cb(wc, xt_idx, xt_io_descr);
+    } else {
+        ret = try_insert_into_xt_cache(wc, extent);
+        if (-1 != ret) {
+            xt_idx = (unsigned)ret;
+            modify_bit(&wc->xt_cache.inflight_bitmap, xt_idx, 1);
+            wc->xt_cache.extent_array[xt_idx].inflight_io_descr = xt_io_descr;
+        }
+    }
+
+    ret = posix_memalign((void *)&xt_io_descr->buf, RRDFILE_ALIGNMENT, ALIGN_BYTES_CEILING(size_bytes));
+    if (unlikely(ret)) {
+        fatal("posix_memalign:%s", strerror(ret));
+        /* freez(xt_io_descr);
+    return;*/
+    }
     real_io_size = ALIGN_BYTES_CEILING(size_bytes);
     xt_io_descr->iov = uv_buf_init((void *)xt_io_descr->buf, real_io_size);
     ret = uv_fs_read(wc->loop, &xt_io_descr->req, datafile->file, &xt_io_descr->iov, 1, pos, read_extent_cb);

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -101,7 +101,8 @@ struct generic_io_descriptor {
 };
 
 struct extent_cache_element {
-    struct extent_info *extent;
+    struct extent_info *extent; /* The ABA problem is avoided with the help of fileno below */
+    unsigned fileno;
     struct extent_cache_element *prev; /* LRU */
     struct extent_cache_element *next; /* LRU */
     struct extent_io_descriptor *inflight_io_descr; /* I/O descriptor for in-flight extent */

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -88,6 +88,7 @@ struct extent_io_descriptor {
     int release_descr;
     struct rrdeng_page_descr *descr_array[MAX_PAGES_PER_EXTENT];
     Word_t descr_commit_idx_array[MAX_PAGES_PER_EXTENT];
+    struct extent_io_descriptor *next; /* multiple requests to be served by the same cached extent */
 };
 
 struct generic_io_descriptor {
@@ -97,6 +98,25 @@ struct generic_io_descriptor {
     uint64_t pos;
     unsigned bytes;
     struct completion *completion;
+};
+
+struct extent_cache_element {
+    struct extent_info *extent;
+    struct extent_cache_element *prev; /* LRU */
+    struct extent_cache_element *next; /* LRU */
+    uint8_t pages[MAX_PAGES_PER_EXTENT][RRDENG_BLOCK_SIZE];
+};
+
+#define MAX_CACHED_EXTENTS 16 /* cannot be over 32 to fit in 32-bit architectures */
+
+/* Initialize by setting the structure to zero */
+struct extent_cache {
+    struct extent_cache_element extent_array[MAX_CACHED_EXTENTS];
+    unsigned long allocation_bitmap; /* 1 if the corresponding position in the extent_array is allocated */
+    unsigned long inflight_bitmap; /* 1 if the corresponding position in the extent_array is waiting for I/O */
+
+    struct extent_cache_element *replaceQ_head; /* LRU */
+    struct extent_cache_element *replaceQ_tail; /* MRU */
 };
 
 struct rrdengine_worker_config {
@@ -121,6 +141,8 @@ struct rrdengine_worker_config {
     uv_cond_t cmd_cond;
     volatile unsigned queue_size;
     struct rrdeng_cmdqueue cmd_queue;
+
+    struct extent_cache xt_cache;
 
     int error;
 };

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -104,7 +104,8 @@ struct extent_cache_element {
     struct extent_info *extent;
     struct extent_cache_element *prev; /* LRU */
     struct extent_cache_element *next; /* LRU */
-    uint8_t pages[MAX_PAGES_PER_EXTENT][RRDENG_BLOCK_SIZE];
+    struct extent_io_descriptor *inflight_io_descr; /* I/O descriptor for in-flight extent */
+    uint8_t pages[MAX_PAGES_PER_EXTENT * RRDENG_BLOCK_SIZE];
 };
 
 #define MAX_CACHED_EXTENTS 16 /* cannot be over 32 to fit in 32-bit architectures */
@@ -112,8 +113,8 @@ struct extent_cache_element {
 /* Initialize by setting the structure to zero */
 struct extent_cache {
     struct extent_cache_element extent_array[MAX_CACHED_EXTENTS];
-    unsigned long allocation_bitmap; /* 1 if the corresponding position in the extent_array is allocated */
-    unsigned long inflight_bitmap; /* 1 if the corresponding position in the extent_array is waiting for I/O */
+    unsigned allocation_bitmap; /* 1 if the corresponding position in the extent_array is allocated */
+    unsigned inflight_bitmap; /* 1 if the corresponding position in the extent_array is waiting for I/O */
 
     struct extent_cache_element *replaceQ_head; /* LRU */
     struct extent_cache_element *replaceQ_tail; /* MRU */

--- a/database/engine/rrdenginelib.h
+++ b/database/engine/rrdenginelib.h
@@ -36,6 +36,34 @@ typedef uintptr_t rrdeng_stats_t;
 
 #define rrd_stat_atomic_add(p, n) rrd_atomic_fetch_add(p, n)
 
+/* returns -1 if it didn't find the first set bit, the position otherwise. Starts from LSB. */
+static inline int find_first_bit(unsigned x)
+{
+    return ffs((int)x) - 1;
+}
+
+/* Starts from LSB. */
+static inline int check_bit(unsigned x, size_t pos)
+{
+    return x & (1 << pos);
+}
+
+/* Starts from LSB. val is 0 or 1 */
+static inline void modify_bit(unsigned x, unsigned pos, uint8_t val)
+{
+    switch(val) {
+    case 0:
+        x &= ~(1U << pos);
+        break;
+    case 1:
+        x |= 1U << pos;
+        break;
+    default:
+        error("modify_bit() called with invalid argument.");
+        break;
+    }
+}
+
 #define RRDENG_PATH_MAX (4096)
 
 /* returns old *ptr value */

--- a/database/engine/rrdenginelib.h
+++ b/database/engine/rrdenginelib.h
@@ -43,9 +43,9 @@ static inline int find_first_zero(unsigned x)
 }
 
 /* Starts from LSB. */
-static inline int check_bit(unsigned x, size_t pos)
+static inline uint8_t check_bit(unsigned x, size_t pos)
 {
-    return x & (1 << pos);
+    return !!(x & (1 << pos));
 }
 
 /* Starts from LSB. val is 0 or 1 */

--- a/database/engine/rrdenginelib.h
+++ b/database/engine/rrdenginelib.h
@@ -36,10 +36,10 @@ typedef uintptr_t rrdeng_stats_t;
 
 #define rrd_stat_atomic_add(p, n) rrd_atomic_fetch_add(p, n)
 
-/* returns -1 if it didn't find the first set bit, the position otherwise. Starts from LSB. */
-static inline int find_first_bit(unsigned x)
+/* returns -1 if it didn't find the first cleared bit, the position otherwise. Starts from LSB. */
+static inline int find_first_zero(unsigned x)
 {
-    return ffs((int)x) - 1;
+    return ffs((int)(~x)) - 1;
 }
 
 /* Starts from LSB. */
@@ -49,14 +49,14 @@ static inline int check_bit(unsigned x, size_t pos)
 }
 
 /* Starts from LSB. val is 0 or 1 */
-static inline void modify_bit(unsigned x, unsigned pos, uint8_t val)
+static inline void modify_bit(unsigned *x, unsigned pos, uint8_t val)
 {
     switch(val) {
     case 0:
-        x &= ~(1U << pos);
+        *x &= ~(1U << pos);
         break;
     case 1:
-        x |= 1U << pos;
+        *x |= 1U << pos;
         break;
     default:
         error("modify_bit() called with invalid argument.");


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Component Name
database/engine
##### Test Plan

Choose a big enough time period in the netdata dashboard and create a snapshot.

Measure disk I/O and time to completion. Compare with the code in master.

You can measure disk I/O reads before and after the experiment by looking at `/proc/diskstats` and subtracting the values of the 6th column. Those are 512-byte sectors.
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
- The typical netdata query will only fetch 1 dimension from disk for a specific chart.
- Subsequent queries will fetch the rest of the dimensions.
- As a result, the extents will be read from disk multiple times.
A small extent cache will speed this up.
