### PR TITLE
Change the data query with context to exclude archived charts

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -504,9 +504,11 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
 
         rrdhost_rdlock(host);
         rrdset_foreach_read(st1, host) {
-            if (st1->hash_context == context_hash && !strcmp(st1->context, context) &&
-                (!chart_label_key || rrdset_contains_label_keylist(st1, chart_label_key)))
-                build_context_param_list(&context_param_list, st1);
+            if (likely(!rrdset_flag_check(st1, RRDSET_FLAG_ARCHIVED))) {
+                if (st1->hash_context == context_hash && !strcmp(st1->context, context) &&
+                    (!chart_label_key || rrdset_contains_label_keylist(st1, chart_label_key)))
+                    build_context_param_list(&context_param_list, st1);
+            }
         }
         rrdhost_unlock(host);
         if (likely(context_param_list && context_param_list->rd))  // Just set the first one


### PR DESCRIPTION
##### Summary
When a data query with the context parameter is given, do not match the archived charts (because
the archived charts do not appear in the /api/v1/charts this currently causes problems)

##### Component Name
database

##### Test Plan
- Should be trivial to verify the code

or

- Start collector with charts having a known context
  - Run a data query with a context parameter
  - Schedule for one of more of the charts in that context to be archived (stop collecting)
  - Run the data query with the context parameter again
    - You should observe the chart is not returned

or

- Starting and stopping k8s pods will cause charts to be obsoleted and archived (do not restart the agent)
  - Make sure to set a low value for chart obsoletion (`cleanup obsolete charts after seconds`)
  - Start a few pods
  - Run a data query with a context parameter and chart_label_key
  - Stop pods
  - Wait `cleanup obsolete charts after seconds` seconds
  - Start more pods
  - Run a data query with a context parameter and chart_label_key again
    - The data query should not include the archived charts

