### PR TITLE
Improve installation method for Alpine

### DIFF
--- a/packaging/installer/methods/alpine.md
+++ b/packaging/installer/methods/alpine.md
@@ -9,7 +9,7 @@ Execute these commands to install Netdata in Alpine Linux 3.x:
 
 ```sh
 # install required packages
-apk add alpine-sdk bash curl libuv-dev zlib-dev util-linux-dev libmnl-dev gcc make git autoconf automake pkgconfig python logrotate
+apk add alpine-sdk bash curl libuv-dev zlib-dev util-linux-dev libmnl-dev gcc make git autoconf automake pkgconfig python3 logrotate
 
 # if you plan to run node.js Netdata plugins
 apk add nodejs
@@ -21,16 +21,20 @@ cd netdata
 # build it, install it, start it
 ./netdata-installer.sh
 
-# make Netdata start at boot
-echo -e "#!/usr/bin/env bash\n/usr/sbin/netdata" >/etc/local.d/netdata.start
-chmod 755 /etc/local.d/netdata.start
+# make Netdata start at boot and stop at shutdown
+cat > /etc/init.d/netdata << EOF
+#!/sbin/openrc-run
 
-# make Netdata stop at shutdown
-echo -e "#!/usr/bin/env bash\nkillall netdata" >/etc/local.d/netdata.stop
-chmod 755 /etc/local.d/netdata.stop
+name="netdata"
+command="/usr/sbin/$SVCNAME"
 
-# enable the local service to start automatically
-rc-update add local
+depend() {
+        need net localmount
+        after firewall
+}
+EOF
 ```
+
+If you have installed Netdata in another directory, you have to change the content of the `command` variable in that script.
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fpackaging%2Finstaller%2Fmethods%2Falpine&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)


### PR DESCRIPTION
##### Summary

Improve installation method for Alpine

##### Component Name

Documentation

##### Additional Information

- the `python` package doesn't exist since Alpine 3.5 (dec 2016), use `python3` instead
- create a proper start script instead of using `/etc/local.d`