### PR TITLE
Check the version of the default cgroup mountpoint

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -162,8 +162,10 @@ static enum cgroups_type cgroups_try_detect_version()
 
 #if defined CGROUP2_SUPER_MAGIC
     // 2. check filesystem type for the default mountpoint
+    char filename[FILENAME_MAX + 1];
+    snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/fs/cgroup");
     struct statfs fsinfo;
-    if (!statfs("/sys/fs/cgroup", &fsinfo)) {
+    if (!statfs(filename, &fsinfo)) {
         if (fsinfo.f_type == CGROUP2_SUPER_MAGIC)
             return CGROUPS_V2;
         if (fsinfo.f_type == CGROUP_SUPER_MAGIC)

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -160,7 +160,18 @@ static enum cgroups_type cgroups_try_detect_version()
     if(!cgroups2_available)
         return CGROUPS_V1;
 
-    // 2. check systemd compiletime setting
+#if defined CGROUP2_SUPER_MAGIC
+    // 2. check filesystem type for the default mountpoint
+    struct statfs fsinfo;
+    if (!statfs("/sys/fs/cgroup", &fsinfo)) {
+        if (fsinfo.f_type == CGROUP2_SUPER_MAGIC)
+            return CGROUPS_V2;
+        if (fsinfo.f_type == CGROUP_SUPER_MAGIC)
+            return CGROUPS_V1;
+    }
+#endif
+
+    // 3. check systemd compiletime setting
     if ((systemd_setting = cgroups_detect_systemd("systemd --version")) == SYSTEMD_CGROUP_ERR)
         systemd_setting = cgroups_detect_systemd(SYSTEMD_CMD_RHEL);
 
@@ -174,7 +185,7 @@ static enum cgroups_type cgroups_try_detect_version()
         return CGROUPS_V1;
     }
 
-    // 3. if we are unified as on Fedora (default cgroups2 only mode)
+    // 4. if we are unified as on Fedora (default cgroups2 only mode)
     //    check kernel command line flag that can override that setting
     f = fopen("/proc/cmdline", "r");
     if (!f) {

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,7 @@ AC_HEADER_RESOLV
 AC_CHECK_HEADERS_ONCE([sys/prctl.h])
 AC_CHECK_HEADERS_ONCE([sys/vfs.h])
 AC_CHECK_HEADERS_ONCE([sys/statfs.h])
+AC_CHECK_HEADERS_ONCE([linux/magic.h])
 AC_CHECK_HEADERS_ONCE([sys/statvfs.h])
 AC_CHECK_HEADERS_ONCE([sys/mount.h])
 

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -118,6 +118,10 @@ extern "C" {
 #include <sys/statfs.h>
 #endif
 
+#ifdef HAVE_LINUX_MAGIC_H
+#include <linux/magic.h>
+#endif
+
 #ifdef HAVE_SYS_MOUNT_H
 #include <sys/mount.h>
 #endif


### PR DESCRIPTION
##### Summary
The PR adds an additional check for the default cgroup mount point. It's a stopgap that fixes incorrect detection of cgroups v1, when `default-hierarchy=hybrid` but only a cgroups v2 hierarchy is mounted.

Fixes #11094

##### Component Name
cgroups plugin

##### Test Plan
Run Netdata with cgroups v2 mounted on `/sys/fs/cgroup` and `default-hierarchy=hybrid`. Unified cgroups should be enabled and working.