### PR TITLE
Fix queue removed alerts

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1244,7 +1244,7 @@ int main(int argc, char **argv) {
     // initialize internal registry
     registry_init();
     // fork the spawn server
-    //spawn_init();
+    spawn_init();
     /*
      * Libuv uv_spawn() uses SIGCHLD internally:
      * https://github.com/libuv/libuv/blob/cc51217a317e96510fbb284721d5e6bc2af31e33/src/unix/process.c#L485

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1244,7 +1244,7 @@ int main(int argc, char **argv) {
     // initialize internal registry
     registry_init();
     // fork the spawn server
-    spawn_init();
+    //spawn_init();
     /*
      * Libuv uv_spawn() uses SIGCHLD internally:
      * https://github.com/libuv/libuv/blob/cc51217a317e96510fbb284721d5e6bc2af31e33/src/unix/process.c#L485

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -607,6 +607,8 @@ void sql_process_queue_removed_alerts_to_aclk(struct aclk_database_worker_config
 
     db_execute(buffer_tostring(sql));
 
+    log_access("AC [%s (%s)]: Queued removed alerts.", wc->node_id, wc->host ? wc->host->hostname : "N/A");
+
     buffer_free(sql);
 #endif
     return;

--- a/health/health.c
+++ b/health/health.c
@@ -388,9 +388,9 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
     ae->exec_run_timestamp = now_realtime_sec(); /* will be updated by real time after spawning */
 
     debug(D_HEALTH, "executing command '%s'", command_to_run);
-    /* ae->flags |= HEALTH_ENTRY_FLAG_EXEC_IN_PROGRESS; */
-    /* ae->exec_spawn_serial = spawn_enq_cmd(command_to_run); */
-    /* enqueue_alarm_notify_in_progress(ae); */
+    ae->flags |= HEALTH_ENTRY_FLAG_EXEC_IN_PROGRESS;
+    ae->exec_spawn_serial = spawn_enq_cmd(command_to_run);
+    enqueue_alarm_notify_in_progress(ae);
 
     freez(edit_command);
     buffer_free(warn_alarms);
@@ -682,7 +682,6 @@ void *health_main(void *ptr) {
     while(!netdata_exit) {
         loop++;
         debug(D_HEALTH, "Health monitoring iteration no %u started", loop);
-        log_access("Loop %u - %d - %u", loop, aclk_alert_reloaded, marked_aclk_reload_loop);
 
         int runnable = 0, apply_hibernation_delay = 0;
         time_t next_run = now + min_run_every;

--- a/health/health.c
+++ b/health/health.c
@@ -1077,7 +1077,7 @@ void *health_main(void *ptr) {
         }
 
 #if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
-            if (netdata_cloud_setting && unlikely(aclk_alert_reloaded) && loop > marked_aclk_reload_loop + 2) {
+        if (netdata_cloud_setting && unlikely(aclk_alert_reloaded) && loop > (marked_aclk_reload_loop + 2)) {
                 rrdhost_foreach_read(host) {
                     if (unlikely(!host->health_enabled))
                         continue;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR tries to fix queuing of removed alerts for the cloud, via the new architecture.

In general, what this tries to accomplish, is that if after a start, or a health reload, there are left over REMOVED alerts (which do not have an updated_by other alert), to send them to the cloud. By default REMOVED are not sent via the streaming protocol.

A REMOVED event can happen in those cases if the configuration of an alert changes.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

1) Claim an agent via new architecture to the cloud.
2) Try to raise an alert.
3) Somehow make this alert obsolete, by either changing it's configuration, or removing the chart it runs on.
4) Issue an agent restart, or a health reload. If that alert has gone to REMOVED status without having a newer status than that, it should be sent to the cloud.

##### Additional Information

The patch was tested also via the test suit of the set team. The tested scenario there is:

1) Have a parent claimed to the cloud with 5 or 10 children (tested both).
2) Raise a test alert to warning in every child and the parent. Alert appears on the cloud.
3) Change the configuration of the alerts, now raising them to critical. This also changes the alert names, ie. now they are new alerts.
4) Send a health reload to the parent. Previous warning alerts on the cloud are removed and the critical ones appear.
5) Change again the configuration as in 3, now making them clear.
6) Send another health reload to the parent. Previous critical alerts are gone.