### PR TITLE
python.d/alarms: fix sending chart definition on every data collection

### DIFF
--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -51,8 +51,8 @@ class Service(UrlService):
         alarms = raw_data.get('alarms', {})
 
         data = {a: self.sm[alarms[a]['status']] for a in alarms if alarms[a]['status'] in self.sm}
-        data['alarms_num'] = len(data)
         self.update_charts(alarms, data)
+        data['alarms_num'] = len(data)
 
         return data
 


### PR DESCRIPTION
##### Summary

Fix bug introduced in #10375

Any additional metrics should be added to `data` after `update_charts` method call.

Bug is adding `alarms_num` to the chart in first loop and remove in 2nd 😅 (should have tried to run it in the debug mode before merging #10375)

https://github.com/netdata/netdata/blob/6e0b9c97bafdd1bda8e501792c608da8d5328220/collectors/python.d.plugin/alarms/alarms.chart.py#L59-L71



##### Component Name

`python.d/alarms`

##### Test Plan

- [X] run new version of alarms.chart.py, ensure it works.
- [X] run new version of alarms.chart.py in debug mode, ensure chart definition is not being sent on every data collection.

##### Additional Information
