### PR TITLE
rename default from job 'local' to 'anomalies'

### DIFF
--- a/collectors/python.d.plugin/anomalies/README.md
+++ b/collectors/python.d.plugin/anomalies/README.md
@@ -82,8 +82,8 @@ The default configuration should look something like this. Here you can see each
 # JOBS (data collection sources)
 
 # Pull data from local Netdata node.
-local:
-    name: 'local'
+anomalies:
+    name: 'Anomalies'
 
     # Host to pull data from.
     host: '127.0.0.1:19999'

--- a/collectors/python.d.plugin/anomalies/anomalies.conf
+++ b/collectors/python.d.plugin/anomalies/anomalies.conf
@@ -31,8 +31,8 @@
 # JOBS (data collection sources)
 
 # Pull data from local Netdata node.
-local:
-    name: 'local'
+anomalies:
+    name: 'Anomalies'
 
     # Host to pull data from.
     host: '127.0.0.1:19999'


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

- Rename default job from 'local' to 'Anomalies'.

'Anomalies local' is not as nice as a 'Anomalies' menu item when using default settings and just enabling it for local node.

So by default users would then have this:

![image](https://user-images.githubusercontent.com/2178292/119339493-1f80ac80-bc89-11eb-815d-0cb525c0425c.png)

as opposed to the "Anomalies local" like here:

![image](https://user-images.githubusercontent.com/2178292/119339561-33c4a980-bc89-11eb-8681-0c5845023f49.png)

It's just cleaner and nicer to have it be called "Anomalies" as opposed to "Anomalies local" where the "local" part could just confuse people. 

##### Component Name

collectors/python.d.plugin/anomalies

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Tested locally on dev agent.
