### PR TITLE
Alerts template styling fixes

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2664,24 +2664,36 @@ if [ -n "$total_warn_alarms" ]; then
                   >
 
                     <table
-                      border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"vertical-align:top;\" width=\"100%\"
+                      border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" width=\"100%\"
                     >
                       <tbody>
-
                       <tr>
-                        <td
-                          align=\"center\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
-                        >
+                        <td  style=\"vertical-align:top;padding-top:13px;\">
 
-                          <div
-                            style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#555555;\"
-                          ><mj-raw style=\"background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 4px 12px;\">
-                            Warning for ${elapsed_txt}
-                          </mj-raw></div>
+                          <table
+                            border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"\" width=\"100%\"
+                          >
+                            <tbody>
+
+                            <tr>
+                              <td
+                                align=\"right\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
+                              >
+
+                                <div
+                                  style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"
+                                ><span style=\"background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px\">
+              Warning for ${elapsed_txt}
+           </span></div>
+
+                              </td>
+                            </tr>
+
+                            </tbody>
+                          </table>
 
                         </td>
                       </tr>
-
                       </tbody>
                     </table>
 
@@ -2771,24 +2783,36 @@ if [ -n "$total_crit_alarms" ]; then
                   >
 
                     <table
-                      border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"vertical-align:top;\" width=\"100%\"
+                      border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" width=\"100%\"
                     >
                       <tbody>
-
                       <tr>
-                        <td
-                          align=\"center\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
-                        >
+                        <td  style=\"vertical-align:top;padding-top:13px;\">
 
-                          <div
-                            style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#555555;\"
-                          ><mj-raw style=\"background-color:#FFEBEF; border: 1px solid #FF4136; border-radius:36px; padding: 4px 12px;\">
-                            Critical for ${elapsed_txt}
-                          </mj-raw></div>
+                          <table
+                            border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"\" width=\"100%\"
+                          >
+                            <tbody>
+
+                            <tr>
+                              <td
+                                align=\"right\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
+                              >
+
+                                <div
+                                  style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"
+                                ><span style=\"background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px\">
+              Critical for ${elapsed_txt}
+           </span></div>
+
+                              </td>
+                            </tr>
+
+                            </tbody>
+                          </table>
 
                         </td>
                       </tr>
-
                       </tbody>
                     </table>
 

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -3026,7 +3026,7 @@ Content-Transfer-Encoding: 8bit
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:418.6px;" ><![endif]-->
 
                   <div
-                    class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                    class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:70%;"
                   >
 
                     <table
@@ -3054,7 +3054,7 @@ Content-Transfer-Encoding: 8bit
                   <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:179.4px;" ><![endif]-->
 
                   <div
-                    class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+                    class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:30%;"
                   >
 
                     <table
@@ -3523,7 +3523,7 @@ Content-Transfer-Encoding: 8bit
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
 
           <div
-            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100px;"
           >
 
             <table
@@ -3575,7 +3575,7 @@ Content-Transfer-Encoding: 8bit
           <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
 
           <div
-            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:80%;"
           >
 
             <table
@@ -3637,7 +3637,7 @@ Content-Transfer-Encoding: 8bit
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
 
           <div
-            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100px;"
           >
 
             <table
@@ -3689,7 +3689,7 @@ Content-Transfer-Encoding: 8bit
           <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
 
           <div
-            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:80%;"
           >
 
             <table

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2639,7 +2639,7 @@ if [ -n "$total_warn_alarms" ]; then
                   <!--[if mso | IE]><table role=\"presentation\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\"><tr><td class=\"\" style=\"vertical-align:top;width:300px;\" ><![endif]-->
 
                   <div
-                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\"
+                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\"
                   >
 
                     <table
@@ -2653,7 +2653,7 @@ if [ -n "$total_warn_alarms" ]; then
                         >
 
                           <div
-                            style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;\"
+                            style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;\"
                           >${key}</div>
 
                         </td>
@@ -2665,7 +2665,7 @@ if [ -n "$total_warn_alarms" ]; then
                         >
 
                           <div
-                            style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;\"
+                            style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;\"
                           >${date}</div>
 
                         </td>
@@ -2679,7 +2679,7 @@ if [ -n "$total_warn_alarms" ]; then
                   <!--[if mso | IE]></td><td class=\"\" style=\"vertical-align:top;width:300px;\" ><![endif]-->
 
                   <div
-                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\"
+                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\"
                   >
 
                     <table
@@ -2700,7 +2700,7 @@ if [ -n "$total_warn_alarms" ]; then
                               >
 
                                 <div
-                                  style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"
+                                  style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"
                                 ><span style=\"background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px\">
               Warning for ${elapsed_txt}
            </span></div>
@@ -2758,7 +2758,7 @@ if [ -n "$total_crit_alarms" ]; then
                   <!--[if mso | IE]><table role=\"presentation\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\"><tr><td class=\"\" style=\"vertical-align:top;width:300px;\" ><![endif]-->
 
                   <div
-                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\"
+                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\"
                   >
 
                     <table
