### PR TITLE
Add POWER8+ support to our official Docker images.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,7 @@ jobs:
           - linux/i386
           - linux/arm/v7
           - linux/arm64
+          - linux/ppc64le
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -92,7 +93,7 @@ jobs:
       - name: Docker Build
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64,linux/i386,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/i386,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true
           tags: ${{ env.tags }}
       - name: Failure Notification

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -99,8 +99,10 @@ RUN chown -R root:root \
     chmod 0755 /usr/libexec/netdata/plugins.d/*.plugin && \
     chmod 4755 \
         /usr/libexec/netdata/plugins.d/cgroup-network \
-        /usr/libexec/netdata/plugins.d/apps.plugin \
-        /usr/libexec/netdata/plugins.d/freeipmi.plugin && \
+        /usr/libexec/netdata/plugins.d/apps.plugin && \
+    if [ -f /usr/libexec/netdata/plugins.d/freeipmi.plugin ]; then \
+        chmod 4755 /usr/libexec/netdata/plugins.d/freeipmi.plugin; \
+    fi && \
     # Group write permissions due to: https://github.com/netdata/netdata/pull/6543
     find /var/lib/netdata /var/cache/netdata -type d -exec chmod 0770 {} \; && \
     find /var/lib/netdata /var/cache/netdata -type f -exec chmod 0660 {} \; && \


### PR DESCRIPTION
##### Summary

This adds 64-bit little-endian POWER8+ support to our official Docker images, allowing use of Netdata Docker images on recent IBM Power Systems, Raptor Talos II, and similar POWER based hardware. The POWER8+ versions of our Docker images are notably missing two features found in our x86 Docker images:

* eBPF is not currently supported due to issues building libbpf. This is likely to be resolved by the same fixes that allow us to properly support it on ARM.
* FreeIPMI is not supported due to FreeIPMI itself not properly supporting POWER.

##### Component Name

area/packaging
area/ci

##### Test Plan

New Docker CI check passes on this PR. Local testing was done using QEMU userspace emulation and Docker.

##### Additional Information

This is simple first step towards proper POWER8+ support in all of our pre-built install methods.