### PR TITLE
Do not use dbengine headers when dbengine is disabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,8 @@ set(LIBNETDATA_FILES
         libnetdata/buffer/buffer.h
         libnetdata/clocks/clocks.c
         libnetdata/clocks/clocks.h
+        libnetdata/completion/completion.c
+        libnetdata/completion/completion.h
         libnetdata/dictionary/dictionary.c
         libnetdata/dictionary/dictionary.h
         libnetdata/eval/eval.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -144,6 +144,8 @@ LIBNETDATA_FILES = \
     libnetdata/circular_buffer/circular_buffer.h \
     libnetdata/clocks/clocks.c \
     libnetdata/clocks/clocks.h \
+    libnetdata/completion/completion.c \
+    libnetdata/completion/completion.h \
     libnetdata/dictionary/dictionary.c \
     libnetdata/dictionary/dictionary.h \
     libnetdata/eval/eval.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1711,6 +1711,7 @@ AC_CONFIG_FILES([
     libnetdata/avl/Makefile
     libnetdata/buffer/Makefile
     libnetdata/clocks/Makefile
+    libnetdata/completion/Makefile
     libnetdata/config/Makefile
     libnetdata/dictionary/Makefile
     libnetdata/ebpf/Makefile

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1986,10 +1986,10 @@ void generate_dbengine_dataset(unsigned history_seconds)
         thread_info[i]->time_present = time_present;
         thread_info[i]->time_max = 0;
         thread_info[i]->done = 0;
-        init_completion(&thread_info[i]->charts_initialized);
+        completion_init(&thread_info[i]->charts_initialized);
         assert(0 == uv_thread_create(&thread_info[i]->thread, generate_dbengine_chart, thread_info[i]));
-        wait_for_completion(&thread_info[i]->charts_initialized);
-        destroy_completion(&thread_info[i]->charts_initialized);
+        completion_wait_for(&thread_info[i]->charts_initialized);
+        completion_destroy(&thread_info[i]->charts_initialized);
     }
     for (i = 0 ; i < DSET_CHARTS ; ++i) {
         assert(0 == uv_thread_join(&thread_info[i]->thread));
@@ -2177,13 +2177,13 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
         chart_threads[i]->time_max = 0;
         chart_threads[i]->done = 0;
         chart_threads[i]->errors = chart_threads[i]->stored_metrics_nr = 0;
-        init_completion(&chart_threads[i]->charts_initialized);
+        completion_init(&chart_threads[i]->charts_initialized);
         assert(0 == uv_thread_create(&chart_threads[i]->thread, generate_dbengine_chart, chart_threads[i]));
     }
     /* barrier so that subsequent queries can access valid chart data */
     for (i = 0 ; i < DSET_CHARTS ; ++i) {
-        wait_for_completion(&chart_threads[i]->charts_initialized);
-        destroy_completion(&chart_threads[i]->charts_initialized);
+        completion_wait_for(&chart_threads[i]->charts_initialized);
+        completion_destroy(&chart_threads[i]->charts_initialized);
     }
     sleep(RAMP_UP_SECONDS);
     /* at this point data have already began being written to the database */

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1917,7 +1917,7 @@ static void generate_dbengine_chart(void *arg)
 
         thread_info->rd[j] = rd[j] = rrddim_add(st, name, NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
-    complete(&thread_info->charts_initialized);
+    completion_mark_complete(&thread_info->charts_initialized);
 
     // feed it with the test data
     time_current = time_present - history_seconds;

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -289,14 +289,14 @@ static void pg_cache_reserve_pages(struct rrdengine_instance *ctx, unsigned numb
             ++failures;
             uv_rwlock_wrunlock(&pg_cache->pg_cache_rwlock);
 
-            init_completion(&compl);
+            completion_init(&compl);
             cmd.opcode = RRDENG_FLUSH_PAGES;
             cmd.completion = &compl;
             rrdeng_enq_cmd(&ctx->worker_config, &cmd);
             /* wait for some pages to be flushed */
             debug(D_RRDENGINE, "%s: waiting for pages to be written to disk before evicting.", __func__);
-            wait_for_completion(&compl);
-            destroy_completion(&compl);
+            completion_wait_for(&compl);
+            completion_destroy(&compl);
 
             if (unlikely(failures > 1)) {
                 unsigned long slots, usecs_to_sleep;

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -207,7 +207,7 @@ void read_cached_extent_cb(struct rrdengine_worker_config* wc, unsigned idx, str
         }
     }
     if (xt_io_descr->completion)
-        complete(xt_io_descr->completion);
+        completion_mark_complete(xt_io_descr->completion);
     freez(xt_io_descr);
 }
 
@@ -360,7 +360,7 @@ after_crc_check:
         freez(uncompressed_buf);
     }
     if (xt_io_descr->completion)
-        complete(xt_io_descr->completion);
+        completion_mark_complete(xt_io_descr->completion);
     uv_fs_req_cleanup(req);
     free(xt_io_descr->buf);
     freez(xt_io_descr);
@@ -634,7 +634,7 @@ void flush_pages_cb(uv_fs_t* req)
         rrdeng_page_descr_mutex_unlock(ctx, descr);
     }
     if (xt_io_descr->completion)
-        complete(xt_io_descr->completion);
+        completion_mark_complete(xt_io_descr->completion);
     uv_fs_req_cleanup(req);
     free(xt_io_descr->buf);
     freez(xt_io_descr);
@@ -712,7 +712,7 @@ static int do_flush_pages(struct rrdengine_worker_config* wc, int force, struct 
     if (!count) {
         debug(D_RRDENGINE, "%s: no pages eligible for flushing.", __func__);
         if (completion)
-            complete(completion);
+            completion_mark_complete(completion);
         return 0;
     }
     wc->inflight_dirty_pages += count;
@@ -975,7 +975,7 @@ static void rrdeng_cleanup_finished_threads(struct rrdengine_worker_config* wc)
     }
     if (unlikely(SET_QUIESCE == ctx->quiesce && !rrdeng_threads_alive(wc))) {
         ctx->quiesce = QUIESCED;
-        complete(&ctx->rrdengine_completion);
+        completion_mark_complete(&ctx->rrdengine_completion);
     }
 }
 
