### PR TITLE
add Travis ctrl file for checking if changes happened

### DIFF
--- a/.travis/create_artifacts.sh
+++ b/.travis/create_artifacts.sh
@@ -38,7 +38,7 @@ if [ -f .travis/current_build_status ]; then
 	  exit 0
   fi
 else
-  echo "File .travis/current_build_status, probably this is the very first build, let's continue"
+  echo "File .travis/current_build_status doesn't exist, probably this is the very first build, let's continue"
 fi
 
 echo "--- Initialize git configuration ---"

--- a/.travis/create_artifacts.sh
+++ b/.travis/create_artifacts.sh
@@ -26,6 +26,21 @@ if [ ! "${TRAVIS_REPO_SLUG}" == "netdata/netdata" ]; then
   exit 0
 fi
 
+# if nightlies.sh has not written this TRAVIS_BUILD_NUMBER, there's no 
+# changes from last nigthly
+if [ -f .travis/current_build_status ]; then
+  FILE_TRAVIS_BUILD_NUMBER=$(cat .travis/current_build_status | cut -d'#' -f 2)
+  FILE_TRAVIS_BUILD_STATUS=$(cat .travis/current_build_status | cut -d- -f 1)
+  if [[ ${FILE_TRAVIS_BUILD_NUMBER} -eq ${TRAVIS_BUILD_NUMBER} ]] && [[ ${FILE_TRAVIS_BUILD_STATUS} == "changes" ]]; then
+  	echo "Changes happen since last nightly release, let's continue"
+  else
+    echo "No changes since last nightly release, nothing else to do"
+	  exit 0
+  fi
+else
+  echo "File .travis/current_build_status, probably this is the very first build, let's continue"
+fi
+
 echo "--- Initialize git configuration ---"
 git checkout "${1-master}"
 git pull

--- a/.travis/generate_changelog_for_nightlies.sh
+++ b/.travis/generate_changelog_for_nightlies.sh
@@ -37,8 +37,9 @@ echo "Changelog created! Adding packaging/version(${NEW_VERSION}) and CHANGELOG.
 echo "${NEW_VERSION}" > packaging/version
 git add packaging/version && echo "1) Added packaging/version to repository" || FAIL=1
 git add CHANGELOG.md && echo "2) Added changelog file to repository" || FAIL=1
-git commit -m '[ci skip] create nightly packages and update changelog' --author "${GIT_USER} <${GIT_MAIL}>" && echo "3) Committed changes to repository" || FAIL=1
-git push "https://${GITHUB_TOKEN}:@${PUSH_URL}" && echo "4) Pushed changes to remote ${PUSH_URL}" || FAIL=1
+git add .travis/current_build_status && echo "3) Added travis current build status file to repository" || FAIL=1
+git commit -m '[ci skip] create nightly packages and update changelog' --author "${GIT_USER} <${GIT_MAIL}>" && echo "4) Committed changes to repository" || FAIL=1
+git push "https://${GITHUB_TOKEN}:@${PUSH_URL}" && echo "5) Pushed changes to remote ${PUSH_URL}" || FAIL=1
 
 # In case of a failure, wrap it up and bail out cleanly
 if [ $FAIL -eq 1 ]; then

--- a/.travis/nightlies.sh
+++ b/.travis/nightlies.sh
@@ -31,6 +31,9 @@ PREVIOUS_NIGHTLY_COUNT="$(rev <packaging/version | cut -d- -f 2 | rev)"
 if [ "${COMMITS_SINCE_RELEASE}" == "${PREVIOUS_NIGHTLY_COUNT}" ]; then
 	echo "No changes since last nightly release, nothing else to do"
 	exit 0
+else
+	echo "Changes happen since last nightly release"
+	echo "changes-#${TRAVIS_BUILD_NUMBER}" > .travis/current_build_status
 fi
 
 if [ ! "${TRAVIS_REPO_SLUG}" == "netdata/netdata" ]; then


### PR DESCRIPTION

##### Summary
Fixes #10298
`nightlies.sh` already checks if changes happened since last nightly. When changes happens, it write a new `current_build_status` file and the subsequent `.travis/generate_changelog_for_nightlies.sh` script commits it and push into repository.

On the next Travis stage, "Nightly Release", the job "Create nightly release artifacts, publish to GCS" will check the previous control file. If the `TRAVIS_BUILD_NUMBER` differs from the one written in the file, it means that `nightlies.sh` previously saw that no changes happened since last nightly release, hence no new release is needed and it exits.


##### Component Name
Packaging

##### Test Plan
1. Commit a new release and ensure Travis CI builds and push new releases to GCS.  
2. Without any new commit, wait the scheduled nightly Travis CI builds or run a Travis build manually and ensure no new releases are pushed.

##### Additional Information
The two trigger jobs of "Nightly Release" stage will run anyway: "Trigger Docker image build and publish" and "Trigger DEB and RPM package build". 
