### PR TITLE
Remove owner check from webserver

### DIFF
--- a/build_external/scenarios/aclk-testing/agent_netdata.conf
+++ b/build_external/scenarios/aclk-testing/agent_netdata.conf
@@ -60,8 +60,6 @@
 	# listen backlog = 4096
 	# default port = 19999
 	# bind to = *
-	# web files owner = netdata
-	# web files group = netdata
 	# disconnect idle clients after seconds = 60
 	# timeout for first request = 60
 	# accept a streaming request every seconds = 0

--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -50,9 +50,7 @@ case "$1" in
 
     dpkg-statoverride --force --update --add root netdata 0775 /var/lib/netdata/registry > /dev/null 2>&1
 
-    chown -R root:netdata /usr/share/netdata
     chown -R root:netdata /usr/libexec/netdata/plugins.d
-    chown -R root:netdata /var/lib/netdata/www
     setcap cap_dac_read_search,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin
     setcap cap_dac_read_search+ep /usr/libexec/netdata/plugins.d/slabinfo.plugin
     capsh --supports=cap_perfmon 2>/dev/null && setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin || setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1212,11 +1212,6 @@ int main(int argc, char **argv) {
 
     info("netdata started on pid %d.", getpid());
 
-    // IMPORTANT: these have to run once, while single threaded
-    // but after we have switched user
-    web_files_uid();
-    web_files_gid();
-
     netdata_threads_init_after_fork((size_t)config_get_number(CONFIG_SECTION_GLOBAL, "pthread stack size", (long)default_stacksize));
 
     // initialize internal registry

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1244,15 +1244,6 @@ NETDATA_GROUP="$(id -g -n "${NETDATA_USER}")"
 [ -z "${NETDATA_GROUP}" ] && NETDATA_GROUP="${NETDATA_USER}"
 echo >&2 "Netdata user and group is finally set to: ${NETDATA_USER}/${NETDATA_GROUP}"
 
-# the owners of the web files
-NETDATA_WEB_USER="$(config_option "web" "web files owner" "${NETDATA_USER}")"
-NETDATA_WEB_GROUP="${NETDATA_GROUP}"
-if [ "$(id -u)" = "0" ] && [ "${NETDATA_USER}" != "${NETDATA_WEB_USER}" ]; then
-  NETDATA_WEB_GROUP="$(id -g -n "${NETDATA_WEB_USER}")"
-  [ -z "${NETDATA_WEB_GROUP}" ] && NETDATA_WEB_GROUP="${NETDATA_WEB_USER}"
-fi
-NETDATA_WEB_GROUP="$(config_option "web" "web files group" "${NETDATA_WEB_GROUP}")"
-
 # port
 defport=19999
 NETDATA_PORT="$(config_option "web" "default port" ${defport})"
@@ -1272,8 +1263,6 @@ cat << OPTIONSEOF
     Permissions
     - netdata user             : ${NETDATA_USER}
     - netdata group            : ${NETDATA_GROUP}
-    - web files user           : ${NETDATA_WEB_USER}
-    - web files group          : ${NETDATA_WEB_GROUP}
     - root user                : ${ROOT_USER}
 
     Directories
@@ -1318,7 +1307,6 @@ if [ ! -d "${NETDATA_WEB_DIR}" ]; then
   echo >&2 "Creating directory '${NETDATA_WEB_DIR}'"
   run mkdir -p "${NETDATA_WEB_DIR}" || exit 1
 fi
-run chown -R "${NETDATA_WEB_USER}:${NETDATA_WEB_GROUP}" "${NETDATA_WEB_DIR}"
 run find "${NETDATA_WEB_DIR}" -type f -exec chmod 0664 {} \;
 run find "${NETDATA_WEB_DIR}" -type d -exec chmod 0775 {} \;
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -514,7 +514,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 
 # Enforce 0644 for files and 0755 for directories
 # for the netdata web directory
-%defattr(0644,root,netdata,0755)
+%defattr(0644,root,root,0755)
 %{_datadir}/%{name}/web
 
 # Enforce 0660 for files and 0770 for directories

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -188,25 +188,20 @@ visit the Agent dashboard at `http://NODE:19999`, you need to update Netdata's p
 system.
 
 Run `ls -la /usr/share/netdata/web/index.html` to find the file's permissions. You may need to change this path based on
-the error you're seeing in your browser. In the below example, the file is owned by the user `netdata` and the group
-`netdata`.
+the error you're seeing in your browser. In the below example, the file is owned by the user `root` and the group
+`root`.
 
 ```bash
 ls -la /usr/share/netdata/web/index.html
--rw-r--r--. 1 netdata netdata 89377 May  5 06:30 /usr/share/netdata/web/index.html
+-rw-r--r--. 1 root root 89377 May  5 06:30 /usr/share/netdata/web/index.html
 ```
 
-Open your `netdata.conf` file and find the `[web]` section, plus the `web files owner`/`web files group` settings. Edit
-the lines to match the output from `ls -la` above and uncomment them if necessary.
+These files need to have the same user and group used to install your netdata. Suppose you installed netdata with user
+`netdata` and group `netdata`, in this scenario you will need to run the following command to fix the error:
 
-```conf
-[web]
-    web files owner = netdata
-    web files group = netdata
+```bash
+# chown -R netdata.netdata /usr/share/netdata/web
 ```
-
-Save the file, restart Netdata using `sudo systemctl restart netdata`, or the [appropriate
-method](/docs/configure/start-stop-restart.md) for your system, and try accessing the dashboard again.
 
 ### Multiple versions of OpenSSL
 

--- a/system/netdata.conf
+++ b/system/netdata.conf
@@ -20,6 +20,3 @@
     process scheduling policy = idle
     OOM score = 1000
 
-[web]
-    web files owner = root
-    web files group = netdata

--- a/tests/alarm_repetition/netdata.conf_with_repetition
+++ b/tests/alarm_repetition/netdata.conf_with_repetition
@@ -22,8 +22,6 @@
     # listen backlog = 4096
     default port = 19999
     #bind to = *=dashboard|registry|streaming|netdata.conf|badges|management *:20000=dashboard|registry|streaming|netdata.conf|badges|management^SSL=optional *:20001=dashboard|registry|streaming|netdata.conf|badges|management^SSL=force unix:/tmp/netdata/netdata.sock
-    # web files owner = netdata
-    # web files group = netdata
     #accept a streaming request every seconds = 2
 
 [plugins]

--- a/tests/alarm_repetition/netdata.conf_without_repetition
+++ b/tests/alarm_repetition/netdata.conf_without_repetition
@@ -22,8 +22,6 @@
     # listen backlog = 4096
     default port = 19999
     #bind to = *=dashboard|registry|streaming|netdata.conf|badges|management *:20000=dashboard|registry|streaming|netdata.conf|badges|management^SSL=optional *:20001=dashboard|registry|streaming|netdata.conf|badges|management^SSL=force unix:/tmp/netdata/netdata.sock
-    # web files owner = netdata
-    # web files group = netdata
     #accept a streaming request every seconds = 2
 
 [plugins]

--- a/web/server/README.md
+++ b/web/server/README.md
@@ -221,8 +221,6 @@ present that may match DNS FQDNs.
 |ses max window|`15`|See [single exponential smoothing](/web/api/queries/des/README.md)|
 |des max window|`15`|See [double exponential smoothing](/web/api/queries/des/README.md)|
 |listen backlog|`4096`|The port backlog. Check `man 2 listen`.|
-|web files owner|`netdata`|The user that owns the web static files. Netdata will refuse to serve a file that is not owned by this user, even if it has read access to that file. If the user given is not found, Netdata will only serve files owned by user given in `run as user`.|
-|web files group|`netdata`|If this is set, Netdata will check if the file is owned by this group and refuse to serve the file if it's not.|
 |disconnect idle clients after seconds|`60`|The time in seconds to disconnect web clients after being totally idle.|
 |timeout for first request|`60`|How long to wait for a client to send a request before closing the socket. Prevents slow request attacks.|
 |accept a streaming request every seconds|`0`|Can be used to set a limit on how often a parent node will accept streaming requests from child nodes in a [streaming and replication setup](/streaming/README.md)|

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -399,18 +399,6 @@ int mysendfile(struct web_client *w, char *filename) {
             return access_to_file_is_not_permitted(w, webfilename);
         }
 
-        // check if the file is owned by expected user
-        if (statbuf.st_uid != web_files_uid()) {
-            error("%llu: File '%s' is owned by user %u (expected user %u). Access Denied.", w->id, webfilename, statbuf.st_uid, web_files_uid());
-            return access_to_file_is_not_permitted(w, webfilename);
-        }
-
-        // check if the file is owned by expected group
-        if (statbuf.st_gid != web_files_gid()) {
-            error("%llu: File '%s' is owned by group %u (expected group %u). Access Denied.", w->id, webfilename, statbuf.st_gid, web_files_gid());
-            return access_to_file_is_not_permitted(w, webfilename);
-        }
-
         done = 1;
     }
 

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -204,37 +204,6 @@ void web_client_request_done(struct web_client *w) {
 #endif // NETDATA_WITH_ZLIB
 }
 
-uid_t web_files_uid(void) {
-    static char *web_owner = NULL;
-    static uid_t owner_uid = 0;
-
-    if(unlikely(!web_owner)) {
-        // getpwuid() is not thread safe,
-        // but we have called this function once
-        // while single threaded
-        struct passwd *pw = getpwuid(geteuid());
-        web_owner = config_get(CONFIG_SECTION_WEB, "web files owner", (pw)?(pw->pw_name?pw->pw_name:""):"");
-        if(!web_owner || !*web_owner)
-            owner_uid = geteuid();
-        else {
-            // getpwnam() is not thread safe,
-            // but we have called this function once
-            // while single threaded
-            pw = getpwnam(web_owner);
-            if(!pw) {
-                error("User '%s' is not present. Ignoring option.", web_owner);
-                owner_uid = geteuid();
-            }
-            else {
-                debug(D_WEB_CLIENT, "Web files owner set to %s.", web_owner);
-                owner_uid = pw->pw_uid;
-            }
-        }
-    }
-
-    return(owner_uid);
-}
-
 static struct {
     const char *extension;
     uint32_t hash;

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -235,37 +235,6 @@ uid_t web_files_uid(void) {
     return(owner_uid);
 }
 
-gid_t web_files_gid(void) {
-    static char *web_group = NULL;
-    static gid_t owner_gid = 0;
-
-    if(unlikely(!web_group)) {
-        // getgrgid() is not thread safe,
-        // but we have called this function once
-        // while single threaded
-        struct group *gr = getgrgid(getegid());
-        web_group = config_get(CONFIG_SECTION_WEB, "web files group", (gr)?(gr->gr_name?gr->gr_name:""):"");
-        if(!web_group || !*web_group)
-            owner_gid = getegid();
-        else {
-            // getgrnam() is not thread safe,
-            // but we have called this function once
-            // while single threaded
-            gr = getgrnam(web_group);
-            if(!gr) {
-                error("Group '%s' is not present. Ignoring option.", web_group);
-                owner_gid = getegid();
-            }
-            else {
-                debug(D_WEB_CLIENT, "Web files group set to %s.", web_group);
-                owner_gid = gr->gr_gid;
-            }
-        }
-    }
-
-    return(owner_gid);
-}
-
 static struct {
     const char *extension;
     uint32_t hash;

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -195,7 +195,6 @@ struct web_client {
 };
 
 extern uid_t web_files_uid(void);
-extern uid_t web_files_gid(void);
 
 extern int web_client_permission_denied(struct web_client *w);
 

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -194,8 +194,6 @@ struct web_client {
 #endif
 };
 
-extern uid_t web_files_uid(void);
-
 extern int web_client_permission_denied(struct web_client *w);
 
 extern ssize_t web_client_send(struct web_client *w);


### PR DESCRIPTION
##### Summary
Fixes  https://github.com/netdata/netdata/issues/12257

This PR is removing the check for owner when web server tries to open files, it also adjusts our package building.
##### Test Plan

1 - Compile this branch and try to access `netdata` dashboard, you should have not problems to open it.
2 - Copy any file as `root` user to `/usr/share/netdata/web/` and be sure other users can read it. Try to get the file using `http://localhost:19999/FILE`.

###### Optional test

It is completely unnecessary to access `api` to get data, because we are not addressing any code related to it, but considering that to add more test will only help us:

3 - Be sure you can also access `http://localhost:19999/api/v1/info`
4 - Start a `child` netdata and verify that you can access its data using `http://localhost:19999/host/CHILD_NAME/`


##### Additional Information
More details will come after package files are adjusted. 