### PR TITLE
Fix formatting issues in ebpf sync charts.

### DIFF
--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -311,22 +311,22 @@ static void ebpf_create_sync_charts()
 {
     if (local_syscalls[NETDATA_SYNC_FSYNC_IDX].enabled || local_syscalls[NETDATA_SYNC_FDATASYNC_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_FILE_SYNC_CHART,
-                               "Monitor calls for <code>fsync(2)</code> and <code>fdatasync(2)</code>.", 21300,
+                               "Calls to fsync(2) and fdatasync(2).", 21300,
                                NETDATA_SYNC_FSYNC_IDX, NETDATA_SYNC_FDATASYNC_IDX);
 
     if (local_syscalls[NETDATA_SYNC_MSYNC_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_MSYNC_CHART,
-                               "Monitor calls for <code>msync(2)</code>.", 21301,
+                               "Calls to msync(2).", 21301,
                                NETDATA_SYNC_MSYNC_IDX, NETDATA_SYNC_MSYNC_IDX);
 
     if (local_syscalls[NETDATA_SYNC_SYNC_IDX].enabled || local_syscalls[NETDATA_SYNC_SYNCFS_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_SYNC_CHART,
-                               "Monitor calls for <code>sync(2)</code> and <code>syncfs(2)</code>.", 21302,
+                               "Calls to sync(2) and syncfs(2).", 21302,
                                NETDATA_SYNC_SYNC_IDX, NETDATA_SYNC_SYNCFS_IDX);
 
     if (local_syscalls[NETDATA_SYNC_SYNC_FILE_RANGE_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_FILE_SEGMENT_CHART,
-                               "Monitor calls for <code>sync_file_range(2)</code>.", 21303,
+                               "Calls to sync_file_range(2).", 21303,
                                NETDATA_SYNC_SYNC_FILE_RANGE_IDX, NETDATA_SYNC_SYNC_FILE_RANGE_IDX);
 }
 


### PR DESCRIPTION
##### Summary

Fixes charts were using `<code>` formatting incorrectly.

![image](https://user-images.githubusercontent.com/10018065/130946957-acce1692-a5b4-460a-a1ad-3233663dbadc.png)

##### Component Name

ebpf.plugin

##### Test Plan

Go to the "synchronization (eBPF)" section and see that the names used are fixed.