### PR TITLE
fix(nfacct.plugin): Netfilter accounting charts priority

### DIFF
--- a/collectors/nfacct.plugin/plugin_nfacct.c
+++ b/collectors/nfacct.plugin/plugin_nfacct.c
@@ -690,7 +690,11 @@ static void nfacct_send_metrics() {
         if(likely(d->updated)) {
             if(unlikely(!d->packets_dimension_added)) {
                 d->packets_dimension_added = 1;
-                printf("CHART netfilter.nfacct_packets '' 'Netfilter Accounting Packets' 'packets/s'\n");
+                printf(
+                    "CHART netfilter.nfacct_packets '' 'Netfilter Accounting Packets' 'packets/s' 'nfacct' '' stacked %d %d %s\n",
+                    NETDATA_CHART_PRIO_NETFILTER_PACKETS,
+                    nfacct_root.update_every,
+                    PLUGIN_NFACCT_NAME);
                 printf("DIMENSION %s '' incremental 1 %d\n", d->name, nfacct_root.update_every);
             }
         }
@@ -721,7 +725,11 @@ static void nfacct_send_metrics() {
         if(likely(d->updated)) {
             if(unlikely(!d->bytes_dimension_added)) {
                 d->bytes_dimension_added = 1;
-                printf("CHART netfilter.nfacct_bytes '' 'Netfilter Accounting Bandwidth' 'kilobytes/s'\n");
+                printf(
+                    "CHART netfilter.nfacct_bytes '' 'Netfilter Accounting Bandwidth' 'kilobytes/s' 'nfacct' '' stacked %d %d %s\n",
+                    NETDATA_CHART_PRIO_NETFILTER_BYTES,
+                    nfacct_root.update_every,
+                    PLUGIN_NFACCT_NAME);
                 printf("DIMENSION %s '' incremental 1 %d\n", d->name, 1000 * nfacct_root.update_every);
             }
         }


### PR DESCRIPTION
##### Summary

The charts priority reset to default (1000) because we don't set it when adding dimensions

```cmd
CHART netfilter.nfacct_packets '' 'Netfilter Accounting Packets' 'packets/s' 'nfacct' '' stacked 8906 1 nfacct.plugin
CHART netfilter.nfacct_packets '' 'Netfilter Accounting Packets' 'packets/s'
DIMENSION myport '' incremental 1 1
BEGIN netfilter.nfacct_packets
SET myport = 1494
END
CHART netfilter.nfacct_bytes '' 'Netfilter Accounting Bandwidth' 'kilobytes/s' 'nfacct' '' stacked 8907 1 nfacct.plugin
CHART netfilter.nfacct_bytes '' 'Netfilter Accounting Bandwidth' 'kilobytes/s'
DIMENSION myport '' incremental 1 1000
BEGIN netfilter.nfacct_bytes
SET myport = 125776
END
```

<img width="1630" alt="Screenshot 2022-01-11 at 17 19 23" src="https://user-images.githubusercontent.com/22274335/148960107-397c8643-572b-4ed1-a547-a12c143ee1f2.png">




##### Component Name

collectors/

##### Test Plan

Checks the Netfilter accounting charts priority, ensure it is correct.

##### Additional Information
