### PR TITLE
Add instructions on enabling explicitly disabled collectors

### DIFF
--- a/collectors/python.d.plugin/chrony/README.md
+++ b/collectors/python.d.plugin/chrony/README.md
@@ -31,8 +31,8 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `chrony` setting to `yes`. Save the file and restart the Netdata Agent with `systemctl netdata
-restart`, or the appropriate method for your system, to finish enabling the `chrony` collector.
+Change the value of the `chrony` setting to `yes`. Save the file and restart the Netdata Agent with `sudo systemctl
+restart netdata`, or the appropriate method for your system, to finish enabling the `chrony` collector.
 
 ## Configuration
 
@@ -55,7 +55,7 @@ local:
   command: 'chronyc -n tracking'
 ```
 
-Save the file and restart the Netdata Agent with `systemctl netdata restart`, or the appropriate method for your system,
-to finish configuring the `chrony` collector.
+Save the file and restart the Netdata Agent with `sudo systemctl restart netdata`, or the appropriate method for your
+system, to finish configuring the `chrony` collector.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fchrony%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/chrony/README.md
+++ b/collectors/python.d.plugin/chrony/README.md
@@ -18,7 +18,21 @@ Monitors the precision and statistics of a local chronyd server, and produces:
 -   system time
 
 ## Requirements
+
 Verify that user Netdata can execute `chronyc tracking`. If necessary, update `/etc/chrony.conf`, `cmdallow`.
+
+## Enable the collector
+
+The `chrony` collector is disabled by default. To enable it, use `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`, to edit the `python.d.conf` file.
+
+```bash
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+sudo ./edit-config python.d.conf
+```
+
+Change the value of the `chrony` setting to `yes`. Save the file and restart the Netdata Agent with `service netdata
+restart`, or the appropriate method for your system, to finish enabling the `chrony` collector.
 
 ## Configuration
 
@@ -26,7 +40,7 @@ Edit the `python.d/chrony.conf` configuration file using `edit-config` from the 
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
-cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
 sudo ./edit-config python.d/chrony.conf
 ```
 
@@ -41,6 +55,7 @@ local:
   command: 'chronyc -n tracking'
 ```
 
----
+Save the file and restart the Netdata Agent with `service netdata restart`, or the appropriate method for your system,
+to finish configuring the `chrony` collector.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fchrony%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/chrony/README.md
+++ b/collectors/python.d.plugin/chrony/README.md
@@ -31,7 +31,7 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `chrony` setting to `yes`. Save the file and restart the Netdata Agent with `service netdata
+Change the value of the `chrony` setting to `yes`. Save the file and restart the Netdata Agent with `systemctl netdata
 restart`, or the appropriate method for your system, to finish enabling the `chrony` collector.
 
 ## Configuration
@@ -55,7 +55,7 @@ local:
   command: 'chronyc -n tracking'
 ```
 
-Save the file and restart the Netdata Agent with `service netdata restart`, or the appropriate method for your system,
+Save the file and restart the Netdata Agent with `systemctl netdata restart`, or the appropriate method for your system,
 to finish configuring the `chrony` collector.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fchrony%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/dns_query_time/README.md
+++ b/collectors/python.d.plugin/dns_query_time/README.md
@@ -20,7 +20,7 @@ Edit the `python.d/dns_query_time.conf` configuration file using `edit-config` f
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
-cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
 sudo ./edit-config python.d/dns_query_time.conf
 ```
 

--- a/collectors/python.d.plugin/dnsdist/README.md
+++ b/collectors/python.d.plugin/dnsdist/README.md
@@ -55,7 +55,7 @@ Edit the `python.d/dnsdist.conf` configuration file using `edit-config` from the
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
-cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
 sudo ./edit-config python.d/dnsdist.conf
 ```
 

--- a/collectors/python.d.plugin/dockerd/README.md
+++ b/collectors/python.d.plugin/dockerd/README.md
@@ -32,7 +32,7 @@ Edit the `python.d/dockerd.conf` configuration file using `edit-config` from the
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
-cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
 sudo ./edit-config python.d/dockerd.conf
 ```
 

--- a/collectors/python.d.plugin/dovecot/README.md
+++ b/collectors/python.d.plugin/dovecot/README.md
@@ -81,7 +81,7 @@ Edit the `python.d/dovecot.conf` configuration file using `edit-config` from the
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
-cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
 sudo ./edit-config python.d/dovecot.conf
 ```
 

--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -70,7 +70,7 @@ Edit the `python.d/elasticsearch.conf` configuration file using `edit-config` fr
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
-cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
 sudo ./edit-config python.d/elasticsearch.conf
 ```
 

