### PR TITLE
Find and replace $family variable in health info strings.

### DIFF
--- a/health/health_json.c
+++ b/health/health_json.c
@@ -87,6 +87,17 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
                    , (ae->flags & HEALTH_ENTRY_FLAG_SILENCED)?"true":"false"
     );
 
+    if (likely(ae->info)) {
+        char *m;
+
+        while ( m = strstr (ae->info, "$family") ) {
+            char *buf=NULL;
+            buf = find_and_replace(ae->info, "$family", ae->family, m);
+            freez(ae->info); ae->info = strdupz(buf);
+            freez(buf);
+        }
+    }
+
     health_string2json(wb, "\t\t", "info", ae->info?ae->info:"", ",\n");
 
     if(unlikely(ae->flags & HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION)) {
@@ -150,6 +161,20 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
     char value_string[100 + 1];
     format_value_and_unit(value_string, 100, rc->value, rc->units, -1);
 
+    char *replaced_info = NULL;
+
+    if (likely(rc->info)) {
+        char *m;
+        replaced_info = strdupz(rc->info);
+
+        while ( m = strstr (replaced_info, "$family") ) {
+            char *buf=NULL;
+            buf = find_and_replace(replaced_info, "$family", (rc->rrdset && rc->rrdset->family)?rc->rrdset->family:"", m);
+            freez(replaced_info); replaced_info = strdupz(buf);
+            freez(buf);
+        }
+    }
+
     buffer_sprintf(wb,
             "\t\t\"%s.%s\": {\n"
                     "\t\t\t\"id\": %lu,\n"
@@ -197,7 +222,7 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                    , rc->recipient?rc->recipient:host->health_default_recipient
                    , rc->source
                    , rc->units?rc->units:""
-                   , rc->info?rc->info:""
+                   , replaced_info?replaced_info:""
                    , rrdcalc_status2string(rc->status)
                    , (unsigned long)rc->last_status_change
                    , (unsigned long)rc->last_updated
@@ -268,6 +293,8 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
     buffer_strcat(wb, "\n");
 
     buffer_strcat(wb, "\t\t}");
+
+    freez(replaced_info);
 }
 
 //void health_rrdcalctemplate2json_nolock(BUFFER *wb, RRDCALCTEMPLATE *rt) {

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -96,6 +96,13 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
             freez(ae->info); ae->info = strdupz(buf);
             freez(buf);
         }
+
+        while ( m = strstr (ae->info, "${family}") ) {
+            char *buf=NULL;
+            buf = find_and_replace(ae->info, "${family}", ae->family, m);
+            freez(ae->info); ae->info = strdupz(buf);
+            freez(buf);
+        }
     }
 
     health_string2json(wb, "\t\t", "info", ae->info?ae->info:"", ",\n");
@@ -170,6 +177,13 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
         while ( m = strstr (replaced_info, "$family") ) {
             char *buf=NULL;
             buf = find_and_replace(replaced_info, "$family", (rc->rrdset && rc->rrdset->family)?rc->rrdset->family:"", m);
+            freez(replaced_info); replaced_info = strdupz(buf);
+            freez(buf);
+        }
+
+        while ( m = strstr (replaced_info, "${family}") ) {
+            char *buf=NULL;
+            buf = find_and_replace(replaced_info, "${family}", (rc->rrdset && rc->rrdset->family)?rc->rrdset->family:"", m);
             freez(replaced_info); replaced_info = strdupz(buf);
             freez(buf);
         }

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -486,7 +486,6 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     if(source) ae->source = strdupz(source);
 
     if(units) ae->units = strdupz(units);
-    if(info) ae->info = strdupz(info);
 
     ae->unique_id = host->health_log.next_log_id++;
     ae->alarm_id = alarm_id;
@@ -498,6 +497,18 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     char value_string[100 + 1];
     ae->old_value_string = strdupz(format_value_and_unit(value_string, 100, ae->old_value, ae->units, -1));
     ae->new_value_string = strdupz(format_value_and_unit(value_string, 100, ae->new_value, ae->units, -1));
+
+    if (likely(info)) {
+        char *m;
+        ae->info = strdupz(info);
+
+        while ( m = strstr (ae->info, "$family") ) {
+            char *buf=NULL;
+            buf = find_and_replace(ae->info, "$family", (ae->family)?ae->family:"Unknown", m);
+            freez(ae->info); ae->info = strdupz(buf);
+            freez(buf);
+        }
+    }
 
     ae->old_status = old_status;
     ae->new_status = new_status;

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -508,6 +508,13 @@ inline ALARM_ENTRY* health_create_alarm_entry(
             freez(ae->info); ae->info = strdupz(buf);
             freez(buf);
         }
+
+        while ( m = strstr (ae->info, "${family}") ) {
+            char *buf=NULL;
+            buf = find_and_replace(ae->info, "${family}", (ae->family)?ae->family:"Unknown", m);
+            freez(ae->info); ae->info = strdupz(buf);
+            freez(buf);
+        }
     }
 
     ae->old_status = old_status;

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1492,3 +1492,37 @@ char *read_by_filename(char *filename, long *file_size)
         *file_size = size;
     return contents;
 }
+
+char *find_and_replace(const char *src, const char *find, const char *replace, const char *where)
+{
+   size_t size        = strlen(src) + 1;
+   size_t find_len    = strlen(find);
+   size_t repl_len    = strlen(replace);
+   char *value, *dst, *temp;
+
+   value = mallocz(size);
+   dst = value;
+   if ( likely(where) ) {
+
+       size_t count = where - src;
+
+       size += repl_len - find_len;
+
+       temp = reallocz(value, size);
+
+       dst = temp + (dst - value);
+       value = temp;
+
+       memmove(dst, src, count);
+       src += count;
+       dst += count;
+
+       memmove(dst, replace, repl_len);
+       src += find_len;
+       dst += repl_len;
+   }
+
+   strcpy(dst, src);
+
+   return value;
+}

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -279,6 +279,7 @@ extern void recursive_config_double_dir_load(
         , size_t depth
 );
 extern char *read_by_filename(char *filename, long *file_size);
+extern char *find_and_replace(const char *src, const char *find, const char *replace, const char *where);
 
 /* fix for alpine linux */
 #ifndef RUSAGE_THREAD


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Finds and replaces `$family` and `${family}` in health info strings. Continues from https://github.com/netdata/netdata/pull/10801. 

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Insert a `$family` or `${family}` variable in an alarm's configuration info string. Observe it to be replaced with the family value in dashboard, aclk, v1/api and notification emails.

##### Additional Information

We should merge this in the feature branch so it can be tested generally. When it goes into master we should have decided if we're going to support both variable formats, or just one of them, and whether we need more (i.e. `$this`, `$units`, etc).