### PR TITLE
Add SQLite unit tests

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -823,6 +823,7 @@ int main(int argc, char **argv) {
 #ifdef ENABLE_DBENGINE
                             if(test_dbengine()) return 1;
 #endif
+                            if(test_sqlite()) return 1;
                             fprintf(stderr, "\n\nALL TESTS PASSED\n\n");
                             return 0;
                         }

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1475,6 +1475,38 @@ int unit_test(long delay, long shift)
     return ret;
 }
 
+int test_sqlite(void) {
+    sqlite3  *db_meta;
+    fprintf(stderr, "Testing SQLIte\n");
+
+    int rc = sqlite3_open(":memory:", &db_meta);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr,"Failed to test SQLite: DB init failed\n");
+        return 1;
+    }
+
+    rc = sqlite3_exec(db_meta, "CREATE TABLE IF NOT EXISTS mine (id1, id2);", 0, 0, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr,"Failed to test SQLite: Create table failed\n");
+        return 1;
+    }
+
+    rc = sqlite3_exec(db_meta, "DELETE FROM MINE LIMIT 1;", 0, 0, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr,"Failed to test SQLite: Delete with LIMIT failed\n");
+        return 1;
+    }
+
+    rc = sqlite3_exec(db_meta, "UPDATE MINE SET id1=1 LIMIT 1;", 0, 0, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr,"Failed to test SQLite: Update with LIMIT failed\n");
+        return 1;
+    }
+    fprintf(stderr,"SQLite is OK\n");
+    return 0;
+}
+
+
 #ifdef ENABLE_DBENGINE
 static inline void rrddim_set_by_pointer_fake_time(RRDDIM *rd, collected_number value, time_t now)
 {

--- a/daemon/unit_test.h
+++ b/daemon/unit_test.h
@@ -8,6 +8,7 @@ extern int unit_test(long delay, long shift);
 extern int run_all_mockup_tests(void);
 extern int unit_test_str2ld(void);
 extern int unit_test_buffer(void);
+extern int test_sqlite(void);
 #ifdef ENABLE_DBENGINE
 extern int test_dbengine(void);
 extern void generate_dbengine_dataset(unsigned history_seconds);


### PR DESCRIPTION
##### Summary
Adds a simple test for SQLite 
- Database can be initialized
- Table can be created
- Make sure that the delete / update statement supports `ORDER BY` and `LIMIT` (syntax error will make the command fail)

##### Component Name
database

##### Test Plan
- Build the agent
- Run `netdata -W unittest`
  - When the tests finish you should see 
     ```
     Testing SQLIte
     SQLite is OK
     ```