### PR TITLE
Try to keep all pages from extents read from disk in the cache.

### DIFF
--- a/database/engine/pagecache.h
+++ b/database/engine/pagecache.h
@@ -172,6 +172,8 @@ extern usec_t pg_cache_oldest_time_in_range(struct rrdengine_instance *ctx, uuid
 extern void pg_cache_get_filtered_info_prev(struct rrdengine_instance *ctx, struct pg_cache_page_index *page_index,
                                             usec_t point_in_time, pg_cache_page_info_filter_t *filter,
                                             struct rrdeng_page_info *page_info);
+extern struct rrdeng_page_descr *pg_cache_lookup_unpopulated_and_lock(struct rrdengine_instance *ctx, uuid_t *id,
+                                                                      usec_t start_time);
 extern unsigned
         pg_cache_preload(struct rrdengine_instance *ctx, uuid_t *id, usec_t start_time, usec_t end_time,
                          struct rrdeng_page_info **page_info_arrayp, struct pg_cache_page_index **ret_page_indexp);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Try to keep all the pages that belong to an extent in the page cache, whenever an extent is read from disk. This should improve spatial and temporal locality and consequently cache hit ratio. It is expected to improve performance and reduce disk I/O volume.

##### Component Name
database/engine
##### Test Plan
1. Populate 64MB worth of dbengine history (in `/var/cache/netdata/dbengine`)
2. Zoom out fully in the dashboard.
3. Export a snapshot.
4. Compare read disk I/O before the export and after (See column 6 [here](https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats))

The PR code should do significantly less I/O than the code in master.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->