### PR TITLE
Fixed handling of perf.plugin capabilities.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1314,7 +1314,7 @@ if [ "${UID}" -eq 0 ]; then
   if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin" ]; then
     run chown root:${NETDATA_GROUP} "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin"
     run chmod 0750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin"
-    run setcap cap_perfmon+ep "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin"
+    run sh -c "setcap cap_perfmon+ep \"${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin\" || setcap cap_sys_admin+ep \"${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/perf.plugin\""
   fi
 
   if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/slabinfo.plugin" ]; then


### PR DESCRIPTION
##### Summary

`CAP_PERFMON` is only available with Linux kernel 5.8 or newer, and needs a sufficiently up-to-date userspace to be able to set it.

With this change, we fall back to `CAP_SYS_ADMIN` (which `CAP_PERFMON` is a proper subset of) if we cannot set `CAP_PERFMON` for the perf plugin.

##### Component Name

area/packaging

##### Test Plan

Check that the script does not report any errors or failures on older Linux systems.