### PR TITLE
get EBPF_VERSION dynamically

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1621,12 +1621,15 @@ install_ebpf() {
   # Detect libc
   libc="${EBPF_LIBC:-"$(detect_libc)"}"
 
-  EBPF_VERSION="$(cat packaging/ebpf.version)"
+  EBPF_VERSION="$(curl -q -SL --connect-timeout 10 --retry 3  https://github.com/netdata/kernel-collector/releases | grep "/netdata/kernel-collector/releases/tag/" | grep -oP "(?<=>Release ).*?(?=<)" | head -1)"
+  if [ -z ${EBPF_VERSION} ];then
+    EBPF_VERSION="$(cat packaging/ebpf.version)"
+  fi
   EBPF_TARBALL="netdata-kernel-collector-${libc}-${EBPF_VERSION}.tar.xz"
 
   tmp="$(mktemp -d -t netdata-ebpf-XXXXXX)"
 
-  if ! fetch_and_verify "ebpf" \
+  if ! fetch_external_component "ebpf" \
     "https://github.com/netdata/kernel-collector/releases/download/${EBPF_VERSION}/${EBPF_TARBALL}" \
     "${EBPF_TARBALL}" \
     "${tmp}" \

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -128,7 +128,7 @@ download_file() {
 # -----------------------------------------------------------------------------
 # external component handling
 
-fetch_and_verify() {
+fetch_external_component() {
   local component=${1}
   local url=${2}
   local base_name=${3}
@@ -144,6 +144,18 @@ fetch_and_verify() {
 
   if [ ! -f "${tmp}/${base_name}" ] || [ ! -s "${tmp}/${base_name}" ]; then
     run_failed "Unable to find usable archive for ${component}"
+    return 1
+  fi
+}
+
+fetch_and_verify() {
+  local component=${1}
+  local url=${2}
+  local base_name=${3}
+  local tmp=${4}
+  local override=${5}
+
+  if fetch_external_component "${1}" "${2}" "${3}" "${4}" "${5}";then
     return 1
   fi
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->
Fixes #11365 

##### Summary
To get ebpf_version dynamically.

##### Component Name
area/packaging
##### Test Plan
1. modify the netdata/packaging/ebpf_version  --> v0.7.4
2. sudo su
3. ./netdata-installer.sh
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
if the network is ok, the latest release of netdata-kernel-collector-glibc-*.tar.xz will be downloaded. Otherwise the default ebpf_version will be applied.
