### PR TITLE
invalid_addr_cleanup: Initialize variables

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -119,12 +119,7 @@ ebpf_module_t ebpf_modules[] = {
 ebpf_process_stat_t *global_process_stat = NULL;
 
 //Network viewer
-ebpf_network_viewer_options_t network_viewer_opt = { .max_dim = NETDATA_NV_CAP_VALUE, .hostname_resolution_enabled = 0,
-                                                     .service_resolution_enabled = 0, .excluded_port = NULL,
-                                                     .included_port = NULL, .names = NULL, .excluded_ips = NULL,
-                                                     .included_ips = NULL, .excluded_hostnames = NULL,
-                                                     .included_hostnames = NULL, .ipv4_local_ip = NULL,
-                                                     .ipv6_local_ip = NULL };
+ebpf_network_viewer_options_t network_viewer_opt;
 
 /*****************************************************************
  *
@@ -1783,6 +1778,9 @@ static void parse_args(int argc, char **argv)
         {"return",   no_argument,    0,  'r' },
         {0, 0, 0, 0}
     };
+
+    memset(&network_viewer_opt, 0, sizeof(network_viewer_opt));
+    network_viewer_opt.max_dim = NETDATA_NV_CAP_VALUE;
 
     if (argc > 1) {
         int n = (int)str2l(argv[1]);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -121,7 +121,9 @@ ebpf_process_stat_t *global_process_stat = NULL;
 //Network viewer
 ebpf_network_viewer_options_t network_viewer_opt = { .max_dim = NETDATA_NV_CAP_VALUE, .hostname_resolution_enabled = 0,
                                                      .service_resolution_enabled = 0, .excluded_port = NULL,
-                                                     .included_port = NULL, .names = NULL, .ipv4_local_ip = NULL,
+                                                     .included_port = NULL, .names = NULL, .excluded_ips = NULL,
+                                                     .included_ips = NULL, .excluded_hostnames = NULL,
+                                                     .included_hostnames = NULL, .ipv4_local_ip = NULL,
                                                      .ipv6_local_ip = NULL };
 
 /*****************************************************************


### PR DESCRIPTION
##### Summary
Fixes #10393 

This PR initializes variables to avoid crash when `ebpf.plugin` is closed.

##### Component Name
`ebpf.plugin`.
##### Test Plan


1 -    Remove /etc/netdata/ebpf.conf
2 -   Go to plugins directory /usr/libexec/netdata/plugins.d/ and run ebpf.plugin.
3 -   Press CTRL+C to end the application
4-    Repeat The steps 2 and 3 at least 3 times, I never needed more than this to create a core dump. With this PR you should not have it more.


##### Additional Information
I tested this PR on `Ubuntu 20.04LTS`, the same distribution used by our user. I had problems with `master`, but I did not have more the problem with this PR.