### PR TITLE
Rename struct fields from class to classification.

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -668,7 +668,7 @@ struct alarm_entry {
 
     char *family;
 
-    char *class;
+    char *classification;
     char *component;
     char *type;
 

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -91,7 +91,7 @@ static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
                 rc->name,
                 rc->rrdset->id,
                 rc->rrdset->family,
-                rc->class,
+                rc->classification,
                 rc->component,
                 rc->type,
                 rc->exec,
@@ -168,7 +168,7 @@ inline void rrdsetcalc_unlink(RRDCALC *rc) {
                 rc->name,
                 rc->rrdset->id,
                 rc->rrdset->family,
-                rc->class,
+                rc->classification,
                 rc->component,
                 rc->type,
                 rc->exec,
@@ -434,7 +434,7 @@ inline RRDCALC *rrdcalc_create_from_template(RRDHOST *host, RRDCALCTEMPLATE *rt,
     if(rt->units) rc->units = strdupz(rt->units);
     if(rt->info) rc->info = strdupz(rt->info);
 
-    if (rt->class) rc->class = strdupz(rt->class);
+    if (rt->classification) rc->classification = strdupz(rt->classification);
     if (rt->component) rc->component = strdupz(rt->component);
     if (rt->type) rc->type = strdupz(rt->type);
 
@@ -545,7 +545,7 @@ inline RRDCALC *rrdcalc_create_from_rrdcalc(RRDCALC *rc, RRDHOST *host, const ch
     if(rc->units) newrc->units = strdupz(rc->units);
     if(rc->info) newrc->info = strdupz(rc->info);
 
-    if (rc->class) newrc->class = strdupz(rc->class);
+    if (rc->classification) newrc->classification = strdupz(rc->classification);
     if (rc->component) newrc->component = strdupz(rc->component);
     if (rc->type) newrc->type = strdupz(rc->type);
 
@@ -587,7 +587,7 @@ void rrdcalc_free(RRDCALC *rc) {
     freez(rc->source);
     freez(rc->units);
     freez(rc->info);
-    freez(rc->class);
+    freez(rc->classification);
     freez(rc->component);
     freez(rc->type);
     simple_pattern_free(rc->spdim);

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -42,7 +42,7 @@ struct rrdcalc {
     char *exec;                     // the command to execute when this alarm switches state
     char *recipient;                // the recipient of the alarm (the first parameter to exec)
 
-    char *class;                    // the class that this alarm belongs
+    char *classification;           // the class that this alarm belongs
     char *component;                // the component that this alarm refers to
     char *type;                     // type of the alarm
 

--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -15,7 +15,7 @@ struct rrdcalctemplate {
     char *exec;
     char *recipient;
 
-    char *class;
+    char *classification;
     char *component;
     char *type;
 

--- a/health/health.c
+++ b/health/health.c
@@ -930,7 +930,7 @@ void *health_main(void *ptr) {
                         if(likely(!rrdcalc_isrepeating(rc))) {
                             ALARM_ENTRY *ae = health_create_alarm_entry(
                                     host, rc->id, rc->next_event_id++, now, rc->name, rc->rrdset->id,
-                                    rc->rrdset->family, rc->class, rc->component, rc->type, rc->exec, rc->recipient, now - rc->last_status_change,
+                                    rc->rrdset->family, rc->classification, rc->component, rc->type, rc->exec, rc->recipient, now - rc->last_status_change,
                                     rc->old_value, rc->value, rc->status, status, rc->source, rc->units, rc->info,
                                     rc->delay_last,
                                     (
@@ -980,7 +980,7 @@ void *health_main(void *ptr) {
                         rc->last_repeat = now;
                         ALARM_ENTRY *ae = health_create_alarm_entry(
                                 host, rc->id, rc->next_event_id++, now, rc->name, rc->rrdset->id,
-                                rc->rrdset->family, rc->class, rc->component, rc->type, rc->exec, rc->recipient, now - rc->last_status_change,
+                                rc->rrdset->family, rc->classification, rc->component, rc->type, rc->exec, rc->recipient, now - rc->last_status_change,
                                 rc->old_value, rc->value, rc->old_status, rc->status, rc->source, rc->units, rc->info,
                                 rc->delay_last,
                                 (

--- a/health/health.h
+++ b/health/health.h
@@ -67,7 +67,7 @@ extern ALARM_ENTRY* health_create_alarm_entry(
         const char *name,
         const char *chart,
         const char *family,
-        const char *class,
+        const char *classification,
         const char *component,
         const char *type,
         const char *exec,

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -707,15 +707,15 @@ static int health_readfile(const char *filename, void *data) {
                 rc->hash_chart = simple_hash(rc->chart);
             }
             else if(hash == hash_class && !strcasecmp(key, HEALTH_CLASS_KEY)) {
-                if(rc->class) {
-                    if(strcmp(rc->class, value) != 0)
+                if(rc->classification) {
+                    if(strcmp(rc->classification, value) != 0)
                         error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rc->name, key, rc->class, value, value);
+                                line, filename, rc->name, key, rc->classification, value, value);
 
-                    freez(rc->class);
+                    freez(rc->classification);
                 }
-                rc->class = strdupz(value);
-                strip_quotes(rc->class);
+                rc->classification = strdupz(value);
+                strip_quotes(rc->classification);
             }
             else if(hash == hash_component && !strcasecmp(key, HEALTH_COMPONENT_KEY)) {
                 if(rc->component) {
@@ -892,15 +892,15 @@ static int health_readfile(const char *filename, void *data) {
                 rt->hash_context = simple_hash(rt->context);
             }
             else if(hash == hash_class && !strcasecmp(key, HEALTH_CLASS_KEY)) {
-                if(rt->class) {
-                    if(strcmp(rt->class, value) != 0)
+                if(rt->classification) {
+                    if(strcmp(rt->classification, value) != 0)
                         error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                              line, filename, rt->name, key, rt->class, value, value);
+                              line, filename, rt->name, key, rt->classification, value, value);
 
-                    freez(rt->class);
+                    freez(rt->classification);
                 }
-                rt->class = strdupz(value);
-                strip_quotes(rt->class);
+                rt->classification = strdupz(value);
+                strip_quotes(rt->classification);
             }
             else if(hash == hash_component && !strcasecmp(key, HEALTH_COMPONENT_KEY)) {
                 if(rt->component) {

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -55,7 +55,7 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
                    , ae->name
                    , ae->chart
                    , ae->family
-                   , ae->class?ae->class:"Unknown"
+                   , ae->classification?ae->classification:"Unknown"
                    , ae->component?ae->component:"Unknown"
                    , ae->type?ae->type:"Unknown"
                    , (ae->flags & HEALTH_ENTRY_FLAG_PROCESSED)?"true":"false"
@@ -215,7 +215,7 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                    , rc->name
                    , rc->chart
                    , (rc->rrdset && rc->rrdset->family)?rc->rrdset->family:""
-                   , rc->class?rc->class:"Unknown"
+                   , rc->classification?rc->classification:"Unknown"
                    , rc->component?rc->component:"Unknown"
                    , rc->type?rc->type:"Unknown"
                    , (rc->rrdset)?"true":"false"

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -146,7 +146,7 @@ inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae) {
                             , ae->new_value
                             , ae->old_value
                             , (uint64_t)ae->last_repeat
-                            , (ae->class)?ae->class:"Unknown"
+                            , (ae->classification)?ae->classification:"Unknown"
                             , (ae->component)?ae->component:"Unknown"
                             , (ae->type)?ae->type:"Unknown"
         ) < 0))
@@ -369,9 +369,9 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
             ae->last_repeat = last_repeat;
 
             if (likely(entries > 28)) {
-                freez(ae->class);
-                ae->class = strdupz(pointers[28]);
-                if(!*ae->class) { freez(ae->class); ae->class = NULL; }
+                freez(ae->classification);
+                ae->classification = strdupz(pointers[28]);
+                if(!*ae->classification) { freez(ae->classification); ae->classification = NULL; }
 
                 freez(ae->component);
                 ae->component = strdupz(pointers[29]);
@@ -491,7 +491,7 @@ inline ALARM_ENTRY* health_create_alarm_entry(
         ae->family = strdupz(family);
 
     if (class)
-        ae->class = strdupz(class);
+        ae->classification = strdupz(class);
 
     if (component)
         ae->component = strdupz(component);
@@ -595,7 +595,7 @@ inline void health_alarm_log_free_one_nochecks_nounlink(ALARM_ENTRY *ae) {
     freez(ae->name);
     freez(ae->chart);
     freez(ae->family);
-    freez(ae->class);
+    freez(ae->classification);
     freez(ae->component);
     freez(ae->type);
     freez(ae->exec);


### PR DESCRIPTION
These fields made our headers incompatible with C++, because `class` is
a reserved keyword.

##### Summary

##### Component Name

##### Test Plan

Build the kmeans-poc branch which uses C++ source files without errors.

##### Additional Information
