### PR TITLE
fix(nfacct.plugin): Netfilter accounting data collection

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -62,6 +62,8 @@ CapabilityBoundingSet=CAP_SYS_RESOURCE
 CapabilityBoundingSet=CAP_NET_RAW
 # is required for cgroups plugin
 CapabilityBoundingSet=CAP_SYS_CHROOT
+# is required for nfacct plugin (bandwidth accounting)
+CapabilityBoundingSet=CAP_NET_ADMIN
 
 # Sandboxing
 ProtectSystem=full


### PR DESCRIPTION
##### Summary

Fixes: #11895

`CAP_NET_ADMIN` is required for [nfacct.plugin](https://github.com/netdata/netdata/tree/master/collectors/nfacct.plugin#nfacctplugin) to collect Netfilter accounting metrics (bytes, packets).

##### Component Name

collectors/

##### Test Plan

Tested manually. As soon as I added `CAP_NET_ADMIN` Netfilter accounting started to work.

##### Additional Information
