### PR TITLE
Fix epbf crash when process exit

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -140,8 +140,6 @@ static void ebpf_exit(int sig)
         freez(cachestat_pid);
     }
 
-    clean_apps_structures(apps_groups_root_target);
-
     /*
     int ret = fork();
     if (ret < 0) // error

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -132,11 +132,15 @@ static void ebpf_exit(int sig)
 
     freez(global_process_stat);
 
-    clean_socket_apps_structures();
-    freez(socket_bandwidth_curr);
+    if (socket_bandwidth_curr) {
+        clean_socket_apps_structures();
+        freez(socket_bandwidth_curr);
+    }
 
-    clean_cachestat_pid_structures();
-    freez(cachestat_pid);
+    if (cachestat_pid) {
+        clean_cachestat_pid_structures();
+        freez(cachestat_pid);
+    }
 
     /*
     int ret = fork();

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -132,6 +132,9 @@ static void ebpf_exit(int sig)
 
     freez(global_process_stat);
 
+    clean_socket_apps_structures();
+    freez(socket_bandwidth_curr);
+
     /*
     int ret = fork();
     if (ret < 0) // error

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -135,6 +135,9 @@ static void ebpf_exit(int sig)
     clean_socket_apps_structures();
     freez(socket_bandwidth_curr);
 
+    clean_cachestat_pid_structures();
+    freez(cachestat_pid);
+
     /*
     int ret = fork();
     if (ret < 0) // error

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -130,14 +130,12 @@ static void ebpf_exit(int sig)
         return;
     }
 
-    freez(global_process_stat);
-
-    if (socket_bandwidth_curr) {
+    if (ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled) {
         clean_socket_apps_structures();
         freez(socket_bandwidth_curr);
     }
 
-    if (cachestat_pid) {
+    if (ebpf_modules[EBPF_MODULE_CACHESTAT_IDX].enabled) {
         clean_cachestat_pid_structures();
         freez(cachestat_pid);
     }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -142,6 +142,8 @@ static void ebpf_exit(int sig)
         freez(cachestat_pid);
     }
 
+    clean_apps_structures(apps_groups_root_target);
+
     /*
     int ret = fork();
     if (ret < 0) // error

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -131,11 +131,13 @@ static void ebpf_exit(int sig)
     }
 
     if (ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled) {
+        ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled = 0;
         clean_socket_apps_structures();
         freez(socket_bandwidth_curr);
     }
 
     if (ebpf_modules[EBPF_MODULE_CACHESTAT_IDX].enabled) {
+        ebpf_modules[EBPF_MODULE_CACHESTAT_IDX].enabled = 0;
         clean_cachestat_pid_structures();
         freez(cachestat_pid);
     }

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -943,7 +943,6 @@ void cleanup_exited_pids()
 
             pid_t r = p->pid;
             p = p->next;
-            del_pid_entry(r);
 
             // Clean process structure
             freez(global_process_stats[r]);
@@ -953,6 +952,8 @@ void cleanup_exited_pids()
             current_apps_data[r] = NULL;
 
             cleanup_variables_from_other_threads(r);
+
+            del_pid_entry(r);
         } else {
             if (unlikely(p->keep))
                 p->keeploops++;

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -430,6 +430,9 @@ extern size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep
 
 extern void collect_data_for_all_processes(int tbl_pid_stats_fd);
 
+extern void clean_apps_structures(struct target *ptr);
+extern void clean_global_memory();
+
 extern ebpf_process_stat_t **global_process_stats;
 extern ebpf_process_publish_apps_t **current_apps_data;
 extern netdata_publish_cachestat_t **cachestat_pid;

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -430,7 +430,6 @@ extern size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep
 
 extern void collect_data_for_all_processes(int tbl_pid_stats_fd);
 
-extern void clean_apps_structures(struct target *ptr);
 extern void clean_global_memory();
 
 extern ebpf_process_stat_t **global_process_stats;

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -363,9 +363,6 @@ void *ebpf_cachestat_read_hash(void *ptr)
         (void)dt;
 
         read_global_table();
-
-        if (apps)
-            read_apps_table();
     }
     read_thread_closed = 1;
 
@@ -508,6 +505,9 @@ static void cachestat_collector(ebpf_module_t *em)
     while (!close_ebpf_plugin) {
         pthread_mutex_lock(&collect_data_mutex);
         pthread_cond_wait(&collect_data_cond_var, &collect_data_mutex);
+
+        if (apps)
+            read_apps_table();
 
         pthread_mutex_lock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -357,7 +357,6 @@ void *ebpf_cachestat_read_hash(void *ptr)
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     usec_t step = NETDATA_LATENCY_CACHESTAT_SLEEP_MS * em->update_time;
-    int apps = em->apps_charts;
     while (!close_ebpf_plugin) {
         usec_t dt = heartbeat_next(&hb, step);
         (void)dt;

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -43,7 +43,7 @@ struct config cachestat_config = { .first_section = NULL,
  *
  * Clean the allocated structures.
  */
