### PR TITLE
Add proper handling for legacy kickstart install detection.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -562,10 +562,24 @@ detect_existing_install() {
 
   if [ -n "${ndprefix}" ]; then
     typefile="${ndprefix}/etc/netdata/.install-type"
+    envfile="${ndprefix}/etc/netdata/.environment"
     if [ -r "${typefile}" ]; then
       ${ROOTCMD} sh -c "cat \"${typefile}\" > \"${tmpdir}/install-type\""
       # shellcheck disable=SC1091
       . "${tmpdir}/install-type"
+    elif [ -r "${envfile}" ]; then
+      ${ROOTCMD} sh -c "cat \"${envfile}\" > \"${tmpdir}/environment\""
+      # shellcheck disable=SC1091
+      . "${tmpdir}/environment"
+      if [ -n "${NETDATA_IS_STATIC_INSTALL}" ]; then
+        if [ "${NETDATA_IS_STATIC_INSTALL}" = "yes" ]; then
+          INSTALL_TYPE="legacy-stati"
+        else
+          INSTALL_TYPE="legacy-build"
+        fi
+      else
+        INSTALL_TYPE="unknown"
+      fi
     else
       INSTALL_TYPE="unknown"
     fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -567,21 +567,23 @@ detect_existing_install() {
       ${ROOTCMD} sh -c "cat \"${typefile}\" > \"${tmpdir}/install-type\""
       # shellcheck disable=SC1091
       . "${tmpdir}/install-type"
-    elif [ -r "${envfile}" ]; then
-      ${ROOTCMD} sh -c "cat \"${envfile}\" > \"${tmpdir}/environment\""
-      # shellcheck disable=SC1091
-      . "${tmpdir}/environment"
-      if [ -n "${NETDATA_IS_STATIC_INSTALL}" ]; then
-        if [ "${NETDATA_IS_STATIC_INSTALL}" = "yes" ]; then
-          INSTALL_TYPE="legacy-static"
-        else
-          INSTALL_TYPE="legacy-build"
-        fi
-      else
-        INSTALL_TYPE="unknown"
-      fi
     else
       INSTALL_TYPE="unknown"
+    fi
+
+    if [ "${INSTALL_TYPE}" = "unknown" ] || [ "${INSTALL_TYPE}" = "custom" ]; then
+      if [ -r "${envfile}" ]; then
+        ${ROOTCMD} sh -c "cat \"${envfile}\" > \"${tmpdir}/environment\""
+        # shellcheck disable=SC1091
+        . "${tmpdir}/environment"
+        if [ -n "${NETDATA_IS_STATIC_INSTALL}" ]; then
+          if [ "${NETDATA_IS_STATIC_INSTALL}" = "yes" ]; then
+            INSTALL_TYPE="legacy-static"
+          else
+            INSTALL_TYPE="legacy-build"
+          fi
+        fi
+      fi
     fi
   fi
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -573,7 +573,7 @@ detect_existing_install() {
       . "${tmpdir}/environment"
       if [ -n "${NETDATA_IS_STATIC_INSTALL}" ]; then
         if [ "${NETDATA_IS_STATIC_INSTALL}" = "yes" ]; then
-          INSTALL_TYPE="legacy-stati"
+          INSTALL_TYPE="legacy-static"
         else
           INSTALL_TYPE="legacy-build"
         fi


### PR DESCRIPTION
##### Summary

By properly looking for and parsing the `.environment` file if we do not see a `.install-type` file.

This particular case was not handled in the existing code as it was assumed that a majority of users would have gotten updated since their original install to a version that did properly include the `.install-type` file.

##### Test Plan

Primary test cases can be replicated with the current kickstart script as follows:

* To simulate a `legacy-build` install type (local source build done with the old kickstart script, or possibly by manually running the `netdata-installer.sh` script), install with the `--build-only` option using the new kickstart script, and then remove `/etc/netdata/.install-type`.
* To simulate a `legacy-static` install type (static install done by the old kickstart-static64.sh script before the `.install-type` file became a thing), install with the `--static-only` option using the new kickstart script and then remove `/opt/netdata/etc/netdata/.install-type`.