### PR TITLE
Dispatch cgroup discovery into another thread

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1468,7 +1468,7 @@ static inline struct cgroup *cgroup_add(const char *id) {
         struct cgroup *t;
         for (t = discovered_cgroup_root; t; t = t->discovered_next) {
             if (t != cg && t->enabled && t->hash_chart == cg->hash_chart && !strcmp(t->chart_id, cg->chart_id)) {
-                // TODO: use it after refactoring if system.slice can be scanned before init.scope/system.slice
+                // TODO: use it after refactoring if system.slice might be scanned before init.scope/system.slice
                 //
                 // if (!strncmp(t->id, "/system.slice/", 14) && !strncmp(cg->id, "/init.scope/system.slice/", 25)) {
                 //     error("CGROUP: chart id '%s' already exists with id '%s' and is enabled. Swapping them by enabling cgroup with id '%s' and disabling cgroup with id '%s'.",

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1473,8 +1473,6 @@ static inline struct cgroup *cgroup_add(const char *id) {
                 // if (!strncmp(t->id, "/system.slice/", 14) && !strncmp(cg->id, "/init.scope/system.slice/", 25)) {
                 //     error("CGROUP: chart id '%s' already exists with id '%s' and is enabled. Swapping them by enabling cgroup with id '%s' and disabling cgroup with id '%s'.",
                 //           cg->chart_id, t->id, cg->id, t->id);
-                //     debug(D_CGROUP, "Control group with chart id '%s' already exists with id '%s' and is enabled. Swapping them by enabling cgroup with id '%s' and disabling cgroup with id '%s'.",
-                //           cg->chart_id, t->id, cg->id, t->id);
                 //     t->enabled = 0;
                 //     t->options |= CGROUP_OPTIONS_DISABLED_DUPLICATE;
                 // }
@@ -1482,8 +1480,6 @@ static inline struct cgroup *cgroup_add(const char *id) {
                 //
                 // https://github.com/netdata/netdata/issues/797#issuecomment-241248884
                 error("CGROUP: chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.",
-                        cg->chart_id, t->id, cg->id);
-                debug(D_CGROUP, "Control group with chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.",
                         cg->chart_id, t->id, cg->id);
                 cg->enabled = 0;
                 cg->options |= CGROUP_OPTIONS_DISABLED_DUPLICATE;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -584,6 +584,7 @@ struct cgroup_network_interface {
 #define CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE 0x00000002
 #define CGROUP_OPTIONS_IS_UNIFIED           0x00000004
 
+// *** WARNING *** The fields are not thread safe. Take care of safe usage.
 struct cgroup {
     uint32_t options;
 
@@ -1181,7 +1182,7 @@ static inline void read_all_cgroups(struct cgroup *root) {
     struct cgroup *cg;
 
     for(cg = root; cg ; cg = cg->next)
-        if(cg->enabled && cg->available && !cg->pending_renames)
+        if(cg->enabled && !cg->pending_renames)
             cgroup_read(cg);
 }
 
@@ -2684,7 +2685,7 @@ void update_systemd_services_charts(
     // update the values
     struct cgroup *cg;
     for(cg = cgroup_root; cg ; cg = cg->next) {
-        if(unlikely(!cg->available || !cg->enabled || cg->pending_renames || !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE)))
+        if(unlikely(!cg->enabled || cg->pending_renames || !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE)))
             continue;
 
         if(likely(do_cpu && cg->cpuacct_stat.updated)) {
@@ -3075,7 +3076,7 @@ void update_cgroup_charts(int update_every) {
 
     struct cgroup *cg;
     for(cg = cgroup_root; cg ; cg = cg->next) {
-        if(unlikely(!cg->available || !cg->enabled || cg->pending_renames))
+        if(unlikely(!cg->enabled || cg->pending_renames))
             continue;
 
         if(likely(cgroup_enable_systemd_services && cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE)) {

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2094,10 +2094,10 @@ void cgroup_discovery_worker(void *ptr)
         discovery_thread.start_discovery = 0;
         uv_mutex_unlock(&discovery_thread.mutex);
 
-        find_all_cgroups();
-
         if (unlikely(netdata_exit))
             break;
+
+        find_all_cgroups();
     }
 
     discovery_thread.exited = 1;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1468,22 +1468,25 @@ static inline struct cgroup *cgroup_add(const char *id) {
         struct cgroup *t;
         for (t = discovered_cgroup_root; t; t = t->discovered_next) {
             if (t != cg && t->enabled && t->hash_chart == cg->hash_chart && !strcmp(t->chart_id, cg->chart_id)) {
-                if (!strncmp(t->chart_id, "/system.slice/", 14) && !strncmp(cg->chart_id, "/init.scope/system.slice/", 25)) {
-                    error("CGROUP: chart id '%s' already exists with id '%s' and is enabled. Swapping them by enabling cgroup with id '%s' and disabling cgroup with id '%s'.",
-                          cg->chart_id, t->id, cg->id, t->id);
-                    debug(D_CGROUP, "Control group with chart id '%s' already exists with id '%s' and is enabled. Swapping them by enabling cgroup with id '%s' and disabling cgroup with id '%s'.",
-                          cg->chart_id, t->id, cg->id, t->id);
-                    t->enabled = 0;
-                    t->options |= CGROUP_OPTIONS_DISABLED_DUPLICATE;
-                }
-                else {
-                    error("CGROUP: chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.",
-                          cg->chart_id, t->id, cg->id);
-                    debug(D_CGROUP, "Control group with chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.",
-                          cg->chart_id, t->id, cg->id);
-                    cg->enabled = 0;
-                    cg->options |= CGROUP_OPTIONS_DISABLED_DUPLICATE;
-                }
+                // TODO: use it after refactoring if system.slice can be scanned before init.scope/system.slice
+                //
+                // if (!strncmp(t->id, "/system.slice/", 14) && !strncmp(cg->id, "/init.scope/system.slice/", 25)) {
+                //     error("CGROUP: chart id '%s' already exists with id '%s' and is enabled. Swapping them by enabling cgroup with id '%s' and disabling cgroup with id '%s'.",
+                //           cg->chart_id, t->id, cg->id, t->id);
+                //     debug(D_CGROUP, "Control group with chart id '%s' already exists with id '%s' and is enabled. Swapping them by enabling cgroup with id '%s' and disabling cgroup with id '%s'.",
+                //           cg->chart_id, t->id, cg->id, t->id);
+                //     t->enabled = 0;
+                //     t->options |= CGROUP_OPTIONS_DISABLED_DUPLICATE;
+                // }
+                // else {}
+                //
+                // https://github.com/netdata/netdata/issues/797#issuecomment-241248884
+                error("CGROUP: chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.",
+                        cg->chart_id, t->id, cg->id);
+                debug(D_CGROUP, "Control group with chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.",
+                        cg->chart_id, t->id, cg->id);
+                cg->enabled = 0;
+                cg->options |= CGROUP_OPTIONS_DISABLED_DUPLICATE;
 
                 break;
             }


### PR DESCRIPTION
##### Summary
This is a quick fix for #10285. cgroup discovery will run in a separate thread and won't stop the main thread from collecting metrics and updating charts.

##### Component Name
cgroups plugin

##### Test Plan
1) Start a container that gives you live charts in Netdata
2) Add `sleep 1` to the end of `/usr/libexec/netdata/plugins.d/cgroup-name.sh`
```
fi

sleep 1
info "cgroup '${CGROUP}' is called '${NAME}'"
echo "${NAME}"

exit ${NAME_NOT_FOUND}
```
3) Run with `sudo` the following script
```
#!/bin/bash

CGROUP_PATH="/sys/fs/cgroup/cpu/test"

# number_of_containers=1000 for memory leak test
number_of_containers=10

mkdir "${CGROUP_PATH}"

for i in $(seq 0 9)
do

    echo "create cgroups, step ${i}"
    seq_boundaries="$((i * number_of_containers + 1)) $((i * number_of_containers + number_of_containers))"
    for j in $(seq ${seq_boundaries}); do mkdir "${CGROUP_PATH}/${j}"; done

    echo "sleep..."
    sleep 30

    echo "remove cgroups, step ${i}"
    for j in $(seq ${seq_boundaries}); do rmdir "${CGROUP_PATH}/${j}"; done

    echo "sleep..."
    sleep 10

done

rmdir "${CGROUP_PATH}"

```
4) Check that you don't have gaps for the container you ran in the first step.