### PR TITLE
Rename abs to ABS to avoid clash with standard definitions. Fixes #10353.

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -371,7 +371,7 @@ int unit_test_str2ld() {
                 return -1;
             }
         }
-        else if(mine != sys && abs(mine-sys) > 0.000001) {
+        else if(mine != sys && ABS(mine-sys) > 0.000001) {
             fprintf(stderr, "Value '%s' is parsed as %" LONG_DOUBLE_MODIFIER ", but system believes it is %" LONG_DOUBLE_MODIFIER ", delta %" LONG_DOUBLE_MODIFIER ".\n", values[i], mine, sys, sys-mine);
             return -1;
         }

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -426,7 +426,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     else {
         RRDDIM *td = st->dimensions;
 
-        if(td->algorithm != rd->algorithm || abs(td->multiplier) != abs(rd->multiplier) || abs(td->divisor) != abs(rd->divisor)) {
+        if(td->algorithm != rd->algorithm || ABS(td->multiplier) != ABS(rd->multiplier) || ABS(td->divisor) != ABS(rd->divisor)) {
             if(!rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS)) {
                 #ifdef NETDATA_INTERNAL_CHECKS
                 info("Dimension '%s' added on chart '%s' of host '%s' is not homogeneous to other dimensions already present (algorithm is '%s' vs '%s', multiplier is " COLLECTED_NUMBER_FORMAT " vs " COLLECTED_NUMBER_FORMAT ", divisor is " COLLECTED_NUMBER_FORMAT " vs " COLLECTED_NUMBER_FORMAT ").",

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -219,11 +219,11 @@ inline void rrdset_update_heterogeneous_flag(RRDSET *st) {
     rrdset_flag_clear(st, RRDSET_FLAG_HOMOGENEOUS_CHECK);
 
     RRD_ALGORITHM algorithm = st->dimensions->algorithm;
-    collected_number multiplier = abs(st->dimensions->multiplier);
-    collected_number divisor = abs(st->dimensions->divisor);
+    collected_number multiplier = ABS(st->dimensions->multiplier);
+    collected_number divisor = ABS(st->dimensions->divisor);
 
     rrddim_foreach_read(rd, st) {
-        if(algorithm != rd->algorithm || multiplier != abs(rd->multiplier) || divisor != abs(rd->divisor)) {
+        if(algorithm != rd->algorithm || multiplier != ABS(rd->multiplier) || divisor != ABS(rd->divisor)) {
             if(!rrdset_flag_check(st, RRDSET_FLAG_HETEROGENEOUS)) {
                 #ifdef NETDATA_INTERNAL_CHECKS
                 info("Dimension '%s' added on chart '%s' of host '%s' is not homogeneous to other dimensions already present (algorithm is '%s' vs '%s', multiplier is " COLLECTED_NUMBER_FORMAT " vs " COLLECTED_NUMBER_FORMAT ", divisor is " COLLECTED_NUMBER_FORMAT " vs " COLLECTED_NUMBER_FORMAT ").",

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -384,7 +384,7 @@ static inline int health_parse_db_lookup(
     }
 
     // sane defaults
-    *every = abs(*after);
+    *every = ABS(*after);
 
     // now we may have optional parameters
     while(*s) {

--- a/libnetdata/eval/eval.c
+++ b/libnetdata/eval/eval.c
@@ -296,7 +296,7 @@ calculated_number eval_abs(EVAL_EXPRESSION *exp, EVAL_NODE *op, int *error) {
     calculated_number n1 = eval_value(exp, &op->ops[0], error);
     if(isnan(n1)) return NAN;
     if(isinf(n1)) return INFINITY;
-    return abs(n1);
+    return ABS(n1);
 }
 calculated_number eval_if_then_else(EVAL_EXPRESSION *exp, EVAL_NODE *op, int *error) {
     if(is_true(eval_value(exp, &op->ops[0], error)))

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -205,11 +205,7 @@ extern "C" {
 #define WARNUNUSED
 #endif
 
-#ifdef abs
-#undef abs
-#endif
-#define abs(x) (((x) < 0)? (-(x)) : (x))
-
+#define ABS(x) (((x) < 0)? (-(x)) : (x))
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
 

--- a/libnetdata/tests/test_str2ld.c
+++ b/libnetdata/tests/test_str2ld.c
@@ -32,7 +32,7 @@ static void test_str2ld(void **state)
         else if (isinf(mine))
             assert_true(isinf(sys));
         else if (mine != sys)
-            assert_false(abs(mine - sys) > 0.000001);
+            assert_false(ABS(mine - sys) > 0.000001);
 
         assert_ptr_equal(e_mine, e_sys);
     }

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -758,8 +758,8 @@ static int rrdr_convert_before_after_to_absolute(
     }
 
     // allow relative for before (smaller than API_RELATIVE_TIME_MAX)
-    if(abs(before_requested) <= API_RELATIVE_TIME_MAX) {
-        if(abs(before_requested) % update_every) {
+    if(ABS(before_requested) <= API_RELATIVE_TIME_MAX) {
+        if(ABS(before_requested) % update_every) {
             // make sure it is multiple of st->update_every
             if(before_requested < 0) before_requested = before_requested - update_every -
                                                         before_requested % update_every;
@@ -772,9 +772,9 @@ static int rrdr_convert_before_after_to_absolute(
     }
 
     // allow relative for after (smaller than API_RELATIVE_TIME_MAX)
-    if(abs(after_requested) <= API_RELATIVE_TIME_MAX) {
+    if(ABS(after_requested) <= API_RELATIVE_TIME_MAX) {
         if(after_requested == 0) after_requested = -update_every;
-        if(abs(after_requested) % update_every) {
+        if(ABS(after_requested) % update_every) {
             // make sure it is multiple of st->update_every
             if(after_requested < 0) after_requested = after_requested - update_every - after_requested % update_every;
             else after_requested = after_requested + update_every - after_requested % update_every;


### PR DESCRIPTION
##### Summary
Fixes: #10353
I have renamed the abs macro to ABS, similarly to already existing MIN and MAX macros. I have replaced all ocurences in the code (although it compiled fine with the "standard" macro in the gcc headers) to use this "internal" version. Resolves the issue described in #10353 for me.

##### Component Name
libnetdata, netdata core.

##### Test Plan
Code compiles natively on amd64 linux, cross compiles on aarch64. Native linux version tested fine.