### PR TITLE
Don’t verify optional dependencies in build test environments in CI.

### DIFF
--- a/.github/dockerfiles/Dockerfile.build_test
+++ b/.github/dockerfiles/Dockerfile.build_test
@@ -15,4 +15,4 @@ RUN echo "${PRE}" > /prep-cmd.sh && \
 
 COPY . /netdata
 
-RUN /netdata/packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata-all
+RUN /netdata/packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata


### PR DESCRIPTION
##### Summary

This makes the CI jobs less sensitive to external packaging stupidity (like openSUSE making systemd a mandatory dependency of the `sensors` package).

##### Component Name

area/ci

##### Test Plan

CI passes correctly on this PR.