### PR TITLE
Add ACLK-NG cloud request type charts

### DIFF
--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -127,7 +127,7 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
 
     if (aclk_stats_enabled) {
         ACLK_STATS_LOCK;
-        int stat_idx = aclk_cloud_req_type_to_idx(mysep ? mysep + 1 : "other");
+        int stat_idx = aclk_cloud_req_http_type_to_idx(mysep ? mysep + 1 : "other");
         aclk_metrics_per_sample.cloud_req_http_by_type[stat_idx]++;
         ACLK_STATS_UNLOCK;
     }

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -125,6 +125,13 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
 
     mysep = strrchr(query->data.http_api_v2.query, '/');
 
+    if (aclk_stats_enabled) {
+        ACLK_STATS_LOCK;
+        int stat_idx = aclk_cloud_req_type_to_idx(mysep ? mysep + 1 : "other");
+        aclk_metrics_per_sample.cloud_req_http_by_type[stat_idx]++;
+        ACLK_STATS_UNLOCK;
+    }
+
     // execute the query
     w->tv_in = query->created_tv;
     now_realtime_timeval(&w->tv_ready);

--- a/aclk/aclk_query_queue.c
+++ b/aclk/aclk_query_queue.c
@@ -45,6 +45,31 @@ static inline int _aclk_queue_query(aclk_query_t query)
 
 }
 
