### PR TITLE
Delay removed event for 60 seconds after the chart's last collected time

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -748,7 +748,8 @@ void *health_main(void *ptr) {
                     continue;
 
                 if (unlikely(rc->rrdset && rc->status != RRDCALC_STATUS_REMOVED &&
-                        rrdset_flag_check(rc->rrdset, RRDSET_FLAG_OBSOLETE))) {
+                             rrdset_flag_check(rc->rrdset, RRDSET_FLAG_OBSOLETE) &&
+                             (now - rc->rrdset->last_collected_time.tv_sec) > 60)) {
                     if (!rrdcalc_isrepeating(rc)) {
                         time_t now = now_realtime_sec();
                         ALARM_ENTRY *ae = health_create_alarm_entry(

--- a/health/health.c
+++ b/health/health.c
@@ -747,9 +747,11 @@ void *health_main(void *ptr) {
                 if (update_disabled_silenced(host, rc))
                     continue;
 
+                // create an alert removed event if the chart is obsolete and
+                // has stopped being collected for 60 seconds
                 if (unlikely(rc->rrdset && rc->status != RRDCALC_STATUS_REMOVED &&
                              rrdset_flag_check(rc->rrdset, RRDSET_FLAG_OBSOLETE) &&
-                             (now - rc->rrdset->last_collected_time.tv_sec) > 60)) {
+                             now > (rc->rrdset->last_collected_time.tv_sec + 60))) {
                     if (!rrdcalc_isrepeating(rc)) {
                         time_t now = now_realtime_sec();
                         ALARM_ENTRY *ae = health_create_alarm_entry(


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR adds a delay before creating a REMOVED alert event when a chart goes obsolete. It should help with cases when charts go in OBSOLETE and then back to ok quickly.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

Similar testing can be conducted as in https://github.com/netdata/netdata/pull/12021 (using e.g. a usb stick). This time around, with this PR, the REMOVED event should be produced 60 seconds after the last_collected time.