### PR TITLE
Limit maximum concurrent CI jobs to avoid blocking other CI.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -23,6 +23,7 @@ jobs:
     name: Build & Install
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         distro:
           - 'alpine:edge'

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -45,6 +45,7 @@ jobs:
       # build failure for one version doesn't prevent us from publishing
       # successfully built and tested packages for another version.
       fail-fast: false
+      max-parallel: 8
     steps:
       - name: Checkout PR # Checkout the PR if it's a PR.
         if: github.event_name == 'pull_request'

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,6 +13,7 @@ jobs:
     name: Install, Build & Update
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         distro:
           - 'alpine:3.12'


### PR DESCRIPTION
##### Summary

Our current GitHub plan limits us to 60 concurrent CI jobs. Because of the very high number of jobs being run in our agent CI, we are regularly running up against that limit and blocking other CI.

This PR limits the most egregious offenders within the agent CI to only run at most 8 jobs in parallel on a per-workflow basis. This makes the best-case scenario for CI run times somewhat worse, but in exchange improves the average CI run times.

##### Component Name

area/ci

##### Test Plan

Behavior verified on this PR (looks like it’s working correctly, but it’s only visible when you actually start the CI process).

##### Additional Info

The choice of 8 concurrent jobs is largely arbitrary. It’s intended to provide enough of a limit to improve the common case without making the best case significantly worse than it currently is. The exact value may need to be tuned in the future, but for right now this should be good enough.