### PR TITLE
Added ARM binary package builds to CI.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -103,16 +103,9 @@ jobs:
             echo "runtype=test" >> $GITHUB_ENV
             echo "pkg_version=$(cut -d'-' -f 1 packaging/version | sed -e 's/^v//')" >> $GITHUB_ENV
           fi
-      - name: Setup QEMU ARM
-        if: matrix.platform == 'linux/arm/v7'
+      - name: Setup QEMU
+        if: matrix.platform != 'linux/amd64' && matrix.platform != 'linux/i386'
         uses: docker/setup-qemu-action@v1
-        with:
-          platforms: arm
-      - name: Setup QEMU AArch64
-        if: matrix.platform == 'linux/arm64/v8'
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: arm64
       - name: Prepare Docker Environment
         shell: bash
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -28,20 +28,37 @@ jobs:
         include:
           - {distro: debian, version: "9", pkgclouddistro: debian/stretch, format: deb, base_image: debian, platform: linux/amd64, arch: amd64}
           - {distro: debian, version: "9", pkgclouddistro: debian/stretch, format: deb, base_image: debian, platform: linux/i386, arch: i386}
+          - {distro: debian, version: "9", pkgclouddistro: debian/stretch, format: deb, base_image: debian, platform: linux/arm/v7, arch: armhf}
+          - {distro: debian, version: "9", pkgclouddistro: debian/stretch, format: deb, base_image: debian, platform: linux/arm64/v8, arch: arm64}
           - {distro: debian, version: "10", pkgclouddistro: debian/buster, format: deb, base_image: debian, platform: linux/amd64, arch: amd64}
           - {distro: debian, version: "10", pkgclouddistro: debian/buster, format: deb, base_image: debian, platform: linux/i386, arch: i386}
+          - {distro: debian, version: "10", pkgclouddistro: debian/buster, format: deb, base_image: debian, platform: linux/arm/v7, arch: armhf}
+          - {distro: debian, version: "10", pkgclouddistro: debian/buster, format: deb, base_image: debian, platform: linux/arm64/v8, arch: arm64}
           - {distro: debian, version: "11", pkgclouddistro: debian/bullseye, format: deb, base_image: debian, platform: linux/amd64, arch: amd64, alias: bullseye}
           - {distro: debian, version: "11", pkgclouddistro: debian/bullseye, format: deb, base_image: debian, platform: linux/i386, arch: i386, alias: bullseye}
+          - {distro: debian, version: "11", pkgclouddistro: debian/bullseye, format: deb, base_image: debian, platform: linux/arm/v7, arch: armhf, alias: bullseye}
+          - {distro: debian, version: "11", pkgclouddistro: debian/bullseye, format: deb, base_image: debian, platform: linux/arm64/v8, arch: arm64, alias: bullseye}
           - {distro: ubuntu, version: "18.04", pkgclouddistro: ubuntu/bionic, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
           - {distro: ubuntu, version: "18.04", pkgclouddistro: ubuntu/bionic, format: deb, base_image: ubuntu, platform: linux/i386, arch: i386}
+          - {distro: ubuntu, version: "18.04", pkgclouddistro: ubuntu/bionic, format: deb, base_image: ubuntu, platform: linux/arm/v7, arch: armhf}
+          - {distro: ubuntu, version: "18.04", pkgclouddistro: ubuntu/bionic, format: deb, base_image: ubuntu, platform: linux/arm64/v8, arch: arm64}
           - {distro: ubuntu, version: "20.04", pkgclouddistro: ubuntu/focal, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
+          - {distro: ubuntu, version: "20.04", pkgclouddistro: ubuntu/focal, format: deb, base_image: ubuntu, platform: linux/arm/v7, arch: armhf}
+          - {distro: ubuntu, version: "20.04", pkgclouddistro: ubuntu/focal, format: deb, base_image: ubuntu, platform: linux/arm64/v8, arch: arm64}
           - {distro: ubuntu, version: "21.04", pkgclouddistro: ubuntu/hirsute, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
+          - {distro: ubuntu, version: "21.04", pkgclouddistro: ubuntu/hirsute, format: deb, base_image: ubuntu, platform: linux/arm/v7, arch: armhf}
+          - {distro: ubuntu, version: "21.04", pkgclouddistro: ubuntu/hirsute, format: deb, base_image: ubuntu, platform: linux/arm64/v8, arch: arm64}
           - {distro: centos, version: "7", pkgclouddistro: el/7, format: rpm, base_image: centos, platform: linux/amd64, arch: amd64}
           - {distro: centos, version: "8", pkgclouddistro: el/8, format: rpm, base_image: centos, platform: linux/amd64, arch: amd64}
           - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
+          - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/arm/v7, arch: armhf}
+          - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/arm64/v8, arch: arm64}
           - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
+          - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/arm64/v8, arch: arm64}
           - {distro: opensuse, version: "15.2", pkgclouddistro: opensuse/15.2, format: rpm, base_image: opensuse/leap, platform: linux/amd64, arch: amd64}
