### PR TITLE
Properly handle eBPF plugin in RPM packages.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -10,12 +10,6 @@
 # PACKAGE IS BROKEN WITHOUT THEM.
 AutoReqProv: yes
 
-%if "@HAVE_LIBBPF@" == "1"
-%global have_bpf 1
-%else
-%global have_bpf 0
-%endif
-
 # This is temporary and should eventually be resolved. This bypasses
 # the default rhel __os_install_post which throws a python compile
 # error.
@@ -228,9 +222,7 @@ export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging
 %if 0%{!?fedora:1} && 0%{!?suse_version:1}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-judy.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 %endif
-%if 0%{?have_bpf}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-libbpf.sh ${RPM_BUILD_DIR}/%{name}-%{version}
-%endif
 
 %build
 # Conf step
@@ -282,9 +274,7 @@ install -m 4750 -p perf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.
 
 # ###########################################################
 # Install ebpf.plugin
-%if 0%{?have_bpf}
 install -m 4750 -p ebpf.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/ebpf.plugin"
-%endif
 
 # ###########################################################
 # Install cups.plugin
@@ -411,9 +401,7 @@ install_go() {
 install_go
 install -m 0640 -p go.d.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/go.d.plugin"
 
-%if 0%{?have_bpf}
 ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-ebpf.sh ${RPM_BUILD_DIR}/%{name}-%{version} ${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d
-%endif
 
 %pre
 

--- a/packaging/bundle-ebpf.sh
+++ b/packaging/bundle-ebpf.sh
@@ -6,12 +6,14 @@ PLUGINDIR="${2}"
 EBPF_VERSION="$(cat "${SRCDIR}/packaging/ebpf.version")"
 EBPF_TARBALL="netdata-kernel-collector-glibc-${EBPF_VERSION}.tar.xz"
 
-mkdir -p "${SRCDIR}/tmp/ebpf"
-curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/kernel-collector/releases/download/${EBPF_VERSION}/${EBPF_TARBALL}" > "${EBPF_TARBALL}" || exit 1
-grep "${EBPF_TARBALL}" "${SRCDIR}/packaging/ebpf.checksums" | sha256sum -c - || exit 1
-tar -xaf "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
-if [ ! -d "${PLUGINDIR}/ebpf.d" ];then
-    mkdir "${PLUGINDIR}/ebpf.d"
+if [ -x "${PLUGINDIR}/ebpf.plugin" ] ; then
+    mkdir -p "${SRCDIR}/tmp/ebpf"
+    curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/kernel-collector/releases/download/${EBPF_VERSION}/${EBPF_TARBALL}" > "${EBPF_TARBALL}" || exit 1
+    grep "${EBPF_TARBALL}" "${SRCDIR}/packaging/ebpf.checksums" | sha256sum -c - || exit 1
+    tar -xaf "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
+    if [ ! -d "${PLUGINDIR}/ebpf.d" ];then
+        mkdir "${PLUGINDIR}/ebpf.d"
+    fi
+    # shellcheck disable=SC2046
+    cp -a $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}/ebpf.d"
 fi
-# shellcheck disable=SC2046
-cp -a $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}/ebpf.d"


### PR DESCRIPTION
##### Summary

This stops trying to make the eBPF build conditional in the RPM spec file, as all the distros we’re building for are supported by our code. This, in turn, results in actually including eBPF support in our RPM packages.

A check is also added to the script used for bundling the eBPF programs to avoid installing them if the eBPF plugin did not get built for some reason.

##### Component Name

area/packaging

##### Test Plan

The packages can be built for testing by running `docker run -it --rm -v $PWD:/netdata -e VERSION=0.1 netdata/package-builders:fedora34` in the root of the Netdata source directory (you can replace `fedora34` with another distro and version number if desired, though do note that our CentOS 8 package builds are currently broken for reasons unrelated to this PR), which will put the built packages in the `artifacts` directory under the source tree. When build without this change, the package will not include `/usr/libexec/netdata/plugins.d/ebpf.plugin`, while with it it will include that file.

##### Additional Information

Fixes #10200 (and possibly other issues).