### PR TITLE
Use the new error mechanism in case host not found

### DIFF
--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -99,6 +99,10 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
     w->acl = 0x1f;
 
     buffer_strcat(log_buffer, query->data.http_api_v2.query);
+    size_t size = 0;
+    size_t sent = 0;
+    w->tv_in = query->created_tv;
+    now_realtime_timeval(&w->tv_ready);
 
     if (!strncmp(query->data.http_api_v2.query, NODE_ID_QUERY, strlen(NODE_ID_QUERY))) {
         char *node_uuid = query->data.http_api_v2.query + strlen(NODE_ID_QUERY);
@@ -106,12 +110,8 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
         if (strlen(node_uuid) < (UUID_STR_LEN - 1)) {
             error("URL requests node_id but there is not enough chars following. Returning 404 to Cloud.");
             retval = 1;
-            aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, 404, NULL, 0);
-            log_access("%d '[ACLK]:%d' '%s' Error parsing node_id Sending 404",
-                    gettid(),
-                    query_thr->idx,
-                    strip_control_characters((char *)buffer_tostring(log_buffer))
-                );
+            w->response.code = 404;
+            aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, w->response.code, NULL, 0);
             goto cleanup;
         }
         strncpyz(nodeid, node_uuid, UUID_STR_LEN - 1);
@@ -120,13 +120,8 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
         if (!query_host) {
             error("Host with node_id \"%s\" not found! Returning 404 to Cloud!", node_uuid);
             retval = 1;
-            aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, 404, NULL, 0);
-            log_access("%d '[ACLK]:%d' '%s' Host with node_id \"%s\" not found. Sending 404",
-                    gettid(),
-                    query_thr->idx,
-                    strip_control_characters((char *)buffer_tostring(log_buffer)),
-                    node_uuid
-                );
+            w->response.code = 404;
+            aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, w->response.code, NULL, 0);
             goto cleanup;
         }
     }
@@ -148,11 +143,9 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
     }
 
     // execute the query
-    w->tv_in = query->created_tv;
-    now_realtime_timeval(&w->tv_ready);
     t = aclk_web_api_v1_request(query_host, w, mysep ? mysep + 1 : "noop");
-    size_t size = (w->mode == WEB_CLIENT_MODE_FILECOPY) ? w->response.rlen : w->response.data->len;
-    size_t sent = size;
+    size = (w->mode == WEB_CLIENT_MODE_FILECOPY) ? w->response.rlen : w->response.data->len;
+    sent = size;
 
 #ifdef NETDATA_WITH_ZLIB
     // check if gzip encoding can and should be used
@@ -186,12 +179,8 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
                 else
                     error("Unknown error during zlib compression.");
                 retval = 1;
-                aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, 500, NULL, 0);
-                log_access("%d '[ACLK]:%d' '%s' Internal server error during zlib compression. Sending 500",
-                    gettid(),
-                    query_thr->idx,
-                    strip_control_characters((char *)buffer_tostring(log_buffer))
-                  );
+                w->response.code = 500;
+                aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, w->response.code, NULL, 0);
                 goto cleanup;
             }
             int bytes_to_cpy = NETDATA_WEB_RESPONSE_ZLIB_CHUNK_SIZE - w->response.zstream.avail_out;
@@ -232,8 +221,9 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
     // send msg.
     aclk_http_msg_v2(query_thr->client, query->callback_topic, query->msg_id, t, query->created, w->response.code, local_buffer->buffer, local_buffer->len);
 
-    // log.
     struct timeval tv;
+
+cleanup:
     now_realtime_timeval(&tv);
     log_access("%llu: %d '[ACLK]:%d' '%s' (sent/all = %zu/%zu bytes %0.0f%%, prep/sent/total = %0.2f/%0.2f/%0.2f ms) %d '%s'",
         w->id
@@ -250,7 +240,6 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
         , strip_control_characters((char *)buffer_tostring(log_buffer))
     );
 
-cleanup:
 #ifdef NETDATA_WITH_ZLIB
     if(w->response.zinitialized)
         deflateEnd(&w->response.zstream);

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -104,6 +104,7 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
         if (strlen(node_uuid) < (UUID_STR_LEN - 1)) {
             error("URL requests node_id but there is not enough chars following");
             retval = 1;
+            aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, 404, NULL, 0);
             goto cleanup;
         }
         strncpyz(nodeid, node_uuid, UUID_STR_LEN - 1);
