### PR TITLE
Add installer log

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -110,6 +110,7 @@ else
   # shellcheck source=packaging/installer/functions.sh
   source "${NETDATA_SOURCE_DIR}/packaging/installer/functions.sh" || exit 1
 fi
+log_create
 
 download_go() {
   download_file "${1}" "${2}" "go.d plugin" "go"
@@ -1588,7 +1589,7 @@ remove_old_ebpf() {
     mv "${NETDATA_PREFIX}/etc/netdata/ebpf_process.conf" "${NETDATA_PREFIX}/etc/netdata/ebpf.d.conf"
   fi
 
-  # Added to remove eBPF programs with name pattern: NAME_VERSION.SUBVERSION.PATCH 
+  # Added to remove eBPF programs with name pattern: NAME_VERSION.SUBVERSION.PATCH
   if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/pnetdata_ebpf_process.3.10.0.o" ]; then
     echo >&2 "Removing old eBPF programs with patch."
     rm -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/rnetdata_ebpf"*.?.*.*.o

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -86,7 +86,6 @@ escaped_print() {
 }
 
 log_create() {
-  local logdir
   logdir="$(dirname ${logpath})"
   if [ ! -d "${logdir}" ] ; then
     echo >&2 "Creating [${logdir}] for installer log file:"
@@ -98,10 +97,12 @@ log_create() {
   fi
   if [ -e "${logpath}" ] ; then
     echo >&2 "Rotating [${logpath}] log file:"
-    for i in {4..1}; do
+    i=4
+    while [ ${i} -gt 0 ] ; do
       if [ -e "${logpath}.${i}" ] ; then
         mv -vf "${logpath}.${i}" "${logpath}.$((i+1))"
       fi
+      i=$((i-1))
     done
     mv -vf "${logpath}" "${logpath}.1"
   fi

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -56,15 +56,18 @@ setup_terminal || echo > /dev/null
 # ----------------------------------------------------------------------------
 fatal() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
+  log_put "[ ABORTED ] ${*}\n\n"
   exit 1
 }
 
 run_ok() {
   printf >&2 "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD} OK ${TPUT_RESET} \n\n"
+  log_put "[ OK ]\n\n"
 }
 
 run_failed() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET} \n\n"
+  log_put "[ FAILED ]\n\n"
 }
 
 ESCAPED_PRINT_METHOD=
@@ -74,17 +77,46 @@ fi
 escaped_print() {
   if [ "${ESCAPED_PRINT_METHOD}" = "printfq" ]; then
     printf "%q " "${@}"
+    log_put "%q " "${@}"
   else
     printf "%s" "${*}"
+    log_put "%s" "${*}"
   fi
   return 0
 }
 
-progress() {
-  echo >&2 " --- ${TPUT_DIM}${TPUT_BOLD}${*}${TPUT_RESET} --- "
+log_create() {
+  local logdir
+  logdir="$(dirname ${logpath})"
+  if [ ! -d "${logdir}" ] ; then
+    echo >&2 "Creating [${logdir}] for installer log file:"
+    mkdir -vp "$(dirname "${logpath}")" >&2
+  fi
+  if ! touch "${logpath}" ; then
+    echo >&2 "Unable to create [$logpath], falling back to current directory"
+    logpath="${PWD}/$(basename "${logpath}")"
+  fi
+  if [ -e "${logpath}" ] ; then
+    echo >&2 "Rotating [${logpath}] log file:"
+    for i in {4..1}; do
+      if [ -e "${logpath}.${i}" ] ; then
+        mv -vf "${logpath}.${i}" "${logpath}.$((i+1))"
+      fi
+    done
+    mv -vf "${logpath}" "${logpath}.1"
+  fi
 }
 
-run_logfile="/dev/null"
+log_put() {
+  # shellcheck disable=SC2059
+  printf "$(date +%FT%T,%3N) ${*}\n" >>"${logpath}"
+}
+
+progress() {
+  echo >&2 " --- ${TPUT_DIM}${TPUT_BOLD}${*}${TPUT_RESET} --- "
+  log_put "${*}"
+}
+
 run() {
   local user="${USER--}" dir="${PWD}" info info_console
 
@@ -96,25 +128,20 @@ run() {
     info_console="[${TPUT_DIM}${dir}${TPUT_RESET}]$ "
   fi
 
-  {
-    printf "${info}"
-    escaped_print "${@}"
-    printf " ... "
-  } >> "${run_logfile}"
-
+  log_put "${info}"
   printf >&2 "${info_console}${TPUT_BOLD}${TPUT_YELLOW}"
   escaped_print >&2 "${@}"
   printf >&2 "${TPUT_RESET}\n"
+  log_put " ... "
 
   "${@}"
 
   local ret=$?
   if [ ${ret} -ne 0 ]; then
     run_failed
-    printf >> "${run_logfile}" "FAILED with exit code ${ret}\n"
+    log_put "FAILED with exit code ${ret}"
   else
     run_ok
-    printf >> "${run_logfile}" "OK\n"
   fi
 
   return ${ret}
@@ -122,6 +149,7 @@ run() {
 
 fatal() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
+  log_put "[ ABORTED ] ${*} \n\n"
   exit 1
 }
 
@@ -335,6 +363,7 @@ fi
 # look for an existing install and try to update that instead if it exists
 
 ndpath="$(command -v netdata 2>/dev/null)"
+logpath="/var/log/netdata/kickstart-static64.log"
 if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ] ; then
     ndpath="/opt/netdata/bin/netdata"
 fi
@@ -344,6 +373,10 @@ if [ -n "$ndpath" ] ; then
 
   if [ "${ndprefix}" = /usr ] ; then
     ndprefix="/"
+  fi
+  if [ "${ndprefix}" != "/" ] ; then
+    logpath="${ndprefix}${logpath}"
+    log_create
   fi
 
   progress "Found existing install of Netdata under: ${ndprefix}"
@@ -392,6 +425,7 @@ if [ -n "$ndpath" ] ; then
     fi
   fi
 fi
+log_create
 
 # ----------------------------------------------------------------------------
 TMPDIR=$(create_tmp_directory)

--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -319,7 +319,7 @@ if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
   fi
 fi
 
-# shellcheck disable=SC2235,SC2030
+# shellcheck disable=SC2235,SC2030,SC2031
 if ( [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_URL}" ] ) || ( [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ -z "${NETDATA_CLAIM_URL}" ] ); then
   run_failed "Invalid claiming options, both a claiming token and URL must be specified."
   exit 1

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -108,7 +108,6 @@ escaped_print() {
 }
 
 log_create() {
-  local logdir
   logdir="$(dirname ${logpath})"
   if [ ! -d "${logdir}" ] ; then
     echo >&2 "Creating [${logdir}] for installer log file:"
@@ -120,10 +119,12 @@ log_create() {
   fi
   if [ -e "${logpath}" ] ; then
     echo >&2 "Rotating [${logpath}] log file:"
-    for i in {4..1}; do
+    i=4
+    while [ ${i} -gt 0 ] ; do
       if [ -e "${logpath}.${i}" ] ; then
         mv -vf "${logpath}.${i}" "${logpath}.$((i+1))"
       fi
+      i=$((i-1))
     done
     mv -vf "${logpath}" "${logpath}.1"
   fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -78,15 +78,18 @@ setup_terminal || echo > /dev/null
 # -----------------------------------------------------------------------------
 fatal() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
+  log_put "[ ABORTED ] ${*} \n\n"
   exit 1
 }
 
 run_ok() {
   printf >&2 "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD} OK ${TPUT_RESET} \n\n"
+  log_put "[ OK ]\n\n"
 }
 
 run_failed() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET} \n\n"
+  log_put "[ FAILED ]\n\n"
 }
 
 ESCAPED_PRINT_METHOD=
@@ -96,17 +99,46 @@ fi
 escaped_print() {
   if [ "${ESCAPED_PRINT_METHOD}" = "printfq" ]; then
     printf "%q " "${@}"
+    log_put "%q " "${@}"
   else
     printf "%s" "${*}"
+    log_put "%s" "${*}"
   fi
   return 0
 }
 
-progress() {
-  echo >&2 " --- ${TPUT_DIM}${TPUT_BOLD}${*}${TPUT_RESET} --- "
+log_create() {
+  local logdir
+  logdir="$(dirname ${logpath})"
+  if [ ! -d "${logdir}" ] ; then
+    echo >&2 "Creating [${logdir}] for installer log file:"
+    mkdir -vp "$(dirname "${logpath}")" >&2
+  fi
+  if ! touch "${logpath}" ; then
+    echo >&2 "Unable to create [$logpath], falling back to current directory"
+    logpath="${PWD}/$(basename "${logpath}")"
+  fi
+  if [ -e "${logpath}" ] ; then
+    echo >&2 "Rotating [${logpath}] log file:"
+    for i in {4..1}; do
+      if [ -e "${logpath}.${i}" ] ; then
+        mv -vf "${logpath}.${i}" "${logpath}.$((i+1))"
+      fi
+    done
+    mv -vf "${logpath}" "${logpath}.1"
+  fi
 }
 
-run_logfile="/dev/null"
+log_put() {
+  # shellcheck disable=SC2059
+  printf "$(date +%FT%T,%3N) ${*}\n" >>"${logpath}"
+}
+
+progress() {
+  echo >&2 " --- ${TPUT_DIM}${TPUT_BOLD}${*}${TPUT_RESET} --- "
+  log_put "${*}"
+}
+
 run() {
   local user="${USER--}" dir="${PWD}" info info_console
 
@@ -118,25 +150,20 @@ run() {
     info_console="[${TPUT_DIM}${dir}${TPUT_RESET}]$ "
   fi
 
-  {
-    printf "${info}"
-    escaped_print "${@}"
-    printf " ... "
-  } >> "${run_logfile}"
-
+  log_put "${info}"
   printf >&2 "${info_console}${TPUT_BOLD}${TPUT_YELLOW}"
   escaped_print >&2 "${@}"
-  printf >&2 "${TPUT_RESET}"
+  printf >&2 "${TPUT_RESET}\n"
+  log_put " ... "
 
   "${@}"
 
   local ret=$?
   if [ ${ret} -ne 0 ]; then
     run_failed
-    printf >> "${run_logfile}" "FAILED with exit code ${ret}\n"
+    log_put "FAILED with exit code ${ret}"
   else
     run_ok
-    printf >> "${run_logfile}" "OK\n"
   fi
 
   return ${ret}
@@ -144,11 +171,13 @@ run() {
 
 fatal() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
+  log_put "[ ABORTED ] ${*} \n\n"
   exit 1
 }
 
 warning() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*} \n\n"
+  log_put "[ WARNING ] ${*} \n\n"
   if [ "${INTERACTIVE}" = "0" ]; then
     fatal "Stopping due to non-interactive mode. Fix the issue or retry installation in an interactive mode."
   else
@@ -439,6 +468,7 @@ fi
 # look for an existing install and try to update that instead if it exists
 
 ndpath="$(command -v netdata 2>/dev/null)"
+logpath="/var/log/netdata/installer.log"
 if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ] ; then
     ndpath="/opt/netdata/bin/netdata"
 fi
@@ -448,6 +478,10 @@ if [ -n "$ndpath" ] ; then
 
   if [ "${ndprefix}" = /usr ] ; then
     ndprefix="/"
+  fi
+  if [ "${ndprefix}" != "/" ] ; then
+    logpath="${ndprefix}${logpath}"
+    log_create
   fi
 
   progress "Found existing install of Netdata under: ${ndprefix}"
@@ -504,6 +538,7 @@ if [ -n "$ndpath" ] ; then
     fi
   fi
 fi
+log_create
 
 # ---------------------------------------------------------------------------------------------------------------------
 # install required system packages

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -465,11 +465,22 @@ elif [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_ROOMS}" ]; then
   exit 1
 fi
 
+logpath_suffix='var/log/netdata/kickstart.log'
+
+# shellcheck disable=SC2031
+state=$(set +o)
+set +u
+if [ -z "${NETDATA_PREFIX}" ] ; then
+  logpath="/${logpath_suffix}"
+else
+  logpath="${NETDATA_PREFIX}/${logpath_suffix}"
+fi
+eval "${state}"
+
 # ---------------------------------------------------------------------------------------------------------------------
 # look for an existing install and try to update that instead if it exists
 
 ndpath="$(command -v netdata 2>/dev/null)"
-logpath="/var/log/netdata/installer.log"
 if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ] ; then
     ndpath="/opt/netdata/bin/netdata"
 fi
@@ -481,7 +492,7 @@ if [ -n "$ndpath" ] ; then
     ndprefix="/"
   fi
   if [ "${ndprefix}" != "/" ] ; then
-    logpath="${ndprefix}${logpath}"
+    logpath="${ndprefix}/${logpath_suffix}"
     log_create
   fi
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -426,7 +426,7 @@ if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
   fi
 fi
 
-# shellcheck disable=SC2235,SC2030
+# shellcheck disable=SC2235,SC2030,SC2031
 if ( [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_URL}" ] ) || ( [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ -z "${NETDATA_CLAIM_URL}" ] ); then
   run_failed "Invalid claiming options, both a claiming token and URL must be specified."
   exit 1


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Add persistent logging to `kickstart.sh`, `kickstart-static64.sh`, and `netdata-installer.sh` fixes #9348:
- Create `/var/log/netdata` if it doesn’t exist.
- Rotate any existing install log as the absolute first thing it does.
- If installing under a prefix, ideally place logs where Netdata would place them by default under that prefix
- Fall back to putting the log in the current working directory if and only if the log directory cannot be accessed and/or cannot be created.
- Rotation should not involve compression (we’re already way too heavy when it comes to installs and updates).
- I would default to saving the logs for the last five installs.

##### Component Name
Install scripts `kickstart.sh`, `kickstart-static64.sh`, and `netdata-installer.sh`.

##### Test Plan
1. Run `./kickstart.sh` or `./kickstart-static64.sh`.
2. Check out `/var/log/netdata/{kickstart,installer}.log` for first and `/opt/netdata/var/log/kickstart-static64.log` for second script log records.
3. After running install scripts, again and again, the old log inside directories above should be renamed to `installer.log.1`, `.2`, and so on, limited by `.5` as described in summary.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
Mentioning @Ferroin as negotiated [here](https://github.com/netdata/netdata/issues/9348#issuecomment-886831404) 😉