### PR TITLE
[WIP] Throttle incoming children connections

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -111,8 +111,14 @@ void web_server_config_options(void)
         (int)config_get_number(CONFIG_SECTION_WEB, "disconnect idle clients after seconds", web_client_timeout);
     web_client_first_request_timeout =
         (int)config_get_number(CONFIG_SECTION_WEB, "timeout for first request", web_client_first_request_timeout);
-    web_client_streaming_rate_t =
-        config_get_number(CONFIG_SECTION_WEB, "accept a streaming request every seconds", web_client_streaming_rate_t);
+    web_client_streaming_rate =
+        config_get(CONFIG_SECTION_WEB, "accept a streaming request every seconds", "0");
+    if (!strcmp(web_client_streaming_rate, "auto"))
+        web_client_streaming_rate_t = 5L;
+    else
+        web_client_streaming_rate_t = strtol(web_client_streaming_rate, NULL, 10);
+    if (web_client_streaming_rate_t < 0)
+        web_client_streaming_rate_t = 0L;
 
     respect_web_browser_do_not_track_policy =
         config_get_boolean(CONFIG_SECTION_WEB, "respect do not track policy", respect_web_browser_do_not_track_policy);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -668,7 +668,6 @@ static int rrdpush_receive(struct receiver_state *rpt)
         }
     }
 
-    info ("Will register in cloud");
 #if defined(ENABLE_ACLK)
     // in case we have cloud connection we inform cloud
     // new slave connected
@@ -683,7 +682,6 @@ static int rrdpush_receive(struct receiver_state *rpt)
     error("STREAM %s [receive from [%s]:%s]: disconnected (completed %zu updates).", rpt->hostname, rpt->client_ip,
           rpt->client_port, count);
 
-    info ("Will un-register in cloud");
 #if defined(ENABLE_ACLK)
     // in case we have cloud connection we inform cloud
     // new slave connected

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -683,7 +683,7 @@ static int rrdpush_receive(struct receiver_state *rpt)
     error("STREAM %s [receive from [%s]:%s]: disconnected (completed %zu updates).", rpt->hostname, rpt->client_ip,
           rpt->client_port, count);
 
-    info ("Will un-cregister in cloud");
+    info ("Will un-register in cloud");
 #if defined(ENABLE_ACLK)
     // in case we have cloud connection we inform cloud
     // new slave connected

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -4,7 +4,7 @@
 
 extern struct config stream_config;
 extern double children_consumed_rate;
-volatile unsigned int children_consumed;
+unsigned int children_consumed;
 
 void destroy_receiver_state(struct receiver_state *rpt) {
     freez(rpt->key);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -684,9 +684,9 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
                 }
                 else {
                     if ( children_in_flight_rate > children_consumed_rate ) {
-                        if (web_client_streaming_rate_t < 5) web_client_streaming_rate_t++;
+                        if (web_client_streaming_rate_t < (5 + children_in_flight/50)) web_client_streaming_rate_t++;
                     } else {
-                        if (web_client_streaming_rate_t > 1) web_client_streaming_rate_t--;
+                        if (web_client_streaming_rate_t > (1 + children_in_flight/50)) web_client_streaming_rate_t--;
                     }
                 }
 		

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -692,9 +692,6 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
                            if (web_client_streaming_rate_t < 15) web_client_streaming_rate_t = (long int)children_in_flight/30;
                    }
                 }
-		
-                info ("[%s]: children in flight rate [%ld] - [%f] ([%d]) / ([%ld] - [%ld]) - Consumed [%f]", hostname, web_client_streaming_rate_t, children_in_flight_rate, children_in_flight, (long)now, (long)last_stream_check_t, children_consumed_rate);
-
             }
         }
     }

--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -6,6 +6,7 @@
 int web_client_timeout = DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS;
 int web_client_first_request_timeout = DEFAULT_TIMEOUT_TO_RECEIVE_FIRST_WEB_REQUEST;
 long web_client_streaming_rate_t = 0L;
+char *web_client_streaming_rate = NULL;
 
 /*
  * --------------------------------------------------------------------------------------------------------------------

--- a/web/server/web_server.h
+++ b/web/server/web_server.h
@@ -46,6 +46,7 @@ extern void api_listen_sockets_setup(void);
 extern int web_client_timeout;
 extern int web_client_first_request_timeout;
 extern long web_client_streaming_rate_t;
+extern char *web_client_streaming_rate;
 
 #ifdef WEB_SERVER_INTERNALS
 extern LISTEN_SOCKETS api_sockets;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR attempts to do some throttling on incoming children connections when these happen concurrently (e.g. after a parent restart perhaps).

The main motive to pursue this is the behavior of the agent when is under this situation in regards with the new architecture. In a few words, when a parent is under stress from many connecting children it will send multiple registering and un-registering messages for children to the cloud. Part of the problem is that some children will timeout while waiting for the parent to complete host structure creation, etc, producing 0 metric updates.

In test runs, a parent with 120 children trying to connect at the same time can issue ~320 registering messages and ~200 un-registering during this time (can take about 7 minutes). This PR can (*but not always*) reduce this number to ~120 register and 0 un-register but with longer total connection time (e.g. 10 minutes). Needs tuning.

We should try to minimize such messages to the cloud as to not induce load to the cloud backend by those flickering messages, and perhaps we need to combine this PR with also a way to delay this initial registering message. There are also other cases such as e.g. buffer exhaustion from children due to parent load.

What this PR tries to do is to adjust the `web_client_streaming_rate_t` variable which when set will reject incoming connections for that period of time. It tries to adjust it by measuring the incoming rate of connections and the consumed rate.

To enable the functionality, the configuration parameter `accept a streaming request every seconds` must be set to `auto` instead of a specific number. It's default value still remains `0`.

The exact adjustment of `web_client_streaming_rate_t` is tricky. It needs to keep a balance of consuming children as they come without bottlenecks, but also to not delay them very much. As such, it still needs investigating and testing to find a good balance between those two.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Observe the behavior of a parent agent when multiple children are trying to connect at the same time, with and without (or by setting `web_client_streaming_rate_t` to `0`).

##### Additional Information

I will leave this as draft for now, as more tests are done and we can decide if this is helpful or not, or how we can tune it better.