### PR TITLE
Fix memory corruption issue when executing context queries in RAM/SAVE memory mode

### DIFF
--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -95,12 +95,8 @@ void build_context_param_list(struct context_param **param_list, RRDSET *st)
         memcpy(rd->state, rd1->state, sizeof(*rd->state));
         memcpy(&rd->state->collect_ops, &rd1->state->collect_ops, sizeof(struct rrddim_collect_ops));
         memcpy(&rd->state->query_ops, &rd1->state->query_ops, sizeof(struct rrddim_query_ops));
-#ifdef ENABLE_DBENGINE
-        if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-            rd->state->metric_uuid = mallocz(sizeof(uuid_t));
-            uuid_copy(*rd->state->metric_uuid, *rd1->state->metric_uuid);
-        }
-#endif
+        rd->state->metric_uuid = mallocz(sizeof(uuid_t));
+        uuid_copy(*rd->state->metric_uuid, *rd1->state->metric_uuid);
         rd->next = (*param_list)->rd;
         (*param_list)->rd = rd;
     }


### PR DESCRIPTION
Fixes #10929
##### Summary
Then executing queries in RAM / SAVE mode, the metric_uuid was never properly allocated and
would result in memory corruption. 

##### Component Name
database
web

##### Test Plan
- Start agent with memory mode not being dbengine e.g RAM / SAVE
- Execute a query `http://127.0.0.1:19999/api/v1/data?context=net.net`
   - This will attempt to free a copy of a `rd->state->metric_uuid` that belongs to the original rrddim and result to a crash
- Apply the PR
- Agent should not crash
 

##### Additional Information
Note: This is a temporary fix. A new PR in the next version avoids the memory allocation of the metric_uuid