### PR TITLE
Add Fedora 36 to CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -74,16 +74,21 @@ include:
 
   - &fedora
     distro: fedora
-    version: "35"
+    version: "36"
     jsonc_removal: |
       dnf remove -y json-c-devel
     packages: &fedora_packages
       type: rpm
-      repo_distro: fedora/35
+      repo_distro: fedora/36
       arches:
         - amd64
         - armhf
         - arm64
+  - <<: *fedora
+    version: "35"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/35
   - <<: *fedora
     version: "34"
     packages:


### PR DESCRIPTION
##### Summary

Expected release date 2022-03-15.

##### Test Plan

CI passes on this PR.

##### Additional info

Depends on https://github.com/netdata/helper-images/pull/150