### PR TITLE
ACLK collector list use mguid instead of hostname

### DIFF
--- a/aclk/agent_cloud_link.c
+++ b/aclk/agent_cloud_link.c
@@ -576,7 +576,7 @@ void aclk_add_collector(RRDHOST *host, const char *plugin_name, const char *modu
 
     COLLECTOR_LOCK;
 
-    tmp_collector = _add_collector(host->hostname, plugin_name, module_name);
+    tmp_collector = _add_collector(host->machine_guid, plugin_name, module_name);
 
     if (unlikely(tmp_collector->count != 1)) {
         COLLECTOR_UNLOCK;
@@ -609,7 +609,7 @@ void aclk_del_collector(RRDHOST *host, const char *plugin_name, const char *modu
 
     COLLECTOR_LOCK;
 
-    tmp_collector = _del_collector(host->hostname, plugin_name, module_name);
+    tmp_collector = _del_collector(host->machine_guid, plugin_name, module_name);
 
     if (unlikely(!tmp_collector || tmp_collector->count)) {
         COLLECTOR_UNLOCK;


### PR DESCRIPTION
##### Summary

Since its inception ACLK collector list used hostname instead of guid. However we can have multiple children with same hostname and different guids. This prevents mixups between children.

##### Component Name

##### Test Plan

##### Additional Information
