### PR TITLE
Create ebpf.d directory in PLUGINDIR for debian packages(netdata#11017)

### DIFF
--- a/packaging/bundle-ebpf.sh
+++ b/packaging/bundle-ebpf.sh
@@ -11,4 +11,7 @@ curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/kernel-coll
 grep "${EBPF_TARBALL}" "${SRCDIR}/packaging/ebpf.checksums" | sha256sum -c - || exit 1
 tar -xaf "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
 # shellcheck disable=SC2046
-cp -a $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}"
+if [ ! -d ${PLUGINDIR}/ebpf.d ];then
+    mkdir ${PLUGINDIR}/ebpf.d
+fi
+cp -a $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}/ebpf.d"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Create ebpf.d directory in PLUGINDIR for debian packages.
(Fixes issue#11017)

##### Component Name
netdata

##### Test Plan
1. Build the debian package of netdata
2. Install the deb package and check the directory /usr/libexec/netdata/plugins.d/ebpf.d
