### PR TITLE
Fix OS name for older agent versions streaming to a parent

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1566,6 +1566,7 @@ int rrdhost_set_system_info_variable(struct rrdhost_system_info *system_info, ch
     else if(!strcmp(name, "NETDATA_HOST_OS_NAME")){
         freez(system_info->host_os_name);
         system_info->host_os_name = strdupz(value);
+        json_fix_string(system_info->host_os_name);
     }
     else if(!strcmp(name, "NETDATA_HOST_OS_ID")){
         freez(system_info->host_os_id);


### PR DESCRIPTION
Fixes #12362

##### Summary
Older agent versions (e.g. v.1.19, commit 5000257f0171271cb3ee2cf0fe02e8a2154ddf2e) do not properly encode an os name (e.g. "Raspbian GNU/Linux") and that results in an 
invalid json payload when viewing that agent from a parent

This PR is a quick fix to address this.

Before the PR the api/v1/info shows 
```
"os_name": ""Raspbian GNU/Linux"",
"os_id": "raspbian",
"os_id_like": "debian",
"os_version": "10 (buster)",
```

After the PR
```
"os_name": "'Raspbian GNU/Linux'",
"os_id": "raspbian",
"os_id_like": "debian",
"os_version": "10 (buster)",
```

##### Test Plan
- Setup parent - child (in this setup child is Raspbian and agent running is version 1.19.0)
  - Visiting the child node from the parent will result in a blank screen because the /api/v1/info of the child node is an invalid json payload
- Apply PR and observe the issue is resolved
