### PR TITLE
fix(ebpf.plugin): remove pid file on exit

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1831,6 +1831,19 @@ static void ebpf_kill_previous_process(char *filename, pid_t pid)
 }
 
 /**
+ * PID file
+ *
+ * Write the filename for PID inside the given vector.
+ *
+ * @param filename  vector where we will store the name.
+ * @param length    number of bytes available in filename vector
+ */
+void ebpf_pid_file(char *filename, size_t length)
+{
+    snprintfz(filename, length, "%s%s/ebpf.d/ebpf.pid", netdata_configured_host_prefix, ebpf_plugin_dir);
+}
+
+/**
  * Manage PID
  *
  * This function kills another instance of eBPF whether it is necessary and update the file content.
@@ -1840,7 +1853,7 @@ static void ebpf_kill_previous_process(char *filename, pid_t pid)
 static void ebpf_manage_pid(pid_t pid)
 {
     char filename[FILENAME_MAX + 1];
-    snprintfz(filename, FILENAME_MAX, "%s%s/ebpf.d/ebpf.pid", netdata_configured_host_prefix, ebpf_plugin_dir);
+    ebpf_pid_file(filename, FILENAME_MAX);
 
     ebpf_kill_previous_process(filename, pid);
     ebpf_update_pid_file(filename, pid);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -300,6 +300,10 @@ static void ebpf_exit(int sig)
         btf__free(default_btf);
 #endif
 
+    char filename[FILENAME_MAX + 1];
+    ebpf_pid_file(filename, FILENAME_MAX);
+    unlink(filename);
+
     exit(sig);
 }
 

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -238,6 +238,8 @@ extern int ebpf_enable_tracepoint(ebpf_tracepoint_t *tp);
 extern int ebpf_disable_tracepoint(ebpf_tracepoint_t *tp);
 extern uint32_t ebpf_enable_tracepoints(ebpf_tracepoint_t *tps);
 
+extern void ebpf_pid_file(char *filename, size_t length);
+
 #define EBPF_PROGRAMS_SECTION "ebpf programs"
 
 #define EBPF_COMMON_DIMENSION_PERCENTAGE "%"


### PR DESCRIPTION
##### Summary
Fixes #12363 

This PR is removing `pid` file used to identify a process that was not correctly closed. This file is removed, if and only if, the process ends successful. 
##### Test Plan

1. Clone this branch
2. Verify that you have the file `/usr/libexec/netdata/plugins.d/ebpf.d/ebpf.pid` present in your system.
3. Compile this branch and start `netdata`.
4. Wait few minutes and stop `netdata`
5. Now run the following command to confirm the file was removed:

```sh
bash-5.1# ls -lh /usr/libexec/netdata/plugins.d/ebpf.d/ebpf.pid
ls: cannot access '/usr/libexec/netdata/plugins.d/ebpf.d/ebpf.pid': No such file or directory
```

##### Additional Information
