### PR TITLE
Fixed condition controlling use of static LWS in RPM builds.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -221,7 +221,7 @@ happened, on your systems and applications.
 %prep
 %setup -q -n %{name}-%{version}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}/%{name}-%{version}
-%if 0%{?centos_ver} >= 8 || 0%{?fedora}
+%if 0%{?centos_ver} < 8 || 0%{!?fedora:1}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-lws.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 %endif
 # Only bundle libJudy if this isn't Fedora or SUSE
@@ -239,7 +239,7 @@ autoreconf -ivf
 	%if 0%{!?fedora:1} && 0%{!?suse_version:1}
 	--with-libJudy=externaldeps/libJudy \
 	%endif
-	%if 0%{?centos_ver} >= 8 || 0%{?fedora}
+	%if 0%{?centos_ver} < 8 || 0%{!?fedora:1}
 	--with-bundled-lws=externaldeps/libwebsockets \
 	%endif
 	--prefix="%{_prefix}" \


### PR DESCRIPTION


<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

The original intent was to only use a static copy of LWS if we couldn’t use a system copy. Due to two incorrect conditionals in the spec file though, what was actually happening was that we were using a static build of LWS on systems where we could use a system copy, and not linking against LWS at all on other systems.

This fixes those conditionals so that we use a system copy if available, and provide a static copy if a system copy is not available.

##### Component Name

area/packaging

##### Test Plan

Verified locally with manual build tests on all platforms we build RPM packages for.

##### Additional Information

Fixes: #10594 