### PR TITLE
remove "vernemq.queue_messages_in_queues" from dashboard_info.js

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -3746,26 +3746,6 @@ netdataDashboard.context = {
             }
         ]
     },
-    'vernemq.queue_messages_in_queues': {
-        mainheads: [
-            function (os, id) {
-                void (os);
-                return '<div data-netdata="' + id + '"'
-                    + ' data-dimensions="queue_messages_current"'
-                    + ' data-chart-library="gauge"'
-                    + ' data-title="Messages in the Queues"'
-                    + ' data-units="messages"'
-                    + ' data-gauge-adjust="width"'
-                    + ' data-width="16%"'
-                    + ' data-before="0"'
-                    + ' data-after="-CHART_DURATION"'
-                    + ' data-points="CHART_DURATION"'
-                    + ' data-colors="' + NETDATA.colors[2] + '"'
-                    + ' data-decimal-digits="2"'
-                    + ' role="application"></div>';
-            }
-        ]
-    },
     'vernemq.queue_messages': {
         mainheads: [
             function (os, id) {


### PR DESCRIPTION
##### Summary

We discovered that it is not possible to calculate messages currently in the queue using ["queue_message_*"](https://github.com/netdata/go.d.plugin/blob/3e6dd58663d8d5a4803fc2cdb9f433c411d91f52/modules/vernemq/metrics.go#L105-L109) metrics.

"queue_messages_current" metric is [removed](https://github.com/netdata/go.d.plugin/pull/601) from `vernemq` collector.

##### Component Name

`web/gui`

##### Test Plan

Not needed

##### Additional Information
