### PR TITLE
Use one transaction to initialize dimension metadata.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,7 @@ set(RRD_PLUGIN_FILES
         database/rrdlabels.c
         database/rrd.c
         database/rrd.h
+        database/rrdops.c
         database/rrdset.c
         database/rrdsetvar.c
         database/rrdsetvar.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -438,6 +438,7 @@ RRD_PLUGIN_FILES = \
     database/rrdlabels.c \
     database/rrd.c \
     database/rrd.h \
+    database/rrdops.c \
     database/rrdset.c \
     database/rrdsetvar.c \
     database/rrdsetvar.h \

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -167,7 +167,9 @@ typedef enum rrddim_flags {
     // No new values have been collected for this dimension since agent start or it was marked RRDDIM_FLAG_OBSOLETE at
     // least rrdset_free_obsolete_time seconds ago.
     RRDDIM_FLAG_ARCHIVED                        = (1 << 3),
-    RRDDIM_FLAG_ACLK                            = (1 << 4)
+    RRDDIM_FLAG_ACLK                            = (1 << 4),
+
+    RRDDIM_FLAG_OPS_INITIALIZED                 = (1 << 5)
 } RRDDIM_FLAGS;
 
 #ifdef HAVE_C___ATOMIC
@@ -1359,6 +1361,22 @@ extern RRDHOST *rrdhost_create(
     int update_every, long entries, RRD_MEMORY_MODE memory_mode, unsigned int health_enabled, unsigned int rrdpush_enabled,
     char *rrdpush_destination, char *rrdpush_api_key, char *rrdpush_send_charts_matching, struct rrdhost_system_info *system_info,
     int is_localhost); //TODO: Remove , int is_archived);
+
+// RRDDIM legacy collection & query functions
+
+extern void rrddim_collect_init(RRDDIM *rd);
+extern void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number);
+extern int rrddim_collect_finalize(RRDDIM *rd);
+
+void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time);
+storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time);
+int rrddim_query_is_finished(struct rrddim_query_handle *handle);
+void rrddim_query_finalize(struct rrddim_query_handle *handle);
+time_t rrddim_query_latest_time(RRDDIM *rd);
+time_t rrddim_query_oldest_time(RRDDIM *rd);
+
+extern void rrdops_initialize(RRDDIM *rd);
+extern void rrddim_initialize_metadata(RRDDIM *rd);
 
 #endif /* NETDATA_RRD_INTERNALS */
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -124,15 +124,15 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
 // ----------------------------------------------------------------------------
 // RRDDIM legacy data collection functions
 
-static void rrddim_collect_init(RRDDIM *rd) {
+void rrddim_collect_init(RRDDIM *rd) {
     rd->values[rd->rrdset->current_entry] = SN_EMPTY_SLOT;
 }
-static void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number) {
+void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number) {
     (void)point_in_time;
 
     rd->values[rd->rrdset->current_entry] = number;
 }
