### PR TITLE
Fix the format=array output in context queries

### DIFF
--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -197,7 +197,7 @@ int rrdset2value_api_v1(
     if(db_before) *db_before = r->before;
 
     long i = (!(options & RRDR_OPTION_REVERSED))?rrdr_rows(r) - 1:0;
-    *n = rrdr2value(r, i, options, value_is_null);
+    *n = rrdr2value(r, i, options, value_is_null, NULL);
 
     rrdr_free(r);
     return HTTP_RESP_OK;
@@ -243,12 +243,12 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
             rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
-            rrdr2ssv(r, wb, options, "", " ", "");
+            rrdr2ssv(r, wb, options, "", " ", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
         else {
             wb->contenttype = CT_TEXT_PLAIN;
-            rrdr2ssv(r, wb, options, "", " ", "");
+            rrdr2ssv(r, wb, options, "", " ", "", temp_rd);
         }
         break;
 
@@ -256,12 +256,12 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
             rrdr_json_wrapper_begin(r, wb, format, options, 1, context_param_list, chart_label_key);
-            rrdr2ssv(r, wb, options, "", ",", "");
+            rrdr2ssv(r, wb, options, "", ",", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
         else {
             wb->contenttype = CT_TEXT_PLAIN;
-            rrdr2ssv(r, wb, options, "", ",", "");
+            rrdr2ssv(r, wb, options, "", ",", "", temp_rd);
         }
         break;
 
@@ -269,12 +269,12 @@ int rrdset2anything_api_v1(
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
             rrdr_json_wrapper_begin(r, wb, format, options, 0, context_param_list, chart_label_key);
-            rrdr2ssv(r, wb, options, "[", ",", "]");
+            rrdr2ssv(r, wb, options, "[", ",", "]", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 0);
         }
         else {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr2ssv(r, wb, options, "[", ",", "]");
+            rrdr2ssv(r, wb, options, "[", ",", "]", temp_rd);
         }
         break;
 

--- a/web/api/formatters/ssv/ssv.c
+++ b/web/api/formatters/ssv/ssv.c
@@ -2,7 +2,7 @@
 
 #include "ssv.h"
 
-void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, const char *separator, const char *suffix) {
+void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, const char *separator, const char *suffix, RRDDIM *temp_rd) {
     //info("RRD2SSV(): %s: BEGIN", r->st->id);
     long i;
 
@@ -17,7 +17,7 @@ void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, con
     // for each line in the array
     for(i = start; i != end ;i += step) {
         int all_values_are_null = 0;
-        calculated_number v = rrdr2value(r, i, options, &all_values_are_null);
+        calculated_number v = rrdr2value(r, i, options, &all_values_are_null, temp_rd);
 
         if(likely(i != start)) {
             if(r->min > v) r->min = v;

--- a/web/api/formatters/ssv/ssv.h
+++ b/web/api/formatters/ssv/ssv.h
@@ -5,6 +5,6 @@
 
 #include "../rrd2json.h"
 
-extern void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, const char *separator, const char *suffix);
+extern void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, const char *separator, const char *suffix, RRDDIM *temp_rd);
 
 #endif //NETDATA_API_FORMATTER_SSV_H

--- a/web/api/formatters/value/value.c
+++ b/web/api/formatters/value/value.c
@@ -20,7 +20,7 @@ inline calculated_number rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *
     int set_min_max = 0;
     if(unlikely(options & RRDR_OPTION_PERCENTAGE)) {
         total = 0;
-        for(c = 0, d = r->st->dimensions; d && c < r->d ;c++, d = d->next) {
+        for (c = 0, d = temp_rd ? temp_rd : r->st->dimensions; d && c < r->d; c++, d = d->next) {
             calculated_number n = cn[c];
 
             if(likely((options & RRDR_OPTION_ABSOLUTE) && n < 0))
@@ -34,7 +34,7 @@ inline calculated_number rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *
     }
 
     // for each dimension
-    for(c = 0, d = r->st->dimensions; d && c < r->d ;c++, d = d->next) {
+    for (c = 0, d = temp_rd ? temp_rd : r->st->dimensions; d && c < r->d; c++, d = d->next) {
         if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
         if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 

--- a/web/api/formatters/value/value.c
+++ b/web/api/formatters/value/value.c
@@ -3,7 +3,7 @@
 #include "value.h"
 
 
-inline calculated_number rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null) {
+inline calculated_number rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null, RRDDIM *temp_rd) {
     if (r->st_needs_lock)
         rrdset_check_rdlock(r->st);
 

--- a/web/api/formatters/value/value.h
+++ b/web/api/formatters/value/value.h
@@ -5,6 +5,6 @@
 
 #include "../rrd2json.h"
 
-extern calculated_number rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null);
+extern calculated_number rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null, RRDDIM *temp_rd);
 
 #endif //NETDATA_API_FORMATTER_VALUE_H


### PR DESCRIPTION
Fixes #12113 
##### Summary
Fixes the bug described in the linked issue

During the processing of a context query if the `format=array` was given, the output would only include values from the first matched chart 

This also affected "ssv", "ssvcomma"

##### Test Plan
- Test a context query before and after the PR
   - Before the fix the returned value in the array output would only include the value of the first chart that matches the context

##### Additional Information
The ability to pass a different processing function (other than sum for the format array will be handled in a separate PR)
