### PR TITLE
Disable eBPF compilation in different platforms

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1620,9 +1620,9 @@ should_install_ebpf() {
     return 1
   fi
 
-  if [ "$(uname -s)" != "Linux" ]; then
-    run_failed "Currently eBPF is only supported on Linux."
-    defer_error "Currently eBPF is only supported on Linux."
+  if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
+    run_failed "Currently eBPF is only supported on Linux on X86_64."
+    defer_error "Currently eBPF is only supported on Linux on X86_64."
     return 1
   fi
 


### PR DESCRIPTION
##### Summary
This PR is bringing the same fix added by @Ferroin [here](https://github.com/netdata/netdata/commit/f6d966909bb5c443e771d312f1686ec3fa2c2aff) for Netdata source-code.

We have plans to bring eBPF plugin for different platforms, but while it is not merged and considering the reported problems per Slack when we use the latest `libbpf`, the safest is to disable.

##### Component Name
netdata-installer
##### Test Plan

1 - Compile this PR on `X86_64`, and verify that `eBPF.plugin` is compiled and it runs normally
2 - Compile this PR on different platform, and verify that `eBPF.plugin` is not compiled.

##### Additional Information
