### PR TITLE
Included link to charts.d example

### DIFF
--- a/collectors/charts.d.plugin/example/README.md
+++ b/collectors/charts.d.plugin/example/README.md
@@ -5,6 +5,6 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/chart
 
 # Example
 
-This is just an example charts.d data collector.
+If you want to understand how charts.d data collector functions, check out the [charts.d example](https://raw.githubusercontent.com/netdata/netdata/master/collectors/charts.d.plugin/example/example.chart.sh). 
 
 [![analytics](https://www.google-analytics.com/collect?v=1&aip=1&t=pageview&_s=1&ds=github&dr=https%3A%2F%2Fgithub.com%2Fnetdata%2Fnetdata&dl=https%3A%2F%2Fmy-netdata.io%2Fgithub%2Fcollectors%2Fcharts.d.plugin%2Fexample%2FREADME&_u=MAC~&cid=5792dfd7-8dc4-476b-af31-da2fdb9f93d2&tid=UA-64295674-3)](<>)


### PR DESCRIPTION
Old page:
![image](https://user-images.githubusercontent.com/13576110/149836822-b1b7338e-73bd-4f0d-beb2-a7fb52d4e901.png)

If you viewed this page on the website, you couldn't see that the Github repo hosted the example. 
I added a link so that the website makes sense. 