### PR TITLE
Sorting the Postgres cluster databases in the postgres collector

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -455,7 +455,8 @@ FROM pg_stat_database
 WHERE
     has_database_privilege(
       (SELECT current_user), datname, 'connect')
-    AND NOT datname ~* '^template\d';
+    AND NOT datname ~* '^template\d'
+ORDER BY datname;
 """,
 }
 


### PR DESCRIPTION
##### Summary

Sorting the list of databases in the postgres cluster in alphabetical order
to simplify the search for charts for clusters with a large number
of databases.

##### Component Name

collectors/python.d.plugin/postgres
