### PR TITLE
Remove access check for install-type file

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -383,10 +383,6 @@ void analytics_get_install_type(void)
     int install_type_filename_len = (strlen(netdata_configured_user_config_dir) + strlen(".install-type") + 3);
     install_type_filename = mallocz(sizeof(char) * install_type_filename_len);
     snprintfz(install_type_filename, install_type_filename_len - 1, "%s/%s", netdata_configured_user_config_dir, ".install-type");
-    if (unlikely(access(install_type_filename, R_OK) != 0)) {
-        freez(install_type_filename);
-        return;
-    }
 
     FILE *fp = fopen(install_type_filename, "r");
     if (fp) {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Removes the check with `access` for the `.install-type` file. The file will be opened right after, so it doesn't make much sense to be there, and fixes a coverity warning on this part.

##### Component Name

Analytics

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
