### PR TITLE
Fix exporting config

### DIFF
--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -238,7 +238,8 @@ struct engine *read_exporting_config()
         prometheus_exporter_instance->config.update_every =
             prometheus_config_get_number(EXPORTING_UPDATE_EVERY_OPTION_NAME, EXPORTING_UPDATE_EVERY_DEFAULT);
 
-        if (prometheus_config_get_boolean("send names instead of ids", CONFIG_BOOLEAN_YES))
+        if (prometheus_config_get_boolean(
+                "send names instead of ids", global_backend_options & EXPORTING_OPTION_SEND_NAMES))
             prometheus_exporter_instance->config.options |= EXPORTING_OPTION_SEND_NAMES;
         else
             prometheus_exporter_instance->config.options &= ~EXPORTING_OPTION_SEND_NAMES;
@@ -257,6 +258,8 @@ struct engine *read_exporting_config()
             simple_pattern_create(prometheus_config_get("send charts matching", "*"), NULL, SIMPLE_PATTERN_EXACT);
         prometheus_exporter_instance->config.hosts_pattern = simple_pattern_create(
             prometheus_config_get("send hosts matching", "localhost *"), NULL, SIMPLE_PATTERN_EXACT);
+
+        prometheus_exporter_instance->config.prefix = prometheus_config_get("prefix", global_backend_prefix);
     }
 
     // TODO: change BACKEND to EXPORTING

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -14,6 +14,9 @@ char *netdata_configured_hostname = "test_host";
 
 char log_line[MAX_LOG_LINE + 1];
 
+BACKEND_OPTIONS global_backend_options = 0;
+const char *global_backend_prefix = "netdata";
+
 void init_connectors_in_tests(struct engine *engine)
 {
     expect_function_call(__wrap_now_realtime_sec);

--- a/web/api/exporters/allmetrics.c
+++ b/web/api/exporters/allmetrics.c
@@ -21,15 +21,15 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
     int format = ALLMETRICS_SHELL;
     const char *prometheus_server = w->client_ip;
 
-    uint32_t prometheus_backend_options;
+    uint32_t prometheus_exporting_options;
     if (prometheus_exporter_instance)
-        prometheus_backend_options = prometheus_exporter_instance->config.options;
+        prometheus_exporting_options = prometheus_exporter_instance->config.options;
     else
-        prometheus_backend_options = global_backend_options;
+        prometheus_exporting_options = global_backend_options;
 
     PROMETHEUS_OUTPUT_OPTIONS prometheus_output_options =
         PROMETHEUS_OUTPUT_TIMESTAMPS |
-        ((prometheus_backend_options & BACKEND_OPTION_SEND_NAMES) ? PROMETHEUS_OUTPUT_NAMES : 0);
+        ((prometheus_exporting_options & BACKEND_OPTION_SEND_NAMES) ? PROMETHEUS_OUTPUT_NAMES : 0);
 
     const char *prometheus_prefix;
     if (prometheus_exporter_instance)
@@ -64,7 +64,7 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
             prometheus_prefix = value;
         }
         else if(!strcmp(name, "data") || !strcmp(name, "source") || !strcmp(name, "data source") || !strcmp(name, "data-source") || !strcmp(name, "data_source") || !strcmp(name, "datasource")) {
-            prometheus_backend_options = backend_parse_data_source(value, prometheus_backend_options);
+            prometheus_exporting_options = backend_parse_data_source(value, prometheus_exporting_options);
         }
         else {
             int i;
@@ -102,7 +102,7 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
                     , w->response.data
                     , prometheus_server
                     , prometheus_prefix
-                    , prometheus_backend_options
+                    , prometheus_exporting_options
                     , prometheus_output_options
             );
             return HTTP_RESP_OK;
@@ -114,7 +114,7 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
                     , w->response.data
                     , prometheus_server
                     , prometheus_prefix
-                    , prometheus_backend_options
+                    , prometheus_exporting_options
                     , prometheus_output_options
             );
             return HTTP_RESP_OK;

--- a/web/api/exporters/allmetrics.c
+++ b/web/api/exporters/allmetrics.c
@@ -20,11 +20,22 @@ struct prometheus_output_options {
 inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client *w, char *url) {
     int format = ALLMETRICS_SHELL;
     const char *prometheus_server = w->client_ip;
-    uint32_t prometheus_backend_options = global_backend_options;
+
+    uint32_t prometheus_backend_options;
+    if (prometheus_exporter_instance)
+        prometheus_backend_options = prometheus_exporter_instance->config.options;
+    else
+        prometheus_backend_options = global_backend_options;
+
     PROMETHEUS_OUTPUT_OPTIONS prometheus_output_options =
         PROMETHEUS_OUTPUT_TIMESTAMPS |
-        ((global_backend_options & BACKEND_OPTION_SEND_NAMES) ? PROMETHEUS_OUTPUT_NAMES : 0);
-    const char *prometheus_prefix = global_backend_prefix;
+        ((prometheus_backend_options & BACKEND_OPTION_SEND_NAMES) ? PROMETHEUS_OUTPUT_NAMES : 0);
+
+    const char *prometheus_prefix;
+    if (prometheus_exporter_instance)
+        prometheus_prefix = prometheus_exporter_instance->config.prefix;
+    else
+        prometheus_prefix = global_backend_prefix;
 
     while(url) {
         char *value = mystrsep(&url, "&");

--- a/web/api/tests/valid_urls.c
+++ b/web/api/tests/valid_urls.c
@@ -7,6 +7,13 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdbool.h>
+
+RRDHOST *sql_create_host_by_uuid(char *hostname)
+{
+    (void) hostname;
+    return NULL;
+}
+
 RRDHOST *__wrap_sql_create_host_by_uuid(char *hostname)
 {
     (void) hostname;

--- a/web/api/tests/web_api.c
+++ b/web/api/tests/web_api.c
@@ -8,6 +8,12 @@
 #include <cmocka.h>
 #include <stdbool.h>
 
+RRDHOST *sql_create_host_by_uuid(char *hostname)
+{
+    (void) hostname;
+    return NULL;
+}
+
 RRDHOST *__wrap_sql_create_host_by_uuid(char *hostname)
 {
     (void) hostname;


### PR DESCRIPTION
##### Summary
The `prefix` and `send names instead of ids` options didn't work in the `prometheus:exporter` section of `exporting.conf`. The options should also inherit values from the `backend` section of `netdata.conf` if they are not set in `exporting.conf`. The PR fixes the issue.

##### Component Name
exporting engine, Web API

##### Test Plan
Check the `http://localhost:19999/api/v1/allmetrics?format=prometheus` endpoint with different settings of `prefix` and `send names instead of ids` in `exporting.conf` and `netdata.conf`.