### PR TITLE
docs: rename kickstart install badges units

### DIFF
--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -7,7 +7,7 @@ import { OneLineInstallWget, OneLineInstallCurl } from '../../../../../src/compo
 
 # Install Netdata with kickstart.sh
 
-![](https://registry.my-netdata.io/api/v1/badge.svg?chart=web_log_nginx.requests_per_url&options=unaligned&dimensions=kickstart&group=sum&after=-3600&label=last+hour&units=installations&value_color=orange&precision=0) ![](https://registry.my-netdata.io/api/v1/badge.svg?chart=web_log_nginx.requests_per_url&options=unaligned&dimensions=kickstart&group=sum&after=-86400&label=today&units=installations&precision=0)
+![](https://registry.my-netdata.io/api/v1/badge.svg?chart=web_log_nginx.requests_per_url&options=unaligned&dimensions=kickstart&group=sum&after=-3600&label=last+hour&units=kickstart%20downloads&value_color=orange&precision=0) ![](https://registry.my-netdata.io/api/v1/badge.svg?chart=web_log_nginx.requests_per_url&options=unaligned&dimensions=kickstart&group=sum&after=-86400&label=today&units=kickstart%20downloads&precision=0)
 
 This page covers detailed instructions on using and configuring the automatic one-line installation script named
 `kickstart.sh`.


### PR DESCRIPTION
##### Summary

"installations" => "kickstart downloads"

"installations" is misleading.

##### Test Plan

Check https://github.com/ilyam8/netdata/blob/install_badges_units/packaging/installer/methods/kickstart.md.

##### Additional Information
