### PR TITLE
Announce proto capability and enable if cloud supports

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -30,8 +30,6 @@ int aclk_alert_reloaded = 1; //1 on startup, and again on health_reload
 
 time_t aclk_block_until = 0;
 
-aclk_env_t *aclk_env = NULL;
-
 mqtt_wss_client mqttwss_client;
 
 netdata_mutex_t aclk_shared_state_mutex = NETDATA_MUTEX_INITIALIZER;

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -598,6 +598,12 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
             .drop_on_publish_fail = 1
         };
 
+#if defined(ENABLE_NEW_CLOUD_PROTOCOL) && defined(ACLK_NEWARCH_DEVMODE)
+        aclk_use_new_cloud_arch = 1;
+#else
+        aclk_use_new_cloud_arch = 0;
+#endif
+
 #ifndef ACLK_DISABLE_CHALLENGE
         if (aclk_env) {
             aclk_env_t_destroy(aclk_env);
@@ -616,7 +622,12 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
         if (netdata_exit)
             return 1;
 
+#ifndef ACLK_NEWARCH_DEVMODE
         if (aclk_env->encoding == ACLK_ENC_PROTO) {
+#ifndef ENABLE_NEW_CLOUD_PROTOCOL
+            error("Cloud requested New Cloud Protocol to be used but this agent cannot support it!");
+            continue;
+#endif
             if (!aclk_env_has_capa("proto")) {
                 error ("Can't encoding=proto without at least \"proto\" capability.");
                 continue;
@@ -624,6 +635,7 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
             info("Switching ACLK to new protobuf protocol");
             aclk_use_new_cloud_arch = 1;
         }
+#endif
 
         memset(&auth_url, 0, sizeof(url_t));
         if (url_parse(aclk_env->auth_endpoint, &auth_url)) {
@@ -723,9 +735,6 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
  */
 void *aclk_main(void *ptr)
 {
-#if defined(ENABLE_NEW_CLOUD_PROTOCOL) && defined(ACLK_NEWARCH_DEVMODE)
-    aclk_use_new_cloud_arch = 1;
-#endif
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
 
     struct aclk_stats_thread *stats_thread = NULL;

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -607,6 +607,7 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
 
 #if defined(ENABLE_NEW_CLOUD_PROTOCOL) && defined(ACLK_NEWARCH_DEVMODE)
         aclk_use_new_cloud_arch = 1;
+        info("Switching ACLK to new protobuf protocol. Due to #define ACLK_NEWARCH_DEVMODE.");
 #else
         aclk_use_new_cloud_arch = 0;
 #endif
@@ -639,7 +640,7 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
                 error ("Can't encoding=proto without at least \"proto\" capability.");
                 continue;
             }
-            info("Switching ACLK to new protobuf protocol");
+            info("Switching ACLK to new protobuf protocol. Due to /env response.");
             aclk_use_new_cloud_arch = 1;
         }
 #endif

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -617,8 +617,8 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
             return 1;
 
         if (aclk_env->encoding == ACLK_ENC_PROTO) {
-            if (!aclk_env_has_capa("proto_node_chart")) {
-                error ("Can't encoding=proto without at least \"proto_node_chart\" capability.");
+            if (!aclk_env_has_capa("proto")) {
+                error ("Can't encoding=proto without at least \"proto\" capability.");
                 continue;
             }
             info("Switching ACLK to new protobuf protocol");

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -618,6 +618,15 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
         if (netdata_exit)
             return 1;
 
+        if (aclk_env->encoding == ACLK_ENC_PROTO) {
+            if (!aclk_env_has_capa("proto_node_chart")) {
+                error ("Can't encoding=proto without at least \"proto_node_chart\" capability.");
+                continue;
+            }
+            info("Switching ACLK to new protobuf protocol");
+            aclk_use_new_cloud_arch = 1;
+        }
+
         memset(&auth_url, 0, sizeof(url_t));
         if (url_parse(aclk_env->auth_endpoint, &auth_url)) {
             error("Parsing URL returned by env endpoint for authentication failed. \"%s\"", aclk_env->auth_endpoint);

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -14,8 +14,6 @@ extern time_t aclk_block_until;
 
 extern int disconnect_req;
 
-extern aclk_env_t *aclk_env;
-
 void *aclk_main(void *ptr);
 
 extern netdata_mutex_t aclk_shared_state_mutex;

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -842,7 +842,7 @@ int aclk_get_env(aclk_env_t *env, const char* aclk_hostname, int aclk_port) {
         return 1;
     }
 
-    buffer_sprintf(buf, "/api/v1/env?v=%s&cap=json&claim_id=%s", &(VERSION[1]) /* skip 'v' at beginning */, agent_id);
+    buffer_sprintf(buf, "/api/v1/env?v=%s&cap=json,proto_node_chart&claim_id=%s", &(VERSION[1]) /* skip 'v' at beginning */, agent_id);
     freez(agent_id);
 
     req.host = (char*)aclk_hostname;

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -842,7 +842,7 @@ int aclk_get_env(aclk_env_t *env, const char* aclk_hostname, int aclk_port) {
         return 1;
     }
 
-    buffer_sprintf(buf, "/api/v1/env?v=%s&cap=json,proto_node_chart&claim_id=%s", &(VERSION[1]) /* skip 'v' at beginning */, agent_id);
+    buffer_sprintf(buf, "/api/v1/env?v=%s&cap=json,proto&claim_id=%s", &(VERSION[1]) /* skip 'v' at beginning */, agent_id);
     freez(agent_id);
 
     req.host = (char*)aclk_hostname;

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -7,6 +7,8 @@
 int aclk_use_new_cloud_arch = 0;
 usec_t aclk_session_newarch = 0;
 
+aclk_env_t *aclk_env = NULL;
+
 int chart_batch_id;
 
 aclk_encoding_type_t aclk_encoding_type_t_from_str(const char *str) {

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -51,6 +51,15 @@ void aclk_env_t_destroy(aclk_env_t *env) {
     }
 }
 
+int aclk_env_has_capa(const char *capa)
+{
+    for (int i = 0; i < aclk_env->capability_count; i++) {
+        if (!strcasecmp(capa, aclk_env->capabilities[i]))
+            return 1;
+    }
+    return 0;
+}
+
 #ifdef ACLK_LOG_CONVERSATION_DIR
 volatile int aclk_conversation_log_counter = 0;
 #if !defined(HAVE_C___ATOMIC) || defined(NETDATA_NO_ATOMIC_INSTRUCTIONS)

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -49,6 +49,8 @@ typedef struct {
     aclk_backoff_t backoff;
 } aclk_env_t;
 
+extern aclk_env_t *aclk_env;
+
 aclk_encoding_type_t aclk_encoding_type_t_from_str(const char *str);
 aclk_transport_type_t aclk_transport_type_t_from_str(const char *str);
 

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -54,6 +54,7 @@ aclk_transport_type_t aclk_transport_type_t_from_str(const char *str);
 
 void aclk_transport_desc_t_destroy(aclk_transport_desc_t *trp_desc);
 void aclk_env_t_destroy(aclk_env_t *env);
+int aclk_env_has_capa(const char *capa);
 
 enum aclk_topics {
     ACLK_TOPICID_UNKNOWN               = 0,


### PR DESCRIPTION
##### Summary
Announces to cloud this agent is capable of proto.
In case the cloud then returns encoding proto we will switch to the new protocol.

##### Component Name
ACLK

##### Test Plan
Test together with the cloud team. Test without `#define ACLK_NEWARCH_DEVMODE`.
At the time of my last testing, not every cloud environment behaved correctly (testing/staging/prod). You might have to check with the cloud on which one is the latest code.

##### Additional Information
