### PR TITLE
move mount points to mount category

### DIFF
--- a/backends/prometheus/README.md
+++ b/backends/prometheus/README.md
@@ -150,15 +150,15 @@ groups:
           summary: Memory alert for container node '{{ $labels.job }}'
 
       - alert: node_low_root_filesystem_space_20
-        expr: 100 / sum(netdata_disk_space_GB_average{family="/"}) by (job)
-          * sum(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}) by (job) < 20
+        expr: 100 / sum(netdata_mount_space_GB_average{family="/"}) by (job)
+          * sum(netdata_mount_space_GB_average{family="/",dimension=~"avail|cached"}) by (job) < 20
         for: 1m
         annotations:
           description: '{{ $labels.job }} root filesystem space is {{ humanize $value}}%.'
           summary: Root filesystem alert for container node '{{ $labels.job }}'
 
       - alert: node_root_filesystem_fill_rate_6h
-        expr: predict_linear(netdata_disk_space_GB_average{family="/",dimension=~"avail|cached"}[1h], 6 * 3600) < 0
+        expr: predict_linear(netdata_mount_space_GB_average{family="/",dimension=~"avail|cached"}[1h], 6 * 3600) < 0
         for: 1h
         labels:
           severity: critical

--- a/build_external/scenarios/aclk-testing/agent_netdata.conf
+++ b/build_external/scenarios/aclk-testing/agent_netdata.conf
@@ -1314,17 +1314,17 @@
 	# dim idle multiplier = 1
 	# dim idle divisor = 1
 
-[disk_space._]
+[mount_space._]
 	history = 5
 	# enabled = yes
-	# cache directory = /var/cache/netdata/disk_space._
+	# cache directory = /var/cache/netdata/mount_space._
 	# chart type = stacked
-	# type = disk_space
+	# type = mount_space
 	# family = /
 	# units = GiB
 	# context = disk.space
 	# priority = 2023
-	# name = disk_space._
+	# name = mount_space._
 	# title = Disk Space Usage for / [overlay]
 	# dim avail name = avail
 	# dim avail algorithm = absolute
@@ -1339,17 +1339,17 @@
 	# dim reserved_for_root multiplier = 4096
 	# dim reserved_for_root divisor = 1073741824
 
-[disk_inodes._]
+[mount_inodes._]
 	history = 5
 	# enabled = yes
-	# cache directory = /var/cache/netdata/disk_inodes._
+	# cache directory = /var/cache/netdata/mount_inodes._
 	# chart type = stacked
-	# type = disk_inodes
+	# type = mount_inodes
 	# family = /
 	# units = inodes
 	# context = disk.inodes
 	# priority = 2024
-	# name = disk_inodes._
+	# name = mount_inodes._
 	# title = Disk Files (inodes) Usage for / [overlay]
 	# dim avail name = avail
 	# dim avail algorithm = absolute
@@ -1364,17 +1364,17 @@
 	# dim reserved_for_root multiplier = 1
 	# dim reserved_for_root divisor = 1
 
-[disk_space._dev]
+[mount_space._dev]
 	history = 5
 	# enabled = yes
-	# cache directory = /var/cache/netdata/disk_space._dev
+	# cache directory = /var/cache/netdata/mount_space._dev
 	# chart type = stacked
-	# type = disk_space
+	# type = mount_space
 	# family = /dev
 	# units = GiB
 	# context = disk.space
 	# priority = 2023
-	# name = disk_space._dev
+	# name = mount_space._dev
 	# title = Disk Space Usage for /dev [tmpfs]
 	# dim avail name = avail
 	# dim avail algorithm = absolute
@@ -1389,17 +1389,17 @@
 	# dim reserved_for_root multiplier = 4096
 	# dim reserved_for_root divisor = 1073741824
 
-[disk_inodes._dev]
+[mount_inodes._dev]
 	history = 5
 	# enabled = yes
-	# cache directory = /var/cache/netdata/disk_inodes._dev
+	# cache directory = /var/cache/netdata/mount_inodes._dev
 	# chart type = stacked
-	# type = disk_inodes
+	# type = mount_inodes
 	# family = /dev
 	# units = inodes
 	# context = disk.inodes
 	# priority = 2024
-	# name = disk_inodes._dev
+	# name = mount_inodes._dev
 	# title = Disk Files (inodes) Usage for /dev [tmpfs]
 	# dim avail name = avail
 	# dim avail algorithm = absolute
