### PR TITLE
Embed build architecture in static build archive names.

### DIFF
--- a/.github/scripts/build-static.sh
+++ b/.github/scripts/build-static.sh
@@ -7,6 +7,7 @@ set -e
 # shellcheck source=.github/scripts/functions.sh
 . "$(dirname "$0")/functions.sh"
 
+BUILDARCH="${1}"
 NAME="${NAME:-netdata}"
 VERSION="${VERSION:-"$(git describe)"}"
 BASENAME="$NAME-$VERSION"
@@ -18,10 +19,10 @@ prepare_build() {
   ) >&2
 }
 
-build_static_x86_64() {
-  progress "Building static x86_64"
+build_static() {
+  progress "Building static ${BUILDARCH}"
   (
-    USER="" ./packaging/makeself/build-x86_64-static.sh
+    USER="" ./packaging/makeself/build-static.sh "${BUILDARCH}"
   ) >&2
 }
 
@@ -36,7 +37,7 @@ prepare_assets() {
   ) >&2
 }
 
-steps="prepare_build build_static_x86_64"
+steps="prepare_build build_static"
 steps="$steps prepare_assets"
 
 _main() {

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -22,8 +22,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - name: Build
-        run: |
-          .github/scripts/build-static.sh ${{ matrix.arch }}
+        run: .github/scripts/build-static.sh ${{ matrix.arch }}
   source-build:
     name: Build & Install
     strategy:

--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -9,18 +9,21 @@ env:
   DO_NOT_TRACK: 1
 jobs:
   static-build:
-    name: Build (x86_64)
+    name: Static Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - 'x86_64'
     steps:
       - name: Git clone repository
         uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: recursive
-      - run: |
-          git fetch --prune --unshallow --tags
       - name: Build
         run: |
-          .github/scripts/build-static-x86_64.sh
+          .github/scripts/build-static.sh ${{ matrix.arch }}
   source-build:
     name: Build & Install
     strategy:

--- a/.travis/create_artifacts.sh
+++ b/.travis/create_artifacts.sh
@@ -67,8 +67,12 @@ make dist
 mv "${BASENAME}.tar.gz" artifacts/
 
 echo "--- Create self-extractor ---"
-command -v git > /dev/null && [ -d .git ] && git clean -d -f
-./packaging/makeself/build-x86_64-static.sh
+sxarches="x86_64"
+for arch in ${sxarches}; do
+  git clean -d -f
+  rm -rf packating/makeself/tmp
+  ./packaging/makeself/build-static.sh ${arch}
+done
 
 # Needed for GCS
 echo "--- Copy artifacts to separate directory ---"
@@ -76,7 +80,13 @@ echo "--- Copy artifacts to separate directory ---"
 cp packaging/version artifacts/latest-version.txt
 cd artifacts
 ln -s "${BASENAME}.tar.gz" netdata-latest.tar.gz
+
+for arch in ${sxarches}; do
+  ln -s "netdata-${arch}-$(git describe).gz.run" netdata-${arch}-latest.gz.run
+done
+
 ln -s "${BASENAME}.gz.run" netdata-latest.gz.run
+
 sha256sum -b ./* > "sha256sums.txt"
 echo "checksums:"
 cat sha256sums.txt

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -39,7 +39,7 @@ if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
   # inside the container and runs the script install-alpine-packages.sh
   # (also inside the container)
   #
-  run docker rmi alpine:3.12
+  run docker pull alpine:3.12
 
   run docker run --platform=${platform} -v "$(pwd)":/usr/src/netdata.git:rw alpine:3.12 \
     /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# shellcheck source=./packaging/installer/functions.sh
+. "$(dirname "$0")"/../installer/functions.sh || exit 1
+
+BUILDARCH="${1}"
+
+set -e
+
+case ${BUILDARCH} in
+  x86_64) platform=linux/amd64 ;;
+  arm7) platform=linux/arm/v7 ;;
+  aarch64) platform=linux/arm64/v8 ;;
+  *)
+    echo "Unknown target architecture '${BUILDARCH}'."
+    exit 1
+    ;;
+esac
+
+DOCKER_CONTAINER_NAME="netdata-package-${BUILDARCH}-static-alpine312"
+
+if [ "${BUILDARCH}" != "x86_64" ]; then
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
+fi
+
+if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
+  # To run interactively:
+  #   docker run -it netdata-package-x86_64-static /bin/sh
+  # (add -v host-dir:guest-dir:rw arguments to mount volumes)
+  #
+  # To remove images in order to re-create:
+  #   docker rm -v $(sudo docker ps -a -q -f status=exited)
+  #   docker rmi netdata-package-x86_64-static
+  #
+  # This command maps the current directory to
+  #   /usr/src/netdata.git
+  # inside the container and runs the script install-alpine-packages.sh
+  # (also inside the container)
+  #
+  run docker rmi alpine:3.12
+
+  run docker run --platform=${platform} -v "$(pwd)":/usr/src/netdata.git:rw alpine:3.12 \
+    /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh
+
+  # save the changes made permanently
+  id=$(docker ps -l -q)
+  run docker commit "${id}" "${DOCKER_CONTAINER_NAME}"
+fi
+
+# Run the build script inside the container
+if [ -t 1 ]; then
+  run docker run -e BUILDARCH="${BUILDARCH}" -a stdin -a stdout -a stderr -i -t -v "$(pwd)":/usr/src/netdata.git:rw \
+    "${DOCKER_CONTAINER_NAME}" \
+    /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
+else
+  run docker run -e BUIDLARCH="${BUILDARCH}" -v "$(pwd)":/usr/src/netdata.git:rw \
+    "${DOCKER_CONTAINER_NAME}" \
+    /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
+fi
+
+if [ "${USER}" ]; then
+  sudo chown -R "${USER}" .
+fi

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -55,7 +55,7 @@ if [ -t 1 ]; then
     "${DOCKER_CONTAINER_NAME}" \
     /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
 else
-  run docker run -e BUIDLARCH="${BUILDARCH}" -v "$(pwd)":/usr/src/netdata.git:rw \
+  run docker run -e BUILDARCH="${BUILDARCH}" -v "$(pwd)":/usr/src/netdata.git:rw \
     "${DOCKER_CONTAINER_NAME}" \
     /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
 fi

--- a/packaging/makeself/build-x86_64-static.sh
+++ b/packaging/makeself/build-x86_64-static.sh
@@ -2,47 +2,6 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# shellcheck source=./packaging/installer/functions.sh
-. "$(dirname "$0")"/../installer/functions.sh || exit 1
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-set -e
-
-DOCKER_CONTAINER_NAME="netdata-package-x86_64-static-alpine312"
-
-if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
-  # To run interactively:
-  #   docker run -it netdata-package-x86_64-static /bin/sh
-  # (add -v host-dir:guest-dir:rw arguments to mount volumes)
-  #
-  # To remove images in order to re-create:
-  #   docker rm -v $(sudo docker ps -a -q -f status=exited)
-  #   docker rmi netdata-package-x86_64-static
-  #
-  # This command maps the current directory to
-  #   /usr/src/netdata.git
-  # inside the container and runs the script install-alpine-packages.sh
-  # (also inside the container)
-  #
-  run docker run -v "$(pwd)":/usr/src/netdata.git:rw alpine:3.12 \
-    /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh
-
-  # save the changes made permanently
-  id=$(docker ps -l -q)
-  run docker commit "${id}" "${DOCKER_CONTAINER_NAME}"
-fi
-
-# Run the build script inside the container
-if [ -t 1 ]; then
-  run docker run -a stdin -a stdout -a stderr -i -t -v \
-    "$(pwd)":/usr/src/netdata.git:rw \
-    "${DOCKER_CONTAINER_NAME}" \
-    /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
-else
-  run docker run -v "$(pwd)":/usr/src/netdata.git:rw \
-    "${DOCKER_CONTAINER_NAME}" \
-    /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
-fi
-
-if [ "${USER}" ]; then
-  sudo chown -R "${USER}" .
-fi
+"${SCRIPT_DIR}/build-static.sh" x86_64

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -102,7 +102,7 @@ if [ "${BUILDARCH}" = "x86_64" ]; then
   [ -f "netdata-latest.gz.run" ] && rm "netdata-latest.gz.run"
   run ln -s "artifacts/${FILE}" "netdata-latest.gz.run"
   [ -f "artifacts/netdata-${VERSION}.gz.run" ] && rm "netdata-${VERSION}.gz.run"
-  run ln -s "artifacts/${FILE}" "artifacts/netdata-${VERSION}.gz.run"
+  run ln -s "./${FILE}" "artifacts/netdata-${VERSION}.gz.run"
 fi
 
 echo >&2 "Self-extracting installer moved to 'artifacts/${FILE}'"

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -90,12 +90,19 @@ run rm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"
 # -----------------------------------------------------------------------------
 # copy it to the netdata build dir
 
-FILE="netdata-${VERSION}.gz.run"
+FILE="netdata-${BUILDARCH}-${VERSION}.gz.run"
 
 run mkdir -p artifacts
 run mv "${NETDATA_INSTALL_PATH}.gz.run" "artifacts/${FILE}"
 
-[ -f netdata-latest.gz.run ] && rm netdata-latest.gz.run
-run ln -s "artifacts/${FILE}" netdata-latest.gz.run
+[ -f "netdata-${BUILDARCH}-latest.gz.run" ] && rm "netdata-${BUILDARCH}-latest.gz.run"
+run ln -s "artifacts/${FILE}" "netdata-${BUILDARCH}-latest.gz.run"
+
+if [ "${BUILDARCH}" = "x86_64" ]; then
+  [ -f "netdata-latest.gz.run" ] && rm "netdata-latest.gz.run"
+  run ln -s "artifacts/${FILE}" "netdata-latest.gz.run"
+  [ -f "artifacts/netdata-${VERSION}.gz.run" ] && rm "netdata-${VERSION}.gz.run"
+  run ln -s "artifacts/${FILE}" "artifacts/netdata-${VERSION}.gz.run"
+fi
 
 echo >&2 "Self-extracting installer moved to 'artifacts/${FILE}'"


### PR DESCRIPTION
##### Summary

This allows installer code to select a static build for a specific architecture, which is a prerequisite for providing static builds for other architectures.

These changes have been done in a way that attempts to preserve compatibility with the existing `kickstart-static64.sh` script and existing static installs. Long-term, we ideally want to drop this legacy support, but it’s essentially free (it just consists of a couple of extra symlinks in the GCS bucket) so it’s not a high priority.

This also includes some preliminary work to support ARMv7 and AArch64 static builds (both highly requested by users).

##### Component Name

area/packaging
area/ci

##### Test Plan

The primary changes to the static build process can be tested directly on any system with a working Docker install. The new `packaging/makeself/build-static.sh` script should be run from the root of the source tree with the target build architecture as the sole argument (currently only `x86_64` is supported). The old `packaging/makeself/build-x86_64-static.sh` script should be usable as it always was, but now it just calls `packaging/makeself/build-static.sh x86_64`.

The Travis CI changes will need to wait to be merged before they can be fully confirmed.

##### Additional Information

This is part of the ongoing overhaul of the installation and updater code.

Fixes: #11473 