### PR TITLE
health/vernemq: use `average` instead of  `sum`

### DIFF
--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -37,11 +37,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute of queue_message_drop
+   lookup: average -1m unaligned absolute of queue_message_drop
     units: dropped messages
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of dropped messaged due to full queues in the last minute
        to: sysadmin
 
@@ -50,11 +50,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Latency
-   lookup: sum -1m unaligned absolute of queue_message_expired
+   lookup: average -1m unaligned absolute of queue_message_expired
     units: expired messages
     every: 1m
-     warn: $this > (($status >= $WARNING) ? (0) : (15))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+     warn: $this > (($status >= $WARNING) ? (0) : (5))
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of messages which expired before delivery in the last minute
        to: sysadmin
 
@@ -63,11 +63,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Latency
-   lookup: sum -1m unaligned absolute of queue_message_unhandled
+   lookup: average -1m unaligned absolute of queue_message_unhandled
     units: unhandled messages
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of unhandled messages (connections with clean session=true) in the last minute
        to: sysadmin
 
@@ -122,11 +122,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !success,*
+   lookup: average -1m unaligned absolute match-names of !success,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of sent unsuccessful v3/v5 CONNACK packets in the last minute
        to: sysadmin
 
@@ -137,11 +137,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Workload
-   lookup: sum -1m unaligned absolute match-names of !normal_disconnect,*
+   lookup: average -1m unaligned absolute match-names of !normal_disconnect,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of received not normal v5 DISCONNECT packets in the last minute
        to: sysadmin
 
@@ -150,11 +150,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !normal_disconnect,*
+   lookup: average -1m unaligned absolute match-names of !normal_disconnect,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of sent not normal v5 DISCONNECT packets in the last minute
        to: sysadmin
 
@@ -165,11 +165,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute
+   lookup: average -1m unaligned absolute
     units: failed ops
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of failed v3/v5 SUBSCRIBE operations in the last minute
        to: sysadmin
 
@@ -178,11 +178,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Workload
-   lookup: sum -1m unaligned absolute
+   lookup: average -1m unaligned absolute
     units: attempts
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of unauthorized v3/v5 SUBSCRIBE attempts in the last minute
        to: sysadmin
 
@@ -193,11 +193,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute
+   lookup: average -1m unaligned absolute
     units: failed ops
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of failed v3/v5 UNSUBSCRIBE operations in the last minute
        to: sysadmin
 
@@ -208,11 +208,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute
+   lookup: average -1m unaligned absolute
     units: failed ops
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of failed v3/v5 PUBLISH operations in the last minute
        to: sysadmin
 
@@ -221,11 +221,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Workload
-   lookup: sum -1m unaligned absolute
+   lookup: average -1m unaligned absolute
     units: attempts
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of unauthorized v3/v5 PUBLISH attempts in the last minute
        to: sysadmin
 
@@ -236,11 +236,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !success,*
+   lookup: average -1m unaligned absolute match-names of !success,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of received unsuccessful v5 PUBACK packets in the last minute
        to: sysadmin
 
@@ -249,11 +249,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !success,*
+   lookup: average -1m unaligned absolute match-names of !success,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of sent unsuccessful v5 PUBACK packets in the last minute
        to: sysadmin
 
@@ -262,11 +262,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Workload
-   lookup: sum -1m unaligned absolute
+   lookup: average -1m unaligned absolute
     units: messages
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of received unexpected v3/v5 PUBACK packets in the last minute
        to: sysadmin
 
@@ -277,11 +277,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !success,*
+   lookup: average -1m unaligned absolute match-names of !success,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of received unsuccessful v5 PUBREC packets in the last minute
        to: sysadmin
 
@@ -290,11 +290,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !success,*
+   lookup: average -1m unaligned absolute match-names of !success,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of sent unsuccessful v5 PUBREC packets in the last minute
        to: sysadmin
 
@@ -303,11 +303,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Workload
-   lookup: sum -1m unaligned absolute
+   lookup: average -1m unaligned absolute
     units: messages
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of received unexpected v3 PUBREC packets in the last minute
        to: sysadmin
 
@@ -318,11 +318,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !success,*
+   lookup: average -1m unaligned absolute match-names of !success,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of received unsuccessful v5 PUBREL packets in the last minute
        to: sysadmin
 
@@ -331,11 +331,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !success,*
+   lookup: average -1m unaligned absolute match-names of !success,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of sent unsuccessful v5 PUBREL packets in the last minute
        to: sysadmin
 
@@ -346,11 +346,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !success,*
+   lookup: average -1m unaligned absolute match-names of !success,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of received unsuccessful v5 PUBCOMP packets in the last minute
        to: sysadmin
 
@@ -359,11 +359,11 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Errors
-   lookup: sum -1m unaligned absolute match-names of !success,*
+   lookup: average -1m unaligned absolute match-names of !success,*
     units: packets
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of sent unsuccessful v5 PUBCOMP packets in the last minute
        to: sysadmin
 
@@ -372,10 +372,10 @@ component: VerneMQ
     class: Messaging
 component: VerneMQ
      type: Workload
-   lookup: sum -1m unaligned absolute
+   lookup: average -1m unaligned absolute
     units: messages
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
-    delay: up 5m down 5m multiplier 1.5 max 2h
+    delay: up 2m down 5m multiplier 1.5 max 2h
      info: number of received unexpected v3/v5 PUBCOMP packets in the last minute
        to: sysadmin


### PR DESCRIPTION
##### Summary

From our experience using `sum` makes VerneMQ alarms too sensitive, this PR changes the `lookup` method to `average`.

##### Component Name

`health/`

##### Test Plan

- install new alarms
- ensure there are no syntax errors checking `error.log`

##### Additional Information

