### PR TITLE
Added Dependabot config to check for updates for GHA workflows.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - "no changelog"
+      - "area/ci"


### PR DESCRIPTION
##### Summary

This will automatically create PRs to update any GitHub Actions we are using when new versions are published. It is set to check weekly, defaults to limiting such PRs to 3 at a time, and will lable them apprpriately with ‘no changelog’ and ‘area/ci’.

This is intended to reduce the manual overhead of maintaining our CI.

##### Component Name

area/ci

##### Test Plan

n/a

##### Additional Information

AFAICT, we are already using the most recent versions of all GitHub Actions we are utilizing, so this should have no immediate effect. It’s also not likely to trigger very often, as it’s very uncommon that an action gets updated in a backwards incompatible way and we are only using major versions.

See https://github.com/Ferroin/Roll35/pull/2 for an example of what a PR generated this way looks like (labels will obviously be different, but otherwise the general format is the same).