### PR TITLE
Default to not using LTO for builds.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,9 +144,9 @@ AC_ARG_ENABLE(
 )
 AC_ARG_ENABLE(
     [lto],
-    [AS_HELP_STRING([--disable-lto], [Link Time Optimizations @<:@default autodetect@:>@])],
+    [AS_HELP_STRING([--enable-lto], [Link Time Optimizations @<:@default disabled@:>@])],
     ,
-    [enable_lto="detect"]
+    [enable_lto="no"]
 )
 AC_ARG_ENABLE(
     [https],

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -232,7 +232,7 @@ USAGE: ${PROGRAM} [options]
   --disable-backend-prometheus-remote-write
   --enable-backend-mongodb   Enable MongoDB backend. Default: enable it when libmongoc is available.
   --disable-backend-mongodb
-  --enable-lto               Enable Link-Time-Optimization. Default: enabled
+  --enable-lto               Enable Link-Time-Optimization. Default: disabled
   --disable-lto
   --disable-x86-sse          Disable SSE instructions. By default SSE optimizations are enabled.
   --use-system-lws           Use a system copy of libwebsockets instead of bundling our own (default is to use the bundled copy).


### PR DESCRIPTION
##### Summary

This significantly speeds up the build process (cutting build times roughly in half) and avoids strange linking errors such as what we’re seeing with Debian 9 in #11374.

##### Component Name

area/build

##### Test Plan

Verified that the build still works correctly without LTO and that the CI runs much faster.

##### Additional Information

We _might_ consider enabling this again at some time in the future, but right now we can’t even quantify the performance benefits of using LTO.

Users who _really_ want this can still enable it by passing `--enable-lto` to the installer or configure script.