### PR TITLE
Use `glibtoolize` on macOS instead of regular `libtoolize`.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -695,13 +695,18 @@ bundle_libwebsockets
 
 build_judy() {
   local env_cmd=''
+  local libtoolize="libtoolize"
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
     env_cmd="env CFLAGS=-fPIC CXXFLAGS= LDFLAGS="
   fi
 
+  if [ "$(uname)" = "Darwin" ]; then
+    libtoolize="glibtoolize"
+  fi
+
   pushd "${1}" > /dev/null || return 1
-  if run ${env_cmd} libtoolize --force --copy &&
+  if run ${env_cmd} ${libtoolize} --force --copy &&
     run ${env_cmd} aclocal &&
     run ${env_cmd} autoheader &&
     run ${env_cmd} automake --add-missing --force --copy --include-deps &&

--- a/packaging/installer/methods/macos.md
+++ b/packaging/installer/methods/macos.md
@@ -53,7 +53,7 @@ Click **Install** on the Software Update popup window that appears. Then, use th
 to install some of Netdata's prerequisites.
 
 ```bash
-brew install ossp-uuid autoconf automake pkg-config libuv lz4 json-c openssl@1.1
+brew install ossp-uuid autoconf automake pkg-config libuv lz4 json-c openssl@1.1 libtool
 ```
 
 If you want to use the [database engine](/database/engine/README.md) to store your metrics, you need to download


### PR DESCRIPTION

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This ensures we get the version from Homebrew instead of the version from XCode.

##### Component Name

area/packaging

##### Test Plan

Without this change, Judy fails to build on macOS, and thus we have no dbengine. With this change, Judy builds correctly, and the dbengine is available.

##### Additional Information

Fixes: #10325 