### PR TITLE
Add protobuf to `-W buildinfo` output.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -702,6 +702,10 @@ AS_IF(
     [have_CXX_compiler=yes]
 )
 
+if test "${have_libprotobuf}" == "yes" && test "${have_CXX_compiler}" == "yes"; then
+    AC_DEFINE([HAVE_PROTOBUF], [1], [Protobuf is available ])
+fi
+
 AC_MSG_CHECKING([if Cloud functionality should be enabled])
 AC_MSG_RESULT([${enable_cloud}])
 if test "$aclk_ng" = "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -703,7 +703,11 @@ AS_IF(
 )
 
 if test "${have_libprotobuf}" == "yes" && test "${have_CXX_compiler}" == "yes"; then
-    AC_DEFINE([HAVE_PROTOBUF], [1], [Protobuf is available ])
+    AC_DEFINE([HAVE_PROTOBUF], [1], [Protobuf is available])
+fi
+
+if test "${have_libprotobuf}" == "yes" && test "${with_bundled_protobuf}" == "yes"; then
+    AC_DEFINE([BUNDLED_PROTOBUF], [1], [Using a bundled copy of protobuf])
 fi
 
 AC_MSG_CHECKING([if Cloud functionality should be enabled])

--- a/configure.ac
+++ b/configure.ac
@@ -668,6 +668,7 @@ if test "${with_bundled_protobuf}" != "no"; then
         AC_MSG_ERROR([Bundled protobuf requested using --with-bundled-protobuf but it cannot be used/found])
     fi
     if test "${with_bundled_protobuf}" == "detect" -a "${bundled_proto_avail}" == "yes"; then
+        AC_DEFINE([BUNDLED_PROTOBUF], [1], [Using a bundled copy of protobuf])
         with_bundled_protobuf="yes"
     fi
 fi
