### PR TITLE
add missing privilege to fix MySQL slave reporting

### DIFF
--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -17,7 +17,7 @@ To create the `netdata` user, execute the following in the MySQL shell:
 
 ```sh
 create user 'netdata'@'localhost';
-grant replication client on *.* to 'netdata'@'localhost';
+grant usage, replication client on *.* to 'netdata'@'localhost';
 flush privileges;
 ```
 The `netdata` user will have the ability to connect to the MySQL server on `localhost` without a password. 

--- a/collectors/python.d.plugin/mysql/README.md
+++ b/collectors/python.d.plugin/mysql/README.md
@@ -17,7 +17,7 @@ To create the `netdata` user, execute the following in the MySQL shell:
 
 ```sh
 create user 'netdata'@'localhost';
-grant usage on *.* to 'netdata'@'localhost';
+grant replication client on *.* to 'netdata'@'localhost';
 flush privileges;
 ```
 The `netdata` user will have the ability to connect to the MySQL server on `localhost` without a password. 


### PR DESCRIPTION
##### Summary
The "netdata" MySQL users needs the "REPLICATION CLIENT" privilege to monitor the slave status. Otherwise, the charts "Slave Status" and "Slave Behind Seconds" are missing and the corresponding alerts don't work either.

##### Component Name
MySQL collector

##### Test Plan

##### Additional Information
