### PR TITLE
Add data query support for archived charts

### DIFF
--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -691,6 +691,36 @@ time_t rrdeng_metric_oldest_time(RRDDIM *rd)
     return page_index->oldest_time / USEC_PER_SEC;
 }
 
+int rrdeng_metric_latest_time_by_uuid(uuid_t *dim_uuid, time_t *first_entry_t, time_t *last_entry_t)
+{
+    struct page_cache *pg_cache;
+    struct rrdengine_instance *ctx;
+    Pvoid_t *PValue;
+    struct pg_cache_page_index *page_index = NULL;
+
+    ctx = get_rrdeng_ctx_from_host(localhost);
+    if (unlikely(!ctx)) {
+        error("Failed to fetch multidb context");
+        return 1;
+    }
+    pg_cache = &ctx->pg_cache;
+
+    uv_rwlock_rdlock(&pg_cache->metrics_index.lock);
+    PValue = JudyHSGet(pg_cache->metrics_index.JudyHS_array, dim_uuid, sizeof(uuid_t));
+    if (likely(NULL != PValue)) {
+        page_index = *PValue;
+    }
+    uv_rwlock_rdunlock(&pg_cache->metrics_index.lock);
+
+    if (likely(page_index)) {
+        *first_entry_t = page_index->oldest_time / USEC_PER_SEC;
+        *last_entry_t = page_index->latest_time / USEC_PER_SEC;
+        return 0;
+    }
+
+    return 1;
+}
+
 /* Also gets a reference for the page */
 void *rrdeng_create_page(struct rrdengine_instance *ctx, uuid_t *id, struct rrdeng_page_descr **ret_descr)
 {

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -59,5 +59,6 @@ extern int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *db
 
 extern int rrdeng_exit(struct rrdengine_instance *ctx);
 extern void rrdeng_prepare_exit(struct rrdengine_instance *ctx);
+extern int rrdeng_metric_latest_time_by_uuid(uuid_t *dim_uuid, time_t *first_entry_t, time_t *last_entry_t);
 
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -41,10 +41,19 @@ struct pg_cache_page_index;
 #include "aclk/aclk.h"
 #endif
 
+enum {
+    CONTEXT_FLAGS_ARCHIVE = 0x01,
+    CONTEXT_FLAGS_CHART   = 0x02,
+    CONTEXT_FLAGS_CONTEXT = 0x04
+};
+
 struct context_param {
     RRDDIM *rd;
     time_t first_entry_t;
     time_t last_entry_t;
+    uint8_t flags;
+//    uint8_t archive_mode;
+//    uint8_t context_mode;
 };
 
 #define META_CHART_UPDATED 1

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -52,8 +52,6 @@ struct context_param {
     time_t first_entry_t;
     time_t last_entry_t;
     uint8_t flags;
-//    uint8_t archive_mode;
-//    uint8_t context_mode;
 };
 
 #define META_CHART_UPDATED 1
@@ -542,7 +540,10 @@ struct rrdset {
     size_t counter;                                 // the number of times we added values to this database
     size_t counter_done;                            // the number of times rrdset_done() has been called
 
-    time_t last_accessed_time;                      // the last time this RRDSET has been accessed
+    union {
+        time_t last_accessed_time;                  // the last time this RRDSET has been accessed
+        time_t last_entry_t;                        // the last_entry_t computed for transient RRDSET
+    };
     time_t upstream_resync_time;                    // the timestamp up to which we should resync clock upstream
 
     char *plugin_name;                              // the name of the plugin that generated this

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -390,16 +390,6 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     if(memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
         uuid_t *dim_uuid = find_dimension_uuid(st, rd);
-
-#ifdef NETDATA_INTERNAL_CHECKS
-        char uuid_str[GUID_LEN + 1];
-        if (dim_uuid) {
-            uuid_unparse_lower(*dim_uuid, uuid_str);
-            debug(D_METADATALOG, " Adding dimension %s with UUID = %s", rd->name, uuid_str);
-        }
-        else
-            debug(D_METADATALOG, " Adding dimension %s with UUID = new", rd->name);
-#endif
         rrdeng_metric_init(rd, dim_uuid);
         rd->state->collect_ops.init = rrdeng_store_metric_init;
         rd->state->collect_ops.store_metric = rrdeng_store_metric_next;

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -390,6 +390,16 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     if(memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
         uuid_t *dim_uuid = find_dimension_uuid(st, rd);
+
+#ifdef NETDATA_INTERNAL_CHECKS
+        char uuid_str[GUID_LEN + 1];
+        if (dim_uuid) {
+            uuid_unparse_lower(*dim_uuid, uuid_str);
+            debug(D_METADATALOG, " Adding dimension %s with UUID = %s", rd->name, uuid_str);
+        }
+        else
+            debug(D_METADATALOG, " Adding dimension %s with UUID = new", rd->name);
+#endif
         rrdeng_metric_init(rd, dim_uuid);
         rd->state->collect_ops.init = rrdeng_store_metric_init;
         rd->state->collect_ops.store_metric = rrdeng_store_metric_next;

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1224,27 +1224,15 @@ void sql_build_context_param_list(struct context_param **param_list, RRDHOST *ho
                 st->name = strdupz(chart);
             }
             uuid_copy(chart_id, *(uuid_t *)sqlite3_column_blob(res, 7));
-
-#ifdef NETDATA_INTERNAL_CHECKS
-            char  uuid_str[GUID_LEN + 1];
-            uuid_unparse_lower(chart_id, uuid_str);
-            debug(D_METADATALOG, "Creating chart %s with UUID = %s", st->name, uuid_str);
-#endif
-
-            st->last_accessed_time = 0;       // This will hold the last_entry_t
+            st->last_entry_t = 0;       // This will hold the last_entry_t
             st->rrdhost = host;
         }
         st->counter++;
 
-#ifdef NETDATA_INTERNAL_CHECKS
-        char  uuid_str[GUID_LEN + 1];
-        uuid_unparse_lower(*((uuid_t *) sqlite3_column_blob(res, 0)), uuid_str);
-        debug(D_METADATALOG, " Adding dimension %s with UUID = %s", (char *) sqlite3_column_text(res, 1), uuid_str);
-#endif
         find_dimension_first_last_t(machine_guid, (char *) st->name, (char *) sqlite3_column_text(res, 1),
                                     (uuid_t *) sqlite3_column_blob(res, 0), &(*param_list)->first_entry_t, &(*param_list)->last_entry_t, &rrdeng_uuid);
 
-        st->last_accessed_time = MAX(st->last_accessed_time, (*param_list)->last_entry_t);
+        st->last_entry_t = MAX(st->last_entry_t, (*param_list)->last_entry_t);
 
         RRDDIM *rd = callocz(1, sizeof(*rd));
         rd->rrdset = st;

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1161,6 +1161,7 @@ int find_dimension_first_last_t(char *machine_guid, char *chart_id, char *dim_id
 #endif
 }
 
+#ifdef ENABLE_DBENGINE
 static RRDDIM *create_rrdim_entry(RRDSET *st, char *id, char *name, uuid_t *metric_uuid)
 {
     RRDDIM *rd = callocz(1, sizeof(*rd));
@@ -1182,6 +1183,7 @@ static RRDDIM *create_rrdim_entry(RRDSET *st, char *id, char *name, uuid_t *metr
     rd->name = strdupz(name);
     return rd;
 }
+#endif
 
 #define SELECT_CHART_CONTEXT  "select d.dim_id, d.id, d.name, c.id, c.type, c.name, c.update_every, c.chart_id from chart c, " \
     "dimension d, host h " \

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -962,7 +962,9 @@ RRDHOST *sql_create_host_by_uuid(char *hostname)
 
     host->system_info = callocz(1, sizeof(*host->system_info));;
     rrdhost_flag_set(host, RRDHOST_FLAG_ARCHIVED);
+#ifdef ENABLE_DBENGINE
     host->rrdeng_ctx = &multidb_ctx;
+#endif
 
     failed:
     rc = sqlite3_finalize(res);
@@ -1282,7 +1284,7 @@ void sql_build_context_param_list(struct context_param **param_list, RRDHOST *ho
         error_report("Failed to finalize the prepared statement when reading archived charts");
 #else
     UNUSED(param_list);
-    UNUSED(host_uuid);
+    UNUSED(host);
     UNUSED(context);
     UNUSED(chart);
 #endif

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1098,3 +1098,185 @@ failed:
 
     return;
 }
+
+int find_dimension_first_last_t(char *machine_guid, char *chart_id, char *dim_id,
+                                uuid_t *uuid, time_t *first_entry_t, time_t *last_entry_t, uuid_t *rrdeng_uuid)
+{
+#ifdef ENABLE_DBENGINE
+    int rc;
+    uuid_t  legacy_uuid;
+    uuid_t  multihost_legacy_uuid;
+    time_t dim_first_entry_t, dim_last_entry_t;
+
+    rc = rrdeng_metric_latest_time_by_uuid(uuid, &dim_first_entry_t, &dim_last_entry_t);
+    if (unlikely(rc)) {
+        rrdeng_generate_legacy_uuid(dim_id, chart_id, &legacy_uuid);
+        rc = rrdeng_metric_latest_time_by_uuid(&legacy_uuid, &dim_first_entry_t, &dim_last_entry_t);
+        if (likely(rc)) {
+            rrdeng_convert_legacy_uuid_to_multihost(machine_guid, &legacy_uuid, &multihost_legacy_uuid);
+            rc = rrdeng_metric_latest_time_by_uuid(&multihost_legacy_uuid, &dim_first_entry_t, &dim_last_entry_t);
+            if (likely(!rc))
+                uuid_copy(*rrdeng_uuid, multihost_legacy_uuid);
+        }
+        else
+            uuid_copy(*rrdeng_uuid, legacy_uuid);
+    }
+    else
+        uuid_copy(*rrdeng_uuid, *uuid);
+
+    if (likely(!rc)) {
+        *first_entry_t = MIN(*first_entry_t, dim_first_entry_t);
+        *last_entry_t = MAX(*last_entry_t, dim_last_entry_t);
+    }
+    return rc;
+#else
+    UNUSED(machine_guid);
+    UNUSED(chart_id);
+    UNUSED(dim_id);
+    UNUSED(uuid);
+    UNUSED(first_entry_t);
+    UNUSED(last_entry_t);
+    UNUSED(rrdeng_uuid);
+    return 1;
+#endif
+}
+
+
+#define SELECT_CHART_CONTEXT  "select d.dim_id, d.id, d.name, c.id, c.type, c.name, c.update_every, c.chart_id from chart c, " \
+    "dimension d, host h " \
+    "where d.chart_id = c.chart_id and c.host_id = h.host_id and c.host_id = @host_id and c.context = @context " \
+    "order by c.chart_id asc, c.type||c.id desc;"
+
+#define SELECT_CHART_SINGLE  "select d.dim_id, d.id, d.name, c.id, c.type, c.name, c.update_every, c.chart_id, c.context from chart c, " \
+    "dimension d, host h " \
+    "where d.chart_id = c.chart_id and c.host_id = h.host_id and c.host_id = @host_id and c.type||'.'||c.id = @chart " \
+    "order by c.chart_id asc, c.type||'.'||c.id desc;"
+
+void sql_build_context_param_list(struct context_param **param_list, RRDHOST *host, char *context, char *chart)
+{
+#ifdef ENABLE_DBENGINE
+    int rc;
+
+    if (unlikely(!param_list) || host->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE)
+        return;
+
+    if (unlikely(!(*param_list))) {
+        *param_list = mallocz(sizeof(struct context_param));
+        (*param_list)->first_entry_t = LONG_MAX;
+        (*param_list)->last_entry_t = 0;
+        (*param_list)->rd = NULL;
+        (*param_list)->flags = CONTEXT_FLAGS_ARCHIVE;
+        if (chart)
+            (*param_list)->flags |= CONTEXT_FLAGS_CHART;
+        else
+            (*param_list)->flags |= CONTEXT_FLAGS_CONTEXT;
+    }
+
+    sqlite3_stmt *res = NULL;
+
+    if (context)
+        rc = sqlite3_prepare_v2(db_meta, SELECT_CHART_CONTEXT, -1, &res, 0);
+    else
+        rc = sqlite3_prepare_v2(db_meta, SELECT_CHART_SINGLE, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement to fetch host archived charts");
+        return;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host parameter to fetch archived charts");
+        return;
+    }
+
+    if (context)
+        rc = sqlite3_bind_text(res, 2, context, -1, SQLITE_STATIC);
+    else
+        rc = sqlite3_bind_text(res, 2, chart, -1, SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host parameter to fetch archived charts");
+        return;
+    }
+
+    RRDSET *st = NULL;
+    char machine_guid[GUID_LEN + 1];
+    uuid_unparse_lower(host->host_uuid, machine_guid);
+    uuid_t rrdeng_uuid;
+    uuid_t chart_id;
+
+    while (sqlite3_step(res) == SQLITE_ROW) {
+        char id[512];
+        sprintf(id, "%s.%s", sqlite3_column_text(res, 3), sqlite3_column_text(res, 1));
+
+        if (!st || uuid_compare(*(uuid_t *)sqlite3_column_blob(res, 7), chart_id)) {
+            st = callocz(1, sizeof(*st));
+            char n[RRD_ID_LENGTH_MAX + 1];
+
+            snprintfz(
+                n, RRD_ID_LENGTH_MAX, "%s.%s", (char *)sqlite3_column_text(res, 4),
+                (char *)sqlite3_column_text(res, 3));
+            st->name = strdupz(n);
+            st->update_every = sqlite3_column_int(res, 6);
+            st->counter = 0;
+            if (chart) {
+                st->context = strdupz((char *)sqlite3_column_text(res, 8));
+                strncpyz(st->id, chart, RRD_ID_LENGTH_MAX);
+                st->name = strdupz(chart);
+            }
+            uuid_copy(chart_id, *(uuid_t *)sqlite3_column_blob(res, 7));
+
+#ifdef NETDATA_INTERNAL_CHECKS
+            char  uuid_str[GUID_LEN + 1];
+            uuid_unparse_lower(chart_id, uuid_str);
+            debug(D_METADATALOG, "Creating chart %s with UUID = %s", st->name, uuid_str);
+#endif
+
+            st->last_accessed_time = 0;       // This will hold the last_entry_t
+            st->rrdhost = host;
+        }
+        st->counter++;
+
+#ifdef NETDATA_INTERNAL_CHECKS
+        char  uuid_str[GUID_LEN + 1];
+        uuid_unparse_lower(*((uuid_t *) sqlite3_column_blob(res, 0)), uuid_str);
+        debug(D_METADATALOG, " Adding dimension %s with UUID = %s", (char *) sqlite3_column_text(res, 1), uuid_str);
+#endif
+        find_dimension_first_last_t(machine_guid, (char *) st->name, (char *) sqlite3_column_text(res, 1),
+                                    (uuid_t *) sqlite3_column_blob(res, 0), &(*param_list)->first_entry_t, &(*param_list)->last_entry_t, &rrdeng_uuid);
+
+        st->last_accessed_time = MAX(st->last_accessed_time, (*param_list)->last_entry_t);
+
+        RRDDIM *rd = callocz(1, sizeof(*rd));
+        rd->rrdset = st;
+        rd->last_stored_value = NAN;
+        rrddim_flag_set(rd, RRDDIM_FLAG_NONE);
+        rd->id = strdupz((char *)sqlite3_column_text(res, 1));
+        rd->name = strdupz((char *)sqlite3_column_text(res, 2));
+        rd->state = mallocz(sizeof(*rd->state));
+        rd->rrd_memory_mode = RRD_MEMORY_MODE_DBENGINE;
+        rd->state->query_ops.init = rrdeng_load_metric_init;
+        rd->state->query_ops.next_metric = rrdeng_load_metric_next;
+        rd->state->query_ops.is_finished = rrdeng_load_metric_is_finished;
+        rd->state->query_ops.finalize = rrdeng_load_metric_finalize;
+        rd->state->query_ops.latest_time = rrdeng_metric_latest_time;
+        rd->state->query_ops.oldest_time = rrdeng_metric_oldest_time;
+        rd->state->rrdeng_uuid = mallocz(sizeof(uuid_t));
+        uuid_copy(*rd->state->rrdeng_uuid, rrdeng_uuid);
+        rd->state->metric_uuid = rd->state->rrdeng_uuid;
+        rd->next = (*param_list)->rd;
+        (*param_list)->rd = rd;
+    }
+    if (likely(st && context && !st->context))
+            st->context = strdupz(context);
+
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when reading archived charts");
+#else
+    UNUSED(param_list);
+    UNUSED(host_uuid);
+    UNUSED(context);
+    UNUSED(chart);
+#endif
+    return;
+}

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -755,7 +755,7 @@ void sql_rrdset2json(RRDHOST *host, BUFFER *wb)
     rc = sqlite3_bind_blob(res_chart, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind host parameter to fetch archived charts");
-        return;
+        goto failed;
     }
 
     rc = sqlite3_prepare_v2(db_meta, SELECT_DIMENSION, -1, &res_dim, 0);

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -59,4 +59,5 @@ extern void db_unlock(void);
 extern void db_lock(void);
 extern void delete_dimension_uuid(uuid_t *dimension_uuid);
 extern void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value);
+extern void sql_build_context_param_list(struct context_param **param_list, RRDHOST *host, char *context, char *chart);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -5,8 +5,14 @@
 #define JSON_DATES_JS 1
 #define JSON_DATES_TIMESTAMP 2
 
-void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, RRDDIM *temp_rd) {
-    rrdset_check_rdlock(r->st);
+void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable,  struct context_param *context_param_list)
+{
+    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
+
+    int should_lock = (!context_param_list || (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)));
+
+    if (should_lock)
+        rrdset_check_rdlock(r->st);
 
     //info("RRD2JSON(): %s: BEGIN", r->st->id);
     int row_annotations = 0, dates, dates_with_new = 0;

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -9,7 +9,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable,  struct
 {
     RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
 
-    int should_lock = (!context_param_list || (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)));
+    int should_lock = (!context_param_list || !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE));
 
     if (should_lock)
         rrdset_check_rdlock(r->st);

--- a/web/api/formatters/json/json.h
+++ b/web/api/formatters/json/json.h
@@ -5,6 +5,6 @@
 
 #include "../rrd2json.h"
 
-extern void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, RRDDIM *temp_rd);
+extern void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, struct context_param *context_param_list);
 
 #endif //NETDATA_API_FORMATTER_JSON_H

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -7,8 +7,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
 {
 
     RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
-    int should_lock = (!context_param_list || (context_param_list && !context_param_list->flags & CONTEXT_FLAGS_ARCHIVE));
-    uint8_t context_mode = (!context_param_list || (context_param_list && context_param_list->flags & CONTEXT_FLAGS_CONTEXT));
+    int should_lock = (!context_param_list || !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE));
+    uint8_t context_mode = (!context_param_list || (context_param_list->flags & CONTEXT_FLAGS_CONTEXT));
 
     if (should_lock)
         rrdset_check_rdlock(r->st);

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -2,8 +2,16 @@
 
 #include "json_wrapper.h"
 
