### PR TITLE
fix(ci/release): limit the number of issues to fetch from GitHub when generating changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
           unreleasedLabel: "**Next release**"
           verbose: true
+          maxIssues: 500
       - name: Generate Release Changelog
         id: release-changelog
         if: steps.target.outputs.run == 'true' && steps.target.outputs.type != 'nightly'
@@ -67,6 +68,7 @@ jobs:
           token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
           unreleasedLabel: "**Next release**"
           verbose: true
+          maxIssues: 500
       - name: Commit Changes
         id: commit
         if: steps.target.outputs.run == 'true'


### PR DESCRIPTION
##### Summary

"[Generate Nightly Changelog](https://github.com/netdata/netdata/blob/4566c0835e99d1b00542ddbc1600450eb61a6a70/.github/workflows/release.yml#L45-L69)" job [fails](https://github.com/netdata/netdata/runs/5504428611?check_suite_focus=true) because it gets rate limited by GitHub - too many fetches.

Set it to the same value [as we use in travis](https://github.com/netdata/netdata/blob/4566c0835e99d1b00542ddbc1600450eb61a6a70/.travis/create_changelog.sh#L46).

##### Test Plan

I checked the option syntax in https://github.com/heinrichreimer/action-github-changelog-generator#inputs. It is valid.

##### Additional Information
