### PR TITLE
Add localhost hostname to the edit_command

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -205,7 +205,7 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
 
         char *edit_command = sqlite3_column_bytes(res, 16) > 0 ?
                                  health_edit_command_from_source((char *)sqlite3_column_text(res, 16)) :
-                                 strdupz("UNKNOWN=0");
+                                 strdupz("UNKNOWN=0=UNKNOWN");
         alarm_log.command = strdupz(edit_command);
 
         alarm_log.duration = (time_t) sqlite3_column_int64(res, 6);
@@ -654,7 +654,7 @@ void aclk_mark_alert_cloud_ack(char *uuid_str, uint64_t alerts_ack_sequence_id)
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
 void health_alarm_entry2proto_nolock(struct alarm_log_entry *alarm_log, ALARM_ENTRY *ae, RRDHOST *host)
 {
-    char *edit_command = ae->source ? health_edit_command_from_source(ae->source) : strdupz("UNKNOWN=0");
+    char *edit_command = ae->source ? health_edit_command_from_source(ae->source) : strdupz("UNKNOWN=0=UNKNOWN");
     char config_hash_id[GUID_LEN + 1];
     uuid_unparse_lower(ae->config_hash_id, config_hash_id);
 

--- a/health/health.c
+++ b/health/health.c
@@ -346,7 +346,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
         }
     }
 
