### PR TITLE
Added sendmail collector

### DIFF
--- a/collectors/python.d.plugin/sendmail/Makefile.inc
+++ b/collectors/python.d.plugin/sendmail/Makefile.inc
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_python_DATA       += sendmail/sendmail.chart.py
+dist_pythonconfig_DATA += sendmail/sendmail.conf
+
+# do not install these files, but include them in the distribution
+dist_noinst_DATA       += sendmail/README.md sendmail/Makefile.inc
+

--- a/collectors/python.d.plugin/sendmail/README.md
+++ b/collectors/python.d.plugin/sendmail/README.md
@@ -1,0 +1,21 @@
+<!--
+title: "Sendmail monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/sendmail/sendmail.md
+sidebar_label: "Sendmail"
+-->
+
+# Collector for Sendmail 
+
+A simple collector for the 'mailstats -p' command for sendmail, parses prog-, local-, and esmtp-mailer as well as total and tcp-stats.  
+Works for the following output format (check mailstats output beforehand): 
+Please notice, that netdata need permissions to perform the 'mailstats -p'-command
+```
+$ mailstats -p
+1625774413 1626159038
+ 0        0          0       24      30421        0       0       0  prog
+ 3     6057     595865     4384    1003859       56       0       0  local
+ 5     3972     931233     7383     649313     1356       0       0  esmtp
+ T    10029    1527098    11791    1683593     1412       0       0
+ C    27553     7292   1412
+```
+

