### PR TITLE
health: make vernemq alarms less sensitive

### DIFF
--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -93,22 +93,13 @@ template: vernemq_netsplits
 
 # Unsuccessful CONNACK
 
-template: vernemq_mqtt_connack_sent_reason_success
-      on: vernemq.mqtt_connack_sent_reason
-  lookup: sum -1m unaligned absolute match-names of success
-   units: packets
-   every: 10s
-    info: successful v3/v5 CONNACK sent in the last minute
-      to: sysadmin
-
 template: vernemq_mqtt_connack_sent_reason_unsuccessful
       on: vernemq.mqtt_connack_sent_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_connack_sent_reason_success
-   units: packets
+  lookup: sum -1m unaligned absolute match-names of !success,*
+   units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v3/v5 CONNACK sent in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -132,8 +132,8 @@ template: vernemq_mqtt_subscribe_error
   lookup: sum -1m unaligned absolute
    units: failed ops
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: failed v3/v5 SUBSCRIBE operations in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -50,9 +50,9 @@ template: vernemq_queue_message_unhandled
       on: vernemq.queue_undelivered_messages
   lookup: sum -1m unaligned absolute of queue_message_unhandled
    units: unhandled messages
-   every: 10s
+   every: 1m
     warn: $this > (($status == $WARNING) ? (0) : (5))
-   delay: down 5m multiplier 1.5 max 2h
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unhandled messages (connections with clean session=true) in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -105,41 +105,23 @@ template: vernemq_mqtt_connack_sent_reason_unsuccessful
 
 # Not normal DISCONNECT
 
-template: vernemq_mqtt_disconnect_received_reason_normal_disconnect
-      on: vernemq.mqtt_disconnect_received_reason
-  lookup: sum -1m unaligned absolute match-names of normal_disconnect
-   units: packets
-   every: 10s
-    info: normal v5 DISCONNECT received in the last minute
-      to: sysadmin
-
-template: vernemq_mqtt_disconnect_sent_reason_normal_disconnect
-      on: vernemq.mqtt_disconnect_sent_reason
-  lookup: sum -1m unaligned absolute match-names of normal_disconnect
-   units: packets
-   every: 10s
-    info: normal v5 DISCONNECT sent in the last minute
-      to: sysadmin
-
 template: vernemq_mqtt_disconnect_received_reason_not_normal
       on: vernemq.mqtt_disconnect_received_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_disconnect_received_reason_normal_disconnect
-   units: packets
+  lookup: sum -1m unaligned absolute match-names of !normal_disconnect,*
+   units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: not normal v5 DISCONNECT received in the last minute
       to: sysadmin
 
 template: vernemq_mqtt_disconnect_sent_reason_not_normal
       on: vernemq.mqtt_disconnect_sent_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_disconnect_sent_reason_normal_disconnect
-   units: packets
+  lookup: sum -1m unaligned absolute match-names of !normal_disconnect,*
+   units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: not normal v5 DISCONNECT sent in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -40,9 +40,9 @@ template: vernemq_queue_message_expired
       on: vernemq.queue_undelivered_messages
   lookup: sum -1m unaligned absolute of queue_message_expired
    units: expired messages
-   every: 10s
+   every: 1m
     warn: $this > (($status == $WARNING) ? (0) : (15))
-   delay: down 5m multiplier 1.5 max 2h
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: messages which expired before delivery in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -30,9 +30,9 @@ template: vernemq_queue_message_drop
       on: vernemq.queue_undelivered_messages
   lookup: sum -1m unaligned absolute of queue_message_drop
    units: dropped messages
-   every: 10s
+   every: 1m
     warn: $this > (($status == $WARNING) ? (0) : (5))
-   delay: down 5m multiplier 1.5 max 2h
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: dropped messaged due to full queues in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -73,11 +73,11 @@ template: vernemq_average_scheduler_utilization
 
 template: vernemq_cluster_dropped
       on: vernemq.cluster_dropped
-  lookup: average -1m unaligned
-   units: KiB/s
-   every: 10s
+  lookup: sum -1m unaligned
+   units: KiB
+   every: 1m
     warn: $this > 0
-   delay: down 5m multiplier 1.5 max 1h
+   delay: up 5m down 5m multiplier 1.5 max 1h
     info: the amount of traffic dropped during communication with the cluster nodes in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -183,41 +183,23 @@ template: vernemq_mqtt_publish_auth_errors
 
 # Unsuccessful and unexpected PUBACK
 
