### PR TITLE
Add custom e-mail headers

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2685,6 +2685,13 @@ Subject: ${host} ${status_message} - ${name//_/ } - ${chart}
 MIME-Version: 1.0
 Content-Type: multipart/alternative; boundary="multipart-boundary"
 ${email_thread_headers}
+X-Netdata-Severity: ${status,,}
+X-Netdata-Alert-Name: $name
+X-Netdata-Chart: $chart
+X-Netdata-Family: $family
+X-Netdata-Classification: $classification
+X-Netdata-Host: $host
+X-Netdata-Role: $roles
 
 This is a MIME-encoded multipart message
 

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -3424,6 +3424,13 @@ Subject: ${html_email_subject}
 MIME-Version: 1.0
 Content-Type: multipart/alternative; boundary="multipart-boundary"
 ${email_thread_headers}
+X-Netdata-Severity: ${status,,}
+X-Netdata-Alert-Name: $name
+X-Netdata-Chart: $chart
+X-Netdata-Family: $family
+X-Netdata-Classification: $classification
+X-Netdata-Host: $host
+X-Netdata-Role: $roles
 
 This is a MIME-encoded multipart message
 

--- a/health/notifications/email/README.md
+++ b/health/notifications/email/README.md
@@ -11,9 +11,9 @@ Netdata sends all emails as user `netdata`, so make sure your `sendmail` works f
 
 email notifications look like this:
 
-![image](https://cloud.githubusercontent.com/assets/2662304/18407294/e9218c68-7714-11e6-8739-e4dd8a498252.png)
+![image](https://user-images.githubusercontent.com/1905463/133216974-a2ca0e4f-787b-4dce-b1b2-9996a8c5f718.png)
 
-## configuration
+## Configuration
 
 To edit `health_alarm_notify.conf` on your system run `/etc/netdata/edit-config health_alarm_notify.conf`.
 
@@ -37,6 +37,20 @@ Where `[ROLE]` is the role you want to test. The default (if you don't give a `[
 
 Note that in versions before 1.16, the plugins.d directory may be installed in a different location in certain OSs (e.g. under `/usr/lib/netdata`). 
 You can always find the location of the alarm-notify.sh script in `netdata.conf`.
+
+## Filtering
+
+Every notification email (both the plain text and the rich html versions) from the Netdata agent, contain a set of custom email headers that can be used for filtering using an email client. Example:
+
+```
+X-Netdata-Severity: warning
+X-Netdata-Alert-Name: inbound_packets_dropped_ratio
+X-Netdata-Chart: net_packets.enp2s0
+X-Netdata-Family: enp2s0
+X-Netdata-Classification: System
+X-Netdata-Host: winterland
+X-Netdata-Role: sysadmin
+```
 
 ## Simple SMTP transport configuration
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This was [requested by a user in the community forum](https://community.netdata.cloud/t/custom-headers-in-email-notifications/1489). Although the user seems to have requested it for the cloud e-mails, it is a simple change to also have in agent e-mails. If we need perhaps to also include it in cloud e-mails, we can wait before merging and synchronize as to not create confusion.

The PR adds some custom headers, which can then be used for filtering from an email client.

##### Component Name

Health notifications

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Raise an alert e-mail notification from an agent. Observe in the e-mail headers e.g.:

```
X-Netdata-Severity: warning
X-Netdata-Alert-Name: exporting_metrics_sent
X-Netdata-Chart: netdata.exporting_my_graphite_instance_bytes
X-Netdata-Family: exporting_my_graphite_instance
X-Netdata-Classification: Workload
X-Netdata-Host: winterland
X-Netdata-Role: dba
```

##### Additional Information

Do we need to edit some piece of documentation to include this feature information?
