### PR TITLE
Add basic support for cloud provider instance information in system info.

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -403,29 +403,32 @@ CLOUD_INSTANCE_REGION="unknown"
 if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
   # Try AWS IMDSv2
   if [ "${CLOUD_TYPE}" = "unknown" ]; then
-    AWS_IMDS_TOKEN="$(curl -s -m 5 --noproxy -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+    AWS_IMDS_TOKEN="$(curl --fail -s -m 5 --noproxy "*" -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
     if [ -n "${AWS_IMDS_TOKEN}" ]; then
       CLOUD_TYPE="AWS"
-      CLOUD_INSTANCE_TYPE="$(curl -s -m 5 --noproxy -H "X-aws-ec2-metadata-token: $TOKEN" -v "http://169.254.169.254/latest/meta-data/instance-type")"
-      CLOUD_INSTANCE_REGION="$(curl -s -m 5 --noproxy -H "X-aws-ec2-metadata-token: $TOKEN" -v "http://169.254.169.254/latest/meta-data/placement/region")"
+      CLOUD_INSTANCE_TYPE="$(curl --fail -s -m 5 --noproxy "*" -H "X-aws-ec2-metadata-token: $TOKEN" -v "http://169.254.169.254/latest/meta-data/instance-type")"
+      CLOUD_INSTANCE_REGION="$(curl --fail -s -m 5 --noproxy "*" -H "X-aws-ec2-metadata-token: $TOKEN" -v "http://169.254.169.254/latest/meta-data/placement/region")"
     fi
   fi
 
   # Try GCE computeMetadata v1
   if [ "${CLOUD_TYPE}" = "unknown" ]; then
-    if [ -n "$(curl -s -m 5 --noproxy -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1")" ]; then
+    if [ -n "$(curl --fail -s -m 5 --noproxy "*" -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1")" ]; then
       CLOUD_TYPE="GCP"
-      CLOUD_INSTANCE_TYPE="$(curl -s -m 5 --noproxy -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/machine-type")"
+      CLOUD_INSTANCE_TYPE="$(curl --fail -s -m 5 --noproxy "*" -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/machine-type")"
+      [ -n "$CLOUD_INSTANCE_TYPE" ] && CLOUD_INSTANCE_TYPE=$(basename "$CLOUD_INSTANCE_TYPE")
+      CLOUD_INSTANCE_REGION="$(curl --fail -s -m 5 --noproxy "*" -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/zone")"
+      [ -n "$CLOUD_INSTANCE_REGION" ] && CLOUD_INSTANCE_REGION=$(basename "$CLOUD_INSTANCE_REGION") && CLOUD_INSTANCE_REGION=${CLOUD_INSTANCE_REGION%-*}
     fi
   fi
 
   # Try Azure IMDS
   if [ "${CLOUD_TYPE}" = "unknown" ]; then
-    AZURE_IMDS_DATA="$(curl -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?version=2021-10-01")"
+    AZURE_IMDS_DATA="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?version=2021-10-01")"
     if [ -n "${AZURE_IMDS_DATA}" ]; then
       CLOUD_TYPE="Azure"
-      CLOUD_INSTANCE_TYPE="$(curl -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?version=2021-10-01&format=text")"
-      CLOUD_INSTANCE_REGION="$(curl -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/location?version=2021-10-01&format=text")"
+      CLOUD_INSTANCE_TYPE="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?version=2021-10-01&format=text")"
+      CLOUD_INSTANCE_REGION="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/location?version=2021-10-01&format=text")"
     fi
   fi
 fi

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -406,8 +406,8 @@ if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
     AWS_IMDS_TOKEN="$(curl --fail -s -m 5 --noproxy "*" -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
     if [ -n "${AWS_IMDS_TOKEN}" ]; then
       CLOUD_TYPE="AWS"
-      CLOUD_INSTANCE_TYPE="$(curl --fail -s -m 5 --noproxy "*" -H "X-aws-ec2-metadata-token: $TOKEN" -v "http://169.254.169.254/latest/meta-data/instance-type")"
-      CLOUD_INSTANCE_REGION="$(curl --fail -s -m 5 --noproxy "*" -H "X-aws-ec2-metadata-token: $TOKEN" -v "http://169.254.169.254/latest/meta-data/placement/region")"
+      CLOUD_INSTANCE_TYPE="$(curl --fail -s -m 5 --noproxy "*" -H "X-aws-ec2-metadata-token: $AWS_IMDS_TOKEN" -v "http://169.254.169.254/latest/meta-data/instance-type" 2> /dev/null)"
+      CLOUD_INSTANCE_REGION="$(curl --fail -s -m 5 --noproxy "*" -H "X-aws-ec2-metadata-token: $AWS_IMDS_TOKEN" -v "http://169.254.169.254/latest/meta-data/placement/region" 2> /dev/null)"
     fi
   fi
 


### PR DESCRIPTION
##### Summary

This provides a basic level of support for retrieving VM instance information from various cloud providers as part of gathering system information.

This adds three new variables in the output of `system-info.sh`:

- `NETDATA_CLOUD_TYPE`: Contains an identifier indicating the cloud provider we detected when attempting to fetch metadata.
- `NETDATA_CLOUD_INSTANCE_TYPE`: Contains an identifier indicating the VM instance type for this system, as indicated by the cloud provider in the instance metadata. Valid values vary by provider.
- `NETDATA_CLOUD_INSTANCE_REGION`: Contains an identifier indicating the region the system is running in as indicated by the cloud provider in the instance metadata, Valid values vary by provider (this is intended to be used for automatic host label generation).

If the system is detected as being virtualized _and_ `curl` is installed, we attempt to retrieve instance metadata via a number of standard methods and fill in the values of these variables. If we cannot retrieve the data for some reason, can’t find `curl`, or are not running virtualized, these variables will all show a value of `unknown`.

This implementation currently provides support for:

- AWS EC2 (based on documentation at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html), providing values for all three variables, identified as `AWS`. May also work for AWS Lightsail, but I could find nothing conclusive regarding that.
- GCP GCE (based on documentation at https://cloud.google.com/compute/docs/metadata/overview), providing values for `CLOUD_TYPE` and `CLOUD_INSTANCE_TYPE` (region information does not appear to be provided in a useful format here), identified as `GCP`
- MS Azure (based on documentation at https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=linux), providing values for all three variables, identified as `Azure`

Note that if running inside a container, this _may or may not_ provide information about the container host if it is virtualized and running on a supported provider. We are dependent in that case on the container networking configuration.

##### Test Plan

This can be tested by running the `system-info.sh` script from this PR on VMs from each of the supported providers.

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/12432

Note that this is largely untested (I do not have readily available access to any of the three platforms it’s adding support for).