### PR TITLE
Fix coverity issues for health config

### DIFF
--- a/health/health_config.c
+++ b/health/health_config.c
@@ -734,7 +734,7 @@ static int health_readfile(const char *filename, void *data) {
         }
         else if(hash == hash_os && !strcasecmp(key, HEALTH_OS_KEY)) {
             char *os_match = value;
-            alert_cfg->os = strdupz(value);
+            if (alert_cfg) alert_cfg->os = strdupz(value);
             SIMPLE_PATTERN *os_pattern = simple_pattern_create(os_match, NULL, SIMPLE_PATTERN_EXACT);
 
             if(!simple_pattern_matches(os_pattern, host->os)) {
@@ -751,7 +751,7 @@ static int health_readfile(const char *filename, void *data) {
         }
         else if(hash == hash_host && !strcasecmp(key, HEALTH_HOST_KEY)) {
             char *host_match = value;
-            alert_cfg->host = strdupz(value);
+            if (alert_cfg) alert_cfg->host = strdupz(value);
             SIMPLE_PATTERN *host_pattern = simple_pattern_create(host_match, NULL, SIMPLE_PATTERN_EXACT);
 
             if(!simple_pattern_matches(host_pattern, host->hostname)) {
@@ -1226,16 +1226,17 @@ static int health_readfile(const char *filename, void *data) {
         //health_add_alarms_loop(host, rc, ignore_this) ;
         if(ignore_this || !alert_hash_and_store_config(rc->config_hash_id, alert_cfg) || !rrdcalc_add_alarm_from_config(host, rc)) {
             rrdcalc_free(rc);
-            alert_config_free(alert_cfg);
         }
     }
 
     if(rt) {
         if(ignore_this || !alert_hash_and_store_config(rt->config_hash_id, alert_cfg) || !rrdcalctemplate_add_template_from_config(host, rt)) {
             rrdcalctemplate_free(rt);
-            alert_config_free(alert_cfg);
         }
     }
+
+    if (alert_cfg)
+        alert_config_free(alert_cfg);
 
     fclose(fp);
     return 1;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fixes coverity issues introduced from https://github.com/netdata/netdata/pull/11399

Fixes `CID 373229` and `CID 373228`.

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Should not have any functional differences. Tested an alert config load table from #11399 against a same load from this PR.

##### Additional Information
