### PR TITLE
Fix issue where initial value in chart was missing in API.

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -922,13 +922,13 @@ static RRDR *rrd2rrdr_fixedstep(
     // an integer number of values per point
     long points_wanted = (before_wanted - after_requested) / (update_every * group);
 
-    time_t after_wanted  = before_wanted - (points_wanted * group * update_every) + update_every;
+    time_t after_wanted  = before_wanted - (points_wanted * group * update_every);
     if(unlikely(after_wanted < first_entry_t)) {
         // hm... we go to the past, calculate again points_wanted using all the db from before_wanted to the beginning
         points_wanted = (before_wanted - first_entry_t) / group;
 
         // recalculate after wanted with the new number of points
-        after_wanted  = before_wanted - (points_wanted * group * update_every) + update_every;
+        after_wanted  = before_wanted - (points_wanted * group * update_every);
 
         if(unlikely(after_wanted < first_entry_t)) {
             #ifdef NETDATA_INTERNAL_CHECKS


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Fix issue where initial value in chart was missing in API.

There is an apparent off-by-one error when (re-)calculating the start time for the chart data.

##### Component Name

web/api

##### Test Plan

* Created a dummy collector that generates a known sequence of values (e.g. 1,2,3,4,...) at 1s collection interval. Chart can be created with store_first or without.
* Configure netdata to use dbengine.
* With netdata stopped, erase dbengine and  metadata.
* Start netdata.
* View chart in default dashboard. OR fetch the chart data via api/1/data.

Actual (prior to change): chart data was missing the first entry.
Expected (after change): chart data includes the first entry.

Note that this only affected the very first entry in the chart, immediately after initial creation. Upon resuming an archived chart, the subsequent initial values were correct.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
