### PR TITLE
Set NETDATA_CONTAINER_OS_DETECTION properly

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1557,8 +1557,8 @@ int rrdhost_set_system_info_variable(struct rrdhost_system_info *system_info, ch
         system_info->container_os_version_id = strdupz(value);
     }
     else if(!strcmp(name, "NETDATA_CONTAINER_OS_DETECTION")){
-        freez(system_info->host_os_detection);
-        system_info->host_os_detection = strdupz(value);
+        freez(system_info->container_os_detection);
+        system_info->container_os_detection = strdupz(value);
     }
     else if(!strcmp(name, "NETDATA_HOST_OS_NAME")){
         freez(system_info->host_os_name);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Assigns the result of `NETDATA_CONTAINER_OS_DETECTION` coming from `system-info.sh` script to the appropriate `system_info` variable.

There seems to be no real practical use for this at the moment, besides including it during streaming, and presenting it in `api/v1/info`.

Most likely the variable has been sent as empty string up to now, and after this PR will in most cases include `none` (or a reasonable value). I would not expect anything to break there, but we should check.

From `api/v1/info`, it might be picked up by analytics sent by dashboard, and might provide some false results.

I've checked the [PR](https://github.com/netdata/netdata/pull/7770) introducing this, I can't be sure if it was an oversight or in purpose...

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Before this PR, `api/v1/info` doesn't have a `container_os_detection` entry. It should include it after this PR.