### PR TITLE
Use submodules in Clang build checks.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Build
         run: |
           docker build -f .github/dockerfiles/Dockerfile.clang .


### PR DESCRIPTION
##### Summary

We need the sub-modules to be able to build properly.

##### Component Name

area/ci

##### Test Plan

Clang checks now pass properly.