### PR TITLE
Bumped version of OpenSSL bundled in static builds to 1.1.1k.

### DIFF
--- a/packaging/makeself/openssl.version
+++ b/packaging/makeself/openssl.version
@@ -1,1 +1,1 @@
-OpenSSL_1_1_1h
+OpenSSL_1_1_1k


### PR DESCRIPTION
##### Summary

This includes a number of security fixes relative to the version we are currently bundling.

##### Component Name

area/packaging

##### Test Plan

Manually build the version from the PR (run `packaging/makeself/build-x86_64-static.sh` from the root of the repository) and verify the resultant static build.