### PR TITLE
Add a dry run mode to the kickstart script.

### DIFF
--- a/packaging/installer/UPDATE.md
+++ b/packaging/installer/UPDATE.md
@@ -27,18 +27,6 @@ Starting with netdata v1.33.0, you can use Netdata itself to determine the insta
 netdata -W buildinfo | grep 'Install type:'
 ```
 
-If this produces no output, you have an older install and will have to manually look in the Netdata config directory.
-If you are not sure where your Netdata config directory is, see the [configuration doc](/docs/configure/nodes.md). In
-most installations, this is `/etc/netdata`.
-
-Use `cd` to navigate to the Netdata config directory, then use `ls -a` to look for a file called `.install-type`.
-
--   If the `.install-type` file doex not exist, look for a file in the same directory called `.environment`.
-    -   If the `.environment` file does not exist, then you have a ‘custom’ install.
-    -   If the `.environment` file does exist, then you have either a ‘static’ or ‘build’ install.
--   If the `.install-type` file does exist, check it’s contents with `cat .install-type`.
-    -   The value of the `INSTALL_TYPE` key indicates what type of install you have.
-
 The exact update method to use depends on the install type:
 
 -   Installs with an install type of 'custom' usually indicate installing a third-party package through the system
@@ -50,6 +38,24 @@ The exact update method to use depends on the install type:
     using our [Docker](#docker) update procedure.
 -   macOS users should check [our update instructions for macOS](#macos).
 -   Manually built installs should check [our update instructions for manual builds](#manual-installation-from-git).
+
+If you are using an older version of Netdata, or the above command produces no output, you can run our one-line
+installation script in dry-run mode to attempt to determine what method to use to update by running the following
+command:
+
+```bash
+wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh --dry-run
+```
+
+Note that if you installed Netdata using an installation prefix, you will need to add an `--install` option
+specifying that prefix to make sure it finds the existing install.
+
+If you see a line starting with `--- Would attempt to update existing installation by running the updater script
+located at:, then our [regular update method](#updates-for-most-systems) will work for you.
+
+Otherwise, it should either indicate that the installation type is not supported (which probably means you either
+have a `custom` instal or built Netdata manually) or indicate that it would create a new install (which means that
+you either used a non-standard install path, or that you don’t actually have Netdata installed).
 
 ## Updates for most systems
 

--- a/packaging/installer/UPDATE.md
+++ b/packaging/installer/UPDATE.md
@@ -17,16 +17,6 @@ or stable version. You can also [enable or disable automatic updates on an exist
 Before you update the Netdata Agent, check to see if your Netdata Agent is already up-to-date by clicking on the update
 icon in the local Agent dashboard's top navigation. This modal informs you whether your Agent needs an update or not.
 
-![Opening the Agent's Update modal](https://user-images.githubusercontent.com/1153921/99738428-add06780-2a87-11eb-8268-0e17b689eb3f.gif)
-
-## Determine which installation method you used
-
-Starting with netdata v1.33.0, you can use Netdata itself to determine the installation type by running:
-
-```bash
-netdata -W buildinfo | grep 'Install type:'
-```
-
 The exact update method to use depends on the install type:
 
 -   Installs with an install type of 'custom' usually indicate installing a third-party package through the system
@@ -38,6 +28,14 @@ The exact update method to use depends on the install type:
     using our [Docker](#docker) update procedure.
 -   macOS users should check [our update instructions for macOS](#macos).
 -   Manually built installs should check [our update instructions for manual builds](#manual-installation-from-git).
+
+## Determine which installation method you used
+
+Starting with netdata v1.33.0, you can use Netdata itself to determine the installation type by running:
+
+```bash
+netdata -W buildinfo | grep 'Install type:'
+```
 
 If you are using an older version of Netdata, or the above command produces no output, you can run our one-line
 installation script in dry-run mode to attempt to determine what method to use to update by running the following

--- a/packaging/installer/UPDATE.md
+++ b/packaging/installer/UPDATE.md
@@ -49,7 +49,7 @@ Note that if you installed Netdata using an installation prefix, you will need t
 specifying that prefix to make sure it finds the existing install.
 
 If you see a line starting with `--- Would attempt to update existing installation by running the updater script
-located at:, then our [regular update method](#updates-for-most-systems) will work for you.
+located at:`, then our [regular update method](#updates-for-most-systems) will work for you.
 
 Otherwise, it should either indicate that the installation type is not supported (which probably means you either
 have a `custom` instal or built Netdata manually) or indicate that it would create a new install (which means that

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -48,6 +48,7 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--non-interactive`: Don’t prompt for anything and assume yes whenever possible, overriding any automatic detection of an interactive run.
 - `--interactive`: Act as if running interactively, even if automatic detection indicates a run is non-interactive.
 - `--dont-wait`: Synonym for `--non-interactive`
+- `--dry-run`: Show what the installer would do, but don’t actually do any of it.
 - `--dont-start-it`: Don’t auto-start the daemon after installing. This parameter is not guaranteed to work.
 - `--nightly-channel`: Use a nightly build instead of a stable release (this is the default).
 - `--stable-channel`: Use a stable release instead of a nightly build.


### PR DESCRIPTION
##### Summary

This will report what the script would try to do on the system on which it’s run without actually doing any of it. This is intended to allow for easier testing of changes to the core logic in the script, as well as providing a way for users to see what the script would do on their system without having to suffer through reading the source code.

Also includes a handful of mnior changes to improve the overall UX of the script, as well as a numerous documentation updates relevant to this new option.

Sample output on one of my own systems which has a static install:

```
 --- Using /tmp/.private/root/netdata-kickstart-JHjsk11vOV as a temporary directory. --- 
 --- Checking for existing installations of Netdata... --- 
 --- Found an existing netdata install at /opt/netdata, with installation type 'manual-static'. --- 
 --- Would attempt to update existing installation by running the updater script located at: /opt/netdata/usr/libexec/netdata/netdata-updater.sh --- 
 --- Not attempting to claim existing install at /opt/netdata (no claiming token provided). --- 
```

##### Test Plan

This can easily be verified by simply running the kickstart script from this PR with the `--dry-run` option. No changes should be made to the system it was run on, but it should produce output outlining what it would do on that system given the options it was passed.