### PR TITLE
Don't include the current alert in host's alerts counter in notification.

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -331,10 +331,8 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
                     buffer_snprintf(warn_alarms, 11, "%ld", rc->last_status_change);
                     l_warn++;
                 }
-            } else if (ae->alarm_id == rc->id) {
+            } else if (ae->alarm_id == rc->id)
                 expr=rc->warning;
-                debug(D_SYSTEM, "WONT COUNT");
-            }
         } else if (unlikely(rc->status == RRDCALC_STATUS_CRITICAL)) {
             if (likely(ae->alarm_id != rc->id) && likely(ae->alarm_event_id != rc->next_event_id - 1)) {
                 n_crit++;
@@ -346,10 +344,8 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
                     buffer_snprintf(crit_alarms, 11, "%ld", rc->last_status_change);
                     l_crit++;
                 }
-            } else if (ae->alarm_id == rc->id) {
+            } else if (ae->alarm_id == rc->id)
                 expr=rc->critical;
-                debug(D_SYSTEM, "WONT COUNT");
-            }
         } else if (unlikely(rc->status == RRDCALC_STATUS_CLEAR)) {
             if (ae->alarm_id == rc->id)
                 expr=rc->warning;

--- a/health/health.c
+++ b/health/health.c
@@ -321,31 +321,35 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
             continue;
 
         if(unlikely(rc->status == RRDCALC_STATUS_WARNING)) {
-            n_warn++;
+            if (likely(ae->alarm_id != rc->id) && likely(ae->alarm_event_id != rc->next_event_id - 1)) {
+                n_warn++;
 
-            if (now - rc->last_status_change <= 1800) {
-                if (l_warn) buffer_strcat(warn_alarms, ",");
-                buffer_strcat(warn_alarms, rc->name);
-                buffer_strcat(warn_alarms, "=");
-                buffer_snprintf(warn_alarms, 11, "%ld", rc->last_status_change);
-                l_warn++;
-            }
-                        
-            if (ae->alarm_id == rc->id)
+                if (now - rc->last_status_change <= 1800) {
+                    if (l_warn) buffer_strcat(warn_alarms, ",");
+                    buffer_strcat(warn_alarms, rc->name);
+                    buffer_strcat(warn_alarms, "=");
+                    buffer_snprintf(warn_alarms, 11, "%ld", rc->last_status_change);
+                    l_warn++;
+                }
+            } else if (ae->alarm_id == rc->id) {
                 expr=rc->warning;
-        } else if (unlikely(rc->status == RRDCALC_STATUS_CRITICAL)) {
-            n_crit++;
-
-            if (now - rc->last_status_change <= 1800) {
-                if (l_crit) buffer_strcat(crit_alarms, ",");
-                buffer_strcat(crit_alarms, rc->name);
-                buffer_strcat(crit_alarms, "=");
-                buffer_snprintf(crit_alarms, 11, "%ld", rc->last_status_change);
-                l_crit++;
+                debug(D_SYSTEM, "WONT COUNT");
             }
-            
-            if (ae->alarm_id == rc->id)
+        } else if (unlikely(rc->status == RRDCALC_STATUS_CRITICAL)) {
+            if (likely(ae->alarm_id != rc->id) && likely(ae->alarm_event_id != rc->next_event_id - 1)) {
+                n_crit++;
+
+                if (now - rc->last_status_change <= 1800) {
+                    if (l_crit) buffer_strcat(crit_alarms, ",");
+                    buffer_strcat(crit_alarms, rc->name);
+                    buffer_strcat(crit_alarms, "=");
+                    buffer_snprintf(crit_alarms, 11, "%ld", rc->last_status_change);
+                    l_crit++;
+                }
+            } else if (ae->alarm_id == rc->id) {
                 expr=rc->critical;
+                debug(D_SYSTEM, "WONT COUNT");
+            }
         } else if (unlikely(rc->status == RRDCALC_STATUS_CLEAR)) {
             if (ae->alarm_id == rc->id)
                 expr=rc->warning;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR excludes the current alert from the count of all active alerts (in warning or critical state), when sending an alert notification. It also won't appear on the table at the bottom part of the new html notifications email.

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Enable mail alerts, and observe if in an email, the current alert is included in the count or not, and also if it appears on the table of active/raised alerts.

##### Additional Information
