### PR TITLE
Add functionality to store node_id for a host

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -165,7 +165,7 @@ void load_claiming_state(void)
     }
     localhost->aclk_state.claimed_id = claimed_id;
 
-    invalidate_node_instances(&localhost->host_uuid, &uuid);
+    invalidate_node_instances(&localhost->host_uuid, claimed_id ? &uuid : NULL);
     store_claim_id(&localhost->host_uuid, claimed_id ? &uuid : NULL);
 
     rrdhost_aclk_state_unlock(localhost);

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -165,6 +165,7 @@ void load_claiming_state(void)
     }
     localhost->aclk_state.claimed_id = claimed_id;
 
+    invalidate_node_instances(&localhost->host_uuid, &uuid);
     store_claim_id(&localhost->host_uuid, claimed_id ? &uuid : NULL);
 
     rrdhost_aclk_state_unlock(localhost);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -879,6 +879,7 @@ struct rrdhost {
     struct rrdengine_instance *rrdeng_ctx;          // DB engine instance for this host
 #endif
     uuid_t  host_uuid;                              // Global GUID for this host
+    uuid_t  *node_id;                               // Cloud node_id
 
 #ifdef ENABLE_HTTPS
     struct netdata_ssl ssl;                         //Structure used to encrypt the connection

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -302,6 +302,7 @@ RRDHOST *rrdhost_create(const char *hostname,
         int rc = sql_store_host(&host->host_uuid, hostname, registry_hostname, update_every, os, timezone, tags);
         if (unlikely(rc))
             error_report("Failed to store machine GUID to the database");
+        sql_load_node_id(host);
     }
     else
         error_report("Host machine GUID %s is not valid", host->machine_guid);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -900,6 +900,7 @@ void rrdhost_free(RRDHOST *host) {
     netdata_rwlock_destroy(&host->labels.labels_rwlock);
     netdata_rwlock_destroy(&host->health_log.alarm_log_rwlock);
     netdata_rwlock_destroy(&host->rrdhost_rwlock);
+    freez(host->node_id);
 
     freez(host);
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1405,13 +1405,13 @@ void update_node_id(uuid_t *host_id, uuid_t *node_id)
         return;
     }
 
-    rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
+    rc = sqlite3_bind_blob(res, 1, node_id, sizeof(*node_id), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind host_id parameter to store node instance information");
         goto failed;
     }
 
-    rc = sqlite3_bind_blob(res, 2, node_id, sizeof(*node_id), SQLITE_STATIC);
+    rc = sqlite3_bind_blob(res, 2, host_id, sizeof(*host_id), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind claim_id parameter to store node instance information");
         goto failed;

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1565,6 +1565,7 @@ struct  node_instance_list *get_node_list(void)
         goto failed;
     }
     node_list = callocz(row + 1, sizeof(*node_list));
+    int max_rows = row;
     row = 0;
     while (sqlite3_step(res) == SQLITE_ROW) {
         if (sqlite3_column_bytes(res, 0) == sizeof(uuid_t))
@@ -1580,6 +1581,8 @@ struct  node_instance_list *get_node_list(void)
                 sqlite3_column_bytes(res, 2) ? strdupz((char *)sqlite3_column_text(res, 2)) : NULL;
         }
         row++;
+        if (row == max_rows)
+            break;
     }
 
 failed:

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1385,3 +1385,81 @@ failed:
 
     return;
 }
