### PR TITLE
adds install method to /api/v1/info as label

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -362,21 +362,15 @@ void analytics_alarms_notifications(void)
 
 void analytics_get_install_type(void)
 {
-    struct install_type_info t = get_install_type();
-
-    if (t.install_type == NULL) {
+    if (localhost->system_info->install_type == NULL) {
         analytics_set_data_str(&analytics_data.netdata_install_type, "unknown");
     } else {
-        analytics_set_data_str(&analytics_data.netdata_install_type, t.install_type);
+        analytics_set_data_str(&analytics_data.netdata_install_type, localhost->system_info->install_type);
     }
 
-    if (t.prebuilt_distro != NULL) {
-        analytics_set_data_str(&analytics_data.netdata_prebuilt_distro, t.prebuilt_distro);
+    if (localhost->system_info->prebuilt_dist != NULL) {
+        analytics_set_data_str(&analytics_data.netdata_prebuilt_distro, localhost->system_info->prebuilt_dist);
     }
-
-    freez(t.prebuilt_arch);
-    freez(t.prebuilt_distro);
-    freez(t.install_type);
 }
 
 /*

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -222,9 +222,8 @@ char *get_value_from_key(char *buffer, char *key) {
     return s;
 }
 
-struct install_type_info get_install_type() {
+void get_install_type(char **install_type, char **prebuilt_arch, char **prebuilt_dist) {
     char *install_type_filename;
-    struct install_type_info ret = {.install_type = NULL, .prebuilt_arch = NULL, .prebuilt_distro = NULL};
 
     int install_type_filename_len = (strlen(netdata_configured_user_config_dir) + strlen(".install-type") + 3);
     install_type_filename = mallocz(sizeof(char) * install_type_filename_len);
@@ -237,41 +236,42 @@ struct install_type_info get_install_type() {
 
         while ((s = fgets_trim_len(buf, 256, fp, &len))) {
             if (!strncmp(buf, "INSTALL_TYPE='", 14))
-                ret.install_type = strdupz((char *)get_value_from_key(buf, "INSTALL_TYPE"));
+                *install_type = strdupz((char *)get_value_from_key(buf, "INSTALL_TYPE"));
             else if (!strncmp(buf, "PREBUILT_ARCH='", 15))
-                ret.prebuilt_arch = strdupz((char *)get_value_from_key(buf, "PREBUILT_ARCH"));
+                *prebuilt_arch = strdupz((char *)get_value_from_key(buf, "PREBUILT_ARCH"));
             else if (!strncmp(buf, "PREBUILT_DISTRO='", 17))
-                ret.prebuilt_distro = strdupz((char *)get_value_from_key(buf, "PREBUILT_DISTRO"));
+                *prebuilt_dist = strdupz((char *)get_value_from_key(buf, "PREBUILT_DISTRO"));
         }
         fclose(fp);
     }
     freez(install_type_filename);
-
-    return ret;
 }
 
 void print_build_info(void) {
-    struct install_type_info t = get_install_type();
+    char *install_type = NULL;
+    char *prebuilt_arch = NULL;
+    char *prebuilt_distro = NULL;
+    get_install_type(&install_type, &prebuilt_arch, &prebuilt_distro);
 
     printf("Configure options: %s\n", CONFIGURE_COMMAND);
 
-    if (t.install_type == NULL) {
+    if (install_type == NULL) {
         printf("Install type: unknown\n");
     } else {
-        printf("Install type: %s\n", t.install_type);
+        printf("Install type: %s\n", install_type);
     }
 
-    if (t.prebuilt_arch != NULL) {
-        printf("    Binary architecture: %s\n", t.prebuilt_arch);
+    if (prebuilt_arch != NULL) {
+        printf("    Binary architecture: %s\n", prebuilt_arch);
     }
 
-    if (t.prebuilt_distro != NULL) {
-        printf("    Packaging distro: %s\n", t.prebuilt_distro);
+    if (prebuilt_distro != NULL) {
+        printf("    Packaging distro: %s\n", prebuilt_distro);
     }
 
-    freez(t.install_type);
-    freez(t.prebuilt_arch);
-    freez(t.prebuilt_distro);
+    freez(install_type);
+    freez(prebuilt_arch);
+    freez(prebuilt_distro);
 
     printf("Features:\n");
     printf("    dbengine:                   %s\n", FEAT_YES_NO(FEAT_DBENGINE));

--- a/daemon/buildinfo.h
+++ b/daemon/buildinfo.h
@@ -3,18 +3,12 @@
 #ifndef NETDATA_BUILDINFO_H
 #define NETDATA_BUILDINFO_H 1
 
-struct install_type_info {
-    char *install_type;
-    char *prebuilt_arch;
-    char *prebuilt_distro;
-};
-
 extern void print_build_info(void);
 
 extern void print_build_info_json(void);
 
 extern char *get_value_from_key(char *buffer, char *key);
 
-extern struct install_type_info get_install_type();
+extern void get_install_type(char **install_type, char **prebuilt_arch, char **prebuilt_dist);
 
 #endif // NETDATA_BUILDINFO_H

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1232,6 +1232,7 @@ int main(int argc, char **argv) {
     struct rrdhost_system_info *system_info = calloc(1, sizeof(struct rrdhost_system_info));
     get_system_info(system_info);
     system_info->hops = 0;
+    get_install_type(&system_info->install_type, &system_info->prebuilt_arch, &system_info->prebuilt_dist);
 
     if(rrd_init(netdata_configured_hostname, system_info))
         fatal("Cannot initialize localhost instance with name '%s'.", netdata_configured_hostname);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -756,6 +756,9 @@ struct rrdhost_system_info {
     uint16_t hops;
     bool ml_capable;
     bool ml_enabled;
+    char *install_type;
+    char *prebuilt_arch;
+    char *prebuilt_dist;
 };
 
 struct rrdhost {

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -834,6 +834,9 @@ void rrdhost_system_info_free(struct rrdhost_system_info *system_info) {
         freez(system_info->container);
         freez(system_info->container_detection);
         freez(system_info->is_k8s_node);
+        freez(system_info->install_type);
+        freez(system_info->prebuilt_arch);
+        freez(system_info->prebuilt_dist);
         freez(system_info);
     }
 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1074,6 +1074,18 @@ static struct label *rrdhost_load_auto_labels(void)
         label_list =
             add_label_to_list(label_list, "_is_k8s_node", localhost->system_info->is_k8s_node, LABEL_SOURCE_AUTO);
 
+    if (localhost->system_info->install_type)
+        label_list =
+            add_label_to_list(label_list, "_install_type", localhost->system_info->install_type, LABEL_SOURCE_AUTO);
+
+    if (localhost->system_info->prebuilt_arch)
+        label_list =
+            add_label_to_list(label_list, "_prebuilt_arch", localhost->system_info->prebuilt_arch, LABEL_SOURCE_AUTO);
+
+    if (localhost->system_info->prebuilt_dist)
+        label_list =
+            add_label_to_list(label_list, "_prebuilt_dist", localhost->system_info->prebuilt_dist, LABEL_SOURCE_AUTO);
+
     label_list = add_aclk_host_labels(label_list);
 
     label_list = add_label_to_list(


### PR DESCRIPTION
##### Summary
As requested by @thiagoftsm this adds the build type info into HTTP API

##### Test Plan
`GET /api/v1/info` should contain new `host_label` keys if it was possible to know their value

##### Additional Information
