### PR TITLE
Add delay on missing priv_key

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -144,7 +144,7 @@ static int wait_till_agent_claim_ready()
         // TODO make it without malloc/free
         memset(&url, 0, sizeof(url_t));
         if (url_parse(cloud_base_url, &url)) {
-            error("Agent is claimed but the configuration is invalid, please fix");
+            error("Agent is claimed but the URL in configuration key \"cloud base url\" is invalid, please fix");
             url_t_destroy(&url);
             sleep(5);
             continue;

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -123,7 +123,7 @@ static int wait_till_agent_claimed(void)
  * @param aclk_hostname points to location where string pointer to hostname will be set
  * @param aclk_port port to int where port will be saved
  * 
- * @return If non 0 returned irrecoverable error happened and ACLK should be terminated
+ * @return If non 0 returned irrecoverable error happened (or netdata_exit) and ACLK should be terminated
  */
 static int wait_till_agent_claim_ready()
 {
@@ -151,13 +151,13 @@ static int wait_till_agent_claim_ready()
         }
         url_t_destroy(&url);
 
-        if (!load_private_key()) {
-            sleep(5);
-            break;
-        }
+        if (!load_private_key())
+            return 0;
+
+        sleep(5);
     }
 
-    return 0;
+    return 1;
 }
 
 void aclk_mqtt_wss_log_cb(mqtt_wss_log_type_t log_type, const char* str)


### PR DESCRIPTION
##### Summary
If `claim_id` contains a valid UUID agent is considered claimed. But if due to some error private key file is missing we were retrying immediately causing high CPU load and noise in log.

##### Test Plan
claim agent and delete `/var/lib/netdata/cloud.d/private.pem`, agent should retry log once per 5 seconds not go into retry loop

##### Additional Information
