### PR TITLE
fix(health): adjust 10s_ipv4_tcp_resets_sent warn trigger

### DIFF
--- a/health/health.d/tcp_resets.conf
+++ b/health/health.d/tcp_resets.conf
@@ -26,7 +26,7 @@ component: Network
    lookup: average -10s unaligned absolute of OutRsts
     units: tcp resets/s
     every: 10s
-     warn: $this > ((($1m_ipv4_tcp_resets_sent < 5)?(5):($1m_ipv4_tcp_resets_sent)) * (($status >= $WARNING)  ? (1) : (20)))
+     warn: $this > ((($1m_ipv4_tcp_resets_sent < 5)?(5):($1m_ipv4_tcp_resets_sent)) * (($status >= $WARNING)  ? (1) : (10)))
     delay: up 20s down 60m multiplier 1.2 max 2h
   options: no-clear-notification
      info: average number of sent TCP RESETS over the last 10 seconds. \


### PR DESCRIPTION
##### Summary

Fixes: #12315

This PR adjusts [10s_ipv4_tcp_resets_sent](https://github.com/netdata/netdata/blob/c59aacc18c7759dfc958f891914ba04dea6473d3/health/health.d/tcp_resets.conf#L19-L36) warn trigger, so it will be equal to [10s_ipv4_tcp_resets_received](https://github.com/netdata/netdata/blob/c59aacc18c7759dfc958f891914ba04dea6473d3/health/health.d/tcp_resets.conf#L53-L69).

See the [issue](https://github.com/netdata/netdata/issues/12315) for details.

##### Test Plan

Not needed.

##### Additional Information
