### PR TITLE
kickstart.sh: fix quoting for globbing

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1392,7 +1392,7 @@ while [ -n "${1}" ]; do
       NETDATA_CLAIM_URL="${2}"
       shift 1
       ;;
-    "--claim-*")
+    "--claim-"*)
       optname="$(echo "${1}" | cut -d '-' -f 4-)"
       case "${optname}" in
         id|proxy|user|hostname)

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -136,7 +136,7 @@ To use `md5sum` to verify the integrity of the `kickstart.sh` script you will do
 run the following:
 
 ```bash
-[ "b63815109547f15a979752fced6bfc2e" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
+[ "f01086a471f030c294d31e49df84850f" = "$(curl -Ss https://my-netdata.io/kickstart.sh | md5sum | cut -d ' ' -f 1)" ] && echo "OK, VALID" || echo "FAILED, INVALID"
 ```
 
 If the script is valid, this command will return `OK, VALID`.


### PR DESCRIPTION

##### Summary

Fix badly placed quote in kickstart.sh preventing us from using `--claim-*` options.

Before :

```
sh kickstart.sh --claim-insecure
...
+ [ -n --claim-insecure ]
+ warning Passing unrecognized option '--claim-insecure' to installer script. If this is intended, please add it to $NETDATA_INSTALLER_OPTIONS instead.
+ printf %s\n\n  WARNING  Passing unrecognized option '--claim-insecure' to installer script. If this is intended, please add it to $NETDATA_INSTALLER_OPTIONS instead.
 WARNING  Passing unrecognized option '--claim-insecure' to installer script. If this is intended, please add it to $NETDATA_INSTALLER_OPTIONS instead.

+ NETDATA_INSTALLER_OPTIONS= --claim-insecure
+ shift 1
```

After:

```
+ [ -n --claim-insecure ]
+ echo --claim-insecure
+ cut -d - -f 4-
+ optname=insecure
+ NETDATA_CLAIM_EXTRA= -insecure
+ shift 1
```

I believe with the quote as it was, it was expecting the litteral `--claim-*` instead of globbing.

##### Test Plan

I tested with --claim-insecure, which now work with this fix
