### PR TITLE
fix `gearman_workers_queued` alarm

### DIFF
--- a/health/health.d/gearman.conf
+++ b/health/health.d/gearman.conf
@@ -4,7 +4,7 @@
     class: Latency
      type: Computing
 component: Gearman
-   lookup: average -10m unaligned match-names of Queued
+   lookup: average -10m unaligned match-names of Pending
     units: workers
     every: 10s
      warn: $this > 30000


### PR DESCRIPTION
##### Summary

It is [Pending](https://github.com/netdata/netdata/blob/e58e59c0f4848a100e9390f8234a83e7b1368c19/collectors/python.d.plugin/gearman/gearman.chart.py#L26), not Queued.

##### Component Name

`heath/`

##### Test Plan

Not needed.

##### Additional Information
