### PR TITLE
Add alternative install command for macOS.

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -41,6 +41,12 @@ updates_, run the following as your normal user:
 wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh
 ```
 
+Or, if you have cURL but not wget (such as on macOS):
+
+```bash
+curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh
+```
+
 This script will preferentially use native DEB/RPM packages if we provide them for your platform.
 
 To see more information about this installation script, including how to disable automatic updates, get nightly vs.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -11,7 +11,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/instal
 This page covers detailed instructions on using and configuring the automatic one-line installation script named
 `kickstart.sh`.
 
-The kickstart script works on all Linux distributions and macOS environments. By default, automatic nightly updates are enabled. If you are installing on macOS, make sure to check the [install documentation for macOS](packaging/installer/methods/macos) before continuing. 
+The kickstart script works on all Linux distributions and macOS environments. By default, automatic nightly updates are enabled. If you are installing on macOS, make sure to check the [install documentation for macOS](packaging/installer/methods/macos) before continuing.
 
 > If you are unsure whether you want nightly or stable releases, read the [installation guide](/packaging/installer/README.md#nightly-vs-stable-releases). 
 > If you want to turn off [automatic updates](/packaging/installer/README.md#automatic-updates), use the `--no-updates` option. You can find more installation options below.
@@ -20,6 +20,12 @@ To install Netdata, run the following as your normal user:
 
 ```bash
 wget -O ./kickstart.sh https://my-netdata.io/kickstart.sh && sh ./kickstart.sh
+```
+
+Or, if you have cURL but not wget (such as on macOS):
+
+```bash
+curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh
 ```
 
 


### PR DESCRIPTION

##### Summary

macOS includes cURL by default, but not wget.

##### Test Plan

n/a