### PR TITLE
Fix eBPF compilation

### DIFF
--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -338,6 +338,17 @@ struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, char *
 
 //----------------------------------------------------------------------------------------------------------------------
 
+void ebpf_mount_config_name(char *filename, size_t length, char *path, char *config)
+{
+    snprintf(filename, length, "%s/ebpf.d/%s", path, config);
+}
+
+int ebpf_load_config(struct config *config, char *filename)
+{
+    return appconfig_load(config, filename, 0, NULL);
+}
+
+
 static netdata_run_mode_t ebpf_select_mode(char *mode)
 {
     if (!strcasecmp(mode, "return"))

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -122,16 +122,8 @@ extern struct bpf_link **ebpf_load_program(char *plugins_dir,
                              struct bpf_object **obj,
                              int *map_fd);
 
-inline void ebpf_mount_config_name(char *filename, size_t length, char *path, char *config)
-{
-    snprintf(filename, length, "%s/ebpf.d/%s", path, config);
-}
-
-inline int ebpf_load_config(struct config *config, char *filename)
-{
-    return appconfig_load(config, filename, 0, NULL);
-}
-
+extern void ebpf_mount_config_name(char *filename, size_t length, char *path, char *config);
+extern int ebpf_load_config(struct config *config, char *filename);
 extern void ebpf_update_module_using_config(ebpf_module_t *modules, struct config *cfg);
 extern void ebpf_update_module(ebpf_module_t *em, struct config *cfg, char *cfg_file);
 


### PR DESCRIPTION
##### Summary
When compiled with the flags `-O0 -ggdb -pg -DACLK_SSL_ALLOW_SELF_SIGNED -DNETDATA_INTERNAL_CHECKS=1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_VERIFY_LOCKS=1` , eBPF plugin cannot be compiled on few distributions (`CentOS` and `Fedora`), this PR is removing `inline` that was creating the errors.

##### Component Name
ebpf.plugin
##### Test Plan

1 - Compile this branch with the flags `-O0 -ggdb -pg -DACLK_SSL_ALLOW_SELF_SIGNED -DNETDATA_INTERNAL_CHECKS=1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_VERIFY_LOCKS=1`
2 - Check if compilation finishes with success.
3 - Start Netdata.

##### Additional Information
Errors were detected only when we tried to compile on RH family.