### PR TITLE
health: use separate packets_dropped_ratio alarms for wifi network interfaces

### DIFF
--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -76,7 +76,7 @@ template: inbound_packets_dropped_ratio
       on: net.packets
       os: linux
    hosts: *
-families: *
+families: !wl* *
   lookup: sum -10m unaligned absolute of received
     calc: (($inbound_packets_dropped != nan AND $this > 1000) ? ($inbound_packets_dropped * 100 / $this) : (0))
    units: %
@@ -90,12 +90,40 @@ template: outbound_packets_dropped_ratio
       on: net.packets
       os: linux
    hosts: *
-families: *
+families: !wl* *
   lookup: sum -10m unaligned absolute of sent
     calc: (($outbound_packets_dropped != nan AND $this > 1000) ? ($outbound_packets_dropped * 100 / $this) : (0))
    units: %
    every: 1m
     warn: $this >= 2
+   delay: up 1m down 1h multiplier 1.5 max 2h
+    info: the ratio of outbound dropped packets vs the total number of sent packets of the network interface, during the last 10 minutes
+      to: sysadmin
+
+template: wifi_inbound_packets_dropped_ratio
+      on: net.packets
+      os: linux
+   hosts: *
+families: wl*
+  lookup: sum -10m unaligned absolute of received
+    calc: (($inbound_packets_dropped != nan AND $this > 1000) ? ($inbound_packets_dropped * 100 / $this) : (0))
+   units: %
+   every: 1m
+    warn: $this >= 10
+   delay: up 1m down 1h multiplier 1.5 max 2h
+    info: the ratio of inbound dropped packets vs the total number of received packets of the network interface, during the last 10 minutes
+      to: sysadmin
+
+template: wifi_outbound_packets_dropped_ratio
+      on: net.packets
+      os: linux
+   hosts: *
+families: wl*
+  lookup: sum -10m unaligned absolute of sent
+    calc: (($outbound_packets_dropped != nan AND $this > 1000) ? ($outbound_packets_dropped * 100 / $this) : (0))
+   units: %
+   every: 1m
+    warn: $this >= 10
    delay: up 1m down 1h multiplier 1.5 max 2h
     info: the ratio of outbound dropped packets vs the total number of sent packets of the network interface, during the last 10 minutes
       to: sysadmin


### PR DESCRIPTION
##### Summary

We need different dropped packets thresholds for wifi and not wifi network interfaces. It is completely expected to have much more drops in wireless networks. I see no other way, than having 2 sets of alarms. 

This PR adss packets_dropped_ratio alarms for wifi network interfaces. 

I use [`families`](https://learn.netdata.cloud/docs/agent/health/reference#alarm-line-families) filter. Wifi iface [prefix is `wl`](https://github.com/systemd/systemd/blob/fa92d38428cdac260e72e280bf1d43539f4ea805/src/udev/udev-builtin-net_id.c#L839-L841) on systemd systems ([PredictableNetworkInterfaceNames](https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/)). I understand that it doesn't cover other cases, but at least it fixes part of them.

I really get tired of having this alarm active.

##### Component Name

##### Test Plan

- use new `net.conf`, ensure it loads correctly
- ensure wifi network interface has applied `wifi_inbound_packets_dropped_ratio/wifi_outbound_packets_dropped_ratio`
- ensure not wifi network interface has applied `inbound_packets_dropped_ratio/outbound_packets_dropped_ratio`


##### Additional Information
