### PR TITLE
Fix handling of disabling telemetry in static installs.

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -49,6 +49,7 @@ while [ "${1}" ]; do
       REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1}"
       ;;
     "--disable-telemetry")
+      NETDATA_DISABLE_TELEMETRY=1
       REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1}"
       ;;
 
@@ -58,6 +59,7 @@ while [ "${1}" ]; do
 done
 
 if [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
+  NETDATA_DISABLE_TELEMETRY=1
   REINSTALL_OPTIONS="${REINSTALL_OPTIONS} --disable-telemetry"
 fi
 
@@ -138,7 +140,7 @@ install_netdata_logrotate || run_failed "Cannot install logrotate file for netda
 progress "Telemetry configuration"
 
 # Opt-out from telemetry program
-if [ -n "${NETDATA_DISABLE_TELEMETRY+x}" ]; then
+if [ -n "${NETDATA_DISABLE_TELEMETRY}" ]; then
   run touch "${NETDATA_USER_CONFIG_DIR}/.opt-out-from-anonymous-statistics"
 else
   printf "You can opt out from anonymous statistics via the --disable-telemetry option, or by creating an empty file %s \n\n" "${NETDATA_USER_CONFIG_DIR}/.opt-out-from-anonymous-statistics"


### PR DESCRIPTION
##### Summary

This fixes the handling of disabling telemetry in static installs. Prior to this commit, we were not actually disabling telemetry t all when the user asked us to do so. This fixes things so that static installs do, in fact, properly disable telemetry.

##### Component Name

area/packaging

##### Test Plan

Behavior verified locally.

##### Additional Information

Existing static installs that had been done with the `--disable-telemetry` option will automatically disable telemetry properly once they update to a version with this fix.