### PR TITLE
ACLK-NG remove 'cmd' switch by message type

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -222,7 +222,7 @@ static void msg_callback_old_protocol(const char *topic, const void *msg, size_t
         return;
     }
 
-    aclk_handle_cloud_message(cmsg);
+    aclk_handle_cloud_cmd_message(cmsg);
 }
 
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL

--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -259,7 +259,10 @@ int handle_old_proto_cmd(const char *msg, size_t msg_len)
     char *str = mallocz(msg_len+1);
     memcpy(str, msg, msg_len);
     str[msg_len] = 0;
-    aclk_handle_cloud_message(str);
+    if (aclk_handle_cloud_cmd_message(str)) {
+        freez(str);
+        return 1;
+    }
     freez(str);
     return 0;
 }

--- a/aclk/aclk_rx_msgs.h
+++ b/aclk/aclk_rx_msgs.h
@@ -8,7 +8,7 @@
 #include "daemon/common.h"
 #include "libnetdata/libnetdata.h"
 
-int aclk_handle_cloud_message(char *payload);
+int aclk_handle_cloud_cmd_message(char *payload);
 
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
 void aclk_init_rx_msg_handlers(void);


### PR DESCRIPTION
##### Summary
Previously we planned to have multiple message types of messages coming to `cmd`. With new cloud architecture that lost its meaning as we will ever only have `http` message. All new messages in future will be proto based.

Additionally it fixes the cloud rx messages ACLK chart in dashboard.

##### Component Name

##### Test Plan

##### Additional Information
