### PR TITLE
Fix Link to New Charts

### DIFF
--- a/docs/visualize/interact-dashboards-charts.md
+++ b/docs/visualize/interact-dashboards-charts.md
@@ -6,7 +6,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/visualize/i
 
 # Interact with dashboards and charts
 
-> ⚠️ There is a new version of charts that is currently **only** available on [Netdata Cloud](/docs/cloud/visualize/interact-new-charts). We didn't
+> ⚠️ There is a new version of charts that is currently **only** available on [Netdata Cloud](https://learn.netdata.cloud/docs/cloud/visualize/interact-new-charts). We didn't
 > want to keep this valuable feature from you, so after we get this into your hands on the Cloud, we will collect and implement your feedback to make sure we are providing the best possible version of the feature on the Netdata Agent dashboard as quickly as possible.
 
 You can find Netdata's dashboards in two places: locally served at `http://NODE:19999` by the Netdata Agent, and in


### PR DESCRIPTION
Fixing a broken link.



##### Summary

Link to new charts was broken and triggering an automated version. 

##### Component Name

Docs

##### Test Plan

N/A

##### Additional Information
