### PR TITLE
Fix proc/interrupts parser

### DIFF
--- a/collectors/proc.plugin/proc_interrupts.c
+++ b/collectors/proc.plugin/proc_interrupts.c
@@ -65,7 +65,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
     if(unlikely(!ff)) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/interrupts");
-        ff = procfile_open(config_get(CONFIG_SECTION_PLUGIN_PROC_INTERRUPTS, "filename to monitor", filename), " \t", PROCFILE_FLAG_DEFAULT);
+        ff = procfile_open(config_get(CONFIG_SECTION_PLUGIN_PROC_INTERRUPTS, "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
     }
     if(unlikely(!ff))
         return 1;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This fixes the same bug as the one highlighted in #4051, with the same fix as in #4055.
This bug surfaces with systems with a very high number of interrupts (especially true for ARM arch): in this case, netdata doesn't parse /proc/interrupts correctly and ends up creating new metrics every few seconds, which eventually leads to insane RAM & CPU usage. See #4051 for more context.
We hit this bug in production with netdata latest stable (v1.31.0).

The bug seems to have been re-introduced during collector refactoring. I did not check if other bugs might have been re-introduced.

##### Component Name

collector -> proc.plugin

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->
As the fix was already present in former netdata release, it has not been re-tested

##### Additional Information
