### PR TITLE
fix: cpu system info detection on macOS

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -234,6 +234,7 @@ else
     else
       CPU_VENDOR="Apple"
     fi
+    echo "${CPU_INFO_SOURCE}" | grep -qv sysctl && CPU_INFO_SOURCE="${CPU_INFO_SOURCE} sysctl"
   elif uname --version 2> /dev/null | grep -qF 'GNU coreutils'; then
     CPU_INFO_SOURCE="${CPU_INFO_SOURCE} uname"
     CPU_MODEL="$(uname -p)"


### PR DESCRIPTION
##### Summary

Fixes: #12291

This PR fixes detection of the following parameters on macOS:
 - CPU_LOGICAL_CPU_COUNT
 - CPU_VENDOR
 - CPU_FREQ (only for x86_64)
 - CPU_MODEL

##### Test Plan

Run the system-info.sh script on intel/m1 mac's, check the CPU info.

```
wget -q -O system-info.sh https://raw.githubusercontent.com/ilyam8/netdata/fix_macos_cpu_system_info/daemon/system-info.sh; sh system-info.sh | grep -i cpu
```

- m1 pro

```cmd
NETDATA_SYSTEM_CPU_LOGICAL_CPU_COUNT=10
NETDATA_SYSTEM_CPU_VENDOR=Apple
NETDATA_SYSTEM_CPU_MODEL=Apple M1 Pro
NETDATA_SYSTEM_CPU_FREQ=unknown
NETDATA_SYSTEM_CPU_DETECTION=nproc sysctl
```

- intel

```cmd
NETDATA_SYSTEM_CPU_LOGICAL_CPU_COUNT=8
NETDATA_SYSTEM_CPU_VENDOR=GenuineIntel
NETDATA_SYSTEM_CPU_MODEL=Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
NETDATA_SYSTEM_CPU_FREQ=2300000000
NETDATA_SYSTEM_CPU_DETECTION=sysctl
```

##### Additional Information
