### PR TITLE
Fix handling of Python dependency for RPM package.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -152,7 +152,15 @@ BuildRequires: json-c-devel
 
 # Runtime dependencies
 #
-Requires:      python
+%if 0%{?centos_ver} == 7 || 0%{?centos_ver} == 6
+Requires: python
+%else
+%if 0%{?centos_ver} == 8
+Requires: python38
+%else
+Requires: python3
+%endif
+%endif
 
 # Core requirements for the install to succeed
 Requires(pre): /usr/sbin/groupadd


### PR DESCRIPTION
##### Summary

CentOS 8 insists on being a pain in the arse and not providing a generic ‘python’ package that pulls in the newest verison, or a generic ‘python3’ package that pulls in the newest version of Python 3.x. As such, we need to special-case it in our RPM spec file.

This also switches dependencies on other platforms to explicitly pull in Python 3.

##### Component Name

area/packaging

##### Test Plan

Build tested locallyin a CentOS 8 container.