### PR TITLE
Fix disk utilization and backlog charts

### DIFF
--- a/collectors/all.h
+++ b/collectors/all.h
@@ -105,10 +105,11 @@
 #define NETDATA_CHART_PRIO_DISK_OPS                   2001
 #define NETDATA_CHART_PRIO_DISK_QOPS                  2002
 #define NETDATA_CHART_PRIO_DISK_BACKLOG               2003
-#define NETDATA_CHART_PRIO_DISK_UTIL                  2004
-#define NETDATA_CHART_PRIO_DISK_AWAIT                 2005
-#define NETDATA_CHART_PRIO_DISK_AVGSZ                 2006
-#define NETDATA_CHART_PRIO_DISK_SVCTM                 2007
+#define NETDATA_CHART_PRIO_DISK_BUSY                  2004
+#define NETDATA_CHART_PRIO_DISK_UTIL                  2005
+#define NETDATA_CHART_PRIO_DISK_AWAIT                 2006
+#define NETDATA_CHART_PRIO_DISK_AVGSZ                 2007
+#define NETDATA_CHART_PRIO_DISK_SVCTM                 2008
 #define NETDATA_CHART_PRIO_DISK_MOPS                  2021
 #define NETDATA_CHART_PRIO_DISK_IOTIME                2022
 #define NETDATA_CHART_PRIO_BCACHE_CACHE_ALLOC         2120

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -1157,13 +1157,13 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
                 rrdset_flag_set(d->st_util, RRDSET_FLAG_DETAIL);
 
-                d->rd_util_utilization = rrddim_add(d->st_util, "utilization", NULL, 1, 10 * update_every, RRD_ALGORITHM_ABSOLUTE);
+                d->rd_util_utilization = rrddim_add(d->st_util, "utilization", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             }
             else rrdset_next(d->st_util);
 
-            collected_number disk_utilization = busy_ms - last_busy_ms;
-            if (disk_utilization > (collected_number)(MSEC_PER_SEC * update_every))
-                disk_utilization = (collected_number)(MSEC_PER_SEC * update_every);
+            collected_number disk_utilization = (busy_ms - last_busy_ms) / (10 * update_every);
+            if (disk_utilization > 100)
+                disk_utilization = 100;
 
             rrddim_set_by_pointer(d->st_util, d->rd_util_utilization, disk_utilization);
             rrdset_done(d->st_util);

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -73,6 +73,9 @@ static struct disk {
     RRDSET *st_backlog;
     RRDDIM *rd_backlog_backlog;
 
+    RRDSET *st_busy;
+    RRDDIM *rd_busy_busy;
+
     RRDSET *st_util;
     RRDDIM *rd_util_utilization;
 
@@ -1094,7 +1097,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
                 rrdset_flag_set(d->st_backlog, RRDSET_FLAG_DETAIL);
 
-                d->rd_backlog_backlog = rrddim_add(d->st_backlog, "backlog", NULL, 1, 10, RRD_ALGORITHM_INCREMENTAL);
+                d->rd_backlog_backlog = rrddim_add(d->st_backlog, "backlog", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
             }
             else rrdset_next(d->st_backlog);
 
@@ -1107,6 +1110,34 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         if(d->do_util == CONFIG_BOOLEAN_YES || (d->do_util == CONFIG_BOOLEAN_AUTO &&
                                                 (busy_ms || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
             d->do_util = CONFIG_BOOLEAN_YES;
+
+            if(unlikely(!d->st_busy)) {
+                d->st_busy = rrdset_create_localhost(
+                        "disk_busy"
+                        , d->device
+                        , d->disk
+                        , family
+                        , "disk.busy"
+                        , "Disk Busy Time"
+                        , "milliseconds"
+                        , PLUGIN_PROC_NAME
+                        , PLUGIN_PROC_MODULE_DISKSTATS_NAME
+                        , NETDATA_CHART_PRIO_DISK_BUSY
+                        , update_every
+                        , RRDSET_TYPE_AREA
+                );
+
+                rrdset_flag_set(d->st_busy, RRDSET_FLAG_DETAIL);
+
+                d->rd_busy_busy =
+                    rrddim_add(d->st_busy, "busy", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+            }
+            else rrdset_next(d->st_busy);
+
+            last_busy_ms = rrddim_set_by_pointer(d->st_busy, d->rd_busy_busy, busy_ms);
+            rrdset_done(d->st_busy);
+
+        // --------------------------------------------------------------------
 
             if(unlikely(!d->st_util)) {
                 d->st_util = rrdset_create_localhost(
@@ -1126,11 +1157,15 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
                 rrdset_flag_set(d->st_util, RRDSET_FLAG_DETAIL);
 
-                d->rd_util_utilization = rrddim_add(d->st_util, "utilization", NULL, 1, 10, RRD_ALGORITHM_INCREMENTAL);
+                d->rd_util_utilization = rrddim_add(d->st_util, "utilization", NULL, 1, 10 * update_every, RRD_ALGORITHM_ABSOLUTE);
             }
             else rrdset_next(d->st_util);
 
-            last_busy_ms = rrddim_set_by_pointer(d->st_util, d->rd_util_utilization, busy_ms);
+            collected_number disk_utilization = busy_ms - last_busy_ms;
+            if (disk_utilization > (collected_number)(MSEC_PER_SEC * update_every))
+                disk_utilization = (collected_number)(MSEC_PER_SEC * update_every);
+
+            rrddim_set_by_pointer(d->st_util, d->rd_util_utilization, disk_utilization);
             rrdset_done(d->st_util);
         }
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1342,6 +1342,11 @@ netdataDashboard.context = {
         info: 'Disk Utilization measures the amount of time the disk was busy with something. This is not related to its performance. 100% means that the system always had an outstanding operation on the disk. Keep in mind that depending on the underlying technology of the disk, 100% here may or may not be an indication of congestion.'
     },
 
+    'disk.busy': {
+        colors: '#FF5588',
+        info: 'Disk Busy Time measures the amount of time the disk was busy with something.'
+    },
+    
     'disk.backlog': {
         colors: '#0099CC',
         info: 'Backlog is an indication of the duration of pending disk operations. On every I/O event the system is multiplying the time spent doing I/O since the last update of this field with the number of pending operations. While not accurate, this metric can provide an indication of the expected completion time of the operations in progress.'


### PR DESCRIPTION
##### Summary
The disk backlog and utilization charts displayed wrong data. We fix that and add a chart for disk busy time.

Fixes #10700

##### Component Name
diskstats module in proc plugin