### PR TITLE
Don't write updater log under root

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -393,7 +393,7 @@ if [ -t 2 ]; then
 else
   # we are headless
   # create a temporary file for the log
-  logfile="$(mktemp "${logfile}"/netdata-updater.log.XXXXXX)"
+  logfile="$(mktemp -t netdata-updater.log.XXXXXX)"
   # open fd 3 and send it to logfile
   exec 3> "${logfile}"
 fi


### PR DESCRIPTION
##### Summary
fixes 3b41c79afdd7d5b2d6f2ed0225a51b0df7e63158

Fixes #10472

##### Component Name
who knows

##### Test Plan
run the updater and don't get `/netdata-updater.log.asjkf` files hopefully

##### Additional Information
fifty years of UNIX! how did this pass review