### PR TITLE
Add noauthcodecheck workaround flag to the freeipmi plugin

### DIFF
--- a/collectors/freeipmi.plugin/README.md
+++ b/collectors/freeipmi.plugin/README.md
@@ -45,7 +45,7 @@ The plugin does a speed test when it starts, to find out the duration needed by 
 
 The plugin supports a few options. To see them, run:
 
-```sh
+```text
 # /usr/libexec/netdata/plugins.d/freeipmi.plugin -h
 
  netdata freeipmi.plugin 1.8.0-546-g72ce5d6b_rolling
@@ -71,6 +71,8 @@ The plugin supports a few options. To see them, run:
   username USER
   password PASS           connect to remote IPMI host
                           default: local IPMI processor
+
+  noauthcodecheck         don't check the authentication codes returned
 
   driver-type IPMIDRIVER
                           Specify the driver type to use instead of doing an auto selection. 

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1619,6 +1619,14 @@ int parse_outofband_driver_type (const char *str)
     return (-1);
 }
 
+int host_is_local(const char *hostname)
+{
+    if (hostname && (!strcmp(hostname, "localhost") || !strcmp(hostname, "127.0.0.1") || !strcmp(hostname, "::1")))
+        return (1);
+
+    return (0);
+}
+
 int main (int argc, char **argv) {
 
     // ------------------------------------------------------------------------
@@ -1688,6 +1696,8 @@ int main (int argc, char **argv) {
                     "  username USER\n"
                     "  password PASS           connect to remote IPMI host\n"
                     "                          default: local IPMI processor\n"
+                    "\n"
+                    "  noauthcodecheck         don't check the authentication codes returned\n"
                     "\n"
                     " driver-type IPMIDRIVER\n"
                     "                          Specify the driver type to use instead of doing an auto selection. \n"
@@ -1761,6 +1771,23 @@ int main (int argc, char **argv) {
             else {
                 driver_type=parse_inband_driver_type(argv[++i]);
                 if(debug) fprintf(stderr, "freeipmi.plugin: inband driver type set to '%d'\n", driver_type);
+            }
+            continue;
+        } else if (i < argc && strcmp("noauthcodecheck", argv[i]) == 0) {
+            if (!hostname || host_is_local(hostname)) {
+                if (debug)
+                    fprintf(
+                        stderr,
+                        "freeipmi.plugin: noauthcodecheck workaround flag is ignored for inband configuration\n");
+            } else if (protocol_version < 0 || protocol_version == IPMI_MONITORING_PROTOCOL_VERSION_1_5) {
+                workaround_flags |= IPMI_MONITORING_WORKAROUND_FLAGS_PROTOCOL_VERSION_1_5_NO_AUTH_CODE_CHECK;
+                if (debug)
+                    fprintf(stderr, "freeipmi.plugin: noauthcodecheck workaround flag enabled\n");
+            } else {
+                if (debug)
+                    fprintf(
+                        stderr,
+                        "freeipmi.plugin: noauthcodecheck workaround flag is ignored for protocol version 2.0\n");
             }
             continue;
         }

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1619,9 +1619,9 @@ int parse_outofband_driver_type (const char *str)
     return (-1);
 }
 
-int host_is_local(const char *hostname)
+int host_is_local(const char *host)
 {
-    if (hostname && (!strcmp(hostname, "localhost") || !strcmp(hostname, "127.0.0.1") || !strcmp(hostname, "::1")))
+    if (host && (!strcmp(host, "localhost") || !strcmp(host, "127.0.0.1") || !strcmp(host, "::1")))
         return (1);
 
     return (0);


### PR DESCRIPTION
##### Summary
Fixes #7066

##### Component Name
freeipmi plugin

##### Test Plan
Run the freeipmi plugin with `noauthcodecheck` flag. Check if it works for protocol 1.5.