### PR TITLE
add resetting CapabilityBoundingSet workaround to the python.d collectors (that use `sudo`) readmes

### DIFF
--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -18,7 +18,7 @@ Executed commands:
 The module uses `arcconf`, which can only be executed by `root`. It uses
 `sudo` and assumes that it is configured such that the `netdata` user can execute `arcconf` as root without a password.
 
-- add to the `/etc/sudoers`
+-  Add to your `/etc/sudoers` file:
 
 `which arcconf` shows the full path to the binary.
 

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -30,7 +30,7 @@ netdata ALL=(root)       NOPASSWD: /path/to/arcconf
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 
-Default CapabilityBoundingSet doesn't allow using `sudo` and is quite strict in general.
+The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
 
 > :warning: Resetting it is not an optimal solution,
 > but we couldn't find exact set of capabilities to execute arcconf with sudo.

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -18,7 +18,9 @@ Executed commands:
 The module uses `arcconf`, which can only be executed by `root`. It uses
 `sudo` and assumes that it is configured such that the `netdata` user can execute `arcconf` as root without a password.
 
-- add to the `sudoers`
+- add to the `/etc/sudoers`
+
+`which arcconf` shows the full path to the binary.
 
 ```bash
 netdata ALL=(root)       NOPASSWD: /path/to/arcconf
@@ -49,13 +51,21 @@ systemctl restart netdata.service
 - Physical Device S.M.A.R.T warnings
 - Physical Device Temperature
 
-## Configuration
+## Enable the collector
 
-`adaptec_raid` is disabled by default. Should be explicitly enabled in `python.d.conf`.
+The `adaptec_raid` collector is disabled by default. To enable it, use `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`, to edit the `python.d.conf`
+file.
 
-```yaml
-adaptec_raid: yes
+```bash
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+sudo ./edit-config python.d.conf
 ```
+
+Change the value of the `adaptec_raid` setting to `yes`. Save the file and restart the Netdata Agent
+with `sudo systemctl restart netdata`, or the appropriate method for your system.
+
+## Configuration
 
 Edit the `python.d/adaptec_raid.conf` configuration file using `edit-config` from the
 Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -26,7 +26,7 @@ The module uses `arcconf`, which can only be executed by `root`. It uses
 netdata ALL=(root)       NOPASSWD: /path/to/arcconf
 ```
 
-- reset netdata systemd
+- Reset Netdata's systemd
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -35,7 +35,7 @@ Default CapabilityBoundingSet doesn't allow using `sudo` and is quite strict in 
 > :warning: Resetting it is not an optimal solution,
 > but we couldn't find exact set of capabilities to execute arcconf with sudo.
 
-As the `root` user do the following:
+As the `root` user, do the following:
 
 ```cmd
 mkdir /etc/systemd/system/netdata.service.d

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -32,8 +32,6 @@ netdata ALL=(root)       NOPASSWD: /path/to/arcconf
 
 The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
 
-> :warning: Resetting it is not an optimal solution,
-> but we couldn't find exact set of capabilities to execute arcconf with sudo.
 
 As the `root` user, do the following:
 

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -10,9 +10,8 @@ Collects logical and physical devices metrics.
 
 ## Requirements
 
-The module uses `arcconf`, which can only be executed by root.  It uses
-`sudo` and assumes that it is configured such that the `netdata` user can
-execute `arcconf` as root without password.
+The module uses `arcconf`, which can only be executed by root. It uses
+`sudo` and assumes that it is configured such that the `netdata` user can execute `arcconf` as root without a password.
 
 Add to `sudoers`:
 
@@ -22,18 +21,18 @@ netdata ALL=(root)       NOPASSWD: /path/to/arcconf
 
 To grab stats it executes:
 
--   `sudo -n arcconf GETCONFIG 1 LD`
--   `sudo -n arcconf GETCONFIG 1 PD`
+- `sudo -n arcconf GETCONFIG 1 LD`
+- `sudo -n arcconf GETCONFIG 1 PD`
 
 It produces:
 
