### PR TITLE
Fix builds where HAVE_C___ATOMIC is not defined.

### DIFF
--- a/ml/Host.h
+++ b/ml/Host.h
@@ -31,7 +31,9 @@ public:
             RRDSET_TYPE_LINE
         );
 
-        rrdset_flag_set(AnomalyRateRS, RRDSET_FLAG_HIDDEN);
+        AnomalyRateRS->flags = static_cast<RRDSET_FLAGS>(
+            static_cast<int>(AnomalyRateRS->flags) | RRDSET_FLAG_HIDDEN
+        );
     }
 
     RRDHOST *getRH() { return RH; }


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

`build/m4/ax_c___atomic.m4` wrongly skips setting HAVE_C___ATOMIC on some 32-bit platforms.
This breaks C++ 11 code because of the definition of `rrdset_flag_set`.

##### Test Plan

CI jobs & local builds after undef-ing the aforementioned macro.