### PR TITLE
Fix artifact consolidation in release build.

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -126,6 +126,8 @@ jobs:
       - build-dist
       - build-static
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Prepare Environment
         run: mkdir -p artifacts
       - name: Retrieve Artifacts
@@ -135,7 +137,7 @@ jobs:
         run: |
           mv ../dist-tarball/* .
           mv ../static-archive/* .
-          cp ../packaging/version latest-version.txt
+          cp ../packaging/version ./latest-version.txt
           sha256sum -b ./* > sha256sums.txt
       - name: Store Artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
##### Summary

When originally writing the code, i forgot to have it check out the source branch so that we could use files from it when preparing the artifacts. This fixes that oversight.

##### Component Name

area/ci

##### Test Plan

n/a