### PR TITLE
Add POWER8+ static builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
           - 'x86_64'
           - 'armv7l'
           - 'aarch64'
+          - 'ppc64le'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -13,6 +13,7 @@ case ${BUILDARCH} in
   x86_64) platform=linux/amd64 ;;
   armv7l) platform=linux/arm/v7 ;;
   aarch64) platform=linux/arm64/v8 ;;
+  ppc64le) platform=linux/ppc64le ;;
   *)
     echo "Unknown target architecture '${BUILDARCH}'."
     exit 1
@@ -21,7 +22,7 @@ esac
 
 DOCKER_CONTAINER_NAME="netdata-package-${BUILDARCH}-static-alpine314"
 
-if [ "${BUILDARCH}" != "$(uname -m)" ]; then
+if [ "${BUILDARCH}" != "$(uname -m)" ] && [ "$(uname -m)" = 'x86_64' ] && [ -z "${SKIP_EMULATION}" ]; then
     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
 fi
 


### PR DESCRIPTION
##### Summary

This adds little-endian 64-bit POWER support (supporting POWER8 and newer) to our static builds.

These new artifacts will only be usable by manually downloading them until the new kickstart script is released.

##### Component Name

area/ci
area/packaging

##### Test Plan

CI passes on this PR.