### PR TITLE
Add retries in preparation of test environments for build CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - matrix
+    env:
+      RETRY_DELAY: 300
     strategy:
       # Unlike the actal build tests, this completes _very_ fast (average of about 3 minutes for each job), so we
       # just run everything in parallel instead lof limiting job concurrency.
@@ -210,7 +212,43 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
       - name: Build test environment
-        id: build
+        id: build1
+        uses: docker/build-push-action@v2
+        continue-on-error: true # We retry 3 times at 5 minute intervals if there is a failure here.
+        with:
+          push: false
+          load: false
+          file: .github/dockerfiles/Dockerfile.build_test
+          build-args: |
+            BASE=${{ matrix.distro }}
+            PRE=${{ matrix.env_prep }}
+            RMJSONC=${{ matrix.jsonc_removal }}
+          outputs: type=oci,dest=/tmp/image.tar
+          tags: test:${{ matrix.artifact_key }}
+      - name: Retry delay
+        if: ${{ steps.build1.outcome }} == 'failure'
+        run: sleep "${RETRY_DELAY}"
+      - name: Build test environment (attempt 2)
+        if: ${{ steps.build1.outcome }} == 'failure'
+        id: build2
+        uses: docker/build-push-action@v2
+        continue-on-error: true # We retry 3 times at 5 minute intervals if there is a failure here.
+        with:
+          push: false
+          load: false
+          file: .github/dockerfiles/Dockerfile.build_test
+          build-args: |
+            BASE=${{ matrix.distro }}
+            PRE=${{ matrix.env_prep }}
+            RMJSONC=${{ matrix.jsonc_removal }}
+          outputs: type=oci,dest=/tmp/image.tar
+          tags: test:${{ matrix.artifact_key }}
+      - name: Retry delay
+        if: ${{ steps.build1.outcome }} == 'failure' && ${{ steps.build2.outcome }} == 'failure'
+        run: sleep "${RETRY_DELAY}"
+      - name: Build test environment (attempt 3)
+        if: ${{ steps.build1.outcome }} == 'failure' && ${{ steps.build2.outcome }} == 'failure'
+        id: build3
         uses: docker/build-push-action@v2
         with:
           push: false
@@ -241,7 +279,9 @@ jobs:
               ${{ github.repository }}: Test environment preparation for ${{ matrix.distro }} failed.
               Checkout: ${{ steps.checkout.outcome }}
               Set up Buildx: ${{ steps.buildx.outcome }}
-              Build test environment: ${{ steps.build.outcome }}
+              Build test environment: ${{ steps.build1.outcome }}
+              Build test environment (attempt 2): ${{ steps.build2.outcome }}
+              Build test environment (attempt 3): ${{ steps.build3.outcome }}
               Upload: ${{ steps.upload.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: >-


### PR DESCRIPTION
##### Summary

This particular part of our CI fails relatively frequently due to external infrastructure problems. By retrying on the first few failures
in a run, we should mitigate most of these issues at the cost of making the worst case runtime about 10 minutes longer.

##### Test Plan

There should be no visible changes in the running CI on this PR relative to any of the others.