### PR TITLE
bytes after last '}' trip JSON parser

### DIFF
--- a/aclk/legacy/agent_cloud_link.c
+++ b/aclk/legacy/agent_cloud_link.c
@@ -639,7 +639,7 @@ static void aclk_graceful_disconnect()
     // Send a graceful disconnect message
     BUFFER *b = buffer_create(512);
     aclk_create_header(b, "disconnect", NULL, 0, 0, aclk_shared_state.version_neg);
-    buffer_strcat(b, ",\n\t\"payload\": \"graceful\"}\n");
+    buffer_strcat(b, ",\n\t\"payload\": \"graceful\"}");
     aclk_send_message(ACLK_METADATA_TOPIC, (char*)buffer_tostring(b), NULL);
     buffer_free(b);
 


### PR DESCRIPTION
##### Summary
JSON parser at the cloud end reports error if anything is behind the last '}' of JSON message. This caused cloud to throw away graceful `disconnect` messages.

##### Component Name

##### Test Plan
TEST 1:
Compile with `ACLK_DISABLE_CHALLENGE` point to your own broker. Subscribe to `meta` topic and listen for `disconnect` message sent when agent is shutting down. Hexdump that message and verify '}' is the last byte (no invisible characters after it)

TEST 2:
this should properly clear alarms on cloud

##### Additional Information
