### PR TITLE
Fix issue with log messages appearing in the terminal instead of the error.log on startup

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -709,7 +709,7 @@ void set_late_global_environment()
     analytics_get_install_type();
 }
 
-static void get_system_timezone(void)
+void get_system_timezone(void)
 {
     // avoid flood calls to stat(/etc/localtime)
     // http://stackoverflow.com/questions/4554271/how-to-avoid-excessive-stat-etc-localtime-calls-in-strftime-on-linux
@@ -915,8 +915,6 @@ void set_global_environment()
     setenv("NETDATA_LISTEN_PORT", default_port, 1);
     if (clean)
         freez(default_port);
-
-    get_system_timezone();
 
     // set the path we need
     char path[1024 + 1], *p = getenv("PATH");

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -730,7 +730,7 @@ void get_system_timezone(void)
     // use the contents of /etc/timezone
     if (!timezone && !read_file("/etc/timezone", buffer, FILENAME_MAX)) {
         timezone = buffer;
-        info("TIMEZONE: using the contents of /etc/timezone: '%s'", timezone);
+        info("TIMEZONE: using the contents of /etc/timezone");
     }
 
     // read the link /etc/localtime

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -91,6 +91,7 @@ extern void analytics_log_prometheus(void);
 extern void analytics_log_dashboard(void);
 extern void analytics_gather_mutable_meta_data(void);
 extern void analytics_report_oom_score(long long int score);
+extern void get_system_timezone(void);
 
 extern struct analytics_data analytics_data;
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1133,6 +1133,7 @@ int main(int argc, char **argv) {
         // initialize the log files
         open_all_log_files();
 
+        get_system_timezone();
         // --------------------------------------------------------------------
         // get the certificate and start security
 #ifdef ENABLE_HTTPS

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1130,6 +1130,8 @@ int main(int argc, char **argv) {
         // get log filenames and settings
         log_init();
         error_log_limit_unlimited();
+        // initialize the log files
+        open_all_log_files();
 
         // --------------------------------------------------------------------
         // get the certificate and start security
@@ -1179,9 +1181,6 @@ int main(int argc, char **argv) {
         if(web_server_mode != WEB_SERVER_MODE_NONE)
             api_listen_sockets_setup();
     }
-
-    // initialize the log files
-    open_all_log_files();
 
 #ifdef NETDATA_INTERNAL_CHECKS
     if(debug_flags != 0) {


### PR DESCRIPTION
Fixes #8926
##### Summary
Rearrange the logs initialization so that lines do not appear in the terminal output as described in #8926 

Typically the following lines appear  (example)

```
netdata INFO  : MAIN : TIMEZONE: using the contents of /etc/timezone: 'Europe/Athens'
netdata INFO  : MAIN : TIMEZONE: fixed as 'Europe/Athens'
netdata INFO  : MAIN : SIGNAL: Not enabling reaper
```

##### Additional Information
- Build the agent and start from the command line
- You should see those messages appear in the `error.log` instead of the terminal


