### PR TITLE
Add the ability to store chart labels in the database

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1933,7 +1933,7 @@ void rrdset_finalize_labels(RRDSET *st)
         replace_label_list(labels, new_labels);
     }
 #ifdef ENABLE_DBENGINE
-    if (likely(st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)) {
+    if (st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
         netdata_rwlock_wrlock(&labels->labels_rwlock);
         struct label *lbl = labels->head;
         while (lbl) {

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1932,6 +1932,18 @@ void rrdset_finalize_labels(RRDSET *st)
     } else {
         replace_label_list(labels, new_labels);
     }
+#ifdef ENABLE_DBENGINE
+    if (likely(st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)) {
+        netdata_rwlock_wrlock(&labels->labels_rwlock);
+        struct label *lbl = labels->head;
+        while (lbl) {
+            sql_store_chart_label(st->chart_uuid, (int)lbl->label_source, lbl->key, lbl->value);
+            lbl = lbl->next;
+        }
+        netdata_rwlock_unlock(&labels->labels_rwlock);
+    }
+#endif
+
     st->state->new_labels = NULL;
 }
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1041,31 +1041,32 @@ void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, cha
     rc = sqlite3_bind_blob(res, 1, chart_uuid, sizeof(*chart_uuid), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind chart_id parameter to store label information");
-        return;
+        goto failed;
     }
 
     rc = sqlite3_bind_int(res, 2, source_type);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind type parameter to store label information");
-        return;
+        goto failed;
     }
 
     rc = sqlite3_bind_text(res, 3, label, -1, SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind label parameter to store label information");
-        return;
+        goto failed;
     }
 
     rc = sqlite3_bind_text(res, 4, value, -1, SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind value parameter to store label information");
-        return;
+        goto failed;
     }
 
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE))
         error_report("Failed to store chart label entry, rc = %d", rc);
 
+failed:
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
         error_report("Failed to finalize the prepared statement when storing chart label information");
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -17,12 +17,14 @@ const char *database_config[] = {
     "CREATE TABLE IF NOT EXISTS metadata_migration(filename text, file_size, date_created int);",
     "CREATE INDEX IF NOT EXISTS ind_d1 on dimension (chart_id, id, name);",
     "CREATE INDEX IF NOT EXISTS ind_c1 on chart (host_id, id, type, name);",
+    "CREATE TABLE IF NOT EXISTS chart_label(chart_id blob, source_type int, label_key text, "
+    "label_value text, date_created int, PRIMARY KEY (chart_id, label_key));",
 
     "delete from chart_active;",
     "delete from dimension_active;",
-
     "delete from chart where chart_id not in (select chart_id from dimension);",
     "delete from host where host_id not in (select host_id from chart);",
+    "delete from chart_label where chart_id not in (select chart_id from chart);",
     NULL
 };
 
@@ -1017,6 +1019,55 @@ void add_migrated_file(char *path, uint64_t file_size)
 
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
         error_report("Failed to finalize the prepared statement when checking if metadata file is migrated");
+
+    return;
+}
+
+#define SQL_INS_CHART_LABEL "insert or replace into chart_label " \
+    "(chart_id, source_type, label_key, label_value, date_created) " \
+    "values (@chart, @source, @label, @value, strftime('%s'));"
+
+void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value)
+{
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_INS_CHART_LABEL, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement store chart labels");
+        return;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, chart_uuid, sizeof(*chart_uuid), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind chart_id parameter to store label information");
+        return;
+    }
+
+    rc = sqlite3_bind_int(res, 2, source_type);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind type parameter to store label information");
+        return;
+    }
+
+    rc = sqlite3_bind_text(res, 3, label, -1, SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind label parameter to store label information");
+        return;
+    }
+
+    rc = sqlite3_bind_text(res, 4, value, -1, SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind value parameter to store label information");
+        return;
+    }
+
+    rc = execute_insert(res);
+    if (unlikely(rc != SQLITE_DONE))
+        error_report("Failed to store chart label entry, rc = %d", rc);
+
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when storing chart label information");
 
     return;
 }

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -58,5 +58,5 @@ extern void add_migrated_file(char *path, uint64_t file_size);
 extern void db_unlock(void);
 extern void db_lock(void);
 extern void delete_dimension_uuid(uuid_t *dimension_uuid);
-
+extern void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
- This PR will create a new database table chart_label if it does not exist
- Store chart labels as they are attached to a chart

The information stored is
- chart_id blob (unique chart UUID)
- source_type int
- label_key text
- label_value text
- date_created (time since epoch)

##### Component Name
database

##### Test Plan
- Start an agent that define chart labels (e.g. k8s cluster)
- Connect to the database via `sqlite3`
  - Type `.schema` 
  - Observe the new table `chart_label` table

example:
```
fccdbc1e-52c6-411c-b8fa-fb5e27523356,4,container_name,qemu_ubuntu18.04
fccdbc1e-52c6-411c-b8fa-fb5e27523356,4,label,value
c4d3832a-5138-464b-9a2a-11147b0b3e8c,4,container_name,qemu_ubuntu18.04
c4d3832a-5138-464b-9a2a-11147b0b3e8c,4,label,value
902891fb-12dc-4f0c-b3bd-d2c1c242308f,4,container_name,qemu_ubuntu18.04
902891fb-12dc-4f0c-b3bd-d2c1c242308f,4,label,value
83a0f039-c47b-4e9c-968f-f569db3ab8b5,4,container_name,qemu_ubuntu18.04
83a0f039-c47b-4e9c-968f-f569db3ab8b5,4,label,value
```