### PR TITLE
Store dimension hidden option in the metadata db

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -132,13 +132,18 @@ PARSER_RC pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name
             rrddim_is_obsolete(st, rd);
         else
             rrddim_isnot_obsolete(st, rd);
-        if (strstr(options, "hidden") != NULL)
+        if (strstr(options, "hidden") != NULL) {
             rrddim_flag_set(rd, RRDDIM_FLAG_HIDDEN);
+            (void) sql_set_dimension_option(&rd->state->metric_uuid, "hidden");
+        }
+        else
+            (void) sql_set_dimension_option(&rd->state->metric_uuid, NULL);
         if (strstr(options, "noreset") != NULL)
             rrddim_flag_set(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
         if (strstr(options, "nooverflow") != NULL)
             rrddim_flag_set(rd, RRDDIM_FLAG_DONT_DETECT_RESETS_OR_OVERFLOWS);
     } else {
+        (void) sql_set_dimension_option(&rd->state->metric_uuid, NULL);
         rrddim_isnot_obsolete(st, rd);
     }
     return PARSER_RC_OK;

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -546,6 +546,7 @@ int rrddim_hide(RRDSET *st, const char *id) {
         error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, st->name, st->id, host->hostname);
         return 1;
     }
+    (void) sql_set_dimension_option(&rd->state->metric_uuid, "hidden");
 
     rrddim_flag_set(rd, RRDDIM_FLAG_HIDDEN);
 #ifdef ENABLE_ACLK
@@ -563,6 +564,7 @@ int rrddim_unhide(RRDSET *st, const char *id) {
         error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, st->name, st->id, host->hostname);
         return 1;
     }
+    (void) sql_set_dimension_option(&rd->state->metric_uuid, NULL);
 
     rrddim_flag_clear(rd, RRDDIM_FLAG_HIDDEN);
 #ifdef ENABLE_ACLK

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -98,4 +98,5 @@ extern void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id);
 extern struct node_instance_list *get_node_list(void);
 extern void sql_load_node_id(RRDHOST *host);
 extern void compute_chart_hash(RRDSET *st);
+extern int sql_set_dimension_option(uuid_t *dim_uuid, char *option);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
Store the `hidden` option of a dimension (e.g.  cpu idle) in the database. This is to ensure that queries on
archived charts (in a following PR) will correctly skip hidden dimensions unless explicitly requested.

##### Test Plan
- After applying this PR the `options` column in the `dimension` table in `/var/cache/netdata/netdata-meta.db` will have the value `hidden` for the appropriate dimensions. 
   - Example: 
     ```
     select distinct name, options from dimension where options is not null;
     name  options
     ----  -------
     idle  hidden 
     ```