--- a/collectors/python.d.plugin/energid/README.md
+++ b/collectors/python.d.plugin/energid/README.md
@@ -52,7 +52,7 @@ Edit the `python.d/energid.conf` configuration file using `edit-config` from the
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
-cd /etc/netdata   # Replace this path with your Netdata config directory, if different, if different
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
 sudo ./edit-config python.d/energid.conf
 ```
 

--- a/collectors/python.d.plugin/go_expvar/README.md
+++ b/collectors/python.d.plugin/go_expvar/README.md
@@ -262,8 +262,8 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `go_expvar` setting to `yes`. Save the file and restart the Netdata Agent with `service netdata
-restart`, or the appropriate method for your system, to finish enabling the `go_expvar` collector.
+Change the value of the `go_expvar` setting to `yes`. Save the file and restart the Netdata Agent with `systemctl
+netdata restart`, or the appropriate method for your system, to finish enabling the `go_expvar` collector.
 
 ## Configuration
 

--- a/collectors/python.d.plugin/go_expvar/README.md
+++ b/collectors/python.d.plugin/go_expvar/README.md
@@ -252,6 +252,19 @@ In the above case, the exported variables will be available under `runtime.gorou
 `counters.cnt1` and `counters.cnt2` expvar_keys. If the flattening results in a key collision,
 the first defined key wins and all subsequent keys with the same name are ignored.
 
+## Enable the collector
+
+The `go_expvar` collector is disabled by default. To enable it, use `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`, to edit the `python.d.conf` file.
+
+```bash
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+sudo ./edit-config python.d.conf
+```
+
+Change the value of the `go_expvar` setting to `yes`. Save the file and restart the Netdata Agent with `service netdata
+restart`, or the appropriate method for your system, to finish enabling the `go_expvar` collector.
+
 ## Configuration
 
 Edit the `python.d/go_expvar.conf` configuration file using `edit-config` from the Netdata [config

--- a/collectors/python.d.plugin/go_expvar/README.md
+++ b/collectors/python.d.plugin/go_expvar/README.md
@@ -262,8 +262,8 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `go_expvar` setting to `yes`. Save the file and restart the Netdata Agent with `systemctl
-netdata restart`, or the appropriate method for your system, to finish enabling the `go_expvar` collector.
+Change the value of the `go_expvar` setting to `yes`. Save the file and restart the Netdata Agent with `sudo systemctl
+restart netdata`, or the appropriate method for your system, to finish enabling the `go_expvar` collector.
 
 ## Configuration
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -39,7 +39,7 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent with `service netdata
+Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent with `systemctl netdata
 restart`, or the appropriate method for your system, to finish enabling the `hpssa` collector.
 
 ## Configuration

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -39,8 +39,8 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent with `systemctl netdata
-restart`, or the appropriate method for your system, to finish enabling the `hpssa` collector.
+Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent with `sudo systemctl
+restart netdata`, or the appropriate method for your system, to finish enabling the `hpssa` collector.
 
 ## Configuration
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -29,14 +29,20 @@ This module produces:
 3.  Logical drive state
 4.  Physical drive state and temperature
 
+## Enable the collector
+
+The `hpssa` collector is disabled by default. To enable it, use `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`, to edit the `python.d.conf` file.
+
+```bash
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+sudo ./edit-config python.d.conf
+```
+
+Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent with `service netdata
+restart`, or the appropriate method for your system, to finish enabling the `hpssa` collector.
 
 ## Configuration
-
-**hpssa** is disabled by default. Should be explicitly enabled in `python.d.conf`.
-
-```yaml
-hpssa: yes
-```
 
 Edit the `python.d/hpssa.conf` configuration file using `edit-config` from the Netdata [config
 directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.

--- a/collectors/python.d.plugin/logind/README.md
+++ b/collectors/python.d.plugin/logind/README.md
@@ -36,8 +36,8 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `logind` setting to `yes`. Save the file and restart the Netdata Agent with `systemctl netdata
-restart`, or the appropriate method for your system, to finish enabling the `logind` collector.
+Change the value of the `logind` setting to `yes`. Save the file and restart the Netdata Agent with `sudo systemctl
+restart netdata`, or the appropriate method for your system, to finish enabling the `logind` collector.
 
 ## Configuration
 

--- a/collectors/python.d.plugin/logind/README.md
+++ b/collectors/python.d.plugin/logind/README.md
@@ -36,7 +36,7 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `logind` setting to `yes`. Save the file and restart the Netdata Agent with `service netdata
+Change the value of the `logind` setting to `yes`. Save the file and restart the Netdata Agent with `systemctl netdata
 restart`, or the appropriate method for your system, to finish enabling the `logind` collector.
 
 ## Configuration

--- a/collectors/python.d.plugin/logind/README.md
+++ b/collectors/python.d.plugin/logind/README.md
@@ -26,6 +26,19 @@ It provides the following charts:
 
     -   Seats
 
+## Enable the collector
+
+The `logind` collector is disabled by default. To enable it, use `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`, to edit the `python.d.conf` file.
+
+```bash
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+sudo ./edit-config python.d.conf
+```
+
+Change the value of the `logind` setting to `yes`. Save the file and restart the Netdata Agent with `service netdata
+restart`, or the appropriate method for your system, to finish enabling the `logind` collector.
+
 ## Configuration
 
 This module needs no configuration. Just make sure the `netdata` user


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds instructions to the few collectors that are explicitly disabled on how users can enable them. Based on feedback on the community forum: https://community.netdata.cloud/t/where-does-chrony-monitoring-show-up/559/4

I also noticed an error in some of code comments, which I fixed in this PR.

##### Component Name

area/docs
area/collectors

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
