### PR TITLE
Assorted cleanups to static builds.

### DIFF
--- a/packaging/makeself/build.sh
+++ b/packaging/makeself/build.sh
@@ -39,6 +39,7 @@ if [ ! -f ../../netdata-installer.sh ]; then
 fi
 
 git clean -dxf
+git submodule foreach --recursive git clean -dxf
 
 cat >&2 << EOF
 This program will create a self-extracting shell package containing
@@ -53,6 +54,10 @@ if [ ! -d tmp ]; then
   mkdir tmp || exit 1
 else
   rm -rf tmp/*
+fi
+
+if [ -z "${GITHUB_ACTIONS}" ]; then
+    export GITHUB_ACTIONS=false
 fi
 
 if ! ./run-all-jobs.sh "$@"; then

--- a/packaging/makeself/jobs/10-prepare-destination.install.sh
+++ b/packaging/makeself/jobs/10-prepare-destination.install.sh
@@ -4,18 +4,20 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::group::Preparing build environment"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Preparing build environment" || true
 
 [ -d "${NETDATA_INSTALL_PATH}.old" ] && run rm -rf "${NETDATA_INSTALL_PATH}.old"
 [ -d "${NETDATA_INSTALL_PATH}" ] && run mv -f "${NETDATA_INSTALL_PATH}" "${NETDATA_INSTALL_PATH}.old"
 
 run mkdir -p "${NETDATA_INSTALL_PATH}/bin"
 run mkdir -p "${NETDATA_INSTALL_PATH}/usr"
-run cd "${NETDATA_INSTALL_PATH}"
+run cd "${NETDATA_INSTALL_PATH}" || exit 1
 run ln -s bin sbin
-run cd "${NETDATA_INSTALL_PATH}/usr"
+run cd "${NETDATA_INSTALL_PATH}/usr" || exit 1
 run ln -s ../bin bin
 run ln -s ../sbin sbin
 run ln -s . local
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/makeself/jobs/20-openssl.install.sh
+++ b/packaging/makeself/jobs/20-openssl.install.sh
@@ -4,7 +4,8 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::group::Building OpenSSL"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building OpenSSL" || true
 
 version="$(cat "$(dirname "${0}")/../openssl.version")"
 
@@ -22,4 +23,5 @@ run ./config -static no-tests --prefix=/openssl-static --openssldir=/opt/netdata
 run make -j "$(nproc)"
 run make -j "$(nproc)" install_sw
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/makeself/jobs/50-bash-5.1.8.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.1.8.install.sh
@@ -4,7 +4,8 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::group::building bash"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::building bash" || true
 
 fetch "bash-5.1.8" "http://ftp.gnu.org/gnu/bash/bash-5.1.8.tar.gz" \
     0cfb5c9bb1a29f800a97bd242d19511c997a1013815b805e0fdd32214113d6be
@@ -32,8 +33,9 @@ EOF
 
 run make install
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/bin/bash
 fi
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/makeself/jobs/50-curl-7.78.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.78.0.install.sh
@@ -4,7 +4,8 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::group::Building cURL"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building cURL" || true
 
 fetch "curl-7.78.0" "https://curl.haxx.se/download/curl-7.78.0.tar.gz" \
     ed936c0b02c06d42cf84b39dd12bb14b62d77c7c4e875ade022280df5dcc81d7
@@ -45,8 +46,9 @@ run make clean
 run make -j "$(nproc)"
 run make install
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/bin/curl
 fi
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::group::Preparing build environment"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Preparing build environment" || true

--- a/packaging/makeself/jobs/50-fping-5.0.install.sh
+++ b/packaging/makeself/jobs/50-fping-5.0.install.sh
@@ -4,7 +4,8 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::group::Building fping"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building fping" || true
 
 fetch "fping-5.0" "https://fping.org/dist/fping-5.0.tar.gz" \
     ed38c0b9b64686a05d1b3bc1d66066114a492e04e44eef1821d43b1263cd57b8
@@ -28,8 +29,9 @@ run make clean
 run make -j "$(nproc)"
 run make install
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/bin/fping
 fi
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/makeself/jobs/50-ioping-1.2.install.sh
+++ b/packaging/makeself/jobs/50-ioping-1.2.install.sh
@@ -4,7 +4,8 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::group::Building ioping"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building ioping" || true
 
 fetch "ioping-1.2" "https://github.com/koct9i/ioping/archive/v1.2.tar.gz" \
     d3e4497c653a1e96df67c72ce2b70da18e9f5e3b93179a5bb57a6e30ceacfa75
@@ -16,8 +17,9 @@ run make -j "$(nproc)"
 run mkdir -p "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/
 run install -o root -g root -m 4750 ioping "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/ioping
 fi
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -6,7 +6,7 @@
 
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   export CFLAGS="-static -O3 -I/openssl-static/include"
 else
   export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include"
@@ -34,7 +34,8 @@ run ./netdata-installer.sh \
   --use-system-protobuf \
   --dont-scrub-cflags-even-though-it-may-break-things
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::group::Finishing netdata install"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Finishing netdata install" || true
 
 # Properly mark the install type
 cat > "${NETDATA_INSTALL_PATH}/etc/netdata/.install-type" <<-EOF
@@ -52,10 +53,11 @@ if run readelf -l "${NETDATA_INSTALL_PATH}"/bin/netdata | grep 'INTERP'; then
   exit 1
 fi
 
-if [ ${NETDATA_BUILD_WITH_DEBUG} -eq 0 ]; then
+if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/bin/netdata
   run strip "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/apps.plugin
   run strip "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/cgroup-network
 fi
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -4,7 +4,8 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::group::Building self-extracting archive"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building self-extracting archive" || true
 
 run cd "${NETDATA_SOURCE_PATH}" || exit 1
 
@@ -107,6 +108,7 @@ if [ "${BUILDARCH}" = "x86_64" ]; then
   run ln -s "./${FILE}" "artifacts/netdata-${VERSION}.gz.run"
 fi
 
-[ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true
 
 echo >&2 "Self-extracting installer moved to 'artifacts/${FILE}'"


### PR DESCRIPTION
##### Summary

* Fixed handling of `GITHUB_ACTIONS` variable so that we can run outside of GitHub Actions again.
* Added code to clean submodules as well as the main repo prior to actually running the static build. This helps make things more reliable.
* Fixed a handful of shellcheck errors.

##### Component Name

area/packaging

##### Test Plan

CI passes properly, and static builds work correctly when run locally.