### PR TITLE
Assorted fixes for Travis CI code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,20 +149,6 @@ jobs:
     # This is the nightly execution step
     #
     - stage: Nightly release
-      _template: &NIGHTLY_TEMPLATE
-        git:
-          depth: false
-        script:
-          - echo "GIT Branch:" && git branch
-          - echo "Last commit:" && git log -1
-          - echo "GIT Describe:" && git describe
-          - echo "packaging/version:" && cat packaging/version
-          - "sudo echo '{\"experimental\": true}' > /etc/docker/daemon.json && sudo systemctl restart docker"
-          - packaging/docker/check_login.sh
-            && tick packaging/docker/build.sh
-            && packaging/docker/publish.sh
-        after_failure: post_message "TRAVIS_MESSAGE" "<!here> Nightly docker image publish failed"
-
       name: Create nightly release artifacts, publish to GCS
       script:
         - echo "GIT Branch:" && git branch

--- a/.travis/create_changelog.sh
+++ b/.travis/create_changelog.sh
@@ -34,6 +34,7 @@ echo "--- Creating changelog ---"
 git checkout master
 git pull
 
+docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PWD}"
 docker run -it -v "$(pwd)":/project markmandel/github-changelog-generator:latest \
 	--user "${ORGANIZATION}" \
 	--project "${PROJECT}" \


### PR DESCRIPTION
##### Summary

* Remove some dad code left over from when we were building Docker images using Travis CI.
* Authenticate against Docker Hub before trying to pull a Docker image, avoiding the anonymous pull limits.

##### Component Name

area/ci

##### Test Plan

Needs to be verified in a nightly build (can’t be properly tested outside of that context).

##### Additional Info

This should fix the issues we’ve been seeing with the nightly builds intermittently not working correctly.