### PR TITLE
Change HDDtemp to report None instead of 0

### DIFF
--- a/collectors/python.d.plugin/hddtemp/hddtemp.chart.py
+++ b/collectors/python.d.plugin/hddtemp/hddtemp.chart.py
@@ -28,7 +28,7 @@ class Disk:
     def __init__(self, id_, name, temp):
         self.id = id_.split('/')[-1]
         self.name = name.replace(' ', '_')
-        self.temp = temp if temp.isdigit() else 0
+        self.temp = temp if temp.isdigit() else None
 
     def __repr__(self):
         return self.id


### PR DESCRIPTION
##### Summary
Currently the HDD temp plugin reports 0 c when a drive fails to report temp correctly.
changing this to reporting None type resolves this issue and the failures simply leave gaps in the chart.

##### Component Name
hddtemp

##### Test Plan
No tests should be needed.
I have patched this manually on my personal instance and it works as expected

##### Additional Information

If the original behaviour is preferred for some reason I'd be curious as to why or if there is a better way that doesn't add erroneous data to the chart?