### PR TITLE
fix: add a delay between starting Netdata and checking pids

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -667,7 +667,7 @@ restart_netdata() {
     # shellcheck disable=SC2086
     run ${NETDATA_INSTALLER_START_CMD} && started=1
 
-    if [ ${started} -eq 1 ] && [ -z "$(netdata_pids)" ]; then
+    if [ ${started} -eq 1 ] && sleep 5 && [ -z "$(netdata_pids)" ]; then
       echo >&2 "Ooops! it seems netdata is not started."
       started=0
     fi
@@ -677,12 +677,13 @@ restart_netdata() {
       # shellcheck disable=SC2086
       run ${NETDATA_INSTALLER_START_CMD} && started=1
     fi
+
+    if [ ${started} -eq 1 ] && sleep 5 && [ -z "$(netdata_pids)" ]; then
+      echo >&2 "Hm... it seems netdata is still not started."
+      started=0
+    fi
   fi
 
-  if [ ${started} -eq 1 ] && [ -z "$(netdata_pids)" ]; then
-    echo >&2 "Hm... it seems netdata is still not started."
-    started=0
-  fi
 
   if [ ${started} -eq 0 ]; then
     # still not started... another forced attempt, just run the binary


### PR DESCRIPTION
##### Summary

The delay is needed on slow servers, that is what I get on my DO droplet (Basic plan):

```cmd
Stopping all netdata threads
[/home/ilyam/netdata]# stop_all_netdata
 OK

Starting netdata using command 'systemctl start netdata'
[/home/ilyam/netdata]# systemctl start netdata
 OK

Ooops! it seems netdata is not started.
Attempting another netdata start using command 'systemctl start netdata'
[/home/ilyam/netdata]# systemctl start netdata
 OK

Hm... it seems netdata is still not started.
Netdata service still not started, attempting another forced restart by running '/opt/netdata/usr/sbin/netdata '
[/home/ilyam/netdata]# stop_all_netdata
 OK

[/home/ilyam/netdata]# /opt/netdata/usr/sbin/netdata
 OK

 OK  netdata started!
```

The reason is:
 - `systemctl start netdata` returns as soon as "netdata.service" cgroup created.
 - Netdata is not started by this moment (ExecStart directive hasn't been executed (or at least completed)).

The end result is:
 - I got running Netdata.
 - but it is not controlled by systemd (systemd netdata unit is failed, I have to kill -9 netdata process).

---

I didn't find a way to delay `systemctl start <service>` returning. 

##### Test Plan

Install Netdata, ensure Netdata is started by systemd and not manually by the script.

<details>
<summary>installer log after the patch</summary>

```cmd
 --- Restarting netdata instance ---

Stopping all netdata threads
[/home/ilyam/src/nd_ilyam8]# stop_all_netdata
 OK

Starting netdata using command 'systemctl start netdata'
[/home/ilyam/src/nd_ilyam8]# systemctl start netdata
 OK

 OK  netdata started!

[/home/ilyam/src/nd_ilyam8]# chmod 0644 /opt/netdata/etc/netdata/netdata.conf
 OK
```

</details>

##### Additional Information
