### PR TITLE
health: update cockroachdb alarms

### DIFF
--- a/health/health.d/cockroachdb.conf
+++ b/health/health.d/cockroachdb.conf
@@ -71,16 +71,3 @@ component: CockroachDB
     every: 10s
      info: number of active SQL connections
        to: dba
-
- template: cockroachdb_sql_executed_statements_total_last_5m
-       on: cockroachdb.sql_statements_total
-    class: Database
-component: CockroachDB
-     type: Workload
-   lookup: sum -5m absolute of sql_query_count
-    units: statements
-    every: 10s
-     warn: $this == 0 AND $cockroachdb_sql_active_connections != 0
-    delay: down 15m up 30s multiplier 1.5 max 1h
-     info: number of executed SQL statements in the last 5 minutes
-       to: dba

--- a/health/health.d/cockroachdb.conf
+++ b/health/health.d/cockroachdb.conf
@@ -44,19 +44,6 @@ component: CockroachDB
      info: number of ranges with fewer live replicas than the replication target
        to: dba
 
- template: cockroachdb_replicas_leaders_not_leaseholders
-       on: cockroachdb.replicas_leaders
-    class: Database
-component: CockroachDB
-     type: Utilization
-     calc: $replicas_leaders_not_leaseholders
-    units: num
-    every: 10s
-     warn: $this > 0
-    delay: down 15m multiplier 1.5 max 1h
-     info: number of replicas that are Raft leaders whose range lease is held by another store
-       to: dba
-
 # FD
 
  template: cockroachdb_open_file_descriptors_limit

--- a/health/health.d/cockroachdb.conf
+++ b/health/health.d/cockroachdb.conf
@@ -58,16 +58,3 @@ component: CockroachDB
     delay: down 15m multiplier 1.5 max 1h
      info: open file descriptors utilization (against softlimit)
        to: dba
-
-# SQL
-
- template: cockroachdb_sql_active_connections
-       on: cockroachdb.sql_connections
-    class: Database
-component: CockroachDB
-     type: Utilization
-     calc: $sql_conns
-    units: active connections
-    every: 10s
-     info: number of active SQL connections
-       to: dba


### PR DESCRIPTION
##### Summary

We used [cockroach/monitoring/rules/alerts.rules.yml](https://github.com/cockroachdb/cockroach/blob/master/monitoring/rules/alerts.rules.yml) as a source for alarms. Since then several alarms were deleted from the file, this PR removes them from our repo.

##### Component Name

`health/`

##### Test Plan

Not needed

##### Additional Information

[`cockroachdb_sql_executed_statements_total_last_5m`](https://github.com/netdata/netdata/blob/e02095b438ab8e4fdc55313e8c7ed5bd7de50835/health/health.d/cockroachdb.conf#L88-L99) alarm seems to be false positive according to our experience and it doesn't work properly when there are 2+ CockroachDB instances on a host (health monitoring variables indexes limitation).