### PR TITLE
Show the number of processes/threads for empty apps groups

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -129,7 +129,6 @@ static int
         max_fds_cache_seconds = 60,
 #endif
         enable_detailed_uptime_charts = 0,
-        show_empty_groups = 0,
         enable_users_charts = 1,
         enable_groups_charts = 1,
         include_exited_childs = 1;
@@ -3508,7 +3507,7 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
 
     send_BEGIN(type, "processes", dt);
     for (w = root; w ; w = w->next) {
-        if(unlikely(w->exposed && (w->processes || show_empty_groups)))
+        if(unlikely(w->exposed && w->processes))
             send_SET(w->name, w->processes);
     }
     send_END();
@@ -3949,11 +3948,6 @@ static void parse_args(int argc, char **argv)
             enable_detailed_uptime_charts = 1;
             continue;
         }
-        
-        if(strcmp("show-empty-groups", argv[i]) == 0) {
-            show_empty_groups = 1;
-            continue;
-        }
 
         if(strcmp("-h", argv[i]) == 0 || strcmp("--help", argv[i]) == 0) {
             fprintf(stderr,
@@ -3989,10 +3983,6 @@ static void parse_args(int argc, char **argv)
                     " without-groups         disable reporting per user group charts\n"
                     "\n"
                     " with-detailed-uptime   enable reporting min/avg/max uptime charts\n"
-                    "\n"
-                    " show-empty-groups      enable reporting the number of processes\n"
-                    "                        for all configured groups, even if they\n"
-                    "                        do not contain any active processes\n"
                     "\n"
 #ifndef __FreeBSD__
                     " fds-cache-secs N       cache the files of processed for N seconds\n"

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3500,14 +3500,14 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
 
     send_BEGIN(type, "threads", dt);
     for (w = root; w ; w = w->next) {
-        if(unlikely(w->exposed && w->processes))
+        if(unlikely(w->exposed))
             send_SET(w->name, w->num_threads);
     }
     send_END();
 
     send_BEGIN(type, "processes", dt);
     for (w = root; w ; w = w->next) {
-        if(unlikely(w->exposed && w->processes))
+        if(unlikely(w->exposed))
             send_SET(w->name, w->processes);
     }
     send_END();

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -129,6 +129,7 @@ static int
         max_fds_cache_seconds = 60,
 #endif
         enable_detailed_uptime_charts = 0,
+        show_empty_groups = 0,
         enable_users_charts = 1,
         enable_groups_charts = 1,
         include_exited_childs = 1;
@@ -3507,7 +3508,7 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
 
     send_BEGIN(type, "processes", dt);
     for (w = root; w ; w = w->next) {
-        if(unlikely(w->exposed && w->processes))
+        if(unlikely(w->exposed && (w->processes || show_empty_groups)))
             send_SET(w->name, w->processes);
     }
     send_END();
@@ -3948,6 +3949,11 @@ static void parse_args(int argc, char **argv)
             enable_detailed_uptime_charts = 1;
             continue;
         }
+        
+        if(strcmp("show-empty-groups", argv[i]) == 0) {
+            show_empty_groups = 1;
+            continue;
+        }
 
         if(strcmp("-h", argv[i]) == 0 || strcmp("--help", argv[i]) == 0) {
             fprintf(stderr,
@@ -3983,6 +3989,10 @@ static void parse_args(int argc, char **argv)
                     " without-groups         disable reporting per user group charts\n"
                     "\n"
                     " with-detailed-uptime   enable reporting min/avg/max uptime charts\n"
+                    "\n"
+                    " show-empty-groups      enable reporting the number of processes\n"
+                    "                        for all configured groups, even if they\n"
+                    "                        do not contain any active processes\n"
                     "\n"
 #ifndef __FreeBSD__
                     " fds-cache-secs N       cache the files of processed for N seconds\n"


### PR DESCRIPTION
##### Summary
Sometimes it is desirable to [send zeroes for empty groups](https://community.netdata.cloud/t/apps-groups-conf-and-exporter-when-process-is-not-running/2141) in the `apps.processes` chart. ~We add the corresponding option for that: `show-empty-groups`.~ We will still send the number of processes/threads when a previously running apps group becomes empty.

##### Component Name
apps plugin

##### Test Plan
Run `fping -l localhost`, wait a couple of seconds, stop `fping`. Check that the `apps.processes` and `apps.threads` chart shows zeroes for the `fping` group after it has been stopped.