### PR TITLE
Revise claiming error message in kickstart script.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -797,13 +797,13 @@ claim() {
       return 0
       ;;
     8)
-      warning "Failed to claim node due to an invalid agent ID. You can usually resolve this by removing ${INSTALL_PREFIX}/var/lib/netdata/registry/netdata.public.unique.id and restarting the agent, then trying to claim it again."
+      warning "Failed to claim node due to an invalid agent ID. You can usually resolve this by removing ${INSTALL_PREFIX}/var/lib/netdata/registry/netdata.public.unique.id and restarting the agent. Then try to claim it again using the same options."
       ;;
     9)
       warning "Failed to claim node due to an invalid node name. This probably means you tried to specify a custom name for this node (for example, using the --claim-hostname option), but the hostname itself was either empty or consisted solely of whitespace. You can resolve this by specifying a valid host name and trying again."
       ;;
     10)
-      warning "Failed to claim node due to an invalid room ID. Please check that the room or rooms you are trying to add the node to exists and that the list of rooms provided to the --claim-rooms option ('${NETDATA_CLAIM_ROOMS}') matches what you saw in the Cloud and try again."
+      warning "Failed to claim node due to an invalid room ID. This issue is most likely caused by a typo.  Please check if the room(s) you are trying to add appear on the list of rooms provided to the --claim-rooms option ('${NETDATA_CLAIM_ROOMS}'). Then verify if the rooms are visible in Netdata Cloud and try again."
       ;;
     11)
       warning "Failed to claim node due to an issue with the generated RSA key pair. You can usually resolve this by removing all files in ${INSTALL_PREFIX}/var/lib/netdata/cloud.d and then trying again."
@@ -812,7 +812,7 @@ claim() {
       warning "Failed to claim node due to an invalid or expired claiming token. Please check that the token specified with the --claim-token option ('${NETDATA_CLAIM_TOKEN}') matches what you see in the Cloud and try again."
       ;;
     13)
-      warning "Failed to claim node because the Cloud thinks it is already claimed. If this node was created by cloning a VM or as a container from a template, please remove the file ${INSTALL_PREFIX}/var/lib/netdata/registry/netdata.public.unique.id and restart the agent, then try to claim it again. Otherwise, if you are certain this node has never been claimed before, you can use the --claim-id option to specify a new node ID to use for claiming, for example by using the uuidgen command like so: --claim-id \"\$(uuidgen)\""
+      warning "Failed to claim node because the Cloud thinks it is already claimed. If this node was created by cloning a VM or as a container from a template, please remove the file ${INSTALL_PREFIX}/var/lib/netdata/registry/netdata.public.unique.id and restart the agent. Then try to claim it again with the same options. Otherwise, if you are certain this node has never been claimed before, you can use the --claim-id option to specify a new node ID to use for claiming, for example by using the uuidgen command like so: --claim-id \"\$(uuidgen)\""
       ;;
     14)
       warning "Failed to claim node because the node is already in the process of being claimed. You should not need to do anything to resolve this, the node should show up properly in the Cloud soon. If it does not, please report a bug at ${AGENT_BUG_REPORT_URL}."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -5,13 +5,15 @@
 # ======================================================================
 # Constants
 
+AGENT_BUG_REPORT_URL="https://github.com/netdata/netdata/issues/new/choose"
+CLOUD_BUG_REPORT_URL="https://github.com/netdata/netdata-cloud/issues/new/choose"
 KICKSTART_OPTIONS="${*}"
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
 PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 REPOCONFIG_URL_PREFIX="https://packagecloud.io/netdata/netdata-repoconfig/packages"
 REPOCONFIG_VERSION="1-1"
-TELEMETRY_URL="https://posthog.netdata.cloud/capture/"
 START_TIME="$(date +%s)"
+TELEMETRY_URL="https://posthog.netdata.cloud/capture/"
 
 # ======================================================================
 # Defaults for environment variables
@@ -779,7 +781,7 @@ claim() {
       return 0
       ;;
     1)
-      warning "Unable to claim node due to invalid claiming options. If you are seeing this message, you’ve probably found a bug."
+      warning "Unable to claim node due to invalid claiming options. If you are seeing this message, you’ve probably found a bug and should open a bug report at ${AGENT_BUG_REPORT_URL}"
       ;;
     2)
       warning "Unable to claim node due to issues creating the claiming directory or preparing the local claiming key. Make sure you have a working openssl command and that ${INSTALL_PREFIX}/var/lib/netdata/cloud.d exists, then try again."
