### PR TITLE
Reduce the number of alarm updates on ACLK

### DIFF
--- a/health/health_log.c
+++ b/health/health_log.c
@@ -153,8 +153,12 @@ inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae) {
         }
     }
 #ifdef ENABLE_ACLK
-    if (netdata_cloud_setting)
-        aclk_update_alarm(host, ae);
+    if (netdata_cloud_setting) {
+        if ((ae->new_status == RRDCALC_STATUS_WARNING || ae->new_status == RRDCALC_STATUS_CRITICAL) ||
+            ((ae->old_status == RRDCALC_STATUS_WARNING || ae->old_status == RRDCALC_STATUS_CRITICAL))) {
+            aclk_update_alarm(host, ae);
+        }
+    }
 #endif
 }
 


### PR DESCRIPTION
##### Summary
Send alarm updates only if the new or old status is warning or critical. 

##### Component Name
aclk
health

##### Test Plan
- Compile agent with `-DNETDATA_INTERNAL_CHECKS=1` and cloud support. This will record and `Sending MQTT` messages as well as the PUBACK messages in the log file e.g. 
  `ACLK_Query_4 : Sending MQTT len=1121 mid=534 wq=0 (0-bytes) readq=0: {	"type": "status-change"`
  `ACLK_Main : Publish_callback: mid=5 latency=158ms`
  **Note:**  A `status-change` message refers to an alarm status update
- Start the agent and notice the total of PUBACKS as the agent initializes. 
- Apply the PR, recompile and observe the reduced number of messages (PUBACKS)