### PR TITLE
python.d: always create a runtime chart on `create` call

### DIFF
--- a/collectors/python.d.plugin/alarms/alarms.conf
+++ b/collectors/python.d.plugin/alarms/alarms.conf
@@ -20,7 +20,7 @@
 
 # update_every sets the default data collection frequency.
 # If unset, the python.d.plugin default is used.
-update_every: 5
+# update_every: 10
 
 # priority controls the order of charts at the netdata dashboard.
 # Lower numbers move the charts towards the top of the page.

--- a/collectors/python.d.plugin/python_modules/bases/charts.py
+++ b/collectors/python.d.plugin/python_modules/bases/charts.py
@@ -42,10 +42,12 @@ def create_runtime_chart(func):
 
     def wrapper(*args, **kwargs):
         self = args[0]
+        chart = RUNTIME_CHART_CREATE.format(
+            job_name=self.name,
+            update_every=self._runtime_counters.update_every,
+        )
+        safe_print(chart)
         ok = func(*args, **kwargs)
-        if ok:
-            safe_print(RUNTIME_CHART_CREATE.format(job_name=self.name,
-                                                   update_every=self._runtime_counters.update_every))
         return ok
 
     return wrapper

--- a/collectors/python.d.plugin/python_modules/bases/charts.py
+++ b/collectors/python.d.plugin/python_modules/bases/charts.py
@@ -16,8 +16,7 @@ CHART_BEGIN = 'BEGIN {type}.{id} {since_last}\n'
 CHART_CREATE = "CHART {type}.{id} '{name}' '{title}' '{units}' '{family}' '{context}' " \
                "{chart_type} {priority} {update_every} '{hidden}' 'python.d.plugin' '{module_name}'\n"
 CHART_OBSOLETE = "CHART {type}.{id} '{name}' '{title}' '{units}' '{family}' '{context}' " \
-               "{chart_type} {priority} {update_every} '{hidden} obsolete'\n"
-
+                 "{chart_type} {priority} {update_every} '{hidden} obsolete'\n"
 
 DIMENSION_CREATE = "DIMENSION '{id}' '{name}' {algorithm} {multiplier} {divisor} '{hidden} {obsolete}'\n"
 DIMENSION_SET = "SET '{id}' = {value}\n"
@@ -40,6 +39,7 @@ def create_runtime_chart(func):
     :param func: class method
     :return:
     """
+
     def wrapper(*args, **kwargs):
         self = args[0]
         ok = func(*args, **kwargs)
@@ -47,6 +47,7 @@ def create_runtime_chart(func):
             safe_print(RUNTIME_CHART_CREATE.format(job_name=self.name,
                                                    update_every=self._runtime_counters.update_every))
         return ok
+
     return wrapper
 
 
@@ -72,6 +73,7 @@ class Charts:
     All charts stored in a dict.
     Chart is a instance of Chart class.
     Charts adding must be done using Charts.add_chart() method only"""
+
     def __init__(self, job_name, priority, cleanup, get_update_every, module_name):
         """
         :param job_name: <bound method>
@@ -138,6 +140,7 @@ class Charts:
 
 class Chart:
     """Represent a chart"""
+
     def __init__(self, params):
         """
         :param params: <list>
@@ -281,6 +284,7 @@ class Chart:
 
 class Dimension:
     """Represent a dimension"""
+
     def __init__(self, params):
         """
         :param params: <list>
@@ -346,6 +350,7 @@ class Dimension:
 
 class ChartVariable:
     """Represent a chart variable"""
+
     def __init__(self, params):
         """
         :param params: <list>


### PR DESCRIPTION
##### Summary

`alarms` collector has no charts after init/check.

As a result i get

```cmd
2020-11-30 17:30:50: netdata ERROR : PLUGINSD[python.d] : requested a BEGIN on chart 'netdata.runtime_alarms_local', which does not exist on host 'pc'. Disabling it. (errno 9, Bad file descriptor)
```

---

runtime chart is being created right after `check` and only if there are any charts 

https://github.com/netdata/netdata/blob/95407a625c6a55f157cdf8b0e59096d178098d41/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py#L136-L178

https://github.com/netdata/netdata/blob/95407a625c6a55f157cdf8b0e59096d178098d41/collectors/python.d.plugin/python_modules/bases/charts.py#L43-L48



##### Component Name

`collectors/python.d/`

##### Test Plan

- [X] install the PR, ensure python.d.plugin is working

##### Additional Information
