### PR TITLE
slabinfo: Handle slabs added after discovery

### DIFF
--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -189,7 +189,7 @@ struct slabinfo *read_file_slabinfo() {
 
     // Iterate on all lines to populate / update the slabinfo struct
     size_t lines = procfile_lines(ff), l;
-    if (lines != lines_discovered) {
+    if (unlikely(lines != lines_discovered)) {
         lines_discovered = lines;
         redraw_chart = 1;
     }
@@ -260,7 +260,7 @@ unsigned int do_slab_stats(int update_every) {
         sactive = read_file_slabinfo();
 
         // Init Charts
-        if (redraw_chart) {
+        if (unlikely(redraw_chart)) {
             redraw_chart = 0;
             // Memory Usage
             printf("CHART %s.%s '' 'Memory Usage' 'B' '%s' '' line %d %d %s\n"

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -51,6 +51,8 @@ char *netdata_configured_host_prefix = "";
 
 int running = 1;
 int debug = 0;
+size_t lines_discovered = 0;
+int redraw_chart = 0;
 
 // ----------------------------------------------------------------------------
 
@@ -187,6 +189,10 @@ struct slabinfo *read_file_slabinfo() {
 
     // Iterate on all lines to populate / update the slabinfo struct
     size_t lines = procfile_lines(ff), l;
+    if (lines != lines_discovered) {
+        lines_discovered = lines;
+        redraw_chart = 1;
+    }
 
     slabdebug("   Read %lu lines from procfile", (unsigned long)lines);
     for(l = 2; l < lines; l++) {
@@ -254,7 +260,8 @@ unsigned int do_slab_stats(int update_every) {
         sactive = read_file_slabinfo();
 
         // Init Charts
-        if (unlikely(loops == 0)) {
+        if (redraw_chart) {
+            redraw_chart = 0;
             // Memory Usage
             printf("CHART %s.%s '' 'Memory Usage' 'B' '%s' '' line %d %d %s\n"
                 , CHART_TYPE


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Instead of only displaying chart during the first iteration, keep track of number of parsed columns, and refresh the chart when that number changes to account for kernel modules added after initial discovery.

Fixes #11254 

##### Component Name
slabinfo

##### Test Plan

- start slabinfo collector,
- grep on "CHART"
- load a module (like kvm)
- unload the module

Both actions should regenerate the CHART

##### Additional Information