@@ -1414,17 +1414,17 @@
 	# dim reserved_for_root multiplier = 1
 	# dim reserved_for_root divisor = 1
 
-[disk_space._dev_shm]
+[mount_space._dev_shm]
 	history = 5
 	# enabled = yes
-	# cache directory = /var/cache/netdata/disk_space._dev_shm
+	# cache directory = /var/cache/netdata/mount_space._dev_shm
 	# chart type = stacked
-	# type = disk_space
+	# type = mount_space
 	# family = /dev/shm
 	# units = GiB
 	# context = disk.space
 	# priority = 2023
-	# name = disk_space._dev_shm
+	# name = mount_space._dev_shm
 	# title = Disk Space Usage for /dev/shm [shm]
 	# dim avail name = avail
 	# dim avail algorithm = absolute
@@ -1439,17 +1439,17 @@
 	# dim reserved_for_root multiplier = 4096
 	# dim reserved_for_root divisor = 1073741824
 
-[disk_inodes._dev_shm]
+[mount_inodes._dev_shm]
 	history = 5
 	# enabled = yes
-	# cache directory = /var/cache/netdata/disk_inodes._dev_shm
+	# cache directory = /var/cache/netdata/mount_inodes._dev_shm
 	# chart type = stacked
-	# type = disk_inodes
+	# type = mount_inodes
 	# family = /dev/shm
 	# units = inodes
 	# context = disk.inodes
 	# priority = 2024
-	# name = disk_inodes._dev_shm
+	# name = mount_inodes._dev_shm
 	# title = Disk Files (inodes) Usage for /dev/shm [shm]
 	# dim avail name = avail
 	# dim avail algorithm = absolute

--- a/build_external/scenarios/gaps_lo/mostly_off.conf
+++ b/build_external/scenarios/gaps_lo/mostly_off.conf
@@ -145,7 +145,7 @@ enabled = no
 [system.cpu]
 enabled = yes
 
-[disk_space._dev]
+[mount_space._dev]
 enabled = no
 
 [netdata.plugin_cgroups_cpu]
@@ -370,43 +370,43 @@ enabled = no
 [netdata.web_thread1_cpu]
 enabled = no
 
-[disk_inodes._dev]
+[mount_inodes._dev]
 enabled = no
 
-[disk_space._run]
+[mount_space._run]
 enabled = no
 
-[disk_inodes._run]
+[mount_inodes._run]
 enabled = no
 
-[disk_space._]
+[mount_space._]
 enabled = no
 
-[disk_inodes._]
+[mount_inodes._]
 enabled = no
 
-[disk_space._dev_shm]
+[mount_space._dev_shm]
 enabled = no
 
-[disk_inodes._dev_shm]
+[mount_inodes._dev_shm]
 enabled = no
 
-[disk_space._run_lock]
+[mount_space._run_lock]
 enabled = no
 
-[disk_inodes._run_lock]
+[mount_inodes._run_lock]
 enabled = no
 
-[disk_space._home]
+[mount_space._home]
 enabled = no
 
-[disk_inodes._home]
+[mount_inodes._home]
 enabled = no
 
-[disk_space._boot_efi]
+[mount_space._boot_efi]
 enabled = no
 
