### PR TITLE
End of support for Ubuntu 16.04

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -49,7 +49,6 @@ jobs:
           - 'ubuntu:21.04'
           - 'ubuntu:20.04'
           - 'ubuntu:18.04'
-          - 'ubuntu:16.04'
         include:
           - distro: 'alpine:edge'
             pre: 'apk add -U bash'
@@ -102,9 +101,6 @@ jobs:
             pre: 'apt-get update'
             rmjsonc: 'apt-get remove -y libjson-c-dev'
           - distro: 'ubuntu:18.04'
-            pre: 'apt-get update'
-            rmjsonc: 'apt-get remove -y libjson-c-dev'
-          - distro: 'ubuntu:16.04'
             pre: 'apt-get update'
             rmjsonc: 'apt-get remove -y libjson-c-dev'
     runs-on: ubuntu-latest

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -32,8 +32,6 @@ jobs:
           - {distro: debian, version: "10", pkgclouddistro: debian/buster, format: deb, base_image: debian, platform: linux/i386, arch: i386}
           - {distro: debian, version: "11", pkgclouddistro: debian/bullseye, format: deb, base_image: debian, platform: linux/amd64, arch: amd64, alias: bullseye}
           - {distro: debian, version: "11", pkgclouddistro: debian/bullseye, format: deb, base_image: debian, platform: linux/i386, arch: i386, alias: bullseye}
-          - {distro: ubuntu, version: "16.04", pkgclouddistro: ubuntu/xenial, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
-          - {distro: ubuntu, version: "16.04", pkgclouddistro: ubuntu/xenial, format: deb, base_image: ubuntu, platform: linux/i386, arch: i386}
           - {distro: ubuntu, version: "18.04", pkgclouddistro: ubuntu/bionic, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
           - {distro: ubuntu, version: "18.04", pkgclouddistro: ubuntu/bionic, format: deb, base_image: ubuntu, platform: linux/i386, arch: i386}
           - {distro: ubuntu, version: "20.04", pkgclouddistro: ubuntu/focal, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -19,7 +19,6 @@ jobs:
           - {distro: debian, version: "9", pkgclouddistro: debian/stretch, format: deb, base_image: debian, platform: linux/amd64, arch: amd64}
           - {distro: debian, version: "10", pkgclouddistro: debian/buster, format: deb, base_image: debian, platform: linux/amd64, arch: amd64}
           - {distro: debian, version: "11", pkgclouddistro: debian/bullseye, format: deb, base_image: debian, platform: linux/amd64, arch: amd64}
-          - {distro: ubuntu, version: "16.04", pkgclouddistro: ubuntu/xenial, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
           - {distro: ubuntu, version: "18.04", pkgclouddistro: ubuntu/bionic, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
           - {distro: ubuntu, version: "20.04", pkgclouddistro: ubuntu/focal, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}
           - {distro: ubuntu, version: "21.04", pkgclouddistro: ubuntu/hirsute, format: deb, base_image: ubuntu, platform: linux/amd64, arch: amd64}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -30,7 +30,6 @@ jobs:
           - 'debian:bullseye' # 11
           - 'fedora:33'
           - 'fedora:34'
-          - 'ubuntu:16.04'
           - 'ubuntu:18.04'
           - 'ubuntu:20.04'
           - 'ubuntu:21.04'
@@ -46,8 +45,6 @@ jobs:
           - distro: 'debian:10'
             pre: 'apt-get update'
           - distro: 'debian:bullseye' # 11
-            pre: 'apt-get update'
-          - distro: 'ubuntu:16.04'
             pre: 'apt-get update'
           - distro: 'ubuntu:18.04'
             pre: 'apt-get update'


### PR DESCRIPTION
##### Summary

It’s actually been EOL upstream for a while now, and the recent transition back into support via Cannoncial’s ESM support tier does not actually change our own support status.

##### Component Name

area/ci
area/packaging

##### Test Plan

n/a