### PR TITLE
Add `--no-same-owner` to `tar xf` in installer

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -701,7 +701,7 @@ bundle_protobuf() {
     "${PROTOBUF_PACKAGE_BASENAME}" \
     "${tmp}" \
     "${NETDATA_LOCAL_TARBALL_VERRIDE_PROTOBUF}"; then
-    if run tar -xf "${tmp}/${PROTOBUF_PACKAGE_BASENAME}" -C "${tmp}" &&
+    if run tar --no-same-owner -xf "${tmp}/${PROTOBUF_PACKAGE_BASENAME}" -C "${tmp}" &&
       build_protobuf "${tmp}/protobuf-${PROTOBUF_PACKAGE_VERSION}" &&
       copy_protobuf "${tmp}/protobuf-${PROTOBUF_PACKAGE_VERSION}" &&
       rm -rf "${tmp}"; then
@@ -786,7 +786,7 @@ bundle_judy() {
     "${JUDY_PACKAGE_BASENAME}" \
     "${tmp}" \
     "${NETDATA_LOCAL_TARBALL_OVERRIDE_JUDY}"; then
-    if run tar -xf "${tmp}/${JUDY_PACKAGE_BASENAME}" -C "${tmp}" &&
+    if run tar --no-same-owner -xf "${tmp}/${JUDY_PACKAGE_BASENAME}" -C "${tmp}" &&
       build_judy "${tmp}/libjudy-${JUDY_PACKAGE_VERSION}" &&
       copy_judy "${tmp}/libjudy-${JUDY_PACKAGE_VERSION}" &&
       rm -rf "${tmp}"; then
@@ -870,7 +870,7 @@ bundle_jsonc() {
     "${JSONC_PACKAGE_BASENAME}" \
     "${tmp}" \
     "${NETDATA_LOCAL_TARBALL_OVERRIDE_JSONC}"; then
-    if run tar -xf "${tmp}/${JSONC_PACKAGE_BASENAME}" -C "${tmp}" &&
+    if run tar --no-same-owner -xf "${tmp}/${JSONC_PACKAGE_BASENAME}" -C "${tmp}" &&
       build_jsonc "${tmp}/json-c-json-c-${JSONC_PACKAGE_VERSION}" &&
       copy_jsonc "${tmp}/json-c-json-c-${JSONC_PACKAGE_VERSION}" &&
       rm -rf "${tmp}"; then
@@ -959,7 +959,7 @@ bundle_libbpf() {
     "${LIBBPF_PACKAGE_BASENAME}" \
     "${tmp}" \
     "${NETDATA_LOCAL_TARBALL_OVERRIDE_LIBBPF}"; then
-    if run tar -xf "${tmp}/${LIBBPF_PACKAGE_BASENAME}" -C "${tmp}" &&
+    if run tar --no-same-owner -xf "${tmp}/${LIBBPF_PACKAGE_BASENAME}" -C "${tmp}" &&
       build_libbpf "${tmp}/libbpf-${LIBBPF_PACKAGE_VERSION}" &&
       copy_libbpf "${tmp}/libbpf-${LIBBPF_PACKAGE_VERSION}" &&
       rm -rf "${tmp}"; then
@@ -1539,10 +1539,10 @@ install_go() {
   # Install new files
   run rm -rf "${NETDATA_STOCK_CONFIG_DIR}/go.d"
   run rm -rf "${NETDATA_STOCK_CONFIG_DIR}/go.d.conf"
-  run tar -xf "${tmp}/config.tar.gz" -C "${NETDATA_STOCK_CONFIG_DIR}/"
+  run tar --no-same-owner -xf "${tmp}/config.tar.gz" -C "${NETDATA_STOCK_CONFIG_DIR}/"
   run chown -R "${ROOT_USER}:${ROOT_GROUP}" "${NETDATA_STOCK_CONFIG_DIR}"
 
-  run tar -xf "${tmp}/${GO_PACKAGE_BASENAME}"
+  run tar --no-same-owner -xf "${tmp}/${GO_PACKAGE_BASENAME}"
   run mv "${GO_PACKAGE_BASENAME%.tar.gz}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
   if [ "$(id -u)" -eq 0 ]; then
     run chown "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
@@ -1671,7 +1671,7 @@ install_ebpf() {
   fi
 
   echo >&2 " Extracting ${EBPF_TARBALL} ..."
-  tar -xf "${tmp}/${EBPF_TARBALL}" -C "${tmp}"
+  tar --no-same-owner -xf "${tmp}/${EBPF_TARBALL}" -C "${tmp}"
 
   # chown everything to root:netdata before we start copying out of our package
   run chown -R root:netdata "${tmp}"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

During installation, I had the following error

    tar: protobuf-3.17.3: Cannot change ownership to uid 576694, gid 89939: Invalid argument

This PR prevents this error and thereby allows for a smoother installation.

##### Component Name

Installer

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Test the kickstart / netdata-installer scripts as you otherwise would. Unfortunately I have no idea how good these are tested by the CI.

##### Additional Information

<details><summary>More log related to the original error</summary>
<p>

```bash
[root@SCGdev ~]# bash kickstart-netdata.sh
 --- Found existing install of Netdata under: / ---
 --- Attempting to update existing install instead of creating a new one ---
[/root]# //usr/libexec/netdata/netdata-updater.sh --not-running-from-cron Thu Jan  6 09:26:11 UTC 2022 : INFO:  Checking if a newer version of the updater script is available.
Thu Jan  6 09:26:11 UTC 2022 : INFO:  Running on a terminal - (this script also supports running headless from crontab)
Thu Jan  6 09:26:11 UTC 2022 : INFO:  Current Version: 00103200100037
Thu Jan  6 09:26:11 UTC 2022 : INFO:  Latest Version: 00103200100037
Thu Jan  6 09:26:11 UTC 2022 : INFO:  Newest version (current=00103200100037 >= latest=00103200100037) is already installed
 OK

 --- Updated existing install at /usr/sbin/netdata ---
[root@SCGdev ~]# bash kickstart-netdata.sh --reinstall
 --- Found existing install of Netdata under: / ---
 --- User requested reinstall instead of update, proceeding. ---
System            : Linux
Operating System  : GNU/Linux
Machine           : x86_64
BASH major version:
 --- Fetching script to detect required packages... ---
[/tmp/netdata-kickstart-xh3qL2rpsH]# curl -q -sSL --connect-timeout 10 --retry 3 --output /tmp/netdata-kickstart-xh3qL2rpsH/install-required-packages.sh https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh  OK

 --- Running downloaded script to detect required packages... ---
[/tmp/netdata-kickstart-xh3qL2rpsH]# /usr/bin/bash /tmp/netdata-kickstart-xh3qL2rpsH/install-required-packages.sh netdata Loading /etc/os-release ...
 > CentOS Version: 7 ...
 > Checking for EPEL ...

/etc/os-release information:
NAME            : CentOS Linux
VERSION         : 7 (Core)
ID              : centos
ID_LIKE         : rhel fedora
VERSION_ID      : 7

We detected these:
Distribution    : centos
Version         : 7
Codename        : 7 (Core)
Package Manager : install_yum
Packages Tree   : centos
Detection Method: /etc/os-release
Default Python v: 2 (will install python3 too)

Searching for distro_sdk ...
Searching for autoconf_archive ...
 > Checking if package 'autoconf-archive' is installed...
Searching for libz_dev ...
 > Checking if package 'zlib-devel' is installed...
Searching for libuuid_dev ...
 > Checking if package 'libuuid-devel' is installed...
Searching for libmnl_dev ...
 > Checking if package 'libmnl-devel' is installed...
Searching for json_c_dev ...
 > Checking if package 'json-c-devel' is installed...
Searching for libuv ...
 > Checking if package 'libuv-devel' is installed...
Searching for lz4 ...
 > Checking if package 'lz4-devel' is installed...
Searching for openssl ...
 > Checking if package 'openssl-devel' is installed...
Searching for judy ...
Searching for libelf ...
 > Checking if package 'elfutils-libelf-devel' is installed...

All required packages are already installed. Now proceed to the next step.

 OK

[/tmp/netdata-kickstart-xh3qL2rpsH]# curl -q -sSL --connect-timeout 10 --retry 3 --output /tmp/netdata-kickstart-xh3qL2rpsH/sha256sum.txt https://storage.googleapis.com/netdata-nightlies/sha256sums.txt  OK

[/tmp/netdata-kickstart-xh3qL2rpsH]# curl -q -sSL --connect-timeout 10 --retry 3 --output /tmp/netdata-kickstart-xh3qL2rpsH/netdata-latest.tar.gz https://storage.googleapis.com/netdata-nightlies/netdata-latest.tar.gz  OK

[/tmp/netdata-kickstart-xh3qL2rpsH]# tar -xf netdata-latest.tar.gz  OK

 --- Installing netdata... ---
[/tmp/netdata-kickstart-xh3qL2rpsH/netdata-v1.32.1-37-gfbf0ee3c5]# ./netdata-installer.sh --auto-update
  ^
  |.-.   .-.   .-.   .-.   .  netdata
  |   '-'   '-'   '-'   '-'   real-time performance monitoring, done right!
  +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->


  You are about to build and install netdata to your system.

  The build process will use /tmp for
  any temporary files. You can override this by setting $TMPDIR to a
  writable directory where you can execute files.

  It will be installed at these locations:

   - the daemon     at /usr/sbin/netdata
   - config files   in /etc/netdata
   - web files      in /usr/share/netdata
   - plugins        in /usr/libexec/netdata
   - cache files    in /var/cache/netdata
   - db files       in /var/lib/netdata
   - log files      in /var/log/netdata
   - pid file       at /var/run/netdata.pid
   - logrotate file at /etc/logrotate.d/netdata

  This installer allows you to change the installation path.
  Press Control-C and run the same command with --help for help.


  NOTE:
  Anonymous usage stats will be collected and sent to Netdata.
  To opt-out, pass --disable-telemetry option to the installer or export
  the environment variable DO_NOT_TRACK to a non-zero or non-empty value
  (e.g: export DO_NOT_TRACK=1).

Press ENTER to build and install netdata to your system >
[/tmp/netdata-kickstart-xh3qL2rpsH/netdata-v1.32.1-37-gfbf0ee3c5]# curl -q -sSL --connect-timeout 10 --retry 3 --output /tmp/netdata-protobuf-iHlpUD/protobuf-cpp-3.17.3.tar.gz https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-cpp-3.17.3.tar.gz
 OK

protobuf-cpp-3.17.3.tar.gz: OK
[/tmp/netdata-kickstart-xh3qL2rpsH/netdata-v1.32.1-37-gfbf0ee3c5]# tar -xf /tmp/netdata-protobuf-iHlpUD/protobuf-cpp-3.17.3.tar.gz -C /tmp/netdata-protobuf-iHlpUD
tar: protobuf-3.17.3/WORKSPACE: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/test-driver: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/config.h.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/gogo/cpp_no_group/cpp_benchmark.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/gogo/cpp_no_group: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/gogo: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message2/benchmark_message2.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message2: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message4/benchmark_message4_1.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message4/benchmark_message4_2.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message4/benchmark_message4_3.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message4/benchmark_message4.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message1/proto3/benchmark_message1_proto3.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message1/proto3: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message1/proto2/benchmark_message1_proto2.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message1/proto2: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message1: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3/benchmark_message3_5.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3/benchmark_message3_1.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3/benchmark_message3_7.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3/benchmark_message3_6.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3/benchmark_message3_4.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3/benchmark_message3.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3/benchmark_message3_2.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3/benchmark_message3_3.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3/benchmark_message3_8.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets/google_message3: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/datasets: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/benchmarks.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/Makefile.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/python/python_benchmark_messages.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/python: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/util/gogo_data_scrubber.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/util/protoc-gen-proto2_to_proto3.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/util/protoc-gen-gogoproto.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/util/proto3_data_stripper.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/util: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/google_size.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/cpp/cpp_benchmark.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/cpp: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks/Makefile.am: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/benchmarks: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/protobuf.bzl: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/build_files_updated_unittest.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/ltmain.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/WORKSPACE: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/codegear/gtest_main.cbproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/codegear/gtest.cbproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/codegear/gtest.groupproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/codegear/gtest_unittest.cbproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/codegear/gtest_all.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/codegear/gtest_link.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/codegear: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Scripts/runtests.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Scripts/versiongenerate.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Scripts: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/gtest.xcodeproj/project.pbxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/gtest.xcodeproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Samples/FrameworkSample/WidgetFramework.xcodeproj/project.pbxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Samples/FrameworkSample/WidgetFramework.xcodeproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Samples/FrameworkSample/widget.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Samples/FrameworkSample/runtests.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Samples/FrameworkSample/widget.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Samples/FrameworkSample/Info.plist: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Samples/FrameworkSample/widget_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Samples/FrameworkSample: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Samples: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Resources/Info.plist: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Resources: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Config/DebugProject.xcconfig: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Config/ReleaseProject.xcconfig: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Config/General.xcconfig: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Config/StaticLibraryTarget.xcconfig: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Config/FrameworkTarget.xcconfig: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Config/TestTarget.xcconfig: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode/Config: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/xcode: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/prime_tables.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample8_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample5_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample2_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample1_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample4.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample1.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample6_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample3_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample4_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample7_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample2.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample9_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples/sample10_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/samples: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest-md.sln: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest_prod_test.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest_unittest-md.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest.sln: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest_main.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest-md.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest_main-md.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest_prod_test-md.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010/gtest_unittest.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc/2010: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/msvc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest-matchers.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest-death-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest-printers.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest-typed-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest-filepath.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest-internal-inl.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest-test-part.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest_main.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest-port.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src/gtest-all.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/src: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux/test-driver: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux/config.h.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux/ltmain.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux/depcomp: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux/compile: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux/config.guess: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux/config.sub: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux/install-sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux/missing: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/build-aux: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/CMakeLists.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/LICENSE: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/configure.ac: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_test_utils.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_xml_test_utils.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-throw-on-failure-test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest-typed-test2_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_xml_outfiles_test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-break-on-failure-unittest.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-color-test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_main_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_no_test_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-filter-unittest.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-uninitialized-test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-filepath-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-printers-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_premature_exit_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-env-var-test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-port-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-shuffle-test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_repeat_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-param-test-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-filter-unittest_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-catch-exceptions-test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-list-tests-unittest_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_all_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-death-test_ex_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_xml_outfile2_test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-test-part-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-uninitialized-test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-param-test-test.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-catch-exceptions-test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-list-tests-unittest.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_prod_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_xml_output_unittest.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-throw-on-failure-test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-color-test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/production.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-listener-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_xml_output_unittest_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest-unittest-api_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-shuffle-test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-env-var-test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_help_test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-death-test-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-break-on-failure-unittest_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-message-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-options-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-output-test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_environment_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_help_test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_sole_header_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-param-test2-test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest-typed-test_test.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/production.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_xml_outfile1_test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_pred_impl_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_stress_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest-typed-test_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-output-test-golden-lin.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/googletest-output-test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test/gtest_throw_on_failure_ex_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/test: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/Makefile.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/aclocal.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/cmake/internal_utils.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/scripts/fuse_gtest_files.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/scripts/gen_gtest_pred_impl.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/scripts/gtest-config.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/scripts/test/Makefile: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/scripts/test: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/scripts/pump.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/scripts: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest-param-test.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest-param-test.h.pump: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest-spi.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-param-util-generated.h.pump: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-string.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-death-test-internal.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-filepath.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-port.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-internal.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-type-util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-param-util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-type-util.h.pump: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-port-arch.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/custom/gtest-port.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/custom/gtest-printers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/custom/gtest.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/custom: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal/gtest-param-util-generated.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/internal: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest_prod.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest-typed-test.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest-message.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest-test-part.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest-printers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest-death-test.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest_pred_impl.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest/gtest-matchers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include/gtest: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/include: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/configure: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/m4/ltoptions.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/m4/acx_pthread.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/m4/ltsugar.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/m4/ltversion.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/m4/gtest.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/m4/libtool.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/m4/lt~obsolete.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/make/Makefile: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/make: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/CONTRIBUTORS: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/fused-src/gtest/gtest_main.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/fused-src/gtest/gtest-all.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/fused-src/gtest/gtest.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/fused-src/gtest: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/fused-src: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest/Makefile.am: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googletest: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/build-aux/install-sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/build-aux/missing: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/build-aux: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/CMakeLists.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/configure.ac: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/Makefile.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/aclocal.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2005/gmock.sln: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2005/gmock_main.vcproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2005/gmock_config.vsprops: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2005/gmock_test.vcproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2005/gmock.vcproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2005: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2010/gmock_test.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2010/gmock.sln: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2010/gmock_config.props: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2010/gmock_main.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2010/gmock.vcxproj: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc/2010: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/msvc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/src/gmock-spec-builders.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/src/gmock-cardinalities.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/src/gmock.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/src/gmock-all.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/src/gmock-internal-utils.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/src/gmock-matchers.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/src/gmock_main.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/src: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux/test-driver: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux/config.h.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux/ltmain.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux/depcomp: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux/compile: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux/config.guess: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux/config.sub: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux/install-sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux/missing: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/build-aux: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/CMakeLists.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/LICENSE: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/configure.ac: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_stress_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_link2_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_output_test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-more-actions_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-actions_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_output_test_golden.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-port_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_test_utils.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-generated-actions_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-nice-strict_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-spec-builders_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_output_test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-generated-function-mockers_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_leak_test.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-cardinalities_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_link_test.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_ex_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_link_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-matchers_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-function-mocker_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_leak_test_.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-generated-matchers_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock-internal-utils_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test/gmock_all_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/test: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/Makefile.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/aclocal.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/gmock_doctor.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/fuse_gmock_files.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/gmock-config.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/gmock_gen.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/LICENSE: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/README: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/README.cppclean: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/cpp/utils.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/cpp/__init__.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/cpp/keywords.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/cpp/tokenize.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/cpp/ast.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/cpp/gmock_class.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator/cpp: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts/generator: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/scripts: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-generated-matchers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-cardinalities.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-matchers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-generated-actions.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/internal/gmock-internal-utils.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/internal/gmock-port.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/internal/custom/gmock-port.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/internal/custom/gmock-matchers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/internal/custom/gmock-generated-actions.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/internal/custom/gmock-generated-actions.h.pump: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/internal/custom: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/internal/gmock-pp.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/internal: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-generated-function-mockers.h.pump: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-actions.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-generated-actions.h.pump: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-nice-strict.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-generated-function-mockers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-more-actions.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-more-matchers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-generated-matchers.h.pump: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-function-mocker.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock/gmock-spec-builders.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include/gmock: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/include: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/configure: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/make/Makefile: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/make: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/CONTRIBUTORS: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/fused-src/gmock/gmock.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/fused-src/gmock: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/fused-src/gmock-gtest-all.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/fused-src/gmock_main.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/fused-src/gtest/gtest.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/fused-src/gtest: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/fused-src: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock/Makefile.am: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/googlemock: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/README.md: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/configure: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/BUILD.bazel: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest/Makefile.am: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/googletest: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/six.BUILD: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/zlib.BUILD: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/wyhash/wyhash.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/wyhash/LICENSE: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party/wyhash: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/third_party: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/protobuf.pc.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/internal.bzl: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/libprotobuf.map: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/wire_format_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/has_bits.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/empty.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/api.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/any_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/metadata_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/test_util_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/arenastring.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_preserve_unknown_enum2.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_entry.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/preserve_unknown_enum_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/field_access_listener.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_table_driven.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/duration.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/descriptor.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_optimize_for.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/any.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/lite_arena_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/timestamp.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/empty.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/no_field_presence_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/golden_message_proto3: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/text_format_unittest_extensions_data_pointy.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/golden_message_maps: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/golden_message: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/map_test_data.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/text_format_unittest_extensions_data.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/bad_utf8_string: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/text_format_unittest_data_pointy_oneof.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/text_format_unittest_data_pointy.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/text_format_unittest_data_oneof_implemented.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/text_format_unittest_data.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/golden_message_oneof_implemented: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata/golden_packed_fields_message: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testdata: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/test_util.inc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/field_access_listener.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_reflection_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/drop_unknown_fields_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/wrappers.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/reflection_ops.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/service.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/wire_format.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/implicit_weak_message.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/test_messages_proto2.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_lite.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/struct.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/arena_test_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/repeated_field_reflection_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_lazy_dependencies_enum.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/duration.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/parse_context.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/dynamic_message.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/reflection_internal.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/dynamic_message_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_proto2_unittest.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_no_field_presence.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/message_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/wire_format_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/reflection.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/reflection_ops.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_preserve_unknown_enum.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/text_format.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/extension_set_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_tctable_decl.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_enormous_descriptor.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/wire_format_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/port_def.inc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testing/googletest.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testing/file.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testing/zcgunzip.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testing/file.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testing/zcgzip.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testing/googletest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/testing: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_no_generic_services.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_mset.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_import_public.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unknown_field_set_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_mset_wire_format.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/service.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_reflection.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_lite_imports_nonlite.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_import.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_proto3_optional.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_tctable_impl.inc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/test_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/extension_set_inl.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_arena.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_lite_test_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/type.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/any_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/timestamp.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/proto3_arena_lite_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/any.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_enum_reflection.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/descriptor.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_lazy_dependencies.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/proto3_lite_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/wrappers.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/wire_format.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_enum_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_import_lite.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/io_win32.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/tokenizer.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/coded_stream_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/gzip_stream_unittest.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/zero_copy_stream_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/zero_copy_stream_impl_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/gzip_stream.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/coded_stream.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/io_win32.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/gzip_stream.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/strtod.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/strtod.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/zero_copy_stream.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/zero_copy_stream_impl_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/printer.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/tokenizer.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/package_info.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/io_win32_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/zero_copy_stream.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/printer_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/tokenizer_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/coded_stream.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/zero_copy_stream_impl.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/printer.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io/zero_copy_stream_impl.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/io: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/type.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/api.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/descriptor_database_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_well_known_types.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/field_mask.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/reflection_ops_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_proto3_lite.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/arena_test_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_proto3.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/js/well_known_types_embed.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/js/well_known_types_embed.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/js/js_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/js/js_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/js: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/parser.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/zip_output_unittest.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_map_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_names.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_generator_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_field_base.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_field_base.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_bootstrap_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_options.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_helpers.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_reflection_class.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_reflection_class.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_message_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_doc_comment.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_message.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_source_generator_base.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_message_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_enum_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_helpers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_map_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_enum_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_enum.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_message.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_enum.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp/csharp_primitive_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/csharp: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/command_line_interface.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/annotation_test_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/plugin.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/php/php_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/php/php_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/php: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/zip_writer.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/plugin.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_extension.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_message_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_message.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_file.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_file.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_enum.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_oneof.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_map_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_enum.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_nsobject_methods.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_helpers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_message_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_helpers_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_extension.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_message.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_enum_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_oneof.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec/objectivec_map_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/objectivec: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/code_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/importer.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/importer.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/subprocess.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/parser.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/mock_code_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/python/python_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/python/python_plugin_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/python/python_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/python: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/subprocess.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_pkg_explicit_legacy_pb.rb: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_code_pb.rb: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_pkg_explicit.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_pkg_explicit_pb.rb: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_pkg_implicit_pb.rb: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_code_proto2_pb.rb: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_code_proto2.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_code.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_pkg_explicit_legacy.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generated_pkg_implicit.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby/ruby_generator_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/ruby: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/importer_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/package_info.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/command_line_interface_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/main.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/plugin.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/zip_writer.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/parser_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/plugin.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/plugin.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_parse_function_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_move_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_unittest.inc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_file.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_options.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_extension.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_service.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_message_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_string_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_enum_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_primitive_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_padding_optimizer.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_unittest.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_file.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_padding_optimizer.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_parse_function_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_message.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_message.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_test_bad_identifiers.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_test_large_enum_value.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_extension.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_plugin_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_enum.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/metadata_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_message_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_bootstrap_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_helpers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_enum.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_enum_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_helpers.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_map_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_service.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_message_layout_helper.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_map_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_names.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp/cpp_string_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/cpp: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/mock_code_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/code_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_builder.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_context.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_string_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_primitive_field_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_context.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_builder_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_helpers.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_file.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_extension_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_doc_comment.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_file.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_helpers.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_enum.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_kotlin_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_service.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_extension.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_name_resolver.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_extension_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_field_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_enum_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_builder_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_kotlin_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_doc_comment_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_options.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_generator_factory.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_names.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_enum_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_enum_field_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_map_field_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_map_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_enum.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_service.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_map_field_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_primitive_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_builder.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_shared_code_generator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_enum_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_primitive_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_primitive_field_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_generator_factory.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_enum_field_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_string_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_string_field_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_name_resolver.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message_field_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_map_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_message.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_doc_comment.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_enum_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_plugin_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_extension.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_shared_code_generator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java/java_string_field_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/java: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/command_line_interface.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/test_plugin.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/scc.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler/annotation_test_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/compiler: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/message_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/arena.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/structurally_valid.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/strutil.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/common.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/common.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/bytestream.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/common_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/logging.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/stl_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/statusor_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/stringpiece.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/stringprintf_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/int128_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/substitute.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/casts.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/stringpiece.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/callback.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/stringprintf.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/statusor.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/map_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/template_util_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/status.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/int128.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/strutil_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/stringprintf.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/once.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/mathutil.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/time.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/stringpiece_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/time_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/substitute.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/port.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/time.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/bytestream.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/hash.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/strutil.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/status_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/statusor.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/template_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/structurally_valid_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/int128.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/status_macros.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/bytestream_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/platform_macros.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/mutex.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/status.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs/macros.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/stubs: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unknown_field_set.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/source_context.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_lite_test_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/extension_set.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_unittest.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/text_format.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_test_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/proto3_lite_unittest.inc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/implicit_weak_message.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_entry_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/test_util_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/test_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/metadata.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/source_context.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/field_comparator.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/time_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/json_format.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/json_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/field_comparator_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/type_resolver_util_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/delimited_message_util_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/json_format_proto3.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/message_differencer.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/default_value_objectwriter.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/json_escaping.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/utility.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/object_writer.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/json_stream_parser.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/mock_error_listener.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/oneofs.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/wrappers.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/proto3.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/default_value.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/timestamp_duration.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/books.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/maps.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/default_value_test.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/struct.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/anys.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata/field_mask.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/testdata: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/field_mask_utility.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/type_info_test_helper.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/error_listener.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/location_tracker.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/protostream_objectsource.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/json_stream_parser_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/utility.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/protostream_objectwriter_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/default_value_objectwriter_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/proto_writer.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/type_info.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/protostream_objectwriter.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/default_value_objectwriter.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/proto_writer.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/datapiece.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/object_writer.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/protostream_objectsource.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/field_mask_utility.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/expecting_objectwriter.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/constants.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/json_objectwriter.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/json_escaping.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/error_listener.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/protostream_objectwriter.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/json_objectwriter.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/json_objectwriter_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/json_stream_parser.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/object_source.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/object_location_tracker.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/datapiece.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/protostream_objectsource_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/type_info_test_helper.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/structured_objectwriter.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal/type_info.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/internal: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/message_differencer_unittest.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/field_comparator.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/delimited_message_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/delimited_message_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/type_resolver_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/json_util_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/time_util_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/message_differencer.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/package_info.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/type_resolver_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/type_resolver.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/json_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/time_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/message_differencer_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/field_mask_util_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/field_mask_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util/field_mask_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/util: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/struct.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/message_unittest.inc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/arena_impl.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_lite_unittest.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/api.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/field_mask.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_table_driven.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/message.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/package_info.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/timestamp.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/lite_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_custom_options.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/text_format_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/any_test.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/port.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/parse_context.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_proto3_arena.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/test_util2.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_empty.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_drop_unknown_fields.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/source_context.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/extension_set_heavy.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/repeated_field.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/struct.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/arenastring_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_tctable_impl.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/duration.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/any.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/test_messages_proto3.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/descriptor_database.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_type_handler.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/extension_set.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/descriptor_database.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/type.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/well_known_types_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/arena.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_field_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_enum_util.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/repeated_field.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/message.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/descriptor.pb.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unknown_field_set.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_test_util.inc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/arenastring.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/proto3_arena_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/repeated_field_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/message_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/dynamic_message.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_lazy_dependencies_custom_option.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_reflection.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_field_inl.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_util.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/descriptor.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/field_mask.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/descriptor_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/port_undef.inc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_table_driven_lite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_test_util_impl.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/wrappers.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_proto3_arena_lite.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/map_field_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/any.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/generated_message_table_driven_lite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/descriptor.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/empty.pb.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/arena_unittest.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/any.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_import_public_lite.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf/unittest_embed_optimize_for.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google/protobuf: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/google: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/libprotoc.map: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/Makefile.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/solaris/libstdc++.la: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/solaris: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/README.md: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/libprotobuf-lite.map: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src/Makefile.am: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/src: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/update_file_lists.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/BUILD: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/generate_descriptor_proto.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/depcomp: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/LICENSE: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/compile: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/objectivec/GPBProtocolBuffers.m: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/objectivec: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/configure.ac: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/CONTRIBUTORS.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/Makefile.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/add_person.go: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/WORKSPACE: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/add_person.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/list_people.go: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/CMakeLists.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/BUILD: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/add_person_test.go: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/list_people.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/AddPerson.java: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/list_people.dart: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/Makefile: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/add_person.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/README.md: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/pubspec.yaml: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/ListPeople.java: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/addressbook.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/add_person.dart: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/list_people_test.go: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples/list_people.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/examples: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/aclocal.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/config.guess: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/compiler_config_setting.bzl: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cc_proto_blacklist_test.bzl: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/util/python/BUILD: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/util/python: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/util: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/config.sub: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/install-sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/README.md: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/protoc.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/protobuf-module.cmake.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/install.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/protobuf-config-version.cmake.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/CMakeLists.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/conformance.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/libprotobuf-lite.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/tests.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/libprotobuf.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/examples.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/libprotoc.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/README.md: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/version.rc.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/protobuf-config.cmake.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/protobuf-lite.pc.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/protobuf-options.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/extract_includes.bat.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake/protobuf.pc.cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/cmake: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/protobuf-lite.pc.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/configure: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/ax_pthread.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/ltoptions.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/ac_system_extensions.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/ax_prog_cc_for_build.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/ltsugar.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/acx_check_suncc.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/ltversion.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/ax_cxx_compile_stdcxx.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/stl_hash.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/ax_prog_cxx_for_build.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/libtool.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4/lt~obsolete.m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/m4: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/ar-lib: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/autogen.sh: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/CHANGES.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/protobuf_deps.bzl: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/missing: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/Makefile.am: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_python-post26.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_php_c.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance_php.php: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance_test.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_ruby.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_python_cpp.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance.proto: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/third_party/jsoncpp/jsoncpp.cpp: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/third_party/jsoncpp/json.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/third_party/jsoncpp: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/third_party: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/binary_json_conformance_suite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance_cpp.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/text_format_conformance_suite.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_python.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_csharp.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance_python.py: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance_test.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/binary_json_conformance_suite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/Makefile.in: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance_objc.m: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/README.md: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance_ruby.rb: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/ConformanceJavaLite.java: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_js.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_cpp.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/text_format_conformance_suite.h: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_java.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/ConformanceJava.java: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_objc.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/failure_list_php.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance_test_runner.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/conformance_test_main.cc: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance/Makefile.am: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/conformance: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/editors/protobuf-mode.el: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/editors/proto.vim: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/editors/README.txt: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3/editors: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: protobuf-3.17.3: Cannot change ownership to uid 576694, gid 89939: Invalid argument
tar: Exiting with failure status due to previous errors
 FAILED

 FAILED  Failed to build protobuf.

...

```

</p>
</details>