### PR TITLE
Remove check for ACLK_NG and PROMETHEUS_WRITE in order to assume PROTOBUF

### DIFF
--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -60,16 +60,11 @@
 // Optional libraries
 
 #ifdef HAVE_PROTOBUF
-#if defined(ACLK_NG) || defined(ENABLE_PROMETHEUS_REMOTE_WRITE)
 #define FEAT_PROTOBUF 1
 #ifdef BUNDLED_PROTOBUF
 #define FEAT_PROTOBUF_BUNDLED " (bundled)"
 #else
 #define FEAT_PROTOBUF_BUNDLED " (system)"
-#endif
-#else
-#define FEAT_PROTOBUF 0
-#define FEAT_PROTOBUF_BUNDLED ""
 #endif
 #else
 #define FEAT_PROTOBUF 0


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR removes the check for define of `ACLK_NG` (which is obsolete) and `PROMETHEUS_REMOTE_WRITE` for buildinfo to assume protobuf exists.

The check for `HAVE_PROTOBUF` should deduce that correctly.

If we compile with `--disable-backend-prometheus-remote-write` or for some reason it doesn't get compiled, then we could have protobuf, correct support for New Architecture, yet `buildinfo` will state protobuf as `NO`

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

1) Compile the agent with `--disable-backend-prometheus-remote-write`. Check the output of `buildinfo`. It most likely will list protobuf as `NO`, but indeed protobuf has been built.
2) Apply this PR and check again. 

Remember to remove the contents of the directory `externaldeps/protobuf` between checks, if installer finds it from a previous build it will include it.