-template: vernemq_mqtt_puback_received_reason_success
-      on: vernemq.mqtt_puback_received_reason
-  lookup: sum -1m unaligned absolute match-names of success
-   units: packets
-   every: 10s
-    info: successful v5 PUBACK received in the last minute
-      to: sysadmin
-
-template: vernemq_mqtt_puback_sent_reason_success
-      on: vernemq.mqtt_puback_sent_reason
-  lookup: sum -1m unaligned absolute match-names of success
-   units: packets
-   every: 10s
-    info: successful v5 PUBACK sent in the last minute
-      to: sysadmin
-
 template: vernemq_mqtt_puback_received_reason_unsuccessful
       on: vernemq.mqtt_puback_received_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_puback_received_reason_success
-   units: packets
+  lookup: sum -1m unaligned absolute match-names of !success,*
+   units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBACK received in the last minute
       to: sysadmin
 
 template: vernemq_mqtt_puback_sent_reason_unsuccessful
       on: vernemq.mqtt_puback_sent_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_puback_sent_reason_success
-   units: packets
+  lookup: sum -1m unaligned absolute match-names of !success,*
+   units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBACK sent in the last minute
       to: sysadmin
 
@@ -226,8 +208,8 @@ template: vernemq_mqtt_puback_unexpected
   lookup: sum -1m unaligned absolute
    units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unexpected v3/v5 PUBACK received in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -154,8 +154,8 @@ template: vernemq_mqtt_unsubscribe_error
   lookup: sum -1m unaligned absolute
    units: failed ops
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: failed v3/v5 UNSUBSCRIBE operations in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -166,8 +166,8 @@ template: vernemq_mqtt_publish_errors
   lookup: sum -1m unaligned absolute
    units: failed ops
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: failed v3/v5 PUBLISH operations in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -18,9 +18,9 @@ template: vernemq_socket_errors
       on: vernemq.socket_errors
   lookup: sum -1m unaligned absolute of socket_error
    units: errors
-   every: 10s
-    warn: $this > (($status == $WARNING) ? (0) : (5))
-   delay: down 5m multiplier 1.5 max 2h
+   every: 1m
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 2m down 5m multiplier 1.5 max 2h
     info: socket errors in the last minute
       to: sysadmin
 
@@ -31,7 +31,7 @@ template: vernemq_queue_message_drop
   lookup: sum -1m unaligned absolute of queue_message_drop
    units: dropped messages
    every: 1m
-    warn: $this > (($status == $WARNING) ? (0) : (5))
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: dropped messaged due to full queues in the last minute
       to: sysadmin
@@ -41,7 +41,7 @@ template: vernemq_queue_message_expired
   lookup: sum -1m unaligned absolute of queue_message_expired
    units: expired messages
    every: 1m
-    warn: $this > (($status == $WARNING) ? (0) : (15))
+    warn: $this > (($status >= $WARNING) ? (0) : (15))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: messages which expired before delivery in the last minute
       to: sysadmin
@@ -51,7 +51,7 @@ template: vernemq_queue_message_unhandled
   lookup: sum -1m unaligned absolute of queue_message_unhandled
    units: unhandled messages
    every: 1m
-    warn: $this > (($status == $WARNING) ? (0) : (5))
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unhandled messages (connections with clean session=true) in the last minute
       to: sysadmin
@@ -96,8 +96,8 @@ template: vernemq_netsplits
 template: vernemq_mqtt_connack_sent_reason_unsuccessful
       on: vernemq.mqtt_connack_sent_reason
   lookup: sum -1m unaligned absolute match-names of !success,*
-   units: messages
-   every: 10s
+   units: packets
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v3/v5 CONNACK sent in the last minute
@@ -108,8 +108,8 @@ template: vernemq_mqtt_connack_sent_reason_unsuccessful
 template: vernemq_mqtt_disconnect_received_reason_not_normal
       on: vernemq.mqtt_disconnect_received_reason
   lookup: sum -1m unaligned absolute match-names of !normal_disconnect,*
