### PR TITLE
Multistatsquery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,6 +718,8 @@ set(API_PLUGIN_FILES
         web/api/queries/incremental_sum/incremental_sum.h
         web/api/queries/max/max.c
         web/api/queries/max/max.h
+        web/api/queries/max_s/max_s.c
+        web/api/queries/max_s/max_s.h
         web/api/queries/min/min.c
         web/api/queries/min/min.h
         web/api/queries/sum/sum.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,6 +718,8 @@ set(API_PLUGIN_FILES
         web/api/queries/incremental_sum/incremental_sum.h
         web/api/queries/max/max.c
         web/api/queries/max/max.h
+        web/api/queries/zscore_s/zscore_s.c
+        web/api/queries/zscore_s/zscore_s.h
         web/api/queries/max_s/max_s.c
         web/api/queries/max_s/max_s.h
         web/api/queries/min/min.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -519,6 +519,8 @@ API_PLUGIN_FILES = \
     web/api/queries/max/max.h \
     web/api/queries/max_s/max_s.c \
     web/api/queries/max_s/max_s.h \
+    web/api/queries/zscore_s/zscore_s.c \
+    web/api/queries/zscore_s/zscore_s.h \
     web/api/queries/median/median.c \
     web/api/queries/median/median.h \
     web/api/queries/min/min.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -517,6 +517,8 @@ API_PLUGIN_FILES = \
     web/api/queries/incremental_sum/incremental_sum.h \
     web/api/queries/max/max.c \
     web/api/queries/max/max.h \
+    web/api/queries/max_s/max_s.c \
+    web/api/queries/max_s/max_s.h \
     web/api/queries/median/median.c \
     web/api/queries/median/median.h \
     web/api/queries/min/min.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1789,6 +1789,7 @@ AC_CONFIG_FILES([
     web/api/queries/incremental_sum/Makefile
     web/api/queries/max/Makefile
     web/api/queries/max_s/Makefile
+    web/api/queries/zscore_s/Makefile
     web/api/queries/median/Makefile
     web/api/queries/min/Makefile
     web/api/queries/ses/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1788,6 +1788,7 @@ AC_CONFIG_FILES([
     web/api/queries/des/Makefile
     web/api/queries/incremental_sum/Makefile
     web/api/queries/max/Makefile
+    web/api/queries/max_s/Makefile
     web/api/queries/median/Makefile
     web/api/queries/min/Makefile
     web/api/queries/ses/Makefile

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1733,7 +1733,7 @@ static int test_dbengine_check_rrdr(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DIMS]
     long points = (time_end - time_start) / update_every;
     for (i = 0 ; i < CHARTS ; ++i) {
         ONEWAYALLOC *owa = onewayalloc_create(0);
-        RRDR *r = rrd2rrdr(owa, st[i], points, time_start + update_every, time_end, RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL, 0);
+        RRDR *r = rrd2rrdr(owa, st[i], points, time_start + update_every, time_end, RRDR_GROUPING_AVERAGE, 0, 0, 0, NULL, NULL, 0);
         if (!r) {
             fprintf(stderr, "    DB-engine unittest %s: empty RRDR ### E R R O R ###\n", st[i]->name);
             return ++errors;
@@ -1854,11 +1854,8 @@ int test_dbengine(void)
     long point_offset = (time_start[current_region] - time_start[0]) / update_every;
     for (i = 0 ; i < CHARTS ; ++i) {
         ONEWAYALLOC *owa = onewayalloc_create(0);
-        RRDR *r = rrd2rrdr(owa, st[i], points, time_start[0] + update_every, time_end[REGIONS - 1], RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL, 0);
+        RRDR *r = rrd2rrdr(owa, st[i], points, time_start[0] + update_every, time_end[REGIONS - 1], RRDR_GROUPING_AVERAGE, 0, 0, 0, NULL, NULL, 0);
         if (!r) {
-            fprintf(stderr, "    DB-engine unittest %s: empty RRDR ### E R R O R ###\n", st[i]->name);
-            ++errors;
-        } else {
             long c;
 
             assert(r->st == st[i]);

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -135,7 +135,7 @@ int run_metric_correlations (BUFFER *wb, RRDSET *st, long long baseline_after, l
     //TODO get everything in one go, when baseline is right before highlight
     //get baseline
     ONEWAYALLOC *owa = onewayalloc_create(0);
-    RRDR *rb = rrd2rrdr(owa, st, max_points, baseline_after, baseline_before, group_method, group_time, options, NULL, context_param_list, 0);
+    RRDR *rb = rrd2rrdr(owa, st, max_points, baseline_after, baseline_before, group_method, group_time, options, 0, NULL, context_param_list, 0);
     if(!rb) {
         info("Cannot generate metric correlations output with these parameters on this chart.");
         onewayalloc_destroy(owa);
@@ -165,7 +165,7 @@ int run_metric_correlations (BUFFER *wb, RRDSET *st, long long baseline_after, l
 
     //get highlight
     owa = onewayalloc_create(0);
-    RRDR *rh = rrd2rrdr(owa, st, max_points, highlight_after, highlight_before, group_method, group_time, options, NULL, context_param_list, 0);
+    RRDR *rh = rrd2rrdr(owa, st, max_points, highlight_after, highlight_before, group_method, group_time, options, 0, NULL, context_param_list, 0);
     if(!rh) {
         info("Cannot generate metric correlations output with these parameters on this chart.");
         freez(pd);

--- a/web/api/formatters/json/json.h
+++ b/web/api/formatters/json/json.h
@@ -5,6 +5,6 @@
 
 #include "../rrd2json.h"
 
-extern void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, struct context_param *context_param_list);
+extern void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, struct context_param *context_param_list, int is_stats);
 
 #endif //NETDATA_API_FORMATTER_JSON_H

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -13,7 +13,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
     if (should_lock)
         rrdset_check_rdlock(r->st);
 
-    long rows = rrdr_rows(r);
+    long rows = rrdr_rows(r) - r->stats_count;
     long c, i;
     RRDDIM *rd;
 
@@ -211,7 +211,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
         if(unlikely(options & RRDR_OPTION_PERCENTAGE)) {
             total = 0;
             for(c = 0, rd = temp_rd?temp_rd:r->st->dimensions; rd && c < r->d ;c++, rd = rd->next) {
-                calculated_number *cn = &r->v[ (rrdr_rows(r) - 1) * r->d ];
+                calculated_number *cn = &r->v[ (rrdr_rows(r) - r->stats_count - 1) * r->d ];
                 calculated_number n = cn[c];
 
                 if(likely((options & RRDR_OPTION_ABSOLUTE) && n < 0))
@@ -230,8 +230,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
             if(i) buffer_strcat(wb, ", ");
             i++;
 
-            calculated_number *cn = &r->v[ (rrdr_rows(r) - 1) * r->d ];
-            RRDR_VALUE_FLAGS *co = &r->o[ (rrdr_rows(r) - 1) * r->d ];
+            calculated_number *cn = &r->v[ (rrdr_rows(r) - r->stats_count - 1) * r->d ];
+            RRDR_VALUE_FLAGS *co = &r->o[ (rrdr_rows(r) - r->stats_count - 1) * r->d ];
             calculated_number n = cn[c];
 
             if(co[c] & RRDR_VALUE_EMPTY) {

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -169,7 +169,7 @@ int rrdset2value_api_v1(
 
     ONEWAYALLOC *owa = onewayalloc_create(0);
 
-    RRDR *r = rrd2rrdr(owa, st, points, after, before, group_method, group_time, options, dimensions, NULL, timeout);
+    RRDR *r = rrd2rrdr(owa, st, points, after, before, group_method, group_time, options, 0, dimensions, NULL, timeout);
 
     if(!r) {
         if(value_is_null) *value_is_null = 1;
@@ -220,17 +220,18 @@ int rrdset2anything_api_v1(
         , int group_method
         , long group_time
         , uint32_t options
+        , uint64_t stats
         , time_t *latest_timestamp
         , struct context_param *context_param_list
         , char *chart_label_key
         , int max_anomaly_rates
         , int timeout
-)
-{
+) {
+
     if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE))
         st->last_accessed_time = now_realtime_sec();
 
-    RRDR *r = rrd2rrdr(owa, st, points, after, before, group_method, group_time, options, dimensions?buffer_tostring(dimensions):NULL, context_param_list, timeout);
+    RRDR *r = rrd2rrdr(owa, st, points, after, before, group_method, group_time, options, stats, dimensions?buffer_tostring(dimensions):NULL, context_param_list, timeout);
     if(!r) {
         buffer_strcat(wb, "Cannot generate output with these parameters on this chart.");
         return HTTP_RESP_INTERNAL_SERVER_ERROR;

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -374,7 +374,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 1, context_param_list);
+        rrdr2json(r, wb, options, 1, context_param_list, 0);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);
@@ -386,7 +386,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 1, context_param_list);
+        rrdr2json(r, wb, options, 1, context_param_list, 0);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);
@@ -397,7 +397,7 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 0, context_param_list);
+        rrdr2json(r, wb, options, 0, context_param_list, 0);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);
@@ -410,7 +410,9 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
 
-        rrdr2json(r, wb, options, 0, context_param_list);
+        rrdr2json(r, wb, options, 0, context_param_list, 0);
+        if(r->stats_count)
+            rrdr2json(r, wb, options, 0, context_param_list, 1);
 
         if(options & RRDR_OPTION_JSON_WRAP)
             rrdr_json_wrapper_end(r, wb, format, options, 0);

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -65,6 +65,7 @@ extern int rrdset2anything_api_v1(
         , int group_method
         , long group_time
         , uint32_t options
+        , uint64_t stats
         , time_t *latest_timestamp
         , struct context_param *context_param_list
         , char *chart_label_key

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -242,6 +242,23 @@
             }
           },
           {
+            "name": "stats",
+            "in": "query",
+            "description": "The multi statistical function query method. This option can be used with multiple statistical functions like \"stats=max_s&stats=zsore_s\". The output is created in a seperate value (\"stats\") in the json format.",
+            "required": false,
+            "allowEmptyValue": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "default": "zscore_s",
+              "enum": [
+                "max_s",
+                "zscore_s"
+              ]
+            }
+          },
+          {
             "name": "gtime",
             "in": "query",
             "description": "The grouping number of seconds. This is used in conjunction with group=average to change the units of metrics (ie when the data is per-second, setting gtime=60 will turn them to per-minute).",

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -209,6 +209,17 @@ paths:
               - sum
               - incremental-sum
             default: average
+        - name: stats
+          in: query
+          description: The multi statistical function query method. This option can be used with multiple statistical functions like "stats=max_s&stats=zsore_s". The output is created in a seperate value ("stats") in the json format.  
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: string
+            enum:
+              - max_s
+              - zscore_s
+            default: zscore_s
         - name: gtime
           in: query
           description: The grouping number of seconds. This is used in conjunction with

--- a/web/api/queries/Makefile.am
+++ b/web/api/queries/Makefile.am
@@ -9,6 +9,7 @@ SUBDIRS = \
     incremental_sum \
     max \
     max_s \
+    zscore_s \
     min \
     sum \
     median \

--- a/web/api/queries/Makefile.am
+++ b/web/api/queries/Makefile.am
@@ -8,6 +8,7 @@ SUBDIRS = \
     des \
     incremental_sum \
     max \
+    max_s \
     min \
     sum \
     median \

--- a/web/api/queries/max_s/Makefile.am
+++ b/web/api/queries/max_s/Makefile.am
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+AUTOMAKE_OPTIONS = subdir-objects
+MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+
+dist_noinst_DATA = \
+    $(NULL)

--- a/web/api/queries/max_s/max_s.c
+++ b/web/api/queries/max_s/max_s.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "max_s.h"
+
+// ----------------------------------------------------------------------------
+// max_s
+
+struct stats_max {
+    calculated_number max;
+    size_t count;
+};
+
+void *stats_create_max(RRDR *r) {
+    (void)r;
+    return callocz(1, sizeof(struct stats_max));
+}
+
+// resets when switches dimensions
+// so, clear everything to restart
+void stats_reset_max(RRDR *r, int index) {
+    struct stats_max *g = (struct stats_max *)r->stats[index].stat_data;
+    g->max = 0;
+    g->count = 0;
+}
+
+void stats_free_max(RRDR *r, int index) {
+    freez(r->stats[index].stat_data);
+    r->internal.grouping_data = NULL;
+}
+
+void stats_add_max(RRDR *r, calculated_number value, int index) {
+    if(!isnan(value)) {
+        struct stats_max *g = (struct stats_max *)r->stats[index].stat_data;
+
+        if(!g->count || calculated_number_fabs(value) > calculated_number_fabs(g->max)) {
+            g->max = value;
+            g->count++;
+        }
+    }
+}
+
+calculated_number stats_flush_max(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr, int index) {
+    struct stats_max *g = (struct stats_max *)r->stats[index].stat_data;
+
+    calculated_number value;
+
+    if(unlikely(!g->count)) {
+        value = 0.0;
+        *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
+    }
+    else {
+        value = g->max;
+    }
+
+    g->max = 0.0;
+    g->count = 0;
+
+    return value;
+}
+

--- a/web/api/queries/max_s/max_s.c
+++ b/web/api/queries/max_s/max_s.c
@@ -25,7 +25,7 @@ void stats_reset_max(RRDR *r, int index) {
 
 void stats_free_max(RRDR *r, int index) {
     freez(r->stats[index].stat_data);
-    r->internal.grouping_data = NULL;
+    r->stats[index].stat_data = NULL;
 }
 
 void stats_add_max(RRDR *r, calculated_number value, int index) {

--- a/web/api/queries/max_s/max_s.h
+++ b/web/api/queries/max_s/max_s.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_API_QUERY_MAX_S_H
+#define NETDATA_API_QUERY_MAX_S_H
+
+#include "../query.h"
+#include "../rrdr.h"
+
+extern void *stats_create_max(RRDR *r);
+extern void stats_reset_max(RRDR *r, int index);
+extern void stats_free_max(RRDR *r, int index);
+extern void stats_add_max(RRDR *r, calculated_number value, int index);
+extern calculated_number stats_flush_max(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr, int index);
+
+#endif //NETDATA_API_QUERY_MAX_S_H

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -14,6 +14,7 @@
 #include "stddev/stddev.h"
 #include "ses/ses.h"
 #include "des/des.h"
+#include "max_s/max_s.h"
 
 // ----------------------------------------------------------------------------
 
@@ -246,6 +247,82 @@ static struct {
         }
 };
 
+static struct {
+    const char *name;
+    uint32_t hash;
+    RRDR_STATS value;
+
+    // One time initialization for the module.
+    // This is called once, when netdata starts.
+    void (*init)(void);
+
+    // Allocate all required structures for a query.
+    // This is called once for each netdata query.
+    void *(*create)(struct rrdresult *r);
+
+    // Cleanup collected values, but don't destroy the structures.
+    // This is called when the query engine switches dimensions,
+    // as part of the same query (so same chart, switching metric).
+    void (*reset)(struct rrdresult *r, int index);
+
+    // Free all resources allocated for the query.
+    void (*free)(struct rrdresult *r, int index);
+
+    // Add a single value into the calculation.
+    // The module may decide to cache it, or use it in the fly.
+    void (*add)(struct rrdresult *r, calculated_number value, int index);
+
+    // Generate a single result for the values added so far.
+    // More values and points may be requested later.
+    // It is up to the module to reset its internal structures
+    // when flushing it (so for a few modules it may be better to
+    // continue after a flush as if nothing changed, for others a
+    // cleanup of the internal structures may be required).
+    calculated_number (*flush)(struct rrdresult *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr, int index);
+} api_v1_data_stats[] = {
+        {.name = "min_s",
+                .hash  = 0,
+                .value = RRDR_STATS_MIN,
+                .init  = NULL,
+                .create= stats_create_max,
+                .reset = stats_reset_max,
+                .free  = stats_free_max,
+                .add   = stats_add_max,
+                .flush = stats_flush_max
+        },
+        {.name = "max_s",
+                .hash  = 0,
+                .value = RRDR_STATS_MAX,
+                .init  = NULL,
+                .create= stats_create_max,
+                .reset = stats_reset_max,
+                .free  = stats_free_max,
+                .add   = stats_add_max,
+                .flush = stats_flush_max
+        },
+        {.name = "zscore_s",
+                .hash  = 0,
+                .value = RRDR_STATS_ZSCORE,
+                .init  = NULL,
+                .create= stats_create_max,
+                .reset = stats_reset_max,
+                .free  = stats_free_max,
+                .add   = stats_add_max,
+                .flush = stats_flush_max
+        },
+        // terminator
+        {.name = NULL,
+                .hash  = 0,
+                .value = RRDR_GROUPING_UNDEFINED,
+                .init = NULL,
+                .create= NULL,
+                .reset = NULL,
+                .free  = NULL,
+                .add   = NULL,
+                .flush = NULL
+        }
+};
+
 void web_client_api_v1_init_grouping(void) {
     int i;
 
@@ -271,9 +348,13 @@ const char *group_method2string(RRDR_GROUPING group) {
 
 int stats_method_count(uint64_t stats) {
     int count = 0;
+    if(!stats)
+        return count;
     for (int i = 0; i < 64; i++)
     {
-        count += stats & 0x00000001;
+        if(stats & 0x00000001){
+            count++;
+        }
         stats >>= 1;
     }
     return count;
@@ -547,6 +628,7 @@ static inline void do_dimension_fixedstep(
         , time_t after_wanted
         , time_t before_wanted
         , uint32_t options
+        , int stats_count
 ){
 #ifdef NETDATA_INTERNAL_CHECKS
     RRDSET *st = r->st;
@@ -647,6 +729,10 @@ static inline void do_dimension_fixedstep(
 
             // add this value for grouping
             grouping_add(r, value);
+            for(int i = 0; i < stats_count; i++){
+                r->stats[i].stat_add(r, value, i);
+                info("Stats value add: %Lf to the index of %d", value, i);
+            }
             values_in_group++;
             db_points_read++;
 
@@ -682,6 +768,20 @@ static inline void do_dimension_fixedstep(
                     // runs only when dim_id_in_rrdr == 0 && points_added == 0
                     // so, on the first point added for the query.
                     min = max = value;
+                }
+                if(points_added + 1 >= points_wanted){
+                    for(int i = 0; i < stats_count; i++){
+                        rrdr_line = rrdr_line_init(r, now, rrdr_line);
+                        // find the place to store our values
+                        RRDR_VALUE_FLAGS *rrdr_value_options_ptr = &r->o[rrdr_line * r->d + dim_id_in_rrdr];
+
+                        // store the specific point options
+                        *rrdr_value_options_ptr = group_value_flags;
+
+                        // store the value
+                        calculated_number value = r->stats[i].stat_flush(r, rrdr_value_options_ptr, i);
+                        r->v[rrdr_line * r->d + dim_id_in_rrdr] = value;
+                    }
                 }
 
                 points_added++;
@@ -876,13 +976,14 @@ static RRDR *rrd2rrdr_fixedstep(
         , struct context_param *context_param_list
         , int timeout
 ) {
-    UNUSED(stats);
     int aligned = !(options & RRDR_OPTION_NOT_ALIGNED);
 
     // the duration of the chart
     time_t duration = before_requested - after_requested;
     long available_points = duration / update_every;
-    int stats_count = stats_method_count(stats);
+    uint64_t stats_temp = stats;
+    int stats_count = stats_method_count(stats_temp);
+
 
     RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
 
@@ -1084,8 +1185,8 @@ static RRDR *rrd2rrdr_fixedstep(
     // assign the processor functions
 
     {
-        int i, found = 0;
-        for(i = 0; !found && api_v1_data_groups[i].name ;i++) {
+        int i, j, found = 0;
+        for(i = 0; !found && api_v1_data_groups[i].name; i++) {
             if(api_v1_data_groups[i].value == group_method) {
                 r->internal.grouping_create= api_v1_data_groups[i].create;
                 r->internal.grouping_reset = api_v1_data_groups[i].reset;
@@ -1105,6 +1206,22 @@ static RRDR *rrd2rrdr_fixedstep(
             r->internal.grouping_free  = grouping_free_average;
             r->internal.grouping_add   = grouping_add_average;
             r->internal.grouping_flush = grouping_flush_average;
+        }
+
+        //assign statistic functions
+        j = 0;
+        for(i = 0; api_v1_data_stats[i].name; i++) {
+            if(api_v1_data_stats[i].value & stats_temp){
+                r->stats[j].stat_create= api_v1_data_stats[i].create;
+                r->stats[j].stat_reset = api_v1_data_stats[i].reset;
+                r->stats[j].stat_free  = api_v1_data_stats[i].free;
+                r->stats[j].stat_add   = api_v1_data_stats[i].add;
+                r->stats[j].stat_flush = api_v1_data_stats[i].flush;
+                r->stats[j].stat_data = r->stats[j].stat_create(r);
+                strcpy(r->stats[j].name, api_v1_data_stats[i].name);
+                stats_temp &= ~api_v1_data_stats[i].value;
+                j++;
+            }
         }
     }
 
@@ -1145,6 +1262,10 @@ static RRDR *rrd2rrdr_fixedstep(
 
         // reset the grouping for the new dimension
         r->internal.grouping_reset(r);
+        for (int i = 0; i < stats_count; i++)
+        {
+            r->stats[i].stat_reset(r, i);
+        }
 
         do_dimension_fixedstep(
                 r
@@ -1154,6 +1275,7 @@ static RRDR *rrd2rrdr_fixedstep(
                 , after_wanted
                 , before_wanted
                 , options
+                , stats_count
                 );
         if (timeout)
             now_realtime_timeval(&query_current_time);
@@ -1231,6 +1353,10 @@ static RRDR *rrd2rrdr_fixedstep(
 
     // free all resources used by the grouping method
     r->internal.grouping_free(r);
+
+    for(int i = 0; i < stats_count; i++){
+        r->stats[i].stat_free(r, i);
+    }
 
     // when all the dimensions are zero, we should return all of them
     if(unlikely(options & RRDR_OPTION_NONZERO && !dimensions_nonzero && !(r->result_options & RRDR_RESULT_OPTION_CANCEL))) {

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -857,6 +857,7 @@ static RRDR *rrd2rrdr_fixedstep(
         , RRDR_GROUPING group_method
         , long resampling_time_requested
         , RRDR_OPTIONS options
+        , uint64_t stats
         , const char *dimensions
         , int update_every
         , time_t first_entry_t
@@ -865,6 +866,7 @@ static RRDR *rrd2rrdr_fixedstep(
         , struct context_param *context_param_list
         , int timeout
 ) {
+    UNUSED(stats);
     int aligned = !(options & RRDR_OPTION_NOT_ALIGNED);
 
     // the duration of the chart
@@ -1243,6 +1245,7 @@ static RRDR *rrd2rrdr_variablestep(
         , RRDR_GROUPING group_method
         , long resampling_time_requested
         , RRDR_OPTIONS options
+        , uint64_t stats
         , const char *dimensions
         , int update_every
         , time_t first_entry_t
@@ -1252,6 +1255,7 @@ static RRDR *rrd2rrdr_variablestep(
         , struct context_param *context_param_list
         , int timeout
 ) {
+    UNUSED(stats);
     int aligned = !(options & RRDR_OPTION_NOT_ALIGNED);
 
     // the duration of the chart
@@ -1636,6 +1640,7 @@ RRDR *rrd2rrdr(
         , RRDR_GROUPING group_method
         , long resampling_time_requested
         , RRDR_OPTIONS options
+        , uint64_t stats
         , const char *dimensions
         , struct context_param *context_param_list
         , int timeout
@@ -1691,7 +1696,7 @@ RRDR *rrd2rrdr(
                 freez(region_info_array);
             }
             return rrd2rrdr_fixedstep(owa, st, points_requested, after_requested, before_requested, group_method,
-                                      resampling_time_requested, options, dimensions, rrd_update_every,
+                                      resampling_time_requested, options, stats, dimensions, rrd_update_every,
                                       first_entry_t, last_entry_t, absolute_period_requested, context_param_list, timeout);
         } else {
             if (rrd_update_every != (uint16_t)max_interval) {
@@ -1702,12 +1707,12 @@ RRDR *rrd2rrdr(
                                                                                   last_entry_t, options);
             }
             return rrd2rrdr_variablestep(owa, st, points_requested, after_requested, before_requested, group_method,
-                                         resampling_time_requested, options, dimensions, rrd_update_every,
+                                         resampling_time_requested, options, stats, dimensions, rrd_update_every,
                                          first_entry_t, last_entry_t, absolute_period_requested, region_info_array, context_param_list, timeout);
         }
     }
 #endif
     return rrd2rrdr_fixedstep(owa, st, points_requested, after_requested, before_requested, group_method,
-                              resampling_time_requested, options, dimensions,
+                              resampling_time_requested, options, stats, dimensions,
                               rrd_update_every, first_entry_t, last_entry_t, absolute_period_requested, context_param_list, timeout);
 }

--- a/web/api/queries/query.h
+++ b/web/api/queries/query.h
@@ -15,8 +15,14 @@ typedef enum rrdr_grouping {
     RRDR_GROUPING_CV,
     RRDR_GROUPING_SES,
     RRDR_GROUPING_DES,
-    RRDR_GROUPING_ZSCORE
 } RRDR_GROUPING;
+
+typedef enum rrdr_stats {
+    RRDR_STATS_UNDEFINED = 0x00000000,
+    RRDR_STATS_MIN = 0x00000001,
+    RRDR_STATS_MAX = 0x00000002,
+    RRDR_STATS_ZSCORE = 0x00000004
+} RRDR_STATS;
 
 extern const char *group_method2string(RRDR_GROUPING group);
 extern void web_client_api_v1_init_grouping(void);

--- a/web/api/queries/query.h
+++ b/web/api/queries/query.h
@@ -15,6 +15,7 @@ typedef enum rrdr_grouping {
     RRDR_GROUPING_CV,
     RRDR_GROUPING_SES,
     RRDR_GROUPING_DES,
+    RRDR_GROUPING_ZSCORE
 } RRDR_GROUPING;
 
 extern const char *group_method2string(RRDR_GROUPING group);

--- a/web/api/queries/query.h
+++ b/web/api/queries/query.h
@@ -18,10 +18,9 @@ typedef enum rrdr_grouping {
 } RRDR_GROUPING;
 
 typedef enum rrdr_stats {
-    RRDR_STATS_UNDEFINED = 0x00000000,
-    RRDR_STATS_MIN = 0x00000001,
-    RRDR_STATS_MAX = 0x00000002,
-    RRDR_STATS_ZSCORE = 0x00000004
+    RRDR_STATS_UNDEFINED = 0,
+    RRDR_STATS_MAX = 1,
+    RRDR_STATS_ZSCORE = 2
 } RRDR_STATS;
 
 extern const char *group_method2string(RRDR_GROUPING group);

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -98,7 +98,7 @@ inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r)
     onewayalloc_freez(owa, r);
 }
 
-RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, struct context_param *context_param_list)
+RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, int stats_count, struct context_param *context_param_list)
 {
     if (unlikely(!st)) {
         error("NULL value given!");
@@ -124,11 +124,11 @@ RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, struct context_pa
     } else
         rrddim_foreach_read(rd, st) r->d++;
 
-    r->n = n;
+    r->n = n * stats_count;
 
-    r->t = onewayalloc_callocz(owa, (size_t)n, sizeof(time_t));
-    r->v = onewayalloc_mallocz(owa, n * r->d * sizeof(calculated_number));
-    r->o = onewayalloc_mallocz(owa, n * r->d * sizeof(RRDR_VALUE_FLAGS));
+    r->t = onewayalloc_callocz(owa, (size_t)(n * stats_count), sizeof(time_t));
+    r->v = onewayalloc_mallocz(owa, n * stats_count * r->d * sizeof(calculated_number));
+    r->o = onewayalloc_mallocz(owa, n * stats_count * r->d * sizeof(RRDR_VALUE_FLAGS));
     r->od = onewayalloc_mallocz(owa, r->d * sizeof(RRDR_DIMENSION_FLAGS));
 
     // set the hidden flag on hidden dimensions

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -107,6 +107,7 @@ RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, int stats_count, 
 
     RRDR *r = onewayalloc_callocz(owa, 1, sizeof(RRDR));
     r->st = st;
+    r->stats_count = stats_count;
 
     if (!context_param_list || !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
         rrdr_lock_rrdset(r);
@@ -124,11 +125,12 @@ RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, int stats_count, 
     } else
         rrddim_foreach_read(rd, st) r->d++;
 
-    r->n = n * stats_count;
+    stats_count++; // group function (1) + stat functions
+    r->n = n + stats_count;
 
-    r->t = onewayalloc_callocz(owa, (size_t)(n * stats_count), sizeof(time_t));
-    r->v = onewayalloc_mallocz(owa, n * stats_count * r->d * sizeof(calculated_number));
-    r->o = onewayalloc_mallocz(owa, n * stats_count * r->d * sizeof(RRDR_VALUE_FLAGS));
+    r->t = onewayalloc_callocz(owa, (size_t)(n + stats_count), sizeof(time_t));
+    r->v = onewayalloc_mallocz(owa, (n + stats_count) * r->d * sizeof(calculated_number));
+    r->o = onewayalloc_mallocz(owa, (n + stats_count) * r->d * sizeof(RRDR_VALUE_FLAGS));
     r->od = onewayalloc_mallocz(owa, r->d * sizeof(RRDR_DIMENSION_FLAGS));
 
     // set the hidden flag on hidden dimensions

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -111,7 +111,7 @@ extern RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, struct con
 extern RRDR *rrd2rrdr(
     ONEWAYALLOC *owa,
     RRDSET *st, long points_requested, long long after_requested, long long before_requested,
-    RRDR_GROUPING group_method, long resampling_time_requested, RRDR_OPTIONS options, const char *dimensions,
+    RRDR_GROUPING group_method, long resampling_time_requested, RRDR_OPTIONS options, uint64_t stats, const char *dimensions,
     struct context_param *context_param_list, int timeout);
 
 #include "query.h"

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -70,6 +70,16 @@ typedef struct internal_s{
     size_t db_points_read;
     size_t result_points_generated;
 } internal_t;
+
+typedef struct stat_s{
+    void *(*stat_create)(struct rrdresult *r);
+    void (*stat_reset)(struct rrdresult *r, int index);
+    void (*stat_free)(struct rrdresult *r, int index);
+    void (*stat_add)(struct rrdresult *r, calculated_number value, int index);
+    calculated_number (*stat_flush)(struct rrdresult *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr, int index);
+    void *stat_data;
+    char name[100];
+} stat_t;
 typedef struct rrdresult {
     struct rrdset *st;         // the chart this result refers to
 
@@ -98,8 +108,9 @@ typedef struct rrdresult {
     uint8_t st_needs_lock;  // if ST should be locked
 
     internal_t internal;
-    internal_t stats[MAX_STAT_FUNCTION_COUNT]; // Max 64 is statistic function,
-                                               // it can be handled with dynamic allocation
+    int stats_count;
+    stat_t stats[MAX_STAT_FUNCTION_COUNT]; // Max 64 is statistic function,
+                                           // it can be handled with dynamic memory allocation
 } RRDR;
 
 #define rrdr_rows(r) ((r)->rows)

--- a/web/api/queries/zscore_s/Makefile.am
+++ b/web/api/queries/zscore_s/Makefile.am
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+AUTOMAKE_OPTIONS = subdir-objects
+MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+
+dist_noinst_DATA = \
+    $(NULL)

--- a/web/api/queries/zscore_s/zscore_s.c
+++ b/web/api/queries/zscore_s/zscore_s.c
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "zscore_s.h"
+
+// ----------------------------------------------------------------------------
+// stddev
+
+// this implementation comes from:
+// https://www.johndcook.com/blog/standard_deviation/
+
+struct stats_zscore {
+    long count;
+    calculated_number m_oldM, m_newM, m_oldS, m_newS, value;
+};
+
+void *stats_create_zscore(RRDR *r) {
+    UNUSED (r);
+    return callocz(1, sizeof(struct stats_zscore));
+}
+
+// resets when switches dimensions
+// so, clear everything to restart
+void stats_reset_zscore(RRDR *r, int index) {
+    struct stats_zscore *g = (struct stats_zscore *)r->stats[index].stat_data;
+    g->count = 0;
+}
+
+void stats_free_zscore(RRDR *r, int index) {
+    freez(r->stats[index].stat_data);
+    r->stats[index].stat_data = NULL;
+}
+
+void stats_add_zscore(RRDR *r, calculated_number value, int index) {
+    struct stats_zscore *g = (struct stats_zscore *)r->stats[index].stat_data;
+
+    if(calculated_number_isnumber(value)) {
+        g->count++;
+        g->value = value;
+        // See Knuth TAOCP vol 2, 3rd edition, page 232
+        if (g->count == 1) {
+            g->m_oldM = g->m_newM = value;
+            g->m_oldS = 0.0;
+        }
+        else {
+            g->m_newM = g->m_oldM + (value - g->m_oldM) / g->count;
+            g->m_newS = g->m_oldS + (value - g->m_oldM) * (value - g->m_newM);
+
+            // set up for next iteration
+            g->m_oldM = g->m_newM;
+            g->m_oldS = g->m_newS;
+        }
+    }
+}
+
+static inline calculated_number value(struct stats_zscore *g) {
+    return (g->value > 0) ? g->value : 0.0;
+}
+
+static inline calculated_number mean(struct stats_zscore *g) {
+    return (g->count > 0) ? g->m_newM : 0.0;
+}
+
+static inline calculated_number variance(struct stats_zscore *g) {
+    return ( (g->count > 1) ? g->m_newS/(g->count - 1) : 0.0 );
+}
+static inline calculated_number zscore(struct stats_zscore *g) {
+    calculated_number sigma = sqrtl(variance(g));
+    if(!sigma)
+        return 0;
+    return (value(g) - mean(g)) / sqrtl(variance(g));
+}
+
+calculated_number stats_flush_zscore(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr, int index) {
+    struct stats_zscore *g = (struct stats_zscore *)r->stats[index].stat_data;
+
+    calculated_number value;
+
+    if(likely(g->count > 1)) {
+        value = zscore(g);
+
+        if(!calculated_number_isnumber(value)) {
+            value = 0.0;
+            *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
+        }
+    }
+    else if(g->count == 1) {
+        value = 0.0;
+    }
+    else {
+        value = 0.0;
+        *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
+    }
+
+    stats_reset_zscore(r, index);
+
+    return  value;
+}

--- a/web/api/queries/zscore_s/zscore_s.h
+++ b/web/api/queries/zscore_s/zscore_s.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_API_QUERY_ZSCORE_S_H
+#define NETDATA_API_QUERY_ZSCORE_S_H
+
+#include "../query.h"
+#include "../rrdr.h"
+
+extern void *stats_create_zscore(RRDR *r);
+extern void stats_reset_zscore(RRDR *r, int index);
+extern void stats_free_zscore(RRDR *r, int index);
+extern void stats_add_zscore(RRDR *r, calculated_number value, int index);
+extern calculated_number stats_flush_zscore(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr, int index);
+
+#endif //NETDATA_API_QUERY_ZSCORE_S_H

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -46,17 +46,9 @@ static struct {
     uint32_t hash;
     RRDR_GROUPING value;
 } api_v1_stats[] = {
-         {"average"             , 0    , RRDR_GROUPING_AVERAGE}
-        , {"min"                , 0    , RRDR_GROUPING_MIN}
-        , {"max"                , 0    , RRDR_GROUPING_MAX}
-        , {"sum"                , 0    , RRDR_GROUPING_SUM}
-        , {"incremental_sum"    , 0    , RRDR_GROUPING_INCREMENTAL_SUM}
-        , {"median"             , 0    , RRDR_GROUPING_MEDIAN}
-        , {"stddev"             , 0    , RRDR_GROUPING_STDDEV}
-        , {"cv"                 , 0    , RRDR_GROUPING_CV}
-        , {"ses"                , 0    , RRDR_GROUPING_SES}
-        , {"des"                , 0    , RRDR_GROUPING_DES}
-        , {"zscore"             , 0    , RRDR_GROUPING_ZSCORE}
+          {"min_s"                , 0    , RRDR_STATS_MIN}
+        , {"max_s"                , 0    , RRDR_STATS_MAX}
+        , {"zscore_s"             , 0    , RRDR_STATS_ZSCORE}
         , {                 NULL, 0, 0}
 };
 static struct {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -46,8 +46,7 @@ static struct {
     uint32_t hash;
     RRDR_GROUPING value;
 } api_v1_stats[] = {
-          {"min_s"                , 0    , RRDR_STATS_MIN}
-        , {"max_s"                , 0    , RRDR_STATS_MAX}
+        {"max_s"                , 0    , RRDR_STATS_MAX}
         , {"zscore_s"             , 0    , RRDR_STATS_ZSCORE}
         , {                 NULL, 0, 0}
 };

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -10,6 +10,7 @@
 
 #define MAX_CHART_LABELS_FILTER (32)
 extern uint32_t web_client_api_request_v1_data_options(char *o);
+extern uint64_t web_client_api_request_v1_stats(char *o);
 extern uint32_t web_client_api_request_v1_data_format(char *name);
 extern uint32_t web_client_api_request_v1_data_google_format(char *name);
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Added an extra parameter "**stats**", with which new statistics functions can be queried.
stats can get more than one parameter like "...&stats=des&stats=ses&...".

##### Discussion Subjects

- [x] Separating of statistical and grouping functions
There are already several grouping functions under the `/web/api/queries` which use same data structure reference/pointer `r->internal.grouping_data`. A separated statistical function `/web/api/queries/max_s` is implemented for demonstration purpose in the current implementation of the PR. 
@stelfrag, should we use same function implementations for both statistic and grouping or keep grouping functions as it is and implement statistical functions apart from grouping ?
- [x] Decision of statistical functions
@andrewm4894, @cpipilas, Which statistical functions do we need to implement at first stage? Most probably `zscore` would be one of them. 
- [x] Output format of the query
@vkalintiris, @stelfrag, @andrewm4894 This is the current output of the PR from statistical query perspective (yes min_s returns max values among all metrics, it is just for demonstration purpose :), I will handle statistical function implementations after they are determined in the previous item);
![image](https://user-images.githubusercontent.com/51407/163777384-9440ce8e-41ac-4303-9178-e2fd62012804.png)

##### Sub Task List

- [x] Fixed step implementation
- [x] Variable step implementation
Need to discuss it with @stelfrag before starting the implementation
- [x] Documentation

##### Component Name

- Query
- Data endpoint API

##### Test Plan

After compilation and restarting Netdata agent, query as below (do not forget changing IP address);

Over Browser:
`http://192.168.1.9:19999/api/v1/data?chart=system.cpu&after=-20&before=0&points=5&group=average&stats=min&stats=des&stats=max&gtime=0&format=json&options=seconds&options=jsonwrap`

Over Console:
`curl -X 'GET'   'http://localhost:19999/api/v1/data?chart=system.cpu&after=-10&before=0&points=2&group=average&stats=zscore&stats=des&gtime=0&format=json&options=seconds&options=jsonwrap'   -H 'accept: application/json'`

##### Additional Information
It is also work for other formats besides "json", but does not create output due to missing implementation of different formats.
You can also query zscore by "`...&stats=zscore&...`"option.