### PR TITLE
Updates the docu with info about dual ACLK

### DIFF
--- a/aclk/README.md
+++ b/aclk/README.md
@@ -81,6 +81,8 @@ Features:
     ACLK Legacy:             YES
 ```
 
+To verify which ACLK implementation your agent uses you can visit `/api/v1/info` endpoint on your local dashboard and check the `aclk-implementation` key.
+
 Please note new Cloud features will be implemented on top of ACLK-NG from this point on. ACLK Legacy is therefore kept as fallback in case some users have issues with ACLK-NG or need to use features which are not yet available in ACLK-NG *(like IPv6 support and SOCKS proxy)*.
 
 ### Improvements of ACLK-NG over Legacy are:

--- a/aclk/README.md
+++ b/aclk/README.md
@@ -74,7 +74,7 @@ You can configure following keys in the `netdata.conf` section `[cloud]`:
 
 Currently we are in process of switching ACLK to brand new technical stack called ACLK-NG. To choose your implementation, change the `aclk implementation` setting in your `netdata.conf` (accepted values `ng` or `legacy`).
 
-Before changing this value check the desired implementation is available in your agent (determined at build time) by running `netdata -W buildinfo`. Following lines indicate which ACLK implementations are available in your agent:
+Before changing this value, check the desired implementation is available (determined at build time) by running `netdata -W buildinfo`. Following lines indicate which ACLK implementations are available:
 
 ```
 Features:

