### PR TITLE
Track anomaly rates with DBEngine.

### DIFF
--- a/backends/backends.c
+++ b/backends/backends.c
@@ -193,6 +193,10 @@ inline int backends_can_send_rrdset(BACKEND_OPTIONS backend_options, RRDSET *st)
     RRDHOST *host = st->rrdhost;
     (void)host;
 
+    // Do not send anomaly rates charts.
+    if (unlikely(st->state->is_ar_chart))
+        return 0;
+
     if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_BACKEND_IGNORE)))
         return 0;
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -436,6 +436,7 @@ struct rrdset_volatile {
     uuid_t hash_id;
     struct label *new_labels;
     struct label_index labels;
+    bool is_ar_chart;
 };
 
 // ----------------------------------------------------------------------------

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -73,9 +73,15 @@ inline int rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name) {
     snprintfz(varname, CONFIG_MAX_NAME, "dim %s name", rd->id);
     rd->name = config_set_default(st->config_section, varname, name);
     rd->hash_name = simple_hash(rd->name);
-    rrddimvar_rename_all(rd);
+
+    if (!st->state->is_ar_chart)
+        rrddimvar_rename_all(rd);
+
     rd->exposed = 0;
     rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
+
+    ml_dimension_update_name(st, rd, name);
+
     return 1;
 }
 
@@ -438,7 +444,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
         td->next = rd;
     }
 
