### PR TITLE
Fixed detection of already claimed node in Docker images.

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -20,7 +20,7 @@ if [ -n "${PGID}" ]; then
   usermod -a -G "${PGID}" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
 fi
 
-if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/claim.d/claimed_id ]; then
+if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/cloud.d/claimed_id ]; then
   /usr/sbin/netdata-claim.sh -token "${NETDATA_CLAIM_TOKEN}" \
                              -url "${NETDATA_CLAIM_URL}" \
                              ${NETDATA_CLAIM_ROOMS:+-rooms "${NETDATA_CLAIM_ROOMS}"} \


### PR DESCRIPTION
##### Summary

The name of the path we are checking was incorrect, which resulted in the check not correctly skipping claiming on startup of containers that are already claimed.

##### Component Name

area/packaging

##### Test Plan

Verified that the check now correctly skips attempting to claim a node that is already claimed.

##### Additional Information

Credit to @ilyam8 for noticing this bug.