### PR TITLE
Allow to build on apple silicon

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -31,9 +31,20 @@ if [ "$(uname -s)" = 'Darwin' ]; then
   if [ "$(uname -m)" = "x86_64" ] && [ -d /usr/local/opt/openssl/include ]; then
     export C_INCLUDE_PATH="/usr/local/opt/openssl/include"
     export LDFLAGS="-L/usr/local/opt/openssl/lib"
-  elif [ "$(uname -m)" = "arm64" ] && [ -d /opt/homebrew/opt/openssl/include ]; then
-    export CFLAGS="${CFLAGS} -I/opt/homebrew/include/ -I/opt/homebrew/opt/openssl/include/"
-    export LDFLAGS="${LDFLAGS} -L/opt/homebrew/lib/ -L/opt/homebrew/opt/openssl/lib/"
+  elif [ "$(uname -m)" = "arm64" ] && [ -d /opt/homebrew/include ]; then
+    export CFLAGS="${CFLAGS} -I/opt/homebrew/include/"
+    export LDFLAGS="${LDFLAGS} -L/opt/homebrew/lib/"
+    # Check all possible brew openssl paths
+    if [ -d /opt/homebrew/opt/openssl/include ]; then
+      export CFLAGS="${CFLAGS} -I/opt/homebrew/opt/openssl/include/"
+      export LDFLAGS="${LDFLAGS} -L/opt/homebrew/opt/openssl/lib/"
+    elif [ -d /opt/homebrew/opt/openssl@1.1/include ]; then
+      export CFLAGS="${CFLAGS} -I/opt/homebrew/opt/openssl@1.1/include/"
+      export LDFLAGS="${LDFLAGS} -L/opt/homebrew/opt/openssl@1.1/lib/"
+    elif [ -d /opt/homebrew/opt/openssl@3/include ]; then
+      export CFLAGS="${CFLAGS} -I/opt/homebrew/opt/openssl@3/include/"
+      export LDFLAGS="${LDFLAGS} -L/opt/homebrew/opt/openssl@3/lib/"
+    fi
   fi
 fi
 
