### PR TITLE
Set a version number for the metadata database to better handle future data migrations

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2,6 +2,8 @@
 
 #include "sqlite_functions.h"
 
+#define DB_METADATA_VERSION "1"
+
 const char *database_config[] = {
     "PRAGMA auto_vacuum=incremental; PRAGMA synchronous=1 ; PRAGMA journal_mode=WAL; PRAGMA temp_store=MEMORY;",
     "PRAGMA journal_size_limit=16777216;",
@@ -52,6 +54,7 @@ const char *database_config[] = {
     "INSERT INTO chart_hash_map (chart_id, hash_id) values (new.chart_id, new.hash_id) "
     "on conflict (chart_id, hash_id) do nothing; END; ",
 
+    "PRAGMA user_version="DB_METADATA_VERSION";",
     NULL
 };
 


### PR DESCRIPTION
##### Summary
Set a user defined version number for the `netdata-meta.db` so that future changes to the database
can include code to correctly handle migration of data. 

##### Test Plan
- Check the current `netdata-meta.db` file using the command like tool `sqlite3` 
  - Type `.dbinfo` and notice the `user version:        0` entry or type `PRAGMA user_version` to notice
  ```
  user_version
  ------------
  0  
  ```

After the PR is applied and running the agent, the number will be 1