-1.  **Logical Device Status**
+1. **Logical Device Status**
 
-2.  **Physical Device State**
+2. **Physical Device State**
 
-3.  **Physical Device S.M.A.R.T warnings**
+3. **Physical Device S.M.A.R.T warnings**
 
-4.  **Physical Device Temperature**
+4. **Physical Device Temperature**
 
 ## Configuration
 
@@ -43,15 +42,13 @@ It produces:
 adaptec_raid: yes
 ```
 
-Edit the `python.d/adaptec_raid.conf` configuration file using `edit-config` from the Netdata [config
-directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
+Edit the `python.d/adaptec_raid.conf` configuration file using `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different
 sudo ./edit-config python.d/adaptec_raid.conf
 ```
-
-
 
 ![image](https://user-images.githubusercontent.com/22274335/47278133-6d306680-d601-11e8-87c2-cc9c0f42d686.png)
 

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -6,37 +6,52 @@ sidebar_label: "Adaptec RAID"
 
 # Adaptec RAID controller monitoring with Netdata
 
-Collects logical and physical devices metrics.
+Collects logical and physical devices metrics using `arcconf` command-line utility.
 
-## Requirements
-
-The module uses `arcconf`, which can only be executed by root. It uses
-`sudo` and assumes that it is configured such that the `netdata` user can execute `arcconf` as root without a password.
-
-Add to `sudoers`:
-
-```
-netdata ALL=(root)       NOPASSWD: /path/to/arcconf
-```
-
-To grab stats it executes:
+Executed commands:
 
 - `sudo -n arcconf GETCONFIG 1 LD`
 - `sudo -n arcconf GETCONFIG 1 PD`
 
-It produces:
+## Requirements
 
-1. **Logical Device Status**
+The module uses `arcconf`, which can only be executed by `root`. It uses
+`sudo` and assumes that it is configured such that the `netdata` user can execute `arcconf` as root without a password.
 
-2. **Physical Device State**
+- add to the `sudoers`
 
-3. **Physical Device S.M.A.R.T warnings**
+```bash
+netdata ALL=(root)       NOPASSWD: /path/to/arcconf
+```
 
-4. **Physical Device Temperature**
+- reset netdata systemd
+  unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
+  distributions with systemd)
+
+Default CapabilityBoundingSet doesn't allow using `sudo` and is quite strict in general.
+
+> :warning: Resetting it is not an optimal solution,
+> but we couldn't find exact set of capabilities to execute arcconf with sudo.
+
+As the `root` user do the following:
+
+```cmd
+mkdir /etc/systemd/system/netdata.service.d
+echo -e '[Service]\nCapabilityBoundingSet=~' | tee /etc/systemd/system/netdata.service.d/unset-capability-bounding-set.conf
+systemctl daemon-reload
+systemctl restart netdata.service
+```
+
+## Charts
+
+- Logical Device Status
+- Physical Device State
+- Physical Device S.M.A.R.T warnings
+- Physical Device Temperature
 
 ## Configuration
 
-**adaptec_raid** is disabled by default. Should be explicitly enabled in `python.d.conf`.
+`adaptec_raid` is disabled by default. Should be explicitly enabled in `python.d.conf`.
 
 ```yaml
 adaptec_raid: yes

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -17,7 +17,9 @@ Executed commands:
 This module uses `ssacli`, which can only be executed by root. It uses
 `sudo` and assumes that it is configured such that the `netdata` user can execute `ssacli` as root without a password.
 
-- add to the `sudoers`
+- add to the `/etc/sudoers`
+
+`which ssacli` shows the full path to the binary.
 
 ```bash
 netdata ALL=(root)       NOPASSWD: /path/to/ssacli
@@ -61,8 +63,7 @@ sudo ./edit-config python.d.conf
 ```
 
 Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent
