### PR TITLE
Fix compilation errors for OpenSSL on macOS

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -27,9 +27,16 @@ fi
 
 # -----------------------------------------------------------------------------
 # Pull in OpenSSL properly if on macOS
-if [ "$(uname -s)" = 'Darwin' ] && [ -d /usr/local/opt/openssl/include ]; then
-  export C_INCLUDE_PATH="/usr/local/opt/openssl/include"
-  export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+if [ "$(uname -s)" = 'Darwin' ]; then
+  if [ -d /usr/local/opt/openssl@1.1 ]; then
+    export CFLAGS="${CFLAGS} -I/usr/local/opt/openssl@1.1/include"
+    export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl@1.1/lib"
+  else
+    if [ -d /usr/local/opt/openssl ]; then
+    export CFLAGS="${CFLAGS} -I/usr/local/opt/openssl/include"
+    export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl/lib"
+    fi
+  fi
 fi
 
 # -----------------------------------------------------------------------------

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -33,8 +33,8 @@ if [ "$(uname -s)" = 'Darwin' ]; then
     export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl@1.1/lib"
   else
     if [ -d /usr/local/opt/openssl ]; then
-    export CFLAGS="${CFLAGS} -I/usr/local/opt/openssl/include"
-    export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl/lib"
+      export CFLAGS="${CFLAGS} -I/usr/local/opt/openssl/include"
+      export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl/lib"
     fi
   fi
 fi

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -31,11 +31,9 @@ if [ "$(uname -s)" = 'Darwin' ]; then
   if [ -d /usr/local/opt/openssl@1.1 ]; then
     export CFLAGS="${CFLAGS} -I/usr/local/opt/openssl@1.1/include"
     export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl@1.1/lib"
-  else
-    if [ -d /usr/local/opt/openssl ]; then
-      export CFLAGS="${CFLAGS} -I/usr/local/opt/openssl/include"
-      export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl/lib"
-    fi
+  elif [ -d /usr/local/opt/openssl ]; then
+    export CFLAGS="${CFLAGS} -I/usr/local/opt/openssl/include"
+    export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl/lib"
   fi
 fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -28,12 +28,16 @@ fi
 # -----------------------------------------------------------------------------
 # Pull in OpenSSL properly if on macOS
 if [ "$(uname -s)" = 'Darwin' ]; then
-  if [ -d /usr/local/opt/openssl@1.1 ]; then
-    export CFLAGS="${CFLAGS} -I/usr/local/opt/openssl@1.1/include"
-    export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl@1.1/lib"
-  elif [ -d /usr/local/opt/openssl ]; then
-    export CFLAGS="${CFLAGS} -I/usr/local/opt/openssl/include"
-    export LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl/lib"
+  if brew --prefix --installed openssl; then
+    HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl)
+  elif brew --prefix --installed openssl@3; then
+    HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@3)
+  elif brew --prefix --installed openssl@1.1; then
+    HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@1.1)
+  fi
+  if [ -n "${HOMEBREW_OPENSSL_PREFIX}" ]; then
+    export CFLAGS="${CFLAGS} -I${HOMEBREW_OPENSSL_PREFIX}/include"
+    export LDFLAGS="${LDFLAGS} -L${HOMEBREW_OPENSSL_PREFIX}/lib"
   fi
 fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -28,16 +28,21 @@ fi
 # -----------------------------------------------------------------------------
 # Pull in OpenSSL properly if on macOS
 if [ "$(uname -s)" = 'Darwin' ]; then
-  if brew --prefix --installed openssl > /dev/null 2>&1; then
-    HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl)
-  elif brew --prefix --installed openssl@3 > /dev/null 2>&1; then
-    HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@3)
-  elif brew --prefix --installed openssl@1.1 > /dev/null 2>&1; then
-    HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@1.1)
-  fi
-  if [ -n "${HOMEBREW_OPENSSL_PREFIX}" ]; then
-    export CFLAGS="${CFLAGS} -I${HOMEBREW_OPENSSL_PREFIX}/include"
-    export LDFLAGS="${LDFLAGS} -L${HOMEBREW_OPENSSL_PREFIX}/lib"
+  if brew --prefix > /dev/null 2>&1; then
+    if brew --prefix --installed openssl > /dev/null 2>&1; then
+      HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl)
+    elif brew --prefix --installed openssl@3 > /dev/null 2>&1; then
+      HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@3)
+    elif brew --prefix --installed openssl@1.1 > /dev/null 2>&1; then
+      HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@1.1)
+    fi
+    if [ -n "${HOMEBREW_OPENSSL_PREFIX}" ]; then
+      export CFLAGS="${CFLAGS} -I${HOMEBREW_OPENSSL_PREFIX}/include"
+      export LDFLAGS="${LDFLAGS} -L${HOMEBREW_OPENSSL_PREFIX}/lib"
+    fi
+    HOMEBREW_PREFIX=$(brew --prefix)
+    export CFLAGS="${CFLAGS} -I${HOMEBREW_PREFIX}/include"
+    export LDFLAGS="${LDFLAGS} -L${HOMEBREW_PREFIX}/lib"
   fi
 fi
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -28,11 +28,11 @@ fi
 # -----------------------------------------------------------------------------
 # Pull in OpenSSL properly if on macOS
 if [ "$(uname -s)" = 'Darwin' ]; then
