### PR TITLE
Update handling of builds of bundled dependencies.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -544,7 +544,7 @@ build_libmosquitto() {
   fi
 
   if [ "$(uname -s)" = Linux ]; then
-    run ${env_cmd} make -C "${1}/lib"
+    run ${env_cmd} ${make} -j$(find_processors) -C "${1}/lib"
   else
     pushd ${1} > /dev/null || return 1
     if [ "$(uname)" = "Darwin" ] && [ -d /usr/local/opt/openssl ]; then
@@ -556,7 +556,7 @@ build_libmosquitto() {
     else
       run ${env_cmd} cmake -D WITH_STATIC_LIBRARIES:boolean=YES .
     fi
-    run ${env_cmd} make -C lib
+    run ${env_cmd} ${make} -j$(find_processors) -C lib
     run mv lib/libmosquitto_static.a lib/libmosquitto.a
     popd || return 1
   fi
@@ -660,7 +660,7 @@ EOF
       $CMAKE_FLAGS \
       .
   fi
-  run ${env_cmd} make -j$(find_processors)
+  run ${env_cmd} ${make} -j$(find_processors)
   popd > /dev/null || exit 1
 }
 
@@ -744,7 +744,7 @@ build_judy() {
     run ${env_cmd} automake --add-missing --force --copy --include-deps &&
     run ${env_cmd} autoconf &&
     run ${env_cmd} ./configure &&
-    run ${env_cmd} make -C src &&
+    run ${env_cmd} ${make} -j$(find_processors) -C src &&
     run ${env_cmd} ar -r src/libJudy.a src/Judy*/*.o; then
     popd > /dev/null || return 1
   else
@@ -822,7 +822,7 @@ build_jsonc() {
 
   pushd "${1}" > /dev/null || exit 1
   run ${env_cmd} cmake -DBUILD_SHARED_LIBS=OFF .
-  run ${env_cmd} make
+  run ${env_cmd} ${make} -j$(find_processors)
   popd > /dev/null || exit 1
 }
 
@@ -888,7 +888,7 @@ bundle_jsonc
 
 build_libbpf() {
   pushd "${1}/src" > /dev/null || exit 1
-  run env CFLAGS=-fPIC CXXFLAGS= LDFLAGS= BUILD_STATIC_ONLY=y OBJDIR=build DESTDIR=.. make install
+  run env CFLAGS=-fPIC CXXFLAGS= LDFLAGS= BUILD_STATIC_ONLY=y OBJDIR=build DESTDIR=.. ${make} -j$(find_processors) install
   popd > /dev/null || exit 1
 }
 


### PR DESCRIPTION
##### Summary

This adds parallelization of the builds of the bundled dependencies (this provides a few percent build time reduction on most systems), and switches them all to use the same version of `make` that Netdata will be built with (this changes nothing on most systems, but means that we will now uniformly use `gmake` on BSD systems).

##### Component Name

area/packaging

##### Test Plan

CI passes without issue.

##### Additional Information

The actual performance difference here is rather dependent on the specifics of the system it’s being tested on. On my lapto, running with `/tmp` in memory, 12 CPU cores, and exceedingly fast NVMe storage, it actually slows down the build by about a tenth of a second. Artificially limiting the storage bandwidth to match up with a typical SATA III SSD causes this to break even, and limiting it to about 1/5 of that (roughly like a nice SATA III HDD) makes it run about 1 second faster than without these changes.

Where this will really excel is systems that have slower processors combined with slower storage, like a Raspberry Pi. The relative percent time reduction should still be in the single digits, or at best the low double digits, but that translates to a significant reduction in absolute build times on such systems (for reference, the current install process takes _multiple hours_ on a standard Raspberry Pi with a reasonably fast SD card).