### PR TITLE
Use the built agent version for Netdata static build archive name.

### DIFF
--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -12,10 +12,7 @@ run cd "${NETDATA_SOURCE_PATH}" || exit 1
 # -----------------------------------------------------------------------------
 # find the netdata version
 
-VERSION="$(git describe 2> /dev/null)"
-if [ -z "${VERSION}" ]; then
-  VERSION=$(cat packaging/version)
-fi
+VERSION="$("${NETDATA_INSTALL_PARENT}/netdata/bin/netdata" -v | cut -f 2 -d ' ')"
 
 if [ "${VERSION}" == "" ]; then
   echo >&2 "Cannot find version number. Create makeself executable from source code with git tree structure."


### PR DESCRIPTION
##### Summary

This ensures that the version reported by `netdata -v` will match up with the version number embedded in the static build archive file names.

##### Test Plan

n/a