-   units: messages
-   every: 10s
+   units: packets
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: not normal v5 DISCONNECT received in the last minute
@@ -118,8 +118,8 @@ template: vernemq_mqtt_disconnect_received_reason_not_normal
 template: vernemq_mqtt_disconnect_sent_reason_not_normal
       on: vernemq.mqtt_disconnect_sent_reason
   lookup: sum -1m unaligned absolute match-names of !normal_disconnect,*
-   units: messages
-   every: 10s
+   units: packets
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: not normal v5 DISCONNECT sent in the last minute
@@ -131,7 +131,7 @@ template: vernemq_mqtt_subscribe_error
       on: vernemq.mqtt_subscribe_error
   lookup: sum -1m unaligned absolute
    units: failed ops
-   every: 10s
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: failed v3/v5 SUBSCRIBE operations in the last minute
@@ -141,7 +141,7 @@ template: vernemq_mqtt_subscribe_auth_error
       on: vernemq.mqtt_subscribe_auth_error
   lookup: sum -1m unaligned absolute
    units: attempts
-   every: 10s
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unauthorized v3/v5 SUBSCRIBE attempts in the last minute
@@ -153,7 +153,7 @@ template: vernemq_mqtt_unsubscribe_error
       on: vernemq.mqtt_unsubscribe_error
   lookup: sum -1m unaligned absolute
    units: failed ops
-   every: 10s
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: failed v3/v5 UNSUBSCRIBE operations in the last minute
@@ -165,7 +165,7 @@ template: vernemq_mqtt_publish_errors
       on: vernemq.mqtt_publish_errors
   lookup: sum -1m unaligned absolute
    units: failed ops
-   every: 10s
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: failed v3/v5 PUBLISH operations in the last minute
@@ -175,7 +175,7 @@ template: vernemq_mqtt_publish_auth_errors
       on: vernemq.mqtt_publish_auth_errors
   lookup: sum -1m unaligned absolute
    units: attempts
-   every: 10s
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unauthorized v3/v5 PUBLISH attempts in the last minute
@@ -186,8 +186,8 @@ template: vernemq_mqtt_publish_auth_errors
 template: vernemq_mqtt_puback_received_reason_unsuccessful
       on: vernemq.mqtt_puback_received_reason
   lookup: sum -1m unaligned absolute match-names of !success,*
-   units: messages
-   every: 10s
+   units: packets
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBACK received in the last minute
@@ -196,8 +196,8 @@ template: vernemq_mqtt_puback_received_reason_unsuccessful
 template: vernemq_mqtt_puback_sent_reason_unsuccessful
       on: vernemq.mqtt_puback_sent_reason
   lookup: sum -1m unaligned absolute match-names of !success,*
-   units: messages
-   every: 10s
+   units: packets
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBACK sent in the last minute
@@ -207,7 +207,7 @@ template: vernemq_mqtt_puback_unexpected
       on: vernemq.mqtt_puback_invalid_error
   lookup: sum -1m unaligned absolute
    units: messages
-   every: 10s
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unexpected v3/v5 PUBACK received in the last minute
@@ -218,8 +218,8 @@ template: vernemq_mqtt_puback_unexpected
 template: vernemq_mqtt_pubrec_received_reason_unsuccessful
       on: vernemq.mqtt_pubrec_received_reason
   lookup: sum -1m unaligned absolute match-names of !success,*
-   units: messages
-   every: 10s
+   units: packets
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBREC received in the last minute
@@ -228,8 +228,8 @@ template: vernemq_mqtt_pubrec_received_reason_unsuccessful
 template: vernemq_mqtt_pubrec_sent_reason_unsuccessful
       on: vernemq.mqtt_pubrec_sent_reason
   lookup: sum -1m unaligned absolute match-names of !success,*
-   units: messages
-   every: 10s
+   units: packets
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBREC sent in the last minute
@@ -239,7 +239,7 @@ template: vernemq_mqtt_pubrec_invalid_error
       on: vernemq.mqtt_pubrec_invalid_error
   lookup: sum -1m unaligned absolute
    units: messages
-   every: 10s
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unexpected v3 PUBREC received in the last minute
@@ -250,8 +250,8 @@ template: vernemq_mqtt_pubrec_invalid_error
 template: vernemq_mqtt_pubrel_received_reason_unsuccessful
       on: vernemq.mqtt_pubrel_received_reason
   lookup: sum -1m unaligned absolute match-names of !success,*
