### PR TITLE
collectors/elasticsearch: document `scheme` option

### DIFF
--- a/collectors/python.d.plugin/elasticsearch/README.md
+++ b/collectors/python.d.plugin/elasticsearch/README.md
@@ -80,6 +80,7 @@ Sample:
 local:
   host               : 'ipaddress'    # Elasticsearch server ip address or hostname.
   port               : 'port'         # Port on which elasticsearch listens.
+  scheme             : 'http'         # URL scheme. Use 'https' if your elasticsearch uses TLS.
   node_status        :  yes/no        # Get metrics from "/_nodes/_local/stats". Enabled by default.
   cluster_health     :  yes/no        # Get metrics from "/_cluster/health". Enabled by default.
   cluster_stats      :  yes/no        # Get metrics from "'/_cluster/stats". Enabled by default.


### PR DESCRIPTION
##### Summary

Document the `scheme` option of the elasticsearch collector.

##### Component Name

`collectors/python.d/elasticsearch`

##### Test Plan

N/A - this is a documentation change

##### References

Introduced option in config file example in #5834