### PR TITLE
Fixes coverity 374746

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -332,6 +332,7 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
                 "AC [%s (N/A)]: ACLK synchronization thread for %s is not yet linked to HOST.",
                 wc->node_id,
                 wc->host_guid);
+            freez(claim_id);
             return;
         }
     }


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR fixes the coverity error #374746:

```
*** CID 374746:  Resource leaks  (RESOURCE_LEAK)
/database/sqlite/sqlite_aclk_alert.c: 335 in aclk_push_alarm_health_log()
329     
330             if (unlikely(!host)) {
331                 log_access(
332                     "AC [%s (N/A)]: ACLK synchronization thread for %s is not yet linked to HOST.",
333                     wc->node_id,
334                     wc->host_guid);
>>>     CID 374746:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "claim_id" going out of scope leaks the storage it points to.
335                 return;
336             }
337         }
338     
339         uint64_t first_sequence = 0;
340         uint64_t last_sequence = 0;
```

##### Component Name

Sqlite/Health

##### Test Plan

N/A
