### PR TITLE
Check in ACLK_NG if --disable-https is used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -722,12 +722,13 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
         can_enable_ng="no"
     fi
     AC_MSG_CHECKING([if SSL available for ACLK Next Generation])
-    if test -n "${SSL_LIBS}"; then
+    if test "$enable_https" != "no" -a -n "${SSL_LIBS}"; then
         AC_MSG_RESULT([yes])
         OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
         OPTIONAL_SSL_LIBS="${SSL_LIBS}"
     else
         AC_MSG_RESULT([no])
+        can_enable_ng="no"
     fi
     AC_MSG_CHECKING([if JSON-C available for ACLK Next Generation])
     if test "$enable_jsonc" != "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -722,13 +722,19 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
         can_enable_ng="no"
     fi
     AC_MSG_CHECKING([if SSL available for ACLK Next Generation])
-    if test "$enable_https" != "no" -a -n "${SSL_LIBS}"; then
+    if test -n "${SSL_LIBS}"; then
         AC_MSG_RESULT([yes])
         OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
         OPTIONAL_SSL_LIBS="${SSL_LIBS}"
     else
         AC_MSG_RESULT([no])
+    fi
+    AC_MSG_CHECKING([if SSL has been disabled with --disable-https for ACLK Next Generation])
+    if test "$enable_https" = "no"; then
+        AC_MSG_RESULT([yes])
         can_enable_ng="no"
+    else
+        AC_MSG_RESULT([no])
     fi
     AC_MSG_CHECKING([if JSON-C available for ACLK Next Generation])
     if test "$enable_jsonc" != "yes"; then

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -310,8 +310,7 @@ while [ -n "${1}" ]; do
     "--nightly-channel") RELEASE_CHANNEL="nightly" ;;
     "--enable-plugin-freeipmi") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-freeipmi/} --enable-plugin-freeipmi" ;;
     "--disable-plugin-freeipmi") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-plugin-freeipmi/} --disable-plugin-freeipmi" ;;
-    "--disable-https")
-        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-https/} --disable-https" ;;
+    "--disable-https") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-https/} --disable-https" ;;
     "--disable-dbengine")
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-dbengine/} --disable-dbengine"
       NETDATA_DISABLE_DBENGINE=1

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -311,9 +311,7 @@ while [ -n "${1}" ]; do
     "--enable-plugin-freeipmi") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-freeipmi/} --enable-plugin-freeipmi" ;;
     "--disable-plugin-freeipmi") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-plugin-freeipmi/} --disable-plugin-freeipmi" ;;
     "--disable-https")
-      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-https/--disable-cloud} --disable-https --disable-cloud"
-      NETDATA_DISABLE_CLOUD=1
-      ;;
+        NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-https/} --disable-https" ;;
     "--disable-dbengine")
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-dbengine/} --disable-dbengine"
       NETDATA_DISABLE_DBENGINE=1

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -310,7 +310,10 @@ while [ -n "${1}" ]; do
     "--nightly-channel") RELEASE_CHANNEL="nightly" ;;
     "--enable-plugin-freeipmi") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-freeipmi/} --enable-plugin-freeipmi" ;;
     "--disable-plugin-freeipmi") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-plugin-freeipmi/} --disable-plugin-freeipmi" ;;
-    "--disable-https") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-https/} --disable-https" ;;
+    "--disable-https")
+      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-https/--disable-cloud} --disable-https --disable-cloud"
+      NETDATA_DISABLE_CLOUD=1
+      ;;
     "--disable-dbengine")
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-dbengine/} --disable-dbengine"
       NETDATA_DISABLE_DBENGINE=1


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Adds a check during configure for ACLK_NG if `--disable-https` is used, thus skipping build of aclk_ng which requires SSL libraries.

##### Component Name

Installer.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Ensure `aclk-ng` requirements are there (protobuf, submodules).
Try to build master with `--disable-https`. `aclk-ng` should fail, since it requires openssl libraries
With this PR, if `--disable-https` is used, it will also prevent `aclk-ng` and `aclk-legacy` from being built, but allowing a build to complete.

##### Additional Information

This PR assumes we can not have cloud connectivity without ssl.
