### PR TITLE
Add a note about pkg-config file location for freeipmi

### DIFF
--- a/collectors/freeipmi.plugin/README.md
+++ b/collectors/freeipmi.plugin/README.md
@@ -15,6 +15,11 @@ Netdata has a [freeipmi](https://www.gnu.org/software/freeipmi/) plugin.
 
 2.  re-install Netdata from source. The installer will detect that the required libraries are now available and will also build `freeipmi.plugin`.
 
+> In some distributions `libipmimonitoring.pc` is located in an unregistered directory.
+> In that case you should find the file and link it to the standard pkg-config directory. Usually, running
+> `sudo ln -s /usr/lib/x86_64-linux-gnu/pkgconfig/libipmimonitoring.pc/libipmimonitoring.pc /usr/lib/pkgconfig/libipmimonitoring.pc`
+> resolves the issue.
+
 Keep in mind IPMI requires root access, so the plugin is setuid to root.
 
 If you just installed the required IPMI tools, please run at least once the command `ipmimonitoring` and verify it returns sensors information. This command initialises IPMI configuration, so that the Netdata plugin will be able to work.

--- a/collectors/freeipmi.plugin/README.md
+++ b/collectors/freeipmi.plugin/README.md
@@ -15,7 +15,7 @@ Netdata has a [freeipmi](https://www.gnu.org/software/freeipmi/) plugin.
 
 2.  re-install Netdata from source. The installer will detect that the required libraries are now available and will also build `freeipmi.plugin`.
 
-> In some distributions `libipmimonitoring.pc` is located in an unregistered directory.
+> ❗ In some distributions `libipmimonitoring.pc` is located in an unregistered directory.
 > In that case you should find the file and link it to the standard pkg-config directory. Usually, running
 > `sudo ln -s /usr/lib/x86_64-linux-gnu/pkgconfig/libipmimonitoring.pc/libipmimonitoring.pc /usr/lib/pkgconfig/libipmimonitoring.pc`
 > resolves the issue.


### PR DESCRIPTION
##### Summary
In some distributions, the pkg-config file for the ipmi monitoring library is located in an unregistered place and our build system can't find it when it checks for dependencies. We add a note to the documentation with a suggestion of how to fix it.

Fixes #11381

##### Component Name
freeipmi plugin documentation