### PR TITLE
Fix CID 339027 and reverse arguments

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -501,7 +501,7 @@ void netdata_cgroup_ebpf_initialize_shm()
         error("Cannot map shared memory used between cgroup and eBPF, integration won't happen");
         goto end_init_shm;
     }
-    shm_cgroup_ebpf.body = (netdata_ebpf_cgroup_shm_body_t *) (shm_cgroup_ebpf.header +
+    shm_cgroup_ebpf.body = (netdata_ebpf_cgroup_shm_body_t *) ((char *)shm_cgroup_ebpf.header +
                                                               sizeof(netdata_ebpf_cgroup_shm_header_t));
 
     shm_mutex_cgroup_ebpf = sem_open(NETDATA_NAMED_SEMAPHORE_EBPF_CGROUP_NAME, O_CREAT,

--- a/collectors/cgroups.plugin/sys_fs_cgroup.h
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.h
@@ -28,7 +28,7 @@ typedef struct netdata_ebpf_cgroup_shm_header {
     int cgroup_root_count;
     int cgroup_max;
     int systemd_enabled;
-    int pad;
+    int __pad;
     size_t body_length;
 } netdata_ebpf_cgroup_shm_header_t;
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.h
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.h
@@ -28,6 +28,7 @@ typedef struct netdata_ebpf_cgroup_shm_header {
     int cgroup_root_count;
     int cgroup_max;
     int systemd_enabled;
+    int pad;
     size_t body_length;
 } netdata_ebpf_cgroup_shm_header_t;
 

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -608,7 +608,7 @@ void *ebpf_disk_read_hash(void *ptr)
 static void ebpf_obsolete_hd_charts(netdata_ebpf_disks_t *w)
 {
     ebpf_write_chart_obsolete(w->histogram.name, w->family, w->histogram.title, EBPF_COMMON_DIMENSION_CALL,
-                              w->family, "disk.latency_io", NETDATA_EBPF_CHART_TYPE_STACKED,
+                              w->family, NETDATA_EBPF_CHART_TYPE_STACKED, "disk.latency_io",
                               w->histogram.order);
 
     w->flags = 0;


### PR DESCRIPTION
##### Summary
Last PR merged changing `cgroup.plugin` created the following warning:

```
CID 339027 (#1 of 1): Extra sizeof expression (SIZEOF_MISMATCH)suspicious_pointer_arithmetic: Adding 24UL /* sizeof (netdata_ebpf_cgroup_shm_header_t) */ to pointer shm_cgroup_ebpf.header of type netdata_ebpf_cgroup_shm_header_t * is suspicious because adding an integral value to this pointer automatically scales that value by the size, 24 bytes, of the pointed-to type, netdata_ebpf_cgroup_shm_header_t. Most likely, sizeof (netdata_ebpf_cgroup_shm_header_t) is extraneous and should be replaced with 1.
``` 

This PR is fixing this warning and also is reverting arguments that could create a problem like [this](https://github.com/netdata/netdata/pull/11573#issuecomment-927744895).

##### Component Name
cgroup.plugin
ebpf.plugin
##### Test Plan

1 - Configure `/etc/netdata/ebpf.d.conf` to:

```conf
[ebpf programs]
    disk = yes
```

2 - Compile this branch.
3 - Run Netdata, wait few minutes and stop it.
4 - You won't have any crash report.

##### Additional Information
It is not necessary to change on different kernels.
The converity report on this branch did not report any error.