### PR TITLE
fix_repeat: Update repeat_every and avoid unecessary test

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -966,12 +966,14 @@ void *health_main(void *ptr) {
                         } else if(unlikely(rc->status == RRDCALC_STATUS_CLEAR)) {
                             if(!(rc->rrdcalc_flags & RRDCALC_FLAG_RUN_ONCE)) {
                                 if(rc->old_status == RRDCALC_STATUS_CRITICAL) {
-                                    repeat_every = rc->crit_repeat_every;
+                                    repeat_every = 1;
                                 } else if (rc->old_status == RRDCALC_STATUS_WARNING) {
-                                    repeat_every = rc->warn_repeat_every;
+                                    repeat_every = 1;
                                 }
                             }
                         }
+                    } else {
+                        continue;
                     }
 
                     if(unlikely(repeat_every > 0 && (rc->last_repeat + repeat_every) <= now)) {


### PR DESCRIPTION
##### Summary
Fixes #10332 

##### Component Name
Health
##### Test Plan

1 - Compile the PR
2 - Configure `/etc/netdata/python.d/example.conf`:

```conf
python_example:
  v: 1
```
3 - Add an alarm to `/etc/netdata/health.d`:

```conf
   alarm: my_example
      on: example_python_example.random
   units: boolean
  lookup: sum -3s foreach *
    warn: $this > 200
    crit: $this > 250
   every: 20s
  repeat: warning 15s critical 10s
  module: example
    info: Testing repeat
      to: sysadmin
```

4 - Confirm that you received an alarm before the expected repeat time:

```
2021-03-23 19:39:19: alarm-notify.sh: INFO: sent telegram notification for: hades example_python_example.random.my_example_random1 is WARNING to '-3'
2021-03-23 19:39:25: alarm-notify.sh: INFO: sent telegram notification for: hades example_python_example.random.my_example_random3 is WARNING to '-3'
2021-03-23 19:39:40: alarm-notify.sh: INFO: sent telegram notification for: hades example_python_example.random.my_example_random3 is WARNING to '-3'
**2021-03-23 19:39:57**: alarm-notify.sh: INFO: sent telegram notification for: hades example_python_example.random.my_example_random3 is WARNING to '-3'
**2021-03-23 19:40:05**: alarm-notify.sh: INFO: sent telegram notification for: hades example_python_example.random.my_example_random3 is CLEAR to '-3' 
```

##### Additional Information

I am also adding a `continue` to code to avoid a condition that will be always  false when `repeat` is not enabled.