### PR TITLE
Makes New Cloud architecture optional for ACLK-NG

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -586,10 +586,6 @@ ACLK_NG_FILES = \
     aclk/aclk_rx_msgs.h \
     aclk/https_client.c \
     aclk/https_client.h \
-    aclk/aclk_charts_api.c \
-    aclk/aclk_charts_api.h \
-    aclk/aclk_alarm_api.c \
-    aclk/aclk_alarm_api.h \
     mqtt_websockets/src/mqtt_wss_client.c \
     mqtt_websockets/src/include/mqtt_wss_client.h \
     mqtt_websockets/src/mqtt_wss_log.c \
@@ -600,7 +596,15 @@ ACLK_NG_FILES = \
     mqtt_websockets/c-rbuf/include/ringbuffer.h \
     mqtt_websockets/c-rbuf/src/ringbuffer_internal.h \
     mqtt_websockets/MQTT-C/src/mqtt.c \
-    mqtt_websockets/MQTT-C/include/mqtt.h \
+    mqtt_websockets/MQTT-C/include/mqtt.h
+    $(NULL)
+
+if ENABLE_NEW_CLOUD_PROTOCOL
+ACLK_NG_FILES += \
+    aclk/aclk_charts_api.c \
+    aclk/aclk_charts_api.h \
+    aclk/aclk_alarm_api.c \
+    aclk/aclk_alarm_api.h \
     aclk/schema-wrappers/connection.cc \
     aclk/schema-wrappers/connection.h \
     aclk/schema-wrappers/node_connection.cc \
@@ -709,6 +713,8 @@ aclk/aclk-schemas/proto/alarm/v1/stream.pb.h: aclk/aclk-schemas/proto/alarm/v1/s
 aclk/aclk-schemas/proto/nodeinstance/info/v1/info.pb.cc \
 aclk/aclk-schemas/proto/nodeinstance/info/v1/info.pb.h: aclk/aclk-schemas/proto/nodeinstance/info/v1/info.proto
 	$(PROTOC) -I=aclk/aclk-schemas --cpp_out=$(builddir)/aclk/aclk-schemas $^
+
+endif #ENABLE_NEW_CLOUD_PROTOCOL
 
 endif #ACLK_NG
 

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -21,10 +21,6 @@
 #include <fcntl.h>
 #endif
 
-#ifndef UUID_STR_LEN
-#define UUID_STR_LEN 37
-#endif
-
 #define ACLK_STABLE_TIMEOUT 3 // Minimum delay to mark AGENT as stable
 
 int aclk_pubacks_per_conn = 0; // How many PubAcks we got since MQTT conn est.

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -21,6 +21,10 @@
 #include <fcntl.h>
 #endif
 
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37
+#endif
+
 #define ACLK_STABLE_TIMEOUT 3 // Minimum delay to mark AGENT as stable
 
 int aclk_pubacks_per_conn = 0; // How many PubAcks we got since MQTT conn est.

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -223,7 +223,7 @@ static void msg_callback(const char *topic, const void *msg, size_t msglen, int 
     aclk_handle_cloud_message(cmsg);
 }
 
