### PR TITLE
add sys_class_infiniband charts info

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -53,6 +53,15 @@ netdataDashboard.menu = {
         '<p>Netdata retrieves this data reading the <code>/proc/net/dev</code> file and <code>/sys/class/net/</code> directory.</p>'
     },
 
+    'Infiniband': {
+        title: 'Infiniband ports',
+        icon: '<i class="fas fa-sitemap"></i>',
+        info: '<p>Performance and exception statistics for '+
+        '<a href="https://en.wikipedia.org/wiki/InfiniBand" target="_blank">Infiniband</a> ports. '+
+        'The individual port and hardware counters can be found in the '+
+        '<a href="https://community.mellanox.com/s/article/understanding-mlx5-linux-counters-and-status-parameters" target="_blank">Mellanox knowledge base</a>.'
+    },
+
     'wireless': {
         title: 'Wireless Interfaces',
         icon: '<i class="fas fa-wifi"></i>',
@@ -2654,6 +2663,29 @@ netdataDashboard.context = {
         'from the Cell or the Access Point have been missed. '+
         'Beacons are sent at regular intervals to maintain the cell coordination, '+
         'failure to receive them usually indicates that the card is out of range.'
+    },
+
+    // ------------------------------------------------------------------------
+    // INFINIBAND
+
+    'ib.bytes': {
+        info: 'The amount of traffic transferred by the port.'
+    },
+
+    'ib.packets': {
+        info: 'The number of packets transferred by the port.'
+    },
+
+    'ib.errors': {
+        info: 'The number of errors encountered by the port.'
+    },
+
+    'ib.hwerrors': {
+        info: 'The number of hardware errors encountered by the port.'
+    },
+
+    'ib.hwpackets': {
+        info: 'The number of hardware packets transferred by the port.'
     },
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

This PR adds dashboard info for [proc_sys_class_infiniband](https://github.com/netdata/netdata/tree/master/collectors/proc.plugin/sys_class_infiniband.c) collector's charts.

##### Component Name

`web/`

##### Test Plan

Install this PR; check the proc sys_class_infiniband info charts; ensure the info is on the dashboard.

##### Additional Information

Fixes part of netdata/product#2104