### PR TITLE
python.d/nvidia_smi: add bar1 chart

### DIFF
--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -28,7 +28,7 @@ GPU_UTIL = 'gpu_utilization'
 MEM_UTIL = 'mem_utilization'
 ENCODER_UTIL = 'encoder_utilization'
 MEM_USAGE = 'mem_usage'
-BAR_USAGE = 'bar1_usage'
+BAR_USAGE = 'bar1_mem_usage'
 TEMPERATURE = 'temperature'
 CLOCKS = 'clocks'
 POWER = 'power'
@@ -98,7 +98,7 @@ def gpu_charts(gpu):
             ]
         },
         BAR_USAGE: {
-            'options': [None, 'Bar1 Memory Usage', 'MiB', fam, 'nvidia_smi.bar1_allocated', 'stacked'],
+            'options': [None, 'Bar1 Memory Usage', 'MiB', fam, 'nvidia_smi.bar1_memory_usage', 'stacked'],
             'lines': [
                 ['bar1_memory_free', 'free'],
                 ['bar1_memory_used', 'used'],

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -28,6 +28,7 @@ GPU_UTIL = 'gpu_utilization'
 MEM_UTIL = 'mem_utilization'
 ENCODER_UTIL = 'encoder_utilization'
 MEM_USAGE = 'mem_usage'
+BAR_USAGE = 'bar1_usage'
 TEMPERATURE = 'temperature'
 CLOCKS = 'clocks'
 POWER = 'power'
@@ -42,6 +43,7 @@ ORDER = [
     MEM_UTIL,
     ENCODER_UTIL,
     MEM_USAGE,
+    BAR_USAGE,
     TEMPERATURE,
     CLOCKS,
     POWER,
@@ -93,6 +95,13 @@ def gpu_charts(gpu):
             'lines': [
                 ['fb_memory_free', 'free'],
                 ['fb_memory_used', 'used'],
+            ]
+        },
+        BAR_USAGE: {
+            'options': [None, 'Bar1 Memory Usage', 'MiB', fam, 'nvidia_smi.bar1_allocated', 'stacked'],
+            'lines': [
+                ['bar1_memory_free', 'free'],
+                ['bar1_memory_used', 'used'],
             ]
         },
         TEMPERATURE: {
@@ -345,6 +354,14 @@ class GPU:
         return self.root.find('fb_memory_usage').find('free').text.split()[0]
 
     @handle_attr_error
+    def bar1_memory_used(self):
+        return self.root.find('bar1_memory_usage').find('used').text.split()[0]
+
+    @handle_attr_error
+    def bar1_memory_free(self):
+        return self.root.find('bar1_memory_usage').find('free').text.split()[0]
+
+    @handle_attr_error
     def temperature(self):
         return self.root.find('temperature').find('gpu_temp').text.split()[0]
 
@@ -399,6 +416,8 @@ class GPU:
             'decoder_util': self.decoder_util(),
             'fb_memory_used': self.fb_memory_used(),
             'fb_memory_free': self.fb_memory_free(),
+            'bar1_memory_used': self.bar1_memory_used(),
+            'bar1_memory_free': self.bar1_memory_free(),
             'gpu_temp': self.temperature(),
             'graphics_clock': self.graphics_clock(),
             'video_clock': self.video_clock(),


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds BAR1 memory usage chart. Bar1 memory already exists in nvidia_smi, it's just not displayed with Netdata.

##### Component Name

collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py

##### Test Plan

Successfull build and running in production in our organization for more than 3 weeks (Ubuntu 18.04, Netdata 1.32.1).

##### Additional Information

![image](https://user-images.githubusercontent.com/89103752/149012520-c945c417-cf48-497b-8803-9f67e0aa22fb.png)
![image](https://user-images.githubusercontent.com/89103752/149013042-a05e7ff5-115a-4a86-b046-5017eecf8f93.png)
