### PR TITLE
Remove Ubuntu 20.10 from CI checks.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -45,7 +45,6 @@ jobs:
           - 'opensuse/leap:15.3'
           - 'opensuse/tumbleweed:latest'
           - 'ubuntu:21.04'
-          - 'ubuntu:20.10'
           - 'ubuntu:20.04'
           - 'ubuntu:18.04'
           - 'ubuntu:16.04'
@@ -92,9 +91,6 @@ jobs:
             rmjsonc: 'zypper rm -y libjson-c-devel'
 
           - distro: 'ubuntu:21.04'
-            pre: 'apt-get update'
-            rmjsonc: 'apt-get remove -y libjson-c-dev'
-          - distro: 'ubuntu:20.10'
             pre: 'apt-get update'
             rmjsonc: 'apt-get remove -y libjson-c-dev'
           - distro: 'ubuntu:20.04'

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -35,7 +35,6 @@ jobs:
           - {distro: ubuntu, version: "18.04", pkgclouddistro: ubuntu/bionic, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
           - {distro: ubuntu, version: "18.04", pkgclouddistro: ubuntu/bionic, format: deb, base_image: ubuntu, platform: linux/i386, arch: i386}
           - {distro: ubuntu, version: "20.04", pkgclouddistro: ubuntu/focal, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
-          - {distro: ubuntu, version: "20.10", pkgclouddistro: ubuntu/groovy, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
           - {distro: ubuntu, version: "21.04", pkgclouddistro: ubuntu/hirsute, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
           - {distro: centos, version: "7", pkgclouddistro: el/7, format: rpm, base_image: centos, platform: linux/amd64, arch: amd64}
           - {distro: centos, version: "8", pkgclouddistro: el/8, format: rpm, base_image: centos, platform: linux/amd64, arch: amd64}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -32,7 +32,6 @@ jobs:
           - 'ubuntu:16.04'
           - 'ubuntu:18.04'
           - 'ubuntu:20.04'
-          - 'ubuntu:20.10'
           - 'ubuntu:21.04'
         include:
           - distro: 'alpine:3.12'
@@ -48,8 +47,6 @@ jobs:
           - distro: 'ubuntu:18.04'
             pre: 'apt-get update'
           - distro: 'ubuntu:20.04'
-            pre: 'apt-get update'
-          - distro: 'ubuntu:20.10'
             pre: 'apt-get update'
           - distro: 'ubuntu:21.04'
             pre: 'apt-get update'


### PR DESCRIPTION
##### Summary

To be merged when Ubuntu 20.10 goes EOL in 2021-07-22.

##### Component Name

area/ci

##### Test Plan

n/a