### PR TITLE
fix postgres password bug and change default config

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -1162,7 +1162,7 @@ def zero_lock_types(databases):
 
 
 def hide_password(config):
-    return dict((k, v if k != 'password' else '*****') for k, v in config.items())
+    return dict((k, v if (k != 'password' or (k == 'password' and v == None) ) else '*****') for k, v in config.items())
 
 
 def add_database_lock_chart(order, definitions, database_name):

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -1162,7 +1162,7 @@ def zero_lock_types(databases):
 
 
 def hide_password(config):
-    return dict((k, v if (k != 'password' or (k == 'password' and v == None) ) else '*****') for k, v in config.items())
+    return dict((k, v if k != 'password' or not v else '*****') for k, v in config.items())
 
 
 def add_database_lock_chart(order, definitions, database_name):

--- a/collectors/python.d.plugin/postgres/postgres.conf
+++ b/collectors/python.d.plugin/postgres/postgres.conf
@@ -128,6 +128,7 @@ tcpipv4:
     name     : 'local'
     database : 'postgres'
     user     : 'postgres'
+    password : 'postgres'
     host     : '127.0.0.1'
     port     : 5432
 
@@ -135,5 +136,6 @@ tcpipv6:
     name     : 'local'
     database : 'postgres'
     user     : 'postgres'
+    password : 'postgres'
     host     : '::1'
     port     : 5432

--- a/collectors/python.d.plugin/postgres/postgres.conf
+++ b/collectors/python.d.plugin/postgres/postgres.conf
@@ -81,7 +81,7 @@
 #     sslkey              : path/to/key        # the location of the client key file
 #
 # SSL connection parameters description: https://www.postgresql.org/docs/current/libpq-ssl.html
-#
+# 
 # Additionally, the following options allow selective disabling of charts
 #
 #     table_stats : false
@@ -92,6 +92,10 @@
 # "trust" local clients to allow netdata to connect, or you can create
 # a postgres user for netdata and add its password below to allow
 # netdata connect.
+#
+# Please note that when running Postgres from inside the container, 
+# the client (Netdata) is not considered local, unless it runs from inside
+# the same container. 
 #
 # Postgres supported versions are : 
 # - 9.3 (without autovacuum)
@@ -130,5 +134,28 @@ tcpipv6:
     name     : 'local'
     database : 'postgres'
     user     : 'postgres'
+    host     : '::1'
+    port     : 5432
+tcp:
+    name     : 'local'
+    database : 'postgres'
+    user     : 'postgres'
+    passowrd:  'postgres'
+    host     : 'localhost'
+    port     : 5432
+
+tcpipv4:
+    name     : 'local'
+    database : 'postgres'
+    user     : 'postgres'
+    passowrd:  'postgres'    
+    host     : '127.0.0.1'
+    port     : 5432
+
+tcpipv6:
+    name     : 'local'
+    database : 'postgres'
+    user     : 'postgres'
+    passowrd:  'postgres'    
     host     : '::1'
     port     : 5432

--- a/collectors/python.d.plugin/postgres/postgres.conf
+++ b/collectors/python.d.plugin/postgres/postgres.conf
@@ -120,6 +120,7 @@ tcp:
     name     : 'local'
     database : 'postgres'
     user     : 'postgres'
+    password : 'postgres'
     host     : 'localhost'
     port     : 5432
 
@@ -134,28 +135,5 @@ tcpipv6:
     name     : 'local'
     database : 'postgres'
     user     : 'postgres'
-    host     : '::1'
-    port     : 5432
-tcp:
-    name     : 'local'
-    database : 'postgres'
-    user     : 'postgres'
-    passowrd:  'postgres'
-    host     : 'localhost'
-    port     : 5432
-
-tcpipv4:
-    name     : 'local'
-    database : 'postgres'
-    user     : 'postgres'
-    passowrd:  'postgres'    
-    host     : '127.0.0.1'
-    port     : 5432
-
-tcpipv6:
-    name     : 'local'
-    database : 'postgres'
-    user     : 'postgres'
-    passowrd:  'postgres'    
     host     : '::1'
     port     : 5432


### PR DESCRIPTION

##### Summary

Fix bug on postgres collector where a `None` password was output as `*****` to the user. 

Add default password to default configuration, so that netdata can collect from containerised postgresql instances, as the no-password `trust` configuration doesn't work for non-local connections.

##### Component Name

##### Test Plan

- Run Postgres in container and see that it automatically connects to the instance.
- Comment-out the configuration jobs that contain the password and see that the debug trace outputs `password: None`

##### Additional Information