+// Gets a pointer to the metric associated with a particular query type.
+// NULL if the query type has no associated metric.
+static inline volatile uint32_t *aclk_stats_qmetric_for_qtype(aclk_query_type_t qtype) {
+    switch (qtype) {
+        case HTTP_API_V2:
+            return &aclk_metrics_per_sample.cloud_req_type_http;
+        case ALARM_STATE_UPDATE:
+            return &aclk_metrics_per_sample.cloud_req_type_alarm_upd;
+        case METADATA_INFO:
+            return &aclk_metrics_per_sample.cloud_req_type_metadata_info;
+        case METADATA_ALARMS:
+            return &aclk_metrics_per_sample.cloud_req_type_metadata_alarms;
+        case CHART_NEW:
+            return &aclk_metrics_per_sample.cloud_req_type_chart_new;
+        case CHART_DEL:
+            return &aclk_metrics_per_sample.cloud_req_type_chart_del;
+        case REGISTER_NODE:
+            return &aclk_metrics_per_sample.cloud_req_type_register_node;
+        case NODE_STATE_UPDATE:
+            return &aclk_metrics_per_sample.cloud_req_type_node_upd;
+        default:
+            return NULL;
+    }
+}
+
 int aclk_queue_query(aclk_query_t query)
 {
     int ret = _aclk_queue_query(query);
@@ -57,23 +82,7 @@ int aclk_queue_query(aclk_query_t query)
         if (aclk_stats_enabled) {
             // get target query type metric before lock so we keep lock for
             // minimal time.
-            volatile uint32_t *metric = NULL;
-            if (qtype == HTTP_API_V2)
-                metric = &aclk_metrics_per_sample.cloud_req_type_http;
-            else if (qtype == ALARM_STATE_UPDATE)
-                metric = &aclk_metrics_per_sample.cloud_req_type_alarm_upd;
-            else if (qtype == METADATA_INFO)
-                metric = &aclk_metrics_per_sample.cloud_req_type_metadata_info;
-            else if (qtype == METADATA_ALARMS)
-                metric = &aclk_metrics_per_sample.cloud_req_type_metadata_alarms;
-            else if (qtype == CHART_NEW)
-                metric = &aclk_metrics_per_sample.cloud_req_type_chart_new;
-            else if (qtype == CHART_DEL)
-                metric = &aclk_metrics_per_sample.cloud_req_type_chart_del;
-            else if (qtype == REGISTER_NODE)
-                metric = &aclk_metrics_per_sample.cloud_req_type_register_node;
-            else if (qtype == NODE_STATE_UPDATE)
-                metric = &aclk_metrics_per_sample.cloud_req_type_node_upd;
+            volatile uint32_t *metric = aclk_stats_qmetric_for_qtype(qtype);
 
             ACLK_STATS_LOCK;
             aclk_metrics_per_sample.queries_queued++;

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -124,7 +124,7 @@ static void aclk_stats_cloud_req_type(struct aclk_metrics_per_sample *per_sample
 
     if (unlikely(!st)) {
         st = rrdset_create_localhost(
-            "netdata", "aclk_cloud_req_type", NULL, "aclk", NULL, "Requests received from cloud via their type", "req/s",
+            "netdata", "aclk_cloud_req_type", NULL, "aclk", NULL, "Requests received from cloud by their type", "req/s",
             "netdata", "stats", 200006, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
         rd_type_http = rrddim_add(st, "http", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -200,7 +200,7 @@ static void aclk_stats_query_threads(uint32_t *queries_per_thread)
     if (unlikely(!st)) {
         st = rrdset_create_localhost(
             "netdata", "aclk_query_threads", NULL, "aclk", NULL, "Queries Processed Per Thread", "req/s",
-            "netdata", "stats", 200007, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
+            "netdata", "stats", 200009, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
         for (int i = 0; i < query_thread_count; i++) {
             if (snprintf(dim_name, MAX_DIM_NAME, "Query %d", i) < 0)
@@ -227,7 +227,7 @@ static void aclk_stats_query_time(struct aclk_metrics_per_sample *per_sample)
     if (unlikely(!st)) {
         st = rrdset_create_localhost(
             "netdata", "aclk_query_time", NULL, "aclk", NULL, "Time it took to process cloud requested DB queries", "us",
-            "netdata", "stats", 200006, localhost->rrd_update_every, RRDSET_TYPE_LINE);
+            "netdata", "stats", 200008, localhost->rrd_update_every, RRDSET_TYPE_LINE);
 
         rd_rq_avg = rrddim_add(st, "avg", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
         rd_rq_max = rrddim_add(st, "max", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -110,6 +110,46 @@ static void aclk_stats_cloud_req(struct aclk_metrics_per_sample *per_sample)
     rrdset_done(st);
 }
 
+static void aclk_stats_cloud_req_type(struct aclk_metrics_per_sample *per_sample)
+{
+    static RRDSET *st = NULL;
+    static RRDDIM *rd_type_http = NULL;
+    static RRDDIM *rd_type_alarm_upd = NULL;
+    static RRDDIM *rd_type_metadata_info = NULL;
+    static RRDDIM *rd_type_metadata_alarms = NULL;
+    static RRDDIM *rd_type_chart_new = NULL;
+    static RRDDIM *rd_type_chart_del = NULL;
+    static RRDDIM *rd_type_register_node = NULL;
+    static RRDDIM *rd_type_node_upd = NULL;
+
+    if (unlikely(!st)) {
+        st = rrdset_create_localhost(
+            "netdata", "aclk_cloud_req_type", NULL, "aclk", NULL, "Requests received from cloud via their type", "req/s",
+            "netdata", "stats", 200006, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
+
+        rd_type_http = rrddim_add(st, "http", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
+        rd_type_alarm_upd = rrddim_add(st, "alarm update", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
+        rd_type_metadata_info = rrddim_add(st, "info metadata", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
+        rd_type_metadata_alarms = rrddim_add(st, "alarms metadata", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
+        rd_type_chart_new = rrddim_add(st, "chart new", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
+        rd_type_chart_del = rrddim_add(st, "chart delete", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
+        rd_type_register_node = rrddim_add(st, "register node", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
+        rd_type_node_upd = rrddim_add(st, "node update", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
+    } else
+        rrdset_next(st);
+
+    rrddim_set_by_pointer(st, rd_type_http, per_sample->cloud_req_type_http);
+    rrddim_set_by_pointer(st, rd_type_alarm_upd, per_sample->cloud_req_type_alarm_upd);
+    rrddim_set_by_pointer(st, rd_type_metadata_info, per_sample->cloud_req_type_metadata_info);
+    rrddim_set_by_pointer(st, rd_type_metadata_alarms, per_sample->cloud_req_type_metadata_alarms);
+    rrddim_set_by_pointer(st, rd_type_chart_new, per_sample->cloud_req_type_chart_new);
+    rrddim_set_by_pointer(st, rd_type_chart_del, per_sample->cloud_req_type_chart_del);
+    rrddim_set_by_pointer(st, rd_type_register_node, per_sample->cloud_req_type_register_node);
+    rrddim_set_by_pointer(st, rd_type_node_upd, per_sample->cloud_req_type_node_upd);
+
+    rrdset_done(st);
+}
+
 static char *cloud_req_http_type_names[ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT] = {
     "other",
     "info",
@@ -256,6 +296,7 @@ void *aclk_stats_main_thread(void *ptr)
 #endif
 
         aclk_stats_cloud_req(&per_sample);
+        aclk_stats_cloud_req_type(&per_sample);
         aclk_stats_cloud_req_http_type(&per_sample);
 
         aclk_stats_query_threads(aclk_queries_per_thread_sample);

--- a/aclk/aclk_stats.h
+++ b/aclk/aclk_stats.h
@@ -16,6 +16,8 @@ extern netdata_mutex_t aclk_stats_mutex;
 // if you change update `cloud_req_http_type_names`.
 #define ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT 7
 
+int aclk_cloud_req_http_type_to_idx(const char *name);
+
 struct aclk_stats_thread {
     netdata_thread_t *thread;
     int query_thread_count;

--- a/aclk/aclk_stats.h
+++ b/aclk/aclk_stats.h
@@ -13,6 +13,9 @@ extern netdata_mutex_t aclk_stats_mutex;
 #define ACLK_STATS_LOCK netdata_mutex_lock(&aclk_stats_mutex)
 #define ACLK_STATS_UNLOCK netdata_mutex_unlock(&aclk_stats_mutex)
 
+// if you change update `cloud_req_http_type_names`.
+#define ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT 7
+
 struct aclk_stats_thread {
     netdata_thread_t *thread;
     int query_thread_count;
@@ -42,6 +45,8 @@ extern struct aclk_metrics_per_sample {
 
     volatile uint32_t cloud_req_recvd;
     volatile uint32_t cloud_req_err;
+
+    volatile uint16_t cloud_req_http_by_type[ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT];
 
     volatile uint32_t cloud_q_process_total;
     volatile uint32_t cloud_q_process_count;

--- a/aclk/aclk_stats.h
+++ b/aclk/aclk_stats.h
@@ -48,7 +48,18 @@ extern struct aclk_metrics_per_sample {
     volatile uint32_t cloud_req_recvd;
     volatile uint32_t cloud_req_err;
 
-    volatile uint16_t cloud_req_http_by_type[ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT];
+    // request types.
+    volatile uint32_t cloud_req_type_http;
+    volatile uint32_t cloud_req_type_alarm_upd;
+    volatile uint32_t cloud_req_type_metadata_info;
+    volatile uint32_t cloud_req_type_metadata_alarms;
+    volatile uint32_t cloud_req_type_chart_new;
+    volatile uint32_t cloud_req_type_chart_del;
+    volatile uint32_t cloud_req_type_register_node;
+    volatile uint32_t cloud_req_type_node_upd;
+
+    // HTTP-specific request types.
+    volatile uint32_t cloud_req_http_by_type[ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT];
 
     volatile uint32_t cloud_q_process_total;
     volatile uint32_t cloud_q_process_count;


### PR DESCRIPTION
##### Summary

Fixes https://github.com/netdata/netdata/issues/10747

This PR adds 2 charts:

- `netdata.aclk_cloud_req_http_type` will show a breakdown of HTTP query types, e.g. `/api/v1/data` vs. `/api/v1/chart` etc.
- `netdata.aclk_cloud_req_type` will show a breakdown at a higher-level, e.g. `http` vs `alarm_update` vs `metadata_alarms` etc. This is based off of the entries found in `aclk/aclk_query.c#aclk_query_handlers`.

##### Component Name

aclk

##### Test Plan

Simply go to the ACLK chart submenu and see these new charts.