### PR TITLE
postgres collector: Fix crash the wal query if wal-file was removed concurrently

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -196,7 +196,7 @@ FROM
     FROM pg_catalog.pg_ls_dir('pg_wal') AS wal(name)
     WHERE name ~ '^[0-9A-F]{24}$'
     ORDER BY
-        (pg_stat_file('pg_wal/'||name)).modification,
+        (pg_stat_file('pg_wal/'||name, true)).modification,
         wal.name DESC) sub;
 """,
     V96: """
@@ -223,7 +223,7 @@ FROM
     FROM pg_catalog.pg_ls_dir('pg_xlog') AS wal(name)
     WHERE name ~ '^[0-9A-F]{24}$'
     ORDER BY
-        (pg_stat_file('pg_xlog/'||name)).modification,
+        (pg_stat_file('pg_xlog/'||name, true)).modification,
         wal.name DESC) sub;
 """,
 }


### PR DESCRIPTION
##### Summary
If the wav file was deleted during the execution of the request, the request will crash and we get an alert that the collector could not get statistics

```
2021-10-21 10:56:24.007 MSK [743187] postgres@postgres ERROR:  could not stat file "pg_wal/0000000100005A6A000000A2": No such file or directory
2021-10-21 10:56:24.007 MSK [743187] postgres@postgres STATEMENT:
        SELECT
            count(*) as total_wal,
            count(*) FILTER (WHERE type = 'recycled') AS recycled_wal,
            count(*) FILTER (WHERE type = 'written') AS written_wal
        FROM
            (SELECT
                wal.name,
                pg_walfile_name(
                  CASE pg_is_in_recovery()
                    WHEN true THEN NULL
                    ELSE pg_current_wal_lsn()
                  END ),
                CASE
                  WHEN wal.name > pg_walfile_name(
                    CASE pg_is_in_recovery()
                      WHEN true THEN NULL
                      ELSE pg_current_wal_lsn()
                    END ) THEN 'recycled'
                  ELSE 'written'
                END AS type
            FROM pg_catalog.pg_ls_dir('pg_wal') AS wal(name)
            WHERE name ~ '^[0-9A-F]{24}$'
            ORDER BY
                (pg_stat_file('pg_wal/'||name)).modification,
                wal.name DESC) sub;
```

The is_missing_ok==true flag has been added to the pg_stat_file function in the query:
```
postgres=# select (pg_stat_file('noname')).modification;
ERROR:  could not stat file "noname": No such file or directory

postgres=# select (pg_stat_file('noname', true)).modification;
 modification
--------------

(1 row)
```

##### Component Name
postgres-collecotr

##### Additional Information
The missing_ok flag was added to the pg_stat_file function in the Postgre 9.5