### PR TITLE
Fix a buffer overflow when extracting information from a STREAM connection

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -864,7 +864,7 @@ static inline char *web_client_valid_method(struct web_client *w, char *s) {
                 copyme += 9;
                 char *end = strchr(copyme,'&');
                 if(end){
-                    size_t length = end - copyme;
+                    size_t length = MIN(255, end - copyme);
                     memcpy(hostname,copyme,length);
                     hostname[length] = 0X00;
                 }


### PR DESCRIPTION
##### Summary
Fixes a buffer overflow when a server configured to accept only SSL connections from children is sent an unencrypted STREAM command with a large hostname.  The server will try to extract the hostname to report that it use should use SSL.

##### Component Name
web

##### Test Plan
- Force agent to accept only SSL connections from children
- Connect to the agent and send a STREAM command with a large (more that 256 bytes) hostname as in
  `STREAM hostname=*very large hostname over 255 characters*`
