### PR TITLE
Better handle creation of UUID for claiming.

### DIFF
--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -151,7 +151,14 @@ NETDATA_USER=$(get_config_value netdata global "run as user")
 gen_id() {
     local id
 
-    id="$(uuidgen)"
+    if command -v uuidgen > /dev/null 2>&1; then
+        id="$(uuidgen)"
+    elif [ -r /proc/sys/kernel/random/uuid ]; then
+        id="$(cat /proc/sys/kernel/random/uuid)"
+    else
+        echo >&2 "Unable to generate machine ID."
+        exit 18
+    fi
 
     if [ "${id}" = "8a795b0c-2311-11e6-8563-000c295076a6" ] || [ "${id}" = "4aed1458-1c3e-11e6-a53f-000c290fc8f5" ]; then
         gen_id


### PR DESCRIPTION
##### Summary

This updates the claiming script to better handle the case of it needing to generate a UUID for the machine being claimed. The old logic blindly called out to `uuidgen` for this. The new logic works as follows:

* Check for the availability of `uuidgen` and use it if it can be found. This will work on all current macOS and FreeBSD systems as this is part of the base system, and will work on many (but not all) Linux systems.
* If it cannot be found, check for the availability of the `/proc/sys/kernel/random/uuid` interface provided by all modern Linux kernels. This will work on essentially all Linux systems.
* In the unlikely event that neither option is available, we produce an actually useful error message instead of a generic ‘command-not-found’ message.

##### Component Name

area/claiming

##### Test Plan

Verified by running locally in a Debian Docker container (which by default lacks `uuidgen`).