### PR TITLE
fix swap_used alarm calc

### DIFF
--- a/health/health.d/swap.conf
+++ b/health/health.d/swap.conf
@@ -25,7 +25,7 @@ component: Memory
 component: Memory
        os: linux freebsd
     hosts: *
-     calc: $used * 100 / ( $used + $free )
+     calc: ($used + $free) > 0 ? ($used * 100 / ($used + $free)) : 0
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (80) : (90))


### PR DESCRIPTION
##### Summary

Fixes the `swap_used` alarm calc when both `$used` and `$free` are 0.

##### Component Name

`health/`

##### Test Plan

Not needed.

##### Additional Information
