### PR TITLE
health: fix cockroachdb replication alarms

### DIFF
--- a/health/health.d/cockroachdb.conf
+++ b/health/health.d/cockroachdb.conf
@@ -44,6 +44,19 @@ component: CockroachDB
      info: number of ranges with fewer live replicas than needed for quorum
        to: dba
 
+ template: cockroachdb_underreplicated_ranges
+       on: cockroachdb.ranges_replication_problem
+    class: Utilization
+     type: Database
+component: CockroachDB
+     calc: $ranges_underreplicated
+    units: num
+    every: 10s
+     warn: $this > 0
+    delay: down 15m multiplier 1.5 max 1h
+     info: number of ranges with fewer live replicas than the replication target
+       to: dba
+
 # FD
 
  template: cockroachdb_open_file_descriptors_limit

--- a/health/health.d/cockroachdb.conf
+++ b/health/health.d/cockroachdb.conf
@@ -33,7 +33,7 @@ component: CockroachDB
 
  template: cockroachdb_unavailable_ranges
        on: cockroachdb.ranges_replication_problem
-    class: Utilization
+    class: Errors
      type: Database
 component: CockroachDB
      calc: $ranges_unavailable
@@ -46,7 +46,7 @@ component: CockroachDB
 
  template: cockroachdb_underreplicated_ranges
        on: cockroachdb.ranges_replication_problem
-    class: Utilization
+    class: Errors
      type: Database
 component: CockroachDB
      calc: $ranges_underreplicated

--- a/health/health.d/cockroachdb.conf
+++ b/health/health.d/cockroachdb.conf
@@ -41,7 +41,7 @@ component: CockroachDB
     every: 10s
      warn: $this > 0
     delay: down 15m multiplier 1.5 max 1h
-     info: number of ranges with fewer live replicas than the replication target
+     info: number of ranges with fewer live replicas than needed for quorum
        to: dba
 
 # FD


### PR DESCRIPTION
##### Summary

This PR:
 - fixes `cockroachdb_unavailable_ranges` alarm description.
 - adds `cockroachdb_underreplicated_ranges` alarm.

##### Component Name

`health/`

##### Test Plan

Not really needed.

##### Additional Information

