### PR TITLE
Fix a parameter binding issue when storing chart names in the database

### DIFF
--- a/database/sqlite/Makefile.am
+++ b/database/sqlite/Makefile.am
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+AUTOMAKE_OPTIONS = subdir-objects
+MAINTAINERCLEANFILES = $(srcdir)/Makefile.in

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -530,11 +530,12 @@ int sql_store_chart(
         goto bind_fail;
 
     param++;
-    if (name) {
+    if (name && *name)
         rc = sqlite3_bind_text(res, 5, name, -1, SQLITE_STATIC);
-        if (unlikely(rc != SQLITE_OK))
-            goto bind_fail;
-    }
+    else
+        rc = sqlite3_bind_null(res, 5);
+    if (unlikely(rc != SQLITE_OK))
+        goto bind_fail;
 
     param++;
     rc = sqlite3_bind_text(res, 6, family, -1, SQLITE_STATIC);


### PR DESCRIPTION
##### Summary
The `name` parameter when storing charts in SQLite was not correctly reset (re-bind). This (under certain conditions) could result in additional chart entries being created. 

It could also result in metrics being inaccessible if : 
- A new chart was created instead of being reused
  - This would result into a new dimension entry being created and assigned to collect metrics
     - Previously collected metrics with a different dimension UUID (due to the duplicate chart) would be inaccessible

Parameter binding should always happen.

##### Component Name
database

##### Test Plan
- With the agent stopped, backup the `netdata-meta.db` file if you don't want to lose data.

- Before patch
- Clear metadata database (/var/cache/netdata/netdata-meta.db)
  - Have the `sqlite3` client installed
  - Start agent with children connected 
    - Connect to the database `sqlite3 /var/cache/netdata-meta.db`
    - Compare charts reported per host by running
       `select h.hostname, count(c.chart_id) from chart c, host h where c.host_id = h.host_id group by h.hostname;`
       - You may notice a larger number of charts being reported
- After the patch
  - With agent stopped, remove the database
  - Repeat test
- Stop the agent
- Restore your previous `netdata-meta.db` file (if needed)
