### PR TITLE
minor - fix analytics_build_info

### DIFF
--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -367,41 +367,104 @@ void print_build_info_json(void) {
     printf("}\n");
 };
 
-//return a list of enabled features for use in analytics
-//find a way to have proper |
+#define add_to_bi(buffer, str)       \
+    { if(first) {                    \
+        buffer_strcat (b, str);      \
+        first = 0;                   \
+    } else                           \
+        buffer_strcat (b, "|" str); }
+
 void analytics_build_info(BUFFER *b) {
-    if(FEAT_DBENGINE)        buffer_strcat (b, "dbengine");
-    if(FEAT_NATIVE_HTTPS)    buffer_strcat (b, "|Native HTTPS");
-    if(FEAT_CLOUD)           buffer_strcat (b, "|Netdata Cloud");
-    if(FEAT_CLOUD)           buffer_strcat (b, "|ACLK Next Generation");
-    if(NEW_CLOUD_PROTO)      buffer_strcat (b, "|New Cloud Protocol Support");
-    if(FEAT_TLS_HOST_VERIFY) buffer_strcat (b, "|TLS Host Verification");
-    if(FEAT_ML)              buffer_strcat (b, "|Machine Learning");
-    if(FEAT_STREAM_COMPRESSION) buffer_strcat (b, "|Stream Compression");
+    int first = 1;
+#ifdef ENABLE_DBENGINE
+    add_to_bi(b, "dbengine");
+#endif
+#ifdef ENABLE_HTTPS
+    add_to_bi(b, "Native HTTPS");
+#endif
+#ifdef ENABLE_ACLK
+    add_to_bi(b, "Netdata Cloud|ACLK Next Generation");
+#endif
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
+    add_to_bi(b, "New Cloud Protocol Support");
+#endif
+#if (FEAT_TLS_HOST_VERIFY!=0)
+    add_to_bi(b, "TLS Host Verification");
+#endif
+#ifdef ENABLE_ML
+    add_to_bi(b, "Machine Learning");
+#endif
+#ifdef ENABLE_COMPRESSION
+    add_to_bi(b, "Stream Compression");
+#endif
 
-    if(FEAT_PROTOBUF)        buffer_strcat (b, "|protobuf");
-    if(FEAT_JEMALLOC)        buffer_strcat (b, "|jemalloc");
-    if(FEAT_JSONC)           buffer_strcat (b, "|JSON-C");
-    if(FEAT_LIBCAP)          buffer_strcat (b, "|libcap");
-    if(FEAT_CRYPTO)          buffer_strcat (b, "|libcrypto");
-    if(FEAT_LIBM)            buffer_strcat (b, "|libm");
+#ifdef HAVE_PROTOBUF
+    add_to_bi(b, "protobuf");
+#endif
+#ifdef ENABLE_JEMALLOC
+    add_to_bi(b, "jemalloc");
+#endif
+#ifdef ENABLE_JSONC
+    add_to_bi(b, "JSON-C");
+#endif
+#ifdef HAVE_CAPABILITY
+    add_to_bi(b, "libcap");
+#endif
+#ifdef HAVE_CRYPTO
+    add_to_bi(b, "libcrypto");
+#endif
+#ifdef STORAGE_WITH_MATH
+    add_to_bi(b, "libm");
+#endif
 
-    if(FEAT_TCMALLOC)       buffer_strcat(b, "|tcalloc");
-    if(FEAT_ZLIB)           buffer_strcat(b, "|zlib");
+#ifdef ENABLE_TCMALLOC
+    add_to_bi(b, "tcalloc");
+#endif
+#ifdef NETDATA_WITH_ZLIB
+    add_to_bi(b, "zlib");
+#endif
 
-    if(FEAT_APPS_PLUGIN)    buffer_strcat(b, "|apps");
-    if(FEAT_CGROUP_NET)     buffer_strcat(b, "|cgroup Network Tracking");
-    if(FEAT_CUPS)           buffer_strcat(b, "|CUPS");
-    if(FEAT_EBPF)           buffer_strcat(b, "|EBPF");
-    if(FEAT_IPMI)           buffer_strcat(b, "|IPMI");
-    if(FEAT_NFACCT)         buffer_strcat(b, "|NFACCT");
-    if(FEAT_PERF)           buffer_strcat(b, "|perf");
-    if(FEAT_SLABINFO)       buffer_strcat(b, "|slabinfo");
-    if(FEAT_XEN)            buffer_strcat(b, "|Xen");
-    if(FEAT_XEN_VBD_ERROR)  buffer_strcat(b, "|Xen VBD Error Tracking");
+#ifdef ENABLE_APPS_PLUGIN
+    add_to_bi(b, "apps");
+#endif
+#ifdef HAVE_SETNS
+    add_to_bi(b, "cgroup Network Tracking");
+#endif
+#ifdef HAVE_CUPS
+    add_to_bi(b, "CUPS");
+#endif
+#ifdef HAVE_LIBBPF
+    add_to_bi(b, "EBPF");
+#endif
+#ifdef HAVE_FREEIPMI
+    add_to_bi(b, "IPMI");
+#endif
+#ifdef HAVE_NFACCT
+    add_to_bi(b, "NFACCT");
+#endif
+#ifdef ENABLE_PERF_PLUGIN
+    add_to_bi(b, "perf");
+#endif
+#ifdef ENABLE_SLABINFO
+    add_to_bi(b, "slabinfo");
+#endif
+#ifdef HAVE_LIBXENSTAT
+    add_to_bi(b, "Xen");
+#endif
+#ifdef HAVE_XENSTAT_VBD_ERROR
+    add_to_bi(b, "Xen VBD Error Tracking");
+#endif
 
-    if(FEAT_KINESIS)        buffer_strcat(b, "|AWS Kinesis");
-    if(FEAT_PUBSUB)         buffer_strcat(b, "|GCP PubSub");
-    if(FEAT_MONGO)          buffer_strcat(b, "|MongoDB");
-    if(FEAT_REMOTE_WRITE)   buffer_strcat(b, "|Prometheus Remote Write");
+#ifdef HAVE_KINESIS
+    add_to_bi(b, "AWS Kinesis");
+#endif
+#ifdef ENABLE_EXPORTING_PUBSUB
+    add_to_bi(b, "GCP PubSub");
+#endif
+#ifdef HAVE_MONGOC
+    add_to_bi(b, "MongoDB");
+#endif
+#ifdef ENABLE_PROMETHEUS_REMOTE_WRITE
+    add_to_bi(b, "Prometheus Remote Write");
+#endif
 }


