### PR TITLE
Minor fixes for AWS Kinesis build checks.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -140,14 +140,14 @@ jobs:
         distro:
           - 'centos:8'
           - 'debian:buster'
-          - 'fedora:32'
+          - 'fedora:34'
           - 'ubuntu:20.04'
         include:
           - distro: 'centos:8'
             pre: >-
-              yum -y update &&
-              yum -y groupinstall 'Development Tools' &&
-              yum -y install libcurl-devel openssl-devel libuuid-devel
+              dnf -y update &&
+              dnf -y groupinstall 'Development Tools' &&
+              dnf -y install libcurl-devel openssl-devel libuuid-devel
             build_kinesis: >-
               git clone --branch 1.8.186 --depth 1 https://github.com/aws/aws-sdk-cpp.git &&
               cmake -DCMAKE_INSTALL_PREFIX=/usr
@@ -167,11 +167,11 @@ jobs:
               ./aws-sdk-cpp &&
               make &&
               make install
-          - distro: 'fedora:32'
+          - distro: 'fedora:34'
             pre: >-
               dnf -y update &&
               dnf -y groupinstall 'Development Tools' &&
-              dnf -y install libcurl-devel openssl-devel libuuid-devel
+              dnf -y install libcurl-devel openssl-devel libuuid-devel gcc-c++
             build_kinesis: >-
               git clone --branch 1.8.186 --depth 1 https://github.com/aws/aws-sdk-cpp.git &&
               cmake -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
##### Summary

* Bump the Fedora build check to use Fedora 34 instead of Fedora 32.
* Switched to using DNF instead of YUM for CentOS 8 check.

##### Component Name

area/ci

##### Test Plan

Behavior verified on this PR.