@@ -2772,7 +2772,7 @@ if [ -n "$total_crit_alarms" ]; then
                         >
 
                           <div
-                            style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;\"
+                            style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;\"
                           >${key}</div>
 
                         </td>
@@ -2784,7 +2784,7 @@ if [ -n "$total_crit_alarms" ]; then
                         >
 
                           <div
-                            style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;\"
+                            style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;\"
                           >${date}</div>
 
                         </td>
@@ -2798,7 +2798,7 @@ if [ -n "$total_crit_alarms" ]; then
                   <!--[if mso | IE]></td><td class=\"\" style=\"vertical-align:top;width:300px;\" ><![endif]-->
 
                   <div
-                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;\"
+                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\"
                   >
 
                     <table
@@ -2819,7 +2819,7 @@ if [ -n "$total_crit_alarms" ]; then
                               >
 
                                 <div
-                                  style=\"font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"
+                                  style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"
                                 ><span style=\"background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px\">
               Critical for ${elapsed_txt}
            </span></div>
@@ -2859,6 +2859,7 @@ Content-Disposition: inline
 Content-Transfer-Encoding: 8bit
 
 
+
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 <head>
@@ -2893,8 +2894,10 @@ Content-Transfer-Encoding: 8bit
 
   <!--[if !mso]><!-->
   <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" type="text/css">
   <style type="text/css">
       @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+      @import url(https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap);
   </style>
   <!--<![endif]-->
 
@@ -2905,9 +2908,9 @@ Content-Transfer-Encoding: 8bit
           .mj-column-per-100 { width:100% !important; max-width: 100%; }
           .mj-column-per-70 { width:70% !important; max-width: 70%; }
           .mj-column-per-30 { width:30% !important; max-width: 30%; }
+          .mj-column-per-50 { width:50% !important; max-width: 50%; }
           .mj-column-px-100 { width:100px !important; max-width: 100px; }
           .mj-column-per-80 { width:80% !important; max-width: 80%; }
-          .mj-column-per-50 { width:50% !important; max-width: 50%; }
       }
   </style>
 
@@ -2930,46 +2933,32 @@ Content-Transfer-Encoding: 8bit
 <body style="word-spacing:normal;">
 
 
-<div
-  style=""
->
+<div style>
 
 
   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div style="margin:0px auto;max-width:600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:50px;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:50px;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
-          <div
-            class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;">
 
-                  <table
-                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
-                  >
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                     <tbody>
                     <tr>
-                      <td  style="width:575px;">
+                      <td style="width:575px;">
 
                         <img
                           height="auto" src="https://app.netdata.cloud/static/email/img/header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="575"
@@ -3000,47 +2989,35 @@ Content-Transfer-Encoding: 8bit
   <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div style="margin:0px auto;max-width:600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="border:1px solid ${border_color};direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-        >
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <td style="border:1px solid ${border_color};direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:418.6px;" ><![endif]-->
 
                   <div
                     class="mj-column-per-70 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:70%;"
                   >
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;">
 
                           <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#555555;"
+                            style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#555555;"
                           >${name}</div>
 
                         </td>
@@ -3053,26 +3030,18 @@ Content-Transfer-Encoding: 8bit
 
                   <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:179.4px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:30%;"
-                  >
+                  <div class="mj-column-per-30 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:30%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <table
-                            border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
-                          >
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                             <tbody>
                             <tr>
-                              <td  style="width:100px;">
+                              <td style="width:100px;">
 
                                 <img
                                   height="auto" src="${alarm_badge}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100"
@@ -3100,37 +3069,27 @@ Content-Transfer-Encoding: 8bit
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                           <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
+                            style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
                           >on ${host}</div>
 
                         </td>
@@ -3150,37 +3109,27 @@ Content-Transfer-Encoding: 8bit
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;">
 
                           <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"
+                            style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"
                           >
               <span style="color: ${text_color}; font-size:26px; background: ${background_color}; padding:4px 24px; border-radius: 36px">${value_string}
               </span>
@@ -3203,37 +3152,27 @@ Content-Transfer-Encoding: 8bit
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                           <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
+                            style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
                           >${info}</div>
 
                         </td>
@@ -3253,46 +3192,34 @@ Content-Transfer-Encoding: 8bit
           </div>
 
 
-          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+          <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:598px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 598px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:0;padding-top:0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:598px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="center" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <table
-                            border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;"
-                          >
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
                             <tr>
                               <td
                                 align="center" bgcolor="${border_color}" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;background:${border_color};" valign="middle"
                               >
                                 <p
-                                  style="display:block;background:${border_color};color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:44px;margin:0;text-decoration:none;text-transform:none;mso-padding-alt:0px;border-radius:3px;"
+                                  style="display:block;background:${border_color};color:#ffffff;font-size:13px;font-weight:normal;line-height:44px;margin:0;text-decoration:none;text-transform:none;mso-padding-alt:0px;border-radius:3px;"
                                 >
