### PR TITLE
proc/mdstat: add raid level to the family

### DIFF
--- a/collectors/proc.plugin/proc_mdstat.c
+++ b/collectors/proc.plugin/proc_mdstat.c
@@ -8,6 +8,7 @@ struct raid {
     int redundant;
     char *name;
     uint32_t hash;
+    char *level;
 
     RRDDIM *rd_health;
     unsigned long long failed_disks;
@@ -149,6 +150,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
         for (raid_idx = 0; raid_idx < raids_allocated; raid_idx++) {
             struct raid *raid = &raids[raid_idx];
             freez(raid->name);
+            freez(raid->level);
             freez(raid->mismatch_cnt_filename);
         }
         if (raids_num) {
@@ -177,12 +179,15 @@ int do_proc_mdstat(int update_every, usec_t dt)
         if (unlikely(!raid->name)) {
             raid->name = strdupz(procfile_lineword(ff, l, 0));
             raid->hash = simple_hash(raid->name);
+            raid->level = strdupz(procfile_lineword(ff, l, 2));
         } else if (unlikely(strcmp(raid->name, procfile_lineword(ff, l, 0)))) {
             freez(raid->name);
             freez(raid->mismatch_cnt_filename);
+            freez(raid->level);
             memset(raid, 0, sizeof(struct raid));
             raid->name = strdupz(procfile_lineword(ff, l, 0));
             raid->hash = simple_hash(raid->name);
+            raid->level = strdupz(procfile_lineword(ff, l, 2));
         }
 
         if (unlikely(!raid->name || !raid->name[0]))
@@ -436,7 +441,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
                 snprintfz(id, 50, "%s_disks", raid->name);
 
                 if (unlikely(!raid->st_disks && !(raid->st_disks = rrdset_find_active_byname_localhost(id)))) {
-                    snprintfz(family, 50, "%s", raid->name);
+                    snprintfz(family, 50, "%s (%s)", raid->name, raid->level);
 
                     raid->st_disks = rrdset_create_localhost(
                         "mdstat",
@@ -473,7 +478,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
                 snprintfz(id, 50, "%s_mismatch", raid->name);
 
                 if (unlikely(!raid->st_mismatch_cnt && !(raid->st_mismatch_cnt = rrdset_find_active_byname_localhost(id)))) {
-                    snprintfz(family, 50, "%s", raid->name);
+                    snprintfz(family, 50, "%s (%s)", raid->name, raid->level);
 
                     raid->st_mismatch_cnt = rrdset_create_localhost(
                         "mdstat",
@@ -507,7 +512,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
                 snprintfz(id, 50, "%s_operation", raid->name);
 
                 if (unlikely(!raid->st_operation && !(raid->st_operation = rrdset_find_active_byname_localhost(id)))) {
-                    snprintfz(family, 50, "%s", raid->name);
+                    snprintfz(family, 50, "%s (%s)", raid->name, raid->level);
 
                     raid->st_operation = rrdset_create_localhost(
                         "mdstat",
@@ -548,7 +553,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
                 snprintfz(id, 50, "%s_finish", raid->name);
 
                 if (unlikely(!raid->st_finish && !(raid->st_finish = rrdset_find_active_byname_localhost(id)))) {
-                    snprintfz(family, 50, "%s", raid->name);
+                    snprintfz(family, 50, "%s (%s)", raid->name, raid->level);
 
                     raid->st_finish = rrdset_create_localhost(
                         "mdstat",
@@ -579,7 +584,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
                 snprintfz(id, 50, "%s_speed", raid->name);
 
                 if (unlikely(!raid->st_speed && !(raid->st_speed = rrdset_find_active_byname_localhost(id)))) {
-                    snprintfz(family, 50, "%s", raid->name);
+                    snprintfz(family, 50, "%s (%s)", raid->name, raid->level);
 
                     raid->st_speed = rrdset_create_localhost(
                         "mdstat",
@@ -613,7 +618,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
                 snprintfz(id, 50, "%s_availability", raid->name);
 
                 if (unlikely(!raid->st_nonredundant && !(raid->st_nonredundant = rrdset_find_active_localhost(id)))) {
-                    snprintfz(family, 50, "%s", raid->name);
+                    snprintfz(family, 50, "%s (%s)", raid->name, raid->level);
 
                     raid->st_nonredundant = rrdset_create_localhost(
                         "mdstat",

--- a/collectors/proc.plugin/proc_mdstat.c
+++ b/collectors/proc.plugin/proc_mdstat.c
@@ -170,7 +170,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
 
         words = procfile_linewords(ff, l);
 
-        if (unlikely(words < 2))
+        if (unlikely(words < 3))
             continue;
 
         if (unlikely(procfile_lineword(ff, l, 1)[0] != 'a'))

--- a/health/health.d/mdstat.conf
+++ b/health/health.d/mdstat.conf
@@ -29,6 +29,7 @@ component: RAID
     class: System
 component: RAID
      type: Errors
+ families: !*(raid1) !*(raid10) *
     units: unsynchronized blocks
      calc: $count
     every: 60s


### PR DESCRIPTION
##### Summary

Relevant discussion: https://github.com/netdata/netdata/issues/10247#issuecomment-824429429

This PR:
 - adds raid level to the family (e.g.: `md0 => md0 (raid1)`)
 - excludes raid1 and raid10 arrays in the [mdstat_mismatch_cnt](https://github.com/netdata/netdata/blob/7b6362767e71b09ad1604de45c754e798c7dd169/health/health.d/mdstat.conf#L27-L38) alarm due to too many false positives (thanks to @mailinglists35)


##### Component Name

`collectors/proc/`

##### Test Plan

- create several arrays using `mdadm`
- delete them
- recreate them again - ensure nothing breaks.


##### Additional Information

That is how it looks on the dashboard:

<img width="1372" alt="Screenshot 2021-04-23 at 20 08 40" src="https://user-images.githubusercontent.com/22274335/115906077-b8948b80-a46f-11eb-84f0-b9fe7c1d7728.png">