### PR TITLE
[makeself] Fix license URL

### DIFF
--- a/packaging/makeself/makeself-license.txt
+++ b/packaging/makeself/makeself-license.txt
@@ -41,4 +41,4 @@
 
   netdata re-distributes a lot of open source software components.
   Check its full license at:
-  https://github.com/netdata/netdata/blob/master/LICENSE.md
+  https://github.com/netdata/netdata/blob/master/LICENSE


### PR DESCRIPTION
##### Summary
Fixes the license link so it works. I noticed this when installing Netdata on a Raspberry Pi

##### Test Plan
👀 
