### PR TITLE
Fixed bundling of libwebsockets in binary packages.

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -39,7 +39,8 @@ override_dh_auto_configure:
 	packaging/bundle-libbpf.sh .
 	autoreconf -ivf
 	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib \
-	--libexecdir=/usr/libexec --with-user=netdata --with-math --with-zlib --with-webdir=/var/lib/netdata/www
+	--libexecdir=/usr/libexec --with-user=netdata --with-math --with-zlib --with-webdir=/var/lib/netdata/www \
+	--with-bundled-lws=externaldeps/libwebsockets
 
 override_dh_install:
 	cp -v $(BASE_CONFIG) debian/netdata.conf

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -234,6 +234,7 @@ autoreconf -ivf
 	%if 0%{!?fedora:1} && 0%{!?suse_version:1}
 	--with-libJudy=externaldeps/libJudy \
 	%endif
+	--with-bundled-lws=externaldeps/libwebsockets
 	--prefix="%{_prefix}" \
 	--sysconfdir="%{_sysconfdir}" \
 	--localstatedir="%{_localstatedir}" \


### PR DESCRIPTION
##### Summary

Unintentionally broken by #9984. This re-enables cloud support in binary packages.

##### Component Name

area/packaging

##### Test Plan

Without this patch, our binary packages do not have cloud support.

With this patch, they have cloud support again.

##### Additional Information

Fixes: #10457 
Fixes: #10403 

Apologies to everyone affected by the bug this is fixing that it took so long to fix.