@@ -1171,7 +1171,7 @@ void rrdeng_worker(void* arg)
 
     wc->error = 0;
     /* wake up initialization thread */
-    complete(&ctx->rrdengine_completion);
+    completion_mark_complete(&ctx->rrdengine_completion);
 
     fatal_assert(0 == uv_timer_start(&timer_req, timer_cb, TIMER_PERIOD_MS, TIMER_PERIOD_MS));
     shutdown = 0;
@@ -1211,7 +1211,7 @@ void rrdeng_worker(void* arg)
                 wal_flush_transaction_buffer(wc);
                 if (!rrdeng_threads_alive(wc)) {
                     ctx->quiesce = QUIESCED;
-                    complete(&ctx->rrdengine_completion);
+                    completion_mark_complete(&ctx->rrdengine_completion);
                 }
                 break;
             case RRDENG_READ_PAGE:
@@ -1226,7 +1226,7 @@ void rrdeng_worker(void* arg)
             case RRDENG_FLUSH_PAGES: {
                 if (wc->now_invalidating_dirty_pages) {
                     /* Do not flush if the disk cannot keep up */
-                    complete(cmd.completion);
+                    completion_mark_complete(cmd.completion);
                 } else {
                     (void)do_flush_pages(wc, 1, cmd.completion);
                 }
@@ -1276,7 +1276,7 @@ error_after_loop_init:
 
     wc->error = UV_EAGAIN;
     /* wake up initialization thread */
-    complete(&ctx->rrdengine_completion);
+    completion_mark_complete(&ctx->rrdengine_completion);
 }
 
 /* C entry point for development purposes

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -944,11 +944,11 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
         goto error_after_init_rrd_files;
     }
 
-    init_completion(&ctx->rrdengine_completion);
+    completion_init(&ctx->rrdengine_completion);
     fatal_assert(0 == uv_thread_create(&ctx->worker_config.thread, rrdeng_worker, &ctx->worker_config));
     /* wait for worker thread to initialize */
