### PR TITLE
Remove uncessary call

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1624,8 +1624,6 @@ static void ebpf_parse_args(int argc, char **argv)
 
         if (disable_cgroups)
             ebpf_disable_cgroups();
-
-        ebpf_enable_all_charts(disable_apps, disable_cgroups);
     }
 
     if (select_threads) {


### PR DESCRIPTION
##### Summary
eBPF plugin is ignoring when user disable some threads inside `ebpf.d.conf`, because there is an unnecessary call for a function. This PR is removing this call to fix the issue.

##### Test Plan

1. Rename or remove your `/etc/netdata/ebpf.d.conf'
2. Create the file again using `/etc/netdata/edit-config` script given as argument for script `ebpf.d.conf`.
3. Compile master branch and start netdata. Wait few seconds and run:

```sh
curl -k -o master_branch.txt https://localhost:19999/api/v1/data?chart=netdata.ebpf_threads
```

You will see that all threads will be enabled.

4. Stop netdata and compile this branch
5. Start netdata again and take a look in the final result, now it will work as expected. For more data related to tests, please, take a look a `Additional information`

##### Additional Information

It is not necessary to test on different kernels.

The following tests were executed while this PR was developed:

| Test  | Expected Result | Report | Result |
|--------|------------------------|-----------|----------|
| Current master Branch with default configuration | 6 threads disabled  | [master_branch.txt](https://github.com/netdata/netdata/files/7901728/master_branch.txt) | Failed |
| This PR with default configuration | 6 threads disabled  | [default_ebpf_conf.txt](https://github.com/netdata/netdata/files/7901730/default_ebpf_conf.txt) | Success|
| This PR with everything enabled | 16 threads running | [everything_enabled.txt](https://github.com/netdata/netdata/files/7901732/everything_enabled.txt) | Success |

I also ran another test running eBPF plugin direct on terminal:

```sh
root@hades:/usr/libexec/netdata/plugins.d# ./ebpf.plugin --process --net 2> err >out
^C^Croot@hades:/usr/libexec/netdata/plugins.d# grep eBPF err 
2022-01-20 00:46:08: ebpf.plugin INFO  : EBPF PROCESS : eBPF program /usr/libexec/netdata/plugins.d/ebpf.d/rnetdata_ebpf_process.5.10.o loaded with success!
2022-01-20 00:46:08: ebpf.plugin INFO  : EBPF SOCKET : eBPF program /usr/libexec/netdata/plugins.d/ebpf.d/rnetdata_ebpf_socket.5.4.o loaded with success!
root@hades:/usr/libexec/netdata/plugins.d# 
```

After few seconds, I stopped the PR and I had the expected result.