### PR TITLE
Improve messaging around unknown install handling in kickstart script.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -586,6 +586,7 @@ handle_existing_install() {
     kickstart-*|legacy-*|binpkg-*|manual-static|unknown)
       if [ "${INSTALL_TYPE}" = "unknown" ]; then
         warning "Found an existing netdata install at ${INSTALL_PREFIX}, but could not determine the install type."
+        warning "Usually this means you installed Netdata through your distribution’s regualr package repositories or some other unsupported method."
       else
         progress "Found an existing netdata install at ${INSTALL_PREFIX}, with installation type '${INSTALL_TYPE}'."
       fi
@@ -613,6 +614,8 @@ handle_existing_install() {
         esac
 
         return 0
+      elif [ "${INSTALL_TYPE}" = "unknown" ]; then
+        fatal "We do not support trying to update or claim installations when we cannot determine the install type.\nYou will need to uninstall the existing install using the same method you used to install it to proceed." F0106
       fi
 
       ret=0

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -586,7 +586,7 @@ handle_existing_install() {
     kickstart-*|legacy-*|binpkg-*|manual-static|unknown)
       if [ "${INSTALL_TYPE}" = "unknown" ]; then
         warning "Found an existing netdata install at ${INSTALL_PREFIX}, but could not determine the install type."
-        warning "Usually this means you installed Netdata through your distribution’s regualr package repositories or some other unsupported method."
+        warning "Usually this means you installed Netdata through your distribution’s regular package repositories or some other unsupported method."
       else
         progress "Found an existing netdata install at ${INSTALL_PREFIX}, with installation type '${INSTALL_TYPE}'."
       fi
@@ -615,7 +615,7 @@ handle_existing_install() {
 
         return 0
       elif [ "${INSTALL_TYPE}" = "unknown" ]; then
-        fatal "We do not support trying to update or claim installations when we cannot determine the install type.\nYou will need to uninstall the existing install using the same method you used to install it to proceed." F0106
+        fatal "We do not support trying to update or claim installations when we cannot determine the install type. You will need to uninstall the existing install using the same method you used to install it to proceed." F0106
       fi
 
       ret=0

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -136,7 +136,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "cc595cd4d057bee59d0c36b0e08e2d30" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "373053d7b715af0d9c30e479a6c53809" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -136,7 +136,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "f01086a471f030c294d31e49df84850f" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "cc595cd4d057bee59d0c36b0e08e2d30" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION
##### Summary

Should hopefully help reduce the number of users who have to reach out to us due to 

##### Test Plan

The changes can be easily tested on any distribution that provides Netdata in their regular package repositories by first installing the distro-provided Netdata package and then attempting to run the kickstart script.

Without the changes in this PR, the script will attempt to update the existing install (and fail to do so).

With the changes in this PR, the script will instead report that we do not support such installs and provide some (terse) instructions for remediation.