### PR TITLE
fix(kickstart.sh): prefer shasum over sha256sum

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -388,9 +388,9 @@ get_redirect() {
 safe_sha256sum() {
   # Within the context of the installer, we only use -c option that is common between the two commands
   # We will have to reconsider if we start using non-common options
-  if command -v sha256sum > /dev/null 2>&1; then
-    sha256sum "$@"
-  elif command -v shasum > /dev/null 2>&1; then
+  if command -v shasum > /dev/null 2>&1; then
+    shasum -a 256 "$@"
+  elif command -v sha256sum > /dev/null 2>&1; then
     shasum -a 256 "$@"
   else
     fatal "I could not find a suitable checksum binary to use" F0004

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -391,7 +391,7 @@ safe_sha256sum() {
   if command -v shasum > /dev/null 2>&1; then
     shasum -a 256 "$@"
   elif command -v sha256sum > /dev/null 2>&1; then
-    shasum -a 256 "$@"
+    sha256sum "$@"
   else
     fatal "I could not find a suitable checksum binary to use" F0004
   fi


### PR DESCRIPTION
##### Summary

Fixes: #12060

- `sha256sum` has a different syntax on FreeBSD
- `shasum` is not
- the fix is to prefer `shasum` over `sha256sum` when calculating checksums.

##### Test Plan

Run the kickstart.sh script on a FreeBSD box, ensure there is no checksum validation error.

##### Additional Information
