### PR TITLE
Optional proto support fix

### DIFF
--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -842,7 +842,11 @@ int aclk_get_env(aclk_env_t *env, const char* aclk_hostname, int aclk_port) {
         return 1;
     }
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
     buffer_sprintf(buf, "/api/v1/env?v=%s&cap=json,proto&claim_id=%s", &(VERSION[1]) /* skip 'v' at beginning */, agent_id);
+#else
+    buffer_sprintf(buf, "/api/v1/env?v=%s&cap=json&claim_id=%s", &(VERSION[1]) /* skip 'v' at beginning */, agent_id);
+#endif
     freez(agent_id);
 
     req.host = (char*)aclk_hostname;


### PR DESCRIPTION
##### Summary

When protobuf was made optional the `aclk_get_env` was not updated accordingly.

##### Component Name

##### Test Plan

##### Additional Information
