### PR TITLE
Fix list corruption in ACLK sync code and remove fatal

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -135,7 +135,9 @@ void aclk_database_enq_cmd(struct aclk_database_worker_config *wc, struct aclk_d
     uv_mutex_unlock(&wc->cmd_mutex);
 
     /* wake up event loop */
-    fatal_assert(0 == uv_async_send(&wc->async));
+    int rc = uv_async_send(&wc->async);
+    if (unlikely(rc))
+        debug(D_ACLK_SYNC, "Failed to wake up event loop");
 }
 
 struct aclk_database_cmd aclk_database_deq_cmd(struct aclk_database_worker_config* wc)

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -47,9 +47,10 @@ void aclk_del_worker_thread(struct aclk_database_worker_config *wc)
 
     uv_mutex_lock(&aclk_async_lock);
     struct aclk_database_worker_config **tmp = &aclk_thread_head;
-    while ((*tmp) != wc)
+    while (*tmp && (*tmp) != wc)
         tmp = &(*tmp)->next;
-    *tmp = wc->next;
+    if (*tmp)
+        *tmp = wc->next;
     uv_mutex_unlock(&aclk_async_lock);
     return;
 }


### PR DESCRIPTION
##### Summary
- Correctly check that an item does not exist in the aclk thread list and ignore it (instead of accessing
invalid memory and crash)
- Ignore error when attempting to wake up event loop (do not fatal)

##### Component Name
aclk

##### Test Plan
- The code is not active yet