### PR TITLE
Remove internal dbengine header from spawn/spawn_client.c

### DIFF
--- a/spawn/spawn_client.c
+++ b/spawn/spawn_client.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "spawn.h"
-#include "database/engine/rrdenginelib.h"
 
 static uv_process_t process;
 static uv_pipe_t spawn_channel;


### PR DESCRIPTION
##### Summary

Missed in #11967 due to the build system not being able to identify usage of undeclared headers (when building without dbengine).

##### Test Plan

Local build without dbengine & CI jobs.