-with `sudo systemctl restart netdata`, or the appropriate method for your system, to finish enabling the `hpssa`
-collector.
+with `sudo systemctl restart netdata`, or the appropriate method for your system.
 
 ## Configuration
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -20,7 +20,7 @@ This module uses `ssacli`, which can only be executed by root. It uses
 - add to the `sudoers`
 
 ```bash
-netdata ALL=(root)       NOPASSWD: /path/to/arcconf
+netdata ALL=(root)       NOPASSWD: /path/to/ssacli
 ```
 
 - reset netdata systemd

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -31,7 +31,7 @@ netdata ALL=(root)       NOPASSWD: /path/to/ssacli
 
 The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
 
-As the `root` user do the following:
+As the `root` user, do the following:
 
 ```cmd
 mkdir /etc/systemd/system/netdata.service.d

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -29,7 +29,7 @@ netdata ALL=(root)       NOPASSWD: /path/to/ssacli
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 
-The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
+The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `ssacli` using `sudo`.
 
 As the `root` user, do the following:
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -29,10 +29,7 @@ netdata ALL=(root)       NOPASSWD: /path/to/ssacli
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 
-Default CapabilityBoundingSet doesn't allow using `sudo` and is quite strict in general.
-
-> :warning: Resetting it is not an optimal solution,
-> but we couldn't find exact set of capabilities to execute ssacli with sudo.
+The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
 
 As the `root` user do the following:
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -17,7 +17,7 @@ Executed commands:
 This module uses `ssacli`, which can only be executed by root. It uses
 `sudo` and assumes that it is configured such that the `netdata` user can execute `ssacli` as root without a password.
 
-- add to the `/etc/sudoers`
+- Add to your `/etc/sudoers` file:
 
 `which ssacli` shows the full path to the binary.
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -8,25 +8,46 @@ sidebar_label: "HP Smart Storage Arrays"
 
 Monitors controller, cache module, logical and physical drive state and temperature using `ssacli` tool.
 
+Executed commands:
+
+- `sudo -n ssacli ctrl all show config detail`
+
 ## Requirements:
 
 This module uses `ssacli`, which can only be executed by root. It uses
-`sudo` and assumes that it is configured such that the `netdata` user can execute `ssacli` as root without password.
+`sudo` and assumes that it is configured such that the `netdata` user can execute `ssacli` as root without a password.
 
-Add to `sudoers`:
+- add to the `sudoers`
 
+```bash
+netdata ALL=(root)       NOPASSWD: /path/to/arcconf
 ```
-netdata ALL=(root)       NOPASSWD: /path/to/ssacli
+
+- reset netdata systemd
+  unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
+  distributions with systemd)
+
+Default CapabilityBoundingSet doesn't allow using `sudo` and is quite strict in general.
+
+> :warning: Resetting it is not an optimal solution,
+> but we couldn't find exact set of capabilities to execute ssacli with sudo.
+
+As the `root` user do the following:
+
+```cmd
+mkdir /etc/systemd/system/netdata.service.d
+echo -e '[Service]\nCapabilityBoundingSet=~' | tee /etc/systemd/system/netdata.service.d/unset-capability-bounding-set.conf
+systemctl daemon-reload
+systemctl restart netdata.service
 ```
 
-To collect metrics, the module executes: `sudo -n ssacli ctrl all show config detail`
+## Charts
 
-This module produces:
-
-1. Controller state and temperature
-2. Cache module state and temperature
-3. Logical drive state
-4. Physical drive state and temperature
+- Controller status
+- Controller temperature
+- Logical drive status
+- Physical drive status
+- Physical drive temperature
 
 ## Enable the collector
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -25,7 +25,7 @@ This module uses `ssacli`, which can only be executed by root. It uses
 netdata ALL=(root)       NOPASSWD: /path/to/ssacli
 ```
 
