### PR TITLE
Reduce memory needed per dimension

### DIFF
--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -49,7 +49,7 @@ void rrdeng_convert_legacy_uuid_to_multihost(char machine_guid[GUID_LEN + 1], uu
     memcpy(ret_uuid, hash_value, sizeof(uuid_t));
 }
 
-void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid)
+void rrdeng_metric_init(RRDDIM *rd)
 {
     struct page_cache *pg_cache;
     struct rrdengine_instance *ctx;
@@ -68,7 +68,6 @@ void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid)
     pg_cache = &ctx->pg_cache;
 
     rrdeng_generate_legacy_uuid(rd->id, rd->rrdset->id, &legacy_uuid);
-    rd->state->metric_uuid = dim_uuid;
     if (host != localhost && host->rrdeng_ctx == &multidb_ctx)
         is_multihost_child = 1;
 
@@ -82,20 +81,17 @@ void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid)
         /* First time we see the legacy UUID or metric belongs to child host in multi-host DB.
          * Drop legacy support, normal path */
 
-        if (unlikely(!rd->state->metric_uuid))
-            rd->state->metric_uuid = create_dimension_uuid(rd->rrdset, rd);
-
         uv_rwlock_rdlock(&pg_cache->metrics_index.lock);
-        PValue = JudyHSGet(pg_cache->metrics_index.JudyHS_array, rd->state->metric_uuid, sizeof(uuid_t));
+        PValue = JudyHSGet(pg_cache->metrics_index.JudyHS_array, &rd->state->metric_uuid, sizeof(uuid_t));
         if (likely(NULL != PValue)) {
             page_index = *PValue;
         }
         uv_rwlock_rdunlock(&pg_cache->metrics_index.lock);
         if (NULL == PValue) {
             uv_rwlock_wrlock(&pg_cache->metrics_index.lock);
-            PValue = JudyHSIns(&pg_cache->metrics_index.JudyHS_array, rd->state->metric_uuid, sizeof(uuid_t), PJE0);
+            PValue = JudyHSIns(&pg_cache->metrics_index.JudyHS_array, &rd->state->metric_uuid, sizeof(uuid_t), PJE0);
             fatal_assert(NULL == *PValue); /* TODO: figure out concurrency model */
-            *PValue = page_index = create_page_index(rd->state->metric_uuid);
+            *PValue = page_index = create_page_index(&rd->state->metric_uuid);
             page_index->prev = pg_cache->metrics_index.last_page_index;
             pg_cache->metrics_index.last_page_index = page_index;
             uv_rwlock_wrunlock(&pg_cache->metrics_index.lock);
@@ -106,15 +102,12 @@ void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid)
         rrdeng_convert_legacy_uuid_to_multihost(rd->rrdset->rrdhost->machine_guid, &legacy_uuid,
                                                 &multihost_legacy_uuid);
 
-        if (unlikely(!rd->state->metric_uuid))
-            rd->state->metric_uuid = mallocz(sizeof(uuid_t));
+        int need_to_store = uuid_compare(rd->state->metric_uuid, multihost_legacy_uuid);
 
-        int need_to_store = (dim_uuid == NULL || uuid_compare(*rd->state->metric_uuid, multihost_legacy_uuid));
-
-        uuid_copy(*rd->state->metric_uuid, multihost_legacy_uuid);
+        uuid_copy(rd->state->metric_uuid, multihost_legacy_uuid);
 
         if (unlikely(need_to_store))
