### PR TITLE
fix: ensure claim_id is always sent lowercase as string

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -161,7 +161,9 @@ void load_claiming_state(void)
         freez(claimed_id);
         claimed_id = NULL;
     }
-    localhost->aclk_state.claimed_id = claimed_id;
+
+    localhost->aclk_state.claimed_id = mallocz(UUID_STR_LEN);
+    uuid_unparse_lower(uuid, localhost->aclk_state.claimed_id);
 
     invalidate_node_instances(&localhost->host_uuid, claimed_id ? &uuid : NULL);
     store_claim_id(&localhost->host_uuid, claimed_id ? &uuid : NULL);
@@ -171,6 +173,8 @@ void load_claiming_state(void)
         info("Unable to load '%s', setting state to AGENT_UNCLAIMED", filename);
         return;
     }
+
+    freez(claimed_id);
 
     info("File '%s' was found. Setting state to AGENT_CLAIMED.", filename);
     netdata_cloud_setting = appconfig_get_boolean(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", 1);


### PR DESCRIPTION
##### Summary
Even if for some reason (e.g. user edits claim_id) some character in uuid is uppercase we regenerate it as lowercase after successful parsing.

This makes agent behave as UUID RFC states:
- on input load UUID as case insensitive (be tolerant)
- on output generated uuids should always be lowercase

##### Test Plan
Change one character in `claim_id` to uppercase. Ensure there is no trailing newline in the claim_id file (otherwise it will fail, this is case also for master). Run `netdatacli aclk-state. Claim ID should be lowercase.

##### Additional Information
Fixes https://github.com/netdata/netdata/issues/12424
related to https://github.com/netdata/netdata/issues/12383