### PR TITLE
Null terminate decoded_query_string if there are no url parameters.

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1076,6 +1076,9 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                         if (url_parse_query_string(w->decoded_query_string, NETDATA_WEB_REQUEST_URL_SIZE + 1, ptr_variables, total_variables)) {
                             return HTTP_VALIDATION_MALFORMED_URL;
                         }
+                    } else {
+                        //make sure there's no leftovers from previous request on the same web client
+                        w->decoded_query_string[1]='\0';
                     }
                 }
                 *ue = ' ';


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

When doing an api request through a client that does not close the connection, it is possible to keep the url parameters stored, even when a next request (over the same connection) does not contain them.

As a small test, try from a web browser to request `/api/v1/alarms`, then `/api/v1/alarms?all` and then again `/api/v1/alarms`.

If those calls are made before the connection is closed, then it is possible to receive the output of `?all` when doing the request `/api/v1/alarms`.

The problem is that `w->decoded_query_string` is not cleared between requests. It is only calculated when the agent detects that there is a separator (`?`) in the url requested. If there's not, then nothing is done on `w->decoded_query_string` potentially leaving there the parameters from a previous request.

This PR just null terminates the string if we don't have any url parameters.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Perform the above scenario to check results with and without this PR. Curl will close the connection on every try, so a web browser should be a better check.