### PR TITLE
Fixed handling of PowerTools repo on CentOS 8.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1550,7 +1550,7 @@ validate_tree_centos() {
     echo >&2 " > Checking for PowerTools ..."
     if ! run yum ${sudo} repolist | grep PowerTools; then
       if prompt "PowerTools not found, shall I install it?"; then
-        run ${sudo} yum ${opts} config-manager --set-enabled PowerTools
+        run ${sudo} yum ${opts} config-manager --set-enabled powertools
       fi
     fi
 

--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -164,7 +164,7 @@ And install the minimum required dependencies:
 yum install -y 'dnf-command(config-manager)'
 
 # Enable PowerTools
-yum config-manager --set-enabled PowerTools
+yum config-manager --set-enabled powertools
 
 # Enable EPEL
 yum install -y epel-release


### PR DESCRIPTION
##### Summary

They appear to have changed DNF to be case-sensitive for repo naming, and the repo name that is expected is all lower case.

##### Component Name

area/packaging

##### Test Plan

Verified through local testing in a CentOS 8 container. Without this change, installing Netdata from sources with `netdata-installer.sh` fails in a clean environment because it cannot install certain required dependencies. With this change, it works correctly.