### PR TITLE
Fix crash when netdatacli command output too long

### DIFF
--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -400,6 +400,10 @@ static inline void add_string_to_command_reply(char *reply_string, unsigned *rep
     unsigned len;
 
     len = strlen(str);
+
+    if (MAX_COMMAND_LENGTH - 1 < len + *reply_string_size)
+        len = MAX_COMMAND_LENGTH - *reply_string_size - 1;
+
     strncpyz(reply_string + *reply_string_size, str, len);
     *reply_string_size += len;
 }
@@ -418,7 +422,7 @@ static void send_command_reply(struct command_context *cmd_ctx, cmd_status_t sta
     add_string_to_command_reply(reply_string, &reply_string_size, exit_status_string);
     add_char_to_command_reply(reply_string, &reply_string_size, '\0');
 
-    if (message) {
+    if (message && reply_string_size < MAX_COMMAND_LENGTH - 2) {
         add_char_to_command_reply(reply_string, &reply_string_size, cmd_prefix_by_status[status]);
         add_string_to_command_reply(reply_string, &reply_string_size, message);
     }

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -422,7 +422,7 @@ static void send_command_reply(struct command_context *cmd_ctx, cmd_status_t sta
     add_string_to_command_reply(reply_string, &reply_string_size, exit_status_string);
     add_char_to_command_reply(reply_string, &reply_string_size, '\0');
 
-    if (message && reply_string_size < MAX_COMMAND_LENGTH - 2) {
+    if (message) {
         add_char_to_command_reply(reply_string, &reply_string_size, cmd_prefix_by_status[status]);
         add_string_to_command_reply(reply_string, &reply_string_size, message);
     }


### PR DESCRIPTION
##### Summary
When some command of `netdatacli` produces output bigger than `MAX_COMMAND_LENGTH` netdata will crash with buffer overflow.
This will cut the string and prevent crash.
This will not solve problem of sending long strings trough `netdata-cli`. We have to fix it in future so that `netdatacli` can send long strings.

##### Test Plan
Host with many children will generate long `netdatacli aclk-state` output. With this patch it should not segfault the agent.

##### Additional Information
fixes https://github.com/netdata/netdata/issues/12384

This is quick fix so that netdata doesn't crash but is not ideal - we still need to think how to proceed with netdatacli so it can send arbitrary long outputs

