### PR TITLE
change netdata user home dir to /var/lib/netdata in a docker container

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -75,7 +75,7 @@ RUN mkdir -p /opt/src /var/log/netdata && \
     chmod 4755 /usr/local/bin/fping && \
     # Add netdata user
     addgroup -g ${NETDATA_GID} -S "${DOCKER_GRP}" && \
-    adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}"
+    adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /var/lib/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}"
 
 # Long-term this should leverage BuildKit’s mount option.
 COPY --from=builder /wheels /wheels


### PR DESCRIPTION
##### Summary

`HOME` is `/var/lib/netdata` by default

https://github.com/netdata/netdata/blob/3b5a69c2a29817f4fe114c09107f7e57e5a4d26d/daemon/common.c#L14

https://github.com/netdata/netdata/blob/3b5a69c2a29817f4fe114c09107f7e57e5a4d26d/daemon/main.c#L545-L546

---

Having netdata user home dir != `HOME` results in a very tricky bugs
Related https://github.com/netdata/netdata/issues/10022#issuecomment-703841073 

##### Component Name

`packaging/docker`

##### Test Plan

- create an image
- start netdata container
- check netdata user home dir

```cmd
0 netdata (docker_change_netdata_user_home_dir)$ docker exec netdata getent passwd netdata
netdata:x:201:201:Linux User,,,:/var/lib/netdata:/usr/sbin/nologin
```

##### Additional Information
