### PR TITLE
Fixed docker image tagging for nightly builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -449,7 +449,7 @@ jobs:
       after_deploy: rm -f .travis/gcs-credentials.json
 
     - name: Trigger Docker image build and publish
-      script: .travis/trigger_docker_build.sh "${GITHUB_TOKEN}" "${BUILD_VERSION}"
+      script: .travis/trigger_docker_build.sh "${GITHUB_TOKEN}" "nightly"
       after_failure: post_message "TRAVIS_MESSAGE" "<!here> Failed to trigger docker build during nightly release" "${NOTIF_CHANNEL}"
 
     - stage: Trigger deb and rpm package build (nightly release)


### PR DESCRIPTION
##### Summary

They were being incorrectly tagged using the stable build tags.

##### Component Name

area/ci

##### Test Plan

Re-checked locally.