### PR TITLE
Fix autogeneration of dashboard update PRs.

### DIFF
--- a/.github/workflows/dashboard-pr.yml
+++ b/.github/workflows/dashboard-pr.yml
@@ -27,7 +27,7 @@ jobs:
           git push -u origin dashboard-${{ github.event.inputs.dashboard_version }}
       - name: Update Files
         run: |
-          curl -o dashboard.tar.gz https://github.com/netdata/dashboard/releases/download/${{ github.event.inputs.dashboard_version }}/dashboard.tar.gz
+          curl -L -o dashboard.tar.gz https://github.com/netdata/dashboard/releases/download/${{ github.event.inputs.dashboard_version }}/dashboard.tar.gz
           echo ${{ github.event.inputs.dashboard_version }} > packaging/dashboard.version
           sha256sum dashboard.tar.gz > packaging/dashboard.checksums
           rm dashboard.tar.gz

--- a/.github/workflows/dashboard-pr.yml
+++ b/.github/workflows/dashboard-pr.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Commit Changes
         uses: swinton/commit@v2.x
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
         with:
           files: |
             packaging/dashboard.version
@@ -47,4 +47,4 @@ jobs:
           source_branch: dashboard-${{ github.event.inputs.dashboard_version }}
           pr_title: 'Update dashboard to version ${{ github.event.inputs.dashboard_version }}.'
           pr_body: 'See https://github.com/netdata/dashboard/releases/tag/${{ github.event.inputs.dashboard_version }} for changes.'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}


### PR DESCRIPTION
##### Summary

* Use the netdatabot PAT instead of the default Github token for creating the commit and PR so that we properly trigger CI checks. Without this we don’t get GHA workflows running on the PR due to the restriction that the default token cannot trigger other worklows.
* Properly follow redirects when downloading the release artifacts. Without this we get the incorrect hash saved, as for some reason Github sends the link access through a redirect before giving you the actual file.

##### Component Name

area/ci

##### Test Plan

cURL fix verified locally.

Token fix will need to be verified by actual usage.