### PR TITLE
Alarms collector add alarm values

### DIFF
--- a/collectors/python.d.plugin/alarms/README.md
+++ b/collectors/python.d.plugin/alarms/README.md
@@ -51,6 +51,8 @@ local:
     CLEAR: 0
     WARNING: 1
     CRITICAL: 2
+  # set to true to include a chart with caclulated alarm values over time
+  show_alarm_values: false
 ```
 
 It will default to pulling all alarms at each time step from the Netdata rest api at `http://127.0.0.1:19999/api/v1/alarms?all`

--- a/collectors/python.d.plugin/alarms/README.md
+++ b/collectors/python.d.plugin/alarms/README.md
@@ -51,8 +51,8 @@ local:
     CLEAR: 0
     WARNING: 1
     CRITICAL: 2
-  # set to true to include a chart with caclulated alarm values over time
-  show_alarm_values: false
+  # set to true to include a chart with calculated alarm values over time
+  collect_alarm_values: false
 ```
 
 It will default to pulling all alarms at each time step from the Netdata rest api at `http://127.0.0.1:19999/api/v1/alarms?all`

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -29,9 +29,6 @@ def charts_template(sm, alarm_status_chart_type='line'):
         'values': {
             'options': [None, 'Alarm Values', 'value', 'value', 'alarms.value', 'line'],
             'lines': [],
-            'variables': [
-                [],
-            ]
         }
     }
     return order, charts

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -64,7 +64,7 @@ class Service(UrlService):
         data['alarms_num'] = len(data)
 
         if self.show_alarm_values:
-            data_values = {a: alarms[a]['value'] * 100 for a in alarms if 'value' in alarms[a] and alarms[a]['value'] is not None}
+            data_values = {'{}_value'.format(a): alarms[a]['value'] * 100 for a in alarms if 'value' in alarms[a] and alarms[a]['value'] is not None}
             self.update_charts('values', alarms, data_values, 1, 100)
             data = {**data, **data_values}
 

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -66,7 +66,7 @@ class Service(UrlService):
         if self.collect_alarm_values:
             data_values = {'{}_value'.format(a): alarms[a]['value'] * 100 for a in alarms if 'value' in alarms[a] and alarms[a]['value'] is not None}
             self.update_charts('values', data_values, divisor=100)
-            data = {**data, **data_values}
+            data.update(data_values)
 
         return data
 

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -63,7 +63,7 @@ class Service(UrlService):
         self.update_charts('alarms', data)
         data['alarms_num'] = len(data)
 
-        if self.show_alarm_values:
+        if self.collect_alarm_values:
             data_values = {'{}_value'.format(a): alarms[a]['value'] * 100 for a in alarms if 'value' in alarms[a] and alarms[a]['value'] is not None}
             self.update_charts('values', data_values, divisor=100)
             data = {**data, **data_values}

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -64,7 +64,7 @@ class Service(UrlService):
 
         if self.show_alarm_values:
             data_values = {'{}_value'.format(a): alarms[a]['value'] * 100 for a in alarms if 'value' in alarms[a] and alarms[a]['value'] is not None}
-            self.update_charts('values', alarms, data_values, multiplier=1, divisor=100)
+            self.update_charts('values', alarms, data_values, divisor=100)
             data = {**data, **data_values}
 
         return data

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -11,7 +11,7 @@ update_every = 10
 disabled_by_default = True
 
 
