### PR TITLE
fix: printing failed messages in kickstart and kickstart-static64

### DIFF
--- a/packaging/installer/kickstart-static64.sh
+++ b/packaging/installer/kickstart-static64.sh
@@ -64,7 +64,7 @@ run_ok() {
 }
 
 run_failed() {
-  printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET} \n\n"
+  printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET} ${*} \n\n"
 }
 
 ESCAPED_PRINT_METHOD=

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -176,7 +176,7 @@ run_ok() {
 }
 
 run_failed() {
-  printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET} \n\n"
+  printf >&2 "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET} ${1} \n\n"
 }
 
 ESCAPED_PRINT_METHOD=

--- a/packaging/installer/methods/kickstart-64.md
+++ b/packaging/installer/methods/kickstart-64.md
@@ -97,7 +97,7 @@ To use `md5sum` to verify the integrity of the `kickstart-static64.sh` script yo
 command above, run the following:
 
 ```bash
-[ "508e16775bfe8aaf6bc2d0f7b91c323e" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "2820c64aae078b8cc22e255725fb5622" = "$(curl -Ss https://my-netdata.io/kickstart-static64.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -96,7 +96,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "1e09c4908ee5a2b0afff92b380e72c27" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "323f9a7f2ec55ed67618346e49e19bc1" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

We use run_failed() for logging messages in both [kickstart](https://github.com/netdata/netdata/blob/78c2af15478ea47e436ed58f0db827e5f37ba26d/packaging/installer/kickstart.sh#L178-L180) and [kickstart-static64](https://github.com/netdata/netdata/blob/78c2af15478ea47e436ed58f0db827e5f37ba26d/packaging/installer/kickstart-static64.sh#L66-L68) scripts, but the function doesn't print any passed text.


##### Component Name

kickstart

##### Test Plan

Make kickstart/kickstart-static64 script fail, ensure the text is visible.

##### Additional Information