-                                  <a href="${goto_url}" style="color: ${action_text_color}; text-decoration: none; width: 100%; display: inline-block">Go to Chart</a>
+                                  <a href="${goto_url}" style="color: ${action_text_color}; text-decoration: none; width: 100%; display: inline-block">GO TO CHART</a>
                                 </p>
                               </td>
                             </tr>
@@ -3327,55 +3254,41 @@ Content-Transfer-Encoding: 8bit
   <!--[if mso | IE]></td></tr></table><![endif]-->
 
 
-  <div
-    style="height:32px;line-height:32px;"
-  >&#8202;</div>
+  <div style="height:32px;line-height:32px;">&#8202;</div>
 
 
-  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="background:${background_color};background-color:${background_color};margin:0px auto;max-width:600px;">
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; background: ${background_color}; background-color: ${background_color}; margin: 0px auto; max-width: 600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:${background_color};background-color:${background_color};width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:${background_color};background-color:${background_color};width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
-          <div
-            class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
                   >Chart:
-                    <mj-raw style="font-weight:700">${chart}</mj-raw></div>
+                    <span style="font-weight:700">${chart}</span></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
                   >Family:
                     <mj-raw style="font-weight:700">${family}</mj-raw></div>
 
@@ -3383,25 +3296,19 @@ Content-Transfer-Encoding: 8bit
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
                   >${severity} ${raised_for}</div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <p
-                    style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;"
-                  >
+                  <p style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;">
                   </p>
 
                   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
@@ -3412,12 +3319,10 @@ Content-Transfer-Encoding: 8bit
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
                   >On
                     <mj-raw style="font-weight:500">${date}</mj-raw></div>
 
@@ -3425,12 +3330,10 @@ Content-Transfer-Encoding: 8bit
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
                   >By:
                     <mj-raw style="font-weight:500">${host}</mj-raw></div>
 
@@ -3438,12 +3341,10 @@ Content-Transfer-Encoding: 8bit
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
                   >Global time:
                     <mj-raw style="font-weight:500">${date_utc}</mj-raw></div>
 
@@ -3451,13 +3352,9 @@ Content-Transfer-Encoding: 8bit
               </tr>
 
               <tr>
-                <td
-                  align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <p
-                    style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;"
-                  >
+                  <p style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:100%;">
                   </p>
 
                   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px lightgrey;font-size:1px;margin:0px auto;width:550px;" role="presentation" width="550px" ><tr><td style="height:0;line-height:0;"> &nbsp;
@@ -3468,12 +3365,10 @@ Content-Transfer-Encoding: 8bit
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
                   >Classification:
                     <mj-raw style="font-weight:500">${classification}</mj-raw></div>
 
@@ -3481,12 +3376,10 @@ Content-Transfer-Encoding: 8bit
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
                   >Role:
                     <mj-raw style="font-weight:500">${roles}</mj-raw></div>
 
@@ -3507,31 +3400,25 @@ Content-Transfer-Encoding: 8bit
   </div>
 
 
-  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
 
           <div
             class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100px;"
           >
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
               <tbody>
               <tr>
-                <td  style="vertical-align:top;padding:0;">
+                <td style="vertical-align:top;padding:0;">
 
                   <table
                     border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%"
@@ -3539,16 +3426,12 @@ Content-Transfer-Encoding: 8bit
                     <tbody>
 
                     <tr>
-                      <td
-                        align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                      >
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                        <table
-                          border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
-                        >
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                           <tbody>
                           <tr>
-                            <td  style="width:50px;">
+                            <td style="width:50px;">
 
                               <img
                                 height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50"
@@ -3578,30 +3461,24 @@ Content-Transfer-Encoding: 8bit
             class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:80%;"
           >
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
                   >Want to know more about this alert?</div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
                   >Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></div>
 
                 </td>
@@ -3621,48 +3498,36 @@ Content-Transfer-Encoding: 8bit
   </div>
 
 
-  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
 
           <div
             class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100px;"
           >
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
               <tbody>
               <tr>
-                <td  style="vertical-align:top;padding:0;">
+                <td style="vertical-align:top;padding:0;">
 
-                  <table
-                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%"
-                  >
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
                     <tbody>
 
                     <tr>
-                      <td
-                        align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                      >
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                        <table
-                          border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
-                        >
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                           <tbody>
                           <tr>
-                            <td  style="width:50px;">
+                            <td style="width:50px;">
 
                               <img
                                 height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50"
@@ -3692,42 +3557,34 @@ Content-Transfer-Encoding: 8bit
             class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:80%;"
           >
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
                   >Need to configure this alert?</div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
                   ><mj-raw style="color: #00AB44">Edit</mj-raw> this alert's configuration file by logging into $host and running the following command:</div>
 
                 </td>
               </tr>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;"
                   >${edit_command} <br />
                     The alarm to edit is at line {${line}}</div>
 
@@ -3751,47 +3608,33 @@ Content-Transfer-Encoding: 8bit
   <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="history-wrapper-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  class="history-wrapper" style="background:#F7F8F8;background-color:#F7F8F8;margin:0px auto;max-width:600px;">
