### PR TITLE
fix: add a note that netfilter's `new` and `ignore` counters are removed in the latest kernel

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -2178,7 +2178,7 @@ netdataDashboard.context = {
     },
 
     'netfilter.conntrack_new': {
-        info: '<p>Packet tracking statistics.</p>'+
+        info: '<p>Packet tracking statistics. <b>New</b> (since v4.9) and <b>Ignore</b> (since v5.10) are hardcoded to zeros in the latest kernel.</p>'+
         '<p><b>New</b> - conntrack entries added which were not expected before. '+
         '<b>Ignore</b> - packets seen which are already connected to a conntrack entry. '+
         '<b>Invalid</b> - packets seen which can not be tracked.</p>'


### PR DESCRIPTION
##### Summary

Fixes #11880. See https://github.com/netdata/netdata/issues/11880#issuecomment-990244086 for details.

##### Component Name

web/

##### Test Plan

Not needed

##### Additional Information