-    if(host->health_enabled) {
+    if(host->health_enabled && !st->state->is_ar_chart) {
         rrddimvar_create(rd, RRDVAR_TYPE_CALCULATED, NULL, NULL, &rd->last_stored_value, RRDVAR_OPTION_DEFAULT);
         rrddimvar_create(rd, RRDVAR_TYPE_COLLECTED, NULL, "_raw", &rd->last_collected_value, RRDVAR_OPTION_DEFAULT);
         rrddimvar_create(rd, RRDVAR_TYPE_TIME_T, NULL, "_last_collected_t", &rd->last_collected_time.tv_sec, RRDVAR_OPTION_DEFAULT);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -385,16 +385,14 @@ RRDHOST *rrdhost_create(const char *hostname,
     // ------------------------------------------------------------------------
     // init new ML host and update system_info to let upstreams know
     // about ML functionality
+    //
+
+    if (is_localhost && host->system_info) {
+        host->system_info->ml_capable = ml_capable();
+        host->system_info->ml_enabled = ml_enabled(host);
+    }
 
     ml_new_host(host);
-    if (is_localhost && host->system_info) {
-#ifndef ENABLE_ML
-        host->system_info->ml_capable = 0;
-#else
-        host->system_info->ml_capable = 1;
-#endif
-        host->system_info->ml_enabled = host->ml_host != NULL;
-    }
 
     info("Host '%s' (at registry as '%s') with guid '%s' initialized"
                  ", os '%s'"

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -22,8 +22,8 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     node_info.claim_id = is_agent_claimed();
     node_info.machine_guid = wc->host_guid;
     node_info.child = (wc->host != localhost);
-    node_info.ml_info.ml_capable = localhost->system_info->ml_capable;
-    node_info.ml_info.ml_enabled = wc->host->ml_host != NULL;
+    node_info.ml_info.ml_capable = ml_capable(localhost);
+    node_info.ml_info.ml_enabled = ml_enabled(wc->host);
     now_realtime_timeval(&node_info.updated_at);
 
     RRDHOST *host = wc->host;

--- a/exporting/check_filters.c
+++ b/exporting/check_filters.c
@@ -47,6 +47,10 @@ int rrdset_is_exportable(struct instance *instance, RRDSET *st)
     RRDHOST *host = st->rrdhost;
 #endif
 
+    // Do not export anomaly rates charts.
+    if (st->state->is_ar_chart)
+        return 0;
+
     if (st->exporting_flags == NULL)
         st->exporting_flags = callocz(instance->engine->instance_num, sizeof(size_t));
 

--- a/exporting/check_filters.c
+++ b/exporting/check_filters.c
@@ -48,7 +48,7 @@ int rrdset_is_exportable(struct instance *instance, RRDSET *st)
 #endif
 
     // Do not export anomaly rates charts.
-    if (st->state->is_ar_chart)
+    if (st->state && st->state->is_ar_chart)
         return 0;
 
     if (st->exporting_flags == NULL)

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -20,6 +20,10 @@ inline int can_send_rrdset(struct instance *instance, RRDSET *st)
     RRDHOST *host = st->rrdhost;
 #endif
 
+    // Do not send anomaly rates charts.
+    if (st->state->is_ar_chart)
+        return 0;
+
     if (unlikely(rrdset_flag_check(st, RRDSET_FLAG_EXPORTING_IGNORE)))
         return 0;
 

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -21,7 +21,7 @@ inline int can_send_rrdset(struct instance *instance, RRDSET *st)
 #endif
 
     // Do not send anomaly rates charts.
-    if (st->state->is_ar_chart)
+    if (st->state && st->state->is_ar_chart)
         return 0;
 
     if (unlikely(rrdset_flag_check(st, RRDSET_FLAG_EXPORTING_IGNORE)))

--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -22,7 +22,7 @@ static T clamp(const T& Value, const T& Min, const T& Max) {
 void Config::readMLConfig(void) {
     const char *ConfigSectionML = CONFIG_SECTION_ML;
 
-    bool EnableAnomalyDetection = config_get_boolean(ConfigSectionML, "enabled", true);
+    bool EnableAnomalyDetection = config_get_boolean(ConfigSectionML, "enabled", false);
 
     /*
      * Read values
@@ -60,6 +60,8 @@ void Config::readMLConfig(void) {
     MaxTrainSamples = clamp(MaxTrainSamples, 1 * 3600u, 6 * 3600u);
     MinTrainSamples = clamp(MinTrainSamples, 1 * 3600u, 6 * 3600u);
     TrainEvery = clamp(TrainEvery, 1 * 3600u, 6 * 3600u);
+
+    DBEngineAnomalyRateEvery = clamp(DBEngineAnomalyRateEvery, 1 * 60u, 15 * 60u);
 
     DiffN = clamp(DiffN, 0u, 1u);
     SmoothN = clamp(SmoothN, 0u, 5u);
@@ -100,19 +102,11 @@ void Config::readMLConfig(void) {
 
     Cfg.EnableAnomalyDetection = EnableAnomalyDetection;
 
-#if 0
     Cfg.MaxTrainSamples = MaxTrainSamples;
     Cfg.MinTrainSamples = MinTrainSamples;
     Cfg.TrainEvery = TrainEvery;
 
     Cfg.DBEngineAnomalyRateEvery = DBEngineAnomalyRateEvery;
-#else
-    Cfg.MaxTrainSamples = 2 * 60;
-    Cfg.MinTrainSamples = 1 * 60;
-    Cfg.TrainEvery = 1 * 60;
-
-    Cfg.DBEngineAnomalyRateEvery = 1 * 5;
-#endif
 
     Cfg.DiffN = DiffN;
     Cfg.SmoothN = SmoothN;
@@ -134,14 +128,9 @@ void Config::readMLConfig(void) {
 
     // Always exclude anomaly_detection charts from training.
     Cfg.ChartsToSkip = "anomaly_detection.* ";
-#if 0
     Cfg.ChartsToSkip += config_get(ConfigSectionML, "charts to skip from training",
             "!system.* !cpu.* !mem.* !disk.* !disk_* "
             "!ip.* !ipv4.* !ipv6.* !net.* !net_* !netfilter.* "
             "!services.* !apps.* !groups.* !user.* !ebpf.* !netdata.* *");
-#else
-    Cfg.ChartsToSkip += config_get(ConfigSectionML, "charts to skip from training", "!system.cpu *");
-#endif
-
     Cfg.SP_ChartsToSkip = simple_pattern_create(ChartsToSkip.c_str(), NULL, SIMPLE_PATTERN_EXACT);
 }

--- a/ml/Config.h
+++ b/ml/Config.h
@@ -15,6 +15,8 @@ public:
     unsigned MinTrainSamples;
     unsigned TrainEvery;
 
+    unsigned DBEngineAnomalyRateEvery;
+
     unsigned DiffN;
     unsigned SmoothN;
     unsigned LagN;

--- a/ml/Dimension.h
+++ b/ml/Dimension.h
@@ -12,11 +12,7 @@ namespace ml {
 
 class RrdDimension {
 public:
-    RrdDimension(RRDDIM *RD) : RD(RD), Ops(&RD->state->query_ops) {
-        std::stringstream SS;
-        SS << RD->rrdset->id << "|" << RD->name;
-        ID = SS.str();
-    }
+    RrdDimension(RRDDIM *RD) : RD(RD), Ops(&RD->state->query_ops) { }
 
     RRDDIM *getRD() const { return RD; }
 
@@ -26,12 +22,27 @@ public:
 
     unsigned updateEvery() const { return RD->update_every; }
 
-    const std::string getID() const { return ID; }
+    const std::string getID() const {
+        std::stringstream SS;
+        SS << RD->rrdset->id << "|" << RD->name;
+        return SS.str();
+    }
 
-    virtual ~RrdDimension() {}
+    void setAnomalyRateRD(RRDDIM *ARRD) { AnomalyRateRD = ARRD; }
+    RRDDIM *getAnomalyRateRD() const { return AnomalyRateRD; }
+
+    void setAnomalyRateRDName(const char *Name) const {
+        rrddim_set_name(AnomalyRateRD->rrdset, AnomalyRateRD, Name);
+    }
+
+    virtual ~RrdDimension() {
+        rrddim_free_custom(AnomalyRateRD->rrdset, AnomalyRateRD, 0);
+    }
 
 private:
     RRDDIM *RD;
+    RRDDIM *AnomalyRateRD;
+
     struct rrddim_volatile::rrddim_query_ops *Ops;
 
     std::string ID;
@@ -88,9 +99,20 @@ public:
 
     bool isAnomalous() { return AnomalyBit; }
 
+    void updateAnomalyBitCounter(RRDSET *RS, unsigned Elapsed, bool IsAnomalous) {
+        AnomalyBitCounter += IsAnomalous;
+
+        if (Elapsed == Cfg.DBEngineAnomalyRateEvery) {
+            double AR = static_cast<double>(AnomalyBitCounter) / Cfg.DBEngineAnomalyRateEvery;
+            rrddim_set_by_pointer(RS, getAnomalyRateRD(), AR * 1000);
+            AnomalyBitCounter = 0;
+        }
+    }
+
 private:
     CalculatedNumber AnomalyScore{0.0};
     std::atomic<bool> AnomalyBit{false};
+    unsigned AnomalyBitCounter{0};
 
     std::vector<CalculatedNumber> CNs;
 };

--- a/ml/Host.cc
+++ b/ml/Host.cc
@@ -40,7 +40,7 @@ static void updateDimensionsChart(RRDHOST *RH,
             P.first.c_str(), // id
             NULL, // name
             "dimensions", // family
-            NULL, // ctx
+            "anomaly_detection.dimensions", // ctx
             P.second.c_str(), // title
             "dimensions", // units
             "netdata", // plugin
@@ -83,7 +83,7 @@ static void updateRateChart(RRDHOST *RH, collected_number AnomalyRate) {
             P.first.c_str(), // id
             NULL, // name
             "anomaly_rate", // family
-            NULL, // ctx
+            "anomaly_detection.anomaly_rate", // ctx
             P.second.c_str(), // title
             "percentage", // units
             "netdata", // plugin
@@ -117,7 +117,7 @@ static void updateWindowLengthChart(RRDHOST *RH, collected_number WindowLength) 
             P.first.c_str(), // id
             NULL, // name
             "detector_window", // family
-            NULL, // ctx
+            "anomaly_detection.detector_window", // ctx
             P.second.c_str(), // title
             "seconds", // units
             "netdata", // plugin
@@ -155,7 +155,7 @@ static void updateEventsChart(RRDHOST *RH,
             P.first.c_str(), // id
             NULL, // name
             "detector_events", // family
-            NULL, // ctx
+            "anomaly_detection.detector_events", // ctx
             P.second.c_str(), // title
             "boolean", // units
             "netdata", // plugin
@@ -198,7 +198,7 @@ static void updateDetectionChart(RRDHOST *RH, collected_number PredictionDuratio
             P.first.c_str(), // id
             NULL, // name
             "prediction_stats", // family
-            NULL, // ctx
+            "anomaly_detection.prediction_stats", // ctx
             P.second.c_str(), // title
             "milliseconds", // units
             "netdata", // plugin
@@ -236,7 +236,7 @@ static void updateTrainingChart(RRDHOST *RH,
             P.first.c_str(), // id
             NULL, // name
             "training_stats", // family
-            NULL, // ctx
+            "anomaly_detection.training_stats", // ctx
             P.second.c_str(), // title
             "milliseconds", // units
             "netdata", // plugin

--- a/ml/Host.cc
+++ b/ml/Host.cc
@@ -425,9 +425,6 @@ void DetectableHost::detectOnce() {
                 DimsOverThreshold.push_back({ AnomalyScore, D->getID() });
 
             D->updateAnomalyBitCounter(AnomalyRateRS, AnomalyRateTimer, IsAnomalous);
-
-            if (NewAnomalyEvent && (AnomalyScore >= Cfg.ADDimensionRateThreshold))
-                DimsOverThreshold.push_back({ AnomalyScore, D->getID() });
         }
 
         if (NumAnomalousDimensions)

--- a/ml/Host.cc
+++ b/ml/Host.cc
@@ -33,15 +33,15 @@ static void updateDimensionsChart(RRDHOST *RH,
     if (!RS) {
         std::string IdPrefix = "dimensions";
         std::string TitlePrefix = "Anomaly detection dimensions for host";
-        auto P = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
+        auto IdTitlePair = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
 
         RS = rrdset_create_localhost(
             "anomaly_detection", // type
-            P.first.c_str(), // id
+            IdTitlePair.first.c_str(), // id
             NULL, // name
             "dimensions", // family
             "anomaly_detection.dimensions", // ctx
-            P.second.c_str(), // title
+            IdTitlePair.second.c_str(), // title
             "dimensions", // units
             "netdata", // plugin
             "ml", // module
@@ -76,15 +76,15 @@ static void updateRateChart(RRDHOST *RH, collected_number AnomalyRate) {
     if (!RS) {
         std::string IdPrefix = "anomaly_rate";
         std::string TitlePrefix = "Percentage of anomalous dimensions for host";
-        auto P = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
+        auto IdTitlePair = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
 
         RS = rrdset_create_localhost(
             "anomaly_detection", // type
-            P.first.c_str(), // id
+            IdTitlePair.first.c_str(), // id
             NULL, // name
             "anomaly_rate", // family
             "anomaly_detection.anomaly_rate", // ctx
-            P.second.c_str(), // title
+            IdTitlePair.second.c_str(), // title
             "percentage", // units
             "netdata", // plugin
             "ml", // module
@@ -110,15 +110,15 @@ static void updateWindowLengthChart(RRDHOST *RH, collected_number WindowLength) 
     if (!RS) {
         std::string IdPrefix = "detector_window";
         std::string TitlePrefix = "Anomaly detector window length for host";
-        auto P = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
+        auto IdTitlePair = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
 
         RS = rrdset_create_localhost(
             "anomaly_detection", // type
-            P.first.c_str(), // id
+            IdTitlePair.first.c_str(), // id
             NULL, // name
             "detector_window", // family
             "anomaly_detection.detector_window", // ctx
-            P.second.c_str(), // title
+            IdTitlePair.second.c_str(), // title
             "seconds", // units
             "netdata", // plugin
             "ml", // module
@@ -148,15 +148,15 @@ static void updateEventsChart(RRDHOST *RH,
     if (!RS) {
         std::string IdPrefix = "detector_events";
         std::string TitlePrefix = "Anomaly events triggered for host";
-        auto P = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
+        auto IdTitlePair = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
 
         RS = rrdset_create_localhost(
             "anomaly_detection", // type
-            P.first.c_str(), // id
+            IdTitlePair.first.c_str(), // id
             NULL, // name
             "detector_events", // family
             "anomaly_detection.detector_events", // ctx
-            P.second.c_str(), // title
+            IdTitlePair.second.c_str(), // title
             "boolean", // units
             "netdata", // plugin
             "ml", // module
@@ -191,15 +191,15 @@ static void updateDetectionChart(RRDHOST *RH, collected_number PredictionDuratio
     if (!RS) {
         std::string IdPrefix = "prediction_stats";
         std::string TitlePrefix = "Time it took to run prediction for host";
-        auto P = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
+        auto IdTitlePair = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
 
         RS = rrdset_create_localhost(
             "anomaly_detection", // type
-            P.first.c_str(), // id
+            IdTitlePair.first.c_str(), // id
             NULL, // name
             "prediction_stats", // family
             "anomaly_detection.prediction_stats", // ctx
-            P.second.c_str(), // title
+            IdTitlePair.second.c_str(), // title
             "milliseconds", // units
             "netdata", // plugin
             "ml", // module
@@ -229,15 +229,15 @@ static void updateTrainingChart(RRDHOST *RH,
     if (!RS) {
         std::string IdPrefix = "training_stats";
         std::string TitlePrefix = "Training step statistics for host";
-        auto P = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
+        auto IdTitlePair = getHostSpecificIdAndTitle(RH, IdPrefix, TitlePrefix);
 
         RS = rrdset_create_localhost(
             "anomaly_detection", // type
-            P.first.c_str(), // id
+            IdTitlePair.first.c_str(), // id
             NULL, // name
             "training_stats", // family
             "anomaly_detection.training_stats", // ctx
-            P.second.c_str(), // title
+            IdTitlePair.second.c_str(), // title
             "milliseconds", // units
             "netdata", // plugin
             "ml", // module

--- a/ml/ml-dummy.c
+++ b/ml/ml-dummy.c
@@ -4,6 +4,15 @@
 
 #if !defined(ENABLE_ML)
 
+bool ml_capable() {
+    return false;
+}
+
+bool ml_enabled(RRDHOST *RH) {
+    (void) RH;
+    return false;
+}
+
 void ml_init(void) {}
 
 void ml_new_host(RRDHOST *RH) { (void) RH; }
@@ -36,6 +45,17 @@ char *ml_get_anomaly_event_info(RRDHOST *RH, const char *AnomalyDetectorName,
     (void) RH; (void) AnomalyDetectorName;
     (void) AnomalyDetectorVersion; (void) After; (void) Before;
     return NULL;
+}
+
+void ml_process_rrdr(RRDR *R, int MaxAnomalyRates) {
+    (void) R;
+    (void) MaxAnomalyRates;
+}
+
+void ml_dimension_update_name(RRDSET *RS, RRDDIM *RD, const char *name) {
+    (void) RS;
+    (void) RD;
+    (void) name;
 }
 
 #endif

--- a/ml/ml.h
+++ b/ml/ml.h
@@ -8,9 +8,18 @@ extern "C" {
 #endif
 
 #include "daemon/common.h"
+#include "web/api/queries/rrdr.h"
+
+// This is an internal DBEngine function redeclared here so that we can free
+// the anomaly rate dimension, whenever its backing dimension is freed.
+extern void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated);
 
 typedef void* ml_host_t;
 typedef void* ml_dimension_t;
+
+bool ml_capable();
+
+bool ml_enabled(RRDHOST *RH);
 
 void ml_init(void);
 
@@ -30,6 +39,12 @@ char *ml_get_anomaly_events(RRDHOST *RH, const char *AnomalyDetectorName,
 
 char *ml_get_anomaly_event_info(RRDHOST *RH, const char *AnomalyDetectorName,
                                 int AnomalyDetectorVersion, time_t After, time_t Before);
+
+void ml_process_rrdr(RRDR *R, int MaxAnomalyRates);
+
+void ml_dimension_update_name(RRDSET *RS, RRDDIM *RD, const char *name);
+
+#define ML_ANOMALY_RATES_CHART_ID  "anomaly_detection.anomaly_rates"
 
 #if defined(ENABLE_ML_TESTS)
 int test_ml(int argc, char *argv[]);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -129,6 +129,10 @@ unsigned int remote_clock_resync_iterations = 60;
 
 
 static inline int should_send_chart_matching(RRDSET *st) {
+    // Do not stream anomaly rates charts.
+    if (unlikely(st->state->is_ar_chart))
+        return false;
+
     if(unlikely(!rrdset_flag_check(st, RRDSET_FLAG_ENABLED))) {
         rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_SEND);
         rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_IGNORE);

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -229,7 +229,7 @@ int rrdset2anything_api_v1(
         return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
 
-    if (st->state->is_ar_chart)
+    if (st && st->state->is_ar_chart)
         ml_process_rrdr(r, max_anomaly_rates);
 
     RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -217,6 +217,7 @@ int rrdset2anything_api_v1(
         , time_t *latest_timestamp
         , struct context_param *context_param_list
         , char *chart_label_key
+        , int max_anomaly_rates
 ) {
 
     if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE))
@@ -227,6 +228,9 @@ int rrdset2anything_api_v1(
         buffer_strcat(wb, "Cannot generate output with these parameters on this chart.");
         return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
+
+    if (st->state->is_ar_chart)
+        ml_process_rrdr(r, max_anomaly_rates);
 
     RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
 

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -67,6 +67,7 @@ extern int rrdset2anything_api_v1(
         , time_t *latest_timestamp
         , struct context_param *context_param_list
         , char *chart_label_key
+        , int max_anomaly_rates
 );
 
 extern int rrdset2value_api_v1(

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -401,13 +401,14 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
 
     time_t last_timestamp_in_data = 0, google_timestamp = 0;
 
-    char *chart = NULL
-    , *before_str = NULL
-    , *after_str = NULL
-    , *group_time_str = NULL
-    , *points_str = NULL
-    , *context = NULL
-    , *chart_label_key = NULL;
+    char *chart = NULL;
+    char *before_str = NULL;
+    char *after_str = NULL;
+    char *group_time_str = NULL;
+    char *points_str = NULL;
+    char *max_anomaly_rates_str = NULL;
+    char *context = NULL;
+    char *chart_label_key = NULL;
 
     int group = RRDR_GROUPING_AVERAGE;
     uint32_t format = DATASOURCE_JSON;
@@ -483,6 +484,9 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
                 else if(!strcmp(tqx_name, "outFileName"))
                     outFileName = tqx_value;
             }
+        }
+        else if(!strcmp(name, "max_anomaly_rates")) {
+            max_anomaly_rates_str = value;
         }
     }
 
@@ -564,6 +568,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     long long after  = (after_str  && *after_str) ?str2l(after_str):-600;
     int       points = (points_str && *points_str)?str2i(points_str):0;
     long      group_time = (group_time_str && *group_time_str)?str2l(group_time_str):0;
+    int       max_anomaly_rates = (max_anomaly_rates_str && *max_anomaly_rates_str) ? str2i(max_anomaly_rates_str) : 0;
 
     debug(D_WEB_CLIENT, "%llu: API command 'data' for chart '%s', dimensions '%s', after '%lld', before '%lld', points '%d', group '%d', format '%u', options '0x%08x'"
           , w->id
@@ -606,8 +611,10 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         buffer_strcat(w->response.data, "(");
     }
 
-    ret = rrdset2anything_api_v1(st, w->response.data, dimensions, format, points, after, before, group, group_time
-                                 , options, &last_timestamp_in_data, context_param_list, chart_label_key);
+    ret = rrdset2anything_api_v1(st, w->response.data, dimensions, format,
+                                 points, after, before, group, group_time,
+                                 options, &last_timestamp_in_data, context_param_list,
+                                 chart_label_key, max_anomaly_rates);
 
     free_context_param_list(&context_param_list);
 


### PR DESCRIPTION
##### Summary

This commit adds support for tracking anomaly rates with DBEngine. We
do so by creating a single chart with id "anomaly_detection.anomaly_rates" for
each trainable/predictable host, which is responsible for tracking the anomaly
rate of each dimension that we train/predict for that host.

The rrdset->state->is_ar_chart boolean flag is set to true only for anomaly
rates charts. We use this flag to:

    - Disable exposing the anomaly rates charts through the functionality
      in backends/, exporting/ and streaming/.
    - Skip generation of configuration options for the name, algorithm,
      multiplier, divisor of each dimension in an anomaly rates chart.
    - Skip the creation of health variables for anomaly rates dimensions.
    - Skip the chart/dim queue of ACLK.
    - Post-process the RRDR result of an anomaly rates chart, so that we can
      return a sorted, trimmed number of anomalous dimensions.

In a child/parent configuration where both the child and the parent run
ML for the child, we want to be able to stream the rest of the ML-related
charts to the parent. To be able to do this without any chart name collisions,
the charts are now created on localhost and their IDs and titles have the node's
machine_guid and hostname as a suffix, respectively.

##### Test Plan

- Local & CI builds.
- Staging once merged.