### PR TITLE
Ignore dbengine journal files that can not be read

### DIFF
--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -428,8 +428,9 @@ static uint64_t iterate_transactions(struct rrdengine_instance *ctx, struct rrde
         iov = uv_buf_init(buf, size_bytes);
         ret = uv_fs_read(NULL, &req, file, &iov, 1, pos, NULL);
         if (ret < 0) {
-            fatal("uv_fs_read: %s", uv_strerror(ret));
-            /*uv_fs_req_cleanup(&req);*/
+            error("uv_fs_read: pos=%lu, %s", pos, uv_strerror(ret));
+            uv_fs_req_cleanup(&req);
+            goto skip_file;
         }
         fatal_assert(req.result >= 0);
         uv_fs_req_cleanup(&req);
@@ -451,7 +452,7 @@ static uint64_t iterate_transactions(struct rrdengine_instance *ctx, struct rrde
             max_id = MAX(max_id, id);
         }
     }
-
+skip_file:
     free(buf);
     return max_id;
 }


### PR DESCRIPTION
##### Summary
When a read fails when processing dbengine journal files, the agent terminates by calling fatal.

This will ignore the error skip the rest of the transactions in that journal file and attempt to continue.

##### Component Name
database

##### Test Plan
- This is hard to reproduce (probably caused by disk/file corruption). However any attempt to alter
  the journal file is almost always gracefully handled with a CRC error warning as in
  `netdata ERROR : MAIN : Transaction 16 was read from disk. CRC32 check: FAILED`
