### PR TITLE
Fixed handling of TLS config so that cURL works in all cases.

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -130,25 +130,6 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-progress "Check SSL certificates paths"
-
-if [ ! -f "/etc/ssl/certs/ca-certificates.crt" ]; then
-  if [ ! -f /opt/netdata/.curlrc ]; then
-    cacert=
-
-    # CentOS
-    [ -f "/etc/ssl/certs/ca-bundle.crt" ] && cacert="/etc/ssl/certs/ca-bundle.crt"
-
-    if [ -n "${cacert}" ]; then
-      echo "Creating /opt/netdata/.curlrc with cacert=${cacert}"
-      echo > /opt/netdata/.curlrc "cacert=${cacert}"
-    else
-      run_failed "Failed to find /etc/ssl/certs/ca-certificates.crt"
-    fi
-  fi
-fi
-
-# -----------------------------------------------------------------------------
 progress "Install logrotate configuration for netdata"
 
 install_netdata_logrotate || run_failed "Cannot install logrotate file for netdata."

--- a/packaging/makeself/jobs/50-curl-7.73.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.73.0.install.sh
@@ -22,8 +22,7 @@ run ./configure \
   --enable-proxy \
   --enable-ipv6 \
   --enable-cookies \
-  --with-ca-fallback \
-  --with-ca-bundle=/opt/netdata/etc/ssl/certs/ca-bundle.crt
+  --with-ca-fallback
 
 # Curl autoconf does not honour the curl_LDFLAGS environment variable
 run sed -i -e "s/curl_LDFLAGS =/curl_LDFLAGS = -all-static/" src/Makefile


### PR DESCRIPTION
##### Summary

We should not be hard-coding the CA file or messing with cURL options to handle this, but should instead be relying on the config detected at setup time for the install to just get it right (as it will in 99% of cases).

##### Component Name

area/packaging

##### Test Plan

Observe that cURL works correctly in the resultant images.

##### Additional Information

Fixes: #10359 
Fixes: #10463 