@@ -788,10 +790,10 @@ claim() {
       warning "Unable to claim node due to missing dependencies. Usually this means that the Netdata Agent was built without support for Netdata Cloud."
       ;;
     4)
-      warning "Failed to claim node due to inabiity to connect to ${NETDATA_CLAIM_URL}. Usually this either means that the specified claiming URL is wrong, or that youare having entworking problems."
+      warning "Failed to claim node due to inability to connect to ${NETDATA_CLAIM_URL}. Usually this either means that the specified claiming URL is wrong, or that you are having networking problems."
       ;;
     5)
-      progress "Successfully claimed node, but was not able to notify the Netdata agent. You will need to restart the Netdata service on this node before it will show up in the Cloud."
+      progress "Successfully claimed node, but was not able to notify the Netdata Agent. You will need to restart the Netdata service on this node before it will show up in the Cloud."
       return 0
       ;;
     8)
@@ -807,22 +809,22 @@ claim() {
       warning "Failed to claim node due to an issue with the generated RSA key pair. You can usually resolve this by removing all files in ${INSTALL_PREFIX}/var/lib/netdata/cloud.d and then trying again."
       ;;
     12)
-      warning "Failed to claim node due to an invalid or expired claiming token. Please check that the toekn specified with the --claim-token option ('${NETDATA_CLAIM_TOKEN}') matches what you see in the Cloud and try again."
+      warning "Failed to claim node due to an invalid or expired claiming token. Please check that the token specified with the --claim-token option ('${NETDATA_CLAIM_TOKEN}') matches what you see in the Cloud and try again."
       ;;
     13)
       warning "Failed to claim node because the Cloud thinks it is already claimed. If this node was created by cloning a VM or as a container from a template, please remove the file ${INSTALL_PREFIX}/var/lib/netdata/registry/netdata.public.unique.id and restart the agent, then try to claim it again. Otherwise, if you are certain this node has never been claimed before, you can use the --claim-id option to specify a new node ID to use for claiming, for example by using the uuidgen command like so: --claim-id \"\$(uuidgen)\""
       ;;
     14)
-      warning "Failed to claim node because the node is already in the process of being claimed. You should not need to do anything to resolve this, the node should show up properly in the Cloud soon. If it does not, please report a bug."
+      warning "Failed to claim node because the node is already in the process of being claimed. You should not need to do anything to resolve this, the node should show up properly in the Cloud soon. If it does not, please report a bug at ${AGENT_BUG_REPORT_URL}."
       ;;
     15|16|17)
-      warning "Failed to claim node due to an internal server error in the Cloud. Please retry claiming this node later, and if you still see this message file a bug report."
+      warning "Failed to claim node due to an internal server error in the Cloud. Please retry claiming this node later, and if you still see this message file a bug report at ${CLOUD_BUG_REPORT_URL}."
       ;;
     18)
       warning "Unable to claim node because this Netdata installation does not have a unique ID yet. Make sure the agent is running and started up correctly, and then try again."
       ;;
     *)
-      warning "Failed to claim node for an unknown reason. This usually means either networking problems or a bug. Please retry claiming later, and if you still see this message file a bug report."
+      warning "Failed to claim node for an unknown reason. This usually means either networking problems or a bug. Please retry claiming later, and if you still see this message file a bug report at ${AGENT_BUG_REPORT_URL}"
       ;;
   esac
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -787,7 +787,7 @@ claim() {
       warning "Unable to claim node due to issues creating the claiming directory or preparing the local claiming key. Make sure you have a working openssl command and that ${INSTALL_PREFIX}/var/lib/netdata/cloud.d exists, then try again."
       ;;
     3)
-      warning "Unable to claim node due to missing dependencies. Usually this means that the Netdata Agent was built without support for Netdata Cloud."
+      warning "Unable to claim node due to missing dependencies. Usually this means that the Netdata Agent was built without support for Netdata Cloud. If you built the agent from source, please install all needed dependencies for Cloud support. If you used the regular installation script and see this error, please file a bug."
       ;;
     4)
       warning "Failed to claim node due to inability to connect to ${NETDATA_CLAIM_URL}. Usually this either means that the specified claiming URL is wrong, or that you are having networking problems."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -5,19 +5,18 @@
 # ======================================================================
 # Constants
 
