### PR TITLE
Fix postdrop handling for systemd systems.

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -71,6 +71,8 @@ ProtectHome=read-only
 ProtectControlGroups=true
 # We whitelist this because it's the standard location to listen on a UNIX socket.
 ReadWriteDirectories=/run/netdata
+# This is needed to make email-based alert deliver work if Postfix is the email provider on the system.
+ReadWriteDirectories=-/var/spool/postfix/maildrop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
##### Summary

This fixes an issue with handling of email-based notification delivery on systemd-based systems that are using Postfix for mail delivery.

##### Component Name

area/packaging

##### Test Plan

Verified through limited local testing (and confirmation from multiple users that a functionally equivalent local fix on their systems worked).

##### Additional Information

Fixes: #8820 