### PR TITLE
fix: temporary disable charts.d apcupsd collectors

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -410,6 +410,7 @@ declare -A obsolete_charts=(
 	['postfix']="python.d.plugin module"
 	['squid']="python.d.plugin module"
 	['tomcat']="python.d.plugin module"
+	['apcupsd']="temporary disabled because of the bug (#12413)"
 )
 
 all_enabled_charts() {

--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -410,7 +410,6 @@ declare -A obsolete_charts=(
 	['postfix']="python.d.plugin module"
 	['squid']="python.d.plugin module"
 	['tomcat']="python.d.plugin module"
-	['apcupsd']="temporary disabled because of the bug (#12413)"
 )
 
 all_enabled_charts() {
@@ -419,6 +418,11 @@ all_enabled_charts() {
 	# find all enabled charts
 	for chart in $(all_charts); do
 		MODULE_NAME="${chart}"
+		
+		if [ "$MODULE_NAME" == "apcupsd" ] && [ -n "$NETDATA_LISTENER_PORT" ]; then
+		  info "apcupsd is temporary disabled because of the bug (#12413)."
+		  continue
+		fi
 
 		if [ -n "${obsolete_charts["$MODULE_NAME"]}" ]; then
 		  debug "is replaced by ${obsolete_charts["$MODULE_NAME"]}, skipping it."

--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -420,7 +420,7 @@ all_enabled_charts() {
 		MODULE_NAME="${chart}"
 		
 		if [ "$MODULE_NAME" == "apcupsd" ] && [ -n "$NETDATA_LISTENER_PORT" ]; then
-		  info "apcupsd is temporary disabled because of the bug (#12413)."
+		  info "apcupsd is temporarily disabled because of bug #12413"
 		  continue
 		fi
 


### PR DESCRIPTION
##### Summary

Because of #12413. We are disabling it and will investigate the problem.

##### Test Plan

Create a docker image, start the container, check CPU usage, and Block IO.

##### Additional Information
