### PR TITLE
Adds _aclk_impl label

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -813,6 +813,7 @@ struct label *add_aclk_host_labels(struct label *label) {
             proxy_str = "none";
             break;
     }
+    label = add_label_to_list(label, "_aclk_impl", "Next Generation", LABEL_SOURCE_AUTO);
     return add_label_to_list(label, "_aclk_proxy", proxy_str, LABEL_SOURCE_AUTO);
 #else
     return label;

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -5,8 +5,6 @@
 
 #include "libnetdata/libnetdata.h"
 
-#include "legacy/aclk_lws_https_client.h"
-
 #include "../daemon/common.h"
 
 #include "../mqtt_websockets/c-rbuf/include/ringbuffer.h"

--- a/aclk/legacy/aclk_common.c
+++ b/aclk/legacy/aclk_common.c
@@ -252,6 +252,7 @@ struct label *add_aclk_host_labels(struct label *label) {
             proxy_str = "none";
             break;
     }
+    label = add_label_to_list(label, "_aclk_impl", "Legacy", LABEL_SOURCE_AUTO);
     return add_label_to_list(label, "_aclk_proxy", proxy_str, LABEL_SOURCE_AUTO);
 #else
     return label;


### PR DESCRIPTION
##### Summary
1. Adds `_aclk_impl` label with values of `Legacy` or `Next Generation` or not present if ACLK not available
2. Removes unneeded include from aclk_otp which references file from legacy ACLK

##### Component Name
ACLK

##### Test Plan
build agent with aclk-ng and look at `/api/v1/info`, build with legacy and do the same.

##### Additional Information
