### PR TITLE
Remove bitfields from rrdhost.

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -801,22 +801,22 @@ struct rrdhost {
     // ------------------------------------------------------------------------
     // streaming of data to remote hosts - rrdpush
 
-    unsigned int rrdpush_send_enabled:1;            // 1 when this host sends metrics to another netdata
+    unsigned int rrdpush_send_enabled;            // 1 when this host sends metrics to another netdata
     char *rrdpush_send_destination;                 // where to send metrics to
     char *rrdpush_send_api_key;                     // the api key at the receiving netdata
 
     // the following are state information for the threading
     // streaming metrics from this netdata to an upstream netdata
     struct sender_state *sender;
-    volatile unsigned int rrdpush_sender_spawn:1;   // 1 when the sender thread has been spawn
+    volatile unsigned int rrdpush_sender_spawn;   // 1 when the sender thread has been spawn
     netdata_thread_t rrdpush_sender_thread;         // the sender thread
     void *dbsync_worker;
 
-    volatile unsigned int rrdpush_sender_connected:1; // 1 when the sender is ready to push metrics
+    volatile unsigned int rrdpush_sender_connected; // 1 when the sender is ready to push metrics
     int rrdpush_sender_socket;                      // the fd of the socket to the remote host, or -1
 
-    volatile unsigned int rrdpush_sender_error_shown:1; // 1 when we have logged a communication error
-    volatile unsigned int rrdpush_sender_join:1;    // 1 when we have to join the sending thread
+    volatile unsigned int rrdpush_sender_error_shown; // 1 when we have logged a communication error
+    volatile unsigned int rrdpush_sender_join;    // 1 when we have to join the sending thread
 
     SIMPLE_PATTERN *rrdpush_send_charts_matching;   // pattern to match the charts to be sent
 
@@ -839,7 +839,7 @@ struct rrdhost {
     // ------------------------------------------------------------------------
     // health monitoring options
 
-    unsigned int health_enabled:1;                  // 1 when this host has health enabled
+    unsigned int health_enabled;                  // 1 when this host has health enabled
     time_t health_delay_up_to;                      // a timestamp to delay alarms processing up to
     char *health_default_exec;                      // the full path of the alarms notifications program
     char *health_default_recipient;                 // the default recipient for all alarms


### PR DESCRIPTION
##### Summary

The order of the struct's fields makes the bitfields irrelevant in this case.

##### Component Name

database

##### Test Plan

- Local & CI builds
- sizeof before/after remains the same at 1256 bytes.