### PR TITLE
fix: use default "bind to" in native packages

### DIFF
--- a/system/netdata.conf
+++ b/system/netdata.conf
@@ -23,6 +23,3 @@
 [web]
     web files owner = root
     web files group = netdata
-
-    # by default do not expose the netdata port
-    bind to = localhost


### PR DESCRIPTION
##### Summary

Fixes: #12256

This PR removes "bind to" option from the netdata.conf that is used in deb/rpm packages. After this PR "bind to" will be the same regardless of installation method.

##### Test Plan

Not needed

##### Additional Information
