### PR TITLE
docs: add some tips on collecting per-queue metrics for RabbitMQ

### DIFF
--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -122,7 +122,7 @@ To create a dedicated user for netdata:
 rabbitmqctl add_user netdata ChangeThisSuperSecretPassword
 rabbitmqctl set_permissions netdata "^$" "^$" ".*"
 ```
-Once the user is set up, add `collect_queues_metrics: yes` to your config:
+Once the user is set up, add `collect_queues_metrics: yes` to your `rabbitmq.conf`:
 
 ```yaml
 local:

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -121,6 +121,11 @@ To create a dedicated user for netdata:
 ```bash
 rabbitmqctl add_user netdata ChangeThisSuperSecretPassword
 rabbitmqctl set_permissions netdata "^$" "^$" ".*"
+```
+
+See [set_permissions](https://www.rabbitmq.com/rabbitmqctl.8.html#set_permissions) for details.
+
+Once the user is set up, add `collect_queues_metrics: yes` to your `rabbitmq.conf`:
 
 ```yaml
 local:

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -115,7 +115,8 @@ socket:
 
 ### Per-Queue Chart configuration
 
-RabbitMQ users with the "monitoring" tag cannot see all queue data, you'll need a user with read permissions here. To create a dedicated user for netdata:
+RabbitMQ users with the "monitoring" tag cannot see all queue data. You'll need a user with read permissions. 
+To create a dedicated user for netdata:
 
 ```bash
 rabbitmqctl add_user netdata ChangeThisSuperSecretPassword

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -114,6 +114,7 @@ socket:
 ---
 
 ### Per-Queue Chart configuration
+
 RabbitMQ users with the "monitoring" tag cannot see all queue data, you'll need a user with read permissions here. To create a dedicated user for netdata:
 
 ```bash

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -121,7 +121,6 @@ To create a dedicated user for netdata:
 ```bash
 rabbitmqctl add_user netdata ChangeThisSuperSecretPassword
 rabbitmqctl set_permissions netdata "^$" "^$" ".*"
-Once the user is set up, add `collect_queues_metrics: yes` to your `rabbitmq.conf`:
 
 ```yaml
 local:

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -113,4 +113,11 @@ socket:
 
 ---
 
+### Per-Queue Chart configuration
+RabbitMQ users with the "monitoring" tag cannot see all queue data, you'll need a user with read permissions here. To create a dedicated user for netdata:
 
+```bash
+rabbitmqctl add_user netdata ChangeThisSuperSecretPassword
+rabbitmqctl set_permissions netdata "^$" "^$" ".*"
+```
+Once the user is set up, add `collect_queues_metrics: yes` to your config.

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -121,7 +121,6 @@ To create a dedicated user for netdata:
 ```bash
 rabbitmqctl add_user netdata ChangeThisSuperSecretPassword
 rabbitmqctl set_permissions netdata "^$" "^$" ".*"
-```
 Once the user is set up, add `collect_queues_metrics: yes` to your `rabbitmq.conf`:
 
 ```yaml

--- a/collectors/python.d.plugin/rabbitmq/README.md
+++ b/collectors/python.d.plugin/rabbitmq/README.md
@@ -120,4 +120,14 @@ RabbitMQ users with the "monitoring" tag cannot see all queue data, you'll need 
 rabbitmqctl add_user netdata ChangeThisSuperSecretPassword
 rabbitmqctl set_permissions netdata "^$" "^$" ".*"
 ```
-Once the user is set up, add `collect_queues_metrics: yes` to your config.
+Once the user is set up, add `collect_queues_metrics: yes` to your config:
+
+```yaml
+local:
+  name                   : 'local'
+  host                   : '127.0.0.1'
+  port                   :  15672
+  user                   : 'netdata'
+  pass                   : 'ChangeThisSuperSecretPassword'
+  collect_queues_metrics : 'yes'
+```


### PR DESCRIPTION
##### Summary
Added some tips on collecting per-queue metrics for RabbitMQ. I had some struggles getting per-queue rmq set up, just adding some details to the permissions needed that I found unintuitive on the rmq permissions side.
