### PR TITLE
collectors/proc: change ksm mem chart type to stacked

### DIFF
--- a/collectors/proc.plugin/sys_kernel_mm_ksm.c
+++ b/collectors/proc.plugin/sys_kernel_mm_ksm.c
@@ -110,7 +110,7 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
                     , PLUGIN_PROC_MODULE_KSM_NAME
                     , NETDATA_CHART_PRIO_MEM_KSM
                     , update_every
-                    , RRDSET_TYPE_AREA
+                    , RRDSET_TYPE_STACKED
             );
 
             rd_shared   = rrddim_add(st_mem_ksm, "shared",   NULL,      1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);


### PR DESCRIPTION

##### Summary

Fixes: #3327, see the issue for details. Thx to @jacekkolasa our dashboard now supports negative values on stacked charts.

ssia

Suggested by @Ferroin

##### Component Name

`collectors/proc`

##### Test Plan

Not needed

##### Additional Information
