### PR TITLE
Documentation: Fixed broken links

### DIFF
--- a/claim/README.md
+++ b/claim/README.md
@@ -460,8 +460,8 @@ using the [ACLK](/aclk/README.md).
 
 The best way to install Netdata and connect your nodes to Netdata Cloud is with our automatic one-line installation script, [kickstart](/packaging/installer/README.md#automatic-one-line-installation-script). This script will install the Netdata Agent, in case it isn't already installed, and connect your node to Netdata Cloud. 
 
-This  works with:
-* all Linux distributions, see [Netdata distribution support matrix](https://learn.netdata.cloud/docs/agent/packaging/distributions)
+This works with:
+* most Linux distributions, see [Netdata's platform support policy](/docs/agent/packaging/platform_support)
 * macOS
 
 For details on how to run this script please check [How to connect a node](#how-to-connect-a-node) and choose your environment.

--- a/claim/README.md
+++ b/claim/README.md
@@ -461,7 +461,7 @@ using the [ACLK](/aclk/README.md).
 The best way to install Netdata and connect your nodes to Netdata Cloud is with our automatic one-line installation script, [kickstart](/packaging/installer/README.md#automatic-one-line-installation-script). This script will install the Netdata Agent, in case it isn't already installed, and connect your node to Netdata Cloud. 
 
 This works with:
-* most Linux distributions, see [Netdata's platform support policy](/docs/agent/packaging/platform_support)
+* most Linux distributions, see [Netdata's platform support policy](/packaging/PLATFORM_SUPPORT.md)
 * macOS
 
 For details on how to run this script please check [How to connect a node](#how-to-connect-a-node) and choose your environment.

--- a/docs/guides/step-by-step/step-99.md
+++ b/docs/guides/step-by-step/step-99.md
@@ -44,7 +44,7 @@ If that feels like too much possibility to you, why not one of these options:
 -   Share your experience with Netdata and this guide. Be sure to [@mention](https://twitter.com/linuxnetdata) us on 
     Twitter!
 -   Contribute to what we do. Browse our [open issues](https://github.com/netdata/netdata/issues) and check out out
-    [contributions doc](/README.md#contribute) for ideas of how you can pitch in.
+    [contributions doc](/contribute) for ideas of how you can pitch in.
 
 We can't wait to see what you monitor next! Bon voyage! ⛵
 

--- a/docs/guides/step-by-step/step-99.md
+++ b/docs/guides/step-by-step/step-99.md
@@ -44,7 +44,7 @@ If that feels like too much possibility to you, why not one of these options:
 -   Share your experience with Netdata and this guide. Be sure to [@mention](https://twitter.com/linuxnetdata) us on 
     Twitter!
 -   Contribute to what we do. Browse our [open issues](https://github.com/netdata/netdata/issues) and check out out
-    [contributions doc](/contribute) for ideas of how you can pitch in.
+    [contributions doc](https://learn.netdata.cloud/contribute/) for ideas of how you can pitch in.
 
 We can't wait to see what you monitor next! Bon voyage! ⛵
 

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -12,7 +12,7 @@ import { OneLineInstallWget, OneLineInstallCurl } from '../../../../../src/compo
 This page covers detailed instructions on using and configuring the automatic one-line installation script named
 `kickstart.sh`.
 
-The kickstart script works on all Linux distributions and macOS environments. By default, automatic nightly updates are enabled. If you are installing on macOS, make sure to check the [install documentation for macOS](packaging/installer/methods/macos.md) before continuing.
+The kickstart script works on all Linux distributions and macOS environments. By default, automatic nightly updates are enabled. If you are installing on macOS, make sure to check the [install documentation for macOS](macos.md) before continuing.
 
 > If you are unsure whether you want nightly or stable releases, read the [installation guide](/packaging/installer/README.md#nightly-vs-stable-releases). 
 > If you want to turn off [automatic updates](/packaging/installer/README.md#automatic-updates), use the `--no-updates` option. You can find more installation options below.

--- a/packaging/installer/methods/macos.md
+++ b/packaging/installer/methods/macos.md
@@ -52,7 +52,7 @@ curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/n
 ```
 The Netdata Agent is installed under `/usr/local/netdata` on your machine. Your machine will also show up as a node in your Netdata Cloud.
 
-If you experience issues while claiming your node, follow the steps in our [Troubleshooting](claim/README.md#troubleshooting) documentation.
+If you experience issues while claiming your node, follow the steps in our [Troubleshooting](/claim/README.md#troubleshooting) documentation.
 ## Install Netdata via Homebrew
 
 To install Netdata and all its dependencies, run Homebrew using the following command: 


### PR DESCRIPTION

##### Summary

The deploy log in Netlify returned the following broken links: 

```
6:34:19 PM: - On source page path = /docs/agent/claim:
6:34:19 PM:    -> linking to /docs/agent/packaging/distributions
6:34:19 PM: 
6:34:19 PM: - On source page path = /docs/agent/packaging/installer/methods/kickstart:
6:34:19 PM:    -> linking to /docs/agent/packaging/installer/methods/packaging/installer/methods/macos
6:34:19 PM: 
6:34:19 PM: - On source page path = /docs/agent/packaging/installer/methods/macos:
6:34:19 PM:    -> linking to /docs/agent/packaging/installer/methods/claim#troubleshooting (resolved as: /docs/agent/packaging/installer/methods/claim)
6:34:19 PM: 
6:34:19 PM: - On source page path = /guides/step-by-step/step-99:
6:34:19 PM:    -> linking to /docs/agent/#contribute (resolved as: /docs/agent/)
```

This PR tries to fix the broken links.


