### PR TITLE
Fixed handling of permissions for some plugins.

### DIFF
--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -54,9 +54,9 @@ case "$1" in
     chown -R root:netdata /usr/libexec/netdata/plugins.d
     chown -R root:netdata /var/lib/netdata/www
     setcap cap_dac_read_search,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin
+    setcap cap_dac_read_search+ep /usr/libexec/netdata/plugins.d/slabinfo.plugin
+    setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin
 
-    chmod 4750 /usr/libexec/netdata/plugins.d/perf.plugin
-    chmod 4750 /usr/libexec/netdata/plugins.d/slabinfo.plugin
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network
     chmod 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin
 

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -103,9 +103,9 @@ override_dh_fixperms:
 	# apps.plugin should only be runnable by the netdata user. It will be
 	# given extra capabilities in the postinst script.
 	#
-	chmod 0754 $(TOP)/usr/libexec/netdata/plugins.d/apps.plugin
-	chmod 0754 $(TOP)/usr/libexec/netdata/plugins.d/perf.plugin
-	chmod 0754 $(TOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin
+	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/apps.plugin
+	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/perf.plugin
+	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin
 	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/go.d.plugin
 
 	# CUPS plugin package

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1313,12 +1313,14 @@ if [ "${UID}" -eq 0 ]; then
 
   if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin" ]; then
     run chown root:${NETDATA_GROUP} "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin"
-    run chmod 4750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin"
+    run chmod 0750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin"
+    run setcap cap_perfmon+ep "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin"
   fi
 
   if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/slabinfo.plugin" ]; then
     run chown root:${NETDATA_GROUP} "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/slabinfo.plugin"
-    run chmod 4750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/slabinfo.plugin"
+    run chmod 0750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/slabinfo.plugin"
+    run setcap cap_dac_read_search+ep "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/slabinfo.plugin"
   fi
 
   if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/ioping" ]; then

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -467,18 +467,18 @@ rm -rf "${RPM_BUILD_ROOT}"
 # cgroup-network detects the network interfaces of CGROUPs
 # it must be able to use setns() and run cgroup-network-helper.sh as root
 # the helper script reads /proc/PID/fdinfo/* files, runs virsh, etc.
-%caps(cap_setuid=ep) %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network
+%attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network
 %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network-helper.sh
 %endif
 
 # perf plugin
-%caps(cap_setuid=ep) %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/perf.plugin
+%caps(cap_perfmon=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/perf.plugin
 
 # perf plugin
-%caps(cap_setuid=ep) %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
+%caps(cap_dac_read_search=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
 
 # freeipmi files
-%caps(cap_setuid=ep) %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
+%attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 
 # Enforce 0644 for files and 0755 for directories
 # for the netdata web directory


### PR DESCRIPTION
##### Summary

* Removed pointless capabilities in our RPM spec file.
* Shifted slabinfo and perf plugins to use proper capabilties instead of being SUID root.

##### Component Name

area/packaging

##### Test Plan

Verification is needed to ensure that the perf and slabinfo plugins still report data correctly with this change.

##### Additional Information

Fixes: #8673 