### PR TITLE
fix(health): `pihole_blocklist_gravity_file` and `pihole_status` info lines

### DIFF
--- a/health/health.d/pihole.conf
+++ b/health/health.d/pihole.conf
@@ -27,7 +27,7 @@ component: Pi-hole
      calc: $file_exists
      crit: $this != 1
     delay: up 2m down 5m
-     info: gravity.list (blocklist) file existence state (0: exists, 1: not-exists)
+     info: gravity.list (blocklist) file existence state (0: not-exists, 1: exists)
        to: sysadmin
 
 # Pi-hole's ability to block unwanted domains.
@@ -43,5 +43,5 @@ component: Pi-hole
      calc: $enabled
      warn: $this != 1
     delay: up 2m down 5m
-     info: unwanted domains blocking status (0: enabled, 1: disabled)
+     info: unwanted domains blocking status (0: disabled, 1: enabled)
        to: sysadmin


### PR DESCRIPTION
##### Summary

[Spotted](https://github.com/netdata/agent-alerts-guides/pull/95#issuecomment-982396295) by @Ancairon 

##### Component Name

health/

##### Test Plan

Not needed

##### Additional Information
