### PR TITLE
Add support to updater for updating native DEB/RPM installs with our official packages.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -388,10 +388,11 @@ update_static() {
   ndtmpdir="$(create_tmp_directory)"
   PREVDIR="$(pwd)"
 
-  echo >&2 "Entering ${ndtmpdir}"
+  info "Entering ${ndtmpdir}"
   cd "${ndtmpdir}" || exit 1
 
   if update_available; then
+    sysarch="$(uname -m)"
     download "${NETDATA_TARBALL_CHECKSUM_URL}" "${ndtmpdir}/sha256sum.txt"
     download "${NETDATA_TARBALL_URL}" "${ndtmpdir}/netdata-latest.gz.run"
     if ! grep netdata-latest.gz.run "${ndtmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
@@ -406,12 +407,11 @@ update_static() {
 
     # Do not pass any options other than the accept, for now
     # shellcheck disable=SC2086
-    if sh "${ndtmpdir}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS} >&3 2>&3; then
-      rm -rf "${ndtmpdir}" >&3 2>&3
+    if sh "${ndtmpdir}/netdata-${sysarch}-latest.gz.run" --accept -- ${REINSTALL_OPTIONS}; then
+      rm -r "${ndtmpdir}"
     else
       info "NOTE: did not remove: ${ndtmpdir}"
     fi
-
     echo "${install_type}" > /opt/netdata/etc/netdata/.install-type
   fi
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -642,7 +642,13 @@ case "${INSTALL_TYPE}" in
         update_build && exit 0
       fi
       ;;
+    custom)
+      fatal "This script does not support updating custom installations."
+      ;;
+    oci)
+      fatal "This script does not support updating Netdata inside our official Docker containers, please instead update the container itself."
+      ;;
     *)
-      fatal "Unrecognized installation type, unable to update."
+      fatal "Unrecognized installation type (${INSTALL_TYPE}), unable to update."
       ;;
 esac

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -627,7 +627,7 @@ case "${INSTALL_TYPE}" in
       set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
       update_build && exit 0
       ;;
-    *-static)
+    *-static*)
       set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
       update_static && exit 0
       ;;


### PR DESCRIPTION
##### Summary

* Updated the script to actually be POSIX compliant shell script (this is an ongoing project to improve our portability).
* Restructured the install type detection to leverage the `.install-type` file if present.
* Added updater code to handle installs done with our official DEB/RPM binary packages.

##### Component Name

area/packaging

##### Test Plan

Testing should be as simple as taking the `netdata-updater.sh` script from this PR and running it on a system with an existing install with the option `--no-updater-self-update`.