### PR TITLE
Fixed handling of self-updating in updater script.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -150,7 +150,7 @@ newer_commit_date() {
   echo >&3 "Checking if a newer version of the updater script is available."
 
   if command -v jq > /dev/null 2>&1; then
-    commit_date="$(_safe_download "https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1" /dev/stdout | jq '.[0].commit.committer.date')"
+    commit_date="$(_safe_download "https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1" /dev/stdout | jq '.[0].commit.committer.date' | tr -d '"')"
   elif command -v python > /dev/null 2>&1;then
     commit_date="$(_safe_download "https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1" /dev/stdout | python -c 'from __future__ import print_function;import sys,json;print(json.load(sys.stdin)["commit"]["committer"]["date"])')"
   fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -176,6 +176,7 @@ self_update() {
     cd "$ndtmpdir" || exit 1
 
     if _safe_download "https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/netdata-updater.sh" ./netdata-updater.sh; then
+      chmod +x ./netdata-updater.sh || exit 1
       exec ./netdata-updater.sh --not-running-from-cron --no-self-update --tmpdir-path "$(pwd)"
     else
       echo >&3 "Failed to download newest version of updater script, continuing with current version."

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -156,7 +156,7 @@ newer_commit_date() {
   fi
 
   if [ -z "${commit_date}" ] ; then
-    commit_date="1970-01-01T00:00:00Z"
+    commit_date="9999-12-31T23:59:59Z"
   fi
 
   if [ -e "${script_source}" ]; then

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -152,7 +152,7 @@ newer_commit_date() {
   if command -v jq > /dev/null 2>&1; then
     commit_date="$(_safe_download "https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1" /dev/stdout | jq '.[0].commit.committer.date' | tr -d '"')"
   elif command -v python > /dev/null 2>&1;then
-    commit_date="$(_safe_download "https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1" /dev/stdout | python -c 'from __future__ import print_function;import sys,json;print(json.load(sys.stdin)["commit"]["committer"]["date"])')"
+    commit_date="$(_safe_download "https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1" /dev/stdout | python -c 'from __future__ import print_function;import sys,json;print(json.load(sys.stdin)[0]["commit"]["committer"]["date"])')"
   fi
 
   if [ -z "${commit_date}" ] ; then

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -28,7 +28,13 @@
 
 set -e
 
-script_source="$("$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)/netdata-updater.sh")"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
+
+if [ -x "${script_dir}/netdata-updater" ]; then
+  script_source="${script_dir}/netdata-updater"
+else
+  script_source="${script_dir}/netdata-updater.sh"
+fi
 
 info() {
   echo >&3 "$(date) : INFO: " "${@}"
@@ -153,7 +159,13 @@ newer_commit_date() {
     commit_date="1970-01-01T00:00:00Z"
   fi
 
-  [ "$(date -d "${commit_date}" +%s)" -ge "$(date -r "${script_source}" +%s)" ]
+  if [ -e "${script_source}" ]; then
+    script_date="$(date -r "${script_source}" +%s)"
+  else
+    script_date="$(date +%s)"
+  fi
+
+  [ "$(date -d "${commit_date}" +%s)" -ge "${script_date}" ]
 }
 
 self_update() {
@@ -312,7 +324,7 @@ while [ -n "${1}" ]; do
   elif [ "${1}" = "--no-updater-self-update" ]; then
     NETDATA_NO_UPDATER_SELF_UPDATE=1
     shift 1
-  elif [ "${1}" = "--tempdir-path" ]; then
+  elif [ "${1}" = "--tmpdir-path" ]; then
     NETDATA_TMPDIR_PATH="${2}"
     shift 2
   else


### PR DESCRIPTION
##### Summary

There’s a bug in the code used to locate the script itself (used for determining whether to self-update or not) that causes either an infinite loop or an immediate failure to run right after invoking the script depending on how it’s invoked.

Also fixes a typo in one of the option names.

##### Component Name

area/packaging

##### Test Plan

Same testing regimen as #10261, which now seems to correctly fail for the broken code now. When the timestamp is explicitly overridden it should get stuck in an infinite loop _after_ checking for a new version of the updater script (because it will pull the version with the bug).

##### Additional Information

Fixes: #10351 

Not sure how this made it past manual testing. Checking now it seems to not work correctly at all (gets stuck in an infinite loop), and looking back at the code it was obviously broken from the start. Ironically though, this further highlights just how useless the lifecycle checks in Trais were, as they should have caught this too but did not.