### PR TITLE
python.d/alarms: add alarms obsoletion and disable by default

### DIFF
--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -8,7 +8,7 @@ from json import loads
 from bases.FrameworkServices.UrlService import UrlService
 
 update_every = 10
-disabled_by_default = False
+disabled_by_default = True
 
 
 def charts_template(sm):

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -10,41 +10,62 @@ from bases.FrameworkServices.UrlService import UrlService
 update_every = 10
 disabled_by_default = False
 
+
+def charts_template(sm):
+    order = [
+        'alarms',
+    ]
+
+    mappings = ', '.join(['{0}={1}'.format(k, v) for k, v in sm.items()])
+    charts = {
+        'alarms': {
+            'options': [None, 'Alarms ({0})'.format(mappings), 'status', 'alarms', 'alarms.status', 'line'],
+            'lines': [],
+            'variables': [
+                ['alarms_num'],
+            ]
+        }
+    }
+    return order, charts
+
+
 DEFAULT_STATUS_MAP = {'CLEAR': 0, 'WARNING': 1, 'CRITICAL': 2}
 
-ORDER = [
-    'alarms',
-]
-
-CHARTS = {
-}
+DEFAULT_URL = 'http://127.0.0.1:19999/api/v1/alarms?all'
 
 
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
-        self.order = ORDER
-        self.definitions = CHARTS
-        self.url = self.configuration.get('url', 'http://127.0.0.1:19999/api/v1/alarms?all')
-        self.status_map = self.configuration.get('status_map', DEFAULT_STATUS_MAP)
-        self.chart_title = f"Alarms ({', '.join([f'{k}={self.status_map[k]}' for k in self.status_map])})"
-
-    def validate_charts(self, name, data, algorithm='absolute', multiplier=1, divisor=1):
-        for dim in data:
-            if name not in self.charts:
-                chart_params = [name] + ['alarms', self.chart_title, 'status', 'alarms', 'alarms.status', 'line']
-                self.charts.add_chart(params=chart_params)
-            if dim not in self.charts[name]:
-                self.charts[name].add_dimension([dim, dim, algorithm, multiplier, divisor])
+        self.sm = self.configuration.get('status_map', DEFAULT_STATUS_MAP)
+        self.order, self.definitions = charts_template(self.sm)
+        self.url = self.configuration.get('url', DEFAULT_URL)
+        self.collected_alarms = set()
 
     def _get_data(self):
         raw_data = self._get_raw_data()
         if raw_data is None:
             return None
+
         raw_data = loads(raw_data)
         alarms = raw_data.get('alarms', {})
-        data = {a: self.status_map[alarms[a]['status']] for a in alarms if alarms[a]['status'] in self.status_map}
-        self.validate_charts('alarms', data)
+
+        data = {a: self.sm[alarms[a]['status']] for a in alarms if alarms[a]['status'] in self.sm}
         data['alarms_num'] = len(data)
+        self.update_charts(alarms, data)
 
         return data
+
+    def update_charts(self, alarms, data):
+        if not self.charts:
+            return
+
+        for a in data:
+            if a not in self.collected_alarms:
+                self.collected_alarms.add(a)
+                self.charts['alarms'].add_dimension([a, a, 'absolute', '1', '1'])
+
+        for a in list(self.collected_alarms):
+            if a not in alarms:
+                self.collected_alarms.remove(a)
+                self.charts['alarms'].del_dimension(a, hide=False)


### PR DESCRIPTION
##### Summary

This PR:
 - adds alarms obsoletion (remove alarms from the `alarms` chart).
 - improves collector performance (`dimID in self.charts[chartID]` is very inefficient).
 - disables collector by default.

That is what i noticed on one of our k8s nodes:

<img width="883" alt="Screenshot 2020-12-11 at 20 23 33" src="https://user-images.githubusercontent.com/22274335/101942240-4034d880-3bfa-11eb-90f7-03531cb93f6e.png">

I checked number of dimensions in the `alarms` chart and it had 800+.

@andrewm4894 since we are about to release new version i suggest to disable it by default for now.


##### Component Name

`python.d/alarms`

##### Test Plan

- run new version of `alarms.chart.py`, ensure it works.

##### Additional Information
