### PR TITLE
Add installer log

### DIFF
--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -306,7 +306,7 @@ if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
   fi
 fi
 
-# shellcheck disable=SC2235,SC2030
+# shellcheck disable=SC2235,SC2030,SC2031
 if ( [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_URL}" ] ) || ( [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ -z "${NETDATA_CLAIM_URL}" ] ); then
   run_failed "Invalid claiming options, both a claiming token and URL must be specified."
   exit 1
@@ -414,9 +414,11 @@ fi
 # --------------------------------------------------------------------------------------------------------------------
 
 if [ -n "${NETDATA_CLAIM_TOKEN}" ]; then
+  # shellcheck disable=SC2031
   progress "Attempting to claim agent to ${NETDATA_CLAIM_URL}"
   NETDATA_CLAIM_PATH=/opt/netdata/bin/netdata-claim.sh
 
+  # shellcheck disable=SC2031
   if "${NETDATA_CLAIM_PATH}" -token=${NETDATA_CLAIM_TOKEN} -rooms=${NETDATA_CLAIM_ROOMS} -url=${NETDATA_CLAIM_URL} ${NETDATA_CLAIM_EXTRA}; then
     progress "Successfully claimed node"
   else

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -56,15 +56,18 @@ setup_terminal || echo > /dev/null
 # ----------------------------------------------------------------------------
 fatal() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
+  log_put " [ ABORTED ] ${*} \n\n"
   exit 1
 }
 
 run_ok() {
   printf >&2 "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD} OK ${TPUT_RESET} \n\n"
+  log_put " [ OK ]\n\n"
 }
 
 run_failed() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET} \n\n"
+  log_put " [ FAILED ]\n\n"
 }
 
 ESCAPED_PRINT_METHOD=
@@ -74,17 +77,45 @@ fi
 escaped_print() {
   if [ "${ESCAPED_PRINT_METHOD}" = "printfq" ]; then
     printf "%q " "${@}"
+    log_put "%q " "${@}"
   else
     printf "%s" "${*}"
+    log_put "%s" "${*}"
   fi
   return 0
 }
 