@@ -112,6 +113,7 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
         if (!query_host) {
             error("Host with node_id \"%s\" not found! Query Ignored!", node_uuid);
             retval = 1;
+            aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, 404, NULL, 0);
             goto cleanup;
         }
     }
@@ -173,6 +175,7 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
                 else
                     error("Unknown error during zlib compression.");
                 retval = 1;
+                aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, 500, NULL, 0);
                 goto cleanup;
             }
             int bytes_to_cpy = NETDATA_WEB_RESPONSE_ZLIB_CHUNK_SIZE - w->response.zstream.avail_out;

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -325,6 +325,18 @@ void aclk_send_alarm_metadata(mqtt_wss_client client, int metadata_submitted)
     buffer_free(local_buffer);
 }
 
+void aclk_http_msg_v2_err(mqtt_wss_client client, const char *topic, const char *msg_id, int http_code, const char *payload, size_t payload_len)
+{
+    json_object *tmp, *msg;
+    msg = create_hdr("http", msg_id, 0, 0, 2);
+    tmp = json_object_new_int(http_code);
+    json_object_object_add(msg, "http-code", tmp);
+    if (aclk_send_message_with_bin_payload(client, msg, topic, payload, payload_len)) {
+        error("Failed to send cancelation message for http reply");
+    }
+    json_object_put(msg);
+}
+
 void aclk_http_msg_v2(mqtt_wss_client client, const char *topic, const char *msg_id, usec_t t_exec, usec_t created, int http_code, const char *payload, size_t payload_len)
 {
     json_object *tmp, *msg;
@@ -343,15 +355,8 @@ void aclk_http_msg_v2(mqtt_wss_client client, const char *topic, const char *msg
     int rc = aclk_send_message_with_bin_payload(client, msg, topic, payload, payload_len);
     json_object_put(msg);
 
-    if (rc) {
-        msg = create_hdr("http", msg_id, 0, 0, 2);
-        tmp = json_object_new_int(rc);
-        json_object_object_add(msg, "http-code", tmp);
-        if (aclk_send_message_with_bin_payload(client, msg, topic, payload, payload_len)) {
-            error("Failed to send cancelation message for http reply");
-        }
-        json_object_put(msg);
-    }
+    if (rc)
+        aclk_http_msg_v2_err(client, topic, msg_id, rc, payload, payload_len);
 }
 
 void aclk_chart_msg(mqtt_wss_client client, RRDHOST *host, const char *chart)

--- a/aclk/aclk_tx_msgs.h
+++ b/aclk/aclk_tx_msgs.h
@@ -14,6 +14,7 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
 void aclk_send_info_metadata(mqtt_wss_client client, int metadata_submitted, RRDHOST *host);
 void aclk_send_alarm_metadata(mqtt_wss_client client, int metadata_submitted);
 
+void aclk_http_msg_v2_err(mqtt_wss_client client, const char *topic, const char *msg_id, int http_code, const char *payload, size_t payload_len);
 void aclk_http_msg_v2(mqtt_wss_client client, const char *topic, const char *msg_id, usec_t t_exec, usec_t created, int http_code, const char *payload, size_t payload_len);
 
 void aclk_chart_msg(mqtt_wss_client client, RRDHOST *host, const char *chart);


### PR DESCRIPTION
##### Summary

Fix for #12243
Uses the error mechanism agreed on with cloud during talks about too big payloads.

Incoming cloud queries should always get a response. Right now an incoming request that refers to a node which is not known to the agent would be silently ignored.

This PR adds a response in this case

##### Test Plan
- Start a claimed agent with a parent child setup 
  - Cloud dashboard should work just fine
  - Access the local database `/var/cache/netdata/netdata-meta.db` via the command line tool `sqlite3` and issue `delete from node_instance;` 
    - This will make the nodes unknown to the agent for incoming cloud requests
    - Notice long timeouts in the cloud (10 second delay)
- Apply the PR and retry
  - The errors should appear immediately to the cloud

##### Additional Information
When this happens cloud should show error badge on chart instead of waiting for reply (the loading animation)
![Screenshot from 2022-03-01 12-31-29](https://user-images.githubusercontent.com/6674623/156161702-a0f756e0-2737-4026-a50c-67e9734e3589.png)
