### PR TITLE
Remove unused entries from structures

### DIFF
--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -120,7 +120,6 @@ void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid)
     }
     rd->state->rrdeng_uuid = &page_index->id;
     rd->state->page_index = page_index;
-    rd->state->compaction_id = 0;
 }
 
 /*

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -409,7 +409,6 @@ struct rrddim_volatile {
 // volatile state per chart
 struct rrdset_volatile {
     char *old_title;
-    char *old_family;
     char *old_context;
     struct label *new_labels;
     struct label_index labels;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -367,7 +367,6 @@ struct rrddim_volatile {
     uuid_t *rrdeng_uuid;                 // database engine metric UUID
     uuid_t *metric_uuid;                 // global UUID for this metric (unique_across hosts)
     struct pg_cache_page_index *page_index;
-    uint32_t compaction_id;              // The last metadata log compaction procedure that has processed this object.
 #endif
     union rrddim_collect_handle handle;
     // ------------------------------------------------------------------------
@@ -531,10 +530,9 @@ struct rrdset {
     char *plugin_name;                              // the name of the plugin that generated this
     char *module_name;                              // the name of the plugin module that generated this
     uuid_t *chart_uuid;                             // Store the global GUID for this chart
-    size_t compaction_id;                           // The last metadata log compaction procedure that has processed
                                                     // this object.
     struct rrdset_volatile *state;                  // volatile state that is not persistently stored
-    size_t unused[2];
+    size_t unused[3];
 
     size_t rrddim_page_alignment;                   // keeps metric pages in alignment when using dbengine
 
@@ -855,8 +853,6 @@ struct rrdhost {
 #ifdef ENABLE_DBENGINE
     struct rrdengine_instance *rrdeng_ctx;          // DB engine instance for this host
     uuid_t  host_uuid;                              // Global GUID for this host
-    uint32_t compaction_id;                         // The last metadata log compaction procedure that has processed
-                                                    // this object.
 #endif
 
 #ifdef ENABLE_HTTPS

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -307,7 +307,6 @@ RRDHOST *rrdhost_create(const char *hostname,
         }
         else
             error_report("Host machine GUID %s is not valid", host->machine_guid);
-        host->compaction_id = 0;
         char dbenginepath[FILENAME_MAX + 1];
         int ret;
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -382,7 +382,6 @@ void rrdset_free(RRDSET *st) {
     freez(st->plugin_name);
     freez(st->module_name);
     freez(st->state->old_title);
-    freez(st->state->old_family);
     freez(st->state->old_context);
     free_label_list(st->state->labels.head);
     freez(st->state);
@@ -554,8 +553,8 @@ RRDSET *rrdset_create_custom(
             changed_from_archived_to_active = 1;
             mark_rebuild |= META_CHART_ACTIVATED;
         }
-        char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_family = NULL, *old_context = NULL,
-             *old_title_v = NULL, *old_family_v = NULL, *old_context_v = NULL;
+        char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_context = NULL,
+             *old_title_v = NULL, *old_context_v = NULL;
         int rc;
 
         if(unlikely(name))
@@ -653,10 +652,8 @@ RRDSET *rrdset_create_custom(
             freez(old_plugin);
             freez(old_module);
             freez(old_title);
-            freez(old_family);
             freez(old_context);
             freez(old_title_v);
-            freez(old_family_v);
             freez(old_context_v);
             if (mark_rebuild != META_CHART_ACTIVATED) {
                 info("Collector updated metadata for chart %s", st->id);
@@ -848,7 +845,6 @@ RRDSET *rrdset_create_custom(
 
     st->state = callocz(1, sizeof(*st->state));
     st->family     = config_get(st->config_section, "family", family?family:st->type);
-    st->state->old_family = strdupz(st->family);
     json_fix_string(st->family);
 
     st->units      = config_get(st->config_section, "units", units?units:"");

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -936,7 +936,6 @@ RRDSET *rrdset_create_custom(
             st->chart_uuid = create_chart_uuid(st, id, name);
 
         store_active_chart(st->chart_uuid);
-        st->compaction_id = 0;
     }
 #endif
 


### PR DESCRIPTION
##### Summary
- Remove the compaction_id from rrdset, rrdhost, rrddim (used in metadata log). For rrdset increment the unused count
- Remove the old_family from rrdset_volatile since changes to `family` are not tracked due to concurrency issues that lead to data corruption

##### Component Name
database

##### Test Plan
- Agent should compile and run with slightly reduced memory consumption
