### PR TITLE
health: fix alarm-line-charts matching

### DIFF
--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -45,9 +45,7 @@ static int rrdcalctemplate_is_there_label_restriction(RRDCALCTEMPLATE *rt,  RRDH
 }
 
 static inline int rrdcalctemplate_test_additional_restriction(RRDCALCTEMPLATE *rt, RRDSET *st) {
-    if (rt->charts_pattern &&
-        !(simple_pattern_matches(rt->charts_pattern, st->id) ||
-         simple_pattern_matches(rt->charts_pattern, st->name)))
+    if (rt->charts_pattern && !simple_pattern_matches(rt->charts_pattern, st->name))
         return 0;
 
     if (rt->family_pattern && !simple_pattern_matches(rt->family_pattern, st->family))


### PR DESCRIPTION
##### Summary

This PR changes [alarm-line-charts](https://learn.netdata.cloud/docs/agent/health/reference#alarm-line-charts) matching from `chart.id OR chart.name` to `chart.name`.

<details>
<summary>Chart name is on the dashboard and as a user I want the pattern to match against it.</summary>

<img width="1114" alt="Screenshot 2021-05-28 at 19 56 00" src="https://user-images.githubusercontent.com/22274335/120017621-c39e8680-bfee-11eb-8624-55a6f7221da3.png">

</details>

We convert some characters to `_`, so id sometimes != name.

```JSON
"id": "cgroup_bla-cloud-crdb-cdc-streamer-service-bla.mem_utilization",
"name": "cgroup_bla_cloud_crdb_cdc_streamer_service_bla.mem_utilization",
```

In that case, I have to **write 2 patterns to exclude the char**t. That is pretty confusing.

##### Component Name

`health/`

##### Test Plan

- ensure `charts` pattern matches against chart name only.

##### Additional Information