+  <div class="history-wrapper" style="background:#F7F8F8;background-color:#F7F8F8;margin:0px auto;max-width:600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F7F8F8;background-color:#F7F8F8;width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F7F8F8;background-color:#F7F8F8;width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:0;padding-bottom:24px;text-align:center;"
-        >
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+        <td style="direction:ltr;font-size:0px;padding:0;padding-bottom:24px;text-align:center;">
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="set-font-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-          <div  style="margin:0px auto;max-width:600px;">
+          <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
 
-            <table
-              align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-            >
+            <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
               <tbody>
               <tr>
-                <td
-                  style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-                >
+                <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
                   <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
-                  <div
-                    class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-                  >
+                  <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-                    <table
-                      border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-                    >
+                    <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                       <tbody>
 
                       <tr>
-                        <td
-                          align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                        >
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                           <div
-                            style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;"
+                            style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;"
                           >The node has
                             <mj-raw style="font-weight:600">${total_warnings} warning</mj-raw>
                             and
@@ -3827,37 +3670,27 @@ Content-Transfer-Encoding: 8bit
   </div>
 
 
-  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="margin:0px auto;max-width:600px;">
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
 
-    <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
-    >
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
       <tbody>
       <tr>
-        <td
-          style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
-        >
+        <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
-          <div
-            class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
-          >
+          <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
-            <table
-              border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
-            >
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
               <tbody>
 
               <tr>
-                <td
-                  align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
-                >
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
                   <div
-                    style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
+                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
                   >© Netdata 2021 - The real-time performance and health monitoring</div>
 
                 </td>

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -3165,10 +3165,10 @@ Content-Transfer-Encoding: 8bit
 
                           <div
                             style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"
-                          ><mr-raw>
-              <span style="color: #FF4136; font-size:26px; background: #FFEBEF; 100%; padding:4px 24px; border-radius: 36px">${value_string}
+                          >
+              <span style="color: ${text_color}; font-size:26px; background: ${background_color}; padding:4px 24px; border-radius: 36px">${value_string}
               </span>
-                          </mr-raw></div>
+                          </div>
 
                         </td>
                       </tr>
@@ -3271,12 +3271,12 @@ Content-Transfer-Encoding: 8bit
                           >
                             <tr>
                               <td
-                                align="center" bgcolor="#FF4136" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;mso-padding-alt:10px 25px;background:#FF4136;" valign="middle"
+                                align="center" bgcolor="${border_color}" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;background:${border_color};" valign="middle"
                               >
                                 <p
-                                  style="display:inline-block;background:#FF4136;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;"
+                                  style="display:block;background:${border_color};color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:44px;margin:0;text-decoration:none;text-transform:none;mso-padding-alt:0px;border-radius:3px;"
                                 >
-                                  <a href="${goto_url}" style="color: #FFFFFF; text-decoration: none;">Go to Chart</a>
+                                  <a href="${goto_url}" style="color: ${action_text_color}; text-decoration: none; width: 100%; display: inline-block">Go to Chart</a>
                                 </p>
                               </td>
                             </tr>

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2271,6 +2271,11 @@ CRITICAL)
   alarm_badge="${NETDATA_REGISTRY_CLOUD_BASE_URL}/static/email/img/label_critical.png"
   status_message="is critical"
   color="#ca414b"
+
+  background_color="#FFEBEF"
+  border_color="#FF4136"
+  text_color="#FF4136"
+  action_text_color="#FFFFFF"
   ;;
 
 WARNING)
@@ -2278,6 +2283,11 @@ WARNING)
   alarm_badge="${NETDATA_REGISTRY_CLOUD_BASE_URL}/static/email/img/label_warning.png"
   status_message="needs attention"
   color="#ffc107"
+
+  background_color="#FFF8E1"
+  border_color="#FFC300"
+  text_color="#536775"
+  action_text_color="#35414A"
   ;;
 
 CLEAR)
@@ -2285,6 +2295,12 @@ CLEAR)
   alarm_badge="${NETDATA_REGISTRY_CLOUD_BASE_URL}/static/email/img/label_recovered.png"
   status_message="recovered"
   color="#77ca6d"
+
+  background_color="#E5F5E8"
+  border_color="#68C47D"
+  text_color="#00AB44"
+  action_text_color="#FFFFFF"
+
   ;;
 esac
 
@@ -2992,7 +3008,7 @@ Content-Transfer-Encoding: 8bit
       <tbody>
       <tr>
         <td
-          style="border:1px solid #FF4136;direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+          style="border:1px solid ${border_color};direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
         >
           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:598px;" width="598" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
@@ -3319,10 +3335,10 @@ Content-Transfer-Encoding: 8bit
   <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div  style="background:#FFEBEF;background-color:#FFEBEF;margin:0px auto;max-width:600px;">
+  <div  style="background:${background_color};background-color:${background_color};margin:0px auto;max-width:600px;">
 
     <table
-      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFEBEF;background-color:#FFEBEF;width:100%;"
+      align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:${background_color};background-color:${background_color};width:100%;"
     >
       <tbody>
       <tr>

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2268,18 +2268,21 @@ image="${images_base_url}/images/banner-icon-144x144.png"
 case "${status}" in
 CRITICAL)
   image="${images_base_url}/images/alert-128-red.png"