-   units: messages
-   every: 10s
+   units: packets
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBREL received in the last minute
@@ -260,8 +260,8 @@ template: vernemq_mqtt_pubrel_received_reason_unsuccessful
 template: vernemq_mqtt_pubrel_sent_reason_unsuccessful
       on: vernemq.mqtt_pubrel_sent_reason
   lookup: sum -1m unaligned absolute match-names of !success,*
-   units: messages
-   every: 10s
+   units: packets
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBREL sent in the last minute
@@ -273,7 +273,7 @@ template: vernemq_mqtt_pubcomp_received_reason_unsuccessful
       on: vernemq.mqtt_pubcomp_received_reason
   lookup: sum -1m unaligned absolute match-names of !success,*
    units: packets
-   every: 10s
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBCOMP received in the last minute
@@ -283,7 +283,7 @@ template: vernemq_mqtt_pubcomp_sent_reason_unsuccessful
       on: vernemq.mqtt_pubcomp_sent_reason
   lookup: sum -1m unaligned absolute match-names of !success,*
    units: packets
-   every: 10s
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBCOMP sent in the last minute
@@ -292,8 +292,8 @@ template: vernemq_mqtt_pubcomp_sent_reason_unsuccessful
 template: vernemq_mqtt_pubcomp_unexpected
       on: vernemq.mqtt_pubcomp_invalid_error
   lookup: sum -1m unaligned absolute
-   units: packets
-   every: 10s
+   units: messages
+   every: 1m
     warn: $this > (($status >= $WARNING) ? (0) : (5))
    delay: up 5m down 5m multiplier 1.5 max 2h
     info: unexpected v3/v5 PUBCOMP received in the last minute

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -247,41 +247,23 @@ template: vernemq_mqtt_pubrec_invalid_error
 
 # Unsuccessful PUBREL
 
-template: vernemq_mqtt_pubrel_received_reason_success
-      on: vernemq.mqtt_pubrel_received_reason
-  lookup: sum -1m unaligned absolute match-names of success
-   units: packets
-   every: 10s
-    info: successful v5 PUBREL received in the last minute
-      to: sysadmin
-
-template: vernemq_mqtt_pubrel_sent_reason_success
-      on: vernemq.mqtt_pubrel_sent_reason
-  lookup: sum -1m unaligned absolute match-names of success
-   units: packets
-   every: 10s
-    info: successful v5 PUBREL sent in the last minute
-      to: sysadmin
-
 template: vernemq_mqtt_pubrel_received_reason_unsuccessful
       on: vernemq.mqtt_pubrel_received_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_pubrel_received_reason_success
-   units: packets
+  lookup: sum -1m unaligned absolute match-names of !success,*
+   units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBREL received in the last minute
       to: sysadmin
 
 template: vernemq_mqtt_pubrel_sent_reason_unsuccessful
       on: vernemq.mqtt_pubrel_sent_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_pubrel_sent_reason_success
-   units: packets
+  lookup: sum -1m unaligned absolute match-names of !success,*
+   units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBREL sent in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -176,8 +176,8 @@ template: vernemq_mqtt_publish_auth_errors
   lookup: sum -1m unaligned absolute
    units: attempts
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unauthorized v3/v5 PUBLISH attempts in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -215,41 +215,23 @@ template: vernemq_mqtt_puback_unexpected
 
 # Unsuccessful and unexpected PUBREC
 
-template: vernemq_mqtt_pubrec_received_reason_success
-      on: vernemq.mqtt_pubrec_received_reason
-  lookup: sum -1m unaligned absolute match-names of success
-   units: packets
-   every: 10s
-    info: successful v5 PUBREC received in the last minute
-      to: sysadmin
-
-template: vernemq_mqtt_pubrec_sent_reason_success
-      on: vernemq.mqtt_pubrec_sent_reason
-  lookup: sum -1m unaligned absolute match-names of success
-   units: packets
-   every: 10s
-    info: successful v5 PUBREC sent in the last minute
-      to: sysadmin
-
 template: vernemq_mqtt_pubrec_received_reason_unsuccessful
       on: vernemq.mqtt_pubrec_received_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_pubrec_received_reason_success
-   units: packets
+  lookup: sum -1m unaligned absolute match-names of !success,*
+   units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBREC received in the last minute
       to: sysadmin
 
 template: vernemq_mqtt_pubrec_sent_reason_unsuccessful
       on: vernemq.mqtt_pubrec_sent_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_pubrec_sent_reason_success
