### PR TITLE
update_kernel_version: Fix overflow on Centos and probably Ubuntu

### DIFF
--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -97,7 +97,7 @@ int get_kernel_version(char *out, int size)
         return -1;
 
     move = patch;
-    while (*version && *version != '\n')
+    while (*version && *version != '\n' && *version != '-')
         *move++ = *version++;
     *move = '\0';
 


### PR DESCRIPTION
##### Summary
On CentOS when we compile with libasan `ebpf.plugin` it crashes with the following error:

```
    #1 0x51a508 in main collectors/ebpf.plugin/ebpf.c:1903
    #2 0x7ff05f5d07b2 in __libc_start_main (/lib64/libc.so.6+0x237b2)
    #3 0x40893d in _start (/usr/libexec/netdata/plugins.d/ebpf.plugin+0x40893d)

Address 0x7fff1f60cc10 is located in stack of thread T0 at offset 176 in frame
    #0 0x587ae4 in get_kernel_version libnetdata/ebpf/ebpf.c:65

  This frame has 4 object(s):
    [32, 48) 'major'
    [96, 112) 'minor'
    [160, 176) 'patch' <== Memory access at offset 176 overflows this variable
    [224, 480) 'ver'
```

This is happening because `/proc/sys/kernel/osrelease` has a different pattern, this bug is probably affecting Ubuntu, because both distributions are appending `-` and additional information for the kernel version. On CentOS 8 we have something like this:

```bash
$ cat /proc/sys/kernel/osrelease 
4.18.0-240.15.1.el8_3.x86_64
```

This PR is adding `-` to parser, to avoid overflow on these distributions.

##### Component Name
ebpf.plugin
##### Test Plan

1 - Install libasan on `CentOS 8`:
```bash
dnf install libasan
```
2 - Compile Netdata:
```bash
CFLAGS="-O1 -ggdb -fsanitize=address -Wall -Wextra -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1" ./netdata-installer.sh --disable-lto --dont-wait --dont-start-it --build-judy --disable-telemetry 2> err >out &
```

##### Additional Information
This problem was never detected on Linux distributions that follows the expected values inside `/proc/sys/kernel/osrelease`, where the expeced value is `VERSION.SUBVERSION.PATCH`.
If you compile without `libasan`, it won't crash.