### PR TITLE
Fix compilation warnings

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -724,6 +724,7 @@ void health_alarm_entry2proto_nolock(struct alarm_log_entry *alarm_log, ALARM_EN
 }
 #endif
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
 {
     ALARM_ENTRY *ae = host->health_log.alarms;
@@ -737,6 +738,7 @@ static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
 
     return 0;
 }
+#endif
 
 #define ALARM_EVENTS_PER_CHUNK 10
 void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -979,6 +979,8 @@ int queue_chart_to_aclk(RRDSET *st)
 #ifndef ENABLE_NEW_CLOUD_PROTOCOL
 #ifdef ENABLE_ACLK
     aclk_update_chart(st->rrdhost, st->id, 1);
+#else
+    UNUSED(st);
 #endif
     return 0;
 #else

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -318,7 +318,7 @@ void aclk_send_chart_event(struct aclk_database_worker_config *wc, struct aclk_d
 
     uint64_t first_sequence;
     uint64_t last_sequence;
-    time_t last_timestamp;
+    time_t last_timestamp = 0;
 
     BUFFER *sql = buffer_create(1024);
 

--- a/ml/ml-dummy.c
+++ b/ml/ml-dummy.c
@@ -10,7 +10,10 @@ void ml_new_host(RRDHOST *RH) { (void) RH; }
 
 void ml_delete_host(RRDHOST *RH) { (void) RH; }
 
-char *ml_get_host_info(RRDHOST *RH) { (void) RH; }
+char *ml_get_host_info(RRDHOST *RH) {
+    (void) RH;
+    return NULL;
+}
 
 void ml_new_dimension(RRDDIM *RD) { (void) RD; }
 


### PR DESCRIPTION
##### Summary
The PR fixes the following compilation warnings
```
sudo stop systemctl stop netdata; sudo rm -rf /var/cache/netdata/*; sudo rm -rf /var/log/netdata/*; sudo CFLAGS="-Og -ggdb -Wall -Wextra -Wformat-signedness -fno-omit-frame-pointer -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTiFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1" ./netdata-installer.sh --enable-plugin-nfacct --enable-plugin-freeipmi --disable-backend-kinesis --enable-backend-prometheus-remote-write --use-system-protobuf --disable-cloud --disable-go --disable-lto --dont-wait --dont-start-it
```
```
ml/ml-dummy.c: In function 'ml_get_host_info':
ml/ml-dummy.c:13:50: warning: control reaches end of non-void function [-Wreturn-type]
   13 | char *ml_get_host_info(RRDHOST *RH) { (void) RH; }
      |  

database/sqlite/sqlite_aclk_chart.c: In function 'queue_chart_to_aclk':
database/sqlite/sqlite_aclk_chart.c:977:33: warning: unused parameter 'st' [-Wunused-parameter]
  977 | int queue_chart_to_aclk(RRDSET *st)
      | 

database/sqlite/sqlite_aclk_alert.c:726:12: warning: 'have_recent_alarm' defined but not used [-Wunused-function]
  726 | static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
      |   
```
and
```
sudo stop systemctl stop netdata; sudo rm -rf /var/cache/netdata/*; sudo rm -rf /var/log/netdata/*; sudo CFLAGS="-Og -ggdb -Wall -Wextra -Wformat-signedness -fno-omit-frame-pointer -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTiFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1" ./netdata-installer.sh --enable-plugin-nfacct --enable-plugin-freeipmi --disable-backend-kinesis --enable-backend-prometheus-remote-write --use-system-protobuf --disable-go --disable-lto --dont-wait --dont-start-it
```
```
aclk/legacy/aclk_rx_msgs.c: In function 'aclk_handle_cloud_request_v2':
aclk/legacy/aclk_rx_msgs.c:166:21: warning: 'data' may be used uninitialized in this function [-Wmaybe-uninitialized]
  166 |     cloud_req->data = data;
      |     ~~~~~~~~~~~~~~~~^~~~~~

database/sqlite/sqlite_aclk_chart.c: In function 'aclk_send_chart_event':
database/sqlite/sqlite_aclk_chart.c:411:33: warning: 'last_timestamp' may be used uninitialized in this function [-Wmaybe-uninitialized]
  411 |             wc->chart_timestamp = last_timestamp;
      |             ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~

```
There is also a warning in SQLite
```
database/sqlite/sqlite3.c: In function 'pager_playback':
database/sqlite/sqlite3.c:55579:5: warning: 'memset' writing 4 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
55579 |     memset(&zSuper[-4], 0, 4);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
database/sqlite/sqlite3.c:55561:21: note: destination object '*pPager.pTmpSpace' of size [0, 9223372036854775807]
55561 |     zSuper = &pPager->pTmpSpace[4];
      |  
```
but it is not fixed yet in SQLite 3.37.0.

##### Component Name
Anomaly detection, ACLK

##### Test Plan
Run Netdata build with the aforementioned options. Check if the warnings are gone except an SQLite's one.