### PR TITLE
Fix RSS memory counter for systemd services

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2862,7 +2862,7 @@ void update_systemd_services_charts(
             if(unlikely(!cg->rd_mem_detailed_rss))
                 cg->rd_mem_detailed_rss = rrddim_add(st_mem_detailed_rss, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
 
-            rrddim_set_by_pointer(st_mem_detailed_rss, cg->rd_mem_detailed_rss, cg->memory.total_rss + cg->memory.total_rss_huge);
+            rrddim_set_by_pointer(st_mem_detailed_rss, cg->rd_mem_detailed_rss, cg->memory.total_rss);
 
             if(unlikely(!cg->rd_mem_detailed_mapped))
                 cg->rd_mem_detailed_mapped = rrddim_add(st_mem_detailed_mapped, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);


### PR DESCRIPTION
##### Summary
It is stated in the [cgroups memory controller documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt):
>rss		- # of bytes of anonymous and swap cache memory (includes transparent hugepages).
rss_huge	- # of bytes of anonymous transparent hugepages.

Therefore, we shouldn't add the values to avoid doubling of transparent hugepages size.

##### Component Name
cgroups plugin