### PR TITLE
Removed Fedora 32 from CI.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -39,7 +39,6 @@ jobs:
           - 'debian:9'
           - 'fedora:34'
           - 'fedora:33'
-          - 'fedora:32'
           - 'opensuse/leap:15.2'
           - 'opensuse/tumbleweed:latest'
           - 'ubuntu:21.04'
@@ -81,9 +80,6 @@ jobs:
             rmjsonc: 'dnf remove -y json-c-devel'
           - distro: 'fedora:33'
             rmjsonc: 'dnf remove -y json-c-devel'
-          - distro: 'fedora:32'
-            rmjsonc: 'dnf remove -y json-c-devel'
-
           - distro: 'opensuse/leap:15.2'
             rmjsonc: 'zypper rm -y libjson-c-devel'
           - distro: 'opensuse/tumbleweed:latest'

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -37,7 +37,6 @@ jobs:
           - {distro: ubuntu, version: "21.04", pkgclouddistro: ubuntu/hirsute, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
           - {distro: centos, version: "7", pkgclouddistro: el/7, format: rpm, base_image: centos, platform: linux/amd64, arch: amd64}
           - {distro: centos, version: "8", pkgclouddistro: el/8, format: rpm, base_image: centos, platform: linux/amd64, arch: amd64}
-          - {distro: fedora, version: "32", pkgclouddistro: fedora/32, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
           - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
           - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
           - {distro: opensuse, version: "15.2", pkgclouddistro: opensuse/15.2, format: rpm, base_image: opensuse/leap, platform: linux/amd64, arch: amd64}


### PR DESCRIPTION
##### Summary

To be merged 2021-05-25 when Fedora 32 officially goes EOL upstream.

##### Component Name

area/ci
area/packaging

##### Test Plan

n/a