### PR TITLE
Fix time_t format

### DIFF
--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -481,8 +481,11 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
 
                 if (!p->discovered)
                     info(
-                        "Infiniband card %s port %s at speed %"PRIu64" width %"PRIu64"", dev_dent->d_name, port_dent->d_name,
-                        p->speed, p->width);
+                        "Infiniband card %s port %s at speed %" PRIu64 " width %" PRIu64 "",
+                        dev_dent->d_name,
+                        port_dent->d_name,
+                        p->speed,
+                        p->width);
 
                 p->discovered = 1;
             }

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -481,7 +481,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
 
                 if (!p->discovered)
                     info(
-                        "Infiniband card %s port %s at speed %lu width %lu", dev_dent->d_name, port_dent->d_name,
+                        "Infiniband card %s port %s at speed %"PRIu64" width %"PRIu64"", dev_dent->d_name, port_dent->d_name,
                         p->speed, p->width);
 
                 p->discovered = 1;

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1181,9 +1181,9 @@ int run_test(struct test *test)
         calculated_number v = unpack_storage_number(rd->values[c]);
         calculated_number n = unpack_storage_number(pack_storage_number(test->results[c], SN_DEFAULT_FLAGS));
         int same = (calculated_number_round(v * 10000000.0) == calculated_number_round(n * 10000000.0))?1:0;
