### PR TITLE
Send ML feature information with UpdateNodeInfo.

### DIFF
--- a/aclk/schema-wrappers/node_info.cc
+++ b/aclk/schema-wrappers/node_info.cc
@@ -62,8 +62,9 @@ static int generate_node_info(nodeinstance::info::v1::NodeInfo *info, struct acl
     if (data->machine_guid)
         info->set_machine_guid(data->machine_guid);
 
-    info->set_ml_capable(data->ml_capable);
-    info->set_ml_enabled(data->ml_enabled);
+    nodeinstance::info::v1::MachineLearningInfo *ml_info = info->mutable_ml_info();
+    ml_info->set_ml_capable(data->ml_info.ml_capable);
+    ml_info->set_ml_enabled(data->ml_info.ml_enabled);
 
     map = info->mutable_host_labels();
     label = data->host_labels_head;
@@ -88,7 +89,10 @@ char *generate_update_node_info_message(size_t *len, struct update_node_info *in
     set_google_timestamp_from_timeval(info->updated_at, msg.mutable_updated_at());
     msg.set_machine_guid(info->machine_guid);
     msg.set_child(info->child);
-    msg.set_ml_on_parent(info->ml_on_parent);
+
+    nodeinstance::info::v1::MachineLearningInfo *ml_info = msg.mutable_ml_info();
+    ml_info->set_ml_capable(info->ml_info.ml_capable);
+    ml_info->set_ml_enabled(info->ml_info.ml_enabled);
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);
     char *bin = (char*)malloc(*len);

--- a/aclk/schema-wrappers/node_info.cc
+++ b/aclk/schema-wrappers/node_info.cc
@@ -62,6 +62,9 @@ static int generate_node_info(nodeinstance::info::v1::NodeInfo *info, struct acl
     if (data->machine_guid)
         info->set_machine_guid(data->machine_guid);
 
+    info->set_ml_capable(data->ml_capable);
+    info->set_ml_enabled(data->ml_enabled);
+
     map = info->mutable_host_labels();
     label = data->host_labels_head;
     while (label) {
@@ -85,6 +88,7 @@ char *generate_update_node_info_message(size_t *len, struct update_node_info *in
     set_google_timestamp_from_timeval(info->updated_at, msg.mutable_updated_at());
     msg.set_machine_guid(info->machine_guid);
     msg.set_child(info->child);
+    msg.set_ml_on_parent(info->ml_on_parent);
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);
     char *bin = (char*)malloc(*len);

--- a/aclk/schema-wrappers/node_info.h
+++ b/aclk/schema-wrappers/node_info.h
@@ -11,6 +11,11 @@
 extern "C" {
 #endif
 
+struct machine_learning_info {
+    bool ml_capable;
+    bool ml_enabled;
+};
+
 struct aclk_node_info {
     char *name;
 
@@ -50,9 +55,7 @@ struct aclk_node_info {
 
     struct label *host_labels_head;
 
-    bool ml_capable;
-
-    bool ml_enabled;
+    struct machine_learning_info ml_info;
 };
 
 struct update_node_info {
@@ -62,7 +65,8 @@ struct update_node_info {
     struct timeval updated_at;
     char *machine_guid;
     int child;
-    bool ml_on_parent;
+
+    struct machine_learning_info ml_info;
 };
 
 char *generate_update_node_info_message(size_t *len, struct update_node_info *info);

--- a/aclk/schema-wrappers/node_info.h
+++ b/aclk/schema-wrappers/node_info.h
@@ -49,6 +49,10 @@ struct aclk_node_info {
     char *machine_guid;
 
     struct label *host_labels_head;
+
+    bool ml_capable;
+
+    bool ml_enabled;
 };
 
 struct update_node_info {
@@ -58,6 +62,7 @@ struct update_node_info {
     struct timeval updated_at;
     char *machine_guid;
     int child;
+    bool ml_on_parent;
 };
 
 char *generate_update_node_info_message(size_t *len, struct update_node_info *info);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -754,6 +754,8 @@ struct rrdhost_system_info {
     char *container_detection;
     char *is_k8s_node;
     uint16_t hops;
+    bool ml_capable;
+    bool ml_enabled;
 };
 
 struct rrdhost {

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -387,8 +387,12 @@ RRDHOST *rrdhost_create(const char *hostname,
     // about ML functionality
 
     ml_new_host(host);
-    if (is_localhost) {
-        host->system_info->ml_capable = ENABLE_ML;
+    if (is_localhost && host->system_info) {
+#ifndef ENABLE_ML
+        host->system_info->ml_capable = 0;
+#else
+        host->system_info->ml_capable = 1;
+#endif
         host->system_info->ml_enabled = host->ml_host != NULL;
     }
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -382,7 +382,15 @@ RRDHOST *rrdhost_create(const char *hostname,
         else localhost = host;
     }
 
+    // ------------------------------------------------------------------------
+    // init new ML host and update system_info to let upstreams know
+    // about ML functionality
+
     ml_new_host(host);
+    if (is_localhost) {
+        host->system_info->ml_capable = ENABLE_ML;
+        host->system_info->ml_enabled = host->ml_host != NULL;
+    }
 
     info("Host '%s' (at registry as '%s') with guid '%s' initialized"
                  ", os '%s'"

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -22,6 +22,7 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     node_info.claim_id = is_agent_claimed();
     node_info.machine_guid = wc->host_guid;
     node_info.child = (wc->host != localhost);
+    node_info.ml_on_parent = (wc->host != localhost) && (wc->host->ml_host != NULL);
     now_realtime_timeval(&node_info.updated_at);
 
     RRDHOST *host = wc->host;
@@ -46,6 +47,8 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     node_info.data.services = NULL;   // char **
     node_info.data.service_count = 0;
     node_info.data.machine_guid = wc->host_guid;
+    node_info.data.ml_capable = host->system_info->ml_capable;
+    node_info.data.ml_enabled = host->system_info->ml_enabled;
 
     struct label_index *labels = &host->labels;
     netdata_rwlock_wrlock(&labels->labels_rwlock);

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -22,7 +22,8 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     node_info.claim_id = is_agent_claimed();
     node_info.machine_guid = wc->host_guid;
     node_info.child = (wc->host != localhost);
-    node_info.ml_on_parent = (wc->host != localhost) && (wc->host->ml_host != NULL);
+    node_info.ml_info.ml_capable = localhost->system_info->ml_capable;
+    node_info.ml_info.ml_enabled = wc->host->ml_host != NULL;
     now_realtime_timeval(&node_info.updated_at);
 
     RRDHOST *host = wc->host;
@@ -47,8 +48,8 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     node_info.data.services = NULL;   // char **
     node_info.data.service_count = 0;
     node_info.data.machine_guid = wc->host_guid;
-    node_info.data.ml_capable = host->system_info->ml_capable;
-    node_info.data.ml_enabled = host->system_info->ml_enabled;
+    node_info.data.ml_info.ml_capable = host->system_info->ml_capable;
+    node_info.data.ml_info.ml_enabled = host->system_info->ml_enabled;
 
     struct label_index *labels = &host->labels;
     netdata_rwlock_wrlock(&labels->labels_rwlock);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -522,6 +522,10 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
             utc_offset = (int32_t)strtol(value, NULL, 0);
         else if(!strcmp(name, "hops"))
             system_info->hops = (uint16_t) strtoul(value, NULL, 0);
+        else if(!strcmp(name, "ml_capable"))
+            system_info->ml_capable = strtoul(value, NULL, 0);
+        else if(!strcmp(name, "ml_enabled"))
+            system_info->ml_enabled = strtoul(value, NULL, 0);
         else if(!strcmp(name, "tags"))
             tags = value;
         else if(!strcmp(name, "ver"))

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -214,7 +214,21 @@ static int rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_po
 
     char http[HTTP_HEADER_SIZE + 1];
     int eol = snprintfz(http, HTTP_HEADER_SIZE,
-            "STREAM key=%s&hostname=%s&registry_hostname=%s&machine_guid=%s&update_every=%d&os=%s&timezone=%s&abbrev_timezone=%s&utc_offset=%d&hops=%d&tags=%s&ver=%u"
+            "STREAM "
+                 "key=%s"
+                 "&hostname=%s"
+                 "&registry_hostname=%s"
+                 "&machine_guid=%s"
+                 "&update_every=%d"
+                 "&os=%s"
+                 "&timezone=%s"
+                 "&abbrev_timezone=%s"
+                 "&utc_offset=%d"
+                 "&hops=%d"
+                 "&ml_capable=%d"
+                 "&ml_enabled=%d"
+                 "&tags=%s"
+                 "&ver=%u"
                  "&NETDATA_SYSTEM_OS_NAME=%s"
                  "&NETDATA_SYSTEM_OS_ID=%s"
                  "&NETDATA_SYSTEM_OS_ID_LIKE=%s"
@@ -253,6 +267,8 @@ static int rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_po
                  , host->abbrev_timezone
                  , host->utc_offset
                  , host->system_info->hops + 1
+                 , host->system_info->ml_capable
+                 , host->system_info->ml_enabled
                  , (host->tags) ? host->tags : ""
                  , STREAMING_PROTOCOL_CURRENT_VERSION
                  , se.os_name


### PR DESCRIPTION
##### Summary

We achieve this by adding the `ml_{capable,enabled}` fields in
`system_info`. When streaming, these fields allow a parent to understand if
the child has ML and if it runs ML for itself.

A newly added protobuf message contains the aforementioned field. Inside
`NodeInfo` the information is an exact copy of `system_info`. Inside
UpdateNodeInfo the `ml_capable` field reflects the ability of the localhost
to run ML, and the `ml_enabled` field denotes the training status of the
specified node instance.

##### Component Name

aclk

##### Test Plan

TBD

##### Additional Information

Setting the `ml_{capable,enabled}` fields inside `rrdhost_create` is a little bit
awkward. The reason we have to do this is because there's an ML configuration
option that allows a user to filter by hostname the nodes to be trained. This means
that we need to create/initialize the `RRDHOST` object first and then check if the
ML component will train it based on the configuration options of the user.