### PR TITLE
Switch to using official Docker actions for GHA CI.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,26 +19,31 @@ jobs:
     strategy:
       matrix:
         arch:
-          - amd64
-          - i386
-          - armhf
-          - aarch64
+          - linux/amd64
+          - linux/i386
+          - linux/arm/v7
+          - linux/arm64
         include:
-          - arch: amd64
-            platform: linux/amd64
-          - arch: i386
-            platform: linux/i386
-          - arch: armhf
-            platform: linux/arm/v7
-          - arch: aarch64
-            platform: linux/arm64
+          - arch: linux/amd64
+            base: amd64
+          - arch: linux/i386
+            base: i386
+          - arch: linux/arm/v7
+            base: armhf
+          - arch: linux/arm64
+            base: aarch64
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Prepare Docker Environment
-        run:
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Test Docker Build
-        run:
-          docker build --build-arg ARCH=${{ matrix.arch }} --platform ${{ matrix.platform }} -f packaging/docker/Dockerfile .
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          platforms: ${{ matrix.arch }}
+          push: false
+          build-args: |
+            ARCH=${{ matrix.base }}


### PR DESCRIPTION
##### Summary

This will make us more forward-portable, simplify eventual migration to GHA for release builds, and make it trivial to set up pushing images to multiple registries.

##### Component Name

area/ci

##### Test Plan

Checks pass on this PR.

##### Additional Information

This is essentially a quick and easy investment in making life simpler when we finally get the whole release workflow migrated to GitHub. It aligns our workflow with BCP for handling of building Docker images in GHA, which will make any troubleshooting much easier. It unfortunately increases run times for Docker CI checks (and will significantly increase run times for actual image builds), but IMO that is an acceptable trade-off for significantly easier maintenance, better consistency of our builds, and the ability to leverage buildx (which will eventually let us shrink our Docker images further).