### PR TITLE
Workflow to trigger cloud regression e2e tests

### DIFF
--- a/.github/workflows/cloud_regression.yml
+++ b/.github/workflows/cloud_regression.yml
@@ -8,6 +8,25 @@ jobs:
   trigger_cloud_regression_tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Evaluate workflow dispatch parameters
+        id: output-workflow-dispatch-params
+        run: |
+          if [ ${{ github.event_name }} == 'pull_request' ]; then
+            NETDATA_CUSTOM_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+            NETDATA_CUSTOM_BRANCH="${{ github.event.pull_request.head.ref }}"
+            NETDATA_CUSTOM_PR_NUMBER="${{ github.event.number }}"
+            NETDATA_CUSTOM_COMMIT_HASH="${{ github.event.pull_request.head.sha }}"
+          elif [ ${{ github.event.event_type }} == 'push' ]; then
+            NETDATA_CUSTOM_REPO="netdata/netdata"
+            NETDATA_CUSTOM_BRANCH="master"
+            NETDATA_CUSTOM_PR_NUMBER=""
+            NETDATA_CUSTOM_COMMIT_HASH="${{ github.sha }}"
+          fi
+            echo "::set-output name=netdata_repo::${NETDATA_CUSTOM_REPO}"
+            echo "::set-output name=netdata_branch::${NETDATA_CUSTOM_BRANCH}"
+            echo "::set-output name=netdata_pr_number::${NETDATA_CUSTOM_PR_NUMBER}"
+            echo "::set-output name=netdata_commit_hash::${NETDATA_CUSTOM_COMMIT_HASH}"
+
       - name: Trigger Cloud Regression
         uses: aurelien-baudet/workflow-dispatch@v2
         with:
@@ -15,10 +34,10 @@ jobs:
           ref: refs/heads/master
           workflow: regression.yml
           token: ${{ secrets.NETDATABOT_GITHUB_TOKEN  }}
-          inputs: '{ "netdata_branch": "${{ github.event.pull_request.head.ref }}",
-               "netdata_repo": "${{ github.event.pull_request.head.repo.full_name }}",
-               "netdata_pr_number": "${{ github.event.number }}",
-               "netdata_branch_commit_hash": "${{ github.event.pull_request.head.sha }}",
+          inputs: '{ "netdata_branch": "${{ steps.output-workflow-dispatch-params.outputs.netdata_branch }}",
+               "netdata_repo": "${{ steps.output-workflow-dispatch-params.outputs.netdata_repo }}",
+               "netdata_pr_number": "${{ steps.output-workflow-dispatch-params.outputs.netdata_pr_number }}",
+               "netdata_branch_commit_hash": "${{ steps.output-workflow-dispatch-params.outputs.netdata_commit_hash }}",
                "custom_netdata_image": "true"
                }'
           wait-for-completion: false

--- a/.github/workflows/cloud_regression.yml
+++ b/.github/workflows/cloud_regression.yml
@@ -1,9 +1,9 @@
 name: Trigger Cloud Regression E2E Tests
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 jobs:
   trigger_cloud_regression_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/cloud_regression.yml
+++ b/.github/workflows/cloud_regression.yml
@@ -1,0 +1,24 @@
+name: Trigger Cloud Regression E2E Tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  trigger_cloud_regression_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloud Regression
+        uses: aurelien-baudet/workflow-dispatch@v2
+        with:
+          repo: netdata/test-automation
+          ref: refs/heads/master
+          workflow: regression.yml
+          token: ${{ secrets.TEST_AUTOMATION_TOKEN }}
+          inputs: '{ "netdata_branch": "${{ github.event.pull_request.head.ref }}",
+               "netdata_repo": "${{ github.event.pull_request.head.repo.full_name }}",
+               "netdata_pr_number": "${{ github.event.number }}",
+               "netdata_branch_commit_hash": "${{ github.event.pull_request.head.sha }}",
+               "custom_netdata_image": "true"
+               }'
+          wait-for-completion: false

--- a/.github/workflows/cloud_regression.yml
+++ b/.github/workflows/cloud_regression.yml
@@ -9,14 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate workflow dispatch parameters
+        env:
+          PR_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          PR_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
         id: output-workflow-dispatch-params
         run: |
           if [ ${{ github.event_name }} == 'pull_request' ]; then
-            NETDATA_CUSTOM_REPO="${{ github.event.pull_request.head.repo.full_name }}"
-            NETDATA_CUSTOM_BRANCH="${{ github.event.pull_request.head.ref }}"
+            NETDATA_CUSTOM_REPO="$PR_REPO_NAME"
+            NETDATA_CUSTOM_BRANCH="$PR_BRANCH_NAME"
             NETDATA_CUSTOM_PR_NUMBER="${{ github.event.number }}"
-            NETDATA_CUSTOM_COMMIT_HASH="${{ github.event.pull_request.head.sha }}"
-          elif [ ${{ github.event.event_type }} == 'push' ]; then
+            NETDATA_CUSTOM_COMMIT_HASH="$PR_COMMIT_HASH"
+          elif [ ${{ github.event_name }} == 'push' ]; then
             NETDATA_CUSTOM_REPO="netdata/netdata"
             NETDATA_CUSTOM_BRANCH="master"
             NETDATA_CUSTOM_PR_NUMBER=""

--- a/.github/workflows/cloud_regression.yml
+++ b/.github/workflows/cloud_regression.yml
@@ -14,7 +14,7 @@ jobs:
           repo: netdata/test-automation
           ref: refs/heads/master
           workflow: regression.yml
-          token: ${{ secrets.TEST_AUTOMATION_TOKEN }}
+          token: ${{ secrets.NETDATABOT_GITHUB_TOKEN  }}
           inputs: '{ "netdata_branch": "${{ github.event.pull_request.head.ref }}",
                "netdata_repo": "${{ github.event.pull_request.head.repo.full_name }}",
                "netdata_pr_number": "${{ github.event.number }}",


### PR DESCRIPTION
This PR introduces a new github actions workflow that triggers the Netdata Cloud e2e regression suite once a new PR is issued to be merged against netdata master, or when a push happens in the master branch.

More details:
- Upon PR or merge on master, a workflow_dispatch event will be sent from agent’s public repo to a private repo in the netdata org (netdata/test-automation).

- The workflow that lives on agent’s repo and triggers the cloud workflow will be asynchronous, meaning it won’t wait for our tests to finish, it will just shoot and go, so it won’t delay agent's release process at all.

- Cloud e2e tests run in about 15 minutes and they will verify the **integration between agent and cloud, NOT the agent dashboard functionality.**

- All of the cloud e2e tests run using the netdata docker image. So in case of a PR or push against master, the cloud workflow will clone the repo and build a docker image from there. That image will be uploaded as an artifact and downloaded in the subsequent jobs that need it. All tests will then run using that image.

- A link to the test-automation repo and the job handling the tests for that specific PR will be displayed in the workflow running in the agent repo, but since test-automation is a private repo, only the ones that belong in netdata org will have access to it.