### PR TITLE
fix: CPU frequency calculation in system-info.sh

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -250,7 +250,8 @@ if [ -r /sys/devices/system/cpu/cpu0/cpufreq/base_frequency ]; then
     CPU_INFO_SOURCE="${CPU_INFO_SOURCE} sysfs"
   fi
 
-  CPU_FREQ="$(cat /sys/devices/system/cpu/cpu0/cpufreq/base_frequency)"
+  value="$(cat /sys/devices/system/cpu/cpu0/cpufreq/base_frequency)"
+  CPU_FREQ="$((value * 1000))"
 elif [ -n "${possible_cpu_freq}" ]; then
   CPU_FREQ="${possible_cpu_freq}"
 elif [ -r /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq ]; then
@@ -258,7 +259,8 @@ elif [ -r /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq ]; then
     CPU_INFO_SOURCE="${CPU_INFO_SOURCE} sysfs"
   fi
 
-  CPU_FREQ="$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq)"
+  value="$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq)"
+  CPU_FREQ="$((value * 1000))"
 fi
 
 freq_units="$(echo "${CPU_FREQ}" | cut -f 2 -d ' ')"


### PR DESCRIPTION
##### Summary

Fixes: #12158

The following values are in kHz:
 - /sys/devices/system/cpu/cpu0/cpufreq/base_frequency
 - /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq

We need to multiply the value by 1000 to convert to Hz.

##### Test Plan

Not needed because the change is very straightforward.

##### Additional Information
