### PR TITLE
disable_ebpf_socket: Disable thread while race condition is fixed

### DIFF
--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -57,7 +57,7 @@
     oomkill = yes
     process = yes
     shm = yes
-    socket = yes
+    socket = no # Disabled while we are fixing race condition
     softirq = yes
     sync = yes
     swap = no


### PR DESCRIPTION
##### Summary
As we were discussing in this [issue ](https://github.com/netdata/netdata/issues/12027), we should not expect that an eBPF program could crash a host, but this is happening in two different distributions. After to talk with @ilyam8 , @cpipilas , and @stelfrag we decide to disable it, while we are working to fix the problem.

##### Test Plan

1. Clone branch
2. remove or rename `/etc/netdata/ebpf.d.conf`.
3. Clone branch and start netdata.
4. Take a look in your dashboard, you should not have the submenu `Networking stack` -> `kernel function(eBPF)`. You won't see any chart from eBPF socket at `Apps` -> `network`.

##### Additional Information
