### PR TITLE
Add latency dimension

### DIFF
--- a/health/health.d/ioping.conf
+++ b/health/health.d/ioping.conf
@@ -4,7 +4,7 @@
     class: Latency
      type: System
 component: Disk
-   lookup: average -10s unaligned of average
+   lookup: average -10s unaligned of latency
     units: ms
     every: 10s
     green: 500


### PR DESCRIPTION
Unless I'm missing something here, this alarm does not work the way it is written because there is no dimension called "average" in the chart created by ioping.
Changed to lookup of latency instead.

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
