### PR TITLE
add `stress-ng` and `gremlin` to apps_groups.conf

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -338,3 +338,10 @@ filecoin: lotus* lotus-miner* lotus-worker*
 solana: solana*
 web3: *hardhat* *ganache* *truffle* *brownie* *waffle*
 terra: terra* mantle*
+
+# -----------------------------------------------------------------------------
+# chaos engineering tools
+
+stress-ng: stress-ng*
+gremlin: gremlin*
+


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Add [stress-ng](https://wiki.ubuntu.com/Kernel/Reference/stress-ng) and [gremlin](https://www.gremlin.com/docs/infrastructure-layer/daemon-client-overview) apps under a new "chaos engineering tools" section.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Tested locally and apps appear as expected when running chaos experiments. 

![image](https://user-images.githubusercontent.com/2178292/154472247-9c40b570-0288-427d-8cf1-0489c523a99b.png)


##### Additional Information
