### PR TITLE
Add JSON output option for buildinfo.

### DIFF
--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -6,228 +6,237 @@
 // Optional features
 
 #ifdef ENABLE_ACLK
-#define FEAT_CLOUD "YES"
+#define FEAT_CLOUD 1
+#define FEAT_CLOUD_MSG ""
 #else
 #ifdef DISABLE_CLOUD
-#define FEAT_CLOUD "NO (by user request e.g. '--disable-cloud')"
+#define FEAT_CLOUD 0
+#define FEAT_CLOUD_MSG "(by user request)"
 #else
-#define FEAT_CLOUD "NO"
+#define FEAT_CLOUD 0
+#define FEAT_CLOUD_MSG ""
 #endif
 #endif
 
 #ifdef ENABLE_DBENGINE
-#define FEAT_DBENGINE "YES"
+#define FEAT_DBENGINE 1
 #else
-#define FEAT_DBENGINE "NO"
+#define FEAT_DBENGINE 0
 #endif
 
 #if defined(HAVE_X509_VERIFY_PARAM_set1_host) && HAVE_X509_VERIFY_PARAM_set1_host == 1
-#define FEAT_TLS_HOST_VERIFY "YES"
+#define FEAT_TLS_HOST_VERIFY 1
 #else
-#define FEAT_TLS_HOST_VERIFY "NO"
+#define FEAT_TLS_HOST_VERIFY 0
 #endif
 
 #ifdef ENABLE_HTTPS
-#define FEAT_NATIVE_HTTPS "YES"
+#define FEAT_NATIVE_HTTPS 1
 #else
-#define FEAT_NATIVE_HTTPS "NO"
+#define FEAT_NATIVE_HTTPS 0
 #endif
 
 // Optional libraries
 
 #ifdef ENABLE_JSONC
-#define FEAT_JSONC "YES"
+#define FEAT_JSONC 1
 #else
-#define FEAT_JSONC "NO"
+#define FEAT_JSONC 0
 #endif
 
 #ifdef ENABLE_JEMALLOC
-#define FEAT_JEMALLOC "YES"
+#define FEAT_JEMALLOC 1
 #else
-#define FEAT_JEMALLOC "NO"
+#define FEAT_JEMALLOC 0
 #endif
 
 #ifdef ENABLE_TCMALLOC
-#define FEAT_TCMALLOC "YES"
+#define FEAT_TCMALLOC 1
 #else
-#define FEAT_TCMALLOC "NO"
+#define FEAT_TCMALLOC 0
 #endif
 
 #ifdef HAVE_CAPABILITY
-#define FEAT_LIBCAP "YES"
+#define FEAT_LIBCAP 1
 #else
-#define FEAT_LIBCAP "NO"
+#define FEAT_LIBCAP 0
 #endif
 
 #ifdef ACLK_NO_LIBMOSQ
-#define FEAT_MOSQUITTO "NO"
+#define FEAT_MOSQUITTO 0
 #else
-#define FEAT_MOSQUITTO "YES"
+#define FEAT_MOSQUITTO 1
 #endif
 
 #ifdef ACLK_NO_LWS
-#define FEAT_LWS "NO"
+#define FEAT_LWS 0
+#define FEAT_LWS_MSG ""
 #else
 #ifdef ENABLE_ACLK
 #include <libwebsockets.h>
 #endif
 #ifdef BUNDLED_LWS
-#define FEAT_LWS "YES static"
+#define FEAT_LWS 1
+#define FEAT_LWS_MSG "static"
 #else
-#define FEAT_LWS "YES shared-lib"
+#define FEAT_LWS 1
+#define FEAT_LWS_MSG "shared-lib"
 #endif
 #endif
 
 #ifdef NETDATA_WITH_ZLIB
-#define FEAT_ZLIB "YES"
+#define FEAT_ZLIB 1
 #else
-#define FEAT_ZLIB "NO"
+#define FEAT_ZLIB 0
 #endif
 
 #ifdef STORAGE_WITH_MATH
-#define FEAT_LIBM "YES"
+#define FEAT_LIBM 1
 #else
-#define FEAT_LIBM "NO"
+#define FEAT_LIBM 0
 #endif
 
 #ifdef HAVE_CRYPTO
