### PR TITLE
Optimize static build and update various dependencies.

### DIFF
--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -19,7 +19,7 @@ case ${BUILDARCH} in
     ;;
 esac
 
-DOCKER_CONTAINER_NAME="netdata-package-${BUILDARCH}-static-alpine312"
+DOCKER_CONTAINER_NAME="netdata-package-${BUILDARCH}-static-alpine314"
 
 if [ "${BUILDARCH}" != "$(uname -m)" ]; then
     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
@@ -39,12 +39,12 @@ if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
   # inside the container and runs the script install-alpine-packages.sh
   # (also inside the container)
   #
-  if docker inspect alpine:3.12 > dev/null 2>&1; then
-    run docker image remove alpine:3.12
-    run docker pull --platform=${platform}  alpine:3.12
+  if docker inspect alpine:3.14 > dev/null 2>&1; then
+    run docker image remove alpine:3.14
+    run docker pull --platform=${platform}  alpine:3.14
   fi
 
-  run docker run --platform=${platform} -v "$(pwd)":/usr/src/netdata.git:rw alpine:3.12 \
+  run docker run --platform=${platform} -v "$(pwd)":/usr/src/netdata.git:rw alpine:3.14 \
     /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh
 
   # save the changes made permanently

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -34,20 +34,10 @@ apk add --no-cache -U \
   pkgconfig \
   protobuf-dev \
   snappy-dev \
+  snappy-static \
   util-linux-dev \
   wget \
   xz \
   zlib-dev \
   zlib-static ||
   exit 1
-
-# snappy doesn't have static version in alpine, let's compile it
-export SNAPPY_VER="1.1.7"
-wget -O /snappy.tar.gz https://github.com/google/snappy/archive/${SNAPPY_VER}.tar.gz
-tar -C / -xf /snappy.tar.gz
-rm /snappy.tar.gz
-cd /snappy-${SNAPPY_VER} || exit 1
-mkdir build
-cd build || exit 1
-cmake -DCMAKE_BUILD_SHARED_LIBS=true -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR=lib ../
-make && make install

--- a/packaging/makeself/jobs/50-bash-5.1.8.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.1.8.install.sh
@@ -4,7 +4,7 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-fetch "bash-5.0" "http://ftp.gnu.org/gnu/bash/bash-5.0.tar.gz"
+fetch "bash-5.1.8" "http://ftp.gnu.org/gnu/bash/bash-5.1.8.tar.gz"
 
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 


### PR DESCRIPTION
##### Summary

The big thing in this is the bump from Alpine 3.12 to Alpine 3.14 for the static build environment. Travis has finally updated to new enough versions of Ubuntu and Docker that we can use recent Alpine images. This change means that we no longer need to build a copy of Snappy as part of the setup process for static builds, which speeds up the build process somewhat.

This also updates Bash from 5.0 to 5.1.8.

##### Component Name

area/packaging

##### Test Plan

CI passes correctly on this PR.