### PR TITLE
Switches ACLK-NG to be the default ACLK impl.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,11 +194,11 @@ AC_ARG_ENABLE(
 )
 
 AC_ARG_WITH(
-    [aclk-ng],
-    [AS_HELP_STRING([--with-aclk-ng],
-                    [Requires ACLK-NG to be used even in case ACLK Legacy can run on this system])],
-    [aclk_ng="$withval"],
-    [aclk_ng="fallback"]
+    [aclk-legacy],
+    [AS_HELP_STRING([--with-aclk-legacy],
+                    [Requires Legacy ACLK to be used even in case ACLK-NG can run on this system])],
+    [aclk_legacy="$withval"],
+    [aclk_legacy="fallback"]
 )
 
 if test "${enable_cloud}" = "no"; then
@@ -636,9 +636,54 @@ AM_CONDITIONAL([ENABLE_CAPABILITY], [test "${with_libcap}" = "yes"])
 
 AC_MSG_CHECKING([if cloud functionality should be enabled])
 AC_MSG_RESULT([${enable_cloud}])
-if test "$enable_cloud" != "no" -a "$aclk_ng" != "yes"; then
-    # just to have all messages that can fail ACLK build in one place
-    # so it is easier to see why it can't be built
+
+if test "$enable_cloud" = "no" -a "$aclk_legacy" = "yes"; then
+    AC_MSG_ERROR([--disable-cloud && --with-aclk-legacy (--aclk-legacy in installer) not allowed together (such configuration is self contradicting)])
+fi
+
+if test "$enable_cloud" != "no" -a "$aclk_legacy" != "yes"; then
+    can_enable_ng="yes"
+    AC_MSG_CHECKING([if git submodules present for ACLK Next Generation])
+    if test -f "mqtt_websockets/src/mqtt_wss_client.c"; then
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
+        can_enable_ng="no"
+    fi
+    AC_MSG_CHECKING([if SSL available for ACLK Next Generation])
+    if test -n "${SSL_LIBS}"; then
+        AC_MSG_RESULT([yes])
+        OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
+        OPTIONAL_SSL_LIBS="${SSL_LIBS}"
+    else
+        AC_MSG_RESULT([no])
+    fi
+    AC_MSG_CHECKING([if JSON-C available for ACLK Next Generation])
+    if test "$enable_jsonc" != "yes"; then
+        AC_MSG_RESULT([no])
+        can_enable_ng="no"
+    else
+        AC_MSG_RESULT([yes])
+    fi
+    AC_MSG_CHECKING([ACLK Next Generation can be built])
+    AC_MSG_RESULT([${can_enable_ng}])
+    if test "$can_enable_ng" = "yes"; then
+        aclk_ng="yes"
+        AC_DEFINE([ACLK_NG], [1], [ACLK Next Generation Should be used])
+        AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
+        enable_aclk="yes"
+        OPTIONAL_ACLK_NG_CFLAGS="-I \$(abs_top_srcdir)/mqtt_websockets/src/include -I \$(abs_top_srcdir)/mqtt_websockets/c-rbuf/include -I \$(abs_top_srcdir)/mqtt_websockets/MQTT-C/include"
+        OPTIONAL_PROTOBUF_CFLAGS="${PROTOBUF_CFLAGS}"
+        CXX11FLAG="-std=c++11"
+        OPTIONAL_PROTOBUF_LIBS="${PROTOBUF_LIBS}"
+    fi
+fi
+
+if test "$enable_cloud" != "no" -a "$aclk_legacy" != "no" -a "$enable_aclk" != "yes"; then
+    if test "$aclk_legacy" != "yes"; then
+        AC_MSG_NOTICE([ACLK-NG could not be built. Trying Legacy ACLK as fallback.])
+    fi
+
     if test -n "${SSL_LIBS}"; then
         OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
         OPTIONAL_SSL_LIBS="${SSL_LIBS}"
@@ -728,50 +773,6 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "yes"; then
     AC_MSG_RESULT([${enable_aclk}])
 fi
 
