### PR TITLE
add proc_meminfo charts info

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1185,7 +1185,8 @@ netdataDashboard.context = {
         '<b>KernelStack</b> is the memory allocated for each task done by the kernel. '+
         '<b>PageTables</b> is the memory dedicated to the lowest level of page tables (A page table is used to turn a virtual address into a physical memory address). '+
         '<b>VmallocUsed</b> is the memory being used as virtual address space. '+
-        '<b>Percpu</b> is the memory allocated to the per-cpu allocator used to back per-cpu allocations (excludes the cost of metadata).'
+        '<b>Percpu</b> is the memory allocated to the per-CPU allocator used to back per-CPU allocations (excludes the cost of metadata). '+
+        'When you create a per-CPU variable, each processor on the system gets its own copy of that variable.'
     },
 
     'mem.slab': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1180,7 +1180,12 @@ netdataDashboard.context = {
     },
 
     'mem.kernel': {
-        info: 'The total amount of memory being used by the kernel. <b>Slab</b> is the amount of memory used by the kernel to cache data structures for its own use. <b>KernelStack</b> is the amount of memory allocated for each task done by the kernel. <b>PageTables</b> is the amount of memory dedicated to the lowest level of page tables (A page table is used to turn a virtual address into a physical memory address). <b>VmallocUsed</b> is the amount of memory being used as virtual address space.'
+        info: 'The total amount of memory being used by the kernel. '+
+        '<b>Slab</b> is the memory used by the kernel to cache data structures for its own use. '+
+        '<b>KernelStack</b> is the memory allocated for each task done by the kernel. '+
+        '<b>PageTables</b> is the memory dedicated to the lowest level of page tables (A page table is used to turn a virtual address into a physical memory address). '+
+        '<b>VmallocUsed</b> is the memory being used as virtual address space. '+
+        '<b>Percpu</b> is the memory allocated to the per-cpu allocator used to back per-cpu allocations (excludes the cost of metadata).'
     },
 
     'mem.slab': {
@@ -1193,6 +1198,10 @@ netdataDashboard.context = {
 
     'mem.transparent_hugepages': {
         info: 'Transparent HugePages (THP) is backing virtual memory with huge pages, supporting automatic promotion and demotion of page sizes. It works for all applications for anonymous memory mappings and tmpfs/shmem.'
+    },
+
+    'mem.hwcorrupt': {
+        info: 'The amount of memory with physical corruption problems, identified by <a href="https://en.wikipedia.org/wiki/ECC_memory" target="_blank">ECC</a> and set aside by the kernel so it does not get used.'
     },
 
     'mem.cachestat_ratio': {


### PR DESCRIPTION
##### Summary

This PR adds missing dashboard info for [proc_meminfo](https://github.com/netdata/netdata/blob/master/collectors/proc.plugin/proc_meminfo.c) collector's charts.

##### Component Name

`web/`

##### Test Plan

Install this PR; check the proc_meminfo charts; ensure the info is on the dashboard.

##### Additional Information

Fixes part of netdata/product#2104