### PR TITLE
Fixed use of multiarch/qemu-user-static image for Docker builds.

### DIFF
--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -64,7 +64,7 @@ echo "Version     : ${VERSION}"
 echo "Repository  : ${REPOSITORY}"
 echo "Architecture: ${ARCH}"
 
-docker run --rm --privileged multiarch/qemu-user-static:register --reset
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 # Build images using multi-arch Dockerfile.
 TAG="${REPOSITORY,,}:${VERSION}-${ARCH}"


### PR DESCRIPTION
##### Summary

Our actual usage of the image was never actually correct, it just happened to work up until some recent changes were made.

##### Component Name

area/ci

##### Test Plan

Docker builds all pass at: https://travis-ci.org/github/Ferroin/netdata/builds/748782070