### PR TITLE
Auto-detect PGID in Dockerfile's ENTRYPOINT script

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -13,6 +13,23 @@ if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
   touch /etc/netdata/.opt-out-from-anonymous-statistics
 fi
 
+
+BALENA_PGID=$(ls -nd /var/run/balena.sock | awk '{print $4}')
+DOCKER_PGID=$(ls -nd /var/run/docker.sock | awk '{print $4}')
+
+re='^[0-9]+$'
+if [[ $BALENA_PGID =~ $re ]]; then
+  echo "Netdata detected balena-engine.sock"
+  DOCKER_HOST='/var/run/balena-engine.sock'
+  PGID="$BALENA_PGID"
+else if [[ $DOCKER_PGID =~ $re ]]; then
+  echo "Netdata detected docker.sock"
+  DOCKER_HOST="/var/run/docker.sock"
+  PGID=$(ls -nd /var/run/docker.sock | awk '{print $4}')
+fi
+export PGID
+export DOCKER_HOST
+
 if [ -n "${PGID}" ]; then
   echo "Creating docker group ${PGID}"
   addgroup -g "${PGID}" "docker" || echo >&2 "Could not add group docker with ID ${PGID}, its already there probably"

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -22,7 +22,7 @@ if [[ $BALENA_PGID =~ $re ]]; then
   echo "Netdata detected balena-engine.sock"
   DOCKER_HOST='/var/run/balena-engine.sock'
   PGID="$BALENA_PGID"
-else if [[ $DOCKER_PGID =~ $re ]]; then
+elif [[ $DOCKER_PGID =~ $re ]]; then
   echo "Netdata detected docker.sock"
   DOCKER_HOST="/var/run/docker.sock"
   PGID=$(ls -nd /var/run/docker.sock | awk '{print $4}')


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Improve the `ENTRYPOINT` script so that it auto-detects the correct PGID for the virtualization technology. This is required for correct name resolution. 

Beforehand, the user must supply the correct PGID as an environment variable. Now it detects the PGID by reading the appropriate `.sock` file, e.g `/var/run/docker.sock`. 

Ideally, we should add support for the most widely used virt engines (e.g podman, LXD containers, etc.)

##### Component Name

`/packaging/docker/run.sh`

##### Test Plan

1. Create a container with a new dockerfiler, based on `netdata/netdata` and supply a new ENTRYPOINT, using the edited `run.sh` script. Example that I am running ATM: https://github.com/OdysLam/home-urbit/tree/master/netdata

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
