### PR TITLE
minor - Remove autoreconf warning

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -44,7 +44,7 @@ dist_healthconfig_DATA = \
     health.d/entropy.conf \
     health.d/exporting.conf \
     health.d/fping.conf \
-    health.d/geth.conf \ 
+    health.d/geth.conf \
     health.d/ioping.conf \
     health.d/fronius.conf \
     health.d/gearman.conf \


### PR DESCRIPTION
When runing `autoreconf -ivf` on netdata source you get annoying warning
```
health/Makefile.am:47: warning: whitespace following trailing backslash
```

This removes it

##### Summary

##### Component Name

##### Test Plan

trivial, run `autoreconf -ivf` warning mentioned above should not be present anymore

##### Additional Information
