### PR TITLE
Fix boolean value for ProtectControlGroups

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -66,7 +66,7 @@ ProtectSystem=full
 ProtectHome=read-only
 # PrivateTmp break netdatacli functionality. See - https://github.com/netdata/netdata/issues/7587
 #PrivateTmp=true
-ProtectControlGroups=true
+ProtectControlGroups=on
 # We whitelist this because it's the standard location to listen on a UNIX socket.
 ReadWriteDirectories=/run/netdata
 # This is needed to make email-based alert deliver work if Postfix is the email provider on the system.


### PR DESCRIPTION
Hi,

In systemd service unit file, change ProtectControlGroups from true to on

On CentOS 7 , each systemd reload write the following line in /var/log/messages (`systemctl daemon-reload`)
`systemd: [/usr/lib/systemd/system/netdata.service:72] Unknown lvalue 'ProtectControlGroups' in section 'Service'`

No error was reported with new value (on or yes)

Original bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1975343
