### PR TITLE
collectors/charts.d/opensips: fix detection of `opensipsctl` executable 

### DIFF
--- a/collectors/charts.d.plugin/opensips/opensips.chart.sh
+++ b/collectors/charts.d.plugin/opensips/opensips.chart.sh
@@ -31,6 +31,7 @@ opensips_check() {
   # try to find it in the system
   if [ -z "$opensips_cmd" ]; then
     require_cmd opensipsctl || return 1
+    opensips_cmd="$OPENSIPSCTL_CMD"
   fi
 
   # check once if the command works


### PR DESCRIPTION
##### Summary

Fixes: #10947

[require_cmd](https://github.com/netdata/netdata/blob/a94408c0cda105e3e68214c16a03c7038a5c2560/collectors/charts.d.plugin/charts.d.plugin.in#L82-L92)


##### Component Name

`collectors/`

##### Test Plan

Not needed


##### Additional Information