-static void clean_pid_structures() {
+void clean_cachestat_pid_structures() {
     struct pid_stat *pids = root_of_pids;
     while (pids) {
         freez(cachestat_pid[pids->pid]);
@@ -70,9 +70,6 @@ static void ebpf_cachestat_cleanup(void *ptr)
         usec_t dt = heartbeat_next(&hb, tick);
         UNUSED(dt);
     }
-
-    clean_pid_structures();
-    freez(cachestat_pid);
 
     ebpf_cleanup_publish_syscall(cachestat_counter_publish_aggregated);
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.h
+++ b/collectors/ebpf.plugin/ebpf_cachestat.h
@@ -60,5 +60,6 @@ typedef struct netdata_publish_cachestat {
 } netdata_publish_cachestat_t;
 
 extern void *ebpf_cachestat_thread(void *ptr);
+extern void clean_cachestat_pid_structures();
 
 #endif // NETDATA_EBPF_CACHESTAT_H

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -905,26 +905,6 @@ void clean_global_memory() {
     }
 }
 
-void clean_pid_on_target(struct pid_on_target *ptr) {
-    while (ptr) {
-        struct pid_on_target *next = ptr->next;
-        freez(ptr);
-
-        ptr = next;
-    }
-}
-
-void clean_apps_structures(struct target *ptr) {
-    struct target *agdt = ptr;
-    while (agdt) {
-        struct target *next = agdt->next;
-        clean_pid_on_target(agdt->root_pid);
-        freez(agdt);
-
-        agdt = next;
-    }
-}
-
 /**
  * Clean up the main thread.
  *

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -949,7 +949,6 @@ static void ebpf_process_cleanup(void *ptr)
     freez(global_process_stats);
     freez(current_apps_data);
 
-    clean_apps_structures(apps_groups_root_target);
     freez(process_data.map_fd);
 
     struct bpf_program *prog;

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1769,7 +1769,7 @@ static void clean_hostnames(ebpf_network_viewer_hostname_list_t *hostnames)
     }
 }
 
-void clean_thread_structures() {
+void clean_socket_apps_structures() {
     struct pid_stat *pids = root_of_pids;
     while (pids) {
         freez(socket_bandwidth_curr[pids->pid]);
@@ -1853,8 +1853,6 @@ static void ebpf_socket_cleanup(void *ptr)
     ebpf_cleanup_publish_syscall(socket_publish_aggregated);
     freez(socket_hash_values);
 
-    clean_thread_structures();
-    freez(socket_bandwidth_curr);
     freez(bandwidth_vector);
 
     freez(socket_values);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2820,6 +2820,8 @@ void *ebpf_socket_thread(void *ptr)
 {
     netdata_thread_cleanup_push(ebpf_socket_cleanup, ptr);
 
+    memset(&inbound_vectors.tree, 0, sizeof(avl_tree_lock));
+    memset(&inbound_vectors.tree, 0, sizeof(avl_tree_lock));
     avl_init_lock(&inbound_vectors.tree, compare_sockets);
     avl_init_lock(&outbound_vectors.tree, compare_sockets);
 

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1325,7 +1325,7 @@ static void read_socket_hash_table(int fd, int family, int network_connection)
         return;
 
     netdata_socket_idx_t key = {};
-    netdata_socket_idx_t next_key;
+    netdata_socket_idx_t next_key = {};
     netdata_socket_idx_t removeme;
     int removesock = 0;
 

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2821,7 +2821,7 @@ void *ebpf_socket_thread(void *ptr)
     netdata_thread_cleanup_push(ebpf_socket_cleanup, ptr);
 
     memset(&inbound_vectors.tree, 0, sizeof(avl_tree_lock));
-    memset(&inbound_vectors.tree, 0, sizeof(avl_tree_lock));
+    memset(&outbound_vectors.tree, 0, sizeof(avl_tree_lock));
     avl_init_lock(&inbound_vectors.tree, compare_sockets);
     avl_init_lock(&outbound_vectors.tree, compare_sockets);
 

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1421,7 +1421,7 @@ void update_listen_table(uint16_t value, uint8_t proto)
 static void read_listen_table()
 {
     uint16_t key = 0;
-    uint16_t next_key;
+    uint16_t next_key = 0;
 
     int fd = map_fd[NETDATA_SOCKET_LISTEN_TABLE];
     uint8_t value;

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -294,6 +294,7 @@ extern void update_listen_table(uint16_t value, uint8_t proto);
 extern void parse_network_viewer_section(struct config *cfg);
 extern void fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_ip_list_t *in, char *table);
 extern void parse_service_name_section(struct config *cfg);
+extern void clean_socket_apps_structures();
 
 extern ebpf_socket_publish_apps_t **socket_bandwidth_curr;
 


### PR DESCRIPTION
##### Summary
Fixes #10955 
Fixes #10953
It probably fixes #10682, I could not recreate the problem, so I am not sure about this last, @vlvkobal , please, test also on an environment that you reported the problem.

This PR fixes almost all reports that valgrind gives, the unique exceptions is the next:

```
==7720==    at 0x40A58E: compare_sockets (ebpf_socket.c:882)
==7720==    by 0x4156D6: avl_search (avl.c:26)
==7720==    by 0x415F7A: avl_search_lock (avl.c:388)
==7720==    by 0x40BD52: store_socket_inside_avl (ebpf_socket.c:1174)
==7720==    by 0x40C1D1: hash_accumulator (ebpf_socket.c:1308)
==7720==    by 0x40C470: read_socket_hash_table (ebpf_socket.c:1371)
==7720==    by 0x40C687: ebpf_socket_read_hash (ebpf_socket.c:1475)
==7720==    by 0x42E3DC: thread_start (threads.c:184)
==7720==    by 0x5016E84: start_thread (in /lib64/libpthread-2.33.so)
==7720==    by 0x513BB3E: clone (in /lib64/libc-2.33.so)
```

, but this is not a problem ,because we only use the variables that are set before the function to be called.

##### Component Name
ebpf.plugin
##### Test Plan
1 - Compile this Branch with the flags: 
```
CFLAGS="-O1 -ggdb -Wall -Wextra -fno-omit-frame-pointer -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1" 
```
2 - Go to directory `/usr/libexec/netdata/plugins.d`
3 - Change the `ebpf.plugin` permission: 

```bash
# chmod 755 ebpf.plugin
```
4 - Run `ebpf.plugin` using valgrind:

```bash
# valgrind ./ebpf.plugin 2> err > out
```
5 - Press `CTRL` + `C` and check the error report, you won't see any memory leak with this PR.

##### Additional Information
