### PR TITLE
fix claiming via env vars in docker container

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -21,10 +21,10 @@ if [ -n "${PGID}" ]; then
 fi
 
 if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/cloud.d/claimed_id ]; then
-  /usr/sbin/netdata-claim.sh -token "${NETDATA_CLAIM_TOKEN}" \
-                             -url "${NETDATA_CLAIM_URL}" \
-                             ${NETDATA_CLAIM_ROOMS:+-rooms "${NETDATA_CLAIM_ROOMS}"} \
-                             ${NETDATA_CLAIM_PROXY:+-proxy "${NETDATA_CLAIM_PROXY}"}
+  /usr/sbin/netdata-claim.sh -token="${NETDATA_CLAIM_TOKEN}" \
+                             -url="${NETDATA_CLAIM_URL}" \
+                             ${NETDATA_CLAIM_ROOMS:+-rooms="${NETDATA_CLAIM_ROOMS}"} \
+                             ${NETDATA_CLAIM_PROXY:+-proxy="${NETDATA_CLAIM_PROXY}"} \
                              -daemon-not-running
 fi
 


### PR DESCRIPTION
##### Summary

Fixes: #10809

netdata-claim.sh script expects -token, -url, -rooms and proxy params to be -param=

##### Component Name

`packaging/docker`

##### Test Plan

- create docker image
- try to claim netdata container using env vars(`NETDATA_CLAIM_TOKEN`, `NETDATA_CLAIM_URL` and `NETDATA_CLAIM_ROOMS`
  - start a new container with empty `/var/lib/netdata`, ensure it is claimed successfully and it is reachable on the Cloud ✅ 
  - restart container, ensure it is reachable on the Cloud ✅ 
  - delete container, create a new one using old `/var/lib/netdata`, ensure it is reachable on the Cloud ✅ 

##### Additional Information