-progress() {
-  echo >&2 " --- ${TPUT_DIM}${TPUT_BOLD}${*}${TPUT_RESET} --- "
+log_create() {
+  local logdir
+  logdir="$(dirname ${logpath})"
+  if [ ! -d "${logdir}" ] ; then
+    echo >&2 "Creating [${logdir}] for installer log file:"
+    mkdir -vp "$(dirname ${logpath})" >&2
+  fi
+  if ! touch ${logpath} ; then
+    echo >&2 "Unable to create [$logpath], falling back to current directory"
+    logpath="${PWD}/$(basename ${logpath})"
+  fi
+  if [ -e "${logpath}" ] ; then
+    echo >&2 "Rotating [${logpath}] log file:"
+    for i in {4..1}; do
+      if [ -e "${logpath}.${i}" ] ; then
+        mv -vf "${logpath}.${i}" "${logpath}.$((i+1))"
+      fi
+    done
+    mv -vf "${logpath}" "${logpath}.1"
+  fi
 }
 
-run_logfile="/dev/null"
+log_put() {
+  printf "$(date +%FT%T,%3N) ${*}\n" >>"${logpath}"
+}
+
+progress() {
+  echo >&2 " --- ${TPUT_DIM}${TPUT_BOLD}${*}${TPUT_RESET} --- "
+  log_put "${*}"
+}
+
 run() {
   local user="${USER--}" dir="${PWD}" info info_console
 
@@ -96,25 +127,20 @@ run() {
     info_console="[${TPUT_DIM}${dir}${TPUT_RESET}]$ "
   fi
 
-  {
-    printf "${info}"
-    escaped_print "${@}"
-    printf " ... "
-  } >> "${run_logfile}"
-
+  log_put "${info}"
   printf >&2 "${info_console}${TPUT_BOLD}${TPUT_YELLOW}"
   escaped_print >&2 "${@}"
   printf >&2 "${TPUT_RESET}\n"
+  log_put " ... "
 
   "${@}"
 
   local ret=$?
   if [ ${ret} -ne 0 ]; then
     run_failed
-    printf >> "${run_logfile}" "FAILED with exit code ${ret}\n"
+    log_put "FAILED with exit code ${ret}"
   else
     run_ok
-    printf >> "${run_logfile}" "OK\n"
   fi
 
   return ${ret}
@@ -122,6 +148,7 @@ run() {
 
 fatal() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
+  log_put " [ ABORTED ] ${*} \n\n"
   exit 1
 }
 
@@ -322,6 +349,7 @@ fi
 # look for an existing install and try to update that instead if it exists
 
 ndpath="$(command -v netdata 2>/dev/null)"
+logpath="/var/log/netdata/installer.log"
 if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ] ; then
     ndpath="/opt/netdata/bin/netdata"
 fi
@@ -331,6 +359,10 @@ if [ -n "$ndpath" ] ; then
 
   if [ "${ndprefix}" = /usr ] ; then
     ndprefix="/"
+  fi
+  if [ "${ndprefix}" != "/" ] ; then
+    logpath="${ndprefix}${logpath}"
+    log_create
   fi
 
   progress "Found existing install of Netdata under: ${ndprefix}"
@@ -373,6 +405,7 @@ if [ -n "$ndpath" ] ; then
     fi
   fi
 fi
+log_create
 
 # ----------------------------------------------------------------------------
 TMPDIR=$(create_tmp_directory)

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -409,7 +409,7 @@ if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
   fi
 fi
 
-# shellcheck disable=SC2235,SC2030
+# shellcheck disable=SC2235,SC2030,SC2031
 if ( [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_URL}" ] ) || ( [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ -z "${NETDATA_CLAIM_URL}" ] ); then
   run_failed "Invalid claiming options, both a claiming token and URL must be specified."
   exit 1
@@ -529,6 +529,7 @@ fi
 # --------------------------------------------------------------------------------------------------------------------
 
 if [ -n "${NETDATA_CLAIM_TOKEN}" ]; then
+  # shellcheck disable=SC2031
   progress "Attempting to claim agent to ${NETDATA_CLAIM_URL}"
   if [ -z "${NETDATA_PREFIX}" ] ; then
     NETDATA_CLAIM_PATH=/usr/sbin/netdata-claim.sh
@@ -536,6 +537,7 @@ if [ -n "${NETDATA_CLAIM_TOKEN}" ]; then
     NETDATA_CLAIM_PATH="${NETDATA_PREFIX}/netdata/usr/sbin/netdata-claim.sh"
   fi
 
+  # shellcheck disable=SC2031
   if "${NETDATA_CLAIM_PATH}" -token=${NETDATA_CLAIM_TOKEN} -rooms=${NETDATA_CLAIM_ROOMS} -url=${NETDATA_CLAIM_URL} ${NETDATA_CLAIM_EXTRA}; then
     progress "Successfully claimed node"
   else


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Add persistent logging to `kickstart.sh` and `kickstart-static64.sh` fixes #9348:
- Create `/var/log/netdata` if it doesn’t exist.
- Rotate any existing install log as the absolute first thing it does.
- If installing under a prefix, ideally place logs where Netdata would place them by default under that prefix
- Fall back to putting the log in the current working directory if and only if the log directory cannot be accessed and/or cannot be created.
- Rotation should not involve compression (we’re already way too heavy when it comes to installs and updates).
- I would default to saving the logs for the last five installs.

##### Component Name
Install scripts `kickstart.sh` and `kickstart-static64.sh`

##### Test Plan
1. Run `./kickstart.sh` or `./kickstart-static64.sh`.
2. Check out `/var/log/netdata/installer.log` for first and `/opt/netdata/var/log/installer.log` for log records.
3. After running install scripts, again and again, the old log inside directories above should be renamed to `installer.log.1`, `.2`, and so on, limited by `.5` as described in summary.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
Mentioning @Ferroin as negotiated [here](https://github.com/netdata/netdata/issues/9348#issuecomment-886831404) 😉