### PR TITLE
eBPF installation fixes

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -904,6 +904,25 @@ get_kernel_version() {
   printf "%03d%03d%03d" "${maj}" "${min}" "${patch}"
 }
 
+detect_libc() {
+  libc=
+  if ldd --version 2>&1 | grep -q -i glibc; then
+    echo >&2 " Detected GLIBC"
+    libc="glibc"
+  elif ldd --version 2>&1 | grep -q -i 'gnu libc'; then
+    echo >&2 " Detected GLIBC"
+    libc="glibc"
+  elif ldd --version 2>&1 | grep -q -i musl; then
+    echo >&2 " Detected musl"
+    libc="musl"
+  else
+    echo >&2 " ERROR: Cannot detect a supported libc on your system!"
+    return 1
+  fi
+  echo "${libc}"
+  return 0
+}
+
 rename_libbpf_packaging() {
   if [ "$(get_kernel_version)" -ge "004014000" ]; then
     cp packaging/current_libbpf.checksums packaging/libbpf.checksums
@@ -1554,25 +1573,6 @@ install_go() {
 }
 
 install_go
-
-detect_libc() {
-  libc=
-  if ldd --version 2>&1 | grep -q -i glibc; then
-    echo >&2 " Detected GLIBC"
-    libc="glibc"
-  elif ldd --version 2>&1 | grep -q -i 'gnu libc'; then
-    echo >&2 " Detected GLIBC"
-    libc="glibc"
-  elif ldd --version 2>&1 | grep -q -i musl; then
-    echo >&2 " Detected musl"
-    libc="musl"
-  else
-    echo >&2 " ERROR: Cannot detect a supported libc on your system!"
-    return 1
-  fi
-  echo "${libc}"
-  return 0
-}
 
 should_install_ebpf() {
   if [ "${NETDATA_DISABLE_EBPF:=0}" -eq 1 ]; then

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -962,6 +962,14 @@ bundle_libbpf() {
     return 0
   fi
 
+  # When libc is not detected, we do not have necessity to compile libbpf and we should not do download of eBPF programs
+  libc="${EBPF_LIBC:-"$(detect_libc)"}"
+  if [ -z "$libc" ]; then
+      NETDATA_DISABLE_EBPF=1
+      NETDATA_CONFIGURE_OPTIONS="$(echo "${NETDATA_CONFIGURE_OPTIONS%--disable-ebpf)}" | sed 's/$/ --disable-ebpf/g')"
+      return 0
+  fi
+
   [ -n "${GITHUB_ACTIONS}" ] && echo "::group::Bundling libbpf."
 
   rename_libbpf_packaging

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -916,9 +916,21 @@ detect_libc() {
     echo >&2 " Detected musl"
     libc="musl"
   else
+    ls_path=$(command -v ls)
+    if [ -n "${ls_path}" ] ; then
+      cmd=$(ldd "$ls_path" | grep -w libc | cut -d" " -f 3)
+      if bash -c "${cmd}" 2>&1 | grep -q -i "GNU C Library"; then
+        echo >&2 " Detected GLIBC"
+        libc="glibc"    
+      fi    
+    fi    
+  fi
+
+  if [ -z "$libc" ]; then
     echo >&2 " ERROR: Cannot detect a supported libc on your system!"
     return 1
   fi
+
   echo "${libc}"
   return 0
 }


### PR DESCRIPTION
##### Summary
Fixes #12233 

As described [here](https://github.com/netdata/netdata/issues/12233#issuecomment-1050215744), our logic to install `eBPF.plugin` had a problem, and this PR is fixing the algorithm  to detect `libc` on Linux distributions that changes `ldd` default output.
##### Test Plan

1. Clone Brach
2. Compile the PR and verify that when `libc` is not detect eBPF.plugin is not installed.
3. Repeat the test on an environment that `libc` is present and install PR to be sure that `eBPF.plugin` is installed without any problems.

##### Additional Information

To develop the fix, I used a [vagrant image](https://app.vagrantup.com/generic/boxes/gentoo). I am bringing the logs for the two last commit to simplify the review:

| Distribution |Commit | Log |
|-----------------|----------|--------|
| Gentoo        | [second](https://github.com/netdata/netdata/commit/e94dec24086ca46219d74f832229dba13da8ae16) | [stderr](https://github.com/netdata/netdata/files/8137876/second_commit.txt) |
| Gentoo        | [third](https://github.com/netdata/netdata/commit/879f721894cbe1be1aa99d49a699df9e6d2df7c1)    | [stderr.txt](https://github.com/netdata/netdata/files/8137883/third_commit.txt) |
| Slackware current | [third](https://github.com/netdata/netdata/commit/879f721894cbe1be1aa99d49a699df9e6d2df7c1) | [slackware_stderr.txt](https://github.com/netdata/netdata/files/8137987/slackware_stderr.txt) |