### PR TITLE
Set repo priority in YUM/DNF repository configuration.

### DIFF
--- a/packaging/repoconfig/netdata-edge.repo.centos
+++ b/packaging/repoconfig/netdata-edge.repo.centos
@@ -7,6 +7,7 @@ gpgkey=https://packagecloud.io/netdata/netdata-edge/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
@@ -17,3 +18,4 @@ gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50

--- a/packaging/repoconfig/netdata-edge.repo.fedora
+++ b/packaging/repoconfig/netdata-edge.repo.fedora
@@ -7,6 +7,7 @@ gpgkey=https://packagecloud.io/netdata/netdata-edge/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
@@ -17,3 +18,4 @@ gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50

--- a/packaging/repoconfig/netdata-edge.repo.ol
+++ b/packaging/repoconfig/netdata-edge.repo.ol
@@ -7,6 +7,7 @@ gpgkey=https://packagecloud.io/netdata/netdata-edge/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
@@ -17,3 +18,4 @@ gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50

--- a/packaging/repoconfig/netdata-repo.spec
+++ b/packaging/repoconfig/netdata-repo.spec
@@ -19,6 +19,10 @@ Source7:        netdata-edge.repo.ol
 
 BuildArch:      noarch
 
+%if 0%{?centos_ver} < 8
+Requires:       yum-plugin-priorities
+%endif
+
 # Overlapping file installs
 Conflicts:      netdata-repo-edge
 

--- a/packaging/repoconfig/netdata.repo.centos
+++ b/packaging/repoconfig/netdata.repo.centos
@@ -7,6 +7,7 @@ gpgkey=https://packagecloud.io/netdata/netdata/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
@@ -17,3 +18,4 @@ gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50

--- a/packaging/repoconfig/netdata.repo.fedora
+++ b/packaging/repoconfig/netdata.repo.fedora
@@ -7,6 +7,7 @@ gpgkey=https://packagecloud.io/netdata/netdata/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
@@ -17,3 +18,4 @@ gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50

--- a/packaging/repoconfig/netdata.repo.ol
+++ b/packaging/repoconfig/netdata.repo.ol
@@ -7,6 +7,7 @@ gpgkey=https://packagecloud.io/netdata/netdata/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
@@ -17,3 +18,4 @@ gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50


### PR DESCRIPTION
##### Summary

This makes us more reliably pull our won packages instead of installing stuff from EPEL or other sources when we try to install with the kickstart script on CentOS and similar systems.

##### Test Plan

n/a

##### Additional Information

Fixes: #12334 