### PR TITLE
Properly handle binary package reuploads.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -121,6 +121,7 @@ jobs:
         run: |
           echo "Packages to upload:\n$(ls artifacts/*.${{ matrix.format }})"
           for pkgfile in artifacts/*.${{ matrix.format }} ; do
+            .github/scripts/package_cloud_wrapper.sh yank ${{ env.repo }}/${{ matrix.pkgclouddistro }} ${pkgfile} || true
             .github/scripts/package_cloud_wrapper.sh push ${{ env.repo }}/${{ matrix.pkgclouddistro }} ${pkgfile}
           done
       - name: Clean


### PR DESCRIPTION
##### Summary

PackageCloud does not allow duplicate uploads, and we currently have no good way to avoid duplicate nightly builds, so we need to remove any existing packages with the same name before we upload newly built packages.

##### Component Name

area/ci

##### Test Plan

n/a

##### Additional Information

The original plan was to update the CI to not run nightly builds if we haven’t seen any changes to `master` since the last nightly build. However, there’s not really any practical way to do that with Travis CI, so while it is still planned, it’s dependent on eventually getting everything moved to GitHub Actions (where it is _very_ easy to do). As a result, we’re just going with this stopgap until such time as we can do it properly (probably some time late Q2 or early Q3 2021).