### PR TITLE
Remove warning when GCC 8.x is used

### DIFF
--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -277,7 +277,7 @@ static void update_disk_table(char *name, int major, int minor, time_t current_t
         if (length >= NETDATA_DISK_NAME_LEN)
             length = NETDATA_DISK_NAME_LEN;
 
-        strncpy(w->family, name, length);
+        memcpy(w->family, name, length);
         w->family[length] = '\0';
         w->major = major;
         w->minor = minor;
@@ -289,7 +289,7 @@ static void update_disk_table(char *name, int major, int minor, time_t current_t
         if (length >= NETDATA_DISK_NAME_LEN)
             length = NETDATA_DISK_NAME_LEN;
 
-        strncpy(disk_list->family, name, length);
+        memcpy(disk_list->family, name, length);
         disk_list->family[length] = '\0';
         disk_list->major = major;
         disk_list->minor = minor;


### PR DESCRIPTION
##### Summary
We received a report on our [fórum](https://community.netdata.cloud/t/compiler-warning-about-strncpy/1568) that when eBPF plugin is compiled using an old GCC version the following warning is shown:

```
  GEN      netdata
In function 'update_disk_table',
    inlined from 'read_local_disks' at collectors/ebpf.plugin/ebpf_disk.c:347:13:
collectors/ebpf.plugin/ebpf_disk.c:292:9: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-overflow=]
         strncpy(disk_list->family, name, length);
         ^
collectors/ebpf.plugin/ebpf_disk.c: In function 'read_local_disks':
collectors/ebpf.plugin/ebpf_disk.c:288:18: note: length computed here
         length = strlen(name);
                  ^
In function 'update_disk_table',
    inlined from 'read_local_disks' at collectors/ebpf.plugin/ebpf_disk.c:347:13:
collectors/ebpf.plugin/ebpf_disk.c:280:9: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-overflow=]
         strncpy(w->family, name, length);
         ^
collectors/ebpf.plugin/ebpf_disk.c: In function 'read_local_disks':
collectors/ebpf.plugin/ebpf_disk.c:276:18: note: length computed here
         length = strlen(name);
```

To avoid these warnings on old versions, this PR is changing the function call from `strncpy` to `memcpy`.
##### Component Name
ebpf.plugin
##### Test Plan

1 - Change your `/etc/netdata/ebpf.d.conf` to:

```conf
[ebpf programs]
    disk = yes
```

2 - Compile this branch with GCC 8.x ( Fedora 29 has this compile) redirecting `stderr` to a file, or take a look in the logs after the compilation.
3 - When the  compilation ends, verify that you do not have any warning.
4 - Start netdata and verify that eBPF.plugin is running and you have a chart `disk_latency_io.sdX`.

##### Additional Information
It is not necessary to test on different kernels, because we are only changing the plugin.