### PR TITLE
Add check for children connecting to a parent agent with unsupported memory mode

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -261,6 +261,14 @@ static int rrdpush_receive(struct receiver_state *rpt)
     mode = rrd_memory_mode_id(appconfig_get(&stream_config, rpt->key, "default memory mode", rrd_memory_mode_name(mode)));
     mode = rrd_memory_mode_id(appconfig_get(&stream_config, rpt->machine_guid, "memory mode", rrd_memory_mode_name(mode)));
 
+#ifndef ENABLE_DBENGINE
+    if (unlikely(mode == RRD_MEMORY_MODE_DBENGINE)) {
+        close(rpt->fd);
+        log_stream_connection(rpt->client_ip, rpt->client_port, rpt->key, rpt->machine_guid, rpt->hostname, "REJECTED -- DBENGINE MEMORY MODE NOT SUPPORTED");
+        return 1;
+    }
+#endif
+
     health_enabled = appconfig_get_boolean_ondemand(&stream_config, rpt->key, "health enabled by default", health_enabled);
     health_enabled = appconfig_get_boolean_ondemand(&stream_config, rpt->machine_guid, "health enabled", health_enabled);
 


### PR DESCRIPTION
##### Summary
When an agent is compiled without dbengine support and a child is configured to use dbengine, as soon
as the child attempts to connect to the parent agent, the parent agent will shutdown with an error: 

`netdata FATAL : netdata : RRD_MEMORY_MODE_DBENGINE is not supported in this platform. # : Success`

This PR adds a check and rejects the connection to prevent the parent agent from shutting down

##### Component Name
database
streaming

##### Test Plan
Before the PR
- Setup streaming such as the parent is configured to use memory mode RAM
- Compile the parent agent with the `--disable-dbengine` flag
- Configure a child to use `default memory mode = dbengine` in `stream.conf`
- Start the parent 
- Start the child
- Observe that the parent will shutdown

After the PR
- Repeat the steps above
- Observe that the parent will not shutdown, notice the extra log entry in `access.log` similar to 
  `REJECTED -- DBENGINE MEMORY MODE NOT SUPPORTED ......`
  as soon as the child attempts to connect
