### PR TITLE
Added new postgres charts and updated standby charts to include slot_name if exists

### DIFF
--- a/collectors/python.d.plugin/postgres/README.md
+++ b/collectors/python.d.plugin/postgres/README.md
@@ -84,6 +84,18 @@ Following charts are drawn:
 14. **Average number of blocking transactions in db** processes
 
     - blocking
+    
+15. **Percent towards emergency autovac** percent
+
+    - percent
+
+16. **Oldest current XID** xid
+
+    - xid
+    
+17. **Percent towards wraparound** percent
+
+    - percent    
 
 ## Configuration
 

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -1019,7 +1019,7 @@ CHARTS = {
     'tx_wraparound_oldest_current_xid': {
         'options': [None, 'Oldest current XID', 'xid', 'tx_wraparound', 'postgres.tx_wraparound_oldest_current_xid', 'line'],
         'lines': [
-            ['oldest_current_xid', 'percent', 'absolute']
+            ['oldest_current_xid', 'xid', 'absolute']
         ]
     },
     'tx_wraparound_percent_towards_wraparound': {

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -55,6 +55,8 @@ QUERY_NAME_REPSLOT_FILES = 'REPSLOT_FILES'
 QUERY_NAME_IF_SUPERUSER = 'IF_SUPERUSER'
 QUERY_NAME_SERVER_VERSION = 'SERVER_VERSION'
 QUERY_NAME_AUTOVACUUM = 'AUTOVACUUM'
+QUERY_NAME_EMERGENCY_AUTOVACUUM = 'EMERGENCY_AUTOVACUUM'
+QUERY_NAME_TX_WRAPAROUND = 'TX_WRAPAROUND'
 QUERY_NAME_DIFF_LSN = 'DIFF_LSN'
 QUERY_NAME_WAL_WRITES = 'WAL_WRITES'
 
@@ -134,6 +136,13 @@ METRICS = {
         'vacuum',
         'vacuum_freeze',
         'brin_summarize'
+    ],
+    QUERY_NAME_EMERGENCY_AUTOVACUUM: [
+        'percent_towards_emergency_autovac'
+    ],
+    QUERY_NAME_TX_WRAPAROUND: [
+        'oldest_current_xid',
+        'percent_towards_wraparound'
     ],
     QUERY_NAME_STANDBY_DELTA: [
         'sent_delta',
@@ -453,10 +462,10 @@ WHERE
 QUERY_STANDBY = {
     DEFAULT: """
 SELECT
-    application_name
-FROM pg_stat_replication
-WHERE application_name IS NOT NULL
-GROUP BY application_name;
+    coalesce(prs.slot_name, psr.application_name) application_name
+FROM pg_stat_replication psr
+LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
+WHERE application_name IS NOT NULL;
 """,
 }
 
@@ -470,7 +479,7 @@ FROM pg_replication_slots;
 QUERY_STANDBY_DELTA = {
     DEFAULT: """
 SELECT
-    application_name,
+    coalesce(prs.slot_name, psr.application_name) application_name,
     pg_wal_lsn_diff(
       CASE pg_is_in_recovery()
         WHEN true THEN pg_last_wal_receive_lsn()
@@ -495,12 +504,13 @@ SELECT
         ELSE pg_current_wal_lsn()
       END,
     replay_lsn) AS replay_delta
-FROM pg_stat_replication
+FROM pg_stat_replication psr
+LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
 WHERE application_name IS NOT NULL;
 """,
     V96: """
 SELECT
-    application_name,
+    coalesce(prs.slot_name, psr.application_name) application_name,
     pg_xlog_location_diff(
       CASE pg_is_in_recovery()
         WHEN true THEN pg_last_xlog_receive_location()
@@ -525,7 +535,8 @@ SELECT
         ELSE pg_current_xlog_location()
       END,
     replay_location) AS replay_delta
-FROM pg_stat_replication
+FROM pg_stat_replication psr
+LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
 WHERE application_name IS NOT NULL;
 """,
 }
@@ -533,11 +544,12 @@ WHERE application_name IS NOT NULL;
 QUERY_STANDBY_LAG = {
     DEFAULT: """
 SELECT
-    application_name,
+    coalesce(prs.slot_name, psr.application_name) application_name,
     COALESCE(EXTRACT(EPOCH FROM write_lag)::bigint, 0) AS write_lag,
     COALESCE(EXTRACT(EPOCH FROM flush_lag)::bigint, 0) AS flush_lag,
     COALESCE(EXTRACT(EPOCH FROM replay_lag)::bigint, 0) AS replay_lag
-FROM pg_stat_replication
+FROM pg_stat_replication psr
+LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
 WHERE application_name IS NOT NULL;
 """
 }
@@ -650,6 +662,43 @@ WHERE query NOT LIKE '%%pg_stat_activity%%';
 """,
 }
 
+QUERY_EMERGENCY_AUTOVACUUM = {
+    DEFAULT: """
+WITH max_age AS (
+    SELECT setting AS autovacuum_freeze_max_age
+        FROM pg_catalog.pg_settings
+        WHERE name = 'autovacuum_freeze_max_age' )
+, per_database_stats AS (
+    SELECT datname
+        , m.autovacuum_freeze_max_age::int
+        , age(d.datfrozenxid) AS oldest_current_xid
+    FROM pg_catalog.pg_database d
+    JOIN max_age m ON (true)
+    WHERE d.datallowconn )
+SELECT max(ROUND(100*(oldest_current_xid/autovacuum_freeze_max_age::float))) AS percent_towards_emergency_autovac
+FROM per_database_stats;
+""",
+}
+
+QUERY_TX_WRAPAROUND = {
+    DEFAULT: """
+WITH max_age AS (
+    SELECT 2000000000 as max_old_xid
+        FROM pg_catalog.pg_settings
+        WHERE name = 'autovacuum_freeze_max_age' )
+, per_database_stats AS (
+    SELECT datname
+        , m.max_old_xid::int
+        , age(d.datfrozenxid) AS oldest_current_xid
+    FROM pg_catalog.pg_database d
+    JOIN max_age m ON (true)
+    WHERE d.datallowconn )
+SELECT max(oldest_current_xid) AS oldest_current_xid
+    , max(ROUND(100*(oldest_current_xid/max_old_xid::float))) AS percent_towards_wraparound
+FROM per_database_stats;
+""",
+}
+
 QUERY_DIFF_LSN = {
     DEFAULT: """
 SELECT
@@ -712,6 +761,10 @@ def query_factory(name, version=NO_VERSION):
         return QUERY_SHOW_VERSION[DEFAULT]
     elif name == QUERY_NAME_AUTOVACUUM:
         return QUERY_AUTOVACUUM[DEFAULT]
+    elif name == QUERY_NAME_EMERGENCY_AUTOVACUUM:
+        return QUERY_EMERGENCY_AUTOVACUUM[DEFAULT]
+    elif name == QUERY_NAME_TX_WRAPAROUND:
+        return QUERY_TX_WRAPAROUND[DEFAULT]
     elif name == QUERY_NAME_WAL:
         if version < 100000:
             return QUERY_WAL[V96]
@@ -767,7 +820,10 @@ ORDER = [
     'replication_slot',
     'standby_delta',
     'standby_lag',
-    'autovacuum'
+    'autovacuum',
+    'emergency_autovacuum',
+    'tx_wraparound_oldest_current_xid',
+    'tx_wraparound_percent_towards_wraparound'
 ]
 
 CHARTS = {
@@ -954,6 +1010,24 @@ CHARTS = {
             ['brin_summarize', 'brin summarize', 'absolute']
         ]
     },
+    'emergency_autovacuum': {
+        'options': [None, 'Percent towards emergency autovac', 'percent', 'autovacuum', 'postgres.emergency_autovacuum', 'line'],
+        'lines': [
+            ['percent_towards_emergency_autovac', 'percent', 'absolute']
+        ]
+    },
+    'tx_wraparound_oldest_current_xid': {
+        'options': [None, 'Oldest current XID', 'xid', 'tx_wraparound', 'postgres.tx_wraparound_oldest_current_xid', 'line'],
+        'lines': [
+            ['oldest_current_xid', 'percent', 'absolute']
+        ]
+    },
+    'tx_wraparound_percent_towards_wraparound': {
+        'options': [None, 'Percent towards wraparound', 'percent', 'tx_wraparound', 'postgres.percent_towards_wraparound', 'line'],
+        'lines': [
+            ['percent_towards_wraparound', 'percent', 'absolute']
+        ]
+    },
     'standby_delta': {
         'options': [None, 'Standby delta', 'KiB', 'replication delta', 'postgres.standby_delta', 'line'],
         'lines': [
@@ -1091,7 +1165,6 @@ class Service(SimpleService):
             cursor = self.conn.cursor(cursor_factory=DictCursor)
 
             self.data.update(zero_lock_types(self.databases))
-
             for query, metrics in self.queries.items():
                 self.query_stats(cursor, query, metrics)
 
@@ -1179,6 +1252,9 @@ class Service(SimpleService):
 
         if self.server_version >= 90400:
             self.queries[query_factory(QUERY_NAME_AUTOVACUUM)] = METRICS[QUERY_NAME_AUTOVACUUM]
+
+        self.queries[query_factory(QUERY_NAME_EMERGENCY_AUTOVACUUM)] = METRICS[QUERY_NAME_EMERGENCY_AUTOVACUUM]
+        self.queries[query_factory(QUERY_NAME_TX_WRAPAROUND)] = METRICS[QUERY_NAME_TX_WRAPAROUND]
 
         if self.server_version >= 100000:
             self.queries[query_factory(QUERY_NAME_STANDBY_LAG)] = METRICS[QUERY_NAME_STANDBY_LAG]

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -1,67 +1,67 @@
 # -*- coding: utf-8 -*-
-# description: example netdata python.d module
-# authors: facetoe, dangtranhoang
-# spdx-license-identifier: gpl-3.0-or-later
+# Description: example netdata python.d module
+# Authors: facetoe, dangtranhoang
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from copy import deepcopy
 
 try:
     import psycopg2
     from psycopg2 import extensions
-    from psycopg2.extras import dictcursor
-    from psycopg2 import operationalerror
+    from psycopg2.extras import DictCursor
+    from psycopg2 import OperationalError
 
-    psycopg2 = true
-except importerror:
-    psycopg2 = false
+    PSYCOPG2 = True
+except ImportError:
+    PSYCOPG2 = False
 
-from bases.frameworkservices.simpleservice import simpleservice
+from bases.FrameworkServices.SimpleService import SimpleService
 
-default_port = 5432
-default_user = 'postgres'
-default_connect_timeout = 2  # seconds
-default_statement_timeout = 5000  # ms
+DEFAULT_PORT = 5432
+DEFAULT_USER = 'postgres'
+DEFAULT_CONNECT_TIMEOUT = 2  # seconds
+DEFAULT_STATEMENT_TIMEOUT = 5000  # ms
 
-conn_param_dsn = 'dsn'
-conn_param_host = 'host'
-conn_param_port = 'port'
-conn_param_database = 'database'
-conn_param_user = 'user'
-conn_param_password = 'password'
-conn_param_conn_timeout = 'connect_timeout'
-conn_param_statement_timeout = 'statement_timeout'
-conn_param_ssl_mode = 'sslmode'
-conn_param_ssl_root_cert = 'sslrootcert'
-conn_param_ssl_crl = 'sslcrl'
-conn_param_ssl_cert = 'sslcert'
-conn_param_ssl_key = 'sslkey'
+CONN_PARAM_DSN = 'dsn'
+CONN_PARAM_HOST = 'host'
+CONN_PARAM_PORT = 'port'
+CONN_PARAM_DATABASE = 'database'
+CONN_PARAM_USER = 'user'
+CONN_PARAM_PASSWORD = 'password'
+CONN_PARAM_CONN_TIMEOUT = 'connect_timeout'
+CONN_PARAM_STATEMENT_TIMEOUT = 'statement_timeout'
+CONN_PARAM_SSL_MODE = 'sslmode'
+CONN_PARAM_SSL_ROOT_CERT = 'sslrootcert'
+CONN_PARAM_SSL_CRL = 'sslcrl'
+CONN_PARAM_SSL_CERT = 'sslcert'
+CONN_PARAM_SSL_KEY = 'sslkey'
 
-query_name_wal = 'wal'
-query_name_archive = 'archive'
-query_name_backends = 'backends'
-query_name_backend_usage = 'backend_usage'
-query_name_table_stats = 'table_stats'
-query_name_index_stats = 'index_stats'
-query_name_database = 'database'
-query_name_bgwriter = 'bgwriter'
-query_name_locks = 'locks'
-query_name_blockers = 'blockers'
-query_name_databases = 'databases'
-query_name_standby = 'standby'
-query_name_replication_slot = 'replication_slot'
-query_name_standby_delta = 'standby_delta'
-query_name_standby_lag = 'standby_lag'
-query_name_repslot_files = 'repslot_files'
-query_name_if_superuser = 'if_superuser'
-query_name_server_version = 'server_version'
-query_name_autovacuum = 'autovacuum'
-query_name_emergency_autovacuum = 'emergency_autovacuum'
-query_name_tx_wraparound = 'tx_wraparound'
-query_name_diff_lsn = 'diff_lsn'
-query_name_wal_writes = 'wal_writes'
+QUERY_NAME_WAL = 'WAL'
+QUERY_NAME_ARCHIVE = 'ARCHIVE'
+QUERY_NAME_BACKENDS = 'BACKENDS'
+QUERY_NAME_BACKEND_USAGE = 'BACKEND_USAGE'
+QUERY_NAME_TABLE_STATS = 'TABLE_STATS'
+QUERY_NAME_INDEX_STATS = 'INDEX_STATS'
+QUERY_NAME_DATABASE = 'DATABASE'
+QUERY_NAME_BGWRITER = 'BGWRITER'
+QUERY_NAME_LOCKS = 'LOCKS'
+QUERY_NAME_BLOCKERS = 'BLOCKERS'
+QUERY_NAME_DATABASES = 'DATABASES'
+QUERY_NAME_STANDBY = 'STANDBY'
+QUERY_NAME_REPLICATION_SLOT = 'REPLICATION_SLOT'
+QUERY_NAME_STANDBY_DELTA = 'STANDBY_DELTA'
+QUERY_NAME_STANDBY_LAG = 'STANDBY_LAG'
+QUERY_NAME_REPSLOT_FILES = 'REPSLOT_FILES'
+QUERY_NAME_IF_SUPERUSER = 'IF_SUPERUSER'
+QUERY_NAME_SERVER_VERSION = 'SERVER_VERSION'
+QUERY_NAME_AUTOVACUUM = 'AUTOVACUUM'
+QUERY_NAME_EMERGENCY_AUTOVACUUM = 'EMERGENCY_AUTOVACUUM'
+QUERY_NAME_TX_WRAPAROUND = 'TX_WRAPAROUND'
+QUERY_NAME_DIFF_LSN = 'DIFF_LSN'
+QUERY_NAME_WAL_WRITES = 'WAL_WRITES'
 
-metrics = {
-    query_name_database: [
+METRICS = {
+    QUERY_NAME_DATABASE: [
         'connections',
         'xact_commit',
         'xact_rollback',
@@ -77,36 +77,36 @@ metrics = {
         'temp_bytes',
         'size'
     ],
-    query_name_backends: [
+    QUERY_NAME_BACKENDS: [
         'backends_active',
         'backends_idle'
     ],
-    query_name_backend_usage: [
+    QUERY_NAME_BACKEND_USAGE: [
         'available',
         'used'
     ],
-    query_name_index_stats: [
+    QUERY_NAME_INDEX_STATS: [
         'index_count',
         'index_size'
     ],
-    query_name_table_stats: [
+    QUERY_NAME_TABLE_STATS: [
         'table_size',
         'table_count'
     ],
-    query_name_wal: [
+    QUERY_NAME_WAL: [
         'written_wal',
         'recycled_wal',
         'total_wal'
     ],
-    query_name_wal_writes: [
+    QUERY_NAME_WAL_WRITES: [
         'wal_writes'
     ],
-    query_name_archive: [
+    QUERY_NAME_ARCHIVE: [
         'ready_count',
         'done_count',
         'file_count'
     ],
-    query_name_bgwriter: [
+    QUERY_NAME_BGWRITER: [
         'checkpoint_scheduled',
         'checkpoint_requested',
         'buffers_checkpoint',
@@ -116,682 +116,682 @@ metrics = {
         'buffers_alloc',
         'buffers_backend_fsync'
     ],
-    query_name_locks: [
-        'exclusivelock',
-        'rowsharelock',
-        'sireadlock',
-        'shareupdateexclusivelock',
-        'accessexclusivelock',
-        'accesssharelock',
-        'sharerowexclusivelock',
-        'sharelock',
-        'rowexclusivelock'
+    QUERY_NAME_LOCKS: [
+        'ExclusiveLock',
+        'RowShareLock',
+        'SIReadLock',
+        'ShareUpdateExclusiveLock',
+        'AccessExclusiveLock',
+        'AccessShareLock',
+        'ShareRowExclusiveLock',
+        'ShareLock',
+        'RowExclusiveLock'
     ],
-    query_name_blockers: [
+    QUERY_NAME_BLOCKERS: [
         'blocking_pids_avg'
     ],
-    query_name_autovacuum: [
+    QUERY_NAME_AUTOVACUUM: [
         'analyze',
         'vacuum_analyze',
         'vacuum',
         'vacuum_freeze',
         'brin_summarize'
     ],
-    query_name_emergency_autovacuum: [
+    QUERY_NAME_EMERGENCY_AUTOVACUUM: [
         'percent_towards_emergency_autovac'
     ],
-    query_name_tx_wraparound: [
+    QUERY_NAME_TX_WRAPAROUND: [
         'oldest_current_xid',
         'percent_towards_wraparound'
     ],
-    query_name_standby_delta: [
+    QUERY_NAME_STANDBY_DELTA: [
         'sent_delta',
         'write_delta',
         'flush_delta',
         'replay_delta'
     ],
-    query_name_standby_lag: [
+    QUERY_NAME_STANDBY_LAG: [
         'write_lag',
         'flush_lag',
         'replay_lag'
     ],
-    query_name_repslot_files: [
+    QUERY_NAME_REPSLOT_FILES: [
         'replslot_wal_keep',
         'replslot_files'
     ]
 }
 
-no_version = 0
-default = 'default'
-v72 = 'v72'
-v82 = 'v82'
-v91 = 'v91'
-v92 = 'v92'
-v96 = 'v96'
-v10 = 'v10'
-v11 = 'v11'
+NO_VERSION = 0
+DEFAULT = 'DEFAULT'
+V72 = 'V72'
+V82 = 'V82'
+V91 = 'V91'
+V92 = 'V92'
+V96 = 'V96'
+V10 = 'V10'
+V11 = 'V11'
 
-query_wal = {
-    default: """
-select
+QUERY_WAL = {
+    DEFAULT: """
+SELECT
     count(*) as total_wal,
-    count(*) filter (where type = 'recycled') as recycled_wal,
-    count(*) filter (where type = 'written') as written_wal
-from
-    (select
+    count(*) FILTER (WHERE type = 'recycled') AS recycled_wal,
+    count(*) FILTER (WHERE type = 'written') AS written_wal
+FROM
+    (SELECT
         wal.name,
         pg_walfile_name(
-          case pg_is_in_recovery()
-            when true then null
-            else pg_current_wal_lsn()
-          end ),
-        case
-          when wal.name > pg_walfile_name(
-            case pg_is_in_recovery()
-              when true then null
-              else pg_current_wal_lsn()
-            end ) then 'recycled'
-          else 'written'
-        end as type
-    from pg_catalog.pg_ls_dir('pg_wal') as wal(name)
-    where name ~ '^[0-9a-f]{24}$'
-    order by
+          CASE pg_is_in_recovery()
+            WHEN true THEN NULL
+            ELSE pg_current_wal_lsn()
+          END ),
+        CASE
+          WHEN wal.name > pg_walfile_name(
+            CASE pg_is_in_recovery()
+              WHEN true THEN NULL
+              ELSE pg_current_wal_lsn()
+            END ) THEN 'recycled'
+          ELSE 'written'
+        END AS type
+    FROM pg_catalog.pg_ls_dir('pg_wal') AS wal(name)
+    WHERE name ~ '^[0-9A-F]{24}$'
+    ORDER BY
         (pg_stat_file('pg_wal/'||name)).modification,
-        wal.name desc) sub;
+        wal.name DESC) sub;
 """,
-    v96: """
-select
+    V96: """
+SELECT
     count(*) as total_wal,
-    count(*) filter (where type = 'recycled') as recycled_wal,
-    count(*) filter (where type = 'written') as written_wal
-from
-    (select
+    count(*) FILTER (WHERE type = 'recycled') AS recycled_wal,
+    count(*) FILTER (WHERE type = 'written') AS written_wal
+FROM
+    (SELECT
         wal.name,
         pg_xlogfile_name(
-          case pg_is_in_recovery()
-            when true then null
-            else pg_current_xlog_location()
-          end ),
-        case
-          when wal.name > pg_xlogfile_name(
-            case pg_is_in_recovery()
-              when true then null
-              else pg_current_xlog_location()
-            end ) then 'recycled'
-          else 'written'
-        end as type
-    from pg_catalog.pg_ls_dir('pg_xlog') as wal(name)
-    where name ~ '^[0-9a-f]{24}$'
-    order by
+          CASE pg_is_in_recovery()
+            WHEN true THEN NULL
+            ELSE pg_current_xlog_location()
+          END ),
+        CASE
+          WHEN wal.name > pg_xlogfile_name(
+            CASE pg_is_in_recovery()
+              WHEN true THEN NULL
+              ELSE pg_current_xlog_location()
+            END ) THEN 'recycled'
+          ELSE 'written'
+        END AS type
+    FROM pg_catalog.pg_ls_dir('pg_xlog') AS wal(name)
+    WHERE name ~ '^[0-9A-F]{24}$'
+    ORDER BY
         (pg_stat_file('pg_xlog/'||name)).modification,
-        wal.name desc) sub;
+        wal.name DESC) sub;
 """,
 }
 
-query_archive = {
-    default: """
-select
-    cast(count(*) as int) as file_count,
-    cast(coalesce(sum(cast(archive_file ~ $r$\.ready$$r$ as int)),0) as int) as ready_count,
-    cast(coalesce(sum(cast(archive_file ~ $r$\.done$$r$ as int)),0) as int) as done_count
-from
-    pg_catalog.pg_ls_dir('pg_wal/archive_status') as archive_files (archive_file);
+QUERY_ARCHIVE = {
+    DEFAULT: """
+SELECT
+    CAST(COUNT(*) AS INT) AS file_count,
+    CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.ready$$r$ as INT)),0) AS INT) AS ready_count,
+    CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.done$$r$ AS INT)),0) AS INT) AS done_count
+FROM
+    pg_catalog.pg_ls_dir('pg_wal/archive_status') AS archive_files (archive_file);
 """,
-    v96: """
-select
-    cast(count(*) as int) as file_count,
-    cast(coalesce(sum(cast(archive_file ~ $r$\.ready$$r$ as int)),0) as int) as ready_count,
-    cast(coalesce(sum(cast(archive_file ~ $r$\.done$$r$ as int)),0) as int) as done_count
-from
-    pg_catalog.pg_ls_dir('pg_xlog/archive_status') as archive_files (archive_file);
+    V96: """
+SELECT
+    CAST(COUNT(*) AS INT) AS file_count,
+    CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.ready$$r$ as INT)),0) AS INT) AS ready_count,
+    CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.done$$r$ AS INT)),0) AS INT) AS done_count
+FROM
+    pg_catalog.pg_ls_dir('pg_xlog/archive_status') AS archive_files (archive_file);
 
 """,
 }
 
-query_backend = {
-    default: """
-select
-    count(*) - (select  count(*)
-                from pg_stat_activity
-                where state = 'idle')
-      as backends_active,
-    (select count(*)
-     from pg_stat_activity
-     where state = 'idle')
-      as backends_idle
-from pg_stat_activity;
+QUERY_BACKEND = {
+    DEFAULT: """
+SELECT
+    count(*) - (SELECT  count(*)
+                FROM pg_stat_activity
+                WHERE state = 'idle')
+      AS backends_active,
+    (SELECT count(*)
+     FROM pg_stat_activity
+     WHERE state = 'idle')
+      AS backends_idle
+FROM pg_stat_activity;
 """,
 }
 
-query_backend_usage = {
-    default: """
-select
-    count(1) as used,
+QUERY_BACKEND_USAGE = {
+    DEFAULT: """
+SELECT
+    COUNT(1) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - count(1) as available
-from pg_catalog.pg_stat_activity
-where backend_type in ('client backend', 'background worker');
+    - COUNT(1) AS available
+FROM pg_catalog.pg_stat_activity
+WHERE backend_type IN ('client backend', 'background worker');
 """,
-    v10: """
-select
-    sum(s.conn) as used,
+    V10: """
+SELECT
+    SUM(s.conn) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - sum(s.conn) as available
-from (
-    select 's' as type, count(1) as conn
-    from pg_catalog.pg_stat_activity
-    where backend_type in ('client backend', 'background worker')
-    union all
-    select 'r', count(1)
-    from pg_catalog.pg_stat_replication
+    - SUM(s.conn) AS available
+FROM (
+    SELECT 's' as type, COUNT(1) as conn
+    FROM pg_catalog.pg_stat_activity
+    WHERE backend_type IN ('client backend', 'background worker')
+    UNION ALL
+    SELECT 'r', COUNT(1)
+    FROM pg_catalog.pg_stat_replication
 ) as s;
 """,
-    v92: """
-select
-    sum(s.conn) as used,
+    V92: """
+SELECT
+    SUM(s.conn) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - sum(s.conn) as available
-from (
-    select 's' as type, count(1) as conn
-    from pg_catalog.pg_stat_activity
-    where query not like 'autovacuum: %%'
-    union all
-    select 'r', count(1)
-    from pg_catalog.pg_stat_replication
+    - SUM(s.conn) AS available
+FROM (
+    SELECT 's' as type, COUNT(1) as conn
+    FROM pg_catalog.pg_stat_activity
+    WHERE query NOT LIKE 'autovacuum: %%'
+    UNION ALL
+    SELECT 'r', COUNT(1)
+    FROM pg_catalog.pg_stat_replication
 ) as s;
 """,
-    v91: """
-select
-    sum(s.conn) as used,
+    V91: """
+SELECT
+    SUM(s.conn) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - sum(s.conn) as available
-from (
-    select 's' as type, count(1) as conn
-    from pg_catalog.pg_stat_activity
-    where current_query not like 'autovacuum: %%'
-    union all
-    select 'r', count(1)
-    from pg_catalog.pg_stat_replication
+    - SUM(s.conn) AS available
+FROM (
+    SELECT 's' as type, COUNT(1) as conn
+    FROM pg_catalog.pg_stat_activity
+    WHERE current_query NOT LIKE 'autovacuum: %%'
+    UNION ALL
+    SELECT 'r', COUNT(1)
+    FROM pg_catalog.pg_stat_replication
 ) as s;
 """,
-    v82: """
-select
-    count(1) as used,
+    V82: """
+SELECT
+    COUNT(1) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - count(1) as available
-from pg_catalog.pg_stat_activity
-where current_query not like 'autovacuum: %%';
+    - COUNT(1) AS available
+FROM pg_catalog.pg_stat_activity
+WHERE current_query NOT LIKE 'autovacuum: %%';
 """,
-    v72: """
-select
-    count(1) as used,
+    V72: """
+SELECT
+    COUNT(1) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - count(1) as available
-from pg_catalog.pg_stat_activity s
-join pg_catalog.pg_database d on d.oid = s.datid
-where d.datallowconn;
+    - COUNT(1) AS available
+FROM pg_catalog.pg_stat_activity s
+JOIN pg_catalog.pg_database d ON d.oid = s.datid
+WHERE d.datallowconn;
 """,
 }
 
-query_table_stats = {
-    default: """
-select
-    ((sum(relpages) * 8) * 1024) as table_size,
-    count(1)                     as table_count
-from pg_class
-where relkind in ('r', 't');
+QUERY_TABLE_STATS = {
+    DEFAULT: """
+SELECT
+    ((sum(relpages) * 8) * 1024) AS table_size,
+    count(1)                     AS table_count
+FROM pg_class
+WHERE relkind IN ('r', 't');
 """,
 }
 
-query_index_stats = {
-    default: """
-select
-    ((sum(relpages) * 8) * 1024) as index_size,
-    count(1)                     as index_count
-from pg_class
-where relkind = 'i';
+QUERY_INDEX_STATS = {
+    DEFAULT: """
+SELECT
+    ((sum(relpages) * 8) * 1024) AS index_size,
+    count(1)                     AS index_count
+FROM pg_class
+WHERE relkind = 'i';
 """,
 }
 
-query_database = {
-    default: """
-select
-    datname as database_name,
-    numbackends as connections,
-    xact_commit as xact_commit,
-    xact_rollback as xact_rollback,
-    blks_read as blks_read,
-    blks_hit as blks_hit,
-    tup_returned as tup_returned,
-    tup_fetched as tup_fetched,
-    tup_inserted as tup_inserted,
-    tup_updated as tup_updated,
-    tup_deleted as tup_deleted,
-    conflicts as conflicts,
-    pg_database_size(datname) as size,
-    temp_files as temp_files,
-    temp_bytes as temp_bytes
-from pg_stat_database
-where datname in %(databases)s ;
+QUERY_DATABASE = {
+    DEFAULT: """
+SELECT
+    datname AS database_name,
+    numbackends AS connections,
+    xact_commit AS xact_commit,
+    xact_rollback AS xact_rollback,
+    blks_read AS blks_read,
+    blks_hit AS blks_hit,
+    tup_returned AS tup_returned,
+    tup_fetched AS tup_fetched,
+    tup_inserted AS tup_inserted,
+    tup_updated AS tup_updated,
+    tup_deleted AS tup_deleted,
+    conflicts AS conflicts,
+    pg_database_size(datname) AS size,
+    temp_files AS temp_files,
+    temp_bytes AS temp_bytes
+FROM pg_stat_database
+WHERE datname IN %(databases)s ;
 """,
 }
 
-query_bgwriter = {
-    default: """
-select
-    checkpoints_timed as checkpoint_scheduled,
-    checkpoints_req as checkpoint_requested,
+QUERY_BGWRITER = {
+    DEFAULT: """
+SELECT
+    checkpoints_timed AS checkpoint_scheduled,
+    checkpoints_req AS checkpoint_requested,
     buffers_checkpoint * current_setting('block_size')::numeric buffers_checkpoint,
     buffers_clean * current_setting('block_size')::numeric buffers_clean,
     maxwritten_clean,
     buffers_backend * current_setting('block_size')::numeric buffers_backend,
     buffers_alloc * current_setting('block_size')::numeric buffers_alloc,
     buffers_backend_fsync
-from pg_stat_bgwriter;
+FROM pg_stat_bgwriter;
 """,
 }
 
-query_locks = {
-    default: """
-select
+QUERY_LOCKS = {
+    DEFAULT: """
+SELECT
     pg_database.datname as database_name,
     mode,
-    count(mode) as locks_count
-from pg_locks
-inner join pg_database
-    on pg_database.oid = pg_locks.database
-group by datname, mode
-order by datname, mode;
+    count(mode) AS locks_count
+FROM pg_locks
+INNER JOIN pg_database
+    ON pg_database.oid = pg_locks.database
+GROUP BY datname, mode
+ORDER BY datname, mode;
 """,
 }
 
-query_blockers = {
-    default: """
-with b as (
-select distinct
+QUERY_BLOCKERS = {
+    DEFAULT: """
+WITH B AS (
+SELECT DISTINCT
     pg_database.datname as database_name,
     pg_locks.pid,
-    cardinality(pg_blocking_pids(pg_locks.pid)) as blocking_pids
-from pg_locks
-inner join pg_database on pg_database.oid = pg_locks.database
-where not pg_locks.granted)
-select database_name, avg(blocking_pids) as blocking_pids_avg
-from b
-group by database_name
+    cardinality(pg_blocking_pids(pg_locks.pid)) AS blocking_pids
+FROM pg_locks
+INNER JOIN pg_database ON pg_database.oid = pg_locks.database
+WHERE NOT pg_locks.granted)
+SELECT database_name, AVG(blocking_pids) AS blocking_pids_avg
+FROM B
+GROUP BY database_name
 """,
-    v96: """
-with b as (
-select distinct
+    V96: """
+WITH B AS (
+SELECT DISTINCT
     pg_database.datname as database_name,
-    blocked_locks.pid as blocked_pid,
-    count(blocking_locks.pid) as blocking_pids
-from  pg_catalog.pg_locks blocked_locks
-inner join pg_database on pg_database.oid = blocked_locks.database
-join pg_catalog.pg_locks blocking_locks
-        on blocking_locks.locktype = blocked_locks.locktype
-        and blocking_locks.database is not distinct from blocked_locks.database
-        and blocking_locks.relation is not distinct from blocked_locks.relation
-        and blocking_locks.page is not distinct from blocked_locks.page
-        and blocking_locks.tuple is not distinct from blocked_locks.tuple
-        and blocking_locks.virtualxid is not distinct from blocked_locks.virtualxid
-        and blocking_locks.transactionid is not distinct from blocked_locks.transactionid
-        and blocking_locks.classid is not distinct from blocked_locks.classid
-        and blocking_locks.objid is not distinct from blocked_locks.objid
-        and blocking_locks.objsubid is not distinct from blocked_locks.objsubid
-        and blocking_locks.pid != blocked_locks.pid
-where not blocked_locks.granted
-group by database_name, blocked_pid)
-select database_name, avg(blocking_pids) as blocking_pids_avg
-from b
-group by database_name
+    blocked_locks.pid AS blocked_pid,
+    COUNT(blocking_locks.pid) AS blocking_pids
+FROM  pg_catalog.pg_locks blocked_locks
+INNER JOIN pg_database ON pg_database.oid = blocked_locks.database
+JOIN pg_catalog.pg_locks blocking_locks
+        ON blocking_locks.locktype = blocked_locks.locktype
+        AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
+        AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+        AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+        AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+        AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+        AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+        AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+        AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+        AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+        AND blocking_locks.pid != blocked_locks.pid
+WHERE NOT blocked_locks.GRANTED
+GROUP BY database_name, blocked_pid)
+SELECT database_name, AVG(blocking_pids) AS blocking_pids_avg
+FROM B
+GROUP BY database_name
 """
 }
 
-query_databases = {
-    default: """
-select
+QUERY_DATABASES = {
+    DEFAULT: """
+SELECT
     datname
-from pg_stat_database
-where
+FROM pg_stat_database
+WHERE
     has_database_privilege(
-      (select current_user), datname, 'connect')
-    and not datname ~* '^template\d';
+      (SELECT current_user), datname, 'connect')
+    AND NOT datname ~* '^template\d';
 """,
 }
 
-query_standby = {
-    default: """
-select
+QUERY_STANDBY = {
+    DEFAULT: """
+SELECT
     coalesce(prs.slot_name, psr.application_name) application_name
-from pg_stat_replication psr
-left outer join pg_replication_slots prs on psr.pid = prs.active_pid
-where application_name is not null;
+FROM pg_stat_replication psr
+LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
+WHERE application_name IS NOT NULL;
 """,
 }
 
-query_replication_slot = {
-    default: """
-select slot_name
-from pg_replication_slots;
+QUERY_REPLICATION_SLOT = {
+    DEFAULT: """
+SELECT slot_name
+FROM pg_replication_slots;
 """
 }
 
-query_standby_delta = {
-    default: """
-select
+QUERY_STANDBY_DELTA = {
+    DEFAULT: """
+SELECT
     coalesce(prs.slot_name, psr.application_name) application_name,
     pg_wal_lsn_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_wal_receive_lsn()
-        else pg_current_wal_lsn()
-      end,
-    sent_lsn) as sent_delta,
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_wal_receive_lsn()
+        ELSE pg_current_wal_lsn()
+      END,
+    sent_lsn) AS sent_delta,
     pg_wal_lsn_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_wal_receive_lsn()
-        else pg_current_wal_lsn()
-      end,
-    write_lsn) as write_delta,
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_wal_receive_lsn()
+        ELSE pg_current_wal_lsn()
+      END,
+    write_lsn) AS write_delta,
     pg_wal_lsn_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_wal_receive_lsn()
-        else pg_current_wal_lsn()
-      end,
-    flush_lsn) as flush_delta,
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_wal_receive_lsn()
+        ELSE pg_current_wal_lsn()
+      END,
+    flush_lsn) AS flush_delta,
     pg_wal_lsn_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_wal_receive_lsn()
-        else pg_current_wal_lsn()
-      end,
-    replay_lsn) as replay_delta
-from pg_stat_replication psr
-left outer join pg_replication_slots prs on psr.pid = prs.active_pid
-where application_name is not null;
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_wal_receive_lsn()
+        ELSE pg_current_wal_lsn()
+      END,
+    replay_lsn) AS replay_delta
+FROM pg_stat_replication psr
+LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
+WHERE application_name IS NOT NULL;
 """,
-    v96: """
-select
+    V96: """
+SELECT
     coalesce(prs.slot_name, psr.application_name) application_name,
     pg_xlog_location_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_xlog_receive_location()
-        else pg_current_xlog_location()
-      end,
-    sent_location) as sent_delta,
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_xlog_receive_location()
+        ELSE pg_current_xlog_location()
+      END,
+    sent_location) AS sent_delta,
     pg_xlog_location_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_xlog_receive_location()
-        else pg_current_xlog_location()
-      end,
-    write_location) as write_delta,
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_xlog_receive_location()
+        ELSE pg_current_xlog_location()
+      END,
+    write_location) AS write_delta,
     pg_xlog_location_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_xlog_receive_location()
-        else pg_current_xlog_location()
-      end,
-    flush_location) as flush_delta,
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_xlog_receive_location()
+        ELSE pg_current_xlog_location()
+      END,
+    flush_location) AS flush_delta,
     pg_xlog_location_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_xlog_receive_location()
-        else pg_current_xlog_location()
-      end,
-    replay_location) as replay_delta
-from pg_stat_replication psr
-left outer join pg_replication_slots prs on psr.pid = prs.active_pid
-where application_name is not null;
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_xlog_receive_location()
+        ELSE pg_current_xlog_location()
+      END,
+    replay_location) AS replay_delta
+FROM pg_stat_replication psr
+LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
+WHERE application_name IS NOT NULL;
 """,
 }
 
-query_standby_lag = {
-    default: """
-select
+QUERY_STANDBY_LAG = {
+    DEFAULT: """
+SELECT
     coalesce(prs.slot_name, psr.application_name) application_name,
-    coalesce(extract(epoch from write_lag)::bigint, 0) as write_lag,
-    coalesce(extract(epoch from flush_lag)::bigint, 0) as flush_lag,
-    coalesce(extract(epoch from replay_lag)::bigint, 0) as replay_lag
-from pg_stat_replication psr
-left outer join pg_replication_slots prs on psr.pid = prs.active_pid
-where application_name is not null;
+    COALESCE(EXTRACT(EPOCH FROM write_lag)::bigint, 0) AS write_lag,
+    COALESCE(EXTRACT(EPOCH FROM flush_lag)::bigint, 0) AS flush_lag,
+    COALESCE(EXTRACT(EPOCH FROM replay_lag)::bigint, 0) AS replay_lag
+FROM pg_stat_replication psr
+LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
+WHERE application_name IS NOT NULL;
 """
 }
 
-query_repslot_files = {
-    default: """
-with wal_size as (
-  select
-    setting::int as val
-  from pg_settings
-  where name = 'wal_segment_size'
+QUERY_REPSLOT_FILES = {
+    DEFAULT: """
+WITH wal_size AS (
+  SELECT
+    setting::int AS val
+  FROM pg_settings
+  WHERE name = 'wal_segment_size'
   )
-select
+SELECT
     slot_name,
     slot_type,
     replslot_wal_keep,
-    count(slot_file) as replslot_files
-from
-    (select
+    count(slot_file) AS replslot_files
+FROM
+    (SELECT
         slot.slot_name,
-        case
-            when slot_file <> 'state' then 1
-        end as slot_file ,
+        CASE
+            WHEN slot_file <> 'state' THEN 1
+        END AS slot_file ,
         slot_type,
-        coalesce (
+        COALESCE (
           floor(
             (pg_wal_lsn_diff(pg_current_wal_lsn (),slot.restart_lsn)
              - (pg_walfile_name_offset (restart_lsn)).file_offset) / (s.val)
-          ),0) as replslot_wal_keep
-    from pg_replication_slots slot
-    left join (
-        select
+          ),0) AS replslot_wal_keep
+    FROM pg_replication_slots slot
+    LEFT JOIN (
+        SELECT
             slot2.slot_name,
-            pg_ls_dir('pg_replslot/' || slot2.slot_name) as slot_file
-        from pg_replication_slots slot2
+            pg_ls_dir('pg_replslot/' || slot2.slot_name) AS slot_file
+        FROM pg_replication_slots slot2
         ) files (slot_name, slot_file)
-        on slot.slot_name = files.slot_name
-    cross join wal_size s
-    ) as d
-group by
+        ON slot.slot_name = files.slot_name
+    CROSS JOIN wal_size s
+    ) AS d
+GROUP BY
     slot_name,
     slot_type,
     replslot_wal_keep;
 """,
-    v10: """
-with wal_size as (
-  select
-    current_setting('wal_block_size')::int * setting::int as val
-  from pg_settings
-  where name = 'wal_segment_size'
+    V10: """
+WITH wal_size AS (
+  SELECT
+    current_setting('wal_block_size')::INT * setting::INT AS val
+  FROM pg_settings
+  WHERE name = 'wal_segment_size'
   )
-select
+SELECT
     slot_name,
     slot_type,
     replslot_wal_keep,
-    count(slot_file) as replslot_files
-from
-    (select
+    count(slot_file) AS replslot_files
+FROM
+    (SELECT
         slot.slot_name,
-        case
-            when slot_file <> 'state' then 1
-        end as slot_file ,
+        CASE
+            WHEN slot_file <> 'state' THEN 1
+        END AS slot_file ,
         slot_type,
-        coalesce (
+        COALESCE (
           floor(
             (pg_wal_lsn_diff(pg_current_wal_lsn (),slot.restart_lsn)
              - (pg_walfile_name_offset (restart_lsn)).file_offset) / (s.val)
-          ),0) as replslot_wal_keep
-    from pg_replication_slots slot
-    left join (
-        select
+          ),0) AS replslot_wal_keep
+    FROM pg_replication_slots slot
+    LEFT JOIN (
+        SELECT
             slot2.slot_name,
-            pg_ls_dir('pg_replslot/' || slot2.slot_name) as slot_file
-        from pg_replication_slots slot2
+            pg_ls_dir('pg_replslot/' || slot2.slot_name) AS slot_file
+        FROM pg_replication_slots slot2
         ) files (slot_name, slot_file)
-        on slot.slot_name = files.slot_name
-    cross join wal_size s
-    ) as d
-group by
+        ON slot.slot_name = files.slot_name
+    CROSS JOIN wal_size s
+    ) AS d
+GROUP BY
     slot_name,
     slot_type,
     replslot_wal_keep;
 """,
 }
 
-query_superuser = {
-    default: """
-select current_setting('is_superuser') = 'on' as is_superuser;
+QUERY_SUPERUSER = {
+    DEFAULT: """
+SELECT current_setting('is_superuser') = 'on' AS is_superuser;
 """,
 }
 
-query_show_version = {
-    default: """
-show server_version_num;
+QUERY_SHOW_VERSION = {
+    DEFAULT: """
+SHOW server_version_num;
 """,
 }
 
-query_autovacuum = {
-    default: """
-select
-    count(*) filter (where query like 'autovacuum: analyze%%') as analyze,
-    count(*) filter (where query like 'autovacuum: vacuum analyze%%') as vacuum_analyze,
-    count(*) filter (where query like 'autovacuum: vacuum%%'
-                       and query not like 'autovacuum: vacuum analyze%%'
-                       and query not like '%%to prevent wraparound%%') as vacuum,
-    count(*) filter (where query like '%%to prevent wraparound%%') as vacuum_freeze,
-    count(*) filter (where query like 'autovacuum: brin summarize%%') as brin_summarize
-from pg_stat_activity
-where query not like '%%pg_stat_activity%%';
+QUERY_AUTOVACUUM = {
+    DEFAULT: """
+SELECT
+    count(*) FILTER (WHERE query LIKE 'autovacuum: ANALYZE%%') AS analyze,
+    count(*) FILTER (WHERE query LIKE 'autovacuum: VACUUM ANALYZE%%') AS vacuum_analyze,
+    count(*) FILTER (WHERE query LIKE 'autovacuum: VACUUM%%'
+                       AND query NOT LIKE 'autovacuum: VACUUM ANALYZE%%'
+                       AND query NOT LIKE '%%to prevent wraparound%%') AS vacuum,
+    count(*) FILTER (WHERE query LIKE '%%to prevent wraparound%%') AS vacuum_freeze,
+    count(*) FILTER (WHERE query LIKE 'autovacuum: BRIN summarize%%') AS brin_summarize
+FROM pg_stat_activity
+WHERE query NOT LIKE '%%pg_stat_activity%%';
 """,
 }
 
-query_emergency_autovacuum = {
-    default: """
-with max_age as (
-    select setting as autovacuum_freeze_max_age
-        from pg_catalog.pg_settings
-        where name = 'autovacuum_freeze_max_age' )
-, per_database_stats as (
-    select datname
+QUERY_EMERGENCY_AUTOVACUUM = {
+    DEFAULT: """
+WITH max_age AS (
+    SELECT setting AS autovacuum_freeze_max_age
+        FROM pg_catalog.pg_settings
+        WHERE name = 'autovacuum_freeze_max_age' )
+, per_database_stats AS (
+    SELECT datname
         , m.autovacuum_freeze_max_age::int
-        , age(d.datfrozenxid) as oldest_current_xid
-    from pg_catalog.pg_database d
-    join max_age m on (true)
-    where d.datallowconn )
-select max(round(100*(oldest_current_xid/autovacuum_freeze_max_age::float))) as percent_towards_emergency_autovac
-from per_database_stats;
+        , age(d.datfrozenxid) AS oldest_current_xid
+    FROM pg_catalog.pg_database d
+    JOIN max_age m ON (true)
+    WHERE d.datallowconn )
+SELECT max(ROUND(100*(oldest_current_xid/autovacuum_freeze_max_age::float))) AS percent_towards_emergency_autovac
+FROM per_database_stats;
 """,
 }
 
-query_tx_wraparound = {
-    default: """
-with max_age as (
-    select 2000000000 as max_old_xid
-        from pg_catalog.pg_settings
-        where name = 'autovacuum_freeze_max_age' )
-, per_database_stats as (
-    select datname
+QUERY_TX_WRAPAROUND = {
+    DEFAULT: """
+WITH max_age AS (
+    SELECT 2000000000 as max_old_xid
+        FROM pg_catalog.pg_settings
+        WHERE name = 'autovacuum_freeze_max_age' )
+, per_database_stats AS (
+    SELECT datname
         , m.max_old_xid::int
-        , age(d.datfrozenxid) as oldest_current_xid
-    from pg_catalog.pg_database d
-    join max_age m on (true)
-    where d.datallowconn )
-select max(oldest_current_xid) as oldest_current_xid
-    , max(round(100*(oldest_current_xid/max_old_xid::float))) as percent_towards_wraparound
-from per_database_stats;
+        , age(d.datfrozenxid) AS oldest_current_xid
+    FROM pg_catalog.pg_database d
+    JOIN max_age m ON (true)
+    WHERE d.datallowconn )
+SELECT max(oldest_current_xid) AS oldest_current_xid
+    , max(ROUND(100*(oldest_current_xid/max_old_xid::float))) AS percent_towards_wraparound
+FROM per_database_stats;
 """,
 }
 
-query_diff_lsn = {
-    default: """
-select
+QUERY_DIFF_LSN = {
+    DEFAULT: """
+SELECT
     pg_wal_lsn_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_wal_receive_lsn()
-        else pg_current_wal_lsn()
-      end,
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_wal_receive_lsn()
+        ELSE pg_current_wal_lsn()
+      END,
     '0/0') as wal_writes ;
 """,
-    v96: """
-select
+    V96: """
+SELECT
     pg_xlog_location_diff(
-      case pg_is_in_recovery()
-        when true then pg_last_xlog_receive_location()
-        else pg_current_xlog_location()
-      end,
+      CASE pg_is_in_recovery()
+        WHEN true THEN pg_last_xlog_receive_location()
+        ELSE pg_current_xlog_location()
+      END,
     '0/0') as wal_writes ;
 """,
 }
 
-def query_factory(name, version=no_version):
-    if name == query_name_backends:
-        return query_backend[default]
-    elif name == query_name_backend_usage:
+def query_factory(name, version=NO_VERSION):
+    if name == QUERY_NAME_BACKENDS:
+        return QUERY_BACKEND[DEFAULT]
+    elif name == QUERY_NAME_BACKEND_USAGE:
         if version < 80200:
-            return query_backend_usage[v72]
+            return QUERY_BACKEND_USAGE[V72]
         if version < 90100:
-            return query_backend_usage[v82]
+            return QUERY_BACKEND_USAGE[V82]
         if version < 90200:
-            return query_backend_usage[v91]
+            return QUERY_BACKEND_USAGE[V91]
         if version < 100000:
-            return query_backend_usage[v92]
+            return QUERY_BACKEND_USAGE[V92]
         elif version < 120000:
-            return query_backend_usage[v10]
-        return query_backend_usage[default]
-    elif name == query_name_table_stats:
-        return query_table_stats[default]
-    elif name == query_name_index_stats:
-        return query_index_stats[default]
-    elif name == query_name_database:
-        return query_database[default]
-    elif name == query_name_bgwriter:
-        return query_bgwriter[default]
-    elif name == query_name_locks:
-        return query_locks[default]
-    elif name == query_name_blockers:
+            return QUERY_BACKEND_USAGE[V10]
+        return QUERY_BACKEND_USAGE[DEFAULT]
+    elif name == QUERY_NAME_TABLE_STATS:
+        return QUERY_TABLE_STATS[DEFAULT]
+    elif name == QUERY_NAME_INDEX_STATS:
+        return QUERY_INDEX_STATS[DEFAULT]
+    elif name == QUERY_NAME_DATABASE:
+        return QUERY_DATABASE[DEFAULT]
+    elif name == QUERY_NAME_BGWRITER:
+        return QUERY_BGWRITER[DEFAULT]
+    elif name == QUERY_NAME_LOCKS:
+        return QUERY_LOCKS[DEFAULT]
+    elif name == QUERY_NAME_BLOCKERS:
         if version < 90600:
-            return query_blockers[v96]
-        return query_blockers[default]
-    elif name == query_name_databases:
-        return query_databases[default]
-    elif name == query_name_standby:
-        return query_standby[default]
-    elif name == query_name_replication_slot:
-        return query_replication_slot[default]
-    elif name == query_name_if_superuser:
-        return query_superuser[default]
-    elif name == query_name_server_version:
-        return query_show_version[default]
-    elif name == query_name_autovacuum:
-        return query_autovacuum[default]
-    elif name == query_name_emergency_autovacuum:
-        return query_emergency_autovacuum[default]
-    elif name == query_name_tx_wraparound:
-        return query_tx_wraparound[default]
-    elif name == query_name_wal:
+            return QUERY_BLOCKERS[V96]
+        return QUERY_BLOCKERS[DEFAULT]
+    elif name == QUERY_NAME_DATABASES:
+        return QUERY_DATABASES[DEFAULT]
+    elif name == QUERY_NAME_STANDBY:
+        return QUERY_STANDBY[DEFAULT]
+    elif name == QUERY_NAME_REPLICATION_SLOT:
+        return QUERY_REPLICATION_SLOT[DEFAULT]
+    elif name == QUERY_NAME_IF_SUPERUSER:
+        return QUERY_SUPERUSER[DEFAULT]
+    elif name == QUERY_NAME_SERVER_VERSION:
+        return QUERY_SHOW_VERSION[DEFAULT]
+    elif name == QUERY_NAME_AUTOVACUUM:
+        return QUERY_AUTOVACUUM[DEFAULT]
+    elif name == QUERY_NAME_EMERGENCY_AUTOVACUUM:
+        return QUERY_EMERGENCY_AUTOVACUUM[DEFAULT]
+    elif name == QUERY_NAME_TX_WRAPAROUND:
+        return QUERY_TX_WRAPAROUND[DEFAULT]
+    elif name == QUERY_NAME_WAL:
         if version < 100000:
-            return query_wal[v96]
-        return query_wal[default]
-    elif name == query_name_archive:
+            return QUERY_WAL[V96]
+        return QUERY_WAL[DEFAULT]
+    elif name == QUERY_NAME_ARCHIVE:
         if version < 100000:
-            return query_archive[v96]
-        return query_archive[default]
-    elif name == query_name_standby_delta:
+            return QUERY_ARCHIVE[V96]
+        return QUERY_ARCHIVE[DEFAULT]
+    elif name == QUERY_NAME_STANDBY_DELTA:
         if version < 100000:
-            return query_standby_delta[v96]
-        return query_standby_delta[default]
-    elif name == query_name_standby_lag:
-        return query_standby_lag[default]
-    elif name == query_name_repslot_files:
+            return QUERY_STANDBY_DELTA[V96]
+        return QUERY_STANDBY_DELTA[DEFAULT]
+    elif name == QUERY_NAME_STANDBY_LAG:
+        return QUERY_STANDBY_LAG[DEFAULT]
+    elif name == QUERY_NAME_REPSLOT_FILES:
         if version < 110000:
-            return query_repslot_files[v10]
-        return query_repslot_files[default]
-    elif name == query_name_diff_lsn:
+            return QUERY_REPSLOT_FILES[V10]
+        return QUERY_REPSLOT_FILES[DEFAULT]
+    elif name == QUERY_NAME_DIFF_LSN:
         if version < 100000:
-            return query_diff_lsn[v96]
-        return query_diff_lsn[default]
+            return QUERY_DIFF_LSN[V96]
+        return QUERY_DIFF_LSN[DEFAULT]
 
-    raise valueerror('unknown query')
+    raise ValueError('unknown query')
 
 
-order = [
+ORDER = [
     'db_stat_temp_files',
     'db_stat_temp_bytes',
     'db_stat_blks',
@@ -826,9 +826,9 @@ order = [
     'tx_wraparound_percent_towards_wraparound'
 ]
 
-charts = {
+CHARTS = {
     'db_stat_transactions': {
-        'options': [none, 'transactions on db', 'transactions/s', 'db statistics', 'postgres.db_stat_transactions',
+        'options': [None, 'Transactions on db', 'transactions/s', 'db statistics', 'postgres.db_stat_transactions',
                     'line'],
         'lines': [
             ['xact_commit', 'committed', 'incremental'],
@@ -836,21 +836,21 @@ charts = {
         ]
     },
     'db_stat_connections': {
-        'options': [none, 'current connections to db', 'count', 'db statistics', 'postgres.db_stat_connections',
+        'options': [None, 'Current connections to db', 'count', 'db statistics', 'postgres.db_stat_connections',
                     'line'],
         'lines': [
             ['connections', 'connections', 'absolute']
         ]
     },
     'db_stat_blks': {
-        'options': [none, 'disk blocks reads from db', 'reads/s', 'db statistics', 'postgres.db_stat_blks', 'line'],
+        'options': [None, 'Disk blocks reads from db', 'reads/s', 'db statistics', 'postgres.db_stat_blks', 'line'],
         'lines': [
             ['blks_read', 'disk', 'incremental'],
             ['blks_hit', 'cache', 'incremental']
         ]
     },
     'db_stat_tuple_returned': {
-        'options': [none, 'tuples returned from db', 'tuples/s', 'db statistics', 'postgres.db_stat_tuple_returned',
+        'options': [None, 'Tuples returned from db', 'tuples/s', 'db statistics', 'postgres.db_stat_tuple_returned',
                     'line'],
         'lines': [
             ['tup_returned', 'sequential', 'incremental'],
@@ -858,7 +858,7 @@ charts = {
         ]
     },
     'db_stat_tuple_write': {
-        'options': [none, 'tuples written to db', 'writes/s', 'db statistics', 'postgres.db_stat_tuple_write', 'line'],
+        'options': [None, 'Tuples written to db', 'writes/s', 'db statistics', 'postgres.db_stat_tuple_write', 'line'],
         'lines': [
             ['tup_inserted', 'inserted', 'incremental'],
             ['tup_updated', 'updated', 'incremental'],
@@ -867,33 +867,33 @@ charts = {
         ]
     },
     'db_stat_temp_bytes': {
-        'options': [none, 'temp files written to disk', 'kib/s', 'db statistics', 'postgres.db_stat_temp_bytes',
+        'options': [None, 'Temp files written to disk', 'KiB/s', 'db statistics', 'postgres.db_stat_temp_bytes',
                     'line'],
         'lines': [
             ['temp_bytes', 'size', 'incremental', 1, 1024]
         ]
     },
     'db_stat_temp_files': {
-        'options': [none, 'temp files written to disk', 'files', 'db statistics', 'postgres.db_stat_temp_files',
+        'options': [None, 'Temp files written to disk', 'files', 'db statistics', 'postgres.db_stat_temp_files',
                     'line'],
         'lines': [
             ['temp_files', 'files', 'incremental']
         ]
     },
     'db_stat_blocking_pids_avg': {
-        'options': [none, 'average number of blocking transactions in db', 'processes', 'db statistics',
+        'options': [None, 'Average number of blocking transactions in db', 'processes', 'db statistics',
                     'postgres.db_stat_blocking_pids_avg', 'line'],
         'lines': [
             ['blocking_pids_avg', 'blocking', 'absolute']
         ]
     },
     'database_size': {
-        'options': [none, 'database size', 'mib', 'database size', 'postgres.db_size', 'stacked'],
+        'options': [None, 'Database size', 'MiB', 'database size', 'postgres.db_size', 'stacked'],
         'lines': [
         ]
     },
     'backend_process': {
-        'options': [none, 'current backend processes', 'processes', 'backend processes', 'postgres.backend_process',
+        'options': [None, 'Current Backend Processes', 'processes', 'backend processes', 'postgres.backend_process',
                     'line'],
         'lines': [
             ['backends_active', 'active', 'absolute'],
@@ -901,38 +901,38 @@ charts = {
         ]
     },
     'backend_usage': {
-        'options': [none, '% of connections in use', 'percentage', 'backend processes', 'postgres.backend_usage', 'stacked'],
+        'options': [None, '% of Connections in use', 'percentage', 'backend processes', 'postgres.backend_usage', 'stacked'],
         'lines': [
             ['available', 'available', 'percentage-of-absolute-row'],
             ['used', 'used', 'percentage-of-absolute-row']
         ]
     },
     'index_count': {
-        'options': [none, 'total indexes', 'index', 'indexes', 'postgres.index_count', 'line'],
+        'options': [None, 'Total indexes', 'index', 'indexes', 'postgres.index_count', 'line'],
         'lines': [
             ['index_count', 'total', 'absolute']
         ]
     },
     'index_size': {
-        'options': [none, 'indexes size', 'mib', 'indexes', 'postgres.index_size', 'line'],
+        'options': [None, 'Indexes size', 'MiB', 'indexes', 'postgres.index_size', 'line'],
         'lines': [
             ['index_size', 'size', 'absolute', 1, 1024 * 1024]
         ]
     },
     'table_count': {
-        'options': [none, 'total tables', 'tables', 'tables', 'postgres.table_count', 'line'],
+        'options': [None, 'Total Tables', 'tables', 'tables', 'postgres.table_count', 'line'],
         'lines': [
             ['table_count', 'total', 'absolute']
         ]
     },
     'table_size': {
-        'options': [none, 'tables size', 'mib', 'tables', 'postgres.table_size', 'line'],
+        'options': [None, 'Tables size', 'MiB', 'tables', 'postgres.table_size', 'line'],
         'lines': [
             ['table_size', 'size', 'absolute', 1, 1024 * 1024]
         ]
     },
     'wal': {
-        'options': [none, 'write-ahead logs', 'files', 'wal', 'postgres.wal', 'line'],
+        'options': [None, 'Write-Ahead Logs', 'files', 'wal', 'postgres.wal', 'line'],
         'lines': [
             ['written_wal', 'written', 'absolute'],
             ['recycled_wal', 'recycled', 'absolute'],
@@ -940,13 +940,13 @@ charts = {
         ]
     },
     'wal_writes': {
-        'options': [none, 'write-ahead logs', 'kib/s', 'wal_writes', 'postgres.wal_writes', 'line'],
+        'options': [None, 'Write-Ahead Logs', 'KiB/s', 'wal_writes', 'postgres.wal_writes', 'line'],
         'lines': [
             ['wal_writes', 'writes', 'incremental', 1, 1024]
         ]
     },
     'archive_wal': {
-        'options': [none, 'archive write-ahead logs', 'files/s', 'archive wal', 'postgres.archive_wal', 'line'],
+        'options': [None, 'Archive Write-Ahead Logs', 'files/s', 'archive wal', 'postgres.archive_wal', 'line'],
         'lines': [
             ['file_count', 'total', 'incremental'],
             ['ready_count', 'ready', 'incremental'],
@@ -954,54 +954,54 @@ charts = {
         ]
     },
     'checkpointer': {
-        'options': [none, 'checkpoints', 'writes', 'checkpointer', 'postgres.checkpointer', 'line'],
+        'options': [None, 'Checkpoints', 'writes', 'checkpointer', 'postgres.checkpointer', 'line'],
         'lines': [
             ['checkpoint_scheduled', 'scheduled', 'incremental'],
             ['checkpoint_requested', 'requested', 'incremental']
         ]
     },
     'stat_bgwriter_alloc': {
-        'options': [none, 'buffers allocated', 'kib/s', 'bgwriter', 'postgres.stat_bgwriter_alloc', 'line'],
+        'options': [None, 'Buffers allocated', 'KiB/s', 'bgwriter', 'postgres.stat_bgwriter_alloc', 'line'],
         'lines': [
             ['buffers_alloc', 'alloc', 'incremental', 1, 1024]
         ]
     },
     'stat_bgwriter_checkpoint': {
-        'options': [none, 'buffers written during checkpoints', 'kib/s', 'bgwriter',
+        'options': [None, 'Buffers written during checkpoints', 'KiB/s', 'bgwriter',
                     'postgres.stat_bgwriter_checkpoint', 'line'],
         'lines': [
             ['buffers_checkpoint', 'checkpoint', 'incremental', 1, 1024]
         ]
     },
     'stat_bgwriter_backend': {
-        'options': [none, 'buffers written directly by a backend', 'kib/s', 'bgwriter',
+        'options': [None, 'Buffers written directly by a backend', 'KiB/s', 'bgwriter',
                     'postgres.stat_bgwriter_backend', 'line'],
         'lines': [
             ['buffers_backend', 'backend', 'incremental', 1, 1024]
         ]
     },
     'stat_bgwriter_backend_fsync': {
-        'options': [none, 'fsync by backend', 'times', 'bgwriter', 'postgres.stat_bgwriter_backend_fsync', 'line'],
+        'options': [None, 'Fsync by backend', 'times', 'bgwriter', 'postgres.stat_bgwriter_backend_fsync', 'line'],
         'lines': [
             ['buffers_backend_fsync', 'backend fsync', 'incremental']
         ]
     },
     'stat_bgwriter_bgwriter': {
-        'options': [none, 'buffers written by the background writer', 'kib/s', 'bgwriter',
+        'options': [None, 'Buffers written by the background writer', 'KiB/s', 'bgwriter',
                     'postgres.bgwriter_bgwriter', 'line'],
         'lines': [
             ['buffers_clean', 'clean', 'incremental', 1, 1024]
         ]
     },
     'stat_bgwriter_maxwritten': {
-        'options': [none, 'too many buffers written', 'times', 'bgwriter', 'postgres.stat_bgwriter_maxwritten',
+        'options': [None, 'Too many buffers written', 'times', 'bgwriter', 'postgres.stat_bgwriter_maxwritten',
                     'line'],
         'lines': [
             ['maxwritten_clean', 'maxwritten', 'incremental']
         ]
     },
     'autovacuum': {
-        'options': [none, 'autovacuum workers', 'workers', 'autovacuum', 'postgres.autovacuum', 'line'],
+        'options': [None, 'Autovacuum workers', 'workers', 'autovacuum', 'postgres.autovacuum', 'line'],
         'lines': [
             ['analyze', 'analyze', 'absolute'],
             ['vacuum', 'vacuum', 'absolute'],
@@ -1011,25 +1011,25 @@ charts = {
         ]
     },
     'emergency_autovacuum': {
-        'options': [none, 'percent towards emergency autovac', 'percent', 'autovacuum', 'postgres.emergency_autovacuum', 'line'],
+        'options': [None, 'Percent towards emergency autovac', 'percent', 'autovacuum', 'postgres.emergency_autovacuum', 'line'],
         'lines': [
             ['percent_towards_emergency_autovac', 'percent', 'absolute']
         ]
     },
     'tx_wraparound_oldest_current_xid': {
-        'options': [none, 'oldest current xid', 'xid', 'tx_wraparound', 'postgres.tx_wraparound_oldest_current_xid', 'line'],
+        'options': [None, 'Oldest current XID', 'xid', 'tx_wraparound', 'postgres.tx_wraparound_oldest_current_xid', 'line'],
         'lines': [
             ['oldest_current_xid', 'percent', 'absolute']
         ]
     },
     'tx_wraparound_percent_towards_wraparound': {
-        'options': [none, 'percent towards wraparound', 'percent', 'tx_wraparound', 'postgres.percent_towards_wraparound', 'line'],
+        'options': [None, 'Percent towards wraparound', 'percent', 'tx_wraparound', 'postgres.percent_towards_wraparound', 'line'],
         'lines': [
             ['percent_towards_wraparound', 'percent', 'absolute']
         ]
     },
     'standby_delta': {
-        'options': [none, 'standby delta', 'kib', 'replication delta', 'postgres.standby_delta', 'line'],
+        'options': [None, 'Standby delta', 'KiB', 'replication delta', 'postgres.standby_delta', 'line'],
         'lines': [
             ['sent_delta', 'sent delta', 'absolute', 1, 1024],
             ['write_delta', 'write delta', 'absolute', 1, 1024],
@@ -1038,7 +1038,7 @@ charts = {
         ]
     },
     'standby_lag': {
-        'options': [none, 'standby lag', 'seconds', 'replication lag', 'postgres.standby_lag', 'line'],
+        'options': [None, 'Standby lag', 'seconds', 'replication lag', 'postgres.standby_lag', 'line'],
         'lines': [
             ['write_lag', 'write lag', 'absolute'],
             ['flush_lag', 'flush lag', 'absolute'],
@@ -1046,7 +1046,7 @@ charts = {
         ]
     },
     'replication_slot': {
-        'options': [none, 'replication slot files', 'files', 'replication slot', 'postgres.replication_slot', 'line'],
+        'options': [None, 'Replication slot files', 'files', 'replication slot', 'postgres.replication_slot', 'line'],
         'lines': [
             ['replslot_wal_keep', 'wal keeped', 'absolute'],
             ['replslot_files', 'pg_replslot files', 'absolute']
@@ -1055,20 +1055,20 @@ charts = {
 }
 
 
-class service(simpleservice):
-    def __init__(self, configuration=none, name=none):
-        simpleservice.__init__(self, configuration=configuration, name=name)
-        self.order = list(order)
-        self.definitions = deepcopy(charts)
-        self.do_table_stats = configuration.pop('table_stats', false)
-        self.do_index_stats = configuration.pop('index_stats', false)
-        self.databases_to_poll = configuration.pop('database_poll', none)
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = list(ORDER)
+        self.definitions = deepcopy(CHARTS)
+        self.do_table_stats = configuration.pop('table_stats', False)
+        self.do_index_stats = configuration.pop('index_stats', False)
+        self.databases_to_poll = configuration.pop('database_poll', None)
         self.configuration = configuration
-        self.conn = none
+        self.conn = None
         self.conn_params = dict()
-        self.server_version = none
-        self.is_superuser = false
-        self.alive = false
+        self.server_version = None
+        self.is_superuser = False
+        self.alive = False
         self.databases = list()
         self.secondaries = list()
         self.replication_slots = list()
@@ -1081,33 +1081,33 @@ class service(simpleservice):
     def build_conn_params(self):
         conf = self.configuration
 
-        # connection uris: https://www.postgresql.org/docs/current/libpq-connect.html#libpq-connstring
-        if conf.get(conn_param_dsn):
-            return {'dsn': conf[conn_param_dsn]}
+        # connection URIs: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+        if conf.get(CONN_PARAM_DSN):
+            return {'dsn': conf[CONN_PARAM_DSN]}
 
         params = {
-            conn_param_host: conf.get(conn_param_host),
-            conn_param_port: conf.get(conn_param_port, default_port),
-            conn_param_database: conf.get(conn_param_database),
-            conn_param_user: conf.get(conn_param_user, default_user),
-            conn_param_password: conf.get(conn_param_password),
-            conn_param_conn_timeout: conf.get(conn_param_conn_timeout, default_connect_timeout),
+            CONN_PARAM_HOST: conf.get(CONN_PARAM_HOST),
+            CONN_PARAM_PORT: conf.get(CONN_PARAM_PORT, DEFAULT_PORT),
+            CONN_PARAM_DATABASE: conf.get(CONN_PARAM_DATABASE),
+            CONN_PARAM_USER: conf.get(CONN_PARAM_USER, DEFAULT_USER),
+            CONN_PARAM_PASSWORD: conf.get(CONN_PARAM_PASSWORD),
+            CONN_PARAM_CONN_TIMEOUT: conf.get(CONN_PARAM_CONN_TIMEOUT, DEFAULT_CONNECT_TIMEOUT),
             'options': '-c statement_timeout={0}'.format(
-                conf.get(conn_param_statement_timeout, default_statement_timeout)),
+                conf.get(CONN_PARAM_STATEMENT_TIMEOUT, DEFAULT_STATEMENT_TIMEOUT)),
         }
 
         # https://www.postgresql.org/docs/current/libpq-ssl.html
         ssl_params = dict(
             (k, v) for k, v in {
-                conn_param_ssl_mode: conf.get(conn_param_ssl_mode),
-                conn_param_ssl_root_cert: conf.get(conn_param_ssl_root_cert),
-                conn_param_ssl_crl: conf.get(conn_param_ssl_crl),
-                conn_param_ssl_cert: conf.get(conn_param_ssl_cert),
-                conn_param_ssl_key: conf.get(conn_param_ssl_key),
+                CONN_PARAM_SSL_MODE: conf.get(CONN_PARAM_SSL_MODE),
+                CONN_PARAM_SSL_ROOT_CERT: conf.get(CONN_PARAM_SSL_ROOT_CERT),
+                CONN_PARAM_SSL_CRL: conf.get(CONN_PARAM_SSL_CRL),
+                CONN_PARAM_SSL_CERT: conf.get(CONN_PARAM_SSL_CERT),
+                CONN_PARAM_SSL_KEY: conf.get(CONN_PARAM_SSL_KEY),
             }.items() if v)
 
-        if conn_param_ssl_mode not in ssl_params and len(ssl_params) > 0:
-            raise valueerror("mandatory 'sslmode' param is missing, please set")
+        if CONN_PARAM_SSL_MODE not in ssl_params and len(ssl_params) > 0:
+            raise ValueError("mandatory 'sslmode' param is missing, please set")
 
         params.update(ssl_params)
 
@@ -1116,61 +1116,61 @@ class service(simpleservice):
     def connect(self):
         if self.conn:
             self.conn.close()
-            self.conn = none
+            self.conn = None
 
         try:
             self.conn = psycopg2.connect(**self.conn_params)
-            self.conn.set_isolation_level(extensions.isolation_level_autocommit)
-            self.conn.set_session(readonly=true)
-        except operationalerror as error:
+            self.conn.set_isolation_level(extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+            self.conn.set_session(readonly=True)
+        except OperationalError as error:
             self.error(error)
-            self.alive = false
+            self.alive = False
         else:
-            self.alive = true
+            self.alive = True
 
         return self.alive
 
     def check(self):
-        if not psycopg2:
+        if not PSYCOPG2:
             self.error("'python-psycopg2' package is needed to use postgres module")
-            return false
+            return False
 
         try:
             self.conn_params = self.build_conn_params()
-        except valueerror as error:
+        except ValueError as error:
             self.error('error on creating connection params : {0}', error)
-            return false
+            return False
 
         if not self.connect():
             self.error('failed to connect to {0}'.format(hide_password(self.conn_params)))
-            return false
+            return False
 
         try:
             self.check_queries()
-        except exception as error:
+        except Exception as error:
             self.error(error)
-            return false
+            return False
 
         self.populate_queries()
         self.create_dynamic_charts()
 
-        return true
+        return True
 
     def get_data(self):
         if not self.alive and not self.reconnect():
-            return none
+            return None
 
         self.data = dict()
         try:
-            cursor = self.conn.cursor(cursor_factory=dictcursor)
+            cursor = self.conn.cursor(cursor_factory=DictCursor)
 
             self.data.update(zero_lock_types(self.databases))
             for query, metrics in self.queries.items():
                 self.query_stats(cursor, query, metrics)
 
-        except operationalerror:
-            self.alive = false
-            return none
+        except OperationalError:
+            self.alive = False
+            return None
 
         cursor.close()
 
@@ -1195,7 +1195,7 @@ class service(simpleservice):
                     dimension_id = metric
 
                 if metric in row:
-                    if row[metric] is not none:
+                    if row[metric] is not None:
                         self.data[dimension_id] = int(row[metric])
                 elif 'locks_count' in row:
                     if metric == row['mode']:
@@ -1204,60 +1204,60 @@ class service(simpleservice):
     def check_queries(self):
         cursor = self.conn.cursor()
 
-        self.server_version = detect_server_version(cursor, query_factory(query_name_server_version))
+        self.server_version = detect_server_version(cursor, query_factory(QUERY_NAME_SERVER_VERSION))
         self.debug('server version: {0}'.format(self.server_version))
 
-        self.is_superuser = check_if_superuser(cursor, query_factory(query_name_if_superuser))
+        self.is_superuser = check_if_superuser(cursor, query_factory(QUERY_NAME_IF_SUPERUSER))
         self.debug('superuser: {0}'.format(self.is_superuser))
 
-        self.databases = discover(cursor, query_factory(query_name_databases))
+        self.databases = discover(cursor, query_factory(QUERY_NAME_DATABASES))
         self.debug('discovered databases {0}'.format(self.databases))
         if self.databases_to_poll:
             to_poll = self.databases_to_poll.split()
             self.databases = [db for db in self.databases if db in to_poll] or self.databases
 
-        self.secondaries = discover(cursor, query_factory(query_name_standby))
+        self.secondaries = discover(cursor, query_factory(QUERY_NAME_STANDBY))
         self.debug('discovered secondaries: {0}'.format(self.secondaries))
 
         if self.server_version >= 94000:
-            self.replication_slots = discover(cursor, query_factory(query_name_replication_slot))
+            self.replication_slots = discover(cursor, query_factory(QUERY_NAME_REPLICATION_SLOT))
             self.debug('discovered replication slots: {0}'.format(self.replication_slots))
 
         cursor.close()
 
     def populate_queries(self):
-        self.queries[query_factory(query_name_database)] = metrics[query_name_database]
-        self.queries[query_factory(query_name_backends)] = metrics[query_name_backends]
-        self.queries[query_factory(query_name_backend_usage, self.server_version)] = metrics[query_name_backend_usage]
-        self.queries[query_factory(query_name_locks)] = metrics[query_name_locks]
-        self.queries[query_factory(query_name_bgwriter)] = metrics[query_name_bgwriter]
-        self.queries[query_factory(query_name_diff_lsn, self.server_version)] = metrics[query_name_wal_writes]
-        self.queries[query_factory(query_name_standby_delta, self.server_version)] = metrics[query_name_standby_delta]
-        self.queries[query_factory(query_name_blockers, self.server_version)] = metrics[query_name_blockers]
+        self.queries[query_factory(QUERY_NAME_DATABASE)] = METRICS[QUERY_NAME_DATABASE]
+        self.queries[query_factory(QUERY_NAME_BACKENDS)] = METRICS[QUERY_NAME_BACKENDS]
+        self.queries[query_factory(QUERY_NAME_BACKEND_USAGE, self.server_version)] = METRICS[QUERY_NAME_BACKEND_USAGE]
+        self.queries[query_factory(QUERY_NAME_LOCKS)] = METRICS[QUERY_NAME_LOCKS]
+        self.queries[query_factory(QUERY_NAME_BGWRITER)] = METRICS[QUERY_NAME_BGWRITER]
+        self.queries[query_factory(QUERY_NAME_DIFF_LSN, self.server_version)] = METRICS[QUERY_NAME_WAL_WRITES]
+        self.queries[query_factory(QUERY_NAME_STANDBY_DELTA, self.server_version)] = METRICS[QUERY_NAME_STANDBY_DELTA]
+        self.queries[query_factory(QUERY_NAME_BLOCKERS, self.server_version)] = METRICS[QUERY_NAME_BLOCKERS]
 
         if self.do_index_stats:
-            self.queries[query_factory(query_name_index_stats)] = metrics[query_name_index_stats]
+            self.queries[query_factory(QUERY_NAME_INDEX_STATS)] = METRICS[QUERY_NAME_INDEX_STATS]
         if self.do_table_stats:
-            self.queries[query_factory(query_name_table_stats)] = metrics[query_name_table_stats]
+            self.queries[query_factory(QUERY_NAME_TABLE_STATS)] = METRICS[QUERY_NAME_TABLE_STATS]
 
         if self.is_superuser:
-            self.queries[query_factory(query_name_archive, self.server_version)] = metrics[query_name_archive]
+            self.queries[query_factory(QUERY_NAME_ARCHIVE, self.server_version)] = METRICS[QUERY_NAME_ARCHIVE]
 
             if self.server_version >= 90400:
-                self.queries[query_factory(query_name_wal, self.server_version)] = metrics[query_name_wal]
+                self.queries[query_factory(QUERY_NAME_WAL, self.server_version)] = METRICS[QUERY_NAME_WAL]
 
             if self.server_version >= 100000:
-                v = metrics[query_name_repslot_files]
-                self.queries[query_factory(query_name_repslot_files, self.server_version)] = v
+                v = METRICS[QUERY_NAME_REPSLOT_FILES]
+                self.queries[query_factory(QUERY_NAME_REPSLOT_FILES, self.server_version)] = v
 
         if self.server_version >= 90400:
-            self.queries[query_factory(query_name_autovacuum)] = metrics[query_name_autovacuum]
+            self.queries[query_factory(QUERY_NAME_AUTOVACUUM)] = METRICS[QUERY_NAME_AUTOVACUUM]
 
-        self.queries[query_factory(query_name_emergency_autovacuum)] = metrics[query_name_emergency_autovacuum]
-        self.queries[query_factory(query_name_tx_wraparound)] = metrics[query_name_tx_wraparound]
+        self.queries[query_factory(QUERY_NAME_EMERGENCY_AUTOVACUUM)] = METRICS[QUERY_NAME_EMERGENCY_AUTOVACUUM]
+        self.queries[query_factory(QUERY_NAME_TX_WRAPAROUND)] = METRICS[QUERY_NAME_TX_WRAPAROUND]
 
         if self.server_version >= 100000:
-            self.queries[query_factory(query_name_standby_lag)] = metrics[query_name_standby_lag]
+            self.queries[query_factory(QUERY_NAME_STANDBY_LAG)] = METRICS[QUERY_NAME_STANDBY_LAG]
 
     def create_dynamic_charts(self):
         for database_name in self.databases[::-1]:
@@ -1329,7 +1329,7 @@ def detect_server_version(cursor, query):
 def zero_lock_types(databases):
     result = dict()
     for database in databases:
-        for lock_type in metrics['locks']:
+        for lock_type in METRICS['LOCKS']:
             key = '_'.join([database, lock_type])
             result[key] = 0
 
@@ -1343,7 +1343,7 @@ def hide_password(config):
 def add_database_lock_chart(order, definitions, database_name):
     def create_lines(database):
         result = list()
-        for lock_type in metrics['locks']:
+        for lock_type in METRICS['LOCKS']:
             dimension_id = '_'.join([database, lock_type])
             result.append([dimension_id, lock_type, 'absolute'])
         return result
@@ -1352,7 +1352,7 @@ def add_database_lock_chart(order, definitions, database_name):
     order.insert(-1, chart_name)
     definitions[chart_name] = {
         'options':
-            [none, 'locks on db: ' + database_name, 'locks', 'db ' + database_name, 'postgres.db_locks', 'line'],
+            [None, 'Locks on db: ' + database_name, 'locks', 'db ' + database_name, 'postgres.db_locks', 'line'],
         'lines': create_lines(database_name)
     }
 
@@ -1365,7 +1365,7 @@ def add_database_stat_chart(order, definitions, name, database_name):
             result.append(new_line)
         return result
 
-    chart_template = charts[name]
+    chart_template = CHARTS[name]
     chart_name = '_'.join([database_name, name])
     order.insert(0, chart_name)
     name, title, units, _, context, chart_type = chart_template['options']
@@ -1382,7 +1382,7 @@ def add_replication_standby_chart(order, definitions, name, application_name, ch
             result.append(new_line)
         return result
 
-    chart_template = charts[name]
+    chart_template = CHARTS[name]
     chart_name = '_'.join([application_name, name])
     position = order.index('database_size')
     order.insert(position, chart_name)
@@ -1400,7 +1400,7 @@ def add_replication_slot_chart(order, definitions, name, slot_name):
             result.append(new_line)
         return result
 
-    chart_template = charts[name]
+    chart_template = CHARTS[name]
     chart_name = '_'.join([slot_name, name])
     position = order.index('database_size')
     order.insert(position, chart_name)

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -1,67 +1,67 @@
 # -*- coding: utf-8 -*-
-# Description: example netdata python.d module
-# Authors: facetoe, dangtranhoang
-# SPDX-License-Identifier: GPL-3.0-or-later
+# description: example netdata python.d module
+# authors: facetoe, dangtranhoang
+# spdx-license-identifier: gpl-3.0-or-later
 
 from copy import deepcopy
 
 try:
     import psycopg2
     from psycopg2 import extensions
-    from psycopg2.extras import DictCursor
-    from psycopg2 import OperationalError
+    from psycopg2.extras import dictcursor
+    from psycopg2 import operationalerror
 
-    PSYCOPG2 = True
-except ImportError:
-    PSYCOPG2 = False
+    psycopg2 = true
+except importerror:
+    psycopg2 = false
 
-from bases.FrameworkServices.SimpleService import SimpleService
+from bases.frameworkservices.simpleservice import simpleservice
 
-DEFAULT_PORT = 5432
-DEFAULT_USER = 'postgres'
-DEFAULT_CONNECT_TIMEOUT = 2  # seconds
-DEFAULT_STATEMENT_TIMEOUT = 5000  # ms
+default_port = 5432
+default_user = 'postgres'
+default_connect_timeout = 2  # seconds
+default_statement_timeout = 5000  # ms
 
-CONN_PARAM_DSN = 'dsn'
-CONN_PARAM_HOST = 'host'
-CONN_PARAM_PORT = 'port'
-CONN_PARAM_DATABASE = 'database'
-CONN_PARAM_USER = 'user'
-CONN_PARAM_PASSWORD = 'password'
-CONN_PARAM_CONN_TIMEOUT = 'connect_timeout'
-CONN_PARAM_STATEMENT_TIMEOUT = 'statement_timeout'
-CONN_PARAM_SSL_MODE = 'sslmode'
-CONN_PARAM_SSL_ROOT_CERT = 'sslrootcert'
-CONN_PARAM_SSL_CRL = 'sslcrl'
-CONN_PARAM_SSL_CERT = 'sslcert'
-CONN_PARAM_SSL_KEY = 'sslkey'
+conn_param_dsn = 'dsn'
+conn_param_host = 'host'
+conn_param_port = 'port'
+conn_param_database = 'database'
+conn_param_user = 'user'
+conn_param_password = 'password'
+conn_param_conn_timeout = 'connect_timeout'
+conn_param_statement_timeout = 'statement_timeout'
+conn_param_ssl_mode = 'sslmode'
+conn_param_ssl_root_cert = 'sslrootcert'
+conn_param_ssl_crl = 'sslcrl'
+conn_param_ssl_cert = 'sslcert'
+conn_param_ssl_key = 'sslkey'
 
-QUERY_NAME_WAL = 'WAL'
-QUERY_NAME_ARCHIVE = 'ARCHIVE'
-QUERY_NAME_BACKENDS = 'BACKENDS'
-QUERY_NAME_BACKEND_USAGE = 'BACKEND_USAGE'
-QUERY_NAME_TABLE_STATS = 'TABLE_STATS'
-QUERY_NAME_INDEX_STATS = 'INDEX_STATS'
-QUERY_NAME_DATABASE = 'DATABASE'
-QUERY_NAME_BGWRITER = 'BGWRITER'
-QUERY_NAME_LOCKS = 'LOCKS'
-QUERY_NAME_BLOCKERS = 'BLOCKERS'
-QUERY_NAME_DATABASES = 'DATABASES'
-QUERY_NAME_STANDBY = 'STANDBY'
-QUERY_NAME_REPLICATION_SLOT = 'REPLICATION_SLOT'
-QUERY_NAME_STANDBY_DELTA = 'STANDBY_DELTA'
-QUERY_NAME_STANDBY_LAG = 'STANDBY_LAG'
-QUERY_NAME_REPSLOT_FILES = 'REPSLOT_FILES'
-QUERY_NAME_IF_SUPERUSER = 'IF_SUPERUSER'
-QUERY_NAME_SERVER_VERSION = 'SERVER_VERSION'
-QUERY_NAME_AUTOVACUUM = 'AUTOVACUUM'
-QUERY_NAME_EMERGENCY_AUTOVACUUM = 'EMERGENCY_AUTOVACUUM'
-QUERY_NAME_TX_WRAPAROUND = 'TX_WRAPAROUND'
-QUERY_NAME_DIFF_LSN = 'DIFF_LSN'
-QUERY_NAME_WAL_WRITES = 'WAL_WRITES'
+query_name_wal = 'wal'
+query_name_archive = 'archive'
+query_name_backends = 'backends'
+query_name_backend_usage = 'backend_usage'
+query_name_table_stats = 'table_stats'
+query_name_index_stats = 'index_stats'
+query_name_database = 'database'
+query_name_bgwriter = 'bgwriter'
+query_name_locks = 'locks'
+query_name_blockers = 'blockers'
+query_name_databases = 'databases'
+query_name_standby = 'standby'
+query_name_replication_slot = 'replication_slot'
+query_name_standby_delta = 'standby_delta'
+query_name_standby_lag = 'standby_lag'
+query_name_repslot_files = 'repslot_files'
+query_name_if_superuser = 'if_superuser'
+query_name_server_version = 'server_version'
+query_name_autovacuum = 'autovacuum'
+query_name_emergency_autovacuum = 'emergency_autovacuum'
+query_name_tx_wraparound = 'tx_wraparound'
+query_name_diff_lsn = 'diff_lsn'
+query_name_wal_writes = 'wal_writes'
 
-METRICS = {
-    QUERY_NAME_DATABASE: [
+metrics = {
+    query_name_database: [
         'connections',
         'xact_commit',
         'xact_rollback',
@@ -77,36 +77,36 @@ METRICS = {
         'temp_bytes',
         'size'
     ],
-    QUERY_NAME_BACKENDS: [
+    query_name_backends: [
         'backends_active',
         'backends_idle'
     ],
-    QUERY_NAME_BACKEND_USAGE: [
+    query_name_backend_usage: [
         'available',
         'used'
     ],
-    QUERY_NAME_INDEX_STATS: [
+    query_name_index_stats: [
         'index_count',
         'index_size'
     ],
-    QUERY_NAME_TABLE_STATS: [
+    query_name_table_stats: [
         'table_size',
         'table_count'
     ],
-    QUERY_NAME_WAL: [
+    query_name_wal: [
         'written_wal',
         'recycled_wal',
         'total_wal'
     ],
-    QUERY_NAME_WAL_WRITES: [
+    query_name_wal_writes: [
         'wal_writes'
     ],
-    QUERY_NAME_ARCHIVE: [
+    query_name_archive: [
         'ready_count',
         'done_count',
         'file_count'
     ],
-    QUERY_NAME_BGWRITER: [
+    query_name_bgwriter: [
         'checkpoint_scheduled',
         'checkpoint_requested',
         'buffers_checkpoint',
@@ -116,682 +116,682 @@ METRICS = {
         'buffers_alloc',
         'buffers_backend_fsync'
     ],
-    QUERY_NAME_LOCKS: [
-        'ExclusiveLock',
-        'RowShareLock',
-        'SIReadLock',
-        'ShareUpdateExclusiveLock',
-        'AccessExclusiveLock',
-        'AccessShareLock',
-        'ShareRowExclusiveLock',
-        'ShareLock',
-        'RowExclusiveLock'
+    query_name_locks: [
+        'exclusivelock',
+        'rowsharelock',
+        'sireadlock',
+        'shareupdateexclusivelock',
+        'accessexclusivelock',
+        'accesssharelock',
+        'sharerowexclusivelock',
+        'sharelock',
+        'rowexclusivelock'
     ],
-    QUERY_NAME_BLOCKERS: [
+    query_name_blockers: [
         'blocking_pids_avg'
     ],
-    QUERY_NAME_AUTOVACUUM: [
+    query_name_autovacuum: [
         'analyze',
         'vacuum_analyze',
         'vacuum',
         'vacuum_freeze',
         'brin_summarize'
     ],
-    QUERY_NAME_EMERGENCY_AUTOVACUUM: [
+    query_name_emergency_autovacuum: [
         'percent_towards_emergency_autovac'
     ],
-    QUERY_NAME_TX_WRAPAROUND: [
+    query_name_tx_wraparound: [
         'oldest_current_xid',
         'percent_towards_wraparound'
     ],
-    QUERY_NAME_STANDBY_DELTA: [
+    query_name_standby_delta: [
         'sent_delta',
         'write_delta',
         'flush_delta',
         'replay_delta'
     ],
-    QUERY_NAME_STANDBY_LAG: [
+    query_name_standby_lag: [
         'write_lag',
         'flush_lag',
         'replay_lag'
     ],
-    QUERY_NAME_REPSLOT_FILES: [
+    query_name_repslot_files: [
         'replslot_wal_keep',
         'replslot_files'
     ]
 }
 
-NO_VERSION = 0
-DEFAULT = 'DEFAULT'
-V72 = 'V72'
-V82 = 'V82'
-V91 = 'V91'
-V92 = 'V92'
-V96 = 'V96'
-V10 = 'V10'
-V11 = 'V11'
+no_version = 0
+default = 'default'
+v72 = 'v72'
+v82 = 'v82'
+v91 = 'v91'
+v92 = 'v92'
+v96 = 'v96'
+v10 = 'v10'
+v11 = 'v11'
 
-QUERY_WAL = {
-    DEFAULT: """
-SELECT
+query_wal = {
+    default: """
+select
     count(*) as total_wal,
-    count(*) FILTER (WHERE type = 'recycled') AS recycled_wal,
-    count(*) FILTER (WHERE type = 'written') AS written_wal
-FROM
-    (SELECT
+    count(*) filter (where type = 'recycled') as recycled_wal,
+    count(*) filter (where type = 'written') as written_wal
+from
+    (select
         wal.name,
         pg_walfile_name(
-          CASE pg_is_in_recovery()
-            WHEN true THEN NULL
-            ELSE pg_current_wal_lsn()
-          END ),
-        CASE
-          WHEN wal.name > pg_walfile_name(
-            CASE pg_is_in_recovery()
-              WHEN true THEN NULL
-              ELSE pg_current_wal_lsn()
-            END ) THEN 'recycled'
-          ELSE 'written'
-        END AS type
-    FROM pg_catalog.pg_ls_dir('pg_wal') AS wal(name)
-    WHERE name ~ '^[0-9A-F]{24}$'
-    ORDER BY
+          case pg_is_in_recovery()
+            when true then null
+            else pg_current_wal_lsn()
+          end ),
+        case
+          when wal.name > pg_walfile_name(
+            case pg_is_in_recovery()
+              when true then null
+              else pg_current_wal_lsn()
+            end ) then 'recycled'
+          else 'written'
+        end as type
+    from pg_catalog.pg_ls_dir('pg_wal') as wal(name)
+    where name ~ '^[0-9a-f]{24}$'
+    order by
         (pg_stat_file('pg_wal/'||name)).modification,
-        wal.name DESC) sub;
+        wal.name desc) sub;
 """,
-    V96: """
-SELECT
+    v96: """
+select
     count(*) as total_wal,
-    count(*) FILTER (WHERE type = 'recycled') AS recycled_wal,
-    count(*) FILTER (WHERE type = 'written') AS written_wal
-FROM
-    (SELECT
+    count(*) filter (where type = 'recycled') as recycled_wal,
+    count(*) filter (where type = 'written') as written_wal
+from
+    (select
         wal.name,
         pg_xlogfile_name(
-          CASE pg_is_in_recovery()
-            WHEN true THEN NULL
-            ELSE pg_current_xlog_location()
-          END ),
-        CASE
-          WHEN wal.name > pg_xlogfile_name(
-            CASE pg_is_in_recovery()
-              WHEN true THEN NULL
-              ELSE pg_current_xlog_location()
-            END ) THEN 'recycled'
-          ELSE 'written'
-        END AS type
-    FROM pg_catalog.pg_ls_dir('pg_xlog') AS wal(name)
-    WHERE name ~ '^[0-9A-F]{24}$'
-    ORDER BY
+          case pg_is_in_recovery()
+            when true then null
+            else pg_current_xlog_location()
+          end ),
+        case
+          when wal.name > pg_xlogfile_name(
+            case pg_is_in_recovery()
+              when true then null
+              else pg_current_xlog_location()
+            end ) then 'recycled'
+          else 'written'
+        end as type
+    from pg_catalog.pg_ls_dir('pg_xlog') as wal(name)
+    where name ~ '^[0-9a-f]{24}$'
+    order by
         (pg_stat_file('pg_xlog/'||name)).modification,
-        wal.name DESC) sub;
+        wal.name desc) sub;
 """,
 }
 
-QUERY_ARCHIVE = {
-    DEFAULT: """
-SELECT
-    CAST(COUNT(*) AS INT) AS file_count,
-    CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.ready$$r$ as INT)),0) AS INT) AS ready_count,
-    CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.done$$r$ AS INT)),0) AS INT) AS done_count
-FROM
-    pg_catalog.pg_ls_dir('pg_wal/archive_status') AS archive_files (archive_file);
+query_archive = {
+    default: """
+select
+    cast(count(*) as int) as file_count,
+    cast(coalesce(sum(cast(archive_file ~ $r$\.ready$$r$ as int)),0) as int) as ready_count,
+    cast(coalesce(sum(cast(archive_file ~ $r$\.done$$r$ as int)),0) as int) as done_count
+from
+    pg_catalog.pg_ls_dir('pg_wal/archive_status') as archive_files (archive_file);
 """,
-    V96: """
-SELECT
-    CAST(COUNT(*) AS INT) AS file_count,
-    CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.ready$$r$ as INT)),0) AS INT) AS ready_count,
-    CAST(COALESCE(SUM(CAST(archive_file ~ $r$\.done$$r$ AS INT)),0) AS INT) AS done_count
-FROM
-    pg_catalog.pg_ls_dir('pg_xlog/archive_status') AS archive_files (archive_file);
+    v96: """
+select
+    cast(count(*) as int) as file_count,
+    cast(coalesce(sum(cast(archive_file ~ $r$\.ready$$r$ as int)),0) as int) as ready_count,
+    cast(coalesce(sum(cast(archive_file ~ $r$\.done$$r$ as int)),0) as int) as done_count
+from
+    pg_catalog.pg_ls_dir('pg_xlog/archive_status') as archive_files (archive_file);
 
 """,
 }
 
-QUERY_BACKEND = {
-    DEFAULT: """
-SELECT
-    count(*) - (SELECT  count(*)
-                FROM pg_stat_activity
-                WHERE state = 'idle')
-      AS backends_active,
-    (SELECT count(*)
-     FROM pg_stat_activity
-     WHERE state = 'idle')
-      AS backends_idle
-FROM pg_stat_activity;
+query_backend = {
+    default: """
+select
+    count(*) - (select  count(*)
+                from pg_stat_activity
+                where state = 'idle')
+      as backends_active,
+    (select count(*)
+     from pg_stat_activity
+     where state = 'idle')
+      as backends_idle
+from pg_stat_activity;
 """,
 }
 
-QUERY_BACKEND_USAGE = {
-    DEFAULT: """
-SELECT
-    COUNT(1) as used,
+query_backend_usage = {
+    default: """
+select
+    count(1) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - COUNT(1) AS available
-FROM pg_catalog.pg_stat_activity
-WHERE backend_type IN ('client backend', 'background worker');
+    - count(1) as available
+from pg_catalog.pg_stat_activity
+where backend_type in ('client backend', 'background worker');
 """,
-    V10: """
-SELECT
-    SUM(s.conn) as used,
+    v10: """
+select
+    sum(s.conn) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - SUM(s.conn) AS available
-FROM (
-    SELECT 's' as type, COUNT(1) as conn
-    FROM pg_catalog.pg_stat_activity
-    WHERE backend_type IN ('client backend', 'background worker')
-    UNION ALL
-    SELECT 'r', COUNT(1)
-    FROM pg_catalog.pg_stat_replication
+    - sum(s.conn) as available
+from (
+    select 's' as type, count(1) as conn
+    from pg_catalog.pg_stat_activity
+    where backend_type in ('client backend', 'background worker')
+    union all
+    select 'r', count(1)
+    from pg_catalog.pg_stat_replication
 ) as s;
 """,
-    V92: """
-SELECT
-    SUM(s.conn) as used,
+    v92: """
+select
+    sum(s.conn) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - SUM(s.conn) AS available
-FROM (
-    SELECT 's' as type, COUNT(1) as conn
-    FROM pg_catalog.pg_stat_activity
-    WHERE query NOT LIKE 'autovacuum: %%'
-    UNION ALL
-    SELECT 'r', COUNT(1)
-    FROM pg_catalog.pg_stat_replication
+    - sum(s.conn) as available
+from (
+    select 's' as type, count(1) as conn
+    from pg_catalog.pg_stat_activity
+    where query not like 'autovacuum: %%'
+    union all
+    select 'r', count(1)
+    from pg_catalog.pg_stat_replication
 ) as s;
 """,
-    V91: """
-SELECT
-    SUM(s.conn) as used,
+    v91: """
+select
+    sum(s.conn) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - SUM(s.conn) AS available
-FROM (
-    SELECT 's' as type, COUNT(1) as conn
-    FROM pg_catalog.pg_stat_activity
-    WHERE current_query NOT LIKE 'autovacuum: %%'
-    UNION ALL
-    SELECT 'r', COUNT(1)
-    FROM pg_catalog.pg_stat_replication
+    - sum(s.conn) as available
+from (
+    select 's' as type, count(1) as conn
+    from pg_catalog.pg_stat_activity
+    where current_query not like 'autovacuum: %%'
+    union all
+    select 'r', count(1)
+    from pg_catalog.pg_stat_replication
 ) as s;
 """,
-    V82: """
-SELECT
-    COUNT(1) as used,
+    v82: """
+select
+    count(1) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - COUNT(1) AS available
-FROM pg_catalog.pg_stat_activity
-WHERE current_query NOT LIKE 'autovacuum: %%';
+    - count(1) as available
+from pg_catalog.pg_stat_activity
+where current_query not like 'autovacuum: %%';
 """,
-    V72: """
-SELECT
-    COUNT(1) as used,
+    v72: """
+select
+    count(1) as used,
     current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int
-    - COUNT(1) AS available
-FROM pg_catalog.pg_stat_activity s
-JOIN pg_catalog.pg_database d ON d.oid = s.datid
-WHERE d.datallowconn;
+    - count(1) as available
+from pg_catalog.pg_stat_activity s
+join pg_catalog.pg_database d on d.oid = s.datid
+where d.datallowconn;
 """,
 }
 
-QUERY_TABLE_STATS = {
-    DEFAULT: """
-SELECT
-    ((sum(relpages) * 8) * 1024) AS table_size,
-    count(1)                     AS table_count
-FROM pg_class
-WHERE relkind IN ('r', 't');
+query_table_stats = {
+    default: """
+select
+    ((sum(relpages) * 8) * 1024) as table_size,
+    count(1)                     as table_count
+from pg_class
+where relkind in ('r', 't');
 """,
 }
 
-QUERY_INDEX_STATS = {
-    DEFAULT: """
-SELECT
-    ((sum(relpages) * 8) * 1024) AS index_size,
-    count(1)                     AS index_count
-FROM pg_class
-WHERE relkind = 'i';
+query_index_stats = {
+    default: """
+select
+    ((sum(relpages) * 8) * 1024) as index_size,
+    count(1)                     as index_count
+from pg_class
+where relkind = 'i';
 """,
 }
 
-QUERY_DATABASE = {
-    DEFAULT: """
-SELECT
-    datname AS database_name,
-    numbackends AS connections,
-    xact_commit AS xact_commit,
-    xact_rollback AS xact_rollback,
-    blks_read AS blks_read,
-    blks_hit AS blks_hit,
-    tup_returned AS tup_returned,
-    tup_fetched AS tup_fetched,
-    tup_inserted AS tup_inserted,
-    tup_updated AS tup_updated,
-    tup_deleted AS tup_deleted,
-    conflicts AS conflicts,
-    pg_database_size(datname) AS size,
-    temp_files AS temp_files,
-    temp_bytes AS temp_bytes
-FROM pg_stat_database
-WHERE datname IN %(databases)s ;
+query_database = {
+    default: """
+select
+    datname as database_name,
+    numbackends as connections,
+    xact_commit as xact_commit,
+    xact_rollback as xact_rollback,
+    blks_read as blks_read,
+    blks_hit as blks_hit,
+    tup_returned as tup_returned,
+    tup_fetched as tup_fetched,
+    tup_inserted as tup_inserted,
+    tup_updated as tup_updated,
+    tup_deleted as tup_deleted,
+    conflicts as conflicts,
+    pg_database_size(datname) as size,
+    temp_files as temp_files,
+    temp_bytes as temp_bytes
+from pg_stat_database
+where datname in %(databases)s ;
 """,
 }
 
-QUERY_BGWRITER = {
-    DEFAULT: """
-SELECT
-    checkpoints_timed AS checkpoint_scheduled,
-    checkpoints_req AS checkpoint_requested,
+query_bgwriter = {
+    default: """
+select
+    checkpoints_timed as checkpoint_scheduled,
+    checkpoints_req as checkpoint_requested,
     buffers_checkpoint * current_setting('block_size')::numeric buffers_checkpoint,
     buffers_clean * current_setting('block_size')::numeric buffers_clean,
     maxwritten_clean,
     buffers_backend * current_setting('block_size')::numeric buffers_backend,
     buffers_alloc * current_setting('block_size')::numeric buffers_alloc,
     buffers_backend_fsync
-FROM pg_stat_bgwriter;
+from pg_stat_bgwriter;
 """,
 }
 
-QUERY_LOCKS = {
-    DEFAULT: """
-SELECT
+query_locks = {
+    default: """
+select
     pg_database.datname as database_name,
     mode,
-    count(mode) AS locks_count
-FROM pg_locks
-INNER JOIN pg_database
-    ON pg_database.oid = pg_locks.database
-GROUP BY datname, mode
-ORDER BY datname, mode;
+    count(mode) as locks_count
+from pg_locks
+inner join pg_database
+    on pg_database.oid = pg_locks.database
+group by datname, mode
+order by datname, mode;
 """,
 }
 
-QUERY_BLOCKERS = {
-    DEFAULT: """
-WITH B AS (
-SELECT DISTINCT
+query_blockers = {
+    default: """
+with b as (
+select distinct
     pg_database.datname as database_name,
     pg_locks.pid,
-    cardinality(pg_blocking_pids(pg_locks.pid)) AS blocking_pids
-FROM pg_locks
-INNER JOIN pg_database ON pg_database.oid = pg_locks.database
-WHERE NOT pg_locks.granted)
-SELECT database_name, AVG(blocking_pids) AS blocking_pids_avg
-FROM B
-GROUP BY database_name
+    cardinality(pg_blocking_pids(pg_locks.pid)) as blocking_pids
+from pg_locks
+inner join pg_database on pg_database.oid = pg_locks.database
+where not pg_locks.granted)
+select database_name, avg(blocking_pids) as blocking_pids_avg
+from b
+group by database_name
 """,
-    V96: """
-WITH B AS (
-SELECT DISTINCT
+    v96: """
+with b as (
+select distinct
     pg_database.datname as database_name,
-    blocked_locks.pid AS blocked_pid,
-    COUNT(blocking_locks.pid) AS blocking_pids
-FROM  pg_catalog.pg_locks blocked_locks
-INNER JOIN pg_database ON pg_database.oid = blocked_locks.database
-JOIN pg_catalog.pg_locks blocking_locks
-        ON blocking_locks.locktype = blocked_locks.locktype
-        AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
-        AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
-        AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
-        AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
-        AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
-        AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
-        AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
-        AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
-        AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-        AND blocking_locks.pid != blocked_locks.pid
-WHERE NOT blocked_locks.GRANTED
-GROUP BY database_name, blocked_pid)
-SELECT database_name, AVG(blocking_pids) AS blocking_pids_avg
-FROM B
-GROUP BY database_name
+    blocked_locks.pid as blocked_pid,
+    count(blocking_locks.pid) as blocking_pids
+from  pg_catalog.pg_locks blocked_locks
+inner join pg_database on pg_database.oid = blocked_locks.database
+join pg_catalog.pg_locks blocking_locks
+        on blocking_locks.locktype = blocked_locks.locktype
+        and blocking_locks.database is not distinct from blocked_locks.database
+        and blocking_locks.relation is not distinct from blocked_locks.relation
+        and blocking_locks.page is not distinct from blocked_locks.page
+        and blocking_locks.tuple is not distinct from blocked_locks.tuple
+        and blocking_locks.virtualxid is not distinct from blocked_locks.virtualxid
+        and blocking_locks.transactionid is not distinct from blocked_locks.transactionid
+        and blocking_locks.classid is not distinct from blocked_locks.classid
+        and blocking_locks.objid is not distinct from blocked_locks.objid
+        and blocking_locks.objsubid is not distinct from blocked_locks.objsubid
+        and blocking_locks.pid != blocked_locks.pid
+where not blocked_locks.granted
+group by database_name, blocked_pid)
+select database_name, avg(blocking_pids) as blocking_pids_avg
+from b
+group by database_name
 """
 }
 
-QUERY_DATABASES = {
-    DEFAULT: """
-SELECT
+query_databases = {
+    default: """
+select
     datname
-FROM pg_stat_database
-WHERE
+from pg_stat_database
+where
     has_database_privilege(
-      (SELECT current_user), datname, 'connect')
-    AND NOT datname ~* '^template\d';
+      (select current_user), datname, 'connect')
+    and not datname ~* '^template\d';
 """,
 }
 
-QUERY_STANDBY = {
-    DEFAULT: """
-SELECT
+query_standby = {
+    default: """
+select
     coalesce(prs.slot_name, psr.application_name) application_name
-FROM pg_stat_replication psr
-LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
-WHERE application_name IS NOT NULL;
+from pg_stat_replication psr
+left outer join pg_replication_slots prs on psr.pid = prs.active_pid
+where application_name is not null;
 """,
 }
 
-QUERY_REPLICATION_SLOT = {
-    DEFAULT: """
-SELECT slot_name
-FROM pg_replication_slots;
+query_replication_slot = {
+    default: """
+select slot_name
+from pg_replication_slots;
 """
 }
 
-QUERY_STANDBY_DELTA = {
-    DEFAULT: """
-SELECT
+query_standby_delta = {
+    default: """
+select
     coalesce(prs.slot_name, psr.application_name) application_name,
     pg_wal_lsn_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_wal_receive_lsn()
-        ELSE pg_current_wal_lsn()
-      END,
-    sent_lsn) AS sent_delta,
+      case pg_is_in_recovery()
+        when true then pg_last_wal_receive_lsn()
+        else pg_current_wal_lsn()
+      end,
+    sent_lsn) as sent_delta,
     pg_wal_lsn_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_wal_receive_lsn()
-        ELSE pg_current_wal_lsn()
-      END,
-    write_lsn) AS write_delta,
+      case pg_is_in_recovery()
+        when true then pg_last_wal_receive_lsn()
+        else pg_current_wal_lsn()
+      end,
+    write_lsn) as write_delta,
     pg_wal_lsn_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_wal_receive_lsn()
-        ELSE pg_current_wal_lsn()
-      END,
-    flush_lsn) AS flush_delta,
+      case pg_is_in_recovery()
+        when true then pg_last_wal_receive_lsn()
+        else pg_current_wal_lsn()
+      end,
+    flush_lsn) as flush_delta,
     pg_wal_lsn_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_wal_receive_lsn()
-        ELSE pg_current_wal_lsn()
-      END,
-    replay_lsn) AS replay_delta
-FROM pg_stat_replication psr
-LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
-WHERE application_name IS NOT NULL;
+      case pg_is_in_recovery()
+        when true then pg_last_wal_receive_lsn()
+        else pg_current_wal_lsn()
+      end,
+    replay_lsn) as replay_delta
+from pg_stat_replication psr
+left outer join pg_replication_slots prs on psr.pid = prs.active_pid
+where application_name is not null;
 """,
-    V96: """
-SELECT
+    v96: """
+select
     coalesce(prs.slot_name, psr.application_name) application_name,
     pg_xlog_location_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_xlog_receive_location()
-        ELSE pg_current_xlog_location()
-      END,
-    sent_location) AS sent_delta,
+      case pg_is_in_recovery()
+        when true then pg_last_xlog_receive_location()
+        else pg_current_xlog_location()
+      end,
+    sent_location) as sent_delta,
     pg_xlog_location_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_xlog_receive_location()
-        ELSE pg_current_xlog_location()
-      END,
-    write_location) AS write_delta,
+      case pg_is_in_recovery()
+        when true then pg_last_xlog_receive_location()
+        else pg_current_xlog_location()
+      end,
+    write_location) as write_delta,
     pg_xlog_location_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_xlog_receive_location()
-        ELSE pg_current_xlog_location()
-      END,
-    flush_location) AS flush_delta,
+      case pg_is_in_recovery()
+        when true then pg_last_xlog_receive_location()
+        else pg_current_xlog_location()
+      end,
+    flush_location) as flush_delta,
     pg_xlog_location_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_xlog_receive_location()
-        ELSE pg_current_xlog_location()
-      END,
-    replay_location) AS replay_delta
-FROM pg_stat_replication psr
-LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
-WHERE application_name IS NOT NULL;
+      case pg_is_in_recovery()
+        when true then pg_last_xlog_receive_location()
+        else pg_current_xlog_location()
+      end,
+    replay_location) as replay_delta
+from pg_stat_replication psr
+left outer join pg_replication_slots prs on psr.pid = prs.active_pid
+where application_name is not null;
 """,
 }
 
-QUERY_STANDBY_LAG = {
-    DEFAULT: """
-SELECT
+query_standby_lag = {
+    default: """
+select
     coalesce(prs.slot_name, psr.application_name) application_name,
-    COALESCE(EXTRACT(EPOCH FROM write_lag)::bigint, 0) AS write_lag,
-    COALESCE(EXTRACT(EPOCH FROM flush_lag)::bigint, 0) AS flush_lag,
-    COALESCE(EXTRACT(EPOCH FROM replay_lag)::bigint, 0) AS replay_lag
-FROM pg_stat_replication psr
-LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
-WHERE application_name IS NOT NULL;
+    coalesce(extract(epoch from write_lag)::bigint, 0) as write_lag,
+    coalesce(extract(epoch from flush_lag)::bigint, 0) as flush_lag,
+    coalesce(extract(epoch from replay_lag)::bigint, 0) as replay_lag
+from pg_stat_replication psr
+left outer join pg_replication_slots prs on psr.pid = prs.active_pid
+where application_name is not null;
 """
 }
 
-QUERY_REPSLOT_FILES = {
-    DEFAULT: """
-WITH wal_size AS (
-  SELECT
-    setting::int AS val
-  FROM pg_settings
-  WHERE name = 'wal_segment_size'
+query_repslot_files = {
+    default: """
+with wal_size as (
+  select
+    setting::int as val
+  from pg_settings
+  where name = 'wal_segment_size'
   )
-SELECT
+select
     slot_name,
     slot_type,
     replslot_wal_keep,
-    count(slot_file) AS replslot_files
-FROM
-    (SELECT
+    count(slot_file) as replslot_files
+from
+    (select
         slot.slot_name,
-        CASE
-            WHEN slot_file <> 'state' THEN 1
-        END AS slot_file ,
+        case
+            when slot_file <> 'state' then 1
+        end as slot_file ,
         slot_type,
-        COALESCE (
+        coalesce (
           floor(
             (pg_wal_lsn_diff(pg_current_wal_lsn (),slot.restart_lsn)
              - (pg_walfile_name_offset (restart_lsn)).file_offset) / (s.val)
-          ),0) AS replslot_wal_keep
-    FROM pg_replication_slots slot
-    LEFT JOIN (
-        SELECT
+          ),0) as replslot_wal_keep
+    from pg_replication_slots slot
+    left join (
+        select
             slot2.slot_name,
-            pg_ls_dir('pg_replslot/' || slot2.slot_name) AS slot_file
-        FROM pg_replication_slots slot2
+            pg_ls_dir('pg_replslot/' || slot2.slot_name) as slot_file
+        from pg_replication_slots slot2
         ) files (slot_name, slot_file)
-        ON slot.slot_name = files.slot_name
-    CROSS JOIN wal_size s
-    ) AS d
-GROUP BY
+        on slot.slot_name = files.slot_name
+    cross join wal_size s
+    ) as d
+group by
     slot_name,
     slot_type,
     replslot_wal_keep;
 """,
-    V10: """
-WITH wal_size AS (
-  SELECT
-    current_setting('wal_block_size')::INT * setting::INT AS val
-  FROM pg_settings
-  WHERE name = 'wal_segment_size'
+    v10: """
+with wal_size as (
+  select
+    current_setting('wal_block_size')::int * setting::int as val
+  from pg_settings
+  where name = 'wal_segment_size'
   )
-SELECT
+select
     slot_name,
     slot_type,
     replslot_wal_keep,
-    count(slot_file) AS replslot_files
-FROM
-    (SELECT
+    count(slot_file) as replslot_files
+from
+    (select
         slot.slot_name,
-        CASE
-            WHEN slot_file <> 'state' THEN 1
-        END AS slot_file ,
+        case
+            when slot_file <> 'state' then 1
+        end as slot_file ,
         slot_type,
-        COALESCE (
+        coalesce (
           floor(
             (pg_wal_lsn_diff(pg_current_wal_lsn (),slot.restart_lsn)
              - (pg_walfile_name_offset (restart_lsn)).file_offset) / (s.val)
-          ),0) AS replslot_wal_keep
-    FROM pg_replication_slots slot
-    LEFT JOIN (
-        SELECT
+          ),0) as replslot_wal_keep
+    from pg_replication_slots slot
+    left join (
+        select
             slot2.slot_name,
-            pg_ls_dir('pg_replslot/' || slot2.slot_name) AS slot_file
-        FROM pg_replication_slots slot2
+            pg_ls_dir('pg_replslot/' || slot2.slot_name) as slot_file
+        from pg_replication_slots slot2
         ) files (slot_name, slot_file)
-        ON slot.slot_name = files.slot_name
-    CROSS JOIN wal_size s
-    ) AS d
-GROUP BY
+        on slot.slot_name = files.slot_name
+    cross join wal_size s
+    ) as d
+group by
     slot_name,
     slot_type,
     replslot_wal_keep;
 """,
 }
 
-QUERY_SUPERUSER = {
-    DEFAULT: """
-SELECT current_setting('is_superuser') = 'on' AS is_superuser;
+query_superuser = {
+    default: """
+select current_setting('is_superuser') = 'on' as is_superuser;
 """,
 }
 
-QUERY_SHOW_VERSION = {
-    DEFAULT: """
-SHOW server_version_num;
+query_show_version = {
+    default: """
+show server_version_num;
 """,
 }
 
-QUERY_AUTOVACUUM = {
-    DEFAULT: """
-SELECT
-    count(*) FILTER (WHERE query LIKE 'autovacuum: ANALYZE%%') AS analyze,
-    count(*) FILTER (WHERE query LIKE 'autovacuum: VACUUM ANALYZE%%') AS vacuum_analyze,
-    count(*) FILTER (WHERE query LIKE 'autovacuum: VACUUM%%'
-                       AND query NOT LIKE 'autovacuum: VACUUM ANALYZE%%'
-                       AND query NOT LIKE '%%to prevent wraparound%%') AS vacuum,
-    count(*) FILTER (WHERE query LIKE '%%to prevent wraparound%%') AS vacuum_freeze,
-    count(*) FILTER (WHERE query LIKE 'autovacuum: BRIN summarize%%') AS brin_summarize
-FROM pg_stat_activity
-WHERE query NOT LIKE '%%pg_stat_activity%%';
+query_autovacuum = {
+    default: """
+select
+    count(*) filter (where query like 'autovacuum: analyze%%') as analyze,
+    count(*) filter (where query like 'autovacuum: vacuum analyze%%') as vacuum_analyze,
+    count(*) filter (where query like 'autovacuum: vacuum%%'
+                       and query not like 'autovacuum: vacuum analyze%%'
+                       and query not like '%%to prevent wraparound%%') as vacuum,
+    count(*) filter (where query like '%%to prevent wraparound%%') as vacuum_freeze,
+    count(*) filter (where query like 'autovacuum: brin summarize%%') as brin_summarize
+from pg_stat_activity
+where query not like '%%pg_stat_activity%%';
 """,
 }
 
-QUERY_EMERGENCY_AUTOVACUUM = {
-    DEFAULT: """
-WITH max_age AS (
-    SELECT setting AS autovacuum_freeze_max_age
-        FROM pg_catalog.pg_settings
-        WHERE name = 'autovacuum_freeze_max_age' )
-, per_database_stats AS (
-    SELECT datname
+query_emergency_autovacuum = {
+    default: """
+with max_age as (
+    select setting as autovacuum_freeze_max_age
+        from pg_catalog.pg_settings
+        where name = 'autovacuum_freeze_max_age' )
+, per_database_stats as (
+    select datname
         , m.autovacuum_freeze_max_age::int
-        , age(d.datfrozenxid) AS oldest_current_xid
-    FROM pg_catalog.pg_database d
-    JOIN max_age m ON (true)
-    WHERE d.datallowconn )
-SELECT max(ROUND(100*(oldest_current_xid/autovacuum_freeze_max_age::float))) AS percent_towards_emergency_autovac
-FROM per_database_stats;
+        , age(d.datfrozenxid) as oldest_current_xid
+    from pg_catalog.pg_database d
+    join max_age m on (true)
+    where d.datallowconn )
+select max(round(100*(oldest_current_xid/autovacuum_freeze_max_age::float))) as percent_towards_emergency_autovac
+from per_database_stats;
 """,
 }
 
-QUERY_TX_WRAPAROUND = {
-    DEFAULT: """
-WITH max_age AS (
-    SELECT 2000000000 as max_old_xid
-        FROM pg_catalog.pg_settings
-        WHERE name = 'autovacuum_freeze_max_age' )
-, per_database_stats AS (
-    SELECT datname
+query_tx_wraparound = {
+    default: """
+with max_age as (
+    select 2000000000 as max_old_xid
+        from pg_catalog.pg_settings
+        where name = 'autovacuum_freeze_max_age' )
+, per_database_stats as (
+    select datname
         , m.max_old_xid::int
-        , age(d.datfrozenxid) AS oldest_current_xid
-    FROM pg_catalog.pg_database d
-    JOIN max_age m ON (true)
-    WHERE d.datallowconn )
-SELECT max(oldest_current_xid) AS oldest_current_xid
-    , max(ROUND(100*(oldest_current_xid/max_old_xid::float))) AS percent_towards_wraparound
-FROM per_database_stats;
+        , age(d.datfrozenxid) as oldest_current_xid
+    from pg_catalog.pg_database d
+    join max_age m on (true)
+    where d.datallowconn )
+select max(oldest_current_xid) as oldest_current_xid
+    , max(round(100*(oldest_current_xid/max_old_xid::float))) as percent_towards_wraparound
+from per_database_stats;
 """,
 }
 
-QUERY_DIFF_LSN = {
-    DEFAULT: """
-SELECT
+query_diff_lsn = {
+    default: """
+select
     pg_wal_lsn_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_wal_receive_lsn()
-        ELSE pg_current_wal_lsn()
-      END,
+      case pg_is_in_recovery()
+        when true then pg_last_wal_receive_lsn()
+        else pg_current_wal_lsn()
+      end,
     '0/0') as wal_writes ;
 """,
-    V96: """
-SELECT
+    v96: """
+select
     pg_xlog_location_diff(
-      CASE pg_is_in_recovery()
-        WHEN true THEN pg_last_xlog_receive_location()
-        ELSE pg_current_xlog_location()
-      END,
+      case pg_is_in_recovery()
+        when true then pg_last_xlog_receive_location()
+        else pg_current_xlog_location()
+      end,
     '0/0') as wal_writes ;
 """,
 }
 
-def query_factory(name, version=NO_VERSION):
-    if name == QUERY_NAME_BACKENDS:
-        return QUERY_BACKEND[DEFAULT]
-    elif name == QUERY_NAME_BACKEND_USAGE:
+def query_factory(name, version=no_version):
+    if name == query_name_backends:
+        return query_backend[default]
+    elif name == query_name_backend_usage:
         if version < 80200:
-            return QUERY_BACKEND_USAGE[V72]
+            return query_backend_usage[v72]
         if version < 90100:
-            return QUERY_BACKEND_USAGE[V82]
+            return query_backend_usage[v82]
         if version < 90200:
-            return QUERY_BACKEND_USAGE[V91]
+            return query_backend_usage[v91]
         if version < 100000:
-            return QUERY_BACKEND_USAGE[V92]
+            return query_backend_usage[v92]
         elif version < 120000:
-            return QUERY_BACKEND_USAGE[V10]
-        return QUERY_BACKEND_USAGE[DEFAULT]
-    elif name == QUERY_NAME_TABLE_STATS:
-        return QUERY_TABLE_STATS[DEFAULT]
-    elif name == QUERY_NAME_INDEX_STATS:
-        return QUERY_INDEX_STATS[DEFAULT]
-    elif name == QUERY_NAME_DATABASE:
-        return QUERY_DATABASE[DEFAULT]
-    elif name == QUERY_NAME_BGWRITER:
-        return QUERY_BGWRITER[DEFAULT]
-    elif name == QUERY_NAME_LOCKS:
-        return QUERY_LOCKS[DEFAULT]
-    elif name == QUERY_NAME_BLOCKERS:
+            return query_backend_usage[v10]
+        return query_backend_usage[default]
+    elif name == query_name_table_stats:
+        return query_table_stats[default]
+    elif name == query_name_index_stats:
+        return query_index_stats[default]
+    elif name == query_name_database:
+        return query_database[default]
+    elif name == query_name_bgwriter:
+        return query_bgwriter[default]
+    elif name == query_name_locks:
+        return query_locks[default]
+    elif name == query_name_blockers:
         if version < 90600:
-            return QUERY_BLOCKERS[V96]
-        return QUERY_BLOCKERS[DEFAULT]
-    elif name == QUERY_NAME_DATABASES:
-        return QUERY_DATABASES[DEFAULT]
-    elif name == QUERY_NAME_STANDBY:
-        return QUERY_STANDBY[DEFAULT]
-    elif name == QUERY_NAME_REPLICATION_SLOT:
-        return QUERY_REPLICATION_SLOT[DEFAULT]
-    elif name == QUERY_NAME_IF_SUPERUSER:
-        return QUERY_SUPERUSER[DEFAULT]
-    elif name == QUERY_NAME_SERVER_VERSION:
-        return QUERY_SHOW_VERSION[DEFAULT]
-    elif name == QUERY_NAME_AUTOVACUUM:
-        return QUERY_AUTOVACUUM[DEFAULT]
-    elif name == QUERY_NAME_EMERGENCY_AUTOVACUUM:
-        return QUERY_EMERGENCY_AUTOVACUUM[DEFAULT]
-    elif name == QUERY_NAME_TX_WRAPAROUND:
-        return QUERY_TX_WRAPAROUND[DEFAULT]
-    elif name == QUERY_NAME_WAL:
+            return query_blockers[v96]
+        return query_blockers[default]
+    elif name == query_name_databases:
+        return query_databases[default]
+    elif name == query_name_standby:
+        return query_standby[default]
+    elif name == query_name_replication_slot:
+        return query_replication_slot[default]
+    elif name == query_name_if_superuser:
+        return query_superuser[default]
+    elif name == query_name_server_version:
+        return query_show_version[default]
+    elif name == query_name_autovacuum:
+        return query_autovacuum[default]
+    elif name == query_name_emergency_autovacuum:
+        return query_emergency_autovacuum[default]
+    elif name == query_name_tx_wraparound:
+        return query_tx_wraparound[default]
+    elif name == query_name_wal:
         if version < 100000:
-            return QUERY_WAL[V96]
-        return QUERY_WAL[DEFAULT]
-    elif name == QUERY_NAME_ARCHIVE:
+            return query_wal[v96]
+        return query_wal[default]
+    elif name == query_name_archive:
         if version < 100000:
-            return QUERY_ARCHIVE[V96]
-        return QUERY_ARCHIVE[DEFAULT]
-    elif name == QUERY_NAME_STANDBY_DELTA:
+            return query_archive[v96]
+        return query_archive[default]
+    elif name == query_name_standby_delta:
         if version < 100000:
-            return QUERY_STANDBY_DELTA[V96]
-        return QUERY_STANDBY_DELTA[DEFAULT]
-    elif name == QUERY_NAME_STANDBY_LAG:
-        return QUERY_STANDBY_LAG[DEFAULT]
-    elif name == QUERY_NAME_REPSLOT_FILES:
+            return query_standby_delta[v96]
+        return query_standby_delta[default]
+    elif name == query_name_standby_lag:
+        return query_standby_lag[default]
+    elif name == query_name_repslot_files:
         if version < 110000:
-            return QUERY_REPSLOT_FILES[V10]
-        return QUERY_REPSLOT_FILES[DEFAULT]
-    elif name == QUERY_NAME_DIFF_LSN:
+            return query_repslot_files[v10]
+        return query_repslot_files[default]
+    elif name == query_name_diff_lsn:
         if version < 100000:
-            return QUERY_DIFF_LSN[V96]
-        return QUERY_DIFF_LSN[DEFAULT]
+            return query_diff_lsn[v96]
+        return query_diff_lsn[default]
 
-    raise ValueError('unknown query')
+    raise valueerror('unknown query')
 
 
-ORDER = [
+order = [
     'db_stat_temp_files',
     'db_stat_temp_bytes',
     'db_stat_blks',
@@ -826,9 +826,9 @@ ORDER = [
     'tx_wraparound_percent_towards_wraparound'
 ]
 
-CHARTS = {
+charts = {
     'db_stat_transactions': {
-        'options': [None, 'Transactions on db', 'transactions/s', 'db statistics', 'postgres.db_stat_transactions',
+        'options': [none, 'transactions on db', 'transactions/s', 'db statistics', 'postgres.db_stat_transactions',
                     'line'],
         'lines': [
             ['xact_commit', 'committed', 'incremental'],
@@ -836,21 +836,21 @@ CHARTS = {
         ]
     },
     'db_stat_connections': {
-        'options': [None, 'Current connections to db', 'count', 'db statistics', 'postgres.db_stat_connections',
+        'options': [none, 'current connections to db', 'count', 'db statistics', 'postgres.db_stat_connections',
                     'line'],
         'lines': [
             ['connections', 'connections', 'absolute']
         ]
     },
     'db_stat_blks': {
-        'options': [None, 'Disk blocks reads from db', 'reads/s', 'db statistics', 'postgres.db_stat_blks', 'line'],
+        'options': [none, 'disk blocks reads from db', 'reads/s', 'db statistics', 'postgres.db_stat_blks', 'line'],
         'lines': [
             ['blks_read', 'disk', 'incremental'],
             ['blks_hit', 'cache', 'incremental']
         ]
     },
     'db_stat_tuple_returned': {
-        'options': [None, 'Tuples returned from db', 'tuples/s', 'db statistics', 'postgres.db_stat_tuple_returned',
+        'options': [none, 'tuples returned from db', 'tuples/s', 'db statistics', 'postgres.db_stat_tuple_returned',
                     'line'],
         'lines': [
             ['tup_returned', 'sequential', 'incremental'],
@@ -858,7 +858,7 @@ CHARTS = {
         ]
     },
     'db_stat_tuple_write': {
-        'options': [None, 'Tuples written to db', 'writes/s', 'db statistics', 'postgres.db_stat_tuple_write', 'line'],
+        'options': [none, 'tuples written to db', 'writes/s', 'db statistics', 'postgres.db_stat_tuple_write', 'line'],
         'lines': [
             ['tup_inserted', 'inserted', 'incremental'],
             ['tup_updated', 'updated', 'incremental'],
@@ -867,33 +867,33 @@ CHARTS = {
         ]
     },
     'db_stat_temp_bytes': {
-        'options': [None, 'Temp files written to disk', 'KiB/s', 'db statistics', 'postgres.db_stat_temp_bytes',
+        'options': [none, 'temp files written to disk', 'kib/s', 'db statistics', 'postgres.db_stat_temp_bytes',
                     'line'],
         'lines': [
             ['temp_bytes', 'size', 'incremental', 1, 1024]
         ]
     },
     'db_stat_temp_files': {
-        'options': [None, 'Temp files written to disk', 'files', 'db statistics', 'postgres.db_stat_temp_files',
+        'options': [none, 'temp files written to disk', 'files', 'db statistics', 'postgres.db_stat_temp_files',
                     'line'],
         'lines': [
             ['temp_files', 'files', 'incremental']
         ]
     },
     'db_stat_blocking_pids_avg': {
-        'options': [None, 'Average number of blocking transactions in db', 'processes', 'db statistics',
+        'options': [none, 'average number of blocking transactions in db', 'processes', 'db statistics',
                     'postgres.db_stat_blocking_pids_avg', 'line'],
         'lines': [
             ['blocking_pids_avg', 'blocking', 'absolute']
         ]
     },
     'database_size': {
-        'options': [None, 'Database size', 'MiB', 'database size', 'postgres.db_size', 'stacked'],
+        'options': [none, 'database size', 'mib', 'database size', 'postgres.db_size', 'stacked'],
         'lines': [
         ]
     },
     'backend_process': {
-        'options': [None, 'Current Backend Processes', 'processes', 'backend processes', 'postgres.backend_process',
+        'options': [none, 'current backend processes', 'processes', 'backend processes', 'postgres.backend_process',
                     'line'],
         'lines': [
             ['backends_active', 'active', 'absolute'],
@@ -901,38 +901,38 @@ CHARTS = {
         ]
     },
     'backend_usage': {
-        'options': [None, '% of Connections in use', 'percentage', 'backend processes', 'postgres.backend_usage', 'stacked'],
+        'options': [none, '% of connections in use', 'percentage', 'backend processes', 'postgres.backend_usage', 'stacked'],
         'lines': [
             ['available', 'available', 'percentage-of-absolute-row'],
             ['used', 'used', 'percentage-of-absolute-row']
         ]
     },
     'index_count': {
-        'options': [None, 'Total indexes', 'index', 'indexes', 'postgres.index_count', 'line'],
+        'options': [none, 'total indexes', 'index', 'indexes', 'postgres.index_count', 'line'],
         'lines': [
             ['index_count', 'total', 'absolute']
         ]
     },
     'index_size': {
-        'options': [None, 'Indexes size', 'MiB', 'indexes', 'postgres.index_size', 'line'],
+        'options': [none, 'indexes size', 'mib', 'indexes', 'postgres.index_size', 'line'],
         'lines': [
             ['index_size', 'size', 'absolute', 1, 1024 * 1024]
         ]
     },
     'table_count': {
-        'options': [None, 'Total Tables', 'tables', 'tables', 'postgres.table_count', 'line'],
+        'options': [none, 'total tables', 'tables', 'tables', 'postgres.table_count', 'line'],
         'lines': [
             ['table_count', 'total', 'absolute']
         ]
     },
     'table_size': {
-        'options': [None, 'Tables size', 'MiB', 'tables', 'postgres.table_size', 'line'],
+        'options': [none, 'tables size', 'mib', 'tables', 'postgres.table_size', 'line'],
         'lines': [
             ['table_size', 'size', 'absolute', 1, 1024 * 1024]
         ]
     },
     'wal': {
-        'options': [None, 'Write-Ahead Logs', 'files', 'wal', 'postgres.wal', 'line'],
+        'options': [none, 'write-ahead logs', 'files', 'wal', 'postgres.wal', 'line'],
         'lines': [
             ['written_wal', 'written', 'absolute'],
             ['recycled_wal', 'recycled', 'absolute'],
@@ -940,13 +940,13 @@ CHARTS = {
         ]
     },
     'wal_writes': {
-        'options': [None, 'Write-Ahead Logs', 'KiB/s', 'wal_writes', 'postgres.wal_writes', 'line'],
+        'options': [none, 'write-ahead logs', 'kib/s', 'wal_writes', 'postgres.wal_writes', 'line'],
         'lines': [
             ['wal_writes', 'writes', 'incremental', 1, 1024]
         ]
     },
     'archive_wal': {
-        'options': [None, 'Archive Write-Ahead Logs', 'files/s', 'archive wal', 'postgres.archive_wal', 'line'],
+        'options': [none, 'archive write-ahead logs', 'files/s', 'archive wal', 'postgres.archive_wal', 'line'],
         'lines': [
             ['file_count', 'total', 'incremental'],
             ['ready_count', 'ready', 'incremental'],
@@ -954,54 +954,54 @@ CHARTS = {
         ]
     },
     'checkpointer': {
-        'options': [None, 'Checkpoints', 'writes', 'checkpointer', 'postgres.checkpointer', 'line'],
+        'options': [none, 'checkpoints', 'writes', 'checkpointer', 'postgres.checkpointer', 'line'],
         'lines': [
             ['checkpoint_scheduled', 'scheduled', 'incremental'],
             ['checkpoint_requested', 'requested', 'incremental']
         ]
     },
     'stat_bgwriter_alloc': {
-        'options': [None, 'Buffers allocated', 'KiB/s', 'bgwriter', 'postgres.stat_bgwriter_alloc', 'line'],
+        'options': [none, 'buffers allocated', 'kib/s', 'bgwriter', 'postgres.stat_bgwriter_alloc', 'line'],
         'lines': [
             ['buffers_alloc', 'alloc', 'incremental', 1, 1024]
         ]
     },
     'stat_bgwriter_checkpoint': {
-        'options': [None, 'Buffers written during checkpoints', 'KiB/s', 'bgwriter',
+        'options': [none, 'buffers written during checkpoints', 'kib/s', 'bgwriter',
                     'postgres.stat_bgwriter_checkpoint', 'line'],
         'lines': [
             ['buffers_checkpoint', 'checkpoint', 'incremental', 1, 1024]
         ]
     },
     'stat_bgwriter_backend': {
-        'options': [None, 'Buffers written directly by a backend', 'KiB/s', 'bgwriter',
+        'options': [none, 'buffers written directly by a backend', 'kib/s', 'bgwriter',
                     'postgres.stat_bgwriter_backend', 'line'],
         'lines': [
             ['buffers_backend', 'backend', 'incremental', 1, 1024]
         ]
     },
     'stat_bgwriter_backend_fsync': {
-        'options': [None, 'Fsync by backend', 'times', 'bgwriter', 'postgres.stat_bgwriter_backend_fsync', 'line'],
+        'options': [none, 'fsync by backend', 'times', 'bgwriter', 'postgres.stat_bgwriter_backend_fsync', 'line'],
         'lines': [
             ['buffers_backend_fsync', 'backend fsync', 'incremental']
         ]
     },
     'stat_bgwriter_bgwriter': {
-        'options': [None, 'Buffers written by the background writer', 'KiB/s', 'bgwriter',
+        'options': [none, 'buffers written by the background writer', 'kib/s', 'bgwriter',
                     'postgres.bgwriter_bgwriter', 'line'],
         'lines': [
             ['buffers_clean', 'clean', 'incremental', 1, 1024]
         ]
     },
     'stat_bgwriter_maxwritten': {
-        'options': [None, 'Too many buffers written', 'times', 'bgwriter', 'postgres.stat_bgwriter_maxwritten',
+        'options': [none, 'too many buffers written', 'times', 'bgwriter', 'postgres.stat_bgwriter_maxwritten',
                     'line'],
         'lines': [
             ['maxwritten_clean', 'maxwritten', 'incremental']
         ]
     },
     'autovacuum': {
-        'options': [None, 'Autovacuum workers', 'workers', 'autovacuum', 'postgres.autovacuum', 'line'],
+        'options': [none, 'autovacuum workers', 'workers', 'autovacuum', 'postgres.autovacuum', 'line'],
         'lines': [
             ['analyze', 'analyze', 'absolute'],
             ['vacuum', 'vacuum', 'absolute'],
@@ -1011,25 +1011,25 @@ CHARTS = {
         ]
     },
     'emergency_autovacuum': {
-        'options': [None, 'Percent towards emergency autovac', 'percent', 'autovacuum', 'postgres.emergency_autovacuum', 'line'],
+        'options': [none, 'percent towards emergency autovac', 'percent', 'autovacuum', 'postgres.emergency_autovacuum', 'line'],
         'lines': [
             ['percent_towards_emergency_autovac', 'percent', 'absolute']
         ]
     },
     'tx_wraparound_oldest_current_xid': {
-        'options': [None, 'Oldest current XID', 'xid', 'tx_wraparound', 'postgres.tx_wraparound_oldest_current_xid', 'line'],
+        'options': [none, 'oldest current xid', 'xid', 'tx_wraparound', 'postgres.tx_wraparound_oldest_current_xid', 'line'],
         'lines': [
             ['oldest_current_xid', 'percent', 'absolute']
         ]
     },
     'tx_wraparound_percent_towards_wraparound': {
-        'options': [None, 'Percent towards wraparound', 'percent', 'tx_wraparound', 'postgres.percent_towards_wraparound', 'line'],
+        'options': [none, 'percent towards wraparound', 'percent', 'tx_wraparound', 'postgres.percent_towards_wraparound', 'line'],
         'lines': [
             ['percent_towards_wraparound', 'percent', 'absolute']
         ]
     },
     'standby_delta': {
-        'options': [None, 'Standby delta', 'KiB', 'replication delta', 'postgres.standby_delta', 'line'],
+        'options': [none, 'standby delta', 'kib', 'replication delta', 'postgres.standby_delta', 'line'],
         'lines': [
             ['sent_delta', 'sent delta', 'absolute', 1, 1024],
             ['write_delta', 'write delta', 'absolute', 1, 1024],
@@ -1038,7 +1038,7 @@ CHARTS = {
         ]
     },
     'standby_lag': {
-        'options': [None, 'Standby lag', 'seconds', 'replication lag', 'postgres.standby_lag', 'line'],
+        'options': [none, 'standby lag', 'seconds', 'replication lag', 'postgres.standby_lag', 'line'],
         'lines': [
             ['write_lag', 'write lag', 'absolute'],
             ['flush_lag', 'flush lag', 'absolute'],
@@ -1046,7 +1046,7 @@ CHARTS = {
         ]
     },
     'replication_slot': {
-        'options': [None, 'Replication slot files', 'files', 'replication slot', 'postgres.replication_slot', 'line'],
+        'options': [none, 'replication slot files', 'files', 'replication slot', 'postgres.replication_slot', 'line'],
         'lines': [
             ['replslot_wal_keep', 'wal keeped', 'absolute'],
             ['replslot_files', 'pg_replslot files', 'absolute']
@@ -1055,20 +1055,20 @@ CHARTS = {
 }
 
 
-class Service(SimpleService):
-    def __init__(self, configuration=None, name=None):
-        SimpleService.__init__(self, configuration=configuration, name=name)
-        self.order = list(ORDER)
-        self.definitions = deepcopy(CHARTS)
-        self.do_table_stats = configuration.pop('table_stats', False)
-        self.do_index_stats = configuration.pop('index_stats', False)
-        self.databases_to_poll = configuration.pop('database_poll', None)
+class service(simpleservice):
+    def __init__(self, configuration=none, name=none):
+        simpleservice.__init__(self, configuration=configuration, name=name)
+        self.order = list(order)
+        self.definitions = deepcopy(charts)
+        self.do_table_stats = configuration.pop('table_stats', false)
+        self.do_index_stats = configuration.pop('index_stats', false)
+        self.databases_to_poll = configuration.pop('database_poll', none)
         self.configuration = configuration
-        self.conn = None
+        self.conn = none
         self.conn_params = dict()
-        self.server_version = None
-        self.is_superuser = False
-        self.alive = False
+        self.server_version = none
+        self.is_superuser = false
+        self.alive = false
         self.databases = list()
         self.secondaries = list()
         self.replication_slots = list()
@@ -1081,33 +1081,33 @@ class Service(SimpleService):
     def build_conn_params(self):
         conf = self.configuration
 
-        # connection URIs: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-        if conf.get(CONN_PARAM_DSN):
-            return {'dsn': conf[CONN_PARAM_DSN]}
+        # connection uris: https://www.postgresql.org/docs/current/libpq-connect.html#libpq-connstring
+        if conf.get(conn_param_dsn):
+            return {'dsn': conf[conn_param_dsn]}
 
         params = {
-            CONN_PARAM_HOST: conf.get(CONN_PARAM_HOST),
-            CONN_PARAM_PORT: conf.get(CONN_PARAM_PORT, DEFAULT_PORT),
-            CONN_PARAM_DATABASE: conf.get(CONN_PARAM_DATABASE),
-            CONN_PARAM_USER: conf.get(CONN_PARAM_USER, DEFAULT_USER),
-            CONN_PARAM_PASSWORD: conf.get(CONN_PARAM_PASSWORD),
-            CONN_PARAM_CONN_TIMEOUT: conf.get(CONN_PARAM_CONN_TIMEOUT, DEFAULT_CONNECT_TIMEOUT),
+            conn_param_host: conf.get(conn_param_host),
+            conn_param_port: conf.get(conn_param_port, default_port),
+            conn_param_database: conf.get(conn_param_database),
+            conn_param_user: conf.get(conn_param_user, default_user),
+            conn_param_password: conf.get(conn_param_password),
+            conn_param_conn_timeout: conf.get(conn_param_conn_timeout, default_connect_timeout),
             'options': '-c statement_timeout={0}'.format(
-                conf.get(CONN_PARAM_STATEMENT_TIMEOUT, DEFAULT_STATEMENT_TIMEOUT)),
+                conf.get(conn_param_statement_timeout, default_statement_timeout)),
         }
 
         # https://www.postgresql.org/docs/current/libpq-ssl.html
         ssl_params = dict(
             (k, v) for k, v in {
-                CONN_PARAM_SSL_MODE: conf.get(CONN_PARAM_SSL_MODE),
-                CONN_PARAM_SSL_ROOT_CERT: conf.get(CONN_PARAM_SSL_ROOT_CERT),
-                CONN_PARAM_SSL_CRL: conf.get(CONN_PARAM_SSL_CRL),
-                CONN_PARAM_SSL_CERT: conf.get(CONN_PARAM_SSL_CERT),
-                CONN_PARAM_SSL_KEY: conf.get(CONN_PARAM_SSL_KEY),
+                conn_param_ssl_mode: conf.get(conn_param_ssl_mode),
+                conn_param_ssl_root_cert: conf.get(conn_param_ssl_root_cert),
+                conn_param_ssl_crl: conf.get(conn_param_ssl_crl),
+                conn_param_ssl_cert: conf.get(conn_param_ssl_cert),
+                conn_param_ssl_key: conf.get(conn_param_ssl_key),
             }.items() if v)
 
-        if CONN_PARAM_SSL_MODE not in ssl_params and len(ssl_params) > 0:
-            raise ValueError("mandatory 'sslmode' param is missing, please set")
+        if conn_param_ssl_mode not in ssl_params and len(ssl_params) > 0:
+            raise valueerror("mandatory 'sslmode' param is missing, please set")
 
         params.update(ssl_params)
 
@@ -1116,61 +1116,61 @@ class Service(SimpleService):
     def connect(self):
         if self.conn:
             self.conn.close()
-            self.conn = None
+            self.conn = none
 
         try:
             self.conn = psycopg2.connect(**self.conn_params)
-            self.conn.set_isolation_level(extensions.ISOLATION_LEVEL_AUTOCOMMIT)
-            self.conn.set_session(readonly=True)
-        except OperationalError as error:
+            self.conn.set_isolation_level(extensions.isolation_level_autocommit)
+            self.conn.set_session(readonly=true)
+        except operationalerror as error:
             self.error(error)
-            self.alive = False
+            self.alive = false
         else:
-            self.alive = True
+            self.alive = true
 
         return self.alive
 
     def check(self):
-        if not PSYCOPG2:
+        if not psycopg2:
             self.error("'python-psycopg2' package is needed to use postgres module")
-            return False
+            return false
 
         try:
             self.conn_params = self.build_conn_params()
-        except ValueError as error:
+        except valueerror as error:
             self.error('error on creating connection params : {0}', error)
-            return False
+            return false
 
         if not self.connect():
             self.error('failed to connect to {0}'.format(hide_password(self.conn_params)))
-            return False
+            return false
 
         try:
             self.check_queries()
-        except Exception as error:
+        except exception as error:
             self.error(error)
-            return False
+            return false
 
         self.populate_queries()
         self.create_dynamic_charts()
 
-        return True
+        return true
 
     def get_data(self):
         if not self.alive and not self.reconnect():
-            return None
+            return none
 
         self.data = dict()
         try:
-            cursor = self.conn.cursor(cursor_factory=DictCursor)
+            cursor = self.conn.cursor(cursor_factory=dictcursor)
 
             self.data.update(zero_lock_types(self.databases))
             for query, metrics in self.queries.items():
                 self.query_stats(cursor, query, metrics)
 
-        except OperationalError:
-            self.alive = False
-            return None
+        except operationalerror:
+            self.alive = false
+            return none
 
         cursor.close()
 
@@ -1195,7 +1195,7 @@ class Service(SimpleService):
                     dimension_id = metric
 
                 if metric in row:
-                    if row[metric] is not None:
+                    if row[metric] is not none:
                         self.data[dimension_id] = int(row[metric])
                 elif 'locks_count' in row:
                     if metric == row['mode']:
@@ -1204,60 +1204,60 @@ class Service(SimpleService):
     def check_queries(self):
         cursor = self.conn.cursor()
 
-        self.server_version = detect_server_version(cursor, query_factory(QUERY_NAME_SERVER_VERSION))
+        self.server_version = detect_server_version(cursor, query_factory(query_name_server_version))
         self.debug('server version: {0}'.format(self.server_version))
 
-        self.is_superuser = check_if_superuser(cursor, query_factory(QUERY_NAME_IF_SUPERUSER))
+        self.is_superuser = check_if_superuser(cursor, query_factory(query_name_if_superuser))
         self.debug('superuser: {0}'.format(self.is_superuser))
 
-        self.databases = discover(cursor, query_factory(QUERY_NAME_DATABASES))
+        self.databases = discover(cursor, query_factory(query_name_databases))
         self.debug('discovered databases {0}'.format(self.databases))
         if self.databases_to_poll:
             to_poll = self.databases_to_poll.split()
             self.databases = [db for db in self.databases if db in to_poll] or self.databases
 
-        self.secondaries = discover(cursor, query_factory(QUERY_NAME_STANDBY))
+        self.secondaries = discover(cursor, query_factory(query_name_standby))
         self.debug('discovered secondaries: {0}'.format(self.secondaries))
 
         if self.server_version >= 94000:
-            self.replication_slots = discover(cursor, query_factory(QUERY_NAME_REPLICATION_SLOT))
+            self.replication_slots = discover(cursor, query_factory(query_name_replication_slot))
             self.debug('discovered replication slots: {0}'.format(self.replication_slots))
 
         cursor.close()
 
     def populate_queries(self):
-        self.queries[query_factory(QUERY_NAME_DATABASE)] = METRICS[QUERY_NAME_DATABASE]
-        self.queries[query_factory(QUERY_NAME_BACKENDS)] = METRICS[QUERY_NAME_BACKENDS]
-        self.queries[query_factory(QUERY_NAME_BACKEND_USAGE, self.server_version)] = METRICS[QUERY_NAME_BACKEND_USAGE]
-        self.queries[query_factory(QUERY_NAME_LOCKS)] = METRICS[QUERY_NAME_LOCKS]
-        self.queries[query_factory(QUERY_NAME_BGWRITER)] = METRICS[QUERY_NAME_BGWRITER]
-        self.queries[query_factory(QUERY_NAME_DIFF_LSN, self.server_version)] = METRICS[QUERY_NAME_WAL_WRITES]
-        self.queries[query_factory(QUERY_NAME_STANDBY_DELTA, self.server_version)] = METRICS[QUERY_NAME_STANDBY_DELTA]
-        self.queries[query_factory(QUERY_NAME_BLOCKERS, self.server_version)] = METRICS[QUERY_NAME_BLOCKERS]
+        self.queries[query_factory(query_name_database)] = metrics[query_name_database]
+        self.queries[query_factory(query_name_backends)] = metrics[query_name_backends]
+        self.queries[query_factory(query_name_backend_usage, self.server_version)] = metrics[query_name_backend_usage]
+        self.queries[query_factory(query_name_locks)] = metrics[query_name_locks]
+        self.queries[query_factory(query_name_bgwriter)] = metrics[query_name_bgwriter]
+        self.queries[query_factory(query_name_diff_lsn, self.server_version)] = metrics[query_name_wal_writes]
+        self.queries[query_factory(query_name_standby_delta, self.server_version)] = metrics[query_name_standby_delta]
+        self.queries[query_factory(query_name_blockers, self.server_version)] = metrics[query_name_blockers]
 
         if self.do_index_stats:
-            self.queries[query_factory(QUERY_NAME_INDEX_STATS)] = METRICS[QUERY_NAME_INDEX_STATS]
+            self.queries[query_factory(query_name_index_stats)] = metrics[query_name_index_stats]
         if self.do_table_stats:
-            self.queries[query_factory(QUERY_NAME_TABLE_STATS)] = METRICS[QUERY_NAME_TABLE_STATS]
+            self.queries[query_factory(query_name_table_stats)] = metrics[query_name_table_stats]
 
         if self.is_superuser:
-            self.queries[query_factory(QUERY_NAME_ARCHIVE, self.server_version)] = METRICS[QUERY_NAME_ARCHIVE]
+            self.queries[query_factory(query_name_archive, self.server_version)] = metrics[query_name_archive]
 
             if self.server_version >= 90400:
-                self.queries[query_factory(QUERY_NAME_WAL, self.server_version)] = METRICS[QUERY_NAME_WAL]
+                self.queries[query_factory(query_name_wal, self.server_version)] = metrics[query_name_wal]
 
             if self.server_version >= 100000:
-                v = METRICS[QUERY_NAME_REPSLOT_FILES]
-                self.queries[query_factory(QUERY_NAME_REPSLOT_FILES, self.server_version)] = v
+                v = metrics[query_name_repslot_files]
+                self.queries[query_factory(query_name_repslot_files, self.server_version)] = v
 
         if self.server_version >= 90400:
-            self.queries[query_factory(QUERY_NAME_AUTOVACUUM)] = METRICS[QUERY_NAME_AUTOVACUUM]
+            self.queries[query_factory(query_name_autovacuum)] = metrics[query_name_autovacuum]
 
-        self.queries[query_factory(QUERY_NAME_EMERGENCY_AUTOVACUUM)] = METRICS[QUERY_NAME_EMERGENCY_AUTOVACUUM]
-        self.queries[query_factory(QUERY_NAME_TX_WRAPAROUND)] = METRICS[QUERY_NAME_TX_WRAPAROUND]
+        self.queries[query_factory(query_name_emergency_autovacuum)] = metrics[query_name_emergency_autovacuum]
+        self.queries[query_factory(query_name_tx_wraparound)] = metrics[query_name_tx_wraparound]
 
         if self.server_version >= 100000:
-            self.queries[query_factory(QUERY_NAME_STANDBY_LAG)] = METRICS[QUERY_NAME_STANDBY_LAG]
+            self.queries[query_factory(query_name_standby_lag)] = metrics[query_name_standby_lag]
 
     def create_dynamic_charts(self):
         for database_name in self.databases[::-1]:
@@ -1329,7 +1329,7 @@ def detect_server_version(cursor, query):
 def zero_lock_types(databases):
     result = dict()
     for database in databases:
-        for lock_type in METRICS['LOCKS']:
+        for lock_type in metrics['locks']:
             key = '_'.join([database, lock_type])
             result[key] = 0
 
@@ -1343,7 +1343,7 @@ def hide_password(config):
 def add_database_lock_chart(order, definitions, database_name):
     def create_lines(database):
         result = list()
-        for lock_type in METRICS['LOCKS']:
+        for lock_type in metrics['locks']:
             dimension_id = '_'.join([database, lock_type])
             result.append([dimension_id, lock_type, 'absolute'])
         return result
@@ -1352,7 +1352,7 @@ def add_database_lock_chart(order, definitions, database_name):
     order.insert(-1, chart_name)
     definitions[chart_name] = {
         'options':
-            [None, 'Locks on db: ' + database_name, 'locks', 'db ' + database_name, 'postgres.db_locks', 'line'],
+            [none, 'locks on db: ' + database_name, 'locks', 'db ' + database_name, 'postgres.db_locks', 'line'],
         'lines': create_lines(database_name)
     }
 
@@ -1365,7 +1365,7 @@ def add_database_stat_chart(order, definitions, name, database_name):
             result.append(new_line)
         return result
 
-    chart_template = CHARTS[name]
+    chart_template = charts[name]
     chart_name = '_'.join([database_name, name])
     order.insert(0, chart_name)
     name, title, units, _, context, chart_type = chart_template['options']
@@ -1382,7 +1382,7 @@ def add_replication_standby_chart(order, definitions, name, application_name, ch
             result.append(new_line)
         return result
 
-    chart_template = CHARTS[name]
+    chart_template = charts[name]
     chart_name = '_'.join([application_name, name])
     position = order.index('database_size')
     order.insert(position, chart_name)
@@ -1400,7 +1400,7 @@ def add_replication_slot_chart(order, definitions, name, slot_name):
             result.append(new_line)
         return result
 
-    chart_template = CHARTS[name]
+    chart_template = charts[name]
     chart_name = '_'.join([slot_name, name])
     position = order.index('database_size')
     order.insert(position, chart_name)

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -462,7 +462,7 @@ WHERE
 QUERY_STANDBY = {
     DEFAULT: """
 SELECT
-    coalesce(prs.slot_name, psr.application_name) application_name
+    COALESCE(prs.slot_name, psr.application_name) application_name
 FROM pg_stat_replication psr
 LEFT OUTER JOIN pg_replication_slots prs on psr.pid = prs.active_pid
 WHERE application_name IS NOT NULL;
@@ -479,7 +479,7 @@ FROM pg_replication_slots;
 QUERY_STANDBY_DELTA = {
     DEFAULT: """
 SELECT
-    coalesce(prs.slot_name, psr.application_name) application_name,
+    COALESCE(prs.slot_name, psr.application_name) application_name,
     pg_wal_lsn_diff(
       CASE pg_is_in_recovery()
         WHEN true THEN pg_last_wal_receive_lsn()
@@ -510,7 +510,7 @@ WHERE application_name IS NOT NULL;
 """,
     V96: """
 SELECT
-    coalesce(prs.slot_name, psr.application_name) application_name,
+    COALESCE(prs.slot_name, psr.application_name) application_name,
     pg_xlog_location_diff(
       CASE pg_is_in_recovery()
         WHEN true THEN pg_last_xlog_receive_location()
@@ -544,7 +544,7 @@ WHERE application_name IS NOT NULL;
 QUERY_STANDBY_LAG = {
     DEFAULT: """
 SELECT
-    coalesce(prs.slot_name, psr.application_name) application_name,
+    COALESCE(prs.slot_name, psr.application_name) application_name,
     COALESCE(EXTRACT(EPOCH FROM write_lag)::bigint, 0) AS write_lag,
     COALESCE(EXTRACT(EPOCH FROM flush_lag)::bigint, 0) AS flush_lag,
     COALESCE(EXTRACT(EPOCH FROM replay_lag)::bigint, 0) AS replay_lag

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1684,9 +1684,9 @@ netdataDashboard.context = {
             'Assuming non-superuser accounts are being used to connect to Postgres (so <i>superuser_reserved_connections</i> are subtracted from <i>max_connections</i>).<br/>' +
             'For more information see <a href="https://www.postgresql.org/docs/current/runtime-config-connection.html" target="_blank">Connections and Authentication</a>.'
     },
-    'postgres.emergency_autovacuum': {
-        info: 'Percent towards emergency autovacuum for one or more tables.<ul>' +
-            '<li><strong>percent_towards_emergency_autovac:</strong> an emergency autovacuum will run once this value reaches 100.</li>' +
+    'postgres.forced_autovacuum': {
+        info: 'Percent towards forced autovacuum for one or more tables.<ul>' +
+            '<li><strong>percent_towards_forced_autovacuum:</strong> a forced autovacuum will run once this value reaches 100.</li>' +
             '</ul>' +
             'For more information see <a href="https://www.postgresql.org/docs/current/routine-vacuuming.html" target="_blank">Preventing Transaction ID Wraparound Failures</a>.'
     },

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1684,6 +1684,25 @@ netdataDashboard.context = {
             'Assuming non-superuser accounts are being used to connect to Postgres (so <i>superuser_reserved_connections</i> are subtracted from <i>max_connections</i>).<br/>' +
             'For more information see <a href="https://www.postgresql.org/docs/current/runtime-config-connection.html" target="_blank">Connections and Authentication</a>.'
     },
+    'postgres.emergency_autovacuum': {
+        info: 'Percent towards emergency autovacuum for one or more tables.<ul>' +
+            '<li><strong>percent_towards_emergency_autovac:</strong> an emergency autovacuum will run once this value reaches 100.</li>' +
+            '</ul>' +
+            'For more information see <a href="https://www.postgresql.org/docs/current/routine-vacuuming.html" target="_blank">Preventing Transaction ID Wraparound Failures</a>.'
+    },
+    'postgres.tx_wraparound_oldest_current_xid': {
+        info: 'The oldest current transaction id (xid).<ul>' +
+            '<li><strong>oldest_current_xid:</strong> oldest current transaction id.</li>' +
+            '</ul>' +
+            'If for some reason autovacuum fails to clear old XIDs from a table, the system will begin to emit warning messages when the database\'s oldest XIDs reach eleven million transactions from the wraparound point.<br/>' +
+            'For more information see <a href="https://www.postgresql.org/docs/current/routine-vacuuming.html" target="_blank">Preventing Transaction ID Wraparound Failures</a>.'
+    },
+    'postgres.percent_towards_wraparound': {
+        info: 'Percent towards transaction wraparound.<ul>' +
+            '<li><strong>percent_towards_wraparound:</strong> transaction wraparound may occur when this value reaches 100.</li>' +
+            '</ul>' +
+            'For more information see <a href="https://www.postgresql.org/docs/current/routine-vacuuming.html" target="_blank">Preventing Transaction ID Wraparound Failures</a>.'
+    },
 
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
I've added three new charts.
1. The first chart adds to the `autovacuum` context.  It measures the current percentage until an emergency autovac process is kicked off.
2. The second and third are under a new `tx wraparound` context.  These measure values related to the dreaded 'transaction wraparound' in postgres.

Additionally I added some naming context around the standby databases.  The `application_name` is pretty generic (in my case, they were all called `walreceiver`).  This makes it hard to have meaningful charts and alarms.  I joined the standby query against `pg_replication_slots` to get the `slot_name` and use that if it exists, otherwise fall back on the `application_name`.

##### Component Name
`collectors/python.d.plugin/postgres/postgres.chart.py`

##### Test Plan
For the naming changes to the standby charts:
My test involved standing up two standby databases.  The first database is tied to a replication_slot, the second is not.
I expect the output of the sql (and consequently the chart) to show both the `slot_name` for the standby associated with a replication slot and the `application_name` for the standby not associated with a replication_slot.

##### Additional Information
