### PR TITLE
Remove Alpine 3.11 from CI.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -39,7 +39,6 @@ jobs:
           - 'alpine:3.14'
           - 'alpine:3.13'
           - 'alpine:3.12'
-          - 'alpine:3.11'
           - 'archlinux:latest'
           - 'centos:8'
           - 'centos:7'
@@ -64,9 +63,6 @@ jobs:
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
           - distro: 'alpine:3.12'
-            pre: 'apk add -U bash'
-            rmjsonc: 'apk del json-c-dev'
-          - distro: 'alpine:3.11'
             pre: 'apk add -U bash'
             rmjsonc: 'apk del json-c-dev'
 


### PR DESCRIPTION
##### Summary

To be merged 2021-11-01 when Alpine 3.11 officially goes EOL.

##### Component Name

area/ci

##### Test Plan

n/a