### PR TITLE
Added new postgres charts and updated standby charts to include slot_…

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1684,6 +1684,25 @@ netdataDashboard.context = {
             'Assuming non-superuser accounts are being used to connect to Postgres (so <i>superuser_reserved_connections</i> are subtracted from <i>max_connections</i>).<br/>' +
             'For more information see <a href="https://www.postgresql.org/docs/current/runtime-config-connection.html" target="_blank">Connections and Authentication</a>.'
     },
+    'postgres.forced_autovacuum': {
+        info: 'Percent towards forced autovacuum for one or more tables.<ul>' +
+            '<li><strong>percent_towards_forced_autovacuum:</strong> a forced autovacuum will run once this value reaches 100.</li>' +
+            '</ul>' +
+            'For more information see <a href="https://www.postgresql.org/docs/current/routine-vacuuming.html" target="_blank">Preventing Transaction ID Wraparound Failures</a>.'
+    },
+    'postgres.tx_wraparound_oldest_current_xid': {
+        info: 'The oldest current transaction id (xid).<ul>' +
+            '<li><strong>oldest_current_xid:</strong> oldest current transaction id.</li>' +
+            '</ul>' +
+            'If for some reason autovacuum fails to clear old XIDs from a table, the system will begin to emit warning messages when the database\'s oldest XIDs reach eleven million transactions from the wraparound point.<br/>' +
+            'For more information see <a href="https://www.postgresql.org/docs/current/routine-vacuuming.html" target="_blank">Preventing Transaction ID Wraparound Failures</a>.'
+    },
+    'postgres.percent_towards_wraparound': {
+        info: 'Percent towards transaction wraparound.<ul>' +
+            '<li><strong>percent_towards_wraparound:</strong> transaction wraparound may occur when this value reaches 100.</li>' +
+            '</ul>' +
+            'For more information see <a href="https://www.postgresql.org/docs/current/routine-vacuuming.html" target="_blank">Preventing Transaction ID Wraparound Failures</a>.'
+    },
 
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
I've added three new charts.

The first chart adds to the autovacuum context. It measures the current percentage until a forced autovac process is kicked off.
The second and third are under a new tx wraparound context. These measure values related to the dreaded 'transaction wraparound' in postgres.
Additionally I added some naming context around the standby databases. The application_name is pretty generic (in my case, they were all called walreceiver). This makes it hard to have meaningful charts and alarms. I joined the standby query against pg_replication_slots to get the slot_name and use that if it exists, otherwise fall back on the application_name.

##### Component Name
`collectors/python.d.plugin/postgres/postgres.chart.py`
`web/gui/dashboard_info.js`

##### Test Plan
For the naming changes to the standby charts:
My test involved standing up two standby databases. The first database is tied to a replication_slot, the second is not.
I expect the output of the sql (and consequently the chart) to show both the slot_name for the standby associated with a replication slot and the application_name for the standby not associated with a replication_slot.

This has been tested on psql v. 9.6, 10, 11, 12, 13

##### Additional Information
This is a clone of PR # 11241 which needed to be closed because of mistakes with the github user doing the committing (see the comments in that PR for details).