-    wait_for_completion(&ctx->rrdengine_completion);
-    destroy_completion(&ctx->rrdengine_completion);
+    completion_wait_for(&ctx->rrdengine_completion);
+    completion_destroy(&ctx->rrdengine_completion);
     uv_thread_set_name_np(ctx->worker_config.thread, "DBENGINE");
     if (ctx->worker_config.error) {
         goto error_after_rrdeng_worker;
@@ -1009,13 +1009,13 @@ void rrdeng_prepare_exit(struct rrdengine_instance *ctx)
         return;
     }
 
-    init_completion(&ctx->rrdengine_completion);
+    completion_init(&ctx->rrdengine_completion);
     cmd.opcode = RRDENG_QUIESCE;
     rrdeng_enq_cmd(&ctx->worker_config, &cmd);
 
     /* wait for dbengine to quiesce */
-    wait_for_completion(&ctx->rrdengine_completion);
-    destroy_completion(&ctx->rrdengine_completion);
+    completion_wait_for(&ctx->rrdengine_completion);
+    completion_destroy(&ctx->rrdengine_completion);
 
     //metalog_prepare_exit(ctx->metalog_ctx);
 }

--- a/database/engine/rrdenginelib.h
+++ b/database/engine/rrdenginelib.h
@@ -14,9 +14,6 @@ struct rrdengine_instance;
 
 #define BITS_PER_ULONG (sizeof(unsigned long) * 8)
 
-/* Taken from linux kernel */
-#define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
-
 #define ALIGN_BYTES_FLOOR(x) (((x) / RRDENG_BLOCK_SIZE) * RRDENG_BLOCK_SIZE)
 #define ALIGN_BYTES_CEILING(x) ((((x) + RRDENG_BLOCK_SIZE - 1) / RRDENG_BLOCK_SIZE) * RRDENG_BLOCK_SIZE)
 
