### PR TITLE
Fix memory leak when archived data is requested

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -50,6 +50,7 @@ void netdata_cleanup_and_exit(int ret) {
         rrdeng_exit(&multidb_ctx);
 #endif
     }
+    sql_close_database();
 
     // unlink the pid
     if(pidfile[0]) {

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -48,8 +48,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                    , kq, kq, sq, context_mode && temp_rd?r->st->context:r->st->name, sq
                    , kq, kq, r->update_every
                    , kq, kq, r->st->update_every
-                   , kq, kq, (uint32_t) (context_param_list ? context_param_list->first_entry_t : rrdset_first_entry_t(r->st))
-                   , kq, kq, (uint32_t) (context_param_list ? context_param_list->last_entry_t : rrdset_last_entry_t(r->st))
+                   , kq, kq, (uint32_t) (context_param_list ? context_param_list->first_entry_t : rrdset_first_entry_t_nolock(r->st))
+                   , kq, kq, (uint32_t) (context_param_list ? context_param_list->last_entry_t : rrdset_last_entry_t_nolock(r->st))
                    , kq, kq, (uint32_t)r->before
                    , kq, kq, (uint32_t)r->after
                    , kq, kq);

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -2,7 +2,28 @@
 
 #include "web/api/web_api_v1.h"
 
-static inline void free_temp_rrddim(RRDDIM *temp_rd)
+static inline void free_single_rrdrim(RRDDIM *temp_rd, int archive_mode)
+{
+    if (unlikely(!temp_rd))
+        return;
+
+    freez((char *)temp_rd->id);
+    freez((char *)temp_rd->name);
+
+    if (unlikely(archive_mode)) {
+        temp_rd->rrdset->counter--;
+        if (!temp_rd->rrdset->counter) {
+            freez((char *)temp_rd->rrdset->name);
+            freez(temp_rd->rrdset->context);
+            freez(temp_rd->rrdset);
+        }
+    }
+    freez(temp_rd->state->metric_uuid);
+    freez(temp_rd->state);
+    freez(temp_rd);
+}
+
+static inline void free_rrddim_list(RRDDIM *temp_rd, int archive_mode)
 {
     if (unlikely(!temp_rd))
         return;
@@ -10,14 +31,7 @@ static inline void free_temp_rrddim(RRDDIM *temp_rd)
     RRDDIM *t;
     while (temp_rd) {
         t = temp_rd->next;
-        freez((char *)temp_rd->id);
-        freez((char *)temp_rd->name);
-#ifdef ENABLE_DBENGINE
-        if (temp_rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
-            freez(temp_rd->state->metric_uuid);
-#endif
-        freez(temp_rd->state);
-        freez(temp_rd);
+        free_single_rrdrim(temp_rd, archive_mode);
         temp_rd = t;
     }
 }
@@ -27,7 +41,7 @@ void free_context_param_list(struct context_param **param_list)
     if (unlikely(!param_list || !*param_list))
         return;
 
-    free_temp_rrddim(((*param_list)->rd));
+    free_rrddim_list(((*param_list)->rd), (*param_list)->flags & CONTEXT_FLAGS_ARCHIVE);
     freez((*param_list));
     *param_list = NULL;
 }
@@ -36,21 +50,17 @@ void rebuild_context_param_list(struct context_param *context_param_list, time_t
 {
     RRDDIM *temp_rd = context_param_list->rd;
     RRDDIM *new_rd_list = NULL, *t;
+    int is_archived = (context_param_list->flags & CONTEXT_FLAGS_ARCHIVE);
     while (temp_rd) {
         t = temp_rd->next;
-        if (rrdset_last_entry_t(temp_rd->rrdset) >= after_requested) {
+        RRDSET *st = temp_rd->rrdset;
+        time_t last_entry_t = is_archived ? st->last_entry_t : rrdset_last_entry_t(st);
+
+        if (last_entry_t >= after_requested) {
             temp_rd->next = new_rd_list;
             new_rd_list = temp_rd;
-        } else {
-            freez((char *)temp_rd->id);
-            freez((char *)temp_rd->name);
-#ifdef ENABLE_DBENGINE
-            if (temp_rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
-                freez(temp_rd->state->metric_uuid);
-#endif
-            freez(temp_rd->state);
-            freez(temp_rd);
-        }
+        } else
+            free_single_rrdrim(temp_rd, is_archived);
         temp_rd = t;
     }
     context_param_list->rd = new_rd_list;

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -75,7 +75,7 @@ void build_context_param_list(struct context_param **param_list, RRDSET *st)
         *param_list = mallocz(sizeof(struct context_param));
         (*param_list)->first_entry_t = LONG_MAX;
         (*param_list)->last_entry_t = 0;
-        (*param_list)->flags = 0;
+        (*param_list)->flags = CONTEXT_FLAGS_CONTEXT;
         (*param_list)->rd = NULL;
     }
 


### PR DESCRIPTION
##### Summary
- Properly release memory used for the charts when accessing archived data (charts are archived) 
- Properly shutdown the SQLite database connection
  - Database close was not issued during agent shutdown
- Store and finalize SQL statements to release memory during shutdown (Quick Fix)
  - Keep a list of statements to finalize and do sqlite3_finalize on shutdown
- Address coverity 
  - CID 369624:  Resource leaks  (RESOURCE_LEAK)
  - CID 369623:  API usage errors  (LOCK)

##### Component Name
database

##### Test Plan
- SQLite Reported memory leaks during shutdown should vanish (or greatly reduced)
  - e.g. run with `valgrind --leak-check=full --show-leak-kinds=all`

