### PR TITLE
Add ACLK proxy setting as host label

### DIFF
--- a/aclk/legacy/aclk_common.c
+++ b/aclk/legacy/aclk_common.c
@@ -234,3 +234,26 @@ int aclk_decode_base_url(char *url, char **aclk_hostname, int *aclk_port)
     info("Setting ACLK target host=%s port=%d from %s", *aclk_hostname, *aclk_port, url);
     return 0;
 }
+
+struct label *add_aclk_host_labels(struct label *label) {
+    #ifdef ENABLE_ACLK
+        ACLK_PROXY_TYPE aclk_proxy;
+        char *proxy_str;
+        aclk_get_proxy(&aclk_proxy);
+
+        switch(aclk_proxy) {
+            case PROXY_TYPE_SOCKS5:
+                proxy_str = "SOCKS5";
+                break;
+            case PROXY_TYPE_HTTP:
+                proxy_str = "HTTP";
+                break;
+            default:
+                proxy_str = "none";
+                break;
+        }
+        return add_label_to_list(label, "_aclk_proxy", proxy_str, LABEL_SOURCE_AUTO);
+    #else
+        return label;
+    #endif
+}

--- a/aclk/legacy/aclk_common.c
+++ b/aclk/legacy/aclk_common.c
@@ -236,24 +236,24 @@ int aclk_decode_base_url(char *url, char **aclk_hostname, int *aclk_port)
 }
 
 struct label *add_aclk_host_labels(struct label *label) {
-    #ifdef ENABLE_ACLK
-        ACLK_PROXY_TYPE aclk_proxy;
-        char *proxy_str;
-        aclk_get_proxy(&aclk_proxy);
+#ifdef ENABLE_ACLK
+    ACLK_PROXY_TYPE aclk_proxy;
+    char *proxy_str;
+    aclk_get_proxy(&aclk_proxy);
 
-        switch(aclk_proxy) {
-            case PROXY_TYPE_SOCKS5:
-                proxy_str = "SOCKS5";
-                break;
-            case PROXY_TYPE_HTTP:
-                proxy_str = "HTTP";
-                break;
-            default:
-                proxy_str = "none";
-                break;
-        }
-        return add_label_to_list(label, "_aclk_proxy", proxy_str, LABEL_SOURCE_AUTO);
-    #else
-        return label;
-    #endif
+    switch(aclk_proxy) {
+        case PROXY_TYPE_SOCKS5:
+            proxy_str = "SOCKS5";
+            break;
+        case PROXY_TYPE_HTTP:
+            proxy_str = "HTTP";
+            break;
+        default:
+            proxy_str = "none";
+            break;
+    }
+    return add_label_to_list(label, "_aclk_proxy", proxy_str, LABEL_SOURCE_AUTO);
+#else
+    return label;
+#endif
 }

--- a/aclk/legacy/aclk_common.h
+++ b/aclk/legacy/aclk_common.h
@@ -67,4 +67,6 @@ void safe_log_proxy_censor(char *proxy);
 int aclk_decode_base_url(char *url, char **aclk_hostname, int *aclk_port);
 const char *aclk_get_proxy(ACLK_PROXY_TYPE *type);
 
+struct label *add_aclk_host_labels(struct label *label);
+
 #endif //ACLK_COMMON_H

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -986,6 +986,8 @@ static struct label *rrdhost_load_auto_labels(void)
         label_list =
             add_label_to_list(label_list, "_is_k8s_node", localhost->system_info->is_k8s_node, LABEL_SOURCE_AUTO);
 
+    label_list = add_aclk_host_labels(label_list);
+
     label_list = add_label_to_list(
         label_list, "_is_parent", (localhost->next || configured_as_parent()) ? "true" : "false", LABEL_SOURCE_AUTO);
 


### PR DESCRIPTION
##### Summary
Add ACLK proxy setting as label.

##### Component Name
ACLK

##### Test Plan
Set different ACLK proxies and check `/api/v1/info`
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
