### PR TITLE
Fixed handling of Docker image tags for release builds.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ on:
     inputs:
       version:
         name: Version Tag
-        default: latest
+        default: nightly
         required: true
 jobs:
   docker-build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -353,7 +353,9 @@ jobs:
       after_failure: post_message "TRAVIS_MESSAGE" "<!here> Draft release submission failed"
 
     - name: Trigger Docker image build and publish
-      script: .travis/trigger_docker_build.sh "${GITHUB_TOKEN}" "${BUILD_VERSION}"
+      script:
+        - git checkout "${TRAVIS_BRANCH}" && export BUILD_VERSION="$(cat packaging/version | cut -d'-' -f1)"
+        - .travis/trigger_docker_build.sh "${GITHUB_TOKEN}" "${BUILD_VERSION}"
       after_failure: post_message "TRAVIS_MESSAGE" "<!here> Failed to trigger docker build during release" "${NOTIF_CHANNEL}"
 
     - stage: Trigger deb and rpm package build (release)


### PR DESCRIPTION
##### Summary

This fixes the handling of docker image tags for release bilds, ensuring that we actually get the current version of the repo correctly so that we don’t overwrite older images.

It also fixes the default value for the version parameter for the workflow that actually does the builds.

##### Component Name

area/ci