### PR TITLE
Change linting standard for Markdown lists

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -7,12 +7,12 @@ exports.settings = {
   spacedTable: false,
   paddedTable: false,
   fences: true,
-  rule: '-',
+  rule: "-",
   ruleRepetition: 3,
   emphasis: "*",
   strong: "*",
   bullet: "-",
-  listItemIndent: 'tab',
+  listItemIndent: "1",
   incrementListMarker: true
 };
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

I was talking to @ilyam8 about the annoyance that our Markdown linter insists on lists having three spaces after the `-`, which is a setting that precedes both of our tenure at Netdata. This PR changes the standard to a single space, which is the most common behavior for developers, so that there's less friction when anyone updates the docs (and less of me nitpicking PRs for Markdown syntax).

Before:

```
-   This is a list.
-   And another one.
```

After:

```
- This is a list.
- And another one.
```

##### Component Name

area/docs

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
