### PR TITLE
Properly check out the repo when running the packaging workflow on push.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -91,8 +91,8 @@ jobs:
       fail-fast: false
       max-parallel: 8
     steps:
-      - name: Checkout PR # Checkout the PR if it's a PR.
-        if: github.event_name == 'pull_request'
+      - name: Checkout # Checkout the repo if it’s not a tag.
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 # We need full history for versioning


### PR DESCRIPTION
##### Summary

#12156 missed a conditional in the early parts of the package build job template in the packaging workflow that needed to be updated so that it would properly check things out when running on a push to master.

This PR fixes that conditional.

##### Test Plan

n/a