### PR TITLE
Check return status of execution of anonymous statistics script

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -876,10 +876,17 @@ void send_statistics(const char *action, const char *action_result, const char *
 
     FILE *fp = mypopen(command_to_run, &command_pid);
     if (fp) {
-        char buffer[100 + 1];
-        while (fgets(buffer, 100, fp) != NULL)
-            ;
-        mypclose(fp, command_pid);
+        char buffer[4 + 1];
+        char *s = fgets(buffer, 4, fp);
+        int exit_code = mypclose(fp, command_pid);
+        if (exit_code || (s && strncmp(buffer, "200", 3))) {
+            error(
+                "Execution of anonymous statistics script returned %s, with http code %s.",
+                strerror(exit_code),
+                buffer);
+        }
+    } else {
+        error("Failed to run anonymous statistics script %s.", as_script);
     }
     freez(command_to_run);
 }

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -879,12 +879,10 @@ void send_statistics(const char *action, const char *action_result, const char *
         char buffer[4 + 1];
         char *s = fgets(buffer, 4, fp);
         int exit_code = mypclose(fp, command_pid);
-        if (exit_code || (s && strncmp(buffer, "200", 3))) {
-            error(
-                "Execution of anonymous statistics script returned %s, with http code %s.",
-                strerror(exit_code),
-                buffer);
-        }
+        if (exit_code)
+            error("Execution of anonymous statistics script returned %s.", strerror(exit_code));
+        if (s && strncmp(buffer, "200", 3))
+            error("Execution of anonymous statistics script returned http code %s.", buffer);
     } else {
         error("Failed to run anonymous statistics script %s.", as_script);
     }

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -148,12 +148,13 @@ EOF
 
 # send the anonymous statistics to the Netdata PostHog
 if [ -n "$(command -v curl 2> /dev/null)" ]; then
-  curl -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" https://posthog.netdata.cloud/capture/ > /dev/null 2>&1
+  curl --silent -o /dev/null --write-out '%{http_code}' -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" https://posthog.netdata.cloud/capture/
 else
   wget -q -O - --no-check-certificate \
+  --server-response \
   --method POST \
   --timeout=1 \
   --header 'Content-Type: application/json' \
   --body-data "${REQ_BODY}" \
-   'https://posthog.netdata.cloud/capture/' > /dev/null 2>&1
+   'https://posthog.netdata.cloud/capture/' 2>&1 | awk '/^  HTTP/{print $2}'
 fi


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds some checks on the execution of `anonymous-statistics.sh` script as discussed in #11115. It adds a check on the exit_code of `mypclose`, a check on `fp`, and tries to force both `curl` and `wget` to output the http response code (and check that too).

##### Component Name

Analytics

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

On normal cases, no error should be reported in the log file.
If an error is found in either the exit code of `mypclose`, or an http response other than `200` is produced, it should be printed in the error.log

##### Additional Information

`wget`'s way of producing the http code is hacky... I don't know if we're comfortable forcing them to give us the http response and parsing it... If not, we can only keep the checks on `mypopen` and `fp`.