### PR TITLE
Update jQuery Dependency

### DIFF
--- a/web/gui/src/dashboard.js/dependencies.js
+++ b/web/gui/src/dashboard.js/dependencies.js
@@ -4,7 +4,7 @@
 // default URLs for all the external files we need
 // make them RELATIVE so that the whole thing can also be
 // installed under a web server
-NETDATA.jQuery = NETDATA.serverStatic + 'lib/jquery-2.2.4.min.js';
+NETDATA.jQuery = NETDATA.serverStatic + 'lib/jquery-3.6.0.min.js';
 NETDATA.peity_js = NETDATA.serverStatic + 'lib/jquery.peity-3.2.0.min.js';
 NETDATA.sparkline_js = NETDATA.serverStatic + 'lib/jquery.sparkline-2.1.2.min.js';
 NETDATA.easypiechart_js = NETDATA.serverStatic + 'lib/jquery.easypiechart-97b5824.min.js';


### PR DESCRIPTION
##### Summary

Fixes: #11742

"master" branch now has jQuery 3.6.0 (https://github.com/netdata/netdata/tree/master/web/gui/dashboard/lib) but the dependency still calls jQuery 2.2.4 (https://github.com/netdata/netdata/blob/master/web/gui/src/dashboard.js/dependencies.js Line: 7)

##### Component Name
Web GUI
