### PR TITLE
Fix cgroup renaming

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -170,7 +170,7 @@ function k8s_get_kubepod_name() {
     # kubepods_kubepods-<QOS_CLASS>
     name=${clean_id//-/_}
     name=${name/#kubepods_kubepods/kubepods}
-  elif [[ $clean_id =~ .+pod[a-f0-9_-]+_(docker|crio|cri-containerd)-([a-f0-9]+)$ ]]; then
+  elif [[ $clean_id =~ .+pod[a-f0-9_-]+/(docker|crio|cri-containerd)-([a-f0-9]+)$ ]]; then
     # ...pod<POD_UID>_(docker|crio|cri-containerd)-<CONTAINER_ID> (POD_UID w/ "_")
     cntr_id=${BASH_REMATCH[2]}
   elif [[ $clean_id =~ .+pod[a-f0-9-]+_([a-f0-9]+)$ ]]; then
@@ -404,7 +404,7 @@ fi
 
 for CONFIG in "${NETDATA_USER_CONFIG_DIR}/cgroups-names.conf" "${NETDATA_STOCK_CONFIG_DIR}/cgroups-names.conf"; do
   if [ -f "${CONFIG}" ]; then
-    NAME="$(grep "^${CGROUP} " "${CONFIG}" | sed 's/[[:space:]]\+/ /g' | cut -d ' ' -f 2)"
+    NAME="$(grep "^${CGROUP} " "${CONFIG}" | sed 's|[[:space:]]\+| |g' | cut -d ' ' -f 2)"
     if [ -z "${NAME}" ]; then
       info "cannot find cgroup '${CGROUP}' in '${CONFIG}'."
     else
@@ -437,28 +437,27 @@ if [ -z "${NAME}" ]; then
     PODMANID="$(echo "${CGROUP}" | sed "s|^.*libpod-\([a-fA-F0-9]\+\).*$|\1|")"
     podman_validate_id "${PODMANID}"
 
-  elif [[ ${CGROUP} =~ machine.slice[_/].*\.service ]]; then
+  elif [[ ${CGROUP} =~ machine.slice/.*\.service ]]; then
     # systemd-nspawn
-    NAME="$(echo "${CGROUP}" | sed 's/.*machine.slice[_\/]\(.*\)\.service/\1/g')"
+    NAME="$(echo "${CGROUP}" | sed 's|.*machine.slice/\(.*\)\.service|\1|g')"
 
-  elif [[ ${CGROUP} =~ machine.slice_machine.*-lxc ]]; then
+  elif [[ ${CGROUP} =~ machine.slice/machine.*-lxc ]]; then
     # libvirtd / lxc containers
 	# examples:
-	# before: machine.slice machine-lxc/x2d969/x2dhubud0xians01.scope
+	# before: machine.slice/machine-lxc/x2d969/x2dhubud0xians01.scope
     # after:  lxc/hubud0xians01
-	# before: machine.slice_machine-lxc/x2d969/x2dhubud0xians01.scope/libvirt_init.scope
+	# before: machine.slice/machine-lxc/x2d969/x2dhubud0xians01.scope/libvirt_init.scope
 	# after:  lxc/hubud0xians01/libvirt_init
-    NAME="lxc/$(echo "${CGROUP}" | sed 's/machine.slice_machine.*-lxc//; s/\/x2d[[:digit:]]*//; s/\/x2d//g; s/\.scope//g')"
-  elif [[ ${CGROUP} =~ machine.slice_machine.*-qemu ]]; then
+    NAME="lxc/$(echo "${CGROUP}" | sed 's|machine.slice/machine.*-lxc||; s|/x2d[[:digit:]]*||; s|/x2d||g; s|\.scope||g')"
+  elif [[ ${CGROUP} =~ machine.slice/machine.*-qemu ]]; then
     # libvirtd / qemu virtual machines
-    # NAME="$(echo ${CGROUP} | sed 's/machine.slice_machine.*-qemu//; s/\/x2d//; s/\/x2d/\-/g; s/\.scope//g')"
-    NAME="qemu_$(echo "${CGROUP}" | sed 's/machine.slice_machine.*-qemu//; s/\/x2d[[:digit:]]*//; s/\/x2d//g; s/\.scope//g')"
+    NAME="qemu_$(echo "${CGROUP}" | sed 's|machine.slice/machine.*-qemu||; s|/x2d[[:digit:]]*||; s|/x2d||g; s|\.scope||g')"
 
-  elif [[ ${CGROUP} =~ machine_.*\.libvirt-qemu ]]; then
+  elif [[ ${CGROUP} =~ machine/.*\.libvirt-qemu ]]; then
     # libvirtd / qemu virtual machines
-    NAME="qemu_$(echo "${CGROUP}" | sed 's/^machine_//; s/\.libvirt-qemu$//; s/-/_/;')"
+    NAME="qemu_$(echo "${CGROUP}" | sed 's|^machine/||; s|\.libvirt-qemu$||; s|-|_|;')"
 
-  elif [[ ${CGROUP} =~ qemu.slice_([0-9]+).scope && -d /etc/pve ]]; then
+  elif [[ ${CGROUP} =~ qemu.slice/([0-9]+).scope && -d /etc/pve ]]; then
     # Proxmox VMs
 
     FILENAME="/etc/pve/qemu-server/${BASH_REMATCH[1]}.conf"
@@ -467,7 +466,7 @@ if [ -z "${NAME}" ]; then
     else
       error "proxmox config file missing ${FILENAME} or netdata does not have read access.  Please ensure netdata is a member of www-data group."
     fi
-  elif [[ ${CGROUP} =~ lxc_([0-9]+) && -d /etc/pve ]]; then
+  elif [[ ${CGROUP} =~ lxc/([0-9]+) && -d /etc/pve ]]; then
     # Proxmox Containers (LXC)
 
     FILENAME="/etc/pve/lxc/${BASH_REMATCH[1]}.conf"
@@ -478,7 +477,7 @@ if [ -z "${NAME}" ]; then
     fi
   elif [[ ${CGROUP} =~ lxc.payload.* ]]; then
     # LXC 4.0
-    NAME="$(echo "${CGROUP}" | sed 's/lxc\.payload\.\(.*\)/\1/g')"
+    NAME="$(echo "${CGROUP}" | sed 's|lxc\.payload\.\(.*\)|\1|g')"
   fi
 
   [ -z "${NAME}" ] && NAME="${CGROUP}"

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -392,9 +392,14 @@ function podman_validate_id() {
 
 DOCKER_HOST="${DOCKER_HOST:=/var/run/docker.sock}"
 PODMAN_HOST="${PODMAN_HOST:=/run/podman/podman.sock}"
-CGROUP="${1}"
 NAME_NOT_FOUND=0
 NAME=
+
+if [ -n "$(echo "${1}" | grep -E '^/.+')" ]; then
+  CGROUP="$(echo "${1}" | sed 's|^/||')"
+else
+  CGROUP="${1}"
+fi
 
 # -----------------------------------------------------------------------------
 

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -395,7 +395,7 @@ PODMAN_HOST="${PODMAN_HOST:=/run/podman/podman.sock}"
 NAME_NOT_FOUND=0
 NAME=
 
-if [ -n "$(echo "${1}" | grep -E '^/.+')" ]; then
+if echo "${1}" | grep -Eq '^/.+'; then
   CGROUP="$(echo "${1}" | sed 's|^/||')"
 else
   CGROUP="${1}"

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1411,7 +1411,7 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
     pid_t cgroup_pid;
     char command[CGROUP_CHARTID_LINE_MAX + 1];
 
-    snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->chart_id);
+    snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->id);
 
     debug(D_CGROUP, "executing command \"%s\" for cgroup '%s'", command, cg->chart_id);
     FILE *fp = mypopen(command, &cgroup_pid);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -663,7 +663,6 @@ struct cgroup {
     char enabled;        // enabled in the config
 
     char pending_renames;
-    char *intermediate_id; // TODO: remove it when the renaming script is fixed
 
     char *id;
     uint32_t hash;
@@ -1368,16 +1367,13 @@ static inline char *cgroup_chart_id_strdupz(const char *s) {
     char *r = strdupz(s);
     netdata_fix_chart_id(r);
 
-    return r;
-}
-
-// TODO: move the code to cgroup_chart_id_strdupz() when the renaming script is fixed
-static inline void substitute_dots_in_id(char *s) {
     // dots are used to distinguish chart type and id in streaming, so we should replace them
-    for (char *d = s; *d; d++) {
+    for (char *d = r; *d; d++) {
         if (*d == '.')
             *d = '-';
     }
+
+    return r;
 }
 
 char *parse_k8s_data(struct label **labels, char *data)
@@ -1415,8 +1411,7 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
     pid_t cgroup_pid;
     char command[CGROUP_CHARTID_LINE_MAX + 1];
 
-    // TODO: use cg->id when the renaming script is fixed
-    snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->intermediate_id);
+    snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->chart_id);
 
     debug(D_CGROUP, "executing command \"%s\" for cgroup '%s'", command, cg->chart_id);
     FILE *fp = mypopen(command, &cgroup_pid);
@@ -1453,7 +1448,6 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
 
                     freez(cg->chart_id);
                     cg->chart_id = cgroup_chart_id_strdupz(name);
-                    substitute_dots_in_id(cg->chart_id);
                     cg->hash_chart = simple_hash(cg->chart_id);
                 }
             }
