### PR TITLE
Prepend context in anomaly rate dimension id.

### DIFF
--- a/ml/Dimension.h
+++ b/ml/Dimension.h
@@ -23,8 +23,10 @@ public:
     unsigned updateEvery() const { return RD->update_every; }
 
     const std::string getID() const {
+        RRDSET *RS = RD->rrdset;
+
         std::stringstream SS;
-        SS << RD->rrdset->id << "|" << RD->name;
+        SS << RS->context << "|" << RS->id << "|" << RD->name;
         return SS.str();
     }
 


### PR DESCRIPTION
##### Summary
FE needs this information when they issue a `/data` request on the
anomaly rates chart. However, this information is only available at
the creation time of the anomaly rate dimension.

##### Test Plan

CI jobs & FE testing on staging.