### PR TITLE
Fix issue with chart metadata sent multiple times over ACLK

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -414,7 +414,8 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_OBSOLETE_DIMENSIONS = 1 << 14, // this is marked by the collector/module when a chart has obsolete dimensions
     // No new values have been collected for this chart since agent start or it was marked RRDSET_FLAG_OBSOLETE at
     // least rrdset_free_obsolete_time seconds ago.
-    RRDSET_FLAG_ARCHIVED            = 1 << 15
+    RRDSET_FLAG_ARCHIVED            = 1 << 15,
+    RRDSET_FLAG_ACLK                = 1 << 16
 } RRDSET_FLAGS;
 
 #ifdef HAVE_C___ATOMIC

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -211,7 +211,7 @@ void rrdcalc_link_to_rrddim(RRDDIM *rd, RRDSET *st, RRDHOST *host) {
     }
 #ifdef ENABLE_ACLK
     if (netdata_cloud_setting)
-        aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
+        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
 }
 
@@ -460,7 +460,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     rrdset_unlock(st);
 #ifdef ENABLE_ACLK
     if (netdata_cloud_setting)
-        aclk_update_chart(host, st->id, ACLK_CMD_CHART);
+        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
     return(rd);
 }
@@ -535,7 +535,7 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
     }
 #ifdef ENABLE_ACLK
     if ((netdata_cloud_setting) && (db_rotated || RRD_MEMORY_MODE_DBENGINE != rrd_memory_mode))
-        aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
+        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
 }
 
@@ -557,7 +557,7 @@ int rrddim_hide(RRDSET *st, const char *id) {
     rrddim_flag_set(rd, RRDDIM_FLAG_HIDDEN);
 #ifdef ENABLE_ACLK
     if (netdata_cloud_setting)
-        aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
+        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
     return 0;
 }
@@ -575,7 +575,7 @@ int rrddim_unhide(RRDSET *st, const char *id) {
     rrddim_flag_clear(rd, RRDDIM_FLAG_HIDDEN);
 #ifdef ENABLE_ACLK
     if (netdata_cloud_setting)
-        aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
+        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
     return 0;
 }
@@ -591,7 +591,7 @@ inline void rrddim_is_obsolete(RRDSET *st, RRDDIM *rd) {
     rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS);
 #ifdef ENABLE_ACLK
     if (netdata_cloud_setting)
-        aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
+        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
 }
 
@@ -601,7 +601,7 @@ inline void rrddim_isnot_obsolete(RRDSET *st __maybe_unused, RRDDIM *rd) {
     rrddim_flag_clear(rd, RRDDIM_FLAG_OBSOLETE);
 #ifdef ENABLE_ACLK
     if (netdata_cloud_setting)
-        aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
+        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
 }
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -210,8 +210,7 @@ void rrdcalc_link_to_rrddim(RRDDIM *rd, RRDSET *st, RRDHOST *host) {
         }
     }
 #ifdef ENABLE_ACLK
-    if (netdata_cloud_setting)
-        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
+    rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
 }
 
@@ -459,8 +458,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
 
     rrdset_unlock(st);
 #ifdef ENABLE_ACLK
-    if (netdata_cloud_setting)
-        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
+    rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
     return(rd);
 }
@@ -534,7 +532,7 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
             break;
     }
 #ifdef ENABLE_ACLK
-    if ((netdata_cloud_setting) && (db_rotated || RRD_MEMORY_MODE_DBENGINE != rrd_memory_mode))
+    if (db_rotated || RRD_MEMORY_MODE_DBENGINE != rrd_memory_mode)
         rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
 }
@@ -556,8 +554,7 @@ int rrddim_hide(RRDSET *st, const char *id) {
 
     rrddim_flag_set(rd, RRDDIM_FLAG_HIDDEN);
 #ifdef ENABLE_ACLK
-    if (netdata_cloud_setting)
-        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
+    rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
     return 0;
 }
@@ -574,8 +571,7 @@ int rrddim_unhide(RRDSET *st, const char *id) {
 
     rrddim_flag_clear(rd, RRDDIM_FLAG_HIDDEN);
 #ifdef ENABLE_ACLK
-    if (netdata_cloud_setting)
-        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
+    rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
     return 0;
 }
@@ -590,8 +586,7 @@ inline void rrddim_is_obsolete(RRDSET *st, RRDDIM *rd) {
     rrddim_flag_set(rd, RRDDIM_FLAG_OBSOLETE);
     rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS);
 #ifdef ENABLE_ACLK
-    if (netdata_cloud_setting)
-        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
+    rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
 }
 
@@ -600,8 +595,7 @@ inline void rrddim_isnot_obsolete(RRDSET *st __maybe_unused, RRDDIM *rd) {
 
     rrddim_flag_clear(rd, RRDDIM_FLAG_OBSOLETE);
 #ifdef ENABLE_ACLK
-    if (netdata_cloud_setting)
-        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
+    rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
 }
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1371,10 +1371,12 @@ void rrdset_done(RRDSET *st) {
     // a read lock is OK here
     rrdset_rdlock(st);
 
-    if (unlikely(rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
+#ifdef ENABLE_ACLK
+    if (netdata_cloud_setting && unlikely(rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
         rrdset_flag_clear(st, RRDSET_FLAG_ACLK);
         aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
     }
+#endif
 
     if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE))) {
         error("Chart '%s' has the OBSOLETE flag set, but it is collected.", st->id);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -932,10 +932,9 @@ RRDSET *rrdset_create_custom(
 
     rrdhost_unlock(host);
 #ifdef ENABLE_ACLK
-    if (netdata_cloud_setting) {
+    if (netdata_cloud_setting)
         aclk_add_collector(host, plugin, module);
-        rrdset_flag_set(st, RRDSET_FLAG_ACLK);
-    }
+    rrdset_flag_set(st, RRDSET_FLAG_ACLK);
 #endif
     return(st);
 }
@@ -1372,7 +1371,7 @@ void rrdset_done(RRDSET *st) {
     rrdset_rdlock(st);
 
 #ifdef ENABLE_ACLK
-    if (netdata_cloud_setting && unlikely(rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
+    if (unlikely(rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
         rrdset_flag_clear(st, RRDSET_FLAG_ACLK);
         aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHART);
     }


### PR DESCRIPTION
##### Summary
Mark a chart as "need to send via ACLK" when a chart is created, has it's direct metadata changed, or a dimension is
added. 

Check if the chart needs to be sent via ACLK when metrics are collected.

##### Component Name
database

##### Test Plan
- Enable cgroups
- Start an agent from the master branch (compile with -DNETDATA_INTERNAL_CHECKS=1)
   - Notice the number of `Sending MQTT len=913 mid=438 wq=0 (0-bytes) readq=0: {	"type": "chart" ... `  msgs (**sample**)
- Apply the PR, compile and restart
   - Notice the reduced number of `Sending MQTT len=913 mid=438 wq=0 (0-bytes) readq=0: {	"type": "chart" ... `  msgs

The type `chart` messages are individual chart updates