-        fprintf(stderr, "    %s/%s: checking position %lu (at %lu secs), expecting value " CALCULATED_NUMBER_FORMAT ", found " CALCULATED_NUMBER_FORMAT ", %s\n",
+        fprintf(stderr, "    %s/%s: checking position %lu (at %"PRId64" secs), expecting value " CALCULATED_NUMBER_FORMAT ", found " CALCULATED_NUMBER_FORMAT ", %s\n",
             test->name, rd->name, c+1,
-            (rrdset_first_entry_t(st) + c * st->update_every) - time_start,
+            (int64_t)((rrdset_first_entry_t(st) + c * st->update_every) - time_start),
             n, v, (same)?"OK":"### E R R O R ###");
 
         if(!same) errors++;
@@ -1192,9 +1192,9 @@ int run_test(struct test *test)
             v = unpack_storage_number(rd2->values[c]);
             n = test->results2[c];
             same = (calculated_number_round(v * 10000000.0) == calculated_number_round(n * 10000000.0))?1:0;
-            fprintf(stderr, "    %s/%s: checking position %lu (at %lu secs), expecting value " CALCULATED_NUMBER_FORMAT ", found " CALCULATED_NUMBER_FORMAT ", %s\n",
+            fprintf(stderr, "    %s/%s: checking position %lu (at %"PRId64" secs), expecting value " CALCULATED_NUMBER_FORMAT ", found " CALCULATED_NUMBER_FORMAT ", %s\n",
                 test->name, rd2->name, c+1,
-                (rrdset_first_entry_t(st) + c * st->update_every) - time_start,
+                (int64_t)((rrdset_first_entry_t(st) + c * st->update_every) - time_start),
                 n, v, (same)?"OK":"### E R R O R ###");
             if(!same) errors++;
         }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1453,7 +1453,14 @@ void rrdset_done(RRDSET *st) {
     // check if we will re-write the entire data set
     if(unlikely(dt_usec(&st->last_collected_time, &st->last_updated) > st->entries * update_every_ut &&
                 st->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE)) {
-        info("%s: too old data (last updated at %ld.%ld, last collected at %ld.%ld). Resetting it. Will not store the next entry.", st->name, st->last_updated.tv_sec, st->last_updated.tv_usec, st->last_collected_time.tv_sec, st->last_collected_time.tv_usec);
+        info(
+            "%s: too old data (last updated at %"PRId64".%"PRId64", last collected at %"PRId64".%"PRId64"). "
+            "Resetting it. Will not store the next entry.",
+            st->name,
+            (int64_t)st->last_updated.tv_sec,
+            (int64_t)st->last_updated.tv_usec,
+            (int64_t)st->last_collected_time.tv_sec,
+            (int64_t)st->last_collected_time.tv_usec);
         rrdset_reset(st);
         rrdset_init_last_updated_time(st);
 

--- a/health/health.c
+++ b/health/health.c
@@ -684,9 +684,10 @@ void *health_main(void *ptr) {
         if (unlikely(check_if_resumed_from_suspension())) {
             apply_hibernation_delay = 1;
 
-            info("Postponing alarm checks for %ld seconds, because it seems that the system was just resumed from suspension.",
-                 hibernation_delay
-            );
+            info(
+                "Postponing alarm checks for %"PRId64" seconds, "
+                "because it seems that the system was just resumed from suspension.",
+                (int64_t)hibernation_delay);
         }
 
         if (unlikely(silencers->all_alarms && silencers->stype == STYPE_DISABLE_ALARMS)) {
@@ -706,9 +707,10 @@ void *health_main(void *ptr) {
                 continue;
 
             if (unlikely(apply_hibernation_delay)) {
-
-                info("Postponing health checks for %ld seconds, on host '%s'.", hibernation_delay, host->hostname
-                );
+                info(
+                    "Postponing health checks for %"PRId64" seconds, on host '%s'.",
+                    (int64_t)hibernation_delay,
+                    host->hostname);
 
                 host->health_delay_up_to = now + hibernation_delay;
             }

--- a/health/health.c
+++ b/health/health.c
@@ -101,7 +101,11 @@ static void health_silencers_init(void) {
                 freez(str);
             }
         } else {
-            error("Health silencers file %s has the size %"PRId64" that is out of range[ 1 , %d ]. Aborting read.", silencers_filename, (int64_t)length, HEALTH_SILENCERS_MAX_FILE_LEN);
+            error(
+                "Health silencers file %s has the size %" PRId64 " that is out of range[ 1 , %d ]. Aborting read.",
+                silencers_filename,
+                (int64_t)length,
+                HEALTH_SILENCERS_MAX_FILE_LEN);
         }
         fclose(fd);
     } else {

--- a/health/health.c
+++ b/health/health.c
@@ -101,7 +101,7 @@ static void health_silencers_init(void) {
                 freez(str);
             }
         } else {
-            error("Health silencers file %s has the size %ld that is out of range[ 1 , %d ]. Aborting read.", silencers_filename, length, HEALTH_SILENCERS_MAX_FILE_LEN);
+            error("Health silencers file %s has the size %"PRId64" that is out of range[ 1 , %d ]. Aborting read.", silencers_filename, (int64_t)length, HEALTH_SILENCERS_MAX_FILE_LEN);
         }
         fclose(fd);
     } else {
@@ -326,7 +326,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
                     buffer_strcat(warn_alarms, ",");
                 buffer_strcat(warn_alarms, rc->name);
                 buffer_strcat(warn_alarms, "=");
-                buffer_snprintf(warn_alarms, 11, "%ld", rc->last_status_change);
+                buffer_snprintf(warn_alarms, 11, "%"PRId64"", (int64_t)rc->last_status_change);
                 n_warn++;
             } else if (ae->alarm_id == rc->id)
                 expr = rc->warning;
@@ -336,7 +336,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
                     buffer_strcat(crit_alarms, ",");
                 buffer_strcat(crit_alarms, rc->name);
                 buffer_strcat(crit_alarms, "=");
-                buffer_snprintf(crit_alarms, 11, "%ld", rc->last_status_change);
+                buffer_snprintf(crit_alarms, 11, "%"PRId64"", (int64_t)rc->last_status_change);
                 n_crit++;
             } else if (ae->alarm_id == rc->id)
                 expr = rc->critical;

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -112,7 +112,7 @@ inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae) {
                         "\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s"
                         "\t%d\t%d\t%d\t%d"
                         "\t" CALCULATED_NUMBER_FORMAT_AUTO "\t" CALCULATED_NUMBER_FORMAT_AUTO
-                        "\t%016lx"
+                        "\t%016"PRIx64""
                         "\t%s\t%s\t%s"
                         "\n"
                             , (ae->flags & HEALTH_ENTRY_FLAG_SAVED)?'U':'A'

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -24,10 +24,10 @@ const char *facility_log = NULL;
 // Log facility(https://tools.ietf.org/html/rfc5424)
 //
 // The facilities accepted in the Netdata are in according with the following
-// header files for their respective operate system:
-// 	sys/syslog.h (Linux )
-// 	sys/sys/syslog.h (FreeBSD)
-// 	bsd/sys/syslog.h (darwin-xnu)
+// header files for their respective operating system:
+// sys/syslog.h (Linux )
+// sys/sys/syslog.h (FreeBSD)
+// bsd/sys/syslog.h (darwin-xnu)
 
 #define LOG_AUTH_KEY "auth"
 #define LOG_AUTHPRIV_KEY "authpriv"
@@ -71,229 +71,229 @@ const char *facility_log = NULL;
 
 static int log_facility_id(const char *facility_name)
 {
-	static int 
-		hash_auth = 0,
-		hash_authpriv = 0,
+    static int
+        hash_auth = 0,
+        hash_authpriv = 0,
 #ifdef __FreeBSD__
-		hash_console = 0,
+        hash_console = 0,
 #endif
-		hash_cron = 0,
-		hash_daemon = 0,
-		hash_ftp = 0,
+        hash_cron = 0,
+        hash_daemon = 0,
+        hash_ftp = 0,
 #ifdef __APPLE__
-		hash_install = 0,
+        hash_install = 0,
 #endif
-		hash_kern = 0,
-		hash_lpr = 0,
-		hash_mail = 0,
-//		hash_mark = 0,
+        hash_kern = 0,
+        hash_lpr = 0,
+        hash_mail = 0,
+//      hash_mark = 0,
 #ifdef __APPLE__
-		hash_netinfo = 0,
-		hash_ras = 0,
-		hash_remoteauth = 0,
+        hash_netinfo = 0,
+        hash_ras = 0,
+        hash_remoteauth = 0,
 #endif
-		hash_news = 0,
+        hash_news = 0,
 #ifdef __FreeBSD__
-		hash_ntp = 0,
+        hash_ntp = 0,
 #endif
-		hash_security = 0,
-		hash_syslog = 0,
-		hash_user = 0,
-		hash_uucp = 0,
+        hash_security = 0,
+        hash_syslog = 0,
+        hash_user = 0,
+        hash_uucp = 0,
 #ifdef __APPLE__
-		hash_launchd = 0,
+        hash_launchd = 0,
 #endif
-		hash_local0 = 0,
-		hash_local1 = 0,
-		hash_local2 = 0,
-		hash_local3 = 0,
-		hash_local4 = 0,
-		hash_local5 = 0,
-		hash_local6 = 0,
-		hash_local7 = 0;
+        hash_local0 = 0,
+        hash_local1 = 0,
+        hash_local2 = 0,
+        hash_local3 = 0,
+        hash_local4 = 0,
+        hash_local5 = 0,
+        hash_local6 = 0,
+        hash_local7 = 0;
 
-	if(unlikely(!hash_auth))
-	{
-		hash_auth = simple_hash(LOG_AUTH_KEY);
-		hash_authpriv = simple_hash(LOG_AUTHPRIV_KEY);
+    if(unlikely(!hash_auth))
+    {
+        hash_auth = simple_hash(LOG_AUTH_KEY);
+        hash_authpriv = simple_hash(LOG_AUTHPRIV_KEY);
 #ifdef __FreeBSD__
-		hash_console = simple_hash(LOG_CONSOLE_KEY);
+        hash_console = simple_hash(LOG_CONSOLE_KEY);
 #endif
-		hash_cron = simple_hash(LOG_CRON_KEY);
-		hash_daemon = simple_hash(LOG_DAEMON_KEY);
-		hash_ftp = simple_hash(LOG_FTP_KEY);
+        hash_cron = simple_hash(LOG_CRON_KEY);
+        hash_daemon = simple_hash(LOG_DAEMON_KEY);
+        hash_ftp = simple_hash(LOG_FTP_KEY);
 #ifdef __APPLE__
-		hash_install = simple_hash(LOG_INSTALL_KEY);
+        hash_install = simple_hash(LOG_INSTALL_KEY);
 #endif
-		hash_kern = simple_hash(LOG_KERN_KEY);
-		hash_lpr = simple_hash(LOG_LPR_KEY);
-		hash_mail = simple_hash(LOG_MAIL_KEY);
-//		hash_mark = simple_uhash();
+        hash_kern = simple_hash(LOG_KERN_KEY);
+        hash_lpr = simple_hash(LOG_LPR_KEY);
+        hash_mail = simple_hash(LOG_MAIL_KEY);
+//        hash_mark = simple_uhash();
 #ifdef __APPLE__
-		hash_netinfo = simple_hash(LOG_NETINFO_KEY);
-		hash_ras = simple_hash(LOG_RAS_KEY);
-		hash_remoteauth = simple_hash(LOG_REMOTEAUTH_KEY);
+        hash_netinfo = simple_hash(LOG_NETINFO_KEY);
+        hash_ras = simple_hash(LOG_RAS_KEY);
+        hash_remoteauth = simple_hash(LOG_REMOTEAUTH_KEY);
 #endif
-		hash_news = simple_hash(LOG_NEWS_KEY);
+        hash_news = simple_hash(LOG_NEWS_KEY);
 #ifdef __FreeBSD__
-		hash_ntp = simple_hash(LOG_NTP_KEY);
+        hash_ntp = simple_hash(LOG_NTP_KEY);
 #endif
-		hash_security = simple_hash(LOG_SECURITY_KEY);
-		hash_syslog = simple_hash(LOG_SYSLOG_KEY);
-		hash_user = simple_hash(LOG_USER_KEY);
-		hash_uucp = simple_hash(LOG_UUCP_KEY);
+        hash_security = simple_hash(LOG_SECURITY_KEY);
+        hash_syslog = simple_hash(LOG_SYSLOG_KEY);
+        hash_user = simple_hash(LOG_USER_KEY);
+        hash_uucp = simple_hash(LOG_UUCP_KEY);
 #ifdef __APPLE__
-		hash_launchd = simple_hash(LOG_LAUNCHD_KEY);
+        hash_launchd = simple_hash(LOG_LAUNCHD_KEY);
 #endif
-		hash_local0 = simple_hash(LOG_LOCAL0_KEY);
-		hash_local1 = simple_hash(LOG_LOCAL1_KEY);
-		hash_local2 = simple_hash(LOG_LOCAL2_KEY);
-		hash_local3 = simple_hash(LOG_LOCAL3_KEY);
-		hash_local4 = simple_hash(LOG_LOCAL4_KEY);
-		hash_local5 = simple_hash(LOG_LOCAL5_KEY);
-		hash_local6 = simple_hash(LOG_LOCAL6_KEY);
-		hash_local7 = simple_hash(LOG_LOCAL7_KEY);
-	}
+        hash_local0 = simple_hash(LOG_LOCAL0_KEY);
+        hash_local1 = simple_hash(LOG_LOCAL1_KEY);
+        hash_local2 = simple_hash(LOG_LOCAL2_KEY);
+        hash_local3 = simple_hash(LOG_LOCAL3_KEY);
+        hash_local4 = simple_hash(LOG_LOCAL4_KEY);
+        hash_local5 = simple_hash(LOG_LOCAL5_KEY);
+        hash_local6 = simple_hash(LOG_LOCAL6_KEY);
+        hash_local7 = simple_hash(LOG_LOCAL7_KEY);
+    }
 
-	int hash = simple_hash(facility_name);
-	if ( hash == hash_auth )
-	{
-		return LOG_AUTH;
-	}
-	else if  ( hash == hash_authpriv )
-	{
-		return LOG_AUTHPRIV;
-	}
+    int hash = simple_hash(facility_name);
+    if ( hash == hash_auth )
+    {
+        return LOG_AUTH;
+    }
+    else if  ( hash == hash_authpriv )
+    {
+        return LOG_AUTHPRIV;
+    }
 #ifdef __FreeBSD__
-	else if ( hash == hash_console )
-	{
-		return LOG_CONSOLE;
-	}
+    else if ( hash == hash_console )
+    {
+        return LOG_CONSOLE;
+    }
 #endif
-	else if ( hash == hash_cron )
-	{
-		return LOG_CRON;
-	}
-	else if ( hash == hash_daemon )
-	{
-		return LOG_DAEMON;
-	}
-	else if ( hash == hash_ftp )
-	{
-		return LOG_FTP;
-	}
+    else if ( hash == hash_cron )
+    {
+        return LOG_CRON;
+    }
+    else if ( hash == hash_daemon )
+    {
+        return LOG_DAEMON;
+    }
+    else if ( hash == hash_ftp )
+    {
+        return LOG_FTP;
+    }
 #ifdef __APPLE__
-	else if ( hash == hash_install )
-	{
-		return LOG_INSTALL;
-	}
+    else if ( hash == hash_install )
+    {
+        return LOG_INSTALL;
+    }
 #endif
-	else if ( hash == hash_kern )
-	{
-		return LOG_KERN;
-	}
-	else if ( hash == hash_lpr )
-	{
-		return LOG_LPR;
-	}
-	else if ( hash == hash_mail )
-	{
-		return LOG_MAIL;
-	}
-	/*
-	else if ( hash == hash_mark )
-	{
-		//this is internal for all OS
-		return INTERNAL_MARK;
-	}
-	*/
+    else if ( hash == hash_kern )
+    {
+        return LOG_KERN;
+    }
+    else if ( hash == hash_lpr )
+    {
+        return LOG_LPR;
+    }
+    else if ( hash == hash_mail )
+    {
+        return LOG_MAIL;
+    }
+    /*
+    else if ( hash == hash_mark )
+    {
+        //this is internal for all OS
+        return INTERNAL_MARK;
+    }
+    */
 #ifdef __APPLE__
-	else if ( hash == hash_netinfo )
-	{
-		return LOG_NETINFO;
-	}
-	else if ( hash == hash_ras )
-	{
-		return LOG_RAS;
-	}
-	else if ( hash == hash_remoteauth )
-	{
-		return LOG_REMOTEAUTH;
-	}
+    else if ( hash == hash_netinfo )
+    {
+        return LOG_NETINFO;
+    }
+    else if ( hash == hash_ras )
+    {
+        return LOG_RAS;
+    }
+    else if ( hash == hash_remoteauth )
+    {
+        return LOG_REMOTEAUTH;
+    }
 #endif
-	else if ( hash == hash_news )
-	{
-		return LOG_NEWS;
-	}
+    else if ( hash == hash_news )
+    {
+        return LOG_NEWS;
+    }
 #ifdef __FreeBSD__
-	else if ( hash == hash_ntp )
-	{
-		return LOG_NTP;
-	}
+    else if ( hash == hash_ntp )
+    {
+        return LOG_NTP;
+    }
 #endif
-	else if ( hash == hash_security )
-	{
-		//FreeBSD is the unique that does not consider
-		//this facility deprecated. We are keeping
-		//it for other OS while they are kept in their headers.
+    else if ( hash == hash_security )
+    {
+        //FreeBSD is the unique that does not consider
+        //this facility deprecated. We are keeping
+        //it for other OS while they are kept in their headers.
 #ifdef __FreeBSD__
-		return LOG_SECURITY;
+        return LOG_SECURITY;
 #else
-		return LOG_AUTH;
+        return LOG_AUTH;
 #endif
-	}
-	else if ( hash == hash_syslog )
-	{
-		return LOG_SYSLOG;
-	}
-	else if ( hash == hash_user )
-	{
-		return LOG_USER;
-	}
-	else if ( hash == hash_uucp )
-	{
-		return LOG_UUCP;
-	}
-	else if ( hash == hash_local0 )
-	{
-		return LOG_LOCAL0;
-	}
-	else if ( hash == hash_local1 )
-	{
-		return LOG_LOCAL1;
-	}
-	else if ( hash == hash_local2 )
-	{
-		return LOG_LOCAL2;
-	}
-	else if ( hash == hash_local3 )
-	{
-		return LOG_LOCAL3;
-	}
-	else if ( hash == hash_local4 )
-	{
-		return LOG_LOCAL4;
-	}
-	else if ( hash == hash_local5 )
-	{
-		return LOG_LOCAL5;
-	}
-	else if ( hash == hash_local6 )
-	{
-		return LOG_LOCAL6;
-	}
-	else if ( hash == hash_local7 )
-	{
-		return LOG_LOCAL7;
-	}
+    }
+    else if ( hash == hash_syslog )
+    {
+        return LOG_SYSLOG;
+    }
+    else if ( hash == hash_user )
+    {
+        return LOG_USER;
+    }
+    else if ( hash == hash_uucp )
+    {
+        return LOG_UUCP;
+    }
+    else if ( hash == hash_local0 )
+    {
+        return LOG_LOCAL0;
+    }
+    else if ( hash == hash_local1 )
+    {
+        return LOG_LOCAL1;
+    }
+    else if ( hash == hash_local2 )
+    {
+        return LOG_LOCAL2;
+    }
+    else if ( hash == hash_local3 )
+    {
+        return LOG_LOCAL3;
+    }
+    else if ( hash == hash_local4 )
+    {
+        return LOG_LOCAL4;
+    }
+    else if ( hash == hash_local5 )
+    {
+        return LOG_LOCAL5;
+    }
+    else if ( hash == hash_local6 )
+    {
+        return LOG_LOCAL6;
+    }
+    else if ( hash == hash_local7 )
+    {
+        return LOG_LOCAL7;
+    }
 #ifdef __APPLE__
-	else if ( hash == hash_launchd )
-	{
-		return LOG_LAUNCHD;
-	}
+    else if ( hash == hash_launchd )
+    {
+        return LOG_LAUNCHD;
+    }
 #endif
 
-	return LOG_DAEMON;
+    return LOG_DAEMON;
 }
 
 //we do not need to use this now, but I already created this function to be
@@ -301,135 +301,135 @@ static int log_facility_id(const char *facility_name)
 /*
 char *log_facility_name(int code)
 {
-	char *defvalue = { "daemon" };
-	switch(code)
-	{
-		case LOG_AUTH:
-			{
-				return "auth";
-			}
-		case LOG_AUTHPRIV:
-			{
-				return "authpriv";
-			}
+    char *defvalue = { "daemon" };
+    switch(code)
+    {
+        case LOG_AUTH:
+            {
+                return "auth";
+            }
+        case LOG_AUTHPRIV:
+            {
+                return "authpriv";
+            }
 #ifdef __FreeBSD__
-		case LOG_CONSOLE:
-			{
-				return "console";
-			}
+        case LOG_CONSOLE:
+            {
+                return "console";
+            }
 #endif
-		case LOG_CRON:
-			{
-				return "cron";
-			}
-		case LOG_DAEMON:
-			{
-				return defvalue;
-			}
-		case LOG_FTP:
-			{
-				return "ftp";
-			}
+        case LOG_CRON:
+            {
+                return "cron";
+            }
+        case LOG_DAEMON:
+            {
+                return defvalue;
+            }
+        case LOG_FTP:
+            {
+                return "ftp";
+            }
 #ifdef __APPLE__
-		case LOG_INSTALL:
-			{
-				return "install";
-			}
+        case LOG_INSTALL:
+            {
+                return "install";
+            }
 #endif
-		case LOG_KERN:
-			{
-				return "kern";
-			}
-		case LOG_LPR:
-			{
-				return "lpr";
-			}
-		case LOG_MAIL:
-			{
-				return "mail";
-			}
+        case LOG_KERN:
+            {
+                return "kern";
+            }
+        case LOG_LPR:
+            {
+                return "lpr";
+            }
+        case LOG_MAIL:
+            {
+                return "mail";
+            }
 #ifdef __APPLE__
-		case LOG_NETINFO:
-			{
-				return "netinfo" ;
-			}
-		case LOG_RAS:
-			{
-				return "ras";
-			}
-		case LOG_REMOTEAUTH:
-			{
-				return "remoteauth";
-			}
+        case LOG_NETINFO:
+            {
+                return "netinfo" ;
+            }
+        case LOG_RAS:
+            {
+                return "ras";
+            }
+        case LOG_REMOTEAUTH:
+            {
+                return "remoteauth";
+            }
 #endif
-		case LOG_NEWS:
-			{
-				return "news";
-			}
+        case LOG_NEWS:
+            {
+                return "news";
+            }
 #ifdef __FreeBSD__
-		case LOG_NTP:
-			{
-				return "ntp" ;
-			}
-		case LOG_SECURITY:
-			{
-				return "security";
-			}
+        case LOG_NTP:
+            {
+                return "ntp" ;
+            }
+        case LOG_SECURITY:
+            {
+                return "security";
+            }
 #endif
-		case LOG_SYSLOG:
-			{
-				return "syslog";
-			}
-		case LOG_USER:
-			{
-				return "user";
-			}
-		case LOG_UUCP:
-			{
-				return "uucp";
-			}
-		case LOG_LOCAL0:
-			{
-				return "local0";
-			}
-		case LOG_LOCAL1:
-			{
-				return "local1";
-			}
-		case LOG_LOCAL2:
-			{
-				return "local2";
-			}
-		case LOG_LOCAL3:
-			{
-				return "local3";
-			}
-		case LOG_LOCAL4:
-			{
-				return "local4" ;
-			}
-		case LOG_LOCAL5:
-			{
-				return "local5";
-			}
-		case LOG_LOCAL6:
-			{
-				return "local6";
-			}
-		case LOG_LOCAL7:
-			{
-				return "local7" ;
-			}
+        case LOG_SYSLOG:
+            {
+                return "syslog";
+            }
+        case LOG_USER:
+            {
+                return "user";
+            }
+        case LOG_UUCP:
+            {
+                return "uucp";
+            }
+        case LOG_LOCAL0:
+            {
+                return "local0";
+            }
+        case LOG_LOCAL1:
+            {
+                return "local1";
+            }
+        case LOG_LOCAL2:
+            {
+                return "local2";
+            }
+        case LOG_LOCAL3:
+            {
+                return "local3";
+            }
+        case LOG_LOCAL4:
+            {
+                return "local4" ;
+            }
+        case LOG_LOCAL5:
+            {
+                return "local5";
+            }
+        case LOG_LOCAL6:
+            {
+                return "local6";
+            }
+        case LOG_LOCAL7:
+            {
+                return "local7" ;
+            }
 #ifdef __APPLE__
-		case LOG_LAUNCHD:
-			{
-				return "launchd";
-			}
+        case LOG_LAUNCHD:
+            {
+                return "launchd";
+            }
 #endif
-	}
+    }
 
-	return defvalue;
-}	
+    return defvalue;
+}
 */
 
 // ----------------------------------------------------------------------------
@@ -486,7 +486,7 @@ static FILE *open_log_file(int fd, FILE *fp, const char *filename, int *enabled_
         filename = "/dev/null";
         devnull = 1;
 
-	syslog_init();
+    syslog_init();
         if(enabled_syslog) *enabled_syslog = 1;
     }
     else if(enabled_syslog) *enabled_syslog = 0;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -607,13 +607,15 @@ int error_log_limit(int reset) {
         if(prevented) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH);
-            fprintf(stderr, "%s: %s LOG FLOOD PROTECTION reset for process '%s' (prevented %lu logs in the last %ld seconds).\n"
-                    , date
-                    , program_name
-                    , program_name
-                    , prevented
-                    , now - start
-            );
+            fprintf(
+                stderr,
+                "%s: %s LOG FLOOD PROTECTION reset for process '%s' "
+				"(prevented %lu logs in the last %"PRId64" seconds).\n",
+                date,
+                program_name,
+                program_name,
+                prevented,
+                (int64_t)(now - start));
         }
 
         start = now;
@@ -628,13 +630,15 @@ int error_log_limit(int reset) {
         if(prevented) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH);
-            fprintf(stderr, "%s: %s LOG FLOOD PROTECTION resuming logging from process '%s' (prevented %lu logs in the last %ld seconds).\n"
-                    , date
-                    , program_name
-                    , program_name
-                    , prevented
-                    , error_log_throttle_period
-            );
+            fprintf(
+                stderr,
+                "%s: %s LOG FLOOD PROTECTION resuming logging from process '%s' "
+				"(prevented %lu logs in the last %"PRId64" seconds).\n",
+                date,
+                program_name,
+                program_name,
+                prevented,
+                (int64_t)error_log_throttle_period);
         }
 
         // restart the period accounting
