### PR TITLE
fix ci dashboard pr branch name

### DIFF
--- a/.github/workflows/dashboard-pr.yml
+++ b/.github/workflows/dashboard-pr.yml
@@ -8,7 +8,7 @@ on:
       dashboard_version:
         # This must be specified, and must _exactly_ match the version
         # tag for the release to be used for the update.
-        name: Dashboard Version
+        description: Dashboard Version
         required: true
 
 env:


### PR DESCRIPTION
##### Summary

 - fix a typo: it is "github.**event**.inputs.dashboard_version", not "github.**events**.inputs.dashboard_version".
 - fix inputs schema, it is "description", not "name" ("name" doesn't exist). See [inputs schema](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs).

##### Component Name

ci

##### Test Plan

Not needed

##### Additional Information
