### PR TITLE
Remove check for enabled health when cloud requests to stream

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -534,11 +534,6 @@ void aclk_start_alert_streaming(char *node_id, uint64_t batch_id, uint64_t start
         wc = (struct aclk_database_worker_config *)host->dbsync_worker;
     rrd_unlock();
 
-    if (unlikely(!host->health_enabled)) {
-        info("Ignoring request to stream alert state changes, health is disabled for %s", host->machine_guid);
-        return;
-    }
-
     if (likely(wc)) {
         info("START streaming alerts for %s enabled with batch_id %"PRIu64" and start_seq_id %"PRIu64, node_id, batch_id, start_seq_id);
         __sync_synchronize();


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Removes the check for enabled health when the cloud (for new arch) requests to start streaming.

It could happen that we get the start streaming message before health is enabled for a children. We should enable `wc->alert_updates` and if health is indeed disabled no alerts will be streamed.

##### Component Name

Health/New architecture

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
