### PR TITLE
anonymous-statistics: add a timeout when using `curl`

### DIFF
--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -80,7 +80,7 @@ EOF
 
 # send the anonymous statistics to the Netdata PostHog
 if [ -n "$(command -v curl 2> /dev/null)" ]; then
-  curl -X POST --header "Content-Type: application/json" -d "${REQ_BODY}" https://posthog.netdata.cloud/capture/ > /dev/null 2>&1
+  curl -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" https://posthog.netdata.cloud/capture/ > /dev/null 2>&1
 else
   wget -q -O - --no-check-certificate \
   --method POST \


### PR DESCRIPTION
##### Summary

This PR adds `--max-time=2` timeout.

I set it to 2 because 
- it [was 2](https://github.com/netdata/netdata/blob/9580ed4d13125adac01483bac14a18c952afd13e/daemon/anonymous-statistics.sh.in#L33) before switching to [PostHog](https://github.com/netdata/netdata/pull/10636)
- @andrewm4894 didn't change `wget` timeout ([it is 1](https://github.com/netdata/netdata/blob/b6d729f96a0b1e17abffb2cf69d1ff29e62004f4/daemon/anonymous-statistics.sh.in#L85-L87))


##### Component Name

`anonymous-statistics`

##### Test Plan

##### Additional Information
