### PR TITLE
Fix coverity issues 

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -751,6 +751,11 @@ void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, stru
         return;
     }
 
+    if (unlikely(!wc->host)) {
+        error_report("ACLK synchronization thread for %s is not linked to HOST", wc->host_guid);
+        return;
+    }
+
     char *claim_id = is_agent_claimed();
     if (unlikely(!claim_id))
         return;

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -870,9 +870,14 @@ void sql_aclk_alert_clean_dead_entries(RRDHOST *host)
 
     buffer_sprintf(sql,"delete from aclk_alert_%s where alert_unique_id not in "
                    " (select unique_id from health_log_%s); ", uuid_str, uuid_str);
-
-    db_execute(buffer_tostring(sql));
-
+    
+    char *err_msg = NULL;
+    int rc = sqlite3_exec(db_meta, buffer_tostring(sql), NULL, NULL, &err_msg);
+    if (rc != SQLITE_OK) {
+        error_report("Failed when trying to clean stale ACLK alert entries from aclk_alert_%s, error message \"%s""",
+                     uuid_str, err_msg);
+        sqlite3_free(err_msg);
+    }
     buffer_free(sql);
 #else
     UNUSED(host);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Add checks for wc->host being null and log an error message

- CID 374279:  Null pointer dereferences  (FORWARD_NULL)
  Passing null pointer "&host->rrdhost_rwlock" to "__netdata_rwlock_rdlock", which
- CID 374280:  Null pointer dereferences  (FORWARD_NULL)
  Passing null pointer "&host->health_log.alarm_log_rwlock" to "__netdata_rwlock_rdlock", which dereferences it.

Alter the query execution to not require to sleep (in a loop). Report an error message on failure -- This query will be retried on the next health log cleanup iteration.

- CID 373611:  Program hangs  (SLEEP)
  Call to "sql_health_alarm_log_cleanup" might sleep while holding lock "rrd_rwlock".

##### Component Name
health, database

##### Test Plan
- Trivial checks for host being null
- Trivial change for query execution by calling sqlite3_exec
- Coverity warning vanish

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
