### PR TITLE
fix(python.d.plugin): prefer python3 if available

### DIFF
--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 '''':;
-pybinary=$(which python || which python3 || which python2)
+pybinary=$(which python3 || which python || which python2)
 filtered=()
 for arg in "$@"
 do


### PR DESCRIPTION
##### Summary

This PR allows avoiding explicitly configuring using python3. This is needed because some of our python.d collectors work only with python3.

Fixes https://github.com/netdata/netdata/issues/11874#issuecomment-988876877

##### Test Plan

Not needed

##### Additional Information
