### PR TITLE
Re-instate plugins_action for clabels

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -368,6 +368,8 @@ size_t streaming_parser(struct receiver_state *rpt, struct plugind *cd, FILE *fp
     parser->plugins_action->overwrite_action = &pluginsd_overwrite_action;
     parser->plugins_action->chart_action     = &pluginsd_chart_action;
     parser->plugins_action->set_action       = &pluginsd_set_action;
+    parser->plugins_action->clabel_commit_action  = &pluginsd_clabel_commit_action;
+    parser->plugins_action->clabel_action    = &pluginsd_clabel_action;
 
     user->parser = parser;
 


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

The PR for stream compression (https://github.com/netdata/netdata/pull/11821) removed 2 lines relating to clabels streaming which were introduced in PR (https://github.com/netdata/netdata/pull/11675)

Specificaly it removed: https://github.com/netdata/netdata/blame/8a01dabf89add0ef473d37bc8f2310cabfc1db43/streaming/receiver.c#L242-L243

This PR re-adds them. Thanks to @odynik for spotting!

All the rest from PR (https://github.com/netdata/netdata/pull/11675) is still there.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Typically re-testing as in https://github.com/netdata/netdata/pull/11675 should be done, but in this case we can assume it's safe to re-add those 2 lines.

##### More Information

The same fix is done in https://github.com/netdata/netdata/pull/12037/commits/d91e93861b620b0934c2d23612386ec6dc35e88a so at least one of these PRs should make it in.