+
+#define SQL_UPDATE_NODE_ID  "update node_instance set node_id = @node_id where host_id = @host_id;"
+
+void update_node_id(uuid_t *host_id, uuid_t *node_id)
+{
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    if (unlikely(!db_meta)) {
+        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            error_report("Database has not been initialized");
+        return;
+    }
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_UPDATE_NODE_ID, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement store chart labels");
+        return;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host_id parameter to store node instance information");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_blob(res, 2, node_id, sizeof(*node_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind claim_id parameter to store node instance information");
+        goto failed;
+    }
+
+    rc = execute_insert(res);
+    if (unlikely(rc != SQLITE_DONE))
+        error_report("Failed to store node instance information, rc = %d", rc);
+
+failed:
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when storing node instance information");
+
+    return;
+}
+
+#define SQL_SELECT_NODE_ID  "select node_id from node_instance where host_id = @host_id and node_id not null;"
+
+int get_node_id(uuid_t *host_id, uuid_t *node_id)
+{
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    if (unlikely(!db_meta)) {
+        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            error_report("Database has not been initialized");
+        return 1;
+    }
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_SELECT_NODE_ID, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement store chart labels");
+        return 1;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host_id parameter to store node instance information");
+        goto failed;
+    }
+
+    rc = sqlite3_step(res);
+    if (likely(rc == SQLITE_ROW && node_id))
+        uuid_copy(*node_id, *((uuid_t *) sqlite3_column_blob(res, 0)));
+
+failed:
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when storing node instance information");
+
+    return (rc != SQLITE_ROW);
+}

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1463,3 +1463,84 @@ failed:
 
     return (rc != SQLITE_ROW);
 }
+
+#define SQL_INVALIDATE_NODE_INSTANCES "update node_instance set node_id = NULL where exists " \
+    "(select host_id from node_instance where host_id = @host_id and claim_id <> @claim_id);"
+
+void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id)
+{
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    if (unlikely(!db_meta)) {
+        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            error_report("Database has not been initialized");
+        return;
+    }
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_INVALIDATE_NODE_INSTANCES, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement store chart labels");
+        return;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host_id parameter to store node instance information");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_blob(res, 2, claim_id, sizeof(*claim_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind claim_id parameter to invalidate node instance information");
+        goto failed;
+    }
+
+    rc = execute_insert(res);
+    if (unlikely(rc != SQLITE_DONE))
+        error_report("Failed to to invalidate node instance information, rc = %d", rc);
+
+failed:
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when invalidating node instance information");
+}
+
+#define SQL_GET_NODE_INSTANCE_LIST "select node_id, host_id from node_instance where node_id is not null;"
+
+struct  node_instance_list *get_node_list(uuid_t *claim_id)
+{
+    struct  node_instance_list *node_list;
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    if (unlikely(!db_meta)) {
+        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            error_report("Database has not been initialized");
+        return NULL;
+    }
+
+    node_list = callocz(128, sizeof(*node_list));
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_GET_NODE_INSTANCE_LIST, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement store chart labels");
+        return NULL;
+    };
+
+    int row = 0;
+    char host_guid[37];
+    while (sqlite3_step(res) == SQLITE_ROW) {
+       uuid_copy(node_list[row].node_id, *((uuid_t *)sqlite3_column_blob(res, 0)));
+       uuid_copy(node_list[row].claim_id, *claim_id);
+       node_list[row].querable = 1;
+       uuid_unparse_lower(*((uuid_t *)sqlite3_column_blob(res, 1)), host_guid);
+       node_list[row].live = rrdhost_find_by_guid(host_guid, 0) ? 1 : 0;
+       node_list[row].hops = uuid_compare(*((uuid_t *)sqlite3_column_blob(res, 1)), localhost->host_uuid) ? 1 : 0;
+       row++;
+    }
+
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when storing node instance information");
+
+    return node_list;
+};

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1486,7 +1486,7 @@ failed:
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
         error_report("Failed to finalize the prepared statement when storing node instance information");
 
-    return (rc != SQLITE_ROW);
+    return (rc == SQLITE_ROW) ? 0 : -1;
 }
 
 #define SQL_INVALIDATE_NODE_INSTANCES "update node_instance set node_id = NULL where exists " \

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1438,7 +1438,7 @@ int update_node_id(uuid_t *host_id, uuid_t *node_id)
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE))
         error_report("Failed to store node instance information, rc = %d", rc);
