### PR TITLE
Fix storing an NULL claim id on a parent node

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -165,8 +165,7 @@ void load_claiming_state(void)
     }
     localhost->aclk_state.claimed_id = claimed_id;
 
-    if (likely(claimed_id))
-        store_claim_id(&localhost->host_uuid, &uuid);
+    store_claim_id(&localhost->host_uuid, claimed_id ? &uuid : NULL);
 
     rrdhost_aclk_state_unlock(localhost);
     if (!claimed_id) {

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1341,8 +1341,7 @@ failed:
 
 #define SQL_STORE_CLAIM_ID  "insert into node_instance " \
     "(host_id, claim_id, date_created) values (@host_id, @claim_id, strftime('%s')) " \
-    "on conflict(host_id) do update set node_id = null, claim_id = excluded.claim_id " \
-    "where claim_id <> excluded.claim_id;"
+    "on conflict(host_id) do update set claim_id = excluded.claim_id;"
 
 void store_claim_id(uuid_t *host_id, uuid_t *claim_id)
 {
@@ -1367,7 +1366,10 @@ void store_claim_id(uuid_t *host_id, uuid_t *claim_id)
         goto failed;
     }
 
-    rc = sqlite3_bind_blob(res, 2, claim_id, sizeof(*claim_id), SQLITE_STATIC);
+    if (claim_id)
+        rc = sqlite3_bind_blob(res, 2, claim_id, sizeof(*claim_id), SQLITE_STATIC);
+    else
+        rc = sqlite3_bind_null(res, 2);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind claim_id parameter to store node instance information");
         goto failed;

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -131,8 +131,7 @@ PARSER_RC streaming_claimed_id(char **words, void *user, PLUGINSD_ACTION *plugin
         freez(host->aclk_state.claimed_id);
     host->aclk_state.claimed_id = strcmp(words[2], "NULL") ? strdupz(words[2]) : NULL;
 
-    if (likely(host->aclk_state.claimed_id))
-        store_claim_id(&host->host_uuid, &uuid);
+    store_claim_id(&host->host_uuid, host->aclk_state.claimed_id ? &uuid : NULL);
 
     rrdhost_aclk_state_unlock(host);
 


### PR DESCRIPTION
##### Summary
- Properly enable the storage of NULL claim ids in the local (parent) database for children
  - Resets claim ids to NULL when the children are unclaimed

Previously a check would prevent this from storing null claim ids

##### Component Name
database
aclk

##### Test Plan
- Verify that you have the new entries there for the parent and children
   - Note unclaimed children would be omitted from this table before this PR
   - use sqlite3 to access the local database `sqlite3 netdata-meta.db` which is stored under `/var/cache/netdata/`
   - Do `select count(*) from node_instance ni, host h where ni.host_id = h.host_id;`

- Connect an unclaimed child to the parent
  - Entry should be available in the node_instance table which claim id NULL
- Connect a claimed child to the parent
  - Entry should be available in the node_instance table 
  - Unclaim the child (remove or move the /var/lib/netdata/cloud.d/claimed_id file
  - Restart the child
  - Entry in the node_instance table should not include an NULL `claim_id` field
