### PR TITLE
Remove condition that was creating gaps

### DIFF
--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -125,8 +125,6 @@ void cachestat_update_publish(netdata_publish_cachestat_t *out, uint64_t mpa, ui
         hits = 0;
     }
 
-    // Changed to avoid gaps
-    // calculated_number ratio = (total > 0) ? hits/total : 0;
     calculated_number ratio = (total > 0) ? hits/total : 1;
 
     out->ratio = (long long )(ratio*100);
@@ -538,7 +536,7 @@ static void ebpf_create_memory_charts()
 {
     ebpf_create_chart(NETDATA_EBPF_MEMORY_GROUP, NETDATA_CACHESTAT_HIT_RATIO_CHART,
                       "Hit is calculating using total cache added without dirties per total added because of red misses.",
-                      EBPF_CACHESTAT_DIMENSION_HITS, NETDATA_CACHESTAT_SUBMENU,
+                      EBPF_COMMON_DIMENSION_PERCENTAGE, NETDATA_CACHESTAT_SUBMENU,
                       NULL,
                       NETDATA_EBPF_CHART_TYPE_LINE,
                       21100,

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -125,7 +125,9 @@ void cachestat_update_publish(netdata_publish_cachestat_t *out, uint64_t mpa, ui
         hits = 0;
     }
 
-    calculated_number ratio = (total > 0) ? hits/total : 0;
+    // Changed to avoid gaps
+    // calculated_number ratio = (total > 0) ? hits/total : 0;
+    calculated_number ratio = (total > 0) ? hits/total : 1;
 
     out->ratio = (long long )(ratio*100);
     out->hit = (long long)hits;
@@ -385,12 +387,9 @@ static void cachestat_send_global(netdata_publish_cachestat_t *publish)
     calculate_stats(publish);
 
     netdata_publish_syscall_t *ptr = cachestat_counter_publish_aggregated;
-    // The algorithm sets this value to zero sometimes, we are not written them to have a smooth chart
-    if (publish->ratio) {
-        ebpf_one_dimension_write_charts(
-            NETDATA_EBPF_MEMORY_GROUP, NETDATA_CACHESTAT_HIT_RATIO_CHART, ptr[NETDATA_CACHESTAT_IDX_RATIO].dimension,
-            publish->ratio);
-    }
+    ebpf_one_dimension_write_charts(
+        NETDATA_EBPF_MEMORY_GROUP, NETDATA_CACHESTAT_HIT_RATIO_CHART, ptr[NETDATA_CACHESTAT_IDX_RATIO].dimension,
+        publish->ratio);
 
     ebpf_one_dimension_write_charts(
         NETDATA_EBPF_MEMORY_GROUP, NETDATA_CACHESTAT_DIRTY_CHART, ptr[NETDATA_CACHESTAT_IDX_DIRTY].dimension,

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1019,7 +1019,7 @@ netdataDashboard.context = {
     },
 
     'mem.cachestat_ratio': {
-        info: 'When the processor needs to read or write a location in main memory, it checks for a corresponding entry in the page cache. If the entry is there, a page cache hit has occurred and the read is from the cache. If the entry is not there, a page cache miss has occurred and the kernel allocates a new entry and copies in data from the disk. Netdata calculates the percentage of accessed files that are cached on memory. <a href="https://github.com/iovisor/bcc/blob/master/tools/cachestat.py#L126-L138" target="_blank">The ratio</a> is calculated counting the accessed cached pages (without counting dirty pages and pages added because of read misses) divided by total access without dirty pages. '
+        info: 'When the processor needs to read or write a location in main memory, it checks for a corresponding entry in the page cache. If the entry is there, a page cache hit has occurred and the read is from the cache. If the entry is not there, a page cache miss has occurred and the kernel allocates a new entry and copies in data from the disk. Netdata calculates the percentage of accessed files that are cached on memory. <a href="https://github.com/iovisor/bcc/blob/master/tools/cachestat.py#L126-L138" target="_blank">The ratio</a> is calculated counting the accessed cached pages (without counting dirty pages and pages added because of read misses) divided by total access without dirty pages.'
     },
 
     'mem.cachestat_dirties': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1019,7 +1019,7 @@ netdataDashboard.context = {
     },
 
     'mem.cachestat_ratio': {
-        info: 'When the processor needs to read or write a location in main memory, it checks for a corresponding entry in the page cache. If the entry is there, a page cache hit has occurred and the read is from the cache. If the entry is not there, a page cache miss has occurred and the kernel allocates a new entry and copies in data from the disk. Netdata calculates the percentage of accessed files that are cached on memory. <a href="https://github.com/iovisor/bcc/blob/master/tools/cachestat.py#L126-L138" target="_blank">The ratio</a> is calculated counting the accessed cached pages (without counting dirty pages and pages added because of read misses) divided by total access without dirty pages. The algorithm will not plot data when ratio is zero and our dashboard will interpolate the plot. '
+        info: 'When the processor needs to read or write a location in main memory, it checks for a corresponding entry in the page cache. If the entry is there, a page cache hit has occurred and the read is from the cache. If the entry is not there, a page cache miss has occurred and the kernel allocates a new entry and copies in data from the disk. Netdata calculates the percentage of accessed files that are cached on memory. <a href="https://github.com/iovisor/bcc/blob/master/tools/cachestat.py#L126-L138" target="_blank">The ratio</a> is calculated counting the accessed cached pages (without counting dirty pages and pages added because of read misses) divided by total access without dirty pages. '
     },
 
     'mem.cachestat_dirties': {


### PR DESCRIPTION
##### Summary
Fixes #10967

##### Component Name
ebpf.plugin
##### Test Plan

1 - Enable chacestat inside your `ebpf.d.conf`:

```conf
[ebpf programs]
    cachestat = yes
```
2 - Compile this PR
3 - Start `netdata` and let it running during 1 minutes, during this interval of time you cannot have gaps described [here](https://github.com/netdata/netdata/issues/10967#issue-856917401)

##### Additional Information

I tested only on Slackware current running kernel `5.10.29`, because we did not bring any modification for eBPF programs.
