### PR TITLE
Add Alpine 3.13 and remove Alpine 3.9 from our CI.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -24,10 +24,10 @@ jobs:
       matrix:
         distro:
           - 'alpine:edge'
+          - 'alpine:3.13'
           - 'alpine:3.12'
           - 'alpine:3.11'
           - 'alpine:3.10'
-          - 'alpine:3.9'
           - 'archlinux:latest'
           - 'centos:8'
           - 'centos:7'
@@ -47,6 +47,9 @@ jobs:
           - distro: 'alpine:edge'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
+          - distro: 'alpine:3.13'
+            pre: 'apk add -U bash'
+            rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.12'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
@@ -54,9 +57,6 @@ jobs:
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.10'
-            pre: 'apk add -U bash'
-            rmjsonc: 'apk del json-c-dev'
-          - distro: 'alpine:3.9'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: >
-          docker run -v "$PWD":/netdata -w /netdata alpine:3.11 /bin/sh -c
+          docker run -v "$PWD":/netdata -w /netdata alpine:latest /bin/sh -c
           'apk add bash;
           ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata;
           apk del openssl openssl-dev;


### PR DESCRIPTION
##### Summary

Alpine 3.13 was released on 2021-01-14

Alpine 3.9 went EOL on 2020-11-01

This also bumps an old Alpine 3.11 reference to use the lastest stable Alpine image.

##### Component Name

area/ci

##### Test Plan

New checks pass correctly.