### PR TITLE
python.d: add plugin and module names to the runtime charts

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/charts.py
+++ b/collectors/python.d.plugin/python_modules/bases/charts.py
@@ -24,7 +24,7 @@ DIMENSION_SET = "SET '{id}' = {value}\n"
 CHART_VARIABLE_SET = "VARIABLE CHART '{id}' = {value}\n"
 
 RUNTIME_CHART_CREATE = "CHART netdata.runtime_{job_name} '' 'Execution time for {job_name}' 'ms' 'python.d' " \
-                       "netdata.pythond_runtime line 145000 {update_every} 'python.d.plugin' '{module_name}'\n" \
+                       "netdata.pythond_runtime line 145000 {update_every} '' 'python.d.plugin' '{module_name}'\n" \
                        "DIMENSION run_time 'run time' absolute 1 1\n"
 
 
@@ -45,7 +45,7 @@ def create_runtime_chart(func):
         chart = RUNTIME_CHART_CREATE.format(
             job_name=self.name,
             update_every=self._runtime_counters.update_every,
-            module=self.module_name,
+            module_name=self.module_name,
         )
         safe_print(chart)
         ok = func(*args, **kwargs)

--- a/collectors/python.d.plugin/python_modules/bases/charts.py
+++ b/collectors/python.d.plugin/python_modules/bases/charts.py
@@ -24,7 +24,7 @@ DIMENSION_SET = "SET '{id}' = {value}\n"
 CHART_VARIABLE_SET = "VARIABLE CHART '{id}' = {value}\n"
 
 RUNTIME_CHART_CREATE = "CHART netdata.runtime_{job_name} '' 'Execution time for {job_name}' 'ms' 'python.d' " \
-                       "netdata.pythond_runtime line 145000 {update_every}\n" \
+                       "netdata.pythond_runtime line 145000 {update_every} 'python.d.plugin' '{module_name}'\n" \
                        "DIMENSION run_time 'run time' absolute 1 1\n"
 
 
@@ -45,6 +45,7 @@ def create_runtime_chart(func):
         chart = RUNTIME_CHART_CREATE.format(
             job_name=self.name,
             update_every=self._runtime_counters.update_every,
+            module=self.module_name,
         )
         safe_print(chart)
         ok = func(*args, **kwargs)


### PR DESCRIPTION
##### Summary

This PR adds plugin and module names to the runtime [charts definitions](https://learn.netdata.cloud/docs/agent/collectors/plugins.d#chart).

These charts can be found in `Netdata Monitoring -> python.d`

> CHART type.id name title units [family [context [charttype [priority [update_every [options [plugin [module]]]]]]]]

We plan to use them for [deprecation alarms](https://github.com/netdata/netdata/issues/10248).

##### Component Name

`collectors/python.d`

##### Test Plan

- check python.d debug output, plugin/module names should be in the charts definitions

```cmd
CHART netdata.runtime_example_Four_Lines '' 'Execution time for example_Four_Lines' 'ms' 'python.d' netdata.pythond_runtime line 145000 1 '' 'python.d.plugin' 'example'
```

- check on the dashboard
<img width="1019" alt="Screenshot 2021-04-21 at 13 43 06" src="https://user-images.githubusercontent.com/22274335/115541225-8afce600-a2a7-11eb-94b3-e756634285ac.png">



##### Additional Information
