### PR TITLE
fix(kickstart): unescaped grep pattern in set_auto_updates()

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -799,7 +799,7 @@ set_auto_updates() {
 
   if [ "${NETDATA_AUTO_UPDATES}" = "1" ]; then
     # This first case is for catching using a new kickstart script with an old build. It can be safely removed after v1.34.0 is released.
-    if grep -qv '--enable-auto-updates' ${updater}; then
+    if grep -qv '\--enable-auto-updates' ${updater}; then
       echo
     elif ! ${updater} --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
       error "Failed to enable auto updates. Netdata will still work, but you will need to update manually."


### PR DESCRIPTION
##### Summary

ssia

- before

```cmd
[ilyam@pc ~]$ grep '--enable-auto-updates'  /opt/netdata/usr/libexec/netdata/netdata-updater.sh
grep: unrecognized option '--enable-auto-updates'
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
```

- after

```cmd
[ilyam@pc ~]$ grep '\--enable-auto-updates'  /opt/netdata/usr/libexec/netdata/netdata-updater.sh
[ilyam@pc ~]$
```

##### Test Plan

Not needed.

##### Additional Information
