### PR TITLE
Disable hashes for charts and alerts if openssl is not available

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1648,6 +1648,7 @@ int sql_store_chart_hash(
 
 void compute_chart_hash(RRDSET *st)
 {
+#ifdef ENABLE_HTTPS
     EVP_MD_CTX *evpctx;
     unsigned char hash_value[EVP_MAX_MD_SIZE];
     unsigned int hash_len;
@@ -1693,6 +1694,9 @@ void compute_chart_hash(RRDSET *st)
         st->module_name,
         st->priority,
         st->chart_type);
+#else
+    UNUSED(st);
+#endif
     return;
 }
 

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -890,11 +890,14 @@ int sql_store_alert_config_hash(uuid_t *hash_id, struct alert_config *cfg)
     return 1;
 }
 
+#ifdef ENABLE_HTTPS
 #define DIGEST_ALERT_CONFIG_VAL(v) ((v) ? EVP_DigestUpdate(evpctx, (v), strlen((v))) : EVP_DigestUpdate(evpctx, "", 1))
+#endif
 int alert_hash_and_store_config(
     uuid_t hash_id,
     struct alert_config *cfg)
 {
+#ifdef ENABLE_HTTPS
     EVP_MD_CTX *evpctx;
     unsigned char hash_value[EVP_MAX_MD_SIZE];
     unsigned int hash_len;
@@ -939,6 +942,10 @@ int alert_hash_and_store_config(
 
     /* store everything, so it can be recreated when not in memory or just a subset ? */
     (void)sql_store_alert_config_hash( (uuid_t *)&hash_value, cfg);
+#else
+    UNUSED(hash_id);
+    UNUSED(cfg);
+#endif
 
     return 1;
 }


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR fixes the case when openssl is not available for compilation, by disabling parts of the code that use openssl libraries to compute chart and alert configuration hashes.

Those hashes are used for the cloud new architecture to reduce data between agents and the cloud by sending them once and kept in the cloud for also future events that reference them.

So, since openssl is disabled, we can assume no cloud connectivity, and as such we don't really need the hashes.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Try a compile of master in an environment without openssl. If that's not possible, then a small change in `configure.ac` in line 418 to read as `SSL_LIBS=""`, and compiling with `--disable-cloud` should do the trick. Without this PR there should be compilation errors in sqlite_health.c and sqlite_functions.c

Applying this PR it should get rid of those errors. The compiled netdata should continue to work as expected, with only changes being not populating tables `alert_hash` and `chart_hash`.

##### Additional Information

Disabling chart hashes should be safe. Alert hashes are stored in alert structures, and in alert events, and in sqlite (health_log). So for alert events, the `config_hash_id` will contain `00000000-0000-0000-0000-000000000000` but should otherwise not interfere or break proper health operations.
