### PR TITLE
Add HTTP access log messages for ACLK-NG

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -826,8 +826,8 @@ endif
 if ACLK_LEGACY
 netdata_LDADD += \
     $(abs_top_srcdir)/externaldeps/mosquitto/libmosquitto.a \
-    $(OPTIONAL_LIBCAP_LIBS) \
     $(OPTIONAL_LWS_LIBS) \
+    $(OPTIONAL_LIBCAP_LIBS) \
     $(NULL)
 endif #ACLK_LEGACY
 

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -214,7 +214,7 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
         , "DATA"
         , sent
         , size
-        , size > sent ? -((size > 0) ? (((size - sent) / (double) size) * 100.0) : 0.0) : ((size > 0) ? (((sent - size ) / (double) size) * 100.0) : 0.0)
+        , size > sent ? -(((size - sent) / (double)size) * 100.0) : ((size > 0) ? (((sent - size ) / (double)size) * 100.0) : 0.0)
         , dt_usec(&w->tv_ready, &w->tv_in) / 1000.0
         , dt_usec(&tv, &w->tv_ready) / 1000.0
         , dt_usec(&tv, &w->tv_in) / 1000.0

--- a/aclk/aclk_query.h
+++ b/aclk/aclk_query.h
@@ -15,6 +15,9 @@ extern pthread_mutex_t query_lock_wait;
 // TODO
 //extern volatile int aclk_connected;
 
+// thread-local ACLK query thread self-reference.
+extern __thread struct aclk_query_thread *aclk_query_thread;
+
 struct aclk_query_thread {
     netdata_thread_t thread;
     int idx;

--- a/aclk/aclk_query.h
+++ b/aclk/aclk_query.h
@@ -15,9 +15,6 @@ extern pthread_mutex_t query_lock_wait;
 // TODO
 //extern volatile int aclk_connected;
 
-// thread-local ACLK query thread self-reference.
-extern __thread struct aclk_query_thread *aclk_query_thread;
-
 struct aclk_query_thread {
     netdata_thread_t thread;
     int idx;

--- a/aclk/aclk_query_queue.c
+++ b/aclk/aclk_query_queue.c
@@ -20,7 +20,9 @@ static struct aclk_query_queue {
 
 static inline int _aclk_queue_query(aclk_query_t query)
 {
+    now_realtime_timeval(&query->created_tv);
     query->created = now_realtime_usec();
+
     ACLK_QUEUE_LOCK;
     if (aclk_query_queue.block_push) {
         ACLK_QUEUE_UNLOCK;
@@ -110,7 +112,7 @@ void aclk_query_free(aclk_query_t query)
 
     if (query->type == CHART_NEW)
         freez(query->data.chart_add_del.chart_name);
-    
+
     if (query->type == ALARM_STATE_UPDATE && query->data.alarm_update)
         json_object_put(query->data.alarm_update);
 

--- a/aclk/aclk_query_queue.h
+++ b/aclk/aclk_query_queue.h
@@ -47,6 +47,7 @@ struct aclk_query {
     char *callback_topic;
     char *msg_id;
 
+    struct timeval created_tv;
     usec_t created;
 
     aclk_query_t next;


### PR DESCRIPTION
Fixes https://github.com/netdata/netdata/issues/10746

##### Summary

Logs a message to access.log for HTTP messages for aclk-ng similar to aclk-legacy.

##### Component Name

aclk

##### Test Plan

Compile your local netdata agent with ACLK-NG enabled.
Connect your local netdata to some Netdata cloud endpoint via ACLK.
Go & view your claimed node on the cloud, scrolling around different charts.
Tail the access.log file to see logs like this:

```
2021-07-07 11:29:45: 0: 56495 '[ACLK]:0' 'DATA' (sent/all = 1729/14555 bytes -88%, prep/sent/total = 3.41/2.52/5.93 ms) 200 '/api/v1/data'
2021-07-07 11:29:48: 0: 56496 '[ACLK]:1' 'DATA' (sent/all = 1570/12875 bytes -88%, prep/sent/total = 0.12/1.47/1.60 ms) 200 '/api/v1/data'
2021-07-07 11:29:48: 0: 56496 '[ACLK]:1' 'DATA' (sent/all = 1743/14567 bytes -88%, prep/sent/total = 0.76/4.76/5.53 ms) 200 '/api/v1/data'
2021-07-07 11:29:48: 0: 56495 '[ACLK]:0' 'DATA' (sent/all = 1705/14563 bytes -88%, prep/sent/total = 0.08/5.96/6.04 ms) 200 '/api/v1/data'
2021-07-07 11:32:22: 0: 56496 '[ACLK]:1' 'DATA' (sent/all = 1564/12875 bytes -88%, prep/sent/total = 0.14/4.91/5.04 ms) 200 '/api/v1/data'
2021-07-07 11:32:22: 0: 56495 '[ACLK]:0' 'DATA' (sent/all = 1691/14558 bytes -88%, prep/sent/total = 0.42/5.69/6.12 ms) 200 '/api/v1/data'
2021-07-07 11:32:22: 0: 56496 '[ACLK]:1' 'DATA' (sent/all = 1731/14561 bytes -88%, prep/sent/total = 5.11/3.44/8.56 ms) 200 '/api/v1/data'
2021-07-07 11:32:25: 0: 56496 '[ACLK]:1' 'DATA' (sent/all = 1565/12875 bytes -88%, prep/sent/total = 0.18/4.44/4.62 ms) 200 '/api/v1/data'
2021-07-07 11:32:25: 0: 56495 '[ACLK]:0' 'DATA' (sent/all = 1690/14563 bytes -88%, prep/sent/total = 0.10/5.25/5.35 ms) 200 '/api/v1/data'
2021-07-07 11:32:25: 0: 56496 '[ACLK]:1' 'DATA' (sent/all = 1740/14569 bytes -88%, prep/sent/total = 4.70/2.23/6.93 ms) 200 '/api/v1/data'
```