### PR TITLE
Fix backend options

### DIFF
--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -238,6 +238,10 @@ struct engine *read_exporting_config()
         prometheus_exporter_instance->config.update_every =
             prometheus_config_get_number(EXPORTING_UPDATE_EVERY_OPTION_NAME, EXPORTING_UPDATE_EVERY_DEFAULT);
 
+        prometheus_exporter_instance->config.options |=
+            global_backend_options &
+            (EXPORTING_SOURCE_DATA_AS_COLLECTED | EXPORTING_SOURCE_DATA_AVERAGE | EXPORTING_SOURCE_DATA_SUM);
+
         if (prometheus_config_get_boolean(
                 "send names instead of ids", global_backend_options & EXPORTING_OPTION_SEND_NAMES))
             prometheus_exporter_instance->config.options |= EXPORTING_OPTION_SEND_NAMES;


### PR DESCRIPTION
##### Summary
A bug was introduced in #10323 - metric names in http://localhost:19999/api/v1/allmetrics?format=prometheus response miss units and data source (e.g. `netdata_apps_mem` instead of `netdata_apps_mem_MiB_average`). The PR brings back missing backend options.

Fixes #10341

##### Component Name
Exporting engine

##### Test Plan
Do the http://localhost:19999/api/v1/allmetrics?format=prometheus request and check if units and data source are present in metric names.