### PR TITLE
Use system copy of protobuf in Docker images and static builds.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /opt/netdata.git
 RUN chmod +x netdata-installer.sh && \
    cp -rp /deps/* /usr/local/ && \
    /bin/echo -e "INSTALL_TYPE='oci'\nPREBUILT_ARCH='$(uname -m)'" > ./system/.install-type && \
-   ./netdata-installer.sh --dont-wait --dont-start-it ${EXTRA_INSTALL_OPTS} \
+   ./netdata-installer.sh --dont-wait --dont-start-it --use-system-protobuf ${EXTRA_INSTALL_OPTS} \
    "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
 
 # files to one directory

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -31,6 +31,7 @@ run ./netdata-installer.sh \
   --dont-wait \
   --dont-start-it \
   --require-cloud \
+  --use-system-protobuf \
   --dont-scrub-cflags-even-though-it-may-break-things
 
 # Properly mark the install type


### PR DESCRIPTION
##### Summary

We know both environments provide a reliably stable copy, and this greatly improves build times.

##### Component Name

area/packaging

##### Test Plan

area/packaging

##### Additional Information

This should have been done when we first added protobuf to the installer.