### PR TITLE
Adds aclk-schemas to dist_noinst_DATA

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ dist_noinst_DATA = \
     contrib \
     docs \
     mqtt_websockets \
+    aclk/aclk-schemas \
     netdata.cppcheck \
     netdata.spec \
     package.json \


### PR DESCRIPTION
##### Summary
This ensures `aclk-schemas` submodule files are distributed in the `dist` tarball.

Fixes #11337
Fixes netdata/product#2193

##### Component Name
netdata build system

##### Test Plan

get git submodules (`git submodule update --init --force --recursive`), build agent and then run `make dist`. The generated tarball should now contain `aclk/aclk-schemas` folder with all proto files in it.

##### Additional Information
