### PR TITLE
updater: don't use api.github.com when checking for latest stable version

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -172,24 +172,24 @@ download() {
   fi
 }
 
-get_netdata_latest_stable_version() {
+get_netdata_latest_tag() {
   local dest="${1}"
   local url="https://github.com/netdata/netdata/releases/latest"
-  local version
+  local tag
 
   if command -v curl >/dev/null 2>&1; then
-    version=$(curl "${url}" -s -L -I -o /dev/null -w '%{url_effective}' | grep -m 1 -o '[^/]*$')
+    tag=$(curl "${url}" -s -L -I -o /dev/null -w '%{url_effective}' | grep -m 1 -o '[^/]*$')
   elif command -v wget >/dev/null 2>&1; then
-    version=$(wget --max-redirect=0 "${url}" 2>&1 | grep Location | cut -d ' ' -f2 | grep -m 1 -o '[^/]*$')
+    tag=$(wget --max-redirect=0 "${url}" 2>&1 | grep Location | cut -d ' ' -f2 | grep -m 1 -o '[^/]*$')
   else
     fatal "I need curl or wget to proceed, but neither of them are available on this system."
   fi
 
-  if [[ ! $version =~ ^v[0-9]+\..+ ]]; then
-    fatal "Cannot download latest stable version from ${url}"
+  if [[ ! $tag =~ ^v[0-9]+\..+ ]]; then
+    fatal "Cannot download latest stable tag from ${url}"
   fi
 
-  echo "${version}" >"${dest}"
+  echo "${tag}" >"${dest}"
 }
 
 newer_commit_date() {
@@ -257,7 +257,7 @@ parse_version() {
 
 get_latest_version() {
   if [ "${RELEASE_CHANNEL}" == "stable" ]; then
-    get_netdata_latest_stable_version /dev/stdout
+    get_netdata_latest_tag /dev/stdout
   else
     download "$NETDATA_NIGHTLIES_BASEURL/latest-version.txt" /dev/stdout
   fi
@@ -272,7 +272,7 @@ set_tarball_urls() {
 
   if [ "$1" = "stable" ]; then
     local latest
-    latest="$(get_netdata_latest_stable_version /dev/stdout)"
+    latest="$(get_netdata_latest_tag /dev/stdout)"
     export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/netdata-$latest.${extension}"
     export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
   else


### PR DESCRIPTION
##### Summary

All requests to https://api.github.com are [rate-limited](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)

> For unauthenticated requests, the rate limit allows for up to 60 requests per hour.

##### Component Name

`packaging/installer/`

##### Test Plan

- install this PR ('--stable-channel').
- run the updater script (with '--no-updater-self-update').
- ensure that the latest version is detected correctly.

Current (API rate limit exceeded):

```cmd
$ sudo /opt/netdata/usr/libexec/netdata/netdata-updater.sh --no-updater-self-update
Чт 21 окт 2021 16:56:26 MSK : INFO:  Running on a terminal - (this script also supports running headless from crontab)
Чт 21 окт 2021 16:56:26 MSK : INFO:  Current Version: 0
Чт 21 окт 2021 16:56:26 MSK : INFO:  Latest Version: 00000000000000
sha256sum: 'standard input': no properly formatted checksum lines found
Чт 21 окт 2021 16:56:27 MSK : ERROR:  FAILED TO UPDATE NETDATA : Tarball checksum validation failed. Stopping netdata upgrade and leaving tarball in /tmp/netdata-updater-NbpiAgox2B\nUsually this is a result of an older copy of the tarball or checksum file being cached somewhere upstream and can be resolved by retrying in an hour.
```

After this PR:

```cmd
$ sudo /opt/netdata/usr/libexec/netdata/netdata-updater.sh --no-updater-self-update
Чт 21 окт 2021 16:53:16 MSK : INFO:  Running on a terminal - (this script also supports running headless from crontab)
Чт 21 окт 2021 16:53:17 MSK : INFO:  Current Version: 0
Чт 21 окт 2021 16:53:17 MSK : INFO:  Latest Version: 00103100000000
./netdata-latest.tar.gz: OK
Чт 21 окт 2021 16:53:23 MSK : INFO:  Re-installing netdata...
```


##### Additional Information
