### PR TITLE
Fix chart config overflow

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -699,11 +699,11 @@ RRDSET *rrdset_create_custom(
     // ------------------------------------------------------------------------
     // compose the config_section for this chart
 
-    char config_section[RRD_ID_LENGTH_MAX + 1];
+    char config_section[RRD_ID_LENGTH_MAX + GUID_LEN + 2];
     if(host == localhost)
         strcpy(config_section, fullid);
     else
-        snprintfz(config_section, RRD_ID_LENGTH_MAX, "%s/%s", host->machine_guid, fullid);
+        snprintfz(config_section, RRD_ID_LENGTH_MAX + GUID_LEN + 1, "%s/%s", host->machine_guid, fullid);
 
     // ------------------------------------------------------------------------
     // get the options from the config, we need to create it


### PR DESCRIPTION
##### Summary
Fix a chart config overflow if the `fullid` size is almost 200 characters

```
165cd67a-f141-4a5b-85fb-965fb7c34ba7/prometheus_prometheus-app_cloud-alarm-processor-service-0-5c5cd7d4fb-l8wwx_cloud-alarm-processor-service_tcp_8081.cloud_alarm_processor_repo_repo_delete_node_instance_alarms_duration_seconds_bucket
```
and

```
165cd67a-f141-4a5b-85fb-965fb7c34ba7/prometheus_prometheus-app_cloud-alarm-processor-service-0-5c5cd7d4fb-l8wwx_cloud-alarm-processor-service_tcp_8081.cloud_alarm_processor_repo_repo_delete_node_instance_alarms_duration_seconds_count
```
are truncated and mapped to the config 

```
165cd67a-f141-4a5b-85fb-965fb7c34ba7/prometheus_prometheus-app_cloud-alarm-processor-service-0-5c5cd7d4fb-l8wwx_cloud-alarm-processor-service_tcp_8081.cloud_alarm_processor_repo_repo_delete_node_inst
```

which causes

- `rrdset_set_name` to assign a different name to `st->name`
  - This is detected as "Chart metadata update" 
- Error `RRDSET: INTERNAL ERROR: attempted to index duplicate chart name XXXXX`


##### Component Name
agent

##### Test Plan
- Simple to verify that config is truncated with long names in a parent / child setup