### PR TITLE
netdata-installer.sh: Enable IPv6 support in libwebsockets

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -650,10 +650,15 @@ EOF
       -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
       -D OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib \
       -D LWS_WITH_SOCKS5:bool=ON \
+      -D LWS_IPV6:bool=ON \
       $CMAKE_FLAGS \
       .
   else
-    run ${env_cmd} cmake -D LWS_WITH_SOCKS5:bool=ON $CMAKE_FLAGS .
+    run ${env_cmd} cmake \
+      -D LWS_WITH_SOCKS5:bool=ON \
+      -D LWS_IPV6:bool=ON \
+      $CMAKE_FLAGS \
+      .
   fi
   run ${env_cmd} make
   popd > /dev/null || exit 1


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Installation script does not build libwebsockets with IPv6 support
enabled. This results in Netdata Cloud being unreachable by agents
running in IPv6-only environments with Internet access via NAT64
gateway. 

This change adds `LWS_IPV6` CMake flag to libwebsockets build options
in netdata-installer.sh. Binaries built with that flag will be able to reach app.netdata.cloud
in environments where access to Internet via IPv4 is done through a NAT64 gateway.

Fixes #11079   

##### Component Name

netdata-installer
aclk

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

1. Build and start Netdata agent on a IPv6-only machine with NAT64 gateway
2. Claim the node in Netdata Cloud
3. Check if the node is marked as reachable in Cloud panel

##### Additional Information
