### PR TITLE
Fix segmentation fault in the agent

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -331,11 +331,6 @@ void rrdset_free(RRDSET *st) {
     rrdset_index_del_name(host, st);
 
     // ------------------------------------------------------------------------
-    // remove it from the configuration
-
-    appconfig_section_destroy_non_loaded(&netdata_config, st->config_section);
-
-    // ------------------------------------------------------------------------
     // free its children structures
 
     freez(st->exporting_flags);
@@ -352,6 +347,11 @@ void rrdset_free(RRDSET *st) {
 
     debug(D_RRD_CALLS, "RRDSET: Cleaning up remaining chart variables for host '%s', chart '%s'", host->hostname, st->id);
     rrdvar_free_remaining_variables(host, &st->rrdvar_root_index);
+
+    // ------------------------------------------------------------------------
+    // remove it from the configuration
+
+    appconfig_section_destroy_non_loaded(&netdata_config, st->config_section);
 
     // ------------------------------------------------------------------------
     // unlink it from the host


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fix heap-use-after-free due to the chart using netdata_config memory for some strings.
##### Component Name
health
database
##### Test Plan
Run with `valgrind --track-origins=yes -s /usr/sbin/netdata -D` or use address sanitizer.
Stop the agent with control - C and observe the [logged error](https://github.com/netdata/netdata/issues/10496#issue-784875612).
Check again with this PR, the error should go away.
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->