### PR TITLE
Always configure multihost database context

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -335,6 +335,11 @@ RRDHOST *rrdhost_create(const char *hostname,
         fatal("RRD_MEMORY_MODE_DBENGINE is not supported in this platform.");
 #endif
     }
+    else {
+#ifdef ENABLE_DBENGINE
+        host->rrdeng_ctx = &multidb_ctx;
+#endif
+    }
 
     // ------------------------------------------------------------------------
     // link it and add it to the index


### PR DESCRIPTION
Fixes #10684

##### Summary
Always configure a multihost database context when dbengine is compiled

##### Component Name
database

##### Test Plan
- As described in #10684 
- The agent should not crash if
  - is compiled with dbengine
  - default agent memory mode is ram
  - statsd configuration is set to dbengine
