### PR TITLE
Fix broken dbengine stress tests.

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -2099,7 +2099,7 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
     struct dbengine_chart_thread **chart_threads;
     struct dbengine_query_thread **query_threads;
     unsigned i, j;
-    time_t time_start, time_end;
+    time_t time_start, test_duration;
 
     error_log_limit_unlimited();
 
@@ -2195,8 +2195,8 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
     for (i = 0 ; i < QUERY_THREADS ; ++i) {
         assert(0 == uv_thread_join(&query_threads[i]->thread));
     }
-    time_end = now_realtime_sec();
-    fprintf(stderr, "\nDB-engine stress test finished in %ld seconds.\n", time_end - time_start);
+    test_duration = now_realtime_sec() - (time_start - HISTORY_SECONDS);
+    fprintf(stderr, "\nDB-engine stress test finished in %ld seconds.\n", test_duration);
     unsigned long stored_metrics_nr = 0;
     for (i = 0 ; i < DSET_CHARTS ; ++i) {
         stored_metrics_nr += chart_threads[i]->stored_metrics_nr;
@@ -2213,7 +2213,7 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
     fprintf(stderr, "Query starting time is randomly chosen from the beginning of the time-series up to the time of\n"
                     "the latest data point, and ending time from 1 second up to 1 hour after the starting time.\n");
     fprintf(stderr, "Performance is %lu written data points/sec and %lu read data points/sec.\n",
-            stored_metrics_nr / (time_end - time_start), queried_metrics_nr / (time_end - time_start));
+            stored_metrics_nr / test_duration, queried_metrics_nr / test_duration);
 
     for (i = 0 ; i < DSET_CHARTS ; ++i) {
         freez(chart_threads[i]);

--- a/database/engine/rrdenginelib.c
+++ b/database/engine/rrdenginelib.c
@@ -214,6 +214,10 @@ int is_legacy_child(const char *machine_guid)
     uuid_t uuid;
     char  dbengine_file[FILENAME_MAX+1];
 
+    if (unlikely(!strcmp(machine_guid, "unittest-dbengine") || !strcmp(machine_guid, "dbengine-dataset") ||
+                 !strcmp(machine_guid, "dbengine-stress-test"))) {
+        return 1;
+    }
     if (!uuid_parse(machine_guid, uuid)) {
         uv_fs_t stat_req;
         snprintfz(dbengine_file, FILENAME_MAX, "%s/%s/dbengine", netdata_configured_cache_dir, machine_guid);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Since the introduction of multi-host DB and SQLite metadata the 3 `dbengine` tests (`unittest`, `createdataset`, `stresstest`) have been broken, some more than others.
##### Component Name
dbengine
##### Test Plan
Run:
```
/usr/sbin/netdata -W stresstest=10,1,1,0,64,256
```
See that it works now.
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->