### PR TITLE
Add timezone to payload for cloud to be able to deduce the local time for timestamps

### DIFF
--- a/health/health_json.c
+++ b/health/health_json.c
@@ -17,6 +17,7 @@ inline void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST 
     buffer_sprintf(wb,
             "\n\t{\n"
                     "\t\t\"hostname\": \"%s\",\n"
+                    "\t\t\"timezone\": \"%s\",\n"
                     "\t\t\"unique_id\": %u,\n"
                     "\t\t\"alarm_id\": %u,\n"
                     "\t\t\"alarm_event_id\": %u,\n"
@@ -49,6 +50,7 @@ inline void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST 
                     "\t\t\"last_repeat\": \"%lu\",\n"
                     "\t\t\"silenced\": \"%s\",\n"
                    , host->hostname
+                   , host->timezone
                    , ae->unique_id
                    , ae->alarm_id
                    , ae->alarm_event_id


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Include the `host->timezone` to the payload to the cloud. This way, the cloud can include a local time for the alerts email notifications based on timezone and timestamp.

##### Component Name

Health

##### Test Plan

Compile this PR, and check the payload to cloud for type `status-change` for `outbound/alarms`. It should include the timezone like this:

2021-03-23 18:41:40: netdata DEBUG : HEALTH : (0247@aclk/legac:aclk_queue_quer): Added query (outbound/alarms) ({	"type": "status-change",
	"msg-id": "c7234f91-2d32-4137-80a6-5e81d3e3ffdf",
	"timestamp": 1616517700,
	"timestamp-offset-usec": 65761,
	"connect": 1616517686,
	"connect-offset-usec": 72920,
	"version": 2,
	"payload": 
	{
		"hostname": "winterland",
		"timezone": "Europe/Athens",
		"unique_id": 1612383578,
		"alarm_id": 1615304162,
		"alarm_event_id": 595,
		"name": "exporting_metrics_sent",
		"chart": "netdata.exporting_my_graphite_instance_bytes",
		"family": "exporting_my_graphite_instance",
....

##### Additional Information

It would be better if the cloud stored a general field for the timezone, instead of sending on every message, so this is something it could be improved upon some time later perhaps.
