### PR TITLE
Properly handle saved temporary directory on updates.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -116,7 +116,7 @@ _cannot_use_tmpdir() {
 
 create_tmp_directory() {
   if [ -n "${NETDATA_TMPDIR_PATH}" ]; then
-    echo "${NETDATA_TMPDIR_PATH}"
+    TMPDIR="${NETDATA_TMPDIR_PATH}"
   else
     if [ -z "${NETDATA_TMPDIR}" ] || _cannot_use_tmpdir "${NETDATA_TMPDIR}" ; then
       if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then


### PR DESCRIPTION
##### Summary

We should have been using the saved `TMPDIR` value as a prefix for a temporary directory, but where using it directly. This resulted in errors in the updater.

##### Component Name

area/packaging

##### Test Plan

Verify that the custom temporary directory is not removed by the script on the first run of the updater.

##### Additional Information

Fixes: #10536 