### PR TITLE
Check for non ascii characters in health log

### DIFF
--- a/health/health_log.c
+++ b/health/health_log.c
@@ -195,7 +195,7 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
         host->health_log_entries_written++;
         line++;
 
-        int max_entries = 33, entries = 0, non_ascii = 0;
+        int max_entries = 33, entries = 0;
         char *pointers[max_entries];
 
         char *c = buf;
@@ -206,13 +206,12 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
                     host->hostname,
                     line,
                     filename);
-                non_ascii = 1;
                 break;
             }
             c++;
         }
 
-        if (unlikely(non_ascii == 1))
+        if (unlikely(c))
             continue;
 
         pointers[entries++] = s++;

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -211,8 +211,10 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
             c++;
         }
 
-        if (unlikely(c))
+        if (unlikely(*c)) {
+            errored++;
             continue;
+        }
 
         pointers[entries++] = s++;
         while(*s) {

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -198,24 +198,6 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
         int max_entries = 33, entries = 0;
         char *pointers[max_entries];
 
-        char *c = buf;
-        while (*c) {
-            if (unlikely(!isascii((unsigned char)*c))) {
-                error(
-                    "HEALTH [%s]: line %zu of file '%s' contains a non-ascii character, ignoring.",
-                    host->hostname,
-                    line,
-                    filename);
-                break;
-            }
-            c++;
-        }
-
-        if (unlikely(*c)) {
-            errored++;
-            continue;
-        }
-
         pointers[entries++] = s++;
         while(*s) {
             if(unlikely(*s == '\t')) {

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -200,7 +200,7 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
 
         char *c = buf;
         while (*c) {
-            if (unlikely(!isascii(*c))) {
+            if (unlikely(!isascii((unsigned char)*c))) {
                 error(
                     "HEALTH [%s]: line %zu of file '%s' contains a non-ascii character, ignoring.",
                     host->hostname,


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

It appears that in some `health-log.db` files, there are random characters in the `family` field of the lines. Sometimes those random characters will contain a tab character, so the count of fields will be wrong. When this happens, the code that reads `class`, `component` and `type` gets executed, and result in a crash... This is fixed by reading these 3 items when at least 31 entries are in a line (instead of previously 29).

However, at that point, because of the extra tab, fields have been most likely assigned to wrong variables, and those characters even if read in correct variables will break json. So a check for non-ascii characters is added, and when it detects one, it will ignore the whole line.

We could just keep the change in line `388`, and it will prevent a crash, but there will be problems with the alarm entries.

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

[health-log.db.old.zip](https://github.com/netdata/netdata/files/6548132/health-log.db.old.zip)

Attached `health-log.db.old` file will cause a core dump, and an alarm-log with json errors. After this PR, only "correct" items should be loaded.

##### Additional Information

Need to see why those entries appear on the `family` field in the first place. The check for non-ascii characters of course only makes sense for ascii files, not sure if we/will do UTF... Comments are welcomed!!
