### PR TITLE
add two more insignificant warnings to suppress in anomalies collector

### DIFF
--- a/collectors/python.d.plugin/anomalies/anomalies.chart.py
+++ b/collectors/python.d.plugin/anomalies/anomalies.chart.py
@@ -26,6 +26,8 @@ from bases.FrameworkServices.SimpleService import SimpleService
 # ignore some sklearn/numpy warnings that are ok
 warnings.filterwarnings('ignore', r'All-NaN slice encountered')
 warnings.filterwarnings('ignore', r'invalid value encountered in true_divide')
+warnings.filterwarnings('ignore', r'divide by zero encountered in true_divide')
+warnings.filterwarnings('ignore', r'invalid value encountered in subtract')
 
 disabled_by_default = True
 


### PR DESCRIPTION

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Following some discussion here: https://community.netdata.cloud/t/collector-anomalies-error-on-loading-source/581/11

The underlying python libraries, mainly numpy and sklearn can sometimes generate warnings for numerous, typically transient reasons relating to some quirk of the underlying data. For the purpose of the anomalies collector they don't really matter as worst case you would end up with the predict step failing and your predictions just becoming a constant values of last successful prediction and charts would just become flat lines making it obvious something is wrong. 

So warnings like this are expected to pop up every now and then from individual charts/models. 

For the most common and harmless ones we explicitly suppress them in the collector code itself so as to avoid risk of excessive logging of them to logs. 

This change just add's two more warning message filters.

##### Component Name

collectors/python.d.plugin/anomalies

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Quite tricky to create an actual realistic test case for this one. It's a very small simple addition to logic that has already been tested and validated as part of original development.  

##### Additional Information
