### PR TITLE
analytics: reduce alarms notifications dump logging

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -305,7 +305,7 @@ void analytics_alarms_notifications(void)
 
     pid_t command_pid;
 
-    info("Executing %s", script);
+    debug(D_ANALYTICS, "Executing %s", script);
 
     BUFFER *b = buffer_create(1000);
     int cnt = 0;


### PR DESCRIPTION
##### Summary

This PR changes log level to `debug`

https://github.com/netdata/netdata/blob/e58768dfff3c2d4dc0382fc702ee1c4c1af30715/daemon/analytics.c#L304-L308

---

We usually ask users to `grep alarm-notify.sh` when debugging health notifications problems.

> Executing /opt/netdata/usr/libexec/netdata/plugins.d/alarm-notify.sh dump_methods

The line doesn't really provide any value and just an additional noise, see https://community.netdata.cloud/t/not-all-alarms-send-to-the-telegram/1263/3

##### Component Name

`daemon/analytics`

##### Test Plan

- set `[global] -> debug flags = 0x0000000080000000`
- check `debug.log`

##### Additional Information
