### PR TITLE
Explicitly update libarchive on CentOS 8 when installing dependencies.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1562,6 +1562,9 @@ validate_tree_centos() {
       fi
     fi
 
+    echo >&2 " > Updating libarchive ..."
+    run ${sudo} yum ${opts} install libarchive
+
     echo >&2 " > Installing Judy-devel directly ..."
     run ${sudo} yum ${opts} install http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64.rpm
 


### PR DESCRIPTION
##### Summary

The version of CMake currently shipped in CentOS 8 has an incorrect version limit in it0s dependency on libarchive. As a result, building LWS without an up to date copy of libarchive on such a system will result in a build failure.

This explicitly updates libarchive so that CMake will work properly. It can be removed again when we finally end support or the legacy ACLK code that depends on LWS.

##### Component Name

area/packaging

##### Test Plan

CentOS 8 CI checks pass again.