### PR TITLE
feat(python.d/fail2ban): add "Failed attempts" chart, cleanup

### DIFF
--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -10,8 +10,44 @@ Monitors the fail2ban log file to show all bans for all active jails.
 
 ## Requirements
 
-- fail2ban.log file must be readable by Netdata (A good idea is to add  **create 0640 root netdata** to fail2ban conf at
-  logrotate.d)
+The `fail2ban.log` file must be readable by the user `netdata`:
+
+- change the file ownership and access permissions.
+- update `/etc/logrotate.d/fail2ban` to persists the changes after rotating the log file.
+
+<details>
+  <summary>Click to expand the instruction.</summary>
+
+To change the file ownership and access permissions, execute the following:
+
+```shell
+sudo chown root:netdata /var/log/fail2ban.log
+sudo chmod 640 /var/log/fail2ban.log
+```
+
+To persists the changes after rotating the log file, add `create 640 root netdata` to the `/etc/logrotate.d/fail2ban`:
+
+```shell
+/var/log/fail2ban.log {
+
+    weekly
+    rotate 4
+    compress
+
+    delaycompress
+    missingok
+    postrotate
+        fail2ban-client flushlogs 1>/dev/null
+    endscript
+
+    # If fail2ban runs as non-root it still needs to have write access
+    # to logfiles.
+    # create 640 fail2ban adm
+    create 640 root netdata
+}
+```
+
+</details>
 
 ## Charts
 

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -10,14 +10,15 @@ Monitors the fail2ban log file to show all bans for all active jails.
 
 ## Requirements
 
--   fail2ban.log file MUST BE readable by Netdata (A good idea is to add  **create 0640 root netdata** to fail2ban conf at logrotate.d)
+- fail2ban.log file MUST BE readable by Netdata (A good idea is to add  **create 0640 root netdata** to fail2ban conf at
+  logrotate.d)
 
 It produces one chart with multiple lines (one line per jail)
 
 ## Configuration
 
-Edit the `python.d/fail2ban.conf` configuration file using `edit-config` from the Netdata [config
-directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
+Edit the `python.d/fail2ban.conf` configuration file using `edit-config` from the
+Netdata [config directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 
 ```bash
 cd /etc/netdata   # Replace this path with your Netdata config directory, if different
@@ -28,13 +29,13 @@ Sample:
 
 ```yaml
 local:
- log_path: '/var/log/fail2ban.log'
- conf_path: '/etc/fail2ban/jail.local'
- exclude: 'dropbear apache'
+  log_path: '/var/log/fail2ban.log'
+  conf_path: '/etc/fail2ban/jail.local'
+  exclude: 'dropbear apache'
 ```
 
-If no configuration is given, module will attempt to read log file at `/var/log/fail2ban.log` and conf file at `/etc/fail2ban/jail.local`.
-If conf file is not found default jail is `ssh`.
+If no configuration is given, module will attempt to read log file at `/var/log/fail2ban.log` and conf file
+at `/etc/fail2ban/jail.local`. If conf file is not found default jail is `ssh`.
 
 ---
 

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -13,7 +13,11 @@ Monitors the fail2ban log file to show all bans for all active jails.
 - fail2ban.log file MUST BE readable by Netdata (A good idea is to add  **create 0640 root netdata** to fail2ban conf at
   logrotate.d)
 
-It produces one chart with multiple lines (one line per jail)
+## Charts
+
+- Failed attempts in attempts/s
+- Bans in bans/s
+- Banned IP addresses (since the last restart of netdata) in ips
 
 ## Configuration
 

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -25,7 +25,7 @@ sudo chown root:netdata /var/log/fail2ban.log
 sudo chmod 640 /var/log/fail2ban.log
 ```
 
-To persists the changes after rotating the log file, add `create 640 root netdata` to the `/etc/logrotate.d/fail2ban`:
+To persist the changes after rotating the log file, add `create 640 root netdata` to the `/etc/logrotate.d/fail2ban`:
 
 ```shell
 /var/log/fail2ban.log {

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -10,7 +10,7 @@ Monitors the fail2ban log file to show all bans for all active jails.
 
 ## Requirements
 
-- fail2ban.log file MUST BE readable by Netdata (A good idea is to add  **create 0640 root netdata** to fail2ban conf at
+- fail2ban.log file must be readable by Netdata (A good idea is to add  **create 0640 root netdata** to fail2ban conf at
   logrotate.d)
 
 ## Charts

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -703,6 +703,12 @@ netdataDashboard.menu = {
         icon: '<i class="fas fa-brain"></i>',
         info: 'Charts relating to anomaly detection, increased <code>anomalous</code> dimensions or a higher than usual <code>anomaly_rate</code> could be signs of some abnormal behaviour. Read our <a href="https://learn.netdata.cloud/guides/monitor/anomaly-detection" target="_blank">anomaly detection guide</a> for more details.'
     },
+
+    'fail2ban': {
+        title: 'Fail2ban',
+        icon: '<i class="fas fa-shield-alt"></i>',
+        info: 'Netdata keeps track of the current jail status by reading the Fail2ban log file.'
+    },
 };
 
 
@@ -6371,6 +6377,25 @@ netdataDashboard.context = {
 
     'anomaly_detection.training_stats': {
         info: 'Diagnostic metrics relating to training time of anomaly detection. '
+    },
+
+    // ------------------------------------------------------------------------
+    // Supervisor
+
+    'fail2ban.failed_attempts': {
+        info: '<p>The number of failed attempts.</p>'+
+        '<p>This chart reflects the number of \'Found\' lines. '+
+        'Found means a line in the service’s log file matches the failregex in its filter.</p>'
+    },
+
+    'fail2ban.bans': {
+        info: '<p>The number of bans.</p>'+
+        '<p>This chart reflects the number of \'Ban\' and \'Restore Ban\' lines. '+
+        'Ban action happens when the number of failed attempts (maxretry) occurred in the last configured interval (findtime).</p>'
+    },
+
+    'fail2ban.banned_ips': {
+        info: '<p>The number of banned IP addresses.</p>'
     },
 
 };


### PR DESCRIPTION
##### Summary

Fixes netdata/product#2590

This PR adds "Failed attempts" charts. 

Fail2ban logs [Found](https://github.com/fail2ban/fail2ban/blob/80805cabfcf57dd0454d47d7f86d43c6738ce629/fail2ban/server/filter.py#L705-L719) when it finds a line that matches 'failregex' in the given log file.


##### Component Name

collectors/python.d/fail2ban

##### Test Plan

Tested by adding manually 'Found' lines to the log file.


##### Additional Information
