### PR TITLE
Minor improvement to CPU number function regarding macOS.

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -224,15 +224,21 @@ safe_pidof() {
 
 # -----------------------------------------------------------------------------
 find_processors() {
-  # Most UNIX systems have `nproc` as part of their userland (including macOS, Linux and BSD)
+  # Most UNIX systems have `nproc` as part of their userland (including Linux and BSD)
   if command -v nproc > /dev/null; then
     nproc && return
+  fi
+
+  # macOS has no nproc but it may have gnproc installed from Homebrew or from Macports.
+  if command -v gnproc > /dev/null; then
+    gnproc && return
   fi
 
   local cpus
   if [ -f "/proc/cpuinfo" ]; then
     # linux
     cpus=$(grep -c ^processor /proc/cpuinfo)
+  elif
   else
     # freebsd
     cpus=$(sysctl hw.ncpu 2> /dev/null | grep ^hw.ncpu | cut -d ' ' -f 2)

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -238,9 +238,8 @@ find_processors() {
   if [ -f "/proc/cpuinfo" ]; then
     # linux
     cpus=$(grep -c ^processor /proc/cpuinfo)
-  elif
   else
-    # freebsd
+  # freebsd
     cpus=$(sysctl hw.ncpu 2> /dev/null | grep ^hw.ncpu | cut -d ' ' -f 2)
   fi
   if [ -z "${cpus}" ] || [ $((cpus)) -lt 1 ]; then


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
nproc does not exists as a base part of macOS, but both Homebrew and Macports contain 'coreutil' with gnproc.

##### Component Name
area/packing
##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
