### PR TITLE
Added numerous improvements to our Docker image.

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
 env:
   run_eslint: 0
+  run_hadolint: 0
   run_shellcheck: 0
   run_yamllint: 0
 jobs:
@@ -28,6 +29,26 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
           eslint_flags: '.'
+
+  hadolint:
+    name: hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check files
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '*Dockerfile*' ; then
+            echo 'run_hadolint=1' >> $GITHUB_ENV
+          fi
+      - name: Run hadolint
+        if: env.run_hadolint == 1
+        uses: reviewdog/action-hadolint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
 
   shellcheck:
     name: shellcheck

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -49,6 +49,7 @@ RUN mkdir -p /app/usr/sbin/ \
     mv /usr/sbin/netdata-claim.sh    /app/usr/sbin/ && \
     mv /usr/sbin/netdatacli    /app/usr/sbin/ && \
     mv packaging/docker/run.sh        /app/usr/sbin/ && \
+    mv packaging/docker/health.sh     /app/usr/sbin/ && \
     cp -rp /deps/* /app/usr/local/ && \
     chmod +x /app/usr/sbin/run.sh
 
@@ -57,12 +58,6 @@ ARG ARCH
 # This image contains preinstalled dependecies
 FROM netdata/base:${ARCH}
 
-# Copy files over
-RUN mkdir -p /opt/src
-COPY --from=builder /app /
-COPY --from=builder /wheels /wheels
-COPY packaging/docker/health.sh /health.sh
-
 # Configure system
 ARG NETDATA_UID=201
 ARG NETDATA_GID=201
@@ -70,17 +65,28 @@ ENV DOCKER_GRP netdata
 ENV DOCKER_USR netdata
 # If DO_NOT_TRACK is set, it will disable anonymous stats collection and reporting
 #ENV DO_NOT_TRACK=1
-RUN \
+
+# Copy files over
+RUN mkdir -p /opt/src /var/log/netdata && \
+    # Link log files to stdout
+    ln -sf /dev/stdout /var/log/netdata/access.log && \
+    ln -sf /dev/stdout /var/log/netdata/debug.log && \
+    ln -sf /dev/stderr /var/log/netdata/error.log && \
     # fping from alpine apk is on a different location. Moving it.
-    mv /usr/sbin/fping /usr/local/bin/fping && \
+    ln -snf /usr/sbin/fping /usr/local/bin/fping && \
     chmod 4755 /usr/local/bin/fping && \
-    mkdir -p /var/log/netdata && \
     # Add netdata user
     addgroup -g ${NETDATA_GID} -S "${DOCKER_GRP}" && \
-    adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}" && \
-    # Apply the permissions as described in
-    # https://docs.netdata.cloud/docs/netdata-security/#netdata-directories, but own everything by root group due to https://github.com/netdata/netdata/pull/6543
-    chown -R root:root \
+    adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}"
+
+# Long-term this should leverage BuildKit’s mount option.
+COPY --from=builder /wheels /wheels
+COPY --from=builder /app /
+
+# Apply the permissions as described in
+# https://docs.netdata.cloud/docs/netdata-security/#netdata-directories, but own everything by root group due to https://github.com/netdata/netdata/pull/6543
+# hadolint ignore=DL3013
+RUN chown -R root:root \
         /etc/netdata \
         /usr/share/netdata \
         /usr/libexec/netdata && \
@@ -99,18 +105,12 @@ RUN \
     # Group write permissions due to: https://github.com/netdata/netdata/pull/6543
     find /var/lib/netdata /var/cache/netdata -type d -exec chmod 0770 {} \; && \
     find /var/lib/netdata /var/cache/netdata -type f -exec chmod 0660 {} \; && \
-    # Link log files to stdout
-    ln -sf /dev/stdout /var/log/netdata/access.log && \
-    ln -sf /dev/stdout /var/log/netdata/debug.log && \
-    ln -sf /dev/stderr /var/log/netdata/error.log
-
-# Install any Python wheels
-# hadolint ignore=DL3013
-RUN pip --no-cache-dir install /wheels/*
+    pip --no-cache-dir install /wheels/* && \
+    rm -rf /wheels
 
 ENV NETDATA_LISTENER_PORT 19999
 EXPOSE $NETDATA_LISTENER_PORT
 
 ENTRYPOINT ["/usr/sbin/run.sh"]
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=3 CMD /health.sh
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 CMD /usr/sbin/health.sh

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /opt/netdata.git
 RUN chmod +x netdata-installer.sh && \
    cp -rp /deps/* /usr/local/ && \
    ./netdata-installer.sh --dont-wait --dont-start-it ${EXTRA_INSTALL_OPTS} \
-   $([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)
+   "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
 
 # files to one directory
 RUN mkdir -p /app/usr/sbin/ \
@@ -105,7 +105,8 @@ RUN \
     ln -sf /dev/stderr /var/log/netdata/error.log
 
 # Install any Python wheels
-RUN pip install /wheels/*
+# hadolint ignore=DL3013
+RUN pip --no-cache-dir install /wheels/*
 
 ENV NETDATA_LISTENER_PORT 19999
 EXPOSE $NETDATA_LISTENER_PORT

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -20,4 +20,11 @@ if [ -n "${PGID}" ]; then
   usermod -a -G "${PGID}" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
 fi
 
+if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/claim.d/claimed_id ]; then
+  /usr/sbin/netdata-claim.sh -token "${NETDATA_CLAIM_TOKEN}" \
+                             -url "${NETDATA_CLAIM_URL}" \
+                             ${NETDATA_CLAIM_ROOMS:+-rooms "${NETDATA_CLAIM_ROOMS}"} \
+                             ${NETDATA_CLAIM_PROXY:+-proxy "${NETDATA_CLAIM_PROXY}"}
+fi
+
 exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_LISTENER_PORT}" -W set web "web files group" root -W set web "web files owner" root "$@"

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -2,16 +2,17 @@
 #
 # Entry point script for netdata
 #
-# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright: 2018 and later Netdata Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Author  : Pavlos Emm. Katsoulakis <paul@netdata.cloud>
+# Author  : Austin S. Hemmelgarn <austin@netdata.cloud>
 set -e
 
 if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
   touch /etc/netdata/.opt-out-from-anonymous-statistics
 fi
 
-echo "Netdata entrypoint script starting"
 if [ -n "${PGID}" ]; then
   echo "Creating docker group ${PGID}"
   addgroup -g "${PGID}" "docker" || echo >&2 "Could not add group docker with ID ${PGID}, its already there probably"
@@ -20,5 +21,3 @@ if [ -n "${PGID}" ]; then
 fi
 
 exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_LISTENER_PORT}" -W set web "web files group" root -W set web "web files owner" root "$@"
-
-echo "Netdata entrypoint script, completed!"


### PR DESCRIPTION
##### Summary

* General cleanup of our Docker entry-point (removed pointless messages and added proper copyright).
* Added hadolint to CI to check our Docker files and fixed any errors it reported.
* Added the ability to automatically claim nodes running the Docker image by specifying claiming parameters in environment variables. Currently uses four variables, all prefixed with `NETDATA_CLAIM_`, one each corresponding to the `-token`, `-url`, `-rooms`, and `-proxy` options for the claiming script. The token and url variables are required for claiming, the other two are optional. Claiming will only be attempted if the node is not already claimed.
* Shuffled some of the layers and changed how we are grouping commands to cut down on the total number of layers and reduce the average number of changed layers in any given update to the image, which will reduce pull times for users. This also shaves about 2MB off of the final image size.

##### Component Name

area/packaging
area/ci

##### Test Plan

Tested locally and passes CI checks.