### PR TITLE
Update fping version

### DIFF
--- a/collectors/fping.plugin/fping.plugin.in
+++ b/collectors/fping.plugin/fping.plugin.in
@@ -16,6 +16,8 @@ if [ "${1}" = "install" ]
     then
     [ "${UID}" != 0 ] && echo >&2 "Please run me as root. This will install a single binary file: /usr/local/bin/fping." && exit 1
 
+    [ -z "${2}" ] && fping_version="5.0" || fping_version="${2}"
+
     run() {
         printf >&2 " > "
         printf >&2 "%q " "${@}"
@@ -38,14 +40,14 @@ if [ "${1}" = "install" ]
 
     run cd /usr/src
 
-    if [ -d fping-4.2 ]
+    if [ -d "fping-${fping_version}" ]
         then
-        run rm -rf fping-4.2 || exit 1
+        run rm -rf "fping-${fping_version}" || exit 1
     fi
 
-    download 'https://github.com/schweikert/fping/releases/download/v4.2/fping-4.2.tar.gz' | run tar -zxvpf -
+    download "https://github.com/schweikert/fping/releases/download/v${fping_version}/fping-${fping_version}.tar.gz" | run tar -zxvpf -
     [ $? -ne 0 ] && exit 1
-    run cd fping-4.2 || exit 1
+    run cd "fping-${fping_version}" || exit 1
 
     run ./configure --prefix=/usr/local
     run make clean


### PR DESCRIPTION
##### Summary

The #10241 have updated fping version for netdata static builds, but missed the same for the `fping.plugin install` command. This PR updates default fping version for `fping.plugin install` command and adds option to specify needed version.

##### Component Name

`agent/collectors/fping.plugin`

##### Test Plan

As the [fping.plugin docs](https://learn.netdata.cloud/docs/agent/collectors/fping.plugin) state, install fping by running

```sh
/usr/libexec/netdata/plugins.d/fping.plugin install
```

Also, specific version could be set too:

```sh
# install fping v4.2
/usr/libexec/netdata/plugins.d/fping.plugin install 4.2
```

##### Additional Information

The [packaging/makeself/jobs/50-fping-5.0.install.sh](https://github.com/netdata/netdata/blob/master/packaging/makeself/jobs/50-fping-5.0.install.sh) has changed source of fping from GitHub to `fping.org` (#10241), same could be done for the `fping.plugin` too, but I've kept GitHub as the source for now.