### PR TITLE
Add Alpine 3.14 to CI.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -29,10 +29,10 @@ jobs:
       matrix:
         distro:
           - 'alpine:edge'
+          - 'alpine:3.14'
           - 'alpine:3.13'
           - 'alpine:3.12'
           - 'alpine:3.11'
-          - 'alpine:3.10'
           - 'archlinux:latest'
           - 'centos:8'
           - 'centos:7'
@@ -53,6 +53,9 @@ jobs:
           - distro: 'alpine:edge'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
+          - distro: 'alpine:3.14'
+            pre: 'apk add -U bash'
+            rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.13'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
@@ -60,9 +63,6 @@ jobs:
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.11'
-            pre: 'apk add -U bash'
-            rmjsonc: 'apk del json-c-dev'
-          - distro: 'alpine:3.10'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
 

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -19,8 +19,9 @@ jobs:
       max-parallel: 8
       matrix:
         distro:
-          - 'alpine:3.12'
+          - 'alpine:3.14'
           - 'alpine:3.13'
+          - 'alpine:3.12'
           - 'archlinux:latest'
           - 'centos:7'
           - 'centos:8'
@@ -35,9 +36,11 @@ jobs:
           - 'ubuntu:20.10'
           - 'ubuntu:21.04'
         include:
-          - distro: 'alpine:3.12'
+          - distro: 'alpine:3.14'
             pre: 'apk add -U bash'
           - distro: 'alpine:3.13'
+            pre: 'apk add -U bash'
+          - distro: 'alpine:3.12'
             pre: 'apk add -U bash'
           - distro: 'debian:9'
             pre: 'apt-get update'


### PR DESCRIPTION
##### Summary

This adds Alpine 3.14 (released over the weekend) to our CI checks and removes Alpine 3.10 (EOL for just short of two months).

##### Component Name

area/ci

##### Test Plan

Checks in CI pass.