### PR TITLE
health: apply megacli alarms for all adapters/physical disks

### DIFF
--- a/health/health.d/megacli.conf
+++ b/health/health.d/megacli.conf
@@ -1,11 +1,39 @@
+
+## Adapters (controllers)
+
 template: megacli_adapter_state
       on: megacli.adapter_degraded
-   units: is degraded
-  lookup: sum -10s
+  lookup: max -10s foreach *
+   units: boolean
    every: 10s
     crit: $this > 0
-    info: adapter state
+   delay: down 5m multiplier 2 max 10m
+    info: adapter state is degraded
       to: sysadmin
+
+## Physical Disks
+
+template: megacli_pd_predictive_failures
+      on: megacli.pd_predictive_failure
+  lookup: sum -10s foreach *
+   units: predictive failures
+   every: 10s
+    warn: $this > 0
+   delay: up 1m down 5m multiplier 2 max 10m
+    info: physical drive predictive failures
+      to: sysadmin
+
+template: megacli_pd_media_errors
+      on: megacli.pd_media_error
+  lookup: sum -10s foreach *
+   units: media errors
+   every: 10s
+    warn: $this > 0
+   delay: up 1m down 5m multiplier 2 max 10m
+    info: physical drive media errors
+      to: sysadmin
+
+## Battery Backup Units (BBU)
 
 template: megacli_bbu_relative_charge
       on: megacli.bbu_relative_charge
@@ -25,24 +53,4 @@ template: megacli_bbu_cycle_count
     warn: $this >= 100
     crit: $this >= 500
     info: BBU cycle count
-      to: sysadmin
-
-template: megacli_pd_media_errors
-      on: megacli.pd_media_error
-   units: media errors
-  lookup: sum -10s
-   every: 10s
-    warn: $this > 0
-   delay: down 1m multiplier 2 max 10m
-    info: physical drive media errors
-      to: sysadmin
-
-template: megacli_pd_predictive_failures
-      on: megacli.pd_predictive_failure
-   units: predictive failures
-  lookup: sum -10s
-   every: 10s
-    warn: $this > 0
-   delay: down 1m multiplier 2 max 10m
-    info: physical drive predictive failures
       to: sysadmin


### PR DESCRIPTION
##### Summary

I think it is better to to apply adapter/physical disks alarms per every device. Back then [`foreach`](https://learn.netdata.cloud/docs/agent/health/reference#alarm-line-lookup) wasnt implemented.

##### Component Name

`health`

##### Test Plan

Not really needed, i basically add `foreach *` to the lookup, [which is the correct syntax](https://learn.netdata.cloud/docs/agent/health/reference#alarm-line-lookup).


##### Additional Information
