### PR TITLE
Add option to skip re-initialization of cluster centers.

### DIFF
--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -49,6 +49,8 @@ void Config::readMLConfig(void) {
     double ADWindowRateThreshold = config_get_float(ConfigSectionML, "window minimum anomaly rate", 0.25);
     double ADDimensionRateThreshold = config_get_float(ConfigSectionML, "anomaly event min dimension rate threshold", 0.05);
 
+    bool ReuseClusterCenters = config_get_boolean(ConfigSectionML, "reuse cluster centers", false);
+
     std::stringstream SS;
     SS << netdata_configured_cache_dir << "/anomaly-detection.db";
     Cfg.AnomalyDBPath = SS.str();
@@ -122,6 +124,8 @@ void Config::readMLConfig(void) {
     Cfg.ADIdleWindowSize = ADIdleWindowSize;
     Cfg.ADWindowRateThreshold = ADWindowRateThreshold;
     Cfg.ADDimensionRateThreshold = ADDimensionRateThreshold;
+
+    Cfg.ReuseClusterCenters = ReuseClusterCenters;
 
     Cfg.HostsToSkip = config_get(ConfigSectionML, "hosts to skip from training", "!*");
     Cfg.SP_HostsToSkip = simple_pattern_create(Cfg.HostsToSkip.c_str(), NULL, SIMPLE_PATTERN_EXACT);

--- a/ml/Config.h
+++ b/ml/Config.h
@@ -40,6 +40,8 @@ public:
 
     std::string AnomalyDBPath;
 
+    bool ReuseClusterCenters;
+
     void readMLConfig();
 };
 

--- a/ml/Dimension.cc
+++ b/ml/Dimension.cc
@@ -126,7 +126,7 @@ MLResult TrainableDimension::trainModel() {
         return MLResult::MissingData;
 
     SamplesBuffer SB = SamplesBuffer(CNs, N, 1, Cfg.DiffN, Cfg.SmoothN, Cfg.LagN);
-    KM.train(SB, Cfg.MaxKMeansIters);
+    KM.train(SB, Cfg.MaxKMeansIters, Cfg.ReuseClusterCenters);
     Trained = true;
     ConstantModel = true;
 

--- a/ml/kmeans/KMeans.cc
+++ b/ml/kmeans/KMeans.cc
@@ -3,7 +3,7 @@
 #include "KMeans.h"
 #include <dlib/clustering.h>
 
-void KMeans::train(SamplesBuffer &SB, size_t MaxIterations) {
+void KMeans::train(SamplesBuffer &SB, size_t MaxIterations, bool ReuseClusterCenters) {
     std::vector<DSample> Samples = SB.preprocess();
 
     MinDist = std::numeric_limits<CalculatedNumber>::max();
@@ -12,9 +12,11 @@ void KMeans::train(SamplesBuffer &SB, size_t MaxIterations) {
     {
         std::lock_guard<std::mutex> Lock(Mutex);
 
-        ClusterCenters.clear();
+        if (ClusterCenters.size() == 0 || ReuseClusterCenters == false) {
+            ClusterCenters.clear();
+            dlib::pick_initial_centers(NumClusters, ClusterCenters, Samples);
+        }
 
-        dlib::pick_initial_centers(NumClusters, ClusterCenters, Samples);
         dlib::find_clusters_using_kmeans(Samples, ClusterCenters, MaxIterations);
 
         for (const auto &S : Samples) {

--- a/ml/kmeans/KMeans.h
+++ b/ml/kmeans/KMeans.h
@@ -17,7 +17,7 @@ public:
         MaxDist = std::numeric_limits<CalculatedNumber>::min();
     };
 
-    void train(SamplesBuffer &SB, size_t MaxIterations);
+    void train(SamplesBuffer &SB, size_t MaxIterations, bool ReuseClusterCenters);
     CalculatedNumber anomalyScore(SamplesBuffer &SB);
 
 private:


### PR DESCRIPTION
##### Summary

Add an option to skip initializing the cluster centers every time we are training a dimension. 

##### Test Plan

- CI jobs
- testing on staging by @andrewm4894 

##### Additional Information
https://github.com/netdata/netdata/discussions/12308