### PR TITLE
fix sending MS Teams notifications to multiple channels

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1388,15 +1388,15 @@ EOF
     )"
 
     # Replacing in the webhook CHANNEL string by the MS Teams channel name from conf file.
-    webhook="${webhook//CHANNEL/${channel}}"
+    cur_webhook="${webhook//CHANNEL/${channel}}"
 
-    httpcode=$(docurl -H "Content-Type: application/json" -d "${payload}" "${webhook}")
+    httpcode=$(docurl -H "Content-Type: application/json" -d "${payload}" "${cur_webhook}")
 
     if [ "${httpcode}" = "200" ]; then
-      info "sent Microsoft team notification for: ${host} ${chart}.${name} is ${status} to '${webhook}'"
+      info "sent Microsoft team notification for: ${host} ${chart}.${name} is ${status} to '${cur_webhook}'"
       sent=$((sent + 1))
     else
-      error "failed to send Microsoft team notification for: ${host} ${chart}.${name} is ${status} to '${webhook}', with HTTP response status code ${httpcode}."
+      error "failed to send Microsoft team notification for: ${host} ${chart}.${name} is ${status} to '${cur_webhook}', with HTTP response status code ${httpcode}."
     fi
   done
 


### PR DESCRIPTION
##### Summary

Fixes: #11354

##### Component Name

`health/`

##### Test Plan

- configure [msteams](https://github.com/netdata/netdata/tree/master/health/notifications/msteams#microsoft-teams) with multiple channels.
- run `./alarm-notify.sh test`.
- ensure the script tries to send data to all the channels.


##### Additional Information
