### PR TITLE
Add support for NVME disks with blkext driver

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -335,7 +335,7 @@ else
     # These translate to the prefixs of files in `/dev` indicating the device type.
     # They are sorted by lowest used device major number, with dynamically assigned ones at the end.
     # We use this to look up device major numbers in `/proc/devices`
-    device_names='hd sd mfm ad ftl pd nftl dasd intfl mmcblk ub xvd rfd vbd nvme blkext'
+    device_names='hd sd mfm ad ftl pd nftl dasd intfl mmcblk ub xvd rfd vbd nvme virtblk blkext'
 
     for name in ${device_names}; do
       if grep -qE " ${name}\$" /proc/devices; then

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -335,7 +335,7 @@ else
     # These translate to the prefixs of files in `/dev` indicating the device type.
     # They are sorted by lowest used device major number, with dynamically assigned ones at the end.
     # We use this to look up device major numbers in `/proc/devices`
-    device_names='hd sd mfm ad ftl pd nftl dasd intfl mmcblk ub xvd rfd vbd nvme'
+    device_names='hd sd mfm ad ftl pd nftl dasd intfl mmcblk ub xvd rfd vbd nvme blkext'
 
     for name in ${device_names}; do
       if grep -qE " ${name}\$" /proc/devices; then


### PR DESCRIPTION
##### Summary

One of my machines was reporting a total amount of 0 bytes of disk space for its system info. Running `system-info.sh` revealed:

```
NETDATA_SYSTEM_TOTAL_DISK_SIZE=0
```

This change adds `blkext` to the list of device names so that the devices with the associated major (259), e.g. NVME partitions, are included in the total amount of disk space.

##### Test Plan

```
ralphm@mag-vii:~$ lsblk -d -e 7
NAME    MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
sda       8:0    1   9.1T  0 disk 
sdb       8:16   1   9.1T  0 disk 
nvme0n1 259:0    0 931.5G  0 disk 
nvme1n1 259:5    0 931.5G  0 disk
```
```
ralphm@mag-vii:~$ ls -al /dev/ | grep 259
brw-rw----   1 root disk    259,   0 Jan 18 12:04 nvme0n1
brw-rw----   1 root disk    259,   1 Jan 18 12:04 nvme0n1p1
brw-rw----   1 root disk    259,   2 Jan 18 12:04 nvme0n1p2
brw-rw----   1 root disk    259,   3 Jan 18 12:04 nvme0n1p3
brw-rw----   1 root disk    259,   4 Jan 18 12:04 nvme0n1p4
brw-rw----   1 root disk    259,   5 Jan 18 12:04 nvme1n1
brw-rw----   1 root disk    259,   6 Jan 18 12:04 nvme1n1p1
brw-rw----   1 root disk    259,   7 Jan 18 12:04 nvme1n1p2
brw-rw----   1 root disk    259,   8 Jan 18 12:04 nvme1n1p3
brw-rw----   1 root disk    259,   9 Jan 18 12:04 nvme1n1p4
```
With this change:

```
NETDATA_SYSTEM_TOTAL_DISK_SIZE=2000409772032
```


##### Additional Information

Note that `sda` and `sdb` are still not included, but this is because the kernel [believes](https://bbs.archlinux.org/viewtopic.php?id=208514) these disks are removable because they are hot pluggable. This is probably a BIOS configuration, which I will pursue separately.