### PR TITLE
[docs] streaming: add a note that streaming protocol is not HTTP

### DIFF
--- a/streaming/README.md
+++ b/streaming/README.md
@@ -20,6 +20,8 @@ capable of:
 The nodes that send metrics are called **child** nodes, and the nodes that receive metrics are called **parent** nodes.
 There are also **proxies**, which collects metrics from a child and sends it to a parent.
 
+:exclamation: This communication is not HTTP (it cannot be proxied by web proxies).
+
 ## Supported configurations
 
 ### Netdata without a database or web API (headless collector)


### PR DESCRIPTION
##### Summary

ssia

https://community.netdata.cloud/t/properly-running-parent-child-nodes/1417 follow up

##### Component Name

`streaming/`

##### Test Plan

Not needed.

##### Additional Information