@@ -75,43 +72,6 @@ static inline unsigned long ulong_compare_and_swap(volatile unsigned long *ptr,
 /* Workaround for OS X */
 #define O_DIRECT (0)
 #endif
-
-struct completion {
-    uv_mutex_t mutex;
-    uv_cond_t cond;
-    volatile unsigned completed;
-};
-
-static inline void init_completion(struct completion *p)
-{
-    p->completed = 0;
-    fatal_assert(0 == uv_cond_init(&p->cond));
-    fatal_assert(0 == uv_mutex_init(&p->mutex));
-}
-
-static inline void destroy_completion(struct completion *p)
-{
-    uv_cond_destroy(&p->cond);
-    uv_mutex_destroy(&p->mutex);
-}
-
-static inline void wait_for_completion(struct completion *p)
-{
-    uv_mutex_lock(&p->mutex);
-    while (0 == p->completed) {
-        uv_cond_wait(&p->cond, &p->mutex);
-    }
-    fatal_assert(1 == p->completed);
-    uv_mutex_unlock(&p->mutex);
-}
-
-static inline void complete(struct completion *p)
-{
-    uv_mutex_lock(&p->mutex);
-    p->completed = 1;
-    uv_mutex_unlock(&p->mutex);
-    uv_cond_broadcast(&p->cond);
-}
 
 static inline int crc32cmp(void *crcp, uLong crc)
 {

--- a/libnetdata/Makefile.am
+++ b/libnetdata/Makefile.am
@@ -8,6 +8,7 @@ SUBDIRS = \
     avl \
     buffer \
     clocks \
+    completion \
     config \
     dictionary \
     ebpf \

--- a/libnetdata/completion/Makefile.am
+++ b/libnetdata/completion/Makefile.am
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+AUTOMAKE_OPTIONS = subdir-objects
+MAINTAINERCLEANFILES = $(srcdir)/Makefile.in

--- a/libnetdata/completion/completion.c
+++ b/libnetdata/completion/completion.c
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "completion.h"
+
+void completion_init(struct completion *p)
+{
+    p->completed = 0;
+    fatal_assert(0 == uv_cond_init(&p->cond));
+    fatal_assert(0 == uv_mutex_init(&p->mutex));
+}
+
+void completion_destroy(struct completion *p)
+{
+    uv_cond_destroy(&p->cond);
+    uv_mutex_destroy(&p->mutex);
+}
+
+void completion_wait_for(struct completion *p)
+{
+    uv_mutex_lock(&p->mutex);
+    while (0 == p->completed) {
+        uv_cond_wait(&p->cond, &p->mutex);
+    }
+    fatal_assert(1 == p->completed);
+    uv_mutex_unlock(&p->mutex);
+}
+
+void completion_mark_complete(struct completion *p)
+{
+    uv_mutex_lock(&p->mutex);
+    p->completed = 1;
+    uv_mutex_unlock(&p->mutex);
+    uv_cond_broadcast(&p->cond);
+}

--- a/libnetdata/completion/completion.h
+++ b/libnetdata/completion/completion.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_COMPLETION_H
+#define NETDATA_COMPLETION_H
+
+#include "../libnetdata.h"
+
+struct completion {
+    uv_mutex_t mutex;
+    uv_cond_t cond;
+    volatile unsigned completed;
+};
+
+void completion_init(struct completion *p);
+
+void completion_destroy(struct completion *p);
+
+void completion_wait_for(struct completion *p);
+
+void completion_mark_complete(struct completion *p);
+
+#endif /* NETDATA_COMPLETION_H */

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -303,8 +303,13 @@ extern char *find_and_replace(const char *src, const char *find, const char *rep
 #define KILOBITS_IN_A_MEGABIT 1000
 
 /* misc. */
+
 #define UNUSED(x) (void)(x)
 #define error_report(x, args...) do { errno = 0; error(x, ##args); } while(0)
+
+// Taken from linux kernel
+#define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
+
 
 extern void netdata_cleanup_and_exit(int ret) NORETURN;
 extern void send_statistics(const char *action, const char *action_result, const char *action_data);
@@ -318,6 +323,7 @@ extern char *netdata_configured_host_prefix;
 #include "avl/avl.h"
 #include "inlined.h"
 #include "clocks/clocks.h"
+#include "completion/completion.h"
 #include "popen/popen.h"
 #include "simple_pattern/simple_pattern.h"
 #ifdef ENABLE_HTTPS

--- a/spawn/spawn.c
+++ b/spawn/spawn.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "spawn.h"
-#include "database/engine/rrdenginelib.h"
 
 static uv_thread_t thread;
 int spawn_thread_error;
@@ -240,15 +239,15 @@ void spawn_init(void)
 
     init_spawn_cmd_queue();
 
-    init_completion(&completion);
+    completion_init(&completion);
     error = uv_thread_create(&thread, spawn_client, &completion);
     if (error) {
         error("uv_thread_create(): %s", uv_strerror(error));
         goto after_error;
     }
     /* wait for spawn client thread to initialize */
-    wait_for_completion(&completion);
-    destroy_completion(&completion);
+    completion_wait_for(&completion);
+    completion_destroy(&completion);
     uv_thread_set_name_np(thread, "DAEMON_SPAWN");
 
     if (spawn_thread_error) {

--- a/spawn/spawn_client.c
+++ b/spawn/spawn_client.c
@@ -201,7 +201,7 @@ void spawn_client(void *arg)
     spawn_thread_error = 0;
     spawn_thread_shutdown = 0;
     /* wake up initialization thread */
-    complete(completion);
+    completion_mark_complete(completion);
 
     prot_buffer_len = 0;
     ret = uv_read_start((uv_stream_t *)&spawn_channel, on_read_alloc, on_pipe_read);
@@ -237,5 +237,5 @@ error_after_loop_init:
     freez(loop);
 
     /* wake up initialization thread */
-    complete(completion);
+    completion_mark_complete(completion);
 }


### PR DESCRIPTION
##### Summary

Prior to this commit both daemon/commands.c and spawn/spawn.c used to
include database/engine/rrdenginelib.h, ie. a header file that is available
only when enabling the dbengine feature.

##### Test Plan

Local builds & CI jobs
