### PR TITLE
Fix crash during shutdown of cgroups internal plugin.

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -3937,9 +3937,10 @@ static void cgroup_main_cleanup(void *ptr) {
 
     if (!discovery_thread.exited) {
         info("stopping discovery thread worker");
-        uv_mutex_unlock(&discovery_thread.mutex);
+        uv_mutex_lock(&discovery_thread.mutex);
         discovery_thread.start_discovery = 1;
         uv_cond_signal(&discovery_thread.cond_var);
+        uv_mutex_unlock(&discovery_thread.mutex);
     }
 
     while (!discovery_thread.exited && max > 0) {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #10611
##### Component Name
collectors
##### Test Plan
Compile netdata in Alpine Linux 3.12 with musl libC. Observe crash during shutdown if the `cgroups` collector is enabled. This PR should not crash in that scenario.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->