### PR TITLE
configure.ac: Unconditionally link against libatomic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1529,36 +1529,14 @@ if test "${enable_backend_kinesis}" = "yes" -o \
         "${new_cloud_protocol}" = "yes" -o \
         "${build_ml}" = "yes"; then
     enable_cxx_linker="yes"
-
-    # Try to unconditionally link with -latomic. If the compiler can satisfy
-    # all the atomic ops with builtins then, the library will be left unused.
-    # Otherwise, some ops will be covered by the compiler's intrinsics and some
-    # will be picked up by the linker from -latomic. In the later case, if
-    # -latomic is not available there will be a build failure, which would
-    # have happened either way before this change.
-    AC_LANG_PUSH([C++])
-
-    AC_MSG_CHECKING(whether we can use -latomic)
-    OLD_LIBS="${LIBS}"
-    LIBS="-latomic"
-    AC_LINK_IFELSE([AC_LANG_SOURCE([[
-      #include <atomic>
-      #include <cstdint>
-      std::atomic<std::int64_t> v;
-      int main() {
-        return v;
-      }
-    ]])], CAN_USE_LIBATOMIC=yes, CAN_USE_LIBATOMIC=no)
-    LIBS="${OLD_LIBS}"
-    AC_MSG_RESULT($CAN_USE_LIBATOMIC)
-
-    if test "x$CAN_USE_LIBATOMIC" = xyes; then
-        OPTIONAL_ATOMIC_LIBS="-latomic"
-    fi
-    AC_SUBST([OPTIONAL_ATOMIC_LIBS])
-
-    AC_LANG_POP([C++])
 fi
+
+# Unconditionally link with the libatomic since:
+# - if atomics are not needed, the library will be unused
+# - if atomics are needed, either atomics are fulfilled by the compiler builtins
+#   and the library is unused or the library is needed anyway.
+OPTIONAL_ATOMIC_LIBS="-latomic"
+AC_SUBST([OPTIONAL_ATOMIC_LIBS])
 
 AM_CONDITIONAL([ENABLE_CXX_LINKER], [test "${enable_cxx_linker}" = "yes"])
 

--- a/packaging/installer/dependencies/alpine.sh
+++ b/packaging/installer/dependencies/alpine.sh
@@ -16,6 +16,7 @@ package_tree="
   autoconf
   cmake
   make
+  libatomic
   libtool
   pkgconfig
   tar

--- a/packaging/installer/dependencies/centos.sh
+++ b/packaging/installer/dependencies/centos.sh
@@ -12,6 +12,7 @@ declare -a package_tree=(
   autoconf-archive
   autogen
   automake
+  libatomic
   libtool
   pkgconfig
   cmake

--- a/packaging/installer/dependencies/debian.sh
+++ b/packaging/installer/dependencies/debian.sh
@@ -17,6 +17,7 @@ package_tree="
   autoconf
   autoconf-archive
   autogen
+  libatomic1
   libtool
   pkg-config
   tar

--- a/packaging/installer/dependencies/fedora.sh
+++ b/packaging/installer/dependencies/fedora.sh
@@ -32,6 +32,7 @@ declare -a package_tree=(
   autoconf-archive
   autogen
   automake
+  libatomic
   libtool
   cmake
   nmap-ncat

--- a/packaging/installer/dependencies/ol.sh
+++ b/packaging/installer/dependencies/ol.sh
@@ -15,6 +15,7 @@ declare -a package_tree=(
   autoconf-archive
   autogen
   automake
+  libatomic
   libtool
   pkgconfig
   cmake

--- a/packaging/installer/dependencies/opensuse.sh
+++ b/packaging/installer/dependencies/opensuse.sh
@@ -17,6 +17,7 @@ declare -a package_tree=(
   autoconf-archive
   autogen
   automake
+  libatomic1
   libtool
   pkg-config
   cmake

--- a/packaging/installer/dependencies/rockylinux.sh
+++ b/packaging/installer/dependencies/rockylinux.sh
@@ -15,6 +15,7 @@ declare -a package_tree=(
   autoconf-archive
   autogen
   automake
+  libatomic
   libtool
   pkgconfig
   cmake

--- a/packaging/installer/dependencies/ubuntu.sh
+++ b/packaging/installer/dependencies/ubuntu.sh
@@ -17,6 +17,7 @@ package_tree="
   autoconf
   autoconf-archive
   autogen
+  libatomic1
   libtool
   pkg-config
   tar

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -699,6 +699,19 @@ declare -A pkg_json_c_dev=(
   ['default']="json-c-devel"
 )
 
+declare -A pkg_libatomic=(
+  ['arch']="NOTREQUIRED"
+  ['clearlinux']="NOTREQUIRED"
+  ['debian']="libatomic1"
+  ['freebsd']="NOTREQUIRED"
+  ['gentoo']="NOTREQUIRED"
+  ['macos']="NOTREQUIRED"
+  ['sabayon']="NOTREQUIRED"
+  ['suse']="libatomic1"
+  ['ubuntu']="libatomic1"
+  ['default']="libatomic"
+)
+
 declare -A pkg_bridge_utils=(
   ['gentoo']="net-misc/bridge-utils"
   ['clearlinux']="network-basic"
@@ -1339,6 +1352,7 @@ packages() {
   # basic build environment
 
   suitable_package distro-sdk
+  suitable_package libatomic
 
   require_cmd git || suitable_package git
   require_cmd find || suitable_package find


### PR DESCRIPTION
##### Summary

The build failed on riscv64 because the build command line lacks libatomic. Fix this by always linking against libatomic since:
- if atomics are not needed, the library will be unused
- if atomics are needed, either atomics are fulfilled by the compiler builtins
  and the library is unused or the library is needed anyway.

Fixes #12319

##### Test Plan

Successfully built on all architectures (https://launchpad.net/~alexghiti/+archive/ubuntu/riscv/+sourcepub/13305735/+listing-archive-extra)

##### Additional Information

Signed-off-by: Alexandre Ghiti <alexandre.ghiti@canonical.com>