### PR TITLE
add filebeat collector

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1392,7 +1392,7 @@ while [ -n "${1}" ]; do
       NETDATA_CLAIM_URL="${2}"
       shift 1
       ;;
-    "--claim-*")
+    "--claim-"*)
       optname="$(echo "${1}" | cut -d '-' -f 4-)"
       case "${optname}" in
         id|proxy|user|hostname)

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -136,7 +136,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "b63815109547f15a979752fced6bfc2e" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "f01086a471f030c294d31e49df84850f" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

Add a new collector to monitor filebeat like metricbeat does ([doc](https://www.elastic.co/guide/en/beats/filebeat/current/monitoring-metricbeat-collection.html))

##### Component Name

collector/filebeat

##### Test Plan

##### Additional Information

Handle only filebeat reading on an IP address, not on a named socket
