### PR TITLE
[area/collectors] Added support for libvirtd LXC containers to the `cgroup-name.sh` cgroup name normalization script

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -430,11 +430,12 @@ if [ -z "${NAME}" ]; then
 
   elif [[ ${CGROUP} =~ machine.slice_machine.*-lxc ]]; then
     # libvirtd / lxc containers
-    # e.g.: machine.slice_machine-lxc/x2d9192/x2datvie0ximta01.scope
+	# examples:
+	# before: machine.slice machine-lxc/x2d969/x2dhubud0xians01.scope
+    # after:  lxc/hubud0xians01
+	# before: machine.slice_machine-lxc/x2d969/x2dhubud0xians01.scope/libvirt_init.scope
+	# after:  lxc/hubud0xians01/libvirt_init
     NAME="lxc/$(echo "${CGROUP}" | sed 's/machine.slice_machine.*-lxc//; s/\/x2d[[:digit:]]*//; s/\/x2d//g; s/\.scope//g')"
-  elif [[ ${CGROUP} =~ machine-lxc.*scope ]]; then
-    # libvirtd / lxc containers
-    NAME="lxc/$(echo "${CGROUP}" | sed -r 's/machine-lxc\\x2d[[:digit:]]+\\x2d//g; s/\.scope//g')"
   elif [[ ${CGROUP} =~ machine.slice_machine.*-qemu ]]; then
     # libvirtd / qemu virtual machines
     # NAME="$(echo ${CGROUP} | sed 's/machine.slice_machine.*-qemu//; s/\/x2d//; s/\/x2d/\-/g; s/\.scope//g')"

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -430,6 +430,7 @@ if [ -z "${NAME}" ]; then
 
   elif [[ ${CGROUP} =~ machine.slice_machine.*-lxc ]]; then
     # libvirtd / lxc containers
+    # e.g.: machine.slice_machine-lxc/x2d9192/x2datvie0ximta01.scope
     NAME="lxc/$(echo "${CGROUP}" | sed 's/machine.slice_machine.*-lxc//; s/\/x2d[[:digit:]]*//; s/\/x2d//g; s/\.scope//g')"
   elif [[ ${CGROUP} =~ machine-lxc.*scope ]]; then
     # libvirtd / lxc containers

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -428,6 +428,12 @@ if [ -z "${NAME}" ]; then
     # systemd-nspawn
     NAME="$(echo "${CGROUP}" | sed 's/.*machine.slice[_\/]\(.*\)\.service/\1/g')"
 
+  elif [[ ${CGROUP} =~ machine.slice_machine.*-lxc ]]; then
+    # libvirtd / lxc containers
+    NAME="lxc/$(echo "${CGROUP}" | sed 's/machine.slice_machine.*-lxc//; s/\/x2d[[:digit:]]*//; s/\/x2d//g; s/\.scope//g')"
+  elif [[ ${CGROUP} =~ machine-lxc.*scope ]]; then
+    # libvirtd / lxc containers
+    NAME="lxc/$(echo "${CGROUP}" | sed -r 's/machine-lxc\\x2d[[:digit:]]+\\x2d//g; s/\.scope//g')"
   elif [[ ${CGROUP} =~ machine.slice_machine.*-qemu ]]; then
     # libvirtd / qemu virtual machines
     # NAME="$(echo ${CGROUP} | sed 's/machine.slice_machine.*-qemu//; s/\/x2d//; s/\/x2d/\-/g; s/\.scope//g')"


### PR DESCRIPTION
Signed-off-by: git@end.re git@end.re

**Summary**

Added support for libvirtd LXC containers to the `cgroup-name.sh` cgroup name normalization helper script found in `netdata/collectors/cgroups.plugin`.

**Component Name**

area/collectors

**Description of testing that the developer performed**

The bash script `cgroup-name.sh`, a "Script to find a better name for cgroups" had support for libvirtd QEMU VMs but not for LXC containers. This PR adds support to get the libvirtd LXC container names normalized as well.

**Additional Information**

Example outputs:

```
$ ./cgroup-name.sh.in 'machine.slice_machine-lxc/x2d9192/x2datvie0ximta01.scope'     
2020-03-05 09:32:22: cgroup-name.sh.in: INFO: cgroup 'machine.slice_machine-lxc/x2d9192/x2datvie0ximta01.scope' is called 'lxc/atvie0ximta01'
lxc/atvie0ximta01
$ ./cgroup-name.sh.in 'machine.slice_machine-lxc/x2d3353752/x2datvie0xifsr01.scope'
2020-03-05 09:32:45: cgroup-name.sh.in: INFO: cgroup 'machine.slice_machine-lxc/x2d3353752/x2datvie0xifsr01.scope' is called 'lxc/atvie0xifsr01'
lxc/atvie0xifsr01
```

Result uniqueness is 'provided' by how `libvirt` works. With `libvirt` (frontend for LXC et al.) you can't launch multiple containers with the same name. The number in the middle is only the PID of the 'supervising' process.

```
[e@ip-172-30-0-48 ~]$ systemctl | grep lxc
  machine-lxc\x2d669\x2diedub0xians01.scope                                 loaded active     running      Container lxc-669-iedub0xians01
[e@ip-172-30-0-48 ~]$ machinectl
MACHINE               CLASS     SERVICE     OS   VERSION ADDRESSES       
lxc-669-iedub0xians01 container libvirt-lxc arch -       

1 machines listed.
[e@ip-172-30-0-48 ~]$ ps aux | grep 669
root         669  0.0  1.9 357516 18864 ?        Sl   13:26   0:00 /usr/lib/libvirt/libvirt_lxc --name iedub0xians01 --console 29 --security=none --handshake 32 --veth vnet0
```
