### PR TITLE
Add info about installer interactivity to anonymous installer telemetry events.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -150,6 +150,7 @@ telemetry_event() {
     "error_code": "${3}",
     "error_message": "${2}",
     "install_options": "${KICKSTART_OPTIONS}",
+    "install_interactivity": "${INTERACTIVE}",
     "total_runtime": "${total_duration}",
     "selected_install_method": "${SELECTED_INSTALL_METHOD}",
     "netdata_release_channel": "${RELEASE_CHANNEL:-null}",

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -139,7 +139,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "42b5969be5d38ac696e21e444df72f86" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "862580a7c6e4b973b6fcfd907e2f1bbc" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

This simply adds a property to he events indicating whether they came
from an interactive or non-interactive run, which will allow for better
handling of some of the other data in the events.

##### Test Plan

n/a