### PR TITLE
Automatically trigger Helmchart PR on agent release.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,4 +75,4 @@ jobs:
           repo: netdata/helmchart
           workflow: Agent Version PR
           ref: refs/heads/master
-          inputs: {"agent_version": "${{ github.event.inputs.version }}"}
+          inputs: '{"agent_version": "${{ github.event.inputs.version }}"}'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,3 +67,11 @@ jobs:
             && github.event_name != 'pull_request'
             && startsWith(github.ref, 'refs/heads/master')
           }}
+      - name: Trigger Helmchart PR
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != 'nightly'
+        with:
+          token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
+          repo: netdata/helmchart
+          workflow: Agent Version PR
+          ref: refs/heads/master
+          inputs: {"agent_version": "${{ github.event.inputs.version }}"}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,6 +69,7 @@ jobs:
           }}
       - name: Trigger Helmchart PR
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != 'nightly'
+        uses: benc-uk/workflow-dispatch@v1
         with:
           token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
           repo: netdata/helmchart


### PR DESCRIPTION
##### Summary

This will automatically trigger the workflow in the netdata/helmchart repo that generates a PR to bump the agent version bundled with the helmchart when we bpulish a docker image for a release.

##### Component Name

area/ci

##### Test Plan

Needs to be actually merged to be able to properly verify that it correctly triggers the workflow in netdata/helmchart, but there is no risk of it breaking the existing build infrastructure.

##### Additional Information

Actually having this integration was the roiginal intent of automating the process of generating the PRs in the netdata/helmchart repo, though it got kind of forgotten about until just recently.