### PR TITLE
Docs fix: Add missing frontmatter

### DIFF
--- a/ml/README.md
+++ b/ml/README.md
@@ -1,3 +1,9 @@
+<!-- 
+title: Machine learning (ML) powered anomaly detection
+custom_edit_url: https://github.com/netdata/netdata/edit/master/ml/README.md
+description: This is an in-depth look at how Netdata uses ML to detect anomalies.
+keywords: [machine learning, anomaly detection, Netdata ML]
+-->
 # Machine learning (ML) powered anomaly detection
 
 ## Overview


### PR DESCRIPTION
##### Problem
Currently, the page doesn't display the actual title in learn. I suppose the ingest script strips away h1, so in this case the fallback title is the filename. 

##### Solution

I supplemented frontmatter, so this issue should be resolved.
