### PR TITLE
Remove ACLK legacy documentation

### DIFF
--- a/aclk/README.md
+++ b/aclk/README.md
@@ -50,39 +50,10 @@ You can configure following keys in the `netdata.conf` section `[cloud]`:
 [cloud]
   statistics = yes
   query thread count = 2
-  aclk implementation = ng
 ```
 
 - `statistics` enables/disables ACLK related statistics and their charts. You can disable this to save some space in the database and slightly reduce memory usage of Netdata Agent.
 - `query thread count` specifies the number of threads to process cloud queries. Increasing this setting is useful for nodes with many children (streaming), which can expect to handle more queries (and/or more complicated queries).
-- `aclk implementation` - see [ACLK implementation](#aclk-implementation) section
-
-## ACLK implementation
-
-Currently we are in process of switching ACLK to brand new technical stack called ACLK-NG. To choose your implementation, change the `aclk implementation` setting in your `netdata.conf` (accepted values `ng` or `legacy`).
-
-Before changing this value, check the desired implementation is available (determined at build time) by running `netdata -W buildinfo`. Following lines indicate which ACLK implementations are available:
-
-```
-Features:
-    ACLK Next Generation:    YES
-    ACLK Legacy:             YES
-```
-
-To verify which ACLK implementation Netdata uses, visit the `/api/v1/info` endpoint on your local dashboard and check the `aclk-implementation` key.
-
-New Netdata Cloud features will be implemented on top of ACLK-NG only. ACLK Legacy is therefore kept as a fallback in case some users have issues.
-
-
-> Note: ACLK Legacy will be removed in following releases! 
-> Update your ACLK configuration to ACLK-NG to prevent any disruptions.
-
-
-### Improvements of ACLK-NG over Legacy are:
-- No dependency on custom patched `libmosquitto` (no bundling of libraries). Which should remove obstacles many GNU/Linux distribution package maintainers had trying to provide Netdata with Cloud support
-- No dependency on libwebsockets
-- Lower latency and higher throughput
-- More up to date, new features for Netdata Cloud are currently developed on top of ACLK-NG first
 
 ## Disable the ACLK
 


### PR DESCRIPTION
##### Summary
ACLK Legacy is removed. This removes information about it from the docs.

##### Test Plan
##### Additional Information