-    rc = sqlite3_changes(res);
+    rc = sqlite3_changes(db_meta);
 
     char host_guid[GUID_LEN + 1];
     uuid_unparse_lower(*host_id, host_guid);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1468,13 +1468,13 @@ int get_node_id(uuid_t *host_id, uuid_t *node_id)
 
     rc = sqlite3_prepare_v2(db_meta, SQL_SELECT_NODE_ID, -1, &res, 0);
     if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to prepare statement store chart labels");
+        error_report("Failed to prepare statement to select node instance information for a host");
         return 1;
     }
 
     rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind host_id parameter to store node instance information");
+        error_report("Failed to bind host_id parameter to select node instance information");
         goto failed;
     }
 
@@ -1484,7 +1484,7 @@ int get_node_id(uuid_t *host_id, uuid_t *node_id)
 
 failed:
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
-        error_report("Failed to finalize the prepared statement when storing node instance information");
+        error_report("Failed to finalize the prepared statement when selecting node instance information");
 
     return (rc == SQLITE_ROW) ? 0 : -1;
 }
@@ -1505,13 +1505,13 @@ void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id)
 
     rc = sqlite3_prepare_v2(db_meta, SQL_INVALIDATE_NODE_INSTANCES, -1, &res, 0);
     if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to prepare statement store chart labels");
+        error_report("Failed to prepare statement to invalidate node instance ids");
         return;
     }
 
     rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind host_id parameter to store node instance information");
+        error_report("Failed to bind host_id parameter to invalidate node instance information");
         goto failed;
     }
 
@@ -1523,7 +1523,7 @@ void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id)
 
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE))
-        error_report("Failed to to invalidate node instance information, rc = %d", rc);
+        error_report("Failed to invalidate node instance information, rc = %d", rc);
 
 failed:
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1386,6 +1386,23 @@ failed:
     return;
 }
 
+static inline void set_host_node_id(RRDHOST *host, uuid_t *node_id)
+{
+    if (unlikely(!host))
+        return;
+
+    if (unlikely(!node_id)) {
+        freez(host->node_id);
+        host->node_id = NULL;
+        return;
+    }
+
+    if (unlikely(!host->node_id))
+        host->node_id = mallocz(sizeof(*host->node_id));
+    uuid_copy(*(host->node_id), *node_id);
+    return;
+}
+
 #define SQL_UPDATE_NODE_ID  "update node_instance set node_id = @node_id where host_id = @host_id;"
 
 void update_node_id(uuid_t *host_id, uuid_t *node_id)
@@ -1401,7 +1418,7 @@ void update_node_id(uuid_t *host_id, uuid_t *node_id)
 
     rc = sqlite3_prepare_v2(db_meta, SQL_UPDATE_NODE_ID, -1, &res, 0);
     if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to prepare statement store chart labels");
+        error_report("Failed to prepare statement to store node instance information");
         return;
     }
 
@@ -1413,13 +1430,21 @@ void update_node_id(uuid_t *host_id, uuid_t *node_id)
 
     rc = sqlite3_bind_blob(res, 2, host_id, sizeof(*host_id), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind claim_id parameter to store node instance information");
+        error_report("Failed to bind host_id parameter to store node instance information");
         goto failed;
     }
 
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE))
         error_report("Failed to store node instance information, rc = %d", rc);
+
+    char host_guid[GUID_LEN + 1];
+    uuid_unparse_lower(*host_id, host_guid);
+    rrd_wrlock();
+    RRDHOST *host = rrdhost_find_by_guid(host_guid, 0);
+    if (likely(host))
+            set_host_node_id(host, node_id);
+    rrd_unlock();
 
 failed:
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
@@ -1543,4 +1568,44 @@ struct  node_instance_list *get_node_list(uuid_t *claim_id)
         error_report("Failed to finalize the prepared statement when storing node instance information");
 
     return node_list;
