### PR TITLE
Adjust cloud dimension update frequency 

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -53,7 +53,6 @@ struct context_param {
     uint8_t flags;
 };
 
-#define RRDSET_MINIMUM_LIVE_COUNT 3
 #define META_CHART_UPDATED 1
 #define META_PLUGIN_UPDATED 2
 #define META_MODULE_UPDATED 4

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -505,7 +505,8 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
 
     // free(rd->annotations);
 #if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
-    aclk_send_dimension_update(rd);
+    if (!netdata_exit)
+        aclk_send_dimension_update(rd);
 #endif
 
     RRD_MEMORY_MODE rrd_memory_mode = rd->rrd_memory_mode;

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -504,6 +504,9 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
         error("RRDDIM: INTERNAL ERROR: attempt to remove from index dimension '%s' on chart '%s', removed a different dimension.", rd->id, st->id);
 
     // free(rd->annotations);
+#if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
+    aclk_send_dimension_update(rd);
+#endif
 
     RRD_MEMORY_MODE rrd_memory_mode = rd->rrd_memory_mode;
     switch(rrd_memory_mode) {

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1516,6 +1516,11 @@ restart_after_removal:
                             }
                             continue;
                         }
+#if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
+                        else {
+                            aclk_send_dimension_update(rd);
+                        }
+#endif
                     }
                     last = rd;
                     rd = rd->next;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1830,7 +1830,8 @@ after_second_database_work:
 #if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
     if (likely(!st->state->is_ar_chart)) {
         if (!rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN)) {
-            int live = ((mark - rd->last_collected_time.tv_sec) < (RRDSET_MINIMUM_LIVE_COUNT * rd->update_every));
+            int live = ((mark - rd->last_collected_time.tv_sec) <
+                 MAX(RRDSET_MINIMUM_LIVE_MULTIPLIER * rd->update_every, rrdset_free_obsolete_time));
             if (unlikely(live != rd->state->aclk_live_status)) {
                 if (likely(rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
                     if (likely(!queue_dimension_to_aclk(rd))) {

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1942,6 +1942,9 @@ after_second_database_work:
                             delete_dimension_uuid(&rd->state->metric_uuid);
                         } else {
                             /* Do not delete this dimension */
+#if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
+                            aclk_send_dimension_update(rd);
+#endif
                             last = rd;
                             rd = rd->next;
                             continue;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1400,10 +1400,8 @@ void rrdset_done(RRDSET *st) {
 #ifdef ENABLE_ACLK
     if (likely(!st->state->is_ar_chart)) {
         if (unlikely(!rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
-            if (st->counter_done >= RRDSET_MINIMUM_LIVE_COUNT && st->dimensions) {
-                if (likely(!queue_chart_to_aclk(st)))
-                    rrdset_flag_set(st, RRDSET_FLAG_ACLK);
-            }
+            if (likely(st->dimensions && !queue_chart_to_aclk(st)))
+                rrdset_flag_set(st, RRDSET_FLAG_ACLK);
         }
     }
 #endif

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -999,6 +999,14 @@ void aclk_send_dimension_update(RRDDIM *rd)
             rd->rrdset->id,
             first_entry_t,
             live ? 0 : last_entry_t);
+
+        if (!first_entry_t)
+            debug(D_ACLK_SYNC, "%s: Update dimension chart=%s dim=%s live=%d (%ld, %ld)",
+              rd->rrdset->rrdhost->hostname, rd->rrdset->name, rd->name, live, first_entry_t, last_entry_t);
+        else
+            debug(D_ACLK_SYNC, "%s: Update dimension chart=%s dim=%s live=%d (%ld, %ld) collected %ld seconds ago",
+                  rd->rrdset->rrdhost->hostname, rd->rrdset->name, rd->name, live, first_entry_t,
+                  last_entry_t, now - last_entry_t);
         rd->state->aclk_live_status = live;
     }
 

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -277,7 +277,7 @@ int aclk_add_dimension_event(struct aclk_database_worker_config *wc, struct aclk
         time_t first_t = rd->state->query_ops.oldest_time(rd);
         time_t last_t  = rd->state->query_ops.latest_time(rd);
 
-        int live = ((now - last_t) < (RRDSET_MINIMUM_LIVE_COUNT * rd->update_every));
+        int live = ((now - last_t) < MAX(RRDSET_MINIMUM_LIVE_MULTIPLIER * rd->update_every, rrdset_free_obsolete_time));
 
         rc = aclk_upd_dimension_event(
             wc,

--- a/database/sqlite/sqlite_aclk_chart.h
+++ b/database/sqlite/sqlite_aclk_chart.h
@@ -12,8 +12,8 @@ typedef enum payload_type {
 
 extern sqlite3 *db_meta;
 
-#ifndef RRDSET_MINIMUM_LIVE_COUNT
-#define RRDSET_MINIMUM_LIVE_COUNT   3
+#ifndef RRDSET_MINIMUM_LIVE_MULTIPLIER
+#define RRDSET_MINIMUM_LIVE_MULTIPLIER   (1.5)
 #endif
 
 extern int queue_chart_to_aclk(RRDSET *st);

--- a/database/sqlite/sqlite_aclk_chart.h
+++ b/database/sqlite/sqlite_aclk_chart.h
@@ -34,4 +34,5 @@ void aclk_receive_chart_reset(struct aclk_database_worker_config *wc, struct acl
 void aclk_receive_chart_ack(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_process_dimension_deletion(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 uint32_t sql_get_pending_count(struct aclk_database_worker_config *wc);
+void aclk_send_dimension_update(RRDDIM *rd);
 #endif //NETDATA_SQLITE_ACLK_CHART_H


### PR DESCRIPTION
Fixes #12283
##### Summary
This PR changes the timing for scheduling a chart and dimension update to cloud as discussed in the linked issue

- A new chart will be sent to the cloud as soon as possible
- A live dimension will be sent to the cloud as soon as possible
- A dimension that switches from live to not being collected will be sent to the cloud after MAX(1.5 * chart_update_every, chart_obsoletion_time) seconds

##### Test Plan
- Set up a parent child setup (claimed) 
  - Compile parent with NETDATA_INTERNAL_CHECKS
- Parent set host obsoletion time to 30 seconds and chart obsoletion time to 20 seconds
- Start parent (with debug flag D_ACLK_SYNC) and child
   - When things settle in the cloud dashboard, shutdown the child and wait at least 40 seconds
      - Monitor the `debug.log` of the parent and notice after host obsoletion some generated messages similar to : 
         `Update dimension chart=system.cpu dim=guest live=0 (1637856712, 1646151268) collected 36 seconds ago` 
