### PR TITLE
Initialize struct with zeroes

### DIFF
--- a/spawn/spawn_client.c
+++ b/spawn/spawn_client.c
@@ -139,7 +139,7 @@ static void spawn_process_cmd(struct spawn_cmd_info *cmdinfo)
     uv_buf_t writebuf[3];
     struct write_context *write_ctx;
 
-    write_ctx = mallocz(sizeof(*write_ctx));
+    write_ctx = callocz(1, sizeof(*write_ctx));
     write_ctx->write_req.data = write_ctx;
 
     uv_mutex_lock(&cmdinfo->mutex);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Zero initialize `write_ctx` to remove a valgrind warning in `spawn/spawn_client.c`.

This should remove this warning:

```
==7869== Thread 2:
==7869== Syscall param writev(vector[...]) points to uninitialised byte(s)
==7869==    at 0x55D3C1D: writev (in /lib64/libc-2.33.so)
==7869==    by 0x4E29909: ??? (in /usr/lib64/libuv.so.1.0.0)
==7869==    by 0x4E29AD8: ??? (in /usr/lib64/libuv.so.1.0.0)
==7869==    by 0x4E2AC25: uv_write2 (in /usr/lib64/libuv.so.1.0.0)
==7869==    by 0x28E641: spawn_process_cmd (spawn_client.c:160)
==7869==    by 0x28E641: spawn_client (spawn_client.c:215)
==7869==    by 0x54C8E5D: start_thread (in /lib64/libpthread-2.33.so)
==7869==    by 0x55DCEFE: clone (in /lib64/libc-2.33.so)
==7869==  Address 0x5a67d54 is 196 bytes inside a block of size 240 alloc'd
==7869==    at 0x483F855: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7869==    by 0x15A64B: mallocz (libnetdata.c:177)
==7869==    by 0x28E591: spawn_process_cmd (spawn_client.c:142)
==7869==    by 0x28E591: spawn_client (spawn_client.c:215)
==7869==    by 0x54C8E5D: start_thread (in /lib64/libpthread-2.33.so)
==7869==    by 0x55DCEFE: clone (in /lib64/libc-2.33.so)
==7869==  Uninitialised value was created by a heap allocation
==7869==    at 0x483F855: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7869==    by 0x15A64B: mallocz (libnetdata.c:177)
==7869==    by 0x28E591: spawn_process_cmd (spawn_client.c:142)
==7869==    by 0x28E591: spawn_client (spawn_client.c:215)
==7869==    by 0x54C8E5D: start_thread (in /lib64/libpthread-2.33.so)
==7869==    by 0x55DCEFE: clone (in /lib64/libc-2.33.so)
==7869== 
```

##### Component Name

Spawn server

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Since spawn server is mainly used for running the `alarm-notify.sh` script, it should be tested that after this PR, notifications still get executed, but there is no warning from valgrind for this case.

##### Additional Information
