### PR TITLE
Add a new workflow to test that updater works as expected

### DIFF
--- a/.github/scripts/build-dist.sh
+++ b/.github/scripts/build-dist.sh
@@ -3,6 +3,8 @@
 # Builds the netdata-vX.y.Z-xxxx.tar.gz source tarball (dist)
 
 set -e
+
+# shellcheck source=.github/scripts/functions.sh
 . "$(dirname "$0")/functions.sh"
 
 NAME="${NAME:-netdata}"

--- a/.github/scripts/build-dist.sh
+++ b/.github/scripts/build-dist.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# Builds the netdata-vX.y.Z-xxxx.tar.gz source tarball (dist)
+
+set -e
+. "$(dirname "$0")/functions.sh"
+
+NAME="${NAME:-netdata}"
+VERSION="${VERSION:-"$(git describe --always)"}"
+BASENAME="$NAME-$VERSION"
+
+prepare_build() {
+  progress "Preparing build"
+  (
+    test -d artifacts || mkdir -p artifacts
+    echo "${VERSION}" > packaging/version
+  ) >&2
+}
+
+build_dist() {
+  progress "Building dist"
+  (
+    command -v git > /dev/null && [ -d .git ] && git clean -d -f
+    autoreconf -ivf
+    ./configure \
+      --prefix=/usr \
+      --sysconfdir=/etc \
+      --localstatedir=/var \
+      --libexecdir=/usr/libexec \
+      --with-zlib \
+      --with-math \
+      --with-user=netdata \
+      CFLAGS=-O2
+    make dist
+    mv "${BASENAME}.tar.gz" artifacts/
+  ) >&2
+}
+
+prepare_assets() {
+  progress "Preparing assets"
+  (
+    cp packaging/version artifacts/latest-version.txt
+    cd artifacts || exit 1
+    ln -f "${BASENAME}.tar.gz" netdata-latest.tar.gz
+    ln -f "${BASENAME}.gz.run" netdata-latest.gz.run
+    sha256sum -b ./* > "sha256sums.txt"
+  ) >&2
+}
+
+steps="prepare_build build_dist prepare_assets"
+
+_main() {
+  for step in $steps; do
+    if ! run "$step"; then
+      if [ -t 1 ]; then
+        debug
+      else
+        fail "Build failed"
+      fi
+    fi
+  done
+
+  echo "🎉 All Done!"
+}
+
+if [ -n "$0" ] && [ x"$0" != x"-bash" ]; then
+  _main "$@"
+fi

--- a/.github/scripts/check-updater.sh
+++ b/.github/scripts/check-updater.sh
@@ -13,7 +13,7 @@ check_successfull_update() {
   (
     netdata_version=$(netdata -v | awk '{print $2}')
     updater_version=$(cat packaging/version)
-    if [ "$netdata_version" == "$netdata_version" ]; then
+    if [ "$netdata_version" == "$updater_version" ]; then
       echo "Update successfull!"
     else
       exit 1

--- a/.github/scripts/check-updater.sh
+++ b/.github/scripts/check-updater.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+set -e
+# shellcheck source=.github/scripts/functions.sh
+. "$(dirname "$0")/functions.sh"
+
+NAME="${NAME:-netdata}"
+VERSION="${VERSION:-"$(git describe --always)"}"
+BASENAME="$NAME-$VERSION"
+
+check_successfull_update() {
+  progress "Check netdata version after update"
+  (
+    netdata_version=$(netdata -v | awk '{print $2}')
+    updater_version=$(cat packaging/version)
+    if [ "$netdata_version" == "$netdata_version" ]; then
+      echo "Update successfull!"
+    else
+      exit 1
+    fi
+  ) >&2
+}
+
+steps="check_successfull_update"
+
+_main() {
+  for step in $steps; do
+    if ! run "$step"; then
+      if [ -t 1 ]; then
+        debug
+      else
+        fail "Build failed"
+      fi
+    fi
+  done
+
+  echo "🎉 All Done!"
+}
+
+if [ -n "$0" ] && [ x"$0" != x"-bash" ]; then
+  _main "$@"
+fi

--- a/.github/scripts/check-updater.sh
+++ b/.github/scripts/check-updater.sh
@@ -4,16 +4,12 @@ set -e
 # shellcheck source=.github/scripts/functions.sh
 . "$(dirname "$0")/functions.sh"
 
-NAME="${NAME:-netdata}"
-VERSION="${VERSION:-"$(git describe --always)"}"
-BASENAME="$NAME-$VERSION"
-
 check_successfull_update() {
   progress "Check netdata version after update"
   (
     netdata_version=$(netdata -v | awk '{print $2}')
     updater_version=$(cat packaging/version)
-    if [ "$netdata_version" == "$updater_version" ]; then
+    if [ "$netdata_version" = "$updater_version" ]; then
       echo "Update successfull!"
     else
       exit 1

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -50,7 +50,6 @@ jobs:
           NEW_CHECKSUM="export NETDATA_TARBALL_CHECKSUM_URL=http://localhost:8080/artifacts/sha256sums.txt"
           sed -i "s|${ORIG_TARBALL}|${NEW_TARBALL}|g" packaging/installer/netdata-updater.sh
           sed -i "s|${ORIG_CHECKSUM}|${NEW_CHECKSUM}|g" packaging/installer/netdata-updater.sh
-          sed -i "s|"current_version=.*"|"current_version=1"|g" packaging/installer/netdata-updater.sh
       - name: Install netdata and run the updater on ${{ matrix.distro }}
         env:
           PRE: ${{ matrix.pre }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -2,9 +2,12 @@
 name: Updater
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+
 jobs:
   source-build:
     name: Install, Build & Update
@@ -14,6 +17,12 @@ jobs:
         distro:
           - 'debian:10'
           - 'fedora:33'
+          - 'ubuntu:20.10'
+          - 'alpine:3.13'
+          - 'archlinux:latest'
+          - 'centos:8'
+          - 'clearlinux:latest'
+          - 'opensuse/tumbleweed:latest'
     runs-on: ubuntu-latest
     steps:
       - name: Install netdata latest
@@ -30,12 +39,22 @@ jobs:
         run: |
           ORIG_TARBALL="export NETDATA_TARBALL_URL=.*"
           ORIG_CHECKSUM="export NETDATA_TARBALL_CHECKSUM_URL=.*"
+          CURRENT_VERSION="current_version=.*"
           NEW_TARBALL="export NETDATA_TARBALL_URL=http://localhost:8080/artifacts/netdata-latest.tar.gz"
           NEW_CHECKSUM="export NETDATA_TARBALL_CHECKSUM_URL=http://localhost:8080/artifacts/sha256sums.txt"
           sed -i "s|${ORIG_TARBALL}|${NEW_TARBALL}|g" packaging/installer/netdata-updater.sh
           sed -i "s|${ORIG_CHECKSUM}|${NEW_CHECKSUM}|g" packaging/installer/netdata-updater.sh
+          sed -i "s|"current_version=.*"|"current_version=1"|g" packaging/installer/netdata-updater.sh
       - name: Run the updater
         run: |
-          netdata -V
-          sudo ./packaging/installer/netdata-updater.sh
-          netdata -V
+          sudo netdata -v
+          sudo ./packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update
+          sudo netdata -v
+          cat ./packaging/version
+          updater_version=$(cat packaging/version)
+          if [[ $(netdata -v | awk '{print $2}') == "${updater_version}" ]];
+          then
+            echo "Update successfull!"
+          else
+            exit 1
+          fi

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -50,6 +50,7 @@ jobs:
           NEW_CHECKSUM="export NETDATA_TARBALL_CHECKSUM_URL=http://localhost:8080/artifacts/sha256sums.txt"
           sed -i "s|${ORIG_TARBALL}|${NEW_TARBALL}|g" packaging/installer/netdata-updater.sh
           sed -i "s|${ORIG_CHECKSUM}|${NEW_CHECKSUM}|g" packaging/installer/netdata-updater.sh
+          sed -i "s|"current_version=.*"|"current_version=1"|g" packaging/installer/netdata-updater.sh
       - name: Install netdata and run the updater on ${{ matrix.distro }}
         env:
           PRE: ${{ matrix.pre }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -1,0 +1,41 @@
+---
+name: Updater
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  source-build:
+    name: Install, Build & Update
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - 'debian:10'
+          - 'fedora:33'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install netdata latest
+        run: bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait
+      - name: Git clone repository
+        uses: actions/checkout@v2
+      - name: Build tarball
+        run: |
+          .github/scripts/build-dist.sh
+      - name: Run a dockerised web server to serve files used by the update script
+        run: |
+          docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
+      - name: Replace URLs in updater script to point at the local web server
+        run: |
+          ORIG_TARBALL="export NETDATA_TARBALL_URL=.*"
+          ORIG_CHECKSUM="export NETDATA_TARBALL_CHECKSUM_URL=.*"
+          NEW_TARBALL="export NETDATA_TARBALL_URL=http://localhost:8080/artifacts/netdata-latest.tar.gz"
+          NEW_CHECKSUM="export NETDATA_TARBALL_CHECKSUM_URL=http://localhost:8080/artifacts/sha256sums.txt"
+          sed -i "s|${ORIG_TARBALL}|${NEW_TARBALL}|g" packaging/installer/netdata-updater.sh
+          sed -i "s|${ORIG_CHECKSUM}|${NEW_CHECKSUM}|g" packaging/installer/netdata-updater.sh
+      - name: Run the updater
+        run: |
+          netdata -V
+          sudo ./packaging/installer/netdata-updater.sh
+          netdata -V

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -16,23 +16,29 @@ jobs:
       matrix:
         distro:
           - 'debian:10'
-          - 'fedora:33'
           - 'ubuntu:20.10'
           - 'alpine:3.13'
-          - 'archlinux:latest'
           - 'centos:8'
           - 'clearlinux:latest'
-          - 'opensuse/tumbleweed:latest'
+          - 'fedora:33'
+        include:
+          - distro: 'alpine:3.13'
+            pre: 'apk add -U bash'
+          - distro: 'centos:8'
+            rmjsonc: 'dnf remove -y json-c-devel'
+          - distro: 'debian:10'
+            pre: 'apt-get update'
+          - distro: 'ubuntu:20.10'
+            pre: 'apt-get update'
     runs-on: ubuntu-latest
     steps:
-      - name: Install netdata latest
-        run: bash <(curl -Ss https://my-netdata.io/kickstart.sh) --dont-wait
       - name: Git clone repository
         uses: actions/checkout@v2
-      - name: Build tarball
+      - name: Install required packages & build tarball
         run: |
+          ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata-all
           .github/scripts/build-dist.sh
-      - name: Run a dockerised web server to serve files used by the update script
+      - name: Run a dockerised web server to serve files used by the custom update script
         run: |
           docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4
       - name: Replace URLs in updater script to point at the local web server
@@ -45,16 +51,13 @@ jobs:
           sed -i "s|${ORIG_TARBALL}|${NEW_TARBALL}|g" packaging/installer/netdata-updater.sh
           sed -i "s|${ORIG_CHECKSUM}|${NEW_CHECKSUM}|g" packaging/installer/netdata-updater.sh
           sed -i "s|"current_version=.*"|"current_version=1"|g" packaging/installer/netdata-updater.sh
-      - name: Run the updater
+      - name: Install netdata and run the updater on ${{ matrix.distro }}
+        env:
+          PRE: ${{ matrix.pre }}
         run: |
-          sudo netdata -v
-          sudo ./packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update
-          sudo netdata -v
-          cat ./packaging/version
-          updater_version=$(cat packaging/version)
-          if [[ $(netdata -v | awk '{print $2}') == "${updater_version}" ]];
-          then
-            echo "Update successfull!"
-          else
-            exit 1
-          fi
+          echo $PRE > ./prep-cmd.sh
+          docker build . -f .github/dockerfiles/Dockerfile.build_test -t test --build-arg BASE=${{ matrix.distro }}
+          docker run --network host -w /netdata test \
+              /bin/sh -c '/netdata/packaging/installer/kickstart.sh --dont-wait \
+              && /netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update \
+              && bash /netdata/.github/scripts/check-updater.sh'


### PR DESCRIPTION
Add workflow for installing latest version of netdata, building from source of this branch & running the updater. Add script build-dist to create the artifacts used for the update.

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

We add a new pipeline, meant to run in PRs and merges to master, that uses the kickstart script to install the latest version of netdata, then checkout the branch of the PR, build netdata and update to this version of the agent. 

##### Component Name

##### Test Plan

Currently the pipeline has been tested for latest Debian and Fedora, more distributions will be added in the near future, along with more checks regarding the updater's behavior.  

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