--- a/collectors/python.d.plugin/sendmail/sendmail.chart.py
+++ b/collectors/python.d.plugin/sendmail/sendmail.chart.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+# Description: sendmail netdata python.d module
+# Author: Ben Gräfe (sthinbetween90)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from bases.FrameworkServices.ExecutableService import ExecutableService
+
+SENDMAIL_COMMAND = 'mailstats -p'
+
+ORDER = [
+    'byte_count',
+    'message_count',
+    'rejected_count',
+    'total_message_count',
+    'total_byte_count',
+    'active_tcp'
+]
+
+CHARTS = {
+    'byte_count': {
+        'options': [None, 'Sendmail Bytecount', 'KiB', 'sendmail', 'sendmail.byteCount', 'stacked'],
+        'lines': [
+            ['bytes_from_local', None, 'incremental'],
+            ['bytes_from_esmtp', None, 'incremental'],
+            ['bytes_to_local', None, 'incremental'],
+            ['bytes_to_esmtp', None, 'incremental'],
+        ]
+    },
+    'message_count': {
+        'options': [None, 'Sendmail Messagecount', 'messages', 'sendmail', 'sendmail.messageCount', 'stacked'],
+        'lines': [
+            ['messages_from_local', None, 'incremental'],
+            ['messages_from_esmtp', None, 'incremental'],
+            ['messages_to_local', None, 'incremental'],
+            ['messages_to_esmtp', None, 'incremental'],
+        ]
+    },
+    'rejected_count': {
+        'options': [None, 'Sendmail Rejected Messages', 'messages', 'sendmail', 'sendmail.rejectedCount', 'stacked'],
+        'lines': [
+            ['rejected_local', None, 'incremental'],
+            ['rejected_esmtp', None, 'incremental'],
+            ['discarded_local', None, 'incremental'],
+            ['discarded_esmtp', None, 'incremental'],
+            ['quarantined_local', None, 'incremental'],
+            ['quarantined_esmtp', None, 'incremental'],
+        ]
+    },
+    'total_message_count': {
+        'options': [None, 'Sendmail Total Messagecount', 'messages', 'sendmail', 'sendmail.totMessageCount', 'stacked'],
+        'lines': [
+            ['total_messages_inc', None, 'incremental'],
+            ['total messages_out', None, 'incremental'],
+            ['total_messages_rej', None, 'incremental'],
+            ['total_messages_dis', None, 'incremental'],
+            ['total_messages_quar', None, 'incremental'],
+        ]
+    },
+    'total_byte_count': {
+        'options': [None, 'Sendmail Total Bytecount', 'KiB', 'sendmail', 'sendmail.totByteCount', 'stacked'],
+        'lines': [
+            ['total_bytes_in', None, 'incremental'],
+            ['total_bytes_out', None, 'incremental'],
+        ]
+    },
+    'active_tcp': {
+        'options': [None, 'Active TCP Connections', 'connections', 'sendmail', 'sendmail.activeTCP', 'stacked'],
+        'lines': [
+            ['tcp_out', None, 'incremental'],
+            ['tcp_in', None, 'incremental'],
+            ['tcp_err', None, 'incremental'],
+        ]
+    },
+}
+
+
+class Service(ExecutableService):
+    def __init__(self, configuration=None, name=None):
+        ExecutableService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.command = SENDMAIL_COMMAND
+
+    def _get_data(self):
+        """
+        Format data received from shell command
+        :return: dict
+        """
+        try:
+            elements = self._get_raw_data() 
+            data = dict()
+
+            for line in elements:
+                if 'local' in line: 
+                    local_line = ' '.join(line.split()).split(' ')
+                    if (len(local_line) == 9):
+                        data['bytes_from_local'] = local_line[2]
+                        data['bytes_to_local'] = local_line[4]
+                        data['messages_from_local'] = local_line[1]
+                        data['messages_to_local'] = local_line[3]
+                        data['rejected_local'] = local_line[5]
+                        data['discarded_local'] = local_line[6]
+                        data['quarantined_local'] = local_line[7]
+            
+                if 'esmtp' in line: 
+                    esmtp_line = ' '.join(line.split()).split(' ')
+                    if (len(esmtp_line) == 9):
+                        data['bytes_from_esmtp'] = esmtp_line[2]
+                        data['bytes_to_esmtp'] = esmtp_line[4]
+                        data['messages_from_esmtp'] = esmtp_line[1]
+                        data['messages_to_esmtp'] = esmtp_line[3]
+                        data['rejected_esmtp'] = esmtp_line[5]
+                        data['discarded_esmtp'] = esmtp_line[6]
+                        data['quarantined_esmtp'] = esmtp_line[7]
+
+                if 'T' in line:
+                    total_line = ' '.join(line.split()).split(' ')
+                    if (len(total_line) == 8):		
+                        data['total_messages_inc'] = total_line[3]
+                        data['total_messages_out'] = total_line[1]
+                        data['total_messages_rej'] = total_line[5]
+                        data['total_messages_dis'] = total_line[6]
+                        data['total_messages_quar'] = total_line[7]
+                        data['total_bytes_in'] = total_line[4]
+                        data['total_bytes_out'] = total_line[2]			
+                if 'C' in line:
+                    tcp_line = ' '.join(line.split()).split(' ')
+                    if (len(tcp_line) == 4):
+                        data['tcp_in'] = tcp_line[2]
+                        data['tcp_out'] = tcp_line[1]
+                        data['tcp_err'] = tcp_line[3]
+            return(data)
+        
+        except (ValueError, AttributeError):
+            return None

--- a/collectors/python.d.plugin/sendmail/sendmail.conf
+++ b/collectors/python.d.plugin/sendmail/sendmail.conf
@@ -1,0 +1,68 @@
+# netdata python.d.plugin configuration for sendmail
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+update_every: 10
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# penalty indicates whether to apply penalty to update_every in case of failures.
+# Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
+# penalty: yes
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+
+local:
+  command: 'mailstats -p'
+


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
This is a a simple collector for sendmail, which uses the output of the 'mailstats -p'-command.
It parses the output for the following mailers (if they exist):
  - prog-mailer
  - local-mailer
  - smtp-mailer
  - total statistics
  - tcp statistics 
 
##### Component Name

python collector for sendmail

##### Test Plan

tested for the mailstats -p output described in the readme. There seem to be other sendmail version with different mailstats output. These are explicitly not covered with this collector. 

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
