### PR TITLE
[WIP] Alert statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ system/edit-config
 system/netdata.crontab
 
 daemon/anonymous-statistics.sh
+daemon/anonymous-statistics-alerts.sh
 daemon/get-kubernetes-labels.sh
 
 health/notifications/alarm-notify.sh

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -4,6 +4,7 @@ AUTOMAKE_OPTIONS = subdir-objects
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 CLEANFILES = \
     anonymous-statistics.sh \
+    anonymous-statistics-alerts.sh \
     $(NULL)
 
 include $(top_srcdir)/build/subst.inc
@@ -13,11 +14,13 @@ dist_noinst_DATA = \
     README.md \
     config/README.md \
     anonymous-statistics.sh.in \
+    anonymous-statistics-alerts.sh.in \
     get-kubernetes-labels.sh.in \
     $(NULL)
 
 dist_plugins_SCRIPTS = \
     anonymous-statistics.sh \
+    anonymous-statistics-alerts.sh \
     system-info.sh \
     get-kubernetes-labels.sh \
     $(NULL)

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -661,7 +661,7 @@ void *analytics_main(void *ptr)
 
     analytics_gather_immutable_meta_data();
     analytics_gather_mutable_meta_data();
-    /* send_statistics("META_START", "-", "-"); */
+    send_statistics("META_START", "-", "-");
     analytics_log_data();
 
     sec = 0;
@@ -676,7 +676,7 @@ void *analytics_main(void *ptr)
             continue;
 
         analytics_gather_mutable_meta_data();
-        /* send_statistics("META", "-", "-"); */
+        send_statistics("META", "-", "-");
         analytics_log_data();
         analytics_gather_alert_data();
         sec = 0;

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -601,6 +601,12 @@ void analytics_gather_alert_data() {
     if(unlikely(!localhost->health_enabled))
         return;
 
+    int stock_enabled = (int)config_get_boolean(CONFIG_SECTION_HEALTH, "enable stock health configuration",
+                                                CONFIG_BOOLEAN_YES);
+
+    if (unlikely(!stock_enabled))
+        return;
+
     BUFFER *b = buffer_create(32768);
 
     if (unlikely(!start))

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -6,10 +6,10 @@
 #include "daemon/common.h"
 
 /* Max number of seconds before the first META analytics is sent */
-#define ANALYTICS_INIT_SLEEP_SEC 120
+#define ANALYTICS_INIT_SLEEP_SEC 30
 
 /* Send a META event every X seconds */
-#define ANALYTICS_HEARTBEAT 7200
+#define ANALYTICS_HEARTBEAT 120
 
 /* Maximum number of hits to log */
 #define ANALYTICS_MAX_PROMETHEUS_HITS 255

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -9,7 +9,7 @@
 #define ANALYTICS_INIT_SLEEP_SEC 30
 
 /* Send a META event every X seconds */
-#define ANALYTICS_HEARTBEAT 120
+#define ANALYTICS_HEARTBEAT 7200
 
 /* Maximum number of hits to log */
 #define ANALYTICS_MAX_PROMETHEUS_HITS 255

--- a/daemon/anonymous-statistics-alerts.sh.in
+++ b/daemon/anonymous-statistics-alerts.sh.in
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+
+# Valid actions:
+
+# - STATISTICS_ALERTS
+#      ACTION_RESULT  -- NaN
+#      ACTION_DATA    -- NaN
+
+ACTION="${1}"
+ACTION_RESULT="${2}"
+ACTION_DATA="${3}"
+ACTION_DATA=$(echo "${ACTION_DATA}" | tr '"' "'")
+
+# -------------------------------------------------------------------------------------------------
+# check opt-out
+
+if [ -f "@configdir_POST@/.opt-out-from-anonymous-statistics" ] || [ ! "${DO_NOT_TRACK:-0}" -eq 0 ] || [ -n "$DO_NOT_TRACK" ]; then
+  exit 0
+fi
+
+# -------------------------------------------------------------------------------------------------
+# Get the extra variables
+
+NETDATA_STATISTICS_ALERTS_START="${4}"
+NETDATA_STATISTICS_ALERTS_END="${5}"
+NETDATA_STATISTICS_ALERTS="${6}"
+
+# define body of request to be sent
+REQ_BODY="$(cat << EOF
+{
+    "api_key": "mqkwGT0JNFqO-zX2t0mW6Tec9yooaVu7xCBlXtHnt5Y",
+    "event": "${ACTION} ${ACTION_RESULT}",
+    "properties": {
+        "distinct_id": "${NETDATA_REGISTRY_UNIQUE_ID}",
+        "\$current_url": "agent backend",
+        "\$pathname": "netdata-backend",
+        "\$host": "backend.netdata.io",
+        "\$ip": "127.0.0.1",
+        "event_source": "agent backend",
+        "action": "${ACTION}",
+        "action_result": "${ACTION_RESULT}",
+        "action_data": "${ACTION_DATA}",
+        "netdata_machine_guid": "${NETDATA_REGISTRY_UNIQUE_ID}",
+        "netdata_version": "${NETDATA_VERSION}",
+        "start_time": "${NETDATA_STATISTICS_ALERTS_START}",
+        "end_time": "${NETDATA_STATISTICS_ALERTS_END}",
+        "alert_stats": {
+            ${NETDATA_STATISTICS_ALERTS}
+        }
+  }
+}
+EOF
+)"
+
+echo "${REQ_BODY}" > /tmp/alert_statistics.json
+
+# send the anonymous statistics to the Netdata PostHog
+# if [ -n "$(command -v curl 2> /dev/null)" ]; then
+#   curl --silent -o /dev/null --write-out '%{http_code}' -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" https://posthog.netdata.cloud/capture/
+# else
+#   wget -q -O - --no-check-certificate \
+#   --server-response \
+#   --method POST \
+#   --timeout=1 \
+#   --header 'Content-Type: application/json' \
+#   --body-data "${REQ_BODY}" \
+#    'https://posthog.netdata.cloud/capture/' 2>&1 | awk '/^  HTTP/{print $2}'
+# fi

