### PR TITLE
Add a workflow to generate version bump PRs for the dashboard.

### DIFF
--- a/.github/workflows/dashboard-pr.yml
+++ b/.github/workflows/dashboard-pr.yml
@@ -1,0 +1,50 @@
+---
+# Create a PR to update the react dashboard code.
+name: Dashboard Version PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      dashboard_version:
+        # This must be specified, and must _exactly_ match the version
+        # tag for the release to be used for the update.
+        name: Dashboard Version
+        required: true
+
+jobs:
+  dashboard-pr:
+    name: Generate Dashboard Version Bump PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create Branch
+        # This is needed because we want to do a PR, and the commit
+        # action used below requires the branch it is commiting to to
+        # already exist.
+        run: |
+          git checkout -b dashboard-${{ github.event.inputs.dashboard_version }}
+          git push -u origin dashboard-${{ github.event.inputs.dashboard_version }}
+      - name: Update Files
+        run: |
+          curl -o dashboard.tar.gz https://github.com/netdata/dashboard/releases/download/${{ github.event.inputs.dashboard_version }}/dashboard.tar.gz
+          echo ${{ github.event.inputs.dashboard_version }} > packaging/dashboard.version
+          sha256sum dashboard.tar.gz > packaging/dashboard.checksums
+          rm dashboard.tar.gz
+      - name: Commit Changes
+        uses: swinton/commit@v2.x
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            packaging/dashboard.version
+            packaging/dashboard.checksums
+          commit-message: 'Update dashboard to version ${{ github.event.inputs.dashboard_version }}.'
+          ref: refs/heads/dashboard-${{ github.event.inputs.dashboard_version }}
+      - name: Create PR
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: dashboard-${{ github.event.inputs.dashboard_version }}
+          pr_title: 'Update dashboard to version ${{ github.event.inputs.dashboard_version }}.'
+          pr_body: 'See https://github.com/netdata/dashboard/releases/tag/${{ github.event.inputs.dashboard_version }} for changes.'
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
##### Summary

See #11072 and #11073 for info.

##### Component Name

area/ci

##### Test Plan

General process is equivalent to https://github.com/netdata/helmchart/blob/master/.github/workflows/agent-pr.yml. Actual testing will require this PR to be merged, but is inherently non-destructive.

##### Additional Information

Closes: #11073 