### PR TITLE
Redirect dependency handling script output to logfile when running from the updater.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -147,12 +147,10 @@ install_build_dependencies() {
   else
     info "Running dependency handling script..."
 
-    if [ "${INTERACTIVE}" -eq 0 ]; then
-      opts="--dont-wait --non-interactive"
-    fi
+    opts="--dont-wait --non-interactive"
 
     # shellcheck disable=SC2086
-    if ! "${bash}" "${TMPDIR}/install-required-packages.sh" ${opts} netdata; then
+    if ! "${bash}" "${TMPDIR}/install-required-packages.sh" ${opts} netdata >&3 2>&3; then
       error "Installing build dependencies failed. The update should still work, but you might be missing some features."
     fi
   fi


### PR DESCRIPTION
##### Summary

This should make updates quiet again.

Also just run the dependency handling script in non-interactive mode when it’s run from the updater, whether the updater is running interactively or not.

##### Test Plan

Output from the `install-required-packages.sh` script should no longer be visible in the updater check step of the updater check CI jobs.