### PR TITLE
Mark g++ for freebsd as NOTREQUIRED

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -736,6 +736,7 @@ declare -A pkg_gxx=(
   ['gentoo']="NOTREQUIRED"
   ['macos']="NOTREQUIRED"
   ['ubuntu']="g++"
+  ['freebsd']="NOTREQUIRED"
   ['default']="gcc-c++"
 )
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR marks the dependency for `g++` for FreeBSD as `NOTREQUIRED`. A `g++` compiler is installed when `gcc` is installed.

Before this PR, when running the kickstart script (and really `install-required-packages.sh`) in FreeBSD it would try to install `gcc-c++` (the default choice) which will error out. By marking it as not required, installation of the rest of the required packages will continue, and eventually build netdata.

##### Component Name

Kickstart

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

On an empty FreeBSD 12 or 13: Install curl, sudo and bash. Use bash, and try the kickstart script (`bash <(curl -Ss https://my-netdata.io/kickstart.sh) --install /some/path`). It should error out with: `pkg: No packages available to install matching 'gcc-c++' have been found in the repositories`.

To test this PR, download the updated `install-required-packages.sh`, and run the kickstart with: `NETDATA_LOCAL_TARBALL_OVERRIDE_DEPS_SCRIPT=/some/path/install-required-packages.sh bash <(curl -Ss https://my-netdata.io/kickstart.sh) --install /some/other/path`. It should compile and start netdata:

```
[evas@test_13 ~]$ ../evas/install-netdata/netdata/usr/sbin/netdata -W buildinfo
Version: netdata v1.31.0-370-nightly
Configure options:  '--prefix=/home/evas/install-netdata/netdata/usr' '--sysconfdir=/home/evas/install-netdata/netdata/etc' '--localstatedir=/home/evas/install-netdata/netdata/var' '--libexecdir=/home/evas/install-netdata/netdata/usr/libexec' '--libdir=/home/evas/install-netdata/netdata/usr/lib' '--with-zlib' '--with-math' '--with-user=netdata' '--disable-dependency-tracking' '--with-bundled-lws' '--with-bundled-protobuf' '--with-bundled-libJudy' 'CFLAGS=-O2' 'LDFLAGS='
Features:
    dbengine:                   YES
    Native HTTPS:               YES
    Netdata Cloud:              YES 
    ACLK Next Generation:       YES
    ACLK-NG New Cloud Protocol: YES
    ACLK Legacy:                YES
    TLS Host Verification:      YES
Libraries:
    jemalloc:                NO
    JSON-C:                  YES
    libcap:                  NO
    libcrypto:               YES
    libm:                    YES
    LWS:                     YES static v3.2.2
    mosquitto:               YES
    tcalloc:                 NO
    zlib:                    YES
Plugins:
    apps:                    YES
    cgroup Network Tracking: NO
    CUPS:                    NO
    EBPF:                    NO
    IPMI:                    NO
    NFACCT:                  NO
    perf:                    NO
    slabinfo:                NO
    Xen:                     NO
    Xen VBD Error Tracking:  NO
Exporters:
    AWS Kinesis:             NO
    GCP PubSub:              NO
    MongoDB:                 NO
    Prometheus Remote Write: NO
```



##### Additional Information
