### PR TITLE
Fix coverity issue (CID 370510)

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -459,11 +459,9 @@ void analytics_gather_mutable_meta_data(void)
     analytics_set_data(
         &analytics_data.netdata_config_is_parent, (localhost->next || configured_as_parent()) ? "true" : "false");
 
-    if (is_agent_claimed())
-        analytics_set_data(&analytics_data.netdata_host_agent_claimed, "true");
-    else {
-        analytics_set_data(&analytics_data.netdata_host_agent_claimed, "false");
-    }
+    char *claim_id = is_agent_claimed();
+    analytics_set_data(&analytics_data.netdata_host_agent_claimed, claim_id ? "true" : "false");
+    freez(claim_id);
 
     {
         char b[7];


### PR DESCRIPTION
##### Summary
Fix memory leak

```
*** CID 370510:  Resource leaks  (RESOURCE_LEAK)
/daemon/analytics.c: 462 in analytics_gather_mutable_meta_data()
456         analytics_mirrored_hosts();
457         analytics_alarms_notifications();
458     
459         analytics_set_data(
460             &analytics_data.netdata_config_is_parent, (localhost->next || configured_as_parent()) ? "true" : "false");
461     
>>>     CID 370510:  Resource leaks  (RESOURCE_LEAK)
>>>     Failing to save or free storage allocated by "is_agent_claimed()" leaks it.
462         if (is_agent_claimed())
463             analytics_set_data(&analytics_data.netdata_host_agent_claimed, "true");
464         else {
465             analytics_set_data(&analytics_data.netdata_host_agent_claimed, "false");
466         }
467     
```

##### Component Name
analytics

##### Test Plan
- The allocated memory from `is_agent_claimed()` is released