### PR TITLE
Allow the REMOVED alarm status via ACLK if the previous status was WARN/CRIT

### DIFF
--- a/health/health_json.c
+++ b/health/health_json.c
@@ -352,14 +352,15 @@ void health_active_log_alarms_2json(RRDHOST *host, BUFFER *wb) {
     unsigned int count = 0;
     ALARM_ENTRY *ae;
     for(ae = host->health_log.alarms; ae && count < max ; ae = ae->next) {
-
-        if(likely(!((ae->new_status == RRDCALC_STATUS_WARNING || ae->new_status == RRDCALC_STATUS_CRITICAL)
-                    && !ae->updated_by_id)))
-            continue;
-
-        if(likely(count)) buffer_strcat(wb, ",");
+        if (!ae->updated_by_id &&
+            ((ae->new_status == RRDCALC_STATUS_WARNING || ae->new_status == RRDCALC_STATUS_CRITICAL) ||
+             ((ae->old_status == RRDCALC_STATUS_WARNING || ae->old_status == RRDCALC_STATUS_CRITICAL) &&
+              ae->new_status == RRDCALC_STATUS_REMOVED))) {
+            if (likely(count))
+                buffer_strcat(wb, ",");
             health_alarm_entry2json_nolock(wb, ae, host);
-        count++;
+            count++;
+        }
     }
     buffer_strcat(wb, "]");
 


### PR DESCRIPTION
##### Summary
On agent startup if an alarm is found in REMOVED state without an updated entry and the old status
is WARN/CRIT then submit the update so the cloud can clear the alarm (if still on the list)

##### Component Name
aclk

##### Test Plan
- Setup a cloud enabled and claimed agent so that it will trigger the following alarm
- Enable something like `/sys/class/power_supply = yes` in the netdata conf
- Change 
   ```
   template: linux_power_supply_capacity
      on: powersupply.capacity
    calc: $capacity
   units: %
   every: 10s
    warn: $this < 100
    crit: $this < 5
   delay: up 30s down 5m multiplier 1.2 max 1h
    info: the percentage remaining capacity of the power supply
      to: sysadmin
   ```

so that it will cause a warning
- Check that you see the warning in the cloud and local dashboard
- Stop the agent and disable  `/sys/class/power_supply = no`
- Start the agent
   - Check alarms on local dashboard and cloud
      - If the alarm does not appear on the dashboard and does not appear on the cloud, then the agent disconnect message was properly processed by the cloud. 
- If the alarm does not appear in the dashboard but appears in the cloud and it is empty then: 
  - Apply the PR 
  - Restart the agent
  - The alarm should disappear from the cloud



##### Additional Information
