### PR TITLE
Free analytics data when analytics thread stops

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -150,7 +150,7 @@ void analytics_get_data(char *name, BUFFER *wb)
  */
 void analytics_log_prometheus(void)
 {
-    if (likely(analytics_data.prometheus_hits < ANALYTICS_MAX_PROMETHEUS_HITS)) {
+    if (netdata_anonymous_statistics_enabled == 1 && likely(analytics_data.prometheus_hits < ANALYTICS_MAX_PROMETHEUS_HITS)) {
         analytics_data.prometheus_hits++;
         char b[7];
         snprintfz(b, 6, "%d", analytics_data.prometheus_hits);
@@ -163,7 +163,7 @@ void analytics_log_prometheus(void)
  */
 void analytics_log_shell(void)
 {
-    if (likely(analytics_data.shell_hits < ANALYTICS_MAX_SHELL_HITS)) {
+    if (netdata_anonymous_statistics_enabled == 1 && likely(analytics_data.shell_hits < ANALYTICS_MAX_SHELL_HITS)) {
         analytics_data.shell_hits++;
         char b[7];
         snprintfz(b, 6, "%d", analytics_data.shell_hits);
@@ -176,7 +176,7 @@ void analytics_log_shell(void)
  */
 void analytics_log_json(void)
 {
-    if (likely(analytics_data.json_hits < ANALYTICS_MAX_JSON_HITS)) {
+    if (netdata_anonymous_statistics_enabled == 1 && likely(analytics_data.json_hits < ANALYTICS_MAX_JSON_HITS)) {
         analytics_data.json_hits++;
         char b[7];
         snprintfz(b, 6, "%d", analytics_data.json_hits);
@@ -189,7 +189,7 @@ void analytics_log_json(void)
  */
 void analytics_log_dashboard(void)
 {
-    if (likely(analytics_data.dashboard_hits < ANALYTICS_MAX_DASHBOARD_HITS)) {
+    if (netdata_anonymous_statistics_enabled == 1 && likely(analytics_data.dashboard_hits < ANALYTICS_MAX_DASHBOARD_HITS)) {
         analytics_data.dashboard_hits++;
         char b[7];
         snprintfz(b, 6, "%d", analytics_data.dashboard_hits);

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -589,6 +589,7 @@ void analytics_main_cleanup(void *ptr)
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
     debug(D_ANALYTICS, "Cleaning up...");
+    analytics_free_data();
 
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -28,7 +28,6 @@ void netdata_cleanup_and_exit(int ret) {
     info("EXIT: netdata prepares to exit with code %d...", ret);
 
     send_statistics("EXIT", ret?"ERROR":"OK","-");
-    analytics_free_data();
 
     char agent_crash_file[FILENAME_MAX + 1];
     char agent_incomplete_shutdown_file[FILENAME_MAX + 1];


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR moves the call of `analytics_free_data()` from `netdata_cleanup_and_exit` to `analytics_main_cleanup`. It should address the second core case in https://github.com/netdata/netdata/issues/11571.

This core could happen during exit, if an external tool was quering the `allmetrics` page during agent shutdown. In that case, analytics would try to log this call by setting e.g. `analytics_data.netdata_allmetrics_prometheus_used`. If `analytics_free_data()` was called already, there could be a double free situation resulting in a crash.

Valgrind also picked this up:

```
==23744== Invalid read of size 1
==23744==    at 0x4846063: strlen (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==23744==    by 0x14035B: analytics_set_data (analytics.c:117)
==23744==    by 0x140466: analytics_log_prometheus (analytics.c:157)
==23744==    by 0x1857AD: prometheus_preparation (prometheus.c:798)
==23744==    by 0x1875A4: rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts (prometheus.c:906)
==23744==    by 0x16F290: web_client_api_request_v1_allmetrics (allmetrics.c:112)
==23744==    by 0x17DC2E: web_client_api_request_v1 (web_api_v1.c:1156)
==23744==    by 0x25F06F: web_client_api_request (web_client.c:606)
==23744==    by 0x25F455: check_host_and_call (web_client.c:582)
==23744==    by 0x25F455: web_client_process_url (web_client.c:1433)
==23744==    by 0x261534: web_client_process_request (web_client.c:1579)
==23744==    by 0x263E63: web_server_rcv_callback (static-threaded.c:255)
==23744==    by 0x166992: poll_events_process (socket.c:1413)
==23744==    by 0x166992: poll_events (socket.c:1694)
==23744==  Address 0x6a46ea1 is 1 bytes inside a block of size 2 free'd
==23744==    at 0x48424BF: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==23744==    by 0x15A56D: freez (libnetdata.c:173)
==23744==    by 0x1401B1: analytics_free_data (analytics.c:75)
==23744==    by 0x143521: netdata_cleanup_and_exit (main.c:31)
==23744==    by 0x14630A: signals_handle (signals.c:261)
==23744==    by 0x145B3A: main (main.c:1343)
==23744==  Block was alloc'd at
==23744==    at 0x483F855: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==23744==    by 0x55621EA: strdup (in /lib64/libc-2.33.so)
==23744==    by 0x15A53B: strdupz (libnetdata.c:166)
==23744==    by 0x140372: analytics_set_data (analytics.c:120)
==23744==    by 0x140466: analytics_log_prometheus (analytics.c:157)
==23744==    by 0x1857AD: prometheus_preparation (prometheus.c:798)
==23744==    by 0x1875A4: rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts (prometheus.c:906)
==23744==    by 0x16F290: web_client_api_request_v1_allmetrics (allmetrics.c:112)
==23744==    by 0x17DC2E: web_client_api_request_v1 (web_api_v1.c:1156)
==23744==    by 0x25F06F: web_client_api_request (web_client.c:606)
==23744==    by 0x25F455: check_host_and_call (web_client.c:582)
==23744==    by 0x25F455: web_client_process_url (web_client.c:1433)
==23744==    by 0x261534: web_client_process_request (web_client.c:1579)
```

It also introduces a check if `netdata_anonymous_statistics_enabled == 1` before logging any calls to allmetrics pages or the dashboard, in order not to consume memory (which in case the user has opted out of analytics would not be freed).

##### Component Name

Analytics

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Run current master with valgrind (`valgrind --show-leak-kinds=all --track-origins=yes --leak-check=full ...`. It should report a problem with `analytics_log_prometheus`.
Run again with this PR, the warning should be gone, with no other functional change to analytics.


##### Additional Information
