### PR TITLE
fix(python.d): ignore decoding errors in ExecutableService

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/ExecutableService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/ExecutableService.py
@@ -35,7 +35,7 @@ class ExecutableService(SimpleService):
         for line in std:
             try:
                 data.append(line.decode('utf-8'))
-            except TypeError:
+            except (TypeError, UnicodeDecodeError):
                 continue
 
         return data


### PR DESCRIPTION
##### Summary

Fixes: #11977

##### Component Name

collectors/python.d.plugin

##### Test Plan

Tested by @tazard in https://github.com/netdata/netdata/issues/11977#issuecomment-1013614832

##### Additional Information
