### PR TITLE
fix: lowercase uuidgen

### DIFF
--- a/claim/netdata-claim.sh.in
+++ b/claim/netdata-claim.sh.in
@@ -152,7 +152,7 @@ gen_id() {
     local id
 
     if command -v uuidgen > /dev/null 2>&1; then
-        id="$(uuidgen)"
+        id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
     elif [ -r /proc/sys/kernel/random/uuid ]; then
         id="$(cat /proc/sys/kernel/random/uuid)"
     else
@@ -199,7 +199,7 @@ do
         case $arg in
                 -token=*) TOKEN=${arg:7} ;;
                 -url=*) [ -n "${arg:5}" ] && URL_BASE=${arg:5} ;;
-                -id=*) ID=${arg:4} ;;
+                -id=*) ID=$(echo "${arg:4}" | tr '[:upper:]' '[:lower:]');;
                 -rooms=*) ROOMS=${arg:7} ;;
                 -hostname=*) HOSTNAME=${arg:10} ;;
                 -verbose) VERBOSE=1 ;;

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -138,7 +138,7 @@ telemetry_event() {
   if [ -f /etc/machine-id ]; then
     DISTINCT_ID="$(cat /etc/machine-id)"
   elif command -v uuidgen > /dev/null 2>&1; then
-    DISTINCT_ID="$(uuidgen)"
+    DISTINCT_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
   else
     DISTINCT_ID="null"
   fi


### PR DESCRIPTION
##### Summary

Fixes: #12421

##### Test Plan

- check there are no other non-fixed uuidgen call cases

```cmd
netdata (lowercase_uuidgen) $ git grep uuidgen -- ':(exclude)*.md' ':(exclude)*.mdx' ':(exclude)*.c' ':(exclude)*.conf'
claim/netdata-claim.sh.in:    if command -v uuidgen > /dev/null 2>&1; then
claim/netdata-claim.sh.in:        id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
claim/netdata-claim.sh.in:                echo >&2 "The cloud may have different credentials already registered for this agent ID and it cannot be reclaimed under different credentials for security reasons. If you are unable to connect use -id=\$(uuidgen) to overwrite this agent ID with a fresh value if the original credentials cannot be restored."
claim/netdata-claim.sh.in:                echo >&2 "The cloud may have different credentials already registered for this agent ID and it cannot be reclaimed under different credentials for security reasons. If you are unable to connect use -id=\$(uuidgen) to overwrite this agent ID with a fresh value if the original credentials cannot be restored."
packaging/installer/kickstart.sh:  elif command -v uuidgen > /dev/null 2>&1; then
packaging/installer/kickstart.sh:    DISTINCT_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
```

- check the conversion to lowercase works 

```cmd
netdata (lowercase_uuidgen) $ uuidgen
4E0E78A9-72AF-47C8-8480-84DF3E91EDB6
netdata (lowercase_uuidgen) $ uuidgen | tr '[:upper:]' '[:lower:]'
7f8fe734-a757-402e-b354-94869433af6c
```

##### Additional Information
