### PR TITLE
Remove ClearLinux from CI.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -36,7 +36,6 @@ jobs:
           - 'archlinux:latest'
           - 'centos:8'
           - 'centos:7'
-          - 'clearlinux:latest'
           - 'debian:10'
           - 'debian:9'
           - 'fedora:34'

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -25,7 +25,6 @@ jobs:
           - 'archlinux:latest'
           - 'centos:7'
           - 'centos:8'
-          - 'clearlinux:latest'
           - 'debian:9'
           - 'debian:10'
           - 'fedora:33'


### PR DESCRIPTION
##### Summary

We’ve never really officially supported it and it’s causing CI failures due to upstream infrastructure issues.

This is not removing any of our code supporting it, just the CI checks for ClearLinux. Officially, we still have some level of support, but it’s community supported.

##### Component Name

area/ci

##### Test Plan

n/a