### PR TITLE
prevents mqtt connection attempt on OTP failure

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -520,9 +520,12 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
             continue;
         }
 
-        // TODO check success
-        aclk_get_mqtt_otp(aclk_private_key, &mqtt_otp_user, &mqtt_otp_pass, &auth_url);
+        ret = aclk_get_mqtt_otp(aclk_private_key, &mqtt_otp_user, &mqtt_otp_pass, &auth_url);
         url_t_destroy(&auth_url);
+        if (ret) {
+            error("Error passing Challenge/Response to get OTP");
+            continue;
+        }
 
         mqtt_conn_params.clientid = mqtt_otp_user;
         mqtt_conn_params.username = mqtt_otp_user;

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -189,7 +189,10 @@ static int aclk_https_request(https_req_t *request, https_req_response_t *respon
 }
 
 #define OTP_URL_PREFIX "/api/v1/auth/node/"
-void aclk_get_mqtt_otp(RSA *p_key, char **mqtt_usr, char **mqtt_pass, url_t *target) {
+int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_usr, char **mqtt_pass, url_t *target) {
+    // TODO this fnc will be rewritten and simplified in following PRs
+    // still carries lot of baggage from ACLK Legacy
+    int rc = 1;
     BUFFER *url = buffer_create(strlen(OTP_URL_PREFIX) + UUID_STR_LEN + 20);
 
     https_req_t req = HTTPS_REQ_T_INITIALIZER;
@@ -289,12 +292,15 @@ void aclk_get_mqtt_otp(RSA *p_key, char **mqtt_usr, char **mqtt_pass, url_t *tar
     *mqtt_usr = agent_id;
     agent_id = NULL;
 
+    rc = 0;
+
 cleanup_resp:
     https_req_response_free(&resp);
 cleanup:
     if (agent_id != NULL)
         freez(agent_id);
     buffer_free(url);
+    return rc;
 }
 
 #define PARSE_ENV_JSON_CHK_TYPE(it, type, name)                                                                        \

--- a/aclk/aclk_otp.h
+++ b/aclk/aclk_otp.h
@@ -7,7 +7,7 @@
 
 #include "https_client.h"
 
-void aclk_get_mqtt_otp(RSA *p_key, char **mqtt_usr, char **mqtt_pass, url_t *target);
+int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_usr, char **mqtt_pass, url_t *target);
 int aclk_get_env(aclk_env_t *env, const char *aclk_hostname, int aclk_port);
 
 #endif /* ACLK_OTP_H */


### PR DESCRIPTION
##### Summary
Fixes MQTT connection being attempted when we couldn't get the OTP.

##### Component Name
ACLK-NG

##### Test Plan
Fail OTP (block cloud IP) see that MQTT connection attempt is not being made until next reconnect attempt (after honoring TBEB)
##### Additional Information