+};
+
+#define SQL_GET_HOST_NODE_ID "select node_id from node_instance where host_id = @host_id;"
+
+void sql_load_node_id(RRDHOST *host)
+{
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    if (unlikely(!db_meta)) {
+        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            error_report("Database has not been initialized");
+        return;
+    }
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_GET_HOST_NODE_ID, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement store chart labels");
+        return;
+    };
+
+    rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host_id parameter to store node instance information");
+        goto failed;
+    }
+
+    rc = sqlite3_step(res);
+    if (likely(rc == SQLITE_ROW)) {
+        if (likely(sqlite3_column_bytes(res, 0) == sizeof(uuid_t)))
+            set_host_node_id(host, (uuid_t *)sqlite3_column_blob(res, 0));
+        else
+            set_host_node_id(host, NULL);
+    }
+
+failed:
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when storing node instance information");
+
+    return;
 };

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -9,7 +9,8 @@
 // return a node list
 struct node_instance_list {
     uuid_t  node_id;
-    uuid_t  claim_id;
+    uuid_t  host_id;
+    char *hostname;
     int live;
     int querable;
     int hops;
@@ -74,6 +75,6 @@ extern void store_claim_id(uuid_t *host_id, uuid_t *claim_id);
 extern void update_node_id(uuid_t *host_id, uuid_t *node_id);
 extern int get_node_id(uuid_t *host_id, uuid_t *node_id);
 extern void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id);
-extern struct node_instance_list *get_node_list(uuid_t *claim_id);
+extern struct node_instance_list *get_node_list(void);
 extern void sql_load_node_id(RRDHOST *host);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -75,4 +75,5 @@ extern void update_node_id(uuid_t *host_id, uuid_t *node_id);
 extern int get_node_id(uuid_t *host_id, uuid_t *node_id);
 extern void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id);
 extern struct node_instance_list *get_node_list(uuid_t *claim_id);
+extern void sql_load_node_id(RRDHOST *host);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -6,6 +6,16 @@
 #include "../../daemon/common.h"
 #include "sqlite3.h"
 
+// return a node list
+struct node_instance_list {
+    uuid_t  node_id;
+    uuid_t  claim_id;
+    int live;
+    int querable;
+    int hops;
+};
+
+
 #define SQLITE_INSERT_DELAY (50)        // Insert delay in case of lock
 
 #define SQL_STORE_HOST "insert or replace into host (host_id,hostname,registry_hostname,update_every,os,timezone,tags) values (?1,?2,?3,?4,?5,?6,?7);"
@@ -63,4 +73,6 @@ extern void sql_build_context_param_list(struct context_param **param_list, RRDH
 extern void store_claim_id(uuid_t *host_id, uuid_t *claim_id);
 extern void update_node_id(uuid_t *host_id, uuid_t *node_id);
 extern int get_node_id(uuid_t *host_id, uuid_t *node_id);
+extern void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id);
+extern struct node_instance_list *get_node_list(uuid_t *claim_id);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -72,7 +72,7 @@ extern void delete_dimension_uuid(uuid_t *dimension_uuid);
 extern void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value);
 extern void sql_build_context_param_list(struct context_param **param_list, RRDHOST *host, char *context, char *chart);
 extern void store_claim_id(uuid_t *host_id, uuid_t *claim_id);
-extern void update_node_id(uuid_t *host_id, uuid_t *node_id);
+extern int update_node_id(uuid_t *host_id, uuid_t *node_id);
 extern int get_node_id(uuid_t *host_id, uuid_t *node_id);
 extern void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id);
 extern struct node_instance_list *get_node_list(void);

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -61,4 +61,6 @@ extern void delete_dimension_uuid(uuid_t *dimension_uuid);
 extern void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value);
 extern void sql_build_context_param_list(struct context_param **param_list, RRDHOST *host, char *context, char *chart);
 extern void store_claim_id(uuid_t *host_id, uuid_t *claim_id);
+extern void update_node_id(uuid_t *host_id, uuid_t *node_id);
+extern int get_node_id(uuid_t *host_id, uuid_t *node_id);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
- Get a list of nodes stored in the database
- Update the node id for a host
- Check or retrieve the node id for a host

It adds support to set the `node_id` field of the  `node_instance` database table

##### Component Name
aclk
database

##### Test Plan
- This is part of the new architecture design and provides basic functionality to be used in subsequent PRs
