### PR TITLE
Fix installer flag --use-system-protobuf

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -286,7 +286,10 @@ while [ -n "${1}" ]; do
     "--zlib-is-really-here") LIBS_ARE_HERE=1 ;;
     "--libs-are-really-here") LIBS_ARE_HERE=1 ;;
     "--use-system-lws") USE_SYSTEM_LWS=1 ;;
-    "--use-system-protobuf") USE_SYSTEM_PROTOBUF=1 ;;
+    "--use-system-protobuf")
+      USE_SYSTEM_PROTOBUF=1
+      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--without-bundled-protobuf/} --without-bundled-protobuf"
+    ;;
     "--dont-scrub-cflags-even-though-it-may-break-things") DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS=1 ;;
     "--dont-start-it") DONOTSTART=1 ;;
     "--dont-wait") DONOTWAIT=1 ;;


### PR DESCRIPTION
##### Summary
The `--use-system-protobuf` flag didn't add configure option `--without-bundled-protobuf`. Doing so it kept default configure behaviour of prefer bundled over system one if present.
Therefore the flag worked only on clean build directory.
If you run installer as default it would build the bundled version.
Afterwards run installer with `--use-system-protobuf` and it would skip building protobuf but configure would find it from previous build. `ldd ./netdata` would confirm suspicion libprotobuf is not dynamically linked.

##### Component Name
installer
##### Test Plan
with master
1. use installer as default with aclk-ng
2. use installer again with flag `--use-system-protobuf`
3. do `ldd ./netdata` -> libprotobuf is missing

with this patch do the same `ldd ./netdata` should list libprotobuf

##### Additional Information
