### PR TITLE
Change comma possition in v1/info if ml-info is missing

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1089,19 +1089,18 @@ inline int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb)
 
     buffer_strcat(wb, "\t\"metrics-count\": ");
     analytics_get_data(analytics_data.netdata_metrics_count, wb);
-    buffer_strcat(wb, ",\n");
 
 #if defined(ENABLE_ML)
+    buffer_strcat(wb, ",\n");
     char *ml_info = ml_get_host_info(host);
 
     buffer_strcat(wb, "\t\"ml-info\": ");
     buffer_strcat(wb, ml_info);
-    buffer_strcat(wb, "\n");
 
     free(ml_info);
 #endif
 
-    buffer_strcat(wb, "}");
+    buffer_strcat(wb, "\n}");
     return 0;
 }
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Small PR to make sure to print a comma after `metrics-count` in `api/v1/info` only if there is also `ml-info` to print.

##### Component Name

web/api

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Compile with default parameters (to enable ml) and using `--disable-ml`. Check that in both cases there is no error emitted when requesting `/api/v1/info`.

##### Additional Information
