### PR TITLE
Fixed links that docusaurus marked as broken

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -230,7 +230,7 @@ Take a look at some more advanced features and configurations:
 -   Enable long-term archiving of Netdata metrics via [exporting engine](/exporting/README.md) to time-series databases.
 -   Improve security by putting Netdata behind an [Nginx proxy with SSL](/docs/Running-behind-nginx.md).
 
-Or, learn more about how you can contribute to [Netdata core](/README.md#contribute) or our
+Or, learn more about how you can contribute to [Netdata core](/contribute) or our
 [documentation](/docs/contributing/contributing-documentation.md)!
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fgetting-started&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -230,7 +230,7 @@ Take a look at some more advanced features and configurations:
 -   Enable long-term archiving of Netdata metrics via [exporting engine](/exporting/README.md) to time-series databases.
 -   Improve security by putting Netdata behind an [Nginx proxy with SSL](/docs/Running-behind-nginx.md).
 
-Or, learn more about how you can contribute to [Netdata core](/contribute) or our
+Or, learn more about how you can contribute to [Netdata core](https://learn.netdata.cloud/contribute/) or our
 [documentation](/docs/contributing/contributing-documentation.md)!
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fdocs%2Fgetting-started&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)

--- a/docs/guides/step-by-step/step-99.md
+++ b/docs/guides/step-by-step/step-99.md
@@ -44,7 +44,7 @@ If that feels like too much possibility to you, why not one of these options:
 -   Share your experience with Netdata and this guide. Be sure to [@mention](https://twitter.com/linuxnetdata) us on 
     Twitter!
 -   Contribute to what we do. Browse our [open issues](https://github.com/netdata/netdata/issues) and check out out
-    [contributions doc](/README.md#contribute) for ideas of how you can pitch in.
+    [contributions doc](/contribute) for ideas of how you can pitch in.
 
 We can't wait to see what you monitor next! Bon voyage! ⛵
 

--- a/docs/guides/step-by-step/step-99.md
+++ b/docs/guides/step-by-step/step-99.md
@@ -44,7 +44,7 @@ If that feels like too much possibility to you, why not one of these options:
 -   Share your experience with Netdata and this guide. Be sure to [@mention](https://twitter.com/linuxnetdata) us on 
     Twitter!
 -   Contribute to what we do. Browse our [open issues](https://github.com/netdata/netdata/issues) and check out out
-    [contributions doc](/contribute) for ideas of how you can pitch in.
+    [contributions doc](https://learn.netdata.cloud/contribute/) for ideas of how you can pitch in.
 
 We can't wait to see what you monitor next! Bon voyage! ⛵
 


### PR DESCRIPTION
A recent docusaurus build showed that two files contained broken links:
```
12:48:59 PM: Exhaustive list of all broken links found:
12:48:59 PM: 
12:48:59 PM: - On source page path = /docs/agent/getting-started:
12:48:59 PM:    -> linking to /docs/agent/#contribute (resolved as: /docs/agent/)
12:48:59 PM: 
12:48:59 PM: - On source page path = /guides/step-by-step/step-99:
12:48:59 PM:    -> linking to /docs/agent/#contribute (resolved as: /docs/agent/)
```
I changed the file path from `README.md/#contribute` to `/contribute` because I wanted to link to https://learn.netdata.cloud/contribute/

However, I'm not sure if that resolves the issue, because I'm not sure if `docs/agent/` is a base URL or is derived from the README.md file. 