### PR TITLE
Fix libbpf handling in RPM package builds.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -235,7 +235,15 @@ export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-judy.sh ${RPM_BUILD_DIR}/%{name}-%{version}
 %endif
 %if 0%{?_have_ebpf}
-export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-libbpf.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+%if 0%{?centos_ver:1}
+%if %{centos_ver} < 8
+export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-libbpf.sh ${RPM_BUILD_DIR}/%{name}-%{version} centos7
+%else
+export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-libbpf.sh ${RPM_BUILD_DIR}/%{name}-%{version} centos8
+%endif
+%else
+export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-libbpf.sh ${RPM_BUILD_DIR}/%{name}-%{version} other
+%endif
 %endif
 
 %build

--- a/packaging/bundle-libbpf.sh
+++ b/packaging/bundle-libbpf.sh
@@ -1,13 +1,21 @@
-#!/bin/sh
-
-LIBBPF_TARBALL="v$(cat "${1}/packaging/libbpf.version").tar.gz"
-LIBBPF_BUILD_PATH="${1}/externaldeps/libbpf/libbpf-$(cat "${1}/packaging/libbpf.version")"
+#!/bin/bash
 
 if [ "$(uname -m)" = x86_64 ]; then
     lib_subdir="lib64"
 else
     lib_subdir="lib"
 fi
+
+if [ "${2}" != "centos7" ]; then
+  cp "${1}/packaging/current_libbpf.checksums" "${1}/packaging/libbpf.checksums"
+  cp "${1}/packaging/current_libbpf.version" "${1}/packaging/libbpf.version"
+else
+  cp "${1}/packaging/libbpf_0_0_9.checksums" "${1}/packaging/libbpf.checksums"
+  cp "${1}/packaging/libbpf_0_0_9.version" "${1}/packaging/libbpf.version"
+fi
+
+LIBBPF_TARBALL="v$(cat "${1}/packaging/libbpf.version").tar.gz"
+LIBBPF_BUILD_PATH="${1}/externaldeps/libbpf/libbpf-$(cat "${1}/packaging/libbpf.version")"
 
 mkdir -p "${1}/externaldeps/libbpf" || exit 1
 curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/libbpf/archive/${LIBBPF_TARBALL}" > "${LIBBPF_TARBALL}" || exit 1


### PR DESCRIPTION
##### Summary

This updates our handling of libbpf in our RPM package builds so that we use the correct version of libbpf for whichever platform we’re building for.

##### Component Name

area/packaging

##### Test Plan

CentOS 7 RPM build passes on this PR.