### PR TITLE
Explicitly opt out of LTO in RPM builds.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -15,6 +15,11 @@ AutoReqProv: yes
 # error.
 %global __os_install_post %{nil}
 
+# We don’t want LTO as it has a minimal performance impact at runtime
+# but a huge impact on build times (we want our CI to not take multiple
+# hours to finish).
+%global _lto_cflags %nil
+
 # Disable eBPF for architectures other than x86
 %ifarch x86_64 i386
 %global _have_ebpf 1


### PR DESCRIPTION
##### Summary

We are intentionally not using LTO by default in almost every case because it provides little to no performance improement for us and has a _huge_ impact on build times, which in turn results in our CI taking an unreasonably long time to run.

##### Component Name

area/packaging.

##### Test Plan

CI passes on this PR, and the Fedora package build jobs take less time to complete than they have on other PRs.

##### Additional Information

This is largely just bringing our RPM builds in-line with our other install methods.