### PR TITLE
Don't repeat the cgroup discovery cleanup info message

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -4002,9 +4002,10 @@ static void cgroup_main_cleanup(void *ptr) {
         uv_mutex_unlock(&discovery_thread.mutex);
     }
 
+    info("waiting for discovery thread to finish...");
+    
     while (!discovery_thread.exited && max > 0) {
         max -= step;
-        info("waiting for discovery thread to finish...");
         sleep_usec(step);
     }
 


### PR DESCRIPTION
##### Summary
SSIA

Fixes #11098

##### Component Name
cgroups plugin

##### Test Plan
Restart Netdata. Check if the "waiting for discovery thread to finish..." message appears only once.