### PR TITLE
feat(apps.plugin): group Apple Filing Protocol daemons into `afp` group

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -169,6 +169,7 @@ nfs: rpcbind rpc.* nfs*
 zfs: spl_* z_* txg_* zil_* arc_* l2arc*
 btrfs: btrfs*
 iscsi: iscsid iscsi_eh
+afp: netatalk afpd cnid_dbd cnid_metad
 
 # -----------------------------------------------------------------------------
 # kubernetes


### PR DESCRIPTION
##### Summary

Fixes #12075

Big thanks @rossburton for the contribution. This PR replaces #12077 because of [signing the CLA nuances](https://github.com/netdata/netdata/pull/12077#issuecomment-1028328557).

##### Test Plan

~~Assuming~~ @rossburton has tested the changes.

##### Additional Information