+          - {distro: opensuse, version: "15.2", pkgclouddistro: opensuse/15.2, format: rpm, base_image: opensuse/leap, platform: linux/arm64/v8, arch: arm64}
           - {distro: opensuse, version: "15.3", pkgclouddistro: opensuse/15.3, format: rpm, base_image: opensuse/leap, platform: linux/amd64, arch: amd64}
+          - {distro: opensuse, version: "15.3", pkgclouddistro: opensuse/15.3, format: rpm, base_image: opensuse/leap, platform: linux/arm64/v8, arch: arm64}
       # We intentiaonally disable the fail-fast behavior so that a
       # build failure for one version doesn't prevent us from publishing
       # successfully built and tested packages for another version.

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Save Packages
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.distro }}-${{ matrix.version }}-packages
+          name: ${{ matrix.distro }}-${{ matrix.version }}-${{ matrix.arch }}-packages
           path: ${{ github.workspace }}/artifacts/*
       - name: Upload to PackageCloud
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -50,6 +50,7 @@ jobs:
           - {distro: ubuntu, version: "21.04", pkgclouddistro: ubuntu/hirsute, format: deb, base_image: ubuntu, platform: linux/arm64/v8, arch: arm64}
           - {distro: centos, version: "7", pkgclouddistro: el/7, format: rpm, base_image: centos, platform: linux/amd64, arch: amd64}
           - {distro: centos, version: "8", pkgclouddistro: el/8, format: rpm, base_image: centos, platform: linux/amd64, arch: amd64}
+          - {distro: centos, version: "8", pkgclouddistro: el/8, format: rpm, base_image: centos, platform: linux/arm64/v8, arch: arm64}
           - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
           - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/arm/v7, arch: armhf}
           - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/arm64/v8, arch: arm64}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -103,9 +103,16 @@ jobs:
             echo "runtype=test" >> $GITHUB_ENV
             echo "pkg_version=$(cut -d'-' -f 1 packaging/version | sed -e 's/^v//')" >> $GITHUB_ENV
           fi
-      - name: Setup QEMU
-        if: matrix.platform != 'linux/amd64'
+      - name: Setup QEMU ARM
+        if: matrix.platform == 'linux/arm/v7'
         uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm
+      - name: Setup QEMU AArch64
+        if: matrix.platform == 'linux/arm64/v8'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
       - name: Prepare Docker Environment
         shell: bash
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -54,6 +54,7 @@ jobs:
           - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/arm/v7, arch: armhf}
           - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/arm64/v8, arch: arm64}
           - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
+          - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/arm/v7, arch: armhf}
           - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/arm64/v8, arch: arm64}
           - {distro: opensuse, version: "15.2", pkgclouddistro: opensuse/15.2, format: rpm, base_image: opensuse/leap, platform: linux/amd64, arch: amd64}
           - {distro: opensuse, version: "15.2", pkgclouddistro: opensuse/15.2, format: rpm, base_image: opensuse/leap, platform: linux/arm64/v8, arch: arm64}

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -84,8 +84,8 @@ override_dh_install:
 		ln -s "/usr/share/netdata/www/$$D" "$(TOP)/var/lib/netdata/www/$$D"; \
 	done
 
-	if [ $(HAVE_EBPF) -eq 1 ]; then
-		packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d
+	if [ $(HAVE_EBPF) -eq 1 ]; then \
+		packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d \
 	fi
 
 	# Install go

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -43,11 +43,13 @@ override_dh_installinit:
 override_dh_auto_configure:
 	packaging/bundle-mosquitto.sh .
 	packaging/bundle-lws.sh .
-	packaging/bundle-libbpf.sh .
+	if [ $(HAVE_EBPF) -eq 1 ]; then \
+		packaging/bundle-libbpf.sh . ${TOP}/usr/libexec/netdata/plugins.d; \
+	fi
 	autoreconf -ivf
 	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib \
 	--libexecdir=/usr/libexec --with-user=netdata --with-math --with-zlib --with-webdir=/var/lib/netdata/www \
-	--with-bundled-lws $(EXTRA_CONFIG)
+	--with-bundled-lws $(EBPF_CONFIG)
 
 override_dh_install:
 	cp -v $(BASE_CONFIG) debian/netdata.conf
@@ -85,7 +87,7 @@ override_dh_install:
 	done
 
 	if [ $(HAVE_EBPF) -eq 1 ]; then \
-		packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d \
+		packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d; \
 	fi
 
 	# Install go

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -84,7 +84,9 @@ override_dh_install:
 		ln -s "/usr/share/netdata/www/$$D" "$(TOP)/var/lib/netdata/www/$$D"; \
 	done
 
-	[ $(HAVE_EBPF) -eq 1 ] && packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d
+	if [ $(HAVE_EBPF) -eq 1 ]; then
+		packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d
+	fi
 
 	# Install go
 	#

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -15,6 +15,13 @@ else
 SYSTEMD_UNIT = system/netdata.service
 endif
 
+ifeq ($(shell test `uname -m` != "x86_64" && echo "1"), 1)
+HAVE_EBPF = 0
+EBPF_CONFIG = --disable-ebpf
+else
+HAVE_EBPF = 1
+endif
+
 %:
 	# For jessie and beyond
 	#
@@ -40,7 +47,7 @@ override_dh_auto_configure:
 	autoreconf -ivf
 	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=/usr/lib \
 	--libexecdir=/usr/libexec --with-user=netdata --with-math --with-zlib --with-webdir=/var/lib/netdata/www \
-	--with-bundled-lws
+	--with-bundled-lws $(EXTRA_CONFIG)
 
 override_dh_install:
 	cp -v $(BASE_CONFIG) debian/netdata.conf
@@ -77,7 +84,7 @@ override_dh_install:
 		ln -s "/usr/share/netdata/www/$$D" "$(TOP)/var/lib/netdata/www/$$D"; \
 	done
 
-	packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d
+	[ $(HAVE_EBPF) -eq 1 ] && packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d
 
 	# Install go
 	#

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -228,6 +228,9 @@ export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging
 # Conf step
 autoreconf -ivf
 %configure \
+	%ifnarch x86_64 i386
+	--disable-ebpf
+	%endif
 	%if 0%{!?fedora:1} && 0%{!?suse_version:1}
 	--with-bundled-libJudy \
 	%endif
@@ -274,7 +277,9 @@ install -m 4750 -p perf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.
 
 # ###########################################################
 # Install ebpf.plugin
+%ifarch x86_64 i386
 install -m 4750 -p ebpf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/ebpf.plugin"
+%endif
 
 # ###########################################################
 # Install cups.plugin
@@ -401,7 +406,9 @@ install_go() {
 install_go
 install -m 0640 -p go.d.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/go.d.plugin"
 
+%ifarch x86_64 i386
 ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-ebpf.sh ${RPM_BUILD_DIR}/%{name}-%{version} ${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d
+%endif
 
 %pre
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -229,7 +229,9 @@ export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging
 %if 0%{!?fedora:1} && 0%{!?suse_version:1}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-judy.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 %endif
+%if 0%{?_have_ebpf}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-libbpf.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+%endif
 
 %build
 # Conf step

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -15,6 +15,13 @@ AutoReqProv: yes
 # error.
 %global __os_install_post %{nil}
 
+# Disable eBPF for architectures other than x86
+%ifarch x86_64 i386
+%global _have_ebpf 1
+%else
+%global _have_ebpf 0
+%endif
+
 # Mitigate the cross-distro mayhem by strictly defining the libexec destination
 %define _prefix /usr
 %define _sysconfdir /etc
@@ -228,7 +235,7 @@ export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging
 # Conf step
 autoreconf -ivf
 %configure \
-	%ifnarch x86_64 i386
+	%if 0%{!?_have_ebpf}
 	--disable-ebpf
 	%endif
 	%if 0%{!?fedora:1} && 0%{!?suse_version:1}
@@ -277,7 +284,7 @@ install -m 4750 -p perf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.
 
 # ###########################################################
 # Install ebpf.plugin
-%ifarch x86_64 i386
+%if 0%{?_have_ebpf}
 install -m 4750 -p ebpf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/ebpf.plugin"
 %endif
 
@@ -406,7 +413,7 @@ install_go() {
 install_go
 install -m 0640 -p go.d.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/go.d.plugin"
 
-%ifarch x86_64 i386
+%if 0%{?_have_ebpf}
 ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-ebpf.sh ${RPM_BUILD_DIR}/%{name}-%{version} ${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d
 %endif
 

--- a/packaging/bundle-lws.sh
+++ b/packaging/bundle-lws.sh
@@ -10,7 +10,7 @@ curl -sSL --connect-timeout 10 --retry 3 "https://github.com/warmcat/libwebsocke
 sha256sum -c "${1}/packaging/libwebsockets.checksums" || exit 1
 tar -xzf "${LWS_TARBALL}" -C "${1}/externaldeps/libwebsockets" || exit 1
 cd "${LWS_BUILD_PATH}" || exit 1
-cmake -D LWS_WITH_SOCKS5:boolean=YES . || exit 1
+cmake -Wno-dev -Wno-deprecated -D LWS_WITH_SOCKS5:boolean=YES -D WITHOUT_LWS_TESTAPPS:boolean=YES . || exit 1
 make || exit 1
 cd "${startdir}" || exit 1
 cp -a "${LWS_BUILD_PATH}/lib/libwebsockets.a" "${1}/externaldeps/libwebsockets" || exit 1


### PR DESCRIPTION
##### Summary

This adds ARMv7 and ARMv8 binary package builds to our CI for all the platforms we can support them on. These still need some testing, but are ready enough to be released as an open beta.

##### Component Name

area/packaging.

##### Test Plan

CI passes correctly (ensures that packages build and are successfully installable).

##### Additional Information

Fixes: #7824 (wow, I did not realize how old this issue was)
Relevant to: #7826, #10481