### PR TITLE
Switched to using system libwebsockets for RPM builds.

### DIFF
--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -101,7 +101,6 @@ def install_common_dependendencies(container):
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "snappy-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-c"])
-        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libwebsockets-devel"])
 
     elif str(os.environ["REPO_TOOL"]).count("yum") == 1:
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "gcc-c++"])

--- a/.travis/package_management/common.py
+++ b/.travis/package_management/common.py
@@ -101,6 +101,7 @@ def install_common_dependendencies(container):
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "snappy-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-c"])
+        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libwebsockets-devel"])
 
     elif str(os.environ["REPO_TOOL"]).count("yum") == 1:
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "gcc-c++"])
@@ -111,6 +112,7 @@ def install_common_dependendencies(container):
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-c-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-compiler"])
+        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libwebsockets-devel"])
 
     elif str(os.environ["REPO_TOOL"]).count("apt-get") == 1:
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "g++"])
@@ -132,6 +134,7 @@ def install_common_dependendencies(container):
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-c-devel"])
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "protobuf-compiler"])
+        run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "libwebsockets-devel"])
 
     if os.environ["BUILD_STRING"].count("el/6") <= 0:
         run_command(container, [os.environ["REPO_TOOL"], "install", "-y", "autogen"])

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -132,7 +132,9 @@ BuildRequires: zlib-devel
 BuildRequires: libuuid-devel
 BuildRequires: libuv-devel >= 1
 BuildRequires: openssl-devel
-BuildRequires: libwebsockets-devel
+%if 0%{?centos_ver} >= 8 || 0%{?fedora}
+BuildRequires: libwebsockets-devel >= 3.2
+%endif
 %if 0%{?suse_version}
 BuildRequires: judy-devel
 BuildRequires: liblz4-devel
@@ -219,6 +221,9 @@ happened, on your systems and applications.
 %prep
 %setup -q -n %{name}-%{version}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+%if 0%{?centos_ver} >= 8 || 0%{?fedora}
+export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-lws.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+%endif
 # Only bundle libJudy if this isn't Fedora or SUSE
 %if 0%{!?fedora:1} && 0%{!?suse_version:1}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-judy.sh ${RPM_BUILD_DIR}/%{name}-%{version}
@@ -233,6 +238,9 @@ autoreconf -ivf
 %configure \
 	%if 0%{!?fedora:1} && 0%{!?suse_version:1}
 	--with-libJudy=externaldeps/libJudy \
+	%endif
+	%if 0%{?centos_ver} >= 8 || 0%{?fedora}
+	--with-libwebsockets=externaldeps/libwebsockets \
 	%endif
 	--prefix="%{_prefix}" \
 	--sysconfdir="%{_sysconfdir}" \

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -132,6 +132,7 @@ BuildRequires: zlib-devel
 BuildRequires: libuuid-devel
 BuildRequires: libuv-devel >= 1
 BuildRequires: openssl-devel
+BuildRequires: libwebsockets-devel
 %if 0%{?suse_version}
 BuildRequires: judy-devel
 BuildRequires: liblz4-devel
@@ -218,7 +219,6 @@ happened, on your systems and applications.
 %prep
 %setup -q -n %{name}-%{version}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}/%{name}-%{version}
-export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-lws.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 # Only bundle libJudy if this isn't Fedora or SUSE
 %if 0%{!?fedora:1} && 0%{!?suse_version:1}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-judy.sh ${RPM_BUILD_DIR}/%{name}-%{version}
@@ -234,15 +234,14 @@ autoreconf -ivf
 	%if 0%{!?fedora:1} && 0%{!?suse_version:1}
 	--with-libJudy=externaldeps/libJudy \
 	%endif
-	--with-bundled-lws=externaldeps/libwebsockets
 	--prefix="%{_prefix}" \
 	--sysconfdir="%{_sysconfdir}" \
 	--localstatedir="%{_localstatedir}" \
 	--libexecdir="%{_libexecdir}" \
-        --libdir="%{_libdir}" \
+	--libdir="%{_libdir}" \
 	--with-zlib \
 	--with-math \
-	--with-user=netdata \
+	--with-user=netdata
 
 # Build step
 %{__make} %{?_smp_mflags}


### PR DESCRIPTION
##### Summary

Also cleans up the configure statement in the RPM spec file.

##### Component Name

area/packaging
area/ci

##### Test Plan

Verified locally for CentOS 7 and 8, Fedora 32 and 33, and OpenSUSE 15.1 and 15.2 by building in Docker containers.

##### Additional Information

This also coincidentally fixes a bug introduced by #10460 that is causing RPM package builds to consistently fail.

We unfortunately cannot do this for DEB packages yet due to the fact that the Debian and Ubuntu environments provide versions of LWS that are too old.