### PR TITLE
Use the chart id instead of chart name in response to incoming cloud context queries

### DIFF
--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -114,7 +114,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
             if (i)
                 buffer_strcat(wb, ", ");
             buffer_strcat(wb, sq);
-            buffer_strcat(wb, rd->rrdset->name);
+            buffer_strcat(wb, rd->rrdset->id);
             buffer_strcat(wb, sq);
             i++;
         }


### PR DESCRIPTION
##### Summary
The context query on the agent side currently returns chart name instead of chart ids. 
This affects metric correlation queries as it will attempt  to incorrectly match chart ids (on the cloud side) with chart names. 
Although the chart id and name are identical in most cases,  this is not always the case. 
This PR changes the response to use chart ids.

##### Component Name
database

##### Test Plan
- Simple change from rrdset->name to rrdset->id
  - Verified by running metric correlations on the cloud. With this PR more charts match in a K8S enabled configuration