### PR TITLE
Timex: make offset rrd independently configurable

### DIFF
--- a/collectors/timex.plugin/plugin_timex.c
+++ b/collectors/timex.plugin/plugin_timex.c
@@ -80,7 +80,7 @@ void *timex_main(void *ptr)
             rrdset_done(st_sync_state);
         }
 
-        if (do_sync) {
+        if (do_offset) {
             static RRDSET *st_offset = NULL;
             static RRDDIM *rd_offset;
 


### PR DESCRIPTION
The offset rrd did not use the `do_offset` boolean but would re-use the `do_sync` boolean. This looks like an oversight/copy&paste error and this very simple pull request just corrects this typo.

I just stumbled upon this by accident and did not bother enough to get to know your test suite/write tests for this PR. Feel free to discard this PR when you will not accept PRs without tests.

Looks like @vkalintiris spotted this in the initial PR, too but there was no answer/action on his remark: https://github.com/netdata/netdata/pull/10895/files#r632975566