-            (void)sql_store_dimension(rd->state->metric_uuid, rd->rrdset->chart_uuid, rd->id, rd->name, rd->multiplier, rd->divisor,
+            (void)sql_store_dimension(&rd->state->metric_uuid, rd->rrdset->chart_uuid, rd->id, rd->name, rd->multiplier, rd->divisor,
                 rd->algorithm);
 
     }

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -36,7 +36,7 @@ extern void rrdeng_convert_legacy_uuid_to_multihost(char machine_guid[GUID_LEN +
                                                     uuid_t *ret_uuid);
 
 
-extern void rrdeng_metric_init(RRDDIM *rd, uuid_t *dim_uuid);
+extern void rrdeng_metric_init(RRDDIM *rd);
 extern void rrdeng_store_metric_init(RRDDIM *rd);
 extern void rrdeng_store_metric_flush_current_page(RRDDIM *rd);
 extern void rrdeng_store_metric_next(RRDDIM *rd, usec_t point_in_time, storage_number number);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -384,7 +384,7 @@ struct rrddim_volatile {
     uuid_t *rrdeng_uuid;                 // database engine metric UUID
     struct pg_cache_page_index *page_index;
 #endif
-    uuid_t *metric_uuid;                 // global UUID for this metric (unique_across hosts)
+    uuid_t metric_uuid;                 // global UUID for this metric (unique_across hosts)
     union rrddim_collect_handle handle;
     // ------------------------------------------------------------------------
     // function pointers that handle data collection

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1396,7 +1396,7 @@ restart_after_removal:
                         uint8_t can_delete_metric = rd->state->collect_ops.finalize(rd);
                         if (can_delete_metric) {
                             /* This metric has no data and no references */
-                            delete_dimension_uuid(rd->state->metric_uuid);
+                            delete_dimension_uuid(&rd->state->metric_uuid);
                             rrddim_free(st, rd);
                             if (unlikely(!last)) {
                                 rd = st->dimensions;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1886,7 +1886,7 @@ after_second_database_work:
                         uint8_t can_delete_metric = rd->state->collect_ops.finalize(rd);
                         if (can_delete_metric) {
                             /* This metric has no data and no references */
-                            delete_dimension_uuid(rd->state->metric_uuid);
+                            delete_dimension_uuid(&rd->state->metric_uuid);
                         } else {
                             /* Do not delete this dimension */
                             last = rd;

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -246,20 +246,20 @@ bind_fail:
     return 0;
 }
 
-uuid_t *find_dimension_uuid(RRDSET *st, RRDDIM *rd)
+int find_dimension_uuid(RRDSET *st, RRDDIM *rd, uuid_t *store_uuid)
 {
     static __thread sqlite3_stmt *res = NULL;
-    uuid_t *uuid = NULL;
     int rc;
+    int status = 1;
 
     if (unlikely(!db_meta) && default_rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE)
-        return NULL;
+        return 1;
 
     if (unlikely(!res)) {
         rc = prepare_statement(db_meta, SQL_FIND_DIMENSION_UUID, &res);
         if (rc != SQLITE_OK) {
             error_report("Failed to bind prepare statement to lookup dimension UUID in the database");
-            return NULL;
+            return 1;
         }
     }
 
@@ -277,49 +277,24 @@ uuid_t *find_dimension_uuid(RRDSET *st, RRDDIM *rd)
 
     rc = sqlite3_step(res);
     if (likely(rc == SQLITE_ROW)) {
-        uuid = mallocz(sizeof(uuid_t));
-        uuid_copy(*uuid, sqlite3_column_blob(res, 0));
+        uuid_copy(*store_uuid, *((uuid_t *) sqlite3_column_blob(res, 0)));
+        status = 0;
+    }
+    else {
+        uuid_generate(*store_uuid);
+        status = sql_store_dimension(store_uuid, st->chart_uuid, rd->id, rd->name, rd->multiplier, rd->divisor, rd->algorithm);
+        if (unlikely(status))
+            error_report("Failed to store dimension metadata in the database");
     }
 
     rc = sqlite3_reset(res);
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to reset statement find dimension uuid, rc = %d", rc);
-
-#ifdef NETDATA_INTERNAL_CHECKS
-    char  uuid_str[GUID_LEN + 1];
-    if (likely(uuid)) {
-        uuid_unparse_lower(*uuid, uuid_str);
-        debug(D_METADATALOG, "Found UUID %s for dimension %s", uuid_str, rd->name);
-    }
-    else
-        debug(D_METADATALOG, "UUID not found for dimension %s", rd->name);
-#endif
-    return uuid;
+    return status;
 
 bind_fail:
     error_report("Failed to bind input parameter to perform dimension UUID database lookup, rc = %d", rc);
-    return NULL;
-}
-
-uuid_t *create_dimension_uuid(RRDSET *st, RRDDIM *rd)
-{
-    uuid_t *uuid = NULL;
-    int rc;
-
-    uuid = mallocz(sizeof(uuid_t));
-    uuid_generate(*uuid);
-
-#ifdef NETDATA_INTERNAL_CHECKS
-    char uuid_str[GUID_LEN + 1];
-    uuid_unparse_lower(*uuid, uuid_str);
-    debug(D_METADATALOG,"Generating uuid [%s] for dimension %s under chart %s", uuid_str, rd->name, st->id);
-#endif
-
-    rc = sql_store_dimension(uuid, st->chart_uuid, rd->id, rd->name, rd->multiplier, rd->divisor, rd->algorithm);
-    if (unlikely(rc))
-       error_report("Failed to store dimension metadata in the database");
-
-    return uuid;
+    return 1;
 }
 
 #define DELETE_DIMENSION_UUID   "delete from dimension where dim_id = @uuid;"
@@ -1206,7 +1181,7 @@ static RRDDIM *create_rrdim_entry(RRDSET *st, char *id, char *name, uuid_t *metr
     rd->state->query_ops.oldest_time = rrdeng_metric_oldest_time;
     rd->state->rrdeng_uuid = mallocz(sizeof(uuid_t));
     uuid_copy(*rd->state->rrdeng_uuid, *metric_uuid);
-    rd->state->metric_uuid = rd->state->rrdeng_uuid;
+    uuid_copy(rd->state->metric_uuid, *metric_uuid);
     rd->id = strdupz(id);
     rd->name = strdupz(name);
     return rd;

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -34,9 +34,10 @@ struct node_instance_list {
 #define SQL_STORE_DIMENSION                                                                                           \
     "INSERT OR REPLACE into dimension (dim_id, chart_id, id, name, multiplier, divisor , algorithm) values (?0001,?0002,?0003,?0004,?0005,?0006,?0007);"
 
-#define SQL_FIND_DIMENSION_UUID "select dim_id from dimension where chart_id=@chart and id=@id and name=@name;"
+#define SQL_FIND_DIMENSION_UUID \
+    "select dim_id from dimension where chart_id=@chart and id=@id and name=@name and length(dim_id)=16;"
 
-#define SQL_STORE_ACTIVE_DIMENSION                                                                                     \
+#define SQL_STORE_ACTIVE_DIMENSION \
     "insert or replace into dimension_active (dim_id, date_created) values (@id, strftime('%s'));"
 extern int sql_init_database(void);
 extern void sql_close_database(void);
@@ -49,8 +50,7 @@ extern int sql_store_chart(
 extern int sql_store_dimension(uuid_t *dim_uuid, uuid_t *chart_uuid, const char *id, const char *name, collected_number multiplier,
                                collected_number divisor, int algorithm);
 
-extern uuid_t *find_dimension_uuid(RRDSET *st, RRDDIM *rd);
-extern uuid_t *create_dimension_uuid(RRDSET *st, RRDDIM *rd);
+extern int find_dimension_uuid(RRDSET *st, RRDDIM *rd, uuid_t *store_uuid);
 extern void store_active_dimension(uuid_t *dimension_uuid);
 
 extern uuid_t *find_chart_uuid(RRDHOST *host, const char *type, const char *id, const char *name);

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -18,7 +18,6 @@ static inline void free_single_rrdrim(RRDDIM *temp_rd, int archive_mode)
             freez(temp_rd->rrdset);
         }
     }
-    freez(temp_rd->state->metric_uuid);
     freez(temp_rd->state);
     freez(temp_rd);
 }
@@ -95,8 +94,6 @@ void build_context_param_list(struct context_param **param_list, RRDSET *st)
         memcpy(rd->state, rd1->state, sizeof(*rd->state));
         memcpy(&rd->state->collect_ops, &rd1->state->collect_ops, sizeof(struct rrddim_collect_ops));
         memcpy(&rd->state->query_ops, &rd1->state->query_ops, sizeof(struct rrddim_query_ops));
-        rd->state->metric_uuid = mallocz(sizeof(uuid_t));
-        uuid_copy(*rd->state->metric_uuid, *rd1->state->metric_uuid);
         rd->next = (*param_list)->rd;
         (*param_list)->rd = rd;
     }


### PR DESCRIPTION
##### Summary
- The metric_uuid is now stored as `uuid_t` in the dimension state instead of `uuid_t *`
   It used to be compiled only if dbengine was available but now it is used in all memory modes so no need to do the extra malloc
- Remove `create_dimension_uuid` and include the functionality in `find_dimension_uuid`
##### Component Name
database

##### Test Plan
- There shouldn't be any change in the functionality
- Start the agent with memory mode dbengine (the metric UUID is directly linked with stored metrics in dbengine)
- Observe metrics being collected
- Build an agent with the PR
- Stop old agent, restart with the PR applied
  - You should have access to the old metrics
