### PR TITLE
python.d/fail2ban: Add handling "yes" and "no" as bool, match flexible spaces

### DIFF
--- a/collectors/python.d.plugin/fail2ban/fail2ban.chart.py
+++ b/collectors/python.d.plugin/fail2ban/fail2ban.chart.py
@@ -50,7 +50,7 @@ def charts(jails):
     return ch
 
 
-RE_JAILS = re.compile(r'\[([a-zA-Z0-9_-]+)\][^\[\]]+?enabled\s+= (true|false)')
+RE_JAILS = re.compile(r'\[([a-zA-Z0-9_-]+)\][^\[\]]+?enabled\s+= +(true|yes|false|no)')
 
 # Example:
 # 2018-09-12 11:45:53,715 fail2ban.actions[25029]: WARNING [ssh] Unban 195.201.88.33
@@ -196,9 +196,9 @@ class Service(LogService):
             if name in exclude:
                 continue
 
-            if status == 'true' and name not in active_jails:
+            if status in ('true','yes') and name not in active_jails:
                 active_jails.append(name)
-            elif status == 'false' and name in active_jails:
+            elif status in ('false','no') and name in active_jails:
                 active_jails.remove(name)
 
         return active_jails or DEFAULT_JAILS


### PR DESCRIPTION
##### Summary
1. `enable = yes` is handled by fail2ban, so we shall, too
2. `enable ________          = ________              true` (_ = space, somehow github eats multiple spaces!) is valid, however stupid it looks

##### Component Name
python.d/fail2ban.chart.py

##### Test Plan
The change is trivial, unless there's a syntax error it shall work as intended.

##### Additional Information
Curiously the 'yes' / 'no' isn't mentioned in the new fail2ban doc but my old files contained such settings and handled. 