### PR TITLE
Fix typo in ZFS ARC Cache size info

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -3130,7 +3130,7 @@ netdataDashboard.context = {
         '<p><b>Arcsz</b> - actual size. '+
         '<b>Target</b> - target size that the ARC is attempting to maintain (adaptive). '+
         '<b>Min</b> - minimum size limit. When the ARC is asked to shrink, it will stop shrinking at this value. '+
-        '<b>Min</b> - maximum size limit.</p>'
+        '<b>Max</b> - maximum size limit.</p>'
     },
 
     'zfs.l2_size': {


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes a small typo in the ZFS cache info, namely that Min is present twice (instead of Min/sMax)
##### Test Plan
Deploy a patched version to my home server when possible.
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
Apologies if this is not the correct branch name to merge into (I did notice a develop branch), the docs on submitting a PR were unclear as to which branch is desired for PRs.