### PR TITLE
Add snapshot message for cloud new architecture

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -25,6 +25,8 @@
 
 int aclk_pubacks_per_conn = 0; // How many PubAcks we got since MQTT conn est.
 
+int aclk_alert_reloaded = 1; //1 on startup, and again on health_reload
+
 time_t aclk_block_until = 0;
 
 aclk_env_t *aclk_env = NULL;

--- a/aclk/aclk_api.h
+++ b/aclk/aclk_api.h
@@ -18,6 +18,7 @@ extern int aclk_disable_runtime;
 extern int aclk_disable_single_updates;
 
 extern int aclk_stats_enabled;
+extern int aclk_alert_reloaded;
 
 extern int aclk_ng;
 

--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -398,6 +398,17 @@ void aclk_handle_new_cloud_msg(const char *message_type, const char *msg, size_t
         freez(config_hash);
         return;
     }
+    if (!strcmp(message_type, "SendAlarmSnapshot")) {
+        struct send_alarm_snapshot *sas = parse_send_alarm_snapshot(msg, msg_len);
+        if (!sas->node_id || !sas->claim_id) {
+            error("Error parsing SendAlarmSnapshot");
+            destroy_send_alarm_snapshot(sas);
+            return;
+        }
+        aclk_process_send_alarm_snapshot(sas->node_id, sas->claim_id, sas->snapshot_id, sas->sequence_id);
+        destroy_send_alarm_snapshot(sas);
+        return;
+    }
     error ("Unknown new cloud arch message type received \"%s\"", message_type);
 }
 #endif

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -412,6 +412,10 @@ void aclk_database_worker(void *arg)
                     debug(D_ACLK_SYNC, "Pushing alarm health log to the cloud for %s", wc->host_guid);
                     aclk_push_alarm_health_log(wc, cmd);
                     break;
+                case ACLK_DATABASE_PUSH_ALERT_SNAPSHOT:
+                    debug(D_ACLK_SYNC, "Pushing alert snapshot to the cloud for node %s", wc->host_guid);
+                    aclk_push_alert_snapshot_event(wc, cmd);
+                    break;
 
 // NODE OPERATIONS
                 case ACLK_DATABASE_NODE_INFO:

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -124,6 +124,7 @@ enum aclk_database_opcode {
     ACLK_DATABASE_NODE_INFO,
     ACLK_DATABASE_PUSH_ALERT,
     ACLK_DATABASE_PUSH_ALERT_CONFIG,
+    ACLK_DATABASE_PUSH_ALERT_SNAPSHOT,
     ACLK_DATABASE_PUSH_CHART,
     ACLK_DATABASE_PUSH_CHART_CONFIG,
     ACLK_DATABASE_RESET_CHART,
@@ -170,6 +171,8 @@ struct aclk_database_worker_config {
     uint64_t alerts_batch_id; // batch id for alerts to use
     uint64_t alerts_start_seq_id; // cloud has asked to start streaming from
     uint64_t alert_sequence_id; // last alert sequence_id
+    uint64_t alerts_snapshot_id; //will contain the snapshot_id value if snapshot was requested
+    uint64_t alerts_ack_sequence_id; //last sequence_id ack'ed from cloud via sendsnapshot message
     uv_loop_t *loop;
     RRDHOST *host;
     uv_async_t async;

--- a/database/sqlite/sqlite_aclk_alert.h
+++ b/database/sqlite/sqlite_aclk_alert.h
@@ -13,5 +13,7 @@ void aclk_send_alarm_configuration (char *config_hash);
 int aclk_push_alert_config_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_start_alert_streaming(char *node_id, uint64_t batch_id, uint64_t start_seq_id);
 int sql_queue_removed_alerts_to_aclk(RRDHOST *host);
+void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
+void aclk_process_send_alarm_snapshot(char *node_id, char *claim_id, uint64_t snapshot_id, uint64_t sequence_id);
 
 #endif //NETDATA_SQLITE_ACLK_ALERT_H

--- a/health/health.c
+++ b/health/health.c
@@ -230,6 +230,9 @@ void health_reload(void) {
     if (netdata_cloud_setting) {
         aclk_single_update_enable();
         aclk_alarm_reload();
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
+        aclk_alert_reloaded = 1;
+#endif
     }
 #endif
 }
@@ -1034,6 +1037,13 @@ void *health_main(void *ptr) {
 
                 rrdhost_unlock(host);
             }
+
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
+            if (aclk_alert_reloaded) {
+                sql_queue_removed_alerts_to_aclk(host);
+                aclk_alert_reloaded = 0;
+            }
+#endif
 
             if (unlikely(netdata_exit))
                 break;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds the Alert Snapshot message for the new cloud architecture.

When the agent receives a `SendAlarmSnapshot` message from the cloud, it responds with one or more (broken in chunks) `AlarmSnapshot` messages.

These contain the last non updated Alarm Log Entries for every alarm currently in the system (except those in status Uninitialised).

It also adds a call to `sql_queue_removed_alerts_to_aclk` function in the health loop. This gets triggered on either restart or after health reload, after the first pass of the health loop. Any leftover alarm entries in status REMOVED will be queued to be sent to cloud.

The code is currently under feature flag.

##### Component Name

Health/ACLK

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Initial tests have been done with the cloud backend, on stress environment.

##### Additional Information
