### PR TITLE
health: add Inconsistent state to the mysql_galera_cluster_state alarm

### DIFF
--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -128,11 +128,11 @@ template: mysql_galera_cluster_state
       on: mysql.galera_cluster_state
     calc: $state
    every: 10s
-    warn: $this < 4
-    crit: $this < 2
+    warn: $this == 2 OR $this == 3
+    crit: $this == 0 OR $this == 1 OR $this >= 5
    delay: up 30s down 5m multiplier 1.5 max 1h
     info: galera node state \
-          (0: undefined, 1: joining, 2: donor/desynced, 3: joined, 4: synced)
+          (0: Undefined, 1: Joining, 2: Donor/Desynced, 3: Joined, 4: Synced, 5: Inconsistent)
       to: dba
 
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1505,11 +1505,12 @@ netdataDashboard.context = {
 
     'mysql.galera_cluster_state': {
         info:
-            '<code>0</code>: undefined, ' +
-            '<code>1</code>: joining, ' +
-            '<code>2</code>: donor/desynced, ' +
-            '<code>3</code>: joined, ' +
-            '<code>4</code>: synced.'
+            '<code>0</code>: Undefined, ' +
+            '<code>1</code>: Joining, ' +
+            '<code>2</code>: Donor/Desynced, ' +
+            '<code>3</code>: Joined, ' +
+            '<code>4</code>: Synced, ' +
+            '<code>5</code>: Inconsistent.'
     },
 
     'mysql.galera_cluster_weight': {


### PR DESCRIPTION
##### Summary

Fixes: #10940

This PR adds checking for _Inconsistent_ state to the [mysql_galera_cluster_state](https://github.com/netdata/netdata/blob/8bc32ad6e61ace3408e4983e020800e8c4c79637/health/health.d/mysql.conf#L127-L136) alarm.

Corresponding chart info is also updated in the dashboard_info.js.

##### Component Name

`health/`
`web/gui`

##### Test Plan

I think no tests needed. (but @ekexcello please check the changes visually at least 😄 )

##### Additional Information
