### PR TITLE
Disable stock alarms

### DIFF
--- a/health/health_config.c
+++ b/health/health_config.c
@@ -1026,9 +1026,10 @@ void health_readdir(RRDHOST *host, const char *user_path, const char *stock_path
     int stock_enabled = (int)config_get_boolean(CONFIG_SECTION_HEALTH, "enable stock health configuration",
                                                 CONFIG_BOOLEAN_YES);
 
-    if (!stock_enabled)
+    if (!stock_enabled) {
         info("Netdata will not load stock alarms.");
+        stock_path = user_path;
+    }
 
-    const char *stock_arg = (stock_enabled)?stock_path:user_path;
-    recursive_config_double_dir_load(user_path, stock_arg, subpath, health_readfile, (void *) host, 0);
+    recursive_config_double_dir_load(user_path, stock_path, subpath, health_readfile, (void *) host, 0);
 }

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -1023,5 +1023,12 @@ void health_readdir(RRDHOST *host, const char *user_path, const char *stock_path
         return;
     }
 
-    recursive_config_double_dir_load(user_path, stock_path, subpath, health_readfile, (void *) host, 0);
+    int stock_enabled = (int)config_get_boolean(CONFIG_SECTION_HEALTH, "enable stock health configuration",
+                                                CONFIG_BOOLEAN_YES);
+
+    if (!stock_enabled)
+        info("Netdata will not load stock alarms.");
+
+    const char *stock_arg = (stock_enabled)?stock_path:user_path;
+    recursive_config_double_dir_load(user_path, stock_arg, subpath, health_readfile, (void *) host, 0);
 }

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1406,7 +1406,7 @@ void recursive_config_double_dir_load(const char *user_path, const char *stock_p
     if (!dir) {
         error("CONFIG cannot open stock config directory '%s'.", sdir);
     }
-    else {
+    else if (strcmp(udir, sdir)) {
         struct dirent *de = NULL;
         while((de = readdir(dir))) {
             if(de->d_type == DT_DIR || de->d_type == DT_LNK) {


### PR DESCRIPTION
##### Summary
Fixes #8641 

This PR brings new option to disable stock alarms when it is necessary.

@underhood I am bringing a fix that you requested, but it is necessary to clarify something, I had a request from to @ktsaou to avoid `negative` variables inside our configuration files as you suggested, so I had to change the variable name.

##### Component Name
Health
##### Test Plan

1 - Edit your `netdata.conf`

``` 
[health]
    enable stock health configuration = yes
```

2 - Compile this branch
3 - Start Netdata and confirm that all alarms are present using the request `http://localhost:19999/api/v1/alarms?all`.
4 - Stop Netdata ans change the new variable ( `enable stock health configuration = yes` )
5 - Start Netdata and do another request `http://localhost:19999/api/v1/alarms?all`, this time only alarms listed at `/etc/netdata/health.d` should be loaded.

##### Additional Information
