### PR TITLE
aclk/legacy: change aclk statistics charts units from kB/s to KiB/s

### DIFF
--- a/aclk/legacy/aclk_stats.c
+++ b/aclk/legacy/aclk_stats.c
@@ -123,7 +123,7 @@ static void aclk_stats_write_q(struct aclk_metrics_per_sample *per_sample)
 
     if (unlikely(!st)) {
         st = rrdset_create_localhost(
-            "netdata", "aclk_write_q", NULL, "aclk", NULL, "Write Queue Mosq->Libwebsockets", "kB/s",
+            "netdata", "aclk_write_q", NULL, "aclk", NULL, "Write Queue Mosq->Libwebsockets", "KiB/s",
             "netdata", "stats", 200003, localhost->rrd_update_every, RRDSET_TYPE_AREA);
 
         rd_wq_add = rrddim_add(st, "added", NULL, 1, 1024 * localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
@@ -145,7 +145,7 @@ static void aclk_stats_read_q(struct aclk_metrics_per_sample *per_sample)
 
     if (unlikely(!st)) {
         st = rrdset_create_localhost(
-            "netdata", "aclk_read_q", NULL, "aclk", NULL, "Read Queue Libwebsockets->Mosq", "kB/s",
+            "netdata", "aclk_read_q", NULL, "aclk", NULL, "Read Queue Libwebsockets->Mosq", "KiB/s",
             "netdata", "stats", 200004, localhost->rrd_update_every, RRDSET_TYPE_AREA);
 
         rd_rq_add = rrddim_add(st, "added", NULL, 1, 1024 * localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);


### PR DESCRIPTION
##### Summary

This PR changes [`aclk_write_q`](https://github.com/netdata/netdata/blob/bebd56cd603bd4a2e68e71dd9021ea4e34c41dc1/aclk/legacy/aclk_stats.c#L125-L130) and [`aclk_cloud_req`](https://github.com/netdata/netdata/blob/bebd56cd603bd4a2e68e71dd9021ea4e34c41dc1/aclk/legacy/aclk_stats.c#L147-L152) units to KiB/s so our dashboard [auto-scale](https://github.com/netdata/dashboard/blob/a4bf51a827856ce68c897a8ee8fa6c5d378e584d/public/dashboard.js#L777-L923) these charts metrics properly.

`kB` is 1000 bytes, `KiB` is 1024 bytes. Those charts metrics are in `KiB`.

Before this PR:

![image](https://user-images.githubusercontent.com/43294513/117172851-0d45d980-ad81-11eb-8acc-ab4d692df79b.png)

##### Component Name

`aclk/legacy`

##### Test Plan

No tests needed

##### Additional Information
