### PR TITLE
add postgresql version to requirements section

### DIFF
--- a/collectors/python.d.plugin/postgres/README.md
+++ b/collectors/python.d.plugin/postgres/README.md
@@ -12,6 +12,8 @@ Collects database health and performance metrics.
 
 -   `python-psycopg2` package. You have to install it manually and make sure that it is available to the `netdata` user, either using `pip`, the package manager of your Linux distribution, or any other method you prefer.
 
+-   PostgreSQL v9.4+
+
 Following charts are drawn:
 
 1.  **Database size** MB

--- a/collectors/python.d.plugin/postgres/postgres.conf
+++ b/collectors/python.d.plugin/postgres/postgres.conf
@@ -97,14 +97,6 @@
 # the client (Netdata) is not considered local, unless it runs from inside
 # the same container. 
 #
-# Postgres supported versions are : 
-# - 9.3 (without autovacuum)
-# - 9.4
-# - 9.5
-# - 9.6
-# - 10
-# - 11
-#
 # Superuser access is needed for theses charts:
 #   Write-Ahead Logs
 #   Archive Write-Ahead Logs

--- a/collectors/python.d.plugin/postgres/postgres.conf
+++ b/collectors/python.d.plugin/postgres/postgres.conf
@@ -103,6 +103,7 @@
 # - 9.5
 # - 9.6
 # - 10
+# - 11
 #
 # Superuser access is needed for theses charts:
 #   Write-Ahead Logs


### PR DESCRIPTION
According to [this](https://github.com/netdata/netdata/blob/77c07842b1111576f521e8ee23fe0494202f31d6/collectors/python.d.plugin/postgres/postgres.chart.py#L172), postgres at version 11 is compatible