### PR TITLE
Fix data source option for Prometheus web API in exporting configuration

### DIFF
--- a/backends/backends.c
+++ b/backends/backends.c
@@ -28,6 +28,7 @@
 const char *global_backend_prefix = "netdata";
 int global_backend_update_every = 10;
 BACKEND_OPTIONS global_backend_options = BACKEND_SOURCE_DATA_AVERAGE | BACKEND_OPTION_SEND_NAMES;
+const char *global_backend_source = NULL;
 
 // ----------------------------------------------------------------------------
 // helper functions for backends
@@ -528,6 +529,7 @@ void *backends_main(void *ptr) {
     // and prepare for sending data to our backend
 
     global_backend_options = backend_parse_data_source(source, global_backend_options);
+    global_backend_source = source;
 
     if(timeoutms < 1) {
         error("BACKEND: invalid timeout %ld ms given. Assuming %d ms.", timeoutms, global_backend_update_every * 2 * 1000);

--- a/backends/backends.h
+++ b/backends/backends.h
@@ -35,6 +35,7 @@ typedef int (**backend_request_formatter_t)(BUFFER *, const char *, RRDHOST *, c
 
 extern int global_backend_update_every;
 extern BACKEND_OPTIONS global_backend_options;
+extern const char *global_backend_source;
 extern const char *global_backend_prefix;
 
 extern void *backends_main(void *ptr);

--- a/exporting/exporting.conf
+++ b/exporting/exporting.conf
@@ -5,6 +5,7 @@
     # update every = 10
 
 [prometheus:exporter]
+    # data source = average
     # send names instead of ids = yes
     # send configured labels = yes
     # send automatic labels = no

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -238,8 +238,11 @@ struct engine *read_exporting_config()
         prometheus_exporter_instance->config.update_every =
             prometheus_config_get_number(EXPORTING_UPDATE_EVERY_OPTION_NAME, EXPORTING_UPDATE_EVERY_DEFAULT);
 
-        while(!global_backend_source)
-            usleep(100);
+        for (int retries = 0; !global_backend_source && retries < 1000; retries++)
+            usleep(10000);
+
+        if (!global_backend_source)
+            global_backend_source = "average";
 
         prometheus_exporter_instance->config.options |= global_backend_options & EXPORTING_OPTIONS_SOURCE_BITS;
 

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -238,6 +238,7 @@ struct engine *read_exporting_config()
         prometheus_exporter_instance->config.update_every =
             prometheus_config_get_number(EXPORTING_UPDATE_EVERY_OPTION_NAME, EXPORTING_UPDATE_EVERY_DEFAULT);
 
+        // wait for backend subsystem to be initialized
         for (int retries = 0; !global_backend_source && retries < 1000; retries++)
             sleep_usec(10000);
 

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -238,9 +238,14 @@ struct engine *read_exporting_config()
         prometheus_exporter_instance->config.update_every =
             prometheus_config_get_number(EXPORTING_UPDATE_EVERY_OPTION_NAME, EXPORTING_UPDATE_EVERY_DEFAULT);
 
-        prometheus_exporter_instance->config.options |=
-            global_backend_options &
-            (EXPORTING_SOURCE_DATA_AS_COLLECTED | EXPORTING_SOURCE_DATA_AVERAGE | EXPORTING_SOURCE_DATA_SUM);
+        while(!global_backend_source)
+            usleep(100);
+
+        prometheus_exporter_instance->config.options |= global_backend_options & EXPORTING_OPTIONS_SOURCE_BITS;
+
+        char *data_source = prometheus_config_get("data source", global_backend_source);
+        prometheus_exporter_instance->config.options =
+            exporting_parse_data_source(data_source, prometheus_exporter_instance->config.options);
 
         if (prometheus_config_get_boolean(
                 "send names instead of ids", global_backend_options & EXPORTING_OPTION_SEND_NAMES))

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -239,7 +239,7 @@ struct engine *read_exporting_config()
             prometheus_config_get_number(EXPORTING_UPDATE_EVERY_OPTION_NAME, EXPORTING_UPDATE_EVERY_DEFAULT);
 
         for (int retries = 0; !global_backend_source && retries < 1000; retries++)
-            usleep(10000);
+            sleep_usec(10000);
 
         if (!global_backend_source)
             global_backend_source = "average";

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -15,6 +15,7 @@ char *netdata_configured_hostname = "test_global_host";
 char log_line[MAX_LOG_LINE + 1];
 
 BACKEND_OPTIONS global_backend_options = 0;
+const char *global_backend_source = "average";
 const char *global_backend_prefix = "netdata";
 
 void init_connectors_in_tests(struct engine *engine)


### PR DESCRIPTION
##### Summary
Fixes #10392

##### Component Name
Exporting engine

##### Test Plan
Set `data source = raw` in the `[prometheus:exporter]` section of `exporting.conf`. Check the output of `http://localhost:19999/api/v1/allmetrics?format=prometheus` - it should not append `_average` to all metrics.