### PR TITLE
Remove dots in cgroup ids

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1300,6 +1300,7 @@ static inline char *cgroup_chart_id_strdupz(const char *s) {
     char *r = strdupz(s);
     netdata_fix_chart_id(r);
 
+    // dots are used to distinguish chart type and id in streaming, so we should replace them
     for (char *d = r; *d; d++) {
         if (*d == '.')
             *d = '-';

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1300,6 +1300,11 @@ static inline char *cgroup_chart_id_strdupz(const char *s) {
     char *r = strdupz(s);
     netdata_fix_chart_id(r);
 
+    for (char *d = r; *d; d++) {
+        if (*d == '.')
+            *d = '-';
+    }
+
     return r;
 }
 


### PR DESCRIPTION
##### Summary

If there are dots in the id of a cgroup on a child node, the dashboard on the parent node shows a truncated name for the cgroup. It happens because our current streaming protocol uses dots to distinguish chart type and id. After streaming of `type.with.dots.id.with.dots` we get type = `type` and id = `with.dots.id.with.dots`.

The solution is to replace dots with dashes in the cgroup id.

Fixes #11049

##### Component Name

cgroups plugin

##### Test Plan

1. Create a docker container on a child node with the name, containing dots: docker run -d --name "first.second.third" nginx
2. Configure streaming.
3. Check the name of the container in the main menu on the parent node - it should be `first-second-third`.