### PR TITLE
Add host_cloud_enabled attribute to analytics

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -569,14 +569,14 @@ void set_late_global_environment()
 {
     analytics_set_data(&analytics_data.netdata_config_stream_enabled, default_rrdpush_enabled ? "true" : "false");
     analytics_set_data_str(&analytics_data.netdata_config_memory_mode, (char *)rrd_memory_mode_name(default_rrd_memory_mode));
-    analytics_set_data(&analytics_data.netdata_config_exporting_enabled, appconfig_get_boolean(&exporting_config, CONFIG_SECTION_EXPORTING, "enabled", 1) ? "true" : "false");
+    analytics_set_data(&analytics_data.netdata_config_exporting_enabled, appconfig_get_boolean(&exporting_config, CONFIG_SECTION_EXPORTING, "enabled", CONFIG_BOOLEAN_NO) ? "true" : "false");
 
 #ifdef DISABLE_CLOUD
     analytics_set_data(&analytics_data.netdata_host_cloud_enabled, "false");
 #else
     analytics_set_data(
         &analytics_data.netdata_host_cloud_enabled,
-        appconfig_get_boolean(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", 1) ? "true" : "false");
+        appconfig_get_boolean(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", CONFIG_BOOLEAN_YES) ? "true" : "false");
 #endif
 
 #ifdef ENABLE_DBENGINE

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -52,8 +52,8 @@ void analytics_log_data(void)
     debug(D_ANALYTICS, "NETDATA_HOST_CLOUD_AVAILABLE       : [%s]", analytics_data.netdata_host_cloud_available);
     debug(D_ANALYTICS, "NETDATA_HOST_ACLK_AVAILABLE        : [%s]", analytics_data.netdata_host_aclk_available);
     debug(D_ANALYTICS, "NETDATA_HOST_ACLK_IMPLEMENTATION   : [%s]", analytics_data.netdata_host_aclk_implementation);
-    debug(D_ANALYTICS, "NETDATA_HOST_CLOUD_ENABLED         : [%s]", analytics_data.netdata_host_cloud_enabled);
     debug(D_ANALYTICS, "NETDATA_HOST_AGENT_CLAIMED         : [%s]", analytics_data.netdata_host_agent_claimed);
+    debug(D_ANALYTICS, "NETDATA_HOST_CLOUD_ENABLED         : [%s]", analytics_data.netdata_host_cloud_enabled);
 }
 
 /*
@@ -91,8 +91,8 @@ void analytics_free_data(void)
     freez(analytics_data.netdata_host_cloud_available);
     freez(analytics_data.netdata_host_aclk_available);
     freez(analytics_data.netdata_host_aclk_implementation);
-    freez(analytics_data.netdata_host_cloud_enabled);
     freez(analytics_data.netdata_host_agent_claimed);
+    freez(analytics_data.netdata_host_cloud_enabled);
 }
 
 /*
@@ -753,8 +753,8 @@ void set_global_environment()
     analytics_set_data(&analytics_data.netdata_host_cloud_available, "null");
     analytics_set_data(&analytics_data.netdata_host_aclk_implementation, "null");
     analytics_set_data(&analytics_data.netdata_host_aclk_available, "null");
-    analytics_set_data(&analytics_data.netdata_host_cloud_enabled, "null");
     analytics_set_data(&analytics_data.netdata_host_agent_claimed, "null");
+    analytics_set_data(&analytics_data.netdata_host_cloud_enabled, "null");
 
     analytics_data.prometheus_hits = 0;
     analytics_data.shell_hits = 0;

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -52,6 +52,7 @@ void analytics_log_data(void)
     debug(D_ANALYTICS, "NETDATA_HOST_CLOUD_AVAILABLE       : [%s]", analytics_data.netdata_host_cloud_available);
     debug(D_ANALYTICS, "NETDATA_HOST_ACLK_AVAILABLE        : [%s]", analytics_data.netdata_host_aclk_available);
     debug(D_ANALYTICS, "NETDATA_HOST_ACLK_IMPLEMENTATION   : [%s]", analytics_data.netdata_host_aclk_implementation);
+    debug(D_ANALYTICS, "NETDATA_HOST_CLOUD_ENABLED         : [%s]", analytics_data.netdata_host_cloud_enabled);
     debug(D_ANALYTICS, "NETDATA_HOST_AGENT_CLAIMED         : [%s]", analytics_data.netdata_host_agent_claimed);
 }
 
@@ -90,6 +91,7 @@ void analytics_free_data(void)
     freez(analytics_data.netdata_host_cloud_available);
     freez(analytics_data.netdata_host_aclk_available);
     freez(analytics_data.netdata_host_aclk_implementation);
+    freez(analytics_data.netdata_host_cloud_enabled);
     freez(analytics_data.netdata_host_agent_claimed);
 }
 
@@ -569,6 +571,14 @@ void set_late_global_environment()
     analytics_set_data_str(&analytics_data.netdata_config_memory_mode, (char *)rrd_memory_mode_name(default_rrd_memory_mode));
     analytics_set_data(&analytics_data.netdata_config_exporting_enabled, appconfig_get_boolean(&exporting_config, CONFIG_SECTION_EXPORTING, "enabled", 1) ? "true" : "false");
 
+#ifdef DISABLE_CLOUD
+    analytics_set_data(&analytics_data.netdata_host_cloud_enabled, "false");
+#else
+    analytics_set_data(
+        &analytics_data.netdata_host_cloud_enabled,
+        appconfig_get_boolean(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", 1) ? "true" : "false");
+#endif
+
 #ifdef ENABLE_DBENGINE
     {
         char b[16];
@@ -743,6 +753,7 @@ void set_global_environment()
     analytics_set_data(&analytics_data.netdata_host_cloud_available, "null");
     analytics_set_data(&analytics_data.netdata_host_aclk_implementation, "null");
     analytics_set_data(&analytics_data.netdata_host_aclk_available, "null");
+    analytics_set_data(&analytics_data.netdata_host_cloud_enabled, "null");
     analytics_set_data(&analytics_data.netdata_host_agent_claimed, "null");
 
     analytics_data.prometheus_hits = 0;
@@ -825,23 +836,43 @@ void send_statistics(const char *action, const char *action_result, const char *
 
     sprintf(
         command_to_run,
-        "%s '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' ",
-        as_script, action, action_result, action_data, analytics_data.netdata_config_stream_enabled,
-        analytics_data.netdata_config_memory_mode, analytics_data.netdata_config_exporting_enabled,
-        analytics_data.netdata_exporting_connectors, analytics_data.netdata_allmetrics_prometheus_used,
-        analytics_data.netdata_allmetrics_shell_used, analytics_data.netdata_allmetrics_json_used,
-        analytics_data.netdata_dashboard_used, analytics_data.netdata_collectors,
-        analytics_data.netdata_collectors_count, analytics_data.netdata_buildinfo,
-        analytics_data.netdata_config_page_cache_size, analytics_data.netdata_config_multidb_disk_quota,
-        analytics_data.netdata_config_https_enabled, analytics_data.netdata_config_web_enabled,
-        analytics_data.netdata_config_release_channel, analytics_data.netdata_mirrored_host_count,
-        analytics_data.netdata_mirrored_hosts_reachable, analytics_data.netdata_mirrored_hosts_unreachable,
-        analytics_data.netdata_notification_methods, analytics_data.netdata_alarms_normal,
-        analytics_data.netdata_alarms_warning, analytics_data.netdata_alarms_critical,
-        analytics_data.netdata_charts_count, analytics_data.netdata_metrics_count,
-        analytics_data.netdata_config_is_parent, analytics_data.netdata_config_hosts_available,
-        analytics_data.netdata_host_cloud_available, analytics_data.netdata_host_aclk_available,
-        analytics_data.netdata_host_aclk_implementation, analytics_data.netdata_host_agent_claimed);
+        "%s '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' ",
+        as_script,
+        action,
+        action_result,
+        action_data,
+        analytics_data.netdata_config_stream_enabled,
+        analytics_data.netdata_config_memory_mode,
+        analytics_data.netdata_config_exporting_enabled,
+        analytics_data.netdata_exporting_connectors,
+        analytics_data.netdata_allmetrics_prometheus_used,
+        analytics_data.netdata_allmetrics_shell_used,
+        analytics_data.netdata_allmetrics_json_used,
+        analytics_data.netdata_dashboard_used,
+        analytics_data.netdata_collectors,
+        analytics_data.netdata_collectors_count,
+        analytics_data.netdata_buildinfo,
+        analytics_data.netdata_config_page_cache_size,
+        analytics_data.netdata_config_multidb_disk_quota,
+        analytics_data.netdata_config_https_enabled,
+        analytics_data.netdata_config_web_enabled,
+        analytics_data.netdata_config_release_channel,
+        analytics_data.netdata_mirrored_host_count,
+        analytics_data.netdata_mirrored_hosts_reachable,
+        analytics_data.netdata_mirrored_hosts_unreachable,
+        analytics_data.netdata_notification_methods,
+        analytics_data.netdata_alarms_normal,
+        analytics_data.netdata_alarms_warning,
+        analytics_data.netdata_alarms_critical,
+        analytics_data.netdata_charts_count,
+        analytics_data.netdata_metrics_count,
+        analytics_data.netdata_config_is_parent,
+        analytics_data.netdata_config_hosts_available,
+        analytics_data.netdata_host_cloud_available,
+        analytics_data.netdata_host_aclk_available,
+        analytics_data.netdata_host_aclk_implementation,
+        analytics_data.netdata_host_agent_claimed,
+        analytics_data.netdata_host_cloud_enabled);
 
     info("%s", command_to_run);
 

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -29,7 +29,7 @@
     },
 
 /* Needed to calculate the space needed for parameters */
-#define ANALYTICS_NO_OF_ITEMS 31
+#define ANALYTICS_NO_OF_ITEMS 32
 
 struct analytics_data {
     char *netdata_config_stream_enabled;
@@ -62,6 +62,7 @@ struct analytics_data {
     char *netdata_host_cloud_available;
     char *netdata_host_aclk_available;
     char *netdata_host_aclk_implementation;
+    char *netdata_host_cloud_enabled;
     char *netdata_host_agent_claimed;
 
     size_t data_length;

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -62,8 +62,8 @@ struct analytics_data {
     char *netdata_host_cloud_available;
     char *netdata_host_aclk_available;
     char *netdata_host_aclk_implementation;
-    char *netdata_host_cloud_enabled;
     char *netdata_host_agent_claimed;
+    char *netdata_host_cloud_enabled;
 
     size_t data_length;
 

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -59,6 +59,7 @@ NETDATA_HOST_CLOUD_AVAILABLE="${31}"
 NETDATA_HOST_ACLK_AVAILABLE="${32}"
 NETDATA_HOST_ACLK_IMPLEMENTATION="${33}"
 NETDATA_HOST_AGENT_CLAIMED="${34}"
+NETDATA_HOST_CLOUD_ENABLED="${35}"
 
 # define body of request to be sent
 REQ_BODY="$(cat << EOF
@@ -132,6 +133,7 @@ REQ_BODY="$(cat << EOF
         "host_allmetrics_json_used": ${NETDATA_ALLMETRICS_JSON_USED},
         "host_dashboard_used": ${NETDATA_DASHBOARD_USED},
         "host_cloud_available": ${NETDATA_HOST_CLOUD_AVAILABLE},
+        "host_cloud_enabled": ${NETDATA_HOST_CLOUD_ENABLED},
         "host_agent_claimed": ${NETDATA_HOST_AGENT_CLAIMED},
         "host_aclk_available": ${NETDATA_HOST_ACLK_AVAILABLE},
         "host_aclk_implementation": ${NETDATA_HOST_ACLK_IMPLEMENTATION},


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Adds a new attribute `host_cloud_enabled` to posthog analytics. The attribute will be false if `--disable-cloud` was used during install, or `enabled = no` is defined in `/var/lib/netdata/cloud.d/cloud.conf`

##### Component Name

Analytics

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

To test, enable debug with analytics debug flag `0x0000000080000000`, or observe the host's page on posthog.
If `--disable-cloud` is used, the attribute should be `false`.
If `enabled = no` is specified in `/var/lib/netdata/cloud.d/cloud.conf`, the attribute should also be `false`.
Otherwise, it should be `true`
