### PR TITLE
Fix nfsd RPC metrics and remove unused nfsd charts and metrics

### DIFF
--- a/collectors/proc.plugin/proc_net_rpc_nfsd.c
+++ b/collectors/proc.plugin/proc_net_rpc_nfsd.c
@@ -305,7 +305,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
             fh_stale = str2ull(procfile_lineword(ff, l, 1));
             
-            // other file handler metrics was never used and are always zero
+            // other file handler metrics were never used and are always zero
 
             if(fh_stale == 0ULL) do_fh = -1;
             else do_fh = 2;
@@ -331,7 +331,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
             th_threads = str2ull(procfile_lineword(ff, l, 1));
 
-            // threads histogram has been disabled since 2009 (kernel 2.6.30)
+            // thread histogram has been disabled since 2009 (kernel 2.6.30)
             // https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=8bbfa9f3889b643fc7de82c0c761ef17097f8faf
             
             do_th = 2;


### PR DESCRIPTION
##### Summary
1. [RPC metrics](https://elixir.bootlin.com/linux/v5.14.9/source/net/sunrpc/stats.c#L96) were parsed incorrectly affecting the `nfsd.rpc` chart. We fix that.
2. [File handler metrics](https://elixir.bootlin.com/linux/v5.14.9/source/fs/nfsd/stats.c#L39) were never used and are always zero. Corresponding dimensions are removed from the `nfsd.filehandles` chart.
3. [Thread histogram](https://elixir.bootlin.com/linux/v5.14.9/source/fs/nfsd/stats.c#L48) has been [disabled](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=8bbfa9f3889b643fc7de82c0c761ef17097f8faf) since 2009 (kernel 2.6.30). We remove two charts - `threads_fullcnt` and `nfsd.threads_histogram`.
4. [Readahead cache](https://elixir.bootlin.com/linux/v5.14.9/source/fs/nfsd/stats.c#L55) has been [disabled](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/fs/nfsd/vfs.c?id=501cb1849f865960501d19d54e6a5af306f9b6fd) since 2019 (kernel 5.4). We add a comment about that.

##### Component Name
proc plugin