### PR TITLE
Ignore clangd cache directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,5 +221,8 @@ externaldeps/
 Session.vim
 Session.*.vim
 
+# clangd cache
+.cache/
+
 # Special exceptions
 !packaging/repoconfig/Makefile


### PR DESCRIPTION
##### Summary

[ycm](https://github.com/ycm-core/YouCompleteMe)'s clangd completer started creating the indexer's cache in the repository's root.

##### Test Plan

CI jobs + verified with `git status`.
