### PR TITLE
fix static build, curl will be staict binary; extra args can be transfer

### DIFF
--- a/packaging/makeself/build-x86_64-static.sh
+++ b/packaging/makeself/build-x86_64-static.sh
@@ -4,4 +4,4 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-"${SCRIPT_DIR}/build-static.sh" x86_64
+"${SCRIPT_DIR}/build-static.sh" x86_64 "${@}"

--- a/packaging/makeself/jobs/50-curl-7.78.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.78.0.install.sh
@@ -40,7 +40,7 @@ run ./configure \
   --with-openssl
 
 # Curl autoconf does not honour the curl_LDFLAGS environment variable
-run sed -i -e "s/curl_LDFLAGS =/curl_LDFLAGS = -all-static/" src/Makefile
+run sed -i -e "s/LDFLAGS =/LDFLAGS = -all-static/" src/Makefile
 
 run make clean
 run make -j "$(nproc)"


### PR DESCRIPTION
##### Summary

###### Curl
curl not static build in version v1.32.0, 
when run on pre-build netdata on ubuntu , `/opt/netdata/bin/curl` ask for need `libc.musl-x86_64.so.1` 
after install musl in ubuntu, it ask for more library and panic

###### build-x86_64-static.sh
the extra args not transfer to build.sh script, and can not build debug verion etc..

##### Component Name
makeself

##### Test Plan

##### Additional Information
I think the issue PR #11490 , update curl version to 7.78.0 make the curl problem happen.
```
root@e6d638b8b4bb:/# ldd /opt/netdata/bin/curl
        linux-vdso.so.1 (0x00007ffe4cef4000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fc9e50ef000)
        libc.musl-x86_64.so.1 => not found
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc9e4efd000)
        /lib/ld-musl-x86_64.so.1 => /lib64/ld-linux-x86-64.so.2 (0x00007fc9e551e000)
root@e6d638b8b4bb:/# /opt/netdata/bin/netdata -v
netdata v1.32.0
root@e6d638b8b4bb:/# cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.3 LTS"
```