### PR TITLE
Add basic failure notifications for the Coverity workflow.

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -34,3 +34,17 @@ jobs:
           COVERITY_SCAN_SUBMIT_MAIL: ${{ secrets.COVERITY_SCAN_SUBMIT_MAIL }}
         run: |
           ./coverity-scan.sh --with-install
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER:
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Coverity run failed:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{
+            failure()
+            && github.event_name != 'pull_request'
+            && startsWith(github.ref, 'refs/heads/master')
+          }}


### PR DESCRIPTION
##### Summary

This should hopefully ensure we notice the workflow itself failing in the future.

##### Component Name

area/ci

##### Test Plan

Exactly replicates working code found elsewhere in the repo.