### PR TITLE
Migrated release build process from Travis CI to GitHub Actions.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -6,19 +6,6 @@ on:
       - master
   pull_request:
 jobs:
-  static-build:
-    name: Build (x86_64)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git clone repository
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - run: |
-          git fetch --prune --unshallow --tags
-      - name: Build
-        run: |
-          .github/scripts/build-static-x86_64.sh
   source-build:
     name: Build & Install
     strategy:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -68,38 +68,6 @@ jobs:
       - name: Build
         run: |
           docker build -f .github/dockerfiles/Dockerfile.clang .
-  dist-checks:
-    name: Dist
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Prepare environment
-        run: |
-          ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata
-          sudo apt-get install -y libjson-c-dev libipmimonitoring-dev libcups2-dev libsnappy-dev \
-                                  libprotobuf-dev libprotoc-dev libssl-dev protobuf-compiler \
-                                  libnetfilter-acct-dev
-      - name: Configure
-        run: |
-          autoreconf -ivf
-          ./configure \
-            --with-zlib \
-            --with-math \
-            --with-user=netdata \
-            CFLAGS=-O2
-      - name: Make dist
-        run: |
-          make dist
-      - name: Verify & Set distfile
-        run: |
-          ls -lah netdata-*.tar.gz
-          echo "DISTFILE=$(ls netdata-*.tar.gz)" >> $GITHUB_ENV
-      - name: Run run_install_with_dist_file.sh
-        run: |
-          ./.github/scripts/run_install_with_dist_file.sh "${DISTFILE}"
   gitignore-check:
     name: .gitignore
     runs-on: ubuntu-latest

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,216 @@
+---
+name: Release Build
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        name: Build Type
+        default: nightly
+        required: true
+      version:
+        name: Version Tag
+        default: nightly
+        required: true
+jobs:
+  build-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Mark Stable
+        if: github.event.inputs.version != "nightly"
+        run: |
+          sed -i 's/^RELEASE_CHANNEL="nightly" *#/RELEASE_CHANNEL="stable" #/' netdata-installer.sh
+      - name: Build
+        run: |
+          mkdir -p artifacts
+          autoreconf -ivf
+          ./configure --prefix=/usr \
+                      --sysconfdir=/etc \
+                      --localstatedir=/var \
+                      --libexecdir=/usr/libexec \
+                      --with-zlib \
+                      --with-math \
+                      --with-user=netdata
+          make dist
+          mv "netdata$(git describe).tar.gz" artifacts/
+      - name: Store
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-tarball
+          path: artifacts/*.tar.gz
+          retention-days: 30
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER:
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Distribution tarball build failed:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: "Distribution tarball build failed."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && startsWith(github.ref, 'refs/heads/master')
+          }}
+
+  build-static:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Mark Stable
+        if: github.event.inputs.version != "nightly"
+        run: |
+          sed -i 's/^RELEASE_CHANNEL="nightly" *#/RELEASE_CHANNEL="stable" #/' netdata-installer.sh packaging/makeself/install-or-update.sh
+      - name: Build
+        run: |
+          packages/makeself/build-x86_64-static.sh
+      - name: Store
+        uses: actions/upload-artifact@v2
+        with:
+          name: static-archive
+          path: artifacts/*.gz.run
+          retention-days: 30
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER:
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Static build failed:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: "Static build failed."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && startsWith(github.ref, 'refs/heads/master')
+          }}
+
+  prepare-upload:
+    runs-on: ubuntu-latest
+    needs:
+      - build-dist
+      - build-static
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Prepare Environment
+        run: mkdir -p artifacts
+      - name: Retrieve Artifacts
+        uses: actions/download-artifact@v2
+      - name: Prepare Artifacts
+        working-directory: ./artifacts/
+        run: |
+          mv ../dist-tarball/* artifacts
+          mv ../static-archive/* artifcts
+          cp ../packaging/version artifacts/latest-version.txt
+          sha256sum -b ./* > "sha256sums.txt"
+      - name: Store Artifacts
+        uses: action/upload-artifact@v2
+        with:
+          name: final-artifacts
+          path: artifacts/*
+          retention-days: 30
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER:
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Failed to prepare release artifacts for upload:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: "Failed to prepare release artifacts for upload."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && startsWith(github.ref, 'refs/heads/master')
+          }}
+
+  upload-nightly:
+    runs-on: ubuntu-latest
+    if: github.event_name == "workflow_dispatch" && github.event.inputs.type == "nightly"
+    needs:
+      - prepare-upload
+    steps:
+      - name: Retrieve Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: final-artifacts
+      - name: Setup Gcloud
+        uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: ${{ secrets.GCP_NIGHTLY_STORAGE_PROJECT }}
+          service_account_key: ${{ secrets.GCP_STORAGE_SERVICE_ACCOUNT_KEY }}
+          export_default_credentials: true
+      - name: Upload Artifacts
+        uses: google-github-actions/upload-cloud-storage@v0.2.1
+        with:
+          destination: ${{ secrets.GCP_NIGHTLY_STORAGE_BUCKET }}
+          gzip: false
+          path: ./
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER:
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Failed to upload nightly release artifacts:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: "Failed to upload nightly release artifacts."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && startsWith(github.ref, 'refs/heads/master')
+          }}
+
+  upload-release:
+    runs-on: ubuntu-latest
+    if: github.event_name == "workflow_dispatch" && github.event.inputs.type == "release"
+    needs:
+      - prepare-upload
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Retrieve Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: final-artifacts
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: false
+          artifactErrorsFailBuild: true
+          artifacts: 'sha256sums.txt,netdata-*.tar.gz,netdata-*.gz.run'
+          draft: true
+          tag: ${{ github.event.inputs.version }}
+          token: ${{ secrets.NETDATABOT_TOKEN }}
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER:
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Failed to draft release:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: "Failed to draft release."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && startsWith(github.ref, 'refs/heads/master')
+          }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,6 +1,11 @@
 ---
+# Ci code for building release artifacts.
 name: Release Build
 on:
+  push: # Master branch checks only validate thebuild and generate artifacts for testing.
+    branches:
+      - master
+  pull_request: # PR checks only validate thebuild and generate artifacts for testing.
   workflow_dispatch:
     inputs:
       type:
@@ -12,7 +17,8 @@ on:
         default: nightly
         required: true
 jobs:
-  build-dist:
+  build-dist: # Build the distribution tarball and store it as an artifact.
+    name: Build Distribution Tarball
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,7 +27,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - name: Mark Stable
-        if: github.event.inputs.version != "nightly"
+        if: gitub.event_name == 'workflow_dispatch' && github.event.inputs.version != "nightly"
         run: |
           sed -i 's/^RELEASE_CHANNEL="nightly" *#/RELEASE_CHANNEL="stable" #/' netdata-installer.sh
       - name: Build
@@ -37,6 +43,10 @@ jobs:
                       --with-user=netdata
           make dist
           mv "netdata$(git describe).tar.gz" artifacts/
+      - name: Test
+        run: |
+          ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata-all
+          .github/scripts/run_install_with_dist_file.sh "artifacts/netdata$(git describe).tar.gz"
       - name: Store
         uses: actions/upload-artifact@v2
         with:
@@ -57,9 +67,11 @@ jobs:
           ${{
             failure()
             && startsWith(github.ref, 'refs/heads/master')
+            && github.event_name != 'pull_request'
           }}
 
-  build-static:
+  build-static: # Build the static binary archives, and store them as artifacts.
+    name: Build Static
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -68,7 +80,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - name: Mark Stable
-        if: github.event.inputs.version != "nightly"
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != "nightly"
         run: |
           sed -i 's/^RELEASE_CHANNEL="nightly" *#/RELEASE_CHANNEL="stable" #/' netdata-installer.sh packaging/makeself/install-or-update.sh
       - name: Build
@@ -94,9 +106,12 @@ jobs:
           ${{
             failure()
             && startsWith(github.ref, 'refs/heads/master')
+            && github.event_name != 'pull_request'
           }}
 
-  prepare-upload:
+  prepare-upload: # Consolidate the artifacts for uploading or releasing.
+    name: Prepare Artifacts
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs:
       - build-dist
@@ -138,9 +153,11 @@ jobs:
           ${{
             failure()
             && startsWith(github.ref, 'refs/heads/master')
+            && github.event_name != 'pull_request'
           }}
 
-  upload-nightly:
+  upload-nightly: # Upload the nightly build artifacts to GCS.
+    name: Upload Nightly Artifacts
     runs-on: ubuntu-latest
     if: github.event_name == "workflow_dispatch" && github.event.inputs.type == "nightly"
     needs:
@@ -176,9 +193,11 @@ jobs:
           ${{
             failure()
             && startsWith(github.ref, 'refs/heads/master')
+            && github.event_name != 'pull_request'
           }}
 
-  upload-release:
+  upload-release: # Create the draft release and upload the build artifacts.
+    name: Create Release Draft
     runs-on: ubuntu-latest
     if: github.event_name == "workflow_dispatch" && github.event.inputs.type == "release"
     needs:
@@ -213,4 +232,5 @@ jobs:
           ${{
             failure()
             && startsWith(github.ref, 'refs/heads/master')
+            && github.event_name == 'wworkflow_dispatch'
           }}


### PR DESCRIPTION
##### Summary

This also consolidates the distribution tarball and static build PR checks into the same workflow, so that we’re always testing our actual release code paths for them instead of handling the testing elsewhere.

##### Component Name

area/ci
area/packaging

##### Test Plan

Basic build process tested on this PR. Further verification needed for the artifact upload and release generation code.

##### Additional Information

Fixes: #11046 

TODO:

- [ ] Verify the artifact upload code.
- [ ] Verify the draft release creation code.
- [ ] Replace the code in Travis CI that does this with a cURL command to trigger this workflow instead.