### PR TITLE
Remove check for config file in stock conf dir

### DIFF
--- a/collectors/ioping.plugin/ioping.plugin.in
+++ b/collectors/ioping.plugin/ioping.plugin.in
@@ -174,16 +174,14 @@ ioping_opts="-T 1000000"
 # -----------------------------------------------------------------------------
 # load the configuration files
 
-for CONFIG in "${NETDATA_USER_CONFIG_DIR}/${plugin}.conf"
-do
-    if [ -f "${CONFIG}" ]
-        then
-        info "Loading config file '${CONFIG}'..."
-        source "${CONFIG}"
-        [ $? -ne 0 ] && error "Failed to load config file '${CONFIG}'."
-    else
-        warning "Cannot find file '${CONFIG}'."
-    fi
+for CONFIG in "${NETDATA_STOCK_CONFIG_DIR}/${plugin}.conf" "${NETDATA_USER_CONFIG_DIR}/${plugin}.conf"; do
+  if [ -f "${CONFIG}" ]; then
+    info "Loading config file '${CONFIG}'..."
+    source "${CONFIG}"
+    [ $? -ne 0 ] && error "Failed to load config file '${CONFIG}'."
+  elif [[ $CONFIG =~ ^$NETDATA_USER_CONFIG_DIR ]]; then
+    warning "Cannot find file '${CONFIG}'."
+  fi
 done
 
 if [ -z "${destination}" ]

--- a/collectors/ioping.plugin/ioping.plugin.in
+++ b/collectors/ioping.plugin/ioping.plugin.in
@@ -174,7 +174,7 @@ ioping_opts="-T 1000000"
 # -----------------------------------------------------------------------------
 # load the configuration files
 
-for CONFIG in "${NETDATA_STOCK_CONFIG_DIR}/${plugin}.conf" "${NETDATA_USER_CONFIG_DIR}/${plugin}.conf"
+for CONFIG in "${NETDATA_USER_CONFIG_DIR}/${plugin}.conf"
 do
     if [ -f "${CONFIG}" ]
         then


### PR DESCRIPTION
Checking the stock config dir `"${NETDATA_STOCK_CONFIG_DIR}/${plugin}.conf"` for .conf files will produce a very confusing error in the logs when a user tries to enable multiple instances of ioping:

> 2022-03-05 11:07:59: ioping2.plugin: WARNING: Cannot find file '/usr/lib/netdata/conf.d/ioping2.conf'.

This is a false warning and the plugin will indeed work. It seems to me that there is no reason whatsoever to even check the stock config since it doesn't contain a workable destination path to monitor until the user edits the file and at that point they will have the file in their /etc/netdata/ directory.
The error makes it seem as though the user should go creating files in /usr/lib/netdata/conf.d/
I had considered fixing this as follows but I think just removing that check altogether is a simpler and better decision:
```
USER_CONF="${NETDATA_USER_CONFIG_DIR}/${plugin}.conf"
STOCK_CONF="${NETDATA_STOCK_CONFIG_DIR}/${plugin}.conf"

if [ -f "$USER_CONF" ]
    then
    info "info Loading user config file '${USER_CONF}'..."
    source "${USER_CONF}"
    [ $? -ne 0 ] && error "Failed to load config file '${USER_CONF}'."
elif [ -f "$STOCK_CONF" ]
    then
    info "Loading config file '${STOCK_CONF}'..."
    source "${STOCK_CONF}"
    [ $? -ne 0 ] && error "Failed to load config file '${STOCK_CONF}'."
else
    warning "Cannot find file '${USER_CONF}' or '${STOCK_CONF}'."
fi
```

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
