### PR TITLE
Fix libjudy installation on CentOS 8.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1563,7 +1563,7 @@ validate_tree_centos() {
     fi
 
     echo >&2 " > Installing Judy-devel directly ..."
-    run ${sudo} yum ${opts} install http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.1.0+217+4d875839.x86_64.rpm
+    run ${sudo} yum ${opts} install http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64.rpm
 
   elif [[ "${version}" =~ ^6\..*$ ]]; then
     echo >&2 " > Detected CentOS 6.x ..."


### PR DESCRIPTION
##### Summary

See https://community.netdata.cloud/t/nodes-shown-as-unreachable/1345/61?u=austin_hemmelgarn

##### Component Name

area/packaging

##### Test Plan

CentOS 8 CI now passes.