### PR TITLE
health: use $family variable in the alarms info

### DIFF
--- a/health/health.d/disks.conf
+++ b/health/health.d/disks.conf
@@ -23,7 +23,7 @@ component: Disk
      warn: $this > (($status >= $WARNING ) ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: disk space utilization
+     info: disk $family space utilization
        to: sysadmin
 
  template: disk_inode_usage
@@ -40,7 +40,7 @@ component: Disk
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: disk inode utilization
+     info: disk $family inode utilization
        to: sysadmin
 
 
@@ -150,7 +150,7 @@ component: Disk
      warn: $this > $green * (($status >= $WARNING)  ? (0.7) : (1))
      crit: $this > $red   * (($status == $CRITICAL) ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
-     info: average percentage of time the disk was busy over the last 10 minutes
+     info: average percentage of time $family disk was busy over the last 10 minutes
        to: silent
 
 
@@ -175,5 +175,5 @@ component: Disk
      warn: $this > $green * (($status >= $WARNING)  ? (0.7) : (1))
      crit: $this > $red   * (($status == $CRITICAL) ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
-     info: average disk backlog size over the last 10 minutes
+     info: average backlog size of the $family disk over the last 10 minutes
        to: silent

--- a/health/health.d/mdstat.conf
+++ b/health/health.d/mdstat.conf
@@ -20,7 +20,7 @@ component: RAID
     every: 10s
      calc: $down
      crit: $this > 0
-     info: number of devices in the down state. \
+     info: number of devices in the down state for the $family array. \
           Any number > 0 indicates that the array is degraded.
        to: sysadmin
 
@@ -34,7 +34,7 @@ component: RAID
     every: 60s
      warn: $this > 1024
     delay: up 30m
-     info: number of unsynchronized blocks
+     info: number of unsynchronized blocks for the $family array
        to: sysadmin
 
  template: mdstat_nonredundant_last_collected

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -15,7 +15,7 @@ component: Network
      calc: ( $nic_speed_max > 0 ) ? ( $nic_speed_max) : ( nan )
     units: Mbit
     every: 10s
-     info: network interface current speed
+     info: network interface $family current speed
 
  template: 1m_received_traffic_overflow
        on: net.net
@@ -31,7 +31,7 @@ component: Network
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
     delay: up 1m down 1m multiplier 1.5 max 1h
-     info: average inbound utilization for the network interface over the last minute
+     info: average inbound utilization for the network interface $family over the last minute
        to: sysadmin
 
  template: 1m_sent_traffic_overflow
@@ -48,7 +48,7 @@ component: Network
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
     delay: up 1m down 1m multiplier 1.5 max 1h
-     info: average outbound utilization for the network interface over the last minute
+     info: average outbound utilization for the network interface $family over the last minute
        to: sysadmin
 
 # -----------------------------------------------------------------------------
@@ -72,7 +72,7 @@ component: Network
    lookup: sum -10m unaligned absolute of inbound
     units: packets
     every: 1m
-     info: number of inbound dropped packets for the network interface in the last 10 minutes
+     info: number of inbound dropped packets for the network interface $family in the last 10 minutes
 
  template: outbound_packets_dropped
        on: net.drops
@@ -85,7 +85,7 @@ component: Network
    lookup: sum -10m unaligned absolute of outbound
     units: packets
     every: 1m
-     info: number of outbound dropped packets for the network interface in the last 10 minutes
+     info: number of outbound dropped packets for the network interface $family in the last 10 minutes
 
  template: inbound_packets_dropped_ratio
        on: net.packets
@@ -101,7 +101,7 @@ component: Network
     every: 1m
      warn: $this >= 2
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of inbound dropped packets for the network interface over the last 10 minutes
+     info: ratio of inbound dropped packets for the network interface $family over the last 10 minutes
        to: sysadmin
 
  template: outbound_packets_dropped_ratio
@@ -118,7 +118,7 @@ component: Network
     every: 1m
      warn: $this >= 2
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of outbound dropped packets for the network interface over the last 10 minutes
+     info: ratio of outbound dropped packets for the network interface $family over the last 10 minutes
        to: sysadmin
 
  template: wifi_inbound_packets_dropped_ratio
@@ -135,7 +135,7 @@ component: Network
     every: 1m
      warn: $this >= 10
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of inbound dropped packets for the network interface over the last 10 minutes
+     info: ratio of inbound dropped packets for the network interface $family over the last 10 minutes
        to: sysadmin
 
  template: wifi_outbound_packets_dropped_ratio
@@ -152,7 +152,7 @@ component: Network
     every: 1m
      warn: $this >= 10
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of outbound dropped packets for the network interface over the last 10 minutes
+     info: ratio of outbound dropped packets for the network interface $family over the last 10 minutes
        to: sysadmin
 
 # -----------------------------------------------------------------------------
@@ -171,7 +171,7 @@ component: Network
     every: 1m
      warn: $this >= 5
     delay: down 1h multiplier 1.5 max 2h
-     info: number of inbound errors for the network interface in the last 10 minutes
+     info: number of inbound errors for the network interface $family in the last 10 minutes
        to: sysadmin
 
  template: interface_outbound_errors
@@ -187,7 +187,7 @@ component: Network
     every: 1m
      warn: $this >= 5
     delay: down 1h multiplier 1.5 max 2h
-     info: number of outbound errors for the network interface in the last 10 minutes
+     info: number of outbound errors for the network interface $family in the last 10 minutes
        to: sysadmin
 
 # -----------------------------------------------------------------------------
@@ -211,7 +211,7 @@ component: Network
     every: 1m
      warn: $this > 0
     delay: down 1h multiplier 1.5 max 2h
-     info: number of FIFO errors for the network interface in the last 10 minutes
+     info: number of FIFO errors for the network interface $family in the last 10 minutes
        to: sysadmin
 
 # -----------------------------------------------------------------------------
@@ -234,7 +234,7 @@ component: Network
    lookup: average -1m unaligned of received
     units: packets
     every: 10s
-     info: average number of packets received by the network interface over the last minute
+     info: average number of packets received by the network interface $family over the last minute
 
  template: 10s_received_packets_storm
        on: net.packets
@@ -251,6 +251,6 @@ component: Network
      warn: $this > (($status >= $WARNING)?(200):(5000))
      crit: $this > (($status == $CRITICAL)?(5000):(6000))
   options: no-clear-notification
-     info: ratio of average number of received packets for the network interface over the last 10 seconds, \
+     info: ratio of average number of received packets for the network interface $family over the last 10 seconds, \
           compared to the rate over the last minute
        to: sysadmin


### PR DESCRIPTION
##### Summary

This PR adds $family variables to the following sets of alarms:
 - net ($family is a network device name)
 - disks ($family is a device or partition name)
 - mdstat ($family is an array name)

##### Component Name

`health`

##### Test Plan

- [x] Install this PR and check net/disks/mdstat alarms info on the dashboard and in the `api/v1/alarms?all`

