### PR TITLE
add k8s_cluster_id host label

### DIFF
--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -2,17 +2,40 @@
 
 # Checks if netdata is running in a kubernetes pod and fetches that pod's labels
 
-if [ -n "${KUBERNETES_SERVICE_HOST}" ] && [ -n "${KUBERNETES_PORT_443_TCP_PORT}" ] && [ -n "${MY_POD_NAMESPACE}" ] && [ -n "${MY_POD_NAME}" ]; then
-	if command -v jq >/dev/null 2>&1; then
-			KUBE_TOKEN="$(</var/run/secrets/kubernetes.io/serviceaccount/token)"
-		URL="https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/$MY_POD_NAMESPACE/pods/$MY_POD_NAME"
-		curl -sSk -H "Authorization: Bearer $KUBE_TOKEN" "$URL" |
-		jq -r '.metadata.labels' | grep ':' | tr -d '," '
-		exit 0
-	else
-		echo "jq command not available. Please install jq to get host labels for kubernetes pods."
-		exit 1
-	fi
-else
-	exit 0
+if [ -z "${KUBERNETES_SERVICE_HOST}" ] || [ -z "${KUBERNETES_PORT_443_TCP_PORT}" ] || [ -z "${MY_POD_NAMESPACE}" ] || [ -z "${MY_POD_NAME}" ]; then
+  exit 0
 fi
+
+if ! command -v jq > /dev/null 2>&1; then
+  echo "jq command not available. Please install jq to get host labels for kubernetes pods."
+  exit 1
+fi
+
+TOKEN="$(< /var/run/secrets/kubernetes.io/serviceaccount/token)"
+HEADER="Authorization: Bearer $TOKEN"
+HOST="$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT"
+
+URL="https://$HOST/api/v1/namespaces/$MY_POD_NAMESPACE/pods/$MY_POD_NAME"
+if ! POD_DATA=$(curl -sSk -H "$HEADER" "$URL" 2>&1); then
+  echo "error on curl '${URL}': ${POD_DATA}."
+  exit 1
+fi
+
+URL="https://$HOST/api/v1/namespaces/kube-system"
+if ! KUBE_SYSTEM_NS_DATA=$(curl -sSk -H "$HEADER" "$URL" 2>&1); then
+  echo "error on curl '${URL}': ${KUBE_SYSTEM_NS_DATA}."
+  exit 1
+fi
+
+if ! POD_LABELS=$(jq -r '.metadata.labels' <<< "$POD_DATA" | grep ':' | tr -d '," ' 2>&1); then
+  echo "error on 'jq' parse pod data: ${POD_LABELS}."
+  exit 1
+fi
+
+if ! KUBE_SYSTEM_NS_UID=$(jq -r '.metadata.uid' <<< "$KUBE_SYSTEM_NS_DATA" 2>&1); then
+  echo "error on 'jq' parse kube_system_ns: ${KUBE_SYSTEM_NS_DATA}."
+  exit 1
+fi
+
+echo -e "$POD_LABELS" "\n" "cluster_id:$KUBE_SYSTEM_NS_UID"
+exit 0

--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -33,7 +33,7 @@ if ! POD_LABELS=$(jq -r '.metadata.labels' <<< "$POD_DATA" | grep ':' | tr -d ',
 fi
 
 if ! KUBE_SYSTEM_NS_UID=$(jq -r '.metadata.uid' <<< "$KUBE_SYSTEM_NS_DATA" 2>&1); then
-  echo "error on 'jq' parse kube_system_ns: ${KUBE_SYSTEM_NS_DATA}."
+  echo "error on 'jq' parse kube_system_ns: ${KUBE_SYSTEM_NS_UID}."
   exit 1
 fi
 

--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -37,5 +37,5 @@ if ! KUBE_SYSTEM_NS_UID=$(jq -r '.metadata.uid' <<< "$KUBE_SYSTEM_NS_DATA" 2>&1)
   exit 1
 fi
 
-echo -e "$POD_LABELS" "\n" "k8s_cluster_id:$KUBE_SYSTEM_NS_UID"
+echo -e "$POD_LABELS\nk8s_cluster_id:$KUBE_SYSTEM_NS_UID"
 exit 0

--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -37,5 +37,5 @@ if ! KUBE_SYSTEM_NS_UID=$(jq -r '.metadata.uid' <<< "$KUBE_SYSTEM_NS_DATA" 2>&1)
   exit 1
 fi
 
-echo -e "$POD_LABELS" "\n" "cluster_id:$KUBE_SYSTEM_NS_UID"
+echo -e "$POD_LABELS" "\n" "k8s_cluster_id:$KUBE_SYSTEM_NS_UID"
 exit 0


### PR DESCRIPTION
##### Summary

Fixes: netdata/product#1800

This PR extends [`get-kubernetes-labels.sh`](https://github.com/netdata/netdata/blob/master/daemon/get-kubernetes-labels.sh.in) script.

In addition to the pod labels it adds `k8s_cluster_id` label. Its value is kube-system namespace uid (immutable, not configurable by a user, unique value).

Now script does two http requests:

- `https://$HOST/api/v1/namespaces/$MY_POD_NAMESPACE/pods/$MY_POD_NAME`
- `https://$HOST/api/v1/namespaces/kube-system`

In case of any problems during http requests or during parsing responses it exits with code `1` and writes an error message to stdout.

```cmd
bash-5.0# ./get-kubernetes-labels.sh
app:netdata
controller-revision-hash:55d85f8f6b
pod-template-generation:7
release:netdata
role:child
k8s_cluster_id:a5a057ed-440d-11e9-ad4e-42010a80013a
```
  
##### Component Name

`daemon/`

##### Test Plan

- create a docker image
- install netdata in k8s cluster using test image
- verify `k8s_cluster_id` label in the host labels using `/api/v1/info` endpoint

```cmd
0 netdata (add_k8s_cluster_id_host_label)$ kubectl exec netdata-child-6bxgq -c netdata -- curl -s http://127.0.0.1:19999/api/v1/info | jq '.host_labels'
{
  ...
  "k8s_cluster_id": "a5a057ed-440d-11e9-ad4e-42010a80013a",
  "role": "child",
  "release": "netdata",
  "pod-template-generation": "8",
  "controller-revision-hash": "6968d6959",
  "app": "netdata"
}

0 netdata (add_k8s_cluster_id_host_label)$ kubectl exec netdata-child-cp8k9 -c netdata -- curl -s http://127.0.0.1:19999/api/v1/info | jq '.host_labels'
{
  ...
  "k8s_cluster_id": "a5a057ed-440d-11e9-ad4e-42010a80013a",
  "role": "child",
  "release": "netdata",
  "pod-template-generation": "8",
  "controller-revision-hash": "6968d6959",
  "app": "netdata"
}
```

##### Additional Information
