### PR TITLE
Use memory mode RAM if memory mode dbengine is specified but not available

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -542,7 +542,6 @@ static void get_netdata_configured_variables() {
     // get default memory mode for the database
 
     default_rrd_memory_mode = rrd_memory_mode_id(config_get(CONFIG_SECTION_GLOBAL, "memory mode", rrd_memory_mode_name(default_rrd_memory_mode)));
-
 #ifdef ENABLE_DBENGINE
     // ------------------------------------------------------------------------
     // get default Database Engine page cache size in MiB
@@ -567,7 +566,11 @@ static void get_netdata_configured_variables() {
         error("Invalid multidb disk space %d given. Defaulting to %d.", default_multidb_disk_quota_mb, default_rrdeng_disk_quota_mb);
         default_multidb_disk_quota_mb = default_rrdeng_disk_quota_mb;
     }
-
+#else
+    if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+       error_report("RRD_MEMORY_MODE_DBENGINE is not supported in this platform. The agent will use memory mode ram instead.");
+       default_rrd_memory_mode = RRD_MEMORY_MODE_RAM;
+    }
 #endif
     // ------------------------------------------------------------------------
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -638,7 +638,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
 
     if (unlikely(sql_init_database())) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
-            return 1;
+            fatal("Failed to initialize SQLite");
         info("Skipping SQLITE metadata initialization since memory mode is not db engine");
     }
 
@@ -689,7 +689,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         rrdhost_free(localhost);
         localhost = NULL;
         rrd_unlock();
-        return 1;
+        fatal("Failed to initialize dbengine");
     }
 #endif
     rrd_unlock();


### PR DESCRIPTION
##### Summary
When the agent is built without dbengine support (on purpose or because the dependencies are not met) then if
memory mode dbengine is specificed in the netdata.conf, the agent will fail to start with the message

`RRD_MEMORY_MODE_DBENGINE is not supported in this platform.`

with this PR the dbengine memory mode will be ignored and memory RAM will be used instead
and the following  message will be logged

`RRD_MEMORY_MODE_DBENGINE is not supported in this platform. The agent will use memory mode ram instead.`

This PR will also tries to further pinpoint failures during `rrd_init` and whether it happens during
- sql_init_database
- rrdeng_init

Statistics show a large number of agents going into a restart loop because dbengine is not available. 
##### Component Name
agent

##### Test Plan
- Compile agent without dbengine support with the flag `--disable-dbengine`
- Set memory mode to `dbengine` in netdata.conf
- Start the agent
   - The agent will not start
- Apply the PR and repeat the test. The agent should start normally and use memory mode RAM
