### PR TITLE
python.d(smartd_log): collect attribute 249 -- NAND Writes 1GiB

### DIFF
--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -333,7 +333,7 @@ CHARTS = {
         'algo': ABSOLUTE,
     },
     'nand_writes_1gib': {
-        'options': [None, 'NAND Writes 1GiB', 'blocks', 'wear', 'smartd_log.nand_writes_1gib', 'line'],
+        'options': [None, 'NAND Writes', 'GiB', 'wear', 'smartd_log.nand_writes_1gib', 'line'],
         'lines': [],
         'attrs': [ATTR249],
         'algo': ABSOLUTE,

--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -50,6 +50,7 @@ ATTR199 = '199'
 ATTR202 = '202'
 ATTR206 = '206'
 ATTR233 = '233'
+ATTR249 = '249'
 ATTR_READ_ERR_COR = 'read-total-err-corrected'
 ATTR_READ_ERR_UNC = 'read-total-unc-errors'
 ATTR_WRITE_ERR_COR = 'write-total-err-corrected'
@@ -330,7 +331,13 @@ CHARTS = {
         'lines': [],
         'attrs': [ATTR233],
         'algo': ABSOLUTE,
-    }
+    },
+    'nand_writes_1gib': {
+        'options': [None, 'NAND Writes 1GiB', 'blocks', 'wear', 'smartd_log.nand_writes_1gib', 'line'],
+        'lines': [],
+        'attrs': [ATTR249],
+        'algo': ABSOLUTE,
+    },
 }
 
 # NOTE: 'parse_temp' decodes ATA 194 raw value. Not heavily tested. Written by @Ferroin


### PR DESCRIPTION
##### Summary

This enables the collection of NAND Writes 1GiB attribute, this enable measurement of write amplification phenomenon: https://en.wikipedia.org/wiki/Write_amplification

##### Component Name

python.d/smartd_log collector

##### Test Plan

Tested on a `SAMSUNG MZ7LN256HMJP-00000`, I suppose that consumer grade SATA SSD might expose a similar attribute compared to a real host writes metric. Knowing the WA, it's possible to guess the host writes metric, which is an important metric knowing the endurance of disks.

---

On another note, I would like to add Total LBAs written/read, would that be a good idea? (see https://www.thomas-krenn.com/en/wiki/SMART_attributes_of_Intel_SSDs)