### PR TITLE
Fix agent crash when executing data query with context and non-existing chart_label_key

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -511,8 +511,10 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         rrdhost_unlock(host);
         if (likely(context_param_list && context_param_list->rd))  // Just set the first one
             st = context_param_list->rd->rrdset;
-        else
-            sql_build_context_param_list(&context_param_list, host, context, NULL);
+        else {
+            if (!chart_label_key)
+                sql_build_context_param_list(&context_param_list, host, context, NULL);
+        }
     }
     else {
         st = rrdset_find(host, chart);


### PR DESCRIPTION
##### Summary
Fix an agent crash when executing a data query with a context and chart_label_key that does not exist.

The extended functionality of chart label key is not supported for archived queries for now. 

This PR will ignore non-matching chart labels keys that do not exist in active (in-memory charts) and do no
attempt to access the sqlite metadata

##### Component Name
database, web

##### Test Plan
- Compile agent from master and execute
  `http://localhost:19999/api/v1/data?context=system.cpu&options=jsonwrap&chart_label_key=this_breaks`
- Apply the PR and try again