### PR TITLE
Add new cookie to fix 8094

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -176,6 +176,17 @@ There can be up to 2 files:
 
 Both files are machine readable text files.
 
+### How can I disable the SameSite and Secure cookies?
+
+Beginning with `v1.30.0`, when the Netdata Agent's web server processes a request, it delivers the `SameSite=none`
+and `Secure` cookies. If you have problems accessing the local Agent dashboard or Netdata Cloud, disable these
+cookies by [editing `netdata.conf`](/docs/configure/nodes.md#use-edit-config-to-edit-configuration-files):
+
+```conf
+[registry]
+    enable cookies SameSite and Secure = no
+```
+
 ## The future
 
 The registry opens a whole world of new possibilities for Netdata. Check here what we think:

--- a/registry/registry.c
+++ b/registry/registry.c
@@ -32,10 +32,12 @@ static void registry_set_cookie(struct web_client *w, const char *guid) {
 
     if(registry.registry_domain && registry.registry_domain[0])
         snprintfz(domain, 511, "Domain=%s", registry.registry_domain);
+    else
+        domain[0]='\0';
 
     snprintfz(w->cookie2, NETDATA_WEB_REQUEST_COOKIE_SIZE,
-              NETDATA_REGISTRY_COOKIE_NAME "=%s; Expires=%s; SameSite=None ; %s",
-              guid, registry.registry_domain, edate, domain);
+              NETDATA_REGISTRY_COOKIE_NAME "=%s; Expires=%s; SameSite=None; Secure; %s",
+              guid, edate, domain);
 }
 
 static inline void registry_set_person_cookie(struct web_client *w, REGISTRY_PERSON *p) {

--- a/registry/registry.c
+++ b/registry/registry.c
@@ -23,7 +23,7 @@ static inline void registry_unlock(void) {
 // COOKIES
 
 static void registry_set_cookie(struct web_client *w, const char *guid) {
-    char edate[100];
+    char edate[100], domain[512];
     time_t et = now_realtime_sec() + registry.persons_expiration;
     struct tm etmbuf, *etm = gmtime_r(&et, &etmbuf);
     strftime(edate, sizeof(edate), "%a, %d %b %Y %H:%M:%S %Z", etm);
@@ -31,9 +31,11 @@ static void registry_set_cookie(struct web_client *w, const char *guid) {
     snprintfz(w->cookie1, NETDATA_WEB_REQUEST_COOKIE_SIZE, NETDATA_REGISTRY_COOKIE_NAME "=%s; Expires=%s", guid, edate);
 
     if(registry.registry_domain && registry.registry_domain[0])
-        snprintfz(w->cookie2, NETDATA_WEB_REQUEST_COOKIE_SIZE,
-                  NETDATA_REGISTRY_COOKIE_NAME "=%s; Domain=%s; Expires=%s; SameSite=None",
-                  guid, registry.registry_domain, edate);
+        snprintfz(domain, 511, "Domain=%s", registry.registry_domain);
+
+    snprintfz(w->cookie2, NETDATA_WEB_REQUEST_COOKIE_SIZE,
+              NETDATA_REGISTRY_COOKIE_NAME "=%s; Expires=%s; SameSite=None ; %s",
+              guid, registry.registry_domain, edate, domain);
 }
 
 static inline void registry_set_person_cookie(struct web_client *w, REGISTRY_PERSON *p) {

--- a/registry/registry.c
+++ b/registry/registry.c
@@ -31,7 +31,9 @@ static void registry_set_cookie(struct web_client *w, const char *guid) {
     snprintfz(w->cookie1, NETDATA_WEB_REQUEST_COOKIE_SIZE, NETDATA_REGISTRY_COOKIE_NAME "=%s; Expires=%s", guid, edate);
 
     if(registry.registry_domain && registry.registry_domain[0])
-        snprintfz(w->cookie2, NETDATA_WEB_REQUEST_COOKIE_SIZE, NETDATA_REGISTRY_COOKIE_NAME "=%s; Domain=%s; Expires=%s", guid, registry.registry_domain, edate);
+        snprintfz(w->cookie2, NETDATA_WEB_REQUEST_COOKIE_SIZE,
+                  NETDATA_REGISTRY_COOKIE_NAME "=%s; Domain=%s; Expires=%s; SameSite=None",
+                  guid, registry.registry_domain, edate);
 }
 
 static inline void registry_set_person_cookie(struct web_client *w, REGISTRY_PERSON *p) {

--- a/registry/registry_init.c
+++ b/registry/registry_init.c
@@ -39,6 +39,7 @@ int registry_init(void) {
     registry.registry_to_announce = config_get(CONFIG_SECTION_REGISTRY, "registry to announce", "https://registry.my-netdata.io");
     registry.hostname = config_get(CONFIG_SECTION_REGISTRY, "registry hostname", netdata_configured_hostname);
     registry.verify_cookies_redirects = config_get_boolean(CONFIG_SECTION_REGISTRY, "verify browser cookies support", 1);
+    registry.enable_cookies_samesite_secure = config_get_boolean(CONFIG_SECTION_REGISTRY, "enable cookies SameSite and Secure", 1);
 
     registry_update_cloud_base_url();
     setenv("NETDATA_REGISTRY_HOSTNAME", registry.hostname, 1);

--- a/registry/registry_internals.h
+++ b/registry/registry_internals.h
@@ -40,6 +40,7 @@ struct registry {
     char *cloud_base_url;
     time_t persons_expiration; // seconds to expire idle persons
     int verify_cookies_redirects;
+    int enable_cookies_samesite_secure;
 
     size_t max_url_length;
     size_t max_name_length;


### PR DESCRIPTION
##### Summary
Fixes #8094

This PR fixes the problem to access cloud with Netdata.

##### Component Name
Webserver

##### Test Plan

1 - Access Netdata dashboard and verify that you do not have the error `Some cookies are misusing the recommended “sameSite“ attribute 11` using browser developer tools

##### Additional Information
