### PR TITLE
Add a missing capability for the perf plugin

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -54,6 +54,7 @@ CapabilityBoundingSet=CAP_FOWNER
 CapabilityBoundingSet=CAP_SETPCAP
 # is required for perf plugin
 CapabilityBoundingSet=CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_PERFMON
 # is required for apps plugin
 CapabilityBoundingSet=CAP_SYS_PTRACE
 # is required for ebpf plugin

--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -53,8 +53,7 @@ CapabilityBoundingSet=CAP_FOWNER
 # is required for apps, perf and slabinfo plugins
 CapabilityBoundingSet=CAP_SETPCAP
 # is required for perf plugin
-CapabilityBoundingSet=CAP_SYS_ADMIN
-CapabilityBoundingSet=CAP_PERFMON
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_PERFMON
 # is required for apps plugin
 CapabilityBoundingSet=CAP_SYS_PTRACE
 # is required for ebpf plugin


### PR DESCRIPTION
##### Summary
If you try to run the perf plugin there is an error
```
2022-01-12 13:50:14: netdata INFO  : PLUGINSD[perf] : connected to '/usr/libexec/netdata/plugins.d/perf.plugin' running on pid 200441
sh: line 1: /usr/libexec/netdata/plugins.d/perf.plugin: Operation not permitted
```
Since Linux 5.8 you need to set [`CAP_PERFMON` capability](https://manned.org/perf_event_open.2#head8) to access PMUs.

Related: #11957

##### Component Name
netdata systemd service settings

##### Test Plan
Enable perf plugin
```
[plugins]
perf = yes

[plugin:perf]
        update every = 1
        command options = all
```
check if it's running after Netdata is restarted.