### PR TITLE
Update packaging CI to only run a limited set of jobs on PRs.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Read build matrix
         id: set-matrix
         shell: python3 {0}
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           from ruamel.yaml import YAML
           import json
@@ -52,7 +54,7 @@ jobs:
           with open('.github/data/distros.yml') as f:
               data = yaml.load(f)
 
-          if "${{ github.event_name }}" == "pull_request" and re.search(FULL_CI_REGEX, "${{ github.event.pull_request.body }}", re.I) is Null:
+          if "${{ github.event_name }}" == "pull_request" and re.search(FULL_CI_REGEX, os.environ["PR_BODY"], re.I) is None:
               run_limited = True
 
           for i, v in enumerate(data['include']):

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
       - develop
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       type:
@@ -38,24 +41,33 @@ jobs:
         run: |
           from ruamel.yaml import YAML
           import json
+          import os
+          import re
+          FULL_CI_REGEX = '/actions run full ci'
+          ALWAYS_RUN_ARCHES = ["amd64"]
           yaml = YAML(typ='safe')
           entries = list()
+          run_limited = False
 
           with open('.github/data/distros.yml') as f:
               data = yaml.load(f)
 
+          if "${{ github.event_name }}" == "pull_request" and re.search(FULL_CI_REGEX, "${{ github.event.pull_request.body }}", re.I) is Null:
+              run_limited = True
+
           for i, v in enumerate(data['include']):
               if 'packages' in data['include'][i]:
                   for arch in data['include'][i]['packages']['arches']:
-                      entries.append({
-                          'distro': data['include'][i]['distro'],
-                          'version': data['include'][i]['version'],
-                          'pkgclouddistro': data['include'][i]['packages']['repo_distro'],
-                          'format': data['include'][i]['packages']['type'],
-                          'base_image': data['include'][i]['base_image'] if 'base_image' in data['include'][i] else data['include'][i]['distro'],
-                          'platform': data['platform_map'][arch],
-                          'arch': arch
-                      })
+                      if arch in ALWAYS_RUN_ARCHES or not run_limited:
+                          entries.append({
+                              'distro': data['include'][i]['distro'],
+                              'version': data['include'][i]['version'],
+                              'pkgclouddistro': data['include'][i]['packages']['repo_distro'],
+                              'format': data['include'][i]['packages']['type'],
+                              'base_image': data['include'][i]['base_image'] if 'base_image' in data['include'][i] else data['include'][i]['distro'],
+                              'platform': data['platform_map'][arch],
+                              'arch': arch
+                          })
 
           entries.sort(key=lambda k: (k['arch'], k['distro'], k['version']))
           matrix = json.dumps({'include': entries}, sort_keys=True)


### PR DESCRIPTION
##### Summary

The jobs for architectures other than 64-bit x86 consistently show no issues unless something is broken for that architecture (which also consistently breaks the static build for the same architecture) or that distribution 9which also consistently breaks the 64-bit x86 build for that distribution), so they functionally serve no real purpose when being run on PRs.

This commit skips running those jobs on PRs only so that we do not waste resources on them. They can be explicitly run by placing the exact words `actions run all ci` in the PR description directly preceded by a `/`.

This also enables running them on merges to master, which we previously did not do, so that we can still confirm for certain that everything is working.

##### Test Plan

Easily verifiable by observing that the package build jobs for architectures other than 64-bit x86 do not run on this PR.