+  alarm_badge="${NETDATA_REGISTRY_CLOUD_BASE_URL}/static/email/img/label_critical.png"
   status_message="is critical"
   color="#ca414b"
   ;;
 
 WARNING)
   image="${images_base_url}/images/alert-128-orange.png"
+  alarm_badge="${NETDATA_REGISTRY_CLOUD_BASE_URL}/static/email/img/label_warning.png"
   status_message="needs attention"
   color="#ffc107"
   ;;
 
 CLEAR)
   image="${images_base_url}/images/check-mark-2-128-green.png"
+  alarm_badge="${NETDATA_REGISTRY_CLOUD_BASE_URL}/static/email/img/label_recovered.png"
   status_message="recovered"
   color="#77ca6d"
   ;;
@@ -3056,7 +3059,7 @@ Content-Transfer-Encoding: 8bit
                               <td  style="width:100px;">
 
                                 <img
-                                  height="auto" src="https://app.netdata.cloud/static/email/img/label_critical.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100"
+                                  height="auto" src="${alarm_badge}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100"
                                 />
 
                               </td>

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2626,7 +2626,7 @@ if [ -n "$total_warn_alarms" ]; then
        elapsed_txt="${REPLY}"
 
        WARN_ALARMS+="
-       <div  style=\"background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;\">
+       <div class=\"set-font\" style=\"font-family: 'IBM Plex Sans', sans-serif; background: #FFFFFF; background-color: #FFFFFF; margin: 0px auto; max-width: 600px;\">
 
             <table
               align=\"center\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"background:#FFFFFF;background-color:#FFFFFF;width:100%;\"
@@ -2660,9 +2660,7 @@ if [ -n "$total_warn_alarms" ]; then
                       </tr>
 
                       <tr>
-                        <td
-                          align=\"left\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
-                        >
+                        <td align=\"left\" style=\"font-size:0px;padding:10px 25px;padding-top:2px;word-break:break-word;\">
 
                           <div
                             style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;\"
@@ -2689,9 +2687,7 @@ if [ -n "$total_warn_alarms" ]; then
                       <tr>
                         <td  style=\"vertical-align:top;padding-top:13px;\">
 
-                          <table
-                            border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"\" width=\"100%\"
-                          >
+                          <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style width=\"100%\">
                             <tbody>
 
                             <tr>
@@ -2745,7 +2741,7 @@ if [ -n "$total_crit_alarms" ]; then
        elapsed_txt="${REPLY}"
 
        CRIT_ALARMS+="
-       <div  style=\"background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;\">
+       <div class=\"set-font\" style=\"font-family: 'IBM Plex Sans', sans-serif; background: #FFFFFF; background-color: #FFFFFF; margin: 0px auto; max-width: 600px;\">
 
             <table
               align=\"center\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"background:#FFFFFF;background-color:#FFFFFF;width:100%;\"
@@ -2779,9 +2775,7 @@ if [ -n "$total_crit_alarms" ]; then
                       </tr>
 
                       <tr>
-                        <td
-                          align=\"left\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
-                        >
+                        <td align=\"left\" style=\"font-size:0px;padding:10px 25px;padding-top:2px;word-break:break-word;\">
 
                           <div
                             style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;\"
@@ -2808,9 +2802,7 @@ if [ -n "$total_crit_alarms" ]; then
                       <tr>
                         <td  style=\"vertical-align:top;padding-top:13px;\">
 
-                          <table
-                            border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"\" width=\"100%\"
-                          >
+                          <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style width=\"100%\">
                             <tbody>
 
                             <tr>

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2860,6 +2860,7 @@ Content-Transfer-Encoding: 8bit
 
 
 
+
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 <head>
@@ -2925,9 +2926,7 @@ Content-Transfer-Encoding: 8bit
       }
 
   </style>
