### PR TITLE
Remove unecessary error report for proc and sys files

### DIFF
--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -275,7 +275,7 @@ int ebpf_read_apps_groups_conf(struct target **agdt, struct target **agrt, const
 
     // ----------------------------------------
 
-    procfile *ff = procfile_open(filename, " :\t", PROCFILE_FLAG_DEFAULT);
+    procfile *ff = procfile_open_no_log(filename, " :\t", PROCFILE_FLAG_DEFAULT);
     if (!ff)
         return -1;
 

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -242,7 +242,7 @@ static ebpf_cgroup_target_t * ebpf_cgroup_find_or_create(netdata_ebpf_cgroup_shm
  */
 static void ebpf_update_pid_link_list(ebpf_cgroup_target_t *ect, char *path)
 {
-    procfile *ff = procfile_open(path, " \t:", PROCFILE_FLAG_DEFAULT);
+    procfile *ff = procfile_open_no_log(path, " \t:", PROCFILE_FLAG_DEFAULT);
     if (!ff)
         return;
 

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -321,7 +321,7 @@ static int read_local_disks()
 {
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, NETDATA_EBPF_PROC_PARTITIONS);
-    procfile *ff = procfile_open(filename, " \t:", PROCFILE_FLAG_DEFAULT);
+    procfile *ff = procfile_open_no_log(filename, " \t:", PROCFILE_FLAG_DEFAULT);
     if (!ff)
         return -1;
 

--- a/libnetdata/procfile/procfile.h
+++ b/libnetdata/procfile/procfile.h
@@ -103,4 +103,7 @@ extern int procfile_adaptive_initial_allocation;
 // return the Nth word of the current line
 #define procfile_lineword(ff, line, word) (((line) < procfile_lines(ff) && (word) < procfile_linewords((ff), (line))) ? procfile_word((ff), (ff)->lines->lines[(line)].first + (word)) : "")
 
+// Open File without to create logs
+#define procfile_open_no_log(filename, separators, flags) procfile_open(filename, separators, flags | PROCFILE_FLAG_NO_ERROR_ON_FILE_IO)
+
 #endif /* NETDATA_PROCFILE_H */


### PR DESCRIPTION
##### Summary
This PR gives the first step to also fix the issue #11397, and It also fixes an analogous issue given in our forum, where it was reported that Netdata creates warnings like this when we use our `libbnetdata`:

```
Jun 1 08:49:58 homeserver ebpf.plugin: Cannot load the ebpf configuration file (null)
Jun 1 08:49:58 homeserver ebpf.plugin: PROCFILE: Cannot open file '/etc/netdata/apps_groups.conf
```

To fix this problem it is necessary to give for function `procfile_open` as argument an additional flag.

##### Test Plan

1. Rename your file `/etc/netdata/apps_group.conf`.
2. Compile this branch
3. Run `netdata`, wait few seconds and run the following command:
```sh
bash-5.1# grep -r "PROCFILE: Cannot open file" /var/log/netdata/error.log
/var/log/netdata/error.log:2022-03-13 22:16:32: apps.plugin ERROR : MAIN : PROCFILE: Cannot open file '/etc/netdata/apps_groups.conf' (errno 2, No such file or directory)
/var/log/netdata/error.log:2022-03-13 22:16:44: netdata ERROR : PLUGIN[proc] : PROCFILE: Cannot open file '/proc/net/sctp/snmp' (errno 2, No such file or directory)
```
4. Bring back your `/etc/netdata/apps_group.conf`.

##### Additional Information

It is not necessary to test on different kernels, because this PR address an issue on `user ring`.

This PR is fixing only `eBPF.plugin`, but as soon it is merged, we need another PR for at least:
- cgroup.plugin
- apps
- proc