### PR TITLE
Update Coverity version so that scanning works again.

### DIFF
--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -40,7 +40,7 @@ set -e
 INSTALL_DIR="/opt"
 
 # the version of coverity to use
-COVERITY_BUILD_VERSION="${COVERITY_BUILD_VERSION:-cov-analysis-linux64-2019.03}"
+COVERITY_BUILD_VERSION="${COVERITY_BUILD_VERSION:-cov-analysis-linux64-2020.09}"
 
 # TODO: For some reasons this does not fully load on Debian 10 (Haven't checked if it happens on other distros yet), it breaks
 source packaging/installer/functions.sh || echo "Failed to fully load the functions library"


### PR DESCRIPTION
##### Summary

The version served by the download link has changed, which means the filename has changed as well, which was causing the scan process to fail.

##### Component Name

area/ci

##### Test Plan

Verified that the version now matches the downloaded tarball name.

##### Additional Information

I’ll be opening a followup PR to add alerts to ensure this does not go unnoticed for so long again.