### PR TITLE
Fix data query option allow_past to correctly work in memory mode ram and save

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -562,7 +562,7 @@ static inline void do_dimension_fixedstep(
     calculated_number min = r->min, max = r->max;
     size_t db_points_read = 0;
     time_t db_now = now;
-
+    time_t first_time_t = rrddim_first_entry_t(rd);
     for(rd->state->query_ops.init(rd, &handle, now, before_wanted) ; points_added < points_wanted ; now += dt) {
         // make sure we return data in the proper time range
         if(unlikely(now > before_wanted)) {
@@ -586,7 +586,11 @@ static inline void do_dimension_fixedstep(
         }
 #endif
         db_now = now; // this is needed to set db_now in case the next_metric implementation does not set it
-        storage_number n = rd->state->query_ops.next_metric(&handle, &db_now);
+        storage_number n;
+        if (rd->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE && now <= first_time_t)
+            n = SN_EMPTY_SLOT;
+        else
+            n = rd->state->query_ops.next_metric(&handle, &db_now);
         if(unlikely(db_now > before_wanted)) {
 #ifdef NETDATA_INTERNAL_CHECKS
             r->internal.log = "stopped, because attempted to access the db after 'wanted before'";


### PR DESCRIPTION
##### Summary
Fixes [product@12135](https://github.com/netdata/netdata/issues/12135)

when using the `allow_past` option in data queries and the agent memory mode is `ram` or `save` it will not
correctly detect that the `after` timestamp requested may be out of range, attempting to map the requested
time in *invalid* locations in the buffer. 

##### Test Plan
- Start an agent in memory mode RAM and immediately
  - Run a query `api/v1/data?chart=system.cpu&after=-60&options=jsonwrap`
    - You should only see a few points being returned
  - Run a query `api/v1/data?chart=system.cpu&after=-60&options=jsonwrap|allow_past`
    - You will  see 60 points returned but the results will be inconsistent; you may get null values for recent timestamps which is wrong
- After applying the PR, run the above tests
  - You will notice that the agent will correctly generate NULL values for the time range that metrics were not collected
 