-[disk_space._media_amoss_deb10]
+[mount_space._media_amoss_deb10]
 enabled = no
 
 [netdata.plugin_diskspace]

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -286,11 +286,11 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
                 char title[4096 + 1];
                 snprintfz(title, 4096, "Disk Space Usage for %s [%s]", family, mi->mount_source);
                 m->st_space = rrdset_create_localhost(
-                        "disk_space"
+                        "mount_space"
                         , disk
                         , NULL
                         , family
-                        , "disk.space"
+                        , "mount.space"
                         , title
                         , "GiB"
                         , PLUGIN_DISKSPACE_NAME
@@ -328,11 +328,11 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
                 char title[4096 + 1];
                 snprintfz(title, 4096, "Disk Files (inodes) Usage for %s [%s]", family, mi->mount_source);
                 m->st_inodes = rrdset_create_localhost(
-                        "disk_inodes"
+                        "mount_inodes"
                         , disk
                         , NULL
                         , family
-                        , "disk.inodes"
+                        , "mount.inodes"
                         , title
                         , "inodes"
                         , PLUGIN_DISKSPACE_NAME

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -105,7 +105,7 @@ int mount_point_is_protected(char *mount_point)
     return 0;
 }
 
-static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
+static inline void do_mount_space_stats(struct mountinfo *mi, int update_every) {
     const char *family = mi->mount_point;
     const char *disk = mi->persistent_id;
 
@@ -281,7 +281,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         if(unlikely(!m->st_space)) {
             m->do_space = CONFIG_BOOLEAN_YES;
-            m->st_space = rrdset_find_active_bytype_localhost("disk_space", disk);
+            m->st_space = rrdset_find_active_bytype_localhost("mount_space", disk);
             if(unlikely(!m->st_space)) {
                 char title[4096 + 1];
                 snprintfz(title, 4096, "Disk Space Usage for %s [%s]", family, mi->mount_source);
@@ -323,7 +323,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
         if(unlikely(!m->st_inodes)) {
             m->do_inodes = CONFIG_BOOLEAN_YES;
-            m->st_inodes = rrdset_find_active_bytype_localhost("disk_inodes", disk);
+            m->st_inodes = rrdset_find_active_bytype_localhost("mount_inodes", disk);
             if(unlikely(!m->st_inodes)) {
                 char title[4096 + 1];
                 snprintfz(title, 4096, "Disk Files (inodes) Usage for %s [%s]", family, mi->mount_source);
@@ -420,7 +420,7 @@ void *diskspace_main(void *ptr) {
             if(mi->flags & MOUNTINFO_READONLY && !strcmp(mi->root, mi->mount_point))
                 continue;
 
-            do_disk_space_stats(mi, update_every);
+            do_mount_space_stats(mi, update_every);
             if(unlikely(netdata_exit)) break;
         }
 

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -121,7 +121,7 @@ typedef struct ebpf_tracepoint {
 #define NETDATA_EBPF_FAMILY "ebpf"
 #define NETDATA_EBPF_IP_FAMILY "ip"
 #define NETDATA_FILESYSTEM_FAMILY "filesystem"
-#define NETDATA_EBPF_MOUNT_GLOBAL_FAMILY "mount_points"
+#define NETDATA_EBPF_MOUNT_GLOBAL_FAMILY "mount"
 #define NETDATA_EBPF_CHART_TYPE_LINE "line"
 #define NETDATA_EBPF_CHART_TYPE_STACKED "stacked"
 #define NETDATA_EBPF_MEMORY_GROUP "mem"

--- a/collectors/ebpf.plugin/ebpf_mount.h
+++ b/collectors/ebpf.plugin/ebpf_mount.h
@@ -10,9 +10,9 @@
 
 #define NETDATA_LATENCY_MOUNT_SLEEP_MS 700000ULL
 
-#define NETDATA_EBPF_MOUNT_CALLS "call"
-#define NETDATA_EBPF_MOUNT_ERRORS "error"
-#define NETDATA_EBPF_MOUNT_FAMILY "mount (eBPF)"
+#define NETDATA_EBPF_MOUNT_CALLS "ebpf_calls"
+#define NETDATA_EBPF_MOUNT_ERRORS "ebpf_errors"
+#define NETDATA_EBPF_MOUNT_FAMILY "mount calls (eBPF)"
 
 // Process configuration name
 #define NETDATA_MOUNT_CONFIG_FILE "mount.conf"

--- a/collectors/freebsd.plugin/freebsd_getmntinfo.c
+++ b/collectors/freebsd.plugin/freebsd_getmntinfo.c
@@ -165,9 +165,9 @@ int do_getmntinfo(int update_every, usec_t dt) {
         if (unlikely(!(mntsize = getmntinfo(&mntbuf, MNT_NOWAIT)))) {
             error("FREEBSD: getmntinfo() failed");
             do_space = 0;
-            error("DISABLED: disk_space.* charts");
+            error("DISABLED: mount_space.* charts");
             do_inodes = 0;
-            error("DISABLED: disk_inodes.* charts");
+            error("DISABLED: mount_inodes.* charts");
             error("DISABLED: getmntinfo module");
             return 1;
         } else {
@@ -222,11 +222,11 @@ int do_getmntinfo(int update_every, usec_t dt) {
                     if (unlikely(!m->st_space)) {
                         snprintfz(title, 4096, "Disk Space Usage for %s [%s]",
                                   mntbuf[i].f_mntonname, mntbuf[i].f_mntfromname);
-                        m->st_space = rrdset_create_localhost("disk_space",
+                        m->st_space = rrdset_create_localhost("mount_space",
                                                               mntbuf[i].f_mntonname,
                                                               NULL,
                                                               mntbuf[i].f_mntonname,
-                                                              "disk.space",
+                                                              "mount.space",
                                                               title,
                                                               "GiB",
                                                               "freebsd.plugin",
@@ -263,11 +263,11 @@ int do_getmntinfo(int update_every, usec_t dt) {
                     if (unlikely(!m->st_inodes)) {
                         snprintfz(title, 4096, "Disk Files (inodes) Usage for %s [%s]",
                                   mntbuf[i].f_mntonname, mntbuf[i].f_mntfromname);
-                        m->st_inodes = rrdset_create_localhost("disk_inodes",
+                        m->st_inodes = rrdset_create_localhost("mount_inodes",
                                                                mntbuf[i].f_mntonname,
                                                                NULL,
                                                                mntbuf[i].f_mntonname,
-                                                               "disk.inodes",
+                                                               "mount.inodes",
                                                                title,
                                                                "inodes",
                                                                "freebsd.plugin",

--- a/collectors/macos.plugin/macos_fw.c
+++ b/collectors/macos.plugin/macos_fw.c
@@ -435,9 +435,9 @@ int do_macos_iokit(int update_every, usec_t dt) {
         if (unlikely(!(mntsize = getmntinfo(&mntbuf, MNT_NOWAIT)))) {
             error("MACOS: getmntinfo() failed");
             do_space = 0;
-            error("DISABLED: disk_space.X");
+            error("DISABLED: mount_space.X");
             do_inodes = 0;
-            error("DISABLED: disk_inodes.X");
+            error("DISABLED: mount_inodes.X");
         } else {
             for (i = 0; i < mntsize; i++) {
                 if (mntbuf[i].f_flags == MNT_RDONLY ||
@@ -453,15 +453,15 @@ int do_macos_iokit(int update_every, usec_t dt) {
                 // --------------------------------------------------------------------------
 
                 if (likely(do_space)) {
-                    st = rrdset_find_active_bytype_localhost("disk_space", mntbuf[i].f_mntonname);
+                    st = rrdset_find_active_bytype_localhost("mount_space", mntbuf[i].f_mntonname);
                     if (unlikely(!st)) {
                         snprintfz(title, 4096, "Disk Space Usage for %s [%s]", mntbuf[i].f_mntonname, mntbuf[i].f_mntfromname);
                         st = rrdset_create_localhost(
-                                "disk_space"
+                                "mount_space"
                                 , mntbuf[i].f_mntonname
                                 , NULL
                                 , mntbuf[i].f_mntonname
-                                , "disk.space"
+                                , "mount.space"
                                 , title
                                 , "GiB"
                                 , "macos.plugin"
@@ -486,15 +486,15 @@ int do_macos_iokit(int update_every, usec_t dt) {
                 // --------------------------------------------------------------------------
 
                 if (likely(do_inodes)) {
-                    st = rrdset_find_active_bytype_localhost("disk_inodes", mntbuf[i].f_mntonname);
+                    st = rrdset_find_active_bytype_localhost("mount_inodes", mntbuf[i].f_mntonname);
                     if (unlikely(!st)) {
                         snprintfz(title, 4096, "Disk Files (inodes) Usage for %s [%s]", mntbuf[i].f_mntonname, mntbuf[i].f_mntfromname);
                         st = rrdset_create_localhost(
-                                "disk_inodes"
+                                "mount_inodes"
                                 , mntbuf[i].f_mntonname
                                 , NULL
                                 , mntbuf[i].f_mntonname
-                                , "disk.inodes"
+                                , "mount.inodes"
                                 , title
                                 , "inodes"
                                 , "macos.plugin"

--- a/docs/configure/common-changes.md
+++ b/docs/configure/common-changes.md
@@ -97,7 +97,7 @@ Open the configuration file for that alarm and set the `to` line to `silent`.
 
 ```conf
 template: disk_fill_rate
-       on: disk.space
+       on: mount.space
    lookup: max -1s at -30m unaligned of avail
      calc: ($this - $avail) / (30 * 60)
     every: 15s

--- a/docs/guides/using-host-labels.md
+++ b/docs/guides/using-host-labels.md
@@ -127,7 +127,7 @@ labeled `webserver`:
 
 ```yaml
     template: disk_fill_rate
-          on: disk.space
+          on: mount.space
       lookup: max -1s at -30m unaligned of avail
         calc: ($this - $avail) / (30 * 60)
        every: 15s

--- a/health/health.d/disks.conf
+++ b/health/health.d/disks.conf
@@ -10,7 +10,7 @@
 # available disk space
 
  template: disk_space_usage
-       on: disk.space
+       on: mount.space
     class: Utilization
      type: System
 component: Disk
@@ -27,7 +27,7 @@ component: Disk
        to: sysadmin
 
  template: disk_inode_usage
-       on: disk.inodes
+       on: mount.inodes
     class: Utilization
      type: System
 component: Disk
@@ -56,7 +56,7 @@ component: Disk
 # the hours remaining
 
 # template: disk_fill_rate
-#       on: disk.space
+#       on: mount.space
 #       os: linux freebsd
 #    hosts: *
 # families: *
@@ -72,7 +72,7 @@ component: Disk
 # in this rate
 
 # template: out_of_disk_space_time
-#       on: disk.space
+#       on: mount.space
 #       os: linux freebsd
 #    hosts: *
 # families: *
@@ -98,7 +98,7 @@ component: Disk
 # the hours remaining
 
 # template: disk_inode_rate
-#       on: disk.inodes
+#       on: mount.inodes
 #       os: linux freebsd
 #    hosts: *
 # families: *
@@ -113,7 +113,7 @@ component: Disk
 # in this rate
 
 # template: out_of_disk_inodes_time
-#       on: disk.inodes
+#       on: mount.inodes
 #       os: linux freebsd
 #    hosts: *
 # families: *

--- a/web/gui/dashboard/dash-example.html
+++ b/web/gui/dashboard/dash-example.html
@@ -31,7 +31,7 @@
                     data-dash-netdata="system.ram">
                 </div>
                 <div class="dash-graph"
-                    data-dash-netdata="disk_space._">
+                    data-dash-netdata="mount_space._">
                 </div>
                 <div class="dash-graph"
                     data-dash-netdata="system.net">

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -2973,10 +2973,10 @@ netdataDashboard.context = {
         info: 'The average time for discard/flush requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.'
     },
 
-    'disk.space': {
-        info: 'Disk space utilization. reserved for root is automatically reserved by the system to prevent the root user from getting out of space.'
+    'mount.space': {
+        info: 'Mount point space utilization. reserved for root is automatically reserved by the system to prevent the root user from getting out of space.'
     },
-    'disk.inodes': {
+    'mount.inodes': {
         info: 'Inodes (or index nodes) are filesystem objects (e.g. files and directories). On many types of file system implementations, the maximum number of inodes is fixed at filesystem creation, limiting the maximum number of files the filesystem can hold. It is possible for a device to run out of inodes. When this happens, new files cannot be created on the device, even though there may be free space available.'
     },
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -5839,11 +5839,11 @@ netdataDashboard.context = {
         info: 'Netdata is attaching <code>kprobes</code> for when the function <code>btrfs_sync_file</code>.'
     },
 
-    'mount_points.call': {
+    'mount.ebpf_calls': {
         info: 'Monitor calls to syscalls <code>mount(2)</code> and <code>umount(2)</code> that are responsible for attaching or removing filesystems.'
     },
 
-    'mount_points.error': {
+    'mount.ebpf_errors': {
         info: 'Monitor errors in calls to syscalls <code>mount(2)</code> and <code>umount(2)</code>.'
     },
 


### PR DESCRIPTION
fixes https://github.com/netdata/product/issues/2345

This PR moves all mount points under the "Mount Points" dashboard menu, together with eBPF.

This is important, to bring clarity to Netdata dashboard and it is just the first step of a series of changes to simplify the dashboard navigation menu. So, we need it.

Tested (ticked the ones that have been tested - the not ticked ones are not - please help):

- [x] Linux dashboards and alarms
- [ ] FreeBSD dashboards and alarms
- [ ] MacOS dashboards and alarms
- [ ] Propagation to netdata.cloud via ACLK
- [ ] Prometheus exports and Grafana dashboards (examples on REAME.md have been updated)

Drawbacks:

1. All disk space and disk inodes charts are renamed, so old data are actually lost. The charts will come brand new. So custom dashboards, metrics exporting to time-series databases, third party dashboard will be broken as far as disk space information is concerned.

2. The motivation behind having disk performance metrics (I/O bandwidth, IOPS, etc) together with mount space (free space, inodes) was to associate the two. So if `/` is `sda` why not to have all the charts of `/` and `sda` together? It was a nice idea. However in most of the cases `/` and `sda` do not match. Because `/` is usually in `sda1`, a partition. So for most cases the association didn't work and users were given menu items for both `/` and `sda`. 