### PR TITLE
health: add system clock synchronization state alarm

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -91,6 +91,7 @@ dist_healthconfig_DATA = \
     health.d/synchronization.conf \
     health.d/swap.conf \
     health.d/systemdunits.conf \
+    health.d/timex.conf \
     health.d/tcp_conn.conf \
     health.d/tcp_listen.conf \
     health.d/tcp_mem.conf \

--- a/health/health.d/timex.conf
+++ b/health/health.d/timex.conf
@@ -1,0 +1,17 @@
+
+# It can take several minutes before ntpd selects a server to synchronize with;
+# try checking after 17 minutes (1024 seconds).
+
+    alarm: system_clock_sync_state
+       on: system.clock_sync_state
+       os: linux
+    class: System
+component: Clock
+     type: Error
+     calc: $state
+    units: synchronization state
+    every: 10s
+     warn: $netdata.uptime.uptime > 17 * 60 AND $this == 0
+    delay: down 5m
+     info: the system time is not synchronized to a reliable server
+       to: silent

--- a/health/health.d/timex.conf
+++ b/health/health.d/timex.conf
@@ -11,7 +11,7 @@ component: Clock
      calc: $state
     units: synchronization state
     every: 10s
-     warn: $netdata.uptime.uptime > 17 * 60 AND $this == 0
+     warn: $system.uptime.uptime > 17 * 60 AND $this == 0
     delay: down 5m
      info: the system time is not synchronized to a reliable server
        to: silent


### PR DESCRIPTION
##### Summary

This PR adds an alarm for the system clock synchronization state.

It takes into account that `ntpd` needs several minutes to select a reliable time server and sync with it.

##### Component Name

`health`

##### Test Plan

- [x] install the PR, ensure the alarm is in the stock config dir.
- [x] test the alarm triggers (not in `WARN` during select/sync period, in `WARN` after select/sync period if the clock is not synchronized).

##### Additional Information

Requested in https://community.netdata.cloud/t/add-timex-alerts/1339
