### PR TITLE
Store and submit dimension delete messages for new cloud architecture

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1392,7 +1392,7 @@ void rrdset_done(RRDSET *st) {
 
 #ifdef ENABLE_ACLK
     if (unlikely(!rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
-        if (st->counter_done >= RRDSET_MINIMUM_LIVE_COUNT) {
+        if (st->counter_done >= RRDSET_MINIMUM_LIVE_COUNT && st->dimensions) {
             if (likely(!queue_chart_to_aclk(st)))
                 rrdset_flag_set(st, RRDSET_FLAG_ACLK);
         }

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -455,10 +455,12 @@ void aclk_database_worker(void *arg)
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
                 case ACLK_DATABASE_DIM_DELETION:
                     debug(D_ACLK_SYNC,"Sending dimension deletion information %s", wc->uuid_str);
+                    aclk_process_dimension_deletion(wc, cmd);
                     break;
                 case ACLK_DATABASE_UPD_RETENTION:
                     debug(D_ACLK_SYNC,"Sending retention info for %s", wc->uuid_str);
                     aclk_update_retention(wc, cmd);
+                    aclk_process_dimension_deletion(wc, cmd);
                     break;
 #endif
 

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -11,6 +11,15 @@
 #endif
 
 const char *aclk_sync_config[] = {
+    "CREATE TABLE IF NOT EXISTS dimension_delete (dimension_id blob, dimension_name text, chart_type_id text, "
+    "dim_id blob, chart_id blob, host_id blob, date_created);",
+
+    "CREATE INDEX IF NOT EXISTS ind_h1 ON dimension_delete (host_id);",
+
+    "CREATE TRIGGER IF NOT EXISTS tr_dim_del AFTER DELETE ON dimension BEGIN INSERT INTO dimension_delete "
+    "(dimension_id, dimension_name, chart_type_id, dim_id, chart_id, host_id, date_created)"
+    " select old.id, old.name, c.type||\".\"||c.id, old.dim_id, old.chart_id, c.host_id, strftime('%s') FROM"
+    " chart c WHERE c.chart_id = old.chart_id; END;",
     NULL,
 };
 

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -170,24 +170,28 @@ int aclk_add_chart_event(struct aclk_database_worker_config *wc, struct aclk_dat
 }
 
 static inline int aclk_upd_dimension_event(struct aclk_database_worker_config *wc, char *claim_id, uuid_t *dim_uuid,
-        const char *dim_id, const char *dim_name, const char *chart_name, time_t first_time, time_t last_time)
+        const char *dim_id, const char *dim_name, const char *chart_type_id, time_t first_time, time_t last_time)
 {
     int rc = 0;
     size_t size;
 
-    if (unlikely(!dim_uuid || !dim_id || !dim_name || !chart_name))
+    if (unlikely(!dim_uuid || !dim_id || !dim_name || !chart_type_id))
         return 0;
 
     struct chart_dimension_updated dim_payload;
     memset(&dim_payload, 0, sizeof(dim_payload));
 
+#ifdef NETDATA_INTERNAL_CHECKS
     if (!first_time)
-        info("DEBUG: Deleting dimension [%s] [%s] [%s] [%s] [%s]", wc->node_id, claim_id, dim_id, dim_name, chart_name);
+        info("Host %s (node %s) deleting dimension id=[%s] name=[%s] chart=[%s]",
+                wc->host_guid, wc->node_id, dim_id, dim_name, chart_type_id);
+#endif
+
     dim_payload.node_id = wc->node_id;
     dim_payload.claim_id = claim_id;
     dim_payload.name = dim_name;
     dim_payload.id = dim_id;
-    dim_payload.chart_id = chart_name;
+    dim_payload.chart_id = chart_type_id;
     dim_payload.created_at.tv_sec = first_time;
     dim_payload.last_timestamp.tv_sec = last_time;
     char *payload = generate_chart_dimension_updated(&size, &dim_payload);
@@ -195,6 +199,66 @@ static inline int aclk_upd_dimension_event(struct aclk_database_worker_config *w
         rc = aclk_add_chart_payload(wc, dim_uuid, claim_id, ACLK_PAYLOAD_DIMENSION, (void *)payload, size);
     freez(payload);
     return rc;
+}
+
+void aclk_process_dimension_deletion(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
+{
+    int rc = 0;
+    sqlite3_stmt *res = NULL;
+
+    if (!aclk_use_new_cloud_arch || !aclk_connected)
+        return;
+
+    if (unlikely(!db_meta))
+        return;
+
+    char *claim_id = is_agent_claimed();
+    if (!claim_id)
+        return;
+
+    rc = sqlite3_prepare_v2(db_meta, "DELETE FROM dimension_delete where host_id = @host_id " \
+            "RETURNING dimension_id, dimension_name, chart_type_id, dim_id LIMIT 10;", -1, &res, 0);
+
+    if (rc != SQLITE_OK) {
+        error_report("Failed to prepare statement when trying to delete dimension deletes");
+        freez(claim_id);
+        return;
+    }
+
+    uuid_t host_id;
+    uuid_parse(wc->host_guid, host_id);
+
+    rc = sqlite3_bind_blob(res, 1, &host_id , sizeof(host_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK))
+        goto bind_fail;
+
+    unsigned count = 0;
+    while (sqlite3_step(res) == SQLITE_ROW) {
+        (void) aclk_upd_dimension_event(
+            wc,
+            claim_id,
+            (uuid_t *)sqlite3_column_text(res, 3),
+            (const char *)sqlite3_column_text(res, 0),
+            (const char *)sqlite3_column_text(res, 1),
+            (const char *)sqlite3_column_text(res, 2),
+            0,
+            0);
+        count++;
+    }
+
+    if (count) {
+        memset(&cmd, 0, sizeof(cmd));
+        cmd.opcode = ACLK_DATABASE_DIM_DELETION;
+        if (aclk_database_enq_cmd_noblock(wc, &cmd))
+            info("Failed to queue a dimension deletion message");
+    }
+
+bind_fail:
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to finalize statement when adding dimension deletion events, rc = %d", rc);
+    freez(claim_id);
+    return;
 }
 
 int aclk_add_dimension_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -212,6 +212,10 @@ void aclk_process_dimension_deletion(struct aclk_database_worker_config *wc, str
     if (unlikely(!db_meta))
         return;
 
+    uuid_t host_id;
+    if (uuid_parse(wc->host_guid, host_id))
+        return;
+
     char *claim_id = is_agent_claimed();
     if (!claim_id)
         return;
@@ -224,9 +228,6 @@ void aclk_process_dimension_deletion(struct aclk_database_worker_config *wc, str
         freez(claim_id);
         return;
     }
-
-    uuid_t host_id;
-    uuid_parse(wc->host_guid, host_id);
 
     rc = sqlite3_bind_blob(res, 1, &host_id , sizeof(host_id), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK))

--- a/database/sqlite/sqlite_aclk_chart.h
+++ b/database/sqlite/sqlite_aclk_chart.h
@@ -32,5 +32,6 @@ void sql_check_rotation_state(struct aclk_database_worker_config *wc, struct acl
 void sql_get_last_chart_sequence(struct aclk_database_worker_config *wc);
 void aclk_receive_chart_reset(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_receive_chart_ack(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
+void aclk_process_dimension_deletion(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 uint32_t sql_get_pending_count(struct aclk_database_worker_config *wc);
 #endif //NETDATA_SQLITE_ACLK_CHART_H


### PR DESCRIPTION
##### Summary
- Add new dimension_delete table and delete trigger on dimension table to record dimension deletions
- Submit the deleted dimensions to the cloud

A follow up PR will cleanup the dimension_delete table if ACLK is disabled
##### Component Name
ACLK, database

##### Test Plan
- Code is being tested in testing and staging environments
