### PR TITLE
Reduce send statistics logging

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -843,7 +843,7 @@ void send_statistics(const char *action, const char *action_result, const char *
         analytics_data.netdata_host_cloud_available, analytics_data.netdata_host_aclk_available,
         analytics_data.netdata_host_aclk_implementation, analytics_data.netdata_host_agent_claimed);
 
-    info("%s", command_to_run);
+    info("%s '%s' '%s' '%s'", as_script, action, action_result, action_data);
 
     FILE *fp = mypopen(command_to_run, &command_pid);
     if (fp) {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

As @ilyam8 observed, the last analytics PR sends the whole `anonymous-statistics.sh` command we run to the log, including all the parameters, which can add up quickly to the size of logs. This PR reduces the logging to just the script, `action`, `action_result` and `action_data` information (as it practically was before adding parameters to the script).

##### Component Name

Analytics

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Observe that only the script, `action`, `action_result` and `action_data` are logged.
