### PR TITLE
ci: remove concurrency for labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,7 +3,7 @@
 name: Pull Request Labeler
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/10 * * * *'
 env:
   DO_NOT_TRACK: 1
 jobs:


### PR DESCRIPTION
##### Summary

@Ferroin labeler [keeps getting canceled](https://github.com/netdata/netdata/actions/workflows/labeler.yml) because of the concurrency option.

This PR:
 - removes concurrency for labeler.
 - changes schedule from every 5 to 10 minutes. 


@Ferroin I think just changing the schedule would fix the issue, but I'm not sure we need this feature for something simple and fast like labeler.

##### Component Name

ci

##### Test Plan



##### Additional Information
