### PR TITLE
[Stream Compression] - Compressor buffer overflow causes stream corruption.

### DIFF
--- a/streaming/README.md
+++ b/streaming/README.md
@@ -362,13 +362,19 @@ To check if your Netdata Agent has stream compression enabled, run the following
 ```
 Note: The `stream-compression` status can be `"enabled" | "disabled" | "N/A"`.
 
-Stream data compression is enabled by default on systems where LZ4 library v1.9.0+ is installed. A compressed data packet is determined and decompressed on the fly.
+A compressed data packet is determined and decompressed on the fly.
 
 #### Limitations
-The current implementation of streaming data compression has the limitation that the size of single data block transmitted must not exceed 16384 bytes. If single data block size exceeds this limit, stream data compression should be disabled.
+ This limitation will be withdrawn asap and is work-in-progress.
+
+The current implementation of streaming data compression can support only a few number of dimensions in a chart with names that cannot exceed the size of 16384 bytes. In case you experience stream connection problems or gaps in the charts please disable stream compresssion in the `stream.conf` file. This limitation can be seen in the error.log file with the sequence of the following messages: 
+```
+Compression error - data discarded
+Message size above limit:
+```
 
 #### How to enable stream compression
-Netdata Agents are shipped with data compression enabled by default. You can also configure which streams will use compression.
+Netdata Agents are shipped with data compression disabled by default. You can also configure which streams will use compression.
 
 With enabled stream compression, a Netdata Agent can negotiate streaming compression with other Netdata Agents. During the negotiation of streaming compression both Netdata Agents should support and enable compression in order to communicate over a compressed stream. The negotiation will result into an uncompressed stream, if one of the Netdata Agents doesn't support **or** has compression disabled.
 

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -41,7 +41,7 @@ struct config stream_config = {
 
 unsigned int default_rrdpush_enabled = 0;
 #ifdef ENABLE_COMPRESSION
-unsigned int default_compression_enabled = 1;
+unsigned int default_compression_enabled = 0;
 #endif
 char *default_rrdpush_destination = NULL;
 char *default_rrdpush_api_key = NULL;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
This PR comes to deactivate the stream compression by default.

Note: This is a mitigation action to reduce the noise coming from the production environment until the [issue #12020](https://github.com/netdata/netdata/issues/12020#issue-1109717498) with the stream compressor buffer overflow is resolved.
##### Test Plan
Set up a simple Parent <-> Child Netdata agent stream and verify that the stream compression is actually disabled by default and the child charts are visible in the parent's dashboard.

How to verify,
1. Check for `"stream-compression": "disabled"` in  `/api/v1/info` JSON response.
2. In the `error.log` of the child agent look for msg `established communication with a parent using protocol version 4 - ready to send metrics...`
3. Enable db flag `D_STREAM` (`netdata -W debug_flags=0x0000000040000000`) and you shouldn't be able to see any compression messages in the logs.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
The change in the README.md file reflects a temporary situation and should be updated once the stream compression buffer overflow is resolved.
