### PR TITLE
Fix misleading long double typedef & macro.

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -23,7 +23,7 @@ static int check_number_printing(void) {
     int i, failed = 0;
     for(i = 0; values[i].correct ; i++) {
         print_calculated_number(netdata, values[i].n);
-        snprintfz(system, 49, "%0.12" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE)values[i].n);
+        snprintfz(system, 49, "%0.12" CALCULATED_NUMBER_MODIFIER, (calculated_number)values[i].n);
 
         int ok = 1;
         if(strcmp(netdata, values[i].correct) != 0) {
@@ -181,10 +181,10 @@ void benchmark_storage_number(int loop, int multiplier) {
     their = (calculated_number)sizeof(calculated_number) * (calculated_number)loop;
 
     if(mine > their) {
-        fprintf(stderr, "\nNETDATA NEEDS %0.2" CALCULATED_NUMBER_MODIFIER " TIMES MORE MEMORY. Sorry!\n", (LONG_DOUBLE)(mine / their));
+        fprintf(stderr, "\nNETDATA NEEDS %0.2" CALCULATED_NUMBER_MODIFIER " TIMES MORE MEMORY. Sorry!\n", (calculated_number)(mine / their));
     }
     else {
-        fprintf(stderr, "\nNETDATA INTERNAL FLOATING POINT ARITHMETICS NEEDS %0.2" CALCULATED_NUMBER_MODIFIER " TIMES LESS MEMORY.\n", (LONG_DOUBLE)(their / mine));
+        fprintf(stderr, "\nNETDATA INTERNAL FLOATING POINT ARITHMETICS NEEDS %0.2" CALCULATED_NUMBER_MODIFIER " TIMES LESS MEMORY.\n", (calculated_number)(their / mine));
     }
 
     fprintf(stderr, "\nNETDATA FLOATING POINT\n");
@@ -217,7 +217,7 @@ void benchmark_storage_number(int loop, int multiplier) {
     total  = user + system;
     mine = total;
 
-    fprintf(stderr, "user %0.5" CALCULATED_NUMBER_MODIFIER", system %0.5" CALCULATED_NUMBER_MODIFIER ", total %0.5" CALCULATED_NUMBER_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
+    fprintf(stderr, "user %0.5" CALCULATED_NUMBER_MODIFIER", system %0.5" CALCULATED_NUMBER_MODIFIER ", total %0.5" CALCULATED_NUMBER_MODIFIER "\n", (calculated_number)(user / 1000000.0), (calculated_number)(system / 1000000.0), (calculated_number)(total / 1000000.0));
 
     // ------------------------------------------------------------------------
 
@@ -241,13 +241,13 @@ void benchmark_storage_number(int loop, int multiplier) {
     total  = user + system;
     their = total;
 
-    fprintf(stderr, "user %0.5" CALCULATED_NUMBER_MODIFIER ", system %0.5" CALCULATED_NUMBER_MODIFIER ", total %0.5" CALCULATED_NUMBER_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
+    fprintf(stderr, "user %0.5" CALCULATED_NUMBER_MODIFIER ", system %0.5" CALCULATED_NUMBER_MODIFIER ", total %0.5" CALCULATED_NUMBER_MODIFIER "\n", (calculated_number)(user / 1000000.0), (calculated_number)(system / 1000000.0), (calculated_number)(total / 1000000.0));
 
     if(mine > total) {
-        fprintf(stderr, "NETDATA CODE IS SLOWER %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (LONG_DOUBLE)(mine * 100.0 / their - 100.0));
+        fprintf(stderr, "NETDATA CODE IS SLOWER %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (calculated_number)(mine * 100.0 / their - 100.0));
     }
     else {
-        fprintf(stderr, "NETDATA CODE IS  F A S T E R  %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (LONG_DOUBLE)(their * 100.0 / mine - 100.0));
+        fprintf(stderr, "NETDATA CODE IS  F A S T E R  %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (calculated_number)(their * 100.0 / mine - 100.0));
     }
 
     // ------------------------------------------------------------------------
@@ -275,13 +275,13 @@ void benchmark_storage_number(int loop, int multiplier) {
     total  = user + system;
     mine = total;
 
-    fprintf(stderr, "user %0.5" CALCULATED_NUMBER_MODIFIER ", system %0.5" CALCULATED_NUMBER_MODIFIER ", total %0.5" CALCULATED_NUMBER_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
+    fprintf(stderr, "user %0.5" CALCULATED_NUMBER_MODIFIER ", system %0.5" CALCULATED_NUMBER_MODIFIER ", total %0.5" CALCULATED_NUMBER_MODIFIER "\n", (calculated_number)(user / 1000000.0), (calculated_number)(system / 1000000.0), (calculated_number)(total / 1000000.0));
 
     if(mine > their) {
-        fprintf(stderr, "WITH PACKING UNPACKING NETDATA CODE IS SLOWER %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (LONG_DOUBLE)(mine * 100.0 / their - 100.0));
+        fprintf(stderr, "WITH PACKING UNPACKING NETDATA CODE IS SLOWER %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (calculated_number)(mine * 100.0 / their - 100.0));
     }
     else {
-        fprintf(stderr, "EVEN WITH PACKING AND UNPACKING, NETDATA CODE IS  F A S T E R  %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (LONG_DOUBLE)(their * 100.0 / mine - 100.0));
+        fprintf(stderr, "EVEN WITH PACKING AND UNPACKING, NETDATA CODE IS  F A S T E R  %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (calculated_number)(their * 100.0 / mine - 100.0));
     }
 
     // ------------------------------------------------------------------------
@@ -356,8 +356,8 @@ int unit_test_str2ld() {
     int i;
     for(i = 0; values[i] ; i++) {
         char *e_mine = "hello", *e_sys = "world";
-        LONG_DOUBLE mine = str2ld(values[i], &e_mine);
-        LONG_DOUBLE sys = strtold(values[i], &e_sys);
+        calculated_number mine = str2ld(values[i], &e_mine);
+        calculated_number sys = strtold(values[i], &e_sys);
 
         if(isnan(mine)) {
             if(!isnan(sys)) {

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -23,7 +23,7 @@ static int check_number_printing(void) {
     int i, failed = 0;
     for(i = 0; values[i].correct ; i++) {
         print_calculated_number(netdata, values[i].n);
-        snprintfz(system, 49, "%0.12" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE)values[i].n);
+        snprintfz(system, 49, "%0.12" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE)values[i].n);
 
         int ok = 1;
         if(strcmp(netdata, values[i].correct) != 0) {
@@ -181,10 +181,10 @@ void benchmark_storage_number(int loop, int multiplier) {
     their = (calculated_number)sizeof(calculated_number) * (calculated_number)loop;
 
     if(mine > their) {
-        fprintf(stderr, "\nNETDATA NEEDS %0.2" LONG_DOUBLE_MODIFIER " TIMES MORE MEMORY. Sorry!\n", (LONG_DOUBLE)(mine / their));
+        fprintf(stderr, "\nNETDATA NEEDS %0.2" CALCULATED_NUMBER_MODIFIER " TIMES MORE MEMORY. Sorry!\n", (LONG_DOUBLE)(mine / their));
     }
     else {
-        fprintf(stderr, "\nNETDATA INTERNAL FLOATING POINT ARITHMETICS NEEDS %0.2" LONG_DOUBLE_MODIFIER " TIMES LESS MEMORY.\n", (LONG_DOUBLE)(their / mine));
+        fprintf(stderr, "\nNETDATA INTERNAL FLOATING POINT ARITHMETICS NEEDS %0.2" CALCULATED_NUMBER_MODIFIER " TIMES LESS MEMORY.\n", (LONG_DOUBLE)(their / mine));
     }
 
     fprintf(stderr, "\nNETDATA FLOATING POINT\n");
@@ -217,7 +217,7 @@ void benchmark_storage_number(int loop, int multiplier) {
     total  = user + system;
     mine = total;
 
-    fprintf(stderr, "user %0.5" LONG_DOUBLE_MODIFIER", system %0.5" LONG_DOUBLE_MODIFIER ", total %0.5" LONG_DOUBLE_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
+    fprintf(stderr, "user %0.5" CALCULATED_NUMBER_MODIFIER", system %0.5" CALCULATED_NUMBER_MODIFIER ", total %0.5" CALCULATED_NUMBER_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
 
     // ------------------------------------------------------------------------
 
@@ -241,13 +241,13 @@ void benchmark_storage_number(int loop, int multiplier) {
     total  = user + system;
     their = total;
 
-    fprintf(stderr, "user %0.5" LONG_DOUBLE_MODIFIER ", system %0.5" LONG_DOUBLE_MODIFIER ", total %0.5" LONG_DOUBLE_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
+    fprintf(stderr, "user %0.5" CALCULATED_NUMBER_MODIFIER ", system %0.5" CALCULATED_NUMBER_MODIFIER ", total %0.5" CALCULATED_NUMBER_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
 
     if(mine > total) {
-        fprintf(stderr, "NETDATA CODE IS SLOWER %0.2" LONG_DOUBLE_MODIFIER " %%\n", (LONG_DOUBLE)(mine * 100.0 / their - 100.0));
+        fprintf(stderr, "NETDATA CODE IS SLOWER %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (LONG_DOUBLE)(mine * 100.0 / their - 100.0));
     }
     else {
-        fprintf(stderr, "NETDATA CODE IS  F A S T E R  %0.2" LONG_DOUBLE_MODIFIER " %%\n", (LONG_DOUBLE)(their * 100.0 / mine - 100.0));
+        fprintf(stderr, "NETDATA CODE IS  F A S T E R  %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (LONG_DOUBLE)(their * 100.0 / mine - 100.0));
     }
 
     // ------------------------------------------------------------------------
@@ -275,13 +275,13 @@ void benchmark_storage_number(int loop, int multiplier) {
     total  = user + system;
     mine = total;
 
-    fprintf(stderr, "user %0.5" LONG_DOUBLE_MODIFIER ", system %0.5" LONG_DOUBLE_MODIFIER ", total %0.5" LONG_DOUBLE_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
+    fprintf(stderr, "user %0.5" CALCULATED_NUMBER_MODIFIER ", system %0.5" CALCULATED_NUMBER_MODIFIER ", total %0.5" CALCULATED_NUMBER_MODIFIER "\n", (LONG_DOUBLE)(user / 1000000.0), (LONG_DOUBLE)(system / 1000000.0), (LONG_DOUBLE)(total / 1000000.0));
 
     if(mine > their) {
-        fprintf(stderr, "WITH PACKING UNPACKING NETDATA CODE IS SLOWER %0.2" LONG_DOUBLE_MODIFIER " %%\n", (LONG_DOUBLE)(mine * 100.0 / their - 100.0));
+        fprintf(stderr, "WITH PACKING UNPACKING NETDATA CODE IS SLOWER %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (LONG_DOUBLE)(mine * 100.0 / their - 100.0));
     }
     else {
-        fprintf(stderr, "EVEN WITH PACKING AND UNPACKING, NETDATA CODE IS  F A S T E R  %0.2" LONG_DOUBLE_MODIFIER " %%\n", (LONG_DOUBLE)(their * 100.0 / mine - 100.0));
+        fprintf(stderr, "EVEN WITH PACKING AND UNPACKING, NETDATA CODE IS  F A S T E R  %0.2" CALCULATED_NUMBER_MODIFIER " %%\n", (LONG_DOUBLE)(their * 100.0 / mine - 100.0));
     }
 
     // ------------------------------------------------------------------------
@@ -361,18 +361,18 @@ int unit_test_str2ld() {
 
         if(isnan(mine)) {
             if(!isnan(sys)) {
-                fprintf(stderr, "Value '%s' is parsed as %" LONG_DOUBLE_MODIFIER ", but system believes it is %" LONG_DOUBLE_MODIFIER ".\n", values[i], mine, sys);
+                fprintf(stderr, "Value '%s' is parsed as %" CALCULATED_NUMBER_MODIFIER ", but system believes it is %" CALCULATED_NUMBER_MODIFIER ".\n", values[i], mine, sys);
                 return -1;
             }
         }
         else if(isinf(mine)) {
             if(!isinf(sys)) {
-                fprintf(stderr, "Value '%s' is parsed as %" LONG_DOUBLE_MODIFIER ", but system believes it is %" LONG_DOUBLE_MODIFIER ".\n", values[i], mine, sys);
+                fprintf(stderr, "Value '%s' is parsed as %" CALCULATED_NUMBER_MODIFIER ", but system believes it is %" CALCULATED_NUMBER_MODIFIER ".\n", values[i], mine, sys);
                 return -1;
             }
         }
         else if(mine != sys && ABS(mine-sys) > 0.000001) {
-            fprintf(stderr, "Value '%s' is parsed as %" LONG_DOUBLE_MODIFIER ", but system believes it is %" LONG_DOUBLE_MODIFIER ", delta %" LONG_DOUBLE_MODIFIER ".\n", values[i], mine, sys, sys-mine);
+            fprintf(stderr, "Value '%s' is parsed as %" CALCULATED_NUMBER_MODIFIER ", but system believes it is %" CALCULATED_NUMBER_MODIFIER ", delta %" CALCULATED_NUMBER_MODIFIER ".\n", values[i], mine, sys, sys-mine);
             return -1;
         }
 
@@ -381,7 +381,7 @@ int unit_test_str2ld() {
             return -1;
         }
 
-        fprintf(stderr, "str2ld() parsed value '%s' exactly the same way with strtold(), returned %" LONG_DOUBLE_MODIFIER " vs %" LONG_DOUBLE_MODIFIER "\n", values[i], mine, sys);
+        fprintf(stderr, "str2ld() parsed value '%s' exactly the same way with strtold(), returned %" CALCULATED_NUMBER_MODIFIER " vs %" CALCULATED_NUMBER_MODIFIER "\n", values[i], mine, sys);
     }
 
     return 0;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -994,7 +994,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
 
         if(unlikely(since_last_usec < 0)) {
             // oops! the database is in the future
-            info("RRD database for chart '%s' on host '%s' is %0.5" CALCULATED_NUMBER_MODIFIER " secs in the future (counter #%zu, update #%zu). Adjusting it to current time.", st->id, st->rrdhost->hostname, (LONG_DOUBLE)-since_last_usec / USEC_PER_SEC, st->counter, st->counter_done);
+            info("RRD database for chart '%s' on host '%s' is %0.5" CALCULATED_NUMBER_MODIFIER " secs in the future (counter #%zu, update #%zu). Adjusting it to current time.", st->id, st->rrdhost->hostname, (calculated_number)-since_last_usec / USEC_PER_SEC, st->counter, st->counter_done);
 
             st->last_collected_time.tv_sec  = now.tv_sec - st->update_every;
             st->last_collected_time.tv_usec = now.tv_usec;
@@ -1011,7 +1011,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
         }
         else if(unlikely((usec_t)since_last_usec > (usec_t)(st->update_every * 5 * USEC_PER_SEC))) {
             // oops! the database is too far behind
-            info("RRD database for chart '%s' on host '%s' is %0.5" CALCULATED_NUMBER_MODIFIER " secs in the past (counter #%zu, update #%zu). Adjusting it to current time.", st->id, st->rrdhost->hostname, (LONG_DOUBLE)since_last_usec / USEC_PER_SEC, st->counter, st->counter_done);
+            info("RRD database for chart '%s' on host '%s' is %0.5" CALCULATED_NUMBER_MODIFIER " secs in the past (counter #%zu, update #%zu). Adjusting it to current time.", st->id, st->rrdhost->hostname, (calculated_number)since_last_usec / USEC_PER_SEC, st->counter, st->counter_done);
 
             microseconds = (usec_t)since_last_usec;
             #ifdef NETDATA_INTERNAL_CHECKS
@@ -1067,7 +1067,7 @@ static inline usec_t rrdset_init_last_collected_time(RRDSET *st) {
     usec_t last_collect_ut = st->last_collected_time.tv_sec * USEC_PER_SEC + st->last_collected_time.tv_usec;
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "initialized last collected time to %0.3" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE)last_collect_ut / USEC_PER_SEC);
+    rrdset_debug(st, "initialized last collected time to %0.3" CALCULATED_NUMBER_MODIFIER, (calculated_number)last_collect_ut / USEC_PER_SEC);
     #endif
 
     return last_collect_ut;
@@ -1080,7 +1080,7 @@ static inline usec_t rrdset_update_last_collected_time(RRDSET *st) {
     st->last_collected_time.tv_usec = (suseconds_t) (ut % USEC_PER_SEC);
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "updated last collected time to %0.3" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE)last_collect_ut / USEC_PER_SEC);
+    rrdset_debug(st, "updated last collected time to %0.3" CALCULATED_NUMBER_MODIFIER, (calculated_number)last_collect_ut / USEC_PER_SEC);
     #endif
 
     return last_collect_ut;
@@ -1099,7 +1099,7 @@ static inline usec_t rrdset_init_last_updated_time(RRDSET *st) {
     usec_t last_updated_ut = st->last_updated.tv_sec * USEC_PER_SEC + st->last_updated.tv_usec;
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "initialized last updated time to %0.3" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE)last_updated_ut / USEC_PER_SEC);
+    rrdset_debug(st, "initialized last updated time to %0.3" CALCULATED_NUMBER_MODIFIER, (calculated_number)last_updated_ut / USEC_PER_SEC);
     #endif
 
     return last_updated_ut;
@@ -1132,8 +1132,8 @@ static inline size_t rrdset_done_interpolate(
 
         #ifdef NETDATA_INTERNAL_CHECKS
         if(iterations < 0) { error("INTERNAL CHECK: %s: iterations calculation wrapped! first_ut = %llu, last_stored_ut = %llu, next_store_ut = %llu, now_collect_ut = %llu", st->name, first_ut, last_stored_ut, next_store_ut, now_collect_ut); }
-        rrdset_debug(st, "last_stored_ut = %0.3" CALCULATED_NUMBER_MODIFIER " (last updated time)", (LONG_DOUBLE)last_stored_ut/USEC_PER_SEC);
-        rrdset_debug(st, "next_store_ut  = %0.3" CALCULATED_NUMBER_MODIFIER " (next interpolation point)", (LONG_DOUBLE)next_store_ut/USEC_PER_SEC);
+        rrdset_debug(st, "last_stored_ut = %0.3" CALCULATED_NUMBER_MODIFIER " (last updated time)", (calculated_number)last_stored_ut/USEC_PER_SEC);
+        rrdset_debug(st, "next_store_ut  = %0.3" CALCULATED_NUMBER_MODIFIER " (next interpolation point)", (calculated_number)next_store_ut/USEC_PER_SEC);
         #endif
 
         last_ut = next_store_ut;
@@ -1385,7 +1385,7 @@ void rrdset_done(RRDSET *st) {
     // check if the chart has a long time to be updated
     if(unlikely(st->usec_since_last_update > st->entries * update_every_ut &&
                 st->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE && st->rrd_memory_mode != RRD_MEMORY_MODE_NONE)) {
-        info("host '%s', chart %s: took too long to be updated (counter #%zu, update #%zu, %0.3" CALCULATED_NUMBER_MODIFIER " secs). Resetting it.", st->rrdhost->hostname, st->name, st->counter, st->counter_done, (LONG_DOUBLE)st->usec_since_last_update / USEC_PER_SEC);
+        info("host '%s', chart %s: took too long to be updated (counter #%zu, update #%zu, %0.3" CALCULATED_NUMBER_MODIFIER " secs). Resetting it.", st->rrdhost->hostname, st->name, st->counter, st->counter_done, (calculated_number)st->usec_since_last_update / USEC_PER_SEC);
         rrdset_reset(st);
         st->usec_since_last_update = update_every_ut;
         store_this_entry = 0;
@@ -1507,10 +1507,10 @@ after_first_database_work:
     }
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "last_collect_ut = %0.3" CALCULATED_NUMBER_MODIFIER " (last collection time)", (LONG_DOUBLE)last_collect_ut/USEC_PER_SEC);
-    rrdset_debug(st, "now_collect_ut  = %0.3" CALCULATED_NUMBER_MODIFIER " (current collection time)", (LONG_DOUBLE)now_collect_ut/USEC_PER_SEC);
-    rrdset_debug(st, "last_stored_ut  = %0.3" CALCULATED_NUMBER_MODIFIER " (last updated time)", (LONG_DOUBLE)last_stored_ut/USEC_PER_SEC);
-    rrdset_debug(st, "next_store_ut   = %0.3" CALCULATED_NUMBER_MODIFIER " (next interpolation point)", (LONG_DOUBLE)next_store_ut/USEC_PER_SEC);
+    rrdset_debug(st, "last_collect_ut = %0.3" CALCULATED_NUMBER_MODIFIER " (last collection time)", (calculated_number)last_collect_ut/USEC_PER_SEC);
+    rrdset_debug(st, "now_collect_ut  = %0.3" CALCULATED_NUMBER_MODIFIER " (current collection time)", (calculated_number)now_collect_ut/USEC_PER_SEC);
+    rrdset_debug(st, "last_stored_ut  = %0.3" CALCULATED_NUMBER_MODIFIER " (last updated time)", (calculated_number)last_stored_ut/USEC_PER_SEC);
+    rrdset_debug(st, "next_store_ut   = %0.3" CALCULATED_NUMBER_MODIFIER " (next interpolation point)", (calculated_number)next_store_ut/USEC_PER_SEC);
     #endif
 
     // calculate totals and count the dimensions

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -994,7 +994,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
 
         if(unlikely(since_last_usec < 0)) {
             // oops! the database is in the future
-            info("RRD database for chart '%s' on host '%s' is %0.5" LONG_DOUBLE_MODIFIER " secs in the future (counter #%zu, update #%zu). Adjusting it to current time.", st->id, st->rrdhost->hostname, (LONG_DOUBLE)-since_last_usec / USEC_PER_SEC, st->counter, st->counter_done);
+            info("RRD database for chart '%s' on host '%s' is %0.5" CALCULATED_NUMBER_MODIFIER " secs in the future (counter #%zu, update #%zu). Adjusting it to current time.", st->id, st->rrdhost->hostname, (LONG_DOUBLE)-since_last_usec / USEC_PER_SEC, st->counter, st->counter_done);
 
             st->last_collected_time.tv_sec  = now.tv_sec - st->update_every;
             st->last_collected_time.tv_usec = now.tv_usec;
@@ -1011,7 +1011,7 @@ inline void rrdset_next_usec(RRDSET *st, usec_t microseconds) {
         }
         else if(unlikely((usec_t)since_last_usec > (usec_t)(st->update_every * 5 * USEC_PER_SEC))) {
             // oops! the database is too far behind
-            info("RRD database for chart '%s' on host '%s' is %0.5" LONG_DOUBLE_MODIFIER " secs in the past (counter #%zu, update #%zu). Adjusting it to current time.", st->id, st->rrdhost->hostname, (LONG_DOUBLE)since_last_usec / USEC_PER_SEC, st->counter, st->counter_done);
+            info("RRD database for chart '%s' on host '%s' is %0.5" CALCULATED_NUMBER_MODIFIER " secs in the past (counter #%zu, update #%zu). Adjusting it to current time.", st->id, st->rrdhost->hostname, (LONG_DOUBLE)since_last_usec / USEC_PER_SEC, st->counter, st->counter_done);
 
             microseconds = (usec_t)since_last_usec;
             #ifdef NETDATA_INTERNAL_CHECKS
@@ -1067,7 +1067,7 @@ static inline usec_t rrdset_init_last_collected_time(RRDSET *st) {
     usec_t last_collect_ut = st->last_collected_time.tv_sec * USEC_PER_SEC + st->last_collected_time.tv_usec;
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "initialized last collected time to %0.3" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE)last_collect_ut / USEC_PER_SEC);
+    rrdset_debug(st, "initialized last collected time to %0.3" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE)last_collect_ut / USEC_PER_SEC);
     #endif
 
     return last_collect_ut;
@@ -1080,7 +1080,7 @@ static inline usec_t rrdset_update_last_collected_time(RRDSET *st) {
     st->last_collected_time.tv_usec = (suseconds_t) (ut % USEC_PER_SEC);
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "updated last collected time to %0.3" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE)last_collect_ut / USEC_PER_SEC);
+    rrdset_debug(st, "updated last collected time to %0.3" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE)last_collect_ut / USEC_PER_SEC);
     #endif
 
     return last_collect_ut;
@@ -1099,7 +1099,7 @@ static inline usec_t rrdset_init_last_updated_time(RRDSET *st) {
     usec_t last_updated_ut = st->last_updated.tv_sec * USEC_PER_SEC + st->last_updated.tv_usec;
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "initialized last updated time to %0.3" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE)last_updated_ut / USEC_PER_SEC);
+    rrdset_debug(st, "initialized last updated time to %0.3" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE)last_updated_ut / USEC_PER_SEC);
     #endif
 
     return last_updated_ut;
@@ -1132,8 +1132,8 @@ static inline size_t rrdset_done_interpolate(
 
         #ifdef NETDATA_INTERNAL_CHECKS
         if(iterations < 0) { error("INTERNAL CHECK: %s: iterations calculation wrapped! first_ut = %llu, last_stored_ut = %llu, next_store_ut = %llu, now_collect_ut = %llu", st->name, first_ut, last_stored_ut, next_store_ut, now_collect_ut); }
-        rrdset_debug(st, "last_stored_ut = %0.3" LONG_DOUBLE_MODIFIER " (last updated time)", (LONG_DOUBLE)last_stored_ut/USEC_PER_SEC);
-        rrdset_debug(st, "next_store_ut  = %0.3" LONG_DOUBLE_MODIFIER " (next interpolation point)", (LONG_DOUBLE)next_store_ut/USEC_PER_SEC);
+        rrdset_debug(st, "last_stored_ut = %0.3" CALCULATED_NUMBER_MODIFIER " (last updated time)", (LONG_DOUBLE)last_stored_ut/USEC_PER_SEC);
+        rrdset_debug(st, "next_store_ut  = %0.3" CALCULATED_NUMBER_MODIFIER " (next interpolation point)", (LONG_DOUBLE)next_store_ut/USEC_PER_SEC);
         #endif
 
         last_ut = next_store_ut;
@@ -1385,7 +1385,7 @@ void rrdset_done(RRDSET *st) {
     // check if the chart has a long time to be updated
     if(unlikely(st->usec_since_last_update > st->entries * update_every_ut &&
                 st->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE && st->rrd_memory_mode != RRD_MEMORY_MODE_NONE)) {
-        info("host '%s', chart %s: took too long to be updated (counter #%zu, update #%zu, %0.3" LONG_DOUBLE_MODIFIER " secs). Resetting it.", st->rrdhost->hostname, st->name, st->counter, st->counter_done, (LONG_DOUBLE)st->usec_since_last_update / USEC_PER_SEC);
+        info("host '%s', chart %s: took too long to be updated (counter #%zu, update #%zu, %0.3" CALCULATED_NUMBER_MODIFIER " secs). Resetting it.", st->rrdhost->hostname, st->name, st->counter, st->counter_done, (LONG_DOUBLE)st->usec_since_last_update / USEC_PER_SEC);
         rrdset_reset(st);
         st->usec_since_last_update = update_every_ut;
         store_this_entry = 0;
@@ -1507,10 +1507,10 @@ after_first_database_work:
     }
 
     #ifdef NETDATA_INTERNAL_CHECKS
-    rrdset_debug(st, "last_collect_ut = %0.3" LONG_DOUBLE_MODIFIER " (last collection time)", (LONG_DOUBLE)last_collect_ut/USEC_PER_SEC);
-    rrdset_debug(st, "now_collect_ut  = %0.3" LONG_DOUBLE_MODIFIER " (current collection time)", (LONG_DOUBLE)now_collect_ut/USEC_PER_SEC);
-    rrdset_debug(st, "last_stored_ut  = %0.3" LONG_DOUBLE_MODIFIER " (last updated time)", (LONG_DOUBLE)last_stored_ut/USEC_PER_SEC);
-    rrdset_debug(st, "next_store_ut   = %0.3" LONG_DOUBLE_MODIFIER " (next interpolation point)", (LONG_DOUBLE)next_store_ut/USEC_PER_SEC);
+    rrdset_debug(st, "last_collect_ut = %0.3" CALCULATED_NUMBER_MODIFIER " (last collection time)", (LONG_DOUBLE)last_collect_ut/USEC_PER_SEC);
+    rrdset_debug(st, "now_collect_ut  = %0.3" CALCULATED_NUMBER_MODIFIER " (current collection time)", (LONG_DOUBLE)now_collect_ut/USEC_PER_SEC);
+    rrdset_debug(st, "last_stored_ut  = %0.3" CALCULATED_NUMBER_MODIFIER " (last updated time)", (LONG_DOUBLE)last_stored_ut/USEC_PER_SEC);
+    rrdset_debug(st, "next_store_ut   = %0.3" CALCULATED_NUMBER_MODIFIER " (next interpolation point)", (LONG_DOUBLE)next_store_ut/USEC_PER_SEC);
     #endif
 
     // calculate totals and count the dimensions

--- a/database/rrdvar.c
+++ b/database/rrdvar.c
@@ -260,7 +260,7 @@ static int single_variable2json(void *entry, void *data) {
         if(unlikely(isnan(value) || isinf(value)))
             buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": null", helper->counter?",":"", rv->name);
         else
-            buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": %0.5" LONG_DOUBLE_MODIFIER, helper->counter?",":"", rv->name, (LONG_DOUBLE)value);
+            buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": %0.5" CALCULATED_NUMBER_MODIFIER, helper->counter?",":"", rv->name, (LONG_DOUBLE)value);
 
         helper->counter++;
     }

--- a/database/rrdvar.c
+++ b/database/rrdvar.c
@@ -260,7 +260,7 @@ static int single_variable2json(void *entry, void *data) {
         if(unlikely(isnan(value) || isinf(value)))
             buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": null", helper->counter?",":"", rv->name);
         else
-            buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": %0.5" CALCULATED_NUMBER_MODIFIER, helper->counter?",":"", rv->name, (LONG_DOUBLE)value);
+            buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": %0.5" CALCULATED_NUMBER_MODIFIER, helper->counter?",":"", rv->name, (calculated_number)value);
 
         helper->counter++;
     }

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -392,7 +392,7 @@ long long appconfig_get_number(struct config *root, const char *section, const c
 LONG_DOUBLE appconfig_get_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value)
 {
     char buffer[100], *s;
-    sprintf(buffer, "%0.5" LONG_DOUBLE_MODIFIER, value);
+    sprintf(buffer, "%0.5" CALCULATED_NUMBER_MODIFIER, value);
 
     s = appconfig_get(root, section, name, buffer);
     if(!s) return value;
@@ -518,7 +518,7 @@ long long appconfig_set_number(struct config *root, const char *section, const c
 LONG_DOUBLE appconfig_set_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value)
 {
     char buffer[100];
-    sprintf(buffer, "%0.5" LONG_DOUBLE_MODIFIER, value);
+    sprintf(buffer, "%0.5" CALCULATED_NUMBER_MODIFIER, value);
 
     appconfig_set(root, section, name, buffer);
 

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -389,7 +389,7 @@ long long appconfig_get_number(struct config *root, const char *section, const c
     return strtoll(s, NULL, 0);
 }
 
-LONG_DOUBLE appconfig_get_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value)
+calculated_number appconfig_get_float(struct config *root, const char *section, const char *name, calculated_number value)
 {
     char buffer[100], *s;
     sprintf(buffer, "%0.5" CALCULATED_NUMBER_MODIFIER, value);
@@ -515,7 +515,7 @@ long long appconfig_set_number(struct config *root, const char *section, const c
     return value;
 }
 
-LONG_DOUBLE appconfig_set_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value)
+calculated_number appconfig_set_float(struct config *root, const char *section, const char *name, calculated_number value)
 {
     char buffer[100];
     sprintf(buffer, "%0.5" CALCULATED_NUMBER_MODIFIER, value);

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -163,7 +163,7 @@ extern void config_section_unlock(struct section *co);
 extern char *appconfig_get_by_section(struct section *co, const char *name, const char *default_value);
 extern char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
 extern long long appconfig_get_number(struct config *root, const char *section, const char *name, long long value);
-extern LONG_DOUBLE appconfig_get_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value);
+extern calculated_number appconfig_get_float(struct config *root, const char *section, const char *name, calculated_number value);
 extern int appconfig_get_boolean_by_section(struct section *co, const char *name, int value);
 extern int appconfig_get_boolean(struct config *root, const char *section, const char *name, int value);
 extern int appconfig_get_boolean_ondemand(struct config *root, const char *section, const char *name, int value);
@@ -172,7 +172,7 @@ extern int appconfig_get_duration(struct config *root, const char *section, cons
 extern const char *appconfig_set(struct config *root, const char *section, const char *name, const char *value);
 extern const char *appconfig_set_default(struct config *root, const char *section, const char *name, const char *value);
 extern long long appconfig_set_number(struct config *root, const char *section, const char *name, long long value);
-extern LONG_DOUBLE appconfig_set_float(struct config *root, const char *section, const char *name, LONG_DOUBLE value);
+extern calculated_number appconfig_set_float(struct config *root, const char *section, const char *name, calculated_number value);
 extern int appconfig_set_boolean(struct config *root, const char *section, const char *name, int value);
 
 extern int appconfig_exists(struct config *root, const char *section, const char *name);

--- a/libnetdata/statistical/statistical.c
+++ b/libnetdata/statistical/statistical.c
@@ -10,7 +10,7 @@ void log_series_to_stderr(LONG_DOUBLE *series, size_t entries, calculated_number
     fprintf(stderr, "%s of %zu entries [ ", msg, entries);
     for(value = series; value < end ;value++) {
         if(value != series) fprintf(stderr, ", ");
-        fprintf(stderr, "%" LONG_DOUBLE_MODIFIER, *value);
+        fprintf(stderr, "%" CALCULATED_NUMBER_MODIFIER, *value);
     }
     fprintf(stderr, " ] results in " CALCULATED_NUMBER_FORMAT "\n", result);
 }

--- a/libnetdata/statistical/statistical.h
+++ b/libnetdata/statistical/statistical.h
@@ -5,22 +5,22 @@
 
 #include "../libnetdata.h"
 
-extern void log_series_to_stderr(LONG_DOUBLE *series, size_t entries, calculated_number result, const char *msg);
+extern void log_series_to_stderr(calculated_number *series, size_t entries, calculated_number result, const char *msg);
 
-extern LONG_DOUBLE average(const LONG_DOUBLE *series, size_t entries);
-extern LONG_DOUBLE moving_average(const LONG_DOUBLE *series, size_t entries, size_t period);
-extern LONG_DOUBLE median(const LONG_DOUBLE *series, size_t entries);
-extern LONG_DOUBLE moving_median(const LONG_DOUBLE *series, size_t entries, size_t period);
-extern LONG_DOUBLE running_median_estimate(const LONG_DOUBLE *series, size_t entries);
-extern LONG_DOUBLE standard_deviation(const LONG_DOUBLE *series, size_t entries);
-extern LONG_DOUBLE single_exponential_smoothing(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha);
-extern LONG_DOUBLE single_exponential_smoothing_reverse(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha);
-extern LONG_DOUBLE double_exponential_smoothing(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha, LONG_DOUBLE beta, LONG_DOUBLE *forecast);
-extern LONG_DOUBLE holtwinters(const LONG_DOUBLE *series, size_t entries, LONG_DOUBLE alpha, LONG_DOUBLE beta, LONG_DOUBLE gamma, LONG_DOUBLE *forecast);
-extern LONG_DOUBLE sum_and_count(const LONG_DOUBLE *series, size_t entries, size_t *count);
-extern LONG_DOUBLE sum(const LONG_DOUBLE *series, size_t entries);
-extern LONG_DOUBLE median_on_sorted_series(const LONG_DOUBLE *series, size_t entries);
-extern LONG_DOUBLE *copy_series(const LONG_DOUBLE *series, size_t entries);
-extern void sort_series(LONG_DOUBLE *series, size_t entries);
+extern calculated_number average(const calculated_number *series, size_t entries);
+extern calculated_number moving_average(const calculated_number *series, size_t entries, size_t period);
+extern calculated_number median(const calculated_number *series, size_t entries);
+extern calculated_number moving_median(const calculated_number *series, size_t entries, size_t period);
+extern calculated_number running_median_estimate(const calculated_number *series, size_t entries);
+extern calculated_number standard_deviation(const calculated_number *series, size_t entries);
+extern calculated_number single_exponential_smoothing(const calculated_number *series, size_t entries, calculated_number alpha);
+extern calculated_number single_exponential_smoothing_reverse(const calculated_number *series, size_t entries, calculated_number alpha);
+extern calculated_number double_exponential_smoothing(const calculated_number *series, size_t entries, calculated_number alpha, calculated_number beta, calculated_number *forecast);
+extern calculated_number holtwinters(const calculated_number *series, size_t entries, calculated_number alpha, calculated_number beta, calculated_number gamma, calculated_number *forecast);
+extern calculated_number sum_and_count(const calculated_number *series, size_t entries, size_t *count);
+extern calculated_number sum(const calculated_number *series, size_t entries);
+extern calculated_number median_on_sorted_series(const calculated_number *series, size_t entries);
+extern calculated_number *copy_series(const calculated_number *series, size_t entries);
+extern void sort_series(calculated_number *series, size_t entries);
 
 #endif //NETDATA_STATISTICAL_H

--- a/libnetdata/storage_number/storage_number.h
+++ b/libnetdata/storage_number/storage_number.h
@@ -20,7 +20,7 @@ typedef double calculated_number;
 #define CALCULATED_NUMBER_FORMAT_ZERO "%0.0f"
 #define CALCULATED_NUMBER_FORMAT_AUTO "%f"
 
-#define LONG_DOUBLE_MODIFIER "f"
+#define CALCULATED_NUMBER_MODIFIER "f"
 typedef double LONG_DOUBLE;
 
 #else // NETDATA_WITHOUT_LONG_DOUBLE
@@ -30,7 +30,7 @@ typedef long double calculated_number;
 #define CALCULATED_NUMBER_FORMAT_ZERO "%0.0Lf"
 #define CALCULATED_NUMBER_FORMAT_AUTO "%Lf"
 
-#define LONG_DOUBLE_MODIFIER "Lf"
+#define CALCULATED_NUMBER_MODIFIER "Lf"
 typedef long double LONG_DOUBLE;
 
 #endif // NETDATA_WITHOUT_LONG_DOUBLE

--- a/libnetdata/storage_number/storage_number.h
+++ b/libnetdata/storage_number/storage_number.h
@@ -21,7 +21,6 @@ typedef double calculated_number;
 #define CALCULATED_NUMBER_FORMAT_AUTO "%f"
 
 #define CALCULATED_NUMBER_MODIFIER "f"
-typedef double LONG_DOUBLE;
 
 #else // NETDATA_WITHOUT_LONG_DOUBLE
 
@@ -31,7 +30,6 @@ typedef long double calculated_number;
 #define CALCULATED_NUMBER_FORMAT_AUTO "%Lf"
 
 #define CALCULATED_NUMBER_MODIFIER "Lf"
-typedef long double LONG_DOUBLE;
 
 #endif // NETDATA_WITHOUT_LONG_DOUBLE
 

--- a/libnetdata/tests/test_str2ld.c
+++ b/libnetdata/tests/test_str2ld.c
@@ -24,8 +24,8 @@ static void test_str2ld(void **state)
 
     for (int i = 0; values[i]; i++) {
         char *e_mine = "hello", *e_sys = "world";
-        LONG_DOUBLE mine = str2ld(values[i], &e_mine);
-        LONG_DOUBLE sys = strtold(values[i], &e_sys);
+        calculated_number mine = str2ld(values[i], &e_mine);
+        calculated_number sys = strtold(values[i], &e_sys);
 
         if (isnan(mine))
             assert_true(isnan(sys));

--- a/web/api/badges/web_buffer_svg.c
+++ b/web/api/badges/web_buffer_svg.c
@@ -267,16 +267,16 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
         }
 
         if(isgreaterequal(abs, 1000)) {
-            len = snprintfz(value_string, value_string_len, "%0.0" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
+            len = snprintfz(value_string, value_string_len, "%0.0" CALCULATED_NUMBER_MODIFIER, (calculated_number) value);
             trim_zeros = 0;
         }
-        else if(isgreaterequal(abs, 10))     len = snprintfz(value_string, value_string_len, "%0.1" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 1))      len = snprintfz(value_string, value_string_len, "%0.2" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 0.1))    len = snprintfz(value_string, value_string_len, "%0.2" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 0.01))   len = snprintfz(value_string, value_string_len, "%0.4" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 0.001))  len = snprintfz(value_string, value_string_len, "%0.5" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 0.0001)) len = snprintfz(value_string, value_string_len, "%0.6" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
-        else                                 len = snprintfz(value_string, value_string_len, "%0.7" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 10))     len = snprintfz(value_string, value_string_len, "%0.1" CALCULATED_NUMBER_MODIFIER, (calculated_number) value);
+        else if(isgreaterequal(abs, 1))      len = snprintfz(value_string, value_string_len, "%0.2" CALCULATED_NUMBER_MODIFIER, (calculated_number) value);
+        else if(isgreaterequal(abs, 0.1))    len = snprintfz(value_string, value_string_len, "%0.2" CALCULATED_NUMBER_MODIFIER, (calculated_number) value);
+        else if(isgreaterequal(abs, 0.01))   len = snprintfz(value_string, value_string_len, "%0.4" CALCULATED_NUMBER_MODIFIER, (calculated_number) value);
+        else if(isgreaterequal(abs, 0.001))  len = snprintfz(value_string, value_string_len, "%0.5" CALCULATED_NUMBER_MODIFIER, (calculated_number) value);
+        else if(isgreaterequal(abs, 0.0001)) len = snprintfz(value_string, value_string_len, "%0.6" CALCULATED_NUMBER_MODIFIER, (calculated_number) value);
+        else                                 len = snprintfz(value_string, value_string_len, "%0.7" CALCULATED_NUMBER_MODIFIER, (calculated_number) value);
 
         if(unlikely(trim_zeros)) {
             int l;
@@ -303,7 +303,7 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
     }
     else {
         if(precision > 50) precision = 50;
-        snprintfz(value_string, value_string_len, "%0.*" CALCULATED_NUMBER_MODIFIER "%s%s", precision, (LONG_DOUBLE) value, separator, units);
+        snprintfz(value_string, value_string_len, "%0.*" CALCULATED_NUMBER_MODIFIER "%s%s", precision, (calculated_number) value, separator, units);
     }
 
     return value_string;

--- a/web/api/badges/web_buffer_svg.c
+++ b/web/api/badges/web_buffer_svg.c
@@ -267,16 +267,16 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
         }
 
         if(isgreaterequal(abs, 1000)) {
-            len = snprintfz(value_string, value_string_len, "%0.0" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
+            len = snprintfz(value_string, value_string_len, "%0.0" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
             trim_zeros = 0;
         }
-        else if(isgreaterequal(abs, 10))     len = snprintfz(value_string, value_string_len, "%0.1" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 1))      len = snprintfz(value_string, value_string_len, "%0.2" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 0.1))    len = snprintfz(value_string, value_string_len, "%0.2" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 0.01))   len = snprintfz(value_string, value_string_len, "%0.4" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 0.001))  len = snprintfz(value_string, value_string_len, "%0.5" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
-        else if(isgreaterequal(abs, 0.0001)) len = snprintfz(value_string, value_string_len, "%0.6" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
-        else                                 len = snprintfz(value_string, value_string_len, "%0.7" LONG_DOUBLE_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 10))     len = snprintfz(value_string, value_string_len, "%0.1" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 1))      len = snprintfz(value_string, value_string_len, "%0.2" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 0.1))    len = snprintfz(value_string, value_string_len, "%0.2" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 0.01))   len = snprintfz(value_string, value_string_len, "%0.4" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 0.001))  len = snprintfz(value_string, value_string_len, "%0.5" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
+        else if(isgreaterequal(abs, 0.0001)) len = snprintfz(value_string, value_string_len, "%0.6" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
+        else                                 len = snprintfz(value_string, value_string_len, "%0.7" CALCULATED_NUMBER_MODIFIER, (LONG_DOUBLE) value);
 
         if(unlikely(trim_zeros)) {
             int l;
@@ -303,7 +303,7 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
     }
     else {
         if(precision > 50) precision = 50;
-        snprintfz(value_string, value_string_len, "%0.*" LONG_DOUBLE_MODIFIER "%s%s", precision, (LONG_DOUBLE) value, separator, units);
+        snprintfz(value_string, value_string_len, "%0.*" CALCULATED_NUMBER_MODIFIER "%s%s", precision, (LONG_DOUBLE) value, separator, units);
     }
 
     return value_string;

--- a/web/api/queries/median/median.c
+++ b/web/api/queries/median/median.c
@@ -10,14 +10,14 @@ struct grouping_median {
     size_t series_size;
     size_t next_pos;
 
-    LONG_DOUBLE series[];
+    calculated_number series[];
 };
 
 void *grouping_create_median(RRDR *r) {
     long entries = r->group;
     if(entries < 0) entries = 0;
 
-    struct grouping_median *g = (struct grouping_median *)callocz(1, sizeof(struct grouping_median) + entries * sizeof(LONG_DOUBLE));
+    struct grouping_median *g = (struct grouping_median *)callocz(1, sizeof(struct grouping_median) + entries * sizeof(calculated_number));
     g->series_size = (size_t)entries;
 
     return g;
@@ -43,7 +43,7 @@ void grouping_add_median(RRDR *r, calculated_number value) {
     }
     else {
         if(calculated_number_isnumber(value))
-            g->series[g->next_pos++] = (LONG_DOUBLE)value;
+            g->series[g->next_pos++] = (calculated_number)value;
     }
 }
 


### PR DESCRIPTION
##### Summary

`LONG_DOUBLE` and `LONG_DOUBLE_MODIFIER` names were misleading,
because they were operating on `doubles` instead of `long doubles`, when
Netdata is built without `long double` support.

This PR fixes this issue by:

1. Renaming the `LONG_DOUBLE_MODIFIER` macro to `CALCULATED_NUMBER_MODIFIER`, and
2. Deleting the `LONG_DOUBLE` macro and switching type references to `calculated_number`.

##### Component Name

agent

##### Test Plan

Built/Run an agent locally + green CI builds.

##### Additional Information
