### PR TITLE
[docs] fix prometheus node cpu alert rule

### DIFF
--- a/backends/prometheus/README.md
+++ b/backends/prometheus/README.md
@@ -135,7 +135,7 @@ groups:
 
   rules:
   - alert: node_high_cpu_usage_70
-    expr: avg(rate(netdata_cpu_cpu_percentage_average{dimension="idle"}[1m])) by (job) > 70
+    expr: sum(avg_over_time(netdata_cpu_cpu_percentage_average{dimension!="idle"}[10m])) by (job) > 70
     for: 1m
     annotations:
       description: '{{ $labels.job }} on ''{{ $labels.job }}'' CPU usage is at {{ humanize $value }}%.'

--- a/backends/prometheus/README.md
+++ b/backends/prometheus/README.md
@@ -131,40 +131,40 @@ add a _- "nodes.yml"_ entry under the _rule_files:_ section in the example prome
 
 ```yaml
 groups:
-- name: nodes
+  - name: nodes
 
-  rules:
-  - alert: node_high_cpu_usage_70
-    expr: sum(sum_over_time(netdata_system_cpu_percentage_average{dimension=~"(user|system|softirq|irq|guest)"}[10m])) by (job) / sum(count_over_time(netdata_system_cpu_percentage_average{dimension="idle"}[10m])) by (job) > 70
-    for: 1m
-    annotations:
-      description: '{{ $labels.job }} on ''{{ $labels.job }}'' CPU usage is at {{ humanize $value }}%.'
-      summary: CPU alert for container node '{{ $labels.job }}'
+    rules:
+      - alert: node_high_cpu_usage_70
+        expr: sum(sum_over_time(netdata_system_cpu_percentage_average{dimension=~"(user|system|softirq|irq|guest)"}[10m])) by (job) / sum(count_over_time(netdata_system_cpu_percentage_average{dimension="idle"}[10m])) by (job) > 70
+        for: 1m
+        annotations:
+          description: '{{ $labels.job }} on ''{{ $labels.job }}'' CPU usage is at {{ humanize $value }}%.'
+          summary: CPU alert for container node '{{ $labels.job }}'
 
-  - alert: node_high_memory_usage_70
-    expr: 100 / sum(netdata_system_ram_MB_average) by (job) 
-      * sum(netdata_system_ram_MB_average{dimension=~"free|cached"}) by (job) < 30
-    for: 1m
-    annotations:
-      description: '{{ $labels.job }} memory usage is {{ humanize $value}}%.'
-      summary: Memory alert for container node '{{ $labels.job }}'
+      - alert: node_high_memory_usage_70
+        expr: 100 / sum(netdata_system_ram_MB_average) by (job)
+          * sum(netdata_system_ram_MB_average{dimension=~"free|cached"}) by (job) < 30
+        for: 1m
+        annotations:
+          description: '{{ $labels.job }} memory usage is {{ humanize $value}}%.'
+          summary: Memory alert for container node '{{ $labels.job }}'
 
-  - alert: node_low_root_filesystem_space_20
-    expr: 100 / sum(netdata_disk_space_GB_average{family="/"}) by (job)
-      * sum(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}) by (job) < 20
-    for: 1m
-    annotations:
-      description: '{{ $labels.job }} root filesystem space is {{ humanize $value}}%.'
-      summary: Root filesystem alert for container node '{{ $labels.job }}'
+      - alert: node_low_root_filesystem_space_20
+        expr: 100 / sum(netdata_disk_space_GB_average{family="/"}) by (job)
+          * sum(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}) by (job) < 20
+        for: 1m
+        annotations:
+          description: '{{ $labels.job }} root filesystem space is {{ humanize $value}}%.'
+          summary: Root filesystem alert for container node '{{ $labels.job }}'
 
-  - alert: node_root_filesystem_fill_rate_6h
-    expr: predict_linear(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}[1h], 6 * 3600) < 0
-    for: 1h
-    labels:
-      severity: critical
-    annotations:
-      description: Container node {{ $labels.job }} root filesystem is going to fill up in 6h.
-      summary: Disk fill alert for Swarm node '{{ $labels.job }}'
+      - alert: node_root_filesystem_fill_rate_6h
+        expr: predict_linear(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}[1h], 6 * 3600) < 0
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          description: Container node {{ $labels.job }} root filesystem is going to fill up in 6h.
+          summary: Disk fill alert for Swarm node '{{ $labels.job }}'
 ```
 
 #### Install prometheus.service

--- a/backends/prometheus/README.md
+++ b/backends/prometheus/README.md
@@ -135,7 +135,7 @@ groups:
 
   rules:
   - alert: node_high_cpu_usage_70
-    expr: sum(avg_over_time(netdata_cpu_cpu_percentage_average{dimension!="idle"}[10m])) by (job) > 70
+    expr: sum(sum_over_time(netdata_system_cpu_percentage_average{dimension=~"(user|system|softirq|irq|guest)"}[10m])) by (job) / sum(count_over_time(netdata_system_cpu_percentage_average{dimension="idle"}[10m])) by (job) > 70
     for: 1m
     annotations:
       description: '{{ $labels.job }} on ''{{ $labels.job }}'' CPU usage is at {{ humanize $value }}%.'