@@ -629,14 +640,26 @@ build_libmosquitto() {
     if [ "$(uname)" = Darwin ]; then
       if [ "$(uname -m)" = x86_64 ] && [ -d /usr/local/opt/openssl ]; then
         run ${env_cmd} cmake \
-          -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
-          -D OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib \
-          -D WITH_STATIC_LIBRARIES:boolean=YES
-      elif [ "$(uname -m)" = arm64 ] && [ -d /opt/homebrew/opt/openssl ]; then
-        run ${env_cmd} cmake \
+        -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
+        -D OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib \
+        -D WITH_STATIC_LIBRARIES:boolean=YES
+      elif [ "$(uname -m)" = arm64 ]; then
+        if [ -d /opt/homebrew/opt/openssl ]; then
+          run ${env_cmd} cmake \
           -D OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl \
           -D OPENSSL_LIBRARIES=/opt/homebrew/opt/openssl/lib \
           -D WITH_STATIC_LIBRARIES:boolean=YES
+        elif [ -d /opt/homebrew/opt/openssl@1.1 ]; then
+          run ${env_cmd} cmake \
+          -D OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@1.1 \
+          -D OPENSSL_LIBRARIES=/opt/homebrew/opt/openssl/lib@1.1 \
+          -D WITH_STATIC_LIBRARIES:boolean=YES
+        elif [ -d /opt/homebrew/opt/openssl@3 ]; then
+          run ${env_cmd} cmake \
+          -D OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3 \
+          -D OPENSSL_LIBRARIES=/opt/homebrew/opt/openssl/lib@3 \
+          -D WITH_STATIC_LIBRARIES:boolean=YES
+        fi
       fi
     else
       run ${env_cmd} cmake -D WITH_STATIC_LIBRARIES:boolean=YES .
@@ -734,13 +757,29 @@ EOF
         -D LWS_WITH_SOCKS5:bool=ON \
         -D LWS_IPV6:bool=ON \
         $CMAKE_FLAGS
-    elif [ "$(uname -m)" = arm64 ] && [ -d /opt/homebrew/opt/openssl ]; then
-      run ${env_cmd} cmake \
+    elif [ "$(uname -m)" = arm64 ]; then
+      if [ -d /opt/homebrew/opt/openssl ]; then
+        run ${env_cmd} cmake \
           -D OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl \
           -D OPENSSL_LIBRARIES=/opt/homebrew/opt/openssl/lib \
           -D LWS_WITH_SOCKS5:bool=ON \
           -D LWS_IPV6:bool=ON \
-          $CMAKE_FLAGS
+           $CMAKE_FLAGS
+      elif [ -d /opt/homebrew/opt/openssl@1.1 ]; then
+         run ${env_cmd} cmake \
+          -D OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@1.1 \
+          -D OPENSSL_LIBRARIES=/opt/homebrew/opt/openssl/lib@1.1 \
+          -D LWS_WITH_SOCKS5:bool=ON \
+          -D LWS_IPV6:bool=ON \
+           $CMAKE_FLAGS
+       elif [ -d /opt/homebrew/opt/openssl@3 ]; then
+         run ${env_cmd} cmake \
+          -D OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3 \
+          -D OPENSSL_LIBRARIES=/opt/homebrew/opt/openssl/lib@3 \
+          -D LWS_WITH_SOCKS5:bool=ON \
+          -D LWS_IPV6:bool=ON \
+           $CMAKE_FLAGS
+      fi
     fi
   else
     run ${env_cmd} cmake \

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -695,6 +695,7 @@ declare -A pkg_json_c_dev=(
   ['sabayon']="dev-libs/json-c"
   ['suse']="libjson-c-devel"
   ['freebsd']="json-c"
+  ['macos']="json-c"
   ['default']="json-c-devel"
 )
 
@@ -1171,7 +1172,7 @@ declare -A pkg_openssl=(
   ['gentoo']="dev-libs/openssl"
   ['arch']="openssl"
   ['freebsd']="openssl"
-  ['macos']="openssl@1.1"
+  ['macos']="openssl"
   ['default']="openssl-devel"
 )
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -363,7 +363,11 @@ dependencies() {
       warning "Downloaded dependency installation script is empty."
     else
       progress "Running downloaded script to detect required packages..."
-      run ${sudo} "${bash}" "${ndtmpdir}/install-required-packages.sh" ${PACKAGES_INSTALLER_OPTIONS}
+      if [ "$(uname -s)" = Darwin ]; then
+          run "${bash}" "${ndtmpdir}/install-required-packages.sh" ${PACKAGES_INSTALLER_OPTIONS}
+      else
+          run ${sudo} "${bash}" "${ndtmpdir}/install-required-packages.sh" ${PACKAGES_INSTALLER_OPTIONS}
+      fi
       # shellcheck disable=SC2181
       if [ $? -ne 0 ]; then
         warning "It failed to install all the required packages, but installation might still be possible."

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -96,7 +96,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "7e8b449ca44e49b7074b5b9d6022cbcc" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "b596f9c98d569cc07cbec97a8dac33c4" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR makes some small adjustments to `netdata-installer.sh` to allow to build on Macs with apple silicon (arm). It basically provides the paths to libraries and includes from homebrew.

##### Component Name

Installer

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Need at least the following packages from homebrew installed:

```
autoconf
automake
bash
cmake
json-c
libtool
libuv
lz4
m4
openssl@1.1
ossp-uuid
pkg-config
```

After that, try running `netdata-installer.sh` specifying a local directory for install, e.g. `/Users/username/install_netdata`. It should build netdata, e.g.:

```
bash-5.1$ uname -a
Darwin MacBook-Air.local 20.5.0 Darwin Kernel Version 20.5.0: Sat May  8 05:10:31 PDT 2021; root:xnu-7195.121.3~9/RELEASE_ARM64_T8101 arm64
bash-5.1$ ../install_netdata/netdata/usr/sbin/netdata -W buildinfo
Version: netdata v1.31.0-420-ga97f06a6e
Configure options:  '--prefix=/Users/mrzammler/stuff/install_netdata/netdata/usr' '--sysconfdir=/Users/mrzammler/stuff/install_netdata/netdata/etc' '--localstatedir=/Users/mrzammler/stuff/install_netdata/netdata/var' '--libexecdir=/Users/mrzammler/stuff/install_netdata/netdata/usr/libexec' '--libdir=/Users/mrzammler/stuff/install_netdata/netdata/usr/lib' '--with-zlib' '--with-math' '--with-user=netdata' '--disable-lto' '--with-bundled-lws' '--with-bundled-protobuf' '--with-bundled-libJudy' 'CFLAGS= -I/opt/homebrew/include/ -I/opt/homebrew/opt/openssl/include/' 'LDFLAGS= -L/opt/homebrew/lib/ -L/opt/homebrew/opt/openssl/lib/'
Features:
    dbengine:                   YES
    Native HTTPS:               YES
    Netdata Cloud:              YES 
    ACLK Next Generation:       YES
    ACLK-NG New Cloud Protocol: YES
    ACLK Legacy:                YES
    TLS Host Verification:      YES
Libraries:
    jemalloc:                NO
    JSON-C:                  YES
    libcap:                  NO
    libcrypto:               YES
    libm:                    YES
    LWS:                     YES static v3.2.2
    mosquitto:               YES
    tcalloc:                 NO
    zlib:                    YES
Plugins:
    apps:                    NO
    cgroup Network Tracking: NO
    CUPS:                    YES
    EBPF:                    NO
    IPMI:                    NO
    NFACCT:                  NO
    perf:                    NO
    slabinfo:                NO
    Xen:                     NO
    Xen VBD Error Tracking:  NO
Exporters:
    AWS Kinesis:             NO
    GCP PubSub:              NO
    MongoDB:                 NO
    Prometheus Remote Write: NO
```

##### Additional Information

* The installer should also already handle intel mac's, if anyone has some time and one, we should test.
* There are various things that can/should be adjusted for macs, to make it more proper for release, e.g:

```
[/Users/mrzammler/stuff/netdata]$ tar xf /var/folders/5s/s8xbf1s93xz5k611dr55wmpr0000gp/T/netdata-go-XXXXXX.vpiHv7Et/go.d.plugin-v0.30.0.darwin-arm64.tar.gz 
tar: Error opening archive: Unrecognized archive format
 FAILED   
```

* We should check various installer options.
* If needed, kickstart could be adjusted to install brew dependencies.
* There are many warnings during compile.