### PR TITLE
health: apply adapter_raid alarms for every logical/physical device

### DIFF
--- a/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
+++ b/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
@@ -23,11 +23,13 @@ ORDER = [
 
 CHARTS = {
     'ld_status': {
-        'options': [None, 'Status Is Not OK', 'bool', 'logical devices', 'adapter_raid.ld_status', 'line'],
+        'options': [None, 'Status of logical devices (1: Failed or Degraded)', 'bool', 'logical devices',
+                    'adapter_raid.ld_status', 'line'],
         'lines': []
     },
     'pd_state': {
-        'options': [None, 'State Is Not OK', 'bool', 'physical devices', 'adapter_raid.pd_state', 'line'],
+        'options': [None, 'State of physical devices (1: not Online)', 'bool', 'physical devices',
+                    'adapter_raid.pd_state', 'line'],
         'lines': []
     },
     'pd_smart_warnings': {

--- a/health/health.d/adaptec_raid.conf
+++ b/health/health.d/adaptec_raid.conf
@@ -3,22 +3,22 @@
 
 template: adapter_raid_ld_status
       on: adapter_raid.ld_status
-  lookup: max -5s
+  lookup: max -10s foreach *
    units: bool
    every: 10s
     crit: $this > 0
    delay: down 5m multiplier 1.5 max 1h
-    info: at least 1 logical device is failed or degraded
+    info: logical device status is failed or degraded
       to: sysadmin
 
 # physical device state check
 
 template: adapter_raid_pd_state
       on: adapter_raid.pd_state
-  lookup: max -5s
+  lookup: max -10s foreach *
    units: bool
    every: 10s
     crit: $this > 0
    delay: down 5m multiplier 1.5 max 1h
-    info: at least 1 physical device is not in online state
+    info: physical device state is not online
       to: sysadmin


### PR DESCRIPTION
##### Summary

I think it is better to to apply LD status/PD state alarms per every device. Back then [`foreach`](https://learn.netdata.cloud/docs/agent/health/reference#alarm-line-lookup) wasnt implemented.

cc @kozicpetar

i have a question, is having a LD/PD not in desired state is CRIT level alarm in general? Or we can change it to WARN?

##### Component Name

`health`

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
