### PR TITLE
Spelling health

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -523,7 +523,7 @@ static inline int rrdcalc_isrunnable(RRDCALC *rc, time_t now, time_t *next_run) 
     return 1;
 }
 
-static inline int check_if_resumed_from_suspention(void) {
+static inline int check_if_resumed_from_suspension(void) {
     static usec_t last_realtime = 0, last_monotonic = 0;
     usec_t realtime = now_realtime_usec(), monotonic = now_monotonic_usec();
     int ret = 0;
@@ -649,7 +649,7 @@ void *health_main(void *ptr) {
         time_t next_run = now + min_run_every;
         RRDCALC *rc;
 
-        if (unlikely(check_if_resumed_from_suspention())) {
+        if (unlikely(check_if_resumed_from_suspension())) {
             apply_hibernation_delay = 1;
 
             info("Postponing alarm checks for %ld seconds, because it seems that the system was just resumed from suspension.",

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -301,7 +301,7 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
                 continue;
             }
 
-            // check for a possible host missmatch
+            // check for a possible host mismatch
             //if(strcmp(pointers[1], host->hostname))
             //    error("HEALTH [%s]: line %zu of file '%s' provides an alarm for host '%s' but this is named '%s'.", host->hostname, line, filename, pointers[1], host->hostname);
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

##### Component Name

health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

The misspellings have been reported at https://github.com/jsoref/netdata/commit/33c5b20ed9511dac0a23ee916fa247cc2f388304#commitcomment-45444734

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/netdata/commit/e2737c090e4b1d7b1bce405b9f702bcf526852a3

##### Additional Information

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

This is split from #10521 per https://github.com/netdata/netdata/pull/10521#issuecomment-813622899