### PR TITLE
Iperf3 python collector

### DIFF
--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -69,6 +69,7 @@ include httpcheck/Makefile.inc
 include hpssa/Makefile.inc
 include icecast/Makefile.inc
 include ipfs/Makefile.inc
+include iperf3/Makefile.inc
 include isc_dhcpd/Makefile.inc
 include litespeed/Makefile.inc
 include logind/Makefile.inc

--- a/collectors/python.d.plugin/iperf3/Makefile.inc
+++ b/collectors/python.d.plugin/iperf3/Makefile.inc
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_python_DATA       += iperf3/iperf3.chart.py
+dist_pythonconfig_DATA += iperf3/iperf3.conf
+
+# do not install these files, but include them in the distribution
+dist_noinst_DATA       += iperf3/Makefile.inc iperf3/README.md

--- a/collectors/python.d.plugin/iperf3/README.md
+++ b/collectors/python.d.plugin/iperf3/README.md
@@ -1,0 +1,21 @@
+<!--
+title: "Iperf3"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/iperf3/README.md
+-->
+
+# Iperf3 data collector
+
+A basic iperf3 collector that parse output of iperf log file with
+basic regexp.
+
+We are not using json output from iperf since data are available only
+after the test is done.
+
+To get the data incrementally, you may want to disable stdout line
+buffering, with stdbuf utility for instance, and redirect the logs to
+a file:
+
+
+```
+stdbuf -o0 iperf3 -s | tee /tmp/iperfs.log
+```

--- a/collectors/python.d.plugin/iperf3/iperf3.chart.py
+++ b/collectors/python.d.plugin/iperf3/iperf3.chart.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# Description: Parse iperf3 server log
+# Author: Leo Sartre
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from bases.FrameworkServices.LogService import LogService
+
+import re
+
+NETDATA_UPDATE_EVERY=1
+priority = 90000
+
+ORDER = [
+    "Bandwidth"
+]
+
+CHARTS = {
+    "Bandwidth": {
+        "options": [None, "Bandwidth", "bits/sec", "IPERF", "iperf3.bandwith", "line"],
+        "lines": [
+            # lines are created dynamically in `check()`
+        ]
+    }
+}
+
+RE_PORT = re.compile(r'Server listening on (\d+)')
+RE_BDWTH = re.compile(r'(\d+\.?\d*)-(\d+\.?\d*).*?(\d+\.?\d*) ([KMGT]?bits)/sec')
+
+class Service(LogService):
+    def __init__(self, configuration=None, name=None):
+        LogService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.log_path = self.configuration.get('path', "/tmp/iperfs.log")
+        self.line_name = None
+        self.bdwth_data = []
+
+    def get_iperf_port_no(self):
+        lines = self._get_raw_data()
+        if not lines:
+            return None
+
+        for l in reversed(lines):
+            port = RE_PORT.findall(l)
+            if port:
+                break # stops as soon as the port is found
+
+        if port:
+            return port[0]
+
+        return None
+
+    def check(self):
+        """
+        Get the port number on which the server listen and create the line
+        """
+        if not LogService.check(self):
+            return False
+
+        if not self.get_iperf_port_no():
+            return False
+
+        self.line_name = "current_bandwidth"
+        self.definitions['Bandwidth']['lines'].append([self.line_name])
+
+        return True
+
+    def get_data(self):
+        # parse new lines and append data to the bdwth_data list
+        lines = self._get_raw_data()
+        for l in lines:
+            t = RE_BDWTH.findall(l)
+            v = 0
+            if t:
+                start, stop, value, unit = t[0]
+                # ignore last iperf line that is garbage
+                if start == stop:
+                    break
+                v = float(value)
+                if unit == "bits":
+                    v *= 1
+                elif unit == 'Kbits':
+                    v *= 1e3
+                elif unit == 'Mbits':
+                    v *= 1e6
+                elif unit == 'Gbits':
+                    v *= 1e9
+                elif unit == 'Tbits':
+                    v *= 1e12
+                else:
+                    self.warning("Unexpected unit found: {}!".format(unit))
+                    continue
+
+                self.bdwth_data.append(int(v))
+
+        # dequeue the bdwth_data list
+        if self.bdwth_data:
+            value = self.bdwth_data.pop(0)
+            self.info("Returning {}".format(value))
+            return {self.line_name: value}
+        else:
+            return {self.line_name: 0}

--- a/collectors/python.d.plugin/iperf3/iperf3.conf
+++ b/collectors/python.d.plugin/iperf3/iperf3.conf
@@ -1,0 +1,7 @@
+iperf_server:
+    name: "iperf server"    # the JOB's name as it will appear on the dashboard
+    update_every: 1         # the JOB's data collection frequency
+    priority: 60000         # the JOB's order on the dashboard
+    penalty: yes            # the JOB's penalty
+    autodetection_retry: 0  # the JOB's re-check interval in seconds
+    path: "/tmp/iperfs.log" # the log file that collects data from iperf server

--- a/collectors/python.d.plugin/python.d.conf
+++ b/collectors/python.d.plugin/python.d.conf
@@ -64,6 +64,7 @@ gunicorn_log: no
 hpssa: no
 # icecast: yes
 # ipfs: yes
+iperf3: no
 # isc_dhcpd: yes
 # litespeed: yes
 logind: no


### PR DESCRIPTION
Signed-off-by: Leo Sartre <sartre.l@ecagroup.com>

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

* add python 'iperf3' log collector

##### Component Name

collectors/python.d/iperf3

##### Test Plan

Tested locally with client connecting both in normal mode (client send to server) and reverse mode (server send to client) with some bandwidth limits:

* ` iperf3 -c -b 100K localhost`
* ` iperf3 -c -b 100M localhost`
*  ` iperf3 -c localhost`
* ` iperf3 -c localhost -R`

Server beeing started with:
 
* `stdbuf -o0 iperf3 -s | tee /tmp/iperfs.log`

The basic regexp based parser deals with server logs only, Tbits/sec data rate was never seen during test but according to the iperf3 source code (https://github.com/esnet/iperf), it can happen.
To get live data, json output format was not used as explained in the README.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information

A tricks is given in the README to unbuffer stdout of iperf3.