-#define FEAT_CRYPTO "YES"
+#define FEAT_CRYPTO 1
 #else
-#define FEAT_CRYPTO "NO"
+#define FEAT_CRYPTO 0
 #endif
 
 // Optional plugins
 
 #ifdef ENABLE_APPS_PLUGIN
-#define FEAT_APPS_PLUGIN "YES"
+#define FEAT_APPS_PLUGIN 1
 #else
-#define FEAT_APPS_PLUGIN "NO"
+#define FEAT_APPS_PLUGIN 0
 #endif
 
 #ifdef HAVE_FREEIPMI
-#define FEAT_IPMI "YES"
+#define FEAT_IPMI 1
 #else
-#define FEAT_IPMI "NO"
+#define FEAT_IPMI 0
 #endif
 
 #ifdef HAVE_CUPS
-#define FEAT_CUPS "YES"
+#define FEAT_CUPS 1
 #else
-#define FEAT_CUPS "NO"
+#define FEAT_CUPS 0
 #endif
 
 #ifdef HAVE_NFACCT
-#define FEAT_NFACCT "YES"
+#define FEAT_NFACCT 1
 #else
-#define FEAT_NFACCT "NO"
+#define FEAT_NFACCT 0
 #endif
 
 #ifdef HAVE_LIBXENSTAT
-#define FEAT_XEN "YES"
+#define FEAT_XEN 1
 #else
-#define FEAT_XEN "NO"
+#define FEAT_XEN 0
 #endif
 
 #ifdef HAVE_XENSTAT_VBD_ERROR
-#define FEAT_XEN_VBD_ERROR "YES"
+#define FEAT_XEN_VBD_ERROR 1
 #else
-#define FEAT_XEN_VBD_ERROR "NO"
+#define FEAT_XEN_VBD_ERROR 0
 #endif
 
 #ifdef HAVE_LIBBPF
-#define FEAT_EBPF "YES"
+#define FEAT_EBPF 1
 #else
-#define FEAT_EBPF "NO"
+#define FEAT_EBPF 0
 #endif
 
 #ifdef HAVE_SETNS
-#define FEAT_CGROUP_NET "YES"
+#define FEAT_CGROUP_NET 1
 #else
-#define FEAT_CGROUP_NET "NO"
+#define FEAT_CGROUP_NET 0
 #endif
 
 #ifdef ENABLE_PERF_PLUGIN
-#define FEAT_PERF "YES"
+#define FEAT_PERF 1
 #else
-#define FEAT_PERF "NO"
+#define FEAT_PERF 0
 #endif
 
 #ifdef ENABLE_SLABINFO
-#define FEAT_SLABINFO "YES"
+#define FEAT_SLABINFO 1
 #else
-#define FEAT_SLABINFO "NO"
+#define FEAT_SLABINFO 0
 #endif
 
 // Optional Exporters
 
 #ifdef HAVE_KINESIS
-#define FEAT_KINESIS "YES"
+#define FEAT_KINESIS 1
 #else
-#define FEAT_KINESIS "NO"
+#define FEAT_KINESIS 0
 #endif
 
 #ifdef ENABLE_EXPORTING_PUBSUB
-#define FEAT_PUBSUB "YES"
+#define FEAT_PUBSUB 1
 #else
-#define FEAT_PUBSUB "NO"
+#define FEAT_PUBSUB 0
 #endif
 
 #ifdef HAVE_MONGOC
-#define FEAT_MONGO "YES"
+#define FEAT_MONGO 1
 #else
-#define FEAT_MONGO "NO"
+#define FEAT_MONGO 0
 #endif
 
 #ifdef ENABLE_PROMETHEUS_REMOTE_WRITE
-#define FEAT_REMOTE_WRITE "YES"
+#define FEAT_REMOTE_WRITE 1
 #else
-#define FEAT_REMOTE_WRITE "NO"
+#define FEAT_REMOTE_WRITE 0
 #endif
 
