### PR TITLE
fix: CPU frequency detection of FreeBSD

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -218,8 +218,7 @@ else
   elif [ "${KERNEL_NAME}" = FreeBSD ]; then
     CPU_INFO_SOURCE="sysctl"
     LCPU_COUNT="$(sysctl -n kern.smp.cpus)"
-    possible_cpu_freq=$(sysctl -n machdep.tsc_freq 2> /dev/null)
-    if [ -z "$possible_cpu_freq" ]; then
+    if ! possible_cpu_freq=$(sysctl -n machdep.tsc_freq 2> /dev/null); then
       possible_cpu_freq=$(sysctl -n hw.model 2> /dev/null | grep -Eo "[0-9\.]+GHz" | grep -o "^[0-9\.]*" | awk '{print int($0*1000)}')
       [ -n "$possible_cpu_freq" ] && possible_cpu_freq="${possible_cpu_freq} MHz"
     fi

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -218,6 +218,11 @@ else
   elif [ "${KERNEL_NAME}" = FreeBSD ]; then
     CPU_INFO_SOURCE="sysctl"
     LCPU_COUNT="$(sysctl -n kern.smp.cpus)"
+    possible_cpu_freq=$(sysctl -n machdep.tsc_freq 2> /dev/null)
+    if [ -z "$possible_cpu_freq" ]; then
+      possible_cpu_freq=$(sysctl -n hw.model 2> /dev/null | grep -Eo "[0-9\.]+GHz" | grep -o "^[0-9\.]*" | awk '{print int($0*1000)}')
+      [ -n "$possible_cpu_freq" ] && possible_cpu_freq="${possible_cpu_freq} MHz"
+    fi
   elif [ "${KERNEL_NAME}" = Darwin ]; then
     CPU_INFO_SOURCE="sysctl"
     LCPU_COUNT="$(sysctl -n hw.logicalcpu)"


### PR DESCRIPTION
##### Summary

ssia

##### Test Plan

Tested on `FreeBSD freebsd 12.3-RELEASE FreeBSD 12.3-RELEASE r371126 GENERIC  amd64`:

- master branch

```cmd
wget -q -O system-info.sh https://raw.githubusercontent.com/netdata/netdata/master/daemon/system-info.sh; sh system-info.sh | grep -i freq; rm system-info.sh
NETDATA_SYSTEM_CPU_FREQ=unknown
```

- this PR

```cmd
wget -q -O system-info.sh https://raw.githubusercontent.com/ilyam8/netdata/fix_cpu_freq_freebsd/daemon/system-info.sh; sh system-info.sh | grep -i freq; rm system-info.sh
NETDATA_SYSTEM_CPU_FREQ=2400069742
```


##### Additional Information
