### PR TITLE
Sanely handle installing on systems with limited RAM.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -404,7 +404,7 @@ if ${NEED_PROTOBUF} && [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
   mega="$((1000 * 1000))"
 
   if [ -n "${MAKEOPTS}" ]; then
-    proc_count="$(echo ${MAKEOPTS} | grep -oE '-j *[[:digit:]]+' | tr -d '-j ')"
+    proc_count="$(echo ${MAKEOPTS} | grep -oE '-j *[[:digit:]]+' | tr -d '\-j ')"
   else
     proc_count="$(find_processors)"
   fi
@@ -426,14 +426,18 @@ if ${NEED_PROTOBUF} && [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
       if [ -n "${SKIP_RAM_CHECK}" ]; then
         MAKEOPTS=""
       else
-        run_failed "Netdata needs at least ${target_ram} bytes of RAM to safely install, but this system only has ${total_ram} bytes."
+        target_ram="$(echo "${target_ram}" | awk '{$1/=1000*1000*1000;printf "%.2fGB\n",$1}')"
+        total_ram="$(echo "${total_ram}" | awk '{$1/=1000*1000*1000;printf "%.2fGB\n",$1}')"
+        run_failed "Netdata needs at least ${target_ram} of RAM to safely install, but this system only has ${total_ram}."
         run_failed "Insufficient RAM available for an install. Try building with the '--use-system-protobuf' flag."
         exit 2
       fi
     fi
   else
     if [ "${target_ram}" -gt "${total_ram}" ] && [ -z "${SKIP_RAM_CHECK}" ]; then
-      run_failed "Netdata needs ${target_ram} bytes of RAM to safely install, but this system only has ${total_ram} bytes."
+      target_ram="$(echo "${target_ram}" | awk '{$1/=1000*1000*1000;printf "%.2fGB\n",$1}')"
+      total_ram="$(echo "${total_ram}" | awk '{$1/=1000*1000*1000;printf "%.2fGB\n",$1}')"
+      run_failed "Netdata needs ${target_ram} of RAM to safely install, but this system only has ${total_ram}."
       run_failed "Insufficient RAM available for an install. Try reducing the number of processes used for the install using the \$MAKEOPTS variable."
       exit 2
     fi

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -398,9 +398,9 @@ fi
 NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//  / }"
 
 if [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
-  mega="$((1000 * 1000))"
-  base=1000
-  scale=250
+  mega="$((1024 * 1023))"
+  base=1024
+  scale=256
 
   if [ -n "${MAKEOPTS}" ]; then
     proc_count="$(echo ${MAKEOPTS} | grep -oE '\-j *[[:digit:]]+' | tr -d '\-j ')"
@@ -427,8 +427,8 @@ if [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
     done
   else
     if [ "${target_ram}" -gt "${total_ram}" ] && [ "${proc_count}" -gt 1 ] && [ -z "${SKIP_RAM_CHECK}" ]; then
-      target_ram="$(echo "${target_ram}" | awk '{$1/=1000*1000*1000;printf "%.2fGB\n",$1}')"
-      total_ram="$(echo "${total_ram}" | awk '{$1/=1000*1000*1000;printf "%.2fGB\n",$1}')"
+      target_ram="$(echo "${target_ram}" | awk '{$1/=1024*1024*1024;printf "%.2fGiB\n",$1}')"
+      total_ram="$(echo "${total_ram}" | awk '{$1/=1024*1024*1024;printf "%.2fGiB\n",$1}')"
       run_failed "Netdata needs ${target_ram} of RAM to safely install, but this system only has ${total_ram}."
       run_failed "Insufficient RAM available for an install. Try reducing the number of processes used for the install using the \$MAKEOPTS variable."
       exit 2

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -419,7 +419,7 @@ if ${NEED_PROTOBUF} && [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
 
     if [ "${proc_count}" -lt 1 ]; then
       run_failed "Netdata needs at least ${target_ram} bytes of RAM to safely install, but this system only has ${total_ram} bytes."
-      run_failed "Insufficient RAM available for an install. Possibly try building with the '--use-system-protobuf' flag."
+      run_failed "Insufficient RAM available for an install. Try building with the '--use-system-protobuf' flag."
       exit 2
     fi
   else

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -398,7 +398,7 @@ fi
 NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//  / }"
 
 if [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
-  mega="$((1024 * 1023))"
+  mega="$((1024 * 1024))"
   base=1024
   scale=256
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -409,6 +409,7 @@ if ${NEED_PROTOBUF} && [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
 
   target_ram="$((1500 * mega + (250 * mega * proc_count)))"
   total_ram="$(grep MemTotal /proc/meminfo | cut -d ':' -f 2 | tr -d ' kB')"
+  total_ram="$((total_ram * 1024))"
 
   if [ -z "${MAKEOPTS}" ]; then
     while [ "${target_ram}" -gt "${total_ram}" ] && [ "${proc_count}" -gt 0 ]; do

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -407,14 +407,16 @@ if ${NEED_PROTOBUF} && [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
     proc_count="$(find_processors)"
   fi
 
-  target_ram="$((1500 * mega + (250 * mega * proc_count)))"
+  target_ram="$((1500 * mega + (250 * mega * (proc_count - 1))))"
   total_ram="$(grep MemTotal /proc/meminfo | cut -d ':' -f 2 | tr -d ' kB')"
   total_ram="$((total_ram * 1024))"
 
   if [ -z "${MAKEOPTS}" ]; then
+    MAKEOPTS="-j${proc_count}"
+
     while [ "${target_ram}" -gt "${total_ram}" ] && [ "${proc_count}" -gt 0 ]; do
       proc_count="$((proc_count - 1))"
-      target_ram="$((1500 * mega + (250 * mega * proc_count)))"
+      target_ram="$((1500 * mega + (250 * mega * (proc_count - 1))))"
       MAKEOPTS="-j${proc_count}"
     done
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -418,14 +418,14 @@ if ${NEED_PROTOBUF} && [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
     done
 
     if [ "${proc_count}" -lt 1 ]; then
-      warning "Netdata needs at least ${target_ram} bytes of RAM to safely install, but this system only has ${total_ram} bytes."
-      warning "Insufficient RAM available for an install."
+      run_failed "Netdata needs at least ${target_ram} bytes of RAM to safely install, but this system only has ${total_ram} bytes."
+      run_failed "Insufficient RAM available for an install. Possibly try building with the '--use-system-protobuf' flag."
       exit 2
     fi
   else
     if [ "${target_ram}" -gt "${total_ram}" ]; then
-      warning "Netdata needs ${target_ram} bytes of RAM to safely install, but this system only has ${total_ram} bytes."
-      warning "Insufficient RAM available for an install. Try reducing the number of processes used for the install using the \$MAKEOPTS variable."
+      run_failed "Netdata needs ${target_ram} bytes of RAM to safely install, but this system only has ${total_ram} bytes."
+      run_failed "Insufficient RAM available for an install. Try reducing the number of processes used for the install using the \$MAKEOPTS variable."
       exit 2
     fi
   fi

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -419,12 +419,14 @@ if ${NEED_PROTOBUF} && [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
 
     if [ "${proc_count}" -lt 1 ]; then
       warning "Netdata needs at least ${target_ram} bytes of RAM to safely install, but this system only has ${total_ram} bytes."
-      fatal "Insufficient RAM available for an install."
+      warning "Insufficient RAM available for an install."
+      exit 2
     fi
   else
     if [ "${target_ram}" -gt "${total_ram}" ]; then
       warning "Netdata needs ${target_ram} bytes of RAM to safely install, but this system only has ${total_ram} bytes."
-      fatal "Insufficient RAM available for an install. Try reducing the number of processes used for the install using the \$MAKEOPTS variable."
+      warning "Insufficient RAM available for an install. Try reducing the number of processes used for the install using the \$MAKEOPTS variable."
+      exit 2
     fi
   fi
 fi

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -404,7 +404,7 @@ if ${NEED_PROTOBUF} && [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
   mega="$((1000 * 1000))"
 
   if [ -n "${MAKEOPTS}" ]; then
-    proc_count="$(echo ${MAKEOPTS} | grep -oE '-j *[[:digit:]]+' | tr -d '\-j ')"
+    proc_count="$(echo ${MAKEOPTS} | grep -oE '\-j *[[:digit:]]+' | tr -d '\-j ')"
   else
     proc_count="$(find_processors)"
   fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -107,7 +107,7 @@ telemetry_event() {
   if [ "${KERNEL_NAME}" = FreeBSD ]; then
     TOTAL_RAM="$(sysctl -n hw.physmem)"
   elif [ "${KERNEL_NAME}" = Darwin ]; then
-    TOTAL_RAM="$(sysctl -n hw.physmem)"
+    TOTAL_RAM="$(sysctl -n hw.memsize)"
   elif [ -r /proc/meminfo ]; then
     TOTAL_RAM="$(grep -F MemTotal /proc/meminfo | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | cut -f 1 -d ' ')"
     TOTAL_RAM="$((TOTAL_RAM * 1024))"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Run me with:

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -515,7 +515,7 @@ if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
   fi
 fi
 
-# shellcheck disable=SC2235,SC2030
+# shellcheck disable=SC2235,SC2030,SC2031
 if ( [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_URL}" ] ) || ( [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ -z "${NETDATA_CLAIM_URL}" ] ); then
   run_failed "Invalid claiming options, both a claiming token and URL must be specified."
   exit 1
@@ -558,12 +558,10 @@ if [ -n "$ndpath" ] ; then
           exit 0
         else
           fatal "Failed to update existing Netdata install" F0100
-          exit 1
         fi
       else
         if [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] || [ "${ndstatic}" = "yes" ] ; then
           fatal "Existing installation detected which cannot be safely updated by this script. Refusing to continue." F0101
-          exit 1
         else
           progress "User explicitly requested duplicate install, proceeding."
         fi
@@ -573,7 +571,6 @@ if [ -n "$ndpath" ] ; then
         progress "User requested reinstall instead of update, proceeding."
       else
         fatal "Existing install is a static install. Please use kickstart-static64.sh instead." F0102
-        exit 1
       fi
     fi
   else
@@ -587,7 +584,6 @@ if [ -n "$ndpath" ] ; then
       exit $?
     elif [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] ; then
       fatal "Existing installation detected which cannot be safely updated by this script. Refusing to continue." F0103
-      exit 1
     else
       progress "User explicitly requested duplicate install, proceeding."
     fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -102,6 +102,8 @@ telemetry_event() {
     fi
   fi
 
+  KERNEL_NAME="$(name -s)"
+
   if [ "${KERNEL_NAME}" = FreeBSD ]; then
     TOTAL_RAM="$(sysctl -n hw.physmem)"
   elif [ "${KERNEL_NAME}" = Darwin ]; then
@@ -141,7 +143,7 @@ telemetry_event() {
     "host_os_id_like": "${HOST_ID_LIKE:-unknown}",
     "host_os_version": "${HOST_VERSION:-unknown}",
     "host_os_version_id": "${HOST_VERSION_ID:-unknown}",
-    "system_kernel_name": "$(uname -s)",
+    "system_kernel_name": "${KERNEL_NAME}",
     "system_kernel_version": "$(uname -r)",
     "system_architecture": "$(uname -m)",
     "system_total_ram": "${TOTAL_RAM:-unknown}"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -102,7 +102,7 @@ telemetry_event() {
     fi
   fi
 
-  KERNEL_NAME="$(name -s)"
+  KERNEL_NAME="$(uname -s)"
 
   if [ "${KERNEL_NAME}" = FreeBSD ]; then
     TOTAL_RAM="$(sysctl -n hw.physmem)"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -560,7 +560,7 @@ if [ -n "$ndpath" ] ; then
         fi
       else
         if [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] || [ "${ndstatic}" = "yes" ] ; then
-          fatal "Existing installation detected which cannot be safely updated by this script, refusing to continue." F0101
+          fatal "Existing installation detected which cannot be safely updated by this script. Refusing to continue." F0101
           exit 1
         else
           progress "User explicitly requested duplicate install, proceeding."
@@ -570,7 +570,7 @@ if [ -n "$ndpath" ] ; then
       if [ "${ndstatic}" = "no" ] ; then
         progress "User requested reinstall instead of update, proceeding."
       else
-        fatal "Existing install is a static install, please use kickstart-static64.sh instead." F0102
+        fatal "Existing install is a static install. Please use kickstart-static64.sh instead." F0102
         exit 1
       fi
     fi
@@ -584,7 +584,7 @@ if [ -n "$ndpath" ] ; then
       claim
       exit $?
     elif [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] ; then
-      fatal "Existing installation detected which cannot be safely updated by this script, refusing to continue." F0103
+      fatal "Existing installation detected which cannot be safely updated by this script. Refusing to continue." F0103
       exit 1
     else
       progress "User explicitly requested duplicate install, proceeding."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -16,6 +16,7 @@
 #  --local-files              set the full path of the desired tarball to run install with
 #  --allow-duplicate-install  do not bail if we detect a duplicate install
 #  --reinstall                if an existing install would be updated, reinstall instead
+#  --disable-telemetry        opt out of anonymous statistics
 #  --claim-token              specify a token to use for claiming the newly installed instance
 #  --claim-url                specify a URL to use for claiming the newly installed isntance
 #  --claim-rooms              specify a list of rooms to claim the newly installed instance to
@@ -42,6 +43,10 @@ PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packag
 
 # Netdata Tarball Base URL (defaults to our Google Storage Bucket)
 [ -z "$NETDATA_TARBALL_BASEURL" ] && NETDATA_TARBALL_BASEURL=https://storage.googleapis.com/netdata-nightlies
+
+TELEMETRY_URL="https://posthog.netdata.cloud/capture/"
+TELEMETRY_API_KEY="${NETDATA_POSTHOG_API_KEY:-mqkwGT0JNFqO-zX2t0mW6Tec9yooaVu7xCBlXtHnt5Y}"
+KICKSTART_OPTIONS="${*}"
 
 # ---------------------------------------------------------------------------------------------------------------------
 # library functions copied from packaging/installer/functions.sh
@@ -76,8 +81,91 @@ setup_terminal() {
 setup_terminal || echo > /dev/null
 
 # -----------------------------------------------------------------------------
+telemetry_event() {
+  if [ -n "${NETDATA_DISABLE_TELEMETRY}" ]; then
+    return 0
+  fi
+
+  if [ -e "/etc/os-release" ]; then
+    eval "$(grep -E "^(NAME|ID|ID_LIKE|VERSION|VERSION_ID)=" < /etc/os-release | sed 's/^/HOST_/')"
+  fi
+
+  if [ -z "${HOST_NAME}" ] || [ -z "${HOST_VERSION}" ] || [ -z "${HOST_ID}" ]; then
+    if [ -f "/etc/lsb-release" ]; then
+      DISTRIB_ID="unknown"
+      DISTRIB_RELEASE="unknown"
+      DISTRIB_CODENAME="unknown"
+      eval "$(grep -E "^(DISTRIB_ID|DISTRIB_RELEASE|DISTRIB_CODENAME)=" < /etc/lsb-release)"
+      if [ -z "${HOST_NAME}" ]; then HOST_NAME="${DISTRIB_ID}"; fi
+      if [ -z "${HOST_VERSION}" ]; then HOST_VERSION="${DISTRIB_RELEASE}"; fi
+      if [ -z "${HOST_ID}" ]; then HOST_ID="${DISTRIB_CODENAME}"; fi
+    fi
+  fi
+
+  if [ "${KERNEL_NAME}" = FreeBSD ]; then
+    TOTAL_RAM="$(sysctl -n hw.physmem)"
+  elif [ "${KERNEL_NAME}" = Darwin ]; then
+    TOTAL_RAM="$(sysctl -n hw.physmem)"
+  elif [ -r /proc/meminfo ]; then
+    TOTAL_RAM="$(grep -F MemTotal /proc/meminfo | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | cut -f 1 -d ' ')"
+    TOTAL_RAM="$((TOTAL_RAM * 1024))"
+  fi
+
+  if [ -f /etc/machine-id ]; then
+    DISTINCT_ID="$(cat /etc/machine-id)"
+  elif command -v uuidgen 2> /dev/null; then
+    DISTINCT_ID="$(uuidgen)"
+  else
+    DISTINCT_ID="null"
+  fi
+
+  REQ_BODY="$(cat << EOF
+{
+  "api_key": "${TELEMETRY_API_KEY}",
+  "event": "${1}",
+  "properties": {
+    "distinct_id": "${DISTINCT_ID}",
+    "event_source": "agent installer",
+    "\$current_url": "agent installer",
+    "\$pathname": "netdata-installer",
+    "\$host": "installer.netdata.io",
+    "\$ip": "127.0.0.1",
+    "script_variant": "legacy-kickstart",
+    "error_code": "${2}",
+    "error_message": "${3}",
+    "install_options": "${KICKSTART_OPTIONS}",
+    "netdata_release_channel": "${RELEASE_CHANNEL:-null}",
+    "netdata_install_type": "kickstart-build",
+    "host_os_name": "${HOST_NAME:-unknown}",
+    "host_os_id": "${HOST_ID:-unknown}",
+    "host_os_id_like": "${HOST_ID_LIKE:-unknown}",
+    "host_os_version": "${HOST_VERSION:-unknown}",
+    "host_os_version_id": "${HOST_VERSION_ID:-unknown}",
+    "system_kernel_name": "$(uname -s)",
+    "system_kernel_version": "$(uname -r)",
+    "system_architecture": "$(uname -m)",
+    "system_total_ram": "${TOTAL_RAM:-unknown}"
+  }
+}
+EOF
+)"
+
+if [ -n "$(command -v curl 2> /dev/null)" ]; then
+  curl --silent -o /dev/null --write-out '%{http_code}' -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" "${TELEMETRY_URL}"
+else
+  wget -q -O - --no-check-certificate \
+  --server-response \
+  --method POST \
+  --timeout=1 \
+  --header 'Content-Type: application/json' \
+  --body-data "${REQ_BODY}" \
+   "${TELEMETRY_URL}" 2>&1 | awk '/^  HTTP/{print $2}'
+fi
+}
+
 fatal() {
-  printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
+  printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${1} \n\n"
+  telemetry_event "INSTALL_FAILED" "${1}" "${2}"
   exit 1
 }
 
@@ -142,15 +230,10 @@ run() {
   return ${ret}
 }
 
-fatal() {
-  printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*} \n\n"
-  exit 1
-}
-
 warning() {
   printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*} \n\n"
   if [ "${INTERACTIVE}" = "0" ]; then
-    fatal "Stopping due to non-interactive mode. Fix the issue or retry installation in an interactive mode."
+    fatal "Stopping due to non-interactive mode. Fix the issue or retry installation in an interactive mode." F0001
   else
     read -r -p "Press ENTER to attempt netdata installation > "
     progress "OK, let's give it a try..."
@@ -200,11 +283,11 @@ download() {
   url="${1}"
   dest="${2}"
   if command -v curl > /dev/null 2>&1; then
-    run curl -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}"
+    run curl -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}" || fatal "Cannot download ${url}" F0002
   elif command -v wget > /dev/null 2>&1; then
-    run wget -T 15 -O "${dest}" "${url}" || fatal "Cannot download ${url}"
+    run wget -T 15 -O "${dest}" "${url}" || fatal "Cannot download ${url}" F0002
   else
-    fatal "I need curl or wget to proceed, but neither is available on this system."
+    fatal "I need curl or wget to proceed, but neither is available on this system." F0003
   fi
 }
 
@@ -268,7 +351,7 @@ dependencies() {
       if [ -f "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" ]; then
         run cp "${NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT}" "${ndtmpdir}/install-required-packages.sh"
       else
-        fatal "Invalid given dependency file, please check your --local-files parameter options and try again"
+        fatal "Invalid given dependency file, please check your --local-files parameter options and try again" F1001
       fi
     else
       download "${PACKAGES_SCRIPT}" "${ndtmpdir}/install-required-packages.sh"
@@ -296,7 +379,7 @@ safe_sha256sum() {
   elif command -v shasum > /dev/null 2>&1; then
     shasum -a 256 "$@"
   else
-    fatal "I could not find a suitable checksum binary to use"
+    fatal "I could not find a suitable checksum binary to use" F0004
   fi
 }
 
@@ -374,33 +457,37 @@ while [ -n "${1}" ]; do
       NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --disable-cloud"
       NETDATA_DISABLE_CLOUD=1
       ;;
+    "--disable-telemetry")
+      NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --disable-telemetry"
+      NETDATA_DISABLE_TELEMETRY=1
+      ;;
     "--local-files")
       if [ -z "${2}" ]; then
-        fatal "Missing netdata: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
+        fatal "Missing netdata: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order" F1002
       fi
 
       export NETDATA_LOCAL_TARBALL_OVERRIDE="${2}"
 
       if [ -z "${3}" ]; then
-        fatal "Missing checksum file: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
+        fatal "Missing checksum file: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order" F1003
       fi
 
       export NETDATA_LOCAL_TARBALL_OVERRIDE_CHECKSUM="${3}"
 
       if [ -z "${4}" ]; then
-        fatal "Missing go.d tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
+        fatal "Missing go.d tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order" F1004
       fi
 
       export NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN="${4}"
 
       if [ -z "${5}" ]; then
-        fatal "Missing go.d config tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
+        fatal "Missing go.d config tarball: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order" F1005
       fi
 
       export NETDATA_LOCAL_TARBALL_OVERRIDE_GO_PLUGIN_CONFIG="${5}"
 
       if [ -z "${6}" ]; then
-        fatal "Missing dependencies management scriptlet: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order"
+        fatal "Missing dependencies management scriptlet: Option --local-files requires extra information. The desired tarball for netdata, the checksum, the go.d plugin tarball , the go.d plugin config tarball and the dependency management script, in this particular order" F1006
       fi
 
       export NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT="${6}"
@@ -468,12 +555,12 @@ if [ -n "$ndpath" ] ; then
           progress "Updated existing install at ${ndpath}"
           exit 0
         else
-          fatal "Failed to update existing Netdata install"
+          fatal "Failed to update existing Netdata install" F0100
           exit 1
         fi
       else
         if [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] || [ "${ndstatic}" = "yes" ] ; then
-          fatal "Existing installation detected which cannot be safely updated by this script, refusing to continue."
+          fatal "Existing installation detected which cannot be safely updated by this script, refusing to continue." F0101
           exit 1
         else
           progress "User explicitly requested duplicate install, proceeding."
@@ -483,7 +570,7 @@ if [ -n "$ndpath" ] ; then
       if [ "${ndstatic}" = "no" ] ; then
         progress "User requested reinstall instead of update, proceeding."
       else
-        fatal "Existing install is a static install, please use kickstart-static64.sh instead."
+        fatal "Existing install is a static install, please use kickstart-static64.sh instead." F0102
         exit 1
       fi
     fi
@@ -497,7 +584,7 @@ if [ -n "$ndpath" ] ; then
       claim
       exit $?
     elif [ -z "${NETDATA_ALLOW_DUPLICATE_INSTALL}" ] ; then
-      fatal "Existing installation detected which cannot be safely updated by this script, refusing to continue."
+      fatal "Existing installation detected which cannot be safely updated by this script, refusing to continue." F0103
       exit 1
     else
       progress "User explicitly requested duplicate install, proceeding."
@@ -528,18 +615,26 @@ else
 fi
 
 if ! grep netdata-latest.tar.gz "${ndtmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-  fatal "Tarball checksum validation failed. Stopping Netdata Agent installation and leaving tarball in ${ndtmpdir}.\nUsually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour."
+  fatal "Tarball checksum validation failed. Stopping Netdata Agent installation and leaving tarball in ${ndtmpdir}.\nUsually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0005
 fi
 run tar -xf netdata-latest.tar.gz
 rm -rf netdata-latest.tar.gz > /dev/null 2>&1
-cd netdata-* || fatal "Cannot cd to netdata source tree"
+cd netdata-* || fatal "Cannot cd to netdata source tree" F0006
 
 # ---------------------------------------------------------------------------------------------------------------------
 # install netdata from source
 
 install() {
   progress "Installing netdata..."
-  run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS} || fatal "netdata-installer.sh exited with error"
+  run ${sudo} ./netdata-installer.sh ${NETDATA_UPDATES} ${NETDATA_INSTALLER_OPTIONS}
+  case $? in
+    1)
+      fatal "netdata-installer.sh exited with error" F0007
+      ;;
+    2)
+      fatal "Insufficient RAM to install netdata" F0008
+      ;;
+  esac
   if [ -d "${ndtmpdir}" ] && [ ! "${ndtmpdir}" = "/" ]; then
     run ${sudo} rm -rf "${ndtmpdir}" > /dev/null 2>&1
   fi
@@ -552,7 +647,7 @@ else
   if [ "$(find . -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ] && [ -x "$(find . -mindepth 1 -maxdepth 1 -type d)/netdata-installer.sh" ]; then
     cd "$(find . -mindepth 1 -maxdepth 1 -type d)" && install "$@"
   else
-    fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${ndtmpdir}"
+    fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${ndtmpdir}" F0009
     exit 1
   fi
 fi

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -96,7 +96,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "490d76882af424f62f8f548f47ef2a72" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "9e33680cf2d6d37233726729836fea9d" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -96,7 +96,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "3af8091f8949f957c32abb0bd6160d5e" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "490d76882af424f62f8f548f47ef2a72" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -96,7 +96,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "f06c7a867c2ab4cbcbe66c89b9fa26e0" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "8f6a4bce801161f2497dee86b8c6bed3" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -96,7 +96,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "146d9b21dc692e93b3856da92aa46b7e" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "f06c7a867c2ab4cbcbe66c89b9fa26e0" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -96,7 +96,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "8f6a4bce801161f2497dee86b8c6bed3" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "3af8091f8949f957c32abb0bd6160d5e" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

This adds checks to our installer script to sanely handle installation on systems with limited RAM. By default, it involves the following specific behavior:

* If the system has less than 1GB of RAM, disable the ML code by default.
* If the user has specified a number of jobs to use in `MAKEOPTS`, check to see if we have enough RAM (defined as 1.25GB for `-j2`, +250MB per additional CPU core used beyond 2) and refuse to build if we don’t. This is _probably_ more aggressive than it needs to be, but that should not be an issue in most cases.
* If the user did not specify a number of jobs to use in `MAKEOPTS`, use the total amount of RAM in the system to try to decide on a sane default (1 job for anything with 1GB or less, one additiona job for every 250MB above that).

This also adds telemetry for installation failures so that we can see how often and in what ways the install is failing. This new telemetry still honors the `--disable-telemetry` option properly.

The actual reported event is relatively similar to the META events the agent sends from time to time, with the following differences:

* The event type is `INSTALL_FAILED`.
* The current URL, pathname, host, and event source are updated to reflect the event comming from the installer.
* The `distinct_id` does not use the Netdata Agent’s registry ID as that is (usually) not going to be available, instead using the contents of `/etc/machine-id`, falling back to `uuidgen` if that does not exist, and a value of `null` if neither works.
* Only a subset of the other properties in the META event are provided.
* Four new properties are added:
   - `script_variant`: Indicates which install script the event came from. This will be used to differentiate between events from the existing kickstart script and the new kickstart script.
   - `error_code`: Provides a short, easily searchable code to aid in diagnosing the failure. This is unique to the particular failure type, and is expected to be time invariant (IOW, once assigned, it _will not_ change for a given failure case).
   - `error_message`: The actual error message that was shown to the user.
   - `install_options`: The full list of options passed to the kickstart script.

##### Component Name

area/packaging

##### Test Plan

RAM checking code verified locally in VMs with varying amounts of memory and CPUs.

New telemetry code was tested specifically using the `--local-files` option with no arguments, with the API key for the PostHog testing project set in the `NETDATA_POSTHOG_API_KEY` environment variable.