### PR TITLE
Fixed option parsing in kickstart.sh.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -374,7 +374,8 @@ while [ -n "${1}" ]; do
     export NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT="${1}"
     shift 1
   else
-    break
+    NETDATA_INSTALLER_OPTIONS="$NETDATA_INSTALLER_OPTIONS ${1}"
+    shift 1
   fi
 done
 
@@ -473,7 +474,7 @@ cd netdata-* || fatal "Cannot cd to netdata source tree"
 
 install() {
   progress "Installing netdata..."
-  run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS} "${@}" || fatal "netdata-installer.sh exited with error"
+  run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS} || fatal "netdata-installer.sh exited with error"
   if [ -d "${ndtmpdir}" ] && [ ! "${ndtmpdir}" = "/" ]; then
     run ${sudo} rm -rf "${ndtmpdir}" > /dev/null 2>&1
   fi

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -61,7 +61,7 @@ To use `md5sum` to verify the intregity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "02efc9e5ae084ad3aff072837dbedb1c" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "71e0dbb4af6f2cc7e89d358a1a942341" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

The existing code is dependent on options specifically for the kickstart script coming before any options to be passed to the installer, resulting in some options being ignored if the were ordered in certain ways.

This fixes the parsing to explicitly parse _all_ options so that we are not dependent on option order.

##### Component Name

area/packaging

##### Test Plan

1. Create a new install of Netdata in a test environment using the kickstart script with the `--disable-telemetry` option (any option that gets passed to the `netdata-installer.sh` script will work).
2. Try to reinstall in the same environment using the kickstart script by adding `--reinstall` to the end of the command you used in step 1 (note, option order is important here, the `--reinstall` _must_ come after the other options).
3. Without this PR, step 2 will result in the updater script being run (with a message indicating that in the output). With this kickstart script from this PR, it will instead print the message `User requested reinstall instead of update, proceeding.` and not run the updater script.

##### Additional Information

Fixes: #10389 
Relevant to: #10372 