### PR TITLE
Extra posthog attributes

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -511,13 +511,13 @@ void analytics_misc(void)
 {
 #ifdef ENABLE_ACLK
     analytics_set_data(&analytics_data.netdata_host_cloud_available, "true");
-    if (aclk_ng)
-        analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "Next Generation");
-    else
-        analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "legacy");
+#ifdef ACLK_NG
+    analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "Next Generation");
+#else
+    analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "legacy");
+#endif
 #else
     analytics_set_data(&analytics_data.netdata_host_cloud_available, "false");
-    analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "");
 #endif
 
 #ifdef ENABLE_ACLK

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -385,8 +385,7 @@ void analytics_get_install_type(void)
                 if (s) {
                     while (*s == '\'')
                         s++;
-                    while (*++t != '\0')
-                        ;
+                    while (*++t != '\0');
                     while (--t > s && *t == '\'')
                         *t = '\0';
                     if (*s)
@@ -398,8 +397,7 @@ void analytics_get_install_type(void)
                 if (s) {
                     while (*s == '\'')
                         s++;
-                    while (*++t != '\0')
-                        ;
+                    while (*++t != '\0');
                     while (--t > s && *t == '\'')
                         *t = '\0';
                     if (*s)

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -393,7 +393,7 @@ void analytics_get_install_type(void)
         char *s, buf[256 + 1];
         size_t len = 0;
 
-        while ((s = fgets_trim_len(buf, 4096, fp, &len))) {
+        while ((s = fgets_trim_len(buf, 256, fp, &len))) {
             if (!strncmp(buf, "INSTALL_TYPE='", 14))
                 analytics_set_data_str(&analytics_data.netdata_install_type, (char *)get_value_from_key(buf, "INSTALL_TYPE"));
             else if (!strncmp(buf, "PREBUILT_DISTRO='", 17))
@@ -412,12 +412,7 @@ void analytics_https(void)
     BUFFER *b = buffer_create(30);
 #ifdef ENABLE_HTTPS
     analytics_exporting_connectors_ssl(b);
-    buffer_strcat(
-        b,
-        netdata_client_ctx && localhost->ssl.flags == NETDATA_SSL_HANDSHAKE_COMPLETE &&
-                localhost->rrdpush_sender_connected == 1 ?
-            "streaming|" :
-            "|");
+    buffer_strcat(b, netdata_client_ctx && localhost->ssl.flags == NETDATA_SSL_HANDSHAKE_COMPLETE && localhost->rrdpush_sender_connected == 1 ? "streaming|" : "|");
     buffer_strcat(b, netdata_srv_ctx ? "web" : "");
 #else
     buffer_strcat(b, "||");
@@ -519,10 +514,7 @@ void analytics_misc(void)
 #endif
         analytics_set_data(&analytics_data.netdata_host_aclk_available, "false");
 
-    analytics_set_data(
-        &analytics_data.netdata_config_exporting_enabled,
-        appconfig_get_boolean(&exporting_config, CONFIG_SECTION_EXPORTING, "enabled", CONFIG_BOOLEAN_NO) ? "true" :
-                                                                                                           "false");
+    analytics_set_data(&analytics_data.netdata_config_exporting_enabled, appconfig_get_boolean(&exporting_config, CONFIG_SECTION_EXPORTING, "enabled", CONFIG_BOOLEAN_NO) ? "true" : "false");
 
     analytics_set_data(&analytics_data.netdata_config_is_private_registry, "false");
     analytics_set_data(&analytics_data.netdata_config_use_private_registry, "false");

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -357,6 +357,20 @@ void analytics_alarms_notifications(void)
     buffer_free(b);
 }
 
+char *get_value_from_key(char *buffer, char *key)
+{
+    char *s = NULL, *t = NULL;
+    s = t = buffer + strlen(key) + 2;
+    if (s) {
+        while (*s == '\'')
+            s++;
+        while (*++t != '\0');
+        while (--t > s && *t == '\'')
+            *t = '\0';
+    }
+    return s;
+}
+
 /*
  * Checks for the existance of .install_type file and reads it
  */
@@ -376,34 +390,14 @@ void analytics_get_install_type(void)
 
     FILE *fp = fopen(install_type_filename, "r");
     if (fp) {
-        char *s, *t, buf[256 + 1];
+        char *s, buf[256 + 1];
         size_t len = 0;
 
         while ((s = fgets_trim_len(buf, 4096, fp, &len))) {
-            if (!strncmp(buf, "INSTALL_TYPE='", 14)) {
-                s = t = buf + 13;
-                if (s) {
-                    while (*s == '\'')
-                        s++;
-                    while (*++t != '\0');
-                    while (--t > s && *t == '\'')
-                        *t = '\0';
-                    if (*s)
-                        analytics_set_data_str(&analytics_data.netdata_install_type, (char *)s);
-                }
-            }
-            else if (!strncmp(buf, "PREBUILT_DISTRO='", 17)) {
-                s = t = buf + 16;
-                if (s) {
-                    while (*s == '\'')
-                        s++;
-                    while (*++t != '\0');
-                    while (--t > s && *t == '\'')
-                        *t = '\0';
-                    if (*s)
-                        analytics_set_data_str(&analytics_data.netdata_prebuilt_distro, (char *)s);
-                }
-            }
+            if (!strncmp(buf, "INSTALL_TYPE='", 14))
+                analytics_set_data_str(&analytics_data.netdata_install_type, (char *)get_value_from_key(buf, "INSTALL_TYPE"));
+            else if (!strncmp(buf, "PREBUILT_DISTRO='", 17))
+                analytics_set_data_str(&analytics_data.netdata_prebuilt_distro, (char *)get_value_from_key(buf, "PREBUILT_DISTRO"));
         }
         fclose(fp);
     }

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -511,13 +511,13 @@ void analytics_misc(void)
 {
 #ifdef ENABLE_ACLK
     analytics_set_data(&analytics_data.netdata_host_cloud_available, "true");
-#ifdef ACLK_NG
-    analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "Next Generation");
-#else
-    analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "legacy");
-#endif
+    if (aclk_ng)
+        analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "Next Generation");
+    else
+        analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "legacy");
 #else
     analytics_set_data(&analytics_data.netdata_host_cloud_available, "false");
