### PR TITLE
Skip `foreach` alarms for dimensions of anomaly rate chart.

### DIFF
--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -7,6 +7,10 @@ static inline void calc_link_to_rrddim(RRDDIM *rd)
 {
     RRDHOST *host = rd->rrdset->rrdhost;
     RRDSET  *st = rd->rrdset;
+
+    if (st->state && st->state->is_ar_chart)
+        return;
+
     if (host->alarms_with_foreach || host->alarms_template_with_foreach) {
         int count = 0;
         int hostlocked;


### PR DESCRIPTION
##### Summary

Health is not enabled for the anomaly rates chart. This was missed in
the original PR that added support for tracking anomaly rates with
dbengine. The side-effect was that the agent would block when opening
the dashboard before its initialization was done.

##### Test Plan

- Local & CI jobs.
- Start an agent with `[ml] enabled = true` and quickly visit the dashboard.

##### Additional Information

Somewhat related to https://github.com/netdata/netdata/issues/12316, in the sense that it made the problem more pronounced because we'd end up write-locking the host ~2x as much.