-  <style type="text/css">.value { background-color: pink; display: inline }
-  .link { color: #00AB44; text-decoration: none;  }
-  .history-wrapper { max-width: 100% !important; }</style>
+
 
 </head>
 <body style="word-spacing:normal;">
@@ -2960,9 +2959,7 @@ Content-Transfer-Encoding: 8bit
                     <tr>
                       <td style="width:575px;">
 
-                        <img
-                          height="auto" src="https://app.netdata.cloud/static/email/img/header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="575"
-                        />
+                        <img height="auto" src="https://app.netdata.cloud/static/email/img/header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="575">
 
                       </td>
                     </tr>
@@ -3086,11 +3083,9 @@ Content-Transfer-Encoding: 8bit
                       <tbody>
 
                       <tr>
-                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div
-                            style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
-                          >on ${host}</div>
+                          <div style="font-family:IBM Plex Sans, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">on ${host}</div>
 
                         </td>
                       </tr>
@@ -3126,14 +3121,10 @@ Content-Transfer-Encoding: 8bit
                       <tbody>
 
                       <tr>
-                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;">
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div
-                            style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"
-                          >
-              <span style="color: ${text_color}; font-size:26px; background: ${background_color}; padding:4px 24px; border-radius: 36px">${value_string}
-              </span>
-                          </div>
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:26px;font-weight:700;line-height:1;text-align:left;color:#555555;"><span style="color: ${text_color}; font-size:26px; background: ${background_color}; padding:4px 24px; border-radius: 36px">${value_string}
+            </span></div>
 
                         </td>
                       </tr>
@@ -3169,11 +3160,9 @@ Content-Transfer-Encoding: 8bit
                       <tbody>
 
                       <tr>
-                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                          <div
-                            style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
-                          >${info}</div>
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:21px;text-align:left;color:#555555;">Details: the percentage of time the disk was busy, during the last 10 minutes</div>
 
                         </td>
                       </tr>
@@ -3217,7 +3206,7 @@ Content-Transfer-Encoding: 8bit
                                 align="center" bgcolor="${border_color}" role="presentation" style="border:none;border-radius:3px;cursor:auto;height:44px;background:${border_color};" valign="middle"
                               >
                                 <p
-                                  style="display:block;background:${border_color};color:#ffffff;font-size:13px;font-weight:normal;line-height:44px;margin:0;text-decoration:none;text-transform:none;mso-padding-alt:0px;border-radius:3px;"
+                                  style="display:block;background:${border_color};color:#ffffff;font-size:13px;font-weight:600;line-height:44px;margin:0;text-decoration:none;text-transform:none;mso-padding-alt:0px;border-radius:3px;"
                                 >
                                   <a href="${goto_url}" style="color: ${action_text_color}; text-decoration: none; width: 100%; display: inline-block">GO TO CHART</a>
                                 </p>
@@ -3274,11 +3263,9 @@ Content-Transfer-Encoding: 8bit
               <tbody>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >Chart:
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Chart:
                     <span style="font-weight:700">${chart}</span></div>
 
                 </td>
@@ -3287,16 +3274,14 @@ Content-Transfer-Encoding: 8bit
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >Family:
-                    <mj-raw style="font-weight:700">${family}</mj-raw></div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;">Family:
+                    <span style="font-weight:700">${family}</span></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;word-break:break-word;">
 
                   <div
                     style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
@@ -3319,12 +3304,10 @@ Content-Transfer-Encoding: 8bit
               </tr>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >On
-                    <mj-raw style="font-weight:500">${date}</mj-raw></div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">On
+                    <span style="font-weight:500">${date}</span></div>
 
                 </td>
               </tr>
@@ -3332,21 +3315,17 @@ Content-Transfer-Encoding: 8bit
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >By:
-                    <mj-raw style="font-weight:500">${host}</mj-raw></div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">By:
+                    <span style="font-weight:500">${host}</span></div>
 
                 </td>
               </tr>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-top:4px;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;"
-                  >Global time:
-                    <mj-raw style="font-weight:500">${date_utc}</mj-raw></div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:left;color:#555555;">Global time:
+                    <span style="font-weight:500">${date_utc}</span></div>
 
                 </td>
               </tr>
@@ -3365,12 +3344,10 @@ Content-Transfer-Encoding: 8bit
               </tr>
 
               <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >Classification:
-                    <mj-raw style="font-weight:500">${classification}</mj-raw></div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Classification:
+                    <span style="font-weight:500">${classification}</span></div>
 
                 </td>
               </tr>
@@ -3378,108 +3355,8 @@ Content-Transfer-Encoding: 8bit
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:left;color:#555555;"
-                  >Role:
-                    <mj-raw style="font-weight:500">${roles}</mj-raw></div>
-
-                </td>
-              </tr>
-
-              </tbody>
-            </table>
-
-          </div>
-
-          <!--[if mso | IE]></td></tr></table><![endif]-->
-        </td>
-      </tr>
-      </tbody>
-    </table>
-
-  </div>
-
-
-  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-
-
-  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
-
-    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-      <tbody>
-      <tr>
-        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;">
-          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
-
-          <div
-            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100px;"
-          >
-
-            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
-              <tbody>
-              <tr>
-                <td style="vertical-align:top;padding:0;">
-
-                  <table
-                    border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%"
-                  >
-                    <tbody>
-
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
-                          <tbody>
-                          <tr>
-                            <td style="width:50px;">
-
-                              <img
-                                height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50"
-                              />
-
-                            </td>
-                          </tr>
-                          </tbody>
-                        </table>
-
-                      </td>
-                    </tr>
-
-                    </tbody>
-                  </table>
-
-                </td>
-              </tr>
-              </tbody>
-            </table>
-
-          </div>
-
-          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
-
-          <div
-            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:80%;"
-          >
-
-            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-              <tbody>
-
-              <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
-                  >Want to know more about this alert?</div>
-
-                </td>
-              </tr>
-
-              <tr>
-                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
-                  >Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link">community forums</a></div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">Role:
+                    <span style="font-weight:500">${roles}</span></div>
 
                 </td>
               </tr>
@@ -3529,9 +3406,7 @@ Content-Transfer-Encoding: 8bit
                           <tr>
                             <td style="width:50px;">
 
-                              <img
-                                height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50"
-                              />
+                              <img height="auto" src="https://app.netdata.cloud/static/email/img/community_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50">
 
                             </td>
                           </tr>
@@ -3563,9 +3438,7 @@ Content-Transfer-Encoding: 8bit
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;"
-                  >Need to configure this alert?</div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Want to know more about this alert?</div>
 
                 </td>
               </tr>
@@ -3573,9 +3446,97 @@ Content-Transfer-Encoding: 8bit
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"
-                  ><mj-raw style="color: #00AB44">Edit</mj-raw> this alert's configuration file by logging into $host and running the following command:</div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;">Discuss and troubleshoot with others on the Netdata <a href="https://community.netdata.cloud/" class="link" style="color: #00AB44; text-decoration: none;">community forums</a></div>
+
+                </td>
+              </tr>
+
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
+
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+      <tbody>
+      <tr>
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:0;text-align:center;">
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:100px;" ><![endif]-->
+
+          <div
+            class="mj-column-px-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100px;"
+          >
+
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+              <tbody>
+              <tr>
+                <td style="vertical-align:top;padding:0;">
+
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                    <tbody>
+
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                          <tbody>
+                          <tr>
+                            <td style="width:50px;">
+
+                              <img height="auto" src="https://app.netdata.cloud/static/email/img/configure_icon.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="50">
+
+                            </td>
+                          </tr>
+                          </tbody>
+                        </table>
+
+                      </td>
+                    </tr>
+
+                    </tbody>
+                  </table>
+
+                </td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+
+          <!--[if mso | IE]></td><td align="left" class="" style="vertical-align:top;width:480px;" ><![endif]-->
+
+          <div
+            class="mj-column-per-80 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:80%;"
+          >
+
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+              <tbody>
+
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#555555;">Need to configure this alert?</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;line-height:1.3;text-align:left;color:#555555;"><span style="color: #00AB44">Edit</span> this alert's configuration file by logging into $host and running the following command:</div>
 
                 </td>
               </tr>
@@ -3583,9 +3544,7 @@ Content-Transfer-Encoding: 8bit
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;"
-                  >${edit_command} <br />
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#555555;">${edit_command} <br>
                     The alarm to edit is at line {${line}}</div>
 
                 </td>
@@ -3608,7 +3567,7 @@ Content-Transfer-Encoding: 8bit
   <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="history-wrapper-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
-  <div class="history-wrapper" style="background:#F7F8F8;background-color:#F7F8F8;margin:0px auto;max-width:600px;">
+  <div class="history-wrapper" style="background: #F7F8F8; background-color: #F7F8F8; margin: 0px auto; max-width: 100%;">
 
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F7F8F8;background-color:#F7F8F8;width:100%;">
       <tbody>
@@ -3633,12 +3592,10 @@ Content-Transfer-Encoding: 8bit
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                          <div
-                            style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;"
-                          >The node has
-                            <mj-raw style="font-weight:600">${total_warnings} warning</mj-raw>
+                          <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#555555;">The node has
+                            <span style="font-weight:600">${total_warnings} warning</span>
                             and
-                            <mj-raw style="font-weight:600">${total_critical} critical</mj-raw>
+                            <span style="font-weight:600">${total_critical} critical</span>
                             alert(s)</div>
 
                         </td>
@@ -3689,9 +3646,7 @@ Content-Transfer-Encoding: 8bit
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
 
-                  <div
-                    style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;"
-                  >© Netdata 2021 - The real-time performance and health monitoring</div>
+                  <div style="font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#555555;">© Netdata 2021 - The real-time performance and health monitoring</div>
 
                 </td>
               </tr>

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2628,33 +2628,21 @@ if [ -n "$total_warn_alarms" ]; then
        WARN_ALARMS+="
        <div class=\"set-font\" style=\"font-family: 'IBM Plex Sans', sans-serif; background: #FFFFFF; background-color: #FFFFFF; margin: 0px auto; max-width: 600px;\">
 
-            <table
-              align=\"center\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"background:#FFFFFF;background-color:#FFFFFF;width:100%;\"
-            >
+            <table align=\"center\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"background:#FFFFFF;background-color:#FFFFFF;width:100%;\">
               <tbody>
               <tr>
-                <td
-                  style=\"border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;\"
-                >
+                <td style=\"border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;\">
                   <!--[if mso | IE]><table role=\"presentation\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\"><tr><td class=\"\" style=\"vertical-align:top;width:300px;\" ><![endif]-->
 
-                  <div
-                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\"
-                  >
+                  <div class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\">
 
-                    <table
-                      border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"vertical-align:top;\" width=\"100%\"
-                    >
+                    <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"vertical-align:top;\" width=\"100%\">
                       <tbody>
 
                       <tr>
-                        <td
-                          align=\"left\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
-                        >
+                        <td align=\"left\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\">
 
-                          <div
-                            style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;\"
-                          >${key}</div>
+                          <div style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;\">${key}</div>
 
                         </td>
                       </tr>
@@ -2662,9 +2650,7 @@ if [ -n "$total_warn_alarms" ]; then
                       <tr>
                         <td align=\"left\" style=\"font-size:0px;padding:10px 25px;padding-top:2px;word-break:break-word;\">
 
-                          <div
-                            style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;\"
-                          >${date}</div>
+                          <div style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:12px;line-height:1;text-align:left;color:#555555;\">${date}</div>
 
                         </td>
                       </tr>
@@ -2676,28 +2662,20 @@ if [ -n "$total_warn_alarms" ]; then
 
                   <!--[if mso | IE]></td><td class=\"\" style=\"vertical-align:top;width:300px;\" ><![endif]-->
 
-                  <div
-                    class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\"
-                  >
+                  <div class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\">
 
-                    <table
-                      border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" width=\"100%\"
-                    >
+                    <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" width=\"100%\">
                       <tbody>
                       <tr>
-                        <td  style=\"vertical-align:top;padding-top:13px;\">
+                        <td style=\"vertical-align:top;padding-top:13px;\">
 
                           <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style width=\"100%\">
                             <tbody>
 
                             <tr>
-                              <td
-                                align=\"right\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
-                              >
+                              <td align=\"right\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\">
 
-                                <div
-                                  style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"
-                                ><span style=\"background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px\">
+                                <div style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"><span style=\"background-color:#FFF8E1; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px\">
               Warning for ${elapsed_txt}
            </span></div>
 
@@ -2719,6 +2697,7 @@ if [ -n "$total_warn_alarms" ]; then
               </tr>
               </tbody>
             </table>
+
           </div>
        "
 
@@ -2743,29 +2722,21 @@ if [ -n "$total_crit_alarms" ]; then
        CRIT_ALARMS+="
        <div class=\"set-font\" style=\"font-family: 'IBM Plex Sans', sans-serif; background: #FFFFFF; background-color: #FFFFFF; margin: 0px auto; max-width: 600px;\">
 
-            <table
-              align=\"center\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"background:#FFFFFF;background-color:#FFFFFF;width:100%;\"
-            >
+            <table align=\"center\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"background:#FFFFFF;background-color:#FFFFFF;width:100%;\">
               <tbody>
               <tr>
-                <td
-                  style=\"border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;\"
-                >
+                <td style=\"border-top:8px solid #F7F8F8;direction:ltr;font-size:0px;padding:20px 0;text-align:center;\">
                   <!--[if mso | IE]><table role=\"presentation\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\"><tr><td class=\"\" style=\"vertical-align:top;width:300px;\" ><![endif]-->
 
                   <div
                     class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\"
                   >
 
-                    <table
-                      border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"vertical-align:top;\" width=\"100%\"
-                    >
+                    <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style=\"vertical-align:top;\" width=\"100%\">
                       <tbody>
 
                       <tr>
-                        <td
-                          align=\"left\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
-                        >
+                        <td align=\"left\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\">
 
                           <div
                             style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:14px;font-weight:600;line-height:1;text-align:left;color:#555555;\"
@@ -2795,24 +2766,18 @@ if [ -n "$total_crit_alarms" ]; then
                     class=\"mj-column-per-50 mj-outlook-group-fix\" style=\"font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;\"
                   >
 
-                    <table
-                      border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" width=\"100%\"
-                    >
+                    <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" width=\"100%\">
                       <tbody>
                       <tr>
-                        <td  style=\"vertical-align:top;padding-top:13px;\">
+                        <td style=\"vertical-align:top;padding-top:13px;\">
 
                           <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" role=\"presentation\" style width=\"100%\">
                             <tbody>
 
                             <tr>
-                              <td
-                                align=\"right\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\"
-                              >
+                              <td align=\"right\" style=\"font-size:0px;padding:10px 25px;word-break:break-word;\">
 
-                                <div
-                                  style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"
-                                ><span style=\"background-color:#FFEDB3; border: 1px solid #FFC300; border-radius:36px; padding: 2px 12px; margin-top: 20px\">
+                                <div style=\"font-family:'IBM Plex Sans', Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:right;color:#555555;\"><span style=\"background-color:#FFEBEF; border: 1px solid #FF4136; border-radius:36px; padding: 2px 12px; margin-top: 20px\">
               Critical for ${elapsed_txt}
            </span></div>
 


### PR DESCRIPTION
##### Summary
- fixed most of the styling problems, especially for outlook (online) and thunderbird
- updated colors based on status (both for active alarms list and the main part of template)

Most of the differences between email and the design is caused by the fact, that it's hard to make sure the proper font is loaded. Most of the time the needed one (IBM Plex Sans) is not loaded, and Helvetica is used instead. Sometimes it results in *bold* fonts (font-weight: 500) to look differently than in design.

![obraz](https://user-images.githubusercontent.com/5786722/112473643-e605f080-8d6e-11eb-90c9-7bb09a70b19a.png)

second part:

![obraz](https://user-images.githubusercontent.com/5786722/112473670-edc59500-8d6e-11eb-9c14-901c211ff15b.png)



##### Component Name
Health / alarm template
