### PR TITLE
claiming: increase curl connect-timeout and decrease number of claim attempts

### DIFF
--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -282,7 +282,7 @@ fi
 
 
 if [ "${URLTOOL}" = "curl" ] ; then
-        URLCOMMAND="curl --connect-timeout 15 --retry 0 -s -i -X PUT -d \"@${CLAIMING_DIR}/tmpin.txt\""
+        URLCOMMAND="curl --connect-timeout 30 --retry 0 -s -i -X PUT -d \"@${CLAIMING_DIR}/tmpin.txt\""
         if [ "${NOPROXY}" = "yes" ] ; then
                 URLCOMMAND="${URLCOMMAND} -x \"\""
         elif [ -n "${PROXY}" ] ; then

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -282,7 +282,7 @@ fi
 
 
 if [ "${URLTOOL}" = "curl" ] ; then
-        URLCOMMAND="curl --connect-timeout 5 --retry 0 -s -i -X PUT -d \"@${CLAIMING_DIR}/tmpin.txt\""
+        URLCOMMAND="curl --connect-timeout 15 --retry 0 -s -i -X PUT -d \"@${CLAIMING_DIR}/tmpin.txt\""
         if [ "${NOPROXY}" = "yes" ] ; then
                 URLCOMMAND="${URLCOMMAND} -x \"\""
         elif [ -n "${PROXY}" ] ; then

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -341,7 +341,7 @@ attempt_contact () {
         return 0
 }
 
-for i in {1..5}
+for i in {1..3}
 do
         if attempt_contact ; then
                 echo "Connection attempt $i successful"


### PR DESCRIPTION
##### Summary

This PR attempts to fix slow DNS lookups, 5 seconds is not enough. I change it to 15 because we use 15 [when using wget](https://github.com/netdata/netdata/blob/e66b02ff6a936454acd63788c7b0e7953f0c1480/claim/netdata-claim.sh.in#L292).

see, sometimes it takes 5+ seconds
 - https://github.com/netdata/netdata/issues/9319#issuecomment-773674215
 - https://community.netdata.cloud/t/error-return-code-28-when-trying-to-claim-node/1047/19?u=ilyam8

The changes:
 - increate curl --connect-timeout from 5 to 30
 - decrease number of claim attempts from 5 to 3

⚠️ [We do 3 attempts](https://github.com/netdata/netdata/blob/e66b02ff6a936454acd63788c7b0e7953f0c1480/claim/netdata-claim.sh.in#L344-L355), so the maximum possible script execution time is up to 90 after this PR.

##### Component Name

`claim`

##### Test Plan

Nothing to test.

##### Additional Information

Difference between wget and curl timeouts

| Tool        | Option            | Description |
| ----------- | ----------------- | ----------- |
| wget        | -T                | Set the network timeout to seconds seconds.  This is equivalent to specifying --dns-timeout, -- connect-timeout, and --read-timeout, all at the same time. |
| curl        | --connect-timeout | Maximum  time  in  seconds that you allow curl's connection to take.  This only limits the connection phase. |

~~curl equivalent of wget's -T is --max-time~~

> -m, --max-time <seconds>
  Maximum time in seconds that you allow the whole operation to take.

~~Could switch to it 🤔 Just thinking out loud.~~ Wrong
