### PR TITLE
Remove pihole_blocked_queries alert

### DIFF
--- a/health/health.d/pihole.conf
+++ b/health/health.d/pihole.conf
@@ -1,21 +1,4 @@
 
-# Blocked DNS queries.
-
- template: pihole_blocked_queries
-       on: pihole.dns_queries_percentage
-    class: Errors
-     type: Ad Filtering
-component: Pi-hole
-    every: 10s
-    units: %
-     calc: $blocked
-     warn: $this > ( ($status >= $WARNING ) ? ( 45 ) : ( 55 ) )
-     crit: $this > ( ($status == $CRITICAL) ? ( 55 ) : ( 75 ) )
-    delay: up 2m down 5m
-     info: percentage of blocked dns queries over the last 24 hour
-       to: sysadmin
-
-
 # Blocklist last update time.
 # Default update interval is a week.
 


### PR DESCRIPTION
Upon further discussion, we found out that we don't need this alert for pi-hole.