### PR TITLE
Invalidate RRDSETVAR pointers on obsoletion.

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -169,6 +169,10 @@ static void netdev_charts_release(struct netdev *d) {
     d->rd_tcollisions = NULL;
     d->rd_tcarrier    = NULL;
     d->rd_tcompressed = NULL;
+
+    d->chart_var_speed     = NULL;
+    d->chart_var_duplex    = NULL;
+    d->chart_var_operstate = NULL;
 }
 
 static void netdev_free_chart_strings(struct netdev *d) {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #10656
##### Component Name
collectors
##### Additional Information
The net_dev collector of the proc plugin should not reuse health variables after obsoleting the corresponding charts.