### PR TITLE
fix retrieving service commands without failure

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -184,9 +184,9 @@ netdata_banner() {
 # -----------------------------------------------------------------------------
 # portable service command
 
-service_cmd="$(command -v service 2> /dev/null)"
-rcservice_cmd="$(command -v rc-service 2> /dev/null)"
-systemctl_cmd="$(command -v systemctl 2> /dev/null)"
+service_cmd="$(command -v service 2> /dev/null || true)"
+rcservice_cmd="$(command -v rc-service 2> /dev/null || true)"
+systemctl_cmd="$(command -v systemctl 2> /dev/null || true)"
 service() {
 
   local cmd="${1}" action="${2}"


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixing retriving service commands so that they don't return failure if don't exist.
This way we keep the current behavior (if the command doesn't exist, the variable is empty) but at the same time, we don't get any failures.
This allows us to import functions.sh in other scripts, while using the `set -e` option.

##### Component Name
functions.sh (used in netdata installer)

##### Test Plan
Verify (manually) that the those variables are receiving same values when the command exists, and when it doesn't exist.
Verified that builds passed with this new change in place.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
