### PR TITLE
Bundle protobuf on CentOS 7 and earlier.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -139,15 +139,23 @@ BuildRequires: libuuid-devel
 BuildRequires: libuv-devel >= 1
 BuildRequires: openssl-devel
 %if 0%{?suse_version}
+BuildRequires: protobuf-devel
+BuildRequires: protobuf-c-devel
 BuildRequires: judy-devel
 BuildRequires: liblz4-devel
 BuildRequires: libjson-c-devel
 %else
 %if 0%{?fedora}
+BuildRequires: protobuf-devel
+BuildRequires: libprotobuf-c-devel
 BuildRequires: Judy-devel
 BuildRequires: lz4-devel
 BuildRequires: json-c-devel
 %else
+%if 0%{?centos_ver} >= 8
+BuildRequires: protobuf-devel
+BuildRequires: protobuf-c-devel
+%endif
 BuildRequires: lz4-devel
 BuildRequires: json-c-devel
 %endif
@@ -200,12 +208,6 @@ BuildRequires: cups-devel >= 1.7
 
 # Prometheus remote write dependencies
 BuildRequires: snappy-devel
-BuildRequires: protobuf-devel
-%if 0%{?suse_version}
-BuildRequires: libprotobuf-c-devel
-%else
-BuildRequires: protobuf-c-devel
-%endif
 # end - prometheus remote write dependencies
 
 # #####################################################################
@@ -226,6 +228,12 @@ happened, on your systems and applications.
 # Only bundle libJudy if this isn't Fedora or SUSE
 %if 0%{!?fedora:1} && 0%{!?suse_version:1}
 export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-judy.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+%endif
+# Only bundle protobuf on CentOS 7 or earlier
+%if 0%{?centos_ver:1}
+%if %{centos_ver} < 8
+export CFLAGS="${CFLAGS} -fPIC" && ${RPM_BUILD_DIR}/%{name}-%{version}/packaging/bundle-protobuf.sh ${RPM_BUILD_DIR}/%{name}-%{version}
+%endif
 %endif
 %if 0%{?_have_ebpf}
 %if 0%{?centos_ver:1}
@@ -248,6 +256,11 @@ autoreconf -ivf
 	%endif
 	%if 0%{!?fedora:1} && 0%{!?suse_version:1}
 	--with-bundled-libJudy \
+	%endif
+	%if 0%{?centos_ver:1}
+	%if %{centos_ver} < 8
+	--with-bundled-protobuf \
+	%endif
 	%endif
 	--prefix="%{_prefix}" \
 	--sysconfdir="%{_sysconfdir}" \

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -140,14 +140,14 @@ BuildRequires: libuv-devel >= 1
 BuildRequires: openssl-devel
 %if 0%{?suse_version}
 BuildRequires: protobuf-devel
-BuildRequires: protobuf-c-devel
+BuildRequires: libprotobuf-c-devel
 BuildRequires: judy-devel
 BuildRequires: liblz4-devel
 BuildRequires: libjson-c-devel
 %else
 %if 0%{?fedora}
 BuildRequires: protobuf-devel
-BuildRequires: libprotobuf-c-devel
+BuildRequires: protobuf-c-devel
 BuildRequires: Judy-devel
 BuildRequires: lz4-devel
 BuildRequires: json-c-devel

--- a/packaging/bundle-protobuf.sh
+++ b/packaging/bundle-protobuf.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+PROTOBUF_TARBALL="protobuf-cpp-$(cat "${1}/packaging/protobuf.version").tar.gz"
+PROTOBUF_BUILD_PATH="${1}/externaldeps/protobuf/protobuf-$(cat "${1}/packaging/protobuf.version")"
+
+mkdir -p "${1}/externaldeps/protobuf" || exit 1
+curl -sSL --connect-timeout 10 --retry 3 "https://github.com/protocolbuffers/protobuf/releases/download/v$(cat "${1}/packaging/protobuf.version")/${PROTOBUF_TARBALL}" > "${PROTOBUF_TARBALL}" || exit 1
+sha256sum -c "${1}/packaging/protobuf.checksums" || exit 1
+tar -xzf "${PROTOBUF_TARBALL}" -C "${1}/externaldeps/protobuf" || exit 1
+OLDPWD="${PWD}"
+cd "${PROTOBUF_BUILD_PATH}" || exit 1
+./configure --disable-shared --without-zlib --disable-dependency-tracking --with-pic || exit 1
+make -j "$(nproc)" || exit 1
+cd "${OLDPWD}" || exit 1
+
+cp -a "${PROTOBUF_BUILD_PATH}/src" "${1}/externaldeps/protobuf" || exit 1


### PR DESCRIPTION
##### Summary

CentOS 7 does not provide a new enough version of protobuf for our usage, so we need to bundle a newer copy to get proper support there.

##### Test Plan

CentOS 7 packages can be downloaded from the checks page and verified locally to confirm that they have a working copy of protobuf (link to relevant artifacts for current CI run: https://github.com/netdata/netdata/suites/5344636126/artifacts/167246445).

##### Additional Information

Fixes: #12157 