### PR TITLE
Include libatomic again to allow protobuf to resolve

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -996,7 +996,8 @@ netdata_LDADD = \
 
 if ACLK_NG
     netdata_LDADD += $(OPTIONAL_PROTOBUF_LIBS) \
-        $(NULL)
+    $(OPTIONAL_ATOMIC_LIBS) \
+    $(NULL)
 endif
 
 if ENABLE_ML_TESTS


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds the `-latomic` reference to the linker after the protobuf libraries, so that `libprotobuf.a` can resolve `__atomic` functions if needed.

Linking is ok without this PR if ml is enabled. If it is not (`--disable-ml`), at the linking stage the error `arena.cc:(.text+0xab4): undefined reference to '__atomic_fetch_add_8'` is produced by the linker for `libprotobuf.a`

##### Component Name

Build

##### Test Plan

This was tested on a clean Raspbian 11 (bullseye), as a response to https://github.com/netdata/netdata/issues/11915.

On a clean Raspbian installation, on a raspberry, try to compile master, or a latest stable release.
Specify `--disable-ml`. Link might fail. Using the changes in this PR, linking should succeed.