### PR TITLE
Don't add duplicate _total suffixes for the prometheus go.d module

### DIFF
--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -660,7 +660,8 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                             rd->algorithm == RRD_ALGORITHM_PCENT_OVER_DIFF_TOTAL) {
                             p.type = "counter";
                             p.relation = "delta gives";
-                            p.suffix = "_total";
+                            if (!prometheus_collector)
+                                p.suffix = "_total";
                         }
 
                         if (homogeneous) {


### PR DESCRIPTION
##### Summary
There are metrics with the `_total` suffix in the generic Prometheus endpoint collector. We shouldn't duplicate the suffixes on export in the Prometheus format.

Fixes #10669

##### Component Name
Prometheus exporting (Web API)

##### Test Plan
Enable the generic Prometheus endpoint collector.
Check `http://localhost:19999/api/v1/allmetrics?format=prometheus&source=raw`. You shouldn't see any metrics with the `_total_total` suffix.