### PR TITLE
health: log an error if any when send email notification

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -885,14 +885,15 @@ send_email() {
       echo >&2 "--- END sendmail command ---"
     fi
 
-    "${sendmail}" -t "${opts[@]}"
+    local cmd_output
+    cmd_output=$("${sendmail}" -t "${opts[@]}" 2>&1)
     ret=$?
 
     if [ ${ret} -eq 0 ]; then
       info "sent email notification for: ${host} ${chart}.${name} is ${status} to '${to_email}'"
       return 0
     else
-      error "failed to send email notification for: ${host} ${chart}.${name} is ${status} to '${to_email}' with error code ${ret}."
+      error "failed to send email notification for: ${host} ${chart}.${name} is ${status} to '${to_email}' with error code ${ret} (${cmd_output})."
       return 1
     fi
   fi


### PR DESCRIPTION
##### Summary

ssia 

We were debugging a problem yesterday and @dimko shared the log line

> alarm-notify.sh: ERROR: failed to send email notification for: 254b9fa2a7d8 system.cpu.custom_crit is CRITICAL to 'dkoutsourelis@netdata.cloud' with error code 78.

There is only error code and no the actuall error message. Recently i had similar problem - email notifications doesn't because of systemd capabilities and it was impossible to debug. When i added logging of the error message it became clear (_exim: setgroups() failed: Operation not permitted_).

Before this PR

```cmd
[netdata@pc plugins.d]$ ./alarm-test.sh

# SENDING TEST WARNING ALARM TO ROLE: sysadmin
./alarm-notify.sh: line 888: /usr/bin/sendmail2: No such file or directory
2021-03-19 13:57:01: alarm-notify.sh: ERROR: failed to send email notification for: pc test.chart.test_alarm is WARNING to 'ilyam' with error code 127.
# FAILED

# SENDING TEST CRITICAL ALARM TO ROLE: sysadmin
./alarm-notify.sh: line 888: /usr/bin/sendmail2: No such file or directory
2021-03-19 13:57:01: alarm-notify.sh: ERROR: failed to send email notification for: pc test.chart.test_alarm is CRITICAL to 'ilyam' with error code 127.
# FAILED

# SENDING TEST CLEAR ALARM TO ROLE: sysadmin
./alarm-notify.sh: line 888: /usr/bin/sendmail2: No such file or directory
2021-03-19 13:57:01: alarm-notify.sh: ERROR: failed to send email notification for: pc test.chart.test_alarm is CLEAR to 'ilyam' with error code 127.
# FAILED
```

After

```cmd
[netdata@pc plugins.d]$ ./alarm-test.sh

# SENDING TEST WARNING ALARM TO ROLE: sysadmin
2021-03-19 13:57:38: alarm-notify.sh: ERROR: failed to send email notification for: pc test.chart.test_alarm is WARNING to 'ilyam' with error code 127 (./alarm-notify.sh: line 890: /usr/bin/sendmail2: No such file or directory).
# FAILED

# SENDING TEST CRITICAL ALARM TO ROLE: sysadmin
2021-03-19 13:57:38: alarm-notify.sh: ERROR: failed to send email notification for: pc test.chart.test_alarm is CRITICAL to 'ilyam' with error code 127 (./alarm-notify.sh: line 890: /usr/bin/sendmail2: No such file or directory).
# FAILED

# SENDING TEST CLEAR ALARM TO ROLE: sysadmin
2021-03-19 13:57:38: alarm-notify.sh: ERROR: failed to send email notification for: pc test.chart.test_alarm is CLEAR to 'ilyam' with error code 127 (./alarm-notify.sh: line 890: /usr/bin/sendmail2: No such file or directory).
# FAILED
``` 

##### Component Name

`health`

##### Test Plan


##### Additional Information
