### PR TITLE
Adds --recursive to docu git clones

### DIFF
--- a/collectors/python.d.plugin/README.md
+++ b/collectors/python.d.plugin/README.md
@@ -93,7 +93,7 @@ have made to do your development on).
 
 ```bash
 # clone your fork (done once at the start but shown here for clarity)
-#git clone --branch my-example-collector https://github.com/mygithubusername/netdata.git --depth=100
+#git clone --branch my-example-collector https://github.com/mygithubusername/netdata.git --depth=100 --recursive
 # go into your netdata source folder
 cd netdata
 # git pull your latest changes (assuming you built from a fork you are using to develop on)

--- a/packaging/installer/methods/alpine.md
+++ b/packaging/installer/methods/alpine.md
@@ -15,7 +15,7 @@ apk add alpine-sdk bash curl libuv-dev zlib-dev util-linux-dev libmnl-dev gcc ma
 apk add nodejs
 
 # download Netdata - the directory 'netdata' will be created
-git clone https://github.com/netdata/netdata.git --depth=100
+git clone https://github.com/netdata/netdata.git --depth=100 --recursive
 cd netdata
 
 # build it, install it, start it

--- a/packaging/installer/methods/macos.md
+++ b/packaging/installer/methods/macos.md
@@ -61,7 +61,7 @@ and install the [Judy library](https://sourceforge.net/projects/judy/) before pr
 Next, download Netdata from our GitHub repository:
 
 ```bash
-git clone https://github.com/netdata/netdata.git
+git clone https://github.com/netdata/netdata.git --recursive
 ```
 
 Finally, `cd` into the newly-created directory and then start the installer script:

--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -186,7 +186,7 @@ Do this to install and run Netdata:
 
 ```sh
 # download it - the directory 'netdata' will be created
-git clone https://github.com/netdata/netdata.git --depth=100
+git clone https://github.com/netdata/netdata.git --depth=100 --recursive
 cd netdata
 
 # run script with root privileges to build, install, start Netdata


### PR DESCRIPTION
##### Summary
We use git submodules for ACLK-NG (and later for protobuf payload definitions for Agent/Cloud comms). Update docu where cloning Netdata repository is mentioned to ensure users get also the submodules downloaded.

##### Component Name
Docs
##### Test Plan
When you use new command the `mqtt_websocets` directory gets populated with files after the clone
##### Additional Information
