### PR TITLE
fix: container virtualization detection with systemd-detect-virt

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -21,7 +21,7 @@ if [ -z "${VIRTUALIZATION}" ]; then
   if [ -n "$(command -v systemd-detect-virt 2> /dev/null)" ]; then
     VIRTUALIZATION="$(systemd-detect-virt -v)"
     VIRT_DETECTION="systemd-detect-virt"
-    CONTAINER="$(systemd-detect-virt -c)"
+    CONTAINER=${CONTAINER:-$(systemd-detect-virt -c)}
     CONT_DETECTION="systemd-detect-virt"
   else
     if grep -q "^flags.*hypervisor" /proc/cpuinfo 2> /dev/null; then


### PR DESCRIPTION
##### Summary

Fixes: #12290

`systemd-detect-virt -c` returns an empty response when executing as systemd unit service on Debian 8 on @ktsaou server (couldn't reproduce it on my deb8 server).

That is not expected here, as the result we treat the server as a container, which is not the case

https://github.com/netdata/netdata/blob/297f02fee3e00205ab69ce2d67312fd043c38034/daemon/system-info.sh#L148-L152


##### Test Plan



##### Additional Information
