### PR TITLE
Always queue alerts to aclk_alert

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -30,7 +30,7 @@ const char *aclk_sync_config[] = {
 uv_mutex_t aclk_async_lock;
 struct aclk_database_worker_config  *aclk_thread_head = NULL;
 
-static inline int claimed()
+int claimed()
 {
     int rc;
     rrdhost_aclk_state_lock(localhost);

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -225,4 +225,5 @@ void sql_aclk_sync_init(void);
 void sql_check_aclk_table_list(struct aclk_database_worker_config *wc);
 void sql_delete_aclk_table_list(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void sql_maint_aclk_sync_database(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
+int claimed();
 #endif //NETDATA_SQLITE_ACLK_H

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -16,17 +16,19 @@ int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae)
     //include also the valid statuses for this case
 #ifdef ENABLE_ACLK
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
-    if (!aclk_use_new_cloud_arch) {
+    if (!aclk_use_new_cloud_arch && aclk_connected) {
 #endif
 
         if ((ae->new_status == RRDCALC_STATUS_WARNING || ae->new_status == RRDCALC_STATUS_CRITICAL) ||
             ((ae->old_status == RRDCALC_STATUS_WARNING || ae->old_status == RRDCALC_STATUS_CRITICAL))) {
             aclk_update_alarm(host, ae);
         }
-        return 0;
 #endif
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
     }
+
+    if (!claimed())
+        return 0;
 
     if (ae->flags & HEALTH_ENTRY_FLAG_ACLK_QUEUED)
         return 0;
@@ -823,4 +825,29 @@ void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, stru
     freez(claim_id);
 #endif
     return;
+}
+
+void sql_aclk_alert_clean_dead_entries(RRDHOST *host)
+{
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
+    if (!claimed())
+        return;
+
+    if (unlikely(!host->dbsync_worker))
+        return;
+
+    char uuid_str[GUID_LEN + 1];
+    uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
+
+    BUFFER *sql = buffer_create(1024);
+
+    buffer_sprintf(sql,"delete from aclk_alert_%s where alert_unique_id not in "
+                   " (select unique_id from health_log_%s); ", uuid_str, uuid_str);
+
+    db_execute(buffer_tostring(sql));
+
+    buffer_free(sql);
+#else
+    UNUSED(host);
+#endif
 }

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -392,6 +392,8 @@ void sql_health_alarm_log_cleanup(RRDHOST *host) {
         error_report("Failed to finalize the prepared statement to cleanup health log table");
 
     host->health_log_entries_written = rotate_every;
+
+    sql_aclk_alert_clean_dead_entries(host);
 }
 
 /* Health related SQL queries

--- a/database/sqlite/sqlite_health.h
+++ b/database/sqlite/sqlite_health.h
@@ -13,5 +13,5 @@ extern void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae);
 extern void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
 extern void sql_health_alarm_log_cleanup(RRDHOST *host);
 extern int alert_hash_and_store_config(uuid_t hash_id, struct alert_config *cfg);
-extern void aclk_sql_alert_clean_dead_entries(RRDHOST *host);
+extern void sql_aclk_alert_clean_dead_entries(RRDHOST *host);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/database/sqlite/sqlite_health.h
+++ b/database/sqlite/sqlite_health.h
@@ -13,4 +13,5 @@ extern void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae);
 extern void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
 extern void sql_health_alarm_log_cleanup(RRDHOST *host);
 extern int alert_hash_and_store_config(uuid_t hash_id, struct alert_config *cfg);
+extern void aclk_sql_alert_clean_dead_entries(RRDHOST *host);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/health/health.c
+++ b/health/health.c
@@ -1040,7 +1040,7 @@ void *health_main(void *ptr) {
 
 #ifdef ENABLE_ACLK
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
-            if (netdata_cloud_setting && unlikely(aclk_alert_reloaded)) {
+            if (netdata_cloud_setting && unlikely(aclk_alert_reloaded) && loop > 2) {
                 sql_queue_removed_alerts_to_aclk(host);
             }
 #endif


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Queue alerts to aclk even if using the old cloud protocol, as to not miss any events during that time.

Queuing removed alerts will also wait for after the second health loop, to make sure no removed is sent that would otherwise be updated by another alert event.

##### Component Name

New architecture

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Testing can be performed by claiming an agent to a whitelisted space (i.e. use the new arch), then switch back to old, and then back to new. Alerts should go out that would otherwise wouldn't during this time.
