### PR TITLE
Add warning about broken Docker hosts in container entrypoint.

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -11,11 +11,7 @@ set -e
 
 if [ ! -w / ] && [ "${EUID}" -eq 0 ]; then
   echo >&2 "WARNING: This Docker host appears to not properly support newer stat system calls. This is known to cause issues with Netdata (most notably, nodes running on such hosts **cannot be claimed**)."
-  echo >&2 "WARNING: To resolve this, please do one of the following:"
-  echo >&2 "WARNING:     * Update to a newer version of Docker and libseccomp."
-  echo >&2 "WARNING:     * Download the default seccomp profile from https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json, replace 'SCMP_ACT_ERRNO' on line 2 with 'SCMP_ACT_TRACE', and then add '--security-opt=seccomp=default.json' to the options being passed to 'docker run' when creating the netdata container."
-  echo >&2 "WARNING:     * Create a modified seccomp profile as outlined above, and then apply it globally for all your Docker containers by adding '--seccomp-profile=default.json' to the options passed to dockerd on startup."
-  echo >&2 "WARNING:     * Add '--security-opt=seccomp=unconfined' to the options being used to run the Netdata container (WARNING: This will significantly reduce the security of the container itself.)."
+  echo >&2 "WARNING: For more information, see https://learn.netdata.cloud/docs/agent/claim#known-issues-on-older-hosts-with-seccomp-enabled"
 fi
 
 if [ ! "${DISABLE_TELEMETRY:-0}" -eq 0 ] ||

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -9,18 +9,13 @@
 # Author  : Austin S. Hemmelgarn <austin@netdata.cloud>
 set -e
 
-if [ ! -w / ]; then
-  if [ "${EUID}" -eq 0 ]; then
-    echo >&2 "WARNING: This Docker host appears to not properly support newer stat system calls. This is known to cause issues with Netdata (most notably, nodes running on such hosts **cannot be claimed**)."
-    echo >&2 "WARNING: To resolve this, please do one of the following:"
-    echo >&2 "WARNING:     * Update to a newer version of Docker and libseccomp (NOTE: This is the only possible resolution for Docker Swarm users)"
-    echo >&2 "WARNING:     * Download the default seccomp profile from https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json, replace 'SCMP_ACT_ERRNO' on line 2 with 'SCMP_ACT_TRACE', and then add '--security-opt=seccomp=default.json' to the options being passed to 'docker run' when creating the netdata container."
-    echo >&2 "WARNING:     * Add '--security-opt=seccomp=unconfined' to the options being used to run the Netdata container (WARNING: This will significantly reduce the security of the container itself.)."
-  else
-    echo >&2 "ERROR: This container must be started in such a way that the entrypoint is runnning as EUID 0 inside the container. Current EUID is ${EUID}."
-    echo >&2 "ERROR: If you want the agent to run as a non-default user ID after the container is initialized, please set DOCKER_USR in the environment to the desired user name instead."
-    exit 1
-  fi
+if [ ! -w / ] && [ "${EUID}" -eq 0 ]; then
+  echo >&2 "WARNING: This Docker host appears to not properly support newer stat system calls. This is known to cause issues with Netdata (most notably, nodes running on such hosts **cannot be claimed**)."
+  echo >&2 "WARNING: To resolve this, please do one of the following:"
+  echo >&2 "WARNING:     * Update to a newer version of Docker and libseccomp."
+  echo >&2 "WARNING:     * Download the default seccomp profile from https://raw.githubusercontent.com/moby/moby/master/profiles/seccomp/default.json, replace 'SCMP_ACT_ERRNO' on line 2 with 'SCMP_ACT_TRACE', and then add '--security-opt=seccomp=default.json' to the options being passed to 'docker run' when creating the netdata container."
+  echo >&2 "WARNING:     * Create a modified seccomp profile as outlined above, and then apply it globally for all your Docker containers by adding '--seccomp-profile=default.json' to the options passed to dockerd on startup."
+  echo >&2 "WARNING:     * Add '--security-opt=seccomp=unconfined' to the options being used to run the Netdata container (WARNING: This will significantly reduce the security of the container itself.)."
 fi
 
 if [ ! "${DISABLE_TELEMETRY:-0}" -eq 0 ] ||


### PR DESCRIPTION
##### Summary

Provides a general warning to catch the case encountered in https://github.com/netdata/netdata/issues/11933 and provide info to the user about it in the container logs.

##### Test Plan

n/a

##### Additional Information

Relevant to (but does not fix): https://github.com/netdata/netdata/issues/11933
