### PR TITLE
Fixed Netdata Cloud support in RPM packages.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -240,7 +240,7 @@ autoreconf -ivf
 	--with-libJudy=externaldeps/libJudy \
 	%endif
 	%if 0%{?centos_ver} >= 8 || 0%{?fedora}
-	--with-libwebsockets=externaldeps/libwebsockets \
+	--with-bundled-lws=externaldeps/libwebsockets \
 	%endif
 	--prefix="%{_prefix}" \
 	--sysconfdir="%{_sysconfdir}" \


### PR DESCRIPTION
##### Summary

This fixes an incorrect configure option in our RPM package which has been causing cloud support to not work on platforms where we can’t use a native copy of libwebsockets.

##### Component Name

area/packaging

##### Test Plan

Option name verified against our configure script.

Actual resultant build tested for CentOS 8 and OpenSUSE Leap 15.2 locally by verifying cloud support using `netdata -W buildinfo`.

##### Additional Information

Fixes the attempt at fixing this from #10507, orginally attempted to be fixed with #10460, with the bug originally introduced by #9984.

Relevant to #10403 and #10457.