### PR TITLE
fixes confusing error in ACLK Legacy

### DIFF
--- a/aclk/legacy/aclk_query.c
+++ b/aclk/legacy/aclk_query.c
@@ -794,8 +794,7 @@ void *legacy_aclk_query_main_thread(void *ptr)
                 sleep(1);
                 continue;
             }
-            errno = 0;
-            error("ACLK version negotiation failed. No reply to \"hello\" with \"version\" from cloud in time of %ds."
+            info("ACLK version negotiation failed (This is expected). No reply to \"hello\" with \"version\" from cloud in time of %ds."
                 " Reverting to default ACLK version of %d.", VERSION_NEG_TIMEOUT, ACLK_VERSION_MIN);
             legacy_aclk_shared_state.version_neg = ACLK_VERSION_MIN;
             aclk_set_rx_handlers(legacy_aclk_shared_state.version_neg);


### PR DESCRIPTION
##### Summary
As we are not maintaining ACLK Legacy anymore we want to keep it as a fallback without any significant changes. For that reason, #10649 was closed unmerged (not to have a big change in Legacy same time as moving to NG). This removes the error message that is not an error anymore as plans on the Cloud side were changed and version negotiation will never be implemented (+new cloud arch coming).

This is done to remove users confusion so they not consider it as something went wrong..

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