+#define FEAT_YES_NO(x) ((x) ? "YES" : "NO")
 
 void print_build_info(void) {
     printf("Configure options: %s\n", CONFIGURE_COMMAND);
 
     printf("Features:\n");
-    printf("    dbengine:                %s\n", FEAT_DBENGINE);
-    printf("    Native HTTPS:            %s\n", FEAT_NATIVE_HTTPS);
-    printf("    Netdata Cloud:           %s\n", FEAT_CLOUD);
-    printf("    TLS Host Verification:   %s\n", FEAT_TLS_HOST_VERIFY);
+    printf("    dbengine:                %s\n", FEAT_YES_NO(FEAT_DBENGINE));
+    printf("    Native HTTPS:            %s\n", FEAT_YES_NO(FEAT_NATIVE_HTTPS));
+    printf("    Netdata Cloud:           %s %s\n", FEAT_YES_NO(FEAT_CLOUD), FEAT_CLOUD_MSG);
+    printf("    TLS Host Verification:   %s\n", FEAT_YES_NO(FEAT_TLS_HOST_VERIFY));
 
     printf("Libraries:\n");
-    printf("    jemalloc:                %s\n", FEAT_JEMALLOC);
-    printf("    JSON-C:                  %s\n", FEAT_JSONC);
-    printf("    libcap:                  %s\n", FEAT_LIBCAP);
-    printf("    libcrypto:               %s\n", FEAT_CRYPTO);
-    printf("    libm:                    %s\n", FEAT_LIBM);
+    printf("    jemalloc:                %s\n", FEAT_YES_NO(FEAT_JEMALLOC));
+    printf("    JSON-C:                  %s\n", FEAT_YES_NO(FEAT_JSONC));
+    printf("    libcap:                  %s\n", FEAT_YES_NO(FEAT_LIBCAP));
+    printf("    libcrypto:               %s\n", FEAT_YES_NO(FEAT_CRYPTO));
+    printf("    libm:                    %s\n", FEAT_YES_NO(FEAT_LIBM));
 #if defined(ENABLE_ACLK)
-    printf("    LWS:                     %s v%d.%d.%d\n", FEAT_LWS, LWS_LIBRARY_VERSION_MAJOR, LWS_LIBRARY_VERSION_MINOR, LWS_LIBRARY_VERSION_PATCH);
+    printf("    LWS:                     %s %s v%d.%d.%d\n", FEAT_YES_NO(FEAT_LWS), FEAT_LWS_MSG, LWS_LIBRARY_VERSION_MAJOR, LWS_LIBRARY_VERSION_MINOR, LWS_LIBRARY_VERSION_PATCH);
 #else
-    printf("    LWS:                     %s\n", FEAT_LWS);
+    printf("    LWS:                     %s %s\n", FEAT_YES_NO(FEAT_LWS), FEAT_LWS_MSG);
 #endif
-    printf("    mosquitto:               %s\n", FEAT_MOSQUITTO);
-    printf("    tcalloc:                 %s\n", FEAT_TCMALLOC);
-    printf("    zlib:                    %s\n", FEAT_ZLIB);
+    printf("    mosquitto:               %s\n", FEAT_YES_NO(FEAT_MOSQUITTO));
+    printf("    tcalloc:                 %s\n", FEAT_YES_NO(FEAT_TCMALLOC));
+    printf("    zlib:                    %s\n", FEAT_YES_NO(FEAT_ZLIB));
 
     printf("Plugins:\n");
-    printf("    apps:                    %s\n", FEAT_APPS_PLUGIN);
-    printf("    cgroup Network Tracking: %s\n", FEAT_CGROUP_NET);
-    printf("    CUPS:                    %s\n", FEAT_CUPS);
-    printf("    EBPF:                    %s\n", FEAT_EBPF);
-    printf("    IPMI:                    %s\n", FEAT_IPMI);
-    printf("    NFACCT:                  %s\n", FEAT_NFACCT);
-    printf("    perf:                    %s\n", FEAT_PERF);
-    printf("    slabinfo:                %s\n", FEAT_SLABINFO);
-    printf("    Xen:                     %s\n", FEAT_XEN);
-    printf("    Xen VBD Error Tracking:  %s\n", FEAT_XEN_VBD_ERROR);
+    printf("    apps:                    %s\n", FEAT_YES_NO(FEAT_APPS_PLUGIN));
+    printf("    cgroup Network Tracking: %s\n", FEAT_YES_NO(FEAT_CGROUP_NET));
+    printf("    CUPS:                    %s\n", FEAT_YES_NO(FEAT_CUPS));
+    printf("    EBPF:                    %s\n", FEAT_YES_NO(FEAT_EBPF));
+    printf("    IPMI:                    %s\n", FEAT_YES_NO(FEAT_IPMI));
+    printf("    NFACCT:                  %s\n", FEAT_YES_NO(FEAT_NFACCT));
+    printf("    perf:                    %s\n", FEAT_YES_NO(FEAT_PERF));
+    printf("    slabinfo:                %s\n", FEAT_YES_NO(FEAT_SLABINFO));
+    printf("    Xen:                     %s\n", FEAT_YES_NO(FEAT_XEN));
+    printf("    Xen VBD Error Tracking:  %s\n", FEAT_YES_NO(FEAT_XEN_VBD_ERROR));
 
     printf("Exporters:\n");
-    printf("    AWS Kinesis:             %s\n", FEAT_KINESIS);
-    printf("    GCP PubSub:              %s\n", FEAT_PUBSUB);
-    printf("    MongoDB:                 %s\n", FEAT_MONGO);
-    printf("    Prometheus Remote Write: %s\n", FEAT_REMOTE_WRITE);
+    printf("    AWS Kinesis:             %s\n", FEAT_YES_NO(FEAT_KINESIS));
+    printf("    GCP PubSub:              %s\n", FEAT_YES_NO(FEAT_PUBSUB));
+    printf("    MongoDB:                 %s\n", FEAT_YES_NO(FEAT_MONGO));
+    printf("    Prometheus Remote Write: %s\n", FEAT_YES_NO(FEAT_REMOTE_WRITE));
 };
 
