### PR TITLE
fix(kickstart): use correct syntax for claiming extra parameters

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1426,7 +1426,7 @@ while [ -n "${1}" ]; do
       optname="$(echo "${1}" | cut -d '-' -f 4-)"
       case "${optname}" in
         id|proxy|user|hostname)
-          NETDATA_CLAIM_EXTRA="${NETDATA_CLAIM_EXTRA} -${optname} ${2}"
+          NETDATA_CLAIM_EXTRA="${NETDATA_CLAIM_EXTRA} -${optname}=${2}"
           shift 1
           ;;
         verbose|insecure|noproxy|noreload|daemon-not-running)


### PR DESCRIPTION

##### Summary

`id`, `proxy`, `user` and `hostname` claiming parameters syntax is key=value, not key[space]value.

https://github.com/netdata/netdata/blob/23fab077290b61507f65885b52307291f624ae9b/claim/netdata-claim.sh.in#L197-L210

##### Test Plan

Tested by @erdem2000 

##### Additional Information
