### PR TITLE
Group Apple Filing Protocol daemons into a AFP group

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -169,6 +169,7 @@ nfs: rpcbind rpc.* nfs*
 zfs: spl_* z_* txg_* zil_* arc_* l2arc*
 btrfs: btrfs*
 iscsi: iscsid iscsi_eh
+afp: netatalk afpd cnid_dbd cnid_metad
 
 # -----------------------------------------------------------------------------
 # kubernetes


### PR DESCRIPTION
Group all of the AFP daemons into a single group.

Fixes #12075.