### PR TITLE
Fix build issue related to legacy aclk and new arch code

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -21,7 +21,6 @@ void sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae)
 
         if ((ae->new_status == RRDCALC_STATUS_WARNING || ae->new_status == RRDCALC_STATUS_CRITICAL) ||
             ((ae->old_status == RRDCALC_STATUS_WARNING || ae->old_status == RRDCALC_STATUS_CRITICAL))) {
-            error("HELLO");
             aclk_update_alarm(host, ae);
         }
         return;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR tries to solve a build issue a user has reported in https://github.com/netdata/netdata/issues/11652

The issue can be reproduced if you try to build current master without having the submodules needed (mqtt_websockets, aclk-schemas) in which case ACLK_NG can not be built.

The relevant code has been ifdef'ed to allow to build in all cases. The tricky bit is that the function `aclk_update_alarm(host, ae);` in `database/sqlite/sqlite_aclk_alert.c` needs to be called in most cases:

* ACLK legacy
* ACLK NG
* New architecture if proto has not been negotiated (and uses json).

##### Component Name

ACLK/Build/Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

To be properly tested, it needs to be checked with various different builds:

1) Skip any submodules (esp. mqtt_websockets) and falls back to legacy ACLK. Make sure it builds, claim to production cloud, and alerts appear in the cloud:

```
Features:
    dbengine:                   YES
    Native HTTPS:               YES
    Netdata Cloud:              YES 
    ACLK Next Generation:       NO
    ACLK-NG New Cloud Protocol: NO
    ACLK Legacy:                YES
    TLS Host Verification:      YES
```

2) Update submodules, and build. It should default to ACLK-NG. Claim to production cloud, and test for alerts to appear in the cloud:

```
Features:
    dbengine:                   YES
    Native HTTPS:               YES
    Netdata Cloud:              YES 
    ACLK Next Generation:       YES
    ACLK-NG New Cloud Protocol: YES
    ACLK Legacy:                YES
    TLS Host Verification:      YES
```

3) Use `--without-new-cloud-protocol` during configure (not yet supported in installer). Claim to production cloud, and test for alerts to appear in the cloud:

```
Features:
    dbengine:                   YES
    Native HTTPS:               YES
    Netdata Cloud:              YES 
    ACLK Next Generation:       YES
    ACLK-NG New Cloud Protocol: NO
    ACLK Legacy:                YES
    TLS Host Verification:      YES
```

4) It should also successfully build with `--disable-cloud`:

```
Features:
    dbengine:                   YES
    Native HTTPS:               YES
    Netdata Cloud:              NO (by user request)
    ACLK Next Generation:       NO
    ACLK-NG New Cloud Protocol: NO
    ACLK Legacy:                NO
    TLS Host Verification:      YES
```

##### Additional Information
