### PR TITLE
packaging/docker: fix claiming via env vars

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -20,7 +20,10 @@ if [ -n "${PGID}" ]; then
   usermod -a -G "${PGID}" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
 fi
 
-if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/claim.d/claimed_id ]; then
+if [ -n "${NETDATA_CLAIM_URL}" ] &&
+  [ -n "${NETDATA_CLAIM_TOKEN}" ] &&
+  [ ! -f /var/lib/netdata/claim.d/claimed_id ] &&
+  [ -f /var/lib/netdata/registry/netdata.public.unique.id ]; then
   /usr/sbin/netdata-claim.sh \
     -token="${NETDATA_CLAIM_TOKEN}" \
     -url="${NETDATA_CLAIM_URL}" \

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -21,10 +21,11 @@ if [ -n "${PGID}" ]; then
 fi
 
 if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/claim.d/claimed_id ]; then
-  /usr/sbin/netdata-claim.sh -token "${NETDATA_CLAIM_TOKEN}" \
-                             -url "${NETDATA_CLAIM_URL}" \
-                             ${NETDATA_CLAIM_ROOMS:+-rooms "${NETDATA_CLAIM_ROOMS}"} \
-                             ${NETDATA_CLAIM_PROXY:+-proxy "${NETDATA_CLAIM_PROXY}"}
+  /usr/sbin/netdata-claim.sh \
+    -token="${NETDATA_CLAIM_TOKEN}" \
+    -url="${NETDATA_CLAIM_URL}" \
+    ${NETDATA_CLAIM_ROOMS:+-rooms="${NETDATA_CLAIM_ROOMS}"} \
+    ${NETDATA_CLAIM_PROXY:+-proxy="${NETDATA_CLAIM_PROXY}"}
 fi
 
 exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_LISTENER_PORT}" -W set web "web files group" root -W set web "web files owner" root "$@"

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -22,7 +22,7 @@ fi
 
 if [ -n "${NETDATA_CLAIM_URL}" ] &&
   [ -n "${NETDATA_CLAIM_TOKEN}" ] &&
-  [ ! -f /var/lib/netdata/claim.d/claimed_id ] &&
+  [ ! -f /var/lib/netdata/cloud.d/claimed_id ] &&
   [ -f /var/lib/netdata/registry/netdata.public.unique.id ]; then
   /usr/sbin/netdata-claim.sh \
     -token="${NETDATA_CLAIM_TOKEN}" \


### PR DESCRIPTION
##### Summary

- `netdata-claim.sh` script expects `-token`, `-url`, `-rooms` and `proxy` params to be `-param=`

https://github.com/netdata/netdata/blob/a3ada604962b126b20c86a41e8aac5ca451b8a33/claim/netdata-claim.sh.in#L163-L178

---

- we shouldn't run `netdata-claim.sh` script if there is no `/var/lib/netdata/registry/netdata.public.unique.id`. That is the case on [the first container start](https://learn.netdata.cloud/docs/agent/claim#using-environment-variables). `netdata.public.unique.id` is not generated at that point.

https://github.com/netdata/netdata/blob/a3ada604962b126b20c86a41e8aac5ca451b8a33/claim/netdata-claim.sh.in#L144-L151

---

Current logic is to execute `netdata-claim.sh` in the [`run.sh`](https://github.com/netdata/netdata/blob/2bddc7a0f4ad406bf45f526a853b3d025839bc3b/packaging/docker/run.sh#L23-L28). If the script fails netdata containers fails to start, docker engine keeps restarting it. 

This PR makes netdata daemon to execute `netdata-claim.sh` script. It means that container no longer fails to start if there are some problems with claiming.

If current behaviour (claim script fails => containers fails to start) is intentional, then it is buggy - there are a lot of different claim errors and we shouldn't exit with code != 0 on some of them, for instance

https://github.com/netdata/netdata/blob/a3ada604962b126b20c86a41e8aac5ca451b8a33/claim/netdata-claim.sh.in#L59-L60

It is not really a problem to do a claim being already claimed, Cloud handles it (that is our default helmchart setup btw - execute claim script on every container start/re-creation).

##### Component Name

`packaging/docker`

##### Test Plan

- [X] start a container **w/o claim env vars**, ensure
  - it works
  - doesn't try to claim

```cmd
[ilyam@pc ~]$ docker exec netdata ps -o args | grep netdata -m 1
/usr/sbin/netdata -u netdata -D -s /host -p 19999 -W set web web files group root -W set web web files owner root
```
 
- [X] start a container **w/ claim env vars** and **w/o claimed_id**, ensure
  - it works
  - it tries to claim
  - available on the Cloud 

```cmd
[ilyam@pc ~]$ docker exec netdata ps -o args | grep netdata -m 1
/usr/sbin/netdata -u netdata -D -s /host -p 19999 -W set web web files group root -W set web web files owner root -W set2 cloud global enabled true -W set2 cloud global cloud base url https://app.netdata.cloud -W claim -url=https://app.netdata.cloud -token=XXXX -rooms=XXXX -proxy=
```

- [X] start a container **w/ claim env vars** and **w/ claimed_id**, ensure
  - it works
  - doesn't try to reclaim
  - available on the Cloud 
  
```cmd
[ilyam@pc ~]$ docker exec netdata ps -o args | grep netdata -m 1
/usr/sbin/netdata -u netdata -D -s /host -p 19999 -W set web web files group root -W set web web files owner root
```


##### Additional Information
