### PR TITLE
fix(ci): install ESLint before running reviewdog/action-eslint

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -98,6 +98,8 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Install eslint
+        run: npm install eslint -D
       - name: Run eslint
         uses: reviewdog/action-eslint@v1
         with:


### PR DESCRIPTION
##### Summary

ESLint [needs to be installed](https://github.com/reviewdog/action-eslint#example-usage) in order to run reviewdog/action-eslint GHA.

Based on https://github.com/reviewdog/action-eslint/issues/56#issuecomment-832074739

The error we are having currently

```
> Running `npm install` to install eslint ...
/home/runner/work/_actions/reviewdog/action-eslint/v1/script.sh: 20: /home/runner/work/netdata/netdata/node_modules/.bin/eslint: not found
eslint version:
> Running eslint with reviewdog 🐶 ...
/home/runner/work/_actions/reviewdog/action-eslint/v1/script.sh: 23: /home/runner/work/netdata/netdata/node_modules/.bin/eslint: not found
```

##### Component Name

ci

##### Test Plan

Not needed

##### Additional Information
