### PR TITLE
Add openSUSE Leap 15.4 to CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -99,16 +99,21 @@ include:
 
   - &opensuse
     distro: opensuse
-    version: "15.3"
+    version: "15.4"
     base_image: opensuse/leap
     jsonc_removal: |
       zypper rm -y libjson-c-devel
-    packages:
+    packages: &opensuse_packages
       type: rpm
-      repo_distro: opensuse/15.3
+      repo_distro: opensuse/15.4
       arches:
         - amd64
         - arm64
+  - <<: *opensuse
+    version: "15.3"
+    packages:
+      <<: *opensuse_packages
+      repo_distro: opensuse/15.3
 
   - distro: oraclelinux
     version: "8"


### PR DESCRIPTION
##### Summary

Expected release date 2022-06-08.

##### Test Plan

CI jobs are created on this PR and pass correctly.

##### Additional Information

Merging of this should be delayed until 2022-05-21, when the final release build is completed, at which point CI jobs on this PR should be manually re-run to confirm that everything is working.

Once merged we will probably see regular failures on the packaging jobs on nightlies as Package Cloud will probably take way too damn long yet again on adding support for 15.4.

Depends on https://github.com/netdata/helper-images/pull/150