### PR TITLE
Fix vulnerability alert, updating normalize-url dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3366,9 +3366,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "npm-prefix": {


### PR DESCRIPTION
There is an advisory [CVE-2021-33502](https://github.com/advisories/GHSA-px4h-xg32-q955) for ReDoS in normalize-url. This updates the dependency version from vulnerable 4.5.0 to patched 4.5.1.