### PR TITLE
Claiming retry/backoff

### DIFF
--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -289,26 +289,46 @@ fi
 if [ "${VERBOSE}" == 1 ]; then
     echo "${URLCOMMAND} \"${TARGET_URL}\""
 fi
-eval "${URLCOMMAND} \"${TARGET_URL}\"" >"${CLAIMING_DIR}/tmpout.txt"
-URLCOMMAND_EXIT_CODE=$?
-if [ "${URLTOOL}" = "wget" ] && [ "${URLCOMMAND_EXIT_CODE}" -eq 8 ] ; then
-# We consider the server issuing an error response a successful attempt at communicating
-        URLCOMMAND_EXIT_CODE=0
-fi
+
+attempt_contact () {
+        eval "${URLCOMMAND} \"${TARGET_URL}\"" >"${CLAIMING_DIR}/tmpout.txt"
+        URLCOMMAND_EXIT_CODE=$?
+        if [ "${URLTOOL}" = "wget" ] && [ "${URLCOMMAND_EXIT_CODE}" -eq 8 ] ; then
+        # We consider the server issuing an error response a successful attempt at communicating
+                URLCOMMAND_EXIT_CODE=0
+        fi
+
+        # Check if URLCOMMAND connected and received reply
+        if [ "${URLCOMMAND_EXIT_CODE}" -ne 0 ] ; then
+                echo >&2 "Failed to connect to ${URL_BASE}, return code ${URLCOMMAND_EXIT_CODE}"
+                rm -f "${CLAIMING_DIR}/tmpout.txt"
+                return 4
+        fi
+
+        if [ "${VERBOSE}" == 1 ] ; then
+            echo "Response from server:"
+            cat "${CLAIMING_DIR}/tmpout.txt"
+        fi
+
+        return 0
+}
+
+for i in {1..5}
+do
+        attempt_contact
+        if [ $? -eq 0 ] ; then
+                echo "Connection attempt $i successful"
+                break
+        fi
+        echo "Connection attempt $i failed. Retry in ${i}s."
+        if [ $i -eq 5 ] ; then
+                rm -f "${CLAIMING_DIR}/tmpin.txt"
+                exit 4
+        fi
+        sleep $i
+done
 
 rm -f "${CLAIMING_DIR}/tmpin.txt"
-
-# Check if URLCOMMAND connected and received reply
-if [ "${URLCOMMAND_EXIT_CODE}" -ne 0 ] ; then
-        echo >&2 "Failed to connect to ${URL_BASE}, return code ${URLCOMMAND_EXIT_CODE}"
-        rm -f "${CLAIMING_DIR}/tmpout.txt"
-        exit 4
-fi
-
-if [ "${VERBOSE}" == 1 ] ; then
-    echo "Response from server:"
-    cat "${CLAIMING_DIR}/tmpout.txt"
-fi
 
 ERROR_KEY=$(grep "\"errorMsgKey\":" "${CLAIMING_DIR}/tmpout.txt" | awk -F "errorMsgKey\":\"" '{print $2}' | awk -F "\"" '{print $1}')
 case ${ERROR_KEY} in

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -315,17 +315,16 @@ attempt_contact () {
 
 for i in {1..5}
 do
-        attempt_contact
-        if [ $? -eq 0 ] ; then
+        if attempt_contact ; then
                 echo "Connection attempt $i successful"
                 break
         fi
         echo "Connection attempt $i failed. Retry in ${i}s."
-        if [ $i -eq 5 ] ; then
+        if [ "$i" -eq 5 ] ; then
                 rm -f "${CLAIMING_DIR}/tmpin.txt"
                 exit 4
         fi
-        sleep $i
+        sleep "$i"
 done
 
 rm -f "${CLAIMING_DIR}/tmpin.txt"


### PR DESCRIPTION
##### Summary
Due to various network conditions claiming can fail. This is problem especially if run automatically trough Docker etc. where user just manually running script again is no go.

This implements retry independent of retry logic of wget/curl and common for them.

Me and bash are not best of friends :) so feel free to make alternative PR/proposal. This was supposed to quick & dirty do this for testing purposes.

##### Component Name
Claiming

##### Test Plan
Block port temporarily and then unblock it.

##### Additional Information
