### PR TITLE
Add SSL_MODE_ENABLE_PARTIAL_WRITE to netdata_srv_ctx

### DIFF
--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -213,6 +213,7 @@ void security_start_ssl(int selector) {
             }
 
             netdata_srv_ctx =  security_initialize_openssl_server();
+            SSL_CTX_set_mode(netdata_srv_ctx, SSL_MODE_ENABLE_PARTIAL_WRITE);
             break;
         }
         case NETDATA_SSL_CONTEXT_STREAMING: {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds the flag `SSL_MODE_ENABLE_PARTIAL_WRITE` to `netdata_srv_ctx`. It thus allows `SSL_write` to return bytes written, instead of an error, if a partial write has been done.

If it's not enabled, `SSL_write` might return error (probably `SSL_ERROR_WANT_WRITE`) and it will be treated as error with no retries from `web_server_snd_callback`.
If it's enabled, `web_server_snd_callback` will be called repeatedly until no more data is left to send.

Closes https://github.com/netdata/netdata/issues/10886

##### Component Name

SSL

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

(Major kudos to @ilyam8 for managing to re-create the problem in https://github.com/netdata/netdata/issues/10886)

Try the scenario on an SSL enabled agent:

* From a different host, try: `curl --insecure https://pc:19999/api/v1/charts`. 
Curl will probably respond with: `(18) transfer closed with XXXXX bytes remaining to read`.

* Apply this PR and repeat the scenario. The above should complete successfully.

There should not be any other changes to other api transfer methods.

##### Additional Information

`SSL_MODE_ENABLE_PARTIAL_WRITE` is already applied for `netdata_client_ctx`. I did not find it though necessary to include the other modes as well.

More info at:  https://www.openssl.org/docs/man1.1.0/man3/SSL_set_mode.html & https://www.openssl.org/docs/man1.0.2/man3/SSL_write.html
