### PR TITLE
Temporary fix for cgroup renaming

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -161,8 +161,6 @@ function k8s_get_kubepod_name() {
   local clean_id="$id"
   clean_id=${clean_id//.slice/}
   clean_id=${clean_id//.scope/}
-  clean_id=${clean_id//-slice/}
-  clean_id=${clean_id//-scope/}
 
   local name pod_uid cntr_id
   if [[ $clean_id == "kubepods" ]]; then

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1647,6 +1647,7 @@ static inline void cgroup_free(struct cgroup *cg) {
     free_pressure(&cg->memory_pressure);
 
     freez(cg->id);
+    freez(cg->intermediate_id);
     freez(cg->chart_id);
     freez(cg->chart_title);
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1524,10 +1524,6 @@ static inline struct cgroup *cgroup_add(const char *id) {
             strncpy(buffer, cg->id, CGROUP_CHARTID_LINE_MAX);
             char *s = buffer;
 
-            //freez(cg->chart_id);
-            //cg->chart_id = cgroup_chart_id_strdupz(s);
-            //cg->hash_chart = simple_hash(cg->chart_id);
-
             // skip to the last slash
             size_t len = strlen(s);
             while(len--) if(unlikely(s[len] == '/')) break;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -663,6 +663,7 @@ struct cgroup {
     char enabled;        // enabled in the config
 
     char pending_renames;
+    char *intermediate_id; // TODO: remove it when the renaming script is fixed
 
     char *id;
     uint32_t hash;
@@ -1367,13 +1368,16 @@ static inline char *cgroup_chart_id_strdupz(const char *s) {
     char *r = strdupz(s);
     netdata_fix_chart_id(r);
 
+    return r;
+}
+
+// TODO: move the code to cgroup_chart_id_strdupz() when the renaming script is fixed
+static inline void substitute_dots_in_id(char *s) {
     // dots are used to distinguish chart type and id in streaming, so we should replace them
-    for (char *d = r; *d; d++) {
+    for (char *d = s; *d; d++) {
         if (*d == '.')
             *d = '-';
     }
-
-    return r;
 }
 
 char *parse_k8s_data(struct label **labels, char *data)
@@ -1411,7 +1415,8 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
     pid_t cgroup_pid;
     char command[CGROUP_CHARTID_LINE_MAX + 1];
 
-    snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->chart_id);
+    // TODO: use cg->id when the renaming script is fixed
+    snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->intermediate_id);
 
     debug(D_CGROUP, "executing command \"%s\" for cgroup '%s'", command, cg->chart_id);
     FILE *fp = mypopen(command, &cgroup_pid);
@@ -1448,6 +1453,7 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
 
                     freez(cg->chart_id);
                     cg->chart_id = cgroup_chart_id_strdupz(name);
+                    substitute_dots_in_id(cg->chart_id);
                     cg->hash_chart = simple_hash(cg->chart_id);
                 }
             }
@@ -1474,7 +1480,10 @@ static inline struct cgroup *cgroup_add(const char *id) {
 
     cg->chart_title = cgroup_title_strdupz(id);
 
+    cg->intermediate_id = cgroup_chart_id_strdupz(id);
+
     cg->chart_id = cgroup_chart_id_strdupz(id);
+    substitute_dots_in_id(cg->chart_id);
     cg->hash_chart = simple_hash(cg->chart_id);
 
     if(cgroup_use_unified_cgroups) cg->options |= CGROUP_OPTIONS_IS_UNIFIED;


### PR DESCRIPTION
##### Summary
After #11050 some of regular expressions in [`cgroup-name.sh`](https://github.com/netdata/netdata/blob/9676eff1bc6dfc28e8f1c4857786ec05613b2646/collectors/cgroups.plugin/cgroup-name.sh.in) work incorrectly. We should use `cg->id` and fix the script, but we decided to make a simple temporary fix because the next release is coming.

Fixes #11760

##### Component Name
cgroups plugin

##### Test Plan
Start as many different types of containers as you can. Check if they are named correctly in the dashboard or charts API.