### PR TITLE
health: add synchronization.conf to the Makefile

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -88,6 +88,7 @@ dist_healthconfig_DATA = \
     health.d/softnet.conf \
     health.d/squid.conf \
     health.d/stiebeleltron.conf \
+    health.d/synchronization.conf \
     health.d/swap.conf \
     health.d/tcp_conn.conf \
     health.d/tcp_listen.conf \


### PR DESCRIPTION
##### Summary

[health/health.d/synchronization.conf](https://github.com/netdata/netdata/blob/master/health/health.d/synchronization.conf) was added in https://github.com/netdata/netdata/pull/10726, but @thiagoftsm forgot to update Makefile. This PR fixes it.


##### Component Name

`health`

##### Test Plan

- install this PR, ensure synchronization.conf in the alarms stock dir.

##### Additional Information
