### PR TITLE
Fix coverity issue 372222

### DIFF
--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -1219,7 +1219,7 @@ static int statsd_readfile(const char *filename, STATSD_APP *app, STATSD_APP_CHA
                             netdata_configured_stock_config_dir,
                             strlen(netdata_configured_stock_config_dir))) {
                         char tmpfilename[FILENAME_MAX + 1];
-                        strcpy(tmpfilename, filename);
+                        strncpyz(tmpfilename, filename, FILENAME_MAX);
                         chart->module = strdupz(basename(tmpfilename));
                     } else {
                         chart->module = strdupz("synthetic_chart");


### PR DESCRIPTION
##### Summary
Fixes a coverity warning 
```
*** CID 372222:  Security best practices violations  (STRING_OVERFLOW)
/collectors/statsd.plugin/statsd.c: 1222 in statsd_readfile()
1216     
1217                         if (!strncmp(
1218                                 filename,
1219                                 netdata_configured_stock_config_dir,
1220                                 strlen(netdata_configured_stock_config_dir))) {
1221                             char tmpfilename[FILENAME_MAX + 1];
>>>     CID 372222:  Security best practices violations  (STRING_OVERFLOW)
>>>     You might overrun the 4097-character fixed-size string "tmpfilename" by copying "filename" without checking the length.
1222                             strcpy(tmpfilename, filename);
1223                             chart->module = strdupz(basename(tmpfilename));
1224                         } else {
1225                             chart->module = strdupz("synthetic_chart");
1226                         }
1227                     }
```

##### Component Name
collectors
##### Test Plan
- Coverity warning goes away after the fix


##### Additional Information
