### PR TITLE
Fix a lock check

### DIFF
--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -152,7 +152,7 @@ int format_host_labels_opentsdb_telnet(struct instance *instance, RRDHOST *host)
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
 
-    rrdhost_check_rdlock(localhost);
+    rrdhost_check_rdlock(host);
     netdata_rwlock_rdlock(&host->labels.labels_rwlock);
     for (struct label *label = host->labels.head; label; label = label->next) {
         if (!should_send_label(instance, label))


### PR DESCRIPTION
##### Summary
There is a sporadic lock error if the plaintext OpenTSDB exporting connector is configured.
```
RRDHOST 'futura' should be read-locked, but it is not, at function format_host_labels_opentsdb_telnet() at line 155 of file 'exporting/opentsdb/opentsdb.c' # : Success
```
This PR should fix it.

##### Component Name
Exporting engine