-   units: packets
+  lookup: sum -1m unaligned absolute match-names of !success,*
+   units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBREC sent in the last minute
       to: sysadmin
 
@@ -258,8 +240,8 @@ template: vernemq_mqtt_pubrec_invalid_error
   lookup: sum -1m unaligned absolute
    units: messages
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unexpected v3 PUBREC received in the last minute
       to: sysadmin
 

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -269,50 +269,32 @@ template: vernemq_mqtt_pubrel_sent_reason_unsuccessful
 
 # Unsuccessful and unexpected PUBCOMP
 
-template: vernemq_mqtt_pubcomp_received_reason_success
-      on: vernemq.mqtt_pubcomp_received_reason
-  lookup: sum -1m unaligned absolute match-names of success
-   units: packets
-   every: 10s
-    info: successful v5 PUBCOMP received in the last minute
-      to: sysadmin
-
-template: vernemq_mqtt_pubcomp_sent_reason_success
-      on: vernemq.mqtt_pubcomp_sent_reason
-  lookup: sum -1m unaligned absolute match-names of success
-   units: packets
-   every: 10s
-    info: successful v5 PUBCOMP sent in the last minute
-      to: sysadmin
-
 template: vernemq_mqtt_pubcomp_received_reason_unsuccessful
       on: vernemq.mqtt_pubcomp_received_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_pubcomp_received_reason_success
+  lookup: sum -1m unaligned absolute match-names of !success,*
    units: packets
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBCOMP received in the last minute
       to: sysadmin
 
 template: vernemq_mqtt_pubcomp_sent_reason_unsuccessful
       on: vernemq.mqtt_pubcomp_sent_reason
-  lookup: sum -1m unaligned absolute
-    calc: $this - $vernemq_mqtt_pubcomp_sent_reason_success
+  lookup: sum -1m unaligned absolute match-names of !success,*
    units: packets
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unsuccessful v5 PUBCOMP sent in the last minute
       to: sysadmin
 
 template: vernemq_mqtt_pubcomp_unexpected
       on: vernemq.mqtt_pubcomp_invalid_error
   lookup: sum -1m unaligned absolute
-   units: messages
+   units: packets
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unexpected v3/v5 PUBCOMP received in the last minute
       to: sysadmin

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -142,8 +142,8 @@ template: vernemq_mqtt_subscribe_auth_error
   lookup: sum -1m unaligned absolute
    units: attempts
    every: 10s
-    warn: $this > 0
-   delay: down 5m multiplier 1.5 max 2h
+    warn: $this > (($status >= $WARNING) ? (0) : (5))
+   delay: up 5m down 5m multiplier 1.5 max 2h
     info: unauthorized v3/v5 SUBSCRIBE attempts in the last minute
       to: sysadmin
 


### PR DESCRIPTION
##### Summary

Related netdata/product#1179

vernemq alarms are very sensitive, basically logic is _sent a notification if there is any error_.

The plan was to use ratio (percentage) instead of exact values whenever is possible. 

Unfortunately, it is not possible. So this PR adds a [`delay up`](https://learn.netdata.cloud/docs/agent/health/reference#alarm-line-delay) to all the alarms (we discussed it with @knatsakis).

---


> Unfortunately, it is not possible

**Reason is lack of job scope variables lookup.**

We have:
 - chart A, which contains _total_ metric.
 - chart B, which contains _specific_ metric.

If we want to calculate % of _specific_, we need to create an alarm for chart A and use its name as a variable in the chart B.

I've talked with @stelfrag and looks like that is how we do variables lookup, these are the scopes:
 - chart local
 - family
 - global

That is why [inbound_packets_dropped_ratio/inbound_packets_dropped_ratio](https://github.com/netdata/netdata/blob/e7e5d0c37242d8457e4b2610a95effe0db5ca1b1/health/health.d/net.conf#L55-L101) alarms work - those are different chart, but they have same family (i bet family scope was added specifically for this case 😄 ).



##### Component Name

`health/`

##### Test Plan

 - configure vernemq job
 - set new alarms
 - restart netdata
 - ensure all the alarms loaded (syntax is correct)
 - ensure all the alarms are active and have values

##### Additional Information
