### PR TITLE
fix kickstart-static64.sh install script fail when trying to access `.install-type` before it is created

### DIFF
--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -208,7 +208,7 @@ safe_sha256sum() {
 
 mark_install_type() {
   install_type_file="/opt/netdata/etc/netdata/.install-type"
-  if [ -e "${install_type_file}" ]; then
+  if [ -f "${install_type_file}" ]; then
     # shellcheck disable=SC1090
     . "${install_type_file}"
     cat > "${install_type_file}" <<- EOF

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -207,13 +207,15 @@ safe_sha256sum() {
 }
 
 mark_install_type() {
-    install_type_file="/opt/netdata/etc/netdata/.install-type"
+  install_type_file="/opt/netdata/etc/netdata/.install-type"
+  if [ -e "${install_type_file}" ]; then
     # shellcheck disable=SC1090
     . "${install_type_file}"
-    cat > "${install_type_file}" <<-EOF
+    cat > "${install_type_file}" <<- EOF
 	INSTALL_TYPE='kickstart-static'
 	PREBUILT_ARCH='${PREBUILT_ARCH}'
 	EOF
+  fi
 }
 
 # ----------------------------------------------------------------------------

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -97,7 +97,7 @@ To use `md5sum` to verify the integrity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "d80cb6e7b48f2825aade13120ec5364d" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "fc735f3faaa5b4aadf72c3a46c448650" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -97,7 +97,7 @@ To use `md5sum` to verify the integrity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "fc735f3faaa5b4aadf72c3a46c448650" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "b723476b538065d280d44387403cabed" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

Fixes: #11228

Making this PR because #11246 was closed by its author.

using @Ferroin comment as a fix

> The correct fix here is to wrap the whole function body in a conditional checking for the existence of the file referenced by ${install_type_file}

##### Component Name

`packaging/`

##### Test Plan

@Ferroin a reminder - upload kickstart filed needed after the merge.

##### Additional Information