-void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value, RRDDIM *temp_rd, char *chart_label_key) {
-    rrdset_check_rdlock(r->st);
+void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value,
+                             struct context_param *context_param_list, char *chart_label_key)
+{
+
+    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
+    int should_lock = (!context_param_list || (context_param_list && !context_param_list->flags & CONTEXT_FLAGS_ARCHIVE));
+    uint8_t context_mode = (!context_param_list || (context_param_list && context_param_list->flags & CONTEXT_FLAGS_CONTEXT));
+
+    if (should_lock)
+        rrdset_check_rdlock(r->st);
 
     long rows = rrdr_rows(r);
     long c, i;
@@ -22,7 +30,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
         sq[0] = '"';
     }
 
-    rrdset_rdlock(r->st);
+    if (should_lock)
+        rrdset_rdlock(r->st);
     buffer_sprintf(wb, "{\n"
                        "   %sapi%s: 1,\n"
                        "   %sid%s: %s%s%s,\n"
@@ -35,16 +44,17 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                        "   %safter%s: %u,\n"
                        "   %sdimension_names%s: ["
                    , kq, kq
-                   , kq, kq, sq, temp_rd?r->st->context:r->st->id, sq
-                   , kq, kq, sq, temp_rd?r->st->context:r->st->name, sq
+                   , kq, kq, sq, context_mode && temp_rd?r->st->context:r->st->id, sq
+                   , kq, kq, sq, context_mode && temp_rd?r->st->context:r->st->name, sq
                    , kq, kq, r->update_every
                    , kq, kq, r->st->update_every
-                   , kq, kq, (uint32_t)rrdset_first_entry_t_nolock(r->st)
-                   , kq, kq, (uint32_t)rrdset_last_entry_t_nolock(r->st)
+                   , kq, kq, context_param_list ? (uint32_t) context_param_list->first_entry_t : (uint32_t)rrdset_first_entry_t(r->st)
+                   , kq, kq, context_param_list ? (uint32_t) context_param_list->last_entry_t : (uint32_t)rrdset_last_entry_t(r->st)
                    , kq, kq, (uint32_t)r->before
                    , kq, kq, (uint32_t)r->after
                    , kq, kq);
