### PR TITLE
Support mulitple jobs in make(1) when building LWS.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -660,7 +660,7 @@ EOF
       $CMAKE_FLAGS \
       .
   fi
-  run ${env_cmd} make
+  run ${env_cmd} make -j$(find_processors)
   popd > /dev/null || exit 1
 }
 


### PR DESCRIPTION
##### Summary

Use `find_processors` to specify the number of jobs in make(1) when building `libwebsockets`.

##### Component Name

area/build

##### Test Plan

Run netdata-installer.sh locally.

##### Additional Information
