### PR TITLE
Store alert log entries even if alert it is repeating.

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -416,6 +416,7 @@ inline RRDCALC *rrdcalc_create_from_template(RRDHOST *host, RRDCALCTEMPLATE *rt,
     rc->delay_multiplier = rt->delay_multiplier;
 
     rc->last_repeat = 0;
+    rc->times_repeat = 0;
     rc->warn_repeat_every = rt->warn_repeat_every;
     rc->crit_repeat_every = rt->crit_repeat_every;
 
@@ -528,6 +529,7 @@ inline RRDCALC *rrdcalc_create_from_rrdcalc(RRDCALC *rc, RRDHOST *host, const ch
     newrc->delay_multiplier = rc->delay_multiplier;
 
     newrc->last_repeat = 0;
+    newrc->times_repeat = 0;
     newrc->warn_repeat_every = rc->warn_repeat_every;
     newrc->crit_repeat_every = rc->crit_repeat_every;
 

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -81,35 +81,32 @@ static void rrdsetcalc_link(RRDSET *st, RRDCALC *rc) {
 
     if(!rc->units) rc->units = strdupz(st->units);
 
-    if(!rrdcalc_isrepeating(rc)) {
-        time_t now = now_realtime_sec();
-        ALARM_ENTRY *ae = health_create_alarm_entry(
-                host,
-                rc->id,
-                rc->next_event_id++,
-                rc->config_hash_id,
-                now,
-                rc->name,
-                rc->rrdset->id,
-                rc->rrdset->family,
-                rc->classification,
-                rc->component,
-                rc->type,
-                rc->exec,
-                rc->recipient,
-                now - rc->last_status_change,
-                rc->old_value,
-                rc->value,
-                rc->status,
-                RRDCALC_STATUS_UNINITIALIZED,
-                rc->source,
-                rc->units,
-                rc->info,
-                0,
-                0
-        );
-        health_alarm_log(host, ae);
-    }
+    time_t now = now_realtime_sec();
+    ALARM_ENTRY *ae = health_create_alarm_entry(
+        host,
+        rc->id,
+        rc->next_event_id++,
+        rc->config_hash_id,
+        now,
+        rc->name,
+        rc->rrdset->id,
+        rc->rrdset->family,
+        rc->classification,
+        rc->component,
+        rc->type,
+        rc->exec,
+        rc->recipient,
+        now - rc->last_status_change,
+        rc->old_value,
+        rc->value,
+        rc->status,
+        RRDCALC_STATUS_UNINITIALIZED,
+        rc->source,
+        rc->units,
+        rc->info,
+        0,
+        0);
+    health_alarm_log(host, ae);
 }
 
 static inline int rrdcalc_test_additional_restriction(RRDCALC *rc, RRDSET *st){
@@ -159,35 +156,32 @@ inline void rrdsetcalc_unlink(RRDCALC *rc) {
 
     RRDHOST *host = st->rrdhost;
 
-    if(!rrdcalc_isrepeating(rc)) {
-        time_t now = now_realtime_sec();
-        ALARM_ENTRY *ae = health_create_alarm_entry(
-                host,
-                rc->id,
-                rc->next_event_id++,
-                rc->config_hash_id,
-                now,
-                rc->name,
-                rc->rrdset->id,
-                rc->rrdset->family,
-                rc->classification,
-                rc->component,
-                rc->type,
-                rc->exec,
-                rc->recipient,
-                now - rc->last_status_change,
-                rc->old_value,
-                rc->value,
-                rc->status,
-                RRDCALC_STATUS_REMOVED,
-                rc->source,
-                rc->units,
-                rc->info,
-                0,
-                0
-        );
-        health_alarm_log(host, ae);
-    }
+    time_t now = now_realtime_sec();
+    ALARM_ENTRY *ae = health_create_alarm_entry(
+        host,
+        rc->id,
+        rc->next_event_id++,
+        rc->config_hash_id,
+        now,
+        rc->name,
+        rc->rrdset->id,
+        rc->rrdset->family,
+        rc->classification,
+        rc->component,
+        rc->type,
+        rc->exec,
+        rc->recipient,
+        now - rc->last_status_change,
+        rc->old_value,
+        rc->value,
+        rc->status,
+        RRDCALC_STATUS_REMOVED,
+        rc->source,
+        rc->units,
+        rc->info,
+        0,
+        0);
+    health_alarm_log(host, ae);
 
     debug(D_HEALTH, "Health unlinking alarm '%s.%s' from chart '%s' of host '%s'", rc->chart?rc->chart:"NOCHART", rc->name, st->id, host->hostname);
 

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -121,6 +121,7 @@ struct rrdcalc {
     time_t next_update;             // the next update timestamp of the alarm
     time_t last_status_change;      // the timestamp of the last time this alarm changed status
     time_t last_repeat; // the last time the alarm got repeated
+    uint32_t times_repeat;          // number of times the alarm got repeated
 
     time_t db_after;                // the first timestamp evaluated by the db lookup
     time_t db_before;               // the last timestamp evaluated by the db lookup

--- a/health/health.c
+++ b/health/health.c
@@ -999,19 +999,19 @@ void *health_main(void *ptr) {
                         rc->delay_last = delay;
                         rc->delay_up_to_timestamp = now + delay;
 
-                        if(likely(!rrdcalc_isrepeating(rc))) {
-                            ALARM_ENTRY *ae = health_create_alarm_entry(
-                                    host, rc->id, rc->next_event_id++, rc->config_hash_id, now, rc->name, rc->rrdset->id,
-                                    rc->rrdset->family, rc->classification, rc->component, rc->type, rc->exec, rc->recipient, now - rc->last_status_change,
-                                    rc->old_value, rc->value, rc->status, status, rc->source, rc->units, rc->info,
-                                    rc->delay_last,
-                                    (
-                                            ((rc->options & RRDCALC_FLAG_NO_CLEAR_NOTIFICATION)? HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION : 0) |
-                                            ((rc->rrdcalc_flags & RRDCALC_FLAG_SILENCED)? HEALTH_ENTRY_FLAG_SILENCED : 0)
-                                    )
-                            );
-                            health_alarm_log(host, ae);
-                        }
+
+                        ALARM_ENTRY *ae = health_create_alarm_entry(
+                                host, rc->id, rc->next_event_id++, rc->config_hash_id, now, rc->name, rc->rrdset->id,
+                                rc->rrdset->family, rc->classification, rc->component, rc->type, rc->exec, rc->recipient, now - rc->last_status_change,
+                                rc->old_value, rc->value, rc->status, status, rc->source, rc->units, rc->info,
+                                rc->delay_last,
+                                (
+                                        ((rc->options & RRDCALC_FLAG_NO_CLEAR_NOTIFICATION)? HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION : 0) |
+                                        ((rc->rrdcalc_flags & RRDCALC_FLAG_SILENCED)? HEALTH_ENTRY_FLAG_SILENCED : 0)
+                                )
+                        );
+                        health_alarm_log(host, ae);
+
                         rc->last_status_change = now;
                         rc->old_status = rc->status;
                         rc->status = status;

--- a/health/health.c
+++ b/health/health.c
@@ -1050,6 +1050,7 @@ void *health_main(void *ptr) {
 
                     if(unlikely(repeat_every > 0 && (rc->last_repeat + repeat_every) <= now)) {
                         rc->last_repeat = now;
+                        if (likely(rc->times_repeat < UINT32_MAX)) rc->times_repeat++;
                         ALARM_ENTRY *ae = health_create_alarm_entry(
                                 host, rc->id, rc->next_event_id++, rc->config_hash_id, now, rc->name, rc->rrdset->id,
                                 rc->rrdset->family, rc->classification, rc->component, rc->type, rc->exec, rc->recipient, now - rc->last_status_change,

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -227,6 +227,7 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                     "\t\t\t\"crit_repeat_every\": \"%u\",\n"
                     "\t\t\t\"value_string\": \"%s\",\n"
                     "\t\t\t\"last_repeat\": \"%lu\",\n"
+                    "\t\t\t\"times_repeat\": %lu,\n"
                    , rc->chart, rc->name
                    , (unsigned long)rc->id
                    , hash_id
@@ -259,6 +260,7 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                    , rc->crit_repeat_every
                    , value_string
                    , (unsigned long)rc->last_repeat
+                   , (unsigned long)rc->times_repeat
     );
 
     if(unlikely(rc->options & RRDCALC_FLAG_NO_CLEAR_NOTIFICATION)) {

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -560,10 +560,6 @@ inline void health_alarm_log(
 ) {
     debug(D_HEALTH, "Health adding alarm log entry with id: %u", ae->unique_id);
 
-    if(unlikely(alarm_entry_isrepeating(host, ae))) {
-        error("Repeating alarms cannot be added to host's alarm log entries. It seems somewhere in the logic, API is being misused. Alarm id: %u", ae->alarm_id);
-        return;
-    }
     // link it
     netdata_rwlock_wrlock(&host->health_log.alarm_log_rwlock);
     ae->next = host->health_log.alarms;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR allows repeating alerts to be stored in health log (both in memory and in sqlite). It merely removes code that checked that if the alert is repeating, it should not store it in health log.

If the global option `default repeat warning` or `default repeat critical` is used, then no entries for any alert will be recorded in the health log.

The health code creates a new alarm log entry for every instance of a repeating alert. What this PR changes, is that the first instance of the alert will be stored and recorded in the health log, along with it's initial and removed states when the agent starts and shuts down. 

The entries for the next repeats will not, but will continue to be created and produce a notification.

However, since all it does is remove code that was there to protect from that, I would like some feedback if that has intentional and I'm missing something.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Enable the e.g. `default repeat warning` on master. Start the agent and observe that nothing is recorded in the health log (/api/v1/alarm_log).
With this PR, repeat the above. It should now store the entries. Raise an alert (e.g. ram_available) and notice that the first instance of the alert is recorded, but not the repeating ones.