### PR TITLE
Fix off-by-one bug in health_alarm_log_read (#10522)

### DIFF
--- a/health/health_log.c
+++ b/health/health_log.c
@@ -209,8 +209,8 @@ inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char *filena
         if(likely(*pointers[0] == 'U' || *pointers[0] == 'A')) {
             ALARM_ENTRY *ae = NULL;
 
-            if(entries < 26) {
-                error("HEALTH [%s]: line %zu of file '%s' should have at least 26 entries, but it has %d. Ignoring it.", host->hostname, line, filename, entries);
+            if(entries < 27) {
+                error("HEALTH [%s]: line %zu of file '%s' should have at least 27 entries, but it has %d. Ignoring it.", host->hostname, line, filename, entries);
                 errored++;
                 continue;
             }


### PR DESCRIPTION
##### Summary
Fixes #10522 - Segfault in health_alarm_log_read

The guard against the number of columns read was one too small
which caused a segfault if there were exactly 26 columns.

##### Component Name

health/

##### Test Plan

##### Additional Information
