### PR TITLE
fix install type in netdata-uninstaller.sh

### DIFF
--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -193,7 +193,7 @@ pkg_installed() {
 
 detect_existing_install
 
-if [ -x "$(command -v apt-get)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; then
+if [ -x "$(command -v apt-get)" ] && [ "${INSTALL_TYPE}" = "binpkg-deb" ]; then
   if dpkg -s netdata > /dev/null; then
     echo "Found netdata native installation"
     if user_input "Do you want to remove netdata? "; then
@@ -211,7 +211,7 @@ if [ -x "$(command -v apt-get)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"
     fi
     exit 0
   fi
-elif [ -x "$(command -v dnf)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; then
+elif [ -x "$(command -v dnf)" ] && [ "${INSTALL_TYPE}" = "binpkg-rpm" ]; then
   if rpm -q netdata > /dev/null; then
     echo "Found netdata native installation."
     if user_input "Do you want to remove netdata? "; then
@@ -229,7 +229,7 @@ elif [ -x "$(command -v dnf)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; 
     fi
     exit 0
   fi
-elif [ -x "$(command -v yum)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; then
+elif [ -x "$(command -v yum)" ] && [ "${INSTALL_TYPE}" = "binpkg-rpm" ]; then
   if rpm -q netdata > /dev/null; then
     echo "Found netdata native installation."
     if user_input "Do you want to remove netdata? "; then
@@ -247,7 +247,7 @@ elif [ -x "$(command -v yum)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; 
     fi
     exit 0
   fi
-elif [ -x "$(command -v zypper)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; then
+elif [ -x "$(command -v zypper)" ] && [ "${INSTALL_TYPE}" = "binpkg-rpm" ]; then
   if [ "${FLAG}" = "-y" ]; then
     FLAG=-n
   fi

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -83,7 +83,7 @@ user_input() {
   fi
 }
 
-if [ -x "$(command -v apt-get)" ]; then
+if [ -x "$(command -v apt-get)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; then
   if dpkg -s netdata > /dev/null; then
     echo "Found netdata native installation"
     if user_input "Do you want to remove netdata? "; then
@@ -101,7 +101,7 @@ if [ -x "$(command -v apt-get)" ]; then
     fi
     exit 0
   fi
-elif [ -x "$(command -v dnf)" ]; then
+elif [ -x "$(command -v dnf)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; then
   if rpm -q netdata > /dev/null; then
     echo "Found netdata native installation."
     if user_input "Do you want to remove netdata? "; then
@@ -119,7 +119,7 @@ elif [ -x "$(command -v dnf)" ]; then
     fi
     exit 0
   fi
-elif [ -x "$(command -v yum)" ]; then
+elif [ -x "$(command -v yum)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; then
   if rpm -q netdata > /dev/null; then
     echo "Found netdata native installation."
     if user_input "Do you want to remove netdata? "; then
@@ -137,7 +137,7 @@ elif [ -x "$(command -v yum)" ]; then
     fi
     exit 0
   fi
-elif [ -x "$(command -v zypper)" ]; then
+elif [ -x "$(command -v zypper)" ] && echo "${INSTALL_TYPE}" | grep -q "binpkg-*"; then
   if [ "${FLAG}" = "-y" ]; then
     FLAG=-n
   fi


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fix detection of install type when static or build installation was performed on a native-supported platform.

##### Test Plan
Installed netdata using static method on a native platform (e.g Ubuntu) and ran the uninstaller.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
