### PR TITLE
fix(collectors/cgroups): filter out all *libvirt cgroups by default

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -403,7 +403,7 @@ void read_cgroup_plugin_configuration() {
                     " !*.user "
                     " !/ "
                     " !/docker "
-                    " !/libvirt "
+                    " !*/libvirt "
                     " !/lxc "
                     " !/lxc/*/* "                          //  #1397 #2649
                     " !/lxc.monitor* "


### PR DESCRIPTION
##### Summary

Partial fix of #12434

##### Test Plan

Tested locally.

##### Additional Information