-AGENT_BUG_REPORT_URL="https://github.com/netdata/netdata/issues/new/choose"
-CLOUD_BUG_REPORT_URL="https://github.com/netdata/netdata-cloud/issues/new/choose"
 KICKSTART_OPTIONS="${*}"
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
 PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 REPOCONFIG_URL_PREFIX="https://packagecloud.io/netdata/netdata-repoconfig/packages"
 REPOCONFIG_VERSION="1-1"
-START_TIME="$(date +%s)"
 TELEMETRY_URL="https://posthog.netdata.cloud/capture/"
+START_TIME="$(date +%s)"
 
 # ======================================================================
 # Defaults for environment variables
 
+DRY_RUN=0
 SELECTED_INSTALL_METHOD="none"
 INSTALL_TYPE="unknown"
 INSTALL_PREFIX=""
@@ -64,6 +63,7 @@ USAGE: kickstart.sh [options]
   --non-interactive          Do not prompt for user input. (default: prompt if there is a controlling terminal)
   --interactive              Prompt for user input even if there is no controlling terminal.
   --dont-start-it            Do not start the agent by default (only for static installs or local builds)
+  --dry-run                  Report what we would do with the given options on this system, but don’t actually do anything.
   --stable-channel           Install a stable version instead of a nightly build (default: install a nightly build)
   --nightly-channel          Install a nightly build instead of a stable version
   --no-updates               Do not enable automatic updates (default: enable automatic updates)
@@ -82,6 +82,7 @@ USAGE: kickstart.sh [options]
   --claim-only               If there is an existing install, only try to claim it, not update it.
   --claim-*                  Specify other options for the claiming script.
   --no-cleanup               Don't do any cleanup steps. This is intended to help with debugging the installer.
+  --uninstall                Uninstall an existing installation of Netdata.
 
 Additionally, this script may use the following environment variables:
 
