### PR TITLE
Fix install prefix handling for claiming code in new kickstart script.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -719,7 +719,7 @@ is_netdata_running() {
 
 claim() {
   progress "Attempting to claim agent to ${NETDATA_CLAIM_URL}"
-  if [ -z "${INSTALL_PREFIX}" ] || [ "${INSTALL_PREFIX}" = "/"]; then
+  if [ -z "${INSTALL_PREFIX}" ] || [ "${INSTALL_PREFIX}" = "/" ]; then
     NETDATA_CLAIM_PATH=/usr/sbin/netdata-claim.sh
   elif [ "${INSTALL_PREFIX}" = "/opt/netdata" ]; then
     NETDATA_CLAIM_PATH="/opt/netdata/bin/netdata-claim.sh"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -719,7 +719,7 @@ is_netdata_running() {
 
 claim() {
   progress "Attempting to claim agent to ${NETDATA_CLAIM_URL}"
-  if [ -z "${INSTALL_PREFIX}" ]; then
+  if [ -z "${INSTALL_PREFIX}" ] || [ "${INSTALL_PREFIX}" = "/"]; then
     NETDATA_CLAIM_PATH=/usr/sbin/netdata-claim.sh
   elif [ "${INSTALL_PREFIX}" = "/opt/netdata" ]; then
     NETDATA_CLAIM_PATH="/opt/netdata/bin/netdata-claim.sh"

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -140,7 +140,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "ae8ba2e88a3239280b5e4a53ed792a71" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "35776dd2432a11522680724dd020d98e" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

The condition checking for an unprefixed install was insufficient, resulting in trying to use an incorrect path for claiming under some cases.

##### Test Plan

Fix can be verified by running the updated copy of the script from this PR on a system which has an existing install of Netdata to attempt to claim the node. Without this fix, it will throw an error due to attempting to use an incorrect path for the claiming script. With this fix, it will properly claim the node.

##### Additional Info

Fixes: #11998 