### PR TITLE
cgroups: fix network interfaces detection when using `virsh`

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network-helper.sh
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh
@@ -169,7 +169,7 @@ virsh_find_all_interfaces_for_cgroup() {
         local d
         d="$(virsh_cgroup_to_domain_name "${c}")"
         # convert hex to character
-        # e.g.: vm01\x2dweb => vm01-dweb (https://github.com/netdata/netdata/issues/11088#issuecomment-832618149)
+        # e.g.: vm01\x2dweb => vm01-web (https://github.com/netdata/netdata/issues/11088#issuecomment-832618149)
         d="$(printf '%b' "${d}")"
 
         if [ ! -z "${d}" ]
@@ -179,7 +179,7 @@ virsh_find_all_interfaces_for_cgroup() {
             # 'virsh -r domiflist <domain>' example output
             # Interface  Type       Source     Model       MAC
             #--------------------------------------------------------------
-            # vnet3       bridge    br0        virtio   52:54:00xx:xx:xx
+            # vnet3       bridge    br0        virtio   52:54:00:xx:xx:xx
             # vnet4       network   default    virtio   52:54:00:yy:yy:yy
 
             # match only 'network' interfaces from virsh output

--- a/collectors/cgroups.plugin/cgroup-network-helper.sh
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh
@@ -123,7 +123,7 @@ proc_pid_fdinfo_iff() {
 find_tun_tap_interfaces_for_cgroup() {
     local c="${1}" # the cgroup path
     [ -d "${c}/emulator" ] && c="${c}/emulator" # check for 'emulator' subdirectory
-    c="${c}/cgroup.procs" # make full path 
+    c="${c}/cgroup.procs" # make full path
 
     # for each pid of the cgroup
     # find any tun/tap devices linked to the pid
@@ -168,18 +168,26 @@ virsh_find_all_interfaces_for_cgroup() {
     then
         local d
         d="$(virsh_cgroup_to_domain_name "${c}")"
+        # convert hex to character
+        # e.g.: vm01\x2dweb => vm01-dweb (https://github.com/netdata/netdata/issues/11088#issuecomment-832618149)
+        d="$(printf '%b' "${d}")"
 
         if [ ! -z "${d}" ]
         then
             debug "running: virsh domiflist ${d}; to find the network interfaces"
 
-            # match only 'network' interfaces from virsh output
+            # 'virsh -r domiflist <domain>' example output
+            # Interface  Type       Source     Model       MAC
+            #--------------------------------------------------------------
+            # vnet3       bridge    br0        virtio   52:54:00xx:xx:xx
+            # vnet4       network   default    virtio   52:54:00:yy:yy:yy
 
+            # match only 'network' interfaces from virsh output
             set_source "virsh"
             "${virsh}" -r domiflist "${d}" |\
                 sed -n \
-                    -e "s|^\([^[:space:]]\+\)[[:space:]]\+network[[:space:]]\+\([^[:space:]]\+\)[[:space:]]\+[^[:space:]]\+[[:space:]]\+[^[:space:]]\+$|\1 \1_\2|p" \
-                    -e "s|^\([^[:space:]]\+\)[[:space:]]\+bridge[[:space:]]\+\([^[:space:]]\+\)[[:space:]]\+[^[:space:]]\+[[:space:]]\+[^[:space:]]\+$|\1 \1_\2|p"
+                    -e "s|^[[:space:]]\?\([^[:space:]]\+\)[[:space:]]\+network[[:space:]]\+\([^[:space:]]\+\)[[:space:]]\+[^[:space:]]\+[[:space:]]\+[^[:space:]]\+$|\1 \1_\2|p" \
+                    -e "s|^[[:space:]]\?\([^[:space:]]\+\)[[:space:]]\+bridge[[:space:]]\+\([^[:space:]]\+\)[[:space:]]\+[^[:space:]]\+[[:space:]]\+[^[:space:]]\+$|\1 \1_\2|p"
         else
             debug "no virsh domain extracted from cgroup ${c}"
         fi

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -453,7 +453,7 @@ void detect_veth_interfaces(pid_t pid) {
 
     if(!eligible_ifaces(host)) {
         errno = 0;
-        error("there are no double-linked host interfaces available.");
+        info("there are no double-linked host interfaces available.");
         goto cleanup;
     }
 


### PR DESCRIPTION
##### Summary

Fixes: #11088

##### Component Name

`collectors/cgroups`

##### Test Plan

Tested by @Izorkin (https://github.com/netdata/netdata/issues/11088#issuecomment-832851379)

##### Additional Information
