### PR TITLE
charts.d.plugin: set "module" when sending CHART

### DIFF
--- a/collectors/charts.d.plugin/ap/ap.chart.sh
+++ b/collectors/charts.d.plugin/ap/ap.chart.sh
@@ -61,25 +61,25 @@ ap_create() {
 
     # create the chart with 3 dimensions
     cat << EOF
-CHART ap_clients.${dev} '' "Connected clients to ${ssid} on ${dev}" "clients" ${dev} ap.clients line $((ap_priority + 1)) $ap_update_every
+CHART ap_clients.${dev} '' "Connected clients to ${ssid} on ${dev}" "clients" ${dev} ap.clients line $((ap_priority + 1)) $ap_update_every '' '' 'ap'
 DIMENSION clients '' absolute 1 1
 
-CHART ap_bandwidth.${dev} '' "Bandwidth for ${ssid} on ${dev}" "kilobits/s" ${dev} ap.net area $((ap_priority + 2)) $ap_update_every
+CHART ap_bandwidth.${dev} '' "Bandwidth for ${ssid} on ${dev}" "kilobits/s" ${dev} ap.net area $((ap_priority + 2)) $ap_update_every '' '' 'ap'
 DIMENSION received '' incremental 8 1024
 DIMENSION sent '' incremental -8 1024
 
-CHART ap_packets.${dev} '' "Packets for ${ssid} on ${dev}" "packets/s" ${dev} ap.packets line $((ap_priority + 3)) $ap_update_every
+CHART ap_packets.${dev} '' "Packets for ${ssid} on ${dev}" "packets/s" ${dev} ap.packets line $((ap_priority + 3)) $ap_update_every '' '' 'ap'
 DIMENSION received '' incremental 1 1
 DIMENSION sent '' incremental -1 1
 
-CHART ap_issues.${dev} '' "Transmit Issues for ${ssid} on ${dev}" "issues/s" ${dev} ap.issues line $((ap_priority + 4)) $ap_update_every
+CHART ap_issues.${dev} '' "Transmit Issues for ${ssid} on ${dev}" "issues/s" ${dev} ap.issues line $((ap_priority + 4)) $ap_update_every '' '' 'ap'
 DIMENSION retries 'tx retries' incremental 1 1
 DIMENSION failures 'tx failures' incremental -1 1
 
-CHART ap_signal.${dev} '' "Average Signal for ${ssid} on ${dev}" "dBm" ${dev} ap.signal line $((ap_priority + 5)) $ap_update_every
+CHART ap_signal.${dev} '' "Average Signal for ${ssid} on ${dev}" "dBm" ${dev} ap.signal line $((ap_priority + 5)) $ap_update_every '' '' 'ap'
 DIMENSION signal 'average signal' absolute 1 1000
 
-CHART ap_bitrate.${dev} '' "Bitrate for ${ssid} on ${dev}" "Mbps" ${dev} ap.bitrate line $((ap_priority + 6)) $ap_update_every
+CHART ap_bitrate.${dev} '' "Bitrate for ${ssid} on ${dev}" "Mbps" ${dev} ap.bitrate line $((ap_priority + 6)) $ap_update_every '' '' 'ap'
 DIMENSION receive '' absolute 1 1000
 DIMENSION transmit '' absolute -1 1000
 DIMENSION expected 'expected throughput' absolute 1 1000

--- a/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
+++ b/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
@@ -80,35 +80,35 @@ apcupsd_create() {
 
     # create the charts
     cat << EOF
-CHART apcupsd_${host}.charge '' "UPS Charge for ${host} on ${src}" "percentage" ups apcupsd.charge area $((apcupsd_priority + 1)) $apcupsd_update_every
+CHART apcupsd_${host}.charge '' "UPS Charge for ${host} on ${src}" "percentage" ups apcupsd.charge area $((apcupsd_priority + 1)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION battery_charge charge absolute 1 100
 
-CHART apcupsd_${host}.battery_voltage '' "UPS Battery Voltage for ${host} on ${src}" "Volts" ups apcupsd.battery.voltage line $((apcupsd_priority + 3)) $apcupsd_update_every
+CHART apcupsd_${host}.battery_voltage '' "UPS Battery Voltage for ${host} on ${src}" "Volts" ups apcupsd.battery.voltage line $((apcupsd_priority + 3)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION battery_voltage voltage absolute 1 100
 DIMENSION battery_voltage_nominal nominal absolute 1 100
 
-CHART apcupsd_${host}.input_voltage '' "UPS Input Voltage for ${host} on ${src}" "Volts" input apcupsd.input.voltage line $((apcupsd_priority + 4)) $apcupsd_update_every
+CHART apcupsd_${host}.input_voltage '' "UPS Input Voltage for ${host} on ${src}" "Volts" input apcupsd.input.voltage line $((apcupsd_priority + 4)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION input_voltage voltage absolute 1 100
 DIMENSION input_voltage_min min absolute 1 100
 DIMENSION input_voltage_max max absolute 1 100
 
-CHART apcupsd_${host}.input_frequency '' "UPS Input Frequency for ${host} on ${src}" "Hz" input apcupsd.input.frequency line $((apcupsd_priority + 5)) $apcupsd_update_every
+CHART apcupsd_${host}.input_frequency '' "UPS Input Frequency for ${host} on ${src}" "Hz" input apcupsd.input.frequency line $((apcupsd_priority + 5)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION input_frequency frequency absolute 1 100
 
-CHART apcupsd_${host}.output_voltage '' "UPS Output Voltage for ${host} on ${src}" "Volts" output apcupsd.output.voltage line $((apcupsd_priority + 6)) $apcupsd_update_every
+CHART apcupsd_${host}.output_voltage '' "UPS Output Voltage for ${host} on ${src}" "Volts" output apcupsd.output.voltage line $((apcupsd_priority + 6)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION output_voltage voltage absolute 1 100
 DIMENSION output_voltage_nominal nominal absolute 1 100
 
-CHART apcupsd_${host}.load '' "UPS Load for ${host} on ${src}" "percentage" ups apcupsd.load area $((apcupsd_priority)) $apcupsd_update_every
+CHART apcupsd_${host}.load '' "UPS Load for ${host} on ${src}" "percentage" ups apcupsd.load area $((apcupsd_priority)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION load load absolute 1 100
 
-CHART apcupsd_${host}.temp '' "UPS Temperature for ${host} on ${src}" "Celsius" ups apcupsd.temperature line $((apcupsd_priority + 7)) $apcupsd_update_every
+CHART apcupsd_${host}.temp '' "UPS Temperature for ${host} on ${src}" "Celsius" ups apcupsd.temperature line $((apcupsd_priority + 7)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION temp temp absolute 1 100
 
-CHART apcupsd_${host}.time '' "UPS Time Remaining for ${host} on ${src}" "Minutes" ups apcupsd.time area $((apcupsd_priority + 2)) $apcupsd_update_every
+CHART apcupsd_${host}.time '' "UPS Time Remaining for ${host} on ${src}" "Minutes" ups apcupsd.time area $((apcupsd_priority + 2)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION time time absolute 1 100
 
-CHART apcupsd_${host}.online '' "UPS ONLINE flag for ${host} on ${src}" "boolean" ups apcupsd.online line $((apcupsd_priority + 8)) $apcupsd_update_every
+CHART apcupsd_${host}.online '' "UPS ONLINE flag for ${host} on ${src}" "boolean" ups apcupsd.online line $((apcupsd_priority + 8)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION online online absolute 0 1
 
 EOF

--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -634,7 +634,7 @@ global_update() {
 		charts_run_counter[$chart]=0
 		charts_serial_failures[$chart]=0
 
-		echo "CHART netdata.plugin_chartsd_$chart '' 'Execution time for $chart plugin' 'milliseconds / run' charts.d netdata.plugin_charts area 145000 ${charts_update_every[$chart]}"
+		echo "CHART netdata.plugin_chartsd_$chart '' 'Execution time for $chart plugin' 'milliseconds / run' charts.d netdata.plugin_charts area 145000 ${charts_update_every[$chart]} '' '' '$chart'"
 		echo "DIMENSION run_time 'run time' absolute 1 1"
 	done
 

--- a/collectors/charts.d.plugin/example/example.chart.sh
+++ b/collectors/charts.d.plugin/example/example.chart.sh
@@ -89,11 +89,11 @@ example_check() {
 example_create() {
   # create the chart with 3 dimensions
   cat << EOF
-CHART example.random '' "Random Numbers Stacked Chart" "% of random numbers" random random stacked $((example_priority)) $example_update_every
+CHART example.random '' "Random Numbers Stacked Chart" "% of random numbers" random random stacked $((example_priority)) $example_update_every '' '' 'example'
 DIMENSION random1 '' percentage-of-absolute-row 1 1
 DIMENSION random2 '' percentage-of-absolute-row 1 1
 DIMENSION random3 '' percentage-of-absolute-row 1 1
-CHART example.random2 '' "A random number" "random number" random random area $((example_priority + 1)) $example_update_every
+CHART example.random2 '' "A random number" "random number" random random area $((example_priority + 1)) $example_update_every '' '' 'example'
 DIMENSION random '' absolute 1 1
 EOF
 

--- a/collectors/charts.d.plugin/libreswan/libreswan.chart.sh
+++ b/collectors/charts.d.plugin/libreswan/libreswan.chart.sh
@@ -124,10 +124,10 @@ libreswan_create_one() {
   libreswan_tunnel_charts[${name}]="$(fixid "${name}")"
 
   cat << EOF
-CHART libreswan.${libreswan_tunnel_charts[${name}]}_net '${name}_net' "LibreSWAN Tunnel ${name} Traffic" "kilobits/s" "${name}" libreswan.net area $((libreswan_priority)) $libreswan_update_every
+CHART libreswan.${libreswan_tunnel_charts[${name}]}_net '${name}_net' "LibreSWAN Tunnel ${name} Traffic" "kilobits/s" "${name}" libreswan.net area $((libreswan_priority)) $libreswan_update_every '' '' 'libreswan'
 DIMENSION in '' incremental 8 1000
 DIMENSION out '' incremental -8 1000
-CHART libreswan.${libreswan_tunnel_charts[${name}]}_uptime '${name}_uptime' "LibreSWAN Tunnel ${name} Uptime" "seconds" "${name}" libreswan.uptime line $((libreswan_priority + 1)) $libreswan_update_every
+CHART libreswan.${libreswan_tunnel_charts[${name}]}_uptime '${name}_uptime' "LibreSWAN Tunnel ${name} Uptime" "seconds" "${name}" libreswan.uptime line $((libreswan_priority + 1)) $libreswan_update_every '' '' 'libreswan'
 DIMENSION uptime '' absolute 1 1
 EOF
 

--- a/collectors/charts.d.plugin/opensips/opensips.chart.sh
+++ b/collectors/charts.d.plugin/opensips/opensips.chart.sh
@@ -49,61 +49,61 @@ opensips_check() {
 opensips_create() {
   # create the charts
   cat << EOF
-CHART opensips.dialogs_active '' "OpenSIPS Active Dialogs" "dialogs" dialogs '' area $((opensips_priority + 1)) $opensips_update_every
+CHART opensips.dialogs_active '' "OpenSIPS Active Dialogs" "dialogs" dialogs '' area $((opensips_priority + 1)) $opensips_update_every '' '' 'opensips'
 DIMENSION dialog_active_dialogs active absolute 1 1
 DIMENSION dialog_early_dialogs early absolute -1 1
 
-CHART opensips.users '' "OpenSIPS Users" "users" users '' line $((opensips_priority + 2)) $opensips_update_every
+CHART opensips.users '' "OpenSIPS Users" "users" users '' line $((opensips_priority + 2)) $opensips_update_every '' '' 'opensips'
 DIMENSION usrloc_registered_users registered absolute 1 1
 DIMENSION usrloc_location_users location absolute 1 1
 DIMENSION usrloc_location_contacts contacts absolute 1 1
 DIMENSION usrloc_location_expires expires incremental -1 1
 
-CHART opensips.registrar '' "OpenSIPS Registrar" "registrations/s" registrar '' line $((opensips_priority + 3)) $opensips_update_every
+CHART opensips.registrar '' "OpenSIPS Registrar" "registrations/s" registrar '' line $((opensips_priority + 3)) $opensips_update_every '' '' 'opensips'
 DIMENSION registrar_accepted_regs accepted incremental 1 1
 DIMENSION registrar_rejected_regs rejected incremental -1 1
 
-CHART opensips.transactions '' "OpenSIPS Transactions" "transactions/s" transactions '' line $((opensips_priority + 4)) $opensips_update_every
+CHART opensips.transactions '' "OpenSIPS Transactions" "transactions/s" transactions '' line $((opensips_priority + 4)) $opensips_update_every '' '' 'opensips'
 DIMENSION tm_UAS_transactions UAS incremental 1 1
 DIMENSION tm_UAC_transactions UAC incremental -1 1
 
-CHART opensips.core_rcv '' "OpenSIPS Core Receives" "queries/s" core '' line $((opensips_priority + 5)) $opensips_update_every
+CHART opensips.core_rcv '' "OpenSIPS Core Receives" "queries/s" core '' line $((opensips_priority + 5)) $opensips_update_every '' '' 'opensips'
 DIMENSION core_rcv_requests requests incremental 1 1
 DIMENSION core_rcv_replies replies incremental -1 1
 
-CHART opensips.core_fwd '' "OpenSIPS Core Forwards" "queries/s" core '' line $((opensips_priority + 6)) $opensips_update_every
+CHART opensips.core_fwd '' "OpenSIPS Core Forwards" "queries/s" core '' line $((opensips_priority + 6)) $opensips_update_every '' '' 'opensips'
 DIMENSION core_fwd_requests requests incremental 1 1
 DIMENSION core_fwd_replies replies incremental -1 1
 
-CHART opensips.core_drop '' "OpenSIPS Core Drops" "queries/s" core '' line $((opensips_priority + 7)) $opensips_update_every
+CHART opensips.core_drop '' "OpenSIPS Core Drops" "queries/s" core '' line $((opensips_priority + 7)) $opensips_update_every '' '' 'opensips'
 DIMENSION core_drop_requests requests incremental 1 1
 DIMENSION core_drop_replies replies incremental -1 1
 
-CHART opensips.core_err '' "OpenSIPS Core Errors" "queries/s" core '' line $((opensips_priority + 8)) $opensips_update_every
+CHART opensips.core_err '' "OpenSIPS Core Errors" "queries/s" core '' line $((opensips_priority + 8)) $opensips_update_every '' '' 'opensips'
 DIMENSION core_err_requests requests incremental 1 1
 DIMENSION core_err_replies replies incremental -1 1
 
-CHART opensips.core_bad '' "OpenSIPS Core Bad" "queries/s" core '' line $((opensips_priority + 9)) $opensips_update_every
+CHART opensips.core_bad '' "OpenSIPS Core Bad" "queries/s" core '' line $((opensips_priority + 9)) $opensips_update_every '' '' 'opensips'
 DIMENSION core_bad_URIs_rcvd bad_URIs_rcvd incremental 1 1
 DIMENSION core_unsupported_methods unsupported_methods incremental 1 1
 DIMENSION core_bad_msg_hdr bad_msg_hdr incremental 1 1
 
-CHART opensips.tm_replies '' "OpenSIPS TM Replies" "replies/s" transactions '' line $((opensips_priority + 10)) $opensips_update_every
+CHART opensips.tm_replies '' "OpenSIPS TM Replies" "replies/s" transactions '' line $((opensips_priority + 10)) $opensips_update_every '' '' 'opensips'
 DIMENSION tm_received_replies received incremental 1 1
 DIMENSION tm_relayed_replies relayed incremental 1 1
 DIMENSION tm_local_replies local incremental 1 1
 
-CHART opensips.transactions_status '' "OpenSIPS Transactions Status" "transactions/s" transactions '' line $((opensips_priority + 11)) $opensips_update_every
+CHART opensips.transactions_status '' "OpenSIPS Transactions Status" "transactions/s" transactions '' line $((opensips_priority + 11)) $opensips_update_every '' '' 'opensips'
 DIMENSION tm_2xx_transactions 2xx incremental 1 1
 DIMENSION tm_3xx_transactions 3xx incremental 1 1
 DIMENSION tm_4xx_transactions 4xx incremental 1 1
 DIMENSION tm_5xx_transactions 5xx incremental 1 1
 DIMENSION tm_6xx_transactions 6xx incremental 1 1
 
-CHART opensips.transactions_inuse '' "OpenSIPS InUse Transactions" "transactions" transactions '' line $((opensips_priority + 12)) $opensips_update_every
+CHART opensips.transactions_inuse '' "OpenSIPS InUse Transactions" "transactions" transactions '' line $((opensips_priority + 12)) $opensips_update_every '' '' 'opensips'
 DIMENSION tm_inuse_transactions inuse absolute 1 1
 
-CHART opensips.sl_replies '' "OpenSIPS SL Replies" "replies/s" core '' line $((opensips_priority + 13)) $opensips_update_every
+CHART opensips.sl_replies '' "OpenSIPS SL Replies" "replies/s" core '' line $((opensips_priority + 13)) $opensips_update_every '' '' 'opensips'
 DIMENSION sl_1xx_replies 1xx incremental 1 1
 DIMENSION sl_2xx_replies 2xx incremental 1 1
 DIMENSION sl_3xx_replies 3xx incremental 1 1
@@ -114,31 +114,30 @@ DIMENSION sl_sent_replies sent incremental 1 1
 DIMENSION sl_sent_err_replies error incremental 1 1
 DIMENSION sl_received_ACKs ACKed incremental 1 1
 
-CHART opensips.dialogs '' "OpenSIPS Dialogs" "dialogs/s" dialogs '' line $((opensips_priority + 14)) $opensips_update_every
-DIMENSION dialog_processed_dialogs processed incremental 1 1
+CHART opensips.dialogs '' "OpenSIPS Dialogs" "dialogs/s" dialogs '' line $((opensips_priority + 14)) $opensips_update_every '' '' 'opensips'
 DIMENSION dialog_expired_dialogs expired incremental 1 1
 DIMENSION dialog_failed_dialogs failed incremental -1 1
 
-CHART opensips.net_waiting '' "OpenSIPS Network Waiting" "kilobytes" net '' line $((opensips_priority + 15)) $opensips_update_every
+CHART opensips.net_waiting '' "OpenSIPS Network Waiting" "kilobytes" net '' line $((opensips_priority + 15)) $opensips_update_every '' '' 'opensips'
 DIMENSION net_waiting_udp UDP absolute 1 1024
 DIMENSION net_waiting_tcp TCP absolute 1 1024
 
-CHART opensips.uri_checks '' "OpenSIPS URI Checks" "checks / sec" uri '' line $((opensips_priority + 16)) $opensips_update_every
+CHART opensips.uri_checks '' "OpenSIPS URI Checks" "checks / sec" uri '' line $((opensips_priority + 16)) $opensips_update_every '' '' 'opensips'
 DIMENSION uri_positive_checks positive incremental 1 1
 DIMENSION uri_negative_checks negative incremental -1 1
 
-CHART opensips.traces '' "OpenSIPS Traces" "traces / sec" traces '' line $((opensips_priority + 17)) $opensips_update_every
+CHART opensips.traces '' "OpenSIPS Traces" "traces / sec" traces '' line $((opensips_priority + 17)) $opensips_update_every '' '' 'opensips'
 DIMENSION siptrace_traced_requests requests incremental 1 1
 DIMENSION siptrace_traced_replies replies incremental -1 1
 
-CHART opensips.shmem '' "OpenSIPS Shared Memory" "kilobytes" mem '' line $((opensips_priority + 18)) $opensips_update_every
+CHART opensips.shmem '' "OpenSIPS Shared Memory" "kilobytes" mem '' line $((opensips_priority + 18)) $opensips_update_every '' '' 'opensips'
 DIMENSION shmem_total_size total absolute 1 1024
 DIMENSION shmem_used_size used absolute 1 1024
 DIMENSION shmem_real_used_size real_used absolute 1 1024
 DIMENSION shmem_max_used_size max_used absolute 1 1024
 DIMENSION shmem_free_size free absolute 1 1024
 
-CHART opensips.shmem_fragments '' "OpenSIPS Shared Memory Fragmentation" "fragments" mem '' line $((opensips_priority + 19)) $opensips_update_every
+CHART opensips.shmem_fragments '' "OpenSIPS Shared Memory Fragmentation" "fragments" mem '' line $((opensips_priority + 19)) $opensips_update_every '' '' 'opensips'
 DIMENSION shmem_fragments fragments absolute 1 1
 EOF
 

--- a/collectors/charts.d.plugin/opensips/opensips.chart.sh
+++ b/collectors/charts.d.plugin/opensips/opensips.chart.sh
@@ -115,6 +115,7 @@ DIMENSION sl_sent_err_replies error incremental 1 1
 DIMENSION sl_received_ACKs ACKed incremental 1 1
 
 CHART opensips.dialogs '' "OpenSIPS Dialogs" "dialogs/s" dialogs '' line $((opensips_priority + 14)) $opensips_update_every '' '' 'opensips'
+DIMENSION dialog_processed_dialogs processed incremental 1 1
 DIMENSION dialog_expired_dialogs expired incremental 1 1
 DIMENSION dialog_failed_dialogs failed incremental -1 1
 

--- a/collectors/charts.d.plugin/sensors/sensors.chart.sh
+++ b/collectors/charts.d.plugin/sensors/sensors.chart.sh
@@ -143,7 +143,7 @@ sensors_create() {
 				files="$(sensors_check_files "$files")"
 				files="$(sensors_check_temp_type "$files")"
 				[ -z "$files" ] && continue
-				echo "CHART sensors.temp_$id '' '$name Temperature' 'Celsius' 'temperature' 'sensors.temp' line $((sensors_priority + 1)) $sensors_update_every"
+				echo "CHART sensors.temp_$id '' '$name Temperature' 'Celsius' 'temperature' 'sensors.temp' line $((sensors_priority + 1)) $sensors_update_every '' '' 'sensors'"
 				echo >>"$TMP_DIR/sensors.sh" "echo \"BEGIN sensors.temp_$id \$1\""
 				divisor=1000
 				;;
@@ -152,7 +152,7 @@ sensors_create() {
 				files="$(ls "$path"/in*_input 2>/dev/null)"
 				files="$(sensors_check_files "$files")"
 				[ -z "$files" ] && continue
-				echo "CHART sensors.volt_$id '' '$name Voltage' 'Volts' 'voltage' 'sensors.volt' line $((sensors_priority + 2)) $sensors_update_every"
+				echo "CHART sensors.volt_$id '' '$name Voltage' 'Volts' 'voltage' 'sensors.volt' line $((sensors_priority + 2)) $sensors_update_every '' '' 'sensors'"
 				echo >>"$TMP_DIR/sensors.sh" "echo \"BEGIN sensors.volt_$id \$1\""
 				divisor=1000
 				;;
@@ -161,7 +161,7 @@ sensors_create() {
 				files="$(ls "$path"/curr*_input 2>/dev/null)"
 				files="$(sensors_check_files "$files")"
 				[ -z "$files" ] && continue
-				echo "CHART sensors.curr_$id '' '$name Current' 'Ampere' 'current' 'sensors.curr' line $((sensors_priority + 3)) $sensors_update_every"
+				echo "CHART sensors.curr_$id '' '$name Current' 'Ampere' 'current' 'sensors.curr' line $((sensors_priority + 3)) $sensors_update_every '' '' 'sensors'"
 				echo >>"$TMP_DIR/sensors.sh" "echo \"BEGIN sensors.curr_$id \$1\""
 				divisor=1000
 				;;
@@ -170,7 +170,7 @@ sensors_create() {
 				files="$(ls "$path"/power*_input 2>/dev/null)"
 				files="$(sensors_check_files "$files")"
 				[ -z "$files" ] && continue
-				echo "CHART sensors.power_$id '' '$name Power' 'Watt' 'power' 'sensors.power' line $((sensors_priority + 4)) $sensors_update_every"
+				echo "CHART sensors.power_$id '' '$name Power' 'Watt' 'power' 'sensors.power' line $((sensors_priority + 4)) $sensors_update_every '' '' 'sensors'"
 				echo >>"$TMP_DIR/sensors.sh" "echo \"BEGIN sensors.power_$id \$1\""
 				divisor=1000000
 				;;
@@ -179,7 +179,7 @@ sensors_create() {
 				files="$(ls "$path"/fan*_input 2>/dev/null)"
 				files="$(sensors_check_files "$files")"
 				[ -z "$files" ] && continue
-				echo "CHART sensors.fan_$id '' '$name Fans Speed' 'Rotations / Minute' 'fans' 'sensors.fans' line $((sensors_priority + 5)) $sensors_update_every"
+				echo "CHART sensors.fan_$id '' '$name Fans Speed' 'Rotations / Minute' 'fans' 'sensors.fans' line $((sensors_priority + 5)) $sensors_update_every '' '' 'sensors'"
 				echo >>"$TMP_DIR/sensors.sh" "echo \"BEGIN sensors.fan_$id \$1\""
 				;;
 
@@ -187,7 +187,7 @@ sensors_create() {
 				files="$(ls "$path"/energy*_input 2>/dev/null)"
 				files="$(sensors_check_files "$files")"
 				[ -z "$files" ] && continue
-				echo "CHART sensors.energy_$id '' '$name Energy' 'Joule' 'energy' 'sensors.energy' areastack $((sensors_priority + 6)) $sensors_update_every"
+				echo "CHART sensors.energy_$id '' '$name Energy' 'Joule' 'energy' 'sensors.energy' areastack $((sensors_priority + 6)) $sensors_update_every '' '' 'sensors'"
 				echo >>"$TMP_DIR/sensors.sh" "echo \"BEGIN sensors.energy_$id \$1\""
 				algorithm="incremental"
 				divisor=1000000
@@ -197,7 +197,7 @@ sensors_create() {
 				files="$(ls "$path"/humidity*_input 2>/dev/null)"
 				files="$(sensors_check_files "$files")"
 				[ -z "$files" ] && continue
-				echo "CHART sensors.humidity_$id '' '$name Humidity' 'Percent' 'humidity' 'sensors.humidity' line $((sensors_priority + 7)) $sensors_update_every"
+				echo "CHART sensors.humidity_$id '' '$name Humidity' 'Percent' 'humidity' 'sensors.humidity' line $((sensors_priority + 7)) $sensors_update_every '' '' 'sensors'"
 				echo >>"$TMP_DIR/sensors.sh" "echo \"BEGIN sensors.humidity_$id \$1\""
 				divisor=1000
 				;;


### PR DESCRIPTION
##### Summary

Fixes part of #11388

ssia, this is needed for accounting plugins usage statistics.

All the changes follow [external plugins API](https://learn.netdata.cloud/docs/agent/collectors/plugins.d#chart):

> CHART type.id name title units [family [context [charttype [priority [update_every [options [plugin [module]]]]]]]]

"module" is the last parameter (12th).

##### Component Name

`collectors/charts.d.plugin`

##### Test Plan

Tested using (only) [example](https://github.com/netdata/netdata/tree/master/collectors/charts.d.plugin/example#example) module.

```cmd
[ilyam@pc ~]$ curl -s localhost:19999/api/v1/info | jq '.collectors[] | select(.plugin=="charts.d.plugin")'
{
  "plugin": "charts.d.plugin",
  "module": "example"
}
```

##### Additional Information
