### PR TITLE
remove `reset_netdata_trace.sh` from netdata.service

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -17,7 +17,6 @@ ExecStartPre=/bin/mkdir -p @localstatedir_POST@/cache/netdata
 ExecStartPre=/bin/chown -R netdata:netdata @localstatedir_POST@/cache/netdata
 ExecStartPre=/bin/mkdir -p @localstatedir_POST@/run/netdata
 ExecStartPre=/bin/chown -R netdata:netdata @localstatedir_POST@/run/netdata
-ExecStopPost=@pluginsdir_POST@/reset_netdata_trace.sh
 PermissionsStartOnly=true
 
 # saving a big db on slow disks may need some time


### PR DESCRIPTION
##### Summary

The script was deleted in https://github.com/netdata/netdata/pull/11516, but we forgot to update `netdata.service` file.

##### Component Name

`packaging`

##### Test Plan

Not needed.

##### Additional Information
