### PR TITLE
Remove ARCHIVE state globally

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -166,7 +166,6 @@ typedef enum rrddim_flags {
     RRDDIM_FLAG_OBSOLETE                        = (1 << 2),  // this is marked by the collector/module as obsolete
     // No new values have been collected for this dimension since agent start or it was marked RRDDIM_FLAG_OBSOLETE at
     // least rrdset_free_obsolete_time seconds ago.
-    RRDDIM_FLAG_ARCHIVED                        = (1 << 3),
     RRDDIM_FLAG_ACLK                            = (1 << 4),
 
     RRDDIM_FLAG_PENDING_FOREACH_ALARM           = (1 << 5), // set when foreach alarm has not been initialized yet
@@ -441,7 +440,6 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_OBSOLETE_DIMENSIONS = 1 << 14, // this is marked by the collector/module when a chart has obsolete dimensions
     // No new values have been collected for this chart since agent start or it was marked RRDSET_FLAG_OBSOLETE at
     // least rrdset_free_obsolete_time seconds ago.
-    RRDSET_FLAG_ARCHIVED            = 1 << 15,
     RRDSET_FLAG_ACLK                = 1 << 16,
     RRDSET_FLAG_PENDING_FOREACH_ALARMS = 1 << 17, // contains dims with uninitialized foreach alarms
     RRDSET_FLAG_ANOMALY_DETECTION   = 1 << 18 // flag to identify anomaly detection charts.
@@ -1038,8 +1036,6 @@ extern RRDSET *rrdset_find(RRDHOST *host, const char *id);
 static inline RRDSET *rrdset_find_active_localhost(const char *id)
 {
     RRDSET *st = rrdset_find_localhost(id);
-    if (unlikely(st && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)))
-        return NULL;
     return st;
 }
 
@@ -1049,8 +1045,6 @@ extern RRDSET *rrdset_find_bytype(RRDHOST *host, const char *type, const char *i
 static inline RRDSET *rrdset_find_active_bytype_localhost(const char *type, const char *id)
 {
     RRDSET *st = rrdset_find_bytype_localhost(type, id);
-    if (unlikely(st && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)))
-        return NULL;
     return st;
 }
 
@@ -1060,8 +1054,6 @@ extern RRDSET *rrdset_find_byname(RRDHOST *host, const char *name);
 static inline RRDSET *rrdset_find_active_byname_localhost(const char *name)
 {
     RRDSET *st = rrdset_find_byname_localhost(name);
-    if (unlikely(st && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)))
-        return NULL;
     return st;
 }
 
@@ -1075,9 +1067,8 @@ extern void rrdset_is_obsolete(RRDSET *st);
 extern void rrdset_isnot_obsolete(RRDSET *st);
 
 // checks if the RRDSET should be offered to viewers
-#define rrdset_is_available_for_viewers(st) (!rrdset_flag_check(st, RRDSET_FLAG_HIDDEN) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
-#define rrdset_is_available_for_exporting_and_alarms(st) (!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
-#define rrdset_is_archived(st) (rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
+#define rrdset_is_available_for_viewers(st) (!rrdset_flag_check(st, RRDSET_FLAG_HIDDEN) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
+#define rrdset_is_available_for_exporting_and_alarms(st) (!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && (st)->dimensions)
 
 // get the total duration in seconds of the round robin database
 #define rrdset_duration(st) ((time_t)( (((st)->counter >= ((unsigned long)(st)->entries))?(unsigned long)(st)->entries:(st)->counter) * (st)->update_every ))
