### PR TITLE
Fix the code that checks for available updates.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -38,6 +38,8 @@ else
   script_source="${script_dir}/netdata-updater.sh"
 fi
 
+PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
+
 info() {
   echo >&3 "$(date) : INFO: " "${@}"
 }
@@ -262,7 +264,17 @@ get_latest_version() {
 }
 
 update_available() {
-  current_version="$(command -v netdata > /dev/null && parse_version "$(netdata -v | cut -f 2 -d ' ')")"
+  basepath="$(basename "$(basename "$(basename "${NETDATA_LIB_DIR}")")")"
+  searchpath="${basepath}/bin:${basepath}/sbin:${basepath}/usr/bin:${basepath}/usr/sbin:${PATH}"
+  searchpath="${basepath}/netdata/bin:${basepath}/netdata/sbin:${basepath}/netdata/usr/bin:${basepath}/netdata/usr/sbin:${searchpath}"
+  ndbinary="$(env PATH="${searchpath}" command -v netdata 2>/dev/null)"
+
+  if [ -z "${ndinary}" ]; then
+    current_version=0
+  else
+    current_version="$(parse_version "$(${ndbinary} -v | cut -f 2 -d ' ')")"
+  fi
+
   latest_tag="$(get_latest_version)"
   latest_version="$(parse_version "${latest_tag}")"
   path_version="$(echo "${latest_tag}" | cut -f 1 -d "-")"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -269,7 +269,7 @@ update_available() {
   searchpath="${basepath}/netdata/bin:${basepath}/netdata/sbin:${basepath}/netdata/usr/bin:${basepath}/netdata/usr/sbin:${searchpath}"
   ndbinary="$(env PATH="${searchpath}" command -v netdata 2>/dev/null)"
 
-  if [ -z "${ndinary}" ]; then
+  if [ -z "${ndbinary}" ]; then
     current_version=0
   else
     current_version="$(parse_version "$(${ndbinary} -v | cut -f 2 -d ' ')")"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -473,8 +473,8 @@ if [ "${IS_NETDATA_STATIC_BINARY}" = "yes" ]; then
 
     # Do not pass any options other than the accept, for now
     # shellcheck disable=SC2086
-    if sh "${ndtmpdir}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS}; then
-      rm -r "${ndtmpdir}"
+    if sh "${ndtmpdir}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS} >&3 2>&3; then
+      rm -rf "${ndtmpdir}" >&3 2>&3
     else
       info "NOTE: did not remove: ${ndtmpdir}"
     fi


### PR DESCRIPTION
##### Summary

This fixes the code responsible for checking for the availability of updates to the local copy of Netdata to correctly handle cases where the default install prefix is not used, as well as static installs.

This should prevent cases of the updater unconditionally running on some systems even if there is no available update.

##### Component Name

area/packaging

##### Test Plan

The simplest way to test this is to intentionally install an older static build and then run the updated version of the updater script from this PR against that install with the `--no-updater-self-update` option.

##### Additional Information

Fixes: #10555