### PR TITLE
Spelling streaming

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -123,7 +123,7 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
 
     if(strcmp(words[1], host->machine_guid)) {
         error("Claim ID is for host \"%s\" but it came over connection for \"%s\"", words[1], host->machine_guid);
-        return PARSER_RC_OK; //the message is OK problem must be somewehere else
+        return PARSER_RC_OK; //the message is OK problem must be somewhere else
     }
 
     rrdhost_aclk_state_lock(host);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -30,7 +30,7 @@ static void rrdpush_receiver_thread_cleanup(void *ptr) {
         executed = 1;
         struct receiver_state *rpt = (struct receiver_state *) ptr;
         // If the shutdown sequence has started, and this receiver is still attached to the host then we cannot touch
-        // the host pointer as it is unpredicable when the RRDHOST is deleted. Do the cleanup from rrdhost_free().
+        // the host pointer as it is unpredictable when the RRDHOST is deleted. Do the cleanup from rrdhost_free().
         if (netdata_exit && rpt->host) {
             rpt->exited = 1;
             return;

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -450,7 +450,7 @@ void attempt_to_send(struct sender_state *s) {
         s->last_sent_t = now_monotonic_sec();
     }
     else if (ret == -1 && (errno == EAGAIN || errno == EINTR || errno == EWOULDBLOCK))
-        debug(D_STREAM, "STREAM %s [send to %s]: unavailable aftering polling POLLOUT", s->host->hostname,
+        debug(D_STREAM, "STREAM %s [send to %s]: unavailable after polling POLLOUT", s->host->hostname,
               s->connected_to);
     else if (ret == -1) {
         debug(D_STREAM, "STREAM: Send failed - closing socket...");


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

##### Component Name

streaming

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

The misspellings have been reported at https://github.com/jsoref/netdata/commit/33c5b20ed9511dac0a23ee916fa247cc2f388304#commitcomment-45444734

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/netdata/commit/e2737c090e4b1d7b1bce405b9f702bcf526852a3

##### Additional Information

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

This is split from #10521 per https://github.com/netdata/netdata/pull/10521#issuecomment-813622899