### PR TITLE
Fix coverity issues 373400-373402

### DIFF
--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -391,6 +391,7 @@ void aclk_handle_new_cloud_msg(const char *message_type, const char *msg, size_t
         char *config_hash = parse_send_alarm_configuration(msg, msg_len);
         if (!config_hash || !*config_hash) {
             error("Error parsing SendAlarmConfiguration");
+            freez(config_hash);
             return;
         }
         aclk_send_alarm_configuration(config_hash);

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -119,8 +119,10 @@ void aclk_update_retention(struct aclk_database_worker_config *wc, struct aclk_d
 
     uuid_t host_uuid;
     rc = uuid_parse(wc->host_guid, host_uuid);
-    if (unlikely(rc))
+    if (unlikely(rc)) {
+        freez(claim_id);
         return;
+    }
 
     if (wc->host)
         memory_mode = wc->host->rrd_memory_mode;


### PR DESCRIPTION
##### Summary
Fixes resource leak report for coverity

- Variable "claim_id" going out of scope leaks the storage it points to (/database/sqlite/sqlite_aclk_node.c)
- Variable "config_hash" going out of scope leaks the storage it points to (/aclk/aclk_rx_msgs.c)

##### Component Name
database, ACLK

##### Test Plan
- Coverity report should be cleared
