### PR TITLE
Add lock check to avoid shutdown when compiled with internal and locking checks

### DIFF
--- a/web/api/formatters/value/value.c
+++ b/web/api/formatters/value/value.c
@@ -4,7 +4,8 @@
 
 
 inline calculated_number rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null) {
-    rrdset_check_rdlock(r->st);
+    if (r->st_needs_lock)
+        rrdset_check_rdlock(r->st);
 
     long c;
     RRDDIM *d;

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -108,7 +108,7 @@ RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param
     RRDR *r = callocz(1, sizeof(RRDR));
     r->st = st;
 
-    if (!context_param_list || (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE))) {
+    if (!context_param_list || !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
         rrdr_lock_rrdset(r);
         r->st_needs_lock = 1;
     }

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -100,7 +100,7 @@ inline void rrdr_free(RRDR *r)
 
 RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param_list)
 {
-    if(unlikely(!st)) {
+    if (unlikely(!st)) {
         error("NULL value given!");
         return NULL;
     }
@@ -108,8 +108,10 @@ RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param
     RRDR *r = callocz(1, sizeof(RRDR));
     r->st = st;
 
-    if (!context_param_list || (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)))
+    if (!context_param_list || (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE))) {
         rrdr_lock_rrdset(r);
+        r->st_needs_lock = 1;
+    }
 
     RRDDIM *temp_rd =  context_param_list ? context_param_list->rd : NULL;
     RRDDIM *rd;

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -73,6 +73,7 @@ typedef struct rrdresult {
     time_t after;
 
     int has_st_lock;        // if st is read locked by us
+    uint8_t st_needs_lock;  // if ST should be locked
 
     // internal rrd2rrdr() members below this point
     struct {


### PR DESCRIPTION
#10832

##### Summary
Add a lock check to avoid agent shutdown when compiled with internal checks and verify lock checks. This is a quick 
fix and it will be improved in the future.

##### Component Name
database, web

##### Test Plan
-  Verify  as  described in #10832, then apply PR and verify that the agent does not shutdown
