### PR TITLE
Use of out-of-line struct definitions.

### DIFF
--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -56,16 +56,20 @@ enum rrdeng_opcode {
     RRDENG_MAX_OPCODE
 };
 
+struct rrdeng_read_page {
+    struct rrdeng_page_descr *page_cache_descr;
+};
+
+struct rrdeng_read_extent {
+    struct rrdeng_page_descr *page_cache_descr[MAX_PAGES_PER_EXTENT];
+    int page_count;
+};
+
 struct rrdeng_cmd {
     enum rrdeng_opcode opcode;
     union {
-        struct rrdeng_read_page {
-            struct rrdeng_page_descr *page_cache_descr;
-        } read_page;
-        struct rrdeng_read_extent {
-            struct rrdeng_page_descr *page_cache_descr[MAX_PAGES_PER_EXTENT];
-            int page_count;
-        } read_extent;
+        struct rrdeng_read_page read_page;
+        struct rrdeng_read_extent read_extent;
         struct completion *completion;
     };
 };

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -336,6 +336,18 @@ union rrddim_collect_handle {
 
 // ----------------------------------------------------------------------------
 // iterator state for RRD dimension data queries
+
+#ifdef ENABLE_DBENGINE
+struct rrdeng_query_handle {
+    struct rrdeng_page_descr *descr;
+    struct rrdengine_instance *ctx;
+    struct pg_cache_page_index *page_index;
+    time_t next_page_time;
+    time_t now;
+    unsigned position;
+};
+#endif
+
 struct rrddim_query_handle {
     RRDDIM *rd;
     time_t start_time;
@@ -347,14 +359,7 @@ struct rrddim_query_handle {
             uint8_t finished;
         } slotted;                         // state the legacy code uses
 #ifdef ENABLE_DBENGINE
-        struct rrdeng_query_handle {
-            struct rrdeng_page_descr *descr;
-            struct rrdengine_instance *ctx;
-            struct pg_cache_page_index *page_index;
-            time_t next_page_time;
-            time_t now;
-            unsigned position;
-        } rrdeng; // state the database engine uses
+        struct rrdeng_query_handle rrdeng; // state the database engine uses
 #endif
     };
 };


### PR DESCRIPTION
##### Summary

This change, which does not change the memory layout of the parent
structs, allows inclusion of daemon/common.h in C++ without relying
on -fpermissive.

##### Component Name

agent, database

##### Test Plan

Built and run locally + CI builds.