-static int rrddim_collect_finalize(RRDDIM *rd) {
+int rrddim_collect_finalize(RRDDIM *rd) {
     (void)rd;
 
     return 0;
@@ -141,7 +141,7 @@ static int rrddim_collect_finalize(RRDDIM *rd) {
 // ----------------------------------------------------------------------------
 // RRDDIM legacy database query functions
 
-static void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time) {
+void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time) {
     handle->rd = rd;
     handle->start_time = start_time;
     handle->end_time = end_time;
@@ -150,7 +150,7 @@ static void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, ti
     handle->slotted.finished = 0;
 }
 
-static storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time) {
+storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time) {
     RRDDIM *rd = handle->rd;
     long entries = rd->rrdset->entries;
     long slot = handle->slotted.slot;
@@ -166,21 +166,21 @@ static storage_number rrddim_query_next_metric(struct rrddim_query_handle *handl
     return n;
 }
 
-static int rrddim_query_is_finished(struct rrddim_query_handle *handle) {
+int rrddim_query_is_finished(struct rrddim_query_handle *handle) {
     return handle->slotted.finished;
 }
 
-static void rrddim_query_finalize(struct rrddim_query_handle *handle) {
+void rrddim_query_finalize(struct rrddim_query_handle *handle) {
     (void)handle;
 
     return;
 }
 
-static time_t rrddim_query_latest_time(RRDDIM *rd) {
+time_t rrddim_query_latest_time(RRDDIM *rd) {
     return rrdset_last_entry_t_nolock(rd->rrdset);
 }
 
-static time_t rrddim_query_oldest_time(RRDDIM *rd) {
+time_t rrddim_query_oldest_time(RRDDIM *rd) {
     return rrdset_first_entry_t_nolock(rd->rrdset);
 }
 
@@ -391,33 +391,9 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
 #ifdef ENABLE_ACLK
     rd->state->aclk_live_status = -1;
 #endif
-    (void) find_dimension_uuid(st, rd, &(rd->state->metric_uuid));
-    if(memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-#ifdef ENABLE_DBENGINE
-        rrdeng_metric_init(rd);
-        rd->state->collect_ops.init = rrdeng_store_metric_init;
-        rd->state->collect_ops.store_metric = rrdeng_store_metric_next;
-        rd->state->collect_ops.finalize = rrdeng_store_metric_finalize;
-        rd->state->query_ops.init = rrdeng_load_metric_init;
-        rd->state->query_ops.next_metric = rrdeng_load_metric_next;
-        rd->state->query_ops.is_finished = rrdeng_load_metric_is_finished;
-        rd->state->query_ops.finalize = rrdeng_load_metric_finalize;
-        rd->state->query_ops.latest_time = rrdeng_metric_latest_time;
-        rd->state->query_ops.oldest_time = rrdeng_metric_oldest_time;
-#endif
-    } else {
-        rd->state->collect_ops.init         = rrddim_collect_init;
-        rd->state->collect_ops.store_metric = rrddim_collect_store_metric;
-        rd->state->collect_ops.finalize     = rrddim_collect_finalize;
-        rd->state->query_ops.init           = rrddim_query_init;
-        rd->state->query_ops.next_metric    = rrddim_query_next_metric;
-        rd->state->query_ops.is_finished    = rrddim_query_is_finished;
-        rd->state->query_ops.finalize       = rrddim_query_finalize;
-        rd->state->query_ops.latest_time    = rrddim_query_latest_time;
-        rd->state->query_ops.oldest_time    = rrddim_query_oldest_time;
-    }
-    store_active_dimension(&rd->state->metric_uuid);
-    rd->state->collect_ops.init(rd);
+
+    rrdops_initialize(rd);
+
     // append this dimension
     if(!st->dimensions)
         st->dimensions = rd;

--- a/database/rrdops.c
+++ b/database/rrdops.c
@@ -1,0 +1,182 @@
+#define NETDATA_RRD_INTERNALS
+#include "rrd.h"
+
+static inline void rrddim_memory_mode_init(RRDDIM *rd) {
+    // init metric
+    if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        rrdeng_metric_init(rd);
+#endif
+    }
+
+    // collect init
+    if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        rrdeng_store_metric_init(rd);
+#endif
+    } else {
+        rrddim_collect_init(rd);
+    }
+}
+
+void rrddim_initialize_metadata(RRDDIM *rd)
+{
+    if (!rd || rrddim_flag_check(rd, RRDDIM_FLAG_OPS_INITIALIZED))
+        return;
+
+#if defined(NETDATA_INTERNAL_CHECKS) && defined(NETDATA_VERIFY_LOCKS)
+    int rc = netdata_rwlock_trywrlock(&rd->rrdset->rrdset_rwlock);
+    if (rc == 0)
+        fatal("called %s @ %s:%d without a rd/wr lock", __FUNCTION__, __FILE__, __LINE__);
+#endif
+
+    // promote to write lock
+    netdata_rwlock_unlock(&rd->rrdset->rrdset_rwlock);
+    netdata_rwlock_wrlock(&rd->rrdset->rrdset_rwlock);
+
+    // double check for the unlikely scenario where another thread might
+    // have acquired the write-lock before us
+    if (rrddim_flag_check(rd, RRDDIM_FLAG_OPS_INITIALIZED))
+        return;
+
+    // find/create uuid for **all** dims and mark them active
+    find_or_update_uuid_of_each_dimension(rd->rrdset);
+
+    // initialize **all* dims for the given memory mode.
+    for (RRDDIM *rdp = rd->rrdset->dimensions; rdp != NULL; rdp = rdp->next) {
+        if (rrddim_flag_check(rdp, RRDDIM_FLAG_OPS_INITIALIZED))
+            continue;
+
+        rrddim_memory_mode_init(rdp);
+        rrddim_flag_set(rdp, RRDDIM_FLAG_OPS_INITIALIZED);
+    }
+}
+
+static void wrap_collect_init(RRDDIM *rd)
+{
+    if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        rrdeng_store_metric_init(rd);
+#endif
+    } else {
+        rrddim_collect_init(rd);
+    }
+}
+
+static void wrap_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number)
+{
+    rrddim_initialize_metadata(rd);
+
+    if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        rrdeng_store_metric_next(rd, point_in_time, number);
+#endif
+    } else {
+        rrddim_collect_store_metric(rd, point_in_time, number);
+    }
+}
+
+static int wrap_collect_finalize(RRDDIM *rd)
+{
+    rrddim_initialize_metadata(rd);
+
+    if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        return rrdeng_store_metric_finalize(rd);
+#endif
+    } else {
+        return rrddim_collect_finalize(rd);
+    }
+}
+
+static void wrap_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time)
+{
+    rrddim_initialize_metadata(rd);
+
+    if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        rrdeng_load_metric_init(rd, handle, start_time, end_time);
+#endif
+    } else {
+        rrddim_query_init(rd,  handle, start_time, end_time);
+    }
+}
+
+static storage_number wrap_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time)
+{
+    rrddim_initialize_metadata(handle->rd);
+
+    if (handle->rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        return rrdeng_load_metric_next(handle, current_time);
+#endif
+    } else {
+        return rrddim_query_next_metric(handle, current_time);
+    }
+}
+
+static int wrap_query_is_finished(struct rrddim_query_handle *handle)
+{
+    rrddim_initialize_metadata(handle->rd);
+
+    if (handle->rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        return rrdeng_load_metric_is_finished(handle);
+#endif
+    } else {
+        return rrddim_query_is_finished(handle);
+    }
+}
+
+void wrap_query_finalize(struct rrddim_query_handle *handle)
+{
+    rrddim_initialize_metadata(handle->rd);
+
+    if (handle->rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        rrdeng_load_metric_finalize(handle);
+#endif
+    } else {
+        rrddim_query_finalize(handle);
+    }
+}
+
+time_t wrap_query_latest_time(RRDDIM *rd)
+{
+    rrddim_initialize_metadata(rd);
+
+    if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        return rrdeng_metric_latest_time(rd);
+#endif
+    } else {
+        return rrddim_query_latest_time(rd);
+    }
+}
+
+time_t wrap_query_oldest_time(RRDDIM *rd)
+{
+    rrddim_initialize_metadata(rd);
+
+    if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+#ifdef ENABLE_DBENGINE
+        return rrdeng_metric_oldest_time(rd);
+#endif
+    } else {
+        return rrddim_query_oldest_time(rd);
+    }
+}
+
+void rrdops_initialize(RRDDIM *rd) {
+    rd->state->collect_ops.init = wrap_collect_init;
+    rd->state->collect_ops.store_metric = wrap_collect_store_metric;
+    rd->state->collect_ops.finalize = wrap_collect_finalize;
+
+    rd->state->query_ops.init = wrap_query_init;
+    rd->state->query_ops.next_metric = wrap_query_next_metric;
+    rd->state->query_ops.is_finished = wrap_query_is_finished;
+    rd->state->query_ops.finalize = wrap_query_finalize;
+
+    rd->state->query_ops.latest_time = wrap_query_latest_time;
+    rd->state->query_ops.oldest_time = wrap_query_oldest_time;
+}

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -67,7 +67,7 @@ extern int sql_store_chart(
 extern int sql_store_dimension(uuid_t *dim_uuid, uuid_t *chart_uuid, const char *id, const char *name, collected_number multiplier,
                                collected_number divisor, int algorithm);
 
-extern int find_dimension_uuid(RRDSET *st, RRDDIM *rd, uuid_t *store_uuid);
+extern int find_dimension_uuid(RRDSET *st, RRDDIM *rd);
 extern void store_active_dimension(uuid_t *dimension_uuid);
 
 extern uuid_t *find_chart_uuid(RRDHOST *host, const char *type, const char *id, const char *name);
@@ -99,4 +99,7 @@ extern struct node_instance_list *get_node_list(void);
 extern void sql_load_node_id(RRDHOST *host);
 extern void compute_chart_hash(RRDSET *st);
 extern int sql_set_dimension_option(uuid_t *dim_uuid, char *option);
+
+extern int find_or_update_uuid_of_each_dimension(RRDSET *rs);
+
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary

Prior to this PR, we'd execute multiple transactions for each newly created dimension. This PR bundles each SQL statement we need to execute for a new dimension in a single transaction. To support this workflow, we wrap the collect/query ops and lazily initialize the metadata of dimensions in one go the first time a dimension is accessed.

##### Test Plan

- Local & CI builds
- Run & profiled both single node and parent/child setups.
