### PR TITLE
Added Slack notifications for build failures.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,3 +59,19 @@ jobs:
           platforms: linux/amd64,linux/i386,linux/arm/v7,linux/arm64
           push: ${{ env.publish }}
           tags: ${{ env.tags }}
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER:
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Docker Build failed:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: "Docker image build failed."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && github.event_name != 'pull_request'
+            && startsWith(github.ref, 'refs/heads/master'
+          }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -127,3 +127,19 @@ jobs:
           PKG_CLOUD_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_TOKEN }}
           PACKAGE_CLOUD_RETENTION_DAYS: ${{ env.pkg_retention_days }}
         run: .github/scripts/old_package_purging.sh
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER:
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Package Build failed:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: "${{ matrix.pkgclouddistro }} ${{ matrix.version }} package build for ${{ matrix.arch }} failed."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && github.event_name != 'pull_request'
+            && startsWith(github.ref, 'refs/heads/master'
+          }}


### PR DESCRIPTION
##### Summary

SSIA

##### Component Name

area/ci

##### Test Plan

Directly replicated from other places we are using Slack notifications from GitHub Actions.

##### Additional Information

Fixes: #10776 

This intentionally flags failures for merges to master as well as actual release build failures.