### PR TITLE
Added number of allocated/stored objects within each Varnish storage

### DIFF
--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -40,6 +40,7 @@ For every backend (VBE):
 For every storage (SMF, SMA, or MSE):
 
 -   Storage Usage in `KiB` 
+-   Storage Allocated Objects
 
 ## Configuration
 

--- a/collectors/python.d.plugin/varnish/varnish.chart.py
+++ b/collectors/python.d.plugin/varnish/varnish.chart.py
@@ -155,7 +155,7 @@ def backend_charts_template(name):
     return order, charts
 
 
-def storage_charts_template(name):
+def storage_usage_charts_template(name):
     order = [
         'storage_{0}_usage'.format(name),
     ]
@@ -172,6 +172,21 @@ def storage_charts_template(name):
 
     return order, charts
 
+def storage_alloc_objs_charts_template(name):
+    order = [
+        'storage_{0}_alloc_objs'.format(name),
+    ]
+
+    charts = {
+        order[0]: {
+            'options': [None, 'Storage "{0}" Allocated Objects'.format(name), 'objects', 'storage usage', 'varnish.storage_usage', 'line'],
+            'lines': [
+                ['{0}.g_alloc'.format(name), 'allocated', 'absolute']
+            ]
+        },
+    }
+
+    return order, charts
 
 VARNISHSTAT = 'varnishstat'
 
@@ -351,7 +366,8 @@ class Service(ExecutableService):
         self.add_charts(backend_name, backend_charts_template)
 
     def add_storage_charts(self, storage_name):
-        self.add_charts(storage_name, storage_charts_template)
+        self.add_charts(storage_name, storage_usage_charts_template)
+        self.add_charts(storage_name, storage_alloc_objs_charts_template)
 
     def add_charts(self, name, charts_template):
         order, charts = charts_template(name)

--- a/collectors/python.d.plugin/varnish/varnish.chart.py
+++ b/collectors/python.d.plugin/varnish/varnish.chart.py
@@ -155,9 +155,10 @@ def backend_charts_template(name):
     return order, charts
 
 
-def storage_usage_charts_template(name):
+def storage_charts_template(name):
     order = [
         'storage_{0}_usage'.format(name),
+        'storage_{0}_alloc_objs'.format(name)
     ]
 
     charts = {
@@ -168,22 +169,12 @@ def storage_usage_charts_template(name):
                 ['{0}.g_bytes'.format(name), 'allocated', 'absolute', 1, 1 << 10]
             ]
         },
-    }
-
-    return order, charts
-
-def storage_alloc_objs_charts_template(name):
-    order = [
-        'storage_{0}_alloc_objs'.format(name),
-    ]
-
-    charts = {
-        order[0]: {
+        order[1]: {
             'options': [None, 'Storage "{0}" Allocated Objects'.format(name), 'objects', 'storage usage', 'varnish.storage_usage', 'line'],
             'lines': [
                 ['{0}.g_alloc'.format(name), 'allocated', 'absolute']
             ]
-        },
+        }
     }
 
     return order, charts
@@ -366,8 +357,7 @@ class Service(ExecutableService):
         self.add_charts(backend_name, backend_charts_template)
 
     def add_storage_charts(self, storage_name):
-        self.add_charts(storage_name, storage_usage_charts_template)
-        self.add_charts(storage_name, storage_alloc_objs_charts_template)
+        self.add_charts(storage_name, storage_charts_template)
 
     def add_charts(self, name, charts_template):
         order, charts = charts_template(name)

--- a/collectors/python.d.plugin/varnish/varnish.chart.py
+++ b/collectors/python.d.plugin/varnish/varnish.chart.py
@@ -170,7 +170,7 @@ def storage_charts_template(name):
             ]
         },
         order[1]: {
-            'options': [None, 'Storage "{0}" Allocated Objects'.format(name), 'objects', 'storage usage', 'varnish.storage_usage', 'line'],
+            'options': [None, 'Storage "{0}" Allocated Objects'.format(name), 'objects', 'storage usage', 'varnish.storage_alloc_objs', 'line'],
             'lines': [
                 ['{0}.g_alloc'.format(name), 'allocated', 'absolute']
             ]
@@ -178,6 +178,7 @@ def storage_charts_template(name):
     }
 
     return order, charts
+
 
 VARNISHSTAT = 'varnishstat'
 


### PR DESCRIPTION

##### Summary

Currently, for each of the Varnish Storages (SMF, SMA, or MSE) we are only providing the free and allocated space in KiB. This Pull Request is also adding a new graph with the number of allocated/stored objects within each storage.

##### Component Name

Affected component: Varnish collector (python.d plugin)

##### Test Plan

I have tested the change in Varnish-Cache 6.4.0 (Free version) and Varnish-Plus 6.0.6r10 (Commercial/Enterprise version).
The new added field `g_alloc` is available [at least from Varnish 5.0](https://varnish-cache.org/docs/5.0/reference/varnish-counters.html#per-malloc-storage-counters-sma).

##### Additional Information

This is an example of the new graphs for the `s0` and `Transient` (SMA) storages:

<img width="1024" alt="Screenshot 2020-12-06 at 19 08 41" src="https://user-images.githubusercontent.com/2565383/101289101-adabc800-37fa-11eb-910f-5370d648b1d3.png">

