### PR TITLE
Check for failed protobuf configure or make

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -657,8 +657,7 @@ if test "${with_bundled_protobuf}" != "no"; then
     fi
     AC_MSG_RESULT([${bundled_proto_avail}])
     if test "${with_bundled_protobuf}" == "yes" -a "${bundled_proto_avail}" != "yes"; then
-        AC_MSG_WARN([Bundled protobuf requested using --with-bundled-protobuf but it cannot be used/found, skipping ACLK NG])
-        aclk_ng="no"
+        AC_MSG_ERROR([Bundled protobuf requested using --with-bundled-protobuf but it cannot be used/found])
     fi
     if test "${with_bundled_protobuf}" == "detect" -a "${bundled_proto_avail}" == "yes"; then
         with_bundled_protobuf="yes"

--- a/configure.ac
+++ b/configure.ac
@@ -657,7 +657,8 @@ if test "${with_bundled_protobuf}" != "no"; then
     fi
     AC_MSG_RESULT([${bundled_proto_avail}])
     if test "${with_bundled_protobuf}" == "yes" -a "${bundled_proto_avail}" != "yes"; then
-        AC_MSG_ERROR([Bundled protobuf requested using --with-bundled-protobuf but it cannot be used/found])
+        AC_MSG_WARN([Bundled protobuf requested using --with-bundled-protobuf but it cannot be used/found, skipping ACLK NG])
+        aclk_ng="no"
     fi
     if test "${with_bundled_protobuf}" == "detect" -a "${bundled_proto_avail}" == "yes"; then
         with_bundled_protobuf="yes"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -738,11 +738,16 @@ build_protobuf() {
   fi
 
   pushd "${1}" > /dev/null || return 1
-  run ${env_cmd} ./configure --disable-shared \
-                             --without-zlib \
-                             --disable-dependency-tracking \
-                             --with-pic || return 1
-  run ${env_cmd} ${make} -j$(find_processors) || return 1
+  if ! run ${env_cmd} ./configure --disable-shared --without-zlib --disable-dependency-tracking --with-pic; then
+    popd > /dev/null || return 1
+    return 1
+  fi
+
+  if ! run ${env_cmd} $make -j$(find_processors); then
+    popd > /dev/null || return 1
+    return 1
+  fi
+
   popd > /dev/null || return 1
 }
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds a check in `netdata-installer.sh` for the status of configure and make phases of protobuf. If any of those fails, it makes sure it returns back to original directory to continue with the rest of the installer.

It also does not bail out from the configure phase of the agent if bundled protobuf is not found. ACLK Legacy should be available in this case, since the builds with NG are separate.

##### Component Name

Installer

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

If dependencies are there (i.e. g++), ACLK NG should be built with protobuf.
If configure phase (uninstall g++) or build of protobuf (`ctrl-z` after configure, break a protobuf file, `fg`), observe that installer continues with the rest of components, and does not build ACLK NG.

##### Additional Information

This does not solve the big problem, which is how to eventually "force" use of ACLK NG with protobuf.