+    analytics_set_data_str(&analytics_data.netdata_host_aclk_implementation, "");
 #endif
 
 #ifdef ENABLE_ACLK

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -4,6 +4,7 @@
 
 struct analytics_data analytics_data;
 extern void analytics_exporting_connectors (BUFFER *b);
+extern void analytics_exporting_connectors_ssl (BUFFER *b);
 extern void analytics_build_info (BUFFER *b);
 extern int aclk_connected;
 
@@ -54,6 +55,11 @@ void analytics_log_data(void)
     debug(D_ANALYTICS, "NETDATA_HOST_ACLK_IMPLEMENTATION   : [%s]", analytics_data.netdata_host_aclk_implementation);
     debug(D_ANALYTICS, "NETDATA_HOST_AGENT_CLAIMED         : [%s]", analytics_data.netdata_host_agent_claimed);
     debug(D_ANALYTICS, "NETDATA_HOST_CLOUD_ENABLED         : [%s]", analytics_data.netdata_host_cloud_enabled);
+    debug(D_ANALYTICS, "NETDATA_CONFIG_HTTPS_AVAILABLE     : [%s]", analytics_data.netdata_config_https_available);
+    debug(D_ANALYTICS, "NETDATA_INSTALL_TYPE               : [%s]", analytics_data.netdata_install_type);
+    debug(D_ANALYTICS, "NETDATA_CONFIG_IS_PRIVATE_REGISTRY : [%s]", analytics_data.netdata_config_is_private_registry);
+    debug(D_ANALYTICS, "NETDATA_CONFIG_USE_PRIVATE_REGISTRY: [%s]", analytics_data.netdata_config_use_private_registry);
+    debug(D_ANALYTICS, "NETDATA_CONFIG_OOM_SCORE           : [%s]", analytics_data.netdata_config_oom_score);
 }
 
 /*
@@ -93,6 +99,11 @@ void analytics_free_data(void)
     freez(analytics_data.netdata_host_aclk_implementation);
     freez(analytics_data.netdata_host_agent_claimed);
     freez(analytics_data.netdata_host_cloud_enabled);
+    freez(analytics_data.netdata_config_https_available);
+    freez(analytics_data.netdata_install_type);
+    freez(analytics_data.netdata_config_is_private_registry);
+    freez(analytics_data.netdata_config_use_private_registry);
+    freez(analytics_data.netdata_config_oom_score);
 }
 
 /*
@@ -182,6 +193,15 @@ void analytics_log_dashboard(void)
         snprintfz(b, 6, "%d", analytics_data.dashboard_hits);
         analytics_set_data(&analytics_data.netdata_dashboard_used, b);
     }
+}
+
+/*
+ * Called when setting the oom score
+ */
+void analytics_report_oom_score(long long int score){
+    char b[7];
+    snprintfz(b, 6, "%d", (int)score);
+    analytics_set_data(&analytics_data.netdata_config_oom_score, b);
 }
 
 void analytics_mirrored_hosts(void)
