### PR TITLE
Create ebpf.d directory in PLUGINDIR for debian and rpm package(netdata#11017)

### DIFF
--- a/packaging/bundle-ebpf.sh
+++ b/packaging/bundle-ebpf.sh
@@ -10,5 +10,8 @@ mkdir -p "${SRCDIR}/tmp/ebpf"
 curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/kernel-collector/releases/download/${EBPF_VERSION}/${EBPF_TARBALL}" > "${EBPF_TARBALL}" || exit 1
 grep "${EBPF_TARBALL}" "${SRCDIR}/packaging/ebpf.checksums" | sha256sum -c - || exit 1
 tar -xaf "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
+if [ ! -d "${PLUGINDIR}/ebpf.d" ];then
+    mkdir "${PLUGINDIR}/ebpf.d"
+fi
 # shellcheck disable=SC2046
-cp -a $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}"
+cp -a $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}/ebpf.d"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #11017 
Create ebpf.d directory in PLUGINDIR

##### Component Name
netdata

##### Test Plan
For Debian
1. Build the debian package of netdata
2. Install the netdata deb and check  the directory in PLUGINDIR

For RPM
1. Build the rpm package of netdata
2. Install the netdata rpm and check the directory in PLUGINDIR

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

