### PR TITLE
Added interactive install script where possible

### DIFF
--- a/docs/guides/export/export-netdata-metrics-graphite.mdx
+++ b/docs/guides/export/export-netdata-metrics-graphite.mdx
@@ -1,9 +1,10 @@
-<!--
+---
 title: Export and visualize Netdata metrics in Graphite 
 description: "Use Netdata to collect and export thousands of metrics to Graphite for long-term storage or further analysis."
 image: /img/seo/guides/export/export-netdata-metrics-graphite.png
--->
+---
 
+import { OneLineInstallWget } from '@site/src/components/OneLineInstall/' 
 # Export and visualize Netdata metrics in Graphite
 
 Collecting metrics is an essential part of monitoring any application, service, or infrastructure, but it's not the
@@ -31,9 +32,7 @@ Let's get started.
 If you don't have the Netdata Agent installed already, visit the [installation guide](/packaging/installer/README.md)
 for the recommended instructions for your system. In most cases, you can use the one-line installation script:
 
-```bash
-wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh
-```
+<OneLineInstallWget/>
 
 Once installation finishes, open your browser and navigate to `http://NODE:19999`, replacing `NODE` with the IP address
 or hostname of your system, to find the Agent dashboard.

--- a/docs/guides/monitor/lamp-stack.mdx
+++ b/docs/guides/monitor/lamp-stack.mdx
@@ -1,4 +1,4 @@
-<!--
+---
 title: "LAMP stack monitoring (Linux, Apache, MySQL, PHP) with Netdata"
 description: "Set up robust LAMP stack monitoring (Linux, Apache, MySQL, PHP) in just a few minutes using a free, open-source monitoring tool that collects metrics every second."
 image: /img/seo/guides/monitor/lamp-stack.png
@@ -6,7 +6,9 @@ author: "Joel Hans"
 author_title: "Editorial Director, Technical & Educational Resources"
 author_img: "/img/authors/joel-hans.jpg"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor/lamp-stack.md
--->
+---
+
+import { OneLineInstallWget } from '@site/src/components/OneLineInstall/'
 
 # LAMP stack monitoring (Linux, Apache, MySQL, PHP) with Netdata
 
@@ -59,9 +61,7 @@ To follow this tutorial, you need:
 If you don't have the free, open-source Netdata monitoring agent installed on your node yet, get started with a [single
 kickstart command](/docs/get-started.mdx):
 
-```bash
-wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh
-```
+<OneLineInstallWget/>
 
 The Netdata Agent is now collecting metrics from your node every second. You don't need to jump into the dashboard yet,
 but if you're curious, open your favorite browser and navigate to `http://localhost:19999` or `http://NODE:19999`,

--- a/docs/guides/monitor/pi-hole-raspberry-pi.mdx
+++ b/docs/guides/monitor/pi-hole-raspberry-pi.mdx
@@ -1,9 +1,11 @@
-<!--
+---
 title: "Monitor Pi-hole (and a Raspberry Pi) with Netdata"
 description: "Monitor Pi-hole metrics, plus Raspberry Pi system metrics, in minutes and completely for free with Netdata's open-source monitoring agent."
 image: /img/seo/guides/monitor/netdata-pi-hole-raspberry-pi.png
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor/pi-hole-raspberry-pi.md
--->
+---
+
+import { OneLineInstallWget } from '@site/src/components/OneLineInstall/'
 
 # Monitor Pi-hole (and a Raspberry Pi) with Netdata
 
