### PR TITLE
Check device names in diskstats plugin

### DIFF
--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -627,12 +627,12 @@ static struct disk *get_disk(unsigned long major, unsigned long minor, char *dis
     // check if we can find its mount point
 
     // mountinfo_find() can be called with NULL disk_mountinfo_root
-    struct mountinfo *mi = mountinfo_find(disk_mountinfo_root, d->major, d->minor);
+    struct mountinfo *mi = mountinfo_find(disk_mountinfo_root, d->major, d->minor, d->device);
     if(unlikely(!mi)) {
         // mountinfo_free_all can be called with NULL
         mountinfo_free_all(disk_mountinfo_root);
         disk_mountinfo_root = mountinfo_read(0);
-        mi = mountinfo_find(disk_mountinfo_root, d->major, d->minor);
+        mi = mountinfo_find(disk_mountinfo_root, d->major, d->minor, d->device);
     }
 
     if(unlikely(mi))

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -394,7 +394,7 @@ static inline int get_disk_name_from_path(const char *path, char *result, size_t
                 continue;
             }
 
-            if(major(sb.st_rdev) != major || minor(sb.st_rdev) != minor) {
+            if(major(sb.st_rdev) != major || minor(sb.st_rdev) != minor || strcmp(basename(filename), disk)) {
                 //info("DEVICE-MAPPER ('%s', %lu:%lu): filename '%s' does not match %lu:%lu.", disk, major, minor, filename, (unsigned long)major(sb.st_rdev), (unsigned long)minor(sb.st_rdev));
                 continue;
             }

--- a/collectors/proc.plugin/proc_self_mountinfo.h
+++ b/collectors/proc.plugin/proc_self_mountinfo.h
@@ -38,6 +38,9 @@ struct mountinfo {
     char *mount_source;     // mount source: filesystem-specific information or "none".
     uint32_t mount_source_hash;
 
+    char *mount_source_name;
+    uint32_t mount_source_name_hash;
+
     char *super_options;    // super options: per-superblock options.
 
     uint32_t flags;
@@ -47,7 +50,7 @@ struct mountinfo {
     struct mountinfo *next;
 };
 
-extern struct mountinfo *mountinfo_find(struct mountinfo *root, unsigned long major, unsigned long minor);
+extern struct mountinfo *mountinfo_find(struct mountinfo *root, unsigned long major, unsigned long minor, char *device);
 extern struct mountinfo *mountinfo_find_by_filesystem_mount_source(struct mountinfo *root, const char *filesystem, const char *mount_source);
 extern struct mountinfo *mountinfo_find_by_filesystem_super_option(struct mountinfo *root, const char *filesystem, const char *super_options);
 


### PR DESCRIPTION
##### Summary
We are checking device names in addition to major/minor numbers to ensure we distinguish devices from each other. 

Fixes #10841

##### Component Name
diskstats module of proc plugin

##### Test Plan
Check if all diskstats charts are available for all disks in the system. Verify if the names of charts and families are correct.