### PR TITLE
Fix memory allocation when computing standard deviation

### DIFF
--- a/web/api/queries/stddev/stddev.c
+++ b/web/api/queries/stddev/stddev.c
@@ -15,10 +15,7 @@ struct grouping_stddev {
 };
 
 void *grouping_create_stddev(RRDR *r) {
-    long entries = r->group;
-    if(entries < 0) entries = 0;
-
-    return callocz(1, sizeof(struct grouping_stddev) + entries * sizeof(LONG_DOUBLE));
+    return callocz(1, sizeof(struct grouping_stddev));
 }
 
 // resets when switches dimensions

--- a/web/api/queries/stddev/stddev.c
+++ b/web/api/queries/stddev/stddev.c
@@ -15,6 +15,7 @@ struct grouping_stddev {
 };
 
 void *grouping_create_stddev(RRDR *r) {
+    UNUSED (r);
     return callocz(1, sizeof(struct grouping_stddev));
 }
 


### PR DESCRIPTION
##### Summary
Tunes the memory allocation when computing stddev. More memory is allocated than required -- 
the extra `entries * sizeof(LONG_DOUBLE))` is not used.

The stddev is computed only with the allocated variables in the 

`grouping_stddev` structure

##### Component Name
database

##### Test Plan
- Run a query with group=stddev