-  if brew --prefix --installed openssl; then
+  if brew --prefix --installed openssl  > /dev/null 2>&1; then
     HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl)
-  elif brew --prefix --installed openssl@3; then
+  elif brew --prefix --installed openssl@3  > /dev/null 2>&1; then
     HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@3)
-  elif brew --prefix --installed openssl@1.1; then
+  elif brew --prefix --installed openssl@1.1  > /dev/null 2>&1; then
     HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@1.1)
   fi
   if [ -n "${HOMEBREW_OPENSSL_PREFIX}" ]; then

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -28,11 +28,11 @@ fi
 # -----------------------------------------------------------------------------
 # Pull in OpenSSL properly if on macOS
 if [ "$(uname -s)" = 'Darwin' ]; then
-  if brew --prefix --installed openssl  > /dev/null 2>&1; then
+  if brew --prefix --installed openssl > /dev/null 2>&1; then
     HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl)
-  elif brew --prefix --installed openssl@3  > /dev/null 2>&1; then
+  elif brew --prefix --installed openssl@3 > /dev/null 2>&1; then
     HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@3)
-  elif brew --prefix --installed openssl@1.1  > /dev/null 2>&1; then
+  elif brew --prefix --installed openssl@1.1 > /dev/null 2>&1; then
     HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@1.1)
   fi
   if [ -n "${HOMEBREW_OPENSSL_PREFIX}" ]; then

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -695,6 +695,7 @@ declare -A pkg_json_c_dev=(
   ['sabayon']="dev-libs/json-c"
   ['suse']="libjson-c-devel"
   ['freebsd']="json-c"
+  ['macos']="json-c"
   ['default']="json-c-devel"
 )
 
@@ -828,7 +829,7 @@ declare -A pkg_libuuid_dev=(
   ['rhel']="libuuid-devel"
   ['ol']="libuuid-devel"
   ['suse']="libuuid-devel"
-  ['macos']="NOTREQUIRED"
+  ['macos']="ossp-uuid"
   ['freebsd']="e2fsprogs-libuuid"
   ['default']=""
 )
@@ -1171,7 +1172,7 @@ declare -A pkg_openssl=(
   ['gentoo']="dev-libs/openssl"
   ['arch']="openssl"
   ['freebsd']="openssl"
-  ['macos']="openssl@1.1"
+  ['macos']="openssl"
   ['default']="openssl-devel"
 )
 

--- a/packaging/installer/methods/macos.md
+++ b/packaging/installer/methods/macos.md
@@ -71,7 +71,7 @@ to install some of Netdata's prerequisites. You can omit `cmake` in case you do 
 [Netdata Cloud](https://learn.netdata.cloud/docs/cloud/).
 
 ```bash
-brew install ossp-uuid autoconf automake pkg-config libuv lz4 json-c openssl@1.1 libtool cmake
+brew install ossp-uuid autoconf automake pkg-config libuv lz4 json-c openssl libtool cmake
 ```
 
 If you want to use the [database engine](/database/engine/README.md) to store your metrics, you need to download


### PR DESCRIPTION
##### Summary
On macOS OpenSSL is not linked to the standard `include` and `lib` directories because LibreSSL is the main library in the system. In order to save our users from the necessity of linking the library, we provide default paths to the Homebrew package. This PR fixes directories for `openssl` packages.

##### Test Plan
1. Install `openssl@1.1`, run Netdata installer.
2. Uninstall `openssl@1.1` and install `openssl@3`, run Netdata installer.
3. Uninstall `openssl@3` and install `openssl`, run Netdata installer.

In all cases, Netdata should be compiled and installed correctly.