### PR TITLE
Get the local utc offset, and pass it to alarms

### DIFF
--- a/daemon/common.c
+++ b/daemon/common.c
@@ -14,6 +14,7 @@ char *netdata_configured_lock_dir            = NULL;
 char *netdata_configured_home_dir            = VARLIB_DIR;
 char *netdata_configured_host_prefix         = NULL;
 char *netdata_configured_timezone            = NULL;
+char *netdata_utc_offset                     = NULL;
 int netdata_ready;
 int netdata_cloud_setting;
 

--- a/daemon/common.c
+++ b/daemon/common.c
@@ -14,7 +14,8 @@ char *netdata_configured_lock_dir            = NULL;
 char *netdata_configured_home_dir            = VARLIB_DIR;
 char *netdata_configured_host_prefix         = NULL;
 char *netdata_configured_timezone            = NULL;
-char *netdata_utc_offset                     = NULL;
+char *netdata_tz                             = NULL;
+int32_t netdata_utc_offset                   = 0;
 int netdata_ready;
 int netdata_cloud_setting;
 

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -96,6 +96,7 @@ extern char *netdata_configured_lock_dir;
 extern char *netdata_configured_home_dir;
 extern char *netdata_configured_host_prefix;
 extern char *netdata_configured_timezone;
+extern char *netdata_utc_offset;
 extern int netdata_zero_metrics_enabled;
 extern int netdata_anonymous_statistics_enabled;
 

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -96,7 +96,8 @@ extern char *netdata_configured_lock_dir;
 extern char *netdata_configured_home_dir;
 extern char *netdata_configured_host_prefix;
 extern char *netdata_configured_timezone;
-extern char *netdata_utc_offset;
+extern char *netdata_tz;
+extern int32_t netdata_utc_offset;
 extern int netdata_zero_metrics_enabled;
 extern int netdata_anonymous_statistics_enabled;
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -696,7 +696,7 @@ static void get_system_timezone(void) {
 
     //get the utc offset
     //could be merged with the above strftime call
-    //Stelios note: This will need an agent restart to get new offset on time change (dst, etc).
+    //Note: This will need an agent restart to get new offset on time change (dst, etc).
     {
         time_t t;
         struct tm *tmp, tmbuf;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -700,20 +700,25 @@ static void get_system_timezone(void) {
     {
         time_t t;
         struct tm *tmp, tmbuf;
-        char helper[6];
+        char zone[FILENAME_MAX + 1]; //can be really less...
+        char utc_off[10]; //enough for 24 * 60 * 60 plus a sign
 
         t = now_realtime_sec();
         tmp = localtime_r(&t, &tmbuf);
 
         if (tmp != NULL) {
-            if(strftime(helper, 6, "%z", tmp) == 0)
-                netdata_utc_offset = strdupz("+0000");
-            else
-                netdata_utc_offset = strdupz(helper);
+            if(strftime(zone, FILENAME_MAX, "%Z", tmp) == 0) {
+                sprintf(zone, "UTC");
+                int str_len = strlen(zone) + strlen(utc_off) + 3;
+                netdata_utc_offset = mallocz(sizeof(char) * str_len);
+                snprintfz(netdata_utc_offset, str_len, "%s=0", zone );
+            }
+            else {
+                int str_len = strlen(zone) + strlen(utc_off) + 3;
+                netdata_utc_offset = mallocz(sizeof(char) * str_len);
+                snprintfz(netdata_utc_offset, str_len, "%s=%ld", zone, tmbuf.tm_gmtoff);
+            }
         }
-
-        info ("[%ld]", tmbuf.tm_gmtoff);
-
     }
 }
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -707,9 +707,9 @@ static void get_system_timezone(void) {
 
         if (tmp != NULL) {
             if(strftime(helper, 6, "%z", tmp) == 0)
-                buffer[0] = '\0';
-
-            netdata_utc_offset = strdupz(helper);
+                netdata_utc_offset = strdupz("+0000");
+            else
+                netdata_utc_offset = strdupz(helper);
         }
     }
 }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -693,6 +693,25 @@ static void get_system_timezone(void) {
         timezone = "unknown";
 
     netdata_configured_timezone = config_get(CONFIG_SECTION_GLOBAL, "timezone", timezone);
+
+    //get the utc offset
+    //could be merged with the above strftime call
+    //Stelios note: This will need an agent restart to get new offset on time change (dst, etc).
+    {
+        time_t t;
+        struct tm *tmp, tmbuf;
+        char helper[6];
+
+        t = now_realtime_sec();
+        tmp = localtime_r(&t, &tmbuf);
+
+        if (tmp != NULL) {
+            if(strftime(helper, 6, "%z", tmp) == 0)
+                buffer[0] = '\0';
+
+            netdata_utc_offset = strdupz(helper);
+        }
+    }
 }
 
 void set_global_environment() {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -711,6 +711,9 @@ static void get_system_timezone(void) {
             else
                 netdata_utc_offset = strdupz(helper);
         }
+
+        info ("[%ld]", tmbuf.tm_gmtoff);
+
     }
 }
 

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -18,7 +18,7 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
     buffer_sprintf(wb,
             "\n\t{\n"
                     "\t\t\"hostname\": \"%s\",\n"
-                    "\t\t\"timezone\": \"%s\",\n"
+                    "\t\t\"utc_offset\": \"%s\",\n"
                     "\t\t\"unique_id\": %u,\n"
                     "\t\t\"alarm_id\": %u,\n"
                     "\t\t\"alarm_event_id\": %u,\n"
@@ -52,7 +52,7 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
                     "\t\t\"last_repeat\": \"%lu\",\n"
                     "\t\t\"silenced\": \"%s\",\n"
                    , host->hostname
-                   , host->timezone
+                   , netdata_utc_offset
                    , ae->unique_id
                    , ae->alarm_id
                    , ae->alarm_event_id

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -18,7 +18,8 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
     buffer_sprintf(wb,
             "\n\t{\n"
                     "\t\t\"hostname\": \"%s\",\n"
-                    "\t\t\"utc_offset\": \"%s\",\n"
+                    "\t\t\"utc_offset\": %d,\n"
+                    "\t\t\"timezone\": \"%s\",\n"
                     "\t\t\"unique_id\": %u,\n"
                     "\t\t\"alarm_id\": %u,\n"
                     "\t\t\"alarm_event_id\": %u,\n"
@@ -53,6 +54,7 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
                     "\t\t\"silenced\": \"%s\",\n"
                    , host->hostname
                    , netdata_utc_offset
+                   , netdata_tz
                    , ae->unique_id
                    , ae->alarm_id
                    , ae->alarm_event_id


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Get the local utc offset from strftime, and pass it to alarms. This is for the cloud to produce a local time for the email notification from utc time.

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