-    rrdset_unlock(r->st);
+    if (should_lock)
+        rrdset_unlock(r->st);
 
     for(c = 0, i = 0, rd = temp_rd?temp_rd:r->st->dimensions; rd && c < r->d ;c++, rd = rd->next) {
         if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
@@ -89,7 +99,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
     buffer_strcat(wb, "],\n");
 
     // Composite charts
-    if (temp_rd) {
+    if (context_mode && temp_rd) {
         buffer_sprintf(
             wb,
             "   %schart_ids%s: [",

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -48,8 +48,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                    , kq, kq, sq, context_mode && temp_rd?r->st->context:r->st->name, sq
                    , kq, kq, r->update_every
                    , kq, kq, r->st->update_every
-                   , kq, kq, context_param_list ? (uint32_t) context_param_list->first_entry_t : (uint32_t)rrdset_first_entry_t(r->st)
-                   , kq, kq, context_param_list ? (uint32_t) context_param_list->last_entry_t : (uint32_t)rrdset_last_entry_t(r->st)
+                   , kq, kq, (uint32_t) (context_param_list ? context_param_list->first_entry_t : rrdset_first_entry_t(r->st))
+                   , kq, kq, (uint32_t) (context_param_list ? context_param_list->last_entry_t : rrdset_last_entry_t(r->st))
                    , kq, kq, (uint32_t)r->before
                    , kq, kq, (uint32_t)r->after
                    , kq, kq);

--- a/web/api/formatters/json_wrapper.h
+++ b/web/api/formatters/json_wrapper.h
@@ -5,7 +5,7 @@
 
 #include "rrd2json.h"
 
-extern void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value, RRDDIM *temp_rd, char *chart_key);
+extern void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value, struct context_param *context_param_list, char *chart_key);
 extern void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
 
 #endif //NETDATA_API_FORMATTER_JSON_WRAPPER_H

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -65,6 +65,7 @@ void build_context_param_list(struct context_param **param_list, RRDSET *st)
         *param_list = mallocz(sizeof(struct context_param));
         (*param_list)->first_entry_t = LONG_MAX;
         (*param_list)->last_entry_t = 0;
+        (*param_list)->flags = 0;
         (*param_list)->rd = NULL;
     }
 
