### PR TITLE
Don't send an alert snapshot with snapshot_id 0

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -659,6 +659,8 @@ void aclk_process_send_alarm_snapshot(char *node_id, char *claim_id, uint64_t sn
             wc->host ? wc->host->hostname : "N/A",
             snapshot_id,
             sequence_id);
+        if (wc->alerts_snapshot_id == snapshot_id)
+            return;
         __sync_synchronize();
         wc->alerts_snapshot_id = snapshot_id;
         wc->alerts_ack_sequence_id = sequence_id;
@@ -780,6 +782,9 @@ void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, stru
         error_report("ACLK synchronization thread for %s is not linked to HOST", wc->host_guid);
         return;
     }
+
+    if (unlikely(!wc->alerts_snapshot_id))
+        return;
 
     char *claim_id = is_agent_claimed();
     if (unlikely(!claim_id))


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

This PR tries to help with the case where the cloud requests multiple alert snapshots from the agent before the agent had time to respond.

When the cloud requests a snapshot, we store in `wc` the snapshot_id provided by the cloud, and queue a command to reply to that request. The reply will contain the snapshot_id send by the cloud. When the reply is finished, the agent sets this snapshot_id to 0.

There are cases where the cloud sends 2 snapshot requests with the same snapshot_id, at the same time. When this happens, the agent sends back a snapshot reply with the correct snapshot_id and another reply with snapshot_id 0. The cloud can not process the last reply.

With this PR, we cover:

1) Never send back a snapshot with snapshot_id 0.
2) If a second request comes with the same snapshot_id before the agent has replied, do not queue a second response.
3) If a second request comes with another snapshot_id than currently stored in `wc`, reply with one snapshot using the second snapshot_id.

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

It can be tricky to test, but there is a way. In function `aclk_push_alert_event` during the loop where alert events are sent, the function `aclk_process_send_alarm_snapshot` can be called to simulate a snapshot request from the cloud. We can pick a time during the loop where this happens by adding a simple if:

```
        if (!strcmp (alarm_log.name, "load_cpu_number")) {
            aclk_process_send_alarm_snapshot(wc->node_id, claim_id, 12, 28);
            aclk_process_send_alarm_snapshot(wc->node_id, claim_id, 12, 28);
        }
```

Without this PR, if the above is running, you will see in `access.log`:

```
2022-03-21 11:49:22: IN [62375427-e2af-407c-b717-ade294d7a602 (6am)]: Request to send alerts snapshot, snapshot_id 12 and ack_sequence_id 28
2022-03-21 11:49:22: IN [62375427-e2af-407c-b717-ade294d7a602 (6am)]: Request to send alerts snapshot, snapshot_id 12 and ack_sequence_id 28
2022-03-21 11:49:22: OG [62375427-e2af-407c-b717-ade294d7a602 (6am)]: Sending alerts snapshot, snapshot_id 12
2022-03-21 11:49:22: OG [62375427-e2af-407c-b717-ade294d7a602 (6am)]: Sending alerts snapshot, snapshot_id 0
```