### PR TITLE
fix permissions of plugins that may be built

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -214,7 +214,7 @@ run chown -R ${NETDATA_USER}:${NETDATA_GROUP} /opt/netdata
 
 progress "fix plugin permissions"
 
-for x in apps.plugin freeipmi.plugin ioping cgroup-network ebpf.plugin; do
+for x in apps.plugin freeipmi.plugin ioping cgroup-network ebpf.plugin perf.plugin slabinfo.plugin freeipmi.plugin nfacct.plugin xenstat.plugin; do
   f="usr/libexec/netdata/plugins.d/${x}"
 
   if [ -f "${f}" ]; then

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -214,7 +214,7 @@ run chown -R ${NETDATA_USER}:${NETDATA_GROUP} /opt/netdata
 
 progress "changing plugins ownership and setting setuid"
 
-for x in apps.plugin freeipmi.plugin ioping cgroup-network ebpf.plugin perf.plugin slabinfo.plugin freeipmi.plugin nfacct.plugin xenstat.plugin; do
+for x in apps.plugin freeipmi.plugin ioping cgroup-network ebpf.plugin perf.plugin slabinfo.plugin nfacct.plugin xenstat.plugin; do
   f="usr/libexec/netdata/plugins.d/${x}"
 
   if [ -f "${f}" ]; then

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -212,7 +212,7 @@ run chown -R ${NETDATA_USER}:${NETDATA_GROUP} /opt/netdata
 
 # -----------------------------------------------------------------------------
 
-progress "fix plugin permissions"
+progress "changing plugins ownership and setting setuid"
 
 for x in apps.plugin freeipmi.plugin ioping cgroup-network ebpf.plugin perf.plugin slabinfo.plugin freeipmi.plugin nfacct.plugin xenstat.plugin; do
   f="usr/libexec/netdata/plugins.d/${x}"


### PR DESCRIPTION
##### Summary
some plugin need root privileges; but when use pre build version, `perf.plugin` `slabinfo.plugin` lost their privileges;and will start failed.

All plugins that have set permissions at build should be reset permissions when they are installed
##### Component Name
area/packaging 

##### Test Plan

##### Additional Information
