### PR TITLE
fix `install_type` detection during update

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -328,7 +328,7 @@ update() {
     fi
 
     if [ -e "${NETDATA_PREFIX}/etc/netdata/.install-type" ] ; then
-      install_type="$(cat /opt/netdata/etc/netdata/.install-type)"
+      install_type="$(cat "${NETDATA_PREFIX}"etc/netdata/.install-type)"
     else
       install_type="INSTALL_TYPE='legacy-build'"
     fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -328,7 +328,7 @@ update() {
     fi
 
     if [ -e "${NETDATA_PREFIX}/etc/netdata/.install-type" ] ; then
-      install_type="$(cat "${NETDATA_PREFIX}"etc/netdata/.install-type)"
+      install_type="$(cat "${NETDATA_PREFIX}"/etc/netdata/.install-type)"
     else
       install_type="INSTALL_TYPE='legacy-build'"
     fi


### PR DESCRIPTION
##### Summary

SSIA, reported in https://github.com/netdata/netdata/pull/11157#issuecomment-850229556

Fixes: #11200

##### Component Name

`installer/`

##### Test Plan

- clean install Netdata from the source **not in `/opt`**
- run `netdata-updater.sh` script
- check `.install-type` file, it shouldn't be empty


##### Additional Information
