### PR TITLE
fix SSL random failures when using multithreaded web server with OpenSSL < 1.1.0

### DIFF
--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -454,49 +454,51 @@ static void socket_listen_main_static_threaded_cleanup(void *ptr) {
 
 void *socket_listen_main_static_threaded(void *ptr) {
     netdata_thread_cleanup_push(socket_listen_main_static_threaded_cleanup, ptr);
-            web_server_mode = WEB_SERVER_MODE_STATIC_THREADED;
+    web_server_mode = WEB_SERVER_MODE_STATIC_THREADED;
 
-            if(!api_sockets.opened)
-                fatal("LISTENER: no listen sockets available.");
+    if(!api_sockets.opened)
+        fatal("LISTENER: no listen sockets available.");
 
 #ifdef ENABLE_HTTPS
-            security_start_ssl(NETDATA_SSL_CONTEXT_SERVER);
+    security_start_ssl(NETDATA_SSL_CONTEXT_SERVER);
 #endif
-            // 6 threads is the optimal value
-            // since 6 are the parallel connections browsers will do
-            // so, if the machine has more CPUs, avoid using resources unnecessarily
-            int def_thread_count = (processors > 6)?6:processors;
+    // 6 threads is the optimal value
+    // since 6 are the parallel connections browsers will do
+    // so, if the machine has more CPUs, avoid using resources unnecessarily
+    int def_thread_count = (processors > 6) ? 6 : processors;
 
-            if (!strcmp(config_get(CONFIG_SECTION_WEB, "mode", ""),"single-threaded")) {
+    if (!strcmp(config_get(CONFIG_SECTION_WEB, "mode", ""),"single-threaded")) {
                 info("Running web server with one thread, because mode is single-threaded");
                 config_set(CONFIG_SECTION_WEB, "mode", "static-threaded");
                 def_thread_count = 1;
-            }
-            static_threaded_workers_count = config_get_number(CONFIG_SECTION_WEB, "web server threads", def_thread_count);
+    }
+    static_threaded_workers_count = config_get_number(CONFIG_SECTION_WEB, "web server threads", def_thread_count);
 
-            if(static_threaded_workers_count < 1) static_threaded_workers_count = 1;
+    if (static_threaded_workers_count < 1) static_threaded_workers_count = 1;
 
-            size_t max_sockets = (size_t)config_get_number(CONFIG_SECTION_WEB, "web server max sockets", (long long int)(rlimit_nofile.rlim_cur / 4));
+    size_t max_sockets = (size_t)config_get_number(CONFIG_SECTION_WEB, "web server max sockets",
+                                                   (long long int)(rlimit_nofile.rlim_cur / 4));
 
-            static_workers_private_data = callocz((size_t)static_threaded_workers_count, sizeof(struct web_server_static_threaded_worker));
+    static_workers_private_data = callocz((size_t)static_threaded_workers_count,
+                                          sizeof(struct web_server_static_threaded_worker));
 
-            web_server_is_multithreaded = (static_threaded_workers_count > 1);
+    web_server_is_multithreaded = (static_threaded_workers_count > 1);
 
-            int i;
-            for(i = 1; i < static_threaded_workers_count; i++) {
-                static_workers_private_data[i].id = i;
-                static_workers_private_data[i].max_sockets = max_sockets / static_threaded_workers_count;
+    int i;
+    for (i = 1; i < static_threaded_workers_count; i++) {
+        static_workers_private_data[i].id = i;
+        static_workers_private_data[i].max_sockets = max_sockets / static_threaded_workers_count;
 
-                char tag[50 + 1];
-                snprintfz(tag, 50, "WEB_SERVER[static%d]", i+1);
+        char tag[50 + 1];
+        snprintfz(tag, 50, "WEB_SERVER[static%d]", i+1);
 
-                info("starting worker %d", i+1);
-                netdata_thread_create(&static_workers_private_data[i].thread, tag, NETDATA_THREAD_OPTION_DEFAULT, socket_listen_main_static_threaded_worker, (void *)&static_workers_private_data[i]);
-            }
+        info("starting worker %d", i+1);
+        netdata_thread_create(&static_workers_private_data[i].thread, tag, NETDATA_THREAD_OPTION_DEFAULT, socket_listen_main_static_threaded_worker, (void *)&static_workers_private_data[i]);
+    }
 
-            // and the main one
-            static_workers_private_data[0].max_sockets = max_sockets / static_threaded_workers_count;
-            socket_listen_main_static_threaded_worker((void *)&static_workers_private_data[0]);
+    // and the main one
+    static_workers_private_data[0].max_sockets = max_sockets / static_threaded_workers_count;
+    socket_listen_main_static_threaded_worker((void *)&static_workers_private_data[0]);
 
     netdata_thread_cleanup_pop(1);
     return NULL;


### PR DESCRIPTION
##### Summary
Fixes #11081 

This PR fixes the reported problem with old OpenSSL version and multithreading webserver.

I am also using this PR to fix the tabulation that was completely wrong for the thread function.
##### Component Name
Web server
##### Test Plan

1 - Compile this PR on an environment that has OpenSSL newer than `1.1.0.`
2 - Create TLS certificate and TLS key and store them inside `/etc/netdata/ssl/`, use the following command to generate them:

```bash
openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -sha512 -subj "/C=US/ST=Denied/L=Somewhere/O=Dis/CN=www.example.com" -keyout key.pem  -out cert.pem
```
3 - Change the permissions for:

```bash
bash-5.1$ ls -lh /etc/netdata/ssl/
total 8.0K
-rw-r--r-- 1 netdata netdata 1.3K Apr 14  2020 cert.pem
-rw------- 1 netdata netdata 1.7K Apr 14  2020 key.pem

```

4 - Run Netdata, and after few seconds run the following command:

```bash
bash-5.1# grep "starting worker" /var/log/netdata/*
/var/log/netdata/error.log:2021-05-05 00:37:53: netdata INFO  : WEB_SERVER[static1] : starting worker 2
/var/log/netdata/error.log:2021-05-05 00:37:53: netdata INFO  : WEB_SERVER[static1] : starting worker 3
/var/log/netdata/error.log:2021-05-05 00:37:53: netdata INFO  : WEB_SERVER[static1] : starting worker 4
```
you need to have "starting worker" messages that will indicate you are running multithreading webserver.

5 - Now compile this same PR on an operate system running OpenSSL version older than `1.1.0`, for example, CentOS 7.x
6 -  Repeat the steps 2 - 4 and you will see that "starting  worker" won't appear.
7 - Run the following command to verify that it has only one thread running:

```bash
# grep "older than 1.1.0" /var/log/netdata/error.log
/var/log/netdata/error.log:2021-05-05 00:30:00: You are running an OpenSSL older than 1.1.0, web server will not enable multithreading
```

##### Additional Information
