### PR TITLE
feat(health): add charts.d/nut alarms

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -65,6 +65,7 @@ dist_healthconfig_DATA = \
     health.d/mysql.conf \
     health.d/net.conf \
     health.d/netfilter.conf \
+    health.d/nut.conf \
     health.d/pihole.conf \
     health.d/portcheck.conf \
     health.d/processes.conf \

--- a/health/health.d/nut.conf
+++ b/health/health.d/nut.conf
@@ -1,0 +1,47 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+ template: nut_10min_ups_load
+       on: nut.load
+    class: Utilization
+     type: Power Supply
+component: UPS
+       os: *
+    hosts: *
+   lookup: average -10m unaligned of load
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 10m multiplier 1.5 max 1h
+     info: average UPS load over the last 10 minutes
+       to: sitemgr
+
+ template: nut_ups_charge
+       on: nut.charge
+    class: Errors
+     type: Power Supply
+component: UPS
+       os: *
+    hosts: *
+   lookup: average -60s unaligned of battery_charge
+    units: %
+    every: 60s
+     warn: $this < 100
+     crit: $this < (($status == $CRITICAL) ? (60) : (50))
+    delay: down 10m multiplier 1.5 max 1h
+     info: average UPS charge over the last minute
+       to: sitemgr
+
+ template: nut_last_collected_secs
+       on: nut.load
+    class: Latency
+     type: Power Supply
+component: UPS device
+     calc: $now - $last_collected_t
+    every: 10s
+    units: seconds ago
+     warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+     crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+    delay: down 5m multiplier 1.5 max 1h
+     info: number of seconds since the last successful data collection
+       to: sitemgr


### PR DESCRIPTION
##### Summary

Fixes: #12187

This PR adds the [same set of alarms](https://github.com/netdata/netdata/blob/master/health/health.d/apcupsd.conf) as we have for [charts.d/apcupsd](https://github.com/netdata/netdata/tree/master/collectors/charts.d.plugin/apcupsd#apc-ups-monitoring-with-netdata).

##### Test Plan

[Tested](https://github.com/netdata/netdata/issues/12187#issuecomment-1055779733) by @Mic-Pod

##### Additional Information
