### PR TITLE
Fix version handling issues in release workflow.

### DIFF
--- a/.github/scripts/prepare-release-base.sh
+++ b/.github/scripts/prepare-release-base.sh
@@ -108,6 +108,7 @@ elif [ "${EVENT_NAME}" = 'schedule' ] || [ "${EVENT_TYPE}" = 'nightly' ]; then
     echo "::set-output name=ref::master"
     echo "::set-output name=type::nightly"
     echo "::set-output name=branch::master"
+    echo "::set-output name=version::nightly"
 elif [ "${EVENT_TYPE}" = 'patch' ] && [ "${EVENT_VERSION}" != "nightly" ]; then
     echo "::notice::Preparing a patch release build."
     check_version_format || exit 1
@@ -127,6 +128,7 @@ elif [ "${EVENT_TYPE}" = 'patch' ] && [ "${EVENT_VERSION}" != "nightly" ]; then
     echo "::set-output name=ref::${EVENT_VERSION}"
     echo "::set-output name=type::release"
     echo "::set-output name=branch::${branch_name}"
+    echo "::set-output name=version::$(tr -d 'v' < packaging/version)"
 elif [ "${EVENT_TYPE}" = 'minor' ] && [ "${EVENT_VERSION}" != "nightly" ]; then
     echo "::notice::Preparing a minor release build."
     check_version_format || exit 1
@@ -147,6 +149,7 @@ elif [ "${EVENT_TYPE}" = 'minor' ] && [ "${EVENT_VERSION}" != "nightly" ]; then
     echo "::set-output name=ref::${EVENT_VERSION}"
     echo "::set-output name=type::release"
     echo "::set-output name=branch::${branch_name}"
+    echo "::set-output name=version::$(tr -d 'v' < packaging/version)"
 elif [ "${EVENT_TYPE}" = 'major' ] && [ "${EVENT_VERSION}" != "nightly" ]; then
     echo "::notice::Preparing a major release build."
     check_version_format || exit 1
@@ -160,10 +163,8 @@ elif [ "${EVENT_TYPE}" = 'major' ] && [ "${EVENT_VERSION}" != "nightly" ]; then
     echo "::set-output name=ref::${EVENT_VERSION}"
     echo "::set-output name=type::release"
     echo "::set-output name=branch::master"
+    echo "::set-output name=version::$(tr -d 'v' < packaging/version)"
 else
     echo '::error::Unrecognized release type or invalid version.'
     exit 1
 fi
-
-# shellcheck disable=SC2002
-echo "::set-output name=version::$(cat packaging/version | sed 's/^v//' packaging/version)"

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -121,7 +121,7 @@ jobs:
                 ;;
               "nightly")
                 echo "::set-output name=repo::${REPO_PREFIX}-edge"
-                echo "::set-output name=version::${{ github.event.inputs.version }}"
+                echo "::set-output name=version::$(tr -d 'v' < packaging/version)"
                 echo "::set-output name=retention::30"
                 ;;
               *)
@@ -131,7 +131,7 @@ jobs:
                 ;;
             esac
           else
-            echo "::set-output name=version::$(cut -d'-' -f 1 packaging/version | sed -e 's/^v//')"
+            echo "::set-output name=version::$(cut -d'-' -f 1 packaging/version | tr -d 'v')"
             echo "::set-output name=retention::0"
           fi
       - name: Failure Notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
           repo: ${{ github.repository }}
           workflow: Build
           ref: ${{ needs.update-changelogs.outputs.ref }}
-          inputs: '{"agent_version": "${{ needs.update-changelogs.outputs.version }}", "type": "${{ github.event.inputs.type }}"}'
+          inputs: '{"version": "${{ needs.update-changelogs.outputs.version }}", "type": "${{ github.event.inputs.type }}"}'
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -154,7 +154,7 @@ jobs:
           repo: ${{ github.repository }}
           workflow: Docker
           ref: ${{ needs.update-changelogs.outputs.ref }}
-          inputs: '{"agent_version": "${{ needs.update-changelogs.outputs.version }}"}'
+          inputs: '{"version": "${{ needs.update-changelogs.outputs.version }}"}'
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -189,7 +189,7 @@ jobs:
           repo: ${{ github.repository }}
           workflow: Packages
           ref: ${{ needs.update-changelogs.outputs.ref }}
-          inputs: '{"agent_version": "${{ needs.update-changelogs.outputs.version }}", "type": "${{ github.event.inputs.type }}"}'
+          inputs: '{"version": "${{ needs.update-changelogs.outputs.version }}", "type": "${{ github.event.inputs.type }}"}'
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
##### Summary

* Pass `nightly` instead of a version for nightly builds.
* Use the correct name for the version input when triggering builds.
* Properly pull the version info for nightly builds in the packaging workflow.

##### Test Plan

n/a