-    char *edit_command = ae->source ? health_edit_command_from_source(ae->source) : strdupz("UNKNOWN=0");
+    char *edit_command = ae->source ? health_edit_command_from_source(ae->source) : strdupz("UNKNOWN=0=UNKNOWN");
 
     snprintfz(command_to_run, ALARM_EXEC_COMMAND_LENGTH, "exec %s '%s' '%s' '%u' '%u' '%u' '%lu' '%s' '%s' '%s' '%s' '%s' '" CALCULATED_NUMBER_FORMAT_ZERO "' '" CALCULATED_NUMBER_FORMAT_ZERO "' '%s' '%u' '%u' '%s' '%s' '%s' '%s' '%s' '%s' '%d' '%d' '%s' '%s' '%s' '%s' '%s'",
               exec,

--- a/health/health.c
+++ b/health/health.c
@@ -348,7 +348,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
 
     char *edit_command = ae->source ? health_edit_command_from_source(ae->source) : strdupz("UNKNOWN=0=UNKNOWN");
 
-    snprintfz(command_to_run, ALARM_EXEC_COMMAND_LENGTH, "exec %s '%s' '%s' '%u' '%u' '%u' '%lu' '%s' '%s' '%s' '%s' '%s' '" CALCULATED_NUMBER_FORMAT_ZERO "' '" CALCULATED_NUMBER_FORMAT_ZERO "' '%s' '%u' '%u' '%s' '%s' '%s' '%s' '%s' '%s' '%d' '%d' '%s' '%s' '%s' '%s' '%s'",
+    snprintfz(command_to_run, ALARM_EXEC_COMMAND_LENGTH, "exec %s '%s' '%s' '%u' '%u' '%u' '%lu' '%s' '%s' '%s' '%s' '%s' '" CALCULATED_NUMBER_FORMAT_ZERO "' '" CALCULATED_NUMBER_FORMAT_ZERO "' '%s' '%u' '%u' '%s' '%s' '%s' '%s' '%s' '%s' '%d' '%d' '%s' '%s' '%s' '%s'",
               exec,
               recipient,
               host->registry_hostname,
@@ -377,8 +377,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
               buffer_tostring(warn_alarms),
               buffer_tostring(crit_alarms),
               ae->classification?ae->classification:"Unknown",
-              edit_command,
-              localhost->registry_hostname
+              edit_command
     );
 
     ae->flags |= HEALTH_ENTRY_FLAG_EXEC_RUN;

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -485,10 +485,11 @@ char *health_edit_command_from_source(const char *source)
         snprintfz(
             buffer,
             FILENAME_MAX,
-            "sudo %s/edit-config health.d/%s=%s",
+            "sudo %s/edit-config health.d/%s=%s=%s",
             netdata_configured_user_config_dir,
             file_no_path + 1,
-            temp);
+            temp,
+            localhost->registry_hostname);
     } else
         buffer[0] = '\0';
 

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -14,7 +14,7 @@ void health_string2json(BUFFER *wb, const char *prefix, const char *label, const
 }
 
 void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) {
-    char *edit_command = ae->source ? health_edit_command_from_source(ae->source) : strdupz("UNKNOWN=0");
+    char *edit_command = ae->source ? health_edit_command_from_source(ae->source) : strdupz("UNKNOWN=0=UNKNOWN");
     char config_hash_id[GUID_LEN + 1];
     uuid_unparse_lower(ae->config_hash_id, config_hash_id);
 

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -243,7 +243,6 @@ else
   total_crit_alarms="${26}"  # List of alarms in critical state
   classification="${27}"     # The class field from .conf files
   edit_command_line="${28}"  # The command to edit the alarm, with the line number
-  sender_host="${29}"        # The host sending this notification
 fi
 
 # -----------------------------------------------------------------------------
@@ -255,17 +254,6 @@ if [ -z ${args_host} ]; then
   args_host="${this_host}"
 else
   host="${args_host}"
-fi
-
-# -----------------------------------------------------------------------------
-# Do the same for sender_host (find a suitable hostname to use, if netdata did not supply a hostname)
-
-if [ -z ${sender_host} ]; then
-  this_host=$(hostname -s 2>/dev/null)
-  s_host="${this_host}"
-  sender_host="${this_host}"
-else
-  s_host="${sender_host}"
 fi
 
 # -----------------------------------------------------------------------------
@@ -2845,7 +2833,7 @@ if [ -n "$total_crit_alarms" ]; then
 fi
 
 if [ -n "$edit_command_line" ]; then
-    IFS='=' read -r edit_command line <<<"$edit_command_line"
+    IFS='=' read -r edit_command line s_host <<<"$edit_command_line"
 fi
 
 IFS='' read -r -d '' email_html_part <<EOF
@@ -3329,7 +3317,7 @@ Content-Transfer-Encoding: 8bit
                     <tr>
                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:8px;padding-left:0;word-break:break-word;">
                         <div style="font-family:Open Sans, sans-serif;font-size:12px;line-height:1.3;text-align:left;color:#35414A;">${edit_command} <br>
-                          The alarm to edit is at line {${line}}</div>
+                          <br>The alarm to edit is at line ${line}</div>
                       </td>
                     </tr>
                     </tbody>


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR, extends the `edit_command` field of an alert event, to include also the localhost's host name, e.g.:

`sudo /home/evas/stuff/netdata/install_netdata_ng_13//netdata/etc/netdata/edit-config health.d/linux_power_supply.conf=3=winterland`

The `edit_command` field is transferred to cloud and is used in the part of the notification email (and in other parts of cloud UI) to indicate which file needs to be edited to adjust the current alarm, .ie:

![image](https://user-images.githubusercontent.com/1905463/142016015-040c1c5d-e383-4641-8ab0-a5037b8100a8.png)

In case the alert is raised by a parent, on metrics from a child, we need to display to the user to login to the parent to edit this alert's config. This change will help with that, as in the cloud will display the hostname of whatever we include in the `edit_command` field.

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Can be tested by running an agent, and observing the `command` field from `api/v1/alarm_log`. If needed, check the same endpoint for a child (e.g. `/host/A_HOST/api/v1/alarm_log`).

Will be tested with the cloud backend team. <- Done.

Best check is to setup a child/parent, claim the parent to the cloud, and raise an alert on the parent on behalf of the child. Observe that notifications from the cloud now contain the parent's hostname. Observe the same on agent alerts.

The cloud backend team will merge this in production in the following days, but it can be tested on staging.

##### Additional Information

Tested with the cloud backend team on staging.