### PR TITLE
Validate JSON values in health code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,7 @@ set(LIBNETDATA_FILES
         libnetdata/json/jsmn.h
         libnetdata/health/health.c
         libnetdata/health/health.h
+        libnetdata/string/utf8.c
         libnetdata/string/utf8.h
         libnetdata/socket/security.c
         libnetdata/socket/security.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -188,6 +188,7 @@ LIBNETDATA_FILES = \
     libnetdata/json/jsmn.h \
     libnetdata/health/health.c \
     libnetdata/health/health.h \
+    libnetdata/string/utf8.c \
     libnetdata/string/utf8.h \
     $(NULL)
 

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -2,6 +2,7 @@
 
 #include "health.h"
 #include "libnetdata/libnetdata.h"
+#include <stdbool.h>
 
 #define BOOL_STR(x)         (x) ? "true" : "false";
 #define DEFAULT_STR(x, y)   (x) ? (x) : (y);

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -1,92 +1,129 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "health.h"
+#include "libnetdata/libnetdata.h"
 
-static inline void health_string2json(BUFFER *wb, const char *prefix, const char *label, const char *value, const char *suffix) {
-    if(value && *value) {
-        buffer_sprintf(wb, "%s\"%s\":\"", prefix, label);
-        buffer_strcat_htmlescape(wb, value);
-        buffer_strcat(wb, "\"");
-        buffer_strcat(wb, suffix);
+#define BOOL_STR(x)         (x) ? "true" : "false";
+#define DEFAULT_STR(x, y)   (x) ? (x) : (y);
+
+static void
+health_kv_html_escape(BUFFER *wb, const char *key, const char *value,
+               const char *prefix, const char *suffix)
+{
+    if (!value || !*value) {
+        buffer_sprintf(wb, "%s\"%s\": null%s", prefix, key, suffix);
+        return;
     }
-    else
-        buffer_sprintf(wb, "%s\"%s\":null%s", prefix, label, suffix);
+
+    if (utf8_check(value)) {
+        error("Found malformed utf8 string for key %s", key);
+        value = "malformed_utf8_string";
+    }
+
+    buffer_sprintf(wb, "%s\"%s\": \"", prefix, key);
+    buffer_strcat_htmlescape(wb, value);
+    buffer_strcat(wb, "\"");
+    buffer_strcat(wb, suffix);
 }
 
-inline void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) {
-    buffer_sprintf(wb,
-            "\n\t{\n"
-                    "\t\t\"hostname\": \"%s\",\n"
-                    "\t\t\"unique_id\": %u,\n"
-                    "\t\t\"alarm_id\": %u,\n"
-                    "\t\t\"alarm_event_id\": %u,\n"
-                    "\t\t\"name\": \"%s\",\n"
-                    "\t\t\"chart\": \"%s\",\n"
-                    "\t\t\"family\": \"%s\",\n"
-                    "\t\t\"processed\": %s,\n"
-                    "\t\t\"updated\": %s,\n"
-                    "\t\t\"exec_run\": %lu,\n"
-                    "\t\t\"exec_failed\": %s,\n"
-                    "\t\t\"exec\": \"%s\",\n"
-                    "\t\t\"recipient\": \"%s\",\n"
-                    "\t\t\"exec_code\": %d,\n"
-                    "\t\t\"source\": \"%s\",\n"
-                    "\t\t\"units\": \"%s\",\n"
-                    "\t\t\"when\": %lu,\n"
-                    "\t\t\"duration\": %lu,\n"
-                    "\t\t\"non_clear_duration\": %lu,\n"
-                    "\t\t\"status\": \"%s\",\n"
-                    "\t\t\"old_status\": \"%s\",\n"
-                    "\t\t\"delay\": %d,\n"
-                    "\t\t\"delay_up_to_timestamp\": %lu,\n"
-                    "\t\t\"updated_by_id\": %u,\n"
-                    "\t\t\"updates_id\": %u,\n"
-                    "\t\t\"value_string\": \"%s\",\n"
-                    "\t\t\"old_value_string\": \"%s\",\n"
-                    "\t\t\"last_repeat\": \"%lu\",\n"
-                    "\t\t\"silenced\": \"%s\",\n"
-                   , host->hostname
-                   , ae->unique_id
-                   , ae->alarm_id
-                   , ae->alarm_event_id
-                   , ae->name
-                   , ae->chart
-                   , ae->family
-                   , (ae->flags & HEALTH_ENTRY_FLAG_PROCESSED)?"true":"false"
-                   , (ae->flags & HEALTH_ENTRY_FLAG_UPDATED)?"true":"false"
-                   , (unsigned long)ae->exec_run_timestamp
-                   , (ae->flags & HEALTH_ENTRY_FLAG_EXEC_FAILED)?"true":"false"
-                   , ae->exec?ae->exec:host->health_default_exec
-                   , ae->recipient?ae->recipient:host->health_default_recipient
-                   , ae->exec_code
-                   , ae->source
-                   , ae->units?ae->units:""
-                   , (unsigned long)ae->when
-                   , (unsigned long)ae->duration
-                   , (unsigned long)ae->non_clear_duration
-                   , rrdcalc_status2string(ae->new_status)
-                   , rrdcalc_status2string(ae->old_status)
-                   , ae->delay
-                   , (unsigned long)ae->delay_up_to_timestamp
-                   , ae->updated_by_id
-                   , ae->updates_id
-                   , ae->new_value_string
-                   , ae->old_value_string
-                   , (unsigned long)ae->last_repeat
-                   , (ae->flags & HEALTH_ENTRY_FLAG_SILENCED)?"true":"false"
-    );
-
-    health_string2json(wb, "\t\t", "info", ae->info?ae->info:"", ",\n");
-
-    if(unlikely(ae->flags & HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION)) {
-        buffer_strcat(wb, "\t\t\"no_clear_notification\": true,\n");
+static void
+health_kv_str(BUFFER *wb, const char *key, const char *value,
+       const char *prefix, const char *suffix) {
+    if (utf8_check(value)) {
+        error("Found malformed utf8 string for key %s", key);
+        value = "malformed_utf8_string";
     }
 
-    buffer_strcat(wb, "\t\t\"value\":");
+    buffer_sprintf(wb, "%s\"%s\": \"", prefix, key);
+    buffer_strcat(wb, value);
+    buffer_strcat(wb, "\"");
+    buffer_strcat(wb, suffix);
+}
+
+static void
+health_kv_lu(BUFFER *wb, const char *key, long unsigned value,
+      const char *prefix, const char *suffix) {
+    buffer_sprintf(wb, "%s\"%s\": %lu%s", prefix, key, value, suffix);
+}
+
+static void
+health_kv_ld(BUFFER *wb, const char *key, long int value,
+      const char *prefix, const char *suffix) {
+    buffer_sprintf(wb, "%s\"%s\": %ld%s", prefix, key, value, suffix);
+}
+
+static void
+health_kv_float(BUFFER *wb, const char *key, float value,
+         const char *prefix, const char *suffix) {
+    buffer_sprintf(wb, "%s\"%s\": %f%s", prefix, key, value, suffix);
+}
+
+static void
+health_kv_bool(BUFFER *wb, const char *key, bool value,
+        const char *prefix, const char *suffix) {
+    const char *s = value ? "true" : "false";
+    buffer_sprintf(wb, "%s\"%s\": %s%s", prefix, key, s, suffix);
+}
+
+void
+health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) {
+    const char *processed = BOOL_STR(ae->flags & HEALTH_ENTRY_FLAG_PROCESSED);
+    const char *updated = BOOL_STR(ae->flags & HEALTH_ENTRY_FLAG_UPDATED);
+
+    const char *exec_failed = BOOL_STR(ae->flags & HEALTH_ENTRY_FLAG_EXEC_FAILED);
+    const char *exec = DEFAULT_STR(ae->exec, host->health_default_exec);
+
+    const char *recipient = DEFAULT_STR(ae->recipient, host->health_default_recipient);
+    const char *units = DEFAULT_STR(ae->units, "");
+
+    const char *status = rrdcalc_status2string(ae->new_status);
+    const char *old_status = rrdcalc_status2string(ae->old_status);
+
+    const char *silenced = BOOL_STR(ae->flags & HEALTH_ENTRY_FLAG_SILENCED);
+    const char *info = DEFAULT_STR(ae->info, "");
+
+    buffer_strcat(wb, "\n\t{\n");
+
+    const char *prefix = "\t\t", *suffix = ",\n";
+    health_kv_str(wb, "hostname", host->hostname, prefix, suffix);
+    health_kv_lu(wb, "unique_id", ae->unique_id, prefix, suffix);
+    health_kv_lu(wb, "alarm_id", ae->alarm_id, prefix, suffix);
+    health_kv_lu(wb, "alarm_event_id", ae->alarm_event_id, prefix, suffix);
+    health_kv_str(wb, "name", ae->name, prefix, suffix);
+    health_kv_str(wb, "chart", ae->chart, prefix, suffix);
+    health_kv_str(wb, "family", ae->family, prefix, suffix);
+    health_kv_str(wb, "processed", processed, prefix, suffix);
+    health_kv_str(wb, "updated", updated, prefix, suffix);
+    health_kv_lu(wb, "exec_run", (unsigned long) ae->exec_run_timestamp, prefix, suffix);
+    health_kv_str(wb, "exec_failed", exec_failed, prefix, suffix);
+    health_kv_str(wb, "exec", exec, prefix, suffix);
+    health_kv_str(wb, "recipient", recipient, prefix, suffix);
+    health_kv_ld(wb, "exec_code", ae->exec_code, prefix, suffix);
+    health_kv_str(wb, "source", ae->source, prefix, suffix);
+    health_kv_str(wb, "units", units, prefix, suffix);
+    health_kv_lu(wb, "when", (unsigned long) ae->when, prefix, suffix);
+    health_kv_lu(wb, "duration", (unsigned long) ae->duration, prefix, suffix);
+    health_kv_lu(wb, "non_clear_duration", (unsigned long) ae->non_clear_duration, prefix, suffix);
+    health_kv_str(wb, "status", status, prefix, suffix);
+    health_kv_str(wb, "old_status", old_status, prefix, suffix);
+    health_kv_ld(wb, "delay", ae->delay, prefix, suffix);
+    health_kv_lu(wb, "delay_up_to_timestamp", (unsigned long) ae->delay_up_to_timestamp, prefix, suffix);
+    health_kv_lu(wb, "updated_by_id", ae->updated_by_id, prefix, suffix);
+    health_kv_lu(wb, "updates_id", ae->updates_id, prefix, suffix);
+    health_kv_str(wb, "value_string", ae->new_value_string, prefix, suffix);
+    health_kv_str(wb, "old_value_string", ae->old_value_string, prefix, suffix);
+    health_kv_lu(wb, "last_repeat", (unsigned long) ae->last_repeat, prefix, suffix);
+    health_kv_str(wb, "silenced", silenced, prefix, suffix);
+    health_kv_html_escape(wb, "info", info, prefix, suffix);
+
+    if (ae->flags & HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION)
+        buffer_strcat(wb, "\t\t\"no_clear_notification\": true,\n");
+
+    buffer_strcat(wb, "\t\t\"value\": ");
     buffer_rrd_value(wb, ae->new_value);
     buffer_strcat(wb, ",\n");
 
-    buffer_strcat(wb, "\t\t\"old_value\":");
+    buffer_strcat(wb, "\t\t\"old_value\": ");
     buffer_rrd_value(wb, ae->old_value);
     buffer_strcat(wb, "\n");
 
@@ -114,145 +151,113 @@ void health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after) {
 }
 
 static inline void health_rrdcalc_values2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC *rc) {
-    (void)host;
-    buffer_sprintf(wb,
-                   "\t\t\"%s.%s\": {\n"
-                   "\t\t\t\"id\": %lu,\n"
-                   , rc->chart, rc->name
-                   , (unsigned long)rc->id);
+    (void) host;
 
-    buffer_strcat(wb, "\t\t\t\"value\":");
+    buffer_sprintf(wb, "\t\t\"%s.%s\": {\n", rc->chart, rc->name);
+
+    const char *prefix="\t\t\t", *suffix = ",\n";
+    health_kv_lu(wb, "id", rc->id, prefix, suffix);
+
+    buffer_strcat(wb, "\t\t\t\"value\": ");
     buffer_rrd_value(wb, rc->value);
     buffer_strcat(wb, ",\n");
 
-    buffer_sprintf(wb,
-                   "\t\t\t\"status\": \"%s\"\n"
-                   , rrdcalc_status2string(rc->status));
+    health_kv_str(wb, "status", rrdcalc_status2string(rc->status), prefix, "\n");
 
     buffer_strcat(wb, "\t\t}");
 }
 
-static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC *rc) {
+static void
+health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC *rc) {
+    const char *family = (rc->rrdset && rc->rrdset->family) ? rc->rrdset->family : "";
+
+    const char *exec = DEFAULT_STR(rc->exec, host->health_default_exec);
+    const char *recipient = DEFAULT_STR(rc->recipient, host->health_default_recipient);
+
+    const char *units = DEFAULT_STR(rc->units, "");
+    const char *info = DEFAULT_STR(rc->info, "");
+
     char value_string[100 + 1];
     format_value_and_unit(value_string, 100, rc->value, rc->units, -1);
 
-    buffer_sprintf(wb,
-            "\t\t\"%s.%s\": {\n"
-                    "\t\t\t\"id\": %lu,\n"
-                    "\t\t\t\"name\": \"%s\",\n"
-                    "\t\t\t\"chart\": \"%s\",\n"
-                    "\t\t\t\"family\": \"%s\",\n"
-                    "\t\t\t\"active\": %s,\n"
-                    "\t\t\t\"disabled\": %s,\n"
-                    "\t\t\t\"silenced\": %s,\n"
-                    "\t\t\t\"exec\": \"%s\",\n"
-                    "\t\t\t\"recipient\": \"%s\",\n"
-                    "\t\t\t\"source\": \"%s\",\n"
-                    "\t\t\t\"units\": \"%s\",\n"
-                    "\t\t\t\"info\": \"%s\",\n"
-                    "\t\t\t\"status\": \"%s\",\n"
-                    "\t\t\t\"last_status_change\": %lu,\n"
-                    "\t\t\t\"last_updated\": %lu,\n"
-                    "\t\t\t\"next_update\": %lu,\n"
-                    "\t\t\t\"update_every\": %d,\n"
-                    "\t\t\t\"delay_up_duration\": %d,\n"
-                    "\t\t\t\"delay_down_duration\": %d,\n"
-                    "\t\t\t\"delay_max_duration\": %d,\n"
-                    "\t\t\t\"delay_multiplier\": %f,\n"
-                    "\t\t\t\"delay\": %d,\n"
-                    "\t\t\t\"delay_up_to_timestamp\": %lu,\n"
-                    "\t\t\t\"warn_repeat_every\": \"%u\",\n"
-                    "\t\t\t\"crit_repeat_every\": \"%u\",\n"
-                    "\t\t\t\"value_string\": \"%s\",\n"
-                    "\t\t\t\"last_repeat\": \"%lu\",\n"
-                   , rc->chart, rc->name
-                   , (unsigned long)rc->id
-                   , rc->name
-                   , rc->chart
-                   , (rc->rrdset && rc->rrdset->family)?rc->rrdset->family:""
-                   , (rc->rrdset)?"true":"false"
-                   , (rc->rrdcalc_flags & RRDCALC_FLAG_DISABLED)?"true":"false"
-                   , (rc->rrdcalc_flags & RRDCALC_FLAG_SILENCED)?"true":"false"
-                   , rc->exec?rc->exec:host->health_default_exec
-                   , rc->recipient?rc->recipient:host->health_default_recipient
-                   , rc->source
-                   , rc->units?rc->units:""
-                   , rc->info?rc->info:""
-                   , rrdcalc_status2string(rc->status)
-                   , (unsigned long)rc->last_status_change
-                   , (unsigned long)rc->last_updated
-                   , (unsigned long)rc->next_update
-                   , rc->update_every
-                   , rc->delay_up_duration
-                   , rc->delay_down_duration
-                   , rc->delay_max_duration
-                   , rc->delay_multiplier
-                   , rc->delay_last
-                   , (unsigned long)rc->delay_up_to_timestamp
-                   , rc->warn_repeat_every
-                   , rc->crit_repeat_every
-                   , value_string
-                   , (unsigned long)rc->last_repeat
-    );
+    buffer_sprintf(wb, "\t\t\"%s.%s\": {\n", rc->chart, rc->name);
 
-    if(unlikely(rc->options & RRDCALC_FLAG_NO_CLEAR_NOTIFICATION)) {
+    const char *prefix = "\t\t\t", *suffix = ",\n";
+    health_kv_lu(wb, "id", rc->id, prefix, suffix);
+    health_kv_str(wb, "name", rc->name, prefix, suffix);
+    health_kv_str(wb, "chart", rc->chart, prefix, suffix);
+    health_kv_str(wb, "family", family, prefix, suffix);
+    health_kv_bool(wb, "active", rc->rrdset, prefix, suffix);
+    health_kv_bool(wb, "disabled", rc->rrdcalc_flags & RRDCALC_FLAG_DISABLED, prefix, suffix);
+    health_kv_bool(wb, "silenced", rc->rrdcalc_flags & RRDCALC_FLAG_SILENCED, prefix, suffix);
+    health_kv_str(wb, "exec", exec, prefix, suffix);
+    health_kv_str(wb, "recipient", recipient, prefix, suffix);
+    health_kv_str(wb, "source", rc->source, prefix, suffix);
+    health_kv_str(wb, "units", units, prefix, suffix);
+    health_kv_str(wb, "info", info, prefix, suffix);
+    health_kv_str(wb, "status", rrdcalc_status2string(rc->status), prefix, suffix);
+    health_kv_lu(wb, "last_status_change", (unsigned long) rc->last_status_change, prefix, suffix);
+    health_kv_lu(wb, "last_updated", (unsigned long) rc->last_updated, prefix, suffix);
+    health_kv_lu(wb, "next_update", (unsigned long) rc->next_update, prefix, suffix);
+    health_kv_ld(wb, "update_every", rc->update_every, prefix, suffix);
+    health_kv_ld(wb, "delay_up_duration", rc->delay_up_duration, prefix, suffix);
+    health_kv_ld(wb, "delay_down_duration", rc->delay_down_duration, prefix, suffix);
+    health_kv_ld(wb, "delay_max_duration", rc->delay_down_duration, prefix, suffix);
+    health_kv_float(wb, "delay_multiplier", rc->delay_multiplier, prefix, suffix);
+    health_kv_ld(wb, "delay", rc->delay_last, prefix, suffix);
+    health_kv_lu(wb, "delay_up_to_timestamp", (unsigned long) rc->delay_up_to_timestamp, prefix, suffix);
+    health_kv_lu(wb, "warn_repeat_every", rc->warn_repeat_every, prefix, suffix);
+    health_kv_lu(wb, "crit_repeat_every", rc->crit_repeat_every, prefix, suffix);
+    health_kv_str(wb, "value_string", value_string, prefix, suffix);
+    health_kv_lu(wb, "last_repeat", (unsigned long) rc->last_repeat, prefix, suffix);
+
+    if (rc->options & RRDCALC_FLAG_NO_CLEAR_NOTIFICATION)
         buffer_strcat(wb, "\t\t\t\"no_clear_notification\": true,\n");
-    }
 
-    if(RRDCALC_HAS_DB_LOOKUP(rc)) {
+    if (RRDCALC_HAS_DB_LOOKUP(rc)) {
         if(rc->dimensions && *rc->dimensions)
-            health_string2json(wb, "\t\t\t", "lookup_dimensions", rc->dimensions, ",\n");
+            health_kv_html_escape(wb, "lookup_dimensions", rc->dimensions, prefix, suffix);
 
-        buffer_sprintf(wb,
-                "\t\t\t\"db_after\": %lu,\n"
-                        "\t\t\t\"db_before\": %lu,\n"
-                        "\t\t\t\"lookup_method\": \"%s\",\n"
-                        "\t\t\t\"lookup_after\": %d,\n"
-                        "\t\t\t\"lookup_before\": %d,\n"
-                        "\t\t\t\"lookup_options\": \"",
-                (unsigned long) rc->db_after,
-                (unsigned long) rc->db_before,
-                group_method2string(rc->group),
-                rc->after,
-                rc->before
-        );
+        health_kv_lu(wb, "db_after", (unsigned long) rc->db_after, prefix, suffix);
+        health_kv_lu(wb, "db_before", (unsigned long) rc->db_before, prefix, suffix);
+        health_kv_str(wb, "lookup_method", group_method2string(rc->group), prefix, suffix);
+        health_kv_ld(wb, "lookup_after", rc->db_after, prefix, suffix);
+        health_kv_ld(wb, "lookup_before", rc->db_before, prefix, suffix);
+
+        buffer_strcat(wb, "\t\t\t\"lookup_options\": \"");
         buffer_data_options2string(wb, rc->options);
         buffer_strcat(wb, "\",\n");
     }
 
     if(rc->calculation) {
-        health_string2json(wb, "\t\t\t", "calc", rc->calculation->source, ",\n");
-        health_string2json(wb, "\t\t\t", "calc_parsed", rc->calculation->parsed_as, ",\n");
+        health_kv_html_escape(wb, "calc", rc->calculation->source, prefix, suffix);
+        health_kv_html_escape(wb, "calc_parsed", rc->calculation->parsed_as, prefix, suffix);
     }
 
     if(rc->warning) {
-        health_string2json(wb, "\t\t\t", "warn", rc->warning->source, ",\n");
-        health_string2json(wb, "\t\t\t", "warn_parsed", rc->warning->parsed_as, ",\n");
+        health_kv_html_escape(wb, "warn", rc->warning->source, prefix, suffix);
+        health_kv_html_escape(wb, "warn_parsed", rc->warning->parsed_as, prefix, suffix);
     }
 
     if(rc->critical) {
-        health_string2json(wb, "\t\t\t", "crit", rc->critical->source, ",\n");
-        health_string2json(wb, "\t\t\t", "crit_parsed", rc->critical->parsed_as, ",\n");
+        health_kv_html_escape(wb, "crit", rc->critical->source, prefix, suffix);
+        health_kv_html_escape(wb, "crit_parsed", rc->critical->parsed_as, prefix, suffix);
     }
 
-    buffer_strcat(wb, "\t\t\t\"green\":");
+    buffer_strcat(wb, "\t\t\t\"green\": ");
     buffer_rrd_value(wb, rc->green);
     buffer_strcat(wb, ",\n");
 
-    buffer_strcat(wb, "\t\t\t\"red\":");
+    buffer_strcat(wb, "\t\t\t\"red\": ");
     buffer_rrd_value(wb, rc->red);
     buffer_strcat(wb, ",\n");
 
-    buffer_strcat(wb, "\t\t\t\"value\":");
+    buffer_strcat(wb, "\t\t\t\"value\": ");
     buffer_rrd_value(wb, rc->value);
     buffer_strcat(wb, "\n");
 
     buffer_strcat(wb, "\t\t}");
 }
-
-//void health_rrdcalctemplate2json_nolock(BUFFER *wb, RRDCALCTEMPLATE *rt) {
-//
-//}
 
 void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCALC_STATUS status) {
     RRDCALC *rc;
@@ -309,39 +314,35 @@ static void health_alarms2json_fill_alarms(RRDHOST *host, BUFFER *wb, int all, v
 
 void health_alarms2json(RRDHOST *host, BUFFER *wb, int all) {
     rrdhost_rdlock(host);
-    buffer_sprintf(wb, "{\n\t\"hostname\": \"%s\","
-                    "\n\t\"latest_alarm_log_unique_id\": %u,"
-                    "\n\t\"status\": %s,"
-                    "\n\t\"now\": %lu,"
-                    "\n\t\"alarms\": {\n",
-            host->hostname,
-            (host->health_log.next_log_id > 0)?(host->health_log.next_log_id - 1):0,
-            host->health_enabled?"true":"false",
-            (unsigned long)now_realtime_sec());
 
+    unsigned next_log_id = host->health_log.next_log_id;
+
+    const char *prefix = "\t", *suffix = ",\n";
+    buffer_strcat(wb, "{\n");
+
+    health_kv_str(wb, "hostname", host->hostname, prefix, suffix);
+    health_kv_lu(wb, "latest_alarm_log_unique_id", next_log_id ? next_log_id - 1 : 0, prefix, suffix);
+    health_kv_bool(wb, "status", host->health_enabled, prefix, suffix);
+    health_kv_lu(wb, "now", (unsigned long) now_realtime_sec(), prefix, suffix);
+
+    buffer_strcat(wb, "\t\"alarms\": {\n");
     health_alarms2json_fill_alarms(host, wb, all,  health_rrdcalc2json_nolock);
-
-//    buffer_strcat(wb, "\n\t},\n\t\"templates\": {");
-//    RRDCALCTEMPLATE *rt;
-//    for(rt = host->templates; rt ; rt = rt->next)
-//        health_rrdcalctemplate2json_nolock(wb, rt);
-
     buffer_strcat(wb, "\n\t}\n}\n");
+
     rrdhost_unlock(host);
 }
 
 void health_alarms_values2json(RRDHOST *host, BUFFER *wb, int all) {
     rrdhost_rdlock(host);
-    buffer_sprintf(wb, "{\n\t\"hostname\": \"%s\","
-                       "\n\t\"alarms\": {\n",
-                   host->hostname);
 
+    health_kv_str(wb, "hostname", host->hostname, "{\n\t", ",\n");
+
+    buffer_strcat(wb, "\n\t\"alarms\": {\n");
     health_alarms2json_fill_alarms(host, wb, all,  health_rrdcalc_values2json_nolock);
-
     buffer_strcat(wb, "\n\t}\n}\n");
+
     rrdhost_unlock(host);
 }
-
 
 void health_active_log_alarms_2json(RRDHOST *host, BUFFER *wb) {
     netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);

--- a/libnetdata/string/utf8.c
+++ b/libnetdata/string/utf8.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "utf8.h"
+#include "../libnetdata.h"
+
+/*
+ * The utf8_check() function scans the '\0'-terminated string starting
+ * at s. It returns a pointer to the first byte of the first malformed
+ * or overlong UTF-8 sequence found, or NULL if the string contains
+ * only correct UTF-8. It also spots UTF-8 sequences that could cause
+ * trouble if converted to UTF-16, namely surrogate characters
+ * (U+D800..U+DFFF) and non-Unicode positions (U+FFFE..U+FFFF). This
+ * routine is very likely to find a malformed sequence if the input
+ * uses any other encoding than UTF-8. It therefore can be used as a
+ * very effective heuristic for distinguishing between UTF-8 and other
+ * encodings.
+ *
+ * Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/> -- 2005-03-30
+ * License: http://www.cl.cam.ac.uk/~mgk25/short-license.html
+ */
+const unsigned char *utf8_check(const unsigned char *s)
+{
+    while (*s)
+    {
+        if (*s < 0x80)
+            /* 0xxxxxxx */
+            s++;
+        else if ((s[0] & 0xe0) == 0xc0)
+        {
+            /* 110XXXXx 10xxxxxx */
+            if ((s[1] & 0xc0) != 0x80 ||
+                (s[0] & 0xfe) == 0xc0) /* overlong? */
+                return s;
+            else
+                s += 2;
+        }
+        else if ((s[0] & 0xf0) == 0xe0)
+        {
+            /* 1110XXXX 10Xxxxxx 10xxxxxx */
+            if ((s[1] & 0xc0) != 0x80 ||
+                (s[2] & 0xc0) != 0x80 ||
+                (s[0] == 0xe0 && (s[1] & 0xe0) == 0x80) || /* overlong? */
+                (s[0] == 0xed && (s[1] & 0xe0) == 0xa0) || /* surrogate? */
+                (s[0] == 0xef && s[1] == 0xbf &&
+                 (s[2] & 0xfe) == 0xbe)) /* U+FFFE or U+FFFF? */
+                return s;
+            else
+                s += 3;
+        }
+        else if ((s[0] & 0xf8) == 0xf0)
+        {
+            /* 11110XXX 10XXxxxx 10xxxxxx 10xxxxxx */
+            if ((s[1] & 0xc0) != 0x80 ||
+                (s[2] & 0xc0) != 0x80 ||
+                (s[3] & 0xc0) != 0x80 ||
+                (s[0] == 0xf0 && (s[1] & 0xf0) == 0x80) ||    /* overlong? */
+                (s[0] == 0xf4 && s[1] > 0x8f) || s[0] > 0xf4) /* > U+10FFFF? */
+                return s;
+            else
+                s += 4;
+        }
+        else
+            return s;
+    }
+
+    return NULL;
+}

--- a/libnetdata/string/utf8.h
+++ b/libnetdata/string/utf8.h
@@ -6,4 +6,6 @@
 #define IS_UTF8_BYTE(x) (x & 0x80)
 #define IS_UTF8_STARTBYTE(x) (IS_UTF8_BYTE(x)&&(x & 0x40))
 
+const unsigned char *utf8_check(const unsigned char *s);
+
 #endif /* NETDATA_STRING_UTF8_H */

--- a/libnetdata/url/url.c
+++ b/libnetdata/url/url.c
@@ -126,69 +126,6 @@ char url_decode_multibyte_utf8(char *s, char *d, char *d_end) {
     return byte_length;
 }
 
-/*
- * The utf8_check() function scans the '\0'-terminated string starting
- * at s. It returns a pointer to the first byte of the first malformed
- * or overlong UTF-8 sequence found, or NULL if the string contains
- * only correct UTF-8. It also spots UTF-8 sequences that could cause
- * trouble if converted to UTF-16, namely surrogate characters
- * (U+D800..U+DFFF) and non-Unicode positions (U+FFFE..U+FFFF). This
- * routine is very likely to find a malformed sequence if the input
- * uses any other encoding than UTF-8. It therefore can be used as a
- * very effective heuristic for distinguishing between UTF-8 and other
- * encodings.
- *
- * Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/> -- 2005-03-30
- * License: http://www.cl.cam.ac.uk/~mgk25/short-license.html
- */
-unsigned char *utf8_check(unsigned char *s)
-{
-    while (*s)
-    {
-        if (*s < 0x80)
-            /* 0xxxxxxx */
-            s++;
-        else if ((s[0] & 0xe0) == 0xc0)
-        {
-            /* 110XXXXx 10xxxxxx */
-            if ((s[1] & 0xc0) != 0x80 ||
-                (s[0] & 0xfe) == 0xc0) /* overlong? */
-                return s;
-            else
-                s += 2;
-        }
-        else if ((s[0] & 0xf0) == 0xe0)
-        {
-            /* 1110XXXX 10Xxxxxx 10xxxxxx */
-            if ((s[1] & 0xc0) != 0x80 ||
-                (s[2] & 0xc0) != 0x80 ||
-                (s[0] == 0xe0 && (s[1] & 0xe0) == 0x80) || /* overlong? */
-                (s[0] == 0xed && (s[1] & 0xe0) == 0xa0) || /* surrogate? */
-                (s[0] == 0xef && s[1] == 0xbf &&
-                 (s[2] & 0xfe) == 0xbe)) /* U+FFFE or U+FFFF? */
-                return s;
-            else
-                s += 3;
-        }
-        else if ((s[0] & 0xf8) == 0xf0)
-        {
-            /* 11110XXX 10XXxxxx 10xxxxxx 10xxxxxx */
-            if ((s[1] & 0xc0) != 0x80 ||
-                (s[2] & 0xc0) != 0x80 ||
-                (s[3] & 0xc0) != 0x80 ||
-                (s[0] == 0xf0 && (s[1] & 0xf0) == 0x80) ||    /* overlong? */
-                (s[0] == 0xf4 && s[1] > 0x8f) || s[0] > 0xf4) /* > U+10FFFF? */
-                return s;
-            else
-                s += 4;
-        }
-        else
-            return s;
-    }
-
-    return NULL;
-}
-
 char *url_decode_r(char *to, char *url, size_t size) {
     char *s = url,           // source
          *d = to,            // destination


### PR DESCRIPTION
##### Summary

This will make sure we don't send unparseable JSON to consumers of the alarm endpoints.

The logic behind this change is that there are multiple different places were the JSON values can come from. If any of them is malformed we don't want to create a malformed JSON. Instead, we should "fail" gracefully by annotating the bad values with a self-explanatory message. 

##### Component Name

health

##### Test Plan

Compared the JSON output of alarm endpoints against master to make sure they are identical.