### PR TITLE
Improve cleaning up of orphan hosts

### DIFF
--- a/daemon/service.c
+++ b/daemon/service.c
@@ -31,6 +31,11 @@ void *service_main(void *ptr)
         heartbeat_next(&hb, step);
 
         rrd_cleanup_obsolete_charts();
+
+        rrd_wrlock();
+        rrdhost_cleanup_orphan_hosts_nolock(localhost);
+        rrd_unlock();
+
     }
 
     netdata_thread_cleanup_pop(1);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -642,8 +642,6 @@ RRDHOST *rrdhost_find_or_create(
         rrdhost_unlock(host);
     }
 
-    rrdhost_cleanup_orphan_hosts_nolock(host);
-
     rrd_unlock();
 
     return host;
@@ -652,7 +650,7 @@ inline int rrdhost_should_be_removed(RRDHOST *host, RRDHOST *protected_host, tim
     if(host != protected_host
        && host != localhost
        && rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN)
-       && host->receiver
+       && !host->receiver
        && host->senders_disconnected_time
        && host->senders_disconnected_time + rrdhost_free_orphan_time < now)
         return 1;

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -508,11 +508,16 @@ void aclk_database_worker(void *arg)
                     aclk_update_retention(wc, cmd);
                     aclk_process_dimension_deletion(wc, cmd);
                     break;
-#endif
 
 // NODE_INSTANCE DETECTION
+                case ACLK_DATABASE_ORPHAN_HOST:
+                    wc->host = NULL;
+                    wc->is_orphan = 1;
+                    aclk_add_worker_thread(wc);
+                    break;
+#endif
                 case ACLK_DATABASE_TIMER:
-                    if (unlikely(localhost && !wc->host)) {
+                    if (unlikely(localhost && !wc->host && !wc->is_orphan)) {
                         if (claimed()) {
                             wc->host = rrdhost_find_by_guid(wc->host_guid, 0);
                             if (wc->host) {

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -125,6 +125,7 @@ enum aclk_database_opcode {
     ACLK_DATABASE_CHART_ACK,
     ACLK_DATABASE_UPD_RETENTION,
     ACLK_DATABASE_DIM_DELETION,
+    ACLK_DATABASE_ORPHAN_HOST,
 #endif
     ACLK_DATABASE_ALARM_HEALTH_LOG,
     ACLK_DATABASE_CLEANUP,
@@ -194,6 +195,7 @@ struct aclk_database_worker_config {
     int chart_pending;
     int chart_reset_count;
     volatile unsigned is_shutting_down;
+    volatile unsigned is_orphan;
     struct aclk_database_worker_config  *next;
 };
 


### PR DESCRIPTION
##### Summary
Add orphan host cleanup, in a separate service thread. This thread is currently used to clean up obsolete charts avoiding the overhead of checking for eligible charts during chart creation

Using the same approach an additional check is made for hosts can be obsoleted (eg. children that disconnected and will most likely not reconnect ; ephemeral nodes)

##### Test Plan
- Setup an agent with a child or mode
  - Configure a low value for `cleanup orphan hosts after seconds =` in netdata.conf e.g `cleanup orphan hosts after seconds = 30`
  - Start the parent and child
     - Shutdown the child and notice the parents error.log indicating that the child is removed from memory approximately 30 seconds later
     