### PR TITLE
health: exclude cgroups net ifaces from packets dropped alarms

### DIFF
--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -56,7 +56,7 @@ template: inbound_packets_dropped
       on: net.drops
       os: linux
    hosts: *
-families: *
+families: !net* *
   lookup: sum -10m unaligned absolute of inbound
    units: packets
    every: 1m
@@ -66,7 +66,7 @@ template: outbound_packets_dropped
       on: net.drops
       os: linux
    hosts: *
-families: *
+families: !net* *
   lookup: sum -10m unaligned absolute of outbound
    units: packets
    every: 1m
@@ -76,7 +76,7 @@ template: inbound_packets_dropped_ratio
       on: net.packets
       os: linux
    hosts: *
-families: !wl* *
+families: !net* !wl* *
   lookup: sum -10m unaligned absolute of received
     calc: (($inbound_packets_dropped != nan AND $this > 1000) ? ($inbound_packets_dropped * 100 / $this) : (0))
    units: %
@@ -90,7 +90,7 @@ template: outbound_packets_dropped_ratio
       on: net.packets
       os: linux
    hosts: *
-families: !wl* *
+families: !net* !wl* *
   lookup: sum -10m unaligned absolute of sent
     calc: (($outbound_packets_dropped != nan AND $this > 1000) ? ($outbound_packets_dropped * 100 / $this) : (0))
    units: %


### PR DESCRIPTION
##### Summary

The following alarms don't work for cgroups

- [inbound_packets_dropped_ratio](https://github.com/netdata/netdata/blob/3b5a69c2a29817f4fe114c09107f7e57e5a4d26d/health/health.d/net.conf#L75-L87)
- [outbound_packets_dropped_ratio](https://github.com/netdata/netdata/blob/3b5a69c2a29817f4fe114c09107f7e57e5a4d26d/health/health.d/net.conf#L89-L101)

They use other other alarms as variables and those alarms attached to another charts.

It works for network interfaces in general, because of [variables lookup logic](https://learn.netdata.cloud/docs/agent/health/reference#variables) - network interfaces have unique family and there is family index.

> family variables.
    Families are used to group charts together. For example all eth0 charts, have family = eth0. This 
    index includes all local variables, but if there are overlapping variables, only the first are exposed.

During containers detection we change network interfaces charts family. All of them have same family - `net eth0`.

So we get

> This index includes all local variables, but if there are overlapping variables, only the first are exposed.

---

I tested it manually:
 - created 2 alarms with the same logic

```cmd
template: sent_packets
      on: net.packets
  lookup: sum -1m unaligned absolute of sent
   units: packets
   every: 10s
    info: interface sent packets in the last minutes

template: sent_packets_test
      on: net.drops
    calc: $sent_packets * 10
   units: packets
   every: 10s
    info: sent packets test
```

 - created 3 netdata containers
 - accessed first netdata dashboard


As you can see we use 1st container `$sent_packets` for all alarms.

```cmd
[pc netdata]# curl -s http://192.168.50.130:19999/api/v1/alarms?all | jq '.alarms[] | select( .chart | contains("cgroup")) | "\(.chart) \(.value)"'
"cgroup_netdata1.net_packets_eth0 25.9999996"
"cgroup_netdata1.net_drops_eth0 259.999996"
"cgroup_netdata2.net_packets_eth0 0"
"cgroup_netdata2.net_drops_eth0 259.999996"
"cgroup_netdata3.net_packets_eth0 0"
"cgroup_netdata3.net_drops_eth0 259.999996"
```


⚠️ There is space in `net eth0` and simple pattern is _a space separated list..._. So `!net*` it is, can not be more specific.

❗ I think this matters, because this PR significantly decreases number of alarms in k8s/any env with a lot of containers.

##### Component Name

`health`

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
