### PR TITLE
fix(python.d/nvidia_smi): use uid when can't find the username

### DIFF
--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -298,8 +298,7 @@ def get_username_by_pid_safe(pid, passwd_file):
     try:
         if IS_INSIDE_DOCKER:
             return passwd_file[uid][0]
-        else:
-            return pwd.getpwuid(uid)[0]
+        return pwd.getpwuid(uid)[0]
     except KeyError:
         return str(uid)
 

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -294,14 +294,14 @@ def get_username_by_pid_safe(pid, passwd_file):
     try:
         uid = os.stat(path).st_uid
     except (OSError, IOError):
-            return ''
-    if IS_INSIDE_DOCKER:
-        try:
+        return ''
+    try:
+        if IS_INSIDE_DOCKER:
             return passwd_file[uid][0]
-        except KeyError:
-            return str(uid)
-    else:
-        return pwd.getpwuid(uid)[0]
+        else:
+            return pwd.getpwuid(uid)[0]
+    except KeyError:
+        return str(uid)
 
 
 class GPU:


### PR DESCRIPTION
##### Summary

This PR fixes the case when UID is not known on the host.

Fixes https://github.com/netdata/netdata/issues/10264#issuecomment-1046045957

##### Test Plan

Thanks to @TheTyrius for [testing](https://github.com/netdata/netdata/issues/10264#issuecomment-1046056075).

##### Additional Information