@@ -102,7 +103,7 @@ HEREDOC
 # Telemetry functions
 
 telemetry_event() {
-  if [ "${NETDATA_DISABLE_TELEMETRY}" -eq 1 ]; then
+  if [ "${NETDATA_DISABLE_TELEMETRY}" -eq 1 ] || [ "${DRY_RUN}" -eq 1 ]; then
     return 0
   fi
 
@@ -139,7 +140,7 @@ telemetry_event() {
   if [ -f /etc/machine-id ]; then
     DISTINCT_ID="$(cat /etc/machine-id)"
   elif command -v uuidgen > /dev/null 2>&1; then
-    DISTINCT_ID="$(uuidgen)"
+    DISTINCT_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
   else
     DISTINCT_ID="null"
   fi
@@ -267,14 +268,14 @@ run_failed() {
 
 ESCAPED_PRINT_METHOD=
 # shellcheck disable=SC3050
-if printf "%q " test > /dev/null 2>&1; then
+if printf "%s " test > /dev/null 2>&1; then
   ESCAPED_PRINT_METHOD="printfq"
 fi
 
 escaped_print() {
   if [ "${ESCAPED_PRINT_METHOD}" = "printfq" ]; then
     # shellcheck disable=SC3050
-    printf "%q " "${@}"
+    printf "%s " "${@}"
   else
     printf "%s" "${*}"
   fi
@@ -298,6 +299,10 @@ run() {
     info_console="[${TPUT_DIM}${dir}${TPUT_RESET}]$ "
   fi
 
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    printf >&2 "%s" "Would run command:\n"
+  fi
+
   {
     printf "%s" "${info}"
     escaped_print "${@}"
@@ -308,9 +313,13 @@ run() {
   escaped_print >&2 "${@}"
   printf >&2 "%s\n" "${TPUT_RESET}"
 
-  "${@}"
+  if [ "${DRY_RUN}" -ne 1 ]; then
+    "${@}"
+    ret=$?
+  else
+    ret=0
+  fi
 
-  ret=$?
   if [ ${ret} -ne 0 ]; then
     run_failed
     printf "%s\n" "FAILED with exit code ${ret}" >> "${run_logfile}"
@@ -360,6 +369,17 @@ create_tmp_directory() {
   fi
 
   mktemp -d -t netdata-kickstart-XXXXXXXXXX
+}
+
+check_for_remote_file() {
+  url="${1}"
+  if command -v curl > /dev/null 2>&1; then
+    curl --output /dev/null --silent --head --fail "${url}" || return 1
+  elif command -v wget > /dev/null 2>&1; then
+    wget -S --spider "${url}" 2>&1 | grep -q 'HTTP/1.1 200 OK' || return 1
+  else
+    fatal "I need curl or wget to proceed, but neither of them are available on this system." F0003
+  fi
 }
 
 download() {
@@ -523,6 +543,11 @@ update() {
   updater="${ndprefix}/usr/libexec/netdata/netdata-updater.sh"
 
   if [ -x "${updater}" ]; then
+    if [ "${DRY_RUN}" -eq 1 ]; then
+      progress "Would attempt to update existing installation by running the updater script located at: ${updater}"
+      return 0
+    fi
+
     if run ${ROOTCMD} "${updater}" --not-running-from-cron; then
       progress "Updated existing install at ${ndprefix}"
       return 0
@@ -530,15 +555,53 @@ update() {
       fatal "Failed to update existing Netdata install at ${ndprefix}" F0100
     fi
   else
+    warning "Could not find a usable copy of the updater script."
     return 1
   fi
 }
 
+uninstall() {
+  get_system_info
+  detect_existing_install
+
+  export INSTALL_PREFIX="${ndprefix}"
+
+  uninstaller="${INSTALL_PREFIX}/usr/libexec/netdata/netdata-uninstaller.sh"
+  uninstaller_url="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/netdata-uninstaller.sh"
+
+  if [ $INTERACTIVE = 0 ]; then
+    FLAGS="--yes --force"
+  else
+    FLAGS="--yes"
+  fi
+
+  if [ -x "${uninstaller}" ]; then
+    if [ "${DRY_RUN}" -eq 1 ]; then
+      progress "Would attempt to uninstall existing install with uninstaller script found at: ${uninstaller}"
+      return 0
+    else
+      progress "Found existing netdata-uninstaller. Running it.."
+      run ${ROOTCMD} "${uninstaller}" $FLAGS
+    fi
+  else
+    if [ "${DRY_RUN}" -eq 1 ]; then
+      progress "Would download installer script from: ${uninstaller_url}"
+      progress "Would attempt to uninstall existing install with downloaded uninstaller script."
+      return 0
+    else
+      progress "Downloading netdata-uninstaller ..."
+      download "${uninstaller_url}" "${tmpdir}/netdata-uninstaller.sh"
+      chmod +x "${tmpdir}/netdata-uninstaller.sh"
+      run ${ROOTCMD} "${tmpdir}/netdata-uninstaller.sh" $FLAGS
+    fi
+  fi
+}
+
 detect_existing_install() {
+  progress "Checking for existing installations of Netdata..."
+
   if pkg_installed netdata; then
     ndprefix="/"
-  elif [ -n "${INSTALL_PREFIX}" ]; then
-    ndprefix="${INSTALL_PREFIX}"
   else
     if [ -n "${INSTALL_PREFIX}" ]; then
       searchpath="${INSTALL_PREFIX}/bin:${INSTALL_PREFIX}/sbin:${INSTALL_PREFIX}/usr/bin:${INSTALL_PREFIX}/usr/sbin:${PATH}"
@@ -566,20 +629,34 @@ detect_existing_install() {
     typefile="${ndprefix}/etc/netdata/.install-type"
     if [ -r "${typefile}" ]; then
       ${ROOTCMD} sh -c "cat \"${typefile}\" > \"${tmpdir}/install-type\""
-      # shellcheck disable=SC1091
+      # shellcheck disable=SC1090,SC1091
       . "${tmpdir}/install-type"
     else
       INSTALL_TYPE="unknown"
     fi
-  fi
 
-  INSTALL_PREFIX="${ndprefix}"
+    envfile="${ndprefix}/etc/netdata/.environment"
+    if [ "${INSTALL_TYPE}" = "unknown" ] || [ "${INSTALL_TYPE}" = "custom" ]; then
+      if [ -r "${envfile}" ]; then
+        ${ROOTCMD} sh -c "cat \"${envfile}\" > \"${tmpdir}/environment\""
+        # shellcheck disable=SC1091
+        . "${tmpdir}/environment"
+        if [ -n "${NETDATA_IS_STATIC_INSTALL}" ]; then
+          if [ "${NETDATA_IS_STATIC_INSTALL}" = "yes" ]; then
+            INSTALL_TYPE="legacy-static"
+          else
+            INSTALL_TYPE="legacy-build"
+          fi
+        fi
+      fi
+    fi
+  fi
 }
 
 handle_existing_install() {
   detect_existing_install
 
-  if [ -z "${INSTALL_PREFIX}" ] || [ -z "${INSTALL_TYPE}" ]; then
+  if [ -z "${ndprefix}" ] || [ -z "${INSTALL_TYPE}" ]; then
     progress "No existing installations of netdata found, assuming this is a fresh install."
     return 0
   fi
@@ -587,14 +664,14 @@ handle_existing_install() {
   case "${INSTALL_TYPE}" in
     kickstart-*|legacy-*|binpkg-*|manual-static|unknown)
       if [ "${INSTALL_TYPE}" = "unknown" ]; then
-        warning "Found an existing netdata install at ${INSTALL_PREFIX}, but could not determine the install type."
+        warning "Found an existing netdata install at ${ndprefix}, but could not determine the install type."
         warning "Usually this means you installed Netdata through your distribution’s regular package repositories or some other unsupported method."
       else
-        progress "Found an existing netdata install at ${INSTALL_PREFIX}, with installation type '${INSTALL_TYPE}'."
+        progress "Found an existing netdata install at ${ndprefix}, with installation type '${INSTALL_TYPE}'."
       fi
 
       if [ -n "${NETDATA_REINSTALL}" ] || [ -n "${NETDATA_UNSAFE_REINSTALL}" ]; then
-        progress "Found an existing netdata install at ${INSTALL_PREFIX}, but user requested reinstall, continuing."
+        progress "Found an existing netdata install at ${ndprefix}, but user requested reinstall, continuing."
 
         case "${INSTALL_TYPE}" in
           binpkg-*) NETDATA_ONLY_NATIVE=1 ;;
@@ -624,20 +701,21 @@ handle_existing_install() {
 
       if [ "${NETDATA_CLAIM_ONLY}" -eq 0 ] && echo "${INSTALL_TYPE}" | grep -vq "binpkg-*"; then
         if ! update; then
-          warning "Unable to find usable updater script, not updating existing install at ${INSTALL_PREFIX}."
+          warning "Unable to find usable updater script, not updating existing install at ${ndprefix}."
         fi
       else
-        warning "Not updating existing install at ${INSTALL_PREFIX}."
+        warning "Not updating existing install at ${ndprefix}."
       fi
 
       if [ -n "${NETDATA_CLAIM_TOKEN}" ]; then
-        progress "Attempting to claim existing install at ${INSTALL_PREFIX}."
+        progress "Attempting to claim existing install at ${ndprefix}."
+        INSTALL_PREFIX="${ndprefix}"
         claim
         ret=$?
       elif [ "${NETDATA_CLAIM_ONLY}" -eq 1 ]; then
         fatal "User asked to claim, but did not proide a claiming token." F0202
       else
-        progress "Not attempting to claim existing install at ${INSTALL_PREFIX} (no claiming token provided)."
+        progress "Not attempting to claim existing install at ${ndprefix} (no claiming token provided)."
       fi
 
       cleanup
@@ -661,7 +739,7 @@ handle_existing_install() {
           fi
         fi
       else
-        fatal "Found an existing netdata install at ${INSTALL_PREFIX}, but the install type is '${INSTALL_TYPE}', which is not supported, refusing to proceed." F0103
+        fatal "Found an existing netdata install at ${ndprefix}, but the install type is '${INSTALL_TYPE}', which is not supported, refusing to proceed." F0103
       fi
       ;;
   esac
@@ -727,7 +805,7 @@ confirm_install_prefix() {
 check_claim_opts() {
 # shellcheck disable=SC2235,SC2030
   if [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_ROOMS}" ]; then
-    fatal "Invalid claiming options, claim rooms may only be specified when a token and URL are specified." F0204
+    fatal "Invalid claiming options, claim rooms may only be specified when a token is specified." F0204
   elif [ -z "${NETDATA_CLAIM_TOKEN}" ] && [ -n "${NETDATA_CLAIM_EXTRA}" ]; then
     fatal "Invalid claiming options, a claiming token must be specified." F0204
   elif [ "${NETDATA_DISABLE_CLOUD}" -eq 1 ] && [ -n "${NETDATA_CLAIM_TOKEN}" ]; then
@@ -760,6 +838,12 @@ is_netdata_running() {
 }
 
 claim() {
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    progress "Would attempt to claim agent to ${NETDATA_CLAIM_URL}"
+  else
+    progress "Attempting to claim agent to ${NETDATA_CLAIM_URL}"
+  fi
+
   progress "Attempting to claim agent to ${NETDATA_CLAIM_URL}"
   if [ -z "${INSTALL_PREFIX}" ] || [ "${INSTALL_PREFIX}" = "/" ]; then
     NETDATA_CLAIM_PATH=/usr/sbin/netdata-claim.sh
@@ -883,10 +967,10 @@ check_special_native_deps() {
     progress "Checking for libuv availability."
     # shellcheck disable=SC2086
     if ${pm_cmd} search ${interactive_opts} -v libuv | grep -q "No matches found"; then
-      progress "libv not found, checking for EPEL availability."
+      progress "libuv not found, checking for EPEL availability."
       # shellcheck disable=SC2086
       if ${pm_cmd} search ${interactive_opts} -v epel-release | grep -q "No matches found"; then
-        warning "Unable to find a suitable source for libuv, cannot install on this system."
+        warning "Unable to find a suitable source for libuv, cannot install using native packages on this system."
         return 1
       else
         progress "EPEL is available, attempting to install so that required dependencies are available."
@@ -909,7 +993,11 @@ try_package_install() {
     return 1
   fi
 
-  progress "Attempting to install using native packages..."
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    progress "Would attempt to install using native packages..."
+  else
+    progress "Attempting to install using native packages..."
+  fi
 
   if [ "${RELEASE_CHANNEL}" = "nightly" ]; then
     release="-edge"
@@ -1023,14 +1111,17 @@ try_package_install() {
   repoconfig_url="${REPOCONFIG_URL_PREFIX}/${repo_prefix}/${repoconfig_file}/download.${pkg_type}"
 
   if ! pkg_installed "${repoconfig_name}"; then
-    progress "Downloading repository configuration package."
-    if ! download "${repoconfig_url}" "${tmpdir}/${repoconfig_file}"; then
-      warning "Failed to download repository configuration package."
+    progress "Checking for availability of repository configuration package."
+    if ! check_for_remote_file "${repoconfig_url}"; then
+      warning "No repository configuration package available for ${DISTRO} ${SYSVERSION}."
       return 2
     fi
 
+    if ! download "${repoconfig_url}" "${tmpdir}/${repoconfig_file}"; then
+      fatal "Failed to download repository configuration package." F0209
+    fi
+
     if [ -n "${needs_early_refresh}" ]; then
-      progress "Updating repository metadata."
       # shellcheck disable=SC2086
       if ! run ${ROOTCMD} env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts}; then
         warning "Failed to refresh repository metadata."
@@ -1038,7 +1129,6 @@ try_package_install() {
       fi
     fi
 
-    progress "Installing repository configuration package."
     # shellcheck disable=SC2086
     if ! run ${ROOTCMD} env ${env} ${pm_cmd} install ${pkg_install_opts} "${tmpdir}/${repoconfig_file}"; then
       warning "Failed to install repository configuration package."
@@ -1046,7 +1136,6 @@ try_package_install() {
     fi
 
     if [ -n "${repo_subcmd}" ]; then
-      progress "Updating repository metadata."
       # shellcheck disable=SC2086
       if ! run ${ROOTCMD} env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts}; then
         fatal "Failed to update repository metadata." F0205
@@ -1057,7 +1146,7 @@ try_package_install() {
   fi
 
   if ! check_special_native_deps; then
-    warning "Could not find secondary dependencies ${DISTRO} on ${SYSARCH}."
+    warning "Could not find secondary dependencies for ${DISTRO} on ${SYSARCH}."
     if [ -z "${NO_CLEANUP}" ]; then
       progress "Attempting to uninstall repository configuration package."
       # shellcheck disable=SC2086
@@ -1066,7 +1155,6 @@ try_package_install() {
     return 2
   fi
 
-  progress "Checking for usable Netdata package."
   if ! netdata_avail_check "${DISTRO_COMPAT_NAME}"; then
     warning "Could not find a usable native package for ${DISTRO} on ${SYSARCH}."
     if [ -z "${NO_CLEANUP}" ]; then
@@ -1082,7 +1170,6 @@ try_package_install() {
     run ${ROOTCMD} touch "/etc/netdata/.opt-out-from-anonymous-statistics"
   fi
 
-  progress "Installing Netdata package."
   # shellcheck disable=SC2086
   if ! run ${ROOTCMD} env ${env} ${pm_cmd} install ${pkg_install_opts} netdata; then
     warning "Failed to install Netdata package."
@@ -1111,19 +1198,32 @@ set_static_archive_urls() {
 
 try_static_install() {
   set_static_archive_urls "${RELEASE_CHANNEL}"
-  progress "Downloading static netdata binary: ${NETDATA_STATIC_ARCHIVE_URL}"
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    progress "Would attempt to install using static build..."
+  else
+    progress "Attempting to install using static build..."
+  fi
+
+  # Check status code first, so that we can provide nicer fallback for dry runs.
+  if ! check_for_remote_file "${NETDATA_STATIC_ARCHIVE_URL}"; then
+    warning "No static build available for ${SYSARCH} CPUs."
+    return 2
+  fi
 
   if ! download "${NETDATA_STATIC_ARCHIVE_URL}" "${tmpdir}/netdata-${SYSARCH}-latest.gz.run"; then
-    warning "Unable to download static build archive for ${SYSARCH}."
-    return 2
+    fatal "Unable to download static build archive for ${SYSARCH}." F0208
   fi
 
   if ! download "${NETDATA_STATIC_ARCHIVE_CHECKSUM_URL}" "${tmpdir}/sha256sum.txt"; then
     fatal "Unable to fetch checksums to verify static build archive." F0206
   fi
 
-  if ! grep "netdata-${SYSARCH}-latest.gz.run" "${tmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-    fatal "Static binary checksum validation failed. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0207
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    progress "Would validate SHA256 checksum of downloaded static build archive."
+  else
+    if ! grep "netdata-${SYSARCH}-latest.gz.run" "${tmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
+      fatal "Static binary checksum validation failed. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0207
+    fi
   fi
 
   if [ "${INTERACTIVE}" -eq 0 ]; then
@@ -1138,18 +1238,20 @@ try_static_install() {
     return 2
   fi
 
+  if [ "${DRY_RUN}" -ne 1 ]; then
   install_type_file="/opt/netdata/etc/netdata/.install-type"
-  if [ -f "${install_type_file}" ]; then
-    ${ROOTCMD} sh -c "cat \"${install_type_file}\" > \"${tmpdir}/install-type\""
-    ${ROOTCMD} chown "$(id -u)":"$(id -g)" "${tmpdir}/install-type"
-    # shellcheck disable=SC1091
-    . "${tmpdir}/install-type"
-    cat > "${tmpdir}/install-type" <<- EOF
+    if [ -f "${install_type_file}" ]; then
+      ${ROOTCMD} sh -c "cat \"${install_type_file}\" > \"${tmpdir}/install-type\""
+      ${ROOTCMD} chown "$(id -u)":"$(id -g)" "${tmpdir}/install-type"
+      # shellcheck disable=SC1090,SC1091
+      . "${tmpdir}/install-type"
+      cat > "${tmpdir}/install-type" <<- EOF
 	INSTALL_TYPE='kickstart-static'
 	PREBUILT_ARCH='${PREBUILT_ARCH}'
 	EOF
-    ${ROOTCMD} chown netdata:netdata "${tmpdir}/install-type"
-    ${ROOTCMD} cp "${tmpdir}/install-type" "${install_type_file}"
+      ${ROOTCMD} chown netdata:netdata "${tmpdir}/install-type"
+      ${ROOTCMD} cp "${tmpdir}/install-type" "${install_type_file}"
+    fi
   fi
 }
 
@@ -1175,13 +1277,16 @@ install_local_build_dependencies() {
     return 1
   fi
 
-  progress "Fetching script to detect required packages..."
   download "${PACKAGES_SCRIPT}" "${tmpdir}/install-required-packages.sh"
 
-  if [ ! -s "${tmpdir}/install-required-packages.sh" ]; then
+  if [ ! -s "${tmpdir}/install-required-packages.sh" ] && [ "${DRY_RUN}" -ne 1 ]; then
     warning "Downloaded dependency installation script is empty."
   else
-    progress "Running downloaded script to detect required packages..."
+    if [ "${DRY_RUN}" -eq 1 ]; then
+      progress "Would run downloaded script to install required build dependencies..."
+    else
+      progress "Running downloaded script to install required build dependencies..."
+    fi
 
     if [ "${INTERACTIVE}" -eq 0 ]; then
       opts="--dont-wait --non-interactive"
@@ -1201,7 +1306,11 @@ install_local_build_dependencies() {
 }
 
 build_and_install() {
-  progress "Building netdata"
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    progress "Would attempt to build netdata..."
+  else
+    progress "Building netdata..."
+  fi
 
   echo "INSTALL_TYPE='kickstart-build'" > system/.install-type
 
@@ -1239,6 +1348,12 @@ build_and_install() {
 }
 
 try_build_install() {
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    progress "Would attempt to install by building locally..."
+  else
+    progress "Attempting to install by building locally..."
+  fi
+
   if ! install_local_build_dependencies; then
     return 1
   fi
@@ -1248,15 +1363,21 @@ try_build_install() {
   download "${NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL}" "${tmpdir}/sha256sum.txt"
   download "${NETDATA_SOURCE_ARCHIVE_URL}" "${tmpdir}/netdata-latest.tar.gz"
 
-  if ! grep netdata-latest.tar.gz "${tmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-    fatal "Tarball checksum validation failed. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0005
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    progress "Would validate SHA256 checksum of downloaded source archive."
+  else
+    if ! grep netdata-latest.tar.gz "${tmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
+      fatal "Tarball checksum validation failed. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0005
+    fi
   fi
 
   run tar -xf "${tmpdir}/netdata-latest.tar.gz" -C "${tmpdir}"
   rm -rf "${tmpdir}/netdata-latest.tar.gz" > /dev/null 2>&1
-  cd "$(find "${tmpdir}" -mindepth 1 -maxdepth 1 -type d -name netdata-)" || fatal "Cannot cd to netdata source tree" F0006
+  if [ "${DRY_RUN}" -ne 1 ]; then
+    cd "$(find "${tmpdir}" -mindepth 1 -maxdepth 1 -type d -name netdata-)" || fatal "Cannot cd to netdata source tree" F0006
+  fi
 
-  if [ -x netdata-installer.sh ]; then
+  if [ -x netdata-installer.sh ] || [ "${DRY_RUN}" -eq 1 ]; then
     build_and_install || return 1
   else
     # This case is needed because some platforms produce an extra directory on the source tarball extraction.
@@ -1390,6 +1511,7 @@ while [ -n "${1}" ]; do
     "--no-cleanup") NO_CLEANUP=1 ;;
     "--dont-wait"|"--non-interactive") INTERACTIVE=0 ;;
     "--interactive") INTERACTIVE=1 ;;
+    "--dry-run") DRY_RUN=1 ;;
     "--stable-channel") RELEASE_CHANNEL="stable" ;;
     "--no-updates") NETDATA_AUTO_UPDATES=0 ;;
     "--auto-update") NETDATA_AUTO_UPDATES="1" ;;
@@ -1415,6 +1537,9 @@ while [ -n "${1}" ]; do
     "--install")
       INSTALL_PREFIX="${2}"
       shift 1
+      ;;
+    "--uninstall")
+      ACTION="uninstall"
       ;;
     "--native-only")
       NETDATA_ONLY_NATIVE=1
@@ -1450,7 +1575,7 @@ while [ -n "${1}" ]; do
       optname="$(echo "${1}" | cut -d '-' -f 4-)"
       case "${optname}" in
         id|proxy|user|hostname)
-          NETDATA_CLAIM_EXTRA="${NETDATA_CLAIM_EXTRA} -${optname} ${2}"
+          NETDATA_CLAIM_EXTRA="${NETDATA_CLAIM_EXTRA} -${optname}=${2}"
           shift 1
           ;;
         verbose|insecure|noproxy|noreload|daemon-not-running)
@@ -1474,9 +1599,16 @@ confirm_root_support
 get_system_info
 confirm_install_prefix
 
+if [ "${ACTION}" = "uninstall" ]; then
+  uninstall
+  cleanup
+  trap - EXIT
+  exit 0
+fi
+
 tmpdir="$(create_tmp_directory)"
 progress "Using ${tmpdir} as a temporary directory."
-cd "${tmpdir}" || exit 1
+cd "${tmpdir}" || fatal "Failed to change current working directory to ${tmpdir}." F000A
 
 handle_existing_install
 


### PR DESCRIPTION
##### Summary

This completely overhauls the error messages output by the kickstart installer script when the claiming process fails.

Relevant messages are the various `progress` and `warning` lines in the diff.

Exit code 5 is explicitly treated as _not_ being an error case, because the user just needs to restart the agent and things should work.

Exit code 6 is intentionally treated as an ‘unknown error’ case because it should never happen.

Exit code 7 is the catch-all for unknown HTTP errors, so it is also handled as part of the ‘unknown error’ case.

Exit codes 15, 16, and 17 are grouped because the differentiation between the cases is not particularly relevant to users and the required action to attempt to resolve the issue is the same for all three.

##### Test Plan

Manually inducing specific exit codes from the claiming script should output the associated error message from the case statement.