### PR TITLE
health: make stocks alarms less sensitive (2)

### DIFF
--- a/health/health.d/disks.conf
+++ b/health/health.d/disks.conf
@@ -170,10 +170,7 @@ component: Disk
    lookup: average -10m unaligned
     units: ms
     every: 1m
-    green: 2000
-      red: 5000
-     warn: $this > $green * (($status >= $WARNING)  ? (0.7) : (1))
-     crit: $this > $red   * (($status == $CRITICAL) ? (0.7) : (1))
+     warn: $this > 5000 * (($status >= $WARNING)  ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
      info: average backlog size of the $family disk over the last 10 minutes
        to: silent

--- a/health/health.d/disks.conf
+++ b/health/health.d/disks.conf
@@ -145,10 +145,7 @@ component: Disk
    lookup: average -10m unaligned
     units: %
     every: 1m
-    green: 90
-      red: 98
-     warn: $this > $green * (($status >= $WARNING)  ? (0.7) : (1))
-     crit: $this > $red   * (($status == $CRITICAL) ? (0.7) : (1))
+     warn: $this > 98 * (($status >= $WARNING)  ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
      info: average percentage of time $family disk was busy over the last 10 minutes
        to: silent

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -96,7 +96,7 @@ component: Network
     hosts: *
  families: !net* !wl* *
    lookup: sum -10m unaligned absolute of received
-     calc: (($inbound_packets_dropped != nan AND $this > 1000) ? ($inbound_packets_dropped * 100 / $this) : (0))
+     calc: (($inbound_packets_dropped != nan AND $this > 10000) ? ($inbound_packets_dropped * 100 / $this) : (0))
     units: %
     every: 1m
      warn: $this >= 2
@@ -130,7 +130,7 @@ component: Network
     hosts: *
  families: wl*
    lookup: sum -10m unaligned absolute of received
-     calc: (($inbound_packets_dropped != nan AND $this > 1000) ? ($inbound_packets_dropped * 100 / $this) : (0))
+     calc: (($inbound_packets_dropped != nan AND $this > 10000) ? ($inbound_packets_dropped * 100 / $this) : (0))
     units: %
     every: 1m
      warn: $this >= 10

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -50,11 +50,11 @@ component: Memory
       on: mem.oom_kill
       os: linux
    hosts: *
-  lookup: sum -1m unaligned
+  lookup: sum -30m unaligned
    units: kills
-   every: 10s
+   every: 1m
     warn: $this > 0
-   delay: down 5m
+   delay: down 10m
     info: number of out of memory kills in the last minute
       to: sysadmin
 

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -56,7 +56,7 @@ component: Memory
     warn: $this > 0
    delay: down 10m
     info: number of out of memory kills in the last 30 minutes
-      to: sysadmin
+      to: silent
 
 ## FreeBSD
     alarm: ram_in_use

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -56,7 +56,7 @@ component: Memory
     warn: $this > 0
    delay: down 10m
     info: number of out of memory kills in the last 30 minutes
-      to: silent
+      to: sysadmin
 
 ## FreeBSD
     alarm: ram_in_use

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -52,7 +52,7 @@ component: Memory
    hosts: *
   lookup: sum -30m unaligned
    units: kills
-   every: 1m
+   every: 5m
     warn: $this > 0
    delay: down 10m
     info: number of out of memory kills in the last 30 minutes

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -55,7 +55,7 @@ component: Memory
    every: 1m
     warn: $this > 0
    delay: down 10m
-    info: number of out of memory kills in the last minute
+    info: number of out of memory kills in the last 30 minutes
       to: sysadmin
 
 ## FreeBSD

--- a/health/health.d/web_log.conf
+++ b/health/health.d/web_log.conf
@@ -66,7 +66,6 @@ component: Web log
     units: %
     every: 10s
      warn: ($1m_requests > 120) ? ($this > (($status >= $WARNING ) ? (  1 ) : ( 20 )) ) : ( 0 )
-     crit: ($1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 20 ) : ( 30 )) ) : ( 0 )
     delay: up 2m down 15m multiplier 1.5 max 1h
      info: ratio of redirection HTTP requests over the last minute (3xx except 304)
        to: webmaster