@@ -650,15 +654,18 @@ int error_log_limit(int reset) {
         if(!prevented) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH);
-            fprintf(stderr, "%s: %s LOG FLOOD PROTECTION too many logs (%lu logs in %ld seconds, threshold is set to %lu logs in %ld seconds). Preventing more logs from process '%s' for %ld seconds.\n"
-                    , date
-                    , program_name
-                    , counter
-                    , now - start
-                    , error_log_errors_per_period
-                    , error_log_throttle_period
-                    , program_name
-                    , start + error_log_throttle_period - now);
+            fprintf(
+                stderr,
+                "%s: %s LOG FLOOD PROTECTION too many logs (%lu logs in %"PRId64" seconds, threshold is set to %lu logs "
+				"in %"PRId64" seconds). Preventing more logs from process '%s' for %"PRId64" seconds.\n",
+                date,
+                program_name,
+                counter,
+                (int64_t)(now - start),
+                error_log_errors_per_period,
+                (int64_t)error_log_throttle_period,
+                program_name,
+                (int64_t)(start + error_log_throttle_period - now));
         }
 
         prevented++;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -610,7 +610,7 @@ int error_log_limit(int reset) {
             fprintf(
                 stderr,
                 "%s: %s LOG FLOOD PROTECTION reset for process '%s' "
-				"(prevented %lu logs in the last %"PRId64" seconds).\n",
+                "(prevented %lu logs in the last %"PRId64" seconds).\n",
                 date,
                 program_name,
                 program_name,
@@ -633,7 +633,7 @@ int error_log_limit(int reset) {
             fprintf(
                 stderr,
                 "%s: %s LOG FLOOD PROTECTION resuming logging from process '%s' "
-				"(prevented %lu logs in the last %"PRId64" seconds).\n",
+                "(prevented %lu logs in the last %"PRId64" seconds).\n",
                 date,
                 program_name,
                 program_name,
@@ -657,7 +657,7 @@ int error_log_limit(int reset) {
             fprintf(
                 stderr,
                 "%s: %s LOG FLOOD PROTECTION too many logs (%lu logs in %"PRId64" seconds, threshold is set to %lu logs "
-				"in %"PRId64" seconds). Preventing more logs from process '%s' for %"PRId64" seconds.\n",
+                "in %"PRId64" seconds). Preventing more logs from process '%s' for %"PRId64" seconds.\n",
                 date,
                 program_name,
                 counter,

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -69,15 +69,33 @@ PARSER_RC streaming_timestamp(char **words, void *user, PLUGINSD_ACTION *plugins
         time_t now = now_realtime_sec(), prev = rrdhost_last_entry_t(host);
         time_t gap = 0;
         if (prev == 0)
-            info("STREAM %s from %s: Initial connection (no gap to check), remote=%ld local=%ld slew=%ld",
-                 host->hostname, cd->cmd, remote_time, now, now-remote_time);
+            info(
+                "STREAM %s from %s: Initial connection (no gap to check), "
+                "remote=%"PRId64" local=%"PRId64" slew=%"PRId64"",
+                host->hostname,
+                cd->cmd,
+                (int64_t)remote_time,
+                (int64_t)now,
+                (int64_t)now - remote_time);
         else {
             gap = now - prev;
-            info("STREAM %s from %s: Checking for gaps... remote=%ld local=%ld..%ld slew=%ld  %ld-sec gap",
-                 host->hostname, cd->cmd, remote_time, prev, now, remote_time - now, gap);
+            info(
+                "STREAM %s from %s: Checking for gaps... "
+                "remote=%"PRId64" local=%"PRId64"..%"PRId64" slew=%"PRId64"  %"PRId64"-sec gap",
+                host->hostname,
+                cd->cmd,
+                (int64_t)remote_time,
+                (int64_t)prev,
+                (int64_t)now,
+                (int64_t)(remote_time - now),
+                (int64_t)gap);
         }
         char message[128];
-        sprintf(message,"REPLICATE %ld %ld\n", remote_time - gap, remote_time);
+        sprintf(
+            message,
+            "REPLICATE %"PRId64" %"PRId64"\n",
+            (int64_t)(remote_time - gap),
+            (int64_t)remote_time);
         int ret;
 #ifdef ENABLE_HTTPS
         SSL *conn = host->stream_ssl.conn ;
@@ -441,10 +459,10 @@ static int rrdpush_receive(struct receiver_state *rpt)
     if(health_enabled != CONFIG_BOOLEAN_NO) {
         if(alarms_delay > 0) {
             rpt->host->health_delay_up_to = now_realtime_sec() + alarms_delay;
-            info("Postponing health checks for %ld seconds, on host '%s', because it was just connected."
-            , alarms_delay
-            , rpt->host->hostname
-            );
+            info(
+                "Postponing health checks for %" PRId64 " seconds, on host '%s', because it was just connected.",
+                (int64_t)alarms_delay,
+                rpt->host->hostname);
         }
     }
     rrdhost_unlock(rpt->host);

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -630,7 +630,7 @@ void *rrdpush_sender_thread(void *ptr) {
             if (s->version >= VERSION_GAP_FILLING) {
                 time_t now = now_realtime_sec();
                 sender_start(s);
-                buffer_sprintf(s->build, "TIMESTAMP %ld", now);
+                buffer_sprintf(s->build, "TIMESTAMP %"PRId64"", (int64_t)now);
                 sender_commit(s);
             }
             rrdpush_claimed_id(s->host);

--- a/web/api/exporters/shell/allmetrics_shell.c
+++ b/web/api/exporters/shell/allmetrics_shell.c
@@ -107,22 +107,23 @@ void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, BUFFER *wb) {
         if(rrdset_is_available_for_viewers(st)) {
             rrdset_rdlock(st);
 
-            buffer_sprintf(wb, "%s\n"
-                               "\t\"%s\": {\n"
-                               "\t\t\"name\":\"%s\",\n"
-                               "\t\t\"family\":\"%s\",\n"
-                               "\t\t\"context\":\"%s\",\n"
-                               "\t\t\"units\":\"%s\",\n"
-                               "\t\t\"last_updated\": %ld,\n"
-                               "\t\t\"dimensions\": {"
-                           , chart_counter?",":""
-                           , st->id
-                           , st->name
-                           , st->family
-                           , st->context
-                           , st->units
-                           , rrdset_last_entry_t_nolock(st)
-            );
+            buffer_sprintf(
+                wb,
+                "%s\n"
+                "\t\"%s\": {\n"
+                "\t\t\"name\":\"%s\",\n"
+                "\t\t\"family\":\"%s\",\n"
+                "\t\t\"context\":\"%s\",\n"
+                "\t\t\"units\":\"%s\",\n"
+                "\t\t\"last_updated\": %"PRId64",\n"
+                "\t\t\"dimensions\": {",
+                chart_counter ? "," : "",
+                st->id,
+                st->name,
+                st->family,
+                st->context,
+                st->units,
+                (int64_t)rrdset_last_entry_t_nolock(st));
 
             chart_counter++;
             dimension_counter = 0;
@@ -131,15 +132,15 @@ void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, BUFFER *wb) {
             RRDDIM *rd;
             rrddim_foreach_read(rd, st) {
                 if(rd->collections_counter && !rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) {
-
-                    buffer_sprintf(wb, "%s\n"
-                                       "\t\t\t\"%s\": {\n"
-                                       "\t\t\t\t\"name\": \"%s\",\n"
-                                       "\t\t\t\t\"value\": "
-                                   , dimension_counter?",":""
-                                   , rd->id
-                                   , rd->name
-                    );
+                    buffer_sprintf(
+                        wb,
+                        "%s\n"
+                        "\t\t\t\"%s\": {\n"
+                        "\t\t\t\t\"name\": \"%s\",\n"
+                        "\t\t\t\t\"value\": ",
+                        dimension_counter ? "," : "",
+                        rd->id,
+                        rd->name);
 
                     if(isnan(rd->last_stored_value))
                         buffer_strcat(wb, "null");

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -589,9 +589,13 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
                 w->id, google_version, google_reqId, google_sig, google_out, responseHandler, outFileName
         );
 
-        buffer_sprintf(w->response.data,
-                "%s({version:'%s',reqId:'%s',status:'ok',sig:'%ld',table:",
-                responseHandler, google_version, google_reqId, st->last_updated.tv_sec);
+        buffer_sprintf(
+            w->response.data,
+            "%s({version:'%s',reqId:'%s',status:'ok',sig:'%"PRId64"',table:",
+            responseHandler,
+            google_version,
+            google_reqId,
+            (int64_t)st->last_updated.tv_sec);
     }
     else if(format == DATASOURCE_JSONP) {
         if(responseHandler == NULL)


### PR DESCRIPTION
##### Summary
`time_t` type may be different on different platforms. We should cast it to a definite type before printing.

Fixes #11830

Thank you @WYC-2020!

##### Test Plan
The PR was tested on the `openwrt/openwrt` master branch.
1. Prepare an OpenWrt build for 32bit architecture (x86 generic). It's a very lo-o-ong and space-consuming process 😉.
```
git clone https://git.openwrt.org/openwrt/openwrt.git
./scripts/feeds update -a
./scripts/feeds install -a
make menuconfig
make -j8
```
2. Make changes to the netdata package
- `Makefile`
```
PKG_VERSION:=time_t-format
PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
PKG_SOURCE_URL:=https://codeload.github.com/vlvkobal/netdata/tar.gz/$(PKG_VERSION)?
PKG_HASH:=4c9615cde21e427c0ab3d900a6acdb0ba7468b89507e8ab480e699f182b8d86a

DEPENDS:=+zlib +libuuid +libuv +libmnl +libjson-c +libopenssl

TARGET_LDFLAGS += -Wl,--gc-sections,-lssl,-lcrypto
```
- Remove patches for `index.html`
- Add a patch for `database/sqlite/sqlite_functions.h`
```
--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -3,6 +3,7 @@
 #ifndef NETDATA_SQLITE_FUNCTIONS_H
 #define NETDATA_SQLITE_FUNCTIONS_H

+#include <openssl/evp.h>
 #include "daemon/common.h"
 #include "sqlite3.h"

```
3. Rebuild the netdata package and make sure all the warnings for `time_t` are gone. 
```
make -j1 V=sc
```