### PR TITLE
Fix coverity issue CID 365322

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -2196,6 +2196,8 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
         assert(0 == uv_thread_join(&query_threads[i]->thread));
     }
     test_duration = now_realtime_sec() - (time_start - HISTORY_SECONDS);
+    if (!test_duration)
+        test_duration = 1;
     fprintf(stderr, "\nDB-engine stress test finished in %ld seconds.\n", test_duration);
     unsigned long stored_metrics_nr = 0;
     for (i = 0 ; i < DSET_CHARTS ; ++i) {


### PR DESCRIPTION
##### Summary
Adds a check to avoid coverity complain on a possible division by zero

##### Component Name
database
unit_test

##### Test Plan
- Running stress test should not finish in 0 time and trigger a div by zero (which doesn't actually)
   - netdata -W stresstest=1,1,1,0,64,256
