### PR TITLE
claiming: exit 0 when daemon not running and the claim was successful

### DIFF
--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -418,7 +418,7 @@ HERE_DOC
                 exit $EXIT_CODE
         fi
         echo >&2 "${PROXYMSG}The claim was successful but the agent could not be notified ($?)- it requires a restart to connect to the cloud."
-        exit 5
+        [ "$NETDATA_RUNNING" -eq 0 ] && exit 0 || exit 5
 fi
 
 echo >&2 "Failed to claim node with the following error message:\"${ERROR_MESSAGES[$EXIT_CODE]}\""


### PR DESCRIPTION
##### Summary

This PR changes claiming script exit code to 0 when 
- the claim was successful, and
- the agent could not be notified, and
- `-daemon-not-running` option was passed to the script

<details>
<summary>We execute claiming script before starting `netdata` process.</summary>

https://github.com/netdata/netdata/blob/e4f0ae2290a36bb1b9184fffac1e9ed1f707c52e/packaging/docker/run.sh#L23-L31

</details>

Docker restarts a container if the exit code is not 0.


##### Component Name

`claiming`

##### Test Plan

Build custom image; install Netdata in k8s using the image; ensure there are no restarts and parent/children are connected to the Cloud.

##### Additional Information

Discovered it working on https://github.com/netdata/helmchart/pull/212

---

@Ferroin likely we shouldn't even try to use `netdatacli` if `-daemon-not-running` option is passed. If so then we need more changes.
