### PR TITLE
[WIP] Time-correlated log extract in notifications

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -214,6 +214,7 @@ elif [[ ${1} = "dump_methods" ]]; then
     status="WARNING"
 else
   roles="${1}"               # the roles that should be notified for this event
+  logwatch=logwatch
   args_host="${2}"           # the host generated this event
   unique_id="${3}"           # the unique id of this event
   alarm_id="${4}"            # the unique id of the alarm that generated this event
@@ -841,6 +842,19 @@ if [ "${SEND_EMAIL}" == "YES" ] && [ "${EMAIL_THREADING}" != "NO" ]; then
 else
   email_thread_headers=
 fi
+
+# -----------------------------------------------------------------------------
+# function to get Logwatch results.
+
+logwatch() {
+  if ! command -v logwatch &> /dev/null; then
+    start=`date "+%Y-%m-%d %T" -d ${date_utc} -1 minute`
+    end=`date "+%Y-%m-%d %T" -d ${date_utc} +1 minute`
+    return `logwatch --range "between ${start} and ${end}" --detail Medium`
+  else
+    return "Please install Logwatch to see an extract from your system state here."
+  fi
+}
 
 # -----------------------------------------------------------------------------
 # function to URL encode a string
@@ -3191,6 +3205,43 @@ Content-Transfer-Encoding: 8bit
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
                   <div style="font-family:Open Sans, sans-serif;font-size:16px;line-height:1;text-align:left;color:#35414A;">Role:
                     <span style="font-weight:600">${roles}</span></div>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+  <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="set-font-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+  <div class="set-font" style="font-family: 'IBM Plex Sans', sans-serif; margin: 0px auto; max-width: 600px;">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+      <tbody>
+      <tr>
+        <td style="direction:ltr;font-size:0px;padding:20px 0;padding-left:25px;text-align:left;">
+          <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:66px;" ><![endif]-->
+          <div class="mj-column-px-400 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:466px;">
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+              <tbody>
+              <tr>
+                <td style="vertical-align:top;padding-left:0;">
+                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                    <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;">
+                        <div style="font-family:Open Sans, sans-serif;font-size:16px;font-weight:700;line-height:1;text-align:left;color:#35414A;">Logs within 1 minute of this alert</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;padding-left:0;word-break:break-word;">
+                        <pre>${logwatch}</pre>
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table>
                 </td>
               </tr>
               </tbody>


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Proposal: notifications should include a relevant extract from the system logs. This is a first attempt at implementing a Logwatch snapshot to come with notifications. It adds a section to the HTML email template, and runs a simple Logwatch command to get relevant system logs and state from 1 minute before and after the alert was raised.  On a test by hand, a snapshot configured this way was helpful in resolving three of my own alerts... so I feel like this is a reasonable place to begin.

I'm _not_ sure if this is the right place to put the logic, though. Seems weird to have a View and the code behind it in one file. Tried to follow the examples in the rest of the codebase though. 

I'm not sure how to test this in my own kubernetes installation with cloud, either. Would love some advice there or others who can test it more directly. :)

##### Component Name

Notifications.

##### Test Plan
No idea - what automated tests are in place for this script already?

##### Additional Information
[Relevant discord conversation](https://discord.com/channels/847502280503590932/858386511777759243/871710567444934686)