-- reset netdata systemd
+- Reset Netdata's systemd
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -11,8 +11,7 @@ Monitors controller, cache module, logical and physical drive state and temperat
 ## Requirements:
 
 This module uses `ssacli`, which can only be executed by root. It uses
-`sudo` and assumes that it is configured such that the `netdata` user can
-execute `ssacli` as root without password.
+`sudo` and assumes that it is configured such that the `netdata` user can execute `ssacli` as root without password.
 
 Add to `sudoers`:
 
@@ -24,28 +23,30 @@ To collect metrics, the module executes: `sudo -n ssacli ctrl all show config de
 
 This module produces:
 
-1.  Controller state and temperature
-2.  Cache module state and temperature
-3.  Logical drive state
-4.  Physical drive state and temperature
+1. Controller state and temperature
+2. Cache module state and temperature
+3. Logical drive state
+4. Physical drive state and temperature
 
 ## Enable the collector
 
-The `hpssa` collector is disabled by default. To enable it, use `edit-config` from the Netdata [config
-directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`, to edit the `python.d.conf` file.
+The `hpssa` collector is disabled by default. To enable it, use `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`, to edit the `python.d.conf`
+file.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent with `sudo systemctl
-restart netdata`, or the appropriate method for your system, to finish enabling the `hpssa` collector.
+Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent
+with `sudo systemctl restart netdata`, or the appropriate method for your system, to finish enabling the `hpssa`
+collector.
 
 ## Configuration
 
-Edit the `python.d/hpssa.conf` configuration file using `edit-config` from the Netdata [config
-directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
+Edit the `python.d/hpssa.conf` configuration file using `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -30,7 +30,7 @@ netdata ALL=(root)       NOPASSWD: /path/to/megacli
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 
-The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
+The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `megacli` using `sudo`.
 
 
 As the `root` user, do the following:

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -18,7 +18,7 @@ Executed commands:
 The module uses `megacli`, which can only be executed by `root`. It uses
 `sudo` and assumes that it is configured such that the `netdata` user can execute `megacli` as root without a password.
 
-- add to the `/etc/sudoers`
+- Add to your `/etc/sudoers` file:
 
 `which megacli` shows the full path to the binary.
 

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -32,8 +32,6 @@ netdata ALL=(root)       NOPASSWD: /path/to/megacli
 
 The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
 
-> :warning: Resetting it is not an optimal solution,
-> but we couldn't find exact set of capabilities to execute megacli with sudo.
 
 As the `root` user, do the following:
 

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -35,7 +35,7 @@ Default CapabilityBoundingSet doesn't allow using `sudo` and is quite strict in 
 > :warning: Resetting it is not an optimal solution,
 > but we couldn't find exact set of capabilities to execute megacli with sudo.
 
-As the `root` user do the following:
+As the `root` user, do the following:
 
 ```cmd
 mkdir /etc/systemd/system/netdata.service.d

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -6,39 +6,53 @@ sidebar_label: "MegaRAID controllers"
 
 # MegaRAID controller monitoring with Netdata
 
-Collects adapter, physical drives and battery stats.
+Collects adapter, physical drives and battery stats using `megacli` command-line tool.
 
-## Requirements
-
-Uses the `megacli` program, which can only be executed by root. It uses
-`sudo` and assumes that it is configured such that the `netdata` user can execute `megacli` as root without password.
-
-Add to `sudoers`:
-
-```
-netdata ALL=(root)       NOPASSWD: /path/to/megacli
-```
-
-To grab stats it executes:
+Executed commands:
 
 - `sudo -n megacli -LDPDInfo -aAll`
 - `sudo -n megacli -AdpBbuCmd -a0`
 
-It produces:
+## Requirements
 
-1. **Adapter State**
+The module uses `megacli`, which can only be executed by `root`. It uses
+`sudo` and assumes that it is configured such that the `netdata` user can execute `megacli` as root without a password.
 
-2. **Physical Drives Media Errors**
+- add to the `sudoers`
 
-3. **Physical Drives Predictive Failures**
+```bash
+netdata ALL=(root)       NOPASSWD: /path/to/megacli
+```
 
-4. **Battery Relative State of Charge**
+- reset netdata systemd
+  unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
+  distributions with systemd)
 
