### PR TITLE
add a dump_methods parameter to alarm-notify.sh.in

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -209,6 +209,9 @@ if [[ ${1} = "unittest" ]]; then
   cfgfile="${3}"    # the location of the config file to use for unit testing
   status="${4}"     # the current status : REMOVED, UNINITIALIZED, UNDEFINED, CLEAR, WARNING, CRITICAL
   old_status="${5}" # the previous status: REMOVED, UNINITIALIZED, UNDEFINED, CLEAR, WARNING, CRITICAL
+elif [[ ${1} = "dump_methods" ]]; then
+    dump_methods=1
+    status="WARNING"
 else
   roles="${1}"               # the roles that should be notified for this event
   args_host="${2}"           # the host generated this event
@@ -549,6 +552,15 @@ filter_recipient_by_criticality() {
 # check stackpulse
 [ -z "${STACKPULSE_WEBHOOK}" ] && SEND_STACKPULSE="NO"
 
+# check msteam
+[ -z "${MSTEAM_WEBHOOK_URL}" ] && SEND_MSTEAM="NO"
+
+# check pd
+[ -z "${DEFAULT_RECIPIENT_PD}" ] && SEND_PD="NO"
+
+# check prowl
+[ -z "${DEFAULT_RECIPIENT_PROWL}" ] && SEND_PROWL="NO"
+
 if [ "${SEND_PUSHOVER}" = "YES" ] ||
   [ "${SEND_SLACK}" = "YES" ] ||
   [ "${SEND_ROCKETCHAT}" = "YES" ] ||
@@ -637,6 +649,15 @@ if [ "${SEND_AWSSNS}" = "YES" ] && [ -z "${aws}" ]; then
     debug "Cannot find aws command in the system path.  Disabling Amazon SNS notifications."
     SEND_AWSSNS="NO"
   fi
+fi
+
+if [ ${dump_methods} ]; then
+    for name in "${!SEND_@}"; do
+        if [ "${!name}" = "YES" ]; then
+            echo "$name"
+        fi
+    done
+    exit
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Add a dump_methods parameter to the alarm-notify.sh.in script. This will be used by the posthog analytics. The agent will execute the script from the user's directory, and will report back the available notification methods.

It also adds a check for `MSTEAM`, `PD` & `PROWL` methods. (Without them, they will be always set to `YES`). Presumably they are set somewhere later, but we need them to be there too for the dump_methods to be accurate.

Comments are very much encouraged, and if there is something I'm missing especially for the methods above.

One thing this PR can't detect is whether `SEND_CUSTOM` is set. Any ideas would be great!

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

When run with the dump_methods parameter, the script should just print the available methods and should NOT try to send anything. 
Normal execution should be possible without this parameter.


##### Additional Information
