### PR TITLE
Fixed bundling of ACLK-NG components in dist tarballs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   # These are release-related artifacts and have to be evaluated before we start doing conditional checks inside stages
   - source ".travis/tagger.sh"
   - export GIT_TAG="$(git tag --points-at)"
+  - git submodule update --init --recursive
 
 
 # Setup notification system

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,37 +55,38 @@ dist_noinst_DATA = \
     cppcheck.sh \
     configs.signatures \
     contrib \
+    docs \
+    mqtt_websockets \
     netdata.cppcheck \
     netdata.spec \
     package.json \
-    docs \
-    packaging/version \
-    packaging/dashboard.version \
-    packaging/dashboard.checksums \
-    packaging/go.d.version \
-    packaging/go.d.checksums \
-    packaging/jsonc.version \
-    packaging/jsonc.checksums \
-    packaging/judy.version \
-    packaging/judy.checksums \
-    packaging/libwebsockets.version \
-    packaging/libwebsockets.checksums \
-    packaging/mosquitto.version \
-    packaging/mosquitto.checksums \
     packaging/bundle-dashboard.sh \
     packaging/bundle-ebpf.sh \
     packaging/bundle-judy.sh \
     packaging/bundle-libbpf.sh \
+    packaging/bundle-lws.sh \
     packaging/bundle-mosquitto.sh \
     packaging/check-kernel-config.sh \
-    packaging/libbpf.checksums \
-    packaging/libbpf.version \
+    packaging/dashboard.checksums \
+    packaging/dashboard.version \
     packaging/ebpf.checksums \
     packaging/ebpf.version \
-    packaging/bundle-lws.sh \
+    packaging/go.d.checksums \
+    packaging/go.d.version \
     packaging/installer/README.md \
     packaging/installer/UNINSTALL.md \
     packaging/installer/UPDATE.md \
+    packaging/jsonc.checksums \
+    packaging/jsonc.version \
+    packaging/judy.checksums \
+    packaging/judy.version \
+    packaging/libbpf.checksums \
+    packaging/libbpf.version \
+    packaging/libwebsockets.checksums \
+    packaging/libwebsockets.version \
+    packaging/mosquitto.checksums \
+    packaging/mosquitto.version \
+    packaging/version \
     $(NULL)
 
 # until integrated within build


### PR DESCRIPTION
##### Summary

This ensures we actually bundle the `mqtt_websockets` code into our nightly and release tarballs so that people can properly build it without needing to build from a git clone of the repo.

##### Component Name

area/packaging

##### Test Plan

Locally verified that the tarball produced by `autoreconf -ivf && ./configure && make dist` can be used to successfully build the agent with the new ACLK code.

The Tavis CI change can be verified by looking at the build logs for this PR.

##### Additional Information

This also sorts the `dist_noinst_DATA` list in the top level Makefile so that future changes are cleaner.

Fixes: #10891 