@@ -356,7 +357,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 1, temp_rd);
+        rrdr2json(r, wb, options, 1, context_param_list);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);
@@ -368,7 +369,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 1, temp_rd);
+        rrdr2json(r, wb, options, 1, context_param_list);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);
@@ -379,7 +380,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 0, temp_rd);
+        rrdr2json(r, wb, options, 0, context_param_list);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);
@@ -392,7 +393,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 0, temp_rd);
+        rrdr2json(r, wb, options, 0, context_param_list);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -215,7 +215,7 @@ int rrdset2anything_api_v1(
         , char *chart_label_key
 ) {
 
-    if (!(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
+    if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
         time_t last_accessed_time = now_realtime_sec();
         st->last_accessed_time = last_accessed_time;
     }
@@ -241,7 +241,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_SSV:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2ssv(r, wb, options, "", " ", "");
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -254,7 +254,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_SSV_COMMA:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2ssv(r, wb, options, "", ",", "");
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -267,7 +267,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_JS_ARRAY:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
             rrdr2ssv(r, wb, options, "[", ",", "]");
             rrdr_json_wrapper_end(r, wb, format, options, 0);
         }
@@ -280,7 +280,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_CSV:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2csv(r, wb, format, options, "", ",", "\\n", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -293,7 +293,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_CSV_MARKDOWN:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2csv(r, wb, format, options, "", "|", "\\n", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -306,7 +306,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_CSV_JSON_ARRAY:
         wb->contenttype = CT_APPLICATION_JSON;
         if(options & RRDR_OPTION_JSON_WRAP) {
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
             buffer_strcat(wb, "[\n");
             rrdr2csv(r, wb, format, options + RRDR_OPTION_LABEL_QUOTES, "[", ",", "]", ",\n", temp_rd);
             buffer_strcat(wb, "\n]");
@@ -323,7 +323,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_TSV:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             rrdr2csv(r, wb, format, options, "", "\t", "\\n", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -336,7 +336,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_HTML:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
             buffer_strcat(wb, "<html>\\n<center>\\n<table border=\\\"0\\\" cellpadding=\\\"5\\\" cellspacing=\\\"5\\\">\\n");
             rrdr2csv(r, wb, format, options, "<tr><td>", "</td><td>", "</td></tr>\\n", "", temp_rd);
             buffer_strcat(wb, "</table>\\n</center>\\n</html>\\n");
@@ -354,7 +354,7 @@ int rrdset2anything_api_v1(
         wb->contenttype = CT_APPLICATION_X_JAVASCRIPT;
 
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
         rrdr2json(r, wb, options, 1, temp_rd);
 
@@ -366,7 +366,7 @@ int rrdset2anything_api_v1(
         wb->contenttype = CT_APPLICATION_JSON;
 
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
         rrdr2json(r, wb, options, 1, temp_rd);
 
@@ -377,7 +377,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_JSONP:
         wb->contenttype = CT_APPLICATION_X_JAVASCRIPT;
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
         rrdr2json(r, wb, options, 0, temp_rd);
 
@@ -390,7 +390,7 @@ int rrdset2anything_api_v1(
         wb->contenttype = CT_APPLICATION_JSON;
 
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, temp_rd, chart_label_key);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
         rrdr2json(r, wb, options, 0, temp_rd);
 

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -214,8 +214,11 @@ int rrdset2anything_api_v1(
         , struct context_param *context_param_list
         , char *chart_label_key
 ) {
-    time_t last_accessed_time = now_realtime_sec();
-    st->last_accessed_time = last_accessed_time;
+
+    if (!(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
+        time_t last_accessed_time = now_realtime_sec();
+        st->last_accessed_time = last_accessed_time;
+    }
 
 
     RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions?buffer_tostring(dimensions):NULL, context_param_list);

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -216,11 +216,8 @@ int rrdset2anything_api_v1(
         , char *chart_label_key
 ) {
 
-    if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
-        time_t last_accessed_time = now_realtime_sec();
-        st->last_accessed_time = last_accessed_time;
-    }
-
+    if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE))
+        st->last_accessed_time = now_realtime_sec();
 
     RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions?buffer_tostring(dimensions):NULL, context_param_list);
     if(!r) {

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -285,7 +285,7 @@ static void rrdr_disable_not_selected_dimensions(RRDR *r, RRDR_OPTIONS options, 
                                                  struct context_param *context_param_list)
 {
     RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
-    int should_lock = (!context_param_list || (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)));
+    int should_lock = (!context_param_list || !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE));
 
     if (should_lock)
         rrdset_check_rdlock(r->st);

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -281,8 +281,14 @@ RRDR_GROUPING web_client_api_request_v1_data_group(const char *name, RRDR_GROUPI
 
 // ----------------------------------------------------------------------------
 
-static void rrdr_disable_not_selected_dimensions(RRDR *r, RRDR_OPTIONS options, const char *dims, RRDDIM *temp_rd) {
-    rrdset_check_rdlock(r->st);
+static void rrdr_disable_not_selected_dimensions(RRDR *r, RRDR_OPTIONS options, const char *dims,
+                                                 struct context_param *context_param_list)
+{
+    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
+    int should_lock = (!context_param_list || (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)));
+
+    if (should_lock)
+        rrdset_check_rdlock(r->st);
 
     if(unlikely(!dims || !*dims || (dims[0] == '*' && dims[1] == '\0'))) return;
 
@@ -1060,10 +1066,11 @@ static RRDR *rrd2rrdr_fixedstep(
     // -------------------------------------------------------------------------
     // disable the not-wanted dimensions
 
-    rrdset_check_rdlock(st);
+    if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE))
+        rrdset_check_rdlock(st);
 
     if(dimensions)
-        rrdr_disable_not_selected_dimensions(r, options, dimensions, temp_rd);
+        rrdr_disable_not_selected_dimensions(r, options, dimensions, context_param_list);
 
 
     // -------------------------------------------------------------------------
@@ -1435,11 +1442,11 @@ static RRDR *rrd2rrdr_variablestep(
 
     // -------------------------------------------------------------------------
     // disable the not-wanted dimensions
-
-    rrdset_check_rdlock(st);
+    if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE))
+        rrdset_check_rdlock(st);
 
     if(dimensions)
-        rrdr_disable_not_selected_dimensions(r, options, dimensions, temp_rd);
+        rrdr_disable_not_selected_dimensions(r, options, dimensions, context_param_list);
 
 
     // -------------------------------------------------------------------------
@@ -1591,8 +1598,12 @@ RRDR *rrd2rrdr(
         if (first_entry_t > after_requested)
             first_entry_t = after_requested;
 
-    if (context_param_list)
+    if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
         rebuild_context_param_list(context_param_list, after_requested);
+        st = context_param_list->rd ? context_param_list->rd->rrdset : NULL;
+        if (unlikely(!st))
+            return NULL;
+    }
 
 #ifdef ENABLE_DBENGINE
     if (st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -108,7 +108,8 @@ RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param
     RRDR *r = callocz(1, sizeof(RRDR));
     r->st = st;
 
-    rrdr_lock_rrdset(r);
+    if (!context_param_list || (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)))
+        rrdr_lock_rrdset(r);
 
     RRDDIM *temp_rd =  context_param_list ? context_param_list->rd : NULL;
     RRDDIM *rd;

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1382,6 +1382,8 @@ static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, ch
             host = sql_create_host_by_uuid(tok);
             if (likely(host)) {
                 rrdhost_flag_set(host, RRDHOST_FLAG_ARCHIVED);
+                host->rrdeng_ctx = &multidb_ctx;
+                host->system_info = callocz(1, sizeof(*host->system_info));
                 release_host = 1;
             }
         }
@@ -1395,6 +1397,7 @@ static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, ch
                 freez(host->program_name);
                 freez(host->program_version);
                 freez(host->registry_hostname);
+                freez(host->system_info);
                 freez(host);
             }
             return rc;

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1374,33 +1374,25 @@ static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, ch
         uint32_t hash = simple_hash(tok);
 
         host = rrdhost_find_by_hostname(tok, hash);
-        if(!host) host = rrdhost_find_by_guid(tok, hash);
-
-#ifdef ENABLE_DBENGINE
-        int release_host = 0;
+        if (!host)
+            host = rrdhost_find_by_guid(tok, hash);
         if (!host) {
             host = sql_create_host_by_uuid(tok);
-            if (likely(host))
-                release_host = 1;
-        }
-        if(host) {
-            int rc = web_client_process_url(host, w, url);
-            if (release_host) {
+            if (likely(host)) {
+                int rc = web_client_process_url(host, w, url);
                 freez(host->hostname);
-                freez((char *) host->os);
-                freez((char *) host->tags);
-                freez((char *) host->timezone);
+                freez((char *)host->os);
+                freez((char *)host->tags);
+                freez((char *)host->timezone);
                 freez(host->program_name);
                 freez(host->program_version);
                 freez(host->registry_hostname);
                 freez(host->system_info);
                 freez(host);
+                return rc;
             }
-            return rc;
         }
-#else
         if (host) return web_client_process_url(host, w, url);
-#endif
     }
 
     buffer_flush(w->response.data);

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1380,12 +1380,8 @@ static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, ch
         int release_host = 0;
         if (!host) {
             host = sql_create_host_by_uuid(tok);
-            if (likely(host)) {
-                rrdhost_flag_set(host, RRDHOST_FLAG_ARCHIVED);
-                host->rrdeng_ctx = &multidb_ctx;
-                host->system_info = callocz(1, sizeof(*host->system_info));
+            if (likely(host))
                 release_host = 1;
-            }
         }
         if(host) {
             int rc = web_client_process_url(host, w, url);


### PR DESCRIPTION
##### Summary
Add the ability to query archived charts. This will only work if the dbengine memory mode is used.

After an agent restart the archived charts are not loaded in memory. When a `/api/v1/data` request is received for such a chart it will lookup the chart in the sqlite database, build the necessary chart and dimension structures and perform the query.

##### Component Name
database

##### Test Plan
- Setup a dbengine-enabled parent with a child (the parent should use dbengine to store the data at least for the child)
- Start the parent and the child e.g. **child1**
  - On the parent you can execute a query 
     `http://parent_ip:19999/host/child1/api/v1/data?chart=system.cpu&after=-10` 
     and receive the collected values for the child
- Stop the parent and child
- Start only the parent and try to execute
  `http://parent_ip:19999/host/child1/api/v1/data?chart=system.cpu&after=-10` 
   it should fail with a `Chart is not found` message

---

- Stop the parent, apply the PR and restart
- Execute
  `http://parent_ip:19999/host/child1/api/v1/data?chart=system.cpu&after=-10` 
   It should return the last collected values for the system.cpu chart for the child


