### PR TITLE
Fix alerts to raise correctly when the delay and repeat parameters are used together.

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -1004,7 +1004,7 @@ void *health_main(void *ptr) {
                 RRDCALC *rc;
                 for(rc = host->alarms; rc ; rc = rc->next) {
                     int repeat_every = 0;
-                    if(unlikely(rrdcalc_isrepeating(rc))) {
+                    if(unlikely(rrdcalc_isrepeating(rc) && rc->delay_up_to_timestamp <= now)) {
                         if(unlikely(rc->status == RRDCALC_STATUS_WARNING)) {
                             rc->rrdcalc_flags &= ~RRDCALC_FLAG_RUN_ONCE;
                             repeat_every = rc->warn_repeat_every;


### PR DESCRIPTION
Fixes #10847 
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fix alerts to raise correctly when the delay and repeat parameters are used together.
(health: delay doesn't work when using repeat [#10847](https://github.com/netdata/netdata/issues/10847))

**Bug explanation:**
[delay](https://learn.netdata.cloud/docs/agent/health/reference#alarm-line-delay) simply doesn't work when using [repeat](https://learn.netdata.cloud/docs/agent/health/reference#alarm-line-repeat). Neither up or down.

**Root problem:**
Repeating of notification code block does not control if there is a delay for the notification.

**Solution:**
Added notification delay control to the related if condition.

##### Test Plan
Set your notification by `sudo /etc/netdata/edit-config health.d/cpu.conf` command

Solution is tested with the notification below:
```
 template: 3s_cpu_usage
       on: system.cpu
    class: Utilization
     type: System
component: CPU
       os: linux
    hosts: *
   lookup: average -3s unaligned of user,system,softirq,irq,guest
    units: %
    every: 3s
     warn: $this > 60
     crit: $this > 90
    delay: up 30s down 40s
   repeat: warning 10s critical 10s
     info: average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)
       to: sysadmin pushover

```
Then test the notification. You can use different methods for testing it such as existing test application or stress command by executing `date && stress --cpu 2 --timeout 50s`. 

**Expected behavior:**
First warning or critical notification should occur after 35. seconds and replicated at least 2-3 times. Then clear notification should occur after 90 seconds from beginning of the test.
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
stress tool installation for the ubuntu: sudo apt install stress (obviously :))
You can use one of the enormous [notification services](https://learn.netdata.cloud/docs/monitor/enable-notifications) of Netdata.  **[Pushover](https://learn.netdata.cloud/docs/agent/health/notifications/pushover)** is used in this fix to check notifications.
