### PR TITLE
systemd service: switch type to forking

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -6,7 +6,7 @@ Description=Real time performance monitoring
 After=network.target httpd.service squid.service nfs-server.service mysqld.service mysql.service named.service postfix.service chronyd.service
 
 [Service]
-Type=simple
+Type=forking
 User=netdata
 Group=netdata
 RuntimeDirectory=netdata


### PR DESCRIPTION
##### Summary

This change makes systemd wait until the main process forks and exits before considering netdata as started.

This allows dependent services (e.g. a registration script) to work without fail.
