### PR TITLE
Add `charts` to templates

### DIFF
--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -45,6 +45,11 @@ static int rrdcalctemplate_is_there_label_restriction(RRDCALCTEMPLATE *rt,  RRDH
 }
 
 static inline int rrdcalctemplate_test_additional_restriction(RRDCALCTEMPLATE *rt, RRDSET *st) {
+    if (rt->charts_pattern &&
+        !simple_pattern_matches(rt->charts_pattern, st->id) &&
+         !simple_pattern_matches(rt->charts_pattern, st->name))
+        return 0;
+
     if (rt->family_pattern && !simple_pattern_matches(rt->family_pattern, st->family))
         return 0;
 

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -111,6 +111,9 @@ inline void rrdcalctemplate_free(RRDCALCTEMPLATE *rt) {
     freez(rt->module_match);
     simple_pattern_free(rt->module_pattern);
 
+    freez(rt->charts_match);
+    simple_pattern_free(rt->charts_pattern);
+
     freez(rt->name);
     freez(rt->exec);
     freez(rt->recipient);

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -46,8 +46,8 @@ static int rrdcalctemplate_is_there_label_restriction(RRDCALCTEMPLATE *rt,  RRDH
 
 static inline int rrdcalctemplate_test_additional_restriction(RRDCALCTEMPLATE *rt, RRDSET *st) {
     if (rt->charts_pattern &&
-        !simple_pattern_matches(rt->charts_pattern, st->id) &&
-         !simple_pattern_matches(rt->charts_pattern, st->name))
+        !(simple_pattern_matches(rt->charts_pattern, st->id) ||
+         simple_pattern_matches(rt->charts_pattern, st->name)))
         return 0;
 
     if (rt->family_pattern && !simple_pattern_matches(rt->family_pattern, st->family))

--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -31,6 +31,9 @@ struct rrdcalctemplate {
     char *module_match;
     SIMPLE_PATTERN *module_pattern;
 
+    char *charts_match;
+    SIMPLE_PATTERN *charts_pattern;
+
     char *source;                   // the source of this alarm
     char *units;                    // the units of the alarm
     char *info;                     // a short description of the alarm

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -62,7 +62,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`hosts`](#alarm-line-hosts)                        | no              | Which hostnames will run this alarm.                                                  |
 | [`plugin`](#alarm-line-plugin)                      | no              | Restrict an alarm or template to only a certain plugin.                                             |
 | [`module`](#alarm-line-module)                      | no              | Restrict an alarm or template to only a certain module.                                             |
-| [`charts`](#alarm-line-charts)                      | no              | Restrict an alarm or template to specified charts.                                             |
+| [`charts`](#alarm-line-charts)                      | no              | Restrict an alarm or template to only certain charts.                                             |
 | [`families`](#alarm-line-families)                  | no              | Restrict a template to only certain families.                                         |
 | [`lookup`](#alarm-line-lookup)                      | yes             | The database lookup to find and process metrics for the chart specified through `on`. |
 | [`calc`](#alarm-line-calc)                          | yes (see above) | A calculation to apply to the value found via `lookup` or another variable.           |
@@ -187,7 +187,7 @@ alarms for the disk `sdb`:
 
 ```yaml
     on: disk.svctm
-charts: !*sdb*
+charts: !*sdb* *
 ```
 
 #### Alarm line `families`

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -180,14 +180,15 @@ module: isc_dhcpd
 
 #### Alarm line `charts`
 
-The `charts` line filters which chart this alarm should apply to. It is only available with [`template`](#alarm-line-alarm-or-template).
+The `charts` line filters which chart this alarm should apply to. It is only available on entities using the 
+[`template`](#alarm-line-alarm-or-template) line.
 The value is a space-separated list of [simple patterns](/libnetdata/simple_pattern/README.md). For
-example, you can create a template that applies on `disk.svctm` (Average Service Time) context, but you exclude
-alarms for the disk `sdb`:
+example, a template that applies to `disk.svctm` (Average Service Time) context, but excludes the disk `sdb` from alarms:
 
 ```yaml
-    on: disk.svctm
-charts: !*sdb* *
+template: disk_svctm_alarm
+      on: disk.svctm
+  charts: !*sdb* *
 ```
 
 #### Alarm line `families`

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -62,6 +62,7 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`hosts`](#alarm-line-hosts)                        | no              | Which hostnames will run this alarm.                                                  |
 | [`plugin`](#alarm-line-plugin)                      | no              | Restrict an alarm or template to only a certain plugin.                                             |
 | [`module`](#alarm-line-module)                      | no              | Restrict an alarm or template to only a certain module.                                             |
+| [`charts`](#alarm-line-charts)                      | no              | Restrict an alarm or template to specified charts.                                             |
 | [`families`](#alarm-line-families)                  | no              | Restrict a template to only certain families.                                         |
 | [`lookup`](#alarm-line-lookup)                      | yes             | The database lookup to find and process metrics for the chart specified through `on`. |
 | [`calc`](#alarm-line-calc)                          | yes (see above) | A calculation to apply to the value found via `lookup` or another variable.           |
@@ -175,6 +176,18 @@ example, you can create an alarm that applies only on the `isc_dhcpd` module sta
 ```yaml
 plugin: python.d.plugin
 module: isc_dhcpd
+```
+
+#### Alarm line `charts`
+
+The `charts` line filters which chart this alarm should apply to. It is only available with [`template`](#alarm-line-alarm-or-template).
+The value is a space-separated list of [simple patterns](/libnetdata/simple_pattern/README.md). For
+example, you can create a template that applies on `disk.svctm` (Average Service Time) context, but you exclude
+alarms for the disk `sdb`:
+
+```yaml
+    on: disk.svctm
+charts: !*sdb*
 ```
 
 #### Alarm line `families`

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -12,7 +12,7 @@
 #define HEALTH_FAMILIES_KEY "families"
 #define HEALTH_PLUGIN_KEY "plugin"
 #define HEALTH_MODULE_KEY "module"
-#define HEALTH_CHARTS_KEY "module"
+#define HEALTH_CHARTS_KEY "charts"
 #define HEALTH_LOOKUP_KEY "lookup"
 #define HEALTH_CALC_KEY "calc"
 #define HEALTH_EVERY_KEY "every"
@@ -525,7 +525,7 @@ static int health_readfile(const char *filename, void *data) {
         hash_families = simple_uhash(HEALTH_FAMILIES_KEY);
         hash_plugin = simple_uhash(HEALTH_PLUGIN_KEY);
         hash_module = simple_uhash(HEALTH_MODULE_KEY);
-        hash_charts = simple_uhash(HEALTH_CHART_KEY);
+        hash_charts = simple_uhash(HEALTH_CHARTS_KEY);
         hash_calc = simple_uhash(HEALTH_CALC_KEY);
         hash_lookup = simple_uhash(HEALTH_LOOKUP_KEY);
         hash_green = simple_uhash(HEALTH_GREEN_KEY);
@@ -948,9 +948,9 @@ static int health_readfile(const char *filename, void *data) {
                 rt->module_match = strdupz(value);
                 rt->module_pattern = simple_pattern_create(rt->module_match, NULL, SIMPLE_PATTERN_EXACT);
             }
-            else if(hash == hash_charts && !strcasecmp(key, HEALTH_MODULE_KEY)) {
+            else if(hash == hash_charts && !strcasecmp(key, HEALTH_CHARTS_KEY)) {
                 freez(rt->charts_match);
-                simple_pattern_free(rt->module_pattern);
+                simple_pattern_free(rt->charts_pattern);
 
                 rt->charts_match = strdupz(value);
                 rt->charts_pattern = simple_pattern_create(rt->charts_match, NULL, SIMPLE_PATTERN_EXACT);

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -12,6 +12,7 @@
 #define HEALTH_FAMILIES_KEY "families"
 #define HEALTH_PLUGIN_KEY "plugin"
 #define HEALTH_MODULE_KEY "module"
+#define HEALTH_CHARTS_KEY "module"
 #define HEALTH_LOOKUP_KEY "lookup"
 #define HEALTH_CALC_KEY "calc"
 #define HEALTH_EVERY_KEY "every"
@@ -493,6 +494,7 @@ static int health_readfile(const char *filename, void *data) {
             hash_families = 0,
             hash_plugin = 0,
             hash_module = 0,
+            hash_charts = 0,
             hash_calc = 0,
             hash_green = 0,
             hash_red = 0,
@@ -523,6 +525,7 @@ static int health_readfile(const char *filename, void *data) {
         hash_families = simple_uhash(HEALTH_FAMILIES_KEY);
         hash_plugin = simple_uhash(HEALTH_PLUGIN_KEY);
         hash_module = simple_uhash(HEALTH_MODULE_KEY);
+        hash_charts = simple_uhash(HEALTH_CHART_KEY);
         hash_calc = simple_uhash(HEALTH_CALC_KEY);
         hash_lookup = simple_uhash(HEALTH_LOOKUP_KEY);
         hash_green = simple_uhash(HEALTH_GREEN_KEY);
@@ -944,6 +947,13 @@ static int health_readfile(const char *filename, void *data) {
 
                 rt->module_match = strdupz(value);
                 rt->module_pattern = simple_pattern_create(rt->module_match, NULL, SIMPLE_PATTERN_EXACT);
+            }
+            else if(hash == hash_charts && !strcasecmp(key, HEALTH_MODULE_KEY)) {
+                freez(rt->charts_match);
+                simple_pattern_free(rt->module_pattern);
+
+                rt->charts_match = strdupz(value);
+                rt->charts_pattern = simple_pattern_create(rt->charts_match, NULL, SIMPLE_PATTERN_EXACT);
             }
             else if(hash == hash_lookup && !strcasecmp(key, HEALTH_LOOKUP_KEY)) {
                 health_parse_db_lookup(line, filename, value, &rt->group, &rt->after, &rt->before,


### PR DESCRIPTION
##### Summary
Fixes #11000 

This  PR adds `charts` entity for alarm `templates`. 
##### Component Name
Health
##### Test Plan

1 - Compile this PR
2 - Create file `/etc/health/go.d/example.conf`:

```
# [ JOBS ]
jobs:
  - name: go_example
````

3 - Create an alarm, for example, `/etc/netdata/health.d/example.conf`:

```
template: go_example
      on: example.random
  plugin: go.d
  module: example
    calc: $last_collected_t
   units: boolean
  charts: *random_0*
   every: 1m
    warn: $this != nan || $this == nan
    info: go.d.plugin example module is up
      to: sysadmin
```

4 - Start Netdata, you will receive an alarm.
5 - Comment the line `#charts: *random_0*` in the  previous alarm.
6 - Restart `health` running `netdatacli reload-health` or restart `netdata`.
7 - You will receive another alarm
8 - Finally set `charts` as `charts: !*random_0*`
9 - Repeat step 6
10 - You won't receive alarms.

##### Additional Information
