### PR TITLE
Remove OpenSUSE Leap 15.1 from CI.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -37,7 +37,6 @@ jobs:
           - 'fedora:33'
           - 'fedora:32'
           - 'opensuse/leap:15.2'
-          - 'opensuse/leap:15.1'
           - 'opensuse/tumbleweed:latest'
           - 'ubuntu:20.10'
           - 'ubuntu:20.04'
@@ -79,8 +78,6 @@ jobs:
             rmjsonc: 'dnf remove -y json-c-devel'
 
           - distro: 'opensuse/leap:15.2'
-            rmjsonc: 'zypper rm -y libjson-c-devel'
-          - distro: 'opensuse/leap:15.1'
             rmjsonc: 'zypper rm -y libjson-c-devel'
           - distro: 'opensuse/tumbleweed:latest'
             rmjsonc: 'zypper rm -y libjson-c-devel'

--- a/.travis.yml
+++ b/.travis.yml
@@ -324,14 +324,6 @@ jobs:
         - PACKAGE_TYPE="rpm" REPO_TOOL="dnf"
         - ALLOW_SOFT_FAILURE_HERE=true
 
-    - name: "Build & Publish RPM package for openSUSE 15.1"
-      <<: *RPM_TEMPLATE
-      if: commit_message =~ /\[Package (amd64|arm64) RPM( openSUSE)?\]/
-      env:
-        - BUILDER_NAME="builder" BUILD_DISTRO="opensuse" BUILD_RELEASE="15.1" BUILD_STRING="opensuse/15.1"
-        - PACKAGE_TYPE="rpm" REPO_TOOL="zypper"
-        - ALLOW_SOFT_FAILURE_HERE=true
-
     - name: "Build & Publish RPM package for openSUSE 15.2"
       <<: *RPM_TEMPLATE
       if: commit_message =~ /\[Package (amd64|arm64) RPM( openSUSE)?\]/


### PR DESCRIPTION
##### Summary

Intended to be merged on or after 2020-01-30 when it officially becomes EOL.

##### Component Name

area/ci

##### Test Plan

n/a