### PR TITLE
Add docs on Nginx with IPv6 listen for certbot to work

### DIFF
--- a/docs/Running-behind-nginx.md
+++ b/docs/Running-behind-nginx.md
@@ -53,6 +53,8 @@ upstream backend {
 server {
     # nginx listens to this
     listen 80;
+    # uncomment the line if you want nginx to listen on IPv6 address
+    #listen [::]:80;
 
     # the virtual host name of this
     server_name netdata.example.com;
@@ -82,16 +84,18 @@ upstream netdata {
 }
 
 server {
-   listen 80;
+    listen 80;
+    # uncomment the line if you want nginx to listen on IPv6 address
+    #listen [::]:80;
 
-   # the virtual host name of this subfolder should be exposed
-   #server_name netdata.example.com;
+    # the virtual host name of this subfolder should be exposed
+    #server_name netdata.example.com;
 
-   location = /netdata {
+    location = /netdata {
         return 301 /netdata/;
-   }
+    }
 
-   location ~ /netdata/(?<ndpath>.*) {
+    location ~ /netdata/(?<ndpath>.*) {
         proxy_redirect off;
         proxy_set_header Host $host;
 
@@ -127,6 +131,8 @@ upstream backend-server2 {
 
 server {
     listen 80;
+    # uncomment the line if you want nginx to listen on IPv6 address
+    #listen [::]:80;
 
     # the virtual host name of this subfolder should be exposed
     #server_name netdata.example.com;

--- a/docs/guides/step-by-step/step-10.md
+++ b/docs/guides/step-by-step/step-10.md
@@ -104,6 +104,8 @@ upstream backend {
 
 server {
     listen 80;
+    # uncomment the line if you want nginx to listen on IPv6 address
+    #listen [::]:80;
 
     # Change `example.com` to match your domain name.
     server_name netdata.example.com;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

The Nginx configs proposed in the documentation only listen for IPv4 traffic. If you have both IPv4 and IPv6 DNS hooked up, then `certbot` seemingly tests both.

I didn't notice the missing IPv6 configuration in the Nginx config I copied from your documentation until after some debugging, googling, and comparing to my other Nginx configs.

In short, I just added the following to the docs:

```diff

 server {
     listen 80;
+    listen [::]:80;

     # the virtual host name of this subfolder should be exposed
     #server_name netdata.example.com;
```

I did not find an open issue on the case.

##### Component Name

Documentation

##### Additional Information

I'm quite new to Nginx and found the solution here: <https://community.letsencrypt.org/t/certbot-invalid-response-from/126715/5>.
Full credit to [DAMO238](https://community.letsencrypt.org/u/DAMO238) and [JuergenAuer](https://community.letsencrypt.org/u/JuergenAuer) over at community.letsencrypt.org.

This fixes the following error recieved when running `certbot --nginx`: _(I've redacted my own website domain name from the logs)_

```
root@localhost:~# certbot --nginx
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator nginx, Installer nginx

Which names would you like to activate HTTPS for?
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
1: mywebsite.com
2: netdata.mywebsite.com
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Select the appropriate numbers separated by commas and/or spaces, or leave input
blank to select all options shown (Enter 'c' to cancel): 2
Requesting a certificate for netdata.mywebsite.com
Performing the following challenges:
http-01 challenge for netdata.mywebsite.com
Waiting for verification...
Challenge failed for domain netdata.mywebsite.com
http-01 challenge for netdata.mywebsite.com
Cleaning up challenges
Some challenges have failed.

IMPORTANT NOTES:
 - The following errors were reported by the server:

   Domain: netdata.mywebsite.com
   Type:   unauthorized
   Detail: Invalid response from
   http://netdata.mywebsite.com/.well-known/acme-challenge/F2nubYGcjA11PO-cPQvxODZ_tC7W86lTKkrceWBEaTU
   [2a01:7e01::f03c:92ff:fe09:773b]: "<html>\r\n<head><title>404 Not
   Found</title></head>\r\n<body>\r\n<center><h1>404 Not
   Found</h1></center>\r\n<hr><center>nginx/1.18.0 (Ub"

   To fix these errors, please make sure that your domain name was
   entered correctly and the DNS A/AAAA record(s) for that domain
   contain(s) the right IP address.
```

For reference, I'm running the following versions:

```
$ netdata -v
netdata v1.28.0-68-nightly

$ certbot --version
certbot 1.11.0

$ nginx -v
nginx version: nginx/1.18.0 (Ubuntu)

$ uname -a
Linux localhost 5.8.0-33-generic #36-Ubuntu SMP Wed Dec 9 09:14:40 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.10
Release:        20.10
Codename:       groovy
```