### PR TITLE
Provide UTC offset in seconds and edit health config command

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -696,6 +696,46 @@ static void get_system_timezone(void)
         timezone = "unknown";
 
     netdata_configured_timezone = config_get(CONFIG_SECTION_GLOBAL, "timezone", timezone);
+
+    //get the utc offset, and the timezone as returned by strftime
+    //will be sent to the cloud
+    //Note: This will need an agent restart to get new offset on time change (dst, etc).
+    {
+        time_t t;
+        struct tm *tmp, tmbuf;
+        char zone[FILENAME_MAX + 1]; //can be really less, but %z could be abbriviated or long
+        char sign[2], hh[3], mm[3];
+
+        t = now_realtime_sec();
+        tmp = localtime_r(&t, &tmbuf);
+
+        if (tmp != NULL) {
+            if (strftime(zone, FILENAME_MAX, "%Z", tmp) == 0) {
+                netdata_configured_abbrev_timezone = strdupz("UTC");
+            } else
+                netdata_configured_abbrev_timezone = strdupz(zone);
+
+            if (strftime(zone, FILENAME_MAX, "%z", tmp) == 0) {
+                netdata_configured_utc_offset = 0;
+            } else {
+                sign[0] = zone[0] == '-' || zone[0] == '+' ? zone[0] : '0';
+                sign[1] = '\0';
+                hh[0] = isdigit(zone[1]) ? zone[1] : '0';
+                hh[1] = isdigit(zone[2]) ? zone[2] : '0';
+                hh[2] = '\0';
+                mm[0] = isdigit(zone[3]) ? zone[3] : '0';
+                mm[1] = isdigit(zone[4]) ? zone[4] : '0';
+                mm[2] = '\0';
+
+                netdata_configured_utc_offset = (atoi(hh) * 60 * 60) + (atoi(mm) * 60);
+                netdata_configured_utc_offset =
+                    sign[0] == '-' ? -netdata_configured_utc_offset : netdata_configured_utc_offset;
+            }
+        } else {
+            netdata_configured_abbrev_timezone = strdupz("UTC");
+            netdata_configured_utc_offset = 0;
+        }
+    }
 }
 
 void set_global_environment()

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -703,7 +703,7 @@ static void get_system_timezone(void)
     {
         time_t t;
         struct tm *tmp, tmbuf;
-        char zone[FILENAME_MAX + 1]; //can be really less, but %z could be abbriviated or long
+        char zone[FILENAME_MAX + 1];
         char sign[2], hh[3], mm[3];
 
         t = now_realtime_sec();

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -727,7 +727,7 @@ static void get_system_timezone(void)
                 mm[1] = isdigit(zone[4]) ? zone[4] : '0';
                 mm[2] = '\0';
 
-                netdata_configured_utc_offset = (atoi(hh) * 60 * 60) + (atoi(mm) * 60);
+                netdata_configured_utc_offset = (str2i(hh) * 3600) + (str2i(mm) * 60);
                 netdata_configured_utc_offset =
                     sign[0] == '-' ? -netdata_configured_utc_offset : netdata_configured_utc_offset;
             }

--- a/daemon/common.c
+++ b/daemon/common.c
@@ -14,6 +14,8 @@ char *netdata_configured_lock_dir            = NULL;
 char *netdata_configured_home_dir            = VARLIB_DIR;
 char *netdata_configured_host_prefix         = NULL;
 char *netdata_configured_timezone            = NULL;
+char *netdata_configured_abbrev_timezone     = NULL;
+int32_t netdata_configured_utc_offset        = 0;
 int netdata_ready;
 int netdata_cloud_setting;
 

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -97,6 +97,8 @@ extern char *netdata_configured_lock_dir;
 extern char *netdata_configured_home_dir;
 extern char *netdata_configured_host_prefix;
 extern char *netdata_configured_timezone;
