### PR TITLE
Add info on other memory modes to performance.md

### DIFF
--- a/docs/guides/configure/performance.md
+++ b/docs/guides/configure/performance.md
@@ -155,6 +155,12 @@ All the settings are found in the `[global]` section of `netdata.conf`:
     dbengine multihost disk space = 256
 ```
 
+Metric retention is not important in certain use cases, such as:
+ - Data collection nodes stream collected metrics collected to a centralization point.
+ - Data collection nodes export their metrics to another time series DB, or are scraped by Prometheus
+ - Netdata installed only during incidents, to get richer information.
+In such cases, you may not want to use the dbengine at all and instead opt for memory mode `memory mode = ram` or `memory mode = none`.
+
 ## Run Netdata behind Nginx
 
 A dedicated web server like Nginx provides far more robustness than the Agent's internal [web server](/web/README.md).


### PR DESCRIPTION
##### Summary

Added use cases in performance optimization that can warrant using memory modes `ram` or `none`. 

##### Component Name

Docs

##### Test Plan

See it on the generated site.

##### Additional Information

I tried to add a link to https://learn.netdata.cloud/docs/agent/database for more info at the very end that would work both from github and on the site, but I don't think that's possible any more. @joelhans please free to improve. 