### PR TITLE
add python.d.plugin/watchtower

### DIFF
--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -108,6 +108,7 @@ include traefik/Makefile.inc
 include uwsgi/Makefile.inc
 include varnish/Makefile.inc
 include w1sensor/Makefile.inc
+include watchtower/Makefile.inc
 include web_log/Makefile.inc
 
 pythonmodulesdir=$(pythondir)/python_modules

--- a/collectors/python.d.plugin/python.d.conf
+++ b/collectors/python.d.plugin/python.d.conf
@@ -106,4 +106,5 @@ nginx_log: no
 # uwsgi: yes
 # varnish: yes
 # w1sensor: yes
+# watchtower: yes
 # web_log: yes

--- a/collectors/python.d.plugin/watchtower/Makefile.inc
+++ b/collectors/python.d.plugin/watchtower/Makefile.inc
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_python_DATA       += watchtower/watchtower.chart.py
+dist_pythonconfig_DATA += watchtower/watchtower.conf
+
+# do not install these files, but include them in the distribution
+dist_noinst_DATA       += watchtower/README.md watchtower/Makefile.inc
+

--- a/collectors/python.d.plugin/watchtower/README.md
+++ b/collectors/python.d.plugin/watchtower/README.md
@@ -1,0 +1,62 @@
+<!--
+title: "Watchtower monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/watchtower/README.md
+-->
+
+# Watchtower monitoring with Netdata
+
+A module for monitoring [Watchtower](https://github.com/containrrr/watchtower), a container-based solution for
+automating Docker container base image updates.
+
+## Requirements
+
+- a running watchtower instance
+    * with a configured [API token](https://containrrr.dev/watchtower/arguments/#http-api-token)
+    * with [http-api-metrics](https://containrrr.dev/watchtower/arguments/#http-api-metrics) enabled.
+
+It produces following charts:
+
+1. **Containers**
+
+    - scanned
+        * Number of containers scanned for changes by watchtower during the last scan
+    - updated
+        * Number of containers updated by watchtower during the last scan
+    - failed
+        * Number of containers where update failed during the last scan
+
+2. **Scans**
+
+    - total
+        * Number of scans since the watchtower started
+    - skipped
+        * Number of skipped scans since watchtower started
+
+## Configuration
+
+Edit the `python.d/watchtower.conf` configuration file using `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
+
+```bash
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+sudo ./edit-config python.d/watchtower.conf
+```
+
+Needs `url` and `api_token` to watchtower instance.
+
+Here is an example for local server:
+
+```yaml
+update_every: 3600
+
+local:
+  update_every: 1             # the JOB's data collection frequency
+  url: http://127.0.0.1:8080  # the url to your watchtower api endpoint
+  api_token: abcdefg          # watchtower's HTTP API Token
+```
+
+Without configuration, module attempts to connect to `http://127.0.0.1:8080`
+
+---
+
+[![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fpython.d.plugin%2Fnginx%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/python.d.plugin/watchtower/watchtower.chart.py
+++ b/collectors/python.d.plugin/watchtower/watchtower.chart.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Description: watchtower netdata python.d module
+# Author: tknobi
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from bases.FrameworkServices.UrlService import UrlService
+
+ORDER = [
+    'containers',
+    'scans'
+]
+
+CHARTS = {
+    'containers': {
+        'options': [None, 'Watchtower Containers', 'containers', None, 'watchtower.containers', 'line'],
+        'lines': [
+            ['watchtower_containers_failed', 'failed'],
+            ['watchtower_containers_scanned', 'scanned'],
+            ['watchtower_containers_updated', 'updated']
+        ]},
+    'scans': {
+        'options': [None, 'Watchtower Scans', 'scans', None, 'watchtower.scans', 'line'],
+        'lines': [
+            ['watchtower_scans_skipped', 'skipped'],
+            ['watchtower_scans_total', 'total'],
+        ]}
+}
+
+
+class Service(UrlService):
+    def __init__(self, configuration=None, name=None):
+        UrlService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.url = self.configuration.get('url', 'http://127.0.0.1:8080') + '/v1/metrics'
+        self.api_token = self.configuration.get('api_token', '')
+        self.header = {'Authorization': 'Bearer ' + self.api_token}
+
+    def check(self):
+        if not (self.api_token and isinstance(self.api_token, str)):
+            self.error('API_TOKEN is not defined or type is not <str>')
+            return False
+        return UrlService.check(self)
+
+    def _get_data(self):
+        raw_data = self._get_raw_data()
+        results = {}
+        for line in raw_data.split('\n'):
+            if line.startswith('#') or ' ' not in line:
+                continue
+            key, value = line.split(' ')
+            results[key] = value
+        return results

--- a/collectors/python.d.plugin/watchtower/watchtower.conf
+++ b/collectors/python.d.plugin/watchtower/watchtower.conf
@@ -1,0 +1,73 @@
+# netdata python.d.plugin configuration for watchtower
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# penalty indicates whether to apply penalty to update_every in case of failures.
+# Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
+# penalty: yes
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear on the dashboard
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 3600      # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, watchtower also supports the following:
+#
+#     url: http://127.0.0.1:8080    # the url to your watchtower api endpoint
+#     api_token: abcdefg            # watchtower's HTTP API Token
+#
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+
+local:
+    update_every: 3600          # the JOB's data collection frequency
+    url: http://127.0.0.1:8080  # the url to your watchtower api endpoint
+    api_token: abcdefg          # watchtower's HTTP API Token

--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -102,6 +102,7 @@ dist_healthconfig_DATA = \
     health.d/vcsa.conf \
     health.d/vernemq.conf \
     health.d/vsphere.conf \
+    health.d/watchtower.conf \
     health.d/web_log.conf \
     health.d/whoisquery.conf \
     health.d/wmi.conf \

--- a/health/health.d/watchtower.conf
+++ b/health/health.d/watchtower.conf
@@ -1,0 +1,9 @@
+ template: watchtower_containers_failed
+       on: watchtower.containers
+     type: Errors
+    units: failed containers
+    every: 1m
+     calc: $failed
+     crit: $this > 0
+     info: Number of containers where update failed during the last scan
+       to: sysadmin


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

A module for monitoring [Watchtower](https://github.com/containrrr/watchtower), a container-based solution for
automating Docker container base image updates.

The modules uses UrlService to collect data from watchtower's [metrics](https://containrrr.dev/watchtower/metrics/).
Also, a health check is added in case updates fail.

##### Component Name

python.d.plugin/watchtower

##### Test Plan

* compare logs of a running watchtower instance with produced charts

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information

See [watchtower's docs](https://containrrr.dev/watchtower/metrics/).

I still have two unanswered questions:
1. in the graphs the entries with the values 0 are hidden. Is there a possibility to show them? Or is it always like this in netdata and thus a desired behavior?
2. is it possible to set up a heath alarm in case the API is not reachable (e.g. when watchtower crashed).

Looking forward to your feedback :)

Note: I am not affiliated with watchtower, I am just a user.
