### PR TITLE
Update dependencies for the pubsub exporting connector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,7 @@ pkg_check_modules(GRPC grpc)
 # -----------------------------------------------------------------------------
 # Detect libgoogleapis_cpp_pubsub_protos
 
-pkg_check_modules(PUBSUB googleapis_cpp_pubsub_protos)
+pkg_check_modules(PUBSUB google_cloud_cpp_pubsub_protos)
 # later we use:
 # ${PUBSUB_LIBRARIES}
 # ${PUBSUB_CFLAGS_OTHER}

--- a/configure.ac
+++ b/configure.ac
@@ -1479,7 +1479,7 @@ PKG_CHECK_MODULES(
 
 PKG_CHECK_MODULES(
     [PUBSUB],
-    [googleapis_cpp_pubsub_protos],
+    [google_cloud_cpp_pubsub_protos],
     [have_pubsub_protos=yes],
     [have_pubsub_protos=no]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -1477,12 +1477,14 @@ PKG_CHECK_MODULES(
     [have_libgrpc=no]
 )
 
-PKG_CHECK_MODULES(
-    [PUBSUB],
-    [google_cloud_cpp_pubsub_protos],
-    [have_pubsub_protos=yes],
-    [have_pubsub_protos=no]
-)
+if test "${enable_exporting_pubsub}" != "no"; then
+    PKG_CHECK_MODULES(
+        [PUBSUB],
+        [google_cloud_cpp_pubsub_protos],
+        [have_pubsub_protos=yes],
+        [have_pubsub_protos=no]
+    )
+fi
 
 AC_PATH_PROG([CXX_BINARY], [${CXX}], [no])
 AS_IF(

--- a/exporting/pubsub/README.md
+++ b/exporting/pubsub/README.md
@@ -10,16 +10,9 @@ sidebar_label: Google Cloud Pub/Sub Service
 ## Prerequisites
 
 To use the Pub/Sub service for metric collecting and processing, you should first
-[install](https://github.com/googleapis/cpp-cmakefiles) Google Cloud Platform C++ Proto Libraries.
+[install](https://github.com/googleapis/google-cloud-cpp/) Google Cloud Platform C++ Client Libraries.
 Pub/Sub support is also dependent on the dependencies of those libraries, like `protobuf`, `protoc`, and `grpc`. Next,
 Netdata should be re-installed from the source. The installer will detect that the required libraries are now available.
-
-> You [cannot compile Netdata](https://github.com/netdata/netdata/issues/10193) with Pub/Sub support enabled using
-> `grpc` 1.32 or higher.
->
-> Some distributions don't have `.cmake` files in packages. To build the C++ Proto Libraries on such distributions we
-> advise you to delete `protobuf`, `protoc`, and `grpc` related packages and
-> [install](https://github.com/grpc/grpc/blob/master/BUILDING.md) `grpc` with its dependencies from source.
 
 ## Configuration
 

--- a/exporting/pubsub/pubsub_publish.cc
+++ b/exporting/pubsub/pubsub_publish.cc
@@ -194,7 +194,7 @@ int pubsub_get_result(
 {
     struct pubsub_specific_data *connector_specific_data = (struct pubsub_specific_data *)pubsub_specific_data_p;
     std::list<struct response> *responses = (std::list<struct response> *)connector_specific_data->responses;
-    grpc_impl::CompletionQueue::NextStatus next_status;
+    grpc::CompletionQueue::NextStatus next_status;
 
     *sent_metrics = 0;
     *sent_bytes = 0;

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -233,6 +233,9 @@ USAGE: ${PROGRAM} [options]
   --disable-backend-prometheus-remote-write
   --enable-backend-mongodb   Enable MongoDB backend. Default: enable it when libmongoc is available.
   --disable-backend-mongodb
+  --enable-exporting-pubsub  Enable Google Cloud PupSub exporting connector. Default: enable it when
+                             libgoogle_cloud_cpp_pubsub_protos and libraries it depends on are available.
+  --disable-exporting-pubsub
   --enable-lto               Enable Link-Time-Optimization. Default: disabled
   --disable-lto
   --enable-ml                Enable anomaly detection with machine learning. (Default: autodetect)
@@ -326,6 +329,8 @@ while [ -n "${1}" ]; do
       ;;
     "--enable-backend-mongodb") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-backend-mongodb/} --enable-backend-mongodb" ;;
     "--disable-backend-mongodb") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-backend-mongodb/} --disable-backend-mongodb" ;;
+    "--enable-exporting-pubsub") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-exporting-pubsub/} --enable-exporting-pubsub" ;;
+    "--disable-exporting-pubsub") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-exporting-pubsub/} --disable-exporting-pubsub" ;;
     "--enable-lto") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-lto/} --enable-lto" ;;
     "--enable-ml")
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-ml/} --enable-ml"


### PR DESCRIPTION
##### Summary
[C++ Client Libraries for Google Cloud Services](https://github.com/googleapis/google-cloud-cpp) are available and stable. We are updating our build system and build instructions in order to use the new library instead of a deprecated one.

pkg-config files for the new libraries include a lot of dependencies so it takes a long time to process the dependency tree. Enable/disable options were added to the installation script to allow bypassing of the package configuration and build of the connector.

Fixes #10193

##### Component Name
exporting engine, build system

##### Test Plan
- Install the `google-clous-cpp` libraries.
- Build netdata.
- Configure the pubsub exporting connector and check if it sends data to Google Cloud PubSub Service.
- Build netdata with `--disable-exporting-pubsub` and `--enable-exporting-pubsub`. Check if the connector is built.