### PR TITLE
Fixes error on --disable-cloud

### DIFF
--- a/daemon/common.h
+++ b/daemon/common.h
@@ -66,9 +66,7 @@
 #include "claim/claim.h"
 
 // netdata agent cloud link
-#ifdef ENABLE_ACLK
 #include "aclk/aclk_api.h"
-#endif
 
 // global GUID map functions
 


### PR DESCRIPTION
##### Summary

PR #11225 broke `--disable-cloud`.

##### Component Name

##### Test Plan
Build with `--disable-cloud` this warnings should be gone:
```
database/rrdhost.c:1018:18: warning: implicit declaration of function 'add_aclk_host_labels'; did you mean 'reload_host_labels'? [-Wimplicit-function-declaration]
 1018 |     label_list = add_aclk_host_labels(label_list);
      |                  ^~~~~~~~~~~~~~~~~~~~
      |                  reload_host_labels
database/rrdhost.c:1018:16: warning: assignment to 'struct label *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
 1018 |     label_list = add_aclk_host_labels(label_list);
      |                ^
```

##### Additional Information
