### PR TITLE
Fix issue #11434 regarding inconsistent status check on  component.

### DIFF
--- a/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
+++ b/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
@@ -154,7 +154,7 @@ BEGIN {
 /^LOADPCT.*/   { load = \$3 * 100 };
 /^ITEMP.*/     { temp = \$3 * 100 };
 /^TIMELEFT.*/  { time = \$3 * 100 };
-/^STATUS.*/    { online=(\$3 == \"ONLINE\" || \$3 == \"ONBATT\")?1:0 };
+/^STATUS.*/    { online=(\$3 != \"COMMLOST\" && !(\$3 == \"SHUTTING\" && \$4 == \"DOWN\"))?1:0 };
 END {
 	print \"BEGIN apcupsd_${host}.online $1\";
 	print \"SET online = \" online;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fixes: #11434

Fix an inconsistent status check on `apcupsd`. After PR #8688, it checks for "COMMLOST" or "SHUTTING DOWN" to check if ups is online, but the PR missed the same check on the `apcupsd_update()` function.

##### Component Name

`apcupsd`

##### Test Plan

I created a file with output from `apcaccess` and run through all possible values for status. Now it consider online all options for status except "COMMLOST" or "SHUTTING DOWN".

##### Additional Information

I got these alarms(`apcupsd_last_collected_secs`) for several months, but I didn't dig, just ignored them. Today I got upset and started looking what was happening, for my surprise, it was indeed a bug.