### PR TITLE
Add concurency limits on GHA workflows.

### DIFF
--- a/.github/workflows/build-and-install.yml
+++ b/.github/workflows/build-and-install.yml
@@ -7,6 +7,9 @@ on:
   pull_request: null
 env:
   DO_NOT_TRACK: 1
+concurrency:
+  group: builder-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   static-build:
     name: Static Build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,9 @@ on:
   pull_request: null
 env:
   DO_NOT_TRACK: 1
+concurrency:
+  group: checks-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   checksum-checks:
     name: Checksums

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,6 +10,9 @@ on:
       - coverity-scan.sh
 env:
   DO_NOT_TRACK: 1
+concurrency:
+  group: coverity-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   coverity:
     if: github.repository == 'netdata/netdata'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,9 @@ on:
         required: true
 env:
   DO_NOT_TRACK: 1
+concurrency:
+  group: docker-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 jobs:
   docker-test:
     name: Docker Runtime Test

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,9 @@ on:
     - cron: '*/5 * * * *'
 env:
   DO_NOT_TRACK: 1
+concurrency:
+  group: labeller
+  cancel-in-progress: true
 jobs:
   labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -17,6 +17,9 @@ on:
         required: false
 env:
   DO_NOT_TRACK: 1
+concurrency:
+  group: packages-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 jobs:
   build:
     name: Build

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,6 +9,9 @@ env:
   run_shellcheck: 0
   run_yamllint: 0
   DO_NOT_TRACK: 1
+concurrency:
+  group: review-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   eslint:
     name: eslint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ on:
       - '**.h'
 env:
   DO_NOT_TRACK: 1
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   unit-tests-legacy:
     name: Unit Tests (legacy)

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,6 +11,10 @@ on:
 env:
   DO_NOT_TRACK: 1
 
+concurrency:
+  group: updater-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   source-build:
     name: Install, Build & Update


### PR DESCRIPTION
##### Summary

This adds concurrency limiting to most of our GitHub Actions workflows, based on the native support for concurrency limits that got added to GitHub Actions since the last time I went looking for such functionality.

Only workflows that are automatically triggered _and_ expected to potentially experience concurrent runs for the same git reference have been modified in this PR. Workflows that are only expected to be manually run, or are never expected to have multiple concurrent instances running, are not modified.

##### Component Name

area/ci

##### Test Plan

Not easily testable. Only real option is to merge it and see what happens (we can easily revert it if things go wrong).

##### Additional information

See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency for information about the actual concurrency limiting functionality being used here.

The Docker and Packages workflows intentionally use not only the git ref but also the event type, as there are cases where they could be triggered concurrently on the same ref with different event types which we do not want to interfere with each other.

The PR labeller workflow intentionally uses a static concurrency group because it only ever runs on it’s own and does not care about the ref it0s running against.