### PR TITLE
Clean up dependency handling for CentOS/RHEL

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -126,7 +126,7 @@ BuildRequires: zlib-devel
 BuildRequires: libuuid-devel
 BuildRequires: libuv-devel >= 1
 BuildRequires: openssl-devel
-%if 0%{?centos_ver} >= 8 || 0%{?fedora}
+%if 0%{?fedora}
 BuildRequires: libwebsockets-devel >= 3.2
 %endif
 %if 0%{?suse_version}
@@ -215,7 +215,7 @@ happened, on your systems and applications.
 %prep
 %setup -q -n %{name}-%{version}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-mosquitto.sh ${RPM_BUILD_DIR}/%{name}-%{version}
-%if 0%{?centos_ver} < 8 || 0%{!?fedora:1}
+%if 0%{!?fedora:1}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-lws.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 %endif
 # Only bundle libJudy if this isn't Fedora or SUSE

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -417,10 +417,12 @@ detect_package_manager_from_distribution() {
       ;;
 
     centos* | clearos*)
-      package_installer="install_yum"
+      package_installer=""
       tree="centos"
+      [ -n "${dnf}" ] && package_installer="install_dnf"
+      [ -n "${yum}" ] && package_installer="install_yum"
       if [ "${IGNORE_INSTALLED}" -eq 0 ] && [ -z "${yum}" ]; then
-        echo >&2 "command 'yum' is required to install packages on a '${distribution} ${version}' system."
+        echo >&2 "command 'yum' or 'dnf' is required to install packages on a '${distribution} ${version}' system."
         exit 1
       fi
       ;;
@@ -428,8 +430,8 @@ detect_package_manager_from_distribution() {
     fedora* | redhat* | red\ hat* | rhel*)
       package_installer=
       tree="rhel"
-      [ -n "${yum}" ] && package_installer="install_yum"
       [ -n "${dnf}" ] && package_installer="install_dnf"
+      [ -n "${yum}" ] && package_installer="install_yum"
       if [ "${IGNORE_INSTALLED}" -eq 0 ] && [ -z "${package_installer}" ]; then
         echo >&2 "command 'yum' or 'dnf' is required to install packages on a '${distribution} ${version}' system."
         exit 1
@@ -497,7 +499,11 @@ check_package_manager() {
     dnf)
       [ "${IGNORE_INSTALLED}" -eq 0 ] && [ -z "${dnf}" ] && echo >&2 "${1} is not available." && return 1
       package_installer="install_dnf"
-      tree="rhel"
+      if [ "${distribution}" = "centos" ]; then
+        tree="centos"
+      else
+        tree="rhel"
+      fi
       detection="user-input"
       return 0
       ;;

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -417,8 +417,6 @@ detect_package_manager_from_distribution() {
       ;;
 
     centos* | clearos*)
-      echo >&2 "You should have EPEL enabled to install all the prerequisites."
-      echo >&2 "Check: http://www.tecmint.com/how-to-enable-epel-repository-for-rhel-centos-6-5/"
       package_installer="install_yum"
       tree="centos"
       if [ "${IGNORE_INSTALLED}" -eq 0 ] && [ -z "${yum}" ]; then
@@ -1548,13 +1546,6 @@ validate_tree_centos() {
 
   echo >&2 " > CentOS Version: ${version} ..."
 
-  echo >&2 " > Checking for epel ..."
-  if ! rpm -qa | grep epel > /dev/null; then
-    if prompt "epel not found, shall I install it?"; then
-      run ${sudo} yum ${opts} install epel-release
-    fi
-  fi
-
   if [[ "${version}" =~ ^8(\..*)?$ ]]; then
     echo >&2 " > Checking for config-manager ..."
     if ! run yum ${sudo} config-manager; then
@@ -1567,13 +1558,6 @@ validate_tree_centos() {
     if ! run yum ${sudo} repolist | grep PowerTools; then
       if prompt "PowerTools not found, shall I install it?"; then
         run ${sudo} yum ${opts} config-manager --set-enabled powertools
-      fi
-    fi
-
-    echo >&2 " > Checking for Okay ..."
-    if ! rpm -qa | grep okay > /dev/null; then
-      if prompt "okay not found, shall I install it?"; then
-        run ${sudo} yum ${opts} install http://repo.okay.com.mx/centos/8/x86_64/release/okay-release-1-5.el8.noarch.rpm
       fi
     fi
 
@@ -1619,7 +1603,7 @@ install_yum() {
   read -r -a yum_opts <<< "${opts}"
 
   # install the required packages
-  run ${sudo} yum "${yum_opts[@]}" install "${@}" # --enablerepo=epel-testing
+  run ${sudo} yum "${yum_opts[@]}" install "${@}"
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

This consists of assorted cleanup work in our CentOS and RHEL dependency handling, specifically:

* Eliminating dependencies on EPEL and OKay repositories. We don’t actually need anything from either repo, so not trying to use them at all makes us more portable and more robust.
* Allowing use of DNF on CentOS.
* Switching to using DNF in preference to YUM. The only reason we still need support for yum is CentOS 7 and other distros based on it.

##### Component Name

area/packaging

##### Test Plan

Relevant CI checks still pass.

##### Additional Information

There will be an associated follow up PR in the helper images repo to remove OKay and EPEL from the CentOS 8 package builder image, which will in turn enable us to offer ARM support for our CentOS RPMs.

This is also part of the prep work to eventually pivot to Rocky Linux for our RHEL 8 compatible builds.