### PR TITLE
Docs: Convert references to `service` to `systemctl`

### DIFF
--- a/collectors/QUICKSTART.md
+++ b/collectors/QUICKSTART.md
@@ -104,8 +104,8 @@ parameters as a reference, to configure the collector.
 Most collectors are enabled and will auto-detect their app/service without manual configuration. However, you need to
 restart Netdata to trigger the auto-detection process.
 
-To restart Netdata on most systems, use `service netdata restart`. For other systems, see the [other restart
-methods](/docs/getting-started.md#start-stop-and-restart-netdata).
+To restart Netdata on most systems, use `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system.
 
 Open Netdata's dashboard in your browser, or refresh the page if you already have it open. You should now see a new
 entry in the menu and new interactive charts!

--- a/collectors/python.d.plugin/README.md
+++ b/collectors/python.d.plugin/README.md
@@ -84,7 +84,12 @@ If you plan to submit the module in a PR, make sure and go through the [PR check
 For a quick start, you can look at the [example
 plugin](https://raw.githubusercontent.com/netdata/netdata/master/collectors/python.d.plugin/example/example.chart.py).
 
-**Note**: If you are working 'locally' on a new collector and would like to run it in an already installed and running Netdata (as opposed to having to install Netdata from source again with your new changes) to can copy over the relevant file to where Netdata expects it and then either `sudo service netdata restart` to have it be picked up and used by Netdata or you can just run the updated collector in debug mode by following a process like below (this assumes you have [installed Netdata from a GitHub fork](https://learn.netdata.cloud/docs/agent/packaging/installer/methods/manual) you have made to do your development on).
+**Note**: If you are working 'locally' on a new collector and would like to run it in an already installed and running
+Netdata (as opposed to having to install Netdata from source again with your new changes) to can copy over the relevant
+file to where Netdata expects it and then either `sudo systemctl restart netdata` to have it be picked up and used by
+Netdata or you can just run the updated collector in debug mode by following a process like below (this assumes you have
+[installed Netdata from a GitHub fork](https://learn.netdata.cloud/docs/agent/packaging/installer/methods/manual) you
+have made to do your development on).
 
 ```bash
 # clone your fork (done once at the start but shown here for clarity)

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -60,8 +60,8 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `adaptec_raid` setting to `yes`. Save the file and restart the Netdata Agent
-with `sudo systemctl restart netdata`, or the appropriate method for your system.
+Change the value of the `adaptec_raid` setting to `yes`. Save the file and restart the Netdata Agent with `sudo
+systemctl restart netdata`, or the [appropriate method](/docs/configure/start-stop-restart.md) for your system.
 
 ## Configuration
 

--- a/collectors/python.d.plugin/alarms/README.md
+++ b/collectors/python.d.plugin/alarms/README.md
@@ -23,7 +23,7 @@ Below is an example of the chart produced when running `stress-ng --all 2` for a
 
 ## Configuration
 
-Enable the collector and restart Netdata.
+Enable the collector and [restart Netdata](/docs/configure/start-stop-restart.md).
 
 ```bash
 cd /etc/netdata/

--- a/collectors/python.d.plugin/anomalies/README.md
+++ b/collectors/python.d.plugin/anomalies/README.md
@@ -45,7 +45,8 @@ pip3 install --user netdata-pandas==0.0.32 numba==0.50.1 scikit-learn==0.23.2 py
 
 ## Configuration
 
-Install the Python requirements above, enable the collector and restart Netdata.
+Install the Python requirements above, enable the collector and [restart
+Netdata](/docs/configure/start-stop-restart.md).
 
 ```bash
 cd /etc/netdata/

--- a/collectors/python.d.plugin/chrony/README.md
+++ b/collectors/python.d.plugin/chrony/README.md
@@ -55,7 +55,7 @@ local:
   command: 'chronyc -n tracking'
 ```
 
-Save the file and restart the Netdata Agent with `sudo systemctl restart netdata`, or the appropriate method for your
-system, to finish configuring the `chrony` collector.
+Save the file and restart the Netdata Agent with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, to finish configuring the `chrony` collector.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fchrony%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -59,8 +59,8 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent
-with `sudo systemctl restart netdata`, or the appropriate method for your system.
+Change the value of the `hpssa` setting to `yes`. Save the file and restart the Netdata Agent with `sudo systemctl
+restart netdata`, or the [appropriate method](/docs/configure/start-stop-restart.md) for your system.
 
 ## Configuration
 
@@ -77,5 +77,8 @@ If `ssacli` cannot be found in the `PATH`, configure it in `hpssa.conf`.
 ```yaml
 ssacli_path: /usr/sbin/ssacli
 ```
+
+Save the file and restart the Netdata Agent with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fhpssa%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)]()

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -80,6 +80,7 @@ Battery stats disabled by default. To enable them, modify `megacli.conf`.
 do_battery: yes
 ```
 
----
+Save the file and restart the Netdata Agent with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fmegacli%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -103,8 +103,8 @@ cd /etc/netdata   # Replace this path with your Netdata config directory, if dif
 sudo ./edit-config python.d.conf
 ```
 
-Change the value of the `samba` setting to `yes`. Save the file and restart the Netdata Agent
-with `sudo systemctl restart netdata`, or the appropriate method for your system.
+Change the value of the `samba` setting to `yes`. Save the file and restart the Netdata Agent with `sudo systemctl
+restart netdata`, or the [appropriate method](/docs/configure/start-stop-restart.md) for your system.
 
 ## Configuration
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -395,10 +395,10 @@ all programs), edit `netdata.conf` and set:
   process nice level = -1
 ```
 
-then execute this to restart netdata:
+then execute this to [restart Netdata](/docs/configure/start-stop-restart.md):
 
 ```sh
-sudo service netdata restart
+sudo systemctl restart netdata
 ```
 
 #### Example 2: Netdata with nice -1 on systemd systems

--- a/daemon/config/README.md
+++ b/daemon/config/README.md
@@ -28,10 +28,11 @@ The configuration file is a `name = value` dictionary. Netdata will not complain
 
 ## Applying changes
 
-After `netdata.conf` has been modified, Netdata needs to be restarted for changes to apply:
+After `netdata.conf` has been modified, Netdata needs to be [restarted](/docs/configure/start-stop-restart.md) for
+changes to apply:
 
 ```bash
-sudo service netdata restart
+sudo systemctl restart netdata
 ```
 
 If the above does not work, try the following:

--- a/docs/Running-behind-apache.md
+++ b/docs/Running-behind-apache.md
@@ -255,9 +255,8 @@ errors while accessing the dashboard.
 DOSPageCount 30
 ```
 
-Restart Apache with `sudo service apache2 restart`, or the appropriate method to restart services on your system, to
+Restart Apache with `sudo systemctl restart apache2`, or the appropriate method to restart services on your system, to
 reload its configuration with your new values.
-
 
 ### Virtual host
 

--- a/docs/collect/enable-configure.md
+++ b/docs/collect/enable-configure.md
@@ -32,7 +32,8 @@ Within this file, you can either disable the orchestrator entirely (`enabled: ye
 enable/disable it with `yes` and `no` settings. Uncomment any line you change to ensure the Netdata daemon reads it on
 start.
 
-After you make your changes, restart the Agent with `service netdata restart`.
+After you make your changes, restart the Agent with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system.
 
 ## Configure a collector
 
@@ -51,7 +52,8 @@ according to your needs. In addition, every collector's documentation shows the 
 configure that collector. Uncomment any line you change to ensure the collector's orchestrator or the Netdata daemon
 read it on start.
 
-After you make your changes, restart the Agent with `service netdata restart`.
+After you make your changes, restart the Agent with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system.
 
 ## What's next?
 

--- a/docs/collect/system-metrics.md
+++ b/docs/collect/system-metrics.md
@@ -48,8 +48,9 @@ windows_exporter-0.14.0-amd64.exe --collectors.enabled="cpu,memory,net,logical_d
 
 Next, [configure the WMI
 collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/wmi#configuration) to point to the URL
-and port of your exposed endpoint. Restart Netdata with `service netdata restart` and you'll start seeing Windows system
-metrics, such as CPU utilization, memory, bandwidth per NIC, number of processes, and much more.
+and port of your exposed endpoint. Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system. You'll start seeing Windows system metrics, such as CPU
+utilization, memory, bandwidth per NIC, number of processes, and much more.
 
 For information about collecting metrics from applications _running on Windows systems_, see the [application metrics
 doc](/docs/collect/application-metrics.md#collect-metrics-from-applications-running-on-windows).

--- a/docs/export/enable-connector.md
+++ b/docs/export/enable-connector.md
@@ -47,9 +47,10 @@ Use the following configuration as a starting point. Copy and paste it into `exp
 Replace `my_opentsdb_http_instance` with an instance name of your choice, and change the `destination` setting to the IP
 address or hostname of your OpenTSDB database.
 
-Restart your Agent with `sudo systemctl restart netdata` to begin exporting to your OpenTSDB database. The Netdata Agent
-exports metrics _beginning from the time the process starts_, and because it exports as metrics are collected, you
-should start seeing data in your external database after only a few seconds.
+Restart your Agent with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, to begin exporting to your OpenTSDB database. The
+Netdata Agent exports metrics _beginning from the time the process starts_, and because it exports as metrics are
+collected, you should start seeing data in your external database after only a few seconds.
 
 Any further configuration is optional, based on your needs and the configuration of your OpenTSDB database. See the
 [OpenTSDB connector doc](/exporting/opentsdb/README.md) and [exporting engine
@@ -68,9 +69,10 @@ Use the following configuration as a starting point. Copy and paste it into `exp
 Replace `my_graphite_instance` with an instance name of your choice, and change the `destination` setting to the IP
 address or hostname of your Graphite-supported database.
 
-Restart your Agent with `sudo systemctl restart netdata` to begin exporting to your Graphite-supported database. Because
-the Agent exports metrics as they're collected, you should start seeing data in your external database after only a few
-seconds.
+Restart your Agent with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, to begin exporting to your Graphite-supported database.
+Because the Agent exports metrics as they're collected, you should start seeing data in your external database after
+only a few seconds.
 
 Any further configuration is optional, based on your needs and the configuration of your Graphite-supported database.
 See [exporting engine reference](/exporting/README.md#configuration) for details.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -211,16 +211,12 @@ You can use these features together or separately&mdash;the decision is up to yo
 When you install Netdata, it's configured to start at boot, and stop and restart/shutdown. You shouldn't need to start
 or stop Netdata manually, but you will probably need to restart Netdata at some point.
 
--   To **start** Netdata, open a terminal and run `service netdata start`.
--   To **stop** Netdata, run `service netdata stop`.
--   To **restart** Netdata, run `service netdata restart`.
+-   To **start** Netdata, open a terminal and run `sudo systemctl start netdata`.
+-   To **stop** Netdata, run `sudo systemctl stop netdata`.
+-   To **restart** Netdata, run `sudo systemctl restart netdata`.
 
-The `service` command is a wrapper script that tries to use your system's preferred method of starting or stopping
-Netdata based on your system. But, if either of those commands fails, try using the equivalent commands for `systemd`
-and `init.d`:
-
--   **systemd**: `systemctl start netdata`, `systemctl stop netdata`, `systemctl restart netdata`
--   **init.d**: `/etc/init.d/netdata start`, `/etc/init.d/netdata stop`, `/etc/init.d/netdata restart`
+See our doc on [starting, stopping, and restarting](/docs/configure/start-stop-restart.md) the Netdata Agent for
+details.
 
 ## What's next?
 

--- a/docs/guides/collect-apache-nginx-web-logs.md
+++ b/docs/guides/collect-apache-nginx-web-logs.md
@@ -52,8 +52,8 @@ Find the `web_log` line, uncomment it, and set it to `web_log: no`. Next, open t
 
 Find the `web_log` line again, uncomment it, and set it to `web_log: yes`.
 
-Finally, restart Netdata with `service netdata restart`, or the appropriate method for your system. You should see
-metrics in your Netdata dashboard!
+Finally, restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system. You should see metrics in your Netdata dashboard!
 
 ![Example of real-time web server log metrics in Netdata's
 dashboard](https://user-images.githubusercontent.com/1153921/69448130-2980c280-0d15-11ea-9fa5-6dcff25a92c3.png)
@@ -120,8 +120,9 @@ jobs:
     log_type: auto
 ```
 
-Restart Netdata with `service netdata restart` or the appropriate method for your system. Netdata should pick up your
-web server's access log and begin showing real-time charts!
+Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system. Netdata should pick up your web server's access log and
+begin showing real-time charts!
 
 ### Custom log formats and fields
 

--- a/docs/guides/collect-unbound-metrics.md
+++ b/docs/guides/collect-unbound-metrics.md
@@ -54,8 +54,9 @@ configuring the collector.
 You may not need to do any more configuration to have Netdata collect your Unbound metrics.
 
 If you followed the steps above to enable `remote-control` and make your Unbound files readable by Netdata, that should
-be enough. Restart Netdata with `service netdata restart`, or the appropriate method for your system. You should see
-Unbound metrics in your Netdata dashboard!
+be enough. Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system. You should see Unbound metrics in your Netdata
+dashboard!
 
 ![Some charts showing Unbound metrics in real-time](https://user-images.githubusercontent.com/1153921/69659974-93160f00-103c-11ea-88e6-27e9efcf8c0d.png)
 
@@ -98,7 +99,8 @@ jobs:
 Netdata will attempt to read `unbound.conf` to get the appropriate `address`, `cumulative`, `use_tls`, `tls_cert`, and
 `tls_key` parameters. 
 
-Restart Netdata with `service netdata restart`, or the appropriate method for your system.
+Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system.
 
 ### Manual setup for a remote Unbound server
 

--- a/docs/guides/export/export-netdata-metrics-graphite.md
+++ b/docs/guides/export/export-netdata-metrics-graphite.md
@@ -115,8 +115,8 @@ the port accordingly.
     ...
 ```
 
-We'll not worry about the rest of the settings for now. Restart the Agent using `sudo service netdata restart`, or the
-appropriate method for your system, to spin up the exporting engine.
+We'll not worry about the rest of the settings for now. Restart the Agent using `sudo systemctl restart netdata`, or the
+[appropriate method](/docs/configure/start-stop-restart.md) for your system, to spin up the exporting engine.
 
 ## See and organize Netdata metrics in Graphite
 

--- a/docs/guides/monitor-cockroachdb.md
+++ b/docs/guides/monitor-cockroachdb.md
@@ -30,9 +30,9 @@ configuring CockroachDB. Netdata only needs to regularly query the database's `_
 display them on the dashboard.
 
 If your CockroachDB instance is accessible through `http://localhost:8080/` or `http://127.0.0.1:8080`, your setup is
-complete. Restart Netdata with `service netdata restart`, or use the [appropriate
-method](../getting-started.md#start-stop-and-restart-netdata) for your system, and refresh your browser. You should see
-CockroachDB metrics in your Netdata dashboard!
+complete. Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, and refresh your browser. You should see CockroachDB
+metrics in your Netdata dashboard!
 
 <figure>
   <img src="https://user-images.githubusercontent.com/1153921/73564467-d7e36b00-441c-11ea-9ec9-b5d5ea7277d4.png" alt="CPU utilization charts from a CockroachDB database monitored by Netdata" />

--- a/docs/guides/monitor-hadoop-cluster.md
+++ b/docs/guides/monitor-hadoop-cluster.md
@@ -161,10 +161,10 @@ jobs:
     address : 203.0.113.10:2182
 ```
 
-Finally, restart Netdata.
+Finally, [restart Netdata](/docs/configure/start-stop-restart.md).
 
 ```sh
-sudo service restart netdata
+sudo systemctl restart netdata
 ```
 
 Upon restart, Netdata should recognize your HDFS/Zookeeper servers, enable the HDFS and Zookeeper modules, and begin

--- a/docs/guides/monitor/anomaly-detection.md
+++ b/docs/guides/monitor/anomaly-detection.md
@@ -79,9 +79,10 @@ yourself if it doesn't already exist. Either way, the final result should look l
 anomalies: yes
 ```
 
-[Restart the Agent](/docs/configure/start-stop-restart.md) with `sudo systemctl restart netdata` to start up the
-anomalies collector. By default, the model training process runs every 30 minutes, and uses the previous 4 hours of
-metrics to establish a baseline for health and performance across the default included charts.
+[Restart the Agent](/docs/configure/start-stop-restart.md) with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, to start up the anomalies collector. By default, the
+model training process runs every 30 minutes, and uses the previous 4 hours of metrics to establish a baseline for
+health and performance across the default included charts.
 
 > 💡 The anomaly collector may need 30-60 seconds to finish its initial training and have enough data to start
 > generating anomaly scores. You may need to refresh your browser tab for the **Anomalies** section to appear in menus

--- a/docs/guides/monitor/pi-hole-raspberry-pi.md
+++ b/docs/guides/monitor/pi-hole-raspberry-pi.md
@@ -83,9 +83,9 @@ As far as configuring Netdata to monitor Pi-hole metrics, there's nothing you ac
 collector](https://learn.netdata.cloud/docs/agent/collectors/go.d.plugin/modules/pihole) will autodetect the new service
 running on your Raspberry Pi and immediately start collecting metrics every second.
 
-Restart Netdata with `sudo service netdata restart` to start Netdata, which will then recognize that Pi-hole is running
-and start a per-second collection job. When you refresh your Netdata dashboard or load it up again in a new tab, you'll
-see a new entry in the menu for **Pi-hole** metrics.
+Restart Netdata with `sudo systemctl restart netdata`, which will then recognize that Pi-hole is running and start a
+per-second collection job. When you refresh your Netdata dashboard or load it up again in a new tab, you'll see a new
+entry in the menu for **Pi-hole** metrics.
 
 ## Use Netdata to explore and monitor your Raspberry Pi and Pi-hole
 
@@ -119,7 +119,7 @@ cd /etc/netdata
 sudo ./edit-config charts.d.conf
 ```
 
-Uncomment the `sensors=force` line and save the file. Restart Netdata with `sudo service netdata restart` to enable
+Uncomment the `sensors=force` line and save the file. Restart Netdata with `sudo systemctl restart netdata` to enable
 Raspberry Pi temperature sensor monitoring.
 
 ### Storing historical metrics on your Raspberry Pi

--- a/docs/guides/monitor/process.md
+++ b/docs/guides/monitor/process.md
@@ -169,8 +169,9 @@ postgres: postgres*
 sql: mariad* postmaster* oracle_* ora_* sqlservr
 ```
 
-Restart Netdata with `service netdata restart`, or the appropriate method for your system, to start collecting
-utilization metrics from your application. Time to [visualize your process metrics](#visualize-process-metrics).
+Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, to start collecting utilization metrics from your
+application. Time to [visualize your process metrics](#visualize-process-metrics).
 
 ### Custom applications
 
@@ -194,8 +195,9 @@ custom-app: custom-app
 ...
 ```
 
-Restart Netdata with `service netdata restart`, or the appropriate method for your system, to start collecting
-utilization metrics from your application.
+Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, to start collecting utilization metrics from your
+application.
 
 ## Visualize process metrics
 

--- a/docs/guides/step-by-step/step-04.md
+++ b/docs/guides/step-by-step/step-04.md
@@ -95,8 +95,8 @@ section and give it the value of `1`.
     test = 1
 ```
 
-Restart Netdata with `service restart netdata` or the [appropriate
-alternative](/docs/getting-started.md#start-stop-and-restart-netdata) for your system.
+Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system.
 
 Now, open up your browser and navigate to `http://HOST:19999/netdata.conf`. You'll see that Netdata has recognized
 that our fake option isn't valid and added a notice that Netdata will ignore it.

--- a/docs/guides/step-by-step/step-05.md
+++ b/docs/guides/step-by-step/step-05.md
@@ -69,8 +69,8 @@ the `warn` and `crit` lines to the values of your choosing. For example:
     crit: $this > (($status == $CRITICAL) ? (75) : (85))
 ```
 
-You _can_ [restart Netdata](/docs/getting-started.md#start-stop-and-restart-netdata) to enable your tune, but you can
-also reload _only_ the health monitoring component using one of the available [methods](/health/QUICKSTART.md#reload-health-configuration).
+You _can_ restart Netdata with `sudo systemctl restart netdata`, to enable your tune, but you can also reload _only_ the
+health monitoring component using one of the available [methods](/health/QUICKSTART.md#reload-health-configuration).
 
 You can also tune any other aspect of the default alarms. To better understand how each line in a health entity works,
 read our [health documentation](/health/README.md).

--- a/docs/guides/step-by-step/step-06.md
+++ b/docs/guides/step-by-step/step-06.md
@@ -7,8 +7,8 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/step
 
 When Netdata _starts_, it auto-detects dozens of **data sources**, such as database servers, web servers, and more.
 
-To auto-detect and collect metrics from a source you just installed, you need to [restart
-Netdata](/docs/getting-started.md#start-stop-and-restart-netdata).
+To auto-detect and collect metrics from a source you just installed, you need to restart Netdata using `sudo systemctl
+restart netdata`, or the [appropriate method](/docs/configure/start-stop-restart.md) for your system.
 
 However, auto-detection only works if you installed the source using its standard installation
 procedure. If Netdata isn't collecting metrics after a restart, your source probably isn't configured
@@ -99,9 +99,9 @@ Next, edit your `/etc/nginx/sites-enabled/default` file to include a `location` 
     }
 ```
 
-Restart Netdata using `service netdata restart` or the [correct
-alternative](/docs/getting-started.md#start-stop-and-restart-netdata) for your system, and Netdata will auto-detect
-metrics from your Nginx web server!
+Restart Netdata using `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, and Netdata will auto-detect metrics from your Nginx web
+server!
 
 While not necessary for most auto-detection and collection purposes, you can also configure the Nginx collector itself
 by editing its configuration file:

--- a/docs/guides/step-by-step/step-09.md
+++ b/docs/guides/step-by-step/step-09.md
@@ -62,7 +62,8 @@ metrics your Agent collects, and more.
     dbengine disk space = 512
 ```
 
-After you've made your changes, [restart Netdata](/docs/getting-started.md#start-stop-and-restart-netdata).
+After you've made your changes, restart Netdata using `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system.
 
 To confirm the database engine is working, go to your Netdata dashboard and click on the **Netdata Monitoring** menu on
 the right-hand side. You can find `dbengine` metrics after `queries`.
@@ -142,9 +143,10 @@ Add the following section to the file:
     collection = netdata_metrics
 ```
 
-[Restart](/docs/getting-started.md#start-stop-and-restart-netdata) Netdata to enable the MongoDB exporting connector.
-Click on the **Netdata Monitoring** menu and check out the **exporting my mongo instance** sub-menu. You should start
-seeing these charts fill up with data about the exporting process!
+Restart Netdata using `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, to enable the MongoDB exporting connector. Click on the
+**Netdata Monitoring** menu and check out the **exporting my mongo instance** sub-menu. You should start seeing these
+charts fill up with data about the exporting process!
 
 ![image](https://user-images.githubusercontent.com/1153921/70443852-25171200-1a56-11ea-8be3-494544b1c295.png)
 

--- a/docs/guides/troubleshoot/monitor-debug-applications-ebpf.md
+++ b/docs/guides/troubleshoot/monitor-debug-applications-ebpf.md
@@ -57,8 +57,9 @@ dev: custom-app
 ...
 ```
 
-Restart Netdata with `sudo service netdata restart` or the appropriate method for your system to begin seeing metrics
-for this particular group+process. You can also add additional processes to the same group.
+Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, to begin seeing metrics for this particular
+group+process. You can also add additional processes to the same group.
 
 You can set up `apps_groups.conf` to more show more precise eBPF metrics for any application or service running on your
 system, even if it's a standard package like Redis, Apache, or any other [application/service Netdata collects
@@ -105,7 +106,8 @@ Replace `entry` with `return`:
     network viewer = yes
 ```
 
-Restart Netdata with `sudo service netdata restart` or the appropriate method for your system.
+Restart Netdata with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system.
 
 ## Get familiar with per-application eBPF metrics and charts
 

--- a/docs/store/change-metrics-storage.md
+++ b/docs/store/change-metrics-storage.md
@@ -54,7 +54,8 @@ multihost disk space` setting. Change it to the value recommended above. For exa
     dbengine multihost disk space = 1024
 ```
 
-Save the file and restart the Agent with `service netdata restart` to change the database engine's size.
+Save the file and restart the Agent with `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, to change the database engine's size.
 
 ## What's next?
 

--- a/health/notifications/stackpulse/README.md
+++ b/health/notifications/stackpulse/README.md
@@ -39,8 +39,9 @@ SEND_STACKPULSE="YES"
 STACKPULSE_WEBHOOK="https://hooks.stackpulse.io/v1/webhooks/YOUR_UNIQUE_ID"
 ```
 
-4.  Now [restart Netdata](/docs/getting-started.md#start-stop-and-restart-netdata). When your node creates an alarm, you
-    can see the associated notification on your StackPulse Administration Portal 
+4.  Now restart Netdata using `sudo systemctl restart netdata`, or the [appropriate
+    method](/docs/configure/start-stop-restart.md) for your system. When your node creates an alarm, you can see the
+    associated notification on your StackPulse Administration Portal 
 
 ## React to alarms with playbooks
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -232,8 +232,8 @@ the lines to match the output from `ls -la` above and uncomment them if necessar
     web files group = netdata
 ```
 
-Save the file, [restart the Netdata Agent](/docs/getting-started.md#start-stop-and-restart-netdata), and try accessing
-the dashboard again.
+Save the file, restart Netdata using `sudo systemctl restart netdata`, or the [appropriate
+method](/docs/configure/start-stop-restart.md) for your system, and try accessing the dashboard again.
 
 ### Multiple versions of OpenSSL
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Based on conversations in  #10415, we should be instructing users to use `systemctl` to restart Netdata for the most part. 

This PR changes all previous references to `service`, and updates most of these references to the latest doc on starting, stopping, and restarting.

##### Component Name

area/docs

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
