### PR TITLE
Updated SNMP v3 documentation

### DIFF
--- a/collectors/node.d.plugin/snmp/README.md
+++ b/collectors/node.d.plugin/snmp/README.md
@@ -183,8 +183,9 @@ The `options` given for each server, are:
 
 To use SNMPv3:
 
--   set `version` to 3
 -   use `user` instead of `community`
+-   set `version` to 3
+
 
 User syntax:
 
@@ -192,6 +193,7 @@ User syntax:
 {
     "user": {
         "name": "userName",
+        "version": 3,
         "level": 3,
         "authProtocol": "3",
         "authKey": "authKey",
@@ -201,19 +203,19 @@ User syntax:
 }
 ```
 
-Security levels:
+Security levels (`level`):
 
 -   1 is `noAuthNoPriv`
 -   2 is `authNoPriv`
 -   3 is `authPriv`
 
-Authentication protocols:
+Authentication protocols (`authProtocol`):
 
 -   "1" is `none`
 -   "2" is `md5`
 -   "3" is `sha`
 
-Privacy protocols:
+Privacy protocols (`privProtocol`):
 
 -   "1" is `none`
 -   "2" is `des`

--- a/collectors/node.d.plugin/snmp/README.md
+++ b/collectors/node.d.plugin/snmp/README.md
@@ -186,20 +186,31 @@ To use SNMPv3:
 -   use `user` instead of `community`
 -   set `version` to 3
 
-
 User syntax:
 
 ```json
 {
-    "user": {
+  "enable_autodetect": false,
+  "update_every": 10,
+  "servers": [
+    {
+      "hostname": "10.11.12.8",
+      "user": {
         "name": "userName",
-        "version": 3,
         "level": 3,
         "authProtocol": "3",
         "authKey": "authKey",
         "privProtocol": "2",
         "privKey": "privKey"
+      },
+      "update_every": 10,
+      "options": {
+        "version": 3
+      },
+      "charts": {
+      }
     }
+  ]
 }
 ```
 


### PR DESCRIPTION
As Ilya and Manos have identified, the documentation about SNMP v3 asks users to set the version=3 option, but the example didn't reflect this.

I updated the exampled and made minor improvements for clarity.