### PR TITLE
Reduce the number of ACLK chart updates during chart obsoletion

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -764,6 +764,7 @@ struct rrdhost {
     const char *os;                                 // the O/S type of the host
     const char *tags;                               // tags for this host
     const char *timezone;                           // the timezone of the host
+    long    obsolete_count;
 
     RRDHOST_FLAGS flags;                            // flags about this RRDHOST
     RRDHOST_FLAGS *exporting_flags;                 // array of flags for exporting connector instances

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -764,7 +764,9 @@ struct rrdhost {
     const char *os;                                 // the O/S type of the host
     const char *tags;                               // tags for this host
     const char *timezone;                           // the timezone of the host
+#ifdef ENABLE_ACLK
     long    obsolete_count;
+#endif
 
     RRDHOST_FLAGS flags;                            // flags about this RRDHOST
     RRDHOST_FLAGS *exporting_flags;                 // array of flags for exporting connector instances

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -452,7 +452,7 @@ void rrdset_delete_custom(RRDSET *st, int db_rotated) {
 #ifdef ENABLE_ACLK
     if ((netdata_cloud_setting) && (db_rotated || RRD_MEMORY_MODE_DBENGINE != st->rrd_memory_mode)) {
         aclk_del_collector(st->rrdhost, st->plugin_name, st->module_name);
-        aclk_update_chart(st->rrdhost, st->id, ACLK_CMD_CHARTDEL);
+        st->rrdhost->obsolete_count++;
     }
 #endif
 
@@ -932,7 +932,10 @@ RRDSET *rrdset_create_custom(
 
     store_active_chart(st->chart_uuid);
 
+    host->obsolete_count = 0;
     rrdhost_cleanup_obsolete_charts(host);
+    if (host->obsolete_count)
+        aclk_update_chart(st->rrdhost, "dummy-chart", ACLK_CMD_CHARTDEL);
 
     rrdhost_unlock(host);
 #ifdef ENABLE_ACLK

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -932,10 +932,14 @@ RRDSET *rrdset_create_custom(
 
     store_active_chart(st->chart_uuid);
 
+#ifdef ENABLE_ACLK
     host->obsolete_count = 0;
+#endif
     rrdhost_cleanup_obsolete_charts(host);
+#ifdef ENABLE_ACLK
     if (host->obsolete_count)
         aclk_update_chart(st->rrdhost, "dummy-chart", ACLK_CMD_CHARTDEL);
+#endif
 
     rrdhost_unlock(host);
 #ifdef ENABLE_ACLK


### PR DESCRIPTION
##### Summary
Reduce the number of full chart update messages when a lot of charts are being deleted

##### Component Name
aclk

##### Test Plan
- Start agent with memory mode RAM
- Set low chart obsoletion timeout (e.g. 20 seconds)
  - Repeat the following a few times
    - Start a docker container
    - Wait a few seconds
    - Stop the container
  - Start the container to trigger chart obsoletion
- Notice low ACLK traffic in the corresponding graphs 