@@ -704,10 +705,6 @@ AS_IF(
 
 if test "${have_libprotobuf}" == "yes" && test "${have_CXX_compiler}" == "yes"; then
     AC_DEFINE([HAVE_PROTOBUF], [1], [Protobuf is available])
-fi
-
-if test "${have_libprotobuf}" == "yes" && test "${with_bundled_protobuf}" == "yes"; then
-    AC_DEFINE([BUNDLED_PROTOBUF], [1], [Using a bundled copy of protobuf])
 fi
 
 AC_MSG_CHECKING([if Cloud functionality should be enabled])

--- a/configure.ac
+++ b/configure.ac
@@ -668,7 +668,6 @@ if test "${with_bundled_protobuf}" != "no"; then
         AC_MSG_ERROR([Bundled protobuf requested using --with-bundled-protobuf but it cannot be used/found])
     fi
     if test "${with_bundled_protobuf}" == "detect" -a "${bundled_proto_avail}" == "yes"; then
-        AC_DEFINE([BUNDLED_PROTOBUF], [1], [Using a bundled copy of protobuf])
         with_bundled_protobuf="yes"
     fi
 fi
@@ -689,6 +688,7 @@ AS_IF(
 )
 else
     AC_MSG_NOTICE([using bundled protobuf])
+    AC_DEFINE([BUNDLED_PROTOBUF], [1], [Using a bundled copy of protobuf])
     PROTOC="\$(abs_top_srcdir)/externaldeps/protobuf/src/protoc"
     PROTOBUF_CFLAGS="-I \$(abs_top_srcdir)/externaldeps/protobuf/src"
     PROTOBUF_LIBS="\$(abs_top_srcdir)/externaldeps/protobuf/src/.libs/libprotobuf.a"

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -57,6 +57,16 @@
 
 // Optional libraries
 
+#ifdef HAVE_PROTOBUF
+#if defined(ACLK_NG) || defined(ENABLE_PROMETHEUS_REMOTE_WRITE)
+#define FEAT_PROTOBUF 1
+#else
+#define FEAT_PROTOBUF 0
+#endif
+#else
+#define FEAT_PROTOBUF 0
+#endif
+
 #ifdef ENABLE_JSONC
 #define FEAT_JSONC 1
 #else
@@ -226,6 +236,7 @@ void print_build_info(void) {
     printf("    TLS Host Verification:      %s\n", FEAT_YES_NO(FEAT_TLS_HOST_VERIFY));
 
     printf("Libraries:\n");
+    printf("    protobuf:                %s\n", FEAT_YES_NO(FEAT_PROTOBUF));
     printf("    jemalloc:                %s\n", FEAT_YES_NO(FEAT_JEMALLOC));
     printf("    JSON-C:                  %s\n", FEAT_YES_NO(FEAT_JSONC));
     printf("    libcap:                  %s\n", FEAT_YES_NO(FEAT_LIBCAP));
@@ -286,6 +297,7 @@ void print_build_info_json(void) {
     printf("  },\n");
 
     printf("  \"libs\": {\n");
+    printf("    \"protobuf\": %s,\n",         FEAT_JSON_BOOL(FEAT_PROTOBUF));
     printf("    \"jemalloc\": %s,\n",         FEAT_JSON_BOOL(FEAT_JEMALLOC));
     printf("    \"jsonc\": %s,\n",            FEAT_JSON_BOOL(FEAT_JSONC));
     printf("    \"libcap\": %s,\n",           FEAT_JSON_BOOL(FEAT_LIBCAP));
@@ -338,6 +350,7 @@ void analytics_build_info(BUFFER *b) {
     if(FEAT_ACLK_LEGACY)     buffer_strcat (b, "|ACLK Legacy");
     if(FEAT_TLS_HOST_VERIFY) buffer_strcat (b, "|TLS Host Verification");
 
+    if(FEAT_PROTOBUF)        buffer_strcat (b, "|protobuf");
     if(FEAT_JEMALLOC)        buffer_strcat (b, "|jemalloc");
     if(FEAT_JSONC)           buffer_strcat (b, "|JSON-C");
     if(FEAT_LIBCAP)          buffer_strcat (b, "|libcap");

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -60,11 +60,18 @@
 #ifdef HAVE_PROTOBUF
 #if defined(ACLK_NG) || defined(ENABLE_PROMETHEUS_REMOTE_WRITE)
 #define FEAT_PROTOBUF 1
+#ifdef BUNDLED_PROTOBUF
+#define FEAT_PROTOBUF_BUNDLED " (bundled)"
 #else
-#define FEAT_PROTOBUF 0
+#define FEAT_PROTOBUF_BUNDLED " (system)"
 #endif
 #else
 #define FEAT_PROTOBUF 0
+#define FEAT_PROTOBUF_BUNDLED ""
+#endif
+#else
+#define FEAT_PROTOBUF 0
+#define FEAT_PROTOBUF_BUNDLED ""
 #endif
 
 #ifdef ENABLE_JSONC
@@ -236,7 +243,7 @@ void print_build_info(void) {
     printf("    TLS Host Verification:      %s\n", FEAT_YES_NO(FEAT_TLS_HOST_VERIFY));
 
     printf("Libraries:\n");
-    printf("    protobuf:                %s\n", FEAT_YES_NO(FEAT_PROTOBUF));
+    printf("    protobuf:                %s%s\n", FEAT_YES_NO(FEAT_PROTOBUF), FEAT_PROTOBUF_BUNDLED);
     printf("    jemalloc:                %s\n", FEAT_YES_NO(FEAT_JEMALLOC));
     printf("    JSON-C:                  %s\n", FEAT_YES_NO(FEAT_JSONC));
     printf("    libcap:                  %s\n", FEAT_YES_NO(FEAT_LIBCAP));
@@ -298,6 +305,7 @@ void print_build_info_json(void) {
 
     printf("  \"libs\": {\n");
     printf("    \"protobuf\": %s,\n",         FEAT_JSON_BOOL(FEAT_PROTOBUF));
+    printf("    \"protobuf-source\": \"%s\",\n", FEAT_PROTOBUF_BUNDLED);
     printf("    \"jemalloc\": %s,\n",         FEAT_JSON_BOOL(FEAT_JEMALLOC));
     printf("    \"jsonc\": %s,\n",            FEAT_JSON_BOOL(FEAT_JSONC));
     printf("    \"libcap\": %s,\n",           FEAT_JSON_BOOL(FEAT_LIBCAP));

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -19,6 +19,24 @@
 #endif
 #endif
 
+#ifdef ACLK_NG
+#define FEAT_ACLK_NG 1
+#else
+#define FEAT_ACLK_NG 0
+#endif
+
+#if defined(ACLK_NG) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
+#define NEW_CLOUD_PROTO 1
+#else
+#define NEW_CLOUD_PROTO 0
+#endif
+
+#ifdef ACLK_LEGACY
+#define FEAT_ACLK_LEGACY 1
+#else
+#define FEAT_ACLK_LEGACY 0
+#endif
+
 #ifdef ENABLE_DBENGINE
 #define FEAT_DBENGINE 1
 #else
@@ -191,24 +209,6 @@
 #define FEAT_REMOTE_WRITE 1
 #else
 #define FEAT_REMOTE_WRITE 0
-#endif
-
-#ifdef ACLK_NG
-#define FEAT_ACLK_NG 1
-#else
-#define FEAT_ACLK_NG 0
-#endif
-
-#if defined(ACLK_NG) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
-#define NEW_CLOUD_PROTO 1
-#else
-#define NEW_CLOUD_PROTO 0
-#endif
-
-#ifdef ACLK_LEGACY
-#define FEAT_ACLK_LEGACY 1
-#else
-#define FEAT_ACLK_LEGACY 0
 #endif
 
 #define FEAT_YES_NO(x) ((x) ? "YES" : "NO")


### PR DESCRIPTION
##### Summary

protobuf is now optional for ACLK, and used by at least one other feature, so we really should have it in the output of the `-W buildinfo` switch (and in the associated anonymous statistics).

##### Component Name

area/daemon

##### Test Plan

Verified locally that the output is correct for protobuf being both present and absent.

##### Additional Information

This also re-sorts the macros in `daemon/buildinfo.c` so that they are grouped properly by feature type.