### PR TITLE
add proc_net_sockstat and sockstat6 charts info

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1466,7 +1466,7 @@ netdataDashboard.context = {
         '<b>Forwarded</b> - input packets for which this host was not their final IP destination, '+
         'as a result of which an attempt was made to find a route to forward them to that final destination. '+
         'In hosts which do not act as IP Gateways, this counter will include only those packets which were '+
-        '<a href="https://en.wikipedia.org/wiki/Source_routing" target="_blank">Source-Routed</a>, '+
+        '<a href="https://en.wikipedia.org/wiki/Source_routing" target="_blank">Source-Routed</a> '+
         'and the Source-Route option processing was successful. '+
         '<b>Delivered</b> - packets delivered to the upper layer protocols, e.g. TCP, UDP, ICMP, and so on.</p>'
     },
@@ -1602,7 +1602,7 @@ netdataDashboard.context = {
         '<b>Forwarded</b> - input packets for which this host was not their final IP destination, '+
         'as a result of which an attempt was made to find a route to forward them to that final destination. '+
         'In hosts which do not act as IP Gateways, this counter will include only those packets which were '+
-        '<a href="https://en.wikipedia.org/wiki/Source_routing" target="_blank">Source-Routed</a>, '+
+        '<a href="https://en.wikipedia.org/wiki/Source_routing" target="_blank">Source-Routed</a> '+
         'and the Source-Route option processing was successful. '+
         '<b>Delivers</b> - packets delivered to the upper layer protocols, e.g. TCP, UDP, ICMP, and so on.</p>'
     },

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1793,22 +1793,24 @@ netdataDashboard.context = {
     },
 
     'ipv6.sockstat6_tcp_sockets': {
-        info: 'The number of TCP sockets in any state, excluding TIME-WAIT and CLOSED.'
+        info: 'The number of TCP sockets in any '+
+        '<a href="https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation" target="">state</a>, '+
+        'excluding TIME-WAIT and CLOSED.'
     },
 
     'ipv6.sockstat6_udp_sockets': {
         info: 'The number of used UDP sockets.'
     },
 
-    'ipv4.sockstat6_udplite_sockets': {
+    'ipv6.sockstat6_udplite_sockets': {
         info: 'The number of used UDP-Lite sockets.'
     },
 
-    'ipv4.sockstat6_raw_sockets': {
+    'ipv6.sockstat6_raw_sockets': {
         info: 'The number of used <a href="https://en.wikipedia.org/wiki/Network_socket#Types" target="_blank"> raw sockets</a>.'
     },
 
-    'ipv4.sockstat6_frag_sockets': {
+    'ipv6.sockstat6_frag_sockets': {
         info: 'The number of entries in hash tables that are used for packet reassembly.'
     },
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1590,6 +1590,50 @@ netdataDashboard.context = {
             + ' <code>TCPSynRetrans</code> shows retries for new outbound TCP connections, which can indicate general connectivity issues or backlog on the remote host.'
     },
 
+    'ipv4.sockstat_sockets': {
+        info: 'The total number of used sockets for all '+
+        '<a href="https://man7.org/linux/man-pages/man7/address_families.7.html" target="_blank">address families</a> '+
+        'in this system.'
+    },
+
+    'ipv4.sockstat_tcp_sockets': {
+        info: '<p>The number of TCP sockets in the system in certain '+
+        '<a href="https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Protocol_operation" target="_blank">states</a>.</p>'+
+        '<p><b>Alloc</b> - in any TCP state. '+
+        '<b>Orphan</b> - no longer attached to a socket descriptor in any user processes, '+
+        'but for which the kernel is still required to maintain state in order to complete the transport protocol. '+
+        '<b>InUse</b> - in any TCP state, excluding TIME-WAIT and CLOSED. '+
+        '<b>TimeWait</b> - in the TIME-WAIT state.</p>'
+    },
+
+    'ipv4.sockstat_tcp_mem': {
+        info: 'The amount of memory used by allocated TCP sockets.'
+    },
+
+    'ipv4.sockstat_udp_sockets': {
+        info: 'The number of used UDP sockets.'
+    },
+
+    'ipv4.sockstat_udp_mem': {
+        info: 'The amount of memory used by allocated UDP sockets.'
+    },
+
+    'ipv4.sockstat_udplite_sockets': {
+        info: 'The number of used UDP-Lite sockets.'
+    },
+
+    'ipv4.sockstat_raw_sockets': {
+        info: 'The number of used <a href="https://en.wikipedia.org/wiki/Network_socket#Types" target="_blank"> raw sockets</a>.'
+    },
+
+    'ipv4.sockstat_frag_sockets': {
+        info: 'The number of entries in hash tables that are used for packet reassembly.'
+    },
+
+    'ipv4.sockstat_frag_mem': {
+        info: 'The amount of memory used for packet reassembly.'
+    },
+
     // ------------------------------------------------------------------------
     // IPv6
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1792,6 +1792,27 @@ netdataDashboard.context = {
         '<b>ECTP0</b> and <b>ECTP1</b> - ECN capable transport.</p>'
     },
 
+    'ipv6.sockstat6_tcp_sockets': {
+        info: 'The number of TCP sockets in any state, excluding TIME-WAIT and CLOSED.'
+    },
+
+    'ipv6.sockstat6_udp_sockets': {
+        info: 'The number of used UDP sockets.'
+    },
+
+    'ipv4.sockstat6_udplite_sockets': {
+        info: 'The number of used UDP-Lite sockets.'
+    },
+
+    'ipv4.sockstat6_raw_sockets': {
+        info: 'The number of used <a href="https://en.wikipedia.org/wiki/Network_socket#Types" target="_blank"> raw sockets</a>.'
+    },
+
+    'ipv4.sockstat6_frag_sockets': {
+        info: 'The number of entries in hash tables that are used for packet reassembly.'
+    },
+
+
     // ------------------------------------------------------------------------
     // SCTP
 


### PR DESCRIPTION
##### Summary

This PR adds dashboard info for [proc_net_sockstat](https://github.com/netdata/netdata/blob/master/collectors/proc.plugin/proc_net_sockstat.c) and [proc_net_sockstat6](https://github.com/netdata/netdata/blob/master/collectors/proc.plugin/proc_net_sockstat6.c) collector's charts.

##### Component Name

`web/`

##### Test Plan

Install this PR; check the proc_net_sockstat and proc_net_sockstat6 charts; ensure the info is on the dashboard.

##### Additional Information

Fixes part of netdata/product#2104