### PR TITLE
Detect whether libatomic should be linked in when using CXX linker.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -969,6 +969,7 @@ NETDATA_COMMON_LIBS = \
     $(OPTIONAL_JUDY_LIBS) \
     $(OPTIONAL_SSL_LIBS) \
     $(OPTIONAL_JSONC_LIBS) \
+    $(OPTIONAL_ATOMIC_LIBS) \
     $(NULL)
 
 if LINK_STATIC_JSONC
@@ -995,7 +996,6 @@ netdata_LDADD = \
 
 if ACLK_NG
     netdata_LDADD += $(OPTIONAL_PROTOBUF_LIBS) \
-        $(OPTIONAL_ATOMIC_LIBS) \
         $(NULL)
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -799,27 +799,6 @@ if test "$enable_cloud" != "no" -a "$aclk_ng" != "no"; then
             AC_MSG_RESULT([yes])
         fi
 
-        if test "${with_bundled_protobuf}" = "yes"; then
-            AC_LANG_PUSH([C++]) 
-            CXXFLAGS="${CXXFLAGS} -std=c++11"
-
-            # On some platforms, std::atomic needs a helper library
-            AC_MSG_CHECKING(whether -latomic is needed for static protobuf)
-            AC_LINK_IFELSE([AC_LANG_SOURCE([[
-              #include <atomic>
-              #include <cstdint>
-              std::atomic<std::int64_t> v;
-              int main() {
-                return v;
-              }
-            ]])], STD_ATOMIC_NEED_LIBATOMIC=no, STD_ATOMIC_NEED_LIBATOMIC=yes)
-            AC_MSG_RESULT($STD_ATOMIC_NEED_LIBATOMIC)
-            if test "x$STD_ATOMIC_NEED_LIBATOMIC" = xyes; then
-                OPTIONAL_ATOMIC_LIBS="-latomic"
-            fi
-            AC_SUBST([OPTIONAL_ATOMIC_LIBS])
-            AC_LANG_POP([C++])
-        fi
         AC_MSG_CHECKING([ACLK Next Generation can support New Cloud protocol])
         AC_MSG_RESULT([${can_build_new_cloud_protocol}])
         if test "$new_cloud_protocol" = "yes" -a "$can_build_new_cloud_protocol" != "yes"; then
@@ -1655,11 +1634,34 @@ AC_MSG_RESULT([${enable_lto}])
 
 # -----------------------------------------------------------------------------
 
-AM_CONDITIONAL([ENABLE_CXX_LINKER], [test "${enable_backend_kinesis}" = "yes" \
-                                     -o "${enable_exporting_pubsub}" = "yes" \
-                                     -o "${enable_backend_prometheus_remote_write}" = "yes" \
-                                     -o "${new_cloud_protocol}" = "yes" \
-                                     -o "${build_ml}" = "yes"])
+if test "${enable_backend_kinesis}" = "yes" -o \
+        "${enable_exporting_pubsub}" = "yes" -o \
+        "${enable_backend_prometheus_remote_write}" = "yes" -o \
+        "${new_cloud_protocol}" = "yes" -o \
+        "${build_ml}" = "yes"; then
+    enable_cxx_linker="yes"
+
+    # Link with libatomic when using toolchains that don't provide all the
+    # atomic ops as builtins.
+    AC_LANG_PUSH([C++])
+    AC_MSG_CHECKING(whether -latomic is needed)
+    AC_LINK_IFELSE([AC_LANG_SOURCE([[
+      #include <atomic>
+      #include <cstdint>
+      std::atomic<std::int64_t> v;
+      int main() {
+        return v;
+      }
+    ]])], STD_ATOMIC_NEED_LIBATOMIC=no, STD_ATOMIC_NEED_LIBATOMIC=yes)
+    AC_MSG_RESULT($STD_ATOMIC_NEED_LIBATOMIC)
+    if test "x$STD_ATOMIC_NEED_LIBATOMIC" = xyes; then
+        OPTIONAL_ATOMIC_LIBS="-latomic"
+    fi
+    AC_SUBST([OPTIONAL_ATOMIC_LIBS])
+    AC_LANG_POP([C++])
+fi
+
+AM_CONDITIONAL([ENABLE_CXX_LINKER], [test "${enable_cxx_linker}" = "yes"])
 
 AC_DEFINE_UNQUOTED([NETDATA_USER], ["${with_user}"], [use this user to drop privileged])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1641,10 +1641,17 @@ if test "${enable_backend_kinesis}" = "yes" -o \
         "${build_ml}" = "yes"; then
     enable_cxx_linker="yes"
 
-    # Link with libatomic when using toolchains that don't provide all the
-    # atomic ops as builtins.
+    # Try to unconditionally link with -latomic. If the compiler can satisfy
+    # all the atomic ops with builtins then, the library will be left unused.
+    # Otherwise, some ops will be covered by the compiler's intrinsics and some
+    # will be picked up by the linker from -latomic. In the later case, if
+    # -latomic is not available there will be a build failure, which would
+    # have happened either way before this change.
     AC_LANG_PUSH([C++])
-    AC_MSG_CHECKING(whether -latomic is needed)
+
+    AC_MSG_CHECKING(whether we can use -latomic)
+    OLD_LIBS="${LIBS}"
+    LIBS="-latomic"
     AC_LINK_IFELSE([AC_LANG_SOURCE([[
       #include <atomic>
       #include <cstdint>
@@ -1652,12 +1659,15 @@ if test "${enable_backend_kinesis}" = "yes" -o \
       int main() {
         return v;
       }
-    ]])], STD_ATOMIC_NEED_LIBATOMIC=no, STD_ATOMIC_NEED_LIBATOMIC=yes)
-    AC_MSG_RESULT($STD_ATOMIC_NEED_LIBATOMIC)
-    if test "x$STD_ATOMIC_NEED_LIBATOMIC" = xyes; then
+    ]])], CAN_USE_LIBATOMIC=yes, CAN_USE_LIBATOMIC=no)
+    LIBS="${OLD_LIBS}"
+    AC_MSG_RESULT($CAN_USE_LIBATOMIC)
+
+    if test "x$CAN_USE_LIBATOMIC" = xyes; then
         OPTIONAL_ATOMIC_LIBS="-latomic"
     fi
     AC_SUBST([OPTIONAL_ATOMIC_LIBS])
+
     AC_LANG_POP([C++])
 fi
 


### PR DESCRIPTION
##### Summary

There was already a check for this when building with the bundled
protobuf. Considering that we needed the same check when building for
ML, I moved the check so that it can happen in either case when a
C++ linker is required for the build to succeed.

##### Test Plan

CI jobs

##### Additional Information

This should fix https://github.com/netdata/netdata/issues/11812 