### PR TITLE
fix UUID_STR_LEN undefined on MacOS

### DIFF
--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -5,6 +5,10 @@
 #include "aclk_stats.h"
 #include "aclk_query.h"
 
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37
+#endif
+
 static inline int aclk_extract_v2_data(char *payload, char **data)
 {
     char* ptr = strstr(payload, ACLK_V2_PAYLOAD_SEPARATOR);


### PR DESCRIPTION
##### Summary
@kaskavel reported on latest master UUID_STR_LEN is undefined on MacOS.
For some reason `uuid.h` doesn't define this on MacOS.
He also tested the fix on MacOS machine.

##### Component Name
ACLK

##### Test Plan

##### Additional Information
