### PR TITLE
Remove unused script

### DIFF
--- a/collectors/ebpf.plugin/Makefile.am
+++ b/collectors/ebpf.plugin/Makefile.am
@@ -16,12 +16,7 @@ userebpfconfigdir=$(configdir)/ebpf.d
 install-exec-local:
 	$(INSTALL) -d $(DESTDIR)$(userebpfconfigdir)
 
-dist_plugins_SCRIPTS = \
-    reset_netdata_trace.sh \
-    $(NULL)
-
 dist_noinst_DATA = \
-    reset_netdata_trace.sh.in \
     README.md \
     $(NULL)
 

--- a/collectors/ebpf.plugin/Makefile.am
+++ b/collectors/ebpf.plugin/Makefile.am
@@ -3,10 +3,6 @@
 AUTOMAKE_OPTIONS = subdir-objects
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
-CLEANFILES = \
-    reset_netdata_trace.sh \
-    $(NULL)
-
 include $(top_srcdir)/build/subst.inc
 SUFFIXES = .in
 

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -597,9 +597,4 @@ shows how the lockdown module impacts `ebpf.plugin` based on the selected option
 If you or your distribution compiled the kernel with the last combination, your system cannot load shared libraries
 required to run `ebpf.plugin`.
 
-## Cleaning `kprobe_events`
-The eBPF collector adds entries to the file `/sys/kernel/debug/tracing/kprobe_events`, and cleans them on exit, unless
-another process prevents it. If you need to clean the eBPF entries safely, you can manually run the script
-`/usr/libexec/netdata/plugins.d/reset_netdata_trace.sh`.
-
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Febpf.plugin%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/collectors/ebpf.plugin/reset_netdata_trace.sh.in
+++ b/collectors/ebpf.plugin/reset_netdata_trace.sh.in
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-KPROBE_FILE="/sys/kernel/debug/tracing/kprobe_events"
-
-DATA="$(grep _netdata_ $KPROBE_FILE| cut -d' ' -f1 | cut -d: -f2)"
-
-for I in $DATA; do
-    echo "-:$I" > $KPROBE_FILE 2>/dev/null;
-done

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1665,6 +1665,12 @@ remove_old_ebpf() {
     echo >&2 "Removing old ebpf_kernel_reject_list.txt."
     rm -f "${NETDATA_PREFIX}/usr/lib/netdata/conf.d/ebpf_kernel_reject_list.txt"
   fi
+
+  # Remove old reset script
+  if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/reset_netdata_trace.sh" ]; then
+    echo >&2 "Removing old reset_netdata_trace.sh."
+    rm -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/reset_netdata_trace.sh"
+  fi
 }
 
 install_ebpf() {


### PR DESCRIPTION
##### Summary
As we talked in this [issue](https://github.com/netdata/netdata/issues/11409), after we start using `libbpf`, we do not need more the script `reset_netdata_trace.sh`, this PR is updating our documentation, and removing the unused script.

##### Component Name
eBPF.plugin
##### Test Plan

1 - Compile this PR
2 - Verify that after installation you do not have more the file `/usr/libexec/netdata/plugins.d/reset_netdata_trace.sh`.

##### Additional Information

It is not necessary to run on different kernels, because this file is not called from `eBPF.plugin` anymore.