### PR TITLE
Add support for local builds to the new kickstart script.

### DIFF
--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -1098,14 +1098,14 @@ while [ -n "${1}" ]; do
     "--reinstall") NETDATA_REINSTALL=1 ;;
     "--reinstall-even-if-unsafe") NETDATA_UNSAFE_REINSTALL=1 ;;
     "--claim-only") NETDATA_CLAIM_ONLY=1 ;;
-  "--disable-cloud") 
-    NETDATA_DISABLE_CLOUD=1
-    NETDATA_REQUIRE_CLOUD=0 
-  ;;
-  "--require-cloud")
-    NETDATA_DISABLE_CLOUD=0
-    NETDATA_REQUIRE_CLOUD=1 
-  ;;
+    "--disable-cloud")
+      NETDATA_DISABLE_CLOUD=1
+      NETDATA_REQUIRE_CLOUD=0
+      ;;
+    "--require-cloud")
+      NETDATA_DISABLE_CLOUD=0
+      NETDATA_REQUIRE_CLOUD=1
+      ;;
     "--dont-start-it")
       NETDATA_NO_START=1
       NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --dont-start-it"


### PR DESCRIPTION
##### Summary

This expands the new kickstart script that was added by #11493 to include support for installing using a local build (equivalent to the existing `kickstart.sh` script).

It includes the following features and updates:

* If installing using both native packages and static builds fail, an install will be attempted using a local build.
* Installation on macOS and FreeBSD should now work correctly and simply default to a local build. If run on either platform with the `--static-only` or `--native-only` options, the script will exit with an error explaining that that install type is not supported on that platform.
* A local build can be explicitly requested using the `--build-only` option.
* The `--install` option is handled, but explicitly limited to local builds (the script should fail if you try to use it without the above mentioned `--build-only` option.
* On macOS and FreeBSD, local builds will default to using a sane prefix for installation, specifically `/usr/local/netdata` for macOS, and `/usr/local` for FreeBSD).
* Reinstall handling now preserves the installation type, ensuring that the `--reinstall` option produces a usable system state.
* Claiming of existing installs now works for native package based installs.
* New `--disable-cloud` and `--require-cloud` options have been added. The require option works like the same option for `netdata-installer.sh` for local builds and acts as a no-op for static and native installs, while `--disabe-cloud` stops the cloud code from being built for local builds, and configures native and static installs to disable cloud support at runtime.
* A new environment variable, `NETDATA_INSTALLER_OPTIONS` has been added to allow explicitly passing options to the second-stage installer scripts used by the static and local builds. Options not handled by the kickstart script will still be passed on unmodified just like the old kickstart scripts do, but a warning will be logged for any such options encouraging users to use this environment variable instead.

Note that this is _still_ not a 100% complete version of the new kickstart script (at minimum, there will be one more PR before the one that pivots to using it as the default, which will add anonymous statistics reporting to the install process (which will properly honor `--disable-telemetry` and `$DO_NOT_TRACK`).

##### Component Name

area/packaging

##### Test Plan

No CI yet, it will be integrated as part of the PR that switches to using the new kickstart script as the default.

All the features listed above, plus all of those listed on #11493 should work as described.

##### Additional Information

Fixes: https://github.com/netdata/product/issues/2309
Fixes: https://github.com/netdata/product/issues/2310

Static installs with the stable channel are expected to fail currently, as the most recent stable release predates the changes to the artifact publishing code. This should start working again once v1.32.0 is released.