### PR TITLE
collectors/proc: fix collecting operstate for virtual network interfaces

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -590,10 +590,9 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
                 snprintfz(buffer, FILENAME_MAX, path_to_sys_class_net_duplex, d->name);
                 d->filename_duplex = strdupz(buffer);
-
-                snprintfz(buffer, FILENAME_MAX, path_to_sys_class_net_operstate, d->name);
-                d->filename_operstate = strdupz(buffer);
             }
+            snprintfz(buffer, FILENAME_MAX, path_to_sys_class_net_operstate, d->name);
+            d->filename_operstate = strdupz(buffer);
 
             snprintfz(buffer, FILENAME_MAX, "plugin:proc:/proc/net/dev:%s", d->name);
             d->enabled = config_get_boolean_ondemand(buffer, "enabled", d->enabled);


### PR DESCRIPTION
##### Summary

Fixes: #10628

For some reason we don't collect `operstate` (`/sys/class/net/<DEV>/operstate`) for virtual interfaces. This PR fixes it.

##### Component Name

`collectors/proc`

##### Test Plan

Install this PR, ensure virtual interfaces Bandwidth charts contain `operstate` variable.


##### Additional Information
