### PR TITLE
Fix chart synchronization with the cloud

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1400,7 +1400,7 @@ void rrdset_done(RRDSET *st) {
 #ifdef ENABLE_ACLK
     if (likely(!st->state->is_ar_chart)) {
         if (unlikely(!rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
-            if (likely(st->dimensions && !queue_chart_to_aclk(st)))
+            if (likely(st->dimensions && st->counter_done && !queue_chart_to_aclk(st)))
                 rrdset_flag_set(st, RRDSET_FLAG_ACLK);
         }
     }


### PR DESCRIPTION
##### Summary
When a new chart is created (and its dimensions have no previously stored metrics), the dimension payload for the chart
may not have the correct timestamps for collected metrics. This will cause the cloud to delete
the dimension from the chart and the it never appears in the cloud dashboard. 

This PR, waits for one iteration of data collection before sending the chart and dimension metadata to the cloud 
to make sure we have a valid timestamps.

##### Test Plan
- Trivial change to make sure we have at least one collection iteration for the chart
