### PR TITLE
Docs: Fix paths to install boxes

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -6,7 +6,7 @@ sidebar_label: "Get started"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/get-started.mdx
 ---
 
-import { OneLineInstall } from '../src/components/OneLineInstall/'
+import { OneLineInstallWget } from '../src/components/OneLineInstall/'
 import { Install, InstallBox } from '../src/components/Install/'
 
 # Get started with Netdata
@@ -29,7 +29,7 @@ builds Netdata from its source code.
 
 Copy the script, paste it into your node's terminal, and hit `Enter` to begin the installation process.
 
-<OneLineInstall />
+<OneLineInstallWget />
 
 Jump down to [what's next](#whats-next) to learn how to view your new dashboard and take your next steps monitoring and
 troubleshooting with Netdata.

--- a/docs/guides/export/export-netdata-metrics-graphite.md
+++ b/docs/guides/export/export-netdata-metrics-graphite.md
@@ -3,7 +3,7 @@ title: Export and visualize Netdata metrics in Graphite
 description: "Use Netdata to collect and export thousands of metrics to Graphite for long-term storage or further analysis."
 image: /img/seo/guides/export/export-netdata-metrics-graphite.png
 -->
-import { OneLineInstallWget } from '../../../src/components/OneLineInstall/'
+import { OneLineInstallWget } from '../../src/components/OneLineInstall/'
 
 # Export and visualize Netdata metrics in Graphite
 

--- a/docs/guides/monitor/lamp-stack.md
+++ b/docs/guides/monitor/lamp-stack.md
@@ -7,7 +7,7 @@ author_title: "Editorial Director, Technical & Educational Resources"
 author_img: "/img/authors/joel-hans.jpg"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor/lamp-stack.md
 -->
-import { OneLineInstallWget } from '../../../src/components/OneLineInstall/'
+import { OneLineInstallWget } from '../../src/components/OneLineInstall/'
 
 # LAMP stack monitoring (Linux, Apache, MySQL, PHP) with Netdata
 

--- a/docs/guides/monitor/pi-hole-raspberry-pi.md
+++ b/docs/guides/monitor/pi-hole-raspberry-pi.md
@@ -4,7 +4,7 @@ description: "Monitor Pi-hole metrics, plus Raspberry Pi system metrics, in minu
 image: /img/seo/guides/monitor/netdata-pi-hole-raspberry-pi.png
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor/pi-hole-raspberry-pi.md
 -->
-import { OneLineInstallWget } from '../../../src/components/OneLineInstall/'
+import { OneLineInstallWget } from '../../src/components/OneLineInstall/'
 
 # Monitor Pi-hole (and a Raspberry Pi) with Netdata
 

--- a/docs/guides/step-by-step/step-00.md
+++ b/docs/guides/step-by-step/step-00.md
@@ -3,7 +3,7 @@ title: "The step-by-step Netdata guide"
 date: 2020-03-31
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/step-by-step/step-00.md
 -->
-import { OneLineInstallWget, OneLineInstallCurl } from '../../../src/components/OneLineInstall/'
+import { OneLineInstallWget, OneLineInstallCurl } from '../../src/components/OneLineInstall/'
 
 # The step-by-step Netdata guide
 

--- a/exporting/prometheus/README.md
+++ b/exporting/prometheus/README.md
@@ -4,7 +4,7 @@ description: "Export Netdata metrics to Prometheus for archiving and further ana
 custom_edit_url: https://github.com/netdata/netdata/edit/master/exporting/prometheus/README.md
 sidebar_label: "Using Netdata with Prometheus"
 -->
-import { OneLineInstallWget, OneLineInstallCurl } from '../../src/components/OneLineInstall/'
+import { OneLineInstallWget, OneLineInstallCurl } from '../../../src/components/OneLineInstall/'
 
 # Using Netdata with Prometheus
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -3,9 +3,9 @@ title: "Installation guide"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/README.md
 -->
 
-import { Install, InstallBox } from '../../src/components/Install/'
+import { Install, InstallBox } from '../../../src/components/Install/'
 
-import { OneLineInstallWget, OneLineInstallCurl } from '../../src/components/OneLineInstall/'
+import { OneLineInstallWget, OneLineInstallCurl } from '../../../src/components/OneLineInstall/'
 
 # Installation guide
 

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -3,7 +3,7 @@ title: "Install Netdata with kickstart.sh"
 description: "The kickstart.sh script installs Netdata from source, including all dependencies required to connect to Netdata Cloud, with a single command."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/kickstart.md
 -->
-import { OneLineInstallWget, OneLineInstallCurl } from '../../../src/components/OneLineInstall/'
+import { OneLineInstallWget, OneLineInstallCurl } from '../../../../../src/components/OneLineInstall/'
 
 # Install Netdata with kickstart.sh
 


### PR DESCRIPTION
### Problem
The repo structure in learn doesn't match 100% with the structure on netdata/netdata so I didn't know how to verify the file paths were correct. 

### How I fixed it
I used the [Netlify deploy log](https://app.netlify.com/sites/netdata-docusaurus/deploys/6204f090a1bb540008dca715) to investigate how the paths change. 

To ensure that the new paths resolve, I navigated to each directory in my terminal and from there, used the `../../../src/Components/OneLineInstall` command to check if I end up in the right place.

So, 🤞 this should be the last PR concerning the install boxes. 
Very sorry for yet another PR about this topic. 

#### For future discussion
These issues arise because we chose to stick with Markdown. 
If we had switched to MDX, we could use the `@site/src/...` syntax to import components, which would probably require less troubleshooting. I'm not bringing this up because I'm sour about it, but just so we can have a more detailed discussion in the future. 