### PR TITLE
Ebpf doc

### DIFF
--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -294,7 +294,7 @@ The eBPF collector also creates charts for each cgroup through an integration wi
 interacts with the Linux kernel.
 
 The integration with `cgroups.plugin` is disabled by default to avoid creating overhead on your system. If you want to
-_enable_ the integration with `cgroups.plugin`, change the `cgroups`setting to `yes`.
+_enable_ the integration with `cgroups.plugin`, change the `cgroups` setting to `yes`.
 
 ```conf
 [global]


### PR DESCRIPTION
##### Summary
When we merged some ebpf PRs we missed description for charts that are integrated with other plugins, this PR is bringing the missing information following the previous pattern that we have. We will have other PRs increasing description for each one of the cited functions.

##### Component Name
Documentation
##### Test Plan

1 - It is not necessary to compile, it is only necessary to check missing chart description or missing information.

##### Additional Information
