### PR TITLE
health: add `wmi_` prefix to the wmi collector network alarms

### DIFF
--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -61,7 +61,7 @@ template: wmi_swap_in_use
 
 ## Network
 
-template: inbound_packets_discarded
+template: wmi_inbound_packets_discarded
       on: wmi.net_discarded
       os: linux
    hosts: *
@@ -74,7 +74,7 @@ families: *
     info: interface inbound discarded packets in the last 10 minutes
       to: sysadmin
 
-template: outbound_packets_discarded
+template: wmi_outbound_packets_discarded
       on: wmi.net_discarded
       os: linux
    hosts: *
@@ -87,7 +87,7 @@ families: *
     info: interface outbound discarded packets in the last 10 minutes
       to: sysadmin
 
-template: inbound_packets_errors
+template: wmi_inbound_packets_errors
       on: wmi.net_errors
       os: linux
    hosts: *
@@ -100,7 +100,7 @@ families: *
     info: interface inbound errors in the last 10 minutes
       to: sysadmin
 
-template: outbound_packets_errors
+template: wmi_outbound_packets_errors
       on: wmi.net_errors
       os: linux
    hosts: *


### PR DESCRIPTION
##### Summary

Templates/alarms names must be unique. Using `collectorName_` as a prefix is a common pattern.

##### Component Name

`health`

##### Test Plan


##### Additional Information
