### PR TITLE
Persist claim ids in local database for parent and children

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -164,6 +164,10 @@ void load_claiming_state(void)
         claimed_id = NULL;
     }
     localhost->aclk_state.claimed_id = claimed_id;
+
+    if (likely(claimed_id))
+        store_claim_id(&localhost->host_uuid, &uuid);
+
     rrdhost_aclk_state_unlock(localhost);
     if (!claimed_id) {
         info("Unable to load '%s', setting state to AGENT_UNCLAIMED", filename);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -19,7 +19,7 @@ const char *database_config[] = {
     "CREATE INDEX IF NOT EXISTS ind_c1 on chart (host_id, id, type, name);",
     "CREATE TABLE IF NOT EXISTS chart_label(chart_id blob, source_type int, label_key text, "
     "label_value text, date_created int, PRIMARY KEY (chart_id, label_key));",
-
+    "CREATE TABLE IF NOT EXISTS node_instance (host_id blob PRIMARY KEY, claim_id, node_id, date_created);",
     "delete from chart_active;",
     "delete from dimension_active;",
     "delete from chart where chart_id not in (select chart_id from dimension);",
@@ -1336,5 +1336,48 @@ failed:
     UNUSED(context);
     UNUSED(chart);
 #endif
+    return;
+}
+
+#define SQL_STORE_CLAIM_ID  "insert or replace into node_instance " \
+    "(host_id, claim_id, date_created) values (@host_id, @claim_id, strftime('%s'));"
+
+void store_claim_id(uuid_t *host_id, uuid_t *claim_id)
+{
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    if (unlikely(!db_meta)) {
+        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            error_report("Database has not been initialized");
+        return;
+    }
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_STORE_CLAIM_ID, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement store chart labels");
+        return;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host_id parameter to store node instance information");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_blob(res, 2, claim_id, sizeof(*claim_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind claim_id parameter to store node instance information");
+        goto failed;
+    }
+
+    rc = execute_insert(res);
+    if (unlikely(rc != SQLITE_DONE))
+        error_report("Failed to store node instance information, rc = %d", rc);
+
+failed:
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when storing node instance information");
+
     return;
 }

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1339,8 +1339,10 @@ failed:
     return;
 }
 
-#define SQL_STORE_CLAIM_ID  "insert or replace into node_instance " \
-    "(host_id, claim_id, date_created) values (@host_id, @claim_id, strftime('%s'));"
+#define SQL_STORE_CLAIM_ID  "insert into node_instance " \
+    "(host_id, claim_id, date_created) values (@host_id, @claim_id, strftime('%s')) " \
+    "on conflict(host_id) do update set node_id = null, claim_id = excluded.claim_id " \
+    "where claim_id <> excluded.claim_id;"
 
 void store_claim_id(uuid_t *host_id, uuid_t *claim_id)
 {

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -60,4 +60,5 @@ extern void db_lock(void);
 extern void delete_dimension_uuid(uuid_t *dimension_uuid);
 extern void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value);
 extern void sql_build_context_param_list(struct context_param **param_list, RRDHOST *host, char *context, char *chart);
+extern void store_claim_id(uuid_t *host_id, uuid_t *claim_id);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -130,6 +130,10 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
     if (host->aclk_state.claimed_id)
         freez(host->aclk_state.claimed_id);
     host->aclk_state.claimed_id = strcmp(words[2], "NULL") ? strdupz(words[2]) : NULL;
+
+    if (likely(host->aclk_state.claimed_id))
+        store_claim_id(&host->host_uuid, &uuid);
+
     rrdhost_aclk_state_unlock(host);
 
     rrdpush_claimed_id(host);


### PR DESCRIPTION
##### Summary
- Store the claim id in the local database
- Add a node_id column to be filled when an aclk connection is established
  - Initially empty

##### Component Name
database
aclk

##### Test Plan
- Creates a new table in the metadata database called `node_instance`
- Verify that you have the new entries there for the parent and children
   - use sqlite3 to access the local database `sqlite3 netdata-meta.db` which is stored under `/var/cache/netdata/`
   - Do `select count(*) from node_instance ni, host h where ni.host_id = h.host_id;`
