### PR TITLE
Perform a host metadata update on child reconnection

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -363,6 +363,31 @@ static int rrdpush_receive(struct receiver_state *rpt)
         }
         netdata_mutex_unlock(&rpt->host->receiver_lock);
     }
+    else {
+        rrd_wrlock();
+        rrdhost_update(
+            rpt->host,
+            rpt->hostname,
+            rpt->registry_hostname,
+            rpt->machine_guid,
+            rpt->os,
+            rpt->timezone,
+            rpt->abbrev_timezone,
+            rpt->utc_offset,
+            rpt->tags,
+            rpt->program_name,
+            rpt->program_version,
+            rpt->update_every,
+            history,
+            mode,
+            (unsigned int)(health_enabled != CONFIG_BOOLEAN_NO),
+            (unsigned int)(rrdpush_enabled && rrdpush_destination && *rrdpush_destination && rrdpush_api_key && *rrdpush_api_key),
+            rrdpush_destination,
+            rrdpush_api_key,
+            rrdpush_send_charts_matching,
+            rpt->system_info);
+        rrd_unlock();
+    }
 
 #ifdef NETDATA_INTERNAL_CHECKS
     int ssl = 0;


### PR DESCRIPTION
##### Summary
On a parent child setup, when `health enabled by default = auto` and a child disconnects, the host health_enabled is set to 0. 
When the child reconnects, if the host structure is still in memory, the health_enabled is not properly initialized

##### Component Name
streaming, health

##### Test Plan
- Set up parent child with `health enabled by default = auto` 
   - Check the `/api/v1/alarms` for the child. It should indicate `"status" : true`
   - Restart the child 
   - Check the `/api/v1/alarms` for the child. It should say `"status" : false` 

Apply the PR and repeat the test. The `/api/v1/alarms` for the child should now say `"status" : true` 
