### PR TITLE
fix(health): make ioping_disk_latency alarm less sensitive

### DIFF
--- a/health/health.d/ioping.conf
+++ b/health/health.d/ioping.conf
@@ -5,11 +5,11 @@
      type: System
 component: Disk
    lookup: average -10s unaligned of latency
-    units: ms
+    units: microseconds
     every: 10s
-    green: 500
-      red: 1000
-     warn: $this > $green OR $max > $red
+    green: 5000
+      red: 10000
+     warn: $this > $green
      crit: $this > $red
     delay: down 30m multiplier 1.5 max 2h
      info: average I/O latency over the last 10 seconds


### PR DESCRIPTION
##### Summary

This PR adjusts green/red thresholds. The chart units is microseconds, not milliseconds.

Fixes https://github.com/netdata/netdata/pull/12329#issuecomment-1063167058

##### Test Plan

Not needed.

##### Additional Information
