### PR TITLE
implements new https client for ACLK

### DIFF
--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -195,7 +195,7 @@ void aclk_get_mqtt_otp(RSA *p_key, char *aclk_hostname, int port, char **mqtt_us
     BUFFER *url = buffer_create(strlen(OTP_URL_PREFIX) + UUID_STR_LEN + 20);
 
     https_req_t req = HTTPS_REQ_T_INITIALIZER;
-    https_req_response_t resp = HTTPS_RES_RESPONSE_T_INITIALIZER;
+    https_req_response_t resp = HTTPS_REQ_RESPONSE_T_INITIALIZER;
 
     char *agent_id = is_agent_claimed();
     if (agent_id == NULL)
@@ -251,7 +251,7 @@ void aclk_get_mqtt_otp(RSA *p_key, char *aclk_hostname, int port, char **mqtt_us
     debug(D_ACLK, "Password phase: %s",response_json);
 
     https_req_response_free(&resp);
-    memset(&resp, 0, sizeof(https_req_response_t));
+    https_req_response_init(&resp);
 
     // POST password
     req.request_type = HTTP_REQ_POST;

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -258,10 +258,10 @@ void aclk_get_mqtt_otp(RSA *p_key, char *aclk_hostname, int port, char **mqtt_us
     req.payload_size = strlen(response_json);
     aclk_https_request(&req, &resp);
         if (resp.http_code != 201) {
-        error ("ACLK_OTP Challenge HTTP code not 201 Created (got %d)", resp.http_code);
+        error ("ACLK_OTP Password HTTP code not 201 Created (got %d)", resp.http_code);
         goto cleanup_resp;
     }
-    info ("ACLK_OTP Got Challenge from Cloud");
+    info ("ACLK_OTP Got Password from Cloud");
 
     struct dictionary_singleton password = { .key = "password", .result = NULL };
     if (json_parse(resp.payload, &password, json_extract_singleton) != JSON_OK)

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -168,6 +168,7 @@ static int private_decrypt(RSA *p_key, unsigned char * enc_data, int data_len, u
 }
 
 static int aclk_https_request(https_req_t *request, https_req_response_t *response) {
+    int rc;
     // wrapper for ACLK only which loads ACLK specific proxy settings
     // then only calls https_request
     struct mqtt_wss_proxy proxy_conf = { .host = NULL, .port = 0, .type = MQTT_WSS_DIRECT };
@@ -178,7 +179,9 @@ static int aclk_https_request(https_req_t *request, https_req_response_t *respon
         request->proxy_port = proxy_conf.port;
     }
 
-    return https_request(request, response);
+    rc = https_request(request, response);
+    freez((char*)proxy_conf.host);
+    return rc;
 }
 
 #define OTP_URL_PREFIX "/api/v1/auth/node/"

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -167,54 +167,54 @@ static int private_decrypt(RSA *p_key, unsigned char * enc_data, int data_len, u
     return result;
 }
 
-// aclk_get_mqtt_otp is slightly modified original code from @amoss
-void aclk_get_mqtt_otp(RSA *p_key, char *aclk_hostname, int port, char **mqtt_usr, char **mqtt_pass)
-{
-    char *data_buffer = mallocz(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
-    debug(D_ACLK, "Performing challenge-response sequence");
-    if (*mqtt_pass != NULL)
-    {
-        freez(*mqtt_pass);
-        *mqtt_pass = NULL;
-    }
-    // curl http://cloud-iam-agent-service:8080/api/v1/auth/node/00000000-0000-0000-0000-000000000000/challenge
-    // TODO - target host?
+#define OTP_URL_PREFIX "/api/v1/auth/node/"
+void aclk_get_mqtt_otp(RSA *p_key, char *aclk_hostname, int port, char **mqtt_usr, char **mqtt_pass) {
+    BUFFER *url = buffer_create(strlen(OTP_URL_PREFIX) + UUID_STR_LEN + 20);
+
+    https_req_t req = HTTPS_REQ_T_INITIALIZER;
+    https_req_response_t resp;
+
     char *agent_id = is_agent_claimed();
     if (agent_id == NULL)
     {
         error("Agent was not claimed - cannot perform challenge/response");
-        goto CLEANUP;
+        goto cleanup;
     }
-    char url[1024];
-    sprintf(url, "/api/v1/auth/node/%s/challenge", agent_id);
-    info("Retrieving challenge from cloud: %s %d %s", aclk_hostname, port, url);
-    if (https_request(HTTP_REQ_GET, aclk_hostname, port, url, data_buffer, NETDATA_WEB_RESPONSE_INITIAL_SIZE, NULL))
-    {
-        error("Challenge failed: %s", data_buffer);
-        goto CLEANUP;
+
+    // GET Challenge
+    req.host = aclk_hostname;
+    req.port = port;
+    buffer_sprintf(url, "%s%s/challenge", OTP_URL_PREFIX, agent_id);
+    req.url = url->buffer;
+
+    https_request_v2(&req, &resp);
+    if (resp.http_code != 200) {
+        error ("ACLK_OTP Challenge HTTP code not 200 OK (got %d)", resp.http_code);
+        goto cleanup_resp;
     }
+    info ("ACLK_OTP Got Challenge from Cloud");
+
     struct dictionary_singleton challenge = { .key = "challenge", .result = NULL };
 
-    debug(D_ACLK, "Challenge response from cloud: %s", data_buffer);
-    if (json_parse(data_buffer, &challenge, json_extract_singleton) != JSON_OK)
+    if (json_parse(resp.payload, &challenge, json_extract_singleton) != JSON_OK)
     {
         freez(challenge.result);
-        error("Could not parse the json response with the challenge: %s", data_buffer);
-        goto CLEANUP;
+        error("Could not parse the the challenge");
+        goto cleanup_resp;
     }
     if (challenge.result == NULL) {
-        error("Could not retrieve challenge from auth response: %s", data_buffer);
-        goto CLEANUP;
+        error("Could not retrieve challenge JSON key from challenge response");
+        goto cleanup_resp;
     }
 
-
+    // Decrypt the Challenge and Calculate Response
     size_t challenge_len = strlen(challenge.result);
     unsigned char decoded[512];
     size_t decoded_len = base64_decode((unsigned char*)challenge.result, challenge_len, decoded, sizeof(decoded));
+    freez(challenge.result);
 
     unsigned char plaintext[4096]={};
     int decrypted_length = private_decrypt(p_key, decoded, decoded_len, plaintext);
-    freez(challenge.result);
     char encoded[512];
     size_t encoded_len = base64_encode(plaintext, decrypted_length, encoded, sizeof(encoded));
     encoded[encoded_len] = 0;
@@ -223,27 +223,34 @@ void aclk_get_mqtt_otp(RSA *p_key, char *aclk_hostname, int port, char **mqtt_us
     char response_json[4096]={};
     sprintf(response_json, "{\"response\":\"%s\"}", encoded);
     debug(D_ACLK, "Password phase: %s",response_json);
-    // TODO - host
-    sprintf(url, "/api/v1/auth/node/%s/password", agent_id);
-    if (https_request(HTTP_REQ_POST, aclk_hostname, port, url, data_buffer, NETDATA_WEB_RESPONSE_INITIAL_SIZE, response_json))
-    {
-        error("Challenge-response failed: %s", data_buffer);
-        goto CLEANUP;
-    }
 
-    debug(D_ACLK, "Password response from cloud: %s", data_buffer);
+    https_req_response_free(&resp);
+
+    // POST password
+    req.request_type = HTTP_REQ_POST;
+    buffer_flush(url);
+    buffer_sprintf(url, "%s%s/password", OTP_URL_PREFIX, agent_id);
+    req.url = url->buffer;
+    req.payload = response_json;
+    req.payload_size = strlen(response_json);
+    https_request_v2(&req, &resp);
+        if (resp.http_code != 201) {
+        error ("ACLK_OTP Challenge HTTP code not 201 Created (got %d)", resp.http_code);
+        goto cleanup_resp;
+    }
+    info ("ACLK_OTP Got Challenge from Cloud");
 
     struct dictionary_singleton password = { .key = "password", .result = NULL };
-    if (json_parse(data_buffer, &password, json_extract_singleton) != JSON_OK)
+    if (json_parse(resp.payload, &password, json_extract_singleton) != JSON_OK)
     {
         freez(password.result);
-        error("Could not parse the json response with the password: %s", data_buffer);
-        goto CLEANUP;
+        error("Could not parse the json response with the password");
+        goto cleanup_resp;
     }
 
     if (password.result == NULL ) {
         error("Could not retrieve password from auth response");
-        goto CLEANUP;
+        goto cleanup_resp;
     }
     if (*mqtt_pass != NULL )
         freez(*mqtt_pass);
@@ -253,9 +260,10 @@ void aclk_get_mqtt_otp(RSA *p_key, char *aclk_hostname, int port, char **mqtt_us
     *mqtt_usr = agent_id;
     agent_id = NULL;
 
-CLEANUP:
+cleanup_resp:
+    https_req_response_free(&resp);
+cleanup:
     if (agent_id != NULL)
         freez(agent_id);
-    freez(data_buffer);
-    return;
+    buffer_free(url);
 }

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -178,7 +178,7 @@ static int aclk_https_request(https_req_t *request, https_req_response_t *respon
         request->proxy_port = proxy_conf.port;
     }
 
-    return https_request_v2(request, response);
+    return https_request(request, response);
 }
 
 #define OTP_URL_PREFIX "/api/v1/auth/node/"

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -9,6 +9,12 @@
 
 #include "../mqtt_websockets/c-rbuf/include/ringbuffer.h"
 
+// CentOS 7 has older version that doesn't define this
+// same goes for MacOS
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37
+#endif
+
 struct dictionary_singleton {
     char *key;
     char *result;

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -345,3 +345,43 @@ const char *aclk_get_proxy(ACLK_PROXY_TYPE *type)
     *type = proxy_type;
     return proxy;
 }
+
+#define HTTP_PROXY_PREFIX "http://"
+void aclk_set_proxy(char **ohost, int *port, enum mqtt_wss_proxy_type *type)
+{
+    ACLK_PROXY_TYPE pt;
+    const char *ptr = aclk_get_proxy(&pt);
+    char *tmp;
+    char *host;
+    if (pt != PROXY_TYPE_HTTP)
+        return;
+
+    *port = 0;
+
+    if (!strncmp(ptr, HTTP_PROXY_PREFIX, strlen(HTTP_PROXY_PREFIX)))
+        ptr += strlen(HTTP_PROXY_PREFIX);
+
+    if ((tmp = strchr(ptr, '@')))
+        ptr = tmp;
+
+    if ((tmp = strchr(ptr, '/'))) {
+        host = mallocz((tmp - ptr) + 1);
+        memcpy(host, ptr, (tmp - ptr));
+        host[tmp - ptr] = 0;
+    } else
+        host = strdupz(ptr);
+
+    if ((tmp = strchr(host, ':'))) {
+        *tmp = 0;
+        tmp++;
+        *port = atoi(tmp);
+    }
+
+    if (*port <= 0 || *port > 65535)
+        *port = 8080;
+
+    *ohost = host;
+
+    if (type)
+        *type = MQTT_WSS_PROXY_HTTP;
+}

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -3,6 +3,7 @@
 #define ACLK_UTIL_H
 
 #include "libnetdata/libnetdata.h"
+#include "mqtt_wss_client.h"
 
 // Helper stuff which should not have any further inside ACLK dependency
 // and are supposed not to be needed outside of ACLK
@@ -48,5 +49,7 @@ const char *aclk_lws_wss_get_proxy_setting(ACLK_PROXY_TYPE *type);
 void safe_log_proxy_censor(char *proxy);
 int aclk_decode_base_url(char *url, char **aclk_hostname, int *aclk_port);
 const char *aclk_get_proxy(ACLK_PROXY_TYPE *type);
+
+void aclk_set_proxy(char **ohost, int *port, enum mqtt_wss_proxy_type *type);
 
 #endif /* ACLK_UTIL_H */

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -91,8 +91,6 @@ static int parse_http_hdr(rbuf_t buf, http_parse_ctx *parse_ctx)
     rbuf_pop(buf, buf_val, idx_end);
     buf_val[idx_end] = 0;
 
-    rbuf_bump_tail(buf, strlen(HTTP_KEYVAL_SEPARATOR));
-
     for (ptr = buf_key; *ptr; ptr++)
         *ptr = tolower(*ptr);
 

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -451,8 +451,7 @@ int https_request_v2(https_req_t *request, https_req_response_t *response) {
             rc = 46;
             goto exit_sock;
         }
-        //TODO change to debug
-        error("Proxy connection accepted!!!!!!!!!!!");
+        info("Proxy accepted CONNECT upgrade");
     }
 
     ctx->ssl_ctx = security_initialize_openssl_client();

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -453,6 +453,7 @@ int https_request(https_req_t *request, https_req_response_t *response) {
 
     ctx->poll_fd.fd = ctx->sock;
 
+    // Do the CONNECT if proxy is used
     if (request->proxy_host) {
         https_req_t req = HTTPS_REQ_T_INITIALIZER;
         req.request_type = HTTP_REQ_CONNECT;
@@ -501,8 +502,7 @@ int https_request(https_req_t *request, https_req_response_t *response) {
         }
     }
 
-
-    // TODO actual request here
+    // The actual request here
     if (handle_http_request(ctx)) {
         error("Couldn't process request");
         goto exit_SSL;

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -10,6 +10,19 @@ enum http_parse_state {
     HTTP_PARSE_CONTENT
 };
 
+static const char *http_req_type_to_str(http_req_type_t req) {
+    switch (req) {
+        case HTTP_REQ_GET:
+            return "GET";
+        case HTTP_REQ_POST:
+            return "POST";
+        case HTTP_REQ_CONNECT:
+            return "CONNECT";
+        default:
+            return "unknown";
+    }
+}
+
 typedef struct {
     enum http_parse_state state;
     int content_length;
@@ -528,6 +541,7 @@ int https_request_v2(https_req_t *request, https_req_response_t *response) {
             response->payload_size = ret;
         }
     }
+    info("HTTPS \"%s\" request to \"%s\" finished with HTTP code: %d", http_req_type_to_str(ctx->request->request_type), ctx->request->host, response->http_code);
 
 exit_SSL:
     SSL_free(ctx->ssl);

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "../libnetdata/libnetdata.h"
+#include "libnetdata/libnetdata.h"
 
 #include "https_client.h"
 

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -240,12 +240,11 @@ static int socket_write_all(https_req_ctx_t *ctx, char *data, size_t data_len) {
 }
 
 static int ssl_write_all(https_req_ctx_t *ctx, char *data, size_t data_len) {
-    int ret;
     ctx->written = 0;
     ctx->poll_fd.events |= POLLOUT;
 
     do {
-        ret = poll(&ctx->poll_fd, 1, POLL_TO_MS);
+        int ret = poll(&ctx->poll_fd, 1, POLL_TO_MS);
         if (ret < 0) {
             error("poll error");
             return 1;

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -210,12 +210,11 @@ static char *_ssl_err_tos(int err)
 }
 
 static int socket_write_all(https_req_ctx_t *ctx, char *data, size_t data_len) {
-    int ret;
     ctx->written = 0;
     ctx->poll_fd.events = POLLOUT;
 
     do {
-        ret = poll(&ctx->poll_fd, 1, POLL_TO_MS);
+        int ret = poll(&ctx->poll_fd, 1, POLL_TO_MS);
         if (ret < 0) {
             error("poll error");
             return 1;

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -544,3 +544,9 @@ exit_req_ctx:
 void https_req_response_free(https_req_response_t *res) {
     freez(res->payload);
 }
+
+void https_req_response_init(https_req_response_t *res) {
+    res->http_code = 0;
+    res->payload = NULL;
+    res->payload_size = 0;
+}

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "../libnetdata/libnetdata.h"
 
 #include "https_client.h"

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -423,19 +423,7 @@ err_exit:
     return rc;
 }
 
-// TODO remove
-int https_request(http_req_type_t method, char *host, int port, char *url, char *b, size_t b_size, char *payload) {
-    UNUSED(method);
-    UNUSED(host);
-    UNUSED(port);
-    UNUSED(url);
-    UNUSED(b);
-    UNUSED(b_size);
-    UNUSED(payload);
-    return 0;
-}
-
-int https_request_v2(https_req_t *request, https_req_response_t *response) {
+int https_request(https_req_t *request, https_req_response_t *response) {
     int rc = 0,ret;
     char connect_port_str[PORT_STR_MAX_BYTES];
 

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -25,14 +25,6 @@ typedef struct {
     int proxy_port;
 } https_req_t;
 
-typedef struct https_req_hdr https_req_hdr_t;
-struct https_req_hdr {
-    char *key;
-    char *val;
-
-    https_req_hdr_t *next;
-};
-
 typedef struct {
     int http_code;
 

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -3,6 +3,8 @@
 #ifndef NETDATA_HTTPS_CLIENT_H
 #define NETDATA_HTTPS_CLIENT_H
 
+#include "libnetdata/libnetdata.h"
+
 typedef enum http_req_type {
     HTTP_REQ_GET = 0,
     HTTP_REQ_POST,

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -2,10 +2,59 @@
 #define NETDATA_HTTPS_CLIENT_H
 
 typedef enum http_req_type {
-    HTTP_REQ_GET,
-    HTTP_REQ_POST
+    HTTP_REQ_GET = 0,
+    HTTP_REQ_POST,
+    HTTP_REQ_CONNECT
 } http_req_type_t;
 
 int https_request(http_req_type_t method, char *host, int port, char *url, char *b, size_t b_size, char *payload);
+
+typedef struct {
+    http_req_type_t request_type;
+
+    char *host;
+    int port;
+    char *url;
+
+    int timeout_s; //timeout in seconds for the network operation (send/recv)
+
+    void *payload;
+    size_t payload_size;
+
+    char *proxy_host;
+    int proxy_port;
+} https_req_t;
+
+typedef struct https_req_hdr https_req_hdr_t;
+struct https_req_hdr {
+    char *key;
+    char *val;
+
+    https_req_hdr_t *next;
+};
+
+typedef struct {
+    int http_code;
+
+    void *payload;
+    size_t payload_size;
+} https_req_response_t;
+
+void https_req_response_free(https_req_response_t *res);
+
+#define HTTPS_REQ_T_INITIALIZER                     \
+    {                                               \
+        .request_type = HTTP_REQ_GET,               \
+        .host = NULL,                               \
+        .port = 443,                                \
+        .url = NULL,                                \
+        .timeout_s = 30,                            \
+        .payload = NULL,                            \
+        .payload_size = 0,                          \
+        .proxy_host = NULL,                         \
+        .proxy_port = 8080                          \
+    }
+
+int https_request_v2(https_req_t *request, https_req_response_t *response);
 
 #endif /* NETDATA_HTTPS_CLIENT_H */

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -18,7 +18,7 @@ typedef struct {
     int port;
     char *url;
 
-    int timeout_s; //timeout in seconds for the network operation (send/recv)
+    time_t timeout_s; //timeout in seconds for the network operation (send/recv)
 
     void *payload;
     size_t payload_size;

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -40,6 +40,13 @@ typedef struct {
 
 void https_req_response_free(https_req_response_t *res);
 
+#define HTTPS_RES_RESPONSE_T_INITIALIZER            \
+    {                                               \
+        .http_code = 0,                             \
+        .payload = NULL,                            \
+        .payload_size = 0                           \
+    }
+
 #define HTTPS_REQ_T_INITIALIZER                     \
     {                                               \
         .request_type = HTTP_REQ_GET,               \

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -35,8 +35,9 @@ typedef struct {
 } https_req_response_t;
 
 void https_req_response_free(https_req_response_t *res);
+void https_req_response_init(https_req_response_t *res);
 
-#define HTTPS_RES_RESPONSE_T_INITIALIZER            \
+#define HTTPS_REQ_RESPONSE_T_INITIALIZER            \
     {                                               \
         .http_code = 0,                             \
         .payload = NULL,                            \

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -7,8 +7,6 @@ typedef enum http_req_type {
     HTTP_REQ_CONNECT
 } http_req_type_t;
 
-int https_request(http_req_type_t method, char *host, int port, char *url, char *b, size_t b_size, char *payload);
-
 typedef struct {
     http_req_type_t request_type;
 
@@ -55,6 +53,6 @@ void https_req_response_free(https_req_response_t *res);
         .proxy_port = 8080                          \
     }
 
-int https_request_v2(https_req_t *request, https_req_response_t *response);
+int https_request(https_req_t *request, https_req_response_t *response);
 
 #endif /* NETDATA_HTTPS_CLIENT_H */

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef NETDATA_HTTPS_CLIENT_H
 #define NETDATA_HTTPS_CLIENT_H
 


### PR DESCRIPTION
##### Summary
Implements more smart/full HTTPS client for ACLK (although in the future other code can use it too(currently it depends on ACLK-NG but after Legacy is removed we can move it to libnetdata to be usable in wider agent))
This is a prerequisite for redesigned new Cloud architecture (/env endpoint etc.)

Currently this is not fully compliant HTTPS client by far (mostly implements what we need) but is made to be extensible so that further features are easy to add without rewrite etc.

##### Component Name
ACLK
##### Test Plan
Everything should work as expected. The agent connects to the cloud without issue.
I also retested the connection through HTTP proxy (squid).

##### Additional Information