@@ -1263,8 +1254,8 @@ extern RRDDIM *rrddim_find(RRDSET *st, const char *id);
 static inline RRDDIM *rrddim_find_active(RRDSET *st, const char *id)
 {
     RRDDIM *rd = rrddim_find(st, id);
-    if (unlikely(rd && rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)))
-        return NULL;
+//    if (unlikely(rd && rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)))
+//        return NULL;
     return rd;
 }
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -592,7 +592,6 @@ typedef enum rrdhost_flags {
     RRDHOST_FLAG_DELETE_ORPHAN_HOST     = 1 << 2, // delete the entire host when orphan
     RRDHOST_FLAG_EXPORTING_SEND           = 1 << 3, // send it to external databases
     RRDHOST_FLAG_EXPORTING_DONT_SEND      = 1 << 4, // don't send it to external databases
-    RRDHOST_FLAG_ARCHIVED               = 1 << 5, // The host is archived, no collected charts yet
     RRDHOST_FLAG_MULTIHOST              = 1 << 6, // Host belongs to localhost/megadb
     RRDHOST_FLAG_PENDING_FOREACH_ALARMS  = 1 << 7, // contains dims with uninitialized foreach alarms
 } RRDHOST_FLAGS;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1449,75 +1449,18 @@ restart_after_removal:
                     && st->last_collected_time.tv_sec + rrdset_free_obsolete_time < now
         )) {
             st->rrdhost->obsolete_charts_count--;
+
 #ifdef ENABLE_DBENGINE
-            if(st->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-                RRDDIM *rd, *last;
-
-                rrdset_flag_set(st, RRDSET_FLAG_ARCHIVED);
-                while (st->variables)  rrdsetvar_free(st->variables);
-                while (st->alarms)     rrdsetcalc_unlink(st->alarms);
-                rrdset_wrlock(st);
-                for (rd = st->dimensions, last = NULL ; likely(rd) ; ) {
-                    if (rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
-                        last = rd;
-                        rd = rd->next;
-                        continue;
-                    }
-
-                    if (rrddim_flag_check(rd, RRDDIM_FLAG_ACLK)) {
-                        last = rd;
-                        rd = rd->next;
-                        continue;
-                    }
-                    rrddim_flag_set(rd, RRDDIM_FLAG_ARCHIVED);
-                    while (rd->variables)
-                        rrddimvar_free(rd->variables);
-
-                    if (rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) {
-                        rrddim_flag_clear(rd, RRDDIM_FLAG_OBSOLETE);
-                        /* only a collector can mark a chart as obsolete, so we must remove the reference */
-                        uint8_t can_delete_metric = rd->state->collect_ops.finalize(rd);
-                        if (can_delete_metric) {
-                            /* This metric has no data and no references */
-                            delete_dimension_uuid(&rd->state->metric_uuid);
-                            rrddim_free(st, rd);
-                            if (unlikely(!last)) {
-                                rd = st->dimensions;
-                            }
-                            else {
-                                rd = last->next;
-                            }
-                            continue;
-                        }
-#if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
-                        else
-                            queue_dimension_to_aclk(rd, rd->last_collected_time.tv_sec);
+            if (unlikely(st->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE))
 #endif
-                    }
-                    last = rd;
-                    rd = rd->next;
-                }
+            {
+                rrdset_rdlock(st);
+                if (rrdhost_delete_obsolete_charts)
+                    rrdset_delete(st);
+                else
+                    rrdset_save(st);
                 rrdset_unlock(st);
-
-                debug(D_RRD_CALLS, "RRDSET: Cleaning up remaining chart variables for host '%s', chart '%s'", host->hostname, st->id);
-                rrdvar_free_remaining_variables(host, &st->rrdvar_root_index);
-
-                rrdset_flag_clear(st, RRDSET_FLAG_OBSOLETE);
-                
-                if (st->dimensions) {
-                    /* If the chart still has dimensions don't delete it from the metadata log */
-                    continue;
-                }
             }
-#endif
-            rrdset_rdlock(st);
-
-            if(rrdhost_delete_obsolete_charts)
-                rrdset_delete(st);
-            else
-                rrdset_save(st);
-
-            rrdset_unlock(st);
 
             rrdset_free(st);
             goto restart_after_removal;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -198,11 +198,6 @@ int rrdset_set_name(RRDSET *st, const char *name) {
 }
 
 inline void rrdset_is_obsolete(RRDSET *st) {
-    if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED))) {
-        info("Cannot obsolete already archived chart %s", st->name);
-        return;
-    }
-
     if(unlikely(!(rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE)))) {
         rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE);
         st->rrdhost->obsolete_charts_count++;
