### PR TITLE
Fix kickstart.md Installation Guide Links

### DIFF
--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -26,8 +26,8 @@ bash <(curl -Ss https://my-netdata.io/kickstart.sh)
 bash <(curl -Ss https://my-netdata.io/kickstart.sh) --install /usr/local/
 ```
 
-> See our [installation guide](../README.md) for details about [automatic updates](../README.md#automatic-updates) or
-> [nightly vs. stable releases](../README.md#nightly-vs-stable-releases).
+> See our [installation guide](/packaging/installer/README.md) for details about [automatic updates](/packaging/installer/README.md#automatic-updates) or
+> [nightly vs. stable releases](/packaging/installer/README.md#nightly-vs-stable-releases).
 
 ## What does `kickstart.sh` do?
 


### PR DESCRIPTION
<!--
Fixing installation guide links. 
-->

##### Summary

Previous link only opened in new window or when refreshing "Page not found"

##### Component Name

Docs

##### Test Plan

<!---
N/a
-->

##### Additional Information
