### PR TITLE
health: add systemdunits alarms

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -89,6 +89,7 @@ dist_healthconfig_DATA = \
     health.d/squid.conf \
     health.d/stiebeleltron.conf \
     health.d/swap.conf \
+    health.d/systemdunits.conf \
     health.d/tcp_conn.conf \
     health.d/tcp_listen.conf \
     health.d/tcp_mem.conf \

--- a/health/health.d/systemdunits.conf
+++ b/health/health.d/systemdunits.conf
@@ -9,7 +9,7 @@ template: systemd_service_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several systemd service units are in the failed state
+    info: one or more systemd service units are in the failed state
       to: sysadmin
 
 ## Socket units
@@ -20,7 +20,7 @@ template: systemd_socket_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several systemd socket units are in the failed state
+    info: one or more systemd socket units are in the failed state
       to: sysadmin
 
 ## Target units
@@ -31,7 +31,7 @@ template: systemd_target_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several systemd target units are in the failed state
+    info: one or more systemd target units are in the failed state
       to: sysadmin
 
 ## Path units
@@ -42,7 +42,7 @@ template: systemd_path_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several systemd path units are in the failed state
+    info: one or more systemd path units are in the failed state
       to: sysadmin
 
 ## Device units
@@ -53,7 +53,7 @@ template: systemd_device_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several the systemd device units are in the failed state
+    info: one or more the systemd device units are in the failed state
       to: sysadmin
 
 ## Mount units
@@ -64,7 +64,7 @@ template: systemd_mount_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several the systemd mount units are in the failed state
+    info: one or more the systemd mount units are in the failed state
       to: sysadmin
 
 ## Automount units
@@ -75,7 +75,7 @@ template: systemd_automount_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several systemd automount units are in the failed state
+    info: one or more systemd automount units are in the failed state
       to: sysadmin
 
 ## Swap units
@@ -86,7 +86,7 @@ template: systemd_swap_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several systemd swap units are in the failed state
+    info: one or more systemd swap units are in the failed state
       to: sysadmin
 
 ## Scope units
@@ -97,7 +97,7 @@ template: systemd_scope_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several systemd scope units are in the failed state
+    info: one or more systemd scope units are in the failed state
       to: sysadmin
 
 ## Slice units
@@ -108,5 +108,5 @@ template: systemd_slice_units_state
    every: 10s
     warn: $this != nan AND $this == 5
    delay: down 5m multiplier 1.5 max 1h
-    info: several systemd slice units are in the failed state
+    info: one or more systemd slice units are in the failed state
       to: sysadmin

--- a/health/health.d/systemdunits.conf
+++ b/health/health.d/systemdunits.conf
@@ -1,0 +1,112 @@
+## Check if the are any systemd units in the failed state (crashed).
+## States: 1 - active, 2 - inactive, 3 - activating, 4 - deactivating, 5 - failed.
+
+## Service units
+template: systemd_service_units_state
+      on: systemd.service_units_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several systemd service units are in the failed state
+      to: sysadmin
+
+## Socket units
+template: systemd_socket_units_state
+      on: systemd.socket_unit_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several systemd socket units are in the failed state
+      to: sysadmin
+
+## Target units
+template: systemd_target_units_state
+      on: systemd.target_unit_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several systemd target units are in the failed state
+      to: sysadmin
+
+## Path units
+template: systemd_path_units_state
+      on: systemd.path_unit_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several systemd path units are in the failed state
+      to: sysadmin
+
+## Device units
+template: systemd_device_units_state
+      on: systemd.device_unit_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several the systemd device units are in the failed state
+      to: sysadmin
+
+## Mount units
+template: systemd_mount_units_state
+      on: systemd.mount_unit_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several the systemd mount units are in the failed state
+      to: sysadmin
+
+## Automount units
+template: systemd_automount_units_state
+      on: systemd.automount_unit_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several systemd automount units are in the failed state
+      to: sysadmin
+
+## Swap units
+template: systemd_swap_units_state
+      on: systemd.swap_unit_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several systemd swap units are in the failed state
+      to: sysadmin
+
+## Scope units
+template: systemd_scope_units_state
+      on: systemd.scope_unit_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several systemd scope units are in the failed state
+      to: sysadmin
+
+## Slice units
+template: systemd_slice_units_state
+      on: systemd.slice_unit_state
+  lookup: max -1s min2max
+   units: ok/failed
+   every: 10s
+    warn: $this != nan AND $this == 5
+   delay: down 5m multiplier 1.5 max 1h
+    info: several systemd slice units are in the failed state
+      to: sysadmin


### PR DESCRIPTION
##### Summary

This PR adds alarms for the [systemdunits collector](https://github.com/netdata/go.d.plugin/tree/master/modules/systemdunits#systemd-units-state-monitoring-with-netdata) charts.

States:
 - `active`: started, bound, plugged in, etc. depending on the unit type. 
 - `inactive`: stopped, unbound, unplugged, etc.
 - `activating`: in the process of being activated.
 - `deactivating`: in the process of being deactivated.
 - `failed`: very similar to inactive and is entered when the service failed in some way (process returned error code on exit, or crashed, an operation timed out, or after too many restarts).

New alarms check if there are any systemd units in the failed state.

I tried to add those alarms using [foreach](https://learn.netdata.cloud/docs/agent/health/reference#alarm-line-lookup) (for every unit), but faced https://github.com/netdata/netdata/issues/10905 (likely there is more problems).


##### Component Name

`health`

##### Test Plan

- [x] install this PR, and ensure
  - there is no errors during install
  - systemdunits.conf file in the stock health dir
  - the alarms are in the Dashboard->Alarms->All and their values are not `-`  

##### Additional Information