-if test "$enable_cloud" = "no" -a "$aclk_ng" = "yes"; then
-    AC_MSG_ERROR([--disable-cloud && --aclk-ng not allowed together (such configuration is self contradicting)])
-fi
-
-if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
-    can_enable_ng="yes"
-    AC_MSG_CHECKING([if git submodules present for ACLK Next Generation])
-    if test -f "mqtt_websockets/src/mqtt_wss_client.c"; then
-        AC_MSG_RESULT([yes])
-    else
-        AC_MSG_RESULT([no])
-        can_enable_ng="no"
-    fi
-    AC_MSG_CHECKING([if SSL available for ACLK Next Generation])
-    if test -n "${SSL_LIBS}"; then
-        AC_MSG_RESULT([yes])
-        OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
-        OPTIONAL_SSL_LIBS="${SSL_LIBS}"
-    else
-        AC_MSG_RESULT([no])
-    fi
-    AC_MSG_CHECKING([if JSON-C available for ACLK Next Generation])
-    if test "$enable_jsonc" != "yes"; then
-        AC_MSG_RESULT([no])
-        can_enable_ng="no"
-    else
-        AC_MSG_RESULT([yes])
-    fi
-    AC_MSG_CHECKING([ACLK Next Generation can be built])
-    AC_MSG_RESULT([${can_enable_ng}])
-    if test "$aclk_ng" = "yes" -a "$can_enable_ng" != "yes"; then
-        AC_MSG_ERROR([ACLK-NG requested but can't be built])
-    fi
-    if test "$aclk_ng" != "yes" -a "$enable_aclk" == "no" -a "$can_enable_ng" = "yes"; then #default "fallback"
-        AC_MSG_NOTICE([ACLK Legacy could not be built. Trying ACLK-NG as fallback.])
-        aclk_ng="yes"
-    fi
-    if test "$aclk_ng" = "yes"; then
-        AC_DEFINE([ACLK_NG], [1], [ACLK Next Generation Should be used])
-        AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
-        enable_aclk="yes"
-        OPTIONAL_ACLK_NG_CFLAGS="-I \$(abs_top_srcdir)/mqtt_websockets/src/include -I \$(abs_top_srcdir)/mqtt_websockets/c-rbuf/include -I \$(abs_top_srcdir)/mqtt_websockets/MQTT-C/include"
-    fi
-fi
 AC_SUBST([enable_cloud])
 AC_SUBST([enable_aclk])
 AM_CONDITIONAL([ACLK_NG], [test "${aclk_ng}" = "yes"])

--- a/configure.ac
+++ b/configure.ac
@@ -673,9 +673,6 @@ if test "$enable_cloud" != "no" -a "$aclk_legacy" != "yes"; then
         AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
         enable_aclk="yes"
         OPTIONAL_ACLK_NG_CFLAGS="-I \$(abs_top_srcdir)/mqtt_websockets/src/include -I \$(abs_top_srcdir)/mqtt_websockets/c-rbuf/include -I \$(abs_top_srcdir)/mqtt_websockets/MQTT-C/include"
-        OPTIONAL_PROTOBUF_CFLAGS="${PROTOBUF_CFLAGS}"
-        CXX11FLAG="-std=c++11"
-        OPTIONAL_PROTOBUF_LIBS="${PROTOBUF_LIBS}"
     fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -752,7 +752,6 @@ if test "$enable_cloud" != "no" -a "$aclk_legacy" != "no" -a "$enable_aclk" != "
     fi
     AC_MSG_RESULT([${can_enable_aclk}])
 
-# TODO fix this (you need to try fallback)
     test "${enable_cloud}" = "yes" -a "${can_enable_aclk}" = "no" && \
         AC_MSG_ERROR([User required agent-cloud-link but it can't be built!])
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -320,6 +320,7 @@ while [ -n "${1}" ]; do
     "--disable-go") NETDATA_DISABLE_GO=1 ;;
     "--enable-ebpf") NETDATA_DISABLE_EBPF=0 ;;
     "--disable-ebpf") NETDATA_DISABLE_EBPF=1 NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-ebpf/} --disable-ebpf" ;;
+    "--aclk-ng") ;;
     "--aclk-legacy")
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--with-aclk-legacy/} --with-aclk-legacy"
       ;;

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -215,7 +215,7 @@ USAGE: ${PROGRAM} [options]
   --disable-ebpf             Disable eBPF Kernel plugin (Default: enabled)
   --disable-cloud            Disable all Netdata Cloud functionality.
   --require-cloud            Fail the install if it can't build Netdata Cloud support.
-  --aclk-ng                  Forces build of ACLK Next Generation which is fallback by default.
+  --aclk-legacy              Forces build of ACLK Legacy which is fallback by default.
   --enable-plugin-freeipmi   Enable the FreeIPMI plugin. Default: enable it when libipmimonitoring is available.
   --disable-plugin-freeipmi
   --disable-https            Explicitly disable TLS support
@@ -320,9 +320,8 @@ while [ -n "${1}" ]; do
     "--disable-go") NETDATA_DISABLE_GO=1 ;;
     "--enable-ebpf") NETDATA_DISABLE_EBPF=0 ;;
     "--disable-ebpf") NETDATA_DISABLE_EBPF=1 NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-ebpf/} --disable-ebpf" ;;
-    "--aclk-ng")
-      NETDATA_ACLK_NG=1
-      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--with-aclk-ng/} --with-aclk-ng"
+    "--aclk-legacy")
+      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--with-aclk-legacy/} --with-aclk-legacy"
       ;;
     "--disable-cloud")
       if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
@@ -572,7 +571,7 @@ copy_libmosquitto() {
 }
 
 bundle_libmosquitto() {
-  if [ -n "${NETDATA_DISABLE_CLOUD}" ] || [ -n "${NETDATA_ACLK_NG}" ]; then
+  if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
     echo "Skipping libmosquitto"
     return 0
   fi
@@ -674,7 +673,8 @@ copy_libwebsockets() {
 }
 
 bundle_libwebsockets() {
-  if [ -n "${NETDATA_DISABLE_CLOUD}" ] || [ -n "${USE_SYSTEM_LWS}" ] || [ -n "${NETDATA_ACLK_NG}" ]; then
+  if [ -n "${NETDATA_DISABLE_CLOUD}" ] || [ -n "${USE_SYSTEM_LWS}" ]; then
+    echo "Skipping libwebsockets"
     return 0
   fi
 


### PR DESCRIPTION
##### Summary
The installer will now try to build ACLK-NG as default.
ACLK Legacy will be built only if requested by the user specifically (`--aclk-legacy` to the installer) or will be tried as fallback if NG could not be built for some reason

##### Component Name
autotools build

##### Test Plan
test with default params -> NG should be built
remove dependency ACLK-NG needs but Legacy doesn´t (e.g. delete mqtt_websockets submodule folder) -> Legacy should be built
make all available for both ACLK implementations and pass `--aclk-legacy` to the installer -> Legacy should be built despite NG being possible

CI will also be useful for this PR

##### Additional Information
