### PR TITLE
fix(cups.plugin): add `cups` prefix to chart context

### DIFF
--- a/collectors/cups.plugin/cups_plugin.c
+++ b/collectors/cups.plugin/cups_plugin.c
@@ -375,12 +375,12 @@ int main(int argc, char **argv) {
         if (unlikely(!cups_printer_by_option_created))
         {
             cups_printer_by_option_created = 1;
-            printf("CHART cups.dest_state '' 'Destinations by state' dests overview cups.dests stacked 100000 %i\n", netdata_update_every);
+            printf("CHART cups.dest_state '' 'Destinations by state' dests overview cups.dests_state stacked 100000 %i\n", netdata_update_every);
             printf("DIMENSION idle '' absolute 1 1\n");
             printf("DIMENSION printing '' absolute 1 1\n");
             printf("DIMENSION stopped '' absolute 1 1\n");
 
-            printf("CHART cups.dest_option '' 'Destinations by option' dests overview cups.dests line 100001 %i\n", netdata_update_every);
+            printf("CHART cups.dest_option '' 'Destinations by option' dests overview cups.dests_option line 100001 %i\n", netdata_update_every);
             printf("DIMENSION total '' absolute 1 1\n");
             printf("DIMENSION acceptingjobs '' absolute 1 1\n");
             printf("DIMENSION shared '' absolute 1 1\n");

--- a/collectors/cups.plugin/cups_plugin.c
+++ b/collectors/cups.plugin/cups_plugin.c
@@ -161,12 +161,12 @@ struct job_metrics *get_job_metrics(char *dest) {
         reset_job_metrics(&new_job_metrics, NULL);
         jm = dictionary_set(dict_dest_job_metrics, dest, &new_job_metrics, sizeof(struct job_metrics));
 
-        printf("CHART cups.job_num_%s '' 'Active job number of destination %s' jobs '%s' job_num stacked %i %i\n", dest, dest, dest, netdata_priority++, netdata_update_every);
+        printf("CHART cups.job_num_%s '' 'Active job number of destination %s' jobs '%s' cups.job_num stacked %i %i\n", dest, dest, dest, netdata_priority++, netdata_update_every);
         printf("DIMENSION pending '' absolute 1 1\n");
         printf("DIMENSION held '' absolute 1 1\n");
         printf("DIMENSION processing '' absolute 1 1\n");
 
-        printf("CHART cups.job_size_%s '' 'Active job size of destination %s' KB '%s' job_size stacked %i %i\n", dest, dest, dest, netdata_priority++, netdata_update_every);
+        printf("CHART cups.job_size_%s '' 'Active job size of destination %s' KB '%s' cups.job_size stacked %i %i\n", dest, dest, dest, netdata_priority++, netdata_update_every);
         printf("DIMENSION pending '' absolute 1 1\n");
         printf("DIMENSION held '' absolute 1 1\n");
         printf("DIMENSION processing '' absolute 1 1\n");
@@ -195,12 +195,12 @@ int collect_job_metrics(char *name, void *entry, void *data) {
             "END\n",
             name, jm->size_pending, jm->size_held, jm->size_processing);
     } else {
-        printf("CHART cups.job_num_%s '' 'Active job number of destination %s' jobs '%s' job_num stacked 1 %i 'obsolete'\n", name, name, name, netdata_update_every);
+        printf("CHART cups.job_num_%s '' 'Active job number of destination %s' jobs '%s' cups.job_num stacked 1 %i 'obsolete'\n", name, name, name, netdata_update_every);
         printf("DIMENSION pending '' absolute 1 1\n");
         printf("DIMENSION held '' absolute 1 1\n");
         printf("DIMENSION processing '' absolute 1 1\n");
 
-        printf("CHART cups.job_size_%s '' 'Active job size of destination %s' KB '%s' job_size stacked 1 %i 'obsolete'\n", name, name, name, netdata_update_every);
+        printf("CHART cups.job_size_%s '' 'Active job size of destination %s' KB '%s' cups.job_size stacked 1 %i 'obsolete'\n", name, name, name, netdata_update_every);
         printf("DIMENSION pending '' absolute 1 1\n");
         printf("DIMENSION held '' absolute 1 1\n");
         printf("DIMENSION processing '' absolute 1 1\n");
@@ -375,22 +375,22 @@ int main(int argc, char **argv) {
         if (unlikely(!cups_printer_by_option_created))
         {
             cups_printer_by_option_created = 1;
-            printf("CHART cups.dest_state '' 'Destinations by state' dests overview dests stacked 100000 %i\n", netdata_update_every);
+            printf("CHART cups.dest_state '' 'Destinations by state' dests overview cups.dests stacked 100000 %i\n", netdata_update_every);
             printf("DIMENSION idle '' absolute 1 1\n");
             printf("DIMENSION printing '' absolute 1 1\n");
             printf("DIMENSION stopped '' absolute 1 1\n");
 
-            printf("CHART cups.dest_option '' 'Destinations by option' dests overview dests line 100001 %i\n", netdata_update_every);
+            printf("CHART cups.dest_option '' 'Destinations by option' dests overview cups.dests line 100001 %i\n", netdata_update_every);
             printf("DIMENSION total '' absolute 1 1\n");
             printf("DIMENSION acceptingjobs '' absolute 1 1\n");
             printf("DIMENSION shared '' absolute 1 1\n");
 
-            printf("CHART cups.job_num '' 'Total active job number' jobs overview job_num stacked 100002 %i\n", netdata_update_every);
+            printf("CHART cups.job_num '' 'Total active job number' jobs overview cups.job_num stacked 100002 %i\n", netdata_update_every);
             printf("DIMENSION pending '' absolute 1 1\n");
             printf("DIMENSION held '' absolute 1 1\n");
             printf("DIMENSION processing '' absolute 1 1\n");
 
-            printf("CHART cups.job_size '' 'Total active job size' KB overview job_size stacked 100003 %i\n", netdata_update_every);
+            printf("CHART cups.job_size '' 'Total active job size' KB overview cups.job_size stacked 100003 %i\n", netdata_update_every);
             printf("DIMENSION pending '' absolute 1 1\n");
             printf("DIMENSION held '' absolute 1 1\n");
             printf("DIMENSION processing '' absolute 1 1\n");


### PR DESCRIPTION
##### Summary

Fixes: #12447

Using the plugin name as a prefix is a common pattern we use (almost) everywhere. This PR applies this pattern to `cups.plugin`.

Lack of prefix is a problem for the Cloud overview page.

##### Test Plan

Not needed

##### Additional Information
