### PR TITLE
Add support for changing the number of pages per extent

### DIFF
--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -9,6 +9,8 @@ rrdeng_stats_t rrdeng_reserved_file_descriptors = 0;
 rrdeng_stats_t global_pg_cache_over_half_dirty_events = 0;
 rrdeng_stats_t global_flushing_pressure_page_deletions = 0;
 
+static unsigned pages_per_extent = MAX_PAGES_PER_EXTENT;
+
 static void sanity_check(void)
 {
     /* Magic numbers must fit in the super-blocks */
@@ -666,7 +668,7 @@ static int do_flush_pages(struct rrdengine_worker_config* wc, int force, struct 
          PValue = JudyLFirst(pg_cache->committed_page_index.JudyL_array, &Index, PJE0),
          descr = unlikely(NULL == PValue) ? NULL : *PValue ;
 
-         descr != NULL && count != MAX_PAGES_PER_EXTENT ;
+         descr != NULL && count != pages_per_extent ;
 
          PValue = JudyLNext(pg_cache->committed_page_index.JudyL_array, &Index, PJE0),
          descr = unlikely(NULL == PValue) ? NULL : *PValue) {
@@ -1031,6 +1033,21 @@ struct rrdeng_cmd rrdeng_deq_cmd(struct rrdengine_worker_config* wc)
     return ret;
 }
 
+static void load_configuration_dynamic(void)
+{
+    unsigned read_num;
+    static int printed_error = 0;
+
+    read_num = (unsigned) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine extent pages",
+                                                    MAX_PAGES_PER_EXTENT);
+    if (read_num > 0 && read_num <= MAX_PAGES_PER_EXTENT) {
+        pages_per_extent = read_num;
+    } else if (!printed_error) {
+        printed_error = 1;
+        error("Invalid dbengine extent pages %u given. Defaulting to %u.", read_num, pages_per_extent);
+    }
+}
+
 void async_cb(uv_async_t *handle)
 {
     uv_stop(handle->loop);
@@ -1084,6 +1101,7 @@ void timer_cb(uv_timer_t* handle)
             }
         }
     }
+    load_configuration_dynamic();
 #ifdef NETDATA_INTERNAL_CHECKS
     {
         char buf[4096];


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Add support for changing the number of dbengine pages per disk extent in `netdata.conf`. Also support changing dynamically during runtime.

##### Component Name
database/engine

##### Test Plan

Play around with `netdata.conf`. Default and maximum value is (Supported range 1-64):
```
[global]
  dbengine extent pages = 64
```

You can change it dynamically by executing:
```
netdatacli write-config 'netdata|global|dbengine extent pages|32'
```

You can only observe the difference after a lot of extents have been written to disk, and most of the database files have rotated. Small extents will have significantly larger metadata:data ratio and as a result much smaller retention period (metric history).

You can play around with various workloads and compare performance with default settings (e.g. export a snapshot from the dashboard).