### PR TITLE
Don’t bail early if we fail to build cloud deps with required cloud.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -879,6 +879,10 @@ if test "$enable_cloud" != "no" -a "$aclk_legacy" != "no"; then
     fi
 fi
 
+if test "$enable_cloud" = "yes" -a "$enable_aclk" != "yes"; then
+    AC_MSG_ERROR([Neither ACLK-NG nor ACLK-Legacy can be built but --enable-cloud was requested])
+fi
+
 AC_SUBST([enable_cloud])
 AC_SUBST([enable_aclk])
 AM_CONDITIONAL([ACLK_NG], [test "${aclk_ng}" = "yes"])

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -601,19 +601,11 @@ bundle_libmosquitto() {
       run_ok "libmosquitto built and prepared."
     else
       run_failed "Failed to build libmosquitto."
-      if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
-        exit 1
-      else
-        defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
-      fi
+      defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
     fi
   else
     run_failed "Unable to fetch sources for libmosquitto."
-    if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
-      exit 1
-    else
-      defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
-    fi
+    defer_error_highlighted "Unable to fetch sources for libmosquitto. You will not be able to connect this node to Netdata Cloud."
   fi
 }
 
@@ -710,19 +702,11 @@ bundle_libwebsockets() {
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-bundled-lws"
     else
       run_failed "Failed to build libwebsockets."
-      if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
-        exit 1
-      else
-        defer_error_highlighted "Failed to build libwebsockets. You may not be able to connect this node to Netdata Cloud."
-      fi
+      defer_error_highlighted "Failed to build libwebsockets. You may not be able to connect this node to Netdata Cloud."
     fi
   else
     run_failed "Unable to fetch sources for libwebsockets."
-    if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
-      exit 1
-    else
-      defer_error_highlighted "Unable to fetch sources for libwebsockets. You may not be able to connect this node to Netdata Cloud."
-    fi
+    defer_error_highlighted "Unable to fetch sources for libwebsockets. You may not be able to connect this node to Netdata Cloud."
   fi
 }
 
@@ -783,19 +767,11 @@ bundle_protobuf() {
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-bundled-protobuf"
     else
       run_failed "Failed to build protobuf."
-      if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
-        exit 1
-      else
-        defer_error_highlighted "Failed to build protobuf. You may not be able to connect this node to Netdata Cloud."
-      fi
+      defer_error_highlighted "Failed to build protobuf. You may not be able to connect this node to Netdata Cloud."
     fi
   else
     run_failed "Unable to fetch sources for protobuf."
-    if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
-      exit 1
-    else
-      defer_error_highlighted "Unable to fetch sources for protobuf. You may not be able to connect this node to Netdata Cloud."
-    fi
+    defer_error_highlighted "Unable to fetch sources for protobuf. You may not be able to connect this node to Netdata Cloud."
   fi
 }
 
@@ -944,19 +920,11 @@ bundle_jsonc() {
       run_ok "JSON-C built and prepared."
     else
       run_failed "Failed to build JSON-C."
-      if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
-        exit 1
-      else
-        defer_error_highlighted "Failed to build JSON-C. Netdata Cloud support will be disabled."
-      fi
+      defer_error_highlighted "Failed to build JSON-C. Netdata Cloud support will be disabled."
     fi
   else
     run_failed "Unable to fetch sources for JSON-C."
-    if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
-      exit 1
-    else
-      defer_error_highlighted "Unable to fetch sources for JSON-C. Netdata Cloud support will be disabled."
-    fi
+    defer_error_highlighted "Unable to fetch sources for JSON-C. Netdata Cloud support will be disabled."
   fi
 }
 


### PR DESCRIPTION
##### Summary

Due to having two ACLK implementations, failing to build any arbitrary set of cloud dependencies is not guaranteed to prevent us from building a working cloud implementation, so we should fall back to relying on the configure script for determining if the cloud can be built.

This also ensures that the configure script properly bails if we can’t enable either ACLK implementation _and_ were asked to require the cloud.

##### Component Name

area/packaging

##### Test Plan

CI passes

##### Additional Information

Fixes: #11443 