### PR TITLE
Adds aclk/cloud state command to netdatacli

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1064,7 +1064,7 @@ char *ng_aclk_state_json(void)
         tmp = json_object_new_string(agent_id);
         freez(agent_id);
     } else
-        tmp = json_object_new_null();
+        tmp = NULL;
     json_object_object_add(msg, "claimed-id", tmp);
 
     tmp = json_object_new_boolean(aclk_connected);

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1019,3 +1019,58 @@ void aclk_send_bin_msg(char *msg, size_t msg_len, enum aclk_topics subtopic, con
 {
     aclk_send_bin_message_subtopic_pid(mqttwss_client, msg, msg_len, subtopic, msgname);
 }
+
+char *ng_aclk_state(void)
+{
+    BUFFER *wb = buffer_create(1024);
+    char *ret;
+
+    buffer_strcat(wb,
+        "ACLK Available: Yes\n"
+        "ACLK Implementation: Next Generation\n"
+        "Claimed: "
+    );
+
+    char *agent_id = is_agent_claimed();
+    if (agent_id == NULL)
+        buffer_strcat(wb, "No\n");
+    else {
+        buffer_sprintf(wb, "Yes\nClaimed Id: %s\n", agent_id);
+        freez(agent_id);
+    }
+
+    buffer_sprintf(wb, "Online: %s", aclk_connected ? "Yes" : "No");
+
+    ret = strdupz(buffer_tostring(wb));
+    buffer_free(wb);
+    return ret;
+}
+
+char *ng_aclk_state_json(void)
+{
+    json_object *tmp, *msg = json_object_new_object();
+
+    tmp = json_object_new_boolean(1);
+    json_object_object_add(msg, "aclk-available", tmp);
+
+    tmp = json_object_new_string("Next Generation");
+    json_object_object_add(msg, "aclk-implementation", tmp);
+
+    char *agent_id = is_agent_claimed();
+    tmp = json_object_new_boolean(agent_id != NULL);
+    json_object_object_add(msg, "agent-claimed", tmp);
+
+    if (agent_id) {
+        tmp = json_object_new_string(agent_id);
+        freez(agent_id);
+    } else
+        tmp = json_object_new_null();
+    json_object_object_add(msg, "claimed-id", tmp);
+
+    tmp = json_object_new_boolean(aclk_connected);
+    json_object_object_add(msg, "online", tmp);
+
+    char *str = strdupz(json_object_to_json_string_ext(msg, JSON_C_TO_STRING_PLAIN));
+    json_object_put(msg);
+    return str;
+}

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -49,4 +49,7 @@ void aclk_send_node_instances(void);
 
 void aclk_send_bin_msg(char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname);
 
+char *ng_aclk_state(void);
+char *ng_aclk_state_json(void);
+
 #endif /* ACLK_H */

--- a/aclk/aclk_api.c
+++ b/aclk/aclk_api.c
@@ -197,7 +197,7 @@ struct label *add_aclk_host_labels(struct label *label) {
 
 char *aclk_state(void) {
 #ifndef ENABLE_ACLK
-    return strdupz("ACLK Available: No\n");
+    return strdupz("ACLK Available: No");
 #else
 #ifdef ACLK_NG
     if (aclk_ng)
@@ -213,7 +213,7 @@ char *aclk_state(void) {
 
 char *aclk_state_json(void) {
 #ifndef ENABLE_ACLK
-    return strdupz("{\"aclk-available\": false}\n");
+    return strdupz("{\"aclk-available\": false}");
 #else
 #ifdef ACLK_NG
     if (aclk_ng)

--- a/aclk/aclk_api.c
+++ b/aclk/aclk_api.c
@@ -194,3 +194,35 @@ struct label *add_aclk_host_labels(struct label *label) {
 #endif
     return label;
 }
+
+char *aclk_state(void) {
+#ifndef ENABLE_ACLK
+    return strdupz("ACLK Available: No\n");
+#else
+#ifdef ACLK_NG
+    if (aclk_ng)
+        return ng_aclk_state();
+#endif
+#ifdef ACLK_LEGACY
+    if (!aclk_ng)
+        return legacy_aclk_state();
+#endif
+#endif /* ENABLE_ACLK */
+    return NULL;
+}
+
+char *aclk_state_json(void) {
+#ifndef ENABLE_ACLK
+    return strdupz("{\"aclk-available\": false}\n");
+#else
+#ifdef ACLK_NG
+    if (aclk_ng)
+        return ng_aclk_state_json();
+#endif
+#ifdef ACLK_LEGACY
+    if (!aclk_ng)
+        return legacy_aclk_state_json();
+#endif
+#endif /* ENABLE_ACLK */
+    return NULL;
+}

--- a/aclk/aclk_api.h
+++ b/aclk/aclk_api.h
@@ -49,5 +49,7 @@ void aclk_host_state_update(RRDHOST *host, int connect);
 #endif
 
 struct label *add_aclk_host_labels(struct label *label);
+char *aclk_state(void);
+char *aclk_state_json(void);
 
 #endif /* ACLK_API_H */

--- a/aclk/legacy/agent_cloud_link.c
+++ b/aclk/legacy/agent_cloud_link.c
@@ -1450,3 +1450,53 @@ int legacy_aclk_update_alarm(RRDHOST *host, ALARM_ENTRY *ae)
 
     return 0;
 }
+
+char *legacy_aclk_state(void)
+{
+    BUFFER *wb = buffer_create(1024);
+    char *ret;
+
+    buffer_strcat(wb,
+        "ACLK Available: Yes\n"
+        "ACLK Implementation: Legacy\n"
+        "Claimed: "
+    );
+
+    char *agent_id = is_agent_claimed();
+    if (agent_id == NULL)
+        buffer_strcat(wb, "No\n");
+    else {
+        buffer_sprintf(wb, "Yes\nClaimed Id: %s\n", agent_id);
+        freez(agent_id);
+    }
+
+    buffer_sprintf(wb, "Online: %s", aclk_connected ? "Yes" : "No");
+
+    ret = strdupz(buffer_tostring(wb));
+    buffer_free(wb);
+    return ret;
+}
+
+char *legacy_aclk_state_json(void)
+{
+    BUFFER *wb = buffer_create(1024);
+    char *agent_id = is_agent_claimed();
+
+    buffer_sprintf(wb,
+        "{\"aclk-available\":true,"
+        "\"aclk-implementation\":\"Legacy\","
+        "\"agent-claimed\":%s,"
+        "\"claimed-id\":",
+        agent_id ? "true" : "false"
+    );
+
+    if (agent_id) {
+        buffer_sprintf(wb, "\"%s\"", agent_id);
+        freez(agent_id);
+    } else
+        buffer_strcat(wb, "null");
+
+    buffer_sprintf(wb, ",\"online\":%s}", aclk_connected ? "true" : "false");
+
+    return strdupz(buffer_tostring(wb));
+}

--- a/aclk/legacy/agent_cloud_link.h
+++ b/aclk/legacy/agent_cloud_link.h
@@ -77,6 +77,9 @@ extern void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST 
 void legacy_aclk_host_state_update(RRDHOST *host, int connect);
 int aclk_send_info_child_connection(RRDHOST *host, ACLK_CMD cmd);
 void aclk_update_next_child_to_popcorn(void);
+
+char *legacy_aclk_state(void);
+char *legacy_aclk_state_json(void);
 #endif
 
 #endif //NETDATA_AGENT_CLOUD_LINK_H

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -46,6 +46,7 @@ static cmd_status_t cmd_reload_labels_execute(char *args, char **message);
 static cmd_status_t cmd_read_config_execute(char *args, char **message);
 static cmd_status_t cmd_write_config_execute(char *args, char **message);
 static cmd_status_t cmd_ping_execute(char *args, char **message);
+static cmd_status_t cmd_aclk_state(char *args, char **message);
 
 static command_info_t command_info_array[] = {
         {"help", cmd_help_execute, CMD_TYPE_HIGH_PRIORITY},                  // show help menu
@@ -58,7 +59,8 @@ static command_info_t command_info_array[] = {
         {"reload-labels", cmd_reload_labels_execute, CMD_TYPE_ORTHOGONAL},   // reload the labels
         {"read-config", cmd_read_config_execute, CMD_TYPE_CONCURRENT},
         {"write-config", cmd_write_config_execute, CMD_TYPE_ORTHOGONAL},
-        {"ping", cmd_ping_execute, CMD_TYPE_ORTHOGONAL}
+        {"ping", cmd_ping_execute, CMD_TYPE_ORTHOGONAL},
+        {"aclk-state", cmd_aclk_state, CMD_TYPE_ORTHOGONAL}
 };
 
 /* Mutexes for commands of type CMD_TYPE_ORTHOGONAL */
@@ -121,7 +123,9 @@ static cmd_status_t cmd_help_execute(char *args, char **message)
              "reload-claiming-state\n"
              "    Reload agent claiming state from disk.\n"
              "ping\n"
-             "    Return with 'pong' if agent is alive.\n",
+             "    Return with 'pong' if agent is alive.\n"
+             "aclk-state [json]\n"
+             "    Returns current state of ACLK and Cloud connection. (optionally in json)\n",
              MAX_COMMAND_LENGTH - 1);
     return CMD_STATUS_SUCCESS;
 }
@@ -306,6 +310,17 @@ static cmd_status_t cmd_ping_execute(char *args, char **message)
     (void)args;
 
     *message = strdupz("pong");
+
+    return CMD_STATUS_SUCCESS;
+}
+
+static cmd_status_t cmd_aclk_state(char *args, char **message)
+{
+    info("COMMAND: Reopening aclk/cloud state.");
+    if (strstr(args, "json"))
+        *message = aclk_state_json();
+    else
+        *message = aclk_state();
 
     return CMD_STATUS_SUCCESS;
 }

--- a/daemon/commands.h
+++ b/daemon/commands.h
@@ -24,6 +24,7 @@ typedef enum cmd {
     CMD_READ_CONFIG,
     CMD_WRITE_CONFIG,
     CMD_PING,
+    CMD_ACLK_STATE,
     CMD_TOTAL_COMMANDS
 } cmd_t;
 


### PR DESCRIPTION
##### Summary
Implements product ask to have current aclk/cloud state available trough `netdatacli`. This is useful for example in cases where the local dashboard is not accessible or is disabled.

Us still having the ACLK Legacy here adds some awkwardness to the thing.

##### Component Name

##### Test Plan
Try with various ACLK implementations. (Hopefully we will get rid of ACLK legacy soon)

run
`netdatacli aclk-state` and/or `netdatacli aclk-state json`

##### Additional Information
