### PR TITLE
Remove chart specific configuration from netdata.conf except enabled

### DIFF
--- a/database/rrd.c
+++ b/database/rrd.c
@@ -140,6 +140,7 @@ const char *rrdset_type_name(RRDSET_TYPE chart_type) {
 // RRD - cache directory
 
 char *rrdset_cache_dir(RRDHOST *host, const char *id, const char *config_section) {
+    UNUSED(config_section);
     char *ret = NULL;
 
     char b[FILENAME_MAX + 1];
@@ -147,7 +148,7 @@ char *rrdset_cache_dir(RRDHOST *host, const char *id, const char *config_section
     rrdset_strncpyz_name(b, id, FILENAME_MAX);
 
     snprintfz(n, FILENAME_MAX, "%s/%s", host->cache_dir, b);
-    ret = config_get(config_section, "cache directory", n);
+    ret = strdupz(n);
 
     if(host->rrd_memory_mode == RRD_MEMORY_MODE_MAP || host->rrd_memory_mode == RRD_MEMORY_MODE_SAVE) {
         int r = mkdir(ret, 0775);

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -252,7 +252,6 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     char filename[FILENAME_MAX + 1];
     char fullfilename[FILENAME_MAX + 1];
 
-    char varname[CONFIG_MAX_NAME + 1];
     unsigned long size = sizeof(RRDDIM) + (st->entries * sizeof(storage_number));
 
     debug(D_RRD_CALLS, "Adding dimension '%s/%s'.", st->id, id);
@@ -350,18 +349,14 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
 
     rd->cache_filename = strdupz(fullfilename);
 
-    snprintfz(varname, CONFIG_MAX_NAME, "dim %s name", rd->id);
-    rd->name = config_get(st->config_section, varname, (name && *name)?name:rd->id);
+    rd->name = (name && *name)?strdupz(name):strdupz(rd->id);
     rd->hash_name = simple_hash(rd->name);
 
-    snprintfz(varname, CONFIG_MAX_NAME, "dim %s algorithm", rd->id);
-    rd->algorithm = rrd_algorithm_id(config_get(st->config_section, varname, rrd_algorithm_name(algorithm)));
+    rd->algorithm = algorithm;
 
-    snprintfz(varname, CONFIG_MAX_NAME, "dim %s multiplier", rd->id);
-    rd->multiplier = config_get_number(st->config_section, varname, multiplier);
+    rd->multiplier = multiplier;
 
-    snprintfz(varname, CONFIG_MAX_NAME, "dim %s divisor", rd->id);
-    rd->divisor = config_get_number(st->config_section, varname, divisor);
+    rd->divisor = divisor;
     if(!rd->divisor) rd->divisor = 1;
 
     rd->entries = st->entries;


### PR DESCRIPTION
Fixes #9320
##### Summary
Remove support for 'per chart' configuration in `netdata.conf` (except the `enabled` option)

Right now on every chart creation there is a lookup in the config file to determine if a section that matches the chart exists

- For parent nodes the section matches the chart name
- For child nodes the section is in the form guid/chart_name

##### Component Name
database
agent

##### Test Plan
- Fetch netdata.conf using ` http://host:19999/netdata.conf` to notice the absence of chart specific configuration.

##### Additional Information
