### PR TITLE
Don't show alarms for charts without data

### DIFF
--- a/backends/backends.c
+++ b/backends/backends.c
@@ -206,7 +206,7 @@ inline int backends_can_send_rrdset(BACKEND_OPTIONS backend_options, RRDSET *st)
         }
     }
 
-    if(unlikely(!rrdset_is_available_for_backends(st))) {
+    if(unlikely(!rrdset_is_available_for_exporting_and_alarms(st))) {
         debug(D_BACKEND, "BACKEND: not sending chart '%s' of host '%s', because it is not available for backends.", st->id, host->hostname);
         return 0;
     }

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1063,7 +1063,7 @@ extern void rrdset_isnot_obsolete(RRDSET *st);
 
 // checks if the RRDSET should be offered to viewers
 #define rrdset_is_available_for_viewers(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_HIDDEN) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
-#define rrdset_is_available_for_backends(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
+#define rrdset_is_available_for_exporting_and_alarms(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
 #define rrdset_is_archived(st) (rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
 
 // get the total duration in seconds of the round robin database

--- a/exporting/check_filters.c
+++ b/exporting/check_filters.c
@@ -64,7 +64,7 @@ int rrdset_is_exportable(struct instance *instance, RRDSET *st)
         }
     }
 
-    if(unlikely(!rrdset_is_available_for_backends(st))) {
+    if(unlikely(!rrdset_is_available_for_exporting_and_alarms(st))) {
         debug(D_BACKEND, "BACKEND: not sending chart '%s' of host '%s', because it is not available for backends.", st->id, host->hostname);
         return 0;
     }

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -37,7 +37,7 @@ inline int can_send_rrdset(struct instance *instance, RRDSET *st)
         }
     }
 
-    if (unlikely(!rrdset_is_available_for_backends(st))) {
+    if (unlikely(!rrdset_is_available_for_exporting_and_alarms(st))) {
         debug(
             D_BACKEND,
             "EXPORTING: not sending chart '%s' of host '%s', because it is not available for exporting.",

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -298,6 +298,9 @@ static void health_alarms2json_fill_alarms(RRDHOST *host, BUFFER *wb, int all, v
         if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
             continue;
 
+        if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
+            continue;
+
         if(likely(!all && !(rc->status == RRDCALC_STATUS_WARNING || rc->status == RRDCALC_STATUS_CRITICAL)))
             continue;
 


### PR DESCRIPTION
##### Summary
An alarm can't work when a corresponding chart doesn't have any data or is obsolete, archived, or disabled. We should neither show such alarms in the dashboard nor provide them through the `api/v1/alarms?all` API response.

Fixes #10797

##### Component Name
health alarms

##### Test Plan
1. Run a docker container.
2. Check `Alarms` -> `All` in the dashboard - no `veth*` alarms should be shown.
3. Check `http://localhost:19999/api/v1/alarms?all` - no `net.veth*` alarms should be in the response.