### PR TITLE
Add basic telemetry to the new kickstart script.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -371,6 +371,10 @@ while [ -n "${1}" ]; do
       NETDATA_PREFIX="${2}/netdata"
       shift 1
       ;;
+    "--install-no-prefix")
+      NETDATA_PREFIX="${2}"
+      shift 1
+      ;;
     "--help" | "-h")
       usage
       exit 1

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -112,6 +112,8 @@ telemetry_event() {
     fi
   fi
 
+  KERNEL_NAME="$(uname -s)"
+
   if [ "${KERNEL_NAME}" = FreeBSD ]; then
     TOTAL_RAM="$(sysctl -n hw.physmem)"
   elif [ "${KERNEL_NAME}" = Darwin ]; then
@@ -153,7 +155,7 @@ telemetry_event() {
     "host_os_id_like": "${HOST_ID_LIKE:-unknown}",
     "host_os_version": "${HOST_VERSION:-unknown}",
     "host_os_version_id": "${HOST_VERSION_ID:-unknown}",
-    "system_kernel_name": "$(uname -s)",
+    "system_kernel_name": "${KERNEL_NAME}",
     "system_kernel_version": "$(uname -r)",
     "system_architecture": "$(uname -m)",
     "system_total_ram": "${TOTAL_RAM:-unknown}"

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -1343,3 +1343,4 @@ fi
 
 telemetry_event INSTALL_SUCCESS "" ""
 cleanup
+trap - EXIT

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -6,13 +6,16 @@
 # Constants
 
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
+PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 REPOCONFIG_URL_PREFIX="https://packagecloud.io/netdata/netdata-repoconfig/packages"
 REPOCONFIG_VERSION="1-1"
-PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
+TELEMETRY_URL="https://posthog.netdata.cloud/capture/"
+START_TIME="$(date +%s)"
 
 # ======================================================================
 # Defaults for environment variables
 
+ACTUAL_INSTALL_METHOD="none"
 INSTALL_PREFIX=""
 NETDATA_AUTO_UPDATES="1"
 NETDATA_CLAIM_ONLY=0
@@ -27,6 +30,7 @@ RELEASE_CHANNEL="nightly"
 NETDATA_DISABLE_TELEMETRY="${DO_NOT_TRACK:-0}"
 NETDATA_TARBALL_BASEURL="${NETDATA_TARBALL_BASEURL:-https://storage.googleapis.com/netdata-nightlies}"
 NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS:-""}"
+TELEMETRY_API_KEY="${NETDATA_POSTHOG_API_KEY:-mqkwGT0JNFqO-zX2t0mW6Tec9yooaVu7xCBlXtHnt5Y}"
 
 if [ ! -t 1 ]; then
   INTERACTIVE=0
@@ -80,6 +84,118 @@ HEREDOC
 }
 
 # ======================================================================