-5. **Battery Cycle Count**
+Default CapabilityBoundingSet doesn't allow using `sudo` and is quite strict in general.
+
+> :warning: Resetting it is not an optimal solution,
+> but we couldn't find exact set of capabilities to execute megacli with sudo.
+
+As the `root` user do the following:
+
+```cmd
+mkdir /etc/systemd/system/netdata.service.d
+echo -e '[Service]\nCapabilityBoundingSet=~' | tee /etc/systemd/system/netdata.service.d/unset-capability-bounding-set.conf
+systemctl daemon-reload
+systemctl restart netdata.service
+```
+
+## Charts
+
+- Adapter State
+- Physical Drives Media Errors
+- Physical Drives Predictive Failures
+- Battery Relative State of Charge
+- Battery Cycle Count
 
 ## Configuration
 
-**megacli** is disabled by default. Should be explicitly enabled in `python.d.conf`.
+`megacli` is disabled by default. Should be explicitly enabled in `python.d.conf`.
 
 ```yaml
 megacli: yes

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -26,7 +26,7 @@ The module uses `megacli`, which can only be executed by `root`. It uses
 netdata ALL=(root)       NOPASSWD: /path/to/megacli
 ```
 
-- reset netdata systemd
+- Reset Netdata's systemd
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -10,9 +10,8 @@ Collects adapter, physical drives and battery stats.
 
 ## Requirements
 
-Uses the `megacli` program, which can only be executed by root.  It uses
-`sudo` and assumes that it is configured such that the `netdata` user can
-execute `megacli` as root without password.
+Uses the `megacli` program, which can only be executed by root. It uses
+`sudo` and assumes that it is configured such that the `netdata` user can execute `megacli` as root without password.
 
 Add to `sudoers`:
 
@@ -20,25 +19,22 @@ Add to `sudoers`:
 netdata ALL=(root)       NOPASSWD: /path/to/megacli
 ```
 
-
 To grab stats it executes:
 
--   `sudo -n megacli -LDPDInfo -aAll`
--   `sudo -n megacli -AdpBbuCmd -a0`
+- `sudo -n megacli -LDPDInfo -aAll`
+- `sudo -n megacli -AdpBbuCmd -a0`
 
 It produces:
 
-1.  **Adapter State**
+1. **Adapter State**
 
-2.  **Physical Drives Media Errors**
+2. **Physical Drives Media Errors**
 
-3.  **Physical Drives Predictive Failures**
+3. **Physical Drives Predictive Failures**
 
-4.  **Battery Relative State of Charge**
+4. **Battery Relative State of Charge**
 
-5.  **Battery Cycle Count**
-
-
+5. **Battery Cycle Count**
 
 ## Configuration
 
@@ -48,8 +44,8 @@ It produces:
 megacli: yes
 ```
 