--- a/daemon/anonymous-statistics-alerts.sh.in
+++ b/daemon/anonymous-statistics-alerts.sh.in
@@ -29,7 +29,7 @@ NETDATA_STATISTICS_ALERTS="${6}"
 REQ_BODY="$(cat << EOF
 {
     "api_key": "mqkwGT0JNFqO-zX2t0mW6Tec9yooaVu7xCBlXtHnt5Y",
-    "event": "${ACTION} ${ACTION_RESULT}",
+    "event": "${ACTION}",
     "properties": {
         "distinct_id": "${NETDATA_REGISTRY_UNIQUE_ID}",
         "\$current_url": "agent backend",

--- a/daemon/anonymous-statistics-alerts.sh.in
+++ b/daemon/anonymous-statistics-alerts.sh.in
@@ -55,14 +55,14 @@ EOF
 echo "${REQ_BODY}" > /tmp/alert_statistics.json
 
 # send the anonymous statistics to the Netdata PostHog
-# if [ -n "$(command -v curl 2> /dev/null)" ]; then
-#   curl --silent -o /dev/null --write-out '%{http_code}' -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" https://posthog.netdata.cloud/capture/
-# else
-#   wget -q -O - --no-check-certificate \
-#   --server-response \
-#   --method POST \
-#   --timeout=1 \
-#   --header 'Content-Type: application/json' \
-#   --body-data "${REQ_BODY}" \
-#    'https://posthog.netdata.cloud/capture/' 2>&1 | awk '/^  HTTP/{print $2}'
-# fi
+if [ -n "$(command -v curl 2> /dev/null)" ]; then
+  curl --silent -o /dev/null --write-out '%{http_code}' -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" https://posthog.netdata.cloud/capture/
+else
+  wget -q -O - --no-check-certificate \
+  --server-response \
+  --method POST \
+  --timeout=1 \
+  --header 'Content-Type: application/json' \
+  --body-data "${REQ_BODY}" \
+   'https://posthog.netdata.cloud/capture/' 2>&1 | awk '/^  HTTP/{print $2}'
+fi

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -794,26 +794,26 @@ int main(int argc, char **argv) {
                         }
 
                         if(strcmp(optarg, "unittest") == 0) {
-/*                             if(unit_test_buffer()) return 1; */
-/*                             if(unit_test_str2ld()) return 1; */
-/*                             // No call to load the config file on this code-path */
-/*                             post_conf_load(&user); */
-/*                             get_netdata_configured_variables(); */
-/*                             default_rrd_update_every = 1; */
-/*                             default_rrd_memory_mode = RRD_MEMORY_MODE_RAM; */
-/*                             default_health_enabled = 0; */
-/*                             registry_init(); */
-/*                             if(rrd_init("unittest", NULL)) { */
-/*                                 fprintf(stderr, "rrd_init failed for unittest\n"); */
-/*                                 return 1; */
-/*                             } */
-/*                             default_rrdpush_enabled = 0; */
-/*                             if(run_all_mockup_tests()) return 1; */
-/*                             if(unit_test_storage()) return 1; */
-/* #ifdef ENABLE_DBENGINE */
-/*                             if(test_dbengine()) return 1; */
-/* #endif */
-/*                             if(test_sqlite()) return 1; */
+                            if(unit_test_buffer()) return 1;
+                            if(unit_test_str2ld()) return 1;
+                            // No call to load the config file on this code-path
+                            post_conf_load(&user);
+                            get_netdata_configured_variables();
+                            default_rrd_update_every = 1;
+                            default_rrd_memory_mode = RRD_MEMORY_MODE_RAM;
+                            default_health_enabled = 0;
+                            registry_init();
+                            if(rrd_init("unittest", NULL)) {
+                                fprintf(stderr, "rrd_init failed for unittest\n");
+                                return 1;
+                            }
+                            default_rrdpush_enabled = 0;
+                            if(run_all_mockup_tests()) return 1;
+                            if(unit_test_storage()) return 1;
+#ifdef ENABLE_DBENGINE
+                            if(test_dbengine()) return 1;
+#endif
+                            if(test_sqlite()) return 1;
                             if(test_sql_alert_stats()) return 1;
                             fprintf(stderr, "\n\nALL TESTS PASSED\n\n");
                             return 0;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -794,26 +794,27 @@ int main(int argc, char **argv) {
                         }
 
                         if(strcmp(optarg, "unittest") == 0) {
-                            if(unit_test_buffer()) return 1;
-                            if(unit_test_str2ld()) return 1;
-                            // No call to load the config file on this code-path
-                            post_conf_load(&user);
-                            get_netdata_configured_variables();
-                            default_rrd_update_every = 1;
-                            default_rrd_memory_mode = RRD_MEMORY_MODE_RAM;
-                            default_health_enabled = 0;
-                            registry_init();
-                            if(rrd_init("unittest", NULL)) {
-                                fprintf(stderr, "rrd_init failed for unittest\n");
-                                return 1;
-                            }
-                            default_rrdpush_enabled = 0;
-                            if(run_all_mockup_tests()) return 1;
-                            if(unit_test_storage()) return 1;
-#ifdef ENABLE_DBENGINE
-                            if(test_dbengine()) return 1;
-#endif
-                            if(test_sqlite()) return 1;
+/*                             if(unit_test_buffer()) return 1; */
+/*                             if(unit_test_str2ld()) return 1; */
+/*                             // No call to load the config file on this code-path */
+/*                             post_conf_load(&user); */
+/*                             get_netdata_configured_variables(); */
+/*                             default_rrd_update_every = 1; */
+/*                             default_rrd_memory_mode = RRD_MEMORY_MODE_RAM; */
+/*                             default_health_enabled = 0; */
+/*                             registry_init(); */
+/*                             if(rrd_init("unittest", NULL)) { */
+/*                                 fprintf(stderr, "rrd_init failed for unittest\n"); */
+/*                                 return 1; */
+/*                             } */
+/*                             default_rrdpush_enabled = 0; */
+/*                             if(run_all_mockup_tests()) return 1; */
+/*                             if(unit_test_storage()) return 1; */
+/* #ifdef ENABLE_DBENGINE */
+/*                             if(test_dbengine()) return 1; */
+/* #endif */
+/*                             if(test_sqlite()) return 1; */
+                            if(test_sql_alert_stats()) return 1;
                             fprintf(stderr, "\n\nALL TESTS PASSED\n\n");
                             return 0;
                         }

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1746,9 +1746,9 @@ int test_sql_alert_stats(void) {
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 1, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 1, 100, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"d-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
 
@@ -1782,9 +1782,9 @@ int test_sql_alert_stats(void) {
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"a-chart\", 3, 100, 138, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 3, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 3, 100, 138, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 3, 100, 138, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"d-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
 
@@ -1817,9 +1817,9 @@ int test_sql_alert_stats(void) {
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"a-chart\", 3, 100, 139, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 3, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 3, 100, 140, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 3, 100, 140, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"d-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
 
@@ -1849,24 +1849,24 @@ int test_sql_alert_stats(void) {
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"a-name\", \"a-chart\", -1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", -2, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", -2, 150, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
 
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"a-chart\", -1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", -1, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", -1, 150, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", -2, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", -2, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", -1, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", -1, 150, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 3, 100, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", -1, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", -1, 150, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"d-chart\", -2, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", -1, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", -1, 150, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
 
     buffer_strcat(b, "{\n");
     sql_get_alert_analytics(host, 99, 200, b);
@@ -1894,47 +1894,47 @@ int test_sql_alert_stats(void) {
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"a-name\", \"a-chart\", -1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 1, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 1, 150, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 3, 170, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 3, 170, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 4, 200, 205, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 4, 200, 205, 4, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 1, 250, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 1, 250, 0, 5, \"usr/lib/netdata/conf.d/health.d/\")");
 
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"a-chart\", -1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 1, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 1, 150, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 3, 170, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 3, 170, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 4, 200, 205, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 4, 200, 205, 4, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 1, 250, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 1, 250, 0, 5, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"b-name\", \"b-chart\", -1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 1, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 1, 150, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 3, 170, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 3, 170, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 4, 200, 205, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 4, 200, 205, 4, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 1, 250, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 1, 250, 0, 5, \"usr/lib/netdata/conf.d/health.d/\")");
 
 
 
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"c-name\", \"a-chart\", -1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"c-name\", \"a-chart\", 1, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"c-name\", \"a-chart\", 1, 150, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"c-name\", \"a-chart\", 3, 170, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"c-name\", \"a-chart\", 3, 170, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"c-name\", \"a-chart\", 4, 200, 205, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"c-name\", \"a-chart\", 4, 200, 205, 4, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"c-name\", \"a-chart\", 1, 250, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"c-name\", \"a-chart\", 1, 250, 0, 5, \"usr/lib/netdata/conf.d/health.d/\")");
 
     buffer_strcat(b, "{\n");
     sql_get_alert_analytics(host, 90, 300, b);
@@ -1968,9 +1968,9 @@ int test_sql_alert_stats(void) {
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"a-name\", \"a-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 3, 120, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 3, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 3, 150, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 3, 150, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
 
     buffer_strcat(b, "{\n");
     sql_get_alert_analytics(host, 125, 200, b);
@@ -1978,6 +1978,103 @@ int test_sql_alert_stats(void) {
 
     if (test_sql_alert_stats_check_json(b, "a-name", 1, 0, 0, 0, 75, 2, 0, 0, 0, 0)) {
         fprintf(stderr, "SQL alerts statistics scenario 8/a failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    /*
+      Same statuses in a row
+    */
+    test_sql_alert_stats_insert("delete from health_log_00000000_0000_0000_0000_000000000000");
+    buffer_reset(b);
+
+    fprintf(stderr, "Running scenario 9...\n");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", -1, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", -1, 140, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", -1, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", -1, 140, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"b-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"b-chart\", -1, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"b-chart\", -1, 140, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", 3, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", 3, 140, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", 3, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", 3, 140, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", 3, 170, 0, 4, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    buffer_strcat(b, "{\n");
+    sql_get_alert_analytics(host, 120, 200, b);
+    buffer_strcat(b, "}");
+
+    if (test_sql_alert_stats_check_json(b, "a-name", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 9/a failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "b-name", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 9/b failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "c-name", 1, 0, 0, 0, 80, 2, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 10/c failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "d-name", 1, 0, 0, 0, 80, 3, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 10/d failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    /*
+      Same statuses in a row
+    */
+    test_sql_alert_stats_insert("delete from health_log_00000000_0000_0000_0000_000000000000");
+    buffer_reset(b);
+
+    fprintf(stderr, "Running scenario 10...\n");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", -1, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", -1, 140, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    buffer_strcat(b, "{\n");
+    sql_get_alert_analytics(host, 100, 200, b);
+    buffer_strcat(b, "}");
+
+    //fprintf(stderr, "[%s]", buffer_tostring(b));
+
+    if (test_sql_alert_stats_check_json(b, "a-name", 1, 20, 1, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 10/a failed.\n");
         buffer_free(b);
         return 1;
     }

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -2079,6 +2079,32 @@ int test_sql_alert_stats(void) {
         return 1;
     }
 
+    /*
+      Some other cases
+    */
+    test_sql_alert_stats_insert("delete from health_log_00000000_0000_0000_0000_000000000000");
+    buffer_reset(b);
+
+    fprintf(stderr, "Running scenario 11...\n");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    buffer_strcat(b, "{\n");
+    sql_get_alert_analytics(host, 110, 130, b);
+    buffer_strcat(b, "}");
+
+    fprintf(stderr, "[%s]", buffer_tostring(b));
+
+    if (test_sql_alert_stats_check_json(b, "a-name", 1, 10, 1, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/a failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
     buffer_free(b);
     return 0;
 }

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1633,39 +1633,39 @@ int test_sql_alert_stats(void) {
     */
     fprintf(stderr, "Running scenario 1...\n");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 1, 1636379565, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", -2, 1636379650, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", -2, 185, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 0, 1636379656, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 0, 200, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
 
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 1, 1636379565, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", -2, 1636379650, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", -2, 185, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 0, 1636379656, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 0, 200, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 1, 1636379565, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", -2, 1636379650, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", -2, 185, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 0, 1636379656, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 0, 200, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 1, 1636379565, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", -2, 1636379650, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", -2, 185, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 0, 1636379656, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 0, 200, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", 1, 1636379565, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", -2, 1636379650, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", -2, 185, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", 0, 1636379656, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", 0, 200, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
 
     buffer_strcat(b, "{\n");
-    sql_get_alert_analytics(host, 1636379565, 1636379665, b);
+    sql_get_alert_analytics(host, 100, 250, b);
     buffer_strcat(b, "}");
 
     if (test_sql_alert_stats_check_json(b, "a-name", 1, 85, 1, 0, 0, 0, 0, 0, 0, 0)) {
@@ -1688,39 +1688,39 @@ int test_sql_alert_stats(void) {
 
     fprintf(stderr, "Running scenario 2...\n");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", -2, 1636538238, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", -2, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 0, 1636538249, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 0, 111, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 1, 1636538258, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
 
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", -2, 1636538238, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", -2, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 0, 1636538249, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 0, 111, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 1, 1636538258, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", -2, 1636538238, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", -2, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 0, 1636538249, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 0, 111, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 1, 1636538258, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", -2, 1636538238, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", -2, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 0, 1636538249, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 0, 111, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 1, 1636538258, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", -2, 1636538238, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", -2, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", 0, 1636538249, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", 0, 111, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", 1, 1636538258, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
 
     buffer_strcat(b, "{\n");
-    sql_get_alert_analytics(host, 1636538248, 1636538398, b);
+    sql_get_alert_analytics(host, 110, 260, b);
     buffer_strcat(b, "}");
 
     if (test_sql_alert_stats_check_json(b, "a-name", 1, 140, 1, 0, 0, 0, 0, 0, 0, 0)) {
@@ -1741,19 +1741,19 @@ int test_sql_alert_stats(void) {
 
     fprintf(stderr, "Running scenario 3...\n");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 1, 1636541465, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
 
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 1, 1636541465, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 1, 1636541465, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 1, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 1, 1636541465, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 1, 100, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", 1, 1636541465, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
 
     buffer_strcat(b, "{\n");
-    sql_get_alert_analytics(host, 1636541604, 1636541724, b);
+    sql_get_alert_analytics(host, 139, 259, b);
     buffer_strcat(b, "}");
 
     if (test_sql_alert_stats_check_json(b, "a-name", 1, 120, 1, 0, 0, 0, 0, 0, 0, 0)) {
@@ -1777,19 +1777,19 @@ int test_sql_alert_stats(void) {
 
     fprintf(stderr, "Running scenario 4...\n");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 3, 1636541465, 1636541603, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 3, 100, 138, 1, \"usr/lib/netdata/conf.d/health.d/\")");
 
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 3, 1636541465, 1636541603, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 3, 100, 138, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 3, 1636541465, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 3, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 3, 1636541465, 1636541603, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 3, 100, 138, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", 3, 1636541465, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
 
     buffer_strcat(b, "{\n");
-    sql_get_alert_analytics(host, 1636541604, 1636541724, b);
+    sql_get_alert_analytics(host, 139, 259, b);
     buffer_strcat(b, "}");
 
     if (test_sql_alert_stats_check_json(b, "a-name", 1, 0, 0, 0, 120, 1, 0, 0, 0, 0)) {
@@ -1812,22 +1812,20 @@ int test_sql_alert_stats(void) {
 
     fprintf(stderr, "Running scenario 5...\n");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"a-name\", \"a-chart\", 3, 1636541465, 1636541604, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"a-name\", \"a-chart\", 3, 100, 139, 1, \"usr/lib/netdata/conf.d/health.d/\")");
 
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"a-chart\", 3, 1636541465, 1636541604, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"a-chart\", 3, 100, 139, 1, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"b-chart\", 3, 1636541465, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"b-chart\", 3, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"c-chart\", 3, 1636541465, 1636541605, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"c-chart\", 3, 100, 140, 3, \"usr/lib/netdata/conf.d/health.d/\")");
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
-                                 values (\"b-name\", \"d-chart\", 3, 1636541465, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+                                 values (\"b-name\", \"d-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
 
     buffer_strcat(b, "{\n");
-    sql_get_alert_analytics(host, 1636541604, 1636541724, b);
+    sql_get_alert_analytics(host, 139, 259, b);
     buffer_strcat(b, "}");
-
-    fprintf(stderr, "[%s]\n", buffer_tostring(b));
 
     if (test_sql_alert_stats_check_json(b, "a-name", 1, 0, 0, 0, 120, 1, 1, 0, 0, 0)) {
         fprintf(stderr, "SQL alerts statistics scenario 5/a failed.\n");

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1976,7 +1976,7 @@ int test_sql_alert_stats(void) {
     sql_get_alert_analytics(host, 125, 200, b);
     buffer_strcat(b, "}");
 
-    if (test_sql_alert_stats_check_json(b, "a-name", 1, 0, 0, 0, 75, 2, 0, 0, 0, 0)) {
+    if (test_sql_alert_stats_check_json(b, "a-name", 1, 0, 0, 0, 75, 1, 0, 0, 0, 0)) {
         fprintf(stderr, "SQL alerts statistics scenario 8/a failed.\n");
         buffer_free(b);
         return 1;
@@ -2029,6 +2029,8 @@ int test_sql_alert_stats(void) {
     sql_get_alert_analytics(host, 120, 200, b);
     buffer_strcat(b, "}");
 
+    //fprintf(stderr, "[%s]", buffer_tostring(b));
+
     if (test_sql_alert_stats_check_json(b, "a-name", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) {
         fprintf(stderr, "SQL alerts statistics scenario 9/a failed.\n");
         buffer_free(b);
@@ -2041,13 +2043,13 @@ int test_sql_alert_stats(void) {
         return 1;
     }
 
-    if (test_sql_alert_stats_check_json(b, "c-name", 1, 0, 0, 0, 80, 2, 0, 0, 0, 0)) {
+    if (test_sql_alert_stats_check_json(b, "c-name", 1, 0, 0, 0, 80, 1, 0, 0, 0, 0)) {
         fprintf(stderr, "SQL alerts statistics scenario 10/c failed.\n");
         buffer_free(b);
         return 1;
     }
 
-    if (test_sql_alert_stats_check_json(b, "d-name", 1, 0, 0, 0, 80, 3, 0, 0, 0, 0)) {
+    if (test_sql_alert_stats_check_json(b, "d-name", 1, 0, 0, 0, 80, 1, 0, 0, 0, 0)) {
         fprintf(stderr, "SQL alerts statistics scenario 10/d failed.\n");
         buffer_free(b);
         return 1;
@@ -2080,7 +2082,7 @@ int test_sql_alert_stats(void) {
     }
 
     /*
-      Some other cases
+      Test_Single_WithTrans_BeforeStart
     */
     test_sql_alert_stats_insert("delete from health_log_00000000_0000_0000_0000_000000000000");
     buffer_reset(b);
@@ -2093,14 +2095,366 @@ int test_sql_alert_stats(void) {
     test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
                                  values (\"a-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
 
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", 3, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", 4, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", 3, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", -1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"e-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"e-name\", \"a-chart\", 3, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"e-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"f-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"f-name\", \"a-chart\", 3, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"f-name\", \"a-chart\", 4, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"g-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"g-name\", \"a-chart\", 4, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"g-name\", \"a-chart\", -1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"h-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"h-name\", \"a-chart\", 3, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"h-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"h-name\", \"b-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"h-name\", \"b-chart\", 3, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"h-name\", \"b-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"i-name\", \"a-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"i-name\", \"a-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"i-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"j-name\", \"a-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"j-name\", \"a-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"j-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"j-name\", \"b-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"j-name\", \"b-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"j-name\", \"b-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"k-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"k-name\", \"a-chart\", 4, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"k-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
     buffer_strcat(b, "{\n");
     sql_get_alert_analytics(host, 110, 130, b);
     buffer_strcat(b, "}");
 
-    fprintf(stderr, "[%s]", buffer_tostring(b));
+    //fprintf(stderr, "[%s]", buffer_tostring(b));
 
     if (test_sql_alert_stats_check_json(b, "a-name", 1, 10, 1, 0, 0, 0, 0, 0, 0, 0)) {
         fprintf(stderr, "SQL alerts statistics scenario 11/a failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "b-name", 1, 0, 0, 0, 10, 1, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/b failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "c-name", 1, 0, 0, 0, 0, 0, 0, 10, 1, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/c failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "d-name", 1, 0, 0, 0, 10, 1, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/d failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "e-name", 1, 10, 1, 0, 10, 1, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/e failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "f-name", 1, 0, 0, 0, 10, 1, 0, 10, 1, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/f failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "g-name", 1, 0, 0, 0, 0, 0, 0, 10, 1, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/g failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "h-name", 2, 20, 2, 0, 20, 2, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/h failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "i-name", 1, 10, 1, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/i failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "j-name", 2, 20, 2, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/j failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "k-name", 1, 10, 1, 0, 0, 0, 0, 10, 1, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 11/k failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    /*
+      Test_Multiple_WithTrans
+    */
+    test_sql_alert_stats_insert("delete from health_log_00000000_0000_0000_0000_000000000000");
+    buffer_reset(b);
+
+    fprintf(stderr, "Running scenario 12...\n");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", 1, 90, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", -1, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", 1, 110, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"b-chart\", 1, 80, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"b-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"b-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"c-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"c-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"c-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"d-chart\", 1, 110, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"d-chart\", -1, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"d-chart\", 1, 130, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", 1, 90, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", -1, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", 1, 110, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"b-chart\", 1, 80, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"b-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"b-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"c-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"c-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"c-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"d-chart\", 1, 110, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"d-chart\", -1, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"d-chart\", 1, 130, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", 1, 90, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", -1, 100, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", 3, 110, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"b-chart\", 1, 80, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"b-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"b-chart\", 3, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"c-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"c-chart\", -1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"c-chart\", 3, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"d-chart\", 1, 110, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"d-chart\", -1, 120, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"d-chart\", 3, 130, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    buffer_strcat(b, "{\n");
+    sql_get_alert_analytics(host, 100, 140, b);
+    buffer_strcat(b, "}");
+
+    //fprintf(stderr, "[%s]", buffer_tostring(b));
+
+    if (test_sql_alert_stats_check_json(b, "a-name", 4, 110, 7, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 12/a failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "b-name", 4, 110, 7, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 12/b failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "c-name", 4, 30, 3, 0, 80, 4, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 12/c failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    /*
+      Test_Single_WithTrans_SameState
+    */
+    test_sql_alert_stats_insert("delete from health_log_00000000_0000_0000_0000_000000000000");
+    buffer_reset(b);
+
+    fprintf(stderr, "Running scenario 13...\n");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", -1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", 1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"a-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", -1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", 3, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"b-name\", \"a-chart\", 3, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", -1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", 4, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"c-name\", \"a-chart\", 4, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", 1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"d-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"e-name\", \"a-chart\", 1, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"e-name\", \"a-chart\", 3, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"e-name\", \"a-chart\", 3, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"f-name\", \"a-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"f-name\", \"a-chart\", 1, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"f-name\", \"a-chart\", 1, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"g-name\", \"a-chart\", 3, 100, 0, 1, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"g-name\", \"a-chart\", 3, 110, 0, 2, \"usr/lib/netdata/conf.d/health.d/\")");
+    test_sql_alert_stats_insert("insert into health_log_00000000_0000_0000_0000_000000000000 (name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id, source) \
+                                 values (\"g-name\", \"a-chart\", 3, 120, 0, 3, \"usr/lib/netdata/conf.d/health.d/\")");
+
+    buffer_strcat(b, "{\n");
+    sql_get_alert_analytics(host, 110, 130, b);
+    buffer_strcat(b, "}");
+
+    //fprintf(stderr, "[%s]", buffer_tostring(b));
+
+    if (test_sql_alert_stats_check_json(b, "a-name", 1, 20, 1, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 13/a failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "b-name", 1, 0, 0, 0, 20, 1, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 13/b failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "c-name", 1, 0, 0, 0, 0, 0, 0, 20, 1, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 13/c failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "d-name", 1, 20, 1, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 13/d failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "e-name", 1, 0, 0, 0, 20, 1, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 13/e failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "f-name", 1, 20, 1, 0, 0, 0, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 13/f failed.\n");
+        buffer_free(b);
+        return 1;
+    }
+
+    if (test_sql_alert_stats_check_json(b, "g-name", 1, 0, 0, 0, 20, 1, 0, 0, 0, 0)) {
+        fprintf(stderr, "SQL alerts statistics scenario 13/g failed.\n");
         buffer_free(b);
         return 1;
     }

--- a/daemon/unit_test.h
+++ b/daemon/unit_test.h
@@ -9,6 +9,7 @@ extern int run_all_mockup_tests(void);
 extern int unit_test_str2ld(void);
 extern int unit_test_buffer(void);
 extern int test_sqlite(void);
+extern int test_sql_alert_stats(void);
 #ifdef ENABLE_DBENGINE
 extern int test_dbengine(void);
 extern void generate_dbengine_dataset(unsigned history_seconds);

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1094,25 +1094,28 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                 {
                 case RRDCALC_STATUS_CLEAR:
                     if (last_status == RRDCALC_STATUS_CLEAR) {
-                        if (when == start) { t_in_clear = 0; }
+                        if (when == start) { t_in_clear--; }
+                        if (t_in_clear == 0) t_in_clear = 1;
                     }
-                    if (last_status == RRDCALC_STATUS_WARNING) {
+                    else if (last_status == RRDCALC_STATUS_WARNING) {
                         in_warn -= range;
                         in_clear += range;
-                        if (when == start) { t_in_warn = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        t_in_clear++;
+                        if (when == start) { t_in_warn--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_CRITICAL) {
                         in_crit -= range;
                         in_clear += range;
-                        if (when == start) { t_in_crit = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        t_in_clear++;
+                        if (when == start) { t_in_crit--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_UNDEFINED) {
                         in_other -= range;
                         in_clear += range;
-                        if (when == start) { t_in_other = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        t_in_clear++;
+                        if (when == start) { t_in_other--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     last_status = RRDCALC_STATUS_CLEAR;
-                    t_in_clear++;
                     if (exec_run_timestamp && exec_run_timestamp < end) n_in_clear++;
                     if (chart_change) { no_of_alerts++; chart_change = 0; }
                     break;
@@ -1120,23 +1123,26 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_CLEAR) {
                         in_clear -= range;
                         in_warn += range;
-                        if (when == start) { t_in_clear = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        t_in_warn++;
+                        if (when == start) { t_in_clear--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
-                    if (last_status == RRDCALC_STATUS_WARNING) {
-                        if (when == start) { t_in_warn = 0; }
+                    else if (last_status == RRDCALC_STATUS_WARNING) {
+                        if (when == start) { t_in_warn--; }
+                        if (t_in_warn == 0) t_in_warn = 1;
                     }
                     else if (last_status == RRDCALC_STATUS_CRITICAL) {
                         in_crit -= range;
                         in_warn += range;
-                        if (when == start) { t_in_crit = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        t_in_warn++;
+                        if (when == start) { t_in_crit--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_UNDEFINED) {
                         in_other -= range;
                         in_warn += range;
-                        if (when == start) { t_in_other = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        t_in_warn++;
+                        if (when == start) { t_in_other--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     last_status = RRDCALC_STATUS_WARNING;
-                    t_in_warn++;
                     if (exec_run_timestamp && exec_run_timestamp < end) n_in_warn++;
                     if (chart_change) { no_of_alerts++; chart_change = 0; }
                     break;
@@ -1144,23 +1150,26 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_CLEAR) {
                         in_clear -= range;
                         in_crit += range;
-                        if (when == start) { t_in_clear = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        t_in_crit++;
+                        if (when == start) { t_in_clear--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_WARNING) {
                         in_warn -= range;
                         in_crit += range;
-                        if (when == start) { t_in_warn = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        t_in_crit++;
+                        if (when == start) { t_in_warn--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
-                    if (last_status == RRDCALC_STATUS_CRITICAL) {
-                        if (when == start) { t_in_crit = 0; }
+                    else if (last_status == RRDCALC_STATUS_CRITICAL) {
+                        if (when == start) { t_in_crit--; }
+                        if (t_in_crit == 0) t_in_crit = 1;
                     }
                     else if (last_status == RRDCALC_STATUS_UNDEFINED) {
                         in_other -= range;
                         in_crit += range;
-                        if (when == start) { t_in_other = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        t_in_crit++;
+                        if (when == start) { t_in_other--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     last_status = RRDCALC_STATUS_CRITICAL;
-                    t_in_crit++;
                     if (exec_run_timestamp && exec_run_timestamp < end) n_in_crit++;
                     if (chart_change) { no_of_alerts++; chart_change = 0; }
                     break;
@@ -1169,21 +1178,20 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_CLEAR) {
                         in_clear -= range;
                         in_other += range;
-                        if (when == start) { t_in_clear = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        if (when == start) { t_in_clear--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_WARNING) {
                         in_warn -= range;
                         in_other += range;
-                        if (when == start) { t_in_warn = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        if (when == start) { t_in_warn--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_CRITICAL) {
                         in_crit -= range;
                         in_other += range;
-                        if (when == start) { t_in_crit = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
+                        if (when == start) { t_in_crit--; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     last_status = RRDCALC_STATUS_UNDEFINED;
                     t_in_other++;
-
                 }
             buffer_sprintf(db_entries, "{ \"name\": \"%s\", \"chart\": \"%s\", \"status\": \"%s\", \"when\": %ld, \"notification\": %ld, \"after_start\": %s, \"in_other\": %ld, \"in_clear\": %ld, \"in_warn\": %ld, \"in_crit\": %ld }", curr_alert, curr_chart, rrdcalc_status2string(status), when, exec_run_timestamp, "true", in_other, in_clear, in_warn, in_crit);
             db_entries_c++;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1093,20 +1093,23 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
             switch (status)
                 {
                 case RRDCALC_STATUS_CLEAR:
+                    if (last_status == RRDCALC_STATUS_CLEAR) {
+                        if (when == start) { t_in_clear = 0; }
+                    }
                     if (last_status == RRDCALC_STATUS_WARNING) {
                         in_warn -= range;
                         in_clear += range;
-                        if (when == start) t_in_warn = 0;
+                        if (when == start) { t_in_warn = 0; if (!chart_change) no_of_alerts--; }
                     }
                     else if (last_status == RRDCALC_STATUS_CRITICAL) {
                         in_crit -= range;
                         in_clear += range;
-                        if (when == start) t_in_crit = 0;
+                        if (when == start) { t_in_crit = 0; if (!chart_change) no_of_alerts--; }
                     }
                     else if (last_status == RRDCALC_STATUS_UNDEFINED) {
                         in_other -= range;
                         in_clear += range;
-                        if (when == start) t_in_other = 0;
+                        if (when == start) { t_in_other = 0; if (!chart_change) no_of_alerts--; }
                     }
                     last_status = RRDCALC_STATUS_CLEAR;
                     t_in_clear++;
@@ -1117,17 +1120,20 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_CLEAR) {
                         in_clear -= range;
                         in_warn += range;
-                        if (when == start) t_in_clear = 0;
+                        if (when == start) { t_in_clear = 0; if (!chart_change) no_of_alerts--; }
+                    }
+                    if (last_status == RRDCALC_STATUS_WARNING) {
+                        if (when == start) { t_in_warn = 0; }
                     }
                     else if (last_status == RRDCALC_STATUS_CRITICAL) {
                         in_crit -= range;
                         in_warn += range;
-                        if (when == start) t_in_crit = 0;
+                        if (when == start) { t_in_crit = 0; if (!chart_change) no_of_alerts--; }
                     }
                     else if (last_status == RRDCALC_STATUS_UNDEFINED) {
                         in_other -= range;
                         in_warn += range;
-                        if (when == start) t_in_other = 0;
+                        if (when == start) { t_in_other = 0; if (!chart_change) no_of_alerts--; }
                     }
                     last_status = RRDCALC_STATUS_WARNING;
                     t_in_warn++;
@@ -1138,17 +1144,20 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_CLEAR) {
                         in_clear -= range;
                         in_crit += range;
-                        if (when == start) t_in_clear = 0;
+                        if (when == start) { t_in_clear = 0; if (!chart_change) no_of_alerts--; }
                     }
                     else if (last_status == RRDCALC_STATUS_WARNING) {
                         in_warn -= range;
                         in_crit += range;
-                        if (when == start) t_in_warn = 0;
+                        if (when == start) { t_in_warn = 0; if (!chart_change) no_of_alerts--; }
+                    }
+                    if (last_status == RRDCALC_STATUS_CRITICAL) {
+                        if (when == start) { t_in_crit = 0; }
                     }
                     else if (last_status == RRDCALC_STATUS_UNDEFINED) {
                         in_other -= range;
                         in_crit += range;
-                        if (when == start) t_in_other = 0;
+                        if (when == start) { t_in_other = 0; if (!chart_change) no_of_alerts--; }
                     }
                     last_status = RRDCALC_STATUS_CRITICAL;
                     t_in_crit++;
@@ -1160,17 +1169,17 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_CLEAR) {
                         in_clear -= range;
                         in_other += range;
-                        if (when == start) t_in_clear = 0;
+                        if (when == start) { t_in_clear = 0; if (!chart_change) no_of_alerts--; }
                     }
                     else if (last_status == RRDCALC_STATUS_WARNING) {
                         in_warn -= range;
                         in_other += range;
-                        if (when == start) t_in_warn = 0;
+                        if (when == start) { t_in_warn = 0; if (!chart_change) no_of_alerts--; }
                     }
                     else if (last_status == RRDCALC_STATUS_CRITICAL) {
                         in_crit -= range;
                         in_other += range;
-                        if (when == start) t_in_crit = 0;
+                        if (when == start) { t_in_crit = 0; if (!chart_change) no_of_alerts--; }
                     }
                     last_status = RRDCALC_STATUS_UNDEFINED;
                     t_in_other++;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -969,16 +969,16 @@ void write_alert_analytics(BUFFER *b, char *name, time_t in_clear, uint8_t t_in_
     buffer_strcat(b, "\t\t\t\t}");
 }
 
-#define SQL_GET_ALERT_ANALYTICS(guid, start, guid2, start2, end) "SELECT name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id FROM health_log_%s \
-where source like '%%usr/lib/netdata/conf.d/health.d/%%' \
+#define SQL_GET_ALERT_ANALYTICS(guid, dir, start, guid2, dir2, start2, end) "SELECT name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id FROM health_log_%s \
+where source like '%%%s%%' \
 and when_key < %ld \
 group by name, chart \
 having max(alarm_event_id) \
 UNION ALL \
 SELECT name, chart, new_status, when_key, exec_run_timestamp, alarm_event_id FROM health_log_%s \
-where source like '%%usr/lib/netdata/conf.d/health.d/%%' \
+where source like '%%%s%%' \
 and (when_key >= %ld and when_key < %ld) \
-order by name, chart, when_key; ", guid, start, guid2, start2, end
+order by name, chart, when_key; ", guid, dir, start, guid2, dir2, start2, end
 int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) {
     sqlite3_stmt *res = NULL;
     int rc, cnt = 0;
@@ -1004,7 +1004,7 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
     char uuid_str[GUID_LEN + 1];
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
 
-    snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_GET_ALERT_ANALYTICS(uuid_str, start, uuid_str, start, end));
+    snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_GET_ALERT_ANALYTICS(uuid_str, health_stock_config_dir(), start, uuid_str, health_stock_config_dir(), start, end));
 
     rc = sqlite3_prepare_v2(db_meta, command, -1, &res, 0);
     if (unlikely(rc != SQLITE_OK)) {

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1099,17 +1099,17 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_WARNING) {
                         in_warn -= range;
                         in_clear += range;
-                        if (when == start) { t_in_warn = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_warn = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_CRITICAL) {
                         in_crit -= range;
                         in_clear += range;
-                        if (when == start) { t_in_crit = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_crit = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_UNDEFINED) {
                         in_other -= range;
                         in_clear += range;
-                        if (when == start) { t_in_other = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_other = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     last_status = RRDCALC_STATUS_CLEAR;
                     t_in_clear++;
@@ -1120,7 +1120,7 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_CLEAR) {
                         in_clear -= range;
                         in_warn += range;
-                        if (when == start) { t_in_clear = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_clear = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     if (last_status == RRDCALC_STATUS_WARNING) {
                         if (when == start) { t_in_warn = 0; }
@@ -1128,12 +1128,12 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     else if (last_status == RRDCALC_STATUS_CRITICAL) {
                         in_crit -= range;
                         in_warn += range;
-                        if (when == start) { t_in_crit = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_crit = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_UNDEFINED) {
                         in_other -= range;
                         in_warn += range;
-                        if (when == start) { t_in_other = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_other = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     last_status = RRDCALC_STATUS_WARNING;
                     t_in_warn++;
@@ -1144,12 +1144,12 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_CLEAR) {
                         in_clear -= range;
                         in_crit += range;
-                        if (when == start) { t_in_clear = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_clear = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_WARNING) {
                         in_warn -= range;
                         in_crit += range;
-                        if (when == start) { t_in_warn = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_warn = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     if (last_status == RRDCALC_STATUS_CRITICAL) {
                         if (when == start) { t_in_crit = 0; }
@@ -1157,7 +1157,7 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     else if (last_status == RRDCALC_STATUS_UNDEFINED) {
                         in_other -= range;
                         in_crit += range;
-                        if (when == start) { t_in_other = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_other = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     last_status = RRDCALC_STATUS_CRITICAL;
                     t_in_crit++;
@@ -1169,20 +1169,21 @@ int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b) 
                     if (last_status == RRDCALC_STATUS_CLEAR) {
                         in_clear -= range;
                         in_other += range;
-                        if (when == start) { t_in_clear = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_clear = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_WARNING) {
                         in_warn -= range;
                         in_other += range;
-                        if (when == start) { t_in_warn = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_warn = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     else if (last_status == RRDCALC_STATUS_CRITICAL) {
                         in_crit -= range;
                         in_other += range;
-                        if (when == start) { t_in_crit = 0; if (!chart_change) no_of_alerts--; }
+                        if (when == start) { t_in_crit = 0; if (!chart_change) { no_of_alerts--; chart_change = 1; } }
                     }
                     last_status = RRDCALC_STATUS_UNDEFINED;
                     t_in_other++;
+
                 }
             buffer_sprintf(db_entries, "{ \"name\": \"%s\", \"chart\": \"%s\", \"status\": \"%s\", \"when\": %ld, \"notification\": %ld, \"after_start\": %s, \"in_other\": %ld, \"in_clear\": %ld, \"in_warn\": %ld, \"in_crit\": %ld }", curr_alert, curr_chart, rrdcalc_status2string(status), when, exec_run_timestamp, "true", in_other, in_clear, in_warn, in_crit);
             db_entries_c++;

--- a/database/sqlite/sqlite_health.h
+++ b/database/sqlite/sqlite_health.h
@@ -14,4 +14,6 @@ extern void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
 extern void sql_health_alarm_log_cleanup(RRDHOST *host);
 extern int alert_hash_and_store_config(uuid_t hash_id, struct alert_config *cfg);
 extern void sql_aclk_alert_clean_dead_entries(RRDHOST *host);
+extern int sql_get_alert_analytics(RRDHOST *host, time_t start, time_t end, BUFFER *b);
+
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/health/health.c
+++ b/health/health.c
@@ -391,6 +391,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
     ae->flags |= HEALTH_ENTRY_FLAG_EXEC_IN_PROGRESS;
     ae->exec_spawn_serial = spawn_enq_cmd(command_to_run);
     enqueue_alarm_notify_in_progress(ae);
+    sql_health_alarm_log_update(host, ae);
 
     freez(edit_command);
     buffer_free(warn_alarms);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR implements alert statistics to posthog. It is currently in WIP to discuss the functionality.

Every 2 (TBD) hours (that we sent `META` events too), it will gather alerts events from the sqlite db, and create a json object that will contain the status of all alerts for this 2 hour window. It will only gather alert events produced by stock alarms.

For each alert there will be a seperate entry in the final json object.

For example, what we expect to get from the following scenario:

![IMG_2645](https://user-images.githubusercontent.com/1905463/142176237-37f176b4-9e9d-441d-bf85-ae745b541242.jpg)

```
"alert1": {
   "num_of_alerts": 1,
   "CLEAR": {
      "time_spent": tx,
      "times_in_status": 1,
      "sent_notifications": 0
   },
   "WARNING": {
      "time_spent": ty,
      "times_in_status": 1,
      "sent_notifications": 1
   },
   "CRITICAL": {
      "time_spent": 0,
      "times_in_status": 0,
      "sent_notifications": 0
   }
}
```
`num_of_alerts` is how many of the same alerts exist that apply to different charts. (e.g. `disk_inode_usage` for different partitions).
Then for every status (CLEAR, WARNING, CRITICAL) it will count the time spent in each status (`time_spent`), how many times it existed in that status (`times_in_status`), and the number of notifications (`sent_notifications`) while in that status.

The json object will also contain the start and end time of the X hour window.

There are some unit tests (which will be extended) to cover some different cases. They work by creating a memory sqlite db, creating a health log table, and running the functions on them. The json object is then checked for expected values for each scenario.

##### Component Name

Health

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Right now the whole thing is in test. No data will be sent to posthog, and the resulting json will be printed to a file in `/tmp/alert_statistics.json`. The json object will also contain the entries from the DB that are considered during checks (these will be removed for the final json).

##### Additional Information

* Consider the time window. Could be 2 hours as the META events, or longer.
* Consider if all agents should participate, given also the size of the json object.
