### PR TITLE
Fix locking after on_connect failure

### DIFF
--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -750,7 +750,7 @@ void *aclk_query_main_thread(void *ptr)
         rrdhost_aclk_state_lock(localhost);
         if (unlikely(localhost->aclk_state.metadata == ACLK_METADATA_REQUIRED)) {
             if (unlikely(aclk_queue_query("on_connect", localhost, NULL, NULL, 0, 1, ACLK_CMD_ONCONNECT))) {
-                ACLK_SHARED_STATE_UNLOCK;
+                rrdhost_aclk_state_unlock(localhost);
                 errno = 0;
                 error("ACLK failed to queue on_connect command");
                 sleep(1);


### PR DESCRIPTION
Fixes #10380
##### Summary
When the ACLK connection drops while the agent is running and there is a failed attempt to queue an `on_connect` message
a lock is not properly released and will deadlock the agent. 

##### Component Name
ACLK

##### Test Plan
Reproduce by 
- Simulate outgoing connection failure by blocking traffic to the cloud
- Wait until the connection fails similar to the log entries below (notice the `ACLK failed to queue on_connect command` entry)
```
2020-12-17 03:31:48: netdata ERROR : ACLK_Main : Connection to cloud failed
2020-12-17 03:31:48: netdata INFO  : ACLK_Main : Disconnect detected (0 queued queries)
2020-12-17 03:31:48: netdata ERROR : ACLK_Main : Closing lws connectino due to libmosquitto error.
2020-12-17 03:31:48: netdata INFO  : ACLK_Main : Processing callback LWS_CALLBACK_CLIENT_CLOSED
2020-12-17 03:31:48: netdata INFO  : ACLK_Main : Processing callback LWS_CALLBACK_WSI_DESTROY
2020-12-17 03:31:48: netdata ERROR : ACLK_Main : Unknown LWS callback 28
2020-12-17 03:31:48: netdata INFO  : ACLK_Main : Processing callback unknown
2020-12-17 03:31:48: netdata ERROR : ACLK_Main : Unknown LWS callback 28
2020-12-17 03:31:48: netdata ERROR : ACLK_Main : Unexpected callback from libwebsockets unknown
2020-12-17 03:31:48: netdata INFO  : ACLK_Main : Retrying to establish the ACLK connection in 0.000 seconds
2020-12-17 03:31:48: netdata INFO  : ACLK_Main : Attempting to establish the agent cloud link
2020-12-17 03:31:48: netdata INFO  : ACLK_Main : Retrieving challenge from cloud: app.netdata.cloud 443 
2020-12-17 03:31:48: netdata INFO  : ACLK_Main : aclk_send_https_request GET
2020-12-17 03:31:48: netdata ERROR : ACLK_Query_1 : ACLK failed to queue on_connect command
2020-12-17 03:31:48: netdata ERROR : ACLK_Main : Libwebsockets: getaddrinfo failed: -3
2020-12-17 03:32:19: netdata ERROR : ACLK_Main : Servicing LWS took too long.
2020-12-17 03:32:19: netdata ERROR : ACLK_Main : Challenge failed:
2020-12-17 03:32:19: netdata INFO  : ACLK_Main : Retrying to establish the ACLK connection in 1.877 seconds
2020-12-17 03:32:21: netdata INFO  : ACLK_Main : Attempting to establish the agent cloud link
```
