### PR TITLE
Fix for older compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,6 +713,7 @@ set(BACKENDS_PLUGIN_FILES
 set(CLAIM_PLUGIN_FILES
         claim/claim.c
         claim/claim.h
+        aclk/aclk_rrdhost_state.h
         aclk/aclk_common.c
         aclk/aclk_common.h
         )

--- a/Makefile.am
+++ b/Makefile.am
@@ -524,6 +524,7 @@ PARSER_FILES = \
     $(NULL)
 
 ACLK_FILES = \
+    aclk/aclk_rrdhost_state.h \
     aclk/aclk_common.c \
     aclk/aclk_common.h \
     aclk/aclk_stats.c \

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -1,44 +1,7 @@
 #ifndef ACLK_COMMON_H
 #define ACLK_COMMON_H
 
-#include "../libnetdata/libnetdata.h"
-
-typedef enum aclk_cmd {
-    ACLK_CMD_CLOUD,
-    ACLK_CMD_ONCONNECT,
-    ACLK_CMD_INFO,
-    ACLK_CMD_CHART,
-    ACLK_CMD_CHARTDEL,
-    ACLK_CMD_ALARM,
-    ACLK_CMD_CLOUD_QUERY_2,
-    ACLK_CMD_CHILD_CONNECT,
-    ACLK_CMD_CHILD_DISCONNECT
-} ACLK_CMD;
-
-typedef enum aclk_metadata_state {
-    ACLK_METADATA_REQUIRED,
-    ACLK_METADATA_CMD_QUEUED,
-    ACLK_METADATA_SENT
-} ACLK_METADATA_STATE;
-
-typedef enum aclk_agent_state {
-    ACLK_HOST_INITIALIZING,
-    ACLK_HOST_STABLE
-} ACLK_POPCORNING_STATE;
-
-typedef struct aclk_rrdhost_state {
-    char *claimed_id; // Claimed ID if host has one otherwise NULL
-
-#ifdef ENABLE_ACLK
-    // per child popcorning
-    ACLK_POPCORNING_STATE state;
-    ACLK_METADATA_STATE metadata;
-
-    time_t timestamp_created;
-    time_t t_last_popcorn_update;
-#endif
-} aclk_rrdhost_state;
-
+#include "aclk_rrdhost_state.h"
 #include "../daemon/common.h"
 
 extern netdata_mutex_t aclk_shared_state_mutex;

--- a/aclk/aclk_common.h
+++ b/aclk/aclk_common.h
@@ -1,33 +1,7 @@
 #ifndef ACLK_COMMON_H
 #define ACLK_COMMON_H
 
-#include "libnetdata/libnetdata.h"
-
-extern netdata_mutex_t aclk_shared_state_mutex;
-#define ACLK_SHARED_STATE_LOCK netdata_mutex_lock(&aclk_shared_state_mutex)
-#define ACLK_SHARED_STATE_UNLOCK netdata_mutex_unlock(&aclk_shared_state_mutex)
-
-// minimum and maximum supported version of ACLK
-// in this version of agent
-#define ACLK_VERSION_MIN 2
-#define ACLK_VERSION_MAX 3
-
-// Version negotiation messages have they own versioning
-// this is also used for LWT message as we set that up
-// before version negotiation
-#define ACLK_VERSION_NEG_VERSION 1
-
-// Maximum time to wait for version negotiation before aborting
-// and defaulting to oldest supported version
-#define VERSION_NEG_TIMEOUT 3
-
-#if ACLK_VERSION_MIN > ACLK_VERSION_MAX
-#error "ACLK_VERSION_MAX must be >= than ACLK_VERSION_MIN"
-#endif
-
-// Define ACLK Feature Version Boundaries Here
-#define ACLK_V_COMPRESSION   2
-#define ACLK_V_CHILDRENSTATE 3
+#include "../libnetdata/libnetdata.h"
 
 typedef enum aclk_cmd {
     ACLK_CMD_CLOUD,
@@ -65,10 +39,36 @@ typedef struct aclk_rrdhost_state {
 #endif
 } aclk_rrdhost_state;
 
+#include "../daemon/common.h"
+
+extern netdata_mutex_t aclk_shared_state_mutex;
+#define ACLK_SHARED_STATE_LOCK netdata_mutex_lock(&aclk_shared_state_mutex)
+#define ACLK_SHARED_STATE_UNLOCK netdata_mutex_unlock(&aclk_shared_state_mutex)
+
+// minimum and maximum supported version of ACLK
+// in this version of agent
+#define ACLK_VERSION_MIN 2
+#define ACLK_VERSION_MAX 3
+
+// Version negotiation messages have they own versioning
+// this is also used for LWT message as we set that up
+// before version negotiation
+#define ACLK_VERSION_NEG_VERSION 1
+
+// Maximum time to wait for version negotiation before aborting
+// and defaulting to oldest supported version
+#define VERSION_NEG_TIMEOUT 3
+
+#if ACLK_VERSION_MIN > ACLK_VERSION_MAX
+#error "ACLK_VERSION_MAX must be >= than ACLK_VERSION_MIN"
+#endif
+
+// Define ACLK Feature Version Boundaries Here
+#define ACLK_V_COMPRESSION   2
+#define ACLK_V_CHILDRENSTATE 3
+
 #define ACLK_IS_HOST_INITIALIZING(host) (host->aclk_state.state == ACLK_HOST_INITIALIZING)
 #define ACLK_IS_HOST_POPCORNING(host) (ACLK_IS_HOST_INITIALIZING(host) && host->aclk_state.t_last_popcorn_update)
-
-typedef struct rrdhost RRDHOST;
 
 extern struct aclk_shared_state {
     // optimization to avoid looping trough hosts

--- a/aclk/aclk_rrdhost_state.h
+++ b/aclk/aclk_rrdhost_state.h
@@ -1,0 +1,44 @@
+#ifndef ACLK_RRDHOST_STATE_H
+#define ACLK_RRDHOST_STATE_H
+
+#include "../libnetdata/libnetdata.h"
+
+typedef enum aclk_cmd {
+    ACLK_CMD_CLOUD,
+    ACLK_CMD_ONCONNECT,
+    ACLK_CMD_INFO,
+    ACLK_CMD_CHART,
+    ACLK_CMD_CHARTDEL,
+    ACLK_CMD_ALARM,
+    ACLK_CMD_CLOUD_QUERY_2,
+    ACLK_CMD_CHILD_CONNECT,
+    ACLK_CMD_CHILD_DISCONNECT
+} ACLK_CMD;
+
+#ifdef ENABLE_ACLK
+typedef enum aclk_metadata_state {
+    ACLK_METADATA_REQUIRED,
+    ACLK_METADATA_CMD_QUEUED,
+    ACLK_METADATA_SENT
+} ACLK_METADATA_STATE;
+
+typedef enum aclk_agent_state {
+    ACLK_HOST_INITIALIZING,
+    ACLK_HOST_STABLE
+} ACLK_POPCORNING_STATE;
+#endif /* ENABLE_ACLK */
+
+typedef struct aclk_rrdhost_state {
+    char *claimed_id; // Claimed ID if host has one otherwise NULL
+
+#ifdef ENABLE_ACLK
+    // per child popcorning
+    ACLK_POPCORNING_STATE state;
+    ACLK_METADATA_STATE metadata;
+
+    time_t timestamp_created;
+    time_t t_last_popcorn_update;
+#endif /* ENABLE_ACLK */
+} aclk_rrdhost_state;
+
+#endif /* ACLK_RRDHOST_STATE_H */

--- a/aclk/aclk_rrdhost_state.h
+++ b/aclk/aclk_rrdhost_state.h
@@ -15,7 +15,6 @@ typedef enum aclk_cmd {
     ACLK_CMD_CHILD_DISCONNECT
 } ACLK_CMD;
 
-#ifdef ENABLE_ACLK
 typedef enum aclk_metadata_state {
     ACLK_METADATA_REQUIRED,
     ACLK_METADATA_CMD_QUEUED,
@@ -26,7 +25,6 @@ typedef enum aclk_agent_state {
     ACLK_HOST_INITIALIZING,
     ACLK_HOST_STABLE
 } ACLK_POPCORNING_STATE;
-#endif /* ENABLE_ACLK */
 
 typedef struct aclk_rrdhost_state {
     char *claimed_id; // Claimed ID if host has one otherwise NULL

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -34,7 +34,7 @@ struct pg_cache_page_index;
 #include "rrdcalc.h"
 #include "rrdcalctemplate.h"
 #include "../streaming/rrdpush.h"
-#include "../aclk/aclk_common.h"
+#include "../aclk/aclk_rrdhost_state.h"
 
 struct context_param {
     RRDDIM *rd;


### PR DESCRIPTION
##### Summary
Older compilers (PRE C11) will complain:
```
./database/../aclk/aclk_common.h:71: error: redefinition of typedef 'RRDHOST'
./database/rrd.h:7: note: previous declaration of 'RRDHOST' was here
```
The 2011 C standard allows redeclaration of typedef names. 6.7 3 says:
> typedef name may be redefined to denote the same type as it currently does, provided that type is not a variably modified type

This caused error on older systems like CentOS6 with old compiler version, see user reported issue:
Fixes https://github.com/netdata/netdata/issues/10421

##### Component Name
ACLK, Build System

##### Test Plan
Should build on older systems like CentOS 6 (tested)

##### Additional Information