-def charts_template(sm):
+def charts_template(sm, alarm_status_chart_type='line'):
     order = [
         'alarms',
         'values'
@@ -20,7 +20,7 @@ def charts_template(sm):
     mappings = ', '.join(['{0}={1}'.format(k, v) for k, v in sm.items()])
     charts = {
         'alarms': {
-            'options': [None, 'Alarms ({0})'.format(mappings), 'status', 'alarms', 'alarms.status', 'line'],
+            'options': [None, 'Alarms ({0})'.format(mappings), 'status', 'alarms', 'alarms.status', alarm_status_chart_type],
             'lines': [],
             'variables': [
                 ['alarms_num'],
@@ -40,13 +40,15 @@ def charts_template(sm):
 DEFAULT_STATUS_MAP = {'CLEAR': 0, 'WARNING': 1, 'CRITICAL': 2}
 DEFAULT_URL = 'http://127.0.0.1:19999/api/v1/alarms?all'
 DEFAULT_COLLECT_ALARM_VALUES = False
+DEFAULT_ALARM_STATUS_CHART_TYPE = 'line'
 
 
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
         UrlService.__init__(self, configuration=configuration, name=name)
         self.sm = self.configuration.get('status_map', DEFAULT_STATUS_MAP)
-        self.order, self.definitions = charts_template(self.sm)
+        self.alarm_status_chart_type = self.configuration.get('alarm_status_chart_type', DEFAULT_ALARM_STATUS_CHART_TYPE)
+        self.order, self.definitions = charts_template(self.sm, self.alarm_status_chart_type)
         self.url = self.configuration.get('url', DEFAULT_URL)
         self.collect_alarm_values = bool(self.configuration.get('collect_alarm_values', DEFAULT_COLLECT_ALARM_VALUES))
         self.collected_dims = {'alarms': set(), 'values': set()}

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -20,14 +20,14 @@ def charts_template(sm):
     mappings = ', '.join(['{0}={1}'.format(k, v) for k, v in sm.items()])
     charts = {
         'alarms': {
-            'options': [None, 'Alarms ({0})'.format(mappings), 'status', 'Alarms', 'alarms.status', 'line'],
+            'options': [None, 'Alarms ({0})'.format(mappings), 'status', 'alarms', 'alarms.status', 'line'],
             'lines': [],
             'variables': [
                 ['alarms_num'],
             ]
         },
         'values': {
-            'options': [None, 'Alarm Values', 'value', 'Values', 'alarms.values', 'line'],
+            'options': [None, 'Alarm Values', 'value', 'values', 'alarms.values', 'line'],
             'lines': [],
             'variables': [
                 [],

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -39,7 +39,7 @@ def charts_template(sm):
 
 DEFAULT_STATUS_MAP = {'CLEAR': 0, 'WARNING': 1, 'CRITICAL': 2}
 DEFAULT_URL = 'http://127.0.0.1:19999/api/v1/alarms?all'
-DEFAULT_SHOW_ALARM_VALUES = False
+DEFAULT_COLLECT_ALARM_VALUES = False
 
 
 class Service(UrlService):
@@ -48,7 +48,7 @@ class Service(UrlService):
         self.sm = self.configuration.get('status_map', DEFAULT_STATUS_MAP)
         self.order, self.definitions = charts_template(self.sm)
         self.url = self.configuration.get('url', DEFAULT_URL)
-        self.show_alarm_values = bool(self.configuration.get('show_alarm_values', DEFAULT_SHOW_ALARM_VALUES))
+        self.collect_alarm_values = bool(self.configuration.get('collect_alarm_values', DEFAULT_COLLECT_ALARM_VALUES))
         self.collected_dims = {'alarms': set(), 'values': set()}
 
     def _get_data(self):

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -64,7 +64,7 @@ class Service(UrlService):
 
         if self.show_alarm_values:
             data_values = {'{}_value'.format(a): alarms[a]['value'] * 100 for a in alarms if 'value' in alarms[a] and alarms[a]['value'] is not None}
-            self.update_charts('values', alarms, data_values, divisor=100)
+            self.update_charts('values', data_values, divisor=100)
             data = {**data, **data_values}
 
         return data

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -27,7 +27,7 @@ def charts_template(sm, alarm_status_chart_type='line'):
             ]
         },
         'values': {
-            'options': [None, 'Alarm Values', 'value', 'values', 'alarms.values', 'line'],
+            'options': [None, 'Alarm Values', 'value', 'value', 'alarms.value', 'line'],
             'lines': [],
             'variables': [
                 [],

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -20,7 +20,7 @@ def charts_template(sm, alarm_status_chart_type='line'):
     mappings = ', '.join(['{0}={1}'.format(k, v) for k, v in sm.items()])
     charts = {
         'alarms': {
-            'options': [None, 'Alarms ({0})'.format(mappings), 'status', 'alarms', 'alarms.status', alarm_status_chart_type],
+            'options': [None, 'Alarms ({0})'.format(mappings), 'status', 'status', 'alarms.status', alarm_status_chart_type],
             'lines': [],
             'variables': [
                 ['alarms_num'],

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -49,6 +49,7 @@ class Service(UrlService):
         self.order, self.definitions = charts_template(self.sm)
         self.url = self.configuration.get('url', DEFAULT_URL)
         self.show_alarm_values = bool(self.configuration.get('show_alarm_values', DEFAULT_SHOW_ALARM_VALUES))
+        self.collected_dims = {'alarms': set(), 'values': set()}
 
     def _get_data(self):
         raw_data = self._get_raw_data()
@@ -74,5 +75,11 @@ class Service(UrlService):
             return
 
         for dim in data:
-            if dim not in self.charts[chart]:
+            if dim not in self.collected_dims[chart]:
+                self.collected_dims[chart].add(dim)
                 self.charts[chart].add_dimension([dim, dim, algorithm, multiplier, divisor])
+
+        for dim in list(self.collected_dims[chart]):
+            if dim not in data:
+                self.collected_dims[chart].remove(dim)
+                self.charts[chart].del_dimension(dim, hide=False)

--- a/collectors/python.d.plugin/alarms/alarms.conf
+++ b/collectors/python.d.plugin/alarms/alarms.conf
@@ -48,5 +48,5 @@ local:
     CLEAR: 0
     WARNING: 1
     CRITICAL: 2
-  # set to true to include a chart with caclulated alarm values over time
+  # set to true to include a chart with calculated alarm values over time
   show_alarm_values: false

--- a/collectors/python.d.plugin/alarms/alarms.conf
+++ b/collectors/python.d.plugin/alarms/alarms.conf
@@ -49,4 +49,4 @@ local:
     WARNING: 1
     CRITICAL: 2
   # set to true to include a chart with calculated alarm values over time
-  show_alarm_values: false
+  collect_alarm_values: false

--- a/collectors/python.d.plugin/alarms/alarms.conf
+++ b/collectors/python.d.plugin/alarms/alarms.conf
@@ -50,3 +50,5 @@ local:
     CRITICAL: 2
   # set to true to include a chart with calculated alarm values over time
   collect_alarm_values: false
+  # define the type of chart for plotting status over time e.g. 'line' or 'stacked'
+  alarm_status_chart_type: 'line'

--- a/collectors/python.d.plugin/alarms/alarms.conf
+++ b/collectors/python.d.plugin/alarms/alarms.conf
@@ -48,3 +48,5 @@ local:
     CLEAR: 0
     WARNING: 1
     CRITICAL: 2
+  # set to true to include a chart with caclulated alarm values over time
+  show_alarm_values: false


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Add option `show_alarm_values` to `alarms.conf` which will show the alarm values themselves over time below the alarm status chart. 

`show_alarm_values` will be set to `false` by default such that a user would have to explicitly enable this in `alarms.conf` if they want the "Values" chart.

For example: 
![image](https://user-images.githubusercontent.com/2178292/108846152-26d6e200-75d6-11eb-85a0-aadf4054127e.png)


##### Component Name

/collectors/python.d.plugin/alarms

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Tested locally for when both show_alarm_values was `true` and `false` in situations where i used `stress-ng --all 2` to trigger lots of alarms. 

##### Additional Information
