### PR TITLE
health/mysql: fix `mysql.slave_status` alarm for go mysql collector

### DIFF
--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -79,7 +79,7 @@ template: mysql_connections
 
 template: mysql_replication
       on: mysql.slave_status
-    calc: ($sql_running == -1 OR $io_running == -1)?0:1
+    calc: ($sql_running <= 0 OR $io_running <= 0)?0:1
    units: ok/failed
    every: 10s
     crit: $this == 0


### PR DESCRIPTION
##### Summary

Fixes: #10427

python mysql version:
 - `1`: slave_sql_running/slave_io_running == `YES`
 - `-1`: any other value.

go mysql version:
 - `1`: slave_sql_running/slave_io_running == `YES`
 - `0`: any other value.


##### Component Name

`health/`

##### Test Plan

The changes are trivial.

##### Additional Information
