### PR TITLE
Removes unused fnc warning in ACLK Legacy

### DIFF
--- a/aclk/legacy/aclk_lws_wss_client.c
+++ b/aclk/legacy/aclk_lws_wss_client.c
@@ -348,6 +348,7 @@ static inline int received_data_to_ringbuff(struct lws_ring *buffer, void *data,
     return 1;
 }
 
+#ifdef ACLK_TRP_DEBUG_VERBOSE
 static const char *aclk_lws_callback_name(enum lws_callback_reasons reason)
 {
     switch (reason) {
@@ -377,12 +378,11 @@ static const char *aclk_lws_callback_name(enum lws_callback_reasons reason)
             return "LWS_CALLBACK_EVENT_WAIT_CANCELLED";
         default:
             // Not using an internal buffer here for thread-safety with unknown calling context.
-#ifdef ACLK_TRP_DEBUG_VERBOSE
             error("Unknown LWS callback %u", reason);
-#endif
             return "unknown";
     }
 }
+#endif
 
 void aclk_lws_wss_fail_report()
 {


### PR DESCRIPTION
##### Summary

minor - remove compile warning if `ACLK_TRP_DEBUG_VERBOSE` not defined:
```
aclk/legacy/aclk_lws_wss_client.c:351:20: warning: 'aclk_lws_callback_name' defined but not used [-Wunused-function]
  351 | static const char *aclk_lws_callback_name(enum lws_callback_reasons reason)
      |                    ^~~~~~~~~~~~~~~~~~~~~~
```

##### Component Name
ACLK
##### Test Plan
The warning should be gone.
##### Additional Information
