### PR TITLE
add freeswitch to apps_groups

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -312,3 +312,5 @@ factorio: factorio
 p4: p4*
 
 git-services: gitea gitlab-runner
+
+freeswitch: freeswitch*


### PR DESCRIPTION
##### Summary

Add freeswitch to apps_groups.conf to regroup [freeswitch servers](https://en.wikipedia.org/wiki/FreeSWITCH) under its own value and not as "others"

##### Component Name

collector / apps.plugin

##### Test Plan

![fs](https://user-images.githubusercontent.com/11300056/107628343-cdc78f80-6c60-11eb-87b5-d15fcfd4b5aa.jpg)

##### Additional Information

Freeswitch processes includes `freeswitch` and `freeswitch-license-server`