### PR TITLE
Fix wrong count for entries

### DIFF
--- a/health/health_log.c
+++ b/health/health_log.c
@@ -213,8 +213,8 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
         if(likely(*pointers[0] == 'U' || *pointers[0] == 'A')) {
             ALARM_ENTRY *ae = NULL;
 
-            if(entries < 26) {
-                error("HEALTH [%s]: line %zu of file '%s' should have at least 26 entries, but it has %d. Ignoring it.", host->hostname, line, filename, entries);
+            if(entries < 27) {
+                error("HEALTH [%s]: line %zu of file '%s' should have at least 27 entries, but it has %d. Ignoring it.", host->hostname, line, filename, entries);
                 errored++;
                 continue;
             }


### PR DESCRIPTION
##### Summary
Fixes #10522 

This PR is a copy from the original PR #10559, because the user could not sign the CLA. A more detailed description about this fix was given from user [here](https://github.com/netdata/netdata/issues/10522#issuecomment-767881289).

##### Component Name
health
##### Test Plan

1 - Compile this Branch.
2 - Change a line inside your `/var/lib/netdata/health/health-log.db` to have less values than expected.
3 - Start Netdata.
4 - Verify if there is the warning `..should have at least 27 entries, but it has..` inside your `/var/log/netdata/error.log`.
5 - Now access `http://localhost:19999/api/v1/alarm_log` and check that all log were loaded.

##### Additional Information
