### PR TITLE
fix(updater): don't produce output when static update succeeded

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -124,9 +124,7 @@ create_tmp_directory() {
       if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
         if _cannot_use_tmpdir /tmp ; then
           if _cannot_use_tmpdir "${PWD}" ; then
-            echo >&3
-            error "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
-            exit 1
+            fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
           else
             TMPDIR="${PWD}"
           fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -453,7 +453,7 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
   # Do not pass any options other than the accept, for now
   # shellcheck disable=SC2086
   if sh "${ndtmpdir}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS} >&3 2>&3; then
-    rm -r "${ndtmpdir}"
+    rm -rf "${ndtmpdir}" >&3 2>&3
   else
     info "NOTE: did not remove: ${ndtmpdir}"
   fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -464,6 +464,8 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
     info "Switching back to ${PREVDIR}"
     cd "${PREVDIR}"
   fi
+  [ -n "${logfile}" ] && rm "${logfile}" && logfile=
+  exit 0
 else
   # the installer updates this script - so we run and exit in a single line
   update && exit 0

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -124,8 +124,8 @@ create_tmp_directory() {
       if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
         if _cannot_use_tmpdir /tmp ; then
           if _cannot_use_tmpdir "${PWD}" ; then
-            echo >&2
-            echo >&2 "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
+            echo >&3
+            error "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
             exit 1
           else
             TMPDIR="${PWD}"
@@ -193,7 +193,7 @@ get_netdata_latest_tag() {
 }
 
 newer_commit_date() {
-  echo >&3 "Checking if a newer version of the updater script is available."
+  info "Checking if a newer version of the updater script is available."
 
   if command -v jq > /dev/null 2>&1; then
     commit_date="$(_safe_download "https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1" /dev/stdout | jq '.[0].commit.committer.date' | tr -d '"')"
@@ -218,7 +218,7 @@ newer_commit_date() {
 
 self_update() {
   if [ -z "${NETDATA_NO_UPDATER_SELF_UPDATE}" ] && newer_commit_date; then
-    echo >&3 "Downloading newest version of updater script."
+    info "Downloading newest version of updater script."
 
     ndtmpdir=$(create_tmp_directory)
     cd "$ndtmpdir" || exit 1
@@ -228,7 +228,7 @@ self_update() {
       export ENVIRONMENT_FILE="${ENVIRONMENT_FILE}"
       exec ./netdata-updater.sh --not-running-from-cron --no-updater-self-update --tmpdir-path "$(pwd)"
     else
-      echo >&3 "Failed to download newest version of updater script, continuing with current version."
+      error "Failed to download newest version of updater script, continuing with current version."
     fi
   fi
 }
@@ -435,7 +435,7 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
   ndtmpdir="$(create_tmp_directory)"
   PREVDIR="$(pwd)"
 
-  echo >&2 "Entering ${ndtmpdir}"
+  info "Entering ${ndtmpdir}"
   cd "${ndtmpdir}" || exit 1
 
   download "${NETDATA_TARBALL_CHECKSUM_URL}" "${ndtmpdir}/sha256sum.txt"
@@ -455,13 +455,13 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
   if sh "${ndtmpdir}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS}; then
     rm -r "${ndtmpdir}"
   else
-    echo >&2 "NOTE: did not remove: ${ndtmpdir}"
+    info "NOTE: did not remove: ${ndtmpdir}"
   fi
 
   echo "${install_type}" > /opt/netdata/etc/netdata/.install-type
 
   if [ -e "${PREVDIR}" ]; then
-    echo >&2 "Switching back to ${PREVDIR}"
+    info "Switching back to ${PREVDIR}"
     cd "${PREVDIR}"
   fi
 else

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -452,7 +452,7 @@ if [ "${IS_NETDATA_STATIC_BINARY}" == "yes" ]; then
 
   # Do not pass any options other than the accept, for now
   # shellcheck disable=SC2086
-  if sh "${ndtmpdir}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS}; then
+  if sh "${ndtmpdir}/netdata-latest.gz.run" --accept -- ${REINSTALL_OPTIONS} >&3 2>&3; then
     rm -r "${ndtmpdir}"
   else
     info "NOTE: did not remove: ${ndtmpdir}"


### PR DESCRIPTION
##### Summary

Another attempt to fix #11519

As @jdelStrother correctly noticed: by default, cron sends an email if a script produces any output.

This PR:
 - changes `echo >` to appropriate logging functions (info, error).
 - redirects netdata-latest.gz.run output to 3.
 - adds logfile removing if static version update is successful.

##### Component Name

packaging/installer

##### Test Plan

- run the updater-script manually, ensure it produces output in the terminal.
- run the update-script in headless mode, ensure it doesn't produce any output if static update is successful, and produces otherwise.

##### Additional Information
