### PR TITLE
Added support for MSE (Massive Storage Engine) in Varnish-Plus

### DIFF
--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -6,8 +6,9 @@ sidebar_label: "Varnish Cache"
 
 # Varnish Cache monitoring with Netdata
 
-Provides HTTP accelerator global, backends (VBE) and disks (SMF) statistics using `varnishstat` tool.
+Provides HTTP accelerator global, Backends (VBE) and Storages (SMF, SMA, MSE) statistics using `varnishstat` tool.
 
+Note that both, Varnish-Cache (free and open source) and Varnish-Plus (Commercial/Enterprise version), are supported.
 
 ## Requirements
 
@@ -29,16 +30,15 @@ This module produces the following charts:
 -   Backend Connections Statistics in `connections/s`
 -   Requests To The Backend in `requests/s`
 -   ESI Statistics in `problems/s`
--   Memory Usage in `MiB`
 -   Uptime in `seconds`
 
 For every backend (VBE):
 
 -   Backend Response Statistics in `kilobits/s`
 
-For every disk (SMF):
+For every storage (SMF, SMA, or MSE):
 
--   Disk Usage in `KiB` 
+-   Storage Usage in `KiB` 
 
 ## Configuration
 

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -30,6 +30,7 @@ This module produces the following charts:
 -   Backend Connections Statistics in `connections/s`
 -   Requests To The Backend in `requests/s`
 -   ESI Statistics in `problems/s`
+-   Memory Usage in `MiB`
 -   Uptime in `seconds`
 
 For every backend (VBE):

--- a/collectors/python.d.plugin/varnish/varnish.chart.py
+++ b/collectors/python.d.plugin/varnish/varnish.chart.py
@@ -227,7 +227,7 @@ class Service(ExecutableService):
         self.parser = Parser()
         self.command = None
         self.collected_vbe = set()
-        self.collected_smf_sma = set()
+        self.collected_storages = set()
 
     def create_command(self):
         varnishstat = find_binary(VARNISHSTAT)
@@ -298,7 +298,7 @@ class Service(ExecutableService):
         data.update(stats)
 
         self.get_vbe_backends(data, raw)
-        self.get_smf_sma_storages(server_stats)
+        self.get_storages(server_stats)
 
         # varnish 5 uses default.g_bytes and default.g_space
         data['memory_allocated'] = data.get('s0.g_bytes') or data.get('default.g_bytes')
@@ -320,7 +320,7 @@ class Service(ExecutableService):
             self.collected_vbe.add(name)
             self.add_backend_charts(name)
 
-    def get_smf_sma_storages(self, server_stats):
+    def get_storages(self, server_stats):
         #  [('SMF.', 'ssdStorage.c_req', '47686'),
         #  ('SMF.', 'ssdStorage.c_fail', '0'),
         #  ('SMF.', 'ssdStorage.c_bytes', '668102656'),
@@ -331,14 +331,14 @@ class Service(ExecutableService):
         #  ('SMF.', 'ssdStorage.g_smf', '40130'),
         #  ('SMF.', 'ssdStorage.g_smf_frag', '311'),
         #  ('SMF.', 'ssdStorage.g_smf_large', '66')]
-        storages = [name for typ, name, _ in server_stats if typ.startswith(('SMF', 'SMA')) and name.endswith('g_space')]
+        storages = [name for typ, name, _ in server_stats if typ.startswith(('SMF', 'SMA', 'MSE')) and name.endswith('g_space')]
         if not storages:
             return
         for storage in storages:
             storage = storage.split('.')[0]
-            if storage in self.collected_smf_sma:
+            if storage in self.collected_storages:
                 continue
-            self.collected_smf_sma.add(storage)
+            self.collected_storages.add(storage)
             self.add_storage_charts(storage)
 
     def add_backend_charts(self, backend_name):

--- a/collectors/python.d.plugin/varnish/varnish.chart.py
+++ b/collectors/python.d.plugin/varnish/varnish.chart.py
@@ -321,6 +321,12 @@ class Service(ExecutableService):
             self.add_backend_charts(name)
 
     def get_storages(self, server_stats):
+        # Storage types:
+        #  - SMF: File Storage
+        #  - SMA: Malloc Storage
+        #  - MSE: Massive Storage Engine (Varnish-Plus only)
+        #
+        # Stats example:
         #  [('SMF.', 'ssdStorage.c_req', '47686'),
         #  ('SMF.', 'ssdStorage.c_fail', '0'),
         #  ('SMF.', 'ssdStorage.c_bytes', '668102656'),


### PR DESCRIPTION

##### Summary

The current Varnish collector is only able to collect metrics from the **SMF** (File) and the **SMA** (Malloc) storages. This pull request is adding support for the [**MSE** (Massive Storage Engine)](https://docs.varnish-software.com/varnish-cache-plus/features/mse/) from Varnish-Plus.

I have also renamed some variables/functions to make them more generic, and updated the documentation.

Related to #9657

##### Component Name

Affected component: Varnish collector (python.d plugin)

##### Test Plan

I have tested the change in Varnish-Cache 6.4.0 (Free version) and Varnish-Plus 6.0.6r10 (Commercial/Enterprise version).
Anyway, the change should not break the compatibility with previous versions.

##### Additional Information

I have just added the prefix `MSE` as a valid one for containing Storage metrics.

Example of MSE stats returned in `varnishstat -1`:
```
MSE.mse.c_req                                 0         0.00 Allocator requests
MSE.mse.c_fail                                0         0.00 Allocator failures
MSE.mse.c_fail_malloc                         0         0.00 System allocator failures
MSE.mse.c_bytes                     44791785968  78858778.11 Bytes allocated
MSE.mse.c_freed                     34535437768  60801827.06 Bytes freed
MSE.mse.g_alloc                         1979990          .   Allocations outstanding
MSE.mse.g_bytes                     10256348200          .   Bytes outstanding
MSE.mse.g_space                               0          .   Bytes available
MSE.mse.n_lru_nuked                     6666994     11737.67 Number of LRU nuked objects
MSE.mse.n_lru_moved                           0         0.00 Number of LRU move operations
MSE.mse.n_vary                                0         0.00 Number of Vary header keys
MSE.mse.c_memcache_hit                        0         0.00 Stored objects cache hits
MSE.mse.c_memcache_miss                       0         0.00 Stored objects cache misses
MSE.mse.g_ykey_keys                           0          .   Number of YKeys registered
MSE.mse.c_ykey_purged                         0         0.00 Number of objects purged with YKey
```

Example of the MSE Storage:

<img width="1191" alt="Screenshot 2020-12-03 at 22 52 05" src="https://user-images.githubusercontent.com/2565383/101093093-941c3d80-35ba-11eb-8bde-8c8a77b977f6.png">