--- a/exporting/prometheus/README.md
+++ b/exporting/prometheus/README.md
@@ -134,40 +134,40 @@ add a _- "nodes.yml"_ entry under the _rule_files:_ section in the example prome
 
 ```yaml
 groups:
-- name: nodes
+  - name: nodes
 
-  rules:
-  - alert: node_high_cpu_usage_70
-    expr: sum(sum_over_time(netdata_system_cpu_percentage_average{dimension=~"(user|system|softirq|irq|guest)"}[10m])) by (job) / sum(count_over_time(netdata_system_cpu_percentage_average{dimension="idle"}[10m])) by (job) > 70
-    for: 1m
-    annotations:
-      description: '{{ $labels.job }} on ''{{ $labels.job }}'' CPU usage is at {{ humanize $value }}%.'
-      summary: CPU alert for container node '{{ $labels.job }}'
+    rules:
+      - alert: node_high_cpu_usage_70
+        expr: sum(sum_over_time(netdata_system_cpu_percentage_average{dimension=~"(user|system|softirq|irq|guest)"}[10m])) by (job) / sum(count_over_time(netdata_system_cpu_percentage_average{dimension="idle"}[10m])) by (job) > 70
+        for: 1m
+        annotations:
+          description: '{{ $labels.job }} on ''{{ $labels.job }}'' CPU usage is at {{ humanize $value }}%.'
+          summary: CPU alert for container node '{{ $labels.job }}'
 
-  - alert: node_high_memory_usage_70
-    expr: 100 / sum(netdata_system_ram_MB_average) by (job) 
-      * sum(netdata_system_ram_MB_average{dimension=~"free|cached"}) by (job) < 30
-    for: 1m
-    annotations:
-      description: '{{ $labels.job }} memory usage is {{ humanize $value}}%.'
-      summary: Memory alert for container node '{{ $labels.job }}'
+      - alert: node_high_memory_usage_70
+        expr: 100 / sum(netdata_system_ram_MB_average) by (job)
+          * sum(netdata_system_ram_MB_average{dimension=~"free|cached"}) by (job) < 30
+        for: 1m
+        annotations:
+          description: '{{ $labels.job }} memory usage is {{ humanize $value}}%.'
+          summary: Memory alert for container node '{{ $labels.job }}'
 
-  - alert: node_low_root_filesystem_space_20
-    expr: 100 / sum(netdata_disk_space_GB_average{family="/"}) by (job)
-      * sum(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}) by (job) < 20
-    for: 1m
-    annotations:
-      description: '{{ $labels.job }} root filesystem space is {{ humanize $value}}%.'
-      summary: Root filesystem alert for container node '{{ $labels.job }}'
+      - alert: node_low_root_filesystem_space_20
+        expr: 100 / sum(netdata_disk_space_GB_average{family="/"}) by (job)
+          * sum(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}) by (job) < 20
+        for: 1m
+        annotations:
+          description: '{{ $labels.job }} root filesystem space is {{ humanize $value}}%.'
+          summary: Root filesystem alert for container node '{{ $labels.job }}'
 
-  - alert: node_root_filesystem_fill_rate_6h
-    expr: predict_linear(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}[1h], 6 * 3600) < 0
-    for: 1h
-    labels:
-      severity: critical
-    annotations:
-      description: Container node {{ $labels.job }} root filesystem is going to fill up in 6h.
-      summary: Disk fill alert for Swarm node '{{ $labels.job }}'
+      - alert: node_root_filesystem_fill_rate_6h
+        expr: predict_linear(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}[1h], 6 * 3600) < 0
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          description: Container node {{ $labels.job }} root filesystem is going to fill up in 6h.
+          summary: Disk fill alert for Swarm node '{{ $labels.job }}'
 ```
 
 #### Install prometheus.service

--- a/exporting/prometheus/README.md
+++ b/exporting/prometheus/README.md
@@ -138,7 +138,7 @@ groups:
 
   rules:
   - alert: node_high_cpu_usage_70
-    expr: sum(avg_over_time(netdata_cpu_cpu_percentage_average{dimension!="idle"}[10m])) by (job) > 70
+    expr: sum(sum_over_time(netdata_system_cpu_percentage_average{dimension=~"(user|system|softirq|irq|guest)"}[10m])) by (job) / sum(count_over_time(netdata_system_cpu_percentage_average{dimension="idle"}[10m])) by (job) > 70
     for: 1m
     annotations:
       description: '{{ $labels.job }} on ''{{ $labels.job }}'' CPU usage is at {{ humanize $value }}%.'

--- a/exporting/prometheus/README.md
+++ b/exporting/prometheus/README.md
@@ -138,7 +138,7 @@ groups:
 
   rules:
   - alert: node_high_cpu_usage_70
-    expr: avg(rate(netdata_cpu_cpu_percentage_average{dimension="idle"}[1m])) by (job) > 70
+    expr: sum(avg_over_time(netdata_cpu_cpu_percentage_average{dimension!="idle"}[10m])) by (job) > 70
     for: 1m
     annotations:
       description: '{{ $labels.job }} on ''{{ $labels.job }}'' CPU usage is at {{ humanize $value }}%.'


### PR DESCRIPTION
##### Summary

Discovered in https://community.netdata.cloud/t/feedback-or-suggestion-on-export-metrics-to-prometheus/1492, see the topic for details.

I updated the rule expression to be == [`10min_cpu_usage`](https://github.com/netdata/netdata/blob/365a8fb8bad397856f110595a65373c0b5ec47a1/health/health.d/cpu.conf#L4-L18) alarm.

❗ see [changes with hidden whitespaces](https://github.com/netdata/netdata/pull/11309/files?w=1)

##### Component Name

`backends/`
`exporting/`

##### Test Plan

[Tested by our community member](https://community.netdata.cloud/t/feedback-or-suggestion-on-export-metrics-to-prometheus/1492/14).

##### Additional Information
