### PR TITLE
Fix hostname configuration in the exporting engine

### DIFF
--- a/exporting/clean_connectors.c
+++ b/exporting/clean_connectors.c
@@ -16,6 +16,7 @@ static void clean_instance_config(struct instance_config *config)
     freez((void *)config->name);
     freez((void *)config->destination);
     freez((void *)config->prefix);
+    freez((void *)config->hostname);
 
     simple_pattern_free(config->charts_pattern);
 

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -67,6 +67,7 @@ struct instance_config {
     const char *name;
     const char *destination;
     const char *prefix;
+    const char *hostname;
 
     int update_every;
     int buffer_on_failures;

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -127,7 +127,6 @@ int format_host_labels_graphite_plaintext(struct instance *instance, RRDHOST *ho
  */
 int format_dimension_collected_graphite_plaintext(struct instance *instance, RRDDIM *rd)
 {
-    struct engine *engine = instance->engine;
     RRDSET *st = rd->rrdset;
     RRDHOST *host = st->rrdhost;
 
@@ -147,7 +146,7 @@ int format_dimension_collected_graphite_plaintext(struct instance *instance, RRD
         instance->buffer,
         "%s.%s.%s.%s%s%s%s " COLLECTED_NUMBER_FORMAT " %llu\n",
         instance->config.prefix,
-        (host == localhost) ? engine->config.hostname : host->hostname,
+        (host == localhost) ? instance->config.hostname : host->hostname,
         chart_name,
         dimension_name,
         (host->tags) ? ";" : "",
@@ -168,7 +167,6 @@ int format_dimension_collected_graphite_plaintext(struct instance *instance, RRD
  */
 int format_dimension_stored_graphite_plaintext(struct instance *instance, RRDDIM *rd)
 {
-    struct engine *engine = instance->engine;
     RRDSET *st = rd->rrdset;
     RRDHOST *host = st->rrdhost;
 
@@ -194,7 +192,7 @@ int format_dimension_stored_graphite_plaintext(struct instance *instance, RRDDIM
         instance->buffer,
         "%s.%s.%s.%s%s%s%s " CALCULATED_NUMBER_FORMAT " %llu\n",
         instance->config.prefix,
-        (host == localhost) ? engine->config.hostname : host->hostname,
+        (host == localhost) ? instance->config.hostname : host->hostname,
         chart_name,
         dimension_name,
         (host->tags) ? ";" : "",

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -154,7 +154,6 @@ int format_host_labels_json_plaintext(struct instance *instance, RRDHOST *host)
  */
 int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM *rd)
 {
-    struct engine *engine = instance->engine;
     RRDSET *st = rd->rrdset;
     RRDHOST *host = st->rrdhost;
 
@@ -200,7 +199,7 @@ int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM 
         "\"timestamp\":%llu}",
 
         instance->config.prefix,
-        (host == localhost) ? engine->config.hostname : host->hostname,
+        (host == localhost) ? instance->config.hostname : host->hostname,
         tags_pre,
         tags,
         tags_post,
@@ -235,7 +234,6 @@ int format_dimension_collected_json_plaintext(struct instance *instance, RRDDIM 
  */
 int format_dimension_stored_json_plaintext(struct instance *instance, RRDDIM *rd)
 {
-    struct engine *engine = instance->engine;
     RRDSET *st = rd->rrdset;
     RRDHOST *host = st->rrdhost;
 
@@ -286,7 +284,7 @@ int format_dimension_stored_json_plaintext(struct instance *instance, RRDDIM *rd
         "\"timestamp\": %llu}",
 
         instance->config.prefix,
-        (host == localhost) ? engine->config.hostname : host->hostname,
+        (host == localhost) ? instance->config.hostname : host->hostname,
         tags_pre,
         tags,
         tags_post,

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -178,7 +178,6 @@ int format_host_labels_opentsdb_telnet(struct instance *instance, RRDHOST *host)
  */
 int format_dimension_collected_opentsdb_telnet(struct instance *instance, RRDDIM *rd)
 {
-    struct engine *engine = instance->engine;
     RRDSET *st = rd->rrdset;
     RRDHOST *host = st->rrdhost;
 
@@ -202,7 +201,7 @@ int format_dimension_collected_opentsdb_telnet(struct instance *instance, RRDDIM
         dimension_name,
         (unsigned long long)rd->last_collected_time.tv_sec,
         rd->last_collected_value,
-        (host == localhost) ? engine->config.hostname : host->hostname,
+        (host == localhost) ? instance->config.hostname : host->hostname,
         (host->tags) ? " " : "",
         (host->tags) ? host->tags : "",
         (instance->labels) ? buffer_tostring(instance->labels) : "");
@@ -219,7 +218,6 @@ int format_dimension_collected_opentsdb_telnet(struct instance *instance, RRDDIM
  */
 int format_dimension_stored_opentsdb_telnet(struct instance *instance, RRDDIM *rd)
 {
-    struct engine *engine = instance->engine;
     RRDSET *st = rd->rrdset;
     RRDHOST *host = st->rrdhost;
 
@@ -249,7 +247,7 @@ int format_dimension_stored_opentsdb_telnet(struct instance *instance, RRDDIM *r
         dimension_name,
         (unsigned long long)last_t,
         value,
-        (host == localhost) ? engine->config.hostname : host->hostname,
+        (host == localhost) ? instance->config.hostname : host->hostname,
         (host->tags) ? " " : "",
         (host->tags) ? host->tags : "",
         (instance->labels) ? buffer_tostring(instance->labels) : "");
@@ -326,7 +324,6 @@ int format_host_labels_opentsdb_http(struct instance *instance, RRDHOST *host)
  */
 int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *rd)
 {
-    struct engine *engine = instance->engine;
     RRDSET *st = rd->rrdset;
     RRDHOST *host = st->rrdhost;
 
@@ -360,7 +357,7 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
         dimension_name,
         (unsigned long long)rd->last_collected_time.tv_sec,
         rd->last_collected_value,
-        (host == localhost) ? engine->config.hostname : host->hostname,
+        (host == localhost) ? instance->config.hostname : host->hostname,
         (host->tags) ? " " : "",
         (host->tags) ? host->tags : "",
         instance->labels ? buffer_tostring(instance->labels) : "");
@@ -377,7 +374,6 @@ int format_dimension_collected_opentsdb_http(struct instance *instance, RRDDIM *
  */
 int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd)
 {
-    struct engine *engine = instance->engine;
     RRDSET *st = rd->rrdset;
     RRDHOST *host = st->rrdhost;
 
@@ -417,7 +413,7 @@ int format_dimension_stored_opentsdb_http(struct instance *instance, RRDDIM *rd)
         dimension_name,
         (unsigned long long)last_t,
         value,
-        (host == localhost) ? engine->config.hostname : host->hostname,
+        (host == localhost) ? instance->config.hostname : host->hostname,
         (host->tags) ? " " : "",
         (host->tags) ? host->tags : "",
         instance->labels ? buffer_tostring(instance->labels) : "");

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -147,7 +147,7 @@ int format_host_prometheus_remote_write(struct instance *instance, RRDHOST *host
     char hostname[PROMETHEUS_ELEMENT_MAX + 1];
     prometheus_label_copy(
         hostname,
-        (host == localhost) ? instance->engine->config.hostname : host->hostname,
+        (host == localhost) ? instance->config.hostname : host->hostname,
         PROMETHEUS_ELEMENT_MAX);
 
     add_host_info(
@@ -236,7 +236,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                     "EXPORTING: not sending dimension '%s' of chart '%s' from host '%s', "
                     "its last data collection (%lu) is not within our timeframe (%lu to %lu)",
                     rd->id, rd->rrdset->id,
-                    (host == localhost) ? instance->engine->config.hostname : host->hostname,
+                    (host == localhost) ? instance->config.hostname : host->hostname,
                     (unsigned long)rd->last_collected_time.tv_sec,
                     (unsigned long)instance->after,
                     (unsigned long)instance->before);
@@ -256,7 +256,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                 add_metric(
                     connector_specific_data->write_request,
                     name, chart, family, dimension,
-                    (host == localhost) ? instance->engine->config.hostname : host->hostname,
+                    (host == localhost) ? instance->config.hostname : host->hostname,
                     rd->last_collected_value, timeval_msec(&rd->last_collected_time));
             } else {
                 // the dimensions of the chart, do not have the same algorithm, multiplier or divisor
@@ -273,7 +273,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                 add_metric(
                     connector_specific_data->write_request,
                     name, chart, family, NULL,
-                    (host == localhost) ? instance->engine->config.hostname : host->hostname,
+                    (host == localhost) ? instance->config.hostname : host->hostname,
                     rd->last_collected_value, timeval_msec(&rd->last_collected_time));
             }
         } else {
@@ -298,7 +298,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                 add_metric(
                     connector_specific_data->write_request,
                     name, chart, family, dimension,
-                    (host == localhost) ? instance->engine->config.hostname : host->hostname,
+                    (host == localhost) ? instance->config.hostname : host->hostname,
                     value, last_t * MSEC_PER_SEC);
             }
         }

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -445,6 +445,8 @@ struct engine *read_exporting_config()
 
         tmp_instance->config.prefix = strdupz(exporter_get(instance_name, "prefix", "netdata"));
 
+        tmp_instance->config.hostname = strdupz(exporter_get(instance_name, "hostname", engine->config.hostname));
+
 #ifdef ENABLE_HTTPS
 
 #define STR_GRAPHITE_HTTPS "graphite:https"

--- a/exporting/tests/exporting_doubles.c
+++ b/exporting/tests/exporting_doubles.c
@@ -12,7 +12,7 @@ struct engine *__wrap_read_exporting_config()
 struct engine *__mock_read_exporting_config()
 {
     struct engine *engine = calloc(1, sizeof(struct engine));
-    engine->config.hostname = strdupz("test-host");
+    engine->config.hostname = strdupz("test_engine_host");
     engine->config.update_every = 3;
 
 
@@ -23,6 +23,7 @@ struct engine *__mock_read_exporting_config()
     instance->config.name = strdupz("instance_name");
     instance->config.destination = strdupz("localhost");
     instance->config.prefix = strdupz("netdata");
+    instance->config.hostname = strdupz("test-host");
     instance->config.update_every = 1;
     instance->config.buffer_on_failures = 10;
     instance->config.timeoutms = 10000;

--- a/exporting/tests/exporting_fixtures.c
+++ b/exporting/tests/exporting_fixtures.c
@@ -20,6 +20,7 @@ int teardown_configured_engine(void **state)
     free((void *)instance->config.destination);
     free((void *)instance->config.name);
     free((void *)instance->config.prefix);
+    free((void *)instance->config.hostname);
     simple_pattern_free(instance->config.charts_pattern);
     simple_pattern_free(instance->config.hosts_pattern);
     free(instance);

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -10,7 +10,7 @@ netdata_rwlock_t rrd_rwlock;
 struct config netdata_config;
 char *netdata_configured_user_config_dir = ".";
 char *netdata_configured_stock_config_dir = ".";
-char *netdata_configured_hostname = "test_host";
+char *netdata_configured_hostname = "test_global_host";
 
 char log_line[MAX_LOG_LINE + 1];
 
@@ -80,7 +80,7 @@ static void test_read_exporting_config(void **state)
     *state = engine;
 
     assert_ptr_not_equal(engine, NULL);
-    assert_string_equal(engine->config.hostname, "test-host");
+    assert_string_equal(engine->config.hostname, "test_engine_host");
     assert_int_equal(engine->config.update_every, 3);
     assert_int_equal(engine->instance_num, 0);
 


### PR DESCRIPTION
##### Summary
The `hostname` option in `exporting.conf` doesn't work if it is set in an instance section. It works only in the `exporting:global` section. The PR makes the exporting engine respect both levels of configuration.

Fixes #10339

##### Component Name
Exporting engine

##### Test Plan
Configure the `hostname` option in an instance section. Check if the connector output contains the configured name. The `hostname` is visible in the output of `graphite`, `json`, `opentsdb`, `opentsdb:http`, and `prometheus_remote_write` connectors.