### PR TITLE
Fixes Wrong Chart Description

### DIFF
--- a/aclk/aclk_query_queue.c
+++ b/aclk/aclk_query_queue.c
@@ -50,21 +50,21 @@ static inline int _aclk_queue_query(aclk_query_t query)
 static inline volatile uint32_t *aclk_stats_qmetric_for_qtype(aclk_query_type_t qtype) {
     switch (qtype) {
         case HTTP_API_V2:
-            return &aclk_metrics_per_sample.cloud_req_type_http;
+            return &aclk_metrics_per_sample.query_type_http;
         case ALARM_STATE_UPDATE:
-            return &aclk_metrics_per_sample.cloud_req_type_alarm_upd;
+            return &aclk_metrics_per_sample.query_type_alarm_upd;
         case METADATA_INFO:
-            return &aclk_metrics_per_sample.cloud_req_type_metadata_info;
+            return &aclk_metrics_per_sample.query_type_metadata_info;
         case METADATA_ALARMS:
-            return &aclk_metrics_per_sample.cloud_req_type_metadata_alarms;
+            return &aclk_metrics_per_sample.query_type_metadata_alarms;
         case CHART_NEW:
-            return &aclk_metrics_per_sample.cloud_req_type_chart_new;
+            return &aclk_metrics_per_sample.query_type_chart_new;
         case CHART_DEL:
-            return &aclk_metrics_per_sample.cloud_req_type_chart_del;
+            return &aclk_metrics_per_sample.query_type_chart_del;
         case REGISTER_NODE:
-            return &aclk_metrics_per_sample.cloud_req_type_register_node;
+            return &aclk_metrics_per_sample.query_type_register_node;
         case NODE_STATE_UPDATE:
-            return &aclk_metrics_per_sample.cloud_req_type_node_upd;
+            return &aclk_metrics_per_sample.query_type_node_upd;
         default:
             return NULL;
     }

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -124,7 +124,7 @@ static void aclk_stats_cloud_req_type(struct aclk_metrics_per_sample *per_sample
 
     if (unlikely(!st)) {
         st = rrdset_create_localhost(
-            "netdata", "aclk_cloud_req_type", NULL, "aclk", NULL, "Requests received from cloud by their type", "req/s",
+            "netdata", "aclk_processed_query_type", NULL, "aclk", NULL, "Query thread commands processed by their type", "cmd/s",
             "netdata", "stats", 200006, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
         rd_type_http = rrddim_add(st, "http", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
@@ -138,14 +138,14 @@ static void aclk_stats_cloud_req_type(struct aclk_metrics_per_sample *per_sample
     } else
         rrdset_next(st);
 
-    rrddim_set_by_pointer(st, rd_type_http, per_sample->cloud_req_type_http);
-    rrddim_set_by_pointer(st, rd_type_alarm_upd, per_sample->cloud_req_type_alarm_upd);
-    rrddim_set_by_pointer(st, rd_type_metadata_info, per_sample->cloud_req_type_metadata_info);
-    rrddim_set_by_pointer(st, rd_type_metadata_alarms, per_sample->cloud_req_type_metadata_alarms);
-    rrddim_set_by_pointer(st, rd_type_chart_new, per_sample->cloud_req_type_chart_new);
-    rrddim_set_by_pointer(st, rd_type_chart_del, per_sample->cloud_req_type_chart_del);
-    rrddim_set_by_pointer(st, rd_type_register_node, per_sample->cloud_req_type_register_node);
-    rrddim_set_by_pointer(st, rd_type_node_upd, per_sample->cloud_req_type_node_upd);
+    rrddim_set_by_pointer(st, rd_type_http, per_sample->query_type_http);
+    rrddim_set_by_pointer(st, rd_type_alarm_upd, per_sample->query_type_alarm_upd);
+    rrddim_set_by_pointer(st, rd_type_metadata_info, per_sample->query_type_metadata_info);
+    rrddim_set_by_pointer(st, rd_type_metadata_alarms, per_sample->query_type_metadata_alarms);
+    rrddim_set_by_pointer(st, rd_type_chart_new, per_sample->query_type_chart_new);
+    rrddim_set_by_pointer(st, rd_type_chart_del, per_sample->query_type_chart_del);
+    rrddim_set_by_pointer(st, rd_type_register_node, per_sample->query_type_register_node);
+    rrddim_set_by_pointer(st, rd_type_node_upd, per_sample->query_type_node_upd);
 
     rrdset_done(st);
 }

--- a/aclk/aclk_stats.h
+++ b/aclk/aclk_stats.h
@@ -48,15 +48,15 @@ extern struct aclk_metrics_per_sample {
     volatile uint32_t cloud_req_recvd;
     volatile uint32_t cloud_req_err;
 
-    // request types.
-    volatile uint32_t cloud_req_type_http;
-    volatile uint32_t cloud_req_type_alarm_upd;
-    volatile uint32_t cloud_req_type_metadata_info;
-    volatile uint32_t cloud_req_type_metadata_alarms;
-    volatile uint32_t cloud_req_type_chart_new;
-    volatile uint32_t cloud_req_type_chart_del;
-    volatile uint32_t cloud_req_type_register_node;
-    volatile uint32_t cloud_req_type_node_upd;
+    // query types.
+    volatile uint32_t query_type_http;
+    volatile uint32_t query_type_alarm_upd;
+    volatile uint32_t query_type_metadata_info;
+    volatile uint32_t query_type_metadata_alarms;
+    volatile uint32_t query_type_chart_new;
+    volatile uint32_t query_type_chart_del;
+    volatile uint32_t query_type_register_node;
+    volatile uint32_t query_type_node_upd;
 
     // HTTP-specific request types.
     volatile uint32_t cloud_req_http_by_type[ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT];


### PR DESCRIPTION
##### Summary
Query thread processes also queries that are originated from agent (pushed). Therefore describing this chart as requests from cloud is wrong.

This fixes user facing chart description and also renames variables to not confuse people in future.

##### Component Name

##### Test Plan

##### Additional Information
