### PR TITLE
Fix issues in Alarm API

### DIFF
--- a/aclk/aclk_alarm_api.c
+++ b/aclk/aclk_alarm_api.c
@@ -14,8 +14,7 @@ void aclk_send_alarm_log_health(struct alarm_log_health *log_health)
     query->data.bin_payload.payload = generate_alarm_log_health(&query->data.bin_payload.size, log_health);
     query->data.bin_payload.topic = ACLK_TOPICID_ALARM_HEALTH;
     query->data.bin_payload.msg_name = "AlarmLogHealth";
-    if (query->data.bin_payload.payload)
-        aclk_queue_query(query);
+    QUEUE_IF_PAYLOAD_PRESENT(query);
 }
 
 void aclk_send_alarm_log_entry(struct alarm_log_entry *log_entry)
@@ -32,6 +31,5 @@ void aclk_send_provide_alarm_cfg(struct provide_alarm_configuration *cfg)
     query->data.bin_payload.payload = generate_provide_alarm_configuration(&query->data.bin_payload.size, cfg);
     query->data.bin_payload.topic = ACLK_TOPICID_ALARM_CONFIG;
     query->data.bin_payload.msg_name = "ProvideAlarmConfiguration";
-    if (query->data.bin_payload.payload)
-        aclk_queue_query(query);
+    QUEUE_IF_PAYLOAD_PRESENT(query);
 }

--- a/aclk/aclk_charts_api.c
+++ b/aclk/aclk_charts_api.c
@@ -5,14 +5,6 @@
 
 #define CHART_DIM_UPDATE_NAME "ChartsAndDimensionsUpdated"
 
-#define QUEUE_IF_PAYLOAD_PRESENT(query)                                                                                \
-    if (likely(query->data.bin_payload.payload)) {                                                                     \
-        aclk_queue_query(query);                                                                                       \
-    } else {                                                                                                           \
-        error("Failed to generate payload (%s)", __FUNCTION__);                                                        \
-        aclk_query_free(query);                                                                                        \
-    }
-
 void aclk_chart_inst_update(char **payloads, size_t *payload_sizes, struct aclk_message_position *new_positions)
 {
     aclk_query_t query = aclk_query_new(CHART_DIMS_UPDATE);

--- a/aclk/aclk_query_queue.h
+++ b/aclk/aclk_query_queue.h
@@ -91,4 +91,12 @@ void aclk_queue_flush(void);
 
 void aclk_queue_lock(void);
 
+#define QUEUE_IF_PAYLOAD_PRESENT(query)                                                                                \
+    if (likely(query->data.bin_payload.payload)) {                                                                     \
+        aclk_queue_query(query);                                                                                       \
+    } else {                                                                                                           \
+        error("Failed to generate payload (%s)", __FUNCTION__);                                                        \
+        aclk_query_free(query);                                                                                        \
+    }
+
 #endif /* NETDATA_ACLK_QUERY_QUEUE_H */


### PR DESCRIPTION
##### Summary
Use QUEUE_IF_PAYLOAD_PRESENT in alarm api.
This prevents query mem leak in case of unlikely failure to generate binary payload by protobuf.
This is currently unused code (new cloud architecture).

##### Component Name
ACLK
##### Test Plan
Coverity CID 372861, 372862 should be gone.

##### Additional Information
