### PR TITLE
Allow the remote write configuration have multiple destinations

### DIFF
--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -98,8 +98,12 @@ struct simple_connector_buffer {
     struct simple_connector_buffer *next;
 };
 
+#define CONNECTED_TO_MAX 1024
+
 struct simple_connector_data {
     void *connector_specific_data;
+
+    char connected_to[CONNECTED_TO_MAX];
 
     size_t total_buffered_metrics;
 

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -31,7 +31,7 @@ void prometheus_remote_write_prepare_header(struct instance *instance)
         "Content-Length: %zu\r\n"
         "\r\n",
         connector_specific_config->remote_write_path,
-        instance->config.destination,
+        simple_connector_data->connected_to,
         buffer_strlen(simple_connector_data->last_buffer->buffer));
 }
 

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -314,7 +314,12 @@ void simple_connector_worker(void *instance_p)
             size_t reconnects = 0;
 
             sock = connect_to_one_of(
-                instance->config.destination, connector_specific_config->default_port, &timeout, &reconnects, NULL, 0);
+                instance->config.destination,
+                connector_specific_config->default_port,
+                &timeout,
+                &reconnects,
+                connector_specific_data->connected_to,
+                CONNECTED_TO_MAX);
 #ifdef ENABLE_HTTPS
             if (exporting_tls_is_enabled(instance->config.type, options) && sock != -1) {
                 if (netdata_exporting_ctx) {

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -618,6 +618,7 @@ static void test_simple_connector_worker(void **state)
     simple_connector_data->buffer = buffer_create(0);
     simple_connector_data->last_buffer->header = buffer_create(0);
     simple_connector_data->last_buffer->buffer = buffer_create(0);
+    strcpy(simple_connector_data->connected_to, "localhost");
 
     buffer_sprintf(simple_connector_data->last_buffer->header, "test header");
     buffer_sprintf(simple_connector_data->last_buffer->buffer, "test buffer");
@@ -626,8 +627,8 @@ static void test_simple_connector_worker(void **state)
     expect_string(__wrap_connect_to_one_of, destination, "localhost");
     expect_value(__wrap_connect_to_one_of, default_port, 2003);
     expect_not_value(__wrap_connect_to_one_of, reconnects_counter, 0);
-    expect_value(__wrap_connect_to_one_of, connected_to, 0);
-    expect_value(__wrap_connect_to_one_of, connected_to_size, 0);
+    expect_string(__wrap_connect_to_one_of, connected_to, "localhost");
+    expect_value(__wrap_connect_to_one_of, connected_to_size, CONNECTED_TO_MAX);
     will_return(__wrap_connect_to_one_of, 2);
 
     expect_function_call(__wrap_send);
@@ -1170,6 +1171,7 @@ static void test_prometheus_remote_write_prepare_header(void **state)
     simple_connector_data->last_buffer = callocz(1, sizeof(struct simple_connector_buffer));
     simple_connector_data->last_buffer->header = buffer_create(0);
     simple_connector_data->last_buffer->buffer = buffer_create(0);
+    strcpy(simple_connector_data->connected_to, "localhost");
 
     buffer_sprintf(simple_connector_data->last_buffer->buffer, "test buffer");
 


### PR DESCRIPTION
##### Summary

Prometheus remote write requires the HTTP Host: header to be correct. We use the destination option as a value of the header. When we configure multiple destinations, the header contains all hosts configured. We should use only the host we are connected to.

Fixes #10608

##### Component Name

exporting engine

##### Test Plan

1. Configure the remote write exporting connector with two destinations:
```
[prometheus_remote_write:my_prometheus_remote_write_instance]
    enabled = yes
    destination = localhost:1234 localhost:1235
```
2. Build two versions of an [example remote write adapter](https://github.com/prometheus/prometheus/tree/main/documentation/examples/remote_storage/example_write_adapter). One for port 1234 and another one for port 1235.
3. Run both adapters. When you kill the first adapter, the second should show received metrics and vice versa.