### PR TITLE
Changed Docker image tagging to use semver tags for releases.

### DIFF
--- a/.github/scripts/gen-docker-tags.py
+++ b/.github/scripts/gen-docker-tags.py
@@ -4,7 +4,7 @@ import sys
 
 REPO = 'netdata/netdata'
 
-version = sys.argv[1].lstrip('v').split('.')
+version = sys.argv[1].split('.')
 
 MAJOR = ':'.join([REPO, version[0]])
 MINOR = ':'.join([REPO, '.'.join(version[0:2])])

--- a/.github/scripts/gen-docker-tags.py
+++ b/.github/scripts/gen-docker-tags.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+
+REPO = 'netdata/netdata'
+
+version = sys.argv[1].lstrip('v').split('.')
+
+MAJOR = ':'.join([REPO, version[0]])
+MINOR = ':'.join([REPO, '.'.join(version[0:2])])
+PATCH = ':'.join([REPO, '.'.join(version[0:3])])
+
+print(','.join([MAJOR, MINOR, PATCH]))

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != 'nightly'
         run: |
           echo "publish=true" >> $GITHUB_ENV
-          echo "tags=netdata/netdata:latest,netdata/netdata:stable,netdata/netdata:${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          echo "tags=netdata/netdata:latest,netdata/netdata:stable,$(.github/scripts/gen-docker-tags.py ${{ github.event.inputs.version }})" >> $GITHUB_ENV
       - name: Determine if we should push changes and which tags to use
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version == 'nightly'
         run: |

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -94,6 +94,22 @@ volumes:
   netdatacache:
 ```
 
+## Docker tags
+
+The official `netdata/netdata` Docker image provides the following named tags:
+
+* `stable`: The `stable` tag will always point to the most recently published stable build.
+* `edge`: The `edge` tag will always point ot the most recently published nightly build. In most cases, this is
+  updated daily at around 01:00 UTC.
+* `latest`: The `latest` tag will always point to the most recently published build, whether it’s a stable build
+  or a nightly build. THis is what Docker will use by default if you do not specify a tag.
+
+Additionally, for each stable release, three tags are pushed, one with the full version of the release (for example,
+`v1.30.0`), one with just the major and minor version (for example, `v1.30`), and one with just the major version
+(for example, `v1`). The tags for the minor versions and major versions are updated whenever a release is published
+that would match that tag (for example, if `v1.30.1` were to be published, the `v1.30` tag would be updated to
+point to that instead of `v1.30.0`).
+
 ## Health Checks
 
 Our Docker image provides integrated support for health checks through the standard Docker interfaces.

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -102,7 +102,7 @@ The official `netdata/netdata` Docker image provides the following named tags:
 * `edge`: The `edge` tag will always point ot the most recently published nightly build. In most cases, this is
   updated daily at around 01:00 UTC.
 * `latest`: The `latest` tag will always point to the most recently published build, whether it’s a stable build
-  or a nightly build. THis is what Docker will use by default if you do not specify a tag.
+  or a nightly build. This is what Docker will use by default if you do not specify a tag.
 
 Additionally, for each stable release, three tags are pushed, one with the full version of the release (for example,
 `v1.30.0`), one with just the major and minor version (for example, `v1.30`), and one with just the major version


### PR DESCRIPTION
##### Summary

This allows users to use image names like `netdata/netdata:1` or `netdata/netdata@1.29` and track the most up-to-date release that matches that version prefix.

Such usage is a common practice for projects using semantic versioning like we are.

##### Component Name

area/ci
area/packaging

##### Test Plan

The tag generations cript can be tested locally, it takes a single argument which is a version string as we normally use them (so `vX.Y.Z`) and outputs a list of version tags to push.

##### Additional Information

Short term, the `1` tag will be functionally identical to the `stable` tag. Long-term, we may eventually end up with a new major version of Netdata, at which point having the `1` tag to let users stick with the old version is important during the transition period.