### PR TITLE
fix(health): used_swap alarm calc

### DIFF
--- a/health/health.d/swap.conf
+++ b/health/health.d/swap.conf
@@ -25,7 +25,7 @@ component: Memory
 component: Memory
        os: linux freebsd
     hosts: *
-     calc: ($used + $free) > 0 ? ($used * 100 / ($used + $free)) : 0
+     calc: (($used + $free) > 0) ? ($used * 100 / ($used + $free)) : 0
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (80) : (90))


### PR DESCRIPTION
##### Summary

Fixes: #11861

> calc: ($used + $free) > 0 ? ($used * 100 / ($used + $free)) : 0

A comparison argument should be enclosed in parentheses. W/o it the used_swap alarm calc is either 1 or 0 (if '($used + $free) > 0' is true => 1 else 0).

##### Component Name

health/

##### Test Plan

Check this on a system with swap, ensure the value is not 1%.

##### Additional Information
