### PR TITLE
Try to find worker config thread from inactive threads for new architecture

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -189,6 +189,24 @@ int aclk_worker_enq_cmd(char *node_id, struct aclk_database_cmd *cmd)
     return (wc == NULL);
 }
 
+struct aclk_database_worker_config *find_inactive_wc_by_node_id(char *node_id)
+{
+    if (unlikely(!node_id))
+        return NULL;
+
+    uv_mutex_lock(&aclk_async_lock);
+    struct aclk_database_worker_config *wc = aclk_thread_head;
+
+    while (wc) {
+        if (!strcmp(wc->node_id, node_id))
+            break;
+        wc = wc->next;
+    }
+    uv_mutex_unlock(&aclk_async_lock);
+
+    return (wc);
+}
+
 void aclk_sync_exit_all()
 {
     rrd_wrlock();

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -229,4 +229,5 @@ void sql_delete_aclk_table_list(struct aclk_database_worker_config *wc, struct a
 void sql_maint_aclk_sync_database(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 int claimed();
 void aclk_sync_exit_all();
+struct aclk_database_worker_config *find_inactive_wc_by_node_id(char *node_id);
 #endif //NETDATA_SQLITE_ACLK_H

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -546,7 +546,9 @@ void aclk_start_alert_streaming(char *node_id, uint64_t batch_id, uint64_t start
     rrd_wrlock();
     RRDHOST *host = find_host_by_node_id(node_id);
     if (likely(host))
-        wc = (struct aclk_database_worker_config *)host->dbsync_worker;
+        wc = (struct aclk_database_worker_config *)host->dbsync_worker ?
+                 (struct aclk_database_worker_config *)host->dbsync_worker :
+                 (struct aclk_database_worker_config *)find_inactive_wc_by_node_id(node_id);
     rrd_unlock();
 
     if (unlikely(!host->health_enabled)) {

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -682,7 +682,9 @@ void aclk_start_streaming(char *node_id, uint64_t sequence_id, time_t created_at
     while(host) {
         if (host->node_id && !(uuid_compare(*host->node_id, node_uuid))) {
             rrd_unlock();
-            wc = (struct aclk_database_worker_config *)host->dbsync_worker;
+            wc = (struct aclk_database_worker_config *)host->dbsync_worker ?
+                     (struct aclk_database_worker_config *)host->dbsync_worker :
+                     (struct aclk_database_worker_config *)find_inactive_wc_by_node_id(node_id);
             if (likely(wc)) {
                 wc->chart_reset_count++;
                 __sync_synchronize();


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR tries to fix a situation, where the agent is slower to activate children threads than the cloud sending start streaming commands.

If a child agent is already known to the parent, then the parent will create a thread for it at the start, but will wait until the child is connected to activate it.

When the child connects, ACLK will send a `status update` message to the cloud for this child. The parent will then connect the thread created at the start with this host. It can happen though that the start streaming commands arrive before the agent has completed this process (runs on the internal timer). If this happens, then the start streaming code will fail to find an active thread and will drop those messages.

This PR adds another check, so that if getting the active thread returns nothing, then it tries to find it by going through the inactive threads.

##### Component Name

New architecture cloud.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

It's not very easy to test, but the following might work:

1) Have a setup with a parent claimed to a whitelisted space, and a child node streaming to the parent.
2) Stop both agents.
3) In a test parent without this PR, increase `TIMER_PERIOD_MS` in `sqlite_aclk.c` to e.g. `10000`.
4) Start the parent, wait for it to connect (wait for `ACLK CONNECTED`).
5) Wait 1-2 seconds, then start the child. It should start streaming, and logs should indicate: `Queuing status update for node=XXXXX`
6) With some luck (not much), `Start streaming charts` and `Start streaming alerts` should appear in the logs, before `HOST XXXX (XXXXXXXX) detected as active`.
7) After the start streaming commands for charts and alerts, it should print `ACLK synchronization thread is not active.` which indicates it did not match an active `wc` thread when receiving those messages.

With having applied this PR to the parent, and re-creating the above scenario, at step 7, it should instead report `Start streaming charts enabled` and `Start streaming alerts enabled`.

