### PR TITLE
Fix handling of removed packages with leftover config files in package check.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -751,7 +751,7 @@ claim() {
 pkg_installed() {
   case "${DISTRO_COMPAT_NAME}" in
     debian|ubuntu)
-      dpkg -l "${1}" > /dev/null 2>&1
+      dpkg-query --show --showformat '${Status}' "${1}" 2>&1 | cut -f 1 -d ' ' | grep -q '^install$'
       return $?
       ;;
     centos|fedora|opensuse)

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -140,7 +140,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "dc50e88ee6e19f50dd395e1e5117a1fa" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "0d1efd304a5a18019a69569d94f6f334" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

`dpkg` uses a special partially installed state for packages which have been removed but still have config files left behind. It will still return an exit code of zero for packages in this state even though the software in question is not actually on the system, which interferes with how we were checking for the presence of an existing binary-package based install.

##### Test Plan

Checked locally by testing installing in a Debian 11 container which had previously had our official package installed and then removed using `apt remove netdata`. Without the changes in this PR, the kickstart script will refuse to attempt an install, thinking there is an existing install even though there is not, while with these changes it will properly install Netdata again.

##### Additional Information

Fixes: #12025 