--- a/aclk/README.md
+++ b/aclk/README.md
@@ -82,7 +82,7 @@ Features:
     ACLK Legacy:             YES
 ```
 
-To verify which ACLK implementation your agent uses you can visit `/api/v1/info` endpoint on your local dashboard and check the `aclk-implementation` key.
+To verify which ACLK implementation Netdata uses, visit the `/api/v1/info` endpoint on your local dashboard and check the `aclk-implementation` key.
 
 Please note new Cloud features will be implemented on top of ACLK-NG from this point on. ACLK Legacy is therefore kept as fallback in case some users have issues with ACLK-NG or need to use features which are not yet available in ACLK-NG *(like IPv6 support and SOCKS proxy)*.
 

--- a/aclk/README.md
+++ b/aclk/README.md
@@ -84,7 +84,7 @@ Features:
 
 To verify which ACLK implementation Netdata uses, visit the `/api/v1/info` endpoint on your local dashboard and check the `aclk-implementation` key.
 
-Please note new Cloud features will be implemented on top of ACLK-NG from this point on. ACLK Legacy is therefore kept as fallback in case some users have issues with ACLK-NG or need to use features which are not yet available in ACLK-NG *(like IPv6 support and SOCKS proxy)*.
+New Netdata Cloud features will be implemented on top of ACLK-NG from this point on. ACLK Legacy is therefore kept as a fallback in case some users have issues with ACLK-NG or need to use features which are not yet available in ACLK-NG *(like IPv6 support and SOCKS proxy)*.
 
 ### Improvements of ACLK-NG over Legacy are:
 - no dependency on custom patched `libmosquitto` (no bundling of libraries). Which should remove obstacles many GNU/Linux distribution package maintainers had trying to provide Netdata with Cloud support

--- a/aclk/README.md
+++ b/aclk/README.md
@@ -53,7 +53,6 @@ configuration uses two settings:
 [global]
   enabled = yes
   cloud base url = https://app.netdata.cloud
-  aclk implementation = legacy
 ```
 
 If your Agent needs to use a proxy to access the internet, you must [set up a proxy for
@@ -62,12 +61,14 @@ claiming](/claim/README.md#claim-through-a-proxy).
 You can configure following keys in the `netdata.conf` section `[cloud]`:
 ```
 [cloud]
-    statistics = yes
-    query thread count = 2
+  statistics = yes
+  query thread count = 2
+  aclk implementation = legacy
 ```
 
 - `statistics` enables/disables ACLK related statistics and their charts. You can disable this to save some space in the database and slightly reduce memory usage of Netdata Agent.
 - `query thread count` specifies the number of threads to process cloud queries. Increasing this setting is useful for nodes with many children (streaming), which can expect to handle more queries (and/or more complicated queries).
+- `aclk implementation` - see [ACLK implementation](#aclk-implementation) section
 
 ## ACLK implementation
 

--- a/aclk/README.md
+++ b/aclk/README.md
@@ -87,10 +87,10 @@ To verify which ACLK implementation Netdata uses, visit the `/api/v1/info` endpo
 New Netdata Cloud features will be implemented on top of ACLK-NG from this point on. ACLK Legacy is therefore kept as a fallback in case some users have issues with ACLK-NG or need to use features which are not yet available in ACLK-NG *(like IPv6 support and SOCKS proxy)*.
 
 ### Improvements of ACLK-NG over Legacy are:
-- no dependency on custom patched `libmosquitto` (no bundling of libraries). Which should remove obstacles many GNU/Linux distribution package maintainers had trying to provide Netdata with Cloud support
-- no dependency on libwebsockets
-- lower latency and higher throughput
-- more up to date, new features for Netdata Cloud are currently developed on top of ACLK-NG first
+- No dependency on custom patched `libmosquitto` (no bundling of libraries). Which should remove obstacles many GNU/Linux distribution package maintainers had trying to provide Netdata with Cloud support
+- No dependency on libwebsockets
+- Lower latency and higher throughput
+- More up to date, new features for Netdata Cloud are currently developed on top of ACLK-NG first
 
 ## Disable the ACLK
 

--- a/aclk/README.md
+++ b/aclk/README.md
@@ -72,7 +72,7 @@ You can configure following keys in the `netdata.conf` section `[cloud]`:
 
 ## ACLK implementation
 
-Currently we are in process of switching ACLK to brand new technical stack called ACLK-NG. To choose implementation your agent should use you can change the `aclk implementation` setting in your `netdata.conf` (accepted values `ng` or `legacy`).
+Currently we are in process of switching ACLK to brand new technical stack called ACLK-NG. To choose your implementation, change the `aclk implementation` setting in your `netdata.conf` (accepted values `ng` or `legacy`).
 
 Before changing this value check the desired implementation is available in your agent (determined at build time) by running `netdata -W buildinfo`. Following lines indicate which ACLK implementations are available in your agent:
 
@@ -173,4 +173,3 @@ If you changed the runtime setting in your `var/lib/netdata/cloud.d/cloud.conf` 
 Restart your Agent and [claim your node](/claim/README.md#how-to-claim-a-node).
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Faclk%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)
-

--- a/aclk/README.md
+++ b/aclk/README.md
@@ -53,6 +53,7 @@ configuration uses two settings:
 [global]
   enabled = yes
   cloud base url = https://app.netdata.cloud
+  aclk implementation = legacy
 ```
 
 If your Agent needs to use a proxy to access the internet, you must [set up a proxy for
@@ -67,6 +68,26 @@ You can configure following keys in the `netdata.conf` section `[cloud]`:
 
 - `statistics` enables/disables ACLK related statistics and their charts. You can disable this to save some space in the database and slightly reduce memory usage of Netdata Agent.
 - `query thread count` specifies the number of threads to process cloud queries. Increasing this setting is useful for nodes with many children (streaming), which can expect to handle more queries (and/or more complicated queries).
+
+## ACLK implementation
+
+Currently we are in process of switching ACLK to brand new technical stack called ACLK-NG. To choose implementation your agent should use you can change the `aclk implementation` setting in your `netdata.conf` (accepted values `ng` or `legacy`).
+
+Before changing this value check the desired implementation is available in your agent (determined at build time) by running `netdata -W buildinfo`. Following lines indicate which ACLK implementations are available in your agent:
+
+```
+Features:
+    ACLK Next Generation:    YES
+    ACLK Legacy:             YES
+```
+
+Please note new Cloud features will be implemented on top of ACLK-NG from this point on. ACLK Legacy is therefore kept as fallback in case some users have issues with ACLK-NG or need to use features which are not yet available in ACLK-NG *(like IPv6 support and SOCKS proxy)*.
+
+### Improvements of ACLK-NG over Legacy are:
+- no dependency on custom patched `libmosquitto` (no bundling of libraries). Which should remove obstacles many GNU/Linux distribution package maintainers had trying to provide Netdata with Cloud support
+- no dependency on libwebsockets
+- lower latency and higher throughput
+- more up to date, new features for Netdata Cloud are currently developed on top of ACLK-NG first
 
 ## Disable the ACLK
 


### PR DESCRIPTION
##### Summary
After recent commits both ACLK implementations can be compiled in the agent. Adds info into the docs on how to choose which one to use and how to verify which one is used
##### Component Name
docs
##### Test Plan
Read the docs and see if the info is understandable for our users.
##### Additional Information