@@ -52,9 +54,7 @@ possible historic data.
 On Raspberry Pis running Raspbian, the best way to install Netdata is our one-line kickstart script. This script asks
 you to install dependencies, then compiles Netdata from source via [GitHub](https://github.com/netdata/netdata).
 
-```bash
-wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh
-```
+<OneLineInstallWget/>
 
 Once installed on a Raspberry Pi 4 with no accessories, Netdata starts collecting roughly 1,500 metrics every second and
 populates its dashboard with more than 250 charts.

--- a/docs/guides/step-by-step/step-00.mdx
+++ b/docs/guides/step-by-step/step-00.mdx
@@ -1,9 +1,9 @@
-<!--
+---
 title: "The step-by-step Netdata guide"
 date: 2020-03-31
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/step-by-step/step-00.md
--->
-
+---
+import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
 # The step-by-step Netdata guide
 
 Welcome to Netdata! We're glad you're interested in our health monitoring and performance troubleshooting system.
@@ -48,14 +48,11 @@ Netdata. We use this information to better understand how we can improve the Net
 
 To install Netdata, run the following as your normal user:
 
-´´´bash
-wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh
-´´´
+<OneLineInstallWget/>
+
 Or, if you have cURL but not wget (such as on macOS):
 
-´´´bash
-curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh
-´´´
+<OneLineInstallCurl/>
 
 
 Once finished, you'll have Netdata installed, and you'll be set up to get _nightly updates_ to get the latest features,

--- a/exporting/prometheus/README.mdx
+++ b/exporting/prometheus/README.mdx
@@ -1,9 +1,10 @@
-<!--
+---
 title: "Export metrics to Prometheus"
 description: "Export Netdata metrics to Prometheus for archiving and further analysis."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/exporting/prometheus/README.md
-sidebar_label: Using Netdata with Prometheus
--->
+sidebar_label: "Using Netdata with Prometheus"
+---
+import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
 
 # Using Netdata with Prometheus
 
@@ -23,15 +24,11 @@ of installing the latest Netdata and keep it upgrade automatically.
 
 To install Netdata, run the following as your normal user:
 
-```bash
-wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh
-```
+<OneLineInstallWget/>
 
 Or, if you have cURL but not wget (such as on macOS):
 
-```bash
-curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh
-```
+<OneLineInstallCurl/>
 
 At this point we should have Netdata listening on port 19999. Attempt to take your browser here:
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -5,6 +5,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/instal
 
 import { Install, InstallBox } from '../../../src/components/Install/'
 
+import { OneLineInstallWget, OneLineInstallCurl } from '../../../src/components/OneLineInstall/'
 # Installation guide
 
 Netdata is a monitoring agent designed to run on all your systems: physical and virtual servers, containers, even
@@ -37,15 +38,11 @@ This method is fully automatic on all Linux distributions, including Ubuntu, Deb
 To install Netdata, including all dependencies required to connect to Netdata Cloud, and get _automatic nightly
 updates_, run the following as your normal user:
 
-```bash
-wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh
-```
+<OneLineInstallWget/>
 
 Or, if you have cURL but not wget (such as on macOS):
 
-```bash
-curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh
-```
+<OneLineInstallCurl/>
 
 This script will preferentially use native DEB/RPM packages if we provide them for your platform.
 

--- a/packaging/installer/methods/kickstart.mdx
+++ b/packaging/installer/methods/kickstart.mdx
@@ -1,8 +1,9 @@
-<!--
+---
 title: "Install Netdata with kickstart.sh"
 description: "The kickstart.sh script installs Netdata from source, including all dependencies required to connect to Netdata Cloud, with a single command."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/kickstart.md
--->
+---
+import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
 
 # Install Netdata with kickstart.sh
 
@@ -18,15 +19,11 @@ The kickstart script works on all Linux distributions and macOS environments. By
 
 To install Netdata, run the following as your normal user:
 
-```bash
-wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh
-```
+<OneLineInstallWget/>
 
 Or, if you have cURL but not wget (such as on macOS):
 
-```bash
-curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh
-```
+<OneLineInstallCurl/>
 
 
 ## What does `kickstart.sh` do?


### PR DESCRIPTION
The documentation uses the kickstart script installation instructions in many places. 
To improve documentation maintainability, I've used the react components `OneLineInstallWget` and `OneLineInstallCurl`. Bonus points: The users can select certain installation options by clicking a checkbox. The install command will be updated with the respective installation options.

Some code snippets are still written in markdown, as they differ from the standard "Install netdata" use case. These instances contain a certain flag, like `--reinstall`, so I can't use the interactive component. 