### PR TITLE
Use absolute features when doing training/prediction.

### DIFF
--- a/ml/kmeans/SamplesBuffer.h
+++ b/ml/kmeans/SamplesBuffer.h
@@ -20,8 +20,9 @@ public:
     Sample(CalculatedNumber *Buf, size_t N) : CNs(Buf), NumDims(N) {}
 
     void initDSample(DSample &DS) const {
-        for (size_t Idx = 0; Idx != NumDims; Idx++)
-            DS(Idx) = CNs[Idx];
+        for (size_t Idx = 0; Idx != NumDims; Idx++) {
+            DS(Idx) = std::abs(CNs[Idx]);
+        }
     }
 
     void add(const Sample &RHS) const {


### PR DESCRIPTION
##### Summary

Add a final step to the preprocessing of feature vectors to make them always be absolute values only. This follows on from some internal research showing the impact of this on the distance measure used to generate anomaly scores ([illustrative colab notebook](https://colab.research.google.com/drive/1nBHxaNDzRFcm5fmctv1sY0_bTfa4k-M7?usp=sharing)).

In below chart we add some contamination to the metric in last part of the chart. 

![image](https://user-images.githubusercontent.com/2178292/145250358-fae724af-444d-4e07-b86d-e90b4cad86ac.png)

Orange line below then shows impact of ensuring feature vectors are all absolute as opposed to allowing both positive and negative which can lead to a bias in distance measures of metics such as system.cpu that tend to randomly move up and down from second to second. 

![image](https://user-images.githubusercontent.com/2178292/145249863-5bd9bb26-98ed-4c74-b2c3-d7d442303ee6.png)

In this case the orange line behaves better as an anomaly score and jumps consistently in the period of contaminated data. Whereas the implementation that does not force absolute values actually performs worse. Essentially this is because allowing positive and negative values "naturally" suppresses distance measures since elements of the feature vector can essentially cancel each other out when you try to compare distances.

##### Component Name

area/ml

##### Test Plan

CI & verification with the ML team.