### PR TITLE
Check if sendmail supports -F parameter

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -939,7 +939,7 @@ send_email() {
     fi
 
     [ -n "${sender_email}" ] && opts+=(-f "${sender_email}")
-    [ -n "${sender_name}" ] && sendmail --help 2>&1 | grep -q "\-F " && opts+=(-F "${sender_name}")
+    [ -n "${sender_name}" ] && [[ ! `readlink "$(command -v sendmail 2>/dev/null)"` == */busybox ]] && opts+=(-F "${sender_name}")
 
     if [ "${debug}" = "1" ]; then
       echo >&2 "--- BEGIN sendmail command ---"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -939,7 +939,7 @@ send_email() {
     fi
 
     [ -n "${sender_email}" ] && opts+=(-f "${sender_email}")
-    [ -n "${sender_name}" ] && [[ ! $(readlink "$(command -v sendmail 2>/dev/null)") == */busybox ]] && opts+=(-F "${sender_name}")
+    [ -n "${sender_name}" ] && ${sendmail} -F 2>&1 | grep -q "requires an argument" && opts+=(-F "${sender_name}")
 
     if [ "${debug}" = "1" ]; then
       echo >&2 "--- BEGIN sendmail command ---"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -939,7 +939,7 @@ send_email() {
     fi
 
     [ -n "${sender_email}" ] && opts+=(-f "${sender_email}")
-    [ -n "${sender_name}" ] && [[ ! `readlink "$(command -v sendmail 2>/dev/null)"` == */busybox ]] && opts+=(-F "${sender_name}")
+    [ -n "${sender_name}" ] && [[ ! $(readlink "$(command -v sendmail 2>/dev/null)") == */busybox ]] && opts+=(-F "${sender_name}")
 
     if [ "${debug}" = "1" ]; then
       echo >&2 "--- BEGIN sendmail command ---"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

`sendmail` from `busybox` does not support the `-F` parameter (setting the full name of the email sender), that the real `sendmail` command does. This patch will try to better check for this, by running `sendmail -F` and checking if the output of this contains `option requires an argument`.

Fixes #11261 

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Set `EMAIL_SENDER` in `health_alarm_notify.conf` to something like `MyName some@email.com`. 
Running in a system where `sendmail` is a symlink to `busybox` it won't set the parameter, and no errors should occur.
Running in a system where `sendmail` is a real binary, it should set the name of the email sender to `MyName`.

##### Additional Information

Real sendmail when run as `sendmail -F` returns: `sendmail: option requires an argument -- F`.
When run inside our docker instance, it returns `sendmail: unrecognized option: F` (along with the usage of sendmail from busybox).