### PR TITLE
adds missing SPDX license info into ACLK-NG

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "aclk.h"
 
 #include "aclk_stats.h"

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "aclk_query.h"
 #include "aclk_stats.h"
 #include "aclk_query_queue.h"

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "aclk_stats.h"
 
 netdata_mutex_t aclk_stats_mutex = NETDATA_MUTEX_INITIALIZER;

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "aclk_util.h"
 
 #include <stdio.h>


### PR DESCRIPTION
##### Summary
@vkalintiris correctly noted some of the ACLK-NG files were missing SPDX license info as first line. This PR fixes that

##### Component Name
ACLK-NG
##### Test Plan
Non functional change

##### Additional Information
