### PR TITLE
Add handling for claiming non-standard install types with kickstart.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -863,6 +863,8 @@ claim() {
     NETDATA_CLAIM_PATH=/usr/sbin/netdata-claim.sh
   elif [ "${INSTALL_PREFIX}" = "/opt/netdata" ]; then
     NETDATA_CLAIM_PATH="/opt/netdata/bin/netdata-claim.sh"
+  elif [ ! -d "${INSTALL_PREFIX}/netdata" ]; then
+    NETDATA_CLAIM_PATH="${INSTALL_PREFIX}/usr/sbin/netdata-claim.sh"
   else
     NETDATA_CLAIM_PATH="${INSTALL_PREFIX}/netdata/usr/sbin/netdata-claim.sh"
   fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -621,7 +621,7 @@ detect_existing_install() {
       ndprefix="$(dirname "$(dirname "${ndpath}")")"
     fi
 
-    if echo "${ndprefix}" | grep -Eq '/usr$'; then
+    if echo "${ndprefix}" | grep -Eq '^/usr$'; then
       ndprefix="$(dirname "${ndprefix}")"
     fi
   fi
@@ -859,12 +859,18 @@ claim() {
   fi
 
   progress "Attempting to claim agent to ${NETDATA_CLAIM_URL}"
-  if [ -z "${INSTALL_PREFIX}" ] || [ "${INSTALL_PREFIX}" = "/" ]; then
+  if command -v netdata-claim.sh > /dev/null 2>&1; then
+    NETDATA_CLAIM_PATH="$(command -v netdata-claim.sh)"
+  elif [ -z "${INSTALL_PREFIX}" ] || [ "${INSTALL_PREFIX}" = "/" ]; then
     NETDATA_CLAIM_PATH=/usr/sbin/netdata-claim.sh
   elif [ "${INSTALL_PREFIX}" = "/opt/netdata" ]; then
     NETDATA_CLAIM_PATH="/opt/netdata/bin/netdata-claim.sh"
   elif [ ! -d "${INSTALL_PREFIX}/netdata" ]; then
-    NETDATA_CLAIM_PATH="${INSTALL_PREFIX}/usr/sbin/netdata-claim.sh"
+    if [ -d "${INSTALL_PREFIX}/usr" ]; then
+        NETDATA_CLAIM_PATH="${INSTALL_PREFIX}/usr/sbin/netdata-claim.sh"
+    else
+        NETDATA_CLAIM_PATH="${INSTALL_PREFIX}/sbin/netdata-claim.sh"
+    fi
   else
     NETDATA_CLAIM_PATH="${INSTALL_PREFIX}/netdata/usr/sbin/netdata-claim.sh"
   fi


### PR DESCRIPTION
##### Summary

SSIA

##### Test Plan

Can be verified by attempting to use the kickstart script from this PR to claim a node that was installed by a method other than the kickstart script (for example, via the FreeBSD Ports tree, or through Homebrew).

##### Additional Information

This also adds an extra sanity check to the claiming code in the kickstart script so that we provide a more user friendly error message if a usable claiming script cannot be found.
