### PR TITLE
collectors/cgroups: fix cpuset.cpus count

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2936,15 +2936,15 @@ static inline void update_cpu_limits(char **filename, unsigned long long *value,
                 // parse the cpuset string and calculate the number of cpus the cgroup is allowed to use
                 while(*s) {
                     unsigned long long n = cpuset_str2ull(&s);
+                    ncpus++;
                     if(*s == ',') {
                         s++;
-                        ncpus++;
                         continue;
                     }
                     if(*s == '-') {
                         s++;
                         unsigned long long m = cpuset_str2ull(&s);
-                        ncpus += m - n + 1; // calculate the number of cpus in the region
+                        ncpus += m - n; // calculate the number of cpus in the region
                     }
                     s++;
                 }


### PR DESCRIPTION
##### Summary

Fixes: #10670

> cpuset.cpus

> specifies the CPUs that tasks in this cgroup are permitted to access. This is a comma-separated list, with dashes ("-") to represent ranges.

##### Component Name

`collectors/cgroups`

##### Test Plan

Tested the following combinations:

| cpuset.cpus   | limit in netdata   |
| :-----------: | :----------------: |
| 5             | 100                |
| 0,2,5         | 300                |
| 2-5           | 400                |
| 0,1-3,5       | 500                |
| 0-1,2,3-5     | 600                |
| 0-1,2-5       | 600                |


##### Additional Information
