### PR TITLE
Fix incorrect install type on some older nightly installs.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -382,6 +382,10 @@ update_build() {
       install_type="INSTALL_TYPE='legacy-build'"
     fi
 
+    if [ "${INSTALL_TYPE}" = "custom" ] && [ -f "${NETDATA_PREFIX}" ]; then
+      install_type="INSTALL_TYPE='legacy-build'"
+    fi
+
     info "Re-installing netdata..."
     eval "${env} ./netdata-installer.sh ${REINSTALL_OPTIONS} --dont-wait ${do_not_start}" >&3 2>&3 || fatal "FAILED TO COMPILE/INSTALL NETDATA"
 


### PR DESCRIPTION
##### Summary

Due to #11200, older nightly installs that predated the install-type introduction may have ended up incorrectly categorized as `custom` installs. This PR adds a check to fix this in a majority of cases for such installs when they run the updater script.

##### Test Plan

This can be tested by creating a local build install and then modifying the `.install-type` file to list `custom` for the `INSTALL_TYPE` key, and then running the updater code from this PR. If things are working, the `.install-type` file should show `legacy-build` for the `INSTALL_TYPE` key after the update.

##### Additional Information

See also: #12273, which fixes detection of affected installs in the kickstart script so they are not incorrectly listed as `custom`.