### PR TITLE
Sanely handle shell metacharacters in PR bodies in package build CI matrix generation.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -38,15 +38,13 @@ jobs:
       - name: Read build matrix
         id: set-matrix
         shell: python3 {0}
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           from ruamel.yaml import YAML
           import json
-          import os
           import re
           FULL_CI_REGEX = '/actions run full ci'
           ALWAYS_RUN_ARCHES = ["amd64"]
+          PR_BODY = """${{ github.event.pull_request.body }}"""
           yaml = YAML(typ='safe')
           entries = list()
           run_limited = False
@@ -54,7 +52,7 @@ jobs:
           with open('.github/data/distros.yml') as f:
               data = yaml.load(f)
 
-          if "${{ github.event_name }}" == "pull_request" and re.search(FULL_CI_REGEX, os.environ["PR_BODY"], re.I) is None:
+          if "${{ github.event_name }}" == "pull_request" and re.search(FULL_CI_REGEX, PR_BODY, re.I) is None:
               run_limited = True
 
           for i, v in enumerate(data['include']):


### PR DESCRIPTION
##### Summary

Trying to pass the PR body as an environment variable runs into problems due to how GHA handles environment variables.

Instead of that, simply template the body text in as a triple-quoted string.

This does not eliminate the issue, but makes the list of problematic cases exponentially smaller (changing from anything that could be interpreted as a metacharacter in a double-quoted shell string being problematic to the exact case of three double quotes in sequence).

##### Test Plan

CI passes on this PR.

##### Additional Information

Filler text below that would excite problematic cases previously...

---

$PATH
$(cat /etc/passwd)