### PR TITLE
Use the correct exit status for the updater with static updates.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -442,7 +442,7 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
   echo "${install_type}" > /opt/netdata/etc/netdata/.install-type
 
   echo >&2 "Switching back to ${PREVDIR}"
-  cd "${PREVDIR}" || exit 1
+  cd "${PREVDIR}"
 else
   # the installer updates this script - so we run and exit in a single line
   update && exit 0


### PR DESCRIPTION
##### Summary

This fixes a minor bug in the updater script which causes it to potentially return a non-zero exit status on a successful update of a static install when there is a newer version of the updater in the repo than is installed locally.

##### Component Name

area/packaging

##### Test Plan

Verified locally.

##### Additional Information

Fixes: #11519 