@@ -82,7 +81,6 @@ component: Web log
     units: %
     every: 10s
      warn: ($1m_requests > 120) ? ($this > (($status >= $WARNING)  ? ( 10 ) : ( 30 )) ) : ( 0 )
-     crit: ($1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 30 ) : ( 50 )) ) : ( 0 )
     delay: up 2m down 15m multiplier 1.5 max 1h
      info: ratio of client error HTTP requests over the last minute (4xx except 401)
        to: webmaster
@@ -335,7 +333,6 @@ component: Web log
     units: %
     every: 10s
      warn: ($web_log_1m_requests > 120) ? ($this > (($status >= $WARNING ) ? (  1 ) : ( 20 )) ) : ( 0 )
-     crit: ($web_log_1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 20 ) : ( 30 )) ) : ( 0 )
     delay: up 2m down 15m multiplier 1.5 max 1h
      info: ratio of redirection HTTP requests over the last minute (3xx except 304)
        to: webmaster
@@ -351,7 +348,6 @@ component: Web log
     units: %
     every: 10s
      warn: ($web_log_1m_requests > 120) ? ($this > (($status >= $WARNING)  ? ( 10 ) : ( 30 )) ) : ( 0 )
-     crit: ($web_log_1m_requests > 120) ? ($this > (($status == $CRITICAL) ? ( 30 ) : ( 50 )) ) : ( 0 )
     delay: up 2m down 15m multiplier 1.5 max 1h
      info: ratio of client error HTTP requests over the last minute (4xx except 401)
        to: webmaster


### PR DESCRIPTION
##### Summary

Continuation of https://github.com/netdata/netdata/pull/10688


| Alarm       | Change      | Reason      |
| ----------- | ----------- | ----------- |
| [inbound_packets_dropped_ratio](https://github.com/netdata/netdata/blob/98c27ffbc5c04e853cb0e055e7b89eb0a4d45527/health/health.d/net.conf#L90-L105)      | increase packets trigger limit      | We calc using 10 min sum, 1k per min is ok for rx |
| [wifi_inbound_packets_dropped_ratio](https://github.com/netdata/netdata/blob/98c27ffbc5c04e853cb0e055e7b89eb0a4d45527/health/health.d/net.conf#L124-L139)      | increase packets trigger limit      | We calc using 10 min sum, 1k per min is ok for rx              |
| [10min_disk_backlog](https://github.com/netdata/netdata/blob/98c27ffbc5c04e853cb0e055e7b89eb0a4d45527/health/health.d/disks.conf#L162-L179)      | remove `crit`      | It is not a backlog, but sum of all i/o operations         time, not a critical event in general taking into account that we have hardcoded limit |
| [10min_disk_utilization](https://github.com/netdata/netdata/blob/98c27ffbc5c04e853cb0e055e7b89eb0a4d45527/health/health.d/disks.conf#L137-L154)      | remove `crit`      | A disk busy time metric, any % means busy time, not utilization (these days disk controllers are able to perform more then 1 concurent operation)             |
| [1m_redirects](https://github.com/netdata/netdata/blob/98c27ffbc5c04e853cb0e055e7b89eb0a4d45527/health/health.d/web_log.conf#L58-L72)      | remove `crit`      | Doesn't seem critical for a server.            |
| [1m_bad_requests](https://github.com/netdata/netdata/blob/98c27ffbc5c04e853cb0e055e7b89eb0a4d45527/health/health.d/web_log.conf#L74-L88)      | remove `crit`      | Doesn't seem critical for a server.             |
| [web_log_1m_redirects](https://github.com/netdata/netdata/blob/98c27ffbc5c04e853cb0e055e7b89eb0a4d45527/health/health.d/web_log.conf#L327-L341)      | remove `crit`      | Doesn't seem critical for a server.             |
| [web_log_1m_bad_requests](https://github.com/netdata/netdata/blob/98c27ffbc5c04e853cb0e055e7b89eb0a4d45527/health/health.d/web_log.conf#L343-L357)      | remove `crit`      | Doesn't seem critical for a server             |


##### Component Name

`health`

##### Test Plan


Not needed

##### Additional Information