@@ -335,6 +355,71 @@ void analytics_alarms_notifications(void)
     buffer_free(b);
 }
 
+/*
+ * Checks for the existance of .install_type file and reads it
+ */
+void analytics_get_install_type(void)
+{
+    char *install_type_filename;
+    analytics_set_data_str(&analytics_data.netdata_install_type, "not-available");
+
+    install_type_filename =
+        mallocz(sizeof(char) * (strlen(netdata_configured_user_config_dir) + strlen(".install-type") + 2));
+    sprintf(install_type_filename, "%s/%s", netdata_configured_user_config_dir, ".install-type");
+    if (unlikely(access(install_type_filename, R_OK) != 0)) {
+        freez(install_type_filename);
+        return;
+    }
+
+    FILE *fp = fopen(install_type_filename, "r");
+    if (fp) {
+        char *s, *t, buf[256 + 1];
+        size_t len = 0;
+
+        while ((s = fgets_trim_len(buf, 4096, fp, &len))) {
+            if (!strncmp(buf, "INSTALL_TYPE='", 14)) {
+                s = t = buf + 13;
+                if (s) {
+                    while (*s == '\'')
+                        s++;
+                    while (*++t != '\0')
+                        ;
+                    while (--t > s && *t == '\'')
+                        *t = '\0';
+                    if (*s)
+                        analytics_set_data_str(&analytics_data.netdata_install_type, (char *)s);
+                }
+                break;
+            }
+        }
+        fclose(fp);
+    }
+    freez(install_type_filename);
+}
+
+/*
+ * Pick up if https is actually used
+ */
+void analytics_https(void)
+{
+    BUFFER *b = buffer_create(30);
+#ifdef ENABLE_HTTPS
+    analytics_exporting_connectors_ssl(b);
+    buffer_strcat(
+        b,
+        netdata_client_ctx && localhost->ssl.flags == NETDATA_SSL_HANDSHAKE_COMPLETE &&
+                localhost->rrdpush_sender_connected == 1 ?
+            "streaming|" :
+            "|");
+    buffer_strcat(b, netdata_srv_ctx ? "web" : "");
+#else
+    buffer_strcat(b, "||");
+#endif
+
+    analytics_set_data_str(&analytics_data.netdata_config_https_available, (char *)buffer_tostring(b));
+    buffer_free(b);
+}
+
 void analytics_charts(void)
 {
     RRDSET *st;
@@ -426,17 +511,36 @@ void analytics_misc(void)
     else
 #endif
         analytics_set_data(&analytics_data.netdata_host_aclk_available, "false");
+
+    analytics_set_data(
+        &analytics_data.netdata_config_exporting_enabled,
+        appconfig_get_boolean(&exporting_config, CONFIG_SECTION_EXPORTING, "enabled", CONFIG_BOOLEAN_NO) ? "true" :
+                                                                                                           "false");
+
+    analytics_set_data(&analytics_data.netdata_config_is_private_registry, "false");
+    analytics_set_data(&analytics_data.netdata_config_use_private_registry, "false");
+
+    if (strcmp(
+        config_get(CONFIG_SECTION_REGISTRY, "registry to announce", "https://registry.my-netdata.io"),
+        "https://registry.my-netdata.io"))
+        analytics_set_data(&analytics_data.netdata_config_use_private_registry, "true");
+
+    //do we need both registry to announce and enabled to indicate that this is a private registry ?
+    if (config_get_boolean(CONFIG_SECTION_REGISTRY, "enabled", CONFIG_BOOLEAN_NO) &&
+        web_server_mode != WEB_SERVER_MODE_NONE)
+        analytics_set_data(&analytics_data.netdata_config_is_private_registry, "true");
 }
 
 /*
  * Get the meta data, called from the thread once after the original delay
- * These are values that won't change between agent restarts, and therefore
+ * These are values that won't change during agent runtime, and therefore
  * don't try to read them on each META event send
  */
 void analytics_gather_immutable_meta_data(void)
 {
     analytics_misc();
     analytics_exporters();
+    analytics_https();
 }
 
 /*
@@ -521,7 +625,7 @@ void *analytics_main(void *ptr)
 
     analytics_gather_immutable_meta_data();
     analytics_gather_mutable_meta_data();
-    send_statistics("META", "-", "-");
+    send_statistics("META_START", "-", "-");
     analytics_log_data();
 
     sec = 0;
@@ -567,7 +671,6 @@ void set_late_global_environment()
 {
     analytics_set_data(&analytics_data.netdata_config_stream_enabled, default_rrdpush_enabled ? "true" : "false");
     analytics_set_data_str(&analytics_data.netdata_config_memory_mode, (char *)rrd_memory_mode_name(default_rrd_memory_mode));
-    analytics_set_data(&analytics_data.netdata_config_exporting_enabled, appconfig_get_boolean(&exporting_config, CONFIG_SECTION_EXPORTING, "enabled", CONFIG_BOOLEAN_NO) ? "true" : "false");
 
 #ifdef DISABLE_CLOUD
     analytics_set_data(&analytics_data.netdata_host_cloud_enabled, "false");
@@ -607,6 +710,8 @@ void set_late_global_environment()
         analytics_set_data_str(&analytics_data.netdata_buildinfo, (char *)buffer_tostring(bi));
         buffer_free(bi);
     }
+
+    analytics_get_install_type();
 }
 
 static void get_system_timezone(void)
@@ -793,6 +898,11 @@ void set_global_environment()
     analytics_set_data(&analytics_data.netdata_host_aclk_available, "null");
     analytics_set_data(&analytics_data.netdata_host_agent_claimed, "null");
     analytics_set_data(&analytics_data.netdata_host_cloud_enabled, "null");
+    analytics_set_data(&analytics_data.netdata_config_https_available, "null");
+    analytics_set_data(&analytics_data.netdata_install_type, "null");
+    analytics_set_data(&analytics_data.netdata_config_is_private_registry, "null");
+    analytics_set_data(&analytics_data.netdata_config_use_private_registry, "null");
+    analytics_set_data(&analytics_data.netdata_config_oom_score, "null");
 
     analytics_data.prometheus_hits = 0;
     analytics_data.shell_hits = 0;
@@ -874,7 +984,7 @@ void send_statistics(const char *action, const char *action_result, const char *
 
     sprintf(
         command_to_run,
-        "%s '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' ",
+        "%s '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' ",
         as_script,
         action,
         action_result,
@@ -910,7 +1020,12 @@ void send_statistics(const char *action, const char *action_result, const char *
         analytics_data.netdata_host_aclk_available,
         analytics_data.netdata_host_aclk_implementation,
         analytics_data.netdata_host_agent_claimed,
-        analytics_data.netdata_host_cloud_enabled);
+        analytics_data.netdata_host_cloud_enabled,
+        analytics_data.netdata_config_https_available,
+        analytics_data.netdata_install_type,
+        analytics_data.netdata_config_is_private_registry,
+        analytics_data.netdata_config_use_private_registry,
+        analytics_data.netdata_config_oom_score);
 
     info("%s '%s' '%s' '%s'", as_script, action, action_result, action_data);
 

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -393,7 +393,7 @@ void analytics_get_install_type(void)
                         analytics_set_data_str(&analytics_data.netdata_install_type, (char *)s);
                 }
             }
-            if (!strncmp(buf, "PREBUILT_DISTRO='", 17)) {
+            else if (!strncmp(buf, "PREBUILT_DISTRO='", 17)) {
                 s = t = buf + 16;
                 if (s) {
                     while (*s == '\'')

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -366,9 +366,9 @@ void analytics_get_install_type(void)
     analytics_set_data_str(&analytics_data.netdata_install_type, "");
     analytics_set_data_str(&analytics_data.netdata_prebuilt_distro, "");
 
-    install_type_filename =
-        mallocz(sizeof(char) * (strlen(netdata_configured_user_config_dir) + strlen(".install-type") + 2));
-    sprintf(install_type_filename, "%s/%s", netdata_configured_user_config_dir, ".install-type");
+    int install_type_filename_len = (strlen(netdata_configured_user_config_dir) + strlen(".install-type") + 3);
+    install_type_filename = mallocz(sizeof(char) * install_type_filename_len);
+    snprintfz(install_type_filename, install_type_filename_len - 1, "%s/%s", netdata_configured_user_config_dir, ".install-type");
     if (unlikely(access(install_type_filename, R_OK) != 0)) {
         freez(install_type_filename);
         return;

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -361,7 +361,7 @@ void analytics_alarms_notifications(void)
 void analytics_get_install_type(void)
 {
     char *install_type_filename;
-    analytics_set_data_str(&analytics_data.netdata_install_type, "not-available");
+    analytics_set_data_str(&analytics_data.netdata_install_type, "");
 
     install_type_filename =
         mallocz(sizeof(char) * (strlen(netdata_configured_user_config_dir) + strlen(".install-type") + 2));

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -29,7 +29,7 @@
     },
 
 /* Needed to calculate the space needed for parameters */
