### PR TITLE
Add shared memory to cgroup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -916,6 +916,9 @@ NETDATACLI_FILES = \
 sbin_PROGRAMS += netdata
 netdata_SOURCES = $(NETDATA_FILES)
 
+if LINUX
+    NETDATA_COMMON_LIBS += -lrt
+endif
 
 netdata_LDADD = \
     $(NETDATA_COMMON_LIBS) \

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2134,11 +2134,6 @@ static void is_there_cgroup_procs(netdata_ebpf_cgroup_shm_body_t *out, char *id)
         return;
     }
 
-    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_unified_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
-        return;
-    }
-
     out->path[0] = '\0';
     out->enabled = 0;
 }

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -481,7 +481,7 @@ void netdata_cgroup_ebpf_set_values(size_t length)
 
 void netdata_cgroup_ebpf_initialize_shm()
 {
-    shm_fd_cgroup_ebpf = shm_open(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME, O_CREAT | O_RDWR, 0666);
+    shm_fd_cgroup_ebpf = shm_open(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME, O_CREAT | O_RDWR, 0660);
     if (shm_fd_cgroup_ebpf < 0) {
         error("Cannot initialize shared memory used by cgroup and eBPF, integration won't happen.");
         return;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -4076,6 +4076,20 @@ static void cgroup_main_cleanup(void *ptr) {
         sleep_usec(step);
     }
 
+    if (shm_mutex_cgroup_ebpf != SEM_FAILED) {
+        sem_close(shm_mutex_cgroup_ebpf);
+        sem_unlink(NETDATA_NAMED_SEMAPHORE_EBPF_CGROUP_NAME);
+    }
+
+    if (shm_cgroup_ebpf.header) {
+        munmap(shm_cgroup_ebpf.header, shm_cgroup_ebpf.header->body_length);
+    }
+
+    if (shm_fd_cgroup_ebpf > 0) {
+        close(shm_fd_cgroup_ebpf);
+        shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
+    }
+
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -595,10 +595,6 @@ struct cgroup_network_interface {
     struct cgroup_network_interface *next;
 };
 
-#define CGROUP_OPTIONS_DISABLED_DUPLICATE   0x00000001
-#define CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE 0x00000002
-#define CGROUP_OPTIONS_IS_UNIFIED           0x00000004
-
 // *** WARNING *** The fields are not thread safe. Take care of safe usage.
 struct cgroup {
     uint32_t options;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.h
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.h
@@ -24,6 +24,28 @@ extern void *cgroups_main(void *ptr);
 #define CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE 0x00000002
 #define CGROUP_OPTIONS_IS_UNIFIED           0x00000004
 
+typedef struct netdata_ebpf_cgroup_shm_header {
+    int cgroup_root_count;
+    int cgroup_max;
+    int systemd_enabled;
+    size_t body_length;
+} netdata_ebpf_cgroup_shm_header_t;
+
+typedef struct netdata_ebpf_cgroup_shm_body {
+    // Considering what is exposed in this link https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
+    // this length is enough to store what we want.
+    char name[256];
+    uint32_t hash;
+    uint32_t options;
+    int enabled;
+    char path[FILENAME_MAX + 1];
+} netdata_ebpf_cgroup_shm_body_t;
+
+typedef struct netdata_ebpf_cgroup_shm {
+    netdata_ebpf_cgroup_shm_header_t *header;
+    netdata_ebpf_cgroup_shm_body_t *body;
+} netdata_ebpf_cgroup_shm_t;
+
 #include "../proc.plugin/plugin_proc.h"
 
 #else // (TARGET_OS == OS_LINUX)

--- a/collectors/cgroups.plugin/sys_fs_cgroup.h
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.h
@@ -20,6 +20,10 @@
 
 extern void *cgroups_main(void *ptr);
 
+#define CGROUP_OPTIONS_DISABLED_DUPLICATE   0x00000001
+#define CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE 0x00000002
+#define CGROUP_OPTIONS_IS_UNIFIED           0x00000004
+
 #include "../proc.plugin/plugin_proc.h"
 
 #else // (TARGET_OS == OS_LINUX)

--- a/collectors/cgroups.plugin/sys_fs_cgroup.h
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.h
@@ -31,10 +31,12 @@ typedef struct netdata_ebpf_cgroup_shm_header {
     size_t body_length;
 } netdata_ebpf_cgroup_shm_header_t;
 
+#define CGROUP_EBPF_NAME_SHARED_LENGTH 256
+
 typedef struct netdata_ebpf_cgroup_shm_body {
     // Considering what is exposed in this link https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
     // this length is enough to store what we want.
-    char name[256];
+    char name[CGROUP_EBPF_NAME_SHARED_LENGTH];
     uint32_t hash;
     uint32_t options;
     int enabled;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.h
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.h
@@ -46,6 +46,9 @@ typedef struct netdata_ebpf_cgroup_shm {
     netdata_ebpf_cgroup_shm_body_t *body;
 } netdata_ebpf_cgroup_shm_t;
 
+#define NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME "netdata_shm_cgroup_ebpf"
+#define NETDATA_NAMED_SEMAPHORE_EBPF_CGROUP_NAME "/netdata_sem_cgroup_ebpf"
+
 #include "../proc.plugin/plugin_proc.h"
 
 #else // (TARGET_OS == OS_LINUX)


### PR DESCRIPTION
##### Summary
This is the second step to bring integration between eBPF and cgroups https://github.com/netdata/netdata/issues/11558.

This PR is creating shared memory with cgroup plugin.
##### Component Name
cgroup
ebpf.plugin
##### Test Plan

1 - Enable flag inside your `netdata.conf`
2 - Compile this branch
3 - Take a look in the logs to verify whether shared memory was filled

##### Additional Information
This PR is part of a huge branch that has almost all modifications proposed for #11558 , and it was tested on:

- Manjaro 21.1 (cgroup version 2)
- CentOS 7.9
- Debian 10.10
- Ubuntu 18.04