### PR TITLE
Include archived hosts in the mirrored_hosts_status list

### DIFF
--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -60,4 +60,5 @@ extern void db_lock(void);
 extern void delete_dimension_uuid(uuid_t *dimension_uuid);
 extern void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value);
 extern void sql_build_context_param_list(struct context_param **param_list, RRDHOST *host, char *context, char *chart);
+extern void sql_archived_database_hosts(BUFFER *wb, int count);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -875,6 +875,7 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 
         count++;
     }
+    sql_archived_database_hosts(wb, count);
     rrd_unlock();
 
     buffer_strcat(wb, "\n\t],\n");


### PR DESCRIPTION
##### Summary
Add the archived hosts in the mirrored_hosts_status list with a `reachable = false` indication

##### Component Name
database

##### Test Plan
- Setup a dbengine-enabled parent with a child. Note down the child's `guid`
- Start the parent and the child
- On the parent you can execute a query 
  `http://parent_ip:19999/api/v1/info` 
   Notice the `child1` appearing in the `mirrored_hosts` (hostname) and `mirrored_hosts_status`  (guid)

- Stop the parent and child
- Start only the parent and execute
  `http://parent_ip:19999/api/v1/info` 
  The `child1` does not appear in the `mirrored_hosts` and `mirrored_hosts_status` 

---

- Stop the parent, apply the PR and restart (the child should be stopped) and execute
  `http://parent_ip:19999/api/v1/info` 
   Notice the `child1` in the `mirrored_hosts_status`  (guid) with reachable set to false
   If you start the child and execute `http://parent_ip:19999/api/v1/info` you will see the updated status