### PR TITLE
Exclude autofs by default in diskspace plugin

### DIFF
--- a/build_external/scenarios/aclk-testing/agent_netdata.conf
+++ b/build_external/scenarios/aclk-testing/agent_netdata.conf
@@ -268,7 +268,7 @@
 	# update every = 1
 	# check for new mount points every = 15
 	# exclude space metrics on paths = /proc/* /sys/* /var/run/user/* /run/user/* /snap/* /var/lib/docker/*
-	# exclude space metrics on filesystems = *gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl
+	# exclude space metrics on filesystems = *gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl autofs
 	# space usage for all disks = auto
 	# inodes usage for all disks = auto
 

--- a/collectors/diskspace.plugin/README.md
+++ b/collectors/diskspace.plugin/README.md
@@ -26,7 +26,7 @@ By default, Netdata will enable monitoring metrics only when they are not zero. 
     # update every = 1
     # check for new mount points every = 15
     # exclude space metrics on paths = /proc/* /sys/* /var/run/user/* /run/user/* /snap/* /var/lib/docker/*
-    # exclude space metrics on filesystems = *gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl
+    # exclude space metrics on filesystems = *gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl autofs
     # space usage for all disks = auto
     # inodes usage for all disks = auto
 ```

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -5,7 +5,7 @@
 #define PLUGIN_DISKSPACE_NAME "diskspace.plugin"
 
 #define DELAULT_EXCLUDED_PATHS "/proc/* /sys/* /var/run/user/* /run/user/* /snap/* /var/lib/docker/*"
-#define DEFAULT_EXCLUDED_FILESYSTEMS "*gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl"
+#define DEFAULT_EXCLUDED_FILESYSTEMS "*gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl autofs"
 #define CONFIG_SECTION_DISKSPACE "plugin:proc:diskspace"
 
 static struct mountinfo *disk_mountinfo_root = NULL;


### PR DESCRIPTION
##### Summary

autofs's point is to be mounted on explicit request, and "automatically by netdata" is not one.

##### Component Name

diskspace.plugin i guess

##### Test Plan

Add this to your existing netdata installation and see that autofs mounts aren't always instamounted.
