### PR TITLE
fix "lsns: unknown column" logging in cgroup-network-helper script

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network-helper.sh
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh
@@ -76,7 +76,7 @@ debug() {
 
 pid=
 cgroup=
-while [ ! -z "${1}" ]
+while [ -n "${1}" ]
 do
     case "${1}" in
         --cgroup) cgroup="${2}"; shift 1;;
@@ -164,7 +164,7 @@ virsh_find_all_interfaces_for_cgroup() {
     # shellcheck disable=SC2230
     virsh="$(which virsh 2>/dev/null || command -v virsh 2>/dev/null)"
 
-    if [ ! -z "${virsh}" ]
+    if [ -n "${virsh}" ]
     then
         local d
         d="$(virsh_cgroup_to_domain_name "${c}")"
@@ -172,7 +172,7 @@ virsh_find_all_interfaces_for_cgroup() {
         # e.g.: vm01\x2dweb => vm01-web (https://github.com/netdata/netdata/issues/11088#issuecomment-832618149)
         d="$(printf '%b' "${d}")"
 
-        if [ ! -z "${d}" ]
+        if [ -n "${d}" ]
         then
             debug "running: virsh domiflist ${d}; to find the network interfaces"
 
@@ -203,8 +203,11 @@ netnsid_find_all_interfaces_for_pid() {
     local pid="${1}"
     [ -z "${pid}" ] && return 1
 
-    local nsid=$(lsns -t net -p ${pid} -o NETNSID -nr 2>/dev/null)
-    [ -z "${nsid}" -o "${nsid}" = "unassigned" ] && return 1
+    local nsid
+    nsid=$(lsns -t net -p "${pid}" -o NETNSID -nr 2>/dev/null)
+    if [ -z "${nsid}" ] || [ "${nsid}" = "unassigned" ]; then
+      return 1
+    fi
 
     set_source "netnsid"
     ip link show |\
@@ -234,14 +237,14 @@ netnsid_find_all_interfaces_for_cgroup() {
 find_all_interfaces_of_pid_or_cgroup() {
     local p="${1}" c="${2}" # the pid and the cgroup path
 
-    if [ ! -z "${pid}" ]
+    if [ -n "${pid}" ]
     then
         # we have been called with a pid
 
         proc_pid_fdinfo_iff "${p}"
         netnsid_find_all_interfaces_for_pid "${p}"
 
-    elif [ ! -z "${c}" ]
+    elif [ -n "${c}" ]
     then
         # we have been called with a cgroup
 


### PR DESCRIPTION
##### Summary

- This PR removes logging `lsns` errors. 

[Quoting](https://github.com/netdata/netdata/issues/8831#issuecomment-623126434) @a-bali "The lsns error is caused by the fact that Ubuntu 18.04 comes with util-linux version 2.31 and NETNSID support was introduced in util-linux version 2.32."

```cmd
2021-10-20 11:38:36: cgroup-network-helper.sh: INFO: searching for network interfaces of cgroup '/sys/fs/cgroup/cpu,cpuacct/docker/222afd2063d9f97c88e95115eb9dd291bfad93405ca04b4f40a2661808e49571'
lsns: unknown column: NETNSID
lsns: unknown column: NETNSID
lsns: unknown column: NETNSID
lsns: unknown column: NETNSID
lsns: unknown column: NETNSID
lsns: unknown column: NETNSID
lsns: unknown column: NETNSID
lsns: unknown column: NETNSID
lsns: unknown column: NETNSID
```

- and fixes shellcheck warnings

##### Component Name

`collectors/cgroups.plugin`

##### Test Plan

Run `cgroup-network-helper.sh` manually, ensure there are no "unknown column" errors on Ubuntu 18.04.


##### Additional Information
