### PR TITLE
health: disable 'used_file_descriptors' alarm

### DIFF
--- a/health/health.d/apps_plugin.conf
+++ b/health/health.d/apps_plugin.conf
@@ -1,13 +1,15 @@
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-   alarm: used_file_descriptors
-      on: apps.files
-   hosts: *
-    calc: $fdperc
-   units: %
-   every: 5s
-    warn: $this > (($status >= $WARNING)  ? (75) : (80))
-    crit: $this > (($status == $CRITICAL) ? (85) : (90))
-   delay: down 5m multiplier 1.5 max 1h
-    info: Peak percentage of file descriptors used
-      to: sysadmin
+#  disabled due to https://github.com/netdata/netdata/issues/10327
+#
+#   alarm: used_file_descriptors
+#      on: apps.files
+#   hosts: *
+#    calc: $fdperc
+#   units: %
+#   every: 5s
+#    warn: $this > (($status >= $WARNING)  ? (75) : (80))
+#    crit: $this > (($status == $CRITICAL) ? (85) : (90))
+#   delay: down 5m multiplier 1.5 max 1h
+#    info: Peak percentage of file descriptors used
+#      to: sysadmin


### PR DESCRIPTION
##### Summary

The alarm and `fdperc` chart variable were added in https://github.com/netdata/netdata/pull/10192

However it seems buggy, see #10327

Unfortunately we have no time to fix and i think we need to disable it to not get into the release (wrong `crit` level alarm).

##### Component Name

`health/`

##### Test Plan

Nothing to test.

##### Additional Information
