### PR TITLE
Install basic netdata deps by default.

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -17,7 +17,7 @@ fi
 
 # These options control which packages we are going to install
 # They can be pre-set, but also can be controlled with command line options
-PACKAGES_NETDATA=${PACKAGES_NETDATA-0}
+PACKAGES_NETDATA=${PACKAGES_NETDATA-1}
 PACKAGES_NETDATA_NODEJS=${PACKAGES_NETDATA_NODEJS-0}
 PACKAGES_NETDATA_PYTHON=${PACKAGES_NETDATA_PYTHON-0}
 PACKAGES_NETDATA_PYTHON3=${PACKAGES_NETDATA_PYTHON3-0}


### PR DESCRIPTION
##### Summary

This changes the default behavior of the `install-required-packages.sh` script to be equivalent to if the user had specified the `netdata` package set.

##### Component Name

area/packaging

##### Test Plan

CI checks pass.

##### Additional Information

This has been a known bug for some time, but never really got fixed due to the script not being intended to be run by a normal user.