### PR TITLE
Fix bundled protobuf linkage on systems needing -latomic

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -825,15 +825,17 @@ netdata_LDADD = \
     $(NULL)
 
 if ACLK_NG
-    netdata_LDADD += $(OPTIONAL_PROTOBUF_LIBS)
+    netdata_LDADD += $(OPTIONAL_PROTOBUF_LIBS) \
+        $(OPTIONAL_ATOMIC_LIBS) \
+        $(NULL)
 endif
 
 if ACLK_LEGACY
-netdata_LDADD += \
-    $(abs_top_srcdir)/externaldeps/mosquitto/libmosquitto.a \
-    $(OPTIONAL_LWS_LIBS) \
-    $(OPTIONAL_LIBCAP_LIBS) \
-    $(NULL)
+    netdata_LDADD += \
+        $(abs_top_srcdir)/externaldeps/mosquitto/libmosquitto.a \
+        $(OPTIONAL_LWS_LIBS) \
+        $(OPTIONAL_LIBCAP_LIBS) \
+        $(NULL)
 endif #ACLK_LEGACY
 
 if ENABLE_CXX_LINKER

--- a/configure.ac
+++ b/configure.ac
@@ -759,7 +759,13 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
     fi
 
     if test "${with_bundled_protobuf}" = "yes"; then
-        AC_LANG_PUSH([C++])
+        AC_LANG_SAVE
+        AC_LANG_CPLUSPLUS
+        # 2 macros above are deprecated
+        # but new macro below doesnt work on older systems
+        # which we still do support. In future replace by
+        # AC_LANG_PUSH([C++]) 
+
         # Add -std=c++11 if necesssary. It is important for us to do this before the
         # libatomic check below, since that also depends on C++11.
         AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
@@ -779,7 +785,11 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
             OPTIONAL_ATOMIC_LIBS="-latomic"
         fi
         AC_SUBST([OPTIONAL_ATOMIC_LIBS])
-        AC_LANG_POP([C++])
+        AC_LANG_RESTORE
+        # macro above are deprecated
+        # but new macro below doesnt work on older systems
+        # which we still do support. In future replace by
+        # AC_LANG_POP([C++])
     fi
 
     AC_MSG_CHECKING([ACLK Next Generation can be built])

--- a/configure.ac
+++ b/configure.ac
@@ -757,6 +757,31 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
     else
         AC_MSG_RESULT([yes])
     fi
+
+    if test "${with_bundled_protobuf}" = "yes"; then
+        AC_LANG_PUSH([C++])
+        # Add -std=c++11 if necesssary. It is important for us to do this before the
+        # libatomic check below, since that also depends on C++11.
+        AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+
+        # On some platforms, std::atomic needs a helper library
+        AC_MSG_CHECKING(whether -latomic is needed for static protobuf)
+        AC_LINK_IFELSE([AC_LANG_SOURCE([[
+          #include <atomic>
+          #include <cstdint>
+          std::atomic<std::int64_t> v;
+          int main() {
+            return v;
+          }
+        ]])], STD_ATOMIC_NEED_LIBATOMIC=no, STD_ATOMIC_NEED_LIBATOMIC=yes)
+        AC_MSG_RESULT($STD_ATOMIC_NEED_LIBATOMIC)
+        if test "x$STD_ATOMIC_NEED_LIBATOMIC" = xyes; then
+            OPTIONAL_ATOMIC_LIBS="-latomic"
+        fi
+        AC_SUBST([OPTIONAL_ATOMIC_LIBS])
+        AC_LANG_POP([C++])
+    fi
+
     AC_MSG_CHECKING([ACLK Next Generation can be built])
     AC_MSG_RESULT([${can_enable_ng}])
     if test "$can_enable_ng" = "no" -a "$aclk_ng" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -759,16 +759,8 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
     fi
 
     if test "${with_bundled_protobuf}" = "yes"; then
-        AC_LANG_SAVE
-        AC_LANG_CPLUSPLUS
-        # 2 macros above are deprecated
-        # but new macro below doesnt work on older systems
-        # which we still do support. In future replace by
-        # AC_LANG_PUSH([C++]) 
-
-        # Add -std=c++11 if necesssary. It is important for us to do this before the
-        # libatomic check below, since that also depends on C++11.
-        AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+        AC_LANG_PUSH([C++]) 
+        CXXFLAGS="${CXXFLAGS} -std=c++11"
 
         # On some platforms, std::atomic needs a helper library
         AC_MSG_CHECKING(whether -latomic is needed for static protobuf)
@@ -785,11 +777,7 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
             OPTIONAL_ATOMIC_LIBS="-latomic"
         fi
         AC_SUBST([OPTIONAL_ATOMIC_LIBS])
-        AC_LANG_RESTORE
-        # macro above are deprecated
-        # but new macro below doesnt work on older systems
-        # which we still do support. In future replace by
-        # AC_LANG_POP([C++])
+        AC_LANG_POP([C++])
     fi
 
     AC_MSG_CHECKING([ACLK Next Generation can be built])


### PR DESCRIPTION
##### Summary
During review of https://github.com/netdata/netdata/pull/11374 @stelfrag noticed on 32 bit Raspbian `netdata` binary will fail to link due to missing libatomic which protobuf needs on some systems (like RPi 32bit).

If bundled/static protobuf is going to be used:
- Detects the need for `-latomic` using same mechanism as protobuf does during build
- links it if detected necessary

##### Component Name
Buildsystem

##### Test Plan
- static protobuf possible to be used on 32bit RPi
- latomic added as shared lib dep check with `ldd netdata`

On regular system like AMD64 Fedora 34 latomic is not needed and should not be linked.

When system protobuf is used (as shared library) this check is skipped entirely and latomic is not linked

##### Additional Information
