### PR TITLE
Postgres: use block_size instead of 8*1024

### DIFF
--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -337,7 +337,7 @@ QUERY_TABLE_STATS = {
     DEFAULT: """
 SELECT
     sum(relpages) * current_setting('block_size')::numeric AS table_size,
-    count(1)                     AS table_count
+    count(1) AS table_count
 FROM pg_class
 WHERE relkind IN ('r', 't');
 """,
@@ -347,7 +347,7 @@ QUERY_INDEX_STATS = {
     DEFAULT: """
 SELECT
     sum(relpages) * current_setting('block_size')::numeric AS index_size,
-    count(1)                     AS index_count
+    count(1) AS index_count
 FROM pg_class
 WHERE relkind = 'i';
 """,

--- a/collectors/python.d.plugin/postgres/postgres.chart.py
+++ b/collectors/python.d.plugin/postgres/postgres.chart.py
@@ -336,7 +336,7 @@ WHERE d.datallowconn;
 QUERY_TABLE_STATS = {
     DEFAULT: """
 SELECT
-    ((sum(relpages) * 8) * 1024) AS table_size,
+    sum(relpages) * current_setting('block_size')::numeric AS table_size,
     count(1)                     AS table_count
 FROM pg_class
 WHERE relkind IN ('r', 't');
@@ -346,7 +346,7 @@ WHERE relkind IN ('r', 't');
 QUERY_INDEX_STATS = {
     DEFAULT: """
 SELECT
-    ((sum(relpages) * 8) * 1024) AS index_size,
+    sum(relpages) * current_setting('block_size')::numeric AS index_size,
     count(1)                     AS index_count
 FROM pg_class
 WHERE relkind = 'i';


### PR DESCRIPTION
Although most Postgres instances in the world have BLCKSZ = 8*1024, it's not correct to hard-code this value.

current_setting('block_size') is already used in the file (e.g., in QUERY_BGWRITER), this commit fixes a couple of more hard-coded entries.

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
