### PR TITLE
Enable apps.plugin aggregation debug messages

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3879,9 +3879,8 @@ static void parse_args(int argc, char **argv)
         }
 
         if(strcmp("debug", argv[i]) == 0) {
-#ifdef NETDATA_INTERNAL_CHECKS
             debug_enabled = 1;
-#else
+#ifndef NETDATA_INTERNAL_CHECKS
             fprintf(stderr, "apps.plugin has been compiled without debugging\n");
 #endif
             continue;


### PR DESCRIPTION
##### Summary
We should print aggregation debug messages when Netdata is compiled without `CFLAGS="-DNETDATA_INTERNAL_CHECKS=1"`.

Fixes #10622

##### Component Name
apps.plugin

##### Test Plan
Run `sudo ./apps.plugin debug 2>&1 | grep "has aggregated"`, you should see target aggregation messages:
```
apps.plugin: target 'netdata' has aggregated 8 processes: 446552 446587 446728 446743 446745 446746 446749 446750
```