### PR DESCRIPTION
##### Summary
While doing other stuff (which will use output of this function) I noticed `analytics_build_info()` will produce wrong output if db-engine is not compiled in.
This fixes it with macro and removes related TODO comment.

Any decent compiler will remove the conditional jump (related to `first` variable) as its value is known at compile time in every case (conflating it to just the needed buffer_strcat calls without ifs). Sample from gcc:
<details>
<summary>gdb disassemble</summary>

```
   0x000000000041248b <+79>:    mov    $0x83a475,%esi
   0x0000000000412490 <+84>:    mov    %rbx,%rdi
   0x0000000000412493 <+87>:    call   0x42444c <buffer_strcat>
   0x0000000000412498 <+92>:    mov    $0x83a489,%esi
   0x000000000041249d <+97>:    mov    %rbx,%rdi
   0x00000000004124a0 <+100>:   call   0x42444c <buffer_strcat>
   0x00000000004124a5 <+105>:   mov    $0x83a493,%esi
   0x00000000004124aa <+110>:   mov    %rbx,%rdi
   0x00000000004124ad <+113>:   call   0x42444c <buffer_strcat>
   0x00000000004124b2 <+118>:   mov    $0x83a49b,%esi
   0x00000000004124b7 <+123>:   mov    %rbx,%rdi
   0x00000000004124ba <+126>:   call   0x42444c <buffer_strcat>
   0x00000000004124bf <+131>:   mov    $0x83a4a6,%esi
   0x00000000004124c4 <+136>:   mov    %rbx,%rdi
   0x00000000004124c7 <+139>:   call   0x42444c <buffer_strcat>
   0x00000000004124cc <+144>:   mov    $0x83a4ac,%esi
   0x00000000004124d1 <+149>:   mov    %rbx,%rdi
   0x00000000004124d4 <+152>:   call   0x42444c <buffer_strcat>
   0x00000000004124d9 <+157>:   mov    $0x83a4b2,%esi
   0x00000000004124de <+162>:   mov    %rbx,%rdi
   0x00000000004124e1 <+165>:   call   0x42444c <buffer_strcat>
   0x00000000004124e6 <+170>:   mov    $0x83a4b8,%esi
   0x00000000004124eb <+175>:   mov    %rbx,%rdi
   0x00000000004124ee <+178>:   call   0x42444c <buffer_strcat>
   0x00000000004124f3 <+183>:   mov    $0x83a4d1,%esi
   0x00000000004124f8 <+188>:   mov    %rbx,%rdi
   0x00000000004124fb <+191>:   call   0x42444c <buffer_strcat>
   0x0000000000412500 <+196>:   mov    $0x83a4d7,%esi
   0x0000000000412505 <+201>:   mov    %rbx,%rdi
   0x0000000000412508 <+204>:   call   0x42444c <buffer_strcat>
   0x000000000041250d <+209>:   mov    $0x83a4dd,%esi
   0x0000000000412512 <+214>:   mov    %rbx,%rdi
   0x0000000000412515 <+217>:   call   0x42444c <buffer_strcat>
```
</details>

##### Test Plan
Build agent without dbengine. Output of `curl 127.0.0.1:19999/api/v1/info | jq .buildinfo` should not start with `|`

Before `|Native HTTPS|Netdata Cloud...`, after `Native HTTPS|Netdata Cloud...`

##### Additional Information
