### PR TITLE
add proc_uptime charts info

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1134,6 +1134,10 @@ netdataDashboard.context = {
         info: 'Amount of memory currently used by messages in System V IPC message queues.'
     },
 
+    'system.uptime': {
+        info: 'The amount of time the system has been running, including time spent in suspend.'
+    },
+
     // ------------------------------------------------------------------------
     // CPU charts
 


### PR DESCRIPTION
##### Summary

This PR adds dashboard info for [proc_net_uptime](https://github.com/netdata/netdata/blob/master/collectors/proc.plugin/proc_uptime.c) collector's charts.

##### Component Name

`web/`

##### Test Plan

Install this PR; check the proc_uptime charts; ensure the info is on the dashboard.

##### Additional Information

Fixes part of netdata/product#2104