### PR TITLE
Handle re-claim while the agent is running in new architecture

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -320,10 +320,9 @@ static int handle_connection(mqtt_wss_client client)
             return 1;
         }
 
-        if (aclk_kill_link) {                       // User has reloaded the claiming state
+        if (aclk_kill_link) { // User has reloaded the claiming state
             aclk_kill_link = 0;
             aclk_graceful_disconnect(client);
-            log_access("Aclk_kill_link detected.");
             aclk_queue_unlock();
             aclk_shared_state.mqtt_shutdown_msg_id = -1;
             aclk_shared_state.mqtt_shutdown_msg_rcvd = 0;

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -320,16 +320,7 @@ static int handle_connection(mqtt_wss_client client)
             return 1;
         }
 
-        if (aclk_kill_link) { // User has reloaded the claiming state
-            aclk_kill_link = 0;
-            aclk_graceful_disconnect(client);
-            aclk_queue_unlock();
-            aclk_shared_state.mqtt_shutdown_msg_id = -1;
-            aclk_shared_state.mqtt_shutdown_msg_rcvd = 0;
-            return 1;
-        }
-
-        if (disconnect_req) {
+        if (disconnect_req || aclk_kill_link) {
             disconnect_req = 0;
             aclk_graceful_disconnect(client);
             aclk_queue_unlock();

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -320,6 +320,16 @@ static int handle_connection(mqtt_wss_client client)
             return 1;
         }
 
+        if (aclk_kill_link) {                       // User has reloaded the claiming state
+            aclk_kill_link = 0;
+            aclk_graceful_disconnect(client);
+            log_access("Aclk_kill_link detected.");
+            aclk_queue_unlock();
+            aclk_shared_state.mqtt_shutdown_msg_id = -1;
+            aclk_shared_state.mqtt_shutdown_msg_rcvd = 0;
+            return 1;
+        }
+
         if (disconnect_req) {
             disconnect_req = 0;
             aclk_graceful_disconnect(client);

--- a/aclk/aclk_rrdhost_state.h
+++ b/aclk/aclk_rrdhost_state.h
@@ -30,6 +30,7 @@ typedef enum aclk_agent_state {
 
 typedef struct aclk_rrdhost_state {
     char *claimed_id; // Claimed ID if host has one otherwise NULL
+    char *prev_claimed_id; // Claimed ID if changed (reclaimed) during runtime
 
 #ifdef ACLK_LEGACY
     // per child popcorning

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -420,7 +420,10 @@ uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable
         rrdhost_aclk_state_unlock(localhost);
         return 0;
     }
-    conn.claim_id = localhost->aclk_state.claimed_id;
+    if (localhost->aclk_state.prev_claimed_id)
+        conn.claim_id = localhost->aclk_state.prev_claimed_id;
+    else
+        conn.claim_id = localhost->aclk_state.claimed_id;
 
     char *msg = generate_update_agent_connection(&len, &conn);
     rrdhost_aclk_state_unlock(localhost);
@@ -432,6 +435,10 @@ uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable
 
     pid = aclk_send_bin_message_subtopic_pid(client, msg, len, ACLK_TOPICID_AGENT_CONN, "UpdateAgentConnection");
     freez(msg);
+    if (localhost->aclk_state.prev_claimed_id) {
+        freez(localhost->aclk_state.prev_claimed_id);
+        localhost->aclk_state.prev_claimed_id = NULL;
+    }
     return pid;
 }
 

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -7,7 +7,6 @@
 
 // Helper stuff which should not have any further inside ACLK dependency
 // and are supposed not to be needed outside of ACLK
-#define ACLK_LOG_CONVERSATION_DIR "/tmp/aclk-messages/"
 extern int aclk_use_new_cloud_arch;
 extern usec_t aclk_session_newarch;
 

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -7,7 +7,7 @@
 
 // Helper stuff which should not have any further inside ACLK dependency
 // and are supposed not to be needed outside of ACLK
-
+#define ACLK_LOG_CONVERSATION_DIR "/tmp/aclk-messages/"
 extern int aclk_use_new_cloud_arch;
 extern usec_t aclk_session_newarch;
 

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -136,6 +136,8 @@ void load_claiming_state(void)
     uuid_t uuid;
     rrdhost_aclk_state_lock(localhost);
     if (localhost->aclk_state.claimed_id) {
+        if (aclk_connected)
+            localhost->aclk_state.prev_claimed_id = strdupz(localhost->aclk_state.claimed_id);
         freez(localhost->aclk_state.claimed_id);
         localhost->aclk_state.claimed_id = NULL;
     }

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -379,7 +379,9 @@ fi
 
 if [ "${HTTP_STATUS_CODE}" = "204" ] || [ "${ERROR_KEY}" = "ErrAlreadyClaimed" ] ; then
         rm -f "${CLAIMING_DIR}/tmpout.txt"
-        echo -n "${ID}" >"${CLAIMING_DIR}/claimed_id" || (echo >&2 "Claiming failed"; set -e; exit 2)
+        if [ "${HTTP_STATUS_CODE}" = "204" ] ; then
+                echo -n "${ID}" >"${CLAIMING_DIR}/claimed_id" || (echo >&2 "Claiming failed"; set -e; exit 2)
+        fi
         rm -f "${CLAIMING_DIR}/token" || (echo >&2 "Claiming failed"; set -e; exit 2)
 
         # Rewrite the cloud.conf on the disk

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -938,6 +938,7 @@ void rrdhost_free(RRDHOST *host) {
 
     pthread_mutex_destroy(&host->aclk_state_lock);
     freez(host->aclk_state.claimed_id);
+    freez(host->aclk_state.prev_claimed_id);
     freez((void *)host->tags);
     free_label_list(host->labels.head);
     freez((void *)host->os);


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds some modifications that allow the agent to handle a re-claim while the agent is running for the new architecture. In this scenario, the agent will disconnect, send an `UpdateAgentConnection` which has the old `claim_id`, and then another `UpdateAgentConnection` containing the new `claim_id`. In cloud terms, the old node instance will become unreachable, and the new node instance will start updating.

Without this PR the agent requires a restart to re-appear in the cloud, and if it doesn't restart the cloud will have a node instance which does not update any more, and a new one in unreachable state.

There is also a small change in the `netdata-claim.sh.in` script: If the cloud responds with `ErrAlreadyClaimed` do not overwrite the the `claimed_id` file. This helps with the following scenario (but we can discuss if I'm missing something):

Agent is claimed for the first time without the `-id` parameter. `claimed_id` contains the `machine_guid`
Agent is re-claimed with the `-id` parameter: `claimed_id` now contains a new id.
Agent is re-claimed without the `-id` parameter. `claimed_id` is overwritten by the `machine_guid`.

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

In a whitelisted space, claim a fresh instance of an agent. Observe that it starts working.
Re-claim the agent using the `-id` parameter.
The old agent instance should become unreachable, and the new one will start updating.

##### Additional Information

There is really more to this than this PR. If re-claimed, the agent appears to the cloud as a completely new instance. As such, the cloud will request streaming from sequence id 1, which might not be available by then to the agent (db rotated). Snapshot events for alerts, and re-syncs for charts should fix the situation (but this is a general problem with re-claiming).