### PR TITLE
Add Working Set charts to the cgroups plugin

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1527,6 +1527,7 @@ static inline void cgroup_free(struct cgroup *cg) {
     if(cg->st_pgfaults)              rrdset_is_obsolete(cg->st_pgfaults);
     if(cg->st_mem_usage)             rrdset_is_obsolete(cg->st_mem_usage);
     if(cg->st_mem_usage_limit)       rrdset_is_obsolete(cg->st_mem_usage_limit);
+    if(cg->st_mem_utilization)       rrdset_is_obsolete(cg->st_mem_utilization);
     if(cg->st_mem_failcnt)           rrdset_is_obsolete(cg->st_mem_failcnt);
     if(cg->st_io)                    rrdset_is_obsolete(cg->st_io);
     if(cg->st_serviced_ops)          rrdset_is_obsolete(cg->st_serviced_ops);
@@ -3555,6 +3556,8 @@ void update_cgroup_charts(int update_every) {
                         rrdset_next(cg->st_mem_utilization);
 
                     if (memory_limit) {
+                        rrdset_isnot_obsolete(cg->st_mem_utilization);
+
                         rrddim_set(
                             cg->st_mem_utilization, "utilization", cg->memory.usage_in_bytes * 100 / memory_limit);
                         rrdset_done(cg->st_mem_utilization);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -3319,7 +3319,7 @@ void update_cgroup_charts(int update_every) {
                         , "MiB"
                         , PLUGIN_CGROUPS_NAME
                         , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
-                        , cgroup_containers_chart_priority + 210
+                        , cgroup_containers_chart_priority + 225
                         , update_every
                         , RRDSET_TYPE_STACKED
                 );
@@ -3379,7 +3379,7 @@ void update_cgroup_charts(int update_every) {
                         , "MiB"
                         , PLUGIN_CGROUPS_NAME
                         , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
-                        , cgroup_containers_chart_priority + 220
+                        , cgroup_containers_chart_priority + 205
                         , update_every
                         , RRDSET_TYPE_AREA
                 );
@@ -3504,7 +3504,7 @@ void update_cgroup_charts(int update_every) {
                         , "MiB"
                         , PLUGIN_CGROUPS_NAME
                         , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
-                        , cgroup_containers_chart_priority + 200
+                        , cgroup_containers_chart_priority + 220
                         , update_every
                         , RRDSET_TYPE_STACKED
                 );
@@ -3567,7 +3567,7 @@ void update_cgroup_charts(int update_every) {
                                 , "MiB"
                                 , PLUGIN_CGROUPS_NAME
                                 , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
-                                , cgroup_containers_chart_priority + 199
+                                , cgroup_containers_chart_priority + 210
                                 , update_every
                                 , RRDSET_TYPE_STACKED
                         );
@@ -3600,7 +3600,7 @@ void update_cgroup_charts(int update_every) {
                                     , "percentage"
                                     , PLUGIN_CGROUPS_NAME
                                     , PLUGIN_CGROUPS_MODULE_CGROUPS_NAME
-                                    , cgroup_containers_chart_priority + 215
+                                    , cgroup_containers_chart_priority + 200
                                     , update_every
                                     , RRDSET_TYPE_AREA
                             );

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1075,7 +1075,7 @@ static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unif
                 arl_expect(mem->arl_base, "total_pgpgout", &mem->total_pgpgout);
                 arl_expect(mem->arl_base, "total_pgfault", &mem->total_pgfault);
                 arl_expect(mem->arl_base, "total_pgmajfault", &mem->total_pgmajfault);
-                arl_expect(mem->arl_base, "total_inactive_files", &mem->total_inactive_file);
+                arl_expect(mem->arl_base, "total_inactive_file", &mem->total_inactive_file);
             } else {
                 mem->arl_base = arl_create("cgroup/memory", NULL, 60);
 
@@ -2748,7 +2748,11 @@ void update_systemd_services_charts(
             if(unlikely(!cg->rd_mem_detailed_working_set))
                 cg->rd_mem_detailed_working_set = rrddim_add(st_mem_detailed_working_set, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
 
-            rrddim_set_by_pointer(st_mem_detailed_working_set, cg->rd_mem_detailed_working_set, cg->memory.usage_in_bytes - cg->memory.total_inactive_file);
+            rrddim_set_by_pointer(
+                st_mem_detailed_working_set,
+                cg->rd_mem_detailed_working_set,
+                (cg->memory.usage_in_bytes > cg->memory.total_inactive_file) ?
+                    (cg->memory.usage_in_bytes - cg->memory.total_inactive_file) : 0);
 
             if(unlikely(!cg->rd_mem_detailed_mapped))
                 cg->rd_mem_detailed_mapped = rrddim_add(st_mem_detailed_mapped, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
@@ -3383,7 +3387,11 @@ void update_cgroup_charts(int update_every) {
             } else
                 rrdset_next(cg->st_mem_working_set);
 
-                rrddim_set(cg->st_mem_working_set, "working_set", cg->memory.usage_in_bytes - cg->memory.total_inactive_file);
+            rrddim_set(
+                cg->st_mem_working_set,
+                "working_set",
+                (cg->memory.usage_in_bytes > cg->memory.total_inactive_file) ?
+                    (cg->memory.usage_in_bytes - cg->memory.total_inactive_file) : 0);
             rrdset_done(cg->st_mem_working_set);
 
             if(unlikely(!cg->st_writeback)) {

--- a/health/health.d/cgroups.conf
+++ b/health/health.d/cgroups.conf
@@ -26,16 +26,3 @@ template: cgroup_ram_in_use
    delay: down 15m multiplier 1.5 max 1h
     info: RAM used by cgroup
       to: sysadmin
-
-template: cgroup_ram_and_swap_in_use
-      on: cgroup.mem_usage
-      os: linux
-   hosts: *
-    calc: ($ram + $swap) * 100 / $memory_and_swap_limit
-   units: %
-   every: 10s
-    warn: $this > (($status >= $WARNING)  ? (80) : (90))
-    crit: $this > (($status == $CRITICAL) ? (90) : (98))
-   delay: down 15m multiplier 1.5 max 1h
-    info: RAM and Swap used by cgroup
-      to: sysadmin

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1820,16 +1820,17 @@ netdataDashboard.context = {
         ]
     },
 
-    'cgroup.mem_working_set_utilization': {
+    'cgroup.mem_usage_limit': {
         mainheads: [
             function (os, id) {
                 void (os);
                 cgroupMemLimitIsSet = 1;
                 return '<div data-netdata="' + id + '"'
-                    + ' data-dimensions="utilization"'
+                    + ' data-dimensions="used"'
+                    + ' data-append-options="percentage"'
                     + ' data-gauge-max-value="100"'
                     + ' data-chart-library="gauge"'
-                    + ' data-title="Memory Working Set"'
+                    + ' data-title="Memory"'
                     + ' data-units="%"'
                     + ' data-gauge-adjust="width"'
                     + ' data-width="12%"'
@@ -1837,34 +1838,7 @@ netdataDashboard.context = {
                     + ' data-after="-CHART_DURATION"'
                     + ' data-points="CHART_DURATION"'
                     + ' data-colors="' + NETDATA.colors[1] + '"'
-                    + ' data-decimal-digits="1"'
                     + ' role="application"></div>';
-            }
-        ]
-    },
-
-    'cgroup.mem_usage_limit': {
-        mainheads: [
-            function (os, id) {
-                void (os);
-                if (cgroupMemLimitIsSet === 0) {
-                    cgroupMemLimitIsSet = 1;
-                    return '<div data-netdata="' + id + '"'
-                        + ' data-dimensions="used"'
-                        + ' data-append-options="percentage"'
-                        + ' data-gauge-max-value="100"'
-                        + ' data-chart-library="gauge"'
-                        + ' data-title="Memory"'
-                        + ' data-units="%"'
-                        + ' data-gauge-adjust="width"'
-                        + ' data-width="12%"'
-                        + ' data-before="0"'
-                        + ' data-after="-CHART_DURATION"'
-                        + ' data-points="CHART_DURATION"'
-                        + ' data-colors="' + NETDATA.colors[1] + '"'
-                        + ' role="application"></div>';
-                } else
-                    return '';
             }
         ]
     },

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1820,17 +1820,16 @@ netdataDashboard.context = {
         ]
     },
 
-    'cgroup.mem_usage_limit': {
+    'cgroup.mem_working_set_utilization': {
         mainheads: [
             function (os, id) {
                 void (os);
                 cgroupMemLimitIsSet = 1;
                 return '<div data-netdata="' + id + '"'
-                    + ' data-dimensions="used"'
-                    + ' data-append-options="percentage"'
+                    + ' data-dimensions="utilization"'
                     + ' data-gauge-max-value="100"'
                     + ' data-chart-library="gauge"'
-                    + ' data-title="Memory"'
+                    + ' data-title="Memory Working Set"'
                     + ' data-units="%"'
                     + ' data-gauge-adjust="width"'
                     + ' data-width="12%"'
@@ -1838,7 +1837,34 @@ netdataDashboard.context = {
                     + ' data-after="-CHART_DURATION"'
                     + ' data-points="CHART_DURATION"'
                     + ' data-colors="' + NETDATA.colors[1] + '"'
+                    + ' data-decimal-digits="1"'
                     + ' role="application"></div>';
+            }
+        ]
+    },
+
+    'cgroup.mem_usage_limit': {
+        mainheads: [
+            function (os, id) {
+                void (os);
+                if (cgroupMemLimitIsSet === 0) {
+                    cgroupMemLimitIsSet = 1;
+                    return '<div data-netdata="' + id + '"'
+                        + ' data-dimensions="used"'
+                        + ' data-append-options="percentage"'
+                        + ' data-gauge-max-value="100"'
+                        + ' data-chart-library="gauge"'
+                        + ' data-title="Memory"'
+                        + ' data-units="%"'
+                        + ' data-gauge-adjust="width"'
+                        + ' data-width="12%"'
+                        + ' data-before="0"'
+                        + ' data-after="-CHART_DURATION"'
+                        + ' data-points="CHART_DURATION"'
+                        + ' data-colors="' + NETDATA.colors[1] + '"'
+                        + ' role="application"></div>';
+                } else
+                    return '';
             }
         ]
     },


### PR DESCRIPTION
##### Summary
SSIA

Closes #10681
##### Component Name
cgroups plugin

##### Test Plan
Enable detailed memory charts for systemd services
```
[plugin:cgroups]
    enable systemd services detailed memory = yes
```
Check `services.mem_working_set` and `cgroup_<cgroup_name>.mem_working_set` charts.