### PR TITLE
Updated static build components to latest versions.

### DIFF
--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -7,6 +7,9 @@
 #
 # Author: Paul Emm. Katsoulakis <paul@netdata.cloud>
 
+apk update ||exit 1
+apk upgrade || exit 1
+
 # Add required APK packages
 apk add --no-cache -U \
   alpine-sdk \

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -7,7 +7,7 @@
 #
 # Author: Paul Emm. Katsoulakis <paul@netdata.cloud>
 
-apk update ||exit 1
+apk update || exit 1
 apk upgrade || exit 1
 
 # Add required APK packages

--- a/packaging/makeself/jobs/50-bash-5.1.16.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.1.16.install.sh
@@ -7,8 +7,8 @@
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::building bash" || true
 
-fetch "bash-5.1.8" "http://ftp.gnu.org/gnu/bash/bash-5.1.8.tar.gz" \
-    0cfb5c9bb1a29f800a97bd242d19511c997a1013815b805e0fdd32214113d6be
+fetch "bash-5.1.16" "http://ftp.gnu.org/gnu/bash/bash-5.1.16.tar.gz" \
+    5bac17218d3911834520dad13cd1f85ab944e1c09ae1aba55906be1f8192f558
 
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 

--- a/packaging/makeself/jobs/50-curl-7.82.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.82.0.install.sh
@@ -7,8 +7,8 @@
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building cURL" || true
 
-fetch "curl-7.78.0" "https://curl.haxx.se/download/curl-7.78.0.tar.gz" \
-    ed936c0b02c06d42cf84b39dd12bb14b62d77c7c4e875ade022280df5dcc81d7
+fetch "curl-7.82.0" "https://curl.haxx.se/download/curl-7.82.0.tar.gz" \
+    910cc5fe279dc36e2cca534172c94364cf3fcf7d6494ba56e6c61a390881ddce
 
 export CFLAGS="-I/openssl-static/include"
 export LDFLAGS="-static -L/openssl-static/lib"

--- a/packaging/makeself/jobs/50-fping-5.1.install.sh
+++ b/packaging/makeself/jobs/50-fping-5.1.install.sh
@@ -7,8 +7,8 @@
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building fping" || true
 
-fetch "fping-5.0" "https://fping.org/dist/fping-5.0.tar.gz" \
-    ed38c0b9b64686a05d1b3bc1d66066114a492e04e44eef1821d43b1263cd57b8
+fetch "fping-5.1" "https://fping.org/dist/fping-5.1.tar.gz" \
+    1ee5268c063d76646af2b4426052e7d81a42b657e6a77d8e7d3d2e60fd7409fe
 
 export CFLAGS="-static -I/openssl-static/include"
 export LDFLAGS="-static -L/openssl-static/lib"

--- a/packaging/makeself/openssl.version
+++ b/packaging/makeself/openssl.version
@@ -1,1 +1,1 @@
-OpenSSL_1_1_1l
+OpenSSL_1_1_1n


### PR DESCRIPTION
Changes:

1. `apk update` is run to update alpine packages
2. `apk upgrade` to install any updates alpine packages
3. `bash` updated to version 5.1.16
4. `openssl` updated to version 1.1.1n
5. `fping` updated to version 5.1
6. `curl` updated to version 7.82

It builds and runs. Tested armv7l version.