### PR TITLE
Add support for runtime configuration of UID/GID for Netdata user.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -60,9 +60,11 @@ FROM netdata/base:latest as base
 # Configure system
 ARG NETDATA_UID=201
 ARG NETDATA_GID=201
+ARG NETDATA_USER=netdata
 
 ENV NETDATA_UID=$NETDATA_UID
 ENV NETDATA_GID=$NETDATA_GID
+ENV NETDATA_USER=$NETDATA_USER
 # If DO_NOT_TRACK is set, it will disable anonymous stats collection and reporting
 #ENV DO_NOT_TRACK=1
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -60,8 +60,9 @@ FROM netdata/base:latest as base
 # Configure system
 ARG NETDATA_UID=201
 ARG NETDATA_GID=201
-ENV DOCKER_GRP netdata
-ENV DOCKER_USR netdata
+
+ENV NETDATA_UID=$NETDATA_UID
+ENV NETDATA_GID=$NETDATA_GID
 # If DO_NOT_TRACK is set, it will disable anonymous stats collection and reporting
 #ENV DO_NOT_TRACK=1
 
@@ -74,9 +75,6 @@ RUN mkdir -p /opt/src /var/log/netdata && \
     # fping from alpine apk is on a different location. Moving it.
     ln -snf /usr/sbin/fping /usr/local/bin/fping && \
     chmod 4755 /usr/local/bin/fping && \
-    # Add netdata user
-    addgroup -g ${NETDATA_GID} -S "${DOCKER_GRP}" && \
-    adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}"
 
 # Long-term this should leverage BuildKit’s mount option.
 COPY --from=builder /wheels /wheels
@@ -89,12 +87,6 @@ RUN chown -R root:root \
         /etc/netdata \
         /usr/share/netdata \
         /usr/libexec/netdata && \
