### PR TITLE
fix sendmail unrecognized option F error

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -855,7 +855,7 @@ send_email() {
     fi
 
     [ -n "${sender_email}" ] && opts+=(-f "${sender_email}")
-    [ -n "${sender_name}" ] && opts+=(-F "${sender_name}")
+    [ -n "${sender_name}" ] && sendmail --help 2>&1 | grep -q "\-F " && opts+=(-F "${sender_name}")
 
     if [ "${debug}" = "1" ]; then
       echo >&2 "--- BEGIN sendmail command ---"
@@ -2054,7 +2054,7 @@ send_dynatrace() {
   local dynatrace_url="${DYNATRACE_SERVER}/e/${DYNATRACE_SPACE}/api/v1/events"
   local description="NetData Notification for: ${host} ${chart}.${name} is ${status}"
   local payload=""
-  
+
   payload=$(cat <<EOF
 {
   "title": "NetData Alarm from ${host}",


### PR DESCRIPTION
##### Summary

Fixes: #10630

Netdata's docker image `sendmail` has not `-F` option.

<details>
<summary>sendmail -F output click click </summary>

```cmd
[ilyam@pc ~]$ docker exec -it lucid_kilby netdata -v
netdata v1.29.1

[ilyam@pc ~]$ docker exec -it lucid_kilby sendmail -F
sendmail: unrecognized option: F
BusyBox v1.31.1 () multi-call binary.

Usage: sendmail [-tv] [-f SENDER] [-amLOGIN 4<user_pass.txt | -auUSER -apPASS]
		[-w SECS] [-H 'PROG ARGS' | -S HOST] [RECIPIENT_EMAIL]...

Read email from stdin and send it

Standard options:
	-t		Read additional recipients from message body
	-f SENDER	For use in MAIL FROM:<sender>. Can be empty string
			Default: -auUSER, or username of current UID
	-o OPTIONS	Various options. -oi implied, others are ignored
	-i		-oi synonym, implied and ignored

Busybox specific options:
	-v		Verbose
	-w SECS		Network timeout
	-H 'PROG ARGS'	Run connection helper. Examples:
		openssl s_client -quiet -tls1 -starttls smtp -connect smtp.gmail.com:25
		openssl s_client -quiet -tls1 -connect smtp.gmail.com:465
			$SMTP_ANTISPAM_DELAY: seconds to wait after helper connect
	-S HOST[:PORT]	Server (default $SMTPHOST or 127.0.0.1)
	-amLOGIN	Log in using AUTH LOGIN
	-amPLAIN	or AUTH PLAIN
			(-amCRAM-MD5 not supported)
	-auUSER		Username for AUTH
	-apPASS 	Password for AUTH

If no -a options are given, authentication is not done.
If -amLOGIN is given but no -au/-ap, user/password is read from fd #4.
Other options are silently ignored; -oi is implied.
Use makemime to create emails with attachments.
```

</details>

Fix: grep sendmail help output. Perhaps there is better way to do it, this one feels hacky.
 


##### Component Name

`health/`

##### Test Plan

```cmd
bash-5.0# sendmail --help 2>&1 | grep -q "\-F " && echo 1
bash-5.0# sendmail --help 2>&1 | grep -q "\-f " && echo 1
1
```


##### Additional Information
