### PR TITLE
Fixing stderr output when testing tmpdir

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -263,7 +263,7 @@ _cannot_use_tmpdir() {
 
   if printf '#!/bin/sh\necho SUCCESS\n' > "${testfile}" ; then
     if chmod +x "${testfile}" ; then
-      if [ "$("${testfile}")" = "SUCCESS" ] ; then
+      if [ "$("${testfile}" 2>/dev/null)" = "SUCCESS" ] ; then
         ret=1
       fi
     fi


### PR DESCRIPTION
Fixes https://github.com/netdata/netdata/issues/12286

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Redirect stderr to `/dev/null` when testing tmpdir options.  Stderr is not needed for the tests and can cause systems to notify root of failed cron job.

##### Test Plan
Tested on a staging server by manually making the changes.
Before changes update script outputs:
```
/etc/cron.daily/netdata-updater: line 120: /tmp/netdata-test.rCn0Lj9eJn: Permission denied
/etc/cron.daily/netdata-updater: line 120: /tmp/netdata-test.w5QyEkgJcA: Permission denied
```

After changes it outputs no errors.