### PR TITLE
Fix quoting on wildcard glob

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -295,7 +295,7 @@ update() {
     NEW_CHECKSUM="$(safe_sha256sum netdata-latest.tar.gz 2> /dev/null | cut -d' ' -f1)"
     tar -xf netdata-latest.tar.gz >&3 2>&3
     rm netdata-latest.tar.gz >&3 2>&3
-    cd netdata-* || exit 1
+    cd "netdata-"* || exit 1
     RUN_INSTALLER=1
     cd "${NETDATA_LOCAL_TARBALL_OVERRIDE}" || exit 1
   fi


### PR DESCRIPTION
This script is failing because of incorrect quoting on a wildcard glob for bash.
Here is the output from running it:

```
+ sudo //usr/libexec/netdata/netdata-updater.sh --not-running-from-cron
Checking if a newer version of the updater script is available.
Downloading newest version of updater script.
Thu Apr  8 08:21:03 EDT 2021 : INFO:  Running on a terminal - (this script also supports running headless from crontab)
Thu Apr  8 08:21:03 EDT 2021 : INFO:  Current Version: 00103000000003
Thu Apr  8 08:21:03 EDT 2021 : INFO:  Latest Version: 00103000000016
./netdata-latest.tar.gz: OK
/tmp/netdata-updater-lz3VVkHsCz/netdata-updater.sh: line 298: cd: too many arguments
+ local ret=1
+ '[' 1 -ne 0 ']'
+ run_failed
+ printf ' FAILED  \n\n'
 FAILED  

+ printf 'FAILED with exit code 1\n'
+ return 1
+ fatal 'Failed to update existing Netdata install'
+ printf ' ABORTED  Failed to update existing Netdata install \n\n'
 ABORTED  Failed to update existing Netdata install
```

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Added quotes to `cd netdata-* || exit 1`
`cd "netdata-"* || exit 1`

##### Component Name
Packaging/Installer

##### Test Plan
Tested on Ubuntu 18.04.5 LTS
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