-
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 static void msg_callback_new(const char *topic, const void *msg, size_t msglen, int qos)
 {
     if (msglen > RX_MSGLEN_MAX)
@@ -261,6 +261,7 @@ static void msg_callback_new(const char *topic, const void *msg, size_t msglen, 
 
     aclk_handle_new_cloud_msg(msgtype, msg, msglen);
 }
+#endif
 
 static void puback_callback(uint16_t packet_id)
 {
@@ -352,6 +353,7 @@ static inline void mqtt_connected_actions(mqtt_wss_client client)
     else
         mqtt_wss_subscribe(client, topic, 1);
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     if (aclk_use_new_cloud_arch) {
         topic = aclk_get_topic(ACLK_TOPICID_CMD_NG_V1);
         if (!topic)
@@ -359,21 +361,26 @@ static inline void mqtt_connected_actions(mqtt_wss_client client)
         else
             mqtt_wss_subscribe(client, topic, 1);
     }
+#endif
 
     aclk_stats_upd_online(1);
     aclk_connected = 1;
     aclk_pubacks_per_conn = 0;
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     if (!aclk_use_new_cloud_arch) {
+#endif
         ACLK_SHARED_STATE_LOCK;
         if (aclk_shared_state.agent_state != ACLK_HOST_INITIALIZING) {
             error("Sending `connect` payload immediately as popcorning was finished already.");
             queue_connect_payloads();
         }
         ACLK_SHARED_STATE_UNLOCK;
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     } else {
         aclk_send_agent_connection_update(client, 1);
     }
+#endif
 }
 
 /* Waits until agent is ready or needs to exit
@@ -416,9 +423,11 @@ void aclk_graceful_disconnect(mqtt_wss_client client)
     error("Preparing to Gracefully Shutdown the ACLK");
     aclk_queue_lock();
     aclk_queue_flush();
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     if (aclk_use_new_cloud_arch)
         aclk_shared_state.mqtt_shutdown_msg_id = aclk_send_agent_connection_update(client, 0);
     else
+#endif
         aclk_shared_state.mqtt_shutdown_msg_id = aclk_send_app_layer_disconnect(client, "graceful");
 
     time_t t = now_monotonic_sec();
@@ -626,13 +635,17 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
         aclk_session_sec = aclk_session_newarch / USEC_PER_SEC;
         aclk_session_us = aclk_session_newarch % USEC_PER_SEC;
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
         if (aclk_use_new_cloud_arch) {
             mqtt_conn_params.will_msg = aclk_generate_lwt(&mqtt_conn_params.will_msg_len);
         } else {
+#endif
             lwt = aclk_generate_disconnect(NULL);
             mqtt_conn_params.will_msg = json_object_to_json_string_ext(lwt, JSON_C_TO_STRING_PLAIN);
             mqtt_conn_params.will_msg_len = strlen(mqtt_conn_params.will_msg);
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
         }
+#endif
 
 #ifdef ACLK_DISABLE_CHALLENGE
         ret = mqtt_wss_connect(client, base_url.host, base_url.port, &mqtt_conn_params, ACLK_SSL_FLAGS, &proxy_conf);
@@ -675,7 +688,7 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
  */
 void *aclk_main(void *ptr)
 {
-#ifdef ACLK_NEWARCH_DEVMODE
+#if defined(ENABLE_NEW_CLOUD_PROTOCOL) && defined(ACLK_NEWARCH_DEVMODE)
     aclk_use_new_cloud_arch = 1;
 #endif
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
@@ -711,7 +724,11 @@ void *aclk_main(void *ptr)
     if (wait_till_agent_claim_ready())
         goto exit;
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     if (!(mqttwss_client = mqtt_wss_new("mqtt_wss", aclk_mqtt_wss_log_cb, (aclk_use_new_cloud_arch ? msg_callback_new : msg_callback), puback_callback))) {
+#else
+    if (!(mqttwss_client = mqtt_wss_new("mqtt_wss", aclk_mqtt_wss_log_cb, msg_callback, puback_callback))) {
+#endif
         error("Couldn't initialize MQTT_WSS network library");
         goto exit;
     }

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1045,6 +1045,11 @@ char *ng_aclk_state(void)
     buffer_strcat(wb,
         "ACLK Available: Yes\n"
         "ACLK Implementation: Next Generation\n"
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
+        "New Cloud Protocol Support: Yes\n"
+#else
+        "New Cloud Protocol Support: No\n"
+#endif
         "Claimed: "
     );
 
@@ -1056,7 +1061,7 @@ char *ng_aclk_state(void)
         freez(agent_id);
     }
 
-    buffer_sprintf(wb, "Online: %s", aclk_connected ? "Yes" : "No");
+    buffer_sprintf(wb, "Online: %s\nUsed Cloud Protocol: %s", aclk_connected ? "Yes" : "No", aclk_use_new_cloud_arch ? "New" : "Legacy");
 
     ret = strdupz(buffer_tostring(wb));
     buffer_free(wb);
@@ -1073,6 +1078,13 @@ char *ng_aclk_state_json(void)
     tmp = json_object_new_string("Next Generation");
     json_object_object_add(msg, "aclk-implementation", tmp);
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
+    tmp = json_object_new_boolean(1);
+#else
+    tmp = json_object_new_boolean(0);
+#endif
+    json_object_object_add(msg, "new-cloud-protocol-supported", tmp);
+
     char *agent_id = is_agent_claimed();
     tmp = json_object_new_boolean(agent_id != NULL);
     json_object_object_add(msg, "agent-claimed", tmp);
@@ -1086,6 +1098,9 @@ char *ng_aclk_state_json(void)
 
     tmp = json_object_new_boolean(aclk_connected);
     json_object_object_add(msg, "online", tmp);
+
+    tmp = json_object_new_string(aclk_use_new_cloud_arch ? "New" : "Legacy");
+    json_object_object_add(msg, "used-cloud-protocol", tmp);
 
     char *str = strdupz(json_object_to_json_string_ext(msg, JSON_C_TO_STRING_PLAIN));
     json_object_put(msg);

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -9,12 +9,6 @@
 
 #include "mqtt_websockets/c-rbuf/include/ringbuffer.h"
 
-// CentOS 7 has older version that doesn't define this
-// same goes for MacOS
-#ifndef UUID_STR_LEN
-#define UUID_STR_LEN 37
-#endif
-
 struct dictionary_singleton {
     char *key;
     char *result;

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -257,6 +257,7 @@ static int alarm_state_update_query(struct aclk_query_thread *query_thr, aclk_qu
     return 0;
 }
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 static int register_node(struct aclk_query_thread *query_thr, aclk_query_t query) {
     // TODO create a pending registrations list
     // with some timeouts to detect registration requests that
@@ -279,6 +280,7 @@ static int send_bin_msg(struct aclk_query_thread *query_thr, aclk_query_t query)
     aclk_send_bin_message_subtopic_pid(query_thr->client, query->data.bin_payload.payload, query->data.bin_payload.size, query->data.bin_payload.topic, query->data.bin_payload.msg_name);
     return 0;
 }
+#endif
 
 aclk_query_handler aclk_query_handlers[] = {
     { .type = HTTP_API_V2,          .name = "http api request v2",      .fnc = http_api_v2              },
@@ -287,6 +289,7 @@ aclk_query_handler aclk_query_handlers[] = {
     { .type = METADATA_ALARMS,      .name = "alarms metadata",          .fnc = alarms_metadata          },
     { .type = CHART_NEW,            .name = "chart new",                .fnc = chart_query              },
     { .type = CHART_DEL,            .name = "chart delete",             .fnc = info_metadata            },
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     { .type = REGISTER_NODE,        .name = "register node",            .fnc = register_node            },
     { .type = NODE_STATE_UPDATE,    .name = "node state update",        .fnc = node_state_update        },
     { .type = CHART_DIMS_UPDATE,    .name = "chart and dim update bin", .fnc = send_bin_msg             },
@@ -296,6 +299,7 @@ aclk_query_handler aclk_query_handlers[] = {
     { .type = UPDATE_NODE_INFO,     .name = "update node info",         .fnc = send_bin_msg             },
     { .type = ALARM_LOG_HEALTH,     .name = "alarm log health",         .fnc = send_bin_msg             },
     { .type = ALARM_PROVIDE_CFG,    .name = "provide alarm config",     .fnc = send_bin_msg             },
+#endif
     { .type = UNKNOWN,              .name = NULL,                       .fnc = NULL                     }
 };
 

--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -260,6 +260,7 @@ err_cleanup_nojson:
     return 1;
 }
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 void aclk_handle_new_cloud_msg(const char *message_type, const char *msg, size_t msg_len)
 {
     // TODO do the look up table with hashes to optimize when there are more
@@ -331,3 +332,4 @@ void aclk_handle_new_cloud_msg(const char *message_type, const char *msg, size_t
 
     error ("Unknown new cloud arch message type received \"%s\"", message_type);
 }
+#endif

--- a/aclk/aclk_rx_msgs.h
+++ b/aclk/aclk_rx_msgs.h
@@ -10,6 +10,8 @@
 
 int aclk_handle_cloud_message(char *payload);
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 void aclk_handle_new_cloud_msg(const char *message_type, const char *msg, size_t msg_len);
+#endif
 
 #endif /* ACLK_RX_MSGS_H */

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -403,6 +403,7 @@ int aclk_send_app_layer_disconnect(mqtt_wss_client client, const char *message)
     return pid;
 }
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 // new protobuf msgs
 uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable) {
     size_t len;
@@ -481,6 +482,7 @@ void aclk_generate_node_state_update(mqtt_wss_client client, node_instance_conne
     aclk_send_bin_message_subtopic_pid(client, msg, len, ACLK_TOPICID_NODE_CONN, "UpdateNodeInstanceConnection");
     freez(msg);
 }
+#endif /* ENABLE_NEW_CLOUD_PROTOCOL */
 
 #ifndef __GNUC__
 #pragma endregion

--- a/aclk/aclk_tx_msgs.h
+++ b/aclk/aclk_tx_msgs.h
@@ -23,11 +23,13 @@ void aclk_alarm_state_msg(mqtt_wss_client client, json_object *msg);
 json_object *aclk_generate_disconnect(const char *message);
 int aclk_send_app_layer_disconnect(mqtt_wss_client client, const char *message);
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 // new protobuf msgs
 uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable);
 char *aclk_generate_lwt(size_t *size);
 
 void aclk_generate_node_registration(mqtt_wss_client client, node_instance_creation_t *node_creation);
 void aclk_generate_node_state_update(mqtt_wss_client client, node_instance_connection_t *node_connection);
+#endif
 
 #endif

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -4,12 +4,6 @@
 
 #include "daemon/common.h"
 
-// CentOS 7 has older version that doesn't define this
-// same goes for MacOS
-#ifndef UUID_STR_LEN
-#define UUID_STR_LEN 37
-#endif
-
 int aclk_use_new_cloud_arch = 0;
 usec_t aclk_session_newarch = 0;
 

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -5,6 +5,12 @@
 #include "libnetdata/libnetdata.h"
 #include "mqtt_wss_client.h"
 
+// CentOS 7 has older version that doesn't define this
+// same goes for MacOS
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37
+#endif
+
 // Helper stuff which should not have any further inside ACLK dependency
 // and are supposed not to be needed outside of ACLK
 

--- a/configure.ac
+++ b/configure.ac
@@ -216,6 +216,14 @@ AC_ARG_WITH(
     [aclk_ng="detect"]
 )
 
+AC_ARG_WITH(
+    [new-cloud-protocol],
+    [AS_HELP_STRING([--with-new-cloud-protocol],
+                    [Requires New Cloud Protocol support to be built])],
+    [new_cloud_protocol="$withval"],
+    [new_cloud_protocol="detect"]
+)
+
 if test "${enable_cloud}" = "no"; then
     AC_DEFINE([DISABLE_CLOUD], [1], [disable netdata cloud functionality])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -744,49 +744,6 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
     else
         AC_MSG_RESULT([yes])
     fi
-    AC_MSG_CHECKING([if protobuf available for ACLK Next Generation])
-    if test "${have_libprotobuf}" != "yes"; then
-        AC_MSG_RESULT([no])
-        can_enable_ng="no"
-    else
-        AC_MSG_RESULT([yes])
-    fi
-    AC_MSG_CHECKING([if protoc available for ACLK Next Generation])
-    if test "${have_protoc}" != "yes"; then
-        AC_MSG_RESULT([no])
-        can_enable_ng="no"
-    else
-        AC_MSG_RESULT([yes])
-    fi
-    AC_MSG_CHECKING([if C++ compiler available for ACLK Next Generation])
-    if test "${have_CXX_compiler}" != "yes"; then
-        AC_MSG_RESULT([no])
-        can_enable_ng="no"
-    else
-        AC_MSG_RESULT([yes])
-    fi
-
-    if test "${with_bundled_protobuf}" = "yes"; then
-        AC_LANG_PUSH([C++]) 
-        CXXFLAGS="${CXXFLAGS} -std=c++11"
-
-        # On some platforms, std::atomic needs a helper library
-        AC_MSG_CHECKING(whether -latomic is needed for static protobuf)
-        AC_LINK_IFELSE([AC_LANG_SOURCE([[
-          #include <atomic>
-          #include <cstdint>
-          std::atomic<std::int64_t> v;
-          int main() {
-            return v;
-          }
-        ]])], STD_ATOMIC_NEED_LIBATOMIC=no, STD_ATOMIC_NEED_LIBATOMIC=yes)
-        AC_MSG_RESULT($STD_ATOMIC_NEED_LIBATOMIC)
-        if test "x$STD_ATOMIC_NEED_LIBATOMIC" = xyes; then
-            OPTIONAL_ATOMIC_LIBS="-latomic"
-        fi
-        AC_SUBST([OPTIONAL_ATOMIC_LIBS])
-        AC_LANG_POP([C++])
-    fi
 
     AC_MSG_CHECKING([ACLK Next Generation can be built])
     AC_MSG_RESULT([${can_enable_ng}])
@@ -798,10 +755,66 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
         enable_aclk="yes"
         AC_DEFINE([ACLK_NG], [1], [ACLK Next Generation Should be used])
         AC_DEFINE([ENABLE_ACLK], [1], [netdata ACLK])
-        OPTIONAL_ACLK_NG_CFLAGS="-I \$(abs_top_srcdir)/mqtt_websockets/src/include -I \$(abs_top_srcdir)/mqtt_websockets/c-rbuf/include -I \$(abs_top_srcdir)/mqtt_websockets/MQTT-C/include -I \$(abs_top_srcdir)/aclk/aclk-schemas"
-        OPTIONAL_PROTOBUF_CFLAGS="${PROTOBUF_CFLAGS}"
-        CXX11FLAG="-std=c++11"
-        OPTIONAL_PROTOBUF_LIBS="${PROTOBUF_LIBS}"
+        OPTIONAL_ACLK_NG_CFLAGS="-I \$(abs_top_srcdir)/mqtt_websockets/src/include -I \$(abs_top_srcdir)/mqtt_websockets/c-rbuf/include -I \$(abs_top_srcdir)/mqtt_websockets/MQTT-C/include"
+    fi
+
+    if test "$aclk_ng" = "yes" -a "$new_cloud_protocol" != "no"; then
+        can_build_new_cloud_protocol="yes"
+        AC_MSG_CHECKING([if protobuf available for New Cloud Protocol])
+        if test "${have_libprotobuf}" != "yes"; then
+            AC_MSG_RESULT([no])
+            can_build_new_cloud_protocol="no"
+        else
+            AC_MSG_RESULT([yes])
+        fi
+        AC_MSG_CHECKING([if protoc available for New Cloud Protocol])
+        if test "${have_protoc}" != "yes"; then
+            AC_MSG_RESULT([no])
+            can_build_new_cloud_protocol="no"
+        else
+            AC_MSG_RESULT([yes])
+        fi
+        AC_MSG_CHECKING([if C++ compiler available for New Cloud Protocol])
+        if test "${have_CXX_compiler}" != "yes"; then
+            AC_MSG_RESULT([no])
+            can_build_new_cloud_protocol="no"
+        else
+            AC_MSG_RESULT([yes])
+        fi
+
+        if test "${with_bundled_protobuf}" = "yes"; then
+            AC_LANG_PUSH([C++]) 
+            CXXFLAGS="${CXXFLAGS} -std=c++11"
+
+            # On some platforms, std::atomic needs a helper library
+            AC_MSG_CHECKING(whether -latomic is needed for static protobuf)
+            AC_LINK_IFELSE([AC_LANG_SOURCE([[
+              #include <atomic>
+              #include <cstdint>
+              std::atomic<std::int64_t> v;
+              int main() {
+                return v;
+              }
+            ]])], STD_ATOMIC_NEED_LIBATOMIC=no, STD_ATOMIC_NEED_LIBATOMIC=yes)
+            AC_MSG_RESULT($STD_ATOMIC_NEED_LIBATOMIC)
+            if test "x$STD_ATOMIC_NEED_LIBATOMIC" = xyes; then
+                OPTIONAL_ATOMIC_LIBS="-latomic"
+            fi
+            AC_SUBST([OPTIONAL_ATOMIC_LIBS])
+            AC_LANG_POP([C++])
+        fi
+        AC_MSG_CHECKING([ACLK Next Generation can support New Cloud protocol])
+        AC_MSG_RESULT([${can_build_new_cloud_protocol}])
+        if test "$new_cloud_protocol" = "yes" -a "$can_build_new_cloud_protocol" != "yes"; then
+            AC_MSG_ERROR([Requested new cloud protocol support but it cant be build])
+        fi
+        if test "$can_build_new_cloud_protocol" = "yes"; then
+            AC_DEFINE([ENABLE_NEW_CLOUD_PROTOCOL], [1], [New protobuf based Netdata Cloud Protocol Support])
+            OPTIONAL_ACLK_NG_CFLAGS="${OPTIONAL_ACLK_NG_CFLAGS} -I \$(abs_top_srcdir)/aclk/aclk-schemas"
+            OPTIONAL_PROTOBUF_CFLAGS="${PROTOBUF_CFLAGS}"
+            CXX11FLAG="-std=c++11"
+            OPTIONAL_PROTOBUF_LIBS="${PROTOBUF_LIBS}"
+        fi
     fi
 fi
 
@@ -896,6 +909,7 @@ AC_SUBST([enable_aclk])
 AM_CONDITIONAL([ACLK_NG], [test "${aclk_ng}" = "yes"])
 AM_CONDITIONAL([ACLK_LEGACY], [test "${aclk_legacy}" = "yes"])
 AM_CONDITIONAL([ENABLE_ACLK], [test "${enable_aclk}" = "yes"])
+AM_CONDITIONAL([ENABLE_NEW_CLOUD_PROTOCOL], [test "${can_build_new_cloud_protocol}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # apps.plugin

--- a/configure.ac
+++ b/configure.ac
@@ -809,6 +809,7 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
             AC_MSG_ERROR([Requested new cloud protocol support but it cant be build])
         fi
         if test "$can_build_new_cloud_protocol" = "yes"; then
+            new_cloud_protocol="yes"
             AC_DEFINE([ENABLE_NEW_CLOUD_PROTOCOL], [1], [New protobuf based Netdata Cloud Protocol Support])
             OPTIONAL_ACLK_NG_CFLAGS="${OPTIONAL_ACLK_NG_CFLAGS} -I \$(abs_top_srcdir)/aclk/aclk-schemas"
             OPTIONAL_PROTOBUF_CFLAGS="${PROTOBUF_CFLAGS}"
@@ -1556,7 +1557,7 @@ AC_MSG_RESULT([${enable_lto}])
 AM_CONDITIONAL([ENABLE_CXX_LINKER], [test "${enable_backend_kinesis}" = "yes" \
                                      -o "${enable_exporting_pubsub}" = "yes" \
                                      -o "${enable_backend_prometheus_remote_write}" = "yes" \
-                                     -o "${aclk_ng}" = "yes"])
+                                     -o "${new_cloud_protocol}" = "yes"])
 
 AC_DEFINE_UNQUOTED([NETDATA_USER], ["${with_user}"], [use this user to drop privileged])
 

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -334,6 +334,7 @@ void analytics_build_info(BUFFER *b) {
     if(FEAT_NATIVE_HTTPS)    buffer_strcat (b, "|Native HTTPS");
     if(FEAT_CLOUD)           buffer_strcat (b, "|Netdata Cloud");
     if(FEAT_ACLK_NG)         buffer_strcat (b, "|ACLK Next Generation");
+    if(NEW_CLOUD_PROTO)      buffer_strcat (b, "|New Cloud Protocol Support");
     if(FEAT_ACLK_LEGACY)     buffer_strcat (b, "|ACLK Legacy");
     if(FEAT_TLS_HOST_VERIFY) buffer_strcat (b, "|TLS Host Verification");
 

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -199,6 +199,12 @@
 #define FEAT_ACLK_NG 0
 #endif
 
+#if defined(ACLK_NG) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
+#define NEW_CLOUD_PROTO 1
+#else
+#define NEW_CLOUD_PROTO 0
+#endif
+
 #ifdef ACLK_LEGACY
 #define FEAT_ACLK_LEGACY 1
 #else
@@ -211,12 +217,13 @@ void print_build_info(void) {
     printf("Configure options: %s\n", CONFIGURE_COMMAND);
 
     printf("Features:\n");
-    printf("    dbengine:                %s\n", FEAT_YES_NO(FEAT_DBENGINE));
-    printf("    Native HTTPS:            %s\n", FEAT_YES_NO(FEAT_NATIVE_HTTPS));
-    printf("    Netdata Cloud:           %s %s\n", FEAT_YES_NO(FEAT_CLOUD), FEAT_CLOUD_MSG);
-    printf("    ACLK Next Generation:    %s\n", FEAT_YES_NO(FEAT_ACLK_NG));
-    printf("    ACLK Legacy:             %s\n", FEAT_YES_NO(FEAT_ACLK_LEGACY));
-    printf("    TLS Host Verification:   %s\n", FEAT_YES_NO(FEAT_TLS_HOST_VERIFY));
+    printf("    dbengine:                   %s\n", FEAT_YES_NO(FEAT_DBENGINE));
+    printf("    Native HTTPS:               %s\n", FEAT_YES_NO(FEAT_NATIVE_HTTPS));
+    printf("    Netdata Cloud:              %s %s\n", FEAT_YES_NO(FEAT_CLOUD), FEAT_CLOUD_MSG);
+    printf("    ACLK Next Generation:       %s\n", FEAT_YES_NO(FEAT_ACLK_NG));
+    printf("    ACLK-NG New Cloud Protocol: %s\n", FEAT_YES_NO(NEW_CLOUD_PROTO));
+    printf("    ACLK Legacy:                %s\n", FEAT_YES_NO(FEAT_ACLK_LEGACY));
+    printf("    TLS Host Verification:      %s\n", FEAT_YES_NO(FEAT_TLS_HOST_VERIFY));
 
     printf("Libraries:\n");
     printf("    jemalloc:                %s\n", FEAT_YES_NO(FEAT_JEMALLOC));
@@ -271,8 +278,9 @@ void print_build_info_json(void) {
 #else
     printf("    \"cloud-disabled\": false,\n");
 #endif
-    printf("    \"aclk-ng\": \"%s\",\n", FEAT_JSON_BOOL(FEAT_ACLK_NG));
-    printf("    \"aclk-legacy\": \"%s\",\n", FEAT_JSON_BOOL(FEAT_ACLK_LEGACY));
+    printf("    \"aclk-ng\": %s,\n", FEAT_JSON_BOOL(FEAT_ACLK_NG));
+    printf("    \"aclk-ng-new-cloud-proto\": %s,\n", FEAT_JSON_BOOL(NEW_CLOUD_PROTO));
+    printf("    \"aclk-legacy\": %s,\n", FEAT_JSON_BOOL(FEAT_ACLK_LEGACY));
 
     printf("    \"tls-host-verify\": %s\n",   FEAT_JSON_BOOL(FEAT_TLS_HOST_VERIFY));
     printf("  },\n");

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -102,7 +102,7 @@ int rrdcalc_status_to_proto_enum(RRDCALC_STATUS status)
 
 void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
 {
-#ifndef ACLK_NG
+#ifndef ENABLE_NEW_CLOUD_PROTOCOL
     UNUSED(wc);
     UNUSED(cmd);
 #else
@@ -259,7 +259,7 @@ void aclk_send_alarm_health_log(char *node_id)
 void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
 {
     UNUSED(cmd);
-#ifndef ACLK_NG
+#ifndef ENABLE_NEW_CLOUD_PROTOCOL
     UNUSED(wc);
 #else
     int rc;
@@ -362,7 +362,7 @@ void aclk_send_alarm_configuration(char *config_hash)
 int aclk_push_alert_config_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
 {
     UNUSED(wc);
-#ifndef ACLK_NG
+#ifndef ENABLE_NEW_CLOUD_PROTOCOL
     UNUSED(cmd);
 #else
     int rc = 0;
@@ -482,7 +482,7 @@ int aclk_push_alert_config_event(struct aclk_database_worker_config *wc, struct 
 // Start streaming alerts
 void aclk_start_alert_streaming(char *node_id, uint64_t batch_id, uint64_t start_seq_id)
 {
-#ifdef ACLK_NG
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     if (unlikely(!node_id))
         return;
 

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -123,7 +123,7 @@ int aclk_add_chart_event(struct aclk_database_worker_config *wc, struct aclk_dat
     int rc = 0;
     CHECK_SQLITE_CONNECTION(db_meta);
 
-#ifdef ACLK_NG
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     char *claim_id = is_agent_claimed();
 
     RRDSET *st = cmd.data;
@@ -169,7 +169,7 @@ int aclk_add_dimension_event(struct aclk_database_worker_config *wc, struct aclk
     int rc = 0;
     CHECK_SQLITE_CONNECTION(db_meta);
 
-#ifdef ACLK_NG
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     char *claim_id = is_agent_claimed();
 
     RRDDIM *rd = cmd.data;
@@ -216,7 +216,7 @@ int aclk_add_dimension_event(struct aclk_database_worker_config *wc, struct aclk
 
 void aclk_send_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
 {
-#ifdef ACLK_NG
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     int rc;
 
     wc->chart_pending = 0;
@@ -351,7 +351,7 @@ bind_fail:
 int aclk_send_chart_config(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
 {
     UNUSED(wc);
-#ifdef ACLK_NG
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 
     CHECK_SQLITE_CONNECTION(db_meta);
 
@@ -470,7 +470,7 @@ void aclk_receive_chart_reset(struct aclk_database_worker_config *wc, struct acl
         wc->chart_sequence_id = 0;
         wc->chart_timestamp = 0;
 
-#ifdef ACLK_NG
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
         RRDHOST *host = wc->host;
         rrdhost_rdlock(host);
         RRDSET *st;
@@ -674,7 +674,7 @@ fail:
 // Start streaming charts / dimensions for node_id
 void aclk_start_streaming(char *node_id, uint64_t sequence_id, time_t created_at, uint64_t batch_id)
 {
-#ifdef ACLK_NG
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     if (unlikely(!node_id))
         return;
 

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -3,7 +3,7 @@
 #include "sqlite_functions.h"
 #include "sqlite_aclk_node.h"
 
-#ifdef ACLK_NG
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 #include "../../aclk/aclk_charts_api.h"
 #endif
 
@@ -11,7 +11,7 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
 {
     UNUSED(cmd);
 
-#ifdef ACLK_NG
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     struct update_node_info node_info;
 
     rrd_wrlock();

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -984,6 +984,11 @@ inline int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb)
 #else
     buffer_strcat(wb, "\t\"aclk-ng-available\": false,\n");
 #endif
+#ifdef defined(ACLK_NG) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
+    buffer_strcat(wb, "\t\"aclk-ng-new-cloud-protocol\": true,\n");
+#else
+    buffer_strcat(wb, "\t\"aclk-ng-new-cloud-protocol\": false,\n");
+#endif
 #ifdef ACLK_LEGACY
     buffer_strcat(wb, "\t\"aclk-legacy-available\": true,\n");
 #else

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -984,7 +984,7 @@ inline int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb)
 #else
     buffer_strcat(wb, "\t\"aclk-ng-available\": false,\n");
 #endif
-#ifdef defined(ACLK_NG) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
+#if defined(ACLK_NG) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
     buffer_strcat(wb, "\t\"aclk-ng-new-cloud-protocol\": true,\n");
 #else
     buffer_strcat(wb, "\t\"aclk-ng-new-cloud-protocol\": false,\n");


### PR DESCRIPTION
##### Summary
ACLK-NG doesn't really need the protobuf and CXX compiler. It is the New Cloud Protocol/Architecture who needs it. This PR allows building ACLK-NG without a new cloud.

Default behavior adds New Cloud Support if possible. This can be overridden by configuring the flag.

This will allow us to remove Legacy ACLK (not maintained anymore) more quickly and thus simplifying the whole thing (code, build system, installer) as the majority of people will be able to build ACLK-NG by default.

##### Component Name
build system + aclk + database/sqlite

##### Test Plan
build with `--without-new-cloud-protocol`, `--with-new-cloud-protocol` and without flag.
Build without any flag and missing protobuf should still make ACLK-NG available with old JSON cloud protocol only.

##### Additional Information
