### PR TITLE
add stats per cloud query type

### DIFF
--- a/aclk/legacy/aclk_query.c
+++ b/aclk/legacy/aclk_query.c
@@ -62,6 +62,7 @@ static void aclk_query_free(struct aclk_query *this_query)
         freez(this_query->query);
     if(this_query->data && this_query->cmd == ACLK_CMD_CLOUD_QUERY_2) {
         struct aclk_cloud_req_v2 *del = (struct aclk_cloud_req_v2 *)this_query->data;
+        freez(del->query_endpoint);
         freez(del->data);
         freez(del);
     }

--- a/aclk/legacy/aclk_query.h
+++ b/aclk/legacy/aclk_query.h
@@ -31,6 +31,7 @@ struct aclk_query_threads {
 struct aclk_cloud_req_v2 {
     char *data;
     RRDHOST *host;
+    char *query_endpoint;
 };
 
 void *aclk_query_main_thread(void *ptr);

--- a/aclk/legacy/aclk_stats.c
+++ b/aclk/legacy/aclk_stats.c
@@ -190,7 +190,7 @@ static void aclk_stats_cloud_req_version(struct aclk_metrics_per_sample *per_sam
     if (unlikely(!st)) {
         st = rrdset_create_localhost(
             "netdata", "aclk_cloud_req_version", NULL, "aclk", NULL, "Requests received from cloud by their version", "req/s",
-            "netdata", "stats", 200005, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
+            "netdata", "stats", 200006, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
         rd_rq_v1 = rrddim_add(st, "v1",  NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
         rd_rq_v2 = rrddim_add(st, "v2+", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
@@ -233,7 +233,7 @@ static void aclk_stats_cloud_req_cmd(struct aclk_metrics_per_sample *per_sample)
         initialized = 1;
         st = rrdset_create_localhost(
             "netdata", "aclk_cloud_req_cmd", NULL, "aclk", NULL, "Requests received from cloud by their type (api endpoint queried)", "req/s",
-            "netdata", "stats", 200005, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
+            "netdata", "stats", 200007, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
         for (int i = 0; i < ACLK_STATS_CLOUD_REQ_TYPE_CNT; i++)
             rd_rq_types[i] = rrddim_add(st, cloud_req_type_names[i], NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
@@ -256,7 +256,7 @@ static void aclk_stats_query_threads(uint32_t *queries_per_thread)
     if (unlikely(!st)) {
         st = rrdset_create_localhost(
             "netdata", "aclk_query_threads", NULL, "aclk", NULL, "Queries Processed Per Thread", "req/s",
-            "netdata", "stats", 200007, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
+            "netdata", "stats", 200008, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
         for (int i = 0; i < query_thread_count; i++) {
             if (snprintf(dim_name, MAX_DIM_NAME, "Query %d", i) < 0)
@@ -309,7 +309,7 @@ static void aclk_stats_cpu_threads(void)
 
             aclk_cpu_data[i].st = rrdset_create_localhost(
                                          "netdata", id, NULL, "aclk", NULL, title, "milliseconds/s",
-                                         "netdata", "stats", 200008 + i, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
+                                         "netdata", "stats", 200020 + i, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
             aclk_cpu_data[i].user   = rrddim_add(aclk_cpu_data[i].st, "user",   NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
             aclk_cpu_data[i].system = rrddim_add(aclk_cpu_data[i].st, "system", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);

--- a/aclk/legacy/aclk_stats.h
+++ b/aclk/legacy/aclk_stats.h
@@ -55,6 +55,11 @@ extern struct aclk_mat_metrics {
 
 void aclk_metric_mat_update(struct aclk_metric_mat_data *metric, usec_t measurement);
 
+#define ACLK_STATS_CLOUD_REQ_TYPE_CNT 7
+// if you change update cloud_req_type_names
+
+int aclk_cloud_req_type_to_idx(const char *name);
+
 // reset to 0 on every sample
 extern struct aclk_metrics_per_sample {
     /* in the unlikely event of ACLK disconnecting
@@ -72,8 +77,13 @@ extern struct aclk_metrics_per_sample {
     volatile uint32_t read_q_added;
     volatile uint32_t read_q_consumed;
 
-    volatile uint32_t cloud_req_recvd;
+    volatile uint32_t cloud_req_ok;
     volatile uint32_t cloud_req_err;
+
+    volatile uint16_t cloud_req_v1;
+    volatile uint16_t cloud_req_v2;
+
+    volatile uint16_t cloud_req_by_type[ACLK_STATS_CLOUD_REQ_TYPE_CNT];
 
 #ifdef NETDATA_INTERNAL_CHECKS
     struct aclk_metric_mat_data latency;


### PR DESCRIPTION
##### Summary
`http` cloud query can query different `/api/v1/info` endpoints. Add chart counting how many queries of each type have been requested by the cloud.

##### Component Name
ACLK

##### Test Plan
Look at the new charts through the cloud (you need to have through cloud traffic to see anything)
##### Additional Information
