### PR TITLE
fix: shellcheck warnings in docker run.sh

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -22,7 +22,7 @@ if [ ! "${DISABLE_TELEMETRY:-0}" -eq 0 ] ||
 fi
 
 BALENA_PGID=$(stat -c %g /var/run/balena.sock 2>/dev/null)
-DOCKER_PGID=$(stat -c %g -nd /var/run/docker.sock 2>/dev/null)
+DOCKER_PGID=$(stat -c %g /var/run/docker.sock 2>/dev/null)
 
 re='^[0-9]+$'
 if [[ $BALENA_PGID =~ $re ]]; then
@@ -32,7 +32,7 @@ if [[ $BALENA_PGID =~ $re ]]; then
 elif [[ $DOCKER_PGID =~ $re ]]; then
   echo "Netdata detected docker.sock"
   DOCKER_HOST="/var/run/docker.sock"
-  PGID=$(stat -c %g /var/run/docker.sock)
+  PGID="$DOCKER_PGID"
 fi
 export PGID
 export DOCKER_HOST

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -21,8 +21,8 @@ if [ ! "${DISABLE_TELEMETRY:-0}" -eq 0 ] ||
   touch /etc/netdata/.opt-out-from-anonymous-statistics
 fi
 
-BALENA_PGID=$(stat -c %g /var/run/balena.sock 2>/dev/null | awk '{print $1}')
-DOCKER_PGID=$(stat -c %g /var/run/docker.sock 2>/dev/null | awk '{print $1}')
+BALENA_PGID=$(stat -c %g /var/run/balena.sock 2>/dev/null || true)
+DOCKER_PGID=$(stat -c %g /var/run/docker.sock 2>/dev/null || true)
 
 re='^[0-9]+$'
 if [[ $BALENA_PGID =~ $re ]]; then

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -21,8 +21,8 @@ if [ ! "${DISABLE_TELEMETRY:-0}" -eq 0 ] ||
   touch /etc/netdata/.opt-out-from-anonymous-statistics
 fi
 
-BALENA_PGID=$(stat -c %g /var/run/balena.sock 2>/dev/null)
-DOCKER_PGID=$(stat -c %g /var/run/docker.sock 2>/dev/null)
+BALENA_PGID=$(stat -c %g /var/run/balena.sock 2>/dev/null | awk '{print $1}')
+DOCKER_PGID=$(stat -c %g /var/run/docker.sock 2>/dev/null | awk '{print $1}')
 
 re='^[0-9]+$'
 if [[ $BALENA_PGID =~ $re ]]; then

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -21,8 +21,8 @@ if [ ! "${DISABLE_TELEMETRY:-0}" -eq 0 ] ||
   touch /etc/netdata/.opt-out-from-anonymous-statistics
 fi
 
-BALENA_PGID=$(ls -nd /var/run/balena.sock | awk '{print $4}')
-DOCKER_PGID=$(ls -nd /var/run/docker.sock | awk '{print $4}')
+BALENA_PGID=$(stat -c %g /var/run/balena.sock 2>/dev/null)
+DOCKER_PGID=$(stat -c %g -nd /var/run/docker.sock 2>/dev/null)
 
 re='^[0-9]+$'
 if [[ $BALENA_PGID =~ $re ]]; then
@@ -32,7 +32,7 @@ if [[ $BALENA_PGID =~ $re ]]; then
 elif [[ $DOCKER_PGID =~ $re ]]; then
   echo "Netdata detected docker.sock"
   DOCKER_HOST="/var/run/docker.sock"
-  PGID=$(ls -nd /var/run/docker.sock | awk '{print $4}')
+  PGID=$(stat -c %g /var/run/docker.sock)
 fi
 export PGID
 export DOCKER_HOST


### PR DESCRIPTION
##### Summary

This PR fixes shellcheck warnings ([SC2012](https://github-wiki-see.page/m/koalaman/shellcheck/wiki/SC2012)) in our docker run.sh file. Thanks to @maneamarius for [noticing the problem and suggesting the solution](https://github.com/netdata/netdata/pull/12310#issuecomment-1064963210).

##### Test Plan

Compare the output using the old and new code

```cmd
$ ls -nd /var/run/docker.sock | awk '{print $4}'
997
$ stat -c %g /var/run/docker.sock 2>/dev/null
997
```



##### Additional Information
