### PR TITLE
fix: CPU frequency detection for some containers

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -200,6 +200,9 @@ if [ -n "${lscpu}" ] && lscpu > /dev/null 2>&1; then
   if [ "${possible_cpu_freq}" = " MHz" ]; then
     possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "CPU MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*') MHz"
   fi
+  if [ "${possible_cpu_freq}" = " MHz" ]; then
+    possible_cpu_freq="$(echo "${lscpu_output}" | grep "^Model name:" | grep -Eo "[0-9\.]+GHz" | grep -o "^[0-9\.]*" | awk '{print int($0*1000)}') MHz"
+  fi
 elif [ -n "${dmidecode}" ] && dmidecode -t processor > /dev/null 2>&1; then
   dmidecode_output="$(${dmidecode} -t processor 2> /dev/null)"
   CPU_INFO_SOURCE="dmidecode"


### PR DESCRIPTION
##### Summary

Fixes: #12291

This PR adds an additional method of detecting CPU frequency: using "Model name" from `lscpu` output.


##### Test Plan

<details>
<summary>lscpu output</summary>

```cmd
bash-5.1# lscpu
Architecture:            x86_64
  CPU op-mode(s):        32-bit, 64-bit
  Address sizes:         46 bits physical, 48 bits virtual
  Byte Order:            Little Endian
CPU(s):                  32
  On-line CPU(s) list:   0-31
Vendor ID:               GenuineIntel
  Model name:            Intel(R) Xeon(R) CPU @ 2.00GHz
    CPU family:          6
    Model:               85
    Thread(s) per core:  2
    Core(s) per socket:  16
    Socket(s):           1
    Stepping:            3
    BogoMIPS:            3999.99
    Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc
                         rep_good nopl xtopology nonstop_tsc cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rd
                         rand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx
                          avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves arat md_clear arch_capabilities
Virtualization features:
  Hypervisor vendor:     KVM
  Virtualization type:   full
Caches (sum of all):
  L1d:                   512 KiB (16 instances)
  L1i:                   512 KiB (16 instances)
  L2:                    16 MiB (16 instances)
  L3:                    38.5 MiB (1 instance)
NUMA:
  NUMA node(s):          1
  NUMA node0 CPU(s):     0-31
Vulnerabilities:
  Itlb multihit:         Not affected
  L1tf:                  Mitigation; PTE Inversion
  Mds:                   Mitigation; Clear CPU buffers; SMT Host state unknown
  Meltdown:              Mitigation; PTI
  Spec store bypass:     Mitigation; Speculative Store Bypass disabled via prctl and seccomp
  Spectre v1:            Mitigation; usercopy/swapgs barriers and __user pointer sanitization
  Spectre v2:            Mitigation; Full generic retpoline, IBPB conditional, IBRS_FW, STIBP conditional, RSB filling
  Srbds:                 Not affected
  Tsx async abort:       Mitigation; Clear CPU buffers; SMT Host state unknown
```



</details>

Current:

```cmd
wget -q -O system-info.sh https://raw.githubusercontent.com/netdata/netdata/master/daemon/system-info.sh; sh system-info.sh | grep -i freq; rm system-info.sh
NETDATA_SYSTEM_CPU_FREQ=0
```

This PR:

```cmd
wget -q -O system-info.sh https://raw.githubusercontent.com/ilyam8/netdata/fix_cpu_freq_from_some_containers/daemon/system-info.sh; sh system-info.sh | grep -i freq; rm system-info.sh
NETDATA_SYSTEM_CPU_FREQ=2000000000
```


##### Additional Information
