### PR TITLE
Better check for supported -F parameter in sendmail

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -939,7 +939,7 @@ send_email() {
     fi
 
     [ -n "${sender_email}" ] && opts+=(-f "${sender_email}")
-    [ -n "${sender_name}" ] && ${sendmail} -F 2>&1 | grep -q "requires an argument" && opts+=(-F "${sender_name}")
+    [ -n "${sender_name}" ] && ${sendmail} -F 2>&1 | head -1 | grep -qv "sendmail: unrecognized option: F" && opts+=(-F "${sender_name}")
 
     if [ "${debug}" = "1" ]; then
       echo >&2 "--- BEGIN sendmail command ---"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Continuing from https://github.com/netdata/netdata/pull/11283, it appears that `sendmail` from the `ssmtp` package, responds differently when executing `sendmail -F` as opposed to other sendmail versions.

So to recap, this is what I've got (only the fist line of response):

1) Real sendmail: `sendmail: option requires an argument -- F`
2) Postfix: `sendmail: option requires an argument -- 'F'`
3) Ssmtp: `sendmail: No recipients supplied - mail will not be sent`
4) Msmtp: `sendmail: option requires an argument -- 'F'`
5) Exim: `exim abandoned: unknown, malformed, or incomplete option -F` (but does support it).
6) Qmail: `sendmail: option requires an argument -- F`
7) Busybox: `sendmail: unrecognized option: F`

So the plan is, unless we get `sendmail: unrecognized option: F` we pass the parameter `-F` to sendmail.

##### Component Name

Health/Notifications

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Set `EMAIL_SENDER` in `health_alarm_notify.conf` to something like `MyName some@email.com`. 
Running in a system where `sendmail` is a symlink to `busybox` it won't set the parameter, and no errors should occur.
Running in a system where `sendmail` is a real binary, it should set the name of the email sender to `MyName`.

##### Additional Information

It could be possible that there is another version of sendmail out there (besides from busybox) that does not support the -F parameter, and will not work with this PR. If you are aware of it, please share.