### PR TITLE
disable oom_kill alarm if the node is k8s node

### DIFF
--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -55,6 +55,7 @@ component: Memory
    every: 5m
     warn: $this > 0
    delay: down 10m
+host labels: _is_k8s_node = false
     info: number of out of memory kills in the last 30 minutes
       to: sysadmin
 

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -46,18 +46,18 @@ component: Memory
      info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
        to: sysadmin
 
-   alarm: oom_kill
-      on: mem.oom_kill
-      os: linux
-   hosts: *
-  lookup: sum -30m unaligned
-   units: kills
-   every: 5m
-    warn: $this > 0
-   delay: down 10m
+      alarm: oom_kill
+         on: mem.oom_kill
+         os: linux
+      hosts: *
+     lookup: sum -30m unaligned
+      units: kills
+      every: 5m
+       warn: $this > 0
+      delay: down 10m
 host labels: _is_k8s_node = false
-    info: number of out of memory kills in the last 30 minutes
-      to: sysadmin
+       info: number of out of memory kills in the last 30 minutes
+         to: sysadmin
 
 ## FreeBSD
     alarm: ram_in_use


### PR DESCRIPTION
##### Summary

This PR disables [oom_kill alarm](https://github.com/netdata/netdata/blob/0c7db731f8dabbd8debe668f5d8fe60ebffb7878/health/health.d/ram.conf#L49-L59) for Kubernetes nodes.

Feedback from @netdata/infra: oom kill is not a warning event in Kubernetes in general (this alarm tracks the number of oom kills per host, not specific containers). It is expected to have some containers get killed by OOM killer from time to time.


##### Component Name

`health/`

##### Test Plan

 - `oom_kill` works if the node is not k8s node.

##### Additional Information
