### PR TITLE
Fix a compilation warning

### DIFF
--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -219,7 +219,7 @@ void read_extent_cb(uv_fs_t* req)
     int ret;
     unsigned i, j, count;
     void *page, *uncompressed_buf = NULL;
-    uint32_t payload_length, payload_offset, page_offset, uncompressed_payload_length;
+    uint32_t payload_length, payload_offset, page_offset, uncompressed_payload_length = 0;
     uint8_t have_read_error = 0;
     /* persistent structures */
     struct rrdeng_df_extent_header *header;


### PR DESCRIPTION
##### Summary
```
  CC       database/engine/metadata_log/metadatalogapi.o
database/engine/rrdengine.c: In function 'read_extent_cb':
database/engine/rrdengine.c:296:23: warning: 'uncompressed_payload_length' may be used uninitialized in this function [-Wmaybe-uninitialized]
  296 |                 (void)memcpy(xt_cache_elem->pages, uncompressed_buf, uncompressed_payload_length);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

##### Component Name
dbengine