### PR TITLE
Have cURL properly fail on non-2xx status codes in the installer.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -356,7 +356,7 @@ download() {
   url="${1}"
   dest="${2}"
   if command -v curl > /dev/null 2>&1; then
-    run curl -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}" || return 1
+    run curl --fail -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}" || return 1
   elif command -v wget > /dev/null 2>&1; then
     run wget -T 15 -O "${dest}" "${url}" || return 1
   else

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -140,7 +140,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "b02afd3bcb4b666487024946703c48d1" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "dc50e88ee6e19f50dd395e1e5117a1fa" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

This fixes a particular issue when trying to install on a system where all of the following conditions are met:

* There is no native package available for the system.
* The system CPU architecture is one for which a static build is not available.
* cURL is available on the system in question.

Under those combined circumstances, we fail to properly fall back to a local build because cURL by default returns a 0 exit code if it was able to _make_ the request, even if the status code of the request was not a successful one.

##### Test Plan

Can be verified by using the updated kickstart script to attempt to install on a system where all the above conditions are met.

##### Additional Information

Fixes: #12032 