### PR TITLE
Fix false poll timeout

### DIFF
--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -303,7 +303,8 @@ static int read_parse_response(https_req_ctx_t *ctx) {
                 error("Poll timed out");
                 return 2;
             }
-            continue;
+            if (!ctx->ssl_ctx)
+                continue;
         }
         ctx->poll_fd.events = 0;
 


### PR DESCRIPTION
##### Summary
During development of mock Cloud server for automated tests of ACLK this bug surfaced. We must call `SSL_read` in case of ssl connection even if raw socket poll returned no data as there might be data already decrypted in SSL buffer but not transfered to our ringbuffer yet.

This prevents us timing out here:
```
static int https_req_check_timedout(https_req_ctx_t *ctx) {
    if (now_realtime_sec() > ctx->req_start_time + ctx->request->timeout_s) {
        error("request timed out");
        return 1;
    }
    return 0;
}
```
in case there are data buffered in SSL but socket is done. (can happen if stars are aligned just right)

##### Component Name
aclk

##### Test Plan
You can test this using WebRick server on localhost to emulate env endpoint.

##### Additional Information
