### PR TITLE
fix(claim): set URL_BASE only if `-url` parameter value is not null

### DIFF
--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -191,7 +191,7 @@ for arg in "$@"
 do
         case $arg in
                 -token=*) TOKEN=${arg:7} ;;
-                -url=*) URL_BASE=${arg:5} ;;
+                -url=*) [ -n "${arg:5}" ] && URL_BASE=${arg:5} ;;
                 -id=*) ID=${arg:4} ;;
                 -rooms=*) ROOMS=${arg:7} ;;
                 -hostname=*) HOSTNAME=${arg:10} ;;


### PR DESCRIPTION
##### Summary

ssia, URL_BASE is set to "https://app.netdata.cloud"

https://github.com/netdata/netdata/blob/14c6322c95bf46cb33f9c3afc9a2d641bd1cfe69/claim/netdata-claim.sh.in#L138-L139

We shouldn't overwrite it when passing `-url=""`.

##### Component Name

claim

##### Test Plan

Not needed

##### Additional Information
