### PR TITLE
Fix edge repository configuration DEB packages.

### DIFF
--- a/packaging/repoconfig/debian/rules
+++ b/packaging/repoconfig/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 TOP = $(CURDIR)/debian/netdata-repo
-TOP_EDGE = $(CURDIR)/debian/netdata-edge-repo
+TOP_EDGE = $(CURDIR)/debian/netdata-repo-edge
 TEMPTOP = $(CURDIR)/debian/tmp
 
 %:


### PR DESCRIPTION
##### Summary

Due to a naming issue in the `debian/rules` file, they were being built without the actual repository configuration data.

##### Component Name

area/packaging

##### Test Plan

Verified by confirming that packages built with the changes here actually configure the repo correctly.

Quick confirmation is to use `dpkg-query -L netdata-repo-edge` in a Docker container with the package installed to check the files installed by the package. Without these changes, it’s only a couple of boilerplate files under `/usr/share`, with this change it includes the configuration files under `/etc/apt`.