+
+#define FEAT_JSON_BOOL(x) ((x) ? "true" : "false")
 // This intentionally does not use JSON-C so it works even if JSON-C is not present
 // This is used for anonymous statistics reporting, so it intentionally
 // does not include the configure options, which would be very easy to use
@@ -235,46 +244,53 @@ void print_build_info(void) {
 void print_build_info_json(void) {
     printf("{\n");
     printf("  \"features\": {\n");
-    printf("    \"dbengine\": \"%s\",\n",         FEAT_DBENGINE);
-    printf("    \"native-https\": \"%s\",\n",     FEAT_NATIVE_HTTPS);
-    printf("    \"cloud\": \"%s\",\n",            FEAT_CLOUD);
-    printf("    \"tls-host-verify\": \"%s\"\n",   FEAT_TLS_HOST_VERIFY);
+    printf("    \"dbengine\": %s,\n",         FEAT_JSON_BOOL(FEAT_DBENGINE));
+    printf("    \"native-https\": %s,\n",     FEAT_JSON_BOOL(FEAT_NATIVE_HTTPS));
+    printf("    \"cloud\": %s,\n",            FEAT_JSON_BOOL(FEAT_CLOUD));
+#ifdef DISABLE_CLOUD
+    printf("    \"cloud-disabled\": true,\n");
+#else
+    printf("    \"cloud-disabled\": false,\n");
+#endif
+    printf("    \"tls-host-verify\": %s\n",   FEAT_JSON_BOOL(FEAT_TLS_HOST_VERIFY));
     printf("  },\n");
 
     printf("  \"libs\": {\n");
-    printf("    \"jemalloc\": \"%s\",\n",         FEAT_JEMALLOC);
-    printf("    \"jsonc\": \"%s\",\n",            FEAT_JSONC);
-    printf("    \"libcap\": \"%s\",\n",           FEAT_LIBCAP);
-    printf("    \"libcrypto\": \"%s\",\n",        FEAT_CRYPTO);
-    printf("    \"libm\": \"%s\",\n",             FEAT_LIBM);
+    printf("    \"jemalloc\": %s,\n",         FEAT_JSON_BOOL(FEAT_JEMALLOC));
+    printf("    \"jsonc\": %s,\n",            FEAT_JSON_BOOL(FEAT_JSONC));
+    printf("    \"libcap\": %s,\n",           FEAT_JSON_BOOL(FEAT_LIBCAP));
+    printf("    \"libcrypto\": %s,\n",        FEAT_JSON_BOOL(FEAT_CRYPTO));
+    printf("    \"libm\": %s,\n",             FEAT_JSON_BOOL(FEAT_LIBM));
 #if defined(ENABLE_ACLK)
-    printf("    \"lws\": \"%s v%d.%d.%d\",\n",    FEAT_LWS, LWS_LIBRARY_VERSION_MAJOR, LWS_LIBRARY_VERSION_MINOR, LWS_LIBRARY_VERSION_PATCH);
+    printf("    \"lws\": \"%s\",\n", FEAT_JSON_BOOL(FEAT_LWS));
+    printf("    \"lws-version\": \"%d.%d.%d\",\n", LWS_LIBRARY_VERSION_MAJOR, LWS_LIBRARY_VERSION_MINOR, LWS_LIBRARY_VERSION_PATCH);
+    printf("    \"lws-type\": %s,\n", FEAT_LWS_MSG);
 #else
-    printf("    \"lws\": \"%s\",\n",              FEAT_LWS);
+    printf("    \"lws\": %s,\n",              FEAT_JSON_BOOL(FEAT_LWS));
 #endif
-    printf("    \"mosquitto\": \"%s\",\n",        FEAT_MOSQUITTO);
-    printf("    \"tcmalloc\": \"%s\",\n",         FEAT_TCMALLOC);
-    printf("    \"zlib\": \"%s\"\n",              FEAT_ZLIB);
+    printf("    \"mosquitto\": %s,\n",        FEAT_JSON_BOOL(FEAT_MOSQUITTO));
+    printf("    \"tcmalloc\": %s,\n",         FEAT_JSON_BOOL(FEAT_TCMALLOC));
+    printf("    \"zlib\": %s\n",              FEAT_JSON_BOOL(FEAT_ZLIB));
     printf("  },\n");
 
     printf("  \"plugins\": {\n");
-    printf("    \"apps\": \"%s\",\n",             FEAT_APPS_PLUGIN);
-    printf("    \"cgroup-net\": \"%s\",\n",       FEAT_CGROUP_NET);
-    printf("    \"cups\": \"%s\",\n",             FEAT_CUPS);
-    printf("    \"ebpf\": \"%s\",\n",             FEAT_EBPF);
-    printf("    \"ipmi\": \"%s\",\n",             FEAT_IPMI);
-    printf("    \"nfacct\": \"%s\",\n",           FEAT_NFACCT);
-    printf("    \"perf\": \"%s\",\n",             FEAT_PERF);
-    printf("    \"slabinfo\": \"%s\",\n",         FEAT_SLABINFO);
-    printf("    \"xen\": \"%s\",\n",              FEAT_XEN);
-    printf("    \"xen-vbd-error\": \"%s\"\n",     FEAT_XEN_VBD_ERROR);
+    printf("    \"apps\": %s,\n",             FEAT_JSON_BOOL(FEAT_APPS_PLUGIN));
+    printf("    \"cgroup-net\": %s,\n",       FEAT_JSON_BOOL(FEAT_CGROUP_NET));
+    printf("    \"cups\": %s,\n",             FEAT_JSON_BOOL(FEAT_CUPS));
+    printf("    \"ebpf\": %s,\n",             FEAT_JSON_BOOL(FEAT_EBPF));
+    printf("    \"ipmi\": %s,\n",             FEAT_JSON_BOOL(FEAT_IPMI));
+    printf("    \"nfacct\": %s,\n",           FEAT_JSON_BOOL(FEAT_NFACCT));
+    printf("    \"perf\": %s,\n",             FEAT_JSON_BOOL(FEAT_PERF));
+    printf("    \"slabinfo\": %s,\n",         FEAT_JSON_BOOL(FEAT_SLABINFO));
+    printf("    \"xen\": %s,\n",              FEAT_JSON_BOOL(FEAT_XEN));
+    printf("    \"xen-vbd-error\": %s\n",     FEAT_JSON_BOOL(FEAT_XEN_VBD_ERROR));
     printf("  },\n");
 
     printf("  \"exporters\": {\n");
-    printf("    \"kinesis\": \"%s\",\n",          FEAT_KINESIS);
-    printf("    \"pubsub\": \"%s\",\n",           FEAT_PUBSUB);
-    printf("    \"mongodb\": \"%s\",\n",          FEAT_MONGO);
-    printf("    \"prom-remote-write\": \"%s\"\n", FEAT_REMOTE_WRITE);
+    printf("    \"kinesis\": %s,\n",          FEAT_JSON_BOOL(FEAT_KINESIS));
+    printf("    \"pubsub\": %s,\n",           FEAT_JSON_BOOL(FEAT_PUBSUB));
+    printf("    \"mongodb\": %s,\n",          FEAT_JSON_BOOL(FEAT_MONGO));
+    printf("    \"prom-remote-write\": %s\n", FEAT_JSON_BOOL(FEAT_REMOTE_WRITE));
     printf("  }\n");
     printf("}\n");
 };

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -227,3 +227,54 @@ void print_build_info(void) {
     printf("    MongoDB:                 %s\n", FEAT_MONGO);
     printf("    Prometheus Remote Write: %s\n", FEAT_REMOTE_WRITE);
 };
+
+// This intentionally does not use JSON-C so it works even if JSON-C is not present
+// This is used for anonymous statistics reporting, so it intentionally
+// does not include the configure options, which would be very easy to use
+// for tracking custom builds (and complicate outputting valid JSON).
+void print_build_info_json(void) {
+    printf("{\n");
+    printf("  \"features\": {\n");
+    printf("    \"dbengine\": \"%s\",\n",         FEAT_DBENGINE);
+    printf("    \"native-https\": \"%s\",\n",     FEAT_NATIVE_HTTPS);
+    printf("    \"cloud\": \"%s\",\n",            FEAT_CLOUD);
+    printf("    \"tls-host-verify\": \"%s\"\n",   FEAT_TLS_HOST_VERIFY);
+    printf("  },\n");
+
+    printf("  \"libs\": {\n");
+    printf("    \"jemalloc\": \"%s\",\n",         FEAT_JEMALLOC);
+    printf("    \"jsonc\": \"%s\",\n",            FEAT_JSONC);
+    printf("    \"libcap\": \"%s\",\n",           FEAT_LIBCAP);
+    printf("    \"libcrypto\": \"%s\",\n",        FEAT_CRYPTO);
+    printf("    \"libm\": \"%s\",\n",             FEAT_LIBM);
+#if defined(ENABLE_ACLK)
+    printf("    \"lws\": \"%s v%d.%d.%d\",\n",    FEAT_LWS, LWS_LIBRARY_VERSION_MAJOR, LWS_LIBRARY_VERSION_MINOR, LWS_LIBRARY_VERSION_PATCH);
+#else
+    printf("    \"lws\": \"%s\",\n",              FEAT_LWS);
+#endif
+    printf("    \"mosquitto\": \"%s\",\n",        FEAT_MOSQUITTO);
+    printf("    \"tcmalloc\": \"%s\",\n",         FEAT_TCMALLOC);
+    printf("    \"zlib\": \"%s\"\n",              FEAT_ZLIB);
+    printf("  },\n");
+
+    printf("  \"plugins\": {\n");
+    printf("    \"apps\": \"%s\",\n",             FEAT_APPS_PLUGIN);
+    printf("    \"cgroup-net\": \"%s\",\n",       FEAT_CGROUP_NET);
+    printf("    \"cups\": \"%s\",\n",             FEAT_CUPS);
+    printf("    \"ebpf\": \"%s\",\n",             FEAT_EBPF);
+    printf("    \"ipmi\": \"%s\",\n",             FEAT_IPMI);
+    printf("    \"nfacct\": \"%s\",\n",           FEAT_NFACCT);
+    printf("    \"perf\": \"%s\",\n",             FEAT_PERF);
+    printf("    \"slabinfo\": \"%s\",\n",         FEAT_SLABINFO);
+    printf("    \"xen\": \"%s\",\n",              FEAT_XEN);
+    printf("    \"xen-vbd-error\": \"%s\"\n",     FEAT_XEN_VBD_ERROR);
+    printf("  },\n");
+
+    printf("  \"exporters\": {\n");
+    printf("    \"kinesis\": \"%s\",\n",          FEAT_KINESIS);
+    printf("    \"pubsub\": \"%s\",\n",           FEAT_PUBSUB);
+    printf("    \"mongodb\": \"%s\",\n",          FEAT_MONGO);
+    printf("    \"prom-remote-write\": \"%s\"\n", FEAT_REMOTE_WRITE);
+    printf("  }\n");
+    printf("}\n");
+};

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -262,9 +262,9 @@ void print_build_info_json(void) {
     printf("    \"libcrypto\": %s,\n",        FEAT_JSON_BOOL(FEAT_CRYPTO));
     printf("    \"libm\": %s,\n",             FEAT_JSON_BOOL(FEAT_LIBM));
 #if defined(ENABLE_ACLK)
-    printf("    \"lws\": \"%s\",\n", FEAT_JSON_BOOL(FEAT_LWS));
+    printf("    \"lws\": %s,\n", FEAT_JSON_BOOL(FEAT_LWS));
     printf("    \"lws-version\": \"%d.%d.%d\",\n", LWS_LIBRARY_VERSION_MAJOR, LWS_LIBRARY_VERSION_MINOR, LWS_LIBRARY_VERSION_PATCH);
-    printf("    \"lws-type\": %s,\n", FEAT_LWS_MSG);
+    printf("    \"lws-type\": \"%s\",\n", FEAT_LWS_MSG);
 #else
     printf("    \"lws\": %s,\n",              FEAT_JSON_BOOL(FEAT_LWS));
 #endif

--- a/daemon/buildinfo.h
+++ b/daemon/buildinfo.h
@@ -5,4 +5,6 @@
 
 extern void print_build_info(void);
 
+extern void print_build_info_json(void);
+
 #endif // NETDATA_BUILDINFO_H

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1258,6 +1258,10 @@ int main(int argc, char **argv) {
                             print_build_info();
                             return 0;
                         }
+                        else if(strcmp(optarg, "buildinfojson") == 0) {
+                            print_build_info_json();
+                            return 0;
+                        }
                         else {
                             fprintf(stderr, "Unknown -W parameter '%s'\n", optarg);
                             return help(1);


### PR DESCRIPTION
##### Summary

This adds a variant of the `-W buildinfo` option called `-W buildinfojson` which outputs JSON instead of plain text, allowing for easier parsing and simpler handling in our anonymous statistics reporting.

Sample output (with JSON syntax hilighting):

```json
{
  "features": {
    "dbengine": "NO",
    "native-https": "YES",
    "cloud": "NO",
    "tls-host-verify": "YES"
  },
  "libs": {
    "jemalloc": "NO",
    "jsonc": "YES",
    "libcap": "YES",
    "libcrypto": "YES",
    "libm": "YES",
    "lws": "NO",
    "mosquitto": "NO",
    "tcmalloc": "NO",
    "zlib": "YES"
  },
  "plugins": {
    "apps": "YES",
    "cgroup-net": "YES",
    "cups": "YES",
    "ebpf": "NO",
    "ipmi": "NO",
    "nfacct": "YES",
    "perf": "YES",
    "slabinfo": "YES",
    "xen": "NO",
    "xen-vbd-error": "NO"
  },
  "exporters": {
    "kinesis": "NO",
    "pubsub": "NO",
    "mongodb": "NO",
    "prom-remote-write": "YES"
  }
}
```

##### Component Name

area/daemon

##### Test Plan

Manually tested by building with various options and verifying that the output from `netdata -W buildinfo` and `netdata -W buildinfojson` match correctly.

Also validated all the output to ensure it’s valid JSON.

##### Additional Information

The resultant output intentionally does not include the configure options. These are very likely to leak identifying information when dealing with custom builds, and would also require comprehensive escaping to be safe for use as part of  a JSON string.

This also intentionally does not use JSON-C. We need this to work even if we don’t have JSON-C, so a trivial static substitution approach like this is really the only option unless we want to include a different JSON implementation (and I strongly suspect we do not, as much as I would love to just vendor [cJSON](https://github.com/DaveGamble/cJSON) instead of depending on JSON-C as an external dependency).