### PR TITLE
Fix handling of nightly and release packages in GHA workflows.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -110,7 +110,7 @@ jobs:
           mkdir -p artifacts
           docker run --platform ${{ matrix.platform }} -v $PWD/artifacts:/artifacts local/package-builder:${{ matrix.distro }}${{ matrix.version }}
       - name: Upload
-        if: github.env.runtype == 'release' || github.env.runtype == 'nightly' || github.env.runtype == 'devel'
+        if: github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           # This figures out the distribution ID for the upload.
@@ -120,7 +120,7 @@ jobs:
                  -F "package[package_file]=@${pkgfile}" \
                  https://${{ secrets.PACKAGE_CLOUD_API_TOKEN }}:@packagecloud.io/api/v1/repos/${{ env.repo }}/packages.json || exit 1
       - name: Clean
-        if: github.env.runtype == 'release' || github.env.runtype == 'nightly' || github.env.runtype == 'devel'
+        if: github.event_name == 'workflow_dispatch'
         shell: bash
         env:
           REPO: ${{ env.repo }}

--- a/packaging/scripts/install.sh
+++ b/packaging/scripts/install.sh
@@ -20,8 +20,10 @@ install_fedora_like() {
 
   PKGMGR="$( (command -v dnf > /dev/null && echo "dnf") || echo "yum")"
 
+  pkg_version="$(echo "${VERSION}" | tr - .)"
+
   # Install NetData
-  "$PKGMGR" install -y /artifacts/netdata-"${VERSION}"-*.rpm
+  "$PKGMGR" install -y /artifacts/netdata-"${pkg_version}"-*.rpm
 
   # Install testing tools
   "$PKGMGR" install -y curl nc jq
@@ -33,11 +35,13 @@ install_centos() {
 
   PKGMGR="$( (command -v dnf > /dev/null && echo "dnf") || echo "yum")"
 
+  pkg_version="$(echo "${VERSION}" | tr - .)"
+
   # Install EPEL (needed for `jq`
   "$PKGMGR" install -y epel-release
 
   # Install NetData
-  "$PKGMGR" install -y /artifacts/netdata-"${VERSION}"-*.rpm
+  "$PKGMGR" install -y /artifacts/netdata-"${pkg_version}"-*.rpm
 
   # Install testing tools
   "$PKGMGR" install -y curl nc jq
@@ -47,10 +51,12 @@ install_suse_like() {
   # Using a glob pattern here because I can't reliably determine what the
   # resulting package name will be (TODO: There must be a better way!)
 
+  pkg_version="$(echo "${VERSION}" | tr - .)"
+
   # Install NetData
   # FIXME: Allow unsigned packages (for now) #7773
   zypper install -y --allow-unsigned-rpm \
-    /artifacts/netdata-"${VERSION}"-*.rpm
+    /artifacts/netdata-"${pkg_version}"-*.rpm
 
   # Install testing tools
   zypper install -y --no-recommends \


### PR DESCRIPTION
##### Summary

Assorted fixes that were missed previously for the GHA packaging workflows.

##### Component Name

area/ci
area/packaging

##### Test Plan

Thoroughly verified the RPM packaging changes in `packaging/scripts/install.sh`.

Simply verified that the conditional changes in the workflow more accurately represent the behavior we want.