### PR TITLE
Insert alert into aclk_alert directly instead of queuing it

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -422,10 +422,6 @@ void aclk_database_worker(void *arg)
                     break;
 #endif
 // ALERTS
-                case ACLK_DATABASE_ADD_ALERT:
-                    debug(D_ACLK_SYNC,"Adding alert event for %s", wc->host_guid);
-                    aclk_add_alert_event(wc, cmd);
-                    break;
                 case ACLK_DATABASE_PUSH_ALERT_CONFIG:
                     debug(D_ACLK_SYNC,"Pushing chart config info to the cloud for %s", wc->host_guid);
                     aclk_push_alert_config_event(wc, cmd);

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -114,7 +114,6 @@ static inline char *get_str_from_uuid(uuid_t *uuid)
 
 enum aclk_database_opcode {
     ACLK_DATABASE_NOOP = 0,
-    ACLK_DATABASE_ADD_ALERT,
 
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
     ACLK_DATABASE_ADD_CHART,

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -10,7 +10,7 @@
 
 // will replace call to aclk_update_alarm in health/health_log.c
 // and handle both cases
-void sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae)
+int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae)
 {
     //check aclk architecture and handle old json alarm update to cloud
     //include also the valid statuses for this case
@@ -23,54 +23,38 @@ void sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae)
             ((ae->old_status == RRDCALC_STATUS_WARNING || ae->old_status == RRDCALC_STATUS_CRITICAL))) {
             aclk_update_alarm(host, ae);
         }
-        return;
+        return 0;
 #endif
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
     }
 
     if (ae->flags & HEALTH_ENTRY_FLAG_ACLK_QUEUED)
-        return;
+        return 0;
 
     if (ae->new_status == RRDCALC_STATUS_REMOVED || ae->new_status == RRDCALC_STATUS_UNINITIALIZED)
-        return;
+        return 0;
 
     if (unlikely(!host->dbsync_worker))
-        return;
+        return 1;
 
     if (unlikely(uuid_is_null(ae->config_hash_id)))
-        return;
+        return 0;
 
-    struct aclk_database_cmd cmd;
-    memset(&cmd, 0, sizeof(cmd));
-    cmd.opcode = ACLK_DATABASE_ADD_ALERT;
-    cmd.data = ae;
-    cmd.completion = NULL;
-    aclk_database_enq_cmd((struct aclk_database_worker_config *) host->dbsync_worker, &cmd);
-    ae->flags |= HEALTH_ENTRY_FLAG_ACLK_QUEUED;
-#else
-    UNUSED(host);
-    UNUSED(ae);
-#endif
-    return;
-}
-
-// stores an alert entry to aclk_alert_ table
-int aclk_add_alert_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
-{
     int rc = 0;
 
     CHECK_SQLITE_CONNECTION(db_meta);
 
     sqlite3_stmt *res_alert = NULL;
-    ALARM_ENTRY *ae = cmd.data;
+    char uuid_str[GUID_LEN + 1];
+    uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
 
     BUFFER *sql = buffer_create(1024);
 
     buffer_sprintf(
         sql,
         "INSERT INTO aclk_alert_%s (alert_unique_id, date_created) "
-        "VALUES (@alert_unique_id, strftime('%%s')); ",
-        wc->uuid_str);
+        "VALUES (@alert_unique_id, strftime('%%s')) on conflict (alert_unique_id) do nothing; ",
+        uuid_str);
 
     rc = sqlite3_prepare_v2(db_meta, buffer_tostring(sql), -1, &res_alert, 0);
     if (unlikely(rc != SQLITE_OK)) {
@@ -84,15 +68,24 @@ int aclk_add_alert_event(struct aclk_database_worker_config *wc, struct aclk_dat
         goto bind_fail;
 
     rc = execute_insert(res_alert);
-    if (unlikely(rc != SQLITE_DONE))
+    if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to store alert event %u, rc = %d", ae->unique_id, rc);
+        goto bind_fail;
+    }
+
+    ae->flags |= HEALTH_ENTRY_FLAG_ACLK_QUEUED;
 
 bind_fail:
     if (unlikely(sqlite3_finalize(res_alert) != SQLITE_OK))
         error_report("Failed to reset statement in store alert event, rc = %d", rc);
 
     buffer_free(sql);
-    return (rc != SQLITE_DONE);
+    return 0;
+#else
+    UNUSED(host);
+    UNUSED(ae);
+#endif
+    return 0;
 }
 
 int rrdcalc_status_to_proto_enum(RRDCALC_STATUS status)

--- a/database/sqlite/sqlite_aclk_chart.h
+++ b/database/sqlite/sqlite_aclk_chart.h
@@ -19,7 +19,7 @@ extern sqlite3 *db_meta;
 extern int queue_chart_to_aclk(RRDSET *st);
 extern int queue_dimension_to_aclk(RRDDIM *rd);
 extern void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id);
-extern void sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae);
+extern int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae);
 int aclk_add_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 int aclk_add_dimension_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 int aclk_send_chart_config(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Changes the way alerts are inserted in aclk_alert_XXXX. Instead of queuing with an `ACLK_DATABASE_ADD_ALERT` opcode, it inserts it directly to the DB.

##### Component Name

ACLK/New architecture

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information

This code is under test in staging environment.
