### PR TITLE
Fix prometheus remote write header

### DIFF
--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -25,9 +25,11 @@ void prometheus_remote_write_prepare_header(struct instance *instance)
         "POST %s HTTP/1.1\r\n"
         "Host: %s\r\n"
         "Accept: */*\r\n"
+        "Content-Encoding: snappy\r\n"
+        "Content-Type: application/x-protobuf\r\n"
         "X-Prometheus-Remote-Write-Version: 0.1.0\r\n"
         "Content-Length: %zu\r\n"
-        "Content-Type: application/x-www-form-urlencoded\r\n\r\n",
+        "\r\n",
         connector_specific_config->remote_write_path,
         instance->config.destination,
         buffer_strlen(simple_connector_data->last_buffer->buffer));

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -1179,9 +1179,11 @@ static void test_prometheus_remote_write_prepare_header(void **state)
         "POST /receive HTTP/1.1\r\n"
         "Host: localhost\r\n"
         "Accept: */*\r\n"
+        "Content-Encoding: snappy\r\n"
+        "Content-Type: application/x-protobuf\r\n"
         "X-Prometheus-Remote-Write-Version: 0.1.0\r\n"
         "Content-Length: 11\r\n"
-        "Content-Type: application/x-www-form-urlencoded\r\n\r\n");
+        "\r\n");
 
     free(connector_specific_config->remote_write_path);
 


### PR DESCRIPTION
##### Summary
When exporting metrics using the Prometheus remote write connector to TimescaleDB via Promscale, it refuses to accept the data:
```
level=error ts=2021-01-15T06:20:50.557Z caller=write.go:239 msg="Write header validation error" err="unsupported data format (not protobuf or json)
```
The header [should contain](https://github.com/timescale/promscale/blob/7581d0430fc97d0149fc864fcd0df0228271ce2a/pkg/api/write.go#L101) `Content-Type: application/x-protobuf` for exporting to work correctly.

Fixes #10537

##### Component Name
The Prometheus remote write exporting connector

##### Test Plan
1. Run Promscale [in a container](https://github.com/timescale/promscale/blob/master/docs/docker.md#-running-docker).
2. Configure Netdata to export metrics using Prometheus remote write
```
[prometheus_remote_write:my_prometheus_remote_write_instance]
    enabled = yes
    destination = localhost:9201
    remote write URL path = /write
    update every = 3
    send charts matching = system.processes
```
3. Check if data is collected by TimeScaleDB
```
http://localhost:9201/api/v1/query?query=netdata_system_processes_processes_average
```