### PR TITLE
fix: handle double host prefix when Netdata running in a podman container

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -213,6 +213,14 @@ static enum cgroups_type cgroups_try_detect_version()
     return CGROUPS_V2;
 }
 
+void set_cgroup_base_path(char *filename, char *path) {
+    if (strncmp(netdata_configured_host_prefix, path, strlen(netdata_configured_host_prefix)) == 0) {
+        snprintfz(filename, FILENAME_MAX, "%s", path);
+    } else {
+        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, path);
+    }
+}
+
 void read_cgroup_plugin_configuration() {
     system_page_size = sysconf(_SC_PAGESIZE);
 
@@ -285,7 +293,7 @@ void read_cgroup_plugin_configuration() {
             s = "/sys/fs/cgroup/cpuacct";
         }
         else s = mi->mount_point;
-        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, s);
+        set_cgroup_base_path(filename, s);
         cgroup_cpuacct_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/cpuacct", filename);
 
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuset");
@@ -295,7 +303,7 @@ void read_cgroup_plugin_configuration() {
             s = "/sys/fs/cgroup/cpuset";
         }
         else s = mi->mount_point;
-        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, s);
+        set_cgroup_base_path(filename, s);
         cgroup_cpuset_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/cpuset", filename);
 
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "blkio");
@@ -305,7 +313,7 @@ void read_cgroup_plugin_configuration() {
             s = "/sys/fs/cgroup/blkio";
         }
         else s = mi->mount_point;
-        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, s);
+        set_cgroup_base_path(filename, s);
         cgroup_blkio_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/blkio", filename);
 
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "memory");
@@ -315,7 +323,7 @@ void read_cgroup_plugin_configuration() {
             s = "/sys/fs/cgroup/memory";
         }
         else s = mi->mount_point;
-        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, s);
+        set_cgroup_base_path(filename, s);
         cgroup_memory_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/memory", filename);
 
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "devices");
@@ -325,7 +333,7 @@ void read_cgroup_plugin_configuration() {
             s = "/sys/fs/cgroup/devices";
         }
         else s = mi->mount_point;
-        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, s);
+        set_cgroup_base_path(filename, s);
         cgroup_devices_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/devices", filename);
     }
     else {
@@ -357,7 +365,7 @@ void read_cgroup_plugin_configuration() {
             s = "/sys/fs/cgroup";
         }
         else s = mi->mount_point;
-        snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, s);
+        set_cgroup_base_path(filename, s);
         cgroup_unified_base = config_get("plugin:cgroups", "path to unified cgroups", filename);
         debug(D_CGROUP, "using cgroup root: '%s'", cgroup_unified_base);
     }


### PR DESCRIPTION
##### Summary

Fixes: #12259

[mountinfo_find_by_filesystem_super_option](https://github.com/netdata/netdata/blob/8c8350371300d8fcafd794f1697bf22b83214120/collectors/cgroups.plugin/sys_fs_cgroup.c#L349) returns the path with `/host` in a podman container and without in a docker container.

```cmd
$ podman exec nd cat /proc/self/mountinfo | grep cgroup
435 433 0:25 / /host/sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup2 rw
447 427 0:25 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup2 rw

$ docker exec nd cat /proc/self/mountinfo | grep cgroup
302 301 0:25 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw
307 305 0:25 / /host/sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup2 rw
```

##### Test Plan

- run podman/docker containers with cgroup v1 enabled, ensure Netdata can discover containers
- run podman/docker containers with cgroup v2 enabled, ensure Netdata can discover containers

##### Additional Information
