### PR TITLE
Fix handling of repository name in CI workflows.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -20,6 +20,7 @@ on:
         required: false
 env:
   DISABLE_TELEMETRY: 1
+  REPO_PREFIX: netdata/netdata
 concurrency:
   group: packages-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
@@ -114,17 +115,17 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             case "${{ github.event.inputs.type }}" in
               "release")
-                echo "::set-output name=repo::${{ secrets.PACKAGE_CLOUD_REPO }}"
+                echo "::set-output name=repo::${REPO_PREFIX}"
                 echo "::set-output name=version::${{ github.event.inputs.version }}"
                 echo "::set-output name=retention::365"
                 ;;
               "nightly")
-                echo "::set-output name=repo::${{ secrets.PACKAGE_CLOUD_REPO }}-edge"
+                echo "::set-output name=repo::${REPO_PREFIX}-edge"
                 echo "::set-output name=version::${{ github.event.inputs.version }}"
                 echo "::set-output name=retention::30"
                 ;;
               *)
-                echo "::set-output name=repo::${{ secrets.PACKAGE_CLOUD_REPO }}-devel"
+                echo "::set-output name=repo::${REPO_PREFIX}-devel"
                 echo "::set-output name=version::0.${GITHUB_SHA}"
                 echo "::set-output name=retention::30"
                 ;;

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -15,6 +15,7 @@ on:
       - .github/workflows/repoconfig-packages.yml
 env:
   DISABLE_TELEMETRY: 1
+  REPO_PREFIX: netdata/netdata
 jobs:
   matrix:
     name: Prepare Build Matrix
@@ -121,15 +122,15 @@ jobs:
         run: |
           printf "Packages to upload:\n%s" "$(ls artifacts/*.${{ matrix.format }})"
           for pkgfile in artifacts/*.${{ matrix.format }} ; do
-            .github/scripts/package_cloud_wrapper.sh yank ${{ secrets.PACKAGE_CLOUD_REPO }}/${{ matrix.pkgclouddistro }} \
+            .github/scripts/package_cloud_wrapper.sh yank "${REPO_PREFIX}/${{ matrix.pkgclouddistro }}" \
                 "$(basename "${pkgfile}")" || true
-            .github/scripts/package_cloud_wrapper.sh push ${{ secrets.PACKAGE_CLOUD_REPO }}/${{ matrix.pkgclouddistro }} "${pkgfile}"
-            .github/scripts/package_cloud_wrapper.sh yank ${{ secrets.PACKAGE_CLOUD_REPO }}-edge/${{ matrix.pkgclouddistro }} \
+            .github/scripts/package_cloud_wrapper.sh push "${REPO_PREFIX}/${{ matrix.pkgclouddistro }}" "${pkgfile}"
+            .github/scripts/package_cloud_wrapper.sh yank "${REPO_PREFIX}-edge/${{ matrix.pkgclouddistro }}" \
                 "$(basename "${pkgfile}")" || true
-            .github/scripts/package_cloud_wrapper.sh push ${{ secrets.PACKAGE_CLOUD_REPO }}-edge/${{ matrix.pkgclouddistro }} "${pkgfile}"
-            .github/scripts/package_cloud_wrapper.sh yank ${{ secrets.PACKAGE_CLOUD_REPO }}-repoconfig/${{ matrix.pkgclouddistro }} \
+            .github/scripts/package_cloud_wrapper.sh push "${REPO_PREFIX}-edge/${{ matrix.pkgclouddistro }}" "${pkgfile}"
+            .github/scripts/package_cloud_wrapper.sh yank "${REPO_PREFIX}-repoconfig/${{ matrix.pkgclouddistro }}" \
                 "$(basename "${pkgfile}")" || true
-            .github/scripts/package_cloud_wrapper.sh push ${{ secrets.PACKAGE_CLOUD_REPO }}-repoconfig/${{ matrix.pkgclouddistro }} "${pkgfile}"
+            .github/scripts/package_cloud_wrapper.sh push "${REPO_PREFIX}-repoconfig/${{ matrix.pkgclouddistro }}" "${pkgfile}"
           done
       - name: Failure Notification
         if: ${{ failure() }}


### PR DESCRIPTION
##### Summary

GitHub Actions understandably does not like passing secrets into step or job outputs, so we need to just use an environment variable for the repo name instead of storing it as a secret.

##### Test Plan

n/a