### PR TITLE
Only store alert hashes when iterated from localhost

### DIFF
--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -900,7 +900,8 @@ int sql_store_alert_config_hash(uuid_t *hash_id, struct alert_config *cfg)
 #endif
 int alert_hash_and_store_config(
     uuid_t hash_id,
-    struct alert_config *cfg)
+    struct alert_config *cfg,
+    int store_hash)
 {
 #if !defined DISABLE_CLOUD && defined ENABLE_HTTPS
     EVP_MD_CTX *evpctx;
@@ -946,7 +947,8 @@ int alert_hash_and_store_config(
     uuid_copy(hash_id, *((uuid_t *)&hash_value));
 
     /* store everything, so it can be recreated when not in memory or just a subset ? */
-    (void)sql_store_alert_config_hash( (uuid_t *)&hash_value, cfg);
+    if (store_hash)
+        (void)sql_store_alert_config_hash( (uuid_t *)&hash_value, cfg);
 #else
     UNUSED(hash_id);
     UNUSED(cfg);

--- a/database/sqlite/sqlite_health.h
+++ b/database/sqlite/sqlite_health.h
@@ -12,6 +12,6 @@ extern void sql_health_alarm_log_update(RRDHOST *host, ALARM_ENTRY *ae);
 extern void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae);
 extern void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
 extern void sql_health_alarm_log_cleanup(RRDHOST *host);
-extern int alert_hash_and_store_config(uuid_t hash_id, struct alert_config *cfg);
+extern int alert_hash_and_store_config(uuid_t hash_id, struct alert_config *cfg, int store_hash);
 extern void sql_aclk_alert_clean_dead_entries(RRDHOST *host);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/health/health.c
+++ b/health/health.c
@@ -223,6 +223,8 @@ void health_reload(void) {
     if (netdata_cloud_setting)
         aclk_single_update_disable();
 #endif
+    sql_refresh_hashes();
+
     rrd_rdlock();
 
     RRDHOST *host;

--- a/health/health.h
+++ b/health/health.h
@@ -87,6 +87,7 @@ extern void *health_cmdapi_thread(void *ptr);
 extern void health_label_log_save(RRDHOST *host);
 
 extern char *health_edit_command_from_source(const char *source);
+extern void sql_refresh_hashes(void);
 
 extern SIMPLE_PATTERN *health_pattern_from_foreach(char *s);
 

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -662,7 +662,9 @@ static int health_readfile(const char *filename, void *data) {
 
         if(hash == hash_alarm && !strcasecmp(key, HEALTH_ALARM_KEY)) {
             if(rc) {
-                if(ignore_this || !alert_hash_and_store_config(rc->config_hash_id, alert_cfg) || !rrdcalc_add_alarm_from_config(host, rc)) {
+                if (host == localhost)
+                    alert_hash_and_store_config(rc->config_hash_id, alert_cfg);
+                if(ignore_this || !rrdcalc_add_alarm_from_config(host, rc)) {
                     rrdcalc_free(rc);
                     alert_config_free(alert_cfg);
                 }
@@ -670,7 +672,9 @@ static int health_readfile(const char *filename, void *data) {
             }
 
             if(rt) {
-                if (ignore_this || !alert_hash_and_store_config(rt->config_hash_id, alert_cfg) || !rrdcalctemplate_add_template_from_config(host, rt)) {
+                if (host == localhost)
+                    alert_hash_and_store_config(rt->config_hash_id, alert_cfg);
+                if (ignore_this || !rrdcalctemplate_add_template_from_config(host, rt)) {
                     rrdcalctemplate_free(rt);
                     alert_config_free(alert_cfg);
                 }
@@ -701,7 +705,9 @@ static int health_readfile(const char *filename, void *data) {
         else if(hash == hash_template && !strcasecmp(key, HEALTH_TEMPLATE_KEY)) {
             if(rc) {
 //                health_add_alarms_loop(host, rc, ignore_this) ;
-                if(ignore_this || !alert_hash_and_store_config(rc->config_hash_id, alert_cfg) || !rrdcalc_add_alarm_from_config(host, rc)) {
+                if (host == localhost)
+                    alert_hash_and_store_config(rc->config_hash_id, alert_cfg);
+                if(ignore_this || !rrdcalc_add_alarm_from_config(host, rc)) {
                     rrdcalc_free(rc);
                     alert_config_free(alert_cfg);
                 }
@@ -710,7 +716,9 @@ static int health_readfile(const char *filename, void *data) {
             }
 
             if(rt) {
-                if(ignore_this || !alert_hash_and_store_config(rt->config_hash_id, alert_cfg) || !rrdcalctemplate_add_template_from_config(host, rt)) {
+                if (host == localhost)
+                    alert_hash_and_store_config(rt->config_hash_id, alert_cfg);
+                if(ignore_this || !rrdcalctemplate_add_template_from_config(host, rt)) {
                     rrdcalctemplate_free(rt);
                     alert_config_free(alert_cfg);
                 }
@@ -1225,13 +1233,17 @@ static int health_readfile(const char *filename, void *data) {
 
     if(rc) {
         //health_add_alarms_loop(host, rc, ignore_this) ;
-        if(ignore_this || !alert_hash_and_store_config(rc->config_hash_id, alert_cfg) || !rrdcalc_add_alarm_from_config(host, rc)) {
+        if (host == localhost)
+            alert_hash_and_store_config(rc->config_hash_id, alert_cfg);
+        if(ignore_this || !rrdcalc_add_alarm_from_config(host, rc)) {
             rrdcalc_free(rc);
         }
     }
 
     if(rt) {
-        if(ignore_this || !alert_hash_and_store_config(rt->config_hash_id, alert_cfg) || !rrdcalctemplate_add_template_from_config(host, rt)) {
+        if (host == localhost)
+            alert_hash_and_store_config(rt->config_hash_id, alert_cfg);
+        if(ignore_this || !rrdcalctemplate_add_template_from_config(host, rt)) {
             rrdcalctemplate_free(rt);
         }
     }


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

For every child connected to a parent, the parent will read the stock and user alert configurations, and will try to create alerts for each host from them. This is maybe an optimization we could do at some point.

This PR though reduces the calculation and storing of alert hashes only when the health config iteration is for the localhost. There's no need to do it again for every child.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Start with a clean new agent. Run it, and do a select in sqlite in table `alert_hash`.
Delete the data from the table, apply this PR and re-run.
The table now will have some more hashes than before. Those are configurations that where not applied before because of `os` or `host` values. (Before this PR, if an alert configuration was not to be applied to this specific host, it would not get written in sqlite. We don't mind a few extra hashes).