-#define ANALYTICS_NO_OF_ITEMS 37
+#define ANALYTICS_NO_OF_ITEMS 38
 
 struct analytics_data {
     char *netdata_config_stream_enabled;
@@ -69,6 +69,7 @@ struct analytics_data {
     char *netdata_config_is_private_registry;
     char *netdata_config_use_private_registry;
     char *netdata_config_oom_score;
+    char *netdata_prebuilt_distro;
 
     size_t data_length;
 

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -29,7 +29,7 @@
     },
 
 /* Needed to calculate the space needed for parameters */
-#define ANALYTICS_NO_OF_ITEMS 32
+#define ANALYTICS_NO_OF_ITEMS 37
 
 struct analytics_data {
     char *netdata_config_stream_enabled;
@@ -64,6 +64,11 @@ struct analytics_data {
     char *netdata_host_aclk_implementation;
     char *netdata_host_agent_claimed;
     char *netdata_host_cloud_enabled;
+    char *netdata_config_https_available;
+    char *netdata_install_type;
+    char *netdata_config_is_private_registry;
+    char *netdata_config_use_private_registry;
+    char *netdata_config_oom_score;
 
     size_t data_length;
 
@@ -84,6 +89,7 @@ extern void analytics_log_json(void);
 extern void analytics_log_prometheus(void);
 extern void analytics_log_dashboard(void);
 extern void analytics_gather_mutable_meta_data(void);
+extern void analytics_report_oom_score(long long int score);
 
 extern struct analytics_data analytics_data;
 

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -65,6 +65,8 @@ NETDATA_INSTALL_TYPE="${37}"
 NETDATA_IS_PRIVATE_REGISTRY="${38}"
 NETDATA_USE_PRIVATE_REGISTRY="${39}"
 NETDATA_CONFIG_OOM_SCORE="${40}"
+NETDATA_PREBUILT_DISTRO="${41}"
+
 
 # define body of request to be sent
 REQ_BODY="$(cat << EOF
@@ -86,6 +88,7 @@ REQ_BODY="$(cat << EOF
         "netdata_buildinfo": ${NETDATA_BUILDINFO},
         "netdata_release_channel": ${NETDATA_CONFIG_RELEASE_CHANNEL},
         "netdata_install_type": ${NETDATA_INSTALL_TYPE},
+        "netdata_prebuilt_distro": ${NETDATA_PREBUILT_DISTRO},
         "netdata_is_in_ci": ${NETDATA_IS_IN_CI},
         "host_os_name": "${NETDATA_HOST_OS_NAME}",
         "host_os_id": "${NETDATA_HOST_OS_ID}",

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -22,9 +22,6 @@ if [ -f "@configdir_POST@/.opt-out-from-anonymous-statistics" ] || [ ! "${DO_NOT
   exit 0
 fi
 
-# Shorten version for easier reporting
-NETDATA_VERSION=$(echo "${NETDATA_VERSION}" | sed 's/-.*//g' | tr -d 'v')
-
 # -------------------------------------------------------------------------------------------------
 # Get the extra variables
 
@@ -60,6 +57,11 @@ NETDATA_HOST_ACLK_AVAILABLE="${32}"
 NETDATA_HOST_ACLK_IMPLEMENTATION="${33}"
 NETDATA_HOST_AGENT_CLAIMED="${34}"
 NETDATA_HOST_CLOUD_ENABLED="${35}"
+NETDATA_CONFIG_HTTPS_AVAILABLE="${36}"
+NETDATA_INSTALL_TYPE="${37}"
+NETDATA_IS_PRIVATE_REGISTRY="${38}"
+NETDATA_USE_PRIVATE_REGISTRY="${39}"
+NETDATA_CONFIG_OOM_SCORE="${40}"
 
 # define body of request to be sent
 REQ_BODY="$(cat << EOF
@@ -80,6 +82,7 @@ REQ_BODY="$(cat << EOF
         "netdata_version": "${NETDATA_VERSION}",
         "netdata_buildinfo": ${NETDATA_BUILDINFO},
         "netdata_release_channel": ${NETDATA_CONFIG_RELEASE_CHANNEL},
+        "netdata_install_type": ${NETDATA_INSTALL_TYPE},
         "host_os_name": "${NETDATA_HOST_OS_NAME}",
         "host_os_id": "${NETDATA_HOST_OS_ID}",
         "host_os_id_like": "${NETDATA_HOST_OS_ID_LIKE}",
@@ -114,10 +117,14 @@ REQ_BODY="$(cat << EOF
         "config_page_cache_size": ${NETDATA_CONFIG_PAGE_CACHE_SIZE},
         "config_multidb_disk_quota": ${NETDATA_CONFIG_MULTIDB_DISK_QUOTA},
         "config_https_enabled": ${NETDATA_CONFIG_HTTPS_ENABLED},
+        "config_https_available": ${NETDATA_CONFIG_HTTPS_AVAILABLE},
         "config_web_enabled": ${NETDATA_CONFIG_WEB_ENABLED},
         "config_exporting_enabled": ${NETDATA_CONFIG_EXPORTING_ENABLED},
         "config_is_parent": ${NETDATA_CONFIG_IS_PARENT},
+        "config_is_private_registry": ${NETDATA_IS_PRIVATE_REGISTRY},
+        "config_private_registry_used": ${NETDATA_USE_PRIVATE_REGISTRY},
         "config_hosts_available": ${NETDATA_CONFIG_HOSTS_AVAILABLE},
+        "config_oom_score": ${NETDATA_CONFIG_OOM_SCORE},
         "alarms_normal": ${NETDATA_ALARMS_NORMAL},
         "alarms_warning": ${NETDATA_ALARMS_WARNING},
         "alarms_critical": ${NETDATA_ALARMS_CRITICAL},

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -22,6 +22,9 @@ if [ -f "@configdir_POST@/.opt-out-from-anonymous-statistics" ] || [ ! "${DO_NOT
   exit 0
 fi
 
+NETDATA_IS_IN_CI="false"
+[ ! -z "${CI}" ] && NETDATA_IS_IN_CI="true"
+
 # -------------------------------------------------------------------------------------------------
 # Get the extra variables
 
@@ -83,6 +86,7 @@ REQ_BODY="$(cat << EOF
         "netdata_buildinfo": ${NETDATA_BUILDINFO},
         "netdata_release_channel": ${NETDATA_CONFIG_RELEASE_CHANNEL},
         "netdata_install_type": ${NETDATA_INSTALL_TYPE},
+        "netdata_is_in_ci": ${NETDATA_IS_IN_CI},
         "host_os_name": "${NETDATA_HOST_OS_NAME}",
         "host_os_id": "${NETDATA_HOST_OS_ID}",
         "host_os_id_like": "${NETDATA_HOST_OS_ID_LIKE}",

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -22,9 +22,6 @@ if [ -f "@configdir_POST@/.opt-out-from-anonymous-statistics" ] || [ ! "${DO_NOT
   exit 0
 fi
 
-NETDATA_IS_IN_CI="false"
-[ -n "${CI}" ] && NETDATA_IS_IN_CI="true"
-
 # -------------------------------------------------------------------------------------------------
 # Get the extra variables
 
@@ -89,7 +86,6 @@ REQ_BODY="$(cat << EOF
         "netdata_release_channel": ${NETDATA_CONFIG_RELEASE_CHANNEL},
         "netdata_install_type": ${NETDATA_INSTALL_TYPE},
         "netdata_prebuilt_distro": ${NETDATA_PREBUILT_DISTRO},
-        "netdata_is_in_ci": ${NETDATA_IS_IN_CI},
         "host_os_name": "${NETDATA_HOST_OS_NAME}",
         "host_os_id": "${NETDATA_HOST_OS_ID}",
         "host_os_id_like": "${NETDATA_HOST_OS_ID_LIKE}",

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -23,7 +23,7 @@ if [ -f "@configdir_POST@/.opt-out-from-anonymous-statistics" ] || [ ! "${DO_NOT
 fi
 
 NETDATA_IS_IN_CI="false"
-[ ! -z "${CI}" ] && NETDATA_IS_IN_CI="true"
+[ -n "${CI}" ] && NETDATA_IS_IN_CI="true"
 
 # -------------------------------------------------------------------------------------------------
 # Get the extra variables

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -325,6 +325,8 @@ void analytics_build_info(BUFFER *b) {
     if(FEAT_DBENGINE)        buffer_strcat (b, "dbengine");
     if(FEAT_NATIVE_HTTPS)    buffer_strcat (b, "|Native HTTPS");
     if(FEAT_CLOUD)           buffer_strcat (b, "|Netdata Cloud");
+    if(FEAT_ACLK_NG)         buffer_strcat (b, "|ACLK Next Generation");
+    if(FEAT_ACLK_LEGACY)     buffer_strcat (b, "|ACLK Legacy");
     if(FEAT_TLS_HOST_VERIFY) buffer_strcat (b, "|TLS Host Verification");
 
     if(FEAT_JEMALLOC)        buffer_strcat (b, "|jemalloc");

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -325,8 +325,6 @@ void analytics_build_info(BUFFER *b) {
     if(FEAT_DBENGINE)        buffer_strcat (b, "dbengine");
     if(FEAT_NATIVE_HTTPS)    buffer_strcat (b, "|Native HTTPS");
     if(FEAT_CLOUD)           buffer_strcat (b, "|Netdata Cloud");
-    if(FEAT_ACLK_NG)         buffer_strcat (b, "|ACLK Next Generation");
-    if(FEAT_ACLK_LEGACY)     buffer_strcat (b, "|ACLK Legacy");
     if(FEAT_TLS_HOST_VERIFY) buffer_strcat (b, "|TLS Host Verification");
 
     if(FEAT_JEMALLOC)        buffer_strcat (b, "|jemalloc");

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -181,8 +181,10 @@ static void oom_score_adj(void) {
         return;
     }
 
-    if(old_score != 0)
+    if (old_score != 0) {
         wanted_score = old_score;
+        analytics_report_oom_score(old_score);
+    }
 
     // check the environment
     char *s = getenv("OOMScoreAdjust");
@@ -234,6 +236,7 @@ static void oom_score_adj(void) {
                 info("Adjusted my Out-Of-Memory (OOM) score from %d to %d.", (int)old_score, (int)final_score);
             else
                 error("Adjusted my Out-Of-Memory (OOM) score from %d to %d, but it has been set to %d.", (int)old_score, (int)wanted_score, (int)final_score);
+            analytics_report_oom_score(final_score);
         }
         else
             error("Failed to adjust my Out-Of-Memory (OOM) score to %d. Running with %d. (systemd systems may change it via netdata.service)", (int)wanted_score, (int)old_score);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1267,6 +1267,8 @@ int main(int argc, char **argv) {
 
     netdata_zero_metrics_enabled = config_get_boolean_ondemand(CONFIG_SECTION_GLOBAL, "enable zero metrics", CONFIG_BOOLEAN_NO);
 
+    set_late_global_environment();
+
     for (i = 0; static_threads[i].name != NULL ; i++) {
         struct netdata_static_thread *st = &static_threads[i];
 
@@ -1285,8 +1287,6 @@ int main(int argc, char **argv) {
 
     info("netdata initialization completed. Enjoy real-time performance monitoring!");
     netdata_ready = 1;
-
-    set_late_global_environment();
 
     send_statistics("START", "-",  "-");
     if (crash_detected)

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -4,6 +4,21 @@
 
 static struct engine *engine = NULL;
 
+void analytics_exporting_connectors_ssl(BUFFER *b)
+{
+#ifdef ENABLE_HTTPS
+    struct simple_connector_data *connector_specific_data;
+    for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
+        connector_specific_data = instance->connector_specific_data;
+        if (netdata_exporting_ctx && connector_specific_data->flags == NETDATA_SSL_HANDSHAKE_COMPLETE) {
+            buffer_strcat(b, "exporting");
+            break;
+        }
+    }
+#endif
+    buffer_strcat(b, "|");
+}
+
 void analytics_exporting_connectors(BUFFER *b)
 {
     if (!engine)

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -7,11 +7,13 @@ static struct engine *engine = NULL;
 void analytics_exporting_connectors_ssl(BUFFER *b)
 {
 #ifdef ENABLE_HTTPS
-    for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
-        struct simple_connector_data *connector_specific_data = instance->connector_specific_data;
-        if (netdata_exporting_ctx && connector_specific_data->flags == NETDATA_SSL_HANDSHAKE_COMPLETE) {
-            buffer_strcat(b, "exporting|");
-            break;
+    if (netdata_exporting_ctx) {
+        for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
+            struct simple_connector_data *connector_specific_data = instance->connector_specific_data;
+            if (connector_specific_data->flags == NETDATA_SSL_HANDSHAKE_COMPLETE) {
+                buffer_strcat(b, "exporting|");
+                break;
+            }
         }
     }
 #endif

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -10,7 +10,7 @@ void analytics_exporting_connectors_ssl(BUFFER *b)
     for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
         struct simple_connector_data *connector_specific_data = instance->connector_specific_data;
         if (netdata_exporting_ctx && connector_specific_data->flags == NETDATA_SSL_HANDSHAKE_COMPLETE) {
-            buffer_strcat(b, "exporting");
+            buffer_strcat(b, "exporting|");
             break;
         }
     }

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -11,7 +11,7 @@ void analytics_exporting_connectors_ssl(BUFFER *b)
         for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
             struct simple_connector_data *connector_specific_data = instance->connector_specific_data;
             if (connector_specific_data->flags == NETDATA_SSL_HANDSHAKE_COMPLETE) {
-                buffer_strcat(b, "exporting|");
+                buffer_strcat(b, "exporting");
                 break;
             }
         }

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -7,9 +7,8 @@ static struct engine *engine = NULL;
 void analytics_exporting_connectors_ssl(BUFFER *b)
 {
 #ifdef ENABLE_HTTPS
-    struct simple_connector_data *connector_specific_data;
     for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
-        connector_specific_data = instance->connector_specific_data;
+        struct simple_connector_data *connector_specific_data = instance->connector_specific_data;
         if (netdata_exporting_ctx && connector_specific_data->flags == NETDATA_SSL_HANDSHAKE_COMPLETE) {
             buffer_strcat(b, "exporting");
             break;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds a few more attributes to posthog, and makes a few changes.

Changes:

* Moves `set_late_global_environment()` before starting any threads to make sure that any events from other threads (e.g. exporting) carries those attributes.
* Provides the full agent version to analytics, instead of the short string of just the major version.
* Changes the first `META` event to be `META_START`

Adds:

* `netdata_is_in_ci`: To indicate whether this agent is in a CI environment.
* `config_oom_score`: The OOM score of the agent (assuming it can be read, and set).
* `netdata_install_type`: Tries to read the string from the `.install-type` file, in /etc/. If it doesn't exist, it will be set to an empty string.
* `config_private_registry_used`: If the user has specified a different than the default in `registry to announce`.
* `config_is_private_registry`: If the user has enabled private registry (Note: Does it also need to have a custom `registry to announce`?
* `config_https_available`: A list of three values, always on the same position, i.e. `exporting|streaming|web`. Each one will be there depending on the following:

If a user has added ssl keys in `/etc/` `ssl` folder, and the agent is able to use them, `web` will appear.
If along with that the user has enabled ssl for streaming, and it has been negotiated with the parent, `streaming` will appear.
If a user along with the keys has enabled ssl for exporting (I understand only some engines support it, if at least one has it enabled) `exporting` will appear in the string.

##### Component Name

Analytics

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Compile with `NETDATA_INTERNAL_CHECKS`, use the debug flag of `0x0000000080000000` and check the debug log if attributes are correctly picked up.

##### Additional Information

We'll leave this PR as a draft at the moment, to discuss the keys with @andrewm4894 and include a change to detect ACLK Legacy/NG, as soon as the changes for building both go into master.
