### PR TITLE
Add serial numbers to chart names

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -144,23 +144,23 @@ int rrdset_set_name(RRDSET *st, const char *name) {
 
     debug(D_RRD_CALLS, "rrdset_set_name() old: '%s', new: '%s'", st->name?st->name:"", name);
 
-    char b[CONFIG_MAX_VALUE + 1];
-    char n[RRD_ID_LENGTH_MAX + 1];
+    char new_name[CONFIG_MAX_VALUE + 1];
+    char full_name[RRD_ID_LENGTH_MAX + 1];
 
-    snprintfz(n, RRD_ID_LENGTH_MAX, "%s.%s", st->type, name);
-    rrdset_strncpyz_name(b, n, CONFIG_MAX_VALUE);
+    snprintfz(full_name, RRD_ID_LENGTH_MAX, "%s.%s", st->type, name);
+    rrdset_strncpyz_name(new_name, full_name, CONFIG_MAX_VALUE);
 
-    if(rrdset_index_find_name(host, b, 0)) {
-        info("RRDSET: chart name '%s' on host '%s' already exists.", b, host->hostname);
-        if(!strcmp(st->id, n) && !st->name) {
+    if(rrdset_index_find_name(host, full_name, 0)) {
+        info("RRDSET: chart name '%s' on host '%s' already exists.", new_name, host->hostname);
+        if(!strcmp(st->id, full_name) && !st->name) {
             unsigned i = 1;
 
             do {
-                snprintfz(b, CONFIG_MAX_VALUE, "%s_%u", n, i);
+                snprintfz(new_name, CONFIG_MAX_VALUE, "%s_%u", full_name, i);
                 i++;
-            } while (rrdset_index_find_name(host, b, 0));
+            } while (rrdset_index_find_name(host, new_name, 0));
 
-            info("RRDSET: using name '%s' for chart '%s' on host '%s'.", b, n, host->hostname);
+            info("RRDSET: using name '%s' for chart '%s' on host '%s'.", new_name, full_name, host->hostname);
         } else {
             return 0;
         }
@@ -168,12 +168,12 @@ int rrdset_set_name(RRDSET *st, const char *name) {
 
     if(st->name) {
         rrdset_index_del_name(host, st);
-        st->name = config_set_default(st->config_section, "name", b);
+        st->name = config_set_default(st->config_section, "name", new_name);
         st->hash_name = simple_hash(st->name);
         rrdsetvar_rename_all(st);
     }
     else {
-        st->name = config_get(st->config_section, "name", b);
+        st->name = config_get(st->config_section, "name", new_name);
         st->hash_name = simple_hash(st->name);
     }
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -144,19 +144,21 @@ int rrdset_set_name(RRDSET *st, const char *name) {
 
     debug(D_RRD_CALLS, "rrdset_set_name() old: '%s', new: '%s'", st->name?st->name:"", name);
 
-    char new_name[CONFIG_MAX_VALUE + 1];
     char full_name[RRD_ID_LENGTH_MAX + 1];
+    char sanitized_name[CONFIG_MAX_VALUE + 1];
+    char new_name[CONFIG_MAX_VALUE + 1];
 
     snprintfz(full_name, RRD_ID_LENGTH_MAX, "%s.%s", st->type, name);
-    rrdset_strncpyz_name(new_name, full_name, CONFIG_MAX_VALUE);
+    rrdset_strncpyz_name(sanitized_name, full_name, CONFIG_MAX_VALUE);
+    strncpyz(new_name, sanitized_name, CONFIG_MAX_VALUE);
 
-    if(rrdset_index_find_name(host, full_name, 0)) {
+    if(rrdset_index_find_name(host, new_name, 0)) {
         info("RRDSET: chart name '%s' on host '%s' already exists.", new_name, host->hostname);
         if(!strcmp(st->id, full_name) && !st->name) {
             unsigned i = 1;
 
             do {
-                snprintfz(new_name, CONFIG_MAX_VALUE, "%s_%u", full_name, i);
+                snprintfz(new_name, CONFIG_MAX_VALUE, "%s_%u", sanitized_name, i);
                 i++;
             } while (rrdset_index_find_name(host, new_name, 0));
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -152,7 +152,18 @@ int rrdset_set_name(RRDSET *st, const char *name) {
 
     if(rrdset_index_find_name(host, b, 0)) {
         info("RRDSET: chart name '%s' on host '%s' already exists.", b, host->hostname);
-        return 0;
+        if(!strcmp(st->id, n) && !st->name) {
+            unsigned i = 1;
+
+            do {
+                snprintfz(b, CONFIG_MAX_VALUE, "%s_%u", n, i);
+                i++;
+            } while (rrdset_index_find_name(host, b, 0));
+
+            info("RRDSET: using name '%s' for chart '%s' on host '%s'.", b, n, host->hostname);
+        } else {
+            return 0;
+        }
     }
 
     if(st->name) {


### PR DESCRIPTION
##### Summary
When charts a created with different ids which differ only by symbols that are not '_' or alphanumeric and no unique names are provided, Netdata crashes with a segmentation fault.
```
#0  0x00007fe374de1515 in __strlen_avx2 () from /usr/lib/libc.so.6
#1  0x00005615a2bd5efd in compute_chart_hash (st=st@entry=0x7fe368e42000) at database/sqlite/sqlite_functions.c:1662
#2  0x00005615a2bcd7f2 in rrdset_create_custom (host=0x5615a501fb10, type=<optimized out>, id=0x5615a5337a53 "job_num_CT_S2000", name=<optimized out>, family=<optimized out>, context=<optimized out>, title=<optimized out>,
    units=<optimized out>, plugin=<optimized out>, module=<optimized out>, priority=<optimized out>, update_every=<optimized out>, chart_type=<optimized out>, memory_mode=<optimized out>, history_entries=<optimized out>)
    at database/rrdset.c:938
#3  0x00005615a2bb56ee in pluginsd_chart_action (user=0x5615a5336f90, type=<optimized out>, id=<optimized out>, name=<optimized out>, family=<optimized out>, context=<optimized out>,
    title=0x5615a5337a68 "Active job number of destination CT_S2000", units=0x5615a5337a93 "jobs", plugin=0x5615a530fe51 "mycups.plugin", module=0x0, priority=100006, update_every=1, chart_type=RRDSET_TYPE_STACKED, options=0x0)
    at collectors/plugins.d/pluginsd_parser.c:53
#4  0x00005615a2bb67c6 in pluginsd_chart (words=<optimized out>, user=0x5615a5336f90, plugins_action=<optimized out>) at collectors/plugins.d/pluginsd_parser.c:379
#5  0x00005615a2c9d1a9 in parser_action (parser=parser@entry=0x5615a53379f0, input=0x5615a5337a48 "CHART", input@entry=0x0) at parser/parser.c:298
#6  0x00005615a2bb7a18 in pluginsd_process (host=0x5615a501fb10, cd=cd@entry=0x5615a530fa50, fp=fp@entry=0x5615a5319300, trust_durations=trust_durations@entry=0) at collectors/plugins.d/pluginsd_parser.c:769
#7  0x00005615a2bb4ca5 in pluginsd_worker_thread (arg=0x5615a530fa50) at collectors/plugins.d/plugins_d.c:248
#8  0x00005615a2b82afb in thread_start (ptr=<optimized out>) at libnetdata/threads/threads.c:184
#9  0x00007fe374e56259 in start_thread () from /usr/lib/libpthread.so.0
#10 0x00007fe374d7f5e3 in clone () from /usr/lib/libc.so.6
```
We will attach serial numbers to the chart names in such cases.

Fixes #12059

##### Test Plan
1. Create a mock plugin `test-chart-names.plugin` in `/usr/libexec/netdata/plugins.d/`, make it runnable by Netdata.
```
#!/bin/bash
cat << EOF
CHART cups.job_num_CT-S2000 '' 'Active job number of destination CT-S2000' jobs 'CT-S2000' job_num stacked 100004 1
DIMENSION pending '' absolute 1 1
DIMENSION held '' absolute 1 1
DIMENSION processing '' absolute 1 1
CHART cups.job_size_CT-S2000 '' 'Active job size of destination CT-S2000' KB 'CT-S2000' job_size stacked 100005 1
DIMENSION pending '' absolute 1 1
DIMENSION held '' absolute 1 1
DIMENSION processing '' absolute 1 1
CHART cups.job_num_CT_S2000 '' 'Active job number of destination CT_S2000' jobs 'CT_S2000' job_num stacked 100006 1
DIMENSION pending '' absolute 1 1
DIMENSION held '' absolute 1 1
DIMENSION processing '' absolute 1 1
CHART cups.job_size_CT_S2000 '' 'Active job size of destination CT_S2000' KB 'CT_S2000' job_size stacked 100007 1
DIMENSION pending '' absolute 1 1
DIMENSION held '' absolute 1 1
DIMENSION processing '' absolute 1 1
BEGIN cups.job_num_CT-S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_size_CT-S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_num_CT_S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_size_CT_S2000
SET pending = 0
SET held = 0
SET processing = 0
END
CHART cups.job_num_CT/S2000 '' 'Active job number of destination CT_S2000' jobs 'CT/S2000' job_num stacked 100006 1
DIMENSION pending '' absolute 1 1
DIMENSION held '' absolute 1 1
DIMENSION processing '' absolute 1 1
CHART cups.job_size_CT/S2000 '' 'Active job size of destination CT_S2000' KB 'CT/S2000' job_size stacked 100007 1
DIMENSION pending '' absolute 1 1
DIMENSION held '' absolute 1 1
DIMENSION processing '' absolute 1 1
BEGIN cups.job_num_CT/S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_size_CT/S2000
SET pending = 0
SET held = 0
SET processing = 0
END
CHART cups.dest_state '' 'Destinations by state' dests overview dests stacked 100000 1
DIMENSION idle '' absolute 1 1
DIMENSION printing '' absolute 1 1
DIMENSION stopped '' absolute 1 1
CHART cups.dest_option '' 'Destinations by option' dests overview dests line 100001 1
DIMENSION total '' absolute 1 1
DIMENSION acceptingjobs '' absolute 1 1
DIMENSION shared '' absolute 1 1
CHART cups.job_num '' 'Total active job number' jobs overview job_num stacked 100002 1
DIMENSION pending '' absolute 1 1
DIMENSION held '' absolute 1 1
DIMENSION processing '' absolute 1 1
CHART cups.job_size '' 'Total active job size' KB overview job_size stacked 100003 1
DIMENSION pending '' absolute 1 1
DIMENSION held '' absolute 1 1
DIMENSION processing '' absolute 1 1
BEGIN cups.dest_state
SET idle = 1
SET printing = 0
SET stopped = 1
END
BEGIN cups.dest_option
SET total = 3
SET acceptingjobs = 1
SET shared = 2
END
BEGIN cups.job_num
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_size
SET pending = 0
SET held = 0
SET processing = 0
END
EOF

while [ true ]
do

sleep 1

cat << EOF
BEGIN cups.job_num_CT-S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_size_CT-S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_num_CT_S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_size_CT_S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_num_CT/S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_size_CT/S2000
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.dest_state
SET idle = 1
SET printing = 0
SET stopped = 1
END
BEGIN cups.dest_option
SET total = 3
SET acceptingjobs = 1
SET shared = 2
END
BEGIN cups.job_num
SET pending = 0
SET held = 0
SET processing = 0
END
BEGIN cups.job_size
SET pending = 0
SET held = 0
SET processing = 0
END
EOF

done
```
2. Check if Netdata doesn't crash and assigns correct names to charts.