### PR TITLE
[Stream Compression] - Bug fix #12043 - lz4.h compilation error - compile from source

### DIFF
--- a/streaming/compression.c
+++ b/streaming/compression.c
@@ -1,7 +1,7 @@
 #include "rrdpush.h"
-#include "lz4.h"
 
 #ifdef ENABLE_COMPRESSION
+#include "lz4.h"
 
 #define LZ4_MAX_MSG_SIZE 0x4000
 #define LZ4_STREAM_BUFFER_SIZE (0x10000 + LZ4_MAX_MSG_SIZE)


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Include "lz4.h" only when compression is enabled.
Note: Fix [#12043](https://github.com/netdata/netdata/issues/12043). 

##### Test Plan
#### Steps
1. Remove any lz4 lib from your system.
```
sudo apt-get remove liblz4-dev
sudo apt-get remove lz4
sudo apt autoclean && sudo apt autoremove
```
2. Configure without stream compression
```
./configure --disable-compression
```
Configuration checking messages should report,
```
...
checking for LZ4_initStream in -llz4... no
checking for LZ4_compress_default in -llz4... no
...
checking if netdata compression should be used... no
...
```
3. Build the netdata project. Run `make`.
4. netdata should build without any error. In details,
Should see,
```
  CC       streaming/rrdpush.o
  CC       streaming/compression.o
  CC       streaming/sender.o
  CC       streaming/receiver.o

```
Should NOT see,
```
  CC       streaming/compression.o
streaming/compression.c:2:10: fatal error: lz4.h: No such file or directory
    2 | #include "lz4.h"
      |          ^~~~~~~
compilation terminated.
make[2]: *** [Makefile:5763: streaming/compression.o] Error 1
make[2]: Leaving directory '/home/user/test_netdata'
make[1]: *** [Makefile:6475: all-recursive] Error 1
make[1]: Leaving directory '/home/user/test_netdata'
make: *** [Makefile:3519: all] Error 2
```
5. Don't forget to re-install lz4 or liblz4-dev libraries in your system.
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
