### PR TITLE
Fix handling of Oracle Linux repoconfig packages.

### DIFF
--- a/packaging/repoconfig/netdata-edge.repo.ol
+++ b/packaging/repoconfig/netdata-edge.repo.ol
@@ -1,0 +1,19 @@
+[netdata-edge]
+name=Netdata Edge
+baseurl=https://packagecloud.io/netdata/netdata-edge/ol/$releasever/$basearch
+repo_gpgcheck=1
+gpgcheck=0
+gpgkey=https://packagecloud.io/netdata/netdata-edge/gpgkey
+enabled=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+
+[netdata-repoconfig]
+name=Netdata Repository Config
+baseurl=https://packagecloud.io/netdata/netdata-repoconfig/ol/$releasever/$basearch
+repo_gpgcheck=1
+gpgcheck=0
+gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+enabled=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/packaging/repoconfig/netdata-repo.spec
+++ b/packaging/repoconfig/netdata-repo.spec
@@ -14,6 +14,8 @@ Source2:        netdata.repo.suse
 Source3:        netdata-edge.repo.suse
 Source4:        netdata.repo.centos
 Source5:        netdata-edge.repo.centos
+Source6:        netdata.repo.ol
+Source7:        netdata-edge.repo.ol
 
 BuildArch:      noarch
 
@@ -39,6 +41,11 @@ install -pm 644 %{SOURCE3} ./netdata-edge.repo
 %if 0%{?centos_ver}
 install -pm 644 %{SOURCE4} ./netdata.repo
 install -pm 644 %{SOURCE5} ./netdata-edge.repo
+%endif
+
+%if 0%{?oraclelinux}
+install -pm 644 %{SOURCE6} ./netdata.repo
+install -pm 644 %{SOURCE7} ./netdata-edge.repo
 %endif
 
 %build

--- a/packaging/repoconfig/netdata.repo.ol
+++ b/packaging/repoconfig/netdata.repo.ol
@@ -1,0 +1,19 @@
+[netdata]
+name=Netdata
+baseurl=https://packagecloud.io/netdata/netdata/ol/$releasever/$basearch
+repo_gpgcheck=1
+gpgcheck=0
+gpgkey=https://packagecloud.io/netdata/netdata/gpgkey
+enabled=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+
+[netdata-repoconfig]
+name=Netdata Repository Config
+baseurl=https://packagecloud.io/netdata/netdata-repoconfig/ol/$releasever/$basearch
+repo_gpgcheck=1
+gpgcheck=0
+gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+enabled=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
##### Summary

Currently, the Oracle Linux 8 repository configuration packages we are publishing are actually configuring the RHEL/CentOS/Rocky repos instead of the correct Oracle Linux specific ones. This PR fixes that so that we properly use the OL-specific repos on OL systems.

##### Test Plan

n/a