### PR TITLE
Cleanup compilation warnings

### DIFF
--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -55,7 +55,7 @@ void aclk_env_t_destroy(aclk_env_t *env) {
 
 int aclk_env_has_capa(const char *capa)
 {
-    for (int i = 0; i < aclk_env->capability_count; i++) {
+    for (int i = 0; i < (int) aclk_env->capability_count; i++) {
         if (!strcasecmp(capa, aclk_env->capabilities[i]))
             return 1;
     }

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -157,7 +157,7 @@ static inline void global_statistics_copy(struct global_statistics *gs, uint8_t 
 
     if(options & GLOBAL_STATS_RESET_WEB_USEC_MAX) {
         uint64_t n = 0;
-        __atomic_compare_exchange(&global_statistics.web_usec_max, &gs->web_usec_max, &n, 1, __ATOMIC_SEQ_CST,
+        __atomic_compare_exchange(&global_statistics.web_usec_max, (uint64_t *) &gs->web_usec_max, &n, 1, __ATOMIC_SEQ_CST,
                                   __ATOMIC_SEQ_CST);
     }
 #else

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -374,7 +374,7 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
     wc->alert_sequence_id = last_sequence;
 
     aclk_send_alarm_log_health(&alarm_log);
-    log_access("OG [%s (%s)]: Alarm health log sent, first sequence id %ld, last sequence id %ld.", wc->node_id, wc->host ? wc->host->hostname : "N/A", first_sequence, last_sequence);
+    log_access("OG [%s (%s)]: Alarm health log sent, first sequence id %"PRIu64", last sequence id %"PRIu64, wc->node_id, wc->host ? wc->host->hostname : "N/A", first_sequence, last_sequence);
 
     rc = sqlite3_finalize(res);
     if (unlikely(rc != SQLITE_OK))

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -406,7 +406,7 @@ void aclk_send_chart_event(struct aclk_database_worker_config *wc, struct aclk_d
             db_unlock();
 
             aclk_chart_inst_and_dim_update(payload_list, payload_list_size, is_dim, position_list, wc->batch_id);
-            log_access("OG [%s (%s)]: Sending charts and dimensions update, batch_id %ld, first sequence %ld, last sequence %ld", wc->node_id, wc->host ? wc->host->hostname : "N/A", wc->batch_id, first_sequence, last_sequence);
+            log_access("OG [%s (%s)]: Sending charts and dimensions update, batch_id %"PRIu64", first sequence %"PRIu64", last sequence %"PRIu64, wc->node_id, wc->host ? wc->host->hostname : "N/A", wc->batch_id, first_sequence, last_sequence);
             wc->chart_sequence_id = last_sequence;
             wc->chart_timestamp = last_timestamp;
         }
@@ -519,7 +519,7 @@ void aclk_receive_chart_ack(struct aclk_database_worker_config *wc, struct aclk_
     int rc;
     sqlite3_stmt *res = NULL;
 
-    log_access("IN [%s (%s)]: Received ack chart sequence id %ld.", wc->node_id, wc->host ? wc->host->hostname : "N/A", cmd.param1);
+    log_access("IN [%s (%s)]: Received ack chart sequence id %"PRIu64, wc->node_id, wc->host ? wc->host->hostname : "N/A", cmd.param1);
 
     BUFFER *sql = buffer_create(1024);
 

--- a/exporting/check_filters.c
+++ b/exporting/check_filters.c
@@ -43,7 +43,9 @@ int rrdhost_is_exportable(struct instance *instance, RRDHOST *host)
  */
 int rrdset_is_exportable(struct instance *instance, RRDSET *st)
 {
+#ifdef NETDATA_INTERNAL_CHECKS
     RRDHOST *host = st->rrdhost;
+#endif
 
     if (st->exporting_flags == NULL)
         st->exporting_flags = callocz(instance->engine->instance_num, sizeof(size_t));

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -276,7 +276,9 @@ void mongodb_cleanup(struct instance *instance)
 void mongodb_connector_worker(void *instance_p)
 {
     struct instance *instance = (struct instance *)instance_p;
+#ifdef NETDATA_INTERNAL_CHECKS
     struct mongodb_specific_config *connector_specific_config = instance->config.connector_specific_config;
+#endif
     struct mongodb_specific_data *connector_specific_data =
         (struct mongodb_specific_data *)instance->connector_specific_data;
 

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -70,7 +70,9 @@ calculated_number exporting_calculate_value_from_stored_data(
     time_t *last_timestamp)
 {
     RRDSET *st = rd->rrdset;
+#ifdef NETDATA_INTERNAL_CHECKS
     RRDHOST *host = st->rrdhost;
+#endif
     time_t after = instance->after;
     time_t before = instance->before;
 

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -16,7 +16,9 @@
  */
 inline int can_send_rrdset(struct instance *instance, RRDSET *st)
 {
+#ifdef NETDATA_INTERNAL_CHECKS
     RRDHOST *host = st->rrdhost;
+#endif
 
     if (unlikely(rrdset_flag_check(st, RRDSET_FLAG_EXPORTING_IGNORE)))
         return 0;

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -346,13 +346,12 @@ static int rrdpush_receive(struct receiver_state *rpt)
         netdata_mutex_unlock(&rpt->host->receiver_lock);
     }
 
+#ifdef NETDATA_INTERNAL_CHECKS
     int ssl = 0;
 #ifdef ENABLE_HTTPS
     if (rpt->ssl.conn != NULL)
         ssl = 1;
 #endif
-
-#ifdef NETDATA_INTERNAL_CHECKS
     info("STREAM %s [receive from [%s]:%s]: client willing to stream metrics for host '%s' with machine_guid '%s': update every = %d, history = %ld, memory mode = %s, health %s,%s tags '%s'"
          , rpt->hostname
          , rpt->client_ip

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -427,7 +427,9 @@ void attempt_to_send(struct sender_state *s) {
 
     rrdpush_send_labels(s->host);
 
+#ifdef NETDATA_INTERNAL_CHECKS
     struct circular_buffer *cb = s->buffer;
+#endif
 
     netdata_thread_disable_cancelability();
     netdata_mutex_lock(&s->mutex);

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -537,7 +537,9 @@ static inline void do_dimension_fixedstep(
         , time_t before_wanted
         , uint32_t options
 ){
+#ifdef NETDATA_INTERNAL_CHECKS
     RRDSET *st = r->st;
+#endif
 
     time_t
             now = after_wanted,


### PR DESCRIPTION
##### Summary
Cleanup the following compilation warnings

- database/sqlite/sqlite_aclk_alert.c:377:74: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
- database/sqlite/sqlite_aclk_alert.c:377:96: warning: format '%ld' expects argument of type 'long int', but argument 5 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
- database/sqlite/sqlite_aclk_chart.c:409:88: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
- database/sqlite/sqlite_aclk_chart.c:409:108: warning: format '%ld' expects argument of type 'long int', but argument 5 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
- database/sqlite/sqlite_aclk_chart.c:409:127: warning: format '%ld' expects argument of type 'long int', but argument 6 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
- database/sqlite/sqlite_aclk_chart.c:522:64: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'uint64_t' {aka 'long unsigned int'} [-Wformat=]
- streaming/sender.c:430:29: warning: unused variable 'cb' [-Wunused-variable]
- streaming/receiver.c:349:9: warning: variable 'ssl' set but not used [-Wunused-but-set-variable]
- aclk/aclk_util.c:58:23: warning: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'long unsigned int'} [-Wsign-compare]
- exporting/mongodb/mongodb.c:279:37: warning: unused variable 'connector_specific_config' [-Wunused-variable]
- daemon/global_statistics.c:160:9: warning: argument 2 of '__atomic_compare_exchange' discards 'volatile' qualifier [-Wincompatible-pointer-types]
- web/api/queries/query.c:540:13: warning: unused variable 'st' [-Wunused-variable]
exporting/prometheus/prometheus.c:19:14: warning: unused variable 'host' [-Wunused-variable]
- exporting/process_data.c:73:14: warning: unused variable 'host' [-Wunused-variable]
- exporting/check_filters.c:46:14: warning: unused variable 'host' [-Wunused-variable]

##### Component Name
agent

##### Test Plan
- Compile with NETDATA_INTERNAL_CHECKS and without 
  - Also use flags `-Wall -Wextra -Wformat-truncation=2 -Wunused-result -Wformat-signedness`  
  - Compilation warnings should be gone in both cases
