### PR TITLE
Docs fix: Match the new install box component name

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -6,7 +6,7 @@ sidebar_label: "Get started"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/get-started.mdx
 ---
 
-import { OneLineInstall } from '../src/components/OneLineInstall/'
+import { OneLineInstallWget } from '../src/components/OneLineInstall/'
 import { Install, InstallBox } from '../src/components/Install/'
 
 # Get started with Netdata
@@ -29,7 +29,7 @@ builds Netdata from its source code.
 
 Copy the script, paste it into your node's terminal, and hit `Enter` to begin the installation process.
 
-<OneLineInstall />
+<OneLineInstallWget />
 
 Jump down to [what's next](#whats-next) to learn how to view your new dashboard and take your next steps monitoring and
 troubleshooting with Netdata.


### PR DESCRIPTION
As mentioned in #12090, the component for the interactive install boxes was renamed from `OneLineInstall` to `OneLineInstallWget`.

This is a minor docs fix so the component names still match.