### PR TITLE
Add support to persist chart labels in the database

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1932,6 +1932,18 @@ void rrdset_finalize_labels(RRDSET *st)
     } else {
         replace_label_list(labels, new_labels);
     }
+#ifdef ENABLE_DBENGINE
+    if (likely(rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+        netdata_rwlock_wrlock(&labels->labels_rwlock);
+        struct label *lbl = labels->head;
+        while (lbl) {
+            sql_store_chart_label(st->chart_uuid, (int)lbl->label_source, lbl->key, lbl->value);
+            lbl = lbl->next;
+        }
+        netdata_rwlock_unlock(&labels->labels_rwlock);
+    }
+#endif
+
     st->state->new_labels = NULL;
 }
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -18,6 +18,9 @@ const char *database_config[] = {
     "CREATE INDEX IF NOT EXISTS ind_d1 on dimension (chart_id, id, name);",
     "CREATE INDEX IF NOT EXISTS ind_c1 on chart (host_id, id, type, name);",
 
+    "CREATE TABLE IF NOT EXISTS chart_label(chart_id blob, source_type int, label_key text, "
+    "label_value text, date_created int, PRIMARY KEY (chart_id, label_key));",
+
     "delete from chart_active;",
     "delete from dimension_active;",
 
@@ -1017,6 +1020,55 @@ void add_migrated_file(char *path, uint64_t file_size)
 
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
         error_report("Failed to finalize the prepared statement when checking if metadata file is migrated");
+
+    return;
+}
+
+#define SQL_INS_CHART_LABEL "insert or replace into chart_label " \
+    "(chart_id, source_type, label_key, label_value, date_created) " \
+    "values (@chart, @source, @label, @value, strftime('%s'));"
+
+void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value)
+{
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_INS_CHART_LABEL, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement to fetch host");
+        return;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, chart_uuid, sizeof(*chart_uuid), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind chart_id parameter to store label information");
+        return;
+    }
+
+    rc = sqlite3_bind_int(res, 2, source_type);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind size parameter to store label information");
+        return;
+    }
+
+    rc = sqlite3_bind_text(res, 3, label, -1, SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind size parameter to store label information");
+        return;
+    }
+
+    rc = sqlite3_bind_text(res, 4, value, -1, SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind size parameter to store label information");
+        return;
+    }
+
+    rc = execute_insert(res);
+    if (unlikely(rc != SQLITE_DONE))
+        error_report("Failed to store migrated file, rc = %d", rc);
+
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when storing chart label information");
 
     return;
 }

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -58,5 +58,5 @@ extern void add_migrated_file(char *path, uint64_t file_size);
 extern void db_unlock(void);
 extern void db_lock(void);
 extern void delete_dimension_uuid(uuid_t *dimension_uuid);
-
+extern void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
Add support to store chart labels in the database. This will be useful for archived charts and the need to access and filter on the their chart labels.

##### Component Name
database

##### Test Plan
- TBA