@@ -283,9 +278,8 @@ void rrdset_reset(RRDSET *st) {
         rd->collections_counter = 0;
         // memset(rd->values, 0, rd->entries * sizeof(storage_number));
 #ifdef ENABLE_DBENGINE
-        if (RRD_MEMORY_MODE_DBENGINE == st->rrd_memory_mode && !rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
+        if (RRD_MEMORY_MODE_DBENGINE == st->rrd_memory_mode)
             rrdeng_store_metric_flush_current_page(rd);
-        }
 #endif
     }
 }
@@ -563,11 +557,6 @@ RRDSET *rrdset_create_custom(
         int mark_rebuild = 0;
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
-        if (rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
-            rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
-            changed_from_archived_to_active = 1;
-            mark_rebuild |= META_CHART_ACTIVATED;
-        }
         char *old_plugin = NULL, *old_module = NULL, *old_title = NULL, *old_context = NULL,
              *old_title_v = NULL, *old_context_v = NULL;
         int rc;
@@ -688,16 +677,6 @@ RRDSET *rrdset_create_custom(
 
     st = rrdset_find_on_create(host, fullid);
     if(st) {
-        if (changed_from_archived_to_active) {
-            rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
-            rrdsetvar_create(st, "last_collected_t",    RRDVAR_TYPE_TIME_T,     &st->last_collected_time.tv_sec, RRDVAR_OPTION_DEFAULT);
-            rrdsetvar_create(st, "collected_total_raw", RRDVAR_TYPE_TOTAL,      &st->last_collected_total,       RRDVAR_OPTION_DEFAULT);
-            rrdsetvar_create(st, "green",               RRDVAR_TYPE_CALCULATED, &st->green,                      RRDVAR_OPTION_DEFAULT);
-            rrdsetvar_create(st, "red",                 RRDVAR_TYPE_CALCULATED, &st->red,                        RRDVAR_OPTION_DEFAULT);
-            rrdsetvar_create(st, "update_every",        RRDVAR_TYPE_INT,        &st->update_every,               RRDVAR_OPTION_DEFAULT);
-            rrdsetcalc_link_matching(st);
-            rrdcalctemplate_link_matching(st);
-        }
         rrdhost_unlock(host);
         rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
@@ -1125,8 +1104,6 @@ static inline size_t rrdset_done_interpolate(
         last_ut = next_store_ut;
 
         rrddim_foreach_read(rd, st) {
-            if (rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED))
-                continue;
 
             calculated_number new_value;
 
@@ -1529,8 +1506,6 @@ after_first_database_work:
     int dimensions = 0;
     st->collected_total = 0;
     rrddim_foreach_read(rd, st) {
-        if (rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED))
-            continue;
         dimensions++;
         if(likely(rd->updated))
             st->collected_total += rd->collected_value;
@@ -1542,9 +1517,6 @@ after_first_database_work:
     // based on the collected figures only
     // at this stage we do not interpolate anything
     rrddim_foreach_read(rd, st) {
-        if (rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED))
-            continue;
-
         if(unlikely(!rd->updated)) {
             rd->calculated_value = 0;
             continue;
@@ -1793,8 +1765,6 @@ after_second_database_work:
     time_t mark = now_realtime_sec();
 #endif
     rrddim_foreach_read(rd, st) {
-        if (rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED))
-            continue;
 
 #if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
         if (likely(!st->state->is_ar_chart)) {

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1159,7 +1159,7 @@ void sql_rrdset2json(RRDHOST *host, BUFFER *wb)
         size_t found = 0;
         RRDHOST *h;
         rrdhost_foreach_read(h) {
-            if(!rrdhost_should_be_removed(h, host, now) && !rrdhost_flag_check(h, RRDHOST_FLAG_ARCHIVED)) {
+            if(!rrdhost_should_be_removed(h, host, now)) {
                 buffer_sprintf(wb
                     , "%s\n\t\t{"
                       "\n\t\t\t\"hostname\": \"%s\""
@@ -1269,7 +1269,6 @@ RRDHOST *sql_create_host_by_uuid(char *hostname)
     uuid_copy(host->host_uuid, *((uuid_t *) sqlite3_column_blob(res, 0)));
 
     host->system_info = callocz(1, sizeof(*host->system_info));;
-    rrdhost_flag_set(host, RRDHOST_FLAG_ARCHIVED);
 #ifdef ENABLE_DBENGINE
     host->rrdeng_ctx = &multidb_ctx;
 #endif

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1090,8 +1090,6 @@ void sql_rrdset2json(RRDHOST *host, BUFFER *wb)
         char id[512];
         sprintf(id, "%s.%s", sqlite3_column_text(res_chart, 3), sqlite3_column_text(res_chart, 1));
         RRDSET *st = rrdset_find(host, id);
-        if (st && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED))
-            continue;
 
         if (c)
             buffer_strcat(wb, ",\n\t\t\"");

--- a/health/health.c
+++ b/health/health.c
@@ -197,8 +197,6 @@ static void health_reload_host(RRDHOST *host) {
     // link the loaded alarms to their charts
     RRDDIM *rd;
     rrdset_foreach_write(st, host) {
-        if (rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED))
-            continue;
         rrdsetcalc_link_matching(st);
         rrdcalctemplate_link_matching(st);
 
@@ -513,11 +511,6 @@ static inline int rrdcalc_isrunnable(RRDCALC *rc, time_t now, time_t *next_run) 
 
     if(unlikely(rrdset_flag_check(rc->rrdset, RRDSET_FLAG_OBSOLETE))) {
         debug(D_HEALTH, "Health not running alarm '%s.%s'. The chart has been marked as obsolete", rc->chart?rc->chart:"NOCHART", rc->name);
-        return 0;
-    }
-
-    if(unlikely(rrdset_flag_check(rc->rrdset, RRDSET_FLAG_ARCHIVED))) {
-        debug(D_HEALTH, "Health not running alarm '%s.%s'. The chart has been marked as archived", rc->chart?rc->chart:"NOCHART", rc->name);
         return 0;
     }
 

--- a/web/api/formatters/charts2json.c
+++ b/web/api/formatters/charts2json.c
@@ -37,6 +37,7 @@ const char* get_release_channel() {
 }
 
 void charts2json(RRDHOST *host, BUFFER *wb, int skip_volatile, int show_archived) {
+    UNUSED(show_archived);
     static char *custom_dashboard_info_js_filename = NULL;
     size_t c, dimensions = 0, memory = 0, alarms = 0;
     RRDSET *st;
@@ -71,7 +72,7 @@ void charts2json(RRDHOST *host, BUFFER *wb, int skip_volatile, int show_archived
     c = 0;
     rrdhost_rdlock(host);
     rrdset_foreach_read(st, host) {
-        if ((!show_archived && rrdset_is_available_for_viewers(st)) || (show_archived && rrdset_is_archived(st))) {
+        if (rrdset_is_available_for_viewers(st))  {
             if(c) buffer_strcat(wb, ",");
             buffer_strcat(wb, "\n\t\t\"");
             buffer_strcat(wb, st->id);


### PR DESCRIPTION
##### Summary
Remove the archived state for hosts and charts

##### Component Name
database

##### Test Plan
1. Create parent with lots of children streaming to it
   - Parent should be set to clean orphan hosts and set chart obsoletion e.g 60 seconds and cleanup orphan hosts after seconds to 120 seconds
2. All the children should appear in the `/api/v1/info' as usual
3. Disconnect almost all children
4. Wait minimum the number of chart obsoletion seconds and reconnect one child
5. Check memory usage

**Apply PR**
1. Stop parent and apply PR
2. Start parent and the children as before
3. All the children should appear in the `/api/v1/info` as usual
4. Disconnect almost all children
5. You should only see the connected child in `/api/v1/info` now
6. Check memory usage



##### Additional Information
