### PR TITLE
Make package builds more resilient against network issues.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -132,6 +132,7 @@ jobs:
         with:
           max_attempts: 3
           retry_wait_seconds: 30
+          timeout_seconds: 900
           command: |
             docker pull --platform ${{ matrix.platform }} ${{ matrix.base_image }}:${{ env.version }}
             docker pull --platform ${{ matrix.platform }} netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           max_attempts: 3
           retry_wait_seconds: 30
+          timeout_seconds: 900
           command: docker pull --platform ${{ matrix.platform }} ${{ matrix.base_image }}:${{ matrix.version }}
       - name: Build Packages
         shell: bash


### PR DESCRIPTION
##### Summary

Recently, we’ve been having issues with our package builds due to external network problems when trying to pull the Docker images that will be used in the builds. This PR updates the package build workflows to pull the required images ahead of time, and retries the pulls a few times if they fail.

##### Component Name

area/ci

##### Test Plan

Package build CI all passes correctly on this PR.