### PR TITLE
Fix online chart in NG not updated properly

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -768,7 +768,7 @@ void *aclk_main(void *ptr)
         if (!aclk_use_new_cloud_arch)
             queue_connect_payloads();
 
-        if (!handle_connection(mqttwss_client)) {
+        if (handle_connection(mqttwss_client)) {
             aclk_stats_upd_online(0);
             aclk_connected = 0;
         }


### PR DESCRIPTION
##### Summary
Due to mistake the ACLK online chart could show online status longer than it should.
##### Component Name
ACLK-NG
##### Test Plan
tested manually by

- iptables block OUTPUT to cloud IP (takes time to be detected)
- iptables block INPUT from cloud IP (takes time to be detected)
- ss -K dst IP (instant)

tested automatically by inducing drops at random times

tested in all cases:
1. re-connection happens after network conditions are restored normal
2. chart properly shows valid data
##### Additional Information

