### PR TITLE
Assorted updater fixes.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -116,7 +116,7 @@ _cannot_use_tmpdir() {
 
 create_tmp_directory() {
   if [ -n "${NETDATA_TMPDIR_PATH}" ]; then
-    TMPDIR="${NETDATA_TMPDIR_PATH}"
+    echo "${NETDATA_TMPDIR_PATH}"
   else
     if [ -z "${NETDATA_TMPDIR}" ] || _cannot_use_tmpdir "${NETDATA_TMPDIR}" ; then
       if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -204,7 +204,7 @@ self_update() {
     if _safe_download "https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/netdata-updater.sh" ./netdata-updater.sh; then
       chmod +x ./netdata-updater.sh || exit 1
       export ENVIRONMENT_FILE="${ENVIRONMENT_FILE}"
-      exec ./netdata-updater.sh --not-running-from-cron --no-self-update --tmpdir-path "$(pwd)" 
+      exec ./netdata-updater.sh --not-running-from-cron --no-updater-self-update --tmpdir-path "$(pwd)"
     else
       echo >&3 "Failed to download newest version of updater script, continuing with current version."
     fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -314,8 +314,10 @@ update() {
       do_not_start="--dont-start-it"
     fi
 
+    env="TMPDIR='${TMPDIR}'"
+
     if [ -n "${NETDATA_SELECTED_DASHBOARD}" ]; then
-      env="NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
+      env="${env} NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
     fi
 
     if [ ! -x ./netdata-installer.sh ]; then


### PR DESCRIPTION
##### Summary

This fixes three issues in the updater:

* Fixed handling of the `NETDATA_TMPDIR_PATH` value passed to the script when it’s been re-invoked after a self-update. This bug was causing the `create_tmp_directory` function to not output anything if this variable was set, causing the update process to fail if the updater script had self-updated.
* Fixed the name of an option passed during re-invocation of the updater after a self-update. This bug was causing the updater to make spurious update checks, wasting time and bandwidth as well as producing unnecessary output from the script.
* Fixed handing of the temporary directory WRT the installer script when invoked from the updater. We were previously just letting the installer inherit the value of `TMPDIR` from the environment, but we need to explicitly pass it in to allow the installer to properly use any saved temporary directory being used by the updater. This bug was causing installs with custom values for `TMPDIR` to not update correctly. 

##### Component Name

area/packaging

##### Test Plan

Behavioral changes verified locally.

##### Additional Information

Fixes: #10606 

Relevant to: #10128 

@cakrit Two of the three fixes here are resolving failures to update, the third is a (mostly) harmless change to bring the updater’s self-updating behavior in line with what it originally should have been. I’ve manually verified all three locally using the same functional sequence of steps as the CI jobs that @kaskavel is working on for verifying the updater.