+# Telemetry functions
+
+telemetry_event() {
+  now="$(date +%s)"
+  total_duration="$((now - START_TIME))"
+
+  if [ -n "${NETDATA_DISABLE_TELEMETRY}" ]; then
+    return 0
+  fi
+
+  if [ -e "/etc/os-release" ]; then
+    eval "$(grep -E "^(NAME|ID|ID_LIKE|VERSION|VERSION_ID)=" < /etc/os-release | sed 's/^/HOST_/')"
+  fi
+
+  if [ -z "${HOST_NAME}" ] || [ -z "${HOST_VERSION}" ] || [ -z "${HOST_ID}" ]; then
+    if [ -f "/etc/lsb-release" ]; then
+      DISTRIB_ID="unknown"
+      DISTRIB_RELEASE="unknown"
+      DISTRIB_CODENAME="unknown"
+      eval "$(grep -E "^(DISTRIB_ID|DISTRIB_RELEASE|DISTRIB_CODENAME)=" < /etc/lsb-release)"
+      if [ -z "${HOST_NAME}" ]; then HOST_NAME="${DISTRIB_ID}"; fi
+      if [ -z "${HOST_VERSION}" ]; then HOST_VERSION="${DISTRIB_RELEASE}"; fi
+      if [ -z "${HOST_ID}" ]; then HOST_ID="${DISTRIB_CODENAME}"; fi
+    fi
+  fi
+
+  if [ "${KERNEL_NAME}" = FreeBSD ]; then
+    TOTAL_RAM="$(sysctl -n hw.physmem)"
+  elif [ "${KERNEL_NAME}" = Darwin ]; then
+    TOTAL_RAM="$(sysctl -n hw.physmem)"
+  elif [ -r /proc/meminfo ]; then
+    TOTAL_RAM="$(grep -F MemTotal /proc/meminfo | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | cut -f 1 -d ' ')"
+    TOTAL_RAM="$((TOTAL_RAM * 1024))"
+  fi
+
+  if [ -f /etc/machine-id ]; then
+    DISTINCT_ID="$(cat /etc/machine-id)"
+  elif command -v uuidgen 2> /dev/null; then
+    DISTINCT_ID="$(uuidgen)"
+  else
+    DISTINCT_ID="null"
+  fi
+
+  REQ_BODY="$(cat << EOF
+{
+  "api_key": "${TELEMETRY_API_KEY}",
+  "event": "${1}",
+  "properties": {
+    "distinct_id": "${DISTINCT_ID}",
+    "event_source": "agent installer",
+    "\$current_url": "agent installer",
+    "\$pathname": "netdata-installer",
+    "\$host": "installer.netdata.io",
+    "\$ip": "127.0.0.1",
+    "script_variant": "kickstart-ng",
+    "error_code": "${2}",
+    "error_message": "${3}",
+    "install_options": "${KICKSTART_OPTIONS}",
+    "total_runtime": "${total_duration}",
+    "selected_install_method": "${ACTUAL_INSTALL_METHOD}",
+    "netdata_release_channel": "${RELEASE_CHANNEL:-null}",
+    "netdata_install_type": "kickstart-build",
+    "host_os_name": "${HOST_NAME:-unknown}",
+    "host_os_id": "${HOST_ID:-unknown}",
+    "host_os_id_like": "${HOST_ID_LIKE:-unknown}",
+    "host_os_version": "${HOST_VERSION:-unknown}",
+    "host_os_version_id": "${HOST_VERSION_ID:-unknown}",
+    "system_kernel_name": "$(uname -s)",
+    "system_kernel_version": "$(uname -r)",
+    "system_architecture": "$(uname -m)",
+    "system_total_ram": "${TOTAL_RAM:-unknown}"
+  }
+}
+EOF
+)"
+
+  if [ -n "$(command -v curl 2> /dev/null)" ]; then
+    curl --silent -o /dev/null --write-out '%{http_code}' -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" "${TELEMETRY_URL}"
+  else
+    wget -q -O - --no-check-certificate \
+    --server-response \
+    --method POST \
+    --timeout=1 \
+    --header 'Content-Type: application/json' \
+    --body-data "${REQ_BODY}" \
+     "${TELEMETRY_URL}" 2>&1 | awk '/^  HTTP/{print $2}'
+  fi
+}
+
+trap_handler() {
+  code="${1}"
+  lineno="${2}"
+
+  printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ERROR ${TPUT_RESET} Installer exited unexpectedly (${code}-${lineno})"
+
+  telemetry_event INSTALL_CRASH "Installer exited unexpectedly (${code}-${lineno})" "E${code}-${lineno}"
+
+  trap - EXIT
+
+  cleanup
+
+  exit 1
+}
+
+trap 'trap_handler 0 ${LINENO}' EXIT
+trap 'trap_handler 1 0' HUP
+trap 'trap_handler 2 0' INT
+trap 'trap_handler 3 0' QUIT
+trap 'trap_handler 13 0' PIPE
+trap 'trap_handler 15 0' TERM
+
+# ======================================================================
 # Utility functions
 
 setup_terminal() {
@@ -118,7 +234,9 @@ cleanup() {
 
 fatal() {
   printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${*}"
+  telemetry_event "INSTALL_FAILED" "${1}" "${2}"
   cleanup
+  trap - EXIT
   exit 1
 }
 
@@ -215,7 +333,7 @@ create_tmp_directory() {
   if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}"; then
     if _cannot_use_tmpdir /tmp; then
       if _cannot_use_tmpdir "${PWD}"; then
-        fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
+        fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." F0400
       else
         TMPDIR="${PWD}"
       fi
@@ -235,7 +353,7 @@ download() {
   elif command -v wget > /dev/null 2>&1; then
     run wget -T 15 -O "${dest}" "${url}" || return 1
   else
-    fatal "I need curl or wget to proceed, but neither of them are available on this system."
+    fatal "I need curl or wget to proceed, but neither of them are available on this system." F0003
   fi
 }
 
@@ -247,7 +365,7 @@ get_redirect() {
   elif command -v wget > /dev/null 2>&1; then
     run sh -c "wget --max-redirect=0 ${url} 2>&1 | grep Location | cut -d ' ' -f2  | grep -o '[^/]*$'" || return 1
   else
-    fatal "I need curl or wget to proceed, but neither of them are available on this system."
+    fatal "I need curl or wget to proceed, but neither of them are available on this system." F0003
   fi
 }
 
@@ -259,7 +377,7 @@ safe_sha256sum() {
   elif command -v shasum > /dev/null 2>&1; then
     shasum -a 256 "$@"
   else
-    fatal "I could not find a suitable checksum binary to use"
+    fatal "I could not find a suitable checksum binary to use" F0004
   fi
 }
 
@@ -274,7 +392,7 @@ get_system_info() {
       elif [ -s "/usr/lib/os-release" ] && [ -r "/usr/lib/os-release" ]; then
         os_release_file="/usr/lib/os-release"
       else
-        fatal "Cannot find an os-release file ..."
+        fatal "Cannot find an os-release file ..." F0401
       fi
 
       # shellcheck disable=SC1090
@@ -314,7 +432,7 @@ get_system_info() {
       SYSARCH="$(uname -m)"
       ;;
     *)
-      fatal "Unsupported system type detected. Netdata cannot be installed on this system using this script."
+      fatal "Unsupported system type detected. Netdata cannot be installed on this system using this script." F0200
       ;;
   esac
 }
@@ -339,7 +457,7 @@ confirm_root_support() {
     fi
 
     if [ -z "${ROOTCMD}" ]; then
-      fatal "We need root privileges to continue, but cannot find a way to gain them. Either re-run this script as root, or set \$ROOTCMD to a command that can be used to gain root privileges"
+      fatal "We need root privileges to continue, but cannot find a way to gain them. Either re-run this script as root, or set \$ROOTCMD to a command that can be used to gain root privileges" F0201
     fi
   fi
 }
@@ -370,7 +488,7 @@ update() {
       progress "Updated existing install at ${ndprefix}"
       return 0
     else
-      fatal "Failed to update existing Netdata install at ${ndprefix}"
+      fatal "Failed to update existing Netdata install at ${ndprefix}" F0100
     fi
   else
     return 1
@@ -430,12 +548,12 @@ handle_existing_install() {
             if [ -n "${NETDATA_UNSAFE_REINSTALL}" ]; then
               warning "Reinstalling over top of a ${INSTALL_TYPE} installation may be unsafe, but the user has requested we proceed."
             elif [ "${INTERACTIVE}" -eq 0 ]; then
-              fatal "User requested reinstall, but we cannot safely reinstall over top of a ${INSTALL_TYPE} installation, exiting."
+              fatal "User requested reinstall, but we cannot safely reinstall over top of a ${INSTALL_TYPE} installation, exiting." F0104
             else
               if confirm "Reinstalling over top of a ${INSTALL_TYPE} installation may be unsafe, do you want to continue?"; then
                 progress "OK, continuing."
               else
-                fatal "Cancelling reinstallation at user request."
+                fatal "Cancelling reinstallation at user request." F0105
               fi
             fi
             ;;
@@ -460,32 +578,33 @@ handle_existing_install() {
         claim
         ret=$?
       elif [ "${NETDATA_CLAIM_ONLY}" -eq 1 ]; then
-        fatal "User asked to claim, but did not proide a claiming token."
+        fatal "User asked to claim, but did not proide a claiming token." F0202
       else
         progress "Not attempting to claim existing install at ${ndprefix} (no claiming token provided)."
       fi
 
       cleanup
+      trap - EXIT
       exit $ret
       ;;
     oci)
-      fatal "This is an OCI container, use the regular image lifecycle management commands in your container instead of this script for managing it."
+      fatal "This is an OCI container, use the regular image lifecycle management commands in your container instead of this script for managing it." F0203
       ;;
     *)
       if [ -n "${NETDATA_REINSTALL}" ] || [ -n "${NETDATA_UNSAFE_REINSTALL}" ]; then
         if [ -n "${NETDATA_UNSAFE_REINSTALL}" ]; then
           warning "Reinstalling over top of a ${INSTALL_TYPE} installation may be unsafe, but the user has requested we proceed."
         elif [ "${INTERACTIVE}" -eq 0 ]; then
-          fatal "User requested reinstall, but we cannot safely reinstall over top of a ${INSTALL_TYPE} installation, exiting."
+          fatal "User requested reinstall, but we cannot safely reinstall over top of a ${INSTALL_TYPE} installation, exiting." F0104
         else
           if confirm "Reinstalling over top of a ${INSTALL_TYPE} installation may be unsafe, do you want to continue?"; then
             progress "OK, continuing."
           else
-            fatal "Cancelling reinstallation at user request."
+            fatal "Cancelling reinstallation at user request." F0105
           fi
         fi
       else
-        fatal "Found an existing netdata install at ${ndprefix}, but the install type is '${INSTALL_TYPE}', which is not supported, refusing to proceed."
+        fatal "Found an existing netdata install at ${ndprefix}, but the install type is '${INSTALL_TYPE}', which is not supported, refusing to proceed." F0103
       fi
       ;;
   esac
@@ -526,7 +645,7 @@ EOF
 
 confirm_install_prefix() {
   if [ -n "${INSTALL_PREFIX}" ] && [ "${NETDATA_ONLY_BUILD}" -ne 1 ]; then
-    fatal "The \`--install\` option is only supported together with the \`--only-build\` option."
+    fatal "The \`--install\` option is only supported together with the \`--only-build\` option." F0204
   fi
 
   case "${SYSTYPE}" in
@@ -545,11 +664,11 @@ confirm_install_prefix() {
 check_claim_opts() {
 # shellcheck disable=SC2235,SC2030
   if [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_ROOMS}" ]; then
-    fatal "Invalid claiming options, claim rooms may only be specified when a token and URL are specified."
+    fatal "Invalid claiming options, claim rooms may only be specified when a token and URL are specified." F0204
   elif [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_EXTRA}" ]; then
-    fatal "Invalid claiming options, a claiming token must be specified."
+    fatal "Invalid claiming options, a claiming token must be specified." F0204
   elif [ "${NETDATA_DISABLE_CLOUD}" -eq 1 ] && [ -n "${NETDATA_CLAIM_TOKEN}" ]; then
-    fatal "Cloud explicitly disabled, but automatic claiming requested. Either enable Netdata Cloud, or remove the --claim-* options."
+    fatal "Cloud explicitly disabled, but automatic claiming requested. Either enable Netdata Cloud, or remove the --claim-* options." F0204
   fi
 }
 
@@ -574,6 +693,7 @@ claim() {
     warning "Unable to claim node, you must do so manually."
     if [ -z "${NETDATA_NEW_INSTALL}" ]; then
       cleanup
+      trap - EXIT
       exit 1
     fi
   fi
@@ -772,7 +892,7 @@ try_package_install() {
       progress "Updating repository metadata."
       # shellcheck disable=SC2086
       if ! run ${ROOTCMD} env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts}; then
-        fatal "Failed to update repository metadata."
+        fatal "Failed to update repository metadata." F0205
       fi
     fi
   else
@@ -842,11 +962,11 @@ try_static_install() {
   fi
 
   if ! download "${NETDATA_STATIC_ARCHIVE_CHECKSUM_URL}" "${tmpdir}/sha256sum.txt"; then
-    fatal "Unable to fetch checksums to verify static build archive."
+    fatal "Unable to fetch checksums to verify static build archive." F0206
   fi
 
   if ! grep "netdata-${SYSARCH}-latest.gz.run" "${tmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-    fatal "Static binary checksum validation failed. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour."
+    fatal "Static binary checksum validation failed. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0207
   fi
 
   if [ "${INTERACTIVE}" -eq 0 ]; then
@@ -856,7 +976,9 @@ try_static_install() {
   progress "Installing netdata"
   # shellcheck disable=SC2086
   if ! run ${ROOTCMD} sh "${tmpdir}/netdata-${SYSARCH}-latest.gz.run" ${opts} -- ${NETDATA_AUTO_UPDATES:+--auto-update} ${NETDATA_INSTALLER_OPTIONS}; then
-    fatal "Failed to install static build of Netdata on ${SYSARCH}."
+    warning "Failed to install static build of Netdata on ${SYSARCH}."
+    run rm -rf /opt/netdata
+    return 2
   fi
 
   install_type_file="/opt/netdata/etc/netdata/.install-type"
@@ -947,7 +1069,16 @@ build_and_install() {
   fi
 
   # shellcheck disable=SC2086
-  run ${ROOTCMD} ./netdata-installer.sh ${opts} || fatal "netdata-installer.sh exited with error"
+  run ${ROOTCMD} ./netdata-installer.sh ${opts}
+
+  case $? in
+    1)
+      fatal "netdata-installer.sh exited with error" F0007
+      ;;
+    2)
+      fatal "Insufficient RAM to install netdata" F0008
+      ;;
+  esac
 }
 
 try_build_install() {
@@ -961,12 +1092,12 @@ try_build_install() {
   download "${NETDATA_SOURCE_ARCHIVE_URL}" "${tmpdir}/netdata-latest.tar.gz"
 
   if ! grep netdata-latest.tar.gz "${tmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-    fatal "Tarball checksum validation failed. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour."
+    fatal "Tarball checksum validation failed. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0005
   fi
 
   run tar -xf "${tmpdir}/netdata-latest.tar.gz" -C "${tmpdir}"
   rm -rf "${tmpdir}/netdata-latest.tar.gz" > /dev/null 2>&1
-  cd "$(find "${tmpdir}" -mindepth 1 -maxdepth 1 -type d -name netdata-)" || fatal "Cannot cd to netdata source tree"
+  cd "$(find "${tmpdir}" -mindepth 1 -maxdepth 1 -type d -name netdata-)" || fatal "Cannot cd to netdata source tree" F0006
 
   if [ -x netdata-installer.sh ]; then
     build_and_install || return 1
@@ -975,7 +1106,7 @@ try_build_install() {
     if [ "$(find . -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ] && [ -x "$(find . -mindepth 1 -maxdepth 1 -type d)/netdata-installer.sh" ]; then
       cd "$(find . -mindepth 1 -maxdepth 1 -type d)" &&  build_and_install || return 1
     else
-      fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${tmpdir}"
+      fatal "Cannot install netdata from source (the source directory does not include netdata-installer.sh). Leaving all files in ${tmpdir}" F0009
     fi
   fi
 }
@@ -992,11 +1123,11 @@ install_on_linux() {
         NETDATA_INSTALL_SUCCESSFUL=1
         ;;
       1)
-        fatal "Unable to install on this system."
+        fatal "Unable to install on this system." F0300
         ;;
       2)
         if [ "${NETDATA_ONLY_NATIVE}" -eq 1 ]; then
-          fatal "Could not install native binary packages."
+          fatal "Could not install native binary packages." F0301
         else
           warning "Could not install native binary packages, falling back to alternative installation method."
         fi
@@ -1013,11 +1144,11 @@ install_on_linux() {
         INSTALL_PREFIX="/opt/netdata"
         ;;
       1)
-        fatal "Unable to install on this system."
+        fatal "Unable to install on this system." F0302
         ;;
       2)
         if [ "${NETDATA_ONLY_STATIC}" -eq 1 ]; then
-          fatal "Could not install static build."
+          fatal "Could not install static build." F0303
         else
           warning "Could not install static build, falling back to alternative installation method."
         fi
@@ -1033,7 +1164,7 @@ install_on_linux() {
         NETDATA_INSTALL_SUCCESSFUL=1
         ;;
       *)
-        fatal "Unable to install on this system."
+        fatal "Unable to install on this system." F0304
         ;;
     esac
   fi
@@ -1041,9 +1172,9 @@ install_on_linux() {
 
 install_on_macos() {
   if [ "${NETDATA_ONLY_NATIVE}" -eq 1 ]; then
-    fatal "User requested native package, but native packages are not available for macOS. Try installing without \`--only-native\` option."
+    fatal "User requested native package, but native packages are not available for macOS. Try installing without \`--only-native\` option." F0305
   elif [ "${NETDATA_ONLY_STATIC}" -eq 1 ]; then
-    fatal "User requested static build, but static builds are not available for macOS. Try installing without \`--only-static\` option."
+    fatal "User requested static build, but static builds are not available for macOS. Try installing without \`--only-static\` option." F0306
   else
     try_build_install
 
@@ -1052,7 +1183,7 @@ install_on_macos() {
         NETDATA_INSTALL_SUCCESSFUL=1
         ;;
       *)
-        fatal "Unable to install on this system."
+        fatal "Unable to install on this system." F0307
         ;;
     esac
   fi
@@ -1060,9 +1191,9 @@ install_on_macos() {
 
 install_on_freebsd() {
   if [ "${NETDATA_ONLY_NATIVE}" -eq 1 ]; then
-    fatal "User requested native package, but native packages are not available for FreeBSD. Try installing without \`--only-native\` option."
+    fatal "User requested native package, but native packages are not available for FreeBSD. Try installing without \`--only-native\` option." F0308
   elif [ "${NETDATA_ONLY_STATIC}" -eq 1 ]; then
-    fatal "User requested static build, but static builds are not available for FreeBSD. Try installing without \`--only-static\` option."
+    fatal "User requested static build, but static builds are not available for FreeBSD. Try installing without \`--only-static\` option." F0309
   else
     try_build_install
 
@@ -1071,7 +1202,7 @@ install_on_freebsd() {
         NETDATA_INSTALL_SUCCESSFUL=1
         ;;
       *)
-        fatal "Unable to install on this system."
+        fatal "Unable to install on this system." F030A
         ;;
     esac
   fi
@@ -1087,6 +1218,7 @@ while [ -n "${1}" ]; do
     "--help")
       usage
       cleanup
+      trap - EXIT
       exit 0
       ;;
     "--no-cleanup") NO_CLEANUP=1 ;;
@@ -1122,18 +1254,20 @@ while [ -n "${1}" ]; do
       NETDATA_ONLY_NATIVE=1
       NETDATA_ONLY_STATIC=0
       NETDATA_ONLY_BUILD=0
+      ACTUAL_INSTALL_METHOD="native"
       ;;
     "--static-only")
       NETDATA_ONLY_STATIC=1
       NETDATA_ONLY_NATIVE=0
       NETDATA_ONLY_BUILD=0
+      ACTUAL_INSTALL_METHOD="static"
       ;;
     "--build-only")
       NETDATA_ONLY_BUILD=1
       NETDATA_ONLY_NATIVE=0
       NETDATA_ONLY_STATIC=0
+      ACTUAL_INSTALL_METHOD="build"
       ;;
-
     "--claim-token")
       NETDATA_CLAIM_TOKEN="${2}"
       shift 1
@@ -1192,4 +1326,5 @@ elif [ "${NETDATA_DISABLE_CLOUD}" -eq 1 ]; then
   soft_disable_cloud
 fi
 
+telemetry_event INSTALL_SUCCESS "" ""
 cleanup

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -519,8 +519,8 @@ handle_existing_install() {
       ndprefix="$(dirname "$(dirname "${ndpath}")")"
     fi
 
-    if [ "${ndprefix}" = /usr ]; then
-      ndprefix="/"
+    if (echo "${ndprefix}" | grep -Eq '/usr$'); then
+      ndprefix="$(dirname "${ndpath}")"
     fi
   fi
 

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -502,6 +502,7 @@ handle_existing_install() {
   else
     if [ -n "${INSTALL_PREFIX}" ]; then
       searchpath="${INSTALL_PREFIX}/bin:${INSTALL_PREFIX}/sbin:${INSTALL_PREFIX}/usr/bin:${INSTALL_PREFIX}/usr/sbin:${PATH}"
+      searchpath="${INSTALL_PREFIX}/netdata/bin:${INSTALL_PREFIX}/netdata/sbin:${INSTALL_PREFIX}/netdata/usr/bin:${INSTALL_PREFIX}/netdata/usr/sbin:${searchpath}"
     else
       searchpath="${PATH}"
     fi
@@ -656,13 +657,19 @@ confirm_install_prefix() {
     fatal "The \`--install\` option is only supported together with the \`--only-build\` option." F0204
   fi
 
-  case "${SYSTYPE}" in
-    Darwin) INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local/netdata}" ;;
-    FreeBSD) INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}" ;;
-  esac
-
   if [ -n "${INSTALL_PREFIX}" ]; then
     NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --install ${INSTALL_PREFIX}"
+  else
+    case "${SYSTYPE}" in
+      Darwin)
+        INSTALL_PREFIX="/usr/local/netdata"
+        NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --install-no-prefix ${INSTALL_PREFIX}"
+        ;;
+      FreeBSD)
+        INSTALL_PREFIX="/usr/local"
+        NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --install-no-prefix ${INSTALL_PREFIX}"
+        ;;
+    esac
   fi
 }
 

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -123,7 +123,7 @@ telemetry_event() {
 
   if [ -f /etc/machine-id ]; then
     DISTINCT_ID="$(cat /etc/machine-id)"
-  elif command -v uuidgen 2> /dev/null; then
+  elif command -v uuidgen > /dev/null 2>&1; then
     DISTINCT_ID="$(uuidgen)"
   else
     DISTINCT_ID="null"

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -16,8 +16,8 @@ START_TIME="$(date +%s)"
 # ======================================================================
 # Defaults for environment variables
 
-ACTUAL_INSTALL_METHOD="none"
-INSTALL_METHOD_CODE="unknown"
+SELECTED_INSTALL_METHOD="none"
+INSTALL_TYPE="unknown"
 INSTALL_PREFIX=""
 NETDATA_AUTO_UPDATES="1"
 NETDATA_CLAIM_ONLY=0
@@ -145,9 +145,9 @@ telemetry_event() {
     "error_message": "${2}",
     "install_options": "${KICKSTART_OPTIONS}",
     "total_runtime": "${total_duration}",
-    "selected_install_method": "${ACTUAL_INSTALL_METHOD}",
+    "selected_install_method": "${SELECTED_INSTALL_METHOD}",
     "netdata_release_channel": "${RELEASE_CHANNEL:-null}",
-    "netdata_install_type": "${INSTALL_METHOD_CODE}",
+    "netdata_install_type": "${INSTALL_TYPE}",
     "host_os_name": "${HOST_NAME:-unknown}",
     "host_os_id": "${HOST_ID:-unknown}",
     "host_os_id_like": "${HOST_ID_LIKE:-unknown}",
@@ -809,7 +809,7 @@ try_package_install() {
       pkg_install_opts="${interactive_opts}"
       repo_update_opts="${interactive_opts}"
       uninstall_subcmd="uninstall"
-      INSTALL_METHOD_CODE="binpkg-deb"
+      INSTALL_TYPE="binpkg-deb"
       ;;
     ubuntu)
       needs_early_refresh=1
@@ -822,7 +822,7 @@ try_package_install() {
       pkg_install_opts="${interactive_opts}"
       repo_update_opts="${interactive_opts}"
       uninstall_subcmd="uninstall"
-      INSTALL_METHOD_CODE="binpkg-deb"
+      INSTALL_TYPE="binpkg-deb"
       ;;
     centos)
       if command -v dnf > /dev/null; then
@@ -838,7 +838,7 @@ try_package_install() {
       pkg_install_opts="${interactive_opts}"
       repo_update_opts="${interactive_opts}"
       uninstall_subcmd="remove"
-      INSTALL_METHOD_CODE="binpkg-rpm"
+      INSTALL_TYPE="binpkg-rpm"
       ;;
     fedora)
       if command -v dnf > /dev/null; then
@@ -854,7 +854,7 @@ try_package_install() {
       pkg_install_opts="${interactive_opts}"
       repo_update_opts="${interactive_opts}"
       uninstall_subcmd="remove"
-      INSTALL_METHOD_CODE="binpkg-rpm"
+      INSTALL_TYPE="binpkg-rpm"
       ;;
     opensuse)
       pm_cmd="zypper"
@@ -866,7 +866,7 @@ try_package_install() {
       pkg_install_opts="${interactive_opts} --allow-unsigned-rpm"
       repo_update_opts=""
       uninstall_subcmd="remove"
-      INSTALL_METHOD_CODE="binpkg-rpm"
+      INSTALL_TYPE="binpkg-rpm"
       ;;
     *)
       warning "We do not provide native packages for ${DISTRO}."
@@ -1129,7 +1129,7 @@ try_build_install() {
 
 install_on_linux() {
   if [ "${NETDATA_ONLY_STATIC}" -ne 1 ] && [ "${NETDATA_ONLY_BUILD}" -ne 1 ]; then
-    ACTUAL_INSTALL_METHOD="native"
+    SELECTED_INSTALL_METHOD="native"
     try_package_install
 
     case "$?" in
@@ -1150,8 +1150,8 @@ install_on_linux() {
   fi
 
   if [ "${NETDATA_ONLY_NATIVE}" -ne 1 ] && [ "${NETDATA_ONLY_BUILD}" -ne 1 ] && [ -z "${NETDATA_INSTALL_SUCCESSFUL}" ]; then
-    ACTUAL_INSTALL_METHOD="static"
-    INSTALL_METHOD_CODE="kickstart-static"
+    SELECTED_INSTALL_METHOD="static"
+    INSTALL_TYPE="kickstart-static"
     try_static_install
 
     case "$?" in
@@ -1173,8 +1173,8 @@ install_on_linux() {
   fi
 
   if [ "${NETDATA_ONLY_NATIVE}" -ne 1 ] && [ "${NETDATA_ONLY_STATIC}" -ne 1 ] && [ -z "${NETDATA_INSTALL_SUCCESSFUL}" ]; then
-    ACTUAL_INSTALL_METHOD="build"
-    INSTALL_METHOD_CODE="kickstart-build"
+    SELECTED_INSTALL_METHOD="build"
+    INSTALL_TYPE="kickstart-build"
     try_build_install
 
     case "$?" in
@@ -1194,8 +1194,8 @@ install_on_macos() {
   elif [ "${NETDATA_ONLY_STATIC}" -eq 1 ]; then
     fatal "User requested static build, but static builds are not available for macOS. Try installing without \`--only-static\` option." F0306
   else
-    ACTUAL_INSTALL_METHOD="build"
-    INSTALL_METHOD_CODE="kickstart-build"
+    SELECTED_INSTALL_METHOD="build"
+    INSTALL_TYPE="kickstart-build"
     try_build_install
 
     case "$?" in
@@ -1215,8 +1215,8 @@ install_on_freebsd() {
   elif [ "${NETDATA_ONLY_STATIC}" -eq 1 ]; then
     fatal "User requested static build, but static builds are not available for FreeBSD. Try installing without \`--only-static\` option." F0309
   else
-    ACTUAL_INSTALL_METHOD="build"
-    INSTALL_METHOD_CODE="kickstart-build"
+    SELECTED_INSTALL_METHOD="build"
+    INSTALL_TYPE="kickstart-build"
     try_build_install
 
     case "$?" in
@@ -1276,19 +1276,19 @@ while [ -n "${1}" ]; do
       NETDATA_ONLY_NATIVE=1
       NETDATA_ONLY_STATIC=0
       NETDATA_ONLY_BUILD=0
-      ACTUAL_INSTALL_METHOD="native"
+      SELECTED_INSTALL_METHOD="native"
       ;;
     "--static-only")
       NETDATA_ONLY_STATIC=1
       NETDATA_ONLY_NATIVE=0
       NETDATA_ONLY_BUILD=0
-      ACTUAL_INSTALL_METHOD="static"
+      SELECTED_INSTALL_METHOD="static"
       ;;
     "--build-only")
       NETDATA_ONLY_BUILD=1
       NETDATA_ONLY_NATIVE=0
       NETDATA_ONLY_STATIC=0
-      ACTUAL_INSTALL_METHOD="build"
+      SELECTED_INSTALL_METHOD="build"
       ;;
     "--claim-token")
       NETDATA_CLAIM_TOKEN="${2}"

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -91,7 +91,7 @@ telemetry_event() {
   if [ "${NETDATA_DISABLE_TELEMETRY}" -eq 1 ]; then
     return 0
   fi
-  
+
   now="$(date +%s)"
   total_duration="$((now - START_TIME))"
 
@@ -140,8 +140,8 @@ telemetry_event() {
     "\$host": "installer.netdata.io",
     "\$ip": "127.0.0.1",
     "script_variant": "kickstart-ng",
-    "error_code": "${2}",
-    "error_message": "${3}",
+    "error_code": "${3}",
+    "error_message": "${2}",
     "install_options": "${KICKSTART_OPTIONS}",
     "total_runtime": "${total_duration}",
     "selected_install_method": "${ACTUAL_INSTALL_METHOD}",
@@ -1258,7 +1258,7 @@ while [ -n "${1}" ]; do
       NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --dont-start-it"
       ;;
     "--disable-telemetry")
-      NETDATA_DISABLE_TELEMETRY="0"
+      NETDATA_DISABLE_TELEMETRY="1"
       NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --disable-telemetry"
       ;;
     "--install")

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -5,6 +5,7 @@
 # ======================================================================
 # Constants
 
+KICKSTART_OPTIONS="${*}"
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
 PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 REPOCONFIG_URL_PREFIX="https://packagecloud.io/netdata/netdata-repoconfig/packages"
@@ -162,15 +163,14 @@ EOF
 )"
 
   if [ -n "$(command -v curl 2> /dev/null)" ]; then
-    curl --silent -o /dev/null --write-out '%{http_code}' -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" "${TELEMETRY_URL}"
+    curl --silent -o /dev/null -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" "${TELEMETRY_URL}" > /dev/null
   else
     wget -q -O - --no-check-certificate \
-    --server-response \
     --method POST \
     --timeout=1 \
     --header 'Content-Type: application/json' \
     --body-data "${REQ_BODY}" \
-     "${TELEMETRY_URL}" 2>&1 | awk '/^  HTTP/{print $2}'
+     "${TELEMETRY_URL}" > /dev/null
   fi
 }
 

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -88,12 +88,12 @@ HEREDOC
 # Telemetry functions
 
 telemetry_event() {
-  now="$(date +%s)"
-  total_duration="$((now - START_TIME))"
-
-  if [ -n "${NETDATA_DISABLE_TELEMETRY}" ]; then
+  if [ "${NETDATA_DISABLE_TELEMETRY}" -eq 1 ]; then
     return 0
   fi
+  
+  now="$(date +%s)"
+  total_duration="$((now - START_TIME))"
 
   if [ -e "/etc/os-release" ]; then
     eval "$(grep -E "^(NAME|ID|ID_LIKE|VERSION|VERSION_ID)=" < /etc/os-release | sed 's/^/HOST_/')"

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -519,8 +519,8 @@ handle_existing_install() {
       ndprefix="$(dirname "$(dirname "${ndpath}")")"
     fi
 
-    if (echo "${ndprefix}" | grep -Eq '/usr$'); then
-      ndprefix="$(dirname "${ndpath}")"
+    if echo "${ndprefix}" | grep -Eq '/usr$'; then
+      ndprefix="$(dirname "${ndprefix}")"
     fi
   fi
 

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -500,7 +500,14 @@ handle_existing_install() {
   if pkg_installed netdata; then
     ndprefix="/"
   else
-    ndpath="$(command -v netdata 2>/dev/null)"
+    if [ -n "${INSTALL_PREFIX}" ]; then
+      searchpath="${INSTALL_PREFIX}/bin:${INSTALL_PREFIX}/sbin:${INSTALL_PREFIX}/usr/bin:${INSTALL_PREFIX}/usr/sbin:${PATH}"
+    else
+      searchpath="${PATH}"
+    fi
+
+    ndpath="$(PATH="${searchpath}" command -v netdata 2>/dev/null)"
+
     if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ]; then
       ndpath="/opt/netdata/bin/netdata"
     fi

--- a/packaging/installer/kickstart-ng.sh
+++ b/packaging/installer/kickstart-ng.sh
@@ -114,7 +114,7 @@ telemetry_event() {
   if [ "${KERNEL_NAME}" = FreeBSD ]; then
     TOTAL_RAM="$(sysctl -n hw.physmem)"
   elif [ "${KERNEL_NAME}" = Darwin ]; then
-    TOTAL_RAM="$(sysctl -n hw.physmem)"
+    TOTAL_RAM="$(sysctl -n hw.memsize)"
   elif [ -r /proc/meminfo ]; then
     TOTAL_RAM="$(grep -F MemTotal /proc/meminfo | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | cut -f 1 -d ' ')"
     TOTAL_RAM="$((TOTAL_RAM * 1024))"


### PR DESCRIPTION
##### Summary

This adds some basic telemetry to the new kickstart script. This new code properly honors the `--disable-telemetry` option and the `DO_NOT_TRACK` environment variable.

The following PostHog events are used for this purpose:

* `INSTALL_SUCCESS`: Sent after a successful install finishes.
* `INSTALL_FAILED`: Sent when an installation fails via an expected (and properly handled) failure path. Includes the error message shown to the user and an error code for easy searching within the script.
* `INSTALL_CRASH`: Sent when an installation fails via an unexpected exit path or due to an external signal. Includes the signal number (or `0` for an unguarded call to `exit`), and the line number if it was due to an unguarded call to exit.

The following properties are used with these events (note that these are backwards compatible with the telemetry in the legacy kickstart script added by https://github.com/netdata/netdata/pull/11658):

* `script_variant`: Currently always set to `kickstart-ng`. This is intended to be used to handle revisions in the event data.
* `error_code`: Empty string for a success event, searchable error code for a failure, signal and line number for a crash.
* `error_message`: User visible error message for failure and crash, empty for success.
* `install_options`: The exact list of arguments passed to the installer on invocation.
* `total_runtime`: Total wall-clock time spent running the script, expressed as seconds.
* `selected_install_method`: For success, the install method that worked on this system. For fail and crash, the install method that was in-use when the fail or crash happened. Set to `none` if the script failed or crashed before installation was attempted and the user had not asked for a specific method.

Additionally, a subset of the standard agent `META` event properties are provided.

##### Component Name

area/packaging

##### Test Plan

* All testing should be done with an environment variable called `NETDATA_POSTHOG_API_KEY` set to `phc_dqzj2jEKyZVh8qPAIRlXHD1iBsuQr8Pxy4uHXXaN3dg`. This will cause events to go to our testing workspace on Posthog instead of our production workspace.
* Simply running the script should generate an `INSTALL_SUCCESS` event on completion.
*  The `INSTALL_CRASH` event should be manually triggerable by hitting <kbd>Ctrl</kbd><kbd>C</kbd> or sending any of signals 1, 2, 3, 13 or 15 to the script. The `error_code` property _should_ look like `X-` where `X` is the signal number that triggered the event.
* The `INSTALL_FAILED` event should be manually triggerable by passing the `--claim-only` option when running against an existing install but not providing a claiming token (the `error_code` property for this case should be `F0202`). There are other ways to trigger it manually, but they all use the same codepath and this is the easiest one to trigger.
* If `DO_NOT_TRACK` is set or `--disable-telemetry` is passed to the script, there should be no events sent at all.

##### Additional Information

@andrewm4894 is listed as a reviewer here because I want his feedback on the event properties (sinc ehe’s probably the one who will have to write the support code to process these events).

---

There is a simple web server written in py3 that helps to test telemetry events locally.

 - put the following code in the `srv.py`.

<details>
<summary>simple py3 web server</summary>

```py
#!/usr/bin/env python3

import json
from http.server import BaseHTTPRequestHandler, HTTPServer


host_name = "localhost"
server_port = 9999

class MyServer(BaseHTTPRequestHandler):
    def do_POST(self):
        body = self.rfile.read(int(self.headers['Content-Length']))
        try:
            parsed = json.loads(body)
            self.send_response_only(200)
            print(json.dumps(parsed, indent=4))
        except Exception as e:
            self.send_response_only(400)
            print("invalid JSON formatted message: {0}".format(e))
        print('-'*80)

if __name__ == "__main__":        
    srv = HTTPServer((host_name, server_port), MyServer)
    print("Server started http://%s:%s" % (host_name, server_port))

    try:
        srv.serve_forever()
    except KeyboardInterrupt:
        pass

    srv.server_close()
    print("Server stopped.")
```

</details>

- start the server

> python3 srv.py

- change TELEMETRY_URL to "http://127.0.0.1:9999" (kickstart-ng.sh). 