### PR TITLE
fix: claiming with wget

### DIFF
--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -296,7 +296,7 @@ if [ "${URLTOOL}" = "curl" ] ; then
                 URLCOMMAND="${URLCOMMAND} -x \"${PROXY}\""
         fi
 else
-        URLCOMMAND="wget -T 15 -O -  -q --save-headers --server-response --content-on-error=on --method=PUT \
+        URLCOMMAND="wget -T 15 -O -  -q --server-response --content-on-error=on --method=PUT \
         --body-file=\"${CLAIMING_DIR}/tmpin.txt\""
         if [ "${NOPROXY}" = "yes" ] ; then
                 URLCOMMAND="${URLCOMMAND} --no-proxy"

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -326,7 +326,11 @@ if [ "${VERBOSE}" == 1 ]; then
 fi
 
 attempt_contact () {
-        eval "${URLCOMMAND} \"${TARGET_URL}\"" >"${CLAIMING_DIR}/tmpout.txt" 2>&1
+        if [ "${URLTOOL}" = "curl" ] ; then
+                eval "${URLCOMMAND} \"${TARGET_URL}\"" >"${CLAIMING_DIR}/tmpout.txt"
+        else
+                eval "${URLCOMMAND} \"${TARGET_URL}\"" >"${CLAIMING_DIR}/tmpout.txt" 2>&1
+        fi
         URLCOMMAND_EXIT_CODE=$?
         if [ "${URLTOOL}" = "wget" ] && [ "${URLCOMMAND_EXIT_CODE}" -eq 8 ] ; then
         # We consider the server issuing an error response a successful attempt at communicating

--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -296,7 +296,7 @@ if [ "${URLTOOL}" = "curl" ] ; then
                 URLCOMMAND="${URLCOMMAND} -x \"${PROXY}\""
         fi
 else
-        URLCOMMAND="wget -T 15 -O -  -q --save-headers --content-on-error=on --method=PUT \
+        URLCOMMAND="wget -T 15 -O -  -q --save-headers --server-response --content-on-error=on --method=PUT \
         --body-file=\"${CLAIMING_DIR}/tmpin.txt\""
         if [ "${NOPROXY}" = "yes" ] ; then
                 URLCOMMAND="${URLCOMMAND} --no-proxy"
@@ -326,7 +326,7 @@ if [ "${VERBOSE}" == 1 ]; then
 fi
 
 attempt_contact () {
-        eval "${URLCOMMAND} \"${TARGET_URL}\"" >"${CLAIMING_DIR}/tmpout.txt"
+        eval "${URLCOMMAND} \"${TARGET_URL}\"" >"${CLAIMING_DIR}/tmpout.txt" 2>&1
         URLCOMMAND_EXIT_CODE=$?
         if [ "${URLTOOL}" = "wget" ] && [ "${URLCOMMAND_EXIT_CODE}" -eq 8 ] ; then
         # We consider the server issuing an error response a successful attempt at communicating


### PR DESCRIPTION
##### Summary

**Problem**:

The claiming script fails despite the successful response from the Cloud.

- current implementation requires saving the headers sent by the Cloud.
- we add `--save-headers` when using `wget`.
> Save the headers sent by the HTTP server to the file, preceding the actual contents, with an empty line as the separator.
- `--save-headers` works only when there is content (response body).
- successful response is 204 No Content.

**Solution**:
- use `--server-response` instead of `--save-headers`
> Print the headers sent by HTTP servers and responses sent by FTP servers.
- redirect stderr to the file when using `wget` (`--server-response` is debugging info)

##### Test Plan

- manually change the script to prefer `wget` over `curl`
- run netdata-claim.sh, ensure claiming is successful

##### Additional Information
