### PR TITLE
Adds legacy protocol deprecation banner to agent log

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -816,12 +816,13 @@ void *aclk_main(void *ptr)
             goto exit_full;
 
 #if defined(ENABLE_ACLK) && !defined(ENABLE_NEW_CLOUD_PROTOCOL)
-        error_report("#########################  WARNING  #########################");
-        error_report("#   Your agent is configured to connect to cloud but has    #");
-        error_report("# no protobuf protocol support (uses legacy JSON protocol). #");
-        error_report("#         Legacy protocol will be deprecated soon.          #");
-        error_report("#  Please update your agent to avoid service interruption.  #");
-        error_report("#############################################################");
+        error_report("############################  WARNING  ###############################");
+        error_report("#       Your agent is configured to connect to cloud but has         #");
+        error_report("#      no protobuf protocol support (uses legacy JSON protocol)      #");
+        error_report("#  Legacy protocol will be deprecated soon (planned 1st March 2022)  #");
+        error_report("#  Visit following link for more info and instructions how to solve  #");
+        error_report("#  https://www.netdata.cloud/blog/netdata-clouds-new-architecture/   #");
+        error_report("######################################################################");
 #endif
 
         // warning this assumes the popcorning is relative short (3s)

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -821,7 +821,7 @@ void *aclk_main(void *ptr)
         error_report("#      no protobuf protocol support (uses legacy JSON protocol)      #");
         error_report("#  Legacy protocol will be deprecated soon (planned 1st March 2022)  #");
         error_report("#  Visit following link for more info and instructions how to solve  #");
-        error_report("#  https://www.netdata.cloud/blog/netdata-clouds-new-architecture/   #");
+        error_report("#   https://www.netdata.cloud/blog/netdata-clouds-new-architecture   #");
         error_report("######################################################################");
 #endif
 

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -815,6 +815,15 @@ void *aclk_main(void *ptr)
         if (aclk_attempt_to_connect(mqttwss_client))
             goto exit_full;
 
+#if defined(ENABLE_ACLK) && !defined(ENABLE_NEW_CLOUD_PROTOCOL)
+        error_report("#########################  WARNING  #########################");
+        error_report("#   Your agent is configured to connect to cloud but has    #");
+        error_report("# no protobuf protocol support (uses legacy JSON protocol). #");
+        error_report("#         Legacy protocol will be deprecated soon.          #");
+        error_report("#  Please update your agent to avoid service interruption.  #");
+        error_report("#############################################################");
+#endif
+
         // warning this assumes the popcorning is relative short (3s)
         // if that changes call mqtt_wss_service from within
         // to keep OpenSSL, WSS and MQTT connection alive


### PR DESCRIPTION
##### Summary
Adds legacy protocol deprecation banner to agent log.
Text will be revised and most probably extended with a link to documentation letting users know how to fix this.

Curent banner looks like this:
```
2022-01-31 18:21:24: netdata ERROR : ACLK_Main : #########################  WARNING  #########################
2022-01-31 18:21:24: netdata ERROR : ACLK_Main : #   Your agent is configured to connect to cloud but has    #
2022-01-31 18:21:24: netdata ERROR : ACLK_Main : # no protobuf protocol support (uses legacy JSON protocol). #
2022-01-31 18:21:24: netdata ERROR : ACLK_Main : #         Legacy protocol will be deprecated soon.          #
2022-01-31 18:21:24: netdata ERROR : ACLK_Main : #  Please update your agent to avoid service interruption.  #
2022-01-31 18:21:24: netdata ERROR : ACLK_Main : #############################################################
```

##### Test Plan
##### Additional Information
