### PR TITLE
Make a lack of an os-release file non-fatal on install.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -399,34 +399,42 @@ get_system_info() {
       elif [ -s "/usr/lib/os-release" ] && [ -r "/usr/lib/os-release" ]; then
         os_release_file="/usr/lib/os-release"
       else
-        fatal "Cannot find an os-release file ..." F0401
+        warning "Cannot find an os-release file ..."
       fi
 
-      # shellcheck disable=SC1090
-      . "${os_release_file}"
+      if [ -n "${os_release_file}" ]; then
+        # shellcheck disable=SC1090
+        . "${os_release_file}"
 
-      DISTRO="${ID}"
-      SYSVERSION="${VERSION_ID}"
-      SYSCODENAME="${VERSION_CODENAME}"
-      SYSARCH="$(uname -m)"
+        DISTRO="${ID}"
+        SYSVERSION="${VERSION_ID}"
+        SYSCODENAME="${VERSION_CODENAME}"
+        SYSARCH="$(uname -m)"
 
-      supported_compat_names="debian ubuntu centos fedora opensuse"
+        supported_compat_names="debian ubuntu centos fedora opensuse"
 
-      if str_in_list "${DISTRO}" "${supported_compat_names}"; then
-        DISTRO_COMPAT_NAME="${DISTRO}"
+        if str_in_list "${DISTRO}" "${supported_compat_names}"; then
+            DISTRO_COMPAT_NAME="${DISTRO}"
+        else
+            case "${DISTRO}" in
+            opensuse-leap)
+                DISTRO_COMPAT_NAME="opensuse"
+                ;;
+            rocky|rhel)
+                DISTRO_COMPAT_NAME="centos"
+                SYSVERSION=$(echo "$SYSVERSION" | cut -d'.' -f1)
+                ;;
+            *)
+                DISTRO_COMPAT_NAME="unknown"
+                ;;
+            esac
+        fi
       else
-        case "${DISTRO}" in
-          opensuse-leap)
-            DISTRO_COMPAT_NAME="opensuse"
-            ;;
-          rocky|rhel)
-            DISTRO_COMPAT_NAME="centos"
-            SYSVERSION=$(echo "$SYSVERSION" | cut -d'.' -f1)
-            ;;
-          *)
-            DISTRO_COMPAT_NAME="unknown"
-            ;;
-        esac
+        DISTRO="unknown"
+        DISTRO_COMPAT_NAME="unknown"
+        SYSVERSION="unknown"
+        SYSCODENAME="unknown"
+        SYSARCH="$(uname -m)"
       fi
       ;;
     Darwin)

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -139,7 +139,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "ec587c2196d71f90831cbe691545f92c" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "42b5969be5d38ac696e21e444df72f86" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

Instead just skip trying native packages and fall back properly to static builds or local builds.

This was the intended behavior originally, it just never got implemented properly.

##### Test Plan

This can be verified by attempting to install on a system which lacks both `/etc/os-release` and `/usr/lib/os-release`. Without this PR, the installer should fail very early with an error indicating that neither file is present. With this PR, the installer should simply issue a warning about the lack of the files, warn about the inability to determine the distro for native packages, and then ultimately attempt to install with a static build or local build.

##### Additional Information

Relevant to, but does not completely fix: #12068 

This will eliminate the F0401 error code in our anonymous statistics being sent from the installer by converting that case to a non-fatal situation. 