### PR TITLE
Added support for claiming existing installs via kickstarter scripts.

### DIFF
--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -97,7 +97,7 @@ To use `md5sum` to verify the integrity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "b723476b538065d280d44387403cabed" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "de3ae7eed8eefc48fe40ae52cead261b" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -80,7 +80,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "836190944d062c712296846c45b68c94" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "755019025d721fc199d52f7fb62d3420" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

This adds code to allow for using the kickstart script to claim existing installs of Netdata.

For this code to be run, the following conditions must be met:

* The user must supply correct claiming options.
* The user must not request a reinstall.

Under such circumstances, if the script can find an existing install of the correct type (using the same logic used to prevent accidental duplicate installs), it will attempt to run the claiming script from that install with the correct claiming arguments and then exit.

##### Component Name

area/packaging

##### Test Plan

See the description. When invoked correctly on a system with an existing install, the kickstart scripts from this PR should attempt to run the claiming script from that install.

##### Additional Information

Fixes: #11346 

A sizable chunk of the changes here are just moving the claiming code in the kickstart scripts into it’s own function to avoid code duplication.