### PR TITLE
Add a check to make sure internal chart state is initialized

### DIFF
--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -229,7 +229,7 @@ int rrdset2anything_api_v1(
         return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
 
-    if (st && st->state->is_ar_chart)
+    if (st && st->state && st->state->is_ar_chart)
         ml_process_rrdr(r, max_anomaly_rates);
 
     RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;


### PR DESCRIPTION
##### Summary
Fix a crash when the chart state is not initialized

```
#0  0x000055e6d3f71593 in rrdset2anything_api_v1 (st=0x55e6eadc8d20, wb=0x55e6ead9bd00, dimensions=0x0, format=8, points=58, after=-900, before=0, group_method=1, group_time=0, options=551, 
    latest_timestamp=0x7fd382336898, context_param_list=0x55e6ea26f5a0, chart_label_key=0x0, max_anomaly_rates=0) at web/api/formatters/rrd2json.c:232
232	    if (st && st->state->is_ar_chart)
(gdb) p st
$8 = (RRDSET *) 0x55e6eadc8d20
(gdb) p st->state
$9 = (struct rrdset_volatile *) 0x0
```

##### Test Plan
- Random crashes when starting the agent (on this piece of code) should be gone