### PR TITLE
ACLK-Legacy remove version negotiation

### DIFF
--- a/aclk/legacy/aclk_common.c
+++ b/aclk/legacy/aclk_common.c
@@ -11,10 +11,7 @@ netdata_mutex_t aclk_shared_state_mutex = NETDATA_MUTEX_INITIALIZER;
 int aclk_disable_runtime = 0;
 int aclk_kill_link = 0;
 
-struct aclk_shared_state aclk_shared_state = {
-    .version_neg = 0,
-    .version_neg_wait_till = 0
-};
+struct aclk_shared_state aclk_shared_state;
 
 struct {
     ACLK_PROXY_TYPE type;

--- a/aclk/legacy/aclk_common.h
+++ b/aclk/legacy/aclk_common.h
@@ -8,23 +8,7 @@ extern netdata_mutex_t aclk_shared_state_mutex;
 #define ACLK_SHARED_STATE_LOCK netdata_mutex_lock(&aclk_shared_state_mutex)
 #define ACLK_SHARED_STATE_UNLOCK netdata_mutex_unlock(&aclk_shared_state_mutex)
 
-// minimum and maximum supported version of ACLK
-// in this version of agent
-#define ACLK_VERSION_MIN 2
-#define ACLK_VERSION_MAX 3
-
-// Version negotiation messages have they own versioning
-// this is also used for LWT message as we set that up
-// before version negotiation
-#define ACLK_VERSION_NEG_VERSION 1
-
-// Maximum time to wait for version negotiation before aborting
-// and defaulting to oldest supported version
-#define VERSION_NEG_TIMEOUT 3
-
-#if ACLK_VERSION_MIN > ACLK_VERSION_MAX
-#error "ACLK_VERSION_MAX must be >= than ACLK_VERSION_MIN"
-#endif
+#define ACLK_VERSION 2
 
 // Define ACLK Feature Version Boundaries Here
 #define ACLK_V_COMPRESSION   2
@@ -38,10 +22,6 @@ extern struct aclk_shared_state {
     // every time Query Thread wakes up
     RRDHOST *next_popcorn_host;
 
-    // read only while ACLK connected
-    // protect by lock otherwise
-    int version_neg;
-    usec_t version_neg_wait_till;
 } aclk_shared_state;
 
 typedef enum aclk_proxy_type {

--- a/aclk/legacy/agent_cloud_link.h
+++ b/aclk/legacy/agent_cloud_link.h
@@ -36,8 +36,6 @@ struct aclk_request {
     char *callback_topic;
     char *payload;
     int version;
-    int min_version;
-    int max_version;
 };
 
 typedef enum aclk_init_action { ACLK_INIT, ACLK_REINIT } ACLK_INIT_ACTION;

--- a/aclk/legacy/mqtt.c
+++ b/aclk/legacy/mqtt.c
@@ -299,7 +299,7 @@ int _link_set_lwt(char *sub_topic, int qos)
 
     usec_t lwt_time = aclk_session_sec * USEC_PER_SEC + aclk_session_us + 1;
     BUFFER *b = buffer_create(512);
-    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC, ACLK_VERSION_NEG_VERSION);
+    aclk_create_header(b, "disconnect", NULL, lwt_time / USEC_PER_SEC, lwt_time % USEC_PER_SEC, ACLK_VERSION);
     buffer_strcat(b, ", \"payload\": \"unexpected\" }");
     rc = mosquitto_will_set(mosq, topic, buffer_strlen(b), buffer_tostring(b), qos, 0);
     buffer_free(b);


### PR DESCRIPTION
##### Summary
Version Negotiation is obsoleted and will not be used. New capabilities-based exchange is being designed and developed.
##### Component Name
ACLK
##### Test Plan
Should work as before. ACLK v2 is forced always.

##### Additional Information
