### PR TITLE
Add proper support for Oracle Linux native packages to installer.

### DIFF
--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -136,7 +136,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "0cfdc04fd4004f77ebc3c1e564ee6476" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "22039cdffef3eef21238c26605085ede" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

They got missed somehow in the initial implementation.

Also fixes a potential bug in version parsing for CentOS systems.

##### Test Plan

Once #12100 is merged and the repoconfig packages are updated, this can be tested by simply running the updated `kickstart.sh` from this PR in an OL8 Docker container. Without the changes here, it will fall back to a static install. With these changes, it will instead install using a native package.