-Edit the `python.d/megacli.conf` configuration file using `edit-config` from the Netdata [config
-directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
+Edit the `python.d/megacli.conf` configuration file using `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -30,7 +30,7 @@ netdata ALL=(root)       NOPASSWD: /path/to/megacli
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 
-Default CapabilityBoundingSet doesn't allow using `sudo` and is quite strict in general.
+The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
 
 > :warning: Resetting it is not an optimal solution,
 > but we couldn't find exact set of capabilities to execute megacli with sudo.

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -18,7 +18,9 @@ Executed commands:
 The module uses `megacli`, which can only be executed by `root`. It uses
 `sudo` and assumes that it is configured such that the `netdata` user can execute `megacli` as root without a password.
 
-- add to the `sudoers`
+- add to the `/etc/sudoers`
+
+`which megacli` shows the full path to the binary.
 
 ```bash
 netdata ALL=(root)       NOPASSWD: /path/to/megacli
@@ -50,13 +52,21 @@ systemctl restart netdata.service
 - Battery Relative State of Charge
 - Battery Cycle Count
 
-## Configuration
+## Enable the collector
 
-`megacli` is disabled by default. Should be explicitly enabled in `python.d.conf`.
+The `megacli` collector is disabled by default. To enable it, use `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`, to edit the `python.d.conf`
+file.
 
-```yaml
-megacli: yes
+```bash
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+sudo ./edit-config python.d.conf
 ```
+
+Change the value of the `megacli` setting to `yes`. Save the file and restart the Netdata Agent
+with `sudo systemctl restart netdata`, or the appropriate method for your system.
+
+## Configuration
 
 Edit the `python.d/megacli.conf` configuration file using `edit-config` from the
 Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -40,7 +40,7 @@ The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite stric
 > :warning: Resetting it is not an optimal solution,
 > but we couldn't find exact set of capabilities to execute smbstatus with sudo.
 
-As the `root` user do the following:
+As the `root` user, do the following:
 
 ```cmd
 mkdir /etc/systemd/system/netdata.service.d

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -31,7 +31,7 @@ password.
 netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
 ```
 
-- reset netdata systemd
+- Reset Netdata's systemd
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -37,8 +37,6 @@ netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
 
 The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
 
-> :warning: Resetting it is not an optimal solution,
-> but we couldn't find exact set of capabilities to execute smbstatus with sudo.
 
 As the `root` user, do the following:
 

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -23,7 +23,7 @@ The module uses `smbstatus`, which can only be executed by `root`. It uses
 `sudo` and assumes that it is configured such that the `netdata` user can execute `smbstatus` as root without a
 password.
 
-- add to the `/etc/sudoers`
+- Add to your `/etc/sudoers` file:
 
 `which smbstatus` shows the full path to the binary.
 

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -35,7 +35,7 @@ netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 
-Default CapabilityBoundingSet doesn't allow using `sudo` and is quite strict in general.
+The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
 
 > :warning: Resetting it is not an optimal solution,
 > but we couldn't find exact set of capabilities to execute smbstatus with sudo.

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -23,7 +23,9 @@ The module uses `smbstatus`, which can only be executed by `root`. It uses
 `sudo` and assumes that it is configured such that the `netdata` user can execute `smbstatus` as root without a
 password.
 
-- add to the `sudoers`
+- add to the `/etc/sudoers`
+
+`which smbstatus` shows the full path to the binary.
 
 ```bash
 netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
@@ -92,13 +94,21 @@ systemctl restart netdata.service
     - break
     - sessetup
 
-## Configuration
+## Enable the collector
 
-`samba` is disabled by default. Should be explicitly enabled in `python.d.conf`.
+The `samba` collector is disabled by default. To enable it, use `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`, to edit the `python.d.conf`
+file.
 
-```yaml
-samba: yes
+```bash
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+sudo ./edit-config python.d.conf
 ```
+
+Change the value of the `samba` setting to `yes`. Save the file and restart the Netdata Agent
+with `sudo systemctl restart netdata`, or the appropriate method for your system.
+
+## Configuration
 
 Edit the `python.d/samba.conf` configuration file using `edit-config` from the
 Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -35,7 +35,7 @@ netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
   unit [CapabilityBoundingSet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Capabilities) (Linux
   distributions with systemd)
 
-The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `arcconf` using `sudo`.
+The default CapabilityBoundingSet doesn't allow using `sudo`, and is quite strict in general. Resetting is not optimal, but a next-best solution given the inability to execute `smbstatus` using `sudo`.
 
 
 As the `root` user, do the following:

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -10,62 +10,61 @@ Monitors the performance metrics of Samba file sharing.
 
 ## Requirements
 
--   `smbstatus` program
--   `sudo` program
--   `smbd` must be compiled with profiling enabled
--   `smbd` must be started either with the `-P 1` option or inside `smb.conf` using `smbd profiling level`
--   `netdata` user needs to be able to sudo the `smbstatus` program without password
+- `smbstatus` program
+- `sudo` program
+- `smbd` must be compiled with profiling enabled
+- `smbd` must be started either with the `-P 1` option or inside `smb.conf` using `smbd profiling level`
+- `netdata` user needs to be able to sudo the `smbstatus` program without password
 
 It produces the following charts:
 
-1.  **Syscall R/Ws** in kilobytes/s
+1. **Syscall R/Ws** in kilobytes/s
 
-    -   sendfile
-    -   recvfile
+    - sendfile
+    - recvfile
 
-2.  **Smb2 R/Ws** in kilobytes/s
+2. **Smb2 R/Ws** in kilobytes/s
 
-    -   readout
-    -   writein
-    -   readin
-    -   writeout
+    - readout
+    - writein
+    - readin
+    - writeout
 
-3.  **Smb2 Create/Close** in operations/s
+3. **Smb2 Create/Close** in operations/s
 
-    -   create
-    -   close
+    - create
+    - close
 
-4.  **Smb2 Info** in operations/s
+4. **Smb2 Info** in operations/s
 
-    -   getinfo
-    -   setinfo
+    - getinfo
+    - setinfo
 
-5.  **Smb2 Find** in operations/s
+5. **Smb2 Find** in operations/s
 
-    -   find
+    - find
 
-6.  **Smb2 Notify** in operations/s
+6. **Smb2 Notify** in operations/s
 
-    -   notify
+    - notify
 
-7.  **Smb2 Lesser Ops** as counters
+7. **Smb2 Lesser Ops** as counters
 
-    -   tcon
-    -   negprot
-    -   tdis
-    -   cancel
-    -   logoff
-    -   flush
-    -   lock
-    -   keepalive
-    -   break
-    -   sessetup
+    - tcon
+    - negprot
+    - tdis
+    - cancel
+    - logoff
+    - flush
+    - lock
+    - keepalive
+    - break
+    - sessetup
 
 ## prerequisite
 
-This module uses `smbstatus` which can only be executed by root.  It uses
-`sudo` and assumes that it is configured such that the `netdata` user can
-execute `smbstatus` as root without password.
+This module uses `smbstatus` which can only be executed by root. It uses
+`sudo` and assumes that it is configured such that the `netdata` user can execute `smbstatus` as root without password.
 
 Add to `sudoers`:
 
@@ -81,8 +80,8 @@ netdata ALL=(root)       NOPASSWD: /path/to/smbstatus
 samba: yes
 ```
 
-Edit the `python.d/samba.conf` configuration file using `edit-config` from the Netdata [config
-directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
+Edit the `python.d/samba.conf` configuration file using `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different


### PR DESCRIPTION
##### Summary

Fixes: #10079
Fixes: #10430
Related #10201

We had a lot of issues with collectors that use `sudo` since we [hardened](https://github.com/netdata/netdata/pull/9234) our netdata systemd unit file.

Affected python collectors:
 - [adaptec_raid](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/adaptec_raid)
 - [hpssa](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/hpssa)
 - [megacli](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/megacli)
 - [samba](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/samba)

To make them working by defaul we need to add `CAP_SETGID`, `CAP_SETUID` and some others i am not aware of (perhaps specific per a collector). If i understand it correctly we don't want to add them to the default CapabilityBoundingSet @Ferroin 

This PR adds a note how to reset CapabilityBoundingSet. I stated that it is not an optimal solution, but it allows to get the collectors working!

In addition i applied auto format to the collectors readmes.

##### Component Name

`collectors/python.d/`

##### Test Plan

not needed

##### Additional Information