-    chown -R netdata:root \
-        /usr/lib/netdata \
-        /var/cache/netdata \
-        /var/lib/netdata \
-        /var/log/netdata && \
-    chown -R netdata:netdata /var/lib/netdata/cloud.d && \
     chmod 0700 /var/lib/netdata/cloud.d && \
     chmod 0755 /usr/libexec/netdata/plugins.d/*.plugin && \
     chmod 4755 \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -66,16 +66,6 @@ ENV NETDATA_GID=$NETDATA_GID
 # If DO_NOT_TRACK is set, it will disable anonymous stats collection and reporting
 #ENV DO_NOT_TRACK=1
 
-# Copy files over
-RUN mkdir -p /opt/src /var/log/netdata && \
-    # Link log files to stdout
-    ln -sf /dev/stdout /var/log/netdata/access.log && \
-    ln -sf /dev/stdout /var/log/netdata/debug.log && \
-    ln -sf /dev/stderr /var/log/netdata/error.log && \
-    # fping from alpine apk is on a different location. Moving it.
-    ln -snf /usr/sbin/fping /usr/local/bin/fping && \
-    chmod 4755 /usr/local/bin/fping && \
-
 # Long-term this should leverage BuildKit’s mount option.
 COPY --from=builder /wheels /wheels
 COPY --from=builder /app /
@@ -87,17 +77,22 @@ RUN chown -R root:root \
         /etc/netdata \
         /usr/share/netdata \
         /usr/libexec/netdata && \
+    mkdir -p /opt/src /var/log/netdata && \
+    ln -sf /dev/stdout /var/log/netdata/access.log && \
+    ln -sf /dev/stdout /var/log/netdata/debug.log && \
+    ln -sf /dev/stderr /var/log/netdata/error.log && \
     chmod 0700 /var/lib/netdata/cloud.d && \
     chmod 0755 /usr/libexec/netdata/plugins.d/*.plugin && \
     chmod 4755 \
         /usr/libexec/netdata/plugins.d/cgroup-network \
         /usr/libexec/netdata/plugins.d/apps.plugin \
         /usr/libexec/netdata/plugins.d/freeipmi.plugin && \
-    # Group write permissions due to: https://github.com/netdata/netdata/pull/6543
     find /var/lib/netdata /var/cache/netdata -type d -exec chmod 0770 {} \; && \
     find /var/lib/netdata /var/cache/netdata -type f -exec chmod 0660 {} \; && \
     pip --no-cache-dir install /wheels/* && \
-    rm -rf /wheels
+    rm -rf /wheels && \
+    ln -snf /usr/sbin/fping /usr/local/bin/fping && \
+    chmod 4755 /usr/local/bin/fping
 
 ENV NETDATA_LISTENER_PORT 19999
 EXPOSE $NETDATA_LISTENER_PORT

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -248,10 +248,9 @@ how you created the container.
 
 ### Custom agent UID/GID
 
-By default, the Netdata Agent in the container will run with a user ID and group ID of 201, matching the default
-IDs used on normal installations of Netdata. In the unlikely event that you need to use a different UID or GID
-for netdata for some reason, you can set the `NETDATA_UID` and/or `NETDATA_GID` environment variables for the
-container to thedesired UID/GID.
+By default, Netdata in the container will run with a user ID and group ID of `201`, matching the default IDs used
+on normal installations of Netdata. In the unlikely event that you need to use a different UID or GID for netdata,
+set the `NETDATA_UID` and/or `NETDATA_GID` environment variables for the container to the desired UID/GID.
 
 ### Add or remove other volumes
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -246,6 +246,13 @@ If you don't want to destroy and recreate your container, you can edit the Agent
 above section on [configuring Agent containers](#configure-agent-containers) to find the appropriate method based on
 how you created the container.
 
+### Custom agent UID/GID
+
+By default, the Netdata Agent in the container will run with a user ID and group ID of 201, matching the default
+IDs used on normal installations of Netdata. In the unlikely event that you need to use a different UID or GID
+for netdata for some reason, you can set the `NETDATA_UID` and/or `NETDATA_GID` environment variables for the
+container to thedesired UID/GID.
+
 ### Add or remove other volumes
 
 Some of the volumes are optional depending on how you use Netdata:

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -13,7 +13,6 @@ if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
   touch /etc/netdata/.opt-out-from-anonymous-statistics
 fi
 
-
 BALENA_PGID=$(ls -nd /var/run/balena.sock | awk '{print $4}')
 DOCKER_PGID=$(ls -nd /var/run/docker.sock | awk '{print $4}')
 
@@ -27,14 +26,77 @@ elif [[ $DOCKER_PGID =~ $re ]]; then
   DOCKER_HOST="/var/run/docker.sock"
   PGID=$(ls -nd /var/run/docker.sock | awk '{print $4}')
 fi
+
 export PGID
 export DOCKER_HOST
+
+create_group=
+remove_group=
+create_user=
+remove_user=
+user_in_group=
+
+if getent group netdata > /dev/null; then
+  existing_gid="$(getent group netdata | cut -d ':' -f 3)"
+
+  if [ "${existing_gid}" != "${NETDATA_GID}" ]; then
+    echo "Netdata group ID mismatch (expected ${NETDATA_GID} but found ${existing_gid}), the existing group will be replaced."
+    remove_group=1
+    create_group=1
+  fi
+else
+  echo "Netdata group not found, preparing to create one with GID=${NETDATA_GID}."
+  create_group=1
+fi
+
+if getent passwd netdata > /dev/null; then
+  existing_user="$(getent passwd netdata)"
+  existing_uid="$(echo "${existing_user}" | cut -d ':' -f 3)"
+  existing_primary_gid="$(echo "${existing_user}" | cut -d ':' -f 4)"
+
+  if [ "${existing_gid}" != "${NETDATA_UID}" ]; then
+    echo "Netdata user ID mismatch (expected ${NETDATA_UID} but found ${existing_uid}), the existing user will be replaced."
+    remove_user=1
+    create_user=1
+  fi
+
+  if [ "${existing_primary_gid}" = "${NETDATA_GID}" ]; then
+    user_in_group=1
+  else
+    echo "Netdata user is not in the correct primary group (expected ${NETDATA_GID} but found ${existing_primary_gid}), the user will be updated."
+  fi
+else
+  echo "Netdata user not found, preparing to create one with UID=${NETDATA_UID}."
+  create_user=1
+fi
+
+if [ -n "${remove_group}" ]; then
+  delgroup netdata netdata
+  delgroup netdata || exit 1
+fi
+
+if [ -n "${create_group}" ]; then
+  addgroup -g "${NETDATA_GID}" -S netdata || exit 1
+fi
+
+if [ -n "${remove_user}" ]; then
+  userdel netdata || exit 1
+fi
+
+if [ -n "${create_user}" ]; then
+  adduser -S -H -s /usr/sbin/nologin -u "${NETDATA_UID}" -h /etc/netdata -G netdata netdata
+elif [ -z "${user_in_group}" ]; then
+  usermod -a -G netdata netdata
+fi
+
+chown -R netdata:root /usr/lib/netdata /var/cache/netdata /var/lib/netdata /var/log/netdata
+chown -R netdata:netdata /var/lib/netdata/cloud.d
 
 if [ -n "${PGID}" ]; then
   echo "Creating docker group ${PGID}"
   addgroup -g "${PGID}" "docker" || echo >&2 "Could not add group docker with ID ${PGID}, its already there probably"
   echo "Assign netdata user to docker group ${PGID}"
-  usermod -a -G "${PGID}" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
+  usermod -a -G "${PGID}" netdata || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
 fi
 
 if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/cloud.d/claimed_id ]; then

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -36,6 +36,10 @@ create_user=
 remove_user=
 user_in_group=
 
+if [ -n "${DOCKER_USR}" ]; then
+  NETDATA_USER="${DOCKER_USR}"
+fi
+
 if getent group netdata > /dev/null; then
   existing_gid="$(getent group netdata | cut -d ':' -f 3)"
 
@@ -49,54 +53,56 @@ else
   create_group=1
 fi
 
-if getent passwd netdata > /dev/null; then
-  existing_user="$(getent passwd netdata)"
-  existing_uid="$(echo "${existing_user}" | cut -d ':' -f 3)"
-  existing_primary_gid="$(echo "${existing_user}" | cut -d ':' -f 4)"
+if [ "${NETDATA_USER}" = "netdata" ]; then
+  if getent passwd netdata > /dev/null; then
+    existing_user="$(getent passwd netdata)"
+    existing_uid="$(echo "${existing_user}" | cut -d ':' -f 3)"
+    existing_primary_gid="$(echo "${existing_user}" | cut -d ':' -f 4)"
 
-  if [ "${existing_gid}" != "${NETDATA_UID}" ]; then
-    echo "Netdata user ID mismatch (expected ${NETDATA_UID} but found ${existing_uid}), the existing user will be replaced."
-    remove_user=1
+    if [ "${existing_gid}" != "${NETDATA_UID}" ]; then
+      echo "Netdata user ID mismatch (expected ${NETDATA_UID} but found ${existing_uid}), the existing user will be replaced."
+      remove_user=1
+      create_user=1
+    fi
+
+    if [ "${existing_primary_gid}" = "${NETDATA_GID}" ]; then
+      user_in_group=1
+    else
+      echo "Netdata user is not in the correct primary group (expected ${NETDATA_GID} but found ${existing_primary_gid}), the user will be updated."
+    fi
+  else
+    echo "Netdata user not found, preparing to create one with UID=${NETDATA_UID}."
     create_user=1
   fi
 
-  if [ "${existing_primary_gid}" = "${NETDATA_GID}" ]; then
-    user_in_group=1
-  else
-    echo "Netdata user is not in the correct primary group (expected ${NETDATA_GID} but found ${existing_primary_gid}), the user will be updated."
+  if [ -n "${remove_group}" ]; then
+    delgroup netdata netdata
+    delgroup netdata || exit 1
   fi
-else
-  echo "Netdata user not found, preparing to create one with UID=${NETDATA_UID}."
-  create_user=1
+
+  if [ -n "${create_group}" ]; then
+    addgroup -g "${NETDATA_GID}" -S netdata || exit 1
+  fi
+
+  if [ -n "${remove_user}" ]; then
+    userdel netdata || exit 1
+  fi
+
+  if [ -n "${create_user}" ]; then
+    adduser -S -H -s /usr/sbin/nologin -u "${NETDATA_UID}" -h /etc/netdata -G netdata netdata
+  elif [ -z "${user_in_group}" ]; then
+    usermod -a -G netdata netdata
+  fi
 fi
 
-if [ -n "${remove_group}" ]; then
-  delgroup netdata netdata
-  delgroup netdata || exit 1
-fi
-
-if [ -n "${create_group}" ]; then
-  addgroup -g "${NETDATA_GID}" -S netdata || exit 1
-fi
-
-if [ -n "${remove_user}" ]; then
-  userdel netdata || exit 1
-fi
-
-if [ -n "${create_user}" ]; then
-  adduser -S -H -s /usr/sbin/nologin -u "${NETDATA_UID}" -h /etc/netdata -G netdata netdata
-elif [ -z "${user_in_group}" ]; then
-  usermod -a -G netdata netdata
-fi
-
-chown -R netdata:root /usr/lib/netdata /var/cache/netdata /var/lib/netdata /var/log/netdata
-chown -R netdata:netdata /var/lib/netdata/cloud.d
+chown -R "${NETDATA_USER}:root" /usr/lib/netdata /var/cache/netdata /var/lib/netdata /var/log/netdata
+chown -R "${NETDATA_USER}:netdata" /var/lib/netdata/cloud.d
 
 if [ -n "${PGID}" ]; then
   echo "Creating docker group ${PGID}"
   addgroup -g "${PGID}" "docker" || echo >&2 "Could not add group docker with ID ${PGID}, its already there probably"
   echo "Assign netdata user to docker group ${PGID}"
-  usermod -a -G "${PGID}" netdata || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
+  usermod -a -G "${PGID}" "${NETDATA_USER}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
 fi
 
 if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/cloud.d/claimed_id ]; then
@@ -107,4 +113,4 @@ if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /v
                              -daemon-not-running
 fi
 
-exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_LISTENER_PORT}" -W set web "web files group" root -W set web "web files owner" root "$@"
+exec /usr/sbin/netdata -u "${NETDATA_USER}" -D -s /host -p "${NETDATA_LISTENER_PORT}" -W set web "web files group" root -W set web "web files owner" root "$@"

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -53,6 +53,15 @@ else
   create_group=1
 fi
 
+if [ -n "${remove_group}" ]; then
+  delgroup netdata netdata
+  delgroup netdata || exit 1
+fi
+
+if [ -n "${create_group}" ]; then
+  addgroup -g "${NETDATA_GID}" -S netdata || exit 1
+fi
+
 if [ "${NETDATA_USER}" = "netdata" ]; then
   if getent passwd netdata > /dev/null; then
     existing_user="$(getent passwd netdata)"
@@ -73,15 +82,6 @@ if [ "${NETDATA_USER}" = "netdata" ]; then
   else
     echo "Netdata user not found, preparing to create one with UID=${NETDATA_UID}."
     create_user=1
-  fi
-
-  if [ -n "${remove_group}" ]; then
-    delgroup netdata netdata
-    delgroup netdata || exit 1
-  fi
-
-  if [ -n "${create_group}" ]; then
-    addgroup -g "${NETDATA_GID}" -S netdata || exit 1
   fi
 
   if [ -n "${remove_user}" ]; then


### PR DESCRIPTION
##### Summary

This adds functionality to the Docker image allowing users to specify a custom UID and/or GID for Netdata to run as using the `NETDATA_UID` and `NETDATA_GID` environment variables.

The changes involve pushing the `netdata` user and group creation from the build process to the entrypoint script, and then adding some code to handle a handful of the most likely edge-cases, aswell as setting things up to automatically fix permissions on startup.

This new behavior is only exhibited if neither `DOCKER_USR` (kept for compatibility) nor `NETDATA_USER` (added for consistency) are set. This behavior was chosen on the assumption that a user who is specifically requesting that Netdata run as a particular user knows what they’re doing, and therefore we shouldn’t risk getting in their way.

This also allows some internal restructuring of the Dockerfile which lets us reduce the total number of layers, resulting in a marginally smaller image overall.

##### Component Name

area/packaging

##### Test Plan

Verified locally to behave identically to the current image after startup when the variables are not set, and to correctly handle updating the user and group when restarted with different values for the variables.

##### Additional Information

I’ve been looking at doing this for a long time now, but hadn’t gotten around to it yet. We need this indirectly for the Helm chart support for setup of persistent volumes though, so it got bumped up in priority.