### PR TITLE
Adding (eBPF) to submenu

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -995,7 +995,7 @@ netdataDashboard.submenu = {
     },
 
     'ip.kernel': {
-        title: 'kernel functions',
+        title: 'kernel functions (eBPF)',
         info: 'Next charts are made when <code>ebpf.plugin</code> is running on your host. When integration with apps is <a href="https://learn.netdata.cloud/guides/troubleshoot/monitor-debug-applications-ebpf" target="_blank">enabled</a>, Netdata also shows calls for kernel functions per <a href="#menu_apps_submenu_net">application</a>.'
     },
 


### PR DESCRIPTION
##### Summary
This PR adds word `(eBPF)` for `latency` and `kernel functions` submenus, because these menus are no following a pattern agreed with product team.
 
##### Component Name
dashboard
##### Test Plan

1 - Compile this PR and verify that word appears for charts

##### Additional Information

It is not necessary to test different kernels, because this PR is only addressing dashboard content.