### PR TITLE
Show stats for protected mount points in diskspace plugin

### DIFF
--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -389,6 +389,10 @@ void *diskspace_main(void *ptr) {
             if(unlikely(mi->flags & (MOUNTINFO_IS_DUMMY | MOUNTINFO_IS_BIND)))
                 continue;
 
+            // exclude mounts made by ProtectHome and ProtectSystem systemd hardening options
+            if(mi->flags && MOUNTINFO_READONLY && !strcmp(mi->root, mi->mount_point))
+                continue;
+
             do_disk_space_stats(mi, update_every);
             if(unlikely(netdata_exit)) break;
         }

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -417,7 +417,7 @@ void *diskspace_main(void *ptr) {
                 continue;
 
             // exclude mounts made by ProtectHome and ProtectSystem systemd hardening options
-            if(mi->flags && MOUNTINFO_READONLY && !strcmp(mi->root, mi->mount_point))
+            if(mi->flags & MOUNTINFO_READONLY && !strcmp(mi->root, mi->mount_point))
                 continue;
 
             do_disk_space_stats(mi, update_every);

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -83,6 +83,28 @@ int mount_point_cleanup(void *entry, void *data) {
     return 0;
 }
 
+// for the full list of protected mount points look at
+// https://github.com/systemd/systemd/blob/1eb3ef78b4df28a9e9f464714208f2682f957e36/src/core/namespace.c#L142-L149
+// https://github.com/systemd/systemd/blob/1eb3ef78b4df28a9e9f464714208f2682f957e36/src/core/namespace.c#L180-L194
+static const char *systemd_protected_mount_points[] = {
+    "/home",
+    "/root",
+    "/usr",
+    "/boot",
+    "/efi",
+    "/etc",
+    NULL
+};
+
+int mount_point_is_protected(char *mount_point)
+{
+    for (size_t i = 0; systemd_protected_mount_points[i] != NULL; i++)
+        if (!strcmp(mount_point, systemd_protected_mount_points[i]))
+            return 1;
+
+    return 0;
+}
+
 static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
     const char *family = mi->mount_point;
     const char *disk = mi->persistent_id;
@@ -190,7 +212,12 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
     if(unlikely(m->do_space == CONFIG_BOOLEAN_NO && m->do_inodes == CONFIG_BOOLEAN_NO))
         return;
 
-    if(unlikely(mi->flags & MOUNTINFO_READONLY && !m->collected && m->do_space != CONFIG_BOOLEAN_YES && m->do_inodes != CONFIG_BOOLEAN_YES))
+    if (unlikely(
+            mi->flags & MOUNTINFO_READONLY &&
+            !mount_point_is_protected(mi->mount_point) &&
+            !m->collected &&
+            m->do_space != CONFIG_BOOLEAN_YES &&
+            m->do_inodes != CONFIG_BOOLEAN_YES))
         return;
 
     struct statvfs buff_statvfs;


### PR DESCRIPTION
##### Summary
In `netdata.service` two protection options [are set by default](https://github.com/netdata/netdata/blob/f2826332672c2486c643ffcc5ecf67c647491cde/system/netdata.service.in#L67-L68). It means, that some mount points are marked as read-only and additional mount points may be added by systemd.

We will display the diskspace charts for some protected mount points by default. For the full list of protected mount points look at [ProtectHome=read-only](https://github.com/systemd/systemd/blob/1eb3ef78b4df28a9e9f464714208f2682f957e36/src/core/namespace.c#L142-L149) and [ProtectSystem=full](https://github.com/systemd/systemd/blob/1eb3ef78b4df28a9e9f464714208f2682f957e36/src/core/namespace.c#L180-L194) lists.

Fixes #3716
Fixes #9585
Fixes #11498

##### Component Name
diskspace.plugin

##### Test Plan
1. Run Netdata without a mount in `/root`. There should be no Disk Space Usage or Disk Files (inodes) Usage charts for mount point `/root` in the Disks section.
2. Become root (`su`) and mount tmpfs into `/root`: `mount -t tmpfs -o size=512M tmpfs /root`. Wait for a couple of seconds and check that there are diskspace charts for the `/root` mount point.
3. Restart Netdata service, check if the charts are still displayed.
4. `umount /root`, wait for a couple of seconds, check if the charts disappeared.