### PR TITLE
health: remove exporting_metrics_lost template

### DIFF
--- a/health/health.d/exporting.conf
+++ b/health/health.d/exporting.conf
@@ -21,14 +21,3 @@ families: *
    delay: down 5m multiplier 1.5 max 1h
     info: percentage of metrics sent to the external database server
       to: dba
-
-template: exporting_metrics_lost
-families: *
-      on: exporting_data_size
-   units: metrics
-    calc: abs($lost)
-   every: 10s
-    crit: ($this != 0) || ($status == $CRITICAL && abs($sent) == 0)
-   delay: down 5m multiplier 1.5 max 1h
-    info: number of metrics lost due to repeating failures to contact the external database server
-      to: dba


### PR DESCRIPTION
##### Summary

We have

https://github.com/netdata/netdata/blob/32344ec967caa60cf1bac7dad1c8baf4a471babc/health/health.d/exporting.conf#L14-L23

if sent % != 100 => there is some metrics lost. No need in having both of these alarms.

##### Component Name

`health`

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
