### PR TITLE
Fix handling of static archive selection for installs.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -994,10 +994,10 @@ try_package_install() {
 set_static_archive_urls() {
   if [ "${RELEASE_CHANNEL}" = "stable" ]; then
     latest="$(get_redirect "https://github.com/netdata/netdata/releases/latest")"
-    export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/${latest}/netdata-${SYSARCH}-${latest}.gz.run"
+    export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/${latest}/netdata-${SYSARCH}-latest.gz.run"
     export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/${latest}/sha256sums.txt"
   else
-    export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-latest.gz.run"
+    export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-${SYSARCH}-latest.gz.run"
     export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/sha256sums.txt"
   fi
 }

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -140,7 +140,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "35776dd2432a11522680724dd020d98e" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "0c43e3f3807bcdbb39f2b4fe842559aa" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

This fixes two bugs in selection of static archives for installation when doing a static install:

* For stable releases, we were trying to use a file name which did not actually exist.
* For nightly builds, we were unconditionally using the x86_64 build irrespective of the local system architecture.

##### Test Plan

Verified by testing locally using the `--static-only` option.

##### Additional Information

Fixes: #12002 