### PR TITLE
Fix `hpssa` parse error

### DIFF
--- a/collectors/python.d.plugin/hpssa/hpssa.chart.py
+++ b/collectors/python.d.plugin/hpssa/hpssa.chart.py
@@ -88,6 +88,7 @@ ignored_sections_regex = re.compile(
         | (?:Expander|Enclosure|SEP|Port[ ]Name:)[ ].+
         | .+[ ]at[ ]Port[ ]\S+,[ ]Box[ ]\d+,[ ].+
         | Mirror[ ]Group[ ]\d+:
+        | Disk[ ]Partition[ ]Information
     $
     ''',
     re.X

--- a/collectors/python.d.plugin/hpssa/hpssa.chart.py
+++ b/collectors/python.d.plugin/hpssa/hpssa.chart.py
@@ -88,12 +88,12 @@ ignored_sections_regex = re.compile(
         | (?:Expander|Enclosure|SEP|Port[ ]Name:)[ ].+
         | .+[ ]at[ ]Port[ ]\S+,[ ]Box[ ]\d+,[ ].+
         | Mirror[ ]Group[ ]\d+:
-        | Disk[ ]Partition[ ]Information
     $
     ''',
     re.X
 )
 mirror_group_regex = re.compile(r'^Mirror Group \d+:$')
+disk_partition_regex = re.compile(r'^Disk Partition Information$')
 array_regex = re.compile(r'^Array: (?P<id>[A-Z]+)$')
 drive_regex = re.compile(
     r'''
@@ -243,7 +243,7 @@ class HPSSA(object):
         }
 
         for line in self:
-            if mirror_group_regex.match(line):
+            if HPSSA.match_any(line, mirror_group_regex, disk_partition_regex):
                 self.parse_ignored_section()
                 continue
 


### PR DESCRIPTION
##### Summary

Fixes #12205. Line with `Disk Partition Information` generates parser error of the `hpssa` collector.
As such lines includes not useful information this patch simply excludes them.

##### Test Plan

Just tested manually by me on failing system, where it works.
On other HP servers where setup is very similar didn't found this issue (no problematic line in `ssacli` output).
So the issue might be quite unique...
Grepping through the repo show no tests of `hpssa` collector.

##### Additional Information
