### PR TITLE
eBPF alerts

### DIFF
--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -804,6 +804,29 @@ If they are already mounted, you will see an error. You can also configure your 
 mount these filesystems on startup. More information can be found in
 the [ftrace documentation](https://www.kernel.org/doc/Documentation/trace/ftrace.txt).
 
+## Alerts
+
+Like other plugins, `eBPF.plugin` also have associated alerts for its charts. You can personalize them modifying
+the file `healt.d/ebpf.conf` using [`edit-config`](/docs/monitor/configure-alarms#edit-health-configuration-files).
+
+### Default alerts
+
+The following alerts are enabled by default:
+
+- retransmit_tcp_error: When at least 2% of packages are retransmitted, `netdata` raises alerts to notify possible
+  network problems.
+- apps_oomkill: When some apps group has an event of [Out Of Memory](#OOM-Killing), `netdata` sends a notification for
+  our users.
+
+### Silent alerts
+
+Certain Alerts are of high interest for specific use cases due to a safety policy or development purposes. To avoid
+alert overload, 'netdata' set them [silent](/guides/monitor/stop-notifications-alarms).
+
+-   task_error: This alert is raised every time a process/thread cannot be created.
+-   mount_call: For security reasons, some companies create policies that does not allow stick drivers to be used,
+    this alert sends notification every time a `mount (2)` or `umount (2)` `syscall` is called.
+
 ## Performance
 
 eBPF monitoring is complex and produces a large volume of metrics. We've discovered scenarios where the eBPF plugin

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -806,16 +806,16 @@ the [ftrace documentation](https://www.kernel.org/doc/Documentation/trace/ftrace
 
 ## Alerts
 
-Like other plugins, `eBPF.plugin` also have associated alerts for its charts. You can personalize them modifying
+Like other plugins, `eBPF.plugin` also has associated alerts for its charts. You can personalize the alerts by modifying
 the file `healt.d/ebpf.conf` using [`edit-config`](/docs/monitor/configure-alarms#edit-health-configuration-files).
 
 ### Default alerts
 
 The following alerts are enabled by default:
 
-- retransmit_tcp_error: When at least 2% of packages are retransmitted, `netdata` raises alerts to notify possible
+- retransmit_tcp_error: When at least 2% of packages are retransmitted, netdata raises alerts to notify possible
   network problems.
-- apps_oomkill: When some apps group has an event of [Out Of Memory](#OOM-Killing), `netdata` sends a notification for
+- apps_oomkill: When some apps group has an event of [Out Of Memory](#OOM-Killing), netdata sends a notification for
   our users.
 
 ### Silent alerts
@@ -824,8 +824,8 @@ Certain Alerts are of high interest for specific use cases due to a safety polic
 alert overload, 'netdata' set them [silent](/guides/monitor/stop-notifications-alarms).
 
 -   task_error: This alert is raised every time a process/thread cannot be created.
--   mount_call: For security reasons, some companies create policies that does not allow stick drivers to be used,
-    this alert sends notification every time a `mount (2)` or `umount (2)` `syscall` is called.
+-   mount_call: For security reasons, some companies create policies that does not allow stick drivers to be used. This
+    alert sends a notification every time a `mount (2)` or `umount (2)` `syscall` is called.
 
 ## Performance
 

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -824,8 +824,6 @@ Certain Alerts are of high interest for specific use cases due to a safety polic
 alert overload, 'netdata' set them [silent](/guides/monitor/stop-notifications-alarms).
 
 -   task_error: This alert is raised every time a process/thread cannot be created.
--   mount_call: For security reasons, some companies create policies that does not allow stick drivers to be used. This
-    alert sends a notification every time a `mount (2)` or `umount (2)` `syscall` is called.
 
 ## Performance
 

--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -41,6 +41,7 @@ dist_healthconfig_DATA = \
     health.d/dnsmasq_dhcp.conf \
     health.d/dns_query.conf \
     health.d/dockerd.conf \
+    health.d/ebpf.conf \
     health.d/entropy.conf \
     health.d/exporting.conf \
     health.d/fping.conf \

--- a/health/health.d/ebpf.conf
+++ b/health/health.d/ebpf.conf
@@ -15,7 +15,7 @@ families: *
    alarm: retransmit_tcp_error
       os: linux
       on: ip.tcp_retransmit  
-  lookup: sum -5m 
+  lookup: sum -10m
    units: percentage
     calc: ($ip.tcp_functions.tcp_sendmsg == 0) ? 0 : ($retransmitted/$ip.tcp_functions.tcp_sendmsg) * 100
    every: 1m

--- a/health/health.d/ebpf.conf
+++ b/health/health.d/ebpf.conf
@@ -38,17 +38,3 @@ families: *
     warn: $this > 1
     info: Number of processes and threads not created
       to: silent
-
-
-# Some filesystem/device was removed from host
-# or inserted on host
-   alarm: mount_call
-      os: linux
-      on: mount_points.call  
-  lookup: sum -10s foreach *
-   units: calls
-   every: 10s
-    warn: $this > 1
-    info: Some device was removed or inserted on host
-      to: silent
-

--- a/health/health.d/ebpf.conf
+++ b/health/health.d/ebpf.conf
@@ -1,0 +1,54 @@
+# When an oom kill event happens, notifies user
+template: apps_oomkill
+      os: linux
+families: *
+      on: apps.oomkills  
+  lookup: sum -10s foreach *
+   units: calls
+   every: 10s
+    warn: $this != 0
+    info: An application raised an OOMkill.
+
+# IP retransmit
+# When 2% of packages are lost it is possible host
+# is having network problems
+   alarm: retransmit_tcp_error
+      os: linux
+      on: ip.tcp_retransmit  
+  lookup: sum -5m 
+   units: percentage
+    calc: ($ip.tcp_functions.tcp_sendmsg == 0) ? 0 : ($retransmitted/$ip.tcp_functions.tcp_sendmsg) * 100
+   every: 1m
+    warn: $this >= 2
+    info: more than 2% of the packages have been retransmitted
+
+#
+#  Silent Alerts
+#
+
+# Check if a process either could not create
+# a process or a thread.
+template: task_error
+families: *
+      os: linux
+      on: apps.task_error  
+  lookup: sum -10s foreach *
+   units: calls
+   every: 10s
+    warn: $this > 1
+    info: Number of processes and threads not created
+      to: silent
+
+
+# Some filesystem/device was removed from host
+# or inserted on host
+   alarm: mount_call
+      os: linux
+      on: mount_points.call  
+  lookup: sum -10s foreach *
+   units: calls
+   every: 10s
+    warn: $this > 1
+    info: Some device was removed or inserted on host
+      to: silent
+


### PR DESCRIPTION
##### Summary
This is the first PR adding alerts for `eBPF.plugin` charts. For this first group of alerts we are addressing alerts where it is not necessary to add additional charts.

##### Component Name
health.
##### Test Plan

1 - Install branch
2 - Access `https://localhost:19999/api/v1/alarms?all` and verify alerts were applied.

##### Additional Information
