### PR TITLE
add k6.conf

### DIFF
--- a/collectors/statsd.plugin/Makefile.am
+++ b/collectors/statsd.plugin/Makefile.am
@@ -10,6 +10,7 @@ dist_noinst_DATA = \
 statsdconfigdir=$(libconfigdir)/statsd.d
 dist_statsdconfig_DATA = \
     example.conf \
+    k6.conf \
     $(NULL)
 
 userstatsdconfigdir=$(configdir)/statsd.d

--- a/collectors/statsd.plugin/k6.conf
+++ b/collectors/statsd.plugin/k6.conf
@@ -1,0 +1,105 @@
+[app]
+    name = k6
+    metrics = k6*
+    private charts = no
+    gaps when not collected = yes
+    memory mode = dbengine
+
+[dictionary]
+http_reqs = HTTP Requests
+vus = Virtual active users
+vus_max = max Virtual active users
+iteration_duration = iteration duration
+iteration_duration_max = max iteration duration
+iteration_duration_min = min iteration duration
+iteration_duration_avg = avg iteration duration
+dropped_iterations = Dropped iterations
+http_req_blocked = Blocked HTTP requests
+http_req_connecting = Connecting HTTP requests
+http_req_sending = Sending HTTP requests
+http_req_receiving = Receiving HTTP requests
+http_req_waiting = Waiting HTTP requests
+http_req_duration_median = Median HTTP req duration
+http_req_duration_average = AVG HTTP req duration
+http_req_duration = HTTP req duration
+http_req_duration_max = max HTTP req duration
+http_req_duration_min = min HTTP req duration
+httP_req_duration_p95 = 95 percentile of HTTP req duration
+data_received = Received data
+data_sent = Sent data
+
+
+[http_reqs]
+    name = http_reqs
+    title = HTTP Requests
+    family = http requests
+    context = k6.http_requests
+    dimension = k6.http_reqs http_reqs last 1 1 sum
+    type = line
+    units = requests/s
+
+[vus]
+    name = vus
+    title = Virtual Active Users
+    family = k6_metrics
+    dimension = k6.vus vus last 1 1 
+    dimension = k6.vus_max vus_max last 1 1 
+    type = line
+    units = vus
+	
+[iteration_duration]
+    name = iteration_duration_2
+    title = Iteration duration
+    family = k6_metrics
+    dimension = k6.iteration_duration iteration_duration last 1 1 
+    dimension = k6.iteration_duration iteration_duration_max max 1 1 
+    dimension = k6.iteration_duration iteration_duration_min min 1 1 
+    dimension = k6.iteration_duration iteration_duration_avg avg 1 1 
+    type = line
+    units = s
+
+[dropped_iterations]
+    name = dropped_iterations
+    title = Dropped Iterations
+    family = k6_metrics
+    dimension = k6.dropped_iterations dropped_iterations last 1 1 
+    units = iterations
+    type = line
+
+[data]
+    name = data
+    title = K6 Data
+    family = k6_metrics
+    dimension = k6.data_received data_received last 1 1
+    dimension = k6.data_sent data_sent last -1 1
+    units = kb/s
+    type = area 
+
+[http_req_status]
+    name = http_req_status
+    title = Time spent on HTTP 
+    family = http requests
+    dimension = k6.http_req_blocked http_req_blocked last 1 1 
+    dimension = k6.http_req_connecting http_req_connecting last 1 1
+    units = ms
+    type = line
+    
+[http_req_duration_types]
+    name = http_req_duration_types
+    title = Time spent on HTTP connection states
+    family = http requests
+    dimension = k6.http_req_sending http_req_sending last 1 1
+    dimension = k6.http_req_waiting http_req_waiting last 1 1
+    dimension = k6.http_req_receiving http_req_receiving last 1 1
+    units = ms
+    type = stacked
+
+[http_req_duration]
+    name = http_req_duration
+    title = Total time for HTTP request
+    family = http requests
+    dimension = k6.http_req_duration http_req_duration_median median 1 1 
+    dimension = k6.http_req_duration http_req_duration_max max 1 1
+    dimension = k6.http_req_duration http_req_duration_average avg 1 1
+    dimension = k6.http_req_duration http_req_duration_min min 1 1
+    dimension = k6.http_req_duration httP_req_duration_p95 percentile 1 1

--- a/collectors/statsd.plugin/k6.conf
+++ b/collectors/statsd.plugin/k6.conf
@@ -24,7 +24,7 @@ http_req_duration_average = AVG HTTP req duration
 http_req_duration = HTTP req duration
 http_req_duration_max = max HTTP req duration
 http_req_duration_min = min HTTP req duration
-httP_req_duration_p95 = 95 percentile of HTTP req duration
+http_req_duration_p95 = 95 percentile of HTTP req duration
 data_received = Received data
 data_sent = Sent data
 

--- a/collectors/statsd.plugin/k6.conf
+++ b/collectors/statsd.plugin/k6.conf
@@ -3,30 +3,29 @@
     metrics = k6*
     private charts = no
     gaps when not collected = yes
-    memory mode = dbengine
 
 [dictionary]
-http_reqs = HTTP Requests
-vus = Virtual active users
-vus_max = max Virtual active users
-iteration_duration = iteration duration
-iteration_duration_max = max iteration duration
-iteration_duration_min = min iteration duration
-iteration_duration_avg = avg iteration duration
-dropped_iterations = Dropped iterations
-http_req_blocked = Blocked HTTP requests
-http_req_connecting = Connecting HTTP requests
-http_req_sending = Sending HTTP requests
-http_req_receiving = Receiving HTTP requests
-http_req_waiting = Waiting HTTP requests
-http_req_duration_median = Median HTTP req duration
-http_req_duration_average = AVG HTTP req duration
-http_req_duration = HTTP req duration
-http_req_duration_max = max HTTP req duration
-http_req_duration_min = min HTTP req duration
-http_req_duration_p95 = 95 percentile of HTTP req duration
-data_received = Received data
-data_sent = Sent data
+    http_reqs = HTTP Requests
+    vus = Virtual active users
+    vus_max = max Virtual active users
+    iteration_duration = iteration duration
+    iteration_duration_max = max iteration duration
+    iteration_duration_min = min iteration duration
+    iteration_duration_avg = avg iteration duration
+    dropped_iterations = Dropped iterations
+    http_req_blocked = Blocked HTTP requests
+    http_req_connecting = Connecting HTTP requests
+    http_req_sending = Sending HTTP requests
+    http_req_receiving = Receiving HTTP requests
+    http_req_waiting = Waiting HTTP requests
+    http_req_duration_median = Median HTTP req duration
+    http_req_duration_average = AVG HTTP req duration
+    http_req_duration = HTTP req duration
+    http_req_duration_max = max HTTP req duration
+    http_req_duration_min = min HTTP req duration
+    http_req_duration_p95 = 95 percentile of HTTP req duration
+    data_received = Received data
+    data_sent = Sent data
 
 
 [http_reqs]


### PR DESCRIPTION
This PR adds our first (to my knowledge) stock collector based on StatsD. It collects data out-of-the-box about [K6](https://k6.io/), a load testing tool for developers. 

The user only needs to have Netdata installed on the machine where it runs the experiments and run ` k6 run --out statsd script.js`. If the user wants to support K6 tags, they will need to run `k6 run --out datadog script.js`.

The data have been organized after coordination with the K6 team.

This example and the new StatsD guide currently in PR should serve as an all-encompassing guide on how to vendor any StatsD collector for Netdata.