### PR TITLE
fix #11544 proc collector: Undefined state DEGRADED for zpool

### DIFF
--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -6,7 +6,7 @@
 #define ZFS_PROC_ARCSTATS "/proc/spl/kstat/zfs/arcstats"
 #define ZFS_PROC_POOLS "/proc/spl/kstat/zfs"
 
-#define STATE_SIZE 8
+#define STATE_SIZE 9
 #define MAX_CHART_ID 256
 
 extern struct arcstats arcstats;


### PR DESCRIPTION
##### Summary
fix the STATE_SIZE define to store the longest state: `"DEGRADED\n"` (8 chars + `\n`).
Fixes #11544 

##### Component Name

collectors

##### Test Plan

no automated is available. I'll try to compile the collector locally and make it read a mock file with "DEGRADED\n" content

##### Additional Information
