### PR TITLE
Add support for passing extra claiming options when claiming with Docker.

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -45,10 +45,12 @@ if [ -n "${PGID}" ]; then
 fi
 
 if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/cloud.d/claimed_id ]; then
+  # shellcheck disable=SC2086
   /usr/sbin/netdata-claim.sh -token="${NETDATA_CLAIM_TOKEN}" \
                              -url="${NETDATA_CLAIM_URL}" \
                              ${NETDATA_CLAIM_ROOMS:+-rooms="${NETDATA_CLAIM_ROOMS}"} \
                              ${NETDATA_CLAIM_PROXY:+-proxy="${NETDATA_CLAIM_PROXY}"} \
+                             ${NETDATA_EXTRA_CLAIM_OPTS} \
                              -daemon-not-running
 fi
 


### PR DESCRIPTION
##### Summary

This adds a new environment variable to our entrypoint script named `NETDATA_EXTRA_CLAIM_OPTS`. The contents of this variable will be passed directly (with word splitting) to the claiming script if it is invoked by the Docker entrypoint, allowing passing of arbitrary additional options.

##### Test Plan

A simple test with a locally built Docker image can be done by adding `-e NETDATA_EXTRA_CLAIM_OPTS=-verbose` to the options passed to `docker run` when creating the image.

Without the changes in this PR, the claiming process should produce it’s normal terse output.

With the changes in this PR, the claiming process should produce verbose output.