### PR TITLE
Add more nics to FreeBSD plugin

### DIFF
--- a/collectors/freebsd.plugin/freebsd_getifaddrs.c
+++ b/collectors/freebsd.plugin/freebsd_getifaddrs.c
@@ -144,7 +144,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
     (void)dt;
 
 #define DEFAULT_EXCLUDED_INTERFACES "lo*"
-#define DEFAULT_PHYSICAL_INTERFACES "igb* ix* cxl* em* ixl* ixlv* bge* ixgbe* vtnet* vmx* re*"
+#define DEFAULT_PHYSICAL_INTERFACES "igb* ix* cxl* em* ixl* ixlv* bge* ixgbe* vtnet* vmx* re* igc* dwc*"
 #define CONFIG_SECTION_GETIFADDRS "plugin:freebsd:getifaddrs"
 
     static int enable_new_interfaces = -1;


### PR DESCRIPTION
Add support for Intel 2.5G and Synopsys DesignWare nic (and variants) driver
Ref: https://reviews.freebsd.org/D30668
https://github.com/freebsd/freebsd-src/blob/master/sys/dev/dwc/if_dwc.c

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>