### PR TITLE
Simple fix for the data API query

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1604,7 +1604,7 @@ static time_t test_dbengine_create_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS
     collected_number next;
 
     update_every = REGION_UPDATE_EVERY[current_region];
-    time_now = time_start + update_every;
+    time_now = time_start;
     // feed it with the test data
     for (i = 0 ; i < CHARTS ; ++i) {
         for (j = 0 ; j < DIMS ; ++j) {
@@ -1615,7 +1615,7 @@ static time_t test_dbengine_create_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS
         }
     }
     for (c = 0; c < REGION_POINTS[current_region] ; ++c) {
-        time_now += update_every; // time_now = start + (c + 2) * update_every
+        time_now += update_every; // time_now = start + (c + 1) * update_every
         for (i = 0 ; i < CHARTS ; ++i) {
             st[i]->usec_since_last_update = USEC_PER_SEC * update_every;
 
@@ -1647,7 +1647,7 @@ static int test_dbengine_check_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DI
 
     // check the result
     for (c = 0; c < REGION_POINTS[current_region] ; c += QUERY_BATCH) {
-        time_now = time_start + (c + 2) * update_every;
+        time_now = time_start + (c + 1) * update_every;
         for (i = 0 ; i < CHARTS ; ++i) {
             for (j = 0; j < DIMS; ++j) {
                 rd[i][j]->state->query_ops.init(rd[i][j], &handle, time_now, time_now + QUERY_BATCH * update_every);
@@ -1692,7 +1692,7 @@ static int test_dbengine_check_rrdr(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DIMS]
 
     errors = 0;
     update_every = REGION_UPDATE_EVERY[current_region];
-    long points = (time_end - time_start) / update_every - 1;
+    long points = (time_end - time_start) / update_every;
     for (i = 0 ; i < CHARTS ; ++i) {
         RRDR *r = rrd2rrdr(st[i], points, time_start + update_every, time_end, RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL);
         if (!r) {
@@ -1711,7 +1711,7 @@ static int test_dbengine_check_rrdr(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DIMS]
                     value = cn[j];
                     assert(rd[i][j] == d);
 
-                    last = i * DIMS * REGION_POINTS[current_region] + j * REGION_POINTS[current_region] + c;
+                    last = i * DIMS * REGION_POINTS[current_region] + j * REGION_POINTS[current_region] + c + 1;
                     expected = unpack_storage_number(pack_storage_number((calculated_number)last, SN_DEFAULT_FLAGS));
 
                     same = (calculated_number_round(value) == calculated_number_round(expected)) ? 1 : 0;
@@ -1810,7 +1810,7 @@ int test_dbengine(void)
     current_region = 1;
     update_every = REGION_UPDATE_EVERY[current_region]; // use the maximum update_every = 3
     errors = 0;
-    long points = (time_end[REGIONS - 1] - time_start[0]) / update_every - 1; // cover all time regions with RRDR
+    long points = (time_end[REGIONS - 1] - time_start[0]) / update_every; // cover all time regions with RRDR
     long point_offset = (time_start[current_region] - time_start[0]) / update_every;
     for (i = 0 ; i < CHARTS ; ++i) {
         RRDR *r = rrd2rrdr(st[i], points, time_start[0] + update_every, time_end[REGIONS - 1], RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL);
@@ -1833,7 +1833,7 @@ int test_dbengine(void)
                     calculated_number value = cn[j];
                     assert(rd[i][j] == d);
 
-                    collected_number last = i * DIMS * REGION_POINTS[current_region] + j * REGION_POINTS[current_region] + c - point_offset;
+                    collected_number last = i * DIMS * REGION_POINTS[current_region] + j * REGION_POINTS[current_region] + c - point_offset + 1;
                     calculated_number expected = unpack_storage_number(pack_storage_number((calculated_number)last, SN_DEFAULT_FLAGS));
 
                     uint8_t same = (calculated_number_round(value) == calculated_number_round(expected)) ? 1 : 0;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1150,7 +1150,10 @@ static inline time_t rrdset_first_entry_t_nolock(RRDSET *st)
         time_t first_entry_t = LONG_MAX;
 
         rrddim_foreach_read(rd, st) {
-            first_entry_t = MIN(first_entry_t, rd->state->query_ops.oldest_time(rd));
+            first_entry_t =
+                MIN(first_entry_t,
+                    rd->state->query_ops.oldest_time(rd) > st->update_every ?
+                        rd->state->query_ops.oldest_time(rd) - st->update_every : 0);
         }
 
         if (unlikely(LONG_MAX == first_entry_t)) return 0;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1362,6 +1362,7 @@ static inline void rrdset_done_fill_the_gap(RRDSET *st) {
         st->last_updated.tv_sec += c * st->update_every;
 
         st->current_entry += c;
+        st->counter += c;
         if(st->current_entry >= st->entries)
             st->current_entry -= st->entries;
     }


### PR DESCRIPTION
##### Summary
1. When an API request is made on the `data` endpoint, `memory mode = dbengine`, and the requested time-frame includes the first stored value - there is no first entry in the response.
2. When an API request is made on the `data` endpoint, `memory mode = save`, Netdata was restarted, and the requested time-frame includes the first stored value - there is no first entry in the response.

The proposed solution fixes both bugs.

While fixing the aforementioned bugs, a few other ones were discovered in the query engine but they are in the scope of upcoming work.

Replaces #11599, 

##### Component Name
dbengine, RRD.

##### Test Plan
As described in #11599, 