### PR TITLE
fix(updater): fix exit code when updating static install && updater script

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -460,8 +460,10 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
 
   echo "${install_type}" > /opt/netdata/etc/netdata/.install-type
 
-  echo >&2 "Switching back to ${PREVDIR}"
-  cd "${PREVDIR}"
+  if [ -e "${PREVDIR}" ]; then
+    echo >&2 "Switching back to ${PREVDIR}"
+    cd "${PREVDIR}"
+  fi
 else
   # the installer updates this script - so we run and exit in a single line
   update && exit 0


### PR DESCRIPTION
##### Summary

Fixes: #11519

The updater script exits with a non-zero exit code even if the update is successful. 

- Only static installs are affected.
- It happens only if a newer version of the updater script is available.

<details>
<summary>Click to see why it happens</summary>

We pass `--tmpdir-path` when running the downloaded version of the updater script.

https://github.com/netdata/netdata/blob/4a432d99fc7167de6deec8c56aef2c116cd008f8/packaging/installer/netdata-updater.sh#L229

We set `NETDATA_TMPDIR_PATH`

https://github.com/netdata/netdata/blob/4a432d99fc7167de6deec8c56aef2c116cd008f8/packaging/installer/netdata-updater.sh#L386-L387

`create_tmp_directory` always returns its value if `NETDATA_TMPDIR_PATH` is set.

https://github.com/netdata/netdata/blob/4a432d99fc7167de6deec8c56aef2c116cd008f8/packaging/installer/netdata-updater.sh#L119-L121

`ndtmpdir` and `PREVDIR` are equal

https://github.com/netdata/netdata/blob/4a432d99fc7167de6deec8c56aef2c116cd008f8/packaging/installer/netdata-updater.sh#L434-L436

`ndtmpdir` is removed after successful install

https://github.com/netdata/netdata/blob/4a432d99fc7167de6deec8c56aef2c116cd008f8/packaging/installer/netdata-updater.sh#L455-L456

Since `PREVDIR` is removed too, we fail right at the end of the script/update process

https://github.com/netdata/netdata/blob/4a432d99fc7167de6deec8c56aef2c116cd008f8/packaging/installer/netdata-updater.sh#L463-L464

The script exit code == return code of the last command (which is 1 - cd: No such file or directory)

</details>

##### Component Name

packaging/installer

##### Test Plan

Not needed

##### Additional Information