@@ -1480,10 +1474,7 @@ static inline struct cgroup *cgroup_add(const char *id) {
 
     cg->chart_title = cgroup_title_strdupz(id);
 
-    cg->intermediate_id = cgroup_chart_id_strdupz(id);
-
     cg->chart_id = cgroup_chart_id_strdupz(id);
-    substitute_dots_in_id(cg->chart_id);
     cg->hash_chart = simple_hash(cg->chart_id);
 
     if(cgroup_use_unified_cgroups) cg->options |= CGROUP_OPTIONS_IS_UNIFIED;
@@ -1647,7 +1638,6 @@ static inline void cgroup_free(struct cgroup *cg) {
     free_pressure(&cg->memory_pressure);
 
     freez(cg->id);
-    freez(cg->intermediate_id);
     freez(cg->chart_id);
     freez(cg->chart_title);
 


### PR DESCRIPTION
##### Summary
We made a temporary fix for cgroup renaming in #11775. This PR reverts the quick fix and provides a correct solution to the problem. We should use untouched cgroup `id` (do not change slashes to underscores) and change regular expressions in the renaming script accordingly.

##### Component Name
cgroups plugin

##### Test Plan
Tested with
1. Docker containers (Netdata installed on a host).
2. Docker containers (Netdata runs in a container).
3. Minikube.