### PR TITLE
Properly handle non-interactive installs as non-root users.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -462,11 +462,19 @@ str_in_list() {
 confirm_root_support() {
   if [ "$(id -u)" -ne "0" ]; then
     if [ -z "${ROOTCMD}" ] && command -v sudo > /dev/null; then
-      ROOTCMD="sudo"
+      if [ "${INTERACTIVE}" -eq 0 ]; then
+        ROOTCMD="sudo -n"
+      else
+        ROOTCMD="sudo"
+      fi
     fi
 
     if [ -z "${ROOTCMD}" ] && command -v doas > /dev/null; then
-      ROOTCMD="doas"
+      if [ "${INTERACTIVE}" -eq 0 ]; then
+        ROOTCMD="doas -n"
+      else
+        ROOTCMD="doas"
+      fi
     fi
 
     if [ -z "${ROOTCMD}" ] && command -v pkexec > /dev/null; then

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -136,7 +136,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "862580a7c6e4b973b6fcfd907e2f1bbc" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "0cfdc04fd4004f77ebc3c1e564ee6476" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

This ensures that `sudo` and `doas` properly fail when we are running non-interactively if they would require the user to input a password.

##### Test Plan

This can be tested by manually running the kickstart script in non-interactive mode as a non-root user on a system that requires password input to run commands as root with `sudo`. Without the changes in this PR, execution will stop the first time the kickstart code tries to invoke `sudo`, while with the changes an error will be thrown instead.