### PR TITLE
web/gui: Fix broken external links

### DIFF
--- a/web/gui/main.js
+++ b/web/gui/main.js
@@ -668,13 +668,13 @@ function renderMachines(machinesArray) {
         if (machines) {
             html += (
                 `<div class="info-item">
-                    <a href="https://github.com/netdata/netdata/tree/master/registry#netdata-registry" target="_blank">Your nodes list is empty</a>
+                    <a href="https://github.com/netdata/netdata/tree/master/registry#registry" target="_blank">Your nodes list is empty</a>
                 </div>`
             )
         } else {
             html += (
                 `<div class="info-item">
-                    <a href="https://github.com/netdata/netdata/tree/master/registry#netdata-registry" target="_blank">Failed to contact the registry</a>
+                    <a href="https://github.com/netdata/netdata/tree/master/registry#registry" target="_blank">Failed to contact the registry</a>
                 </div>`
             )
         }
@@ -812,7 +812,7 @@ function renderMyNetdataMenu(machinesArray) {
             </div>
             <div class="agent-item">
                 <i class="fas fa-question-circle""></i>
-                <a href="https://github.com/netdata/netdata/tree/master/registry#netdata-registry" target="_blank">What is this?</a>
+                <a href="https://github.com/netdata/netdata/tree/master/registry#registry" target="_blank">What is this?</a>
                 <div></div>
             </div>`
         )
@@ -1815,8 +1815,8 @@ function renderPage(menus, data) {
 
     const isMemoryModeDbEngine = data.memory_mode === "dbengine";
 
-    sidebar += '<li class="" style="padding-top:15px;"><a href="https://docs.netdata.cloud/collectors/quickstart/" target="_blank"><i class="fas fa-plus"></i> Add more charts</a></li>';
-    sidebar += '<li class=""><a href="https://docs.netdata.cloud/health/quickstart/" target="_blank"><i class="fas fa-plus"></i> Add more alarms</a></li>';
+    sidebar += '<li class="" style="padding-top:15px;"><a href="https://learn.netdata.cloud/docs/agent/collectors/quickstart/" target="_blank"><i class="fas fa-plus"></i> Add more charts</a></li>';
+    sidebar += '<li class=""><a href="https://learn.netdata.cloud/docs/agent/health/quickstart/" target="_blank"><i class="fas fa-plus"></i> Add more alarms</a></li>';
     sidebar += '<li class="" style="margin:20px;color:#666;"><small>Every ' +
       ((data.update_every === 1) ? 'second' : data.update_every.toString() + ' seconds') + ', ' +
       'Netdata collects <strong>' + data.dimensions_count.toLocaleString() + '</strong> metrics on ' +
@@ -1828,7 +1828,7 @@ function renderPage(menus, data) {
 
     if (!isMemoryModeDbEngine) {
         sidebar += '<br />&nbsp;<br />Get more history by ' +
-          '<a href="https://docs.netdata.cloud/docs/configuration-guide/#increase-the-metrics-retention-period" target=_blank>configuring Netdata\'s <strong>history</strong></a> or using the <a href="https://docs.netdata.cloud/database/engine/" target=_blank>DB engine.</a>';
+          '<a href="https://learn.netdata.cloud/guides/longer-metrics-storage#using-the-round-robin-database" target=_blank>configuring Netdata\'s <strong>history</strong></a> or using the <a href="https://learn.netdata.cloud/docs/agent/database/engine/" target=_blank>DB engine.</a>';
     }
 
     sidebar += '<br/>&nbsp;<br/><strong>netdata</strong><br/>' + data.version.toString() + '</small></li>';
@@ -3052,7 +3052,7 @@ function notifyForUpdate(force) {
             versionLog('<p><big>You already have the latest netdata!</big></p><p>No update yet?<br/>We probably need some motivation to keep going on!</p><p>If you haven\'t already, <a href="https://github.com/netdata/netdata" target="_blank">give netdata a <b><i class="fas fa-star"></i></b> at its github page</a>.</p>');
         } else {
             save = true;
-            var compare = 'https://docs.netdata.cloud/changelog/';
+            var compare = 'https://learn.netdata.cloud/docs/agent/changelog/';
             versionLog('<p><big><strong>New version of netdata available!</strong></big></p><p>Latest version: <b><code>' + sha2 + '</code></b></p><p><a href="' + compare + '" target="_blank">Click here for the changes log</a> and<br/><a href="https://github.com/netdata/netdata/tree/master/packaging/installer/UPDATE.md" target="_blank">click here for directions on updating</a> your netdata installation.</p><p>We suggest to review the changes log for new features you may be interested, or important bug fixes you may need.<br/>Keeping your netdata updated is generally a good idea.</p>');
 
             document.getElementById('update_badge').innerHTML = '!';


### PR DESCRIPTION
##### Summary

This PR fixes outdated documentation links in web GUI. Old ones lead to 404 error pages, new ones work as expected.

##### Component Name

netdata/web/gui

##### Test Plan

Examples of old links and their replacements:

- https://docs.netdata.cloud/collectors/quickstart/ vs https://learn.netdata.cloud/docs/agent/collectors/quickstart/
- https://docs.netdata.cloud/health/quickstart/ vs https://learn.netdata.cloud/docs/agent/health/quickstart/
- https://docs.netdata.cloud/changelog/ vs https://learn.netdata.cloud/docs/agent/changelog/

##### Additional Information

It might be easier to sync netdata/web/gui with [dashboard/src](https://github.com/netdata/dashboard/tree/master/src).