### PR TITLE
Add Fedora 35 to CI.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -29,6 +29,7 @@ jobs:
           - 'debian:bullseye' # 11
           - 'debian:10'
           - 'debian:9'
+          - 'fedora:35'
           - 'fedora:34'
           - 'fedora:33'
           - 'opensuse/leap:15.2'
@@ -70,6 +71,8 @@ jobs:
             pre: 'apt-get update'
             rmjsonc: 'apt-get remove -y libjson-c-dev'
 
+          - distro: 'fedora:35'
+            rmjsonc: 'dnf remove -y json-c-devel'
           - distro: 'fedora:34'
             rmjsonc: 'dnf remove -y json-c-devel'
           - distro: 'fedora:33'

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -63,6 +63,9 @@ jobs:
           - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
           - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/arm/v7, arch: armhf}
           - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/arm64/v8, arch: arm64}
+          - {distro: fedora, version: "35", pkgclouddistro: fedora/35, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
+          - {distro: fedora, version: "35", pkgclouddistro: fedora/35, format: rpm, base_image: fedora, platform: linux/arm/v7, arch: armhf}
+          - {distro: fedora, version: "35", pkgclouddistro: fedora/35, format: rpm, base_image: fedora, platform: linux/arm64/v8, arch: arm64}
           - {distro: opensuse, version: "15.2", pkgclouddistro: opensuse/15.2, format: rpm, base_image: opensuse/leap, platform: linux/amd64, arch: amd64}
           - {distro: opensuse, version: "15.2", pkgclouddistro: opensuse/15.2, format: rpm, base_image: opensuse/leap, platform: linux/arm64/v8, arch: arm64}
           - {distro: opensuse, version: "15.3", pkgclouddistro: opensuse/15.3, format: rpm, base_image: opensuse/leap, platform: linux/amd64, arch: amd64}

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -27,6 +27,7 @@ jobs:
           - {distro: centos, version: "8", pkgclouddistro: el/8, format: rpm, base_image: centos, platform: linux/amd64, arch: amd64}
           - {distro: fedora, version: "33", pkgclouddistro: fedora/33, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
           - {distro: fedora, version: "34", pkgclouddistro: fedora/34, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
+          - {distro: fedora, version: "35", pkgclouddistro: fedora/35, format: rpm, base_image: fedora, platform: linux/amd64, arch: amd64}
           - {distro: opensuse, version: "15.2", pkgclouddistro: opensuse/15.2, format: rpm, base_image: opensuse/leap, platform: linux/amd64, arch: amd64}
           - {distro: opensuse, version: "15.3", pkgclouddistro: opensuse/15.3, format: rpm, base_image: opensuse/leap, platform: linux/amd64, arch: amd64}
       # We intentiaonally disable the fail-fast behavior so that a

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -34,6 +34,7 @@ jobs:
           - 'debian:bullseye' # 11
           - 'fedora:33'
           - 'fedora:34'
+          - 'fedora:35'
           - 'ubuntu:18.04'
           - 'ubuntu:20.04'
           - 'ubuntu:21.04'


### PR DESCRIPTION
##### Summary

Expected release date is 2021-11-02.

##### Component Name

area/ci

##### Test Plan

CI checks pass on this PR.

##### Additional Information

This ideally needs to be merged prior to our next stable release.