### PR TITLE
If host_id is not found, do insert of both node_id and host_id in node_instance

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1776,8 +1776,9 @@ static inline void set_host_node_id(RRDHOST *host, uuid_t *node_id)
     return;
 }
 
-#define SQL_UPDATE_NODE_ID  "update node_instance set node_id = @node_id where host_id = @host_id;"
-
+#define SQL_UPDATE_NODE_ID "insert or replace into node_instance (node_id, host_id) " \
+    "values ( @node_id, @host_id ) " \
+    "on conflict (host_id) do update set node_id=excluded.node_id; "
 int update_node_id(uuid_t *host_id, uuid_t *node_id)
 {
     sqlite3_stmt *res = NULL;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

In some cases, it could be that the call to `update_node_id` for a host_id comes before the call to `store_claim_id`. If that happens, the entry in `node_instance` is left without the node_id until the agent is restarted.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Will be tested on staging.
