### PR TITLE
Add archive uploads for dist, package build, and static build checks.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -23,6 +23,11 @@ jobs:
           submodules: recursive
       - name: Build
         run: .github/scripts/build-static.sh ${{ matrix.arch }}
+      - name: Save Packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.arch }}-static-builds
+          path: ${{ github.workspace }}/artifacts/*
   source-build:
     name: Build & Install
     strategy:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,6 +77,11 @@ jobs:
         run: |
           ls -lah netdata-*.tar.gz
           echo "DISTFILE=$(ls netdata-*.tar.gz)" >> $GITHUB_ENV
+      - name: Save Packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-archive
+          path: ${{ github.workspace }}/${{ env.DISTFILE }}
       - name: Run run_install_with_dist_file.sh
         run: |
           ./.github/scripts/run_install_with_dist_file.sh "${DISTFILE}"

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -112,7 +112,12 @@ jobs:
         shell: bash
         run: |
           docker run -e DO_NOT_TRACK=1 -e DISTRO=${{ matrix.distro }} -e VERSION=${{ env.pkg_version }} -e DISTRO_VERSION=${{ env.version }} --platform=${{ matrix.platform }} -v $PWD:/netdata ${{ matrix.base_image }}:${{ env.version }} /netdata/.github/scripts/pkg-test.sh
-      - name: Upload
+      - name: Save Packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.distro }}-${{ matrix.version }}-packages
+          path: ${{ github.workspace }}/artifacts/*
+      - name: Upload to PackageCloud
         if: github.event_name == 'workflow_dispatch'
         shell: bash
         env:


### PR DESCRIPTION
##### Summary

This should speed up the testing loop for verifying changes related to the static builds, native package builds, and dist archive generation.

##### Component Name

area/ci

##### Test Plan

Artifacts are correctly visible on CI on this PR.