### PR TITLE
Add hop count for children

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1230,6 +1230,7 @@ int main(int argc, char **argv) {
     netdata_anonymous_statistics_enabled=-1;
     struct rrdhost_system_info *system_info = calloc(1, sizeof(struct rrdhost_system_info));
     get_system_info(system_info);
+    system_info->hops = 0;
 
     if(rrd_init(netdata_configured_hostname, system_info))
         fatal("Cannot initialize localhost instance with name '%s'.", netdata_configured_hostname);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -740,6 +740,7 @@ struct rrdhost_system_info {
     char *container;
     char *container_detection;
     char *is_k8s_node;
+    uint16_t hops;
 };
 
 struct rrdhost {

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -471,7 +471,7 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
     char buf[GUID_LEN + 1];
 
     struct rrdhost_system_info *system_info = callocz(1, sizeof(struct rrdhost_system_info));
-
+    system_info->hops = 1;
     while(url) {
         char *value = mystrsep(&url, "&");
         if(!value || !*value) continue;
@@ -498,6 +498,8 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
             abbrev_timezone = value;
         else if(!strcmp(name, "utc_offset"))
             utc_offset = (int32_t)strtol(value, NULL, 0);
+        else if(!strcmp(name, "hops"))
+            system_info->hops = (uint16_t) strtoul(value, NULL, 0);
         else if(!strcmp(name, "tags"))
             tags = value;
         else if(!strcmp(name, "ver"))

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -214,7 +214,7 @@ static int rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_po
 
     char http[HTTP_HEADER_SIZE + 1];
     int eol = snprintfz(http, HTTP_HEADER_SIZE,
-            "STREAM key=%s&hostname=%s&registry_hostname=%s&machine_guid=%s&update_every=%d&os=%s&timezone=%s&abbrev_timezone=%s&utc_offset=%d&tags=%s&ver=%u"
+            "STREAM key=%s&hostname=%s&registry_hostname=%s&machine_guid=%s&update_every=%d&os=%s&timezone=%s&abbrev_timezone=%s&utc_offset=%d&hops=%d&tags=%s&ver=%u"
                  "&NETDATA_SYSTEM_OS_NAME=%s"
                  "&NETDATA_SYSTEM_OS_ID=%s"
                  "&NETDATA_SYSTEM_OS_ID_LIKE=%s"
@@ -252,6 +252,7 @@ static int rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_po
                  , host->timezone
                  , host->abbrev_timezone
                  , host->utc_offset
+                 , host->system_info->hops + 1
                  , (host->tags) ? host->tags : ""
                  , STREAMING_PROTOCOL_CURRENT_VERSION
                  , se.os_name

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -867,8 +867,8 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 
         netdata_mutex_lock(&host->receiver_lock);
         buffer_sprintf(
-            wb, "\t\t{ \"guid\": \"%s\", \"reachable\": %s, \"claim_id\": ", host->machine_guid,
-            (host->receiver || host == localhost) ? "true" : "false");
+            wb, "\t\t{ \"guid\": \"%s\", \"reachable\": %s, \"hops\": %d, \"claim_id\": ", host->machine_guid,
+            (host->receiver || host == localhost) ? "true" : "false", host->system_info ? host->system_info->hops : (host == localhost) ? 0 : 1);
         netdata_mutex_unlock(&host->receiver_lock);
 
         rrdhost_aclk_state_lock(host);


### PR DESCRIPTION
##### Summary
Adds a hop count for children in the system_info of the host structure. 
The local agent is hop 0 and each time a child connects to a parent it will send a `hops` variable that will +1 of its hop count.

The `hops` parameter is added to the initial STREAM connect command (child --> parent)

A parent that accepts a STREAM command (child) will initially assume that the hop count will be 1 and then:
-  Remain 1 (if the child runs an older version of the agent and therefore cannot supply a hops parameter)
- Update it to the value supplied in the STREAM command

If a child running a version with this PR connects to a parent running an older version, then the parents error.log will
have the following

```
STREAM [receive from XXXX]:nnnnnn]: request has parameter 'hops' = '1', which is not used.
STREAM [receive from XXXX]:nnnnnn]: request has parameter 'hops' = '2', which is not used.
```

for children connecting that supply a `hops` parameter with a value of 1 and 2 respectively

###### Note: The hops count will be used for the new agent cloud architecture

##### Component Name
streaming

##### Test Plan
- The agent should compile and run (no visible changes)
