### PR TITLE
Update libmongoc CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,9 +317,10 @@ pkg_check_modules(SNAPPY snappy)
 # -----------------------------------------------------------------------------
 # Detect libmongoc
 
-find_package(mongoc-1.0)
+find_package(libmongoc-1.0)
 # later we use:
-# mongo::mongoc_shared
+# ${MONGOC_LIBRARIES}
+# ${MONGOC_INCLUDE_DIRS}
 
 
 # -----------------------------------------------------------------------------
@@ -1102,12 +1103,12 @@ ENDIF()
 # -----------------------------------------------------------------------------
 # mongodb backend
 
-IF(mongoc-1.0_FOUND)
+IF(libmongoc-1.0_FOUND)
     message(STATUS "mongodb backend: enabled")
 
     list(APPEND NETDATA_FILES ${MONGODB_BACKEND_FILES} ${MONGODB_EXPORTING_FILES})
-    list(APPEND NETDATA_COMMON_LIBRARIES mongo::mongoc_shared)
-    list(APPEND NETDATA_COMMON_INCLUDE_DIRS mongo::mongoc_shared)
+    list(APPEND NETDATA_COMMON_LIBRARIES ${MONGOC_LIBRARIES})
+    list(APPEND NETDATA_COMMON_INCLUDE_DIRS ${MONGOC_INCLUDE_DIRS})
 ELSE()
     message(STATUS "mongodb backend: disabled (requires mongoc library)")
 ENDIF()
@@ -1428,7 +1429,7 @@ if(ENABLE_EXPORTING_PUBSUB)
         -Wl,--wrap=pubsub_get_result
     )
 endif()
-if(mongoc-1.0_FOUND)
+if(MONGOC_LIBRARIES)
     list(APPEND EXPORTING_ENGINE_FILES ${MONGODB_EXPORTING_FILES})
     list(
         APPEND MONGODB_LINK_OPTIONS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,9 +317,10 @@ pkg_check_modules(SNAPPY snappy)
 # -----------------------------------------------------------------------------
 # Detect libmongoc
 
-find_package(libmongoc-1.0)
+pkg_check_modules(MONGOC libmongoc-1.0)
 # later we use:
 # ${MONGOC_LIBRARIES}
+# ${MONGOC_CFLAGS_OTHER}
 # ${MONGOC_INCLUDE_DIRS}
 
 
@@ -1103,12 +1104,13 @@ ENDIF()
 # -----------------------------------------------------------------------------
 # mongodb backend
 
-IF(libmongoc-1.0_FOUND)
+IF(MONGOC_LIBRARIES)
     message(STATUS "mongodb backend: enabled")
 
     list(APPEND NETDATA_FILES ${MONGODB_BACKEND_FILES} ${MONGODB_EXPORTING_FILES})
     list(APPEND NETDATA_COMMON_LIBRARIES ${MONGOC_LIBRARIES})
     list(APPEND NETDATA_COMMON_INCLUDE_DIRS ${MONGOC_INCLUDE_DIRS})
+    list(APPEND NETDATA_COMMON_CFLAGS ${MONGOC_CFLAGS_OTHER})
 ELSE()
     message(STATUS "mongodb backend: disabled (requires mongoc library)")
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,10 +317,9 @@ pkg_check_modules(SNAPPY snappy)
 # -----------------------------------------------------------------------------
 # Detect libmongoc
 
-find_package(libmongoc-1.0)
+find_package(mongoc-1.0)
 # later we use:
-# ${MONGOC_LIBRARIES}
-# ${MONGOC_INCLUDE_DIRS}
+# mongo::mongoc_shared
 
 
 # -----------------------------------------------------------------------------
@@ -1103,12 +1102,12 @@ ENDIF()
 # -----------------------------------------------------------------------------
 # mongodb backend
 
-IF(libmongoc-1.0_FOUND)
+IF(mongoc-1.0_FOUND)
     message(STATUS "mongodb backend: enabled")
 
     list(APPEND NETDATA_FILES ${MONGODB_BACKEND_FILES} ${MONGODB_EXPORTING_FILES})
-    list(APPEND NETDATA_COMMON_LIBRARIES ${MONGOC_LIBRARIES})
-    list(APPEND NETDATA_COMMON_INCLUDE_DIRS ${MONGOC_INCLUDE_DIRS})
+    list(APPEND NETDATA_COMMON_LIBRARIES mongo::mongoc_shared)
+    list(APPEND NETDATA_COMMON_INCLUDE_DIRS mongo::mongoc_shared)
 ELSE()
     message(STATUS "mongodb backend: disabled (requires mongoc library)")
 ENDIF()
@@ -1429,7 +1428,7 @@ if(ENABLE_EXPORTING_PUBSUB)
         -Wl,--wrap=pubsub_get_result
     )
 endif()
-if(MONGOC_LIBRARIES)
+if(mongoc-1.0_FOUND)
     list(APPEND EXPORTING_ENGINE_FILES ${MONGODB_EXPORTING_FILES})
     list(
         APPEND MONGODB_LINK_OPTIONS


### PR DESCRIPTION
##### Summary
There is a deprecation warning for `libmongoc` configuration in CMake build
```
CMake Warning at /usr/lib64/cmake/libmongoc-1.0/libmongoc-1.0-config.cmake:15 (message):
  This CMake target is deprecated.  Use 'mongo::mongoc_shared' instead.
  Consult the example projects for further details.
Call Stack (most recent call first):
  CMakeLists.txt:320 (find_package)

CMake Warning at /usr/lib64/cmake/libbson-1.0/libbson-1.0-config.cmake:15 (message):
  This CMake target is deprecated.  Use 'mongo::bson_shared' instead.
  Consult the example projects for further details.
Call Stack (most recent call first):
  /usr/lib64/cmake/libmongoc-1.0/libmongoc-1.0-config.cmake:22 (find_package)
  CMakeLists.txt:320 (find_package)
```
~We switch to a new [recommended configuration](http://mongoc.org/libmongoc/current/tutorial.html#cmake) for `libmongoc`~.
The recommended configuration doesn't work on all distributions. The `libmongoc-dev` package is broken in Debian 10 and Ubuntu 20.04. Thus, we will use a `.pc` file to get compilation options for the CMake build.

##### Component Name
CMake build

##### Test Plan
1. Install `mongo-c-driver`.
2. Build Netdata with CMake.
3. Check if there are no deprecations warnings and Netdata is built correctly.