### PR TITLE
Allow PushBullet notifications to be sent to PushBullet channels

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1012,10 +1012,21 @@ send_pushover() {
 # pushbullet sender
 
 send_pushbullet() {
-  local userapikey="${1}" source_device="${2}" recipients="${3}" url="${4}" title="${5}" message="${6}" httpcode sent=0 user
+  local userapikey="${1}" source_device="${2}" recipients="${3}" url="${4}" title="${5}" message="${6}" httpcode sent=0 userOrChannelTag
   if [ "${SEND_PUSHBULLET}" = "YES" ] && [ -n "${userapikey}" ] && [ -n "${recipients}" ] && [ -n "${message}" ] && [ -n "${title}" ]; then
-    #https://docs.pushbullet.com/#create-push
-    for user in ${recipients}; do
+
+    # https://docs.pushbullet.com/#create-push
+    # Accept specification of user(s) (PushBullet account email address) and/or channel tag(s), separated by spaces.
+    # If recipient begins with a "#" then send to channel tag, otherwise send to email recipient.
+
+    for userOrChannelTag in ${recipients}; do
+      if [ "${userOrChannelTag::1}" = "#" ]; then
+        userOrChannelTag_type="channel_tag"
+        userOrChannelTag="${userOrChannelTag:1}" # Remove hash from start of channel tag (required by pushbullet API)
+      else
+        userOrChannelTag_type="email"
+      fi
+
       httpcode=$(docurl \
         --header 'Access-Token: '${userapikey}'' \
         --header 'Content-Type: application/json' \
@@ -1023,7 +1034,7 @@ send_pushbullet() {
           cat <<EOF
                               {"title": "${title}",
                               "type": "link",
-                              "email": "${user}",
+                              "${userOrChannelTag_type}": "${userOrChannelTag}",
                               "body": "$(echo -n ${message})",
                               "url": "${url}",
                               "source_device_iden": "${source_device}"}
@@ -1031,10 +1042,10 @@ EOF
         ) "https://api.pushbullet.com/v2/pushes" -X POST)
 
       if [ "${httpcode}" = "200" ]; then
-        info "sent pushbullet notification for: ${host} ${chart}.${name} is ${status} to '${user}'"
+        info "sent pushbullet notification for: ${host} ${chart}.${name} is ${status} to '${userOrChannelTag}'"
         sent=$((sent + 1))
       else
-        error "failed to send pushbullet notification for: ${host} ${chart}.${name} is ${status} to '${user}' with HTTP response status code ${httpcode}."
+        error "failed to send pushbullet notification for: ${host} ${chart}.${name} is ${status} to '${userOrChannelTag}' with HTTP response status code ${httpcode}."
       fi
     done
 

--- a/health/notifications/pushbullet/README.md
+++ b/health/notifications/pushbullet/README.md
@@ -14,13 +14,15 @@ And like this on your Android device:
 
 You will need:
 
-1.  Signup and Login to pushbullet.com
-2.  Get your Access Token, go to <https://www.pushbullet.com/#settings/account> and create a new one
-3.  Fill in the PUSHBULLET_ACCESS_TOKEN with that value
-4.  Add the recipient emails or channel tags (each channel tag must be prefixed with #, e.g. #channeltag) to DEFAULT_RECIPIENT_PUSHBULLET
-    !!PLEASE NOTE THAT IF AN EMAIL RECIPIENT DOES NOT HAVE A PUSHBULLET ACCOUNT, PUSHBULLET SERVICE WILL SEND AN EMAIL!!
+1.  Sign up and log in to [pushbullet.com](pushbullet.com)
+2.  Create a new access token in your [account settings](https://www.pushbullet.com/#settings/account).
+3.  Fill in the `PUSHBULLET_ACCESS_TOKEN` with the newly generated access token.
+4.  Add the recipient emails or channel tags (each channel tag must be prefixed with #, e.g. #channeltag) to `DEFAULT_RECIPIENT_PUSHBULLET`.
+    > 🚨 The pushbullet notification service will send emails to the email recipient, regardless of if they have a pushbullet account.
 
-Set them in `/etc/netdata/health_alarm_notify.conf` (to edit it on your system run `/etc/netdata/edit-config health_alarm_notify.conf`), like this:
+To add notification channels, run `/etc/netdata/edit-config health_alarm_notify.conf` 
+
+You can change the configuration like this:
 
 ```
 ###############################################################################

--- a/health/notifications/pushbullet/README.md
+++ b/health/notifications/pushbullet/README.md
@@ -17,8 +17,8 @@ You will need:
 1.  Signup and Login to pushbullet.com
 2.  Get your Access Token, go to <https://www.pushbullet.com/#settings/account> and create a new one
 3.  Fill in the PUSHBULLET_ACCESS_TOKEN with that value
-4.  Add the recipient emails to DEFAULT_RECIPIENT_PUSHBULLET
-    !!PLEASE NOTE THAT IF THE RECIPIENT DOES NOT HAVE A PUSHBULLET ACCOUNT, PUSHBULLET SERVICE WILL SEND AN EMAIL!!
+4.  Add the recipient emails or channel tags (each channel tag must be prefixed with #, e.g. #channeltag) to DEFAULT_RECIPIENT_PUSHBULLET
+    !!PLEASE NOTE THAT IF AN EMAIL RECIPIENT DOES NOT HAVE A PUSHBULLET ACCOUNT, PUSHBULLET SERVICE WILL SEND AN EMAIL!!
 
 Set them in `/etc/netdata/health_alarm_notify.conf` (to edit it on your system run `/etc/netdata/edit-config health_alarm_notify.conf`), like this:
 
@@ -26,8 +26,8 @@ Set them in `/etc/netdata/health_alarm_notify.conf` (to edit it on your system r
 ###############################################################################
 # pushbullet (pushbullet.com) push notification options
 
-# multiple recipients can be given like this:
-#                  "user1@email.com user2@mail.com"
+# multiple recipients (a combination of email addresses or channel tags) can be given like this:
+#                  "user1@email.com user2@mail.com #channel1 #channel2"
 
 # enable/disable sending pushbullet notifications
 SEND_PUSHBULLET="YES"
@@ -35,14 +35,14 @@ SEND_PUSHBULLET="YES"
 # Signup and Login to pushbullet.com
 # To get your Access Token, go to https://www.pushbullet.com/#settings/account
 # And create a new access token
-# Then just set the recipients emails
-# Please note that the if the email in the DEFAULT_RECIPIENT_PUSHBULLET does
+# Then just set the recipients emails and/or channel tags (channel tags must be prefixed with #)
+# Please note that the if an email in the DEFAULT_RECIPIENT_PUSHBULLET does
 # not have a pushbullet account, the pushbullet service will send an email
 # to that address instead
 
 # Without an access token, Netdata cannot send pushbullet notifications.
 PUSHBULLET_ACCESS_TOKEN="o.Sometokenhere"
-DEFAULT_RECIPIENT_PUSHBULLET="admin1@example.com admin3@somemail.com"
+DEFAULT_RECIPIENT_PUSHBULLET="admin1@example.com admin3@somemail.com #examplechanneltag #anotherchanneltag"
 ```
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fhealth%2Fnotifications%2Fpushbullet%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Allows notifications to be sent to PushBullet channels, in addition to or instead of PushBullet user email addresses.

A combination of user email addresses and/or channels can be specified, they are not exclusive. e.g:
`DEFAULT_RECIPIENT_PUSHBULLET="user1@example.com user2@example.com #channel1 #channel2"`

Channel tags must be prefixed with a hash (e.g. #channel), as explained in the updated README.md.

Backward compatible with only user email addresses being specified; does not remove or affect any existing functionality.

##### Component Name
PushBullet notifications

##### Test Plan
Tested with PushBullet channel names, email addresses and a combination of the two. All notifications received as expected.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