+extern char *netdata_configured_abbrev_timezone;
+extern int32_t netdata_configured_utc_offset;
 extern int netdata_zero_metrics_enabled;
 extern int netdata_anonymous_statistics_enabled;
 

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1500,6 +1500,8 @@ static RRDHOST *dbengine_rrdhost_find_or_create(char *name)
             , name
             , os_type
             , netdata_configured_timezone
+            , netdata_configured_abbrev_timezone
+            , netdata_configured_utc_offset
             , config_get(CONFIG_SECTION_BACKEND, "host tags", "")
             , program_name
             , program_version

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -764,9 +764,13 @@ struct rrdhost {
     const char *os;                                 // the O/S type of the host
     const char *tags;                               // tags for this host
     const char *timezone;                           // the timezone of the host
+
 #ifdef ENABLE_ACLK
     long    obsolete_count;
 #endif
+
+    const char *abbrev_timezone;                    // the abbriviated timezone of the host
+    int32_t utc_offset;                             // the offset in seconds from utc
 
     RRDHOST_FLAGS flags;                            // flags about this RRDHOST
     RRDHOST_FLAGS *exporting_flags;                 // array of flags for exporting connector instances
@@ -938,6 +942,8 @@ extern RRDHOST *rrdhost_find_or_create(
         , const char *guid
         , const char *os
         , const char *timezone
+        , const char *abbrev_timezone
+        , int32_t utc_offset
         , const char *tags
         , const char *program_name
         , const char *program_version
@@ -958,6 +964,8 @@ extern void rrdhost_update(RRDHOST *host
     , const char *guid
     , const char *os
     , const char *timezone
+    , const char *abbrev_timezone
+    , int32_t utc_offset
     , const char *tags
     , const char *program_name
     , const char *program_version
@@ -1325,17 +1333,17 @@ extern void rrdset_delete_obsolete_dimensions(RRDSET *st);
 extern void rrdhost_cleanup_obsolete_charts(RRDHOST *host);
 extern RRDHOST *rrdhost_create(
     const char *hostname, const char *registry_hostname, const char *guid, const char *os, const char *timezone,
-    const char *tags, const char *program_name, const char *program_version, int update_every, long entries,
-    RRD_MEMORY_MODE memory_mode, unsigned int health_enabled, unsigned int rrdpush_enabled, char *rrdpush_destination,
-    char *rrdpush_api_key, char *rrdpush_send_charts_matching, struct rrdhost_system_info *system_info,
+    const char *abbrev_timezone, int32_t utc_offset,const char *tags, const char *program_name, const char *program_version,
+    int update_every, long entries, RRD_MEMORY_MODE memory_mode, unsigned int health_enabled, unsigned int rrdpush_enabled,
+    char *rrdpush_destination, char *rrdpush_api_key, char *rrdpush_send_charts_matching, struct rrdhost_system_info *system_info,
     int is_localhost); //TODO: Remove , int is_archived);
 
 #endif /* NETDATA_RRD_INTERNALS */
 
 extern void set_host_properties(
     RRDHOST *host, int update_every, RRD_MEMORY_MODE memory_mode, const char *hostname, const char *registry_hostname,
-    const char *guid, const char *os, const char *tags, const char *tzone, const char *program_name,
-    const char *program_version);
+    const char *guid, const char *os, const char *tags, const char *tzone, const char *abbrev_tzone, int32_t utc_offset,
+    const char *program_name, const char *program_version);
 
 // ----------------------------------------------------------------------------
 // RRD DB engine declarations

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -98,7 +98,7 @@ static inline void rrdhost_init_timezone(RRDHOST *host, const char *timezone, co
     freez(old);
 
     old = (void *)host->abbrev_timezone;
-    host->abbrev_timezone = strdupz((abbrev_timezone && *abbrev_timezone)?abbrev_timezone:"UTC");
+    host->abbrev_timezone = strdupz((abbrev_timezone && *abbrev_timezone) ? abbrev_timezone : "UTC");
     freez(old);
 
     host->utc_offset = utc_offset;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -88,13 +88,20 @@ static inline void rrdhost_init_os(RRDHOST *host, const char *os) {
     freez(old);
 }
 
-static inline void rrdhost_init_timezone(RRDHOST *host, const char *timezone) {
-    if(host->timezone && timezone && !strcmp(host->timezone, timezone))
+static inline void rrdhost_init_timezone(RRDHOST *host, const char *timezone, const char *abbrev_timezone, int32_t utc_offset) {
+    if (host->timezone && timezone && !strcmp(host->timezone, timezone) && host->abbrev_timezone && abbrev_timezone &&
+        !strcmp(host->abbrev_timezone, abbrev_timezone) && host->utc_offset == utc_offset)
         return;
 
     void *old = (void *)host->timezone;
     host->timezone = strdupz((timezone && *timezone)?timezone:"unknown");
     freez(old);
+
+    old = (void *)host->abbrev_timezone;
+    host->abbrev_timezone = strdupz((abbrev_timezone && *abbrev_timezone)?abbrev_timezone:"UTC");
+    freez(old);
+
+    host->utc_offset = utc_offset;
 }
 
 static inline void rrdhost_init_machine_guid(RRDHOST *host, const char *machine_guid) {
@@ -105,7 +112,8 @@ static inline void rrdhost_init_machine_guid(RRDHOST *host, const char *machine_
 
 void set_host_properties(RRDHOST *host, int update_every, RRD_MEMORY_MODE memory_mode, const char *hostname,
                          const char *registry_hostname, const char *guid, const char *os, const char *tags,
-                         const char *tzone, const char *program_name, const char *program_version)
+                         const char *tzone, const char *abbrev_tzone, int32_t utc_offset, const char *program_name,
+                         const char *program_version)
 {
 
     host->rrd_update_every = update_every;
@@ -116,7 +124,7 @@ void set_host_properties(RRDHOST *host, int update_every, RRD_MEMORY_MODE memory
     rrdhost_init_machine_guid(host, guid);
 
     rrdhost_init_os(host, os);
-    rrdhost_init_timezone(host, tzone);
+    rrdhost_init_timezone(host, tzone, abbrev_tzone, utc_offset);
     rrdhost_init_tags(host, tags);
 
     host->program_name = strdupz((program_name && *program_name) ? program_name : "unknown");
@@ -133,6 +141,8 @@ RRDHOST *rrdhost_create(const char *hostname,
                         const char *guid,
                         const char *os,
                         const char *timezone,
+                        const char *abbrev_timezone,
+                        int32_t utc_offset,
                         const char *tags,
                         const char *program_name,
                         const char *program_version,
@@ -160,7 +170,7 @@ RRDHOST *rrdhost_create(const char *hostname,
     RRDHOST *host = callocz(1, sizeof(RRDHOST));
 
     set_host_properties(host, (update_every > 0)?update_every:1, memory_mode, hostname, registry_hostname, guid, os,
-                        tags, timezone, program_name, program_version);
+                        tags, timezone, abbrev_timezone, utc_offset, program_name, program_version);
 
     host->rrd_history_entries = align_entries_to_pagesize(memory_mode, entries);
     host->health_enabled      = ((memory_mode == RRD_MEMORY_MODE_NONE)) ? 0 : health_enabled;
@@ -408,6 +418,8 @@ void rrdhost_update(RRDHOST *host
                     , const char *guid
                     , const char *os
                     , const char *timezone
+                    , const char *abbrev_timezone
+                    , int32_t utc_offset
                     , const char *tags
                     , const char *program_name
                     , const char *program_version
@@ -435,7 +447,7 @@ void rrdhost_update(RRDHOST *host
     host->system_info = system_info;
 
     rrdhost_init_os(host, os);
-    rrdhost_init_timezone(host, timezone);
+    rrdhost_init_timezone(host, timezone, abbrev_timezone, utc_offset);
 
     freez(host->registry_hostname);
     host->registry_hostname = strdupz((registry_hostname && *registry_hostname)?registry_hostname:hostname);
@@ -510,6 +522,8 @@ RRDHOST *rrdhost_find_or_create(
         , const char *guid
         , const char *os
         , const char *timezone
+        , const char *abbrev_timezone
+        , int32_t utc_offset
         , const char *tags
         , const char *program_name
         , const char *program_version
@@ -541,6 +555,8 @@ RRDHOST *rrdhost_find_or_create(
                 , guid
                 , os
                 , timezone
+                , abbrev_timezone
+                , utc_offset
                 , tags
                 , program_name
                 , program_version
@@ -563,6 +579,8 @@ RRDHOST *rrdhost_find_or_create(
            , guid
            , os
            , timezone
+           , abbrev_timezone
+           , utc_offset
            , tags
            , program_name
            , program_version
@@ -654,6 +672,8 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
             , registry_get_this_machine_guid()
             , os_type
             , netdata_configured_timezone
+            , netdata_configured_abbrev_timezone
+            , netdata_configured_utc_offset
             , config_get(CONFIG_SECTION_BACKEND, "host tags", "")
             , program_name
             , program_version
@@ -883,6 +903,7 @@ void rrdhost_free(RRDHOST *host) {
     free_label_list(host->labels.head);
     freez((void *)host->os);
     freez((void *)host->timezone);
+    freez((void *)host->abbrev_timezone);
     freez(host->program_version);
     freez(host->program_name);
     rrdhost_system_info_free(host->system_info);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -984,7 +984,7 @@ RRDHOST *sql_create_host_by_uuid(char *hostname)
     set_host_properties(host, sqlite3_column_int(res, 2), RRD_MEMORY_MODE_DBENGINE, hostname,
                         (char *) sqlite3_column_text(res, 1), (const char *) uuid_str,
                         (char *) sqlite3_column_text(res, 3), (char *) sqlite3_column_text(res, 5),
-                        (char *) sqlite3_column_text(res, 4), NULL, NULL);
+                        (char *) sqlite3_column_text(res, 4), NULL, 0, NULL, NULL);
 
     uuid_copy(host->host_uuid, *((uuid_t *) sqlite3_column_blob(res, 0)));
 

--- a/health/health.h
+++ b/health/health.h
@@ -96,6 +96,8 @@ extern void *health_cmdapi_thread(void *ptr);
 
 extern void health_label_log_save(RRDHOST *host);
 
+extern char *health_edit_command_from_source(const char *source);
+
 extern SIMPLE_PATTERN *health_pattern_from_foreach(char *s);
 
 #endif //NETDATA_HEALTH_H

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -473,6 +473,31 @@ static inline char *health_source_file(size_t line, const char *file) {
     return strdupz(buffer);
 }
 
+char *health_edit_command_from_source(const char *source)
+{
+    char buffer[FILENAME_MAX + 1];
+    char *temp = NULL;
+    temp = strdupz(source);
+    char *line_num = strchr(temp, '@');
+    char *file_no_path = strrchr(temp, '/');
+
+    if (likely(file_no_path && line_num)) {
+        *line_num = '\0';
+        snprintfz(
+            buffer,
+            FILENAME_MAX,
+            "sudo %s/edit-config health.d/%s=%s",
+            netdata_configured_user_config_dir,
+            file_no_path + 1,
+            temp);
+    } else
+        buffer[0] = '\0';
+
+    freez(temp);
+
+    return strdupz(buffer);
+}
+
 static inline void strip_quotes(char *s) {
     while(*s) {
         if(*s == '\'' || *s == '"') *s = ' ';

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -476,8 +476,7 @@ static inline char *health_source_file(size_t line, const char *file) {
 char *health_edit_command_from_source(const char *source)
 {
     char buffer[FILENAME_MAX + 1];
-    char *temp = NULL;
-    temp = strdupz(source);
+    char *temp = strdupz(source);
     char *line_num = strchr(temp, '@');
     char *file_no_path = strrchr(temp, '/');
 
@@ -494,7 +493,6 @@ char *health_edit_command_from_source(const char *source)
         buffer[0] = '\0';
 
     freez(temp);
-
     return strdupz(buffer);
 }
 

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -14,9 +14,13 @@ void health_string2json(BUFFER *wb, const char *prefix, const char *label, const
 }
 
 void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) {
+    char *edit_command = ae->source ? health_edit_command_from_source(ae->source) : strdupz("UNKNOWN=0");
+
     buffer_sprintf(wb,
             "\n\t{\n"
                     "\t\t\"hostname\": \"%s\",\n"
+                    "\t\t\"utc_offset\": %d,\n"
+                    "\t\t\"timezone\": \"%s\",\n"
                     "\t\t\"unique_id\": %u,\n"
                     "\t\t\"alarm_id\": %u,\n"
                     "\t\t\"alarm_event_id\": %u,\n"
@@ -34,6 +38,7 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
                     "\t\t\"recipient\": \"%s\",\n"
                     "\t\t\"exec_code\": %d,\n"
                     "\t\t\"source\": \"%s\",\n"
+                    "\t\t\"command\": \"%s\",\n"
                     "\t\t\"units\": \"%s\",\n"
                     "\t\t\"when\": %lu,\n"
                     "\t\t\"duration\": %lu,\n"
@@ -49,6 +54,8 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
                     "\t\t\"last_repeat\": \"%lu\",\n"
                     "\t\t\"silenced\": \"%s\",\n"
                    , host->hostname
+                   , host->utc_offset
+                   , host->abbrev_timezone
                    , ae->unique_id
                    , ae->alarm_id
                    , ae->alarm_event_id
@@ -66,6 +73,7 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
                    , ae->recipient?ae->recipient:host->health_default_recipient
                    , ae->exec_code
                    , ae->source
+                   , edit_command
                    , ae->units?ae->units:""
                    , (unsigned long)ae->when
                    , (unsigned long)ae->duration
@@ -114,6 +122,7 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
     buffer_strcat(wb, "\t}");
 
     freez(replaced_info);
+    freez(edit_command);
 }
 
 void health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart) {

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -11,6 +11,7 @@ void destroy_receiver_state(struct receiver_state *rpt) {
     freez(rpt->machine_guid);
     freez(rpt->os);
     freez(rpt->timezone);
+    freez(rpt->abbrev_timezone);
     freez(rpt->tags);
     freez(rpt->client_ip);
     freez(rpt->client_port);
@@ -307,6 +308,8 @@ static int rrdpush_receive(struct receiver_state *rpt)
                 , rpt->machine_guid
                 , rpt->os
                 , rpt->timezone
+                , rpt->abbrev_timezone
+                , rpt->utc_offset
                 , rpt->tags
                 , rpt->program_name
                 , rpt->program_version

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -464,7 +464,8 @@ void *rrdpush_receiver_thread(void *ptr);
 int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
     info("clients wants to STREAM metrics.");
 
-    char *key = NULL, *hostname = NULL, *registry_hostname = NULL, *machine_guid = NULL, *os = "unknown", *timezone = "unknown", *tags = NULL;
+    char *key = NULL, *hostname = NULL, *registry_hostname = NULL, *machine_guid = NULL, *os = "unknown", *timezone = "unknown", *abbrev_timezone = "UTC", *tags = NULL;
+    int32_t utc_offset = 0;
     int update_every = default_rrd_update_every;
     uint32_t stream_version = UINT_MAX;
     char buf[GUID_LEN + 1];
@@ -493,6 +494,10 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
             os = value;
         else if(!strcmp(name, "timezone"))
             timezone = value;
+        else if(!strcmp(name, "abbrev_timezone"))
+            abbrev_timezone = value;
+        else if(!strcmp(name, "utc_offset"))
+            utc_offset = (int32_t)strtol(value, NULL, 0);
         else if(!strcmp(name, "tags"))
             tags = value;
         else if(!strcmp(name, "ver"))
@@ -680,6 +685,8 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
     rpt->machine_guid      = strdupz(machine_guid);
     rpt->os                = strdupz(os);
     rpt->timezone          = strdupz(timezone);
+    rpt->abbrev_timezone   = strdupz(abbrev_timezone);
+    rpt->utc_offset        = utc_offset;
     rpt->tags              = (tags)?strdupz(tags):NULL;
     rpt->client_ip         = strdupz(w->client_ip);
     rpt->client_port       = strdupz(w->client_port);

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -72,6 +72,8 @@ struct receiver_state {
     char *machine_guid;
     char *os;
     char *timezone;         // Unused?
+    char *abbrev_timezone;
+    int32_t utc_offset;
     char *tags;
     char *client_ip;        // Duplicated in pluginsd 
     char *client_port;        // Duplicated in pluginsd 

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -214,7 +214,7 @@ static int rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_po
 
     char http[HTTP_HEADER_SIZE + 1];
     int eol = snprintfz(http, HTTP_HEADER_SIZE,
-            "STREAM key=%s&hostname=%s&registry_hostname=%s&machine_guid=%s&update_every=%d&os=%s&timezone=%s&tags=%s&ver=%u"
+            "STREAM key=%s&hostname=%s&registry_hostname=%s&machine_guid=%s&update_every=%d&os=%s&timezone=%s&abbrev_timezone=%s&utc_offset=%d&tags=%s&ver=%u"
                  "&NETDATA_SYSTEM_OS_NAME=%s"
                  "&NETDATA_SYSTEM_OS_ID=%s"
                  "&NETDATA_SYSTEM_OS_ID_LIKE=%s"
@@ -250,6 +250,8 @@ static int rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_po
                  , default_rrd_update_every
                  , host->os
                  , host->timezone
+                 , host->abbrev_timezone
+                 , host->utc_offset
                  , (host->tags) ? host->tags : ""
                  , STREAMING_PROTOCOL_CURRENT_VERSION
                  , se.os_name


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

For the cloud to be able to include an agent local time in the alerts email notification, the agent needs to send the UTC offset in seconds for each host (parent and/or children), together with the abbreviated time zone format. It also constructs and sends an  `edit_command` string, which when parsed by the cloud, will appear on the email message to provide the user with a copy-paste command to use to edit the alert's configuration:

![Screenshot from 2021-04-27 16-55-56](https://user-images.githubusercontent.com/1905463/116253817-7cb43b80-a779-11eb-9483-02eb3de0edee.png)

The UTC offset is calculated based on the string returned from `strftime` using the `%z` field, i.e. from a string with format `+hhmm` or `-hhmm`. For example, for `+0300` the UTC offset will be `10800`.

The `edit_command` string is constructed from the `source` string, and includes the line number of the configuration file to edit. Example: `sudo /etc/netdata/edit-config health.d/exporting.conf=15`. The string will be split at the `=` character.

The `edit_command` will also be used by the agent in it's own email alarm messages (will come in next PR).

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

The `status-change` aclk message for an alarm, should contain `utc_offset`, `timezone` and `edit_command`.

To make sure that e.g. a child's `utc-offset` and `timezone` is correctly included in the parent's `host` entry, the child's `/etc/localtime` could be temporarly changed to point to e.g. `/usr/share/zoneinfo/America/Havana`.

If both a child and and the parent are running an agent with this PR, then each of the hosts on the parent will have it's own `abbrev_timezone` and `utc_offset` (if they are in different timezones of course).

If a child is running an older version of the agent, then the parent should set `UTC` as the abbreviated timezone, and `0` as the utc_offset for that child.

If the parent is running an older version of the agent, then in the `error.log` it will list `request has parameter 'abbrev_timezone' = 'CDT', which is not used.` but streaming should work as usual.

##### Additional Information

The json entry is called `timezone` even though it contains the abbreviated one; it is already agreed upon with the cloud so it can not change now, perhaps it could be changed with the new architecture messages.

The `edit_command` string includes `sudo`. It is not required if the agent is installed and run under another user and not root, but it doesn't harm either. Even new configurations created with sudo, will have the correct permissions. However, if in some cases it is a problem (maybe when the agent runs as an X user, and the config must be edited from another?), then the function should check and maybe add sudo or not.

The UTC offset is calculated on agent start. That means it will have wrong value when daylight savings time kicks in, and will need an agent restart to re-calculate.