### PR TITLE
Configurable storage engine for Netdata agents

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -443,6 +443,10 @@ RRD_PLUGIN_FILES = \
     database/rrdsetvar.h \
     database/rrdvar.c \
     database/rrdvar.h \
+    database/rrddim_mem.c \
+    database/rrddim_mem.h \
+    database/storage_engine.c \
+    database/storage_engine.h \
     database/sqlite/sqlite_functions.c \
     database/sqlite/sqlite_functions.h \
     database/sqlite/sqlite_aclk.c \

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -2,6 +2,9 @@
 
 #include "common.h"
 #include "buildinfo.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 struct analytics_data analytics_data;
 extern void analytics_exporting_connectors (BUFFER *b);

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "common.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 #define GLOBAL_STATS_RESET_WEB_USEC_MAX 0x01
 
@@ -526,17 +529,20 @@ static void global_statistics_charts(void) {
     rrd_rdlock();
     rrdhost_foreach_read(host) {
         if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && !rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
-            if (&multidb_ctx == host->rrdeng_ctx) {
+            STORAGE_ENGINE* eng = host->rrdeng_ctx->engine;
+            if (eng->multidb_instance == host->rrdeng_ctx) {
                 if (counted_multihost_db)
                     continue; /* Only count multi-host DB once */
                 counted_multihost_db = 1;
             }
-            ++dbengine_contexts;
-            /* get localhost's DB engine's statistics */
-            rrdeng_get_37_statistics(host->rrdeng_ctx, local_stats_array);
-            for (i = 0 ; i < RRDENG_NR_STATS ; ++i) {
-                /* aggregate statistics across hosts */
-                stats_array[i] += local_stats_array[i];
+            if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+                ++dbengine_contexts;
+                /* get localhost's DB engine's statistics */
+                rrdeng_get_37_statistics((struct rrdengine_instance*)host->rrdeng_ctx, local_stats_array);
+                for (i = 0 ; i < RRDENG_NR_STATS ; ++i) {
+                    /* aggregate statistics across hosts */
+                    stats_array[i] += local_stats_array[i];
+                }
             }
         }
     }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -3,6 +3,10 @@
 #include "common.h"
 #include "buildinfo.h"
 #include "static_threads.h"
+#include "database/storage_engine.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 int netdata_zero_metrics_enabled;
 int netdata_anonymous_statistics_enabled;
@@ -54,13 +58,18 @@ void netdata_cleanup_and_exit(int ret) {
 
         // free the database
         info("EXIT: freeing database memory...");
-#ifdef ENABLE_DBENGINE
-        rrdeng_prepare_exit(&multidb_ctx);
-#endif
+        for (STORAGE_ENGINE* eng = engine_foreach_init(); eng; eng = engine_foreach_next(eng)) {
+            if (eng->multidb_instance && eng->api.engine_ops.exit)
+                eng->api.engine_ops.exit(eng->multidb_instance);
+        }
+
         rrdhost_free_all();
-#ifdef ENABLE_DBENGINE
-        rrdeng_exit(&multidb_ctx);
-#endif
+        for (STORAGE_ENGINE* eng = engine_foreach_init(); eng; eng = engine_foreach_next(eng)) {
+            if (eng->multidb_instance && eng->api.engine_ops.exit) {
+                eng->api.engine_ops.destroy(eng->multidb_instance);
+                eng->multidb_instance = NULL;
+            }
+        }
     }
     sql_close_database();
 

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "common.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 static int check_number_printing(void) {
     struct {
@@ -1157,7 +1160,7 @@ int run_test(struct test *test)
     RRDSET *st = rrdset_create_localhost("netdata", name, name, "netdata", NULL, "Unit Testing", "a value", "unittest", NULL, 1
                                          , test->update_every, RRDSET_TYPE_LINE);
     RRDDIM *rd = rrddim_add(st, "dim1", NULL, test->multiplier, test->divisor, test->algorithm);
-    
+
     RRDDIM *rd2 = NULL;
     if(test->feed2)
         rd2 = rrddim_add(st, "dim2", NULL, test->multiplier, test->divisor, test->algorithm);
@@ -1173,7 +1176,7 @@ int run_test(struct test *test)
 
         if(c) {
             time_now += test->feed[c].microseconds;
-            fprintf(stderr, "    > %s: feeding position %lu, after %0.3f seconds (%0.3f seconds from start), delta " CALCULATED_NUMBER_FORMAT ", rate " CALCULATED_NUMBER_FORMAT "\n", 
+            fprintf(stderr, "    > %s: feeding position %lu, after %0.3f seconds (%0.3f seconds from start), delta " CALCULATED_NUMBER_FORMAT ", rate " CALCULATED_NUMBER_FORMAT "\n",
                 test->name, c+1,
                 (float)test->feed[c].microseconds / 1000000.0,
                 (float)time_now / 1000000.0,
@@ -1893,9 +1896,9 @@ int test_dbengine(void)
     }
 error_out:
     rrd_wrlock();
-    rrdeng_prepare_exit(host->rrdeng_ctx);
+    rrdeng_prepare_exit((struct rrdengine_instance*)host->rrdeng_ctx);
     rrdhost_delete_charts(host);
-    rrdeng_exit(host->rrdeng_ctx);
+    rrdeng_exit((struct rrdengine_instance*)host->rrdeng_ctx);
     rrd_unlock();
 
     return errors;
@@ -2285,9 +2288,9 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
     }
     freez(query_threads);
     rrd_wrlock();
-    rrdeng_prepare_exit(host->rrdeng_ctx);
+    rrdeng_prepare_exit((struct rrdengine_instance*)host->rrdeng_ctx);
     rrdhost_delete_charts(host);
-    rrdeng_exit(host->rrdeng_ctx);
+    rrdeng_exit((struct rrdengine_instance*)host->rrdeng_ctx);
     rrd_unlock();
 }
 

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -1284,13 +1284,12 @@ error_after_loop_init:
  */
 void rrdengine_main(void)
 {
-    int ret;
     struct rrdengine_instance *ctx;
 
     sanity_check();
-    ret = rrdeng_init(NULL, &ctx, "/tmp", RRDENG_MIN_PAGE_CACHE_SIZE_MB, RRDENG_MIN_DISK_SPACE_MB);
-    if (ret) {
-        exit(ret);
+    ctx = (struct rrdengine_instance *)rrdeng_init(engine_get(RRD_MEMORY_MODE_DBENGINE), NULL);
+    if (!ctx) {
+        exit(1);
     }
     rrdeng_exit(ctx);
     fprintf(stderr, "Hello world!");

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -13,6 +13,7 @@
 #include <openssl/evp.h>
 #include "daemon/common.h"
 #include "../rrd.h"
+#include "../storage_engine.h"
 #include "rrddiskprotocol.h"
 #include "rrdenginelib.h"
 #include "datafile.h"
@@ -220,6 +221,7 @@ extern rrdeng_stats_t global_flushing_pressure_page_deletions; /* number of dele
 #define QUIESCED    (2) /* is set after all threads have finished running */
 
 struct rrdengine_instance {
+    STORAGE_ENGINE_INSTANCE parent;
     struct metalog_instance *metalog_ctx;
     struct rrdengine_worker_config worker_config;
     struct completion rrdengine_completion;

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -34,6 +34,22 @@ struct rrdengine_instance;
 #define RRDENG_FILE_NUMBER_SCAN_TMPL "%1u-%10u"
 #define RRDENG_FILE_NUMBER_PRINT_TMPL "%1.1u-%10.10u"
 
+struct rrdeng_collect_handle {
+    struct rrdeng_page_descr *descr, *prev_descr;
+    unsigned long page_correlation_id;
+    struct rrdengine_instance *ctx;
+    // set to 1 when this dimension is not page aligned with the other dimensions in the chart
+    uint8_t unaligned_page;
+};
+
+struct rrdeng_query_handle {
+    struct rrdeng_page_descr *descr;
+    struct rrdengine_instance *ctx;
+    struct pg_cache_page_index *page_index;
+    time_t next_page_time;
+    time_t now;
+    unsigned position;
+};
 
 typedef enum {
     RRDENGINE_STATUS_UNINITIALIZED = 0,

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "rrdengine.h"
-
-/* Default global database instance */
-struct rrdengine_instance multidb_ctx;
+#include "../storage_engine.h"
 
 int default_rrdeng_page_cache_mb = 32;
 int default_rrdeng_disk_quota_mb = 256;
@@ -12,7 +10,7 @@ uint8_t rrdeng_drop_metrics_under_page_cache_pressure = 1;
 
 static inline struct rrdengine_instance *get_rrdeng_ctx_from_host(RRDHOST *host)
 {
-    return host->rrdeng_ctx;
+    return (struct rrdengine_instance*) host->rrdeng_ctx;
 }
 
 /* This UUID is not unique across hosts */
@@ -68,7 +66,7 @@ void rrdeng_metric_init(RRDDIM *rd)
     pg_cache = &ctx->pg_cache;
 
     rrdeng_generate_legacy_uuid(rd->id, rd->rrdset->id, &legacy_uuid);
-    if (host != localhost && host->rrdeng_ctx == &multidb_ctx)
+    if (host != localhost && host->rrdeng_ctx->engine && host->rrdeng_ctx == host->rrdeng_ctx->engine->multidb_instance)
         is_multihost_child = 1;
 
     uv_rwlock_rdlock(&pg_cache->metrics_index.lock);
@@ -213,15 +211,11 @@ void rrdeng_store_metric_flush_current_page(RRDDIM *rd)
 void rrdeng_store_metric_next(RRDDIM *rd, usec_t point_in_time, storage_number number)
 {
     struct rrdeng_collect_handle *handle = (struct rrdeng_collect_handle *)rd->state->handle;
-    struct rrdengine_instance *ctx;
-    struct page_cache *pg_cache;
-    struct rrdeng_page_descr *descr;
+    struct rrdengine_instance *ctx = handle->ctx;
+    struct page_cache *pg_cache = &ctx->pg_cache;
+    struct rrdeng_page_descr *descr = handle->descr;
     storage_number *page;
     uint8_t must_flush_unaligned_page = 0, perfect_page_alignment = 0;
-
-    ctx = handle->ctx;
-    pg_cache = &ctx->pg_cache;
-    descr = handle->descr;
 
     if (descr) {
         /* Make alignment decisions */
@@ -880,11 +874,9 @@ void rrdeng_put_page(struct rrdengine_instance *ctx, void *handle)
     pg_cache_put(ctx, (struct rrdeng_page_descr *)handle);
 }
 
-/*
- * Returns 0 on success, negative on error
- */
-int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_path, unsigned page_cache_mb,
-                unsigned disk_space_mb)
+
+STORAGE_ENGINE_INSTANCE*
+rrdeng_init(STORAGE_ENGINE* eng, RRDHOST *host)
 {
     struct rrdengine_instance *ctx;
     int error;
@@ -901,15 +893,19 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
 
         rrd_stat_atomic_add(&global_fs_errors, 1);
         rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
-        return UV_EMFILE;
+        return NULL;//UV_EMFILE;
     }
+    char dbfiles_path[FILENAME_MAX + 1];
+    int ret;
 
-    if (NULL == ctxp) {
-        ctx = &multidb_ctx;
-        memset(ctx, 0, sizeof(*ctx));
-    } else {
-        *ctxp = ctx = callocz(1, sizeof(*ctx));
-    }
+    snprintfz(dbfiles_path, FILENAME_MAX, "%s/dbengine", host->cache_dir);
+    ret = mkdir(dbfiles_path, 0775);
+
+    int page_cache_mb = default_rrdeng_page_cache_mb;
+    int disk_space_mb = default_rrdeng_disk_quota_mb;
+
+    ctx = callocz(1, sizeof(*ctx));
+    ctx->parent.engine = eng;
     ctx->global_compress_alg = RRD_LZ4;
     if (page_cache_mb < RRDENG_MIN_PAGE_CACHE_SIZE_MB)
         page_cache_mb = RRDENG_MIN_PAGE_CACHE_SIZE_MB;
@@ -956,18 +952,15 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
         goto error_after_rrdeng_worker;
     }
 
-    return 0;
+    return (STORAGE_ENGINE_INSTANCE *)ctx;
 
 error_after_rrdeng_worker:
     finalize_rrd_files(ctx);
 error_after_init_rrd_files:
     free_page_cache(ctx);
-    if (ctx != &multidb_ctx) {
-        freez(ctx);
-        *ctxp = NULL;
-    }
+    freez(ctx);
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
-    return UV_EIO;
+    return NULL;//UV_EIO;
 }
 
 /*
@@ -990,10 +983,7 @@ int rrdeng_exit(struct rrdengine_instance *ctx)
     finalize_rrd_files(ctx);
     //metalog_exit(ctx->metalog_ctx);
     free_page_cache(ctx);
-
-    if (ctx != &multidb_ctx) {
-        freez(ctx);
-    }
+    freez(ctx);
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
     return 0;
 }

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -126,12 +126,13 @@ void rrdeng_store_metric_init(RRDDIM *rd)
     struct pg_cache_page_index *page_index;
 
     ctx = get_rrdeng_ctx_from_host(rd->rrdset->rrdhost);
-    handle = &rd->state->handle.rrdeng;
-    handle->ctx = ctx;
 
+    handle = callocz(1, sizeof(struct rrdeng_collect_handle));
+    handle->ctx = ctx;
     handle->descr = NULL;
     handle->prev_descr = NULL;
     handle->unaligned_page = 0;
+    rd->state->handle = (STORAGE_COLLECT_HANDLE *)handle;
 
     page_index = rd->state->page_index;
     uv_rwlock_wrlock(&page_index->lock);
@@ -162,7 +163,7 @@ void rrdeng_store_metric_flush_current_page(RRDDIM *rd)
     struct rrdengine_instance *ctx;
     struct rrdeng_page_descr *descr;
 
-    handle = &rd->state->handle.rrdeng;
+    handle = (struct rrdeng_collect_handle *)rd->state->handle;
     ctx = handle->ctx;
     if (unlikely(!ctx))
         return;
@@ -211,14 +212,13 @@ void rrdeng_store_metric_flush_current_page(RRDDIM *rd)
 
 void rrdeng_store_metric_next(RRDDIM *rd, usec_t point_in_time, storage_number number)
 {
-    struct rrdeng_collect_handle *handle;
+    struct rrdeng_collect_handle *handle = (struct rrdeng_collect_handle *)rd->state->handle;
     struct rrdengine_instance *ctx;
     struct page_cache *pg_cache;
     struct rrdeng_page_descr *descr;
     storage_number *page;
     uint8_t must_flush_unaligned_page = 0, perfect_page_alignment = 0;
 
-    handle = &rd->state->handle.rrdeng;
     ctx = handle->ctx;
     pg_cache = &ctx->pg_cache;
     descr = handle->descr;
@@ -301,7 +301,7 @@ int rrdeng_store_metric_finalize(RRDDIM *rd)
     struct pg_cache_page_index *page_index;
     uint8_t can_delete_metric = 0;
 
-    handle = &rd->state->handle.rrdeng;
+    handle = (struct rrdeng_collect_handle *)rd->state->handle;
     ctx = handle->ctx;
     page_index = rd->state->page_index;
     rrdeng_store_metric_flush_current_page(rd);
@@ -314,6 +314,7 @@ int rrdeng_store_metric_finalize(RRDDIM *rd)
         can_delete_metric = 1;
     }
     uv_rwlock_wrunlock(&page_index->lock);
+    freez(handle);
 
    return can_delete_metric;
 }
@@ -535,12 +536,14 @@ void rrdeng_load_metric_init(RRDDIM *rd, struct rrddim_query_handle *rrdimm_hand
     ctx = get_rrdeng_ctx_from_host(rd->rrdset->rrdhost);
     rrdimm_handle->start_time = start_time;
     rrdimm_handle->end_time = end_time;
-    handle = &rrdimm_handle->rrdeng;
+
+    handle = calloc(1, sizeof(struct rrdeng_query_handle));
     handle->next_page_time = start_time;
     handle->now = start_time;
     handle->position = 0;
     handle->ctx = ctx;
     handle->descr = NULL;
+    rrdimm_handle->handle = (STORAGE_QUERY_HANDLE *)handle;
     pages_nr = pg_cache_preload(ctx, rd->state->rrdeng_uuid, start_time * USEC_PER_SEC, end_time * USEC_PER_SEC,
                                 NULL, &handle->page_index);
     if (unlikely(NULL == handle->page_index || 0 == pages_nr))
@@ -551,7 +554,7 @@ void rrdeng_load_metric_init(RRDDIM *rd, struct rrddim_query_handle *rrdimm_hand
 /* Returns the metric and sets its timestamp into current_time */
 storage_number rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle, time_t *current_time)
 {
-    struct rrdeng_query_handle *handle;
+    struct rrdeng_query_handle *handle = (struct rrdeng_query_handle *)rrdimm_handle->handle;
     struct rrdengine_instance *ctx;
     struct rrdeng_page_descr *descr;
     storage_number *page, ret;
@@ -559,7 +562,6 @@ storage_number rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle
     usec_t next_page_time = 0, current_position_time, page_end_time = 0;
     uint32_t page_length;
 
-    handle = &rrdimm_handle->rrdeng;
     if (unlikely(INVALID_TIME == handle->next_page_time)) {
         return SN_EMPTY_SLOT;
     }
@@ -641,9 +643,7 @@ no_more_metrics:
 
 int rrdeng_load_metric_is_finished(struct rrddim_query_handle *rrdimm_handle)
 {
-    struct rrdeng_query_handle *handle;
-
-    handle = &rrdimm_handle->rrdeng;
+    struct rrdeng_query_handle *handle = (struct rrdeng_query_handle *)rrdimm_handle->handle;
     return (INVALID_TIME == handle->next_page_time);
 }
 
@@ -652,13 +652,10 @@ int rrdeng_load_metric_is_finished(struct rrddim_query_handle *rrdimm_handle)
  */
 void rrdeng_load_metric_finalize(struct rrddim_query_handle *rrdimm_handle)
 {
-    struct rrdeng_query_handle *handle;
-    struct rrdengine_instance *ctx;
-    struct rrdeng_page_descr *descr;
+    struct rrdeng_query_handle *handle = (struct rrdeng_query_handle *)rrdimm_handle->handle;
+    struct rrdengine_instance *ctx = handle->ctx;
+    struct rrdeng_page_descr *descr = handle->descr;
 
-    handle = &rrdimm_handle->rrdeng;
-    ctx = handle->ctx;
-    descr = handle->descr;
     if (descr) {
 #ifdef NETDATA_INTERNAL_CHECKS
         rrd_stat_atomic_add(&ctx->stats.metric_API_consumers, -1);

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -16,7 +16,6 @@ extern int default_rrdeng_page_cache_mb;
 extern int default_rrdeng_disk_quota_mb;
 extern int default_multidb_disk_quota_mb;
 extern uint8_t rrdeng_drop_metrics_under_page_cache_pressure;
-extern struct rrdengine_instance multidb_ctx;
 
 struct rrdeng_region_info {
     time_t start_time;
@@ -54,8 +53,7 @@ extern time_t rrdeng_metric_oldest_time(RRDDIM *rd);
 extern void rrdeng_get_37_statistics(struct rrdengine_instance *ctx, unsigned long long *array);
 
 /* must call once before using anything */
-extern int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_path, unsigned page_cache_mb,
-                       unsigned disk_space_mb);
+extern STORAGE_ENGINE_INSTANCE* rrdeng_init(STORAGE_ENGINE* eng, RRDHOST *host);
 
 extern int rrdeng_exit(struct rrdengine_instance *ctx);
 extern void rrdeng_prepare_exit(struct rrdengine_instance *ctx);

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -17,12 +17,6 @@ extern int default_rrdeng_disk_quota_mb;
 extern int default_multidb_disk_quota_mb;
 extern uint8_t rrdeng_drop_metrics_under_page_cache_pressure;
 
-struct rrdeng_region_info {
-    time_t start_time;
-    int update_every;
-    unsigned points;
-};
-
 extern void *rrdeng_create_page(struct rrdengine_instance *ctx, uuid_t *id, struct rrdeng_page_descr **ret_descr);
 extern void rrdeng_commit_page(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr,
                                Word_t page_correlation_id);
@@ -42,7 +36,7 @@ extern void rrdeng_store_metric_next(RRDDIM *rd, usec_t point_in_time, storage_n
 extern int rrdeng_store_metric_finalize(RRDDIM *rd);
 extern unsigned
     rrdeng_variable_step_boundaries(RRDSET *st, time_t start_time, time_t end_time,
-                                    struct rrdeng_region_info **region_info_arrayp, unsigned *max_intervalp, struct context_param *context_param_list);
+                                    struct rrdr_region_info **region_info_arrayp, unsigned *max_intervalp, struct context_param *context_param_list);
 extern void rrdeng_load_metric_init(RRDDIM *rd, struct rrddim_query_handle *rrdimm_handle,
                                     time_t start_time, time_t end_time);
 extern storage_number rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle, time_t *current_time);
@@ -58,5 +52,20 @@ extern STORAGE_ENGINE_INSTANCE* rrdeng_init(STORAGE_ENGINE* eng, RRDHOST *host);
 extern int rrdeng_exit(struct rrdengine_instance *ctx);
 extern void rrdeng_prepare_exit(struct rrdengine_instance *ctx);
 extern int rrdeng_metric_latest_time_by_uuid(uuid_t *dim_uuid, time_t *first_entry_t, time_t *last_entry_t);
+
+extern RRDR* rrdeng_query(
+        RRDSET *st
+        , long points_requested
+        , long long after_requested
+        , long long before_requested
+        , RRDR_GROUPING group_method
+        , long resampling_time_requested
+        , RRDR_OPTIONS options
+        , const char *dimensions
+        , int update_every
+        , time_t first_entry_t
+        , time_t last_entry_t
+        , int absolute_period_requested
+        , struct context_param *context_param_list);
 
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -2,6 +2,7 @@
 #define NETDATA_RRD_INTERNALS 1
 
 #include "rrd.h"
+#include "storage_engine.h"
 
 // ----------------------------------------------------------------------------
 // globals
@@ -47,24 +48,19 @@ inline const char *rrd_memory_mode_name(RRD_MEMORY_MODE id) {
             return RRD_MEMORY_MODE_DBENGINE_NAME;
     }
 
+    STORAGE_ENGINE* eng = engine_get(id);
+    if (eng) {
+        return eng->name;
+    }
+
     return RRD_MEMORY_MODE_SAVE_NAME;
 }
 
 RRD_MEMORY_MODE rrd_memory_mode_id(const char *name) {
-    if(unlikely(!strcmp(name, RRD_MEMORY_MODE_RAM_NAME)))
-        return RRD_MEMORY_MODE_RAM;
-
-    else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_MAP_NAME)))
-        return RRD_MEMORY_MODE_MAP;
-
-    else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_NONE_NAME)))
-        return RRD_MEMORY_MODE_NONE;
-
-    else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_ALLOC_NAME)))
-        return RRD_MEMORY_MODE_ALLOC;
-
-    else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_DBENGINE_NAME)))
-        return RRD_MEMORY_MODE_DBENGINE;
+    STORAGE_ENGINE* eng = engine_find(name);
+    if (eng) {
+        return eng->id;
+    }
 
     return RRD_MEMORY_MODE_SAVE;
 }

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1083,6 +1083,11 @@ extern void rrdset_done(RRDSET *st);
 extern void rrdset_is_obsolete(RRDSET *st);
 extern void rrdset_isnot_obsolete(RRDSET *st);
 
+static inline void last_updated_time_align(RRDSET *st) {
+    st->last_updated.tv_sec -= st->last_updated.tv_sec % st->update_every;
+    st->last_updated.tv_usec = 0;
+}
+
 // checks if the RRDSET should be offered to viewers
 #define rrdset_is_available_for_viewers(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_HIDDEN) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
 #define rrdset_is_available_for_exporting_and_alarms(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -14,6 +14,7 @@ typedef struct rrdcalc RRDCALC;
 typedef struct rrdcalctemplate RRDCALCTEMPLATE;
 typedef struct alarm_entry ALARM_ENTRY;
 typedef struct context_param CONTEXT_PARAM;
+typedef struct storage_engine_instance STORAGE_ENGINE_INSTANCE;
 
 typedef void *ml_host_t;
 typedef void *ml_dimension_t;
@@ -408,19 +409,6 @@ struct rrdset_volatile {
     struct label *new_labels;
     struct label_index labels;
     bool is_ar_chart;
-};
-
-// RRDDIM legacy data collection structures
-
-struct mem_collect_handle {
-    long slot;
-    long entries;
-};
-
-struct mem_query_handle {
-    long slot;
-    long last_slot;
-    uint8_t finished;
 };
 
 // ----------------------------------------------------------------------------
@@ -889,9 +877,7 @@ struct rrdhost {
     avl_tree_lock rrdfamily_root_index;             // the host's chart families index
     avl_tree_lock rrdvar_root_index;                // the host's chart variables index
 
-#ifdef ENABLE_DBENGINE
-    struct rrdengine_instance *rrdeng_ctx;          // DB engine instance for this host
-#endif
+    STORAGE_ENGINE_INSTANCE *rrdeng_ctx;          // DB engine instance for this host
     uuid_t  host_uuid;                              // Global GUID for this host
     uuid_t  *node_id;                               // Cloud node_id
 
@@ -1358,9 +1344,6 @@ extern void set_host_properties(
 // ----------------------------------------------------------------------------
 // RRD DB engine declarations
 
-#ifdef ENABLE_DBENGINE
-#include "database/engine/rrdengineapi.h"
-#endif
 #include "sqlite/sqlite_functions.h"
 #include "sqlite/sqlite_aclk.h"
 #include "sqlite/sqlite_aclk_chart.h"

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -2,6 +2,10 @@
 
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
+#include "database/rrddim_mem.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 // ----------------------------------------------------------------------------
 // RRDDIM index
@@ -94,74 +98,6 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
     rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
     return 1;
 }
-
-// ----------------------------------------------------------------------------
-// RRDDIM legacy data collection functions
-
-static void rrddim_collect_init(RRDDIM *rd) {
-    rd->state->handle = callocz(1, sizeof(struct mem_collect_handle));
-    rd->values[rd->rrdset->current_entry] = SN_EMPTY_SLOT;
-}
-static void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number) {
-    (void)point_in_time;
-
-    rd->values[rd->rrdset->current_entry] = number;
-}
-static int rrddim_collect_finalize(RRDDIM *rd) {
-    freez(rd->state->handle);
-    return 0;
-}
-
-
-// ----------------------------------------------------------------------------
-// RRDDIM legacy database query functions
-
-static void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time) {
-    handle->rd = rd;
-    handle->start_time = start_time;
-    handle->end_time = end_time;
-    struct mem_query_handle* mem_handle = callocz(1, sizeof(struct mem_query_handle));
-    mem_handle->slot = rrdset_time2slot(rd->rrdset, start_time);
-    mem_handle->last_slot = rrdset_time2slot(rd->rrdset, end_time);
-    mem_handle->finished = 0;
-    handle->handle = mem_handle;
-}
-
-static storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time) {
-    RRDDIM *rd = handle->rd;
-    struct mem_query_handle* mem_handle = handle->handle;
-    long entries = rd->rrdset->entries;
-    long slot = mem_handle->slot;
-
-    (void)current_time;
-    if (unlikely(mem_handle->slot == mem_handle->last_slot))
-        mem_handle->finished = 1;
-    storage_number n = rd->values[slot++];
-
-    if(unlikely(slot >= entries)) slot = 0;
-    mem_handle->slot = slot;
-
-    return n;
-}
-
-static int rrddim_query_is_finished(struct rrddim_query_handle *handle) {
-    struct mem_query_handle* mem_handle = handle->handle;
-    return mem_handle->finished;
-}
-
-static void rrddim_query_finalize(struct rrddim_query_handle *handle) {
-    freez(handle->handle);
-    return;
-}
-
-static time_t rrddim_query_latest_time(RRDDIM *rd) {
-    return rrdset_last_entry_t_nolock(rd->rrdset);
-}
-
-static time_t rrddim_query_oldest_time(RRDDIM *rd) {
-    return rrdset_first_entry_t_nolock(rd->rrdset);
-}
-
 
 // ----------------------------------------------------------------------------
 // RRDDIM create a dimension

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -175,95 +175,13 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     char filename[FILENAME_MAX + 1];
     char fullfilename[FILENAME_MAX + 1];
 
-    unsigned long size = sizeof(RRDDIM) + (st->entries * sizeof(storage_number));
-
     debug(D_RRD_CALLS, "Adding dimension '%s/%s'.", st->id, id);
 
     rrdset_strncpyz_name(filename, id, FILENAME_MAX);
     snprintfz(fullfilename, FILENAME_MAX, "%s/%s.db", st->cache_dir, filename);
 
-    if(memory_mode == RRD_MEMORY_MODE_SAVE || memory_mode == RRD_MEMORY_MODE_MAP ||
-       memory_mode == RRD_MEMORY_MODE_RAM) {
-        rd = (RRDDIM *)mymmap(
-                  (memory_mode == RRD_MEMORY_MODE_RAM) ? NULL : fullfilename
-                , size
-                , ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE)
-                , 1
-        );
-
-        if(likely(rd)) {
-            // we have a file mapped for rd
-
-            memset(&rd->avl, 0, sizeof(avl_t));
-            rd->id = NULL;
-            rd->name = NULL;
-            rd->cache_filename = NULL;
-            rd->variables = NULL;
-            rd->next = NULL;
-            rd->rrdset = NULL;
-            rd->exposed = 0;
-
-            struct timeval now;
-            now_realtime_timeval(&now);
-
-            if(memory_mode == RRD_MEMORY_MODE_RAM) {
-                memset(rd, 0, size);
-            }
-            else {
-                int reset = 0;
-
-                if(strcmp(rd->magic, RRDDIMENSION_MAGIC) != 0) {
-                    info("Initializing file %s.", fullfilename);
-                    memset(rd, 0, size);
-                    reset = 1;
-                }
-                else if(rd->memsize != size) {
-                    error("File %s does not have the desired size, expected %lu but found %lu. Clearing it.", fullfilename, size, rd->memsize);
-                    memset(rd, 0, size);
-                    reset = 1;
-                }
-                else if(rd->update_every != st->update_every) {
-                    error("File %s does not have the same update frequency, expected %d but found %d. Clearing it.", fullfilename, st->update_every, rd->update_every);
-                    memset(rd, 0, size);
-                    reset = 1;
-                }
-                else if(dt_usec(&now, &rd->last_collected_time) > (rd->entries * rd->update_every * USEC_PER_SEC)) {
-                    info("File %s is too old (last collected %llu seconds ago, but the database is %ld seconds). Clearing it.", fullfilename, dt_usec(&now, &rd->last_collected_time) / USEC_PER_SEC, rd->entries * rd->update_every);
-                    memset(rd, 0, size);
-                    reset = 1;
-                }
-
-                if(!reset) {
-                    if(rd->algorithm != algorithm) {
-                        info("File %s does not have the expected algorithm (expected %u '%s', found %u '%s'). Previous values may be wrong.",
-                              fullfilename, algorithm, rrd_algorithm_name(algorithm), rd->algorithm, rrd_algorithm_name(rd->algorithm));
-                    }
-
-                    if(rd->multiplier != multiplier) {
-                        info("File %s does not have the expected multiplier (expected " COLLECTED_NUMBER_FORMAT ", found " COLLECTED_NUMBER_FORMAT "). Previous values may be wrong.", fullfilename, multiplier, rd->multiplier);
-                    }
-
-                    if(rd->divisor != divisor) {
-                        info("File %s does not have the expected divisor (expected " COLLECTED_NUMBER_FORMAT ", found " COLLECTED_NUMBER_FORMAT "). Previous values may be wrong.", fullfilename, divisor, rd->divisor);
-                    }
-                }
-            }
-
-            // make sure we have the right memory mode
-            // even if we cleared the memory
-            rd->rrd_memory_mode = memory_mode;
-        }
-    }
-
-    if(unlikely(!rd)) {
-        // if we didn't manage to get a mmap'd dimension, just create one
-        rd = callocz(1, size);
-        if (memory_mode == RRD_MEMORY_MODE_DBENGINE)
-            rd->rrd_memory_mode = RRD_MEMORY_MODE_DBENGINE;
-        else
-            rd->rrd_memory_mode = (memory_mode == RRD_MEMORY_MODE_NONE) ? RRD_MEMORY_MODE_NONE : RRD_MEMORY_MODE_ALLOC;
-    }
-    rd->memsize = size;
+    STORAGE_ENGINE* eng = engine_get(memory_mode);
+    rd = eng->api.dim_ops.create(st, id, fullfilename, multiplier, divisor, algorithm);
 
     strcpy(rd->magic, RRDDIMENSION_MAGIC);
 
@@ -309,29 +227,12 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     rd->state->aclk_live_status = -1;
 #endif
     (void) find_dimension_uuid(st, rd, &(rd->state->metric_uuid));
-    if(memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-#ifdef ENABLE_DBENGINE
-        rrdeng_metric_init(rd);
-        rd->state->collect_ops.init = rrdeng_store_metric_init;
-        rd->state->collect_ops.store_metric = rrdeng_store_metric_next;
-        rd->state->collect_ops.finalize = rrdeng_store_metric_finalize;
-        rd->state->query_ops.init = rrdeng_load_metric_init;
-        rd->state->query_ops.next_metric = rrdeng_load_metric_next;
-        rd->state->query_ops.is_finished = rrdeng_load_metric_is_finished;
-        rd->state->query_ops.finalize = rrdeng_load_metric_finalize;
-        rd->state->query_ops.latest_time = rrdeng_metric_latest_time;
-        rd->state->query_ops.oldest_time = rrdeng_metric_oldest_time;
-#endif
-    } else {
-        rd->state->collect_ops.init         = rrddim_collect_init;
-        rd->state->collect_ops.store_metric = rrddim_collect_store_metric;
-        rd->state->collect_ops.finalize     = rrddim_collect_finalize;
-        rd->state->query_ops.init           = rrddim_query_init;
-        rd->state->query_ops.next_metric    = rrddim_query_next_metric;
-        rd->state->query_ops.is_finished    = rrddim_query_is_finished;
-        rd->state->query_ops.finalize       = rrddim_query_finalize;
-        rd->state->query_ops.latest_time    = rrddim_query_latest_time;
-        rd->state->query_ops.oldest_time    = rrddim_query_oldest_time;
+
+    rd->state->collect_ops = eng->api.collect_ops;
+    rd->state->query_ops = eng->api.query_ops;
+
+    if(eng->api.dim_ops.init) {
+        eng->api.dim_ops.init(rd);
     }
     store_active_dimension(&rd->state->metric_uuid);
     rd->state->collect_ops.init(rd);

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -99,6 +99,7 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
 // RRDDIM legacy data collection functions
 
 static void rrddim_collect_init(RRDDIM *rd) {
+    rd->state->handle = callocz(1, sizeof(struct mem_collect_handle));
     rd->values[rd->rrdset->current_entry] = SN_EMPTY_SLOT;
 }
 static void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number) {
@@ -107,10 +108,10 @@ static void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storag
     rd->values[rd->rrdset->current_entry] = number;
 }
 static int rrddim_collect_finalize(RRDDIM *rd) {
-    (void)rd;
-
+    freez(rd->state->handle);
     return 0;
 }
+
 
 // ----------------------------------------------------------------------------
 // RRDDIM legacy database query functions
@@ -119,34 +120,37 @@ static void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, ti
     handle->rd = rd;
     handle->start_time = start_time;
     handle->end_time = end_time;
-    handle->slotted.slot = rrdset_time2slot(rd->rrdset, start_time);
-    handle->slotted.last_slot = rrdset_time2slot(rd->rrdset, end_time);
-    handle->slotted.finished = 0;
+    struct mem_query_handle* mem_handle = callocz(1, sizeof(struct mem_query_handle));
+    mem_handle->slot = rrdset_time2slot(rd->rrdset, start_time);
+    mem_handle->last_slot = rrdset_time2slot(rd->rrdset, end_time);
+    mem_handle->finished = 0;
+    handle->handle = mem_handle;
 }
 
 static storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time) {
     RRDDIM *rd = handle->rd;
+    struct mem_query_handle* mem_handle = handle->handle;
     long entries = rd->rrdset->entries;
-    long slot = handle->slotted.slot;
+    long slot = mem_handle->slot;
 
     (void)current_time;
-    if (unlikely(handle->slotted.slot == handle->slotted.last_slot))
-        handle->slotted.finished = 1;
+    if (unlikely(mem_handle->slot == mem_handle->last_slot))
+        mem_handle->finished = 1;
     storage_number n = rd->values[slot++];
 
     if(unlikely(slot >= entries)) slot = 0;
-    handle->slotted.slot = slot;
+    mem_handle->slot = slot;
 
     return n;
 }
 
 static int rrddim_query_is_finished(struct rrddim_query_handle *handle) {
-    return handle->slotted.finished;
+    struct mem_query_handle* mem_handle = handle->handle;
+    return mem_handle->finished;
 }
 
 static void rrddim_query_finalize(struct rrddim_query_handle *handle) {
-    (void)handle;
-
+    freez(handle->handle);
     return;
 }
 

--- a/database/rrddim_mem.c
+++ b/database/rrddim_mem.c
@@ -1,0 +1,250 @@
+#include "rrddim_mem.h"
+
+RRDSET* rrdset_init(RRD_MEMORY_MODE memory_mode, const char *id, const char *fullid, const char *filename, long entries, int update_every)
+{
+    size_t size = sizeof(RRDSET);
+
+    RRDSET *st = (RRDSET *) mymmap(
+                (memory_mode == RRD_MEMORY_MODE_RAM) ? NULL : filename
+            , size
+            , ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE)
+            , 0
+    );
+
+    if(st) {
+        memset(&st->avl, 0, sizeof(avl_t));
+        memset(&st->avlname, 0, sizeof(avl_t));
+        memset(&st->rrdvar_root_index, 0, sizeof(avl_tree_lock));
+        memset(&st->dimensions_index, 0, sizeof(avl_tree_lock));
+        memset(&st->rrdset_rwlock, 0, sizeof(netdata_rwlock_t));
+
+        st->name = NULL;
+        st->config_section = NULL;
+        st->type = NULL;
+        st->family = NULL;
+        st->title = NULL;
+        st->units = NULL;
+        st->context = NULL;
+        st->cache_dir = NULL;
+        st->plugin_name = NULL;
+        st->module_name = NULL;
+        st->dimensions = NULL;
+        st->rrdfamily = NULL;
+        st->rrdhost = NULL;
+        st->next = NULL;
+        st->variables = NULL;
+        st->alarms = NULL;
+        st->flags = 0x00000000;
+        st->exporting_flags = NULL;
+
+        if(memory_mode == RRD_MEMORY_MODE_RAM) {
+            memset(st, 0, size);
+        }
+        else {
+            time_t now = now_realtime_sec();
+
+            if(strcmp(st->magic, RRDSET_MAGIC) != 0) {
+                info("Initializing file %s.", filename);
+                memset(st, 0, size);
+            }
+            else if(strcmp(st->id, fullid) != 0) {
+                error("File %s contents are not for chart %s. Clearing it.", filename, fullid);
+                // munmap(st, size);
+                // st = NULL;
+                memset(st, 0, size);
+            }
+            else if(st->memsize != size || st->entries != entries) {
+                error("File %s does not have the desired size. Clearing it.", filename);
+                memset(st, 0, size);
+            }
+            else if(st->update_every != update_every) {
+                error("File %s does not have the desired update frequency. Clearing it.", filename);
+                memset(st, 0, size);
+            }
+            else if((now - st->last_updated.tv_sec) > update_every * entries) {
+                info("File %s is too old. Clearing it.", filename);
+                memset(st, 0, size);
+            }
+            else if(st->last_updated.tv_sec > now + update_every) {
+                error("File %s refers to the future by %zd secs. Resetting it to now.", filename, (ssize_t)(st->last_updated.tv_sec - now));
+                st->last_updated.tv_sec = now;
+            }
+
+            // make sure the database is aligned
+            if(st->last_updated.tv_sec) {
+                st->update_every = update_every;
+                last_updated_time_align(st);
+            }
+        }
+
+        // make sure we have the right memory mode
+        // even if we cleared the memory
+        st->rrd_memory_mode = memory_mode;
+    }
+    return st;
+}
+
+
+RRDSET* rrdset_init_map(const char *id, const char *fullid, const char *filename, long entries, int update_every)
+{
+    return rrdset_init(RRD_MEMORY_MODE_MAP, id, fullid, filename, entries, update_every);
+}
+
+RRDSET* rrdset_init_ram(const char *id, const char *fullid, const char *filename, long entries, int update_every)
+{
+    return rrdset_init(RRD_MEMORY_MODE_RAM, id, fullid, filename, entries, update_every);
+}
+
+RRDSET* rrdset_init_save(const char *id, const char *fullid, const char *filename, long entries, int update_every)
+{
+    return rrdset_init(RRD_MEMORY_MODE_SAVE, id, fullid, filename, entries, update_every);
+}
+
+
+RRDDIM* rrddim_init(RRDSET *st, RRD_MEMORY_MODE memory_mode, const char* filename, int map_mode, collected_number multiplier,
+                          collected_number divisor, RRD_ALGORITHM algorithm)
+{
+    unsigned long size = sizeof(RRDDIM) + (st->entries * sizeof(storage_number));
+    RRDDIM* rd = (RRDDIM *)mymmap(filename, size, map_mode, 1);
+
+    if(likely(rd)) {
+        // we have a file mapped for rd
+
+        memset(&rd->avl, 0, sizeof(avl_t));
+        rd->id = NULL;
+        rd->name = NULL;
+        rd->cache_filename = NULL;
+        rd->variables = NULL;
+        rd->next = NULL;
+        rd->rrdset = NULL;
+        rd->exposed = 0;
+
+        struct timeval now;
+        now_realtime_timeval(&now);
+
+        if(memory_mode == RRD_MEMORY_MODE_RAM) {
+            memset(rd, 0, size);
+        }
+        else {
+            int reset = 0;
+
+            if(strcmp(rd->magic, RRDDIMENSION_MAGIC) != 0) {
+                info("Initializing file %s.", filename);
+                memset(rd, 0, size);
+                reset = 1;
+            }
+            else if(rd->memsize != size) {
+                error("File %s does not have the desired size, expected %lu but found %lu. Clearing it.", filename, size, rd->memsize);
+                memset(rd, 0, size);
+                reset = 1;
+            }
+            else if(rd->update_every != st->update_every) {
+                error("File %s does not have the same update frequency, expected %d but found %d. Clearing it.", filename, st->update_every, rd->update_every);
+                memset(rd, 0, size);
+                reset = 1;
+            }
+            else if(dt_usec(&now, &rd->last_collected_time) > (rd->entries * rd->update_every * USEC_PER_SEC)) {
+                info("File %s is too old (last collected %llu seconds ago, but the database is %ld seconds). Clearing it.", filename, dt_usec(&now, &rd->last_collected_time) / USEC_PER_SEC, rd->entries * rd->update_every);
+                memset(rd, 0, size);
+                reset = 1;
+            }
+
+            if(!reset) {
+                if(rd->algorithm != algorithm) {
+                    info("File %s does not have the expected algorithm (expected %u '%s', found %u '%s'). Previous values may be wrong.",
+                            filename, algorithm, rrd_algorithm_name(algorithm), rd->algorithm, rrd_algorithm_name(rd->algorithm));
+                }
+
+                if(rd->multiplier != multiplier) {
+                    info("File %s does not have the expected multiplier (expected " COLLECTED_NUMBER_FORMAT ", found " COLLECTED_NUMBER_FORMAT "). Previous values may be wrong.", filename, multiplier, rd->multiplier);
+                }
+
+                if(rd->divisor != divisor) {
+                    info("File %s does not have the expected divisor (expected " COLLECTED_NUMBER_FORMAT ", found " COLLECTED_NUMBER_FORMAT "). Previous values may be wrong.", filename, divisor, rd->divisor);
+                }
+            }
+        }
+
+        // make sure we have the right memory mode
+        // even if we cleared the memory
+        rd->rrd_memory_mode = memory_mode;
+    }
+    return rd;
+}
+
+RRDDIM* rrddim_init_map(RRDSET *st, const char *id, const char *filename, collected_number multiplier, collected_number divisor, RRD_ALGORITHM algorithm)
+{
+    return rrddim_init(st, RRD_MEMORY_MODE_MAP, filename, MAP_SHARED, multiplier, divisor, algorithm);
+}
+RRDDIM* rrddim_init_ram(RRDSET *st, const char *id, const char *filename, collected_number multiplier, collected_number divisor, RRD_ALGORITHM algorithm)
+{
+    return rrddim_init(st, RRD_MEMORY_MODE_RAM, NULL, MAP_PRIVATE, multiplier, divisor, algorithm);
+}
+RRDDIM* rrddim_init_save(RRDSET *st, const char *id, const char *filename, collected_number multiplier, collected_number divisor, RRD_ALGORITHM algorithm)
+{
+    return rrddim_init(st, RRD_MEMORY_MODE_SAVE, filename, MAP_PRIVATE, multiplier, divisor, algorithm);
+}
+
+// ----------------------------------------------------------------------------
+// RRDDIM legacy data collection functions
+
+void rrddim_collect_init(RRDDIM *rd) {
+    rd->values[rd->rrdset->current_entry] = SN_EMPTY_SLOT;
+    rd->state->handle = calloc(1, sizeof(struct mem_collect_handle));
+}
+void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number) {
+    (void)point_in_time;
+    rd->values[rd->rrdset->current_entry] = number;
+}
+int rrddim_collect_finalize(RRDDIM *rd) {
+    free((struct mem_collect_handle*)rd->state->handle);
+    return 0;
+}
+
+// ----------------------------------------------------------------------------
+// RRDDIM legacy database query functions
+
+void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time) {
+    handle->rd = rd;
+    handle->start_time = start_time;
+    handle->end_time = end_time;
+    struct mem_query_handle* h = calloc(1, sizeof(struct mem_query_handle));
+    h->slot = rrdset_time2slot(rd->rrdset, start_time);
+    h->last_slot = rrdset_time2slot(rd->rrdset, end_time);
+    h->finished = 0;
+    handle->handle = (STORAGE_QUERY_HANDLE *)h;
+}
+
+storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time) {
+    RRDDIM *rd = handle->rd;
+    struct mem_query_handle* h = (struct mem_query_handle*)handle->handle;
+    long entries = rd->rrdset->entries;
+    long slot = h->slot;
+
+    (void)current_time;
+    if (unlikely(h->slot == h->last_slot))
+        h->finished = 1;
+    storage_number n = rd->values[slot++];
+
+    if(unlikely(slot >= entries)) slot = 0;
+    h->slot = slot;
+
+    return n;
+}
+
+int rrddim_query_is_finished(struct rrddim_query_handle *handle) {
+    struct mem_query_handle* h = (struct mem_query_handle*)handle->handle;
+    return h->finished;
+}
+
+void rrddim_query_finalize(struct rrddim_query_handle *handle) {
+    freez(handle->handle);
+}
+
+time_t rrddim_query_latest_time(RRDDIM *rd) {
+    return rrdset_last_entry_t_nolock(rd->rrdset);
+}
+
+time_t rrddim_query_oldest_time(RRDDIM *rd) {
+    return rrdset_first_entry_t_nolock(rd->rrdset);
+}

--- a/database/rrddim_mem.h
+++ b/database/rrddim_mem.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_RRDDIMMEM_H
+#define NETDATA_RRDDIMMEM_H
+
+#include "rrd.h"
+
+struct mem_collect_handle {
+    long slot;
+    long entries;
+};
+struct mem_query_handle {
+    long slot;
+    long last_slot;
+    uint8_t finished;
+};
+
+RRDDIM* rrddim_init_map(RRDSET *st, const char *id, const char *filename, collected_number multiplier,
+                          collected_number divisor, RRD_ALGORITHM algorithm);
+RRDDIM* rrddim_init_ram(RRDSET *st, const char *id, const char *filename, collected_number multiplier,
+                          collected_number divisor, RRD_ALGORITHM algorithm);
+RRDDIM* rrddim_init_save(RRDSET *st, const char *id, const char *filename, collected_number multiplier,
+                          collected_number divisor, RRD_ALGORITHM algorithm);
+
+RRDSET* rrdset_init_map(const char *id, const char *fullid, const char *filename, long entries, int update_every);
+RRDSET* rrdset_init_ram(const char *id, const char *fullid, const char *filename, long entries, int update_every);
+RRDSET* rrdset_init_save(const char *id, const char *fullid, const char *filename, long entries, int update_every);
+
+void rrddim_destroy(RRDDIM *rd);
+
+void rrddim_collect_init(RRDDIM *rd);
+void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number);
+int rrddim_collect_finalize(RRDDIM *rd);
+
+void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time);
+storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time);
+int rrddim_query_is_finished(struct rrddim_query_handle *handle);
+void rrddim_query_finalize(struct rrddim_query_handle *handle);
+time_t rrddim_query_latest_time(RRDDIM *rd);
+time_t rrddim_query_oldest_time(RRDDIM *rd);
+
+#endif

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -3,6 +3,9 @@
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
 #include <sched.h>
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrddiskprotocol.h"
+#endif
 
 void __rrdset_check_rdlock(RRDSET *st, const char *file, const char *function, const unsigned long line) {
     debug(D_RRD_CALLS, "Checking read lock on chart '%s'", st->id);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -3,8 +3,9 @@
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
 #include <sched.h>
+#include "storage_engine.h"
 #ifdef ENABLE_DBENGINE
-#include "database/engine/rrddiskprotocol.h"
+#include "engine/rrdengineapi.h"
 #endif
 
 void __rrdset_check_rdlock(RRDSET *st, const char *file, const char *function, const unsigned long line) {
@@ -325,11 +326,6 @@ static inline void last_collected_time_align(RRDSET *st) {
         st->last_collected_time.tv_usec = 500000;
 }
 
-static inline void last_updated_time_align(RRDSET *st) {
-    st->last_updated.tv_sec -= st->last_updated.tv_sec % st->update_every;
-    st->last_updated.tv_usec = 0;
-}
-
 // ----------------------------------------------------------------------------
 // RRDSET - free a chart
 
@@ -414,21 +410,10 @@ void rrdset_free(RRDSET *st) {
     freez(st->state);
     freez(st->chart_uuid);
 
-    switch(st->rrd_memory_mode) {
-        case RRD_MEMORY_MODE_SAVE:
-        case RRD_MEMORY_MODE_MAP:
-        case RRD_MEMORY_MODE_RAM:
-            debug(D_RRD_CALLS, "Unmapping stats '%s'.", st->name);
-            munmap(st, st->memsize);
-            break;
-
-        case RRD_MEMORY_MODE_ALLOC:
-        case RRD_MEMORY_MODE_NONE:
-        case RRD_MEMORY_MODE_DBENGINE:
-            freez(st);
-            break;
-    }
-
+    STORAGE_ENGINE* engine = (host->rrdeng_ctx && st->rrd_memory_mode == host->rrdeng_ctx->engine->id)
+        ? host->rrdeng_ctx->engine
+        : engine_get(st->rrd_memory_mode);
+    engine->api.set_ops.destroy(st);
 }
 
 void rrdset_save(RRDSET *st) {
@@ -737,101 +722,18 @@ RRDSET *rrdset_create_custom(
     unsigned long size = sizeof(RRDSET);
     char *cache_dir = rrdset_cache_dir(host, fullid, config_section);
 
-    time_t now = now_realtime_sec();
-
     // ------------------------------------------------------------------------
     // load it or allocate it
 
     debug(D_RRD_CALLS, "Creating RRD_STATS for '%s.%s'.", type, id);
 
     snprintfz(fullfilename, FILENAME_MAX, "%s/main.db", cache_dir);
-    if(memory_mode == RRD_MEMORY_MODE_SAVE || memory_mode == RRD_MEMORY_MODE_MAP ||
-       memory_mode == RRD_MEMORY_MODE_RAM) {
-        st = (RRDSET *) mymmap(
-                  (memory_mode == RRD_MEMORY_MODE_RAM) ? NULL : fullfilename
-                , size
-                , ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE)
-                , 0
-        );
-
-        if(st) {
-            memset(&st->avl, 0, sizeof(avl_t));
-            memset(&st->avlname, 0, sizeof(avl_t));
-            memset(&st->rrdvar_root_index, 0, sizeof(avl_tree_lock));
-            memset(&st->dimensions_index, 0, sizeof(avl_tree_lock));
-            memset(&st->rrdset_rwlock, 0, sizeof(netdata_rwlock_t));
-
-            st->name = NULL;
-            st->config_section = NULL;
-            st->type = NULL;
-            st->family = NULL;
-            st->title = NULL;
-            st->units = NULL;
-            st->context = NULL;
-            st->cache_dir = NULL;
-            st->plugin_name = NULL;
-            st->module_name = NULL;
-            st->dimensions = NULL;
-            st->rrdfamily = NULL;
-            st->rrdhost = NULL;
-            st->next = NULL;
-            st->variables = NULL;
-            st->alarms = NULL;
-            st->flags = 0x00000000;
-            st->exporting_flags = NULL;
-
-            if(memory_mode == RRD_MEMORY_MODE_RAM) {
-                memset(st, 0, size);
-            }
-            else {
-                if(strcmp(st->magic, RRDSET_MAGIC) != 0) {
-                    info("Initializing file %s.", fullfilename);
-                    memset(st, 0, size);
-                }
-                else if(strcmp(st->id, fullid) != 0) {
-                    error("File %s contents are not for chart %s. Clearing it.", fullfilename, fullid);
-                    // munmap(st, size);
-                    // st = NULL;
-                    memset(st, 0, size);
-                }
-                else if(st->memsize != size || st->entries != entries) {
-                    error("File %s does not have the desired size. Clearing it.", fullfilename);
-                    memset(st, 0, size);
-                }
-                else if(st->update_every != update_every) {
-                    error("File %s does not have the desired update frequency. Clearing it.", fullfilename);
-                    memset(st, 0, size);
-                }
-                else if((now - st->last_updated.tv_sec) > update_every * entries) {
-                    info("File %s is too old. Clearing it.", fullfilename);
-                    memset(st, 0, size);
-                }
-                else if(st->last_updated.tv_sec > now + update_every) {
-                    error("File %s refers to the future by %zd secs. Resetting it to now.", fullfilename, (ssize_t)(st->last_updated.tv_sec - now));
-                    st->last_updated.tv_sec = now;
-                }
-
-                // make sure the database is aligned
-                if(st->last_updated.tv_sec) {
-                    st->update_every = update_every;
-                    last_updated_time_align(st);
-                }
-            }
-
-            // make sure we have the right memory mode
-            // even if we cleared the memory
-            st->rrd_memory_mode = memory_mode;
-        }
+    STORAGE_ENGINE* engine = engine_get(memory_mode);
+    if (unlikely(!engine)) {
+        fatal("Can't find memory mode %s", rrd_memory_mode_name(memory_mode));
+        return NULL;
     }
-
-    if(unlikely(!st)) {
-        st = callocz(1, size);
-        if (memory_mode == RRD_MEMORY_MODE_DBENGINE)
-            st->rrd_memory_mode = RRD_MEMORY_MODE_DBENGINE;
-        else
-            st->rrd_memory_mode = (memory_mode == RRD_MEMORY_MODE_NONE) ? RRD_MEMORY_MODE_NONE : RRD_MEMORY_MODE_ALLOC;
-    }
-
+    st = engine->api.set_ops.create(id, fullid, fullfilename, entries, update_every);
     st->plugin_name = plugin?strdupz(plugin):NULL;
     st->module_name = module?strdupz(module):NULL;
 

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -2,6 +2,9 @@
 
 #include "sqlite_functions.h"
 #include "sqlite_aclk_chart.h"
+#ifdef ENABLE_DBENGINE
+#include "../engine/rrdengineapi.h"
+#endif
 
 #if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
 #include "../../aclk/aclk_charts_api.h"

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "sqlite_functions.h"
+#ifdef ENABLE_DBENGINE
+#include "../engine/rrdengineapi.h"
+#endif
 
 #define DB_METADATA_VERSION "1"
 
@@ -1217,9 +1220,9 @@ RRDHOST *sql_create_host_by_uuid(char *hostname)
 
     host->system_info = callocz(1, sizeof(*host->system_info));;
     rrdhost_flag_set(host, RRDHOST_FLAG_ARCHIVED);
-#ifdef ENABLE_DBENGINE
-    host->rrdeng_ctx = &multidb_ctx;
-#endif
+
+    // Create multidb engine instance if necessary
+    host->rrdeng_ctx = engine_new(engine_get(RRD_MEMORY_MODE_DBENGINE), host, false);
 
 failed:
     rc = sqlite3_finalize(res);

--- a/database/storage_engine.c
+++ b/database/storage_engine.c
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "storage_engine.h"
+#include "rrddim_mem.h"
+#ifdef ENABLE_DBENGINE
+#include "engine/rrdengineapi.h"
+#endif
+
+static void dimension_destroy_freez(RRDDIM *rd) {
+    freez(rd);
+}
+static void dimension_destroy_unmap(RRDDIM *rd) {
+    munmap(rd, rd->memsize);
+}
+static void set_destroy_freez(RRDSET *st) {
+    freez(st);
+}
+static void set_destroy_unmap(RRDSET *st) {
+    munmap(st, st->memsize);
+}
+
+// Initialize a rrdset with calloc and the provided memory mode
+static RRDSET* set_init_calloc(RRD_MEMORY_MODE mode) {
+    RRDSET* st = callocz(1, sizeof(RRDSET));
+    st->rrd_memory_mode = mode;
+    return st;
+}
+
+#define SET_INIT(MMODE) \
+static RRDSET* rrdset_init_##MMODE(const char *id, const char *fullid, const char *filename, long entries, int update_every) { \
+    return set_init_calloc(RRD_MEMORY_MODE_##MMODE); \
+}
+SET_INIT(NONE)
+SET_INIT(ALLOC)
+SET_INIT(DBENGINE)
+
+// Initialize a rrddim with calloc and the provided memory mode
+static RRDDIM* dim_init_calloc(RRDSET *st, RRD_MEMORY_MODE mode) {
+    size_t size = sizeof(RRDDIM) + (st->entries * sizeof(storage_number));
+    RRDDIM* rd = callocz(1, size);
+    rd->memsize = size;
+    rd->rrd_memory_mode = mode;
+    return rd;
+}
+
+#define DIM_INIT(MMODE) \
+static RRDDIM* rrddim_init_##MMODE(RRDSET *st, const char *id, const char *filename, collected_number multiplier, collected_number divisor, RRD_ALGORITHM algorithm) { \
+    return dim_init_calloc((st), RRD_MEMORY_MODE_##MMODE); \
+}
+DIM_INIT(NONE)
+DIM_INIT(ALLOC)
+DIM_INIT(DBENGINE)
+
+static const struct rrddim_collect_ops im_collect_ops = {
+    .init = rrddim_collect_init,
+    .store_metric = rrddim_collect_store_metric,
+    .finalize = rrddim_collect_finalize
+};
+
+static const struct rrddim_query_ops im_query_ops = {
+    .init = rrddim_query_init,
+    .next_metric = rrddim_query_next_metric,
+    .is_finished = rrddim_query_is_finished,
+    .finalize = rrddim_query_finalize,
+    .latest_time = rrddim_query_latest_time,
+    .oldest_time = rrddim_query_oldest_time
+};
+
+STORAGE_ENGINE engines[] = {
+    {
+        .id = RRD_MEMORY_MODE_NONE,
+        .name = RRD_MEMORY_MODE_NONE_NAME,
+        .api = {
+            .engine_ops = {
+                .create = NULL,
+                .exit = NULL,
+                .destroy = NULL
+            },
+            .set_ops = {
+                .create = rrdset_init_NONE,
+                .destroy = set_destroy_freez,
+            },
+            .dim_ops = {
+                .create = rrddim_init_NONE,
+                .init = NULL,
+                .destroy = dimension_destroy_freez,
+            },
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        },
+        .instance_per_host = true,
+        .multidb_instance = NULL
+    },
+    {
+        .id = RRD_MEMORY_MODE_RAM,
+        .name = RRD_MEMORY_MODE_RAM_NAME,
+        .api = {
+            .engine_ops = {
+                .create = NULL,
+                .exit = NULL,
+                .destroy = NULL
+            },
+            .set_ops = {
+                .create = rrdset_init_ram,
+                .destroy = set_destroy_unmap,
+            },
+            .dim_ops = {
+                .create = rrddim_init_ram,
+                .init = NULL,
+                .destroy = dimension_destroy_unmap,
+            },
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        },
+        .instance_per_host = true,
+        .multidb_instance = NULL
+    },
+    {
+        .id = RRD_MEMORY_MODE_MAP,
+        .name = RRD_MEMORY_MODE_MAP_NAME,
+        .api = {
+            .engine_ops = {
+                .create = NULL,
+                .exit = NULL,
+                .destroy = NULL
+            },
+            .set_ops = {
+                .create = rrdset_init_map,
+                .destroy = set_destroy_unmap,
+            },
+            .dim_ops = {
+                .create = rrddim_init_map,
+                .init = NULL,
+                .destroy = dimension_destroy_unmap,
+            },
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        },
+        .instance_per_host = true,
+        .multidb_instance = NULL
+    },
+    {
+        .id = RRD_MEMORY_MODE_SAVE,
+        .name = RRD_MEMORY_MODE_SAVE_NAME,
+        .api = {
+            .engine_ops = {
+                .create = NULL,
+                .exit = NULL,
+                .destroy = NULL
+            },
+            .set_ops = {
+                .create = rrdset_init_save,
+                .destroy = set_destroy_unmap,
+            },
+            .dim_ops = {
+                .create = rrddim_init_save,
+                .init = NULL,
+                .destroy = dimension_destroy_unmap,
+            },
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        },
+        .instance_per_host = true,
+        .multidb_instance = NULL
+    },
+    {
+        .id = RRD_MEMORY_MODE_ALLOC,
+        .name = RRD_MEMORY_MODE_ALLOC_NAME,
+        .api = {
+            .engine_ops = {
+                .create = NULL,
+                .exit = NULL,
+                .destroy = NULL
+            },
+            .set_ops = {
+                .create = rrdset_init_ALLOC,
+                .destroy = set_destroy_unmap,
+            },
+            .dim_ops = {
+                .create = rrddim_init_ALLOC,
+                .init = NULL,
+                .destroy = dimension_destroy_unmap,
+            },
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        },
+        .instance_per_host = true,
+        .multidb_instance = NULL
+    },
+#ifdef ENABLE_DBENGINE
+    {
+        .id = RRD_MEMORY_MODE_DBENGINE,
+        .name = RRD_MEMORY_MODE_DBENGINE_NAME,
+        .api = {
+            .engine_ops = {
+                .create = rrdeng_init,
+                .exit = rrdeng_prepare_exit,
+                .destroy = rrdeng_exit
+            },
+            .set_ops = {
+                .create = rrdset_init_DBENGINE,
+                .destroy = set_destroy_freez,
+            },
+            .dim_ops = {
+                .create = rrddim_init_DBENGINE,
+                .init = rrdeng_metric_init,
+                .destroy = dimension_destroy_freez,
+            },
+            .collect_ops = {
+                .init = rrdeng_store_metric_init,
+                .store_metric = rrdeng_store_metric_next,
+                .finalize = rrdeng_store_metric_finalize
+            },
+            .query_ops = {
+                .init = rrdeng_load_metric_init,
+                .next_metric = rrdeng_load_metric_next,
+                .is_finished = rrdeng_load_metric_is_finished,
+                .finalize = rrdeng_load_metric_finalize,
+                .latest_time = rrdeng_metric_latest_time,
+                .oldest_time = rrdeng_metric_oldest_time
+            }
+        },
+        .instance_per_host = false,
+        .multidb_instance = NULL
+    },
+#endif
+    { .id = RRD_MEMORY_MODE_NONE, .name = NULL }
+};
+
+STORAGE_ENGINE* engine_find(const char* name)
+{
+    for (STORAGE_ENGINE* it = engines; it->name; it++) {
+        if (strcmp(it->name, name) == 0)
+            return it;
+    }
+    return NULL;
+}
+
+STORAGE_ENGINE* engine_get(RRD_MEMORY_MODE mmode)
+{
+    for (STORAGE_ENGINE* it = engines; it->name; it++) {
+        if (it->id == mmode)
+            return it;
+    }
+    return NULL;
+}
+
+STORAGE_ENGINE* engine_foreach_init()
+{
+    // Assuming at least one engine exists
+    return &engines[0];
+}
+
+STORAGE_ENGINE* engine_foreach_next(STORAGE_ENGINE* it)
+{
+    if (!it || !it->name)
+        return NULL;
+
+    it++;
+    return it->name ? it : NULL;
+}
+
+STORAGE_ENGINE_INSTANCE* engine_new(STORAGE_ENGINE* eng, RRDHOST *host, bool force_new)
+{
+    STORAGE_ENGINE_INSTANCE* instance = NULL;
+    if (eng) {
+        bool multidb = !force_new && !eng->instance_per_host;
+        if (multidb && eng->multidb_instance) {
+            instance = eng->multidb_instance;
+        } else {
+            if (eng->api.engine_ops.create) {
+                instance = eng->api.engine_ops.create(eng, host);
+            }
+            if (instance) {
+                instance->engine = eng;
+                if (multidb) {
+                    eng->multidb_instance = instance;
+                }
+            }
+        }
+    }
+    //host->rrdeng_ctx = instance;
+    return instance;
+}
+
+void engine_delete(STORAGE_ENGINE_INSTANCE* instance) {
+    if (instance) {
+        STORAGE_ENGINE* eng = instance->engine;
+        if (instance == eng->multidb_instance) {
+            eng->multidb_instance = NULL;
+        }
+        if (eng && eng->api.engine_ops.destroy) {
+            eng->api.engine_ops.destroy(instance);
+        }
+    }
+}

--- a/database/storage_engine.c
+++ b/database/storage_engine.c
@@ -71,14 +71,11 @@ STORAGE_ENGINE engines[] = {
         .id = RRD_MEMORY_MODE_NONE,
         .name = RRD_MEMORY_MODE_NONE_NAME,
         .api = {
-            .engine_ops = {
-                .create = NULL,
-                .exit = NULL,
-                .destroy = NULL
-            },
+            .engine_ops = {NULL, NULL, NULL},
             .set_ops = {
                 .create = rrdset_init_NONE,
                 .destroy = set_destroy_freez,
+                .query = NULL,
             },
             .dim_ops = {
                 .create = rrddim_init_NONE,
@@ -95,14 +92,11 @@ STORAGE_ENGINE engines[] = {
         .id = RRD_MEMORY_MODE_RAM,
         .name = RRD_MEMORY_MODE_RAM_NAME,
         .api = {
-            .engine_ops = {
-                .create = NULL,
-                .exit = NULL,
-                .destroy = NULL
-            },
+            .engine_ops = {NULL, NULL, NULL},
             .set_ops = {
                 .create = rrdset_init_ram,
                 .destroy = set_destroy_unmap,
+                .query = NULL,
             },
             .dim_ops = {
                 .create = rrddim_init_ram,
@@ -119,14 +113,11 @@ STORAGE_ENGINE engines[] = {
         .id = RRD_MEMORY_MODE_MAP,
         .name = RRD_MEMORY_MODE_MAP_NAME,
         .api = {
-            .engine_ops = {
-                .create = NULL,
-                .exit = NULL,
-                .destroy = NULL
-            },
+            .engine_ops = {NULL, NULL, NULL},
             .set_ops = {
                 .create = rrdset_init_map,
                 .destroy = set_destroy_unmap,
+                .query = NULL,
             },
             .dim_ops = {
                 .create = rrddim_init_map,
@@ -143,14 +134,11 @@ STORAGE_ENGINE engines[] = {
         .id = RRD_MEMORY_MODE_SAVE,
         .name = RRD_MEMORY_MODE_SAVE_NAME,
         .api = {
-            .engine_ops = {
-                .create = NULL,
-                .exit = NULL,
-                .destroy = NULL
-            },
+            .engine_ops = {NULL, NULL, NULL},
             .set_ops = {
                 .create = rrdset_init_save,
                 .destroy = set_destroy_unmap,
+                .query = NULL,
             },
             .dim_ops = {
                 .create = rrddim_init_save,
@@ -167,14 +155,11 @@ STORAGE_ENGINE engines[] = {
         .id = RRD_MEMORY_MODE_ALLOC,
         .name = RRD_MEMORY_MODE_ALLOC_NAME,
         .api = {
-            .engine_ops = {
-                .create = NULL,
-                .exit = NULL,
-                .destroy = NULL
-            },
+            .engine_ops = {NULL, NULL, NULL},
             .set_ops = {
                 .create = rrdset_init_ALLOC,
                 .destroy = set_destroy_unmap,
+                .query = NULL,
             },
             .dim_ops = {
                 .create = rrddim_init_ALLOC,
@@ -200,6 +185,7 @@ STORAGE_ENGINE engines[] = {
             .set_ops = {
                 .create = rrdset_init_DBENGINE,
                 .destroy = set_destroy_freez,
+                .query = rrdeng_query,
             },
             .dim_ops = {
                 .create = rrddim_init_DBENGINE,

--- a/database/storage_engine.h
+++ b/database/storage_engine.h
@@ -21,6 +21,22 @@ struct storage_engine_ops {
 struct rrdset_ops {
     RRDSET*(*create)(const char *id, const char *fullid, const char *filename, long entries, int update_every);
     void(*destroy)(RRDSET *rd);
+
+    //
+    RRDR*(*query)(
+        RRDSET *st
+        , long points_requested
+        , long long after_requested
+        , long long before_requested
+        , RRDR_GROUPING group_method
+        , long resampling_time_requested
+        , RRDR_OPTIONS options
+        , const char *dimensions
+        , int update_every
+        , time_t first_entry_t
+        , time_t last_entry_t
+        , int absolute_period_requested
+        , struct context_param *context_param_list);
 };
 
 // ------------------------------------------------------------------------

--- a/database/storage_engine.h
+++ b/database/storage_engine.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_STORAGEENGINEAPI_H
+#define NETDATA_STORAGEENGINEAPI_H
+
+#include "rrd.h"
+
+typedef struct storage_engine STORAGE_ENGINE;
+typedef struct storage_engine_instance STORAGE_ENGINE_INSTANCE;
+
+// ------------------------------------------------------------------------
+// function pointers that handle storage engine instance creation and destruction
+struct storage_engine_ops {
+    STORAGE_ENGINE_INSTANCE*(*create)(STORAGE_ENGINE* engine, RRDHOST *host);
+    void(*exit)(STORAGE_ENGINE_INSTANCE*);
+    void(*destroy)(STORAGE_ENGINE_INSTANCE*);
+};
+
+// ------------------------------------------------------------------------
+// function pointers that handle RRDSET creation, destruction and query
+struct rrdset_ops {
+    RRDSET*(*create)(const char *id, const char *fullid, const char *filename, long entries, int update_every);
+    void(*destroy)(RRDSET *rd);
+};
+
+// ------------------------------------------------------------------------
+// function pointers that handle RRDDIM creation and destruction
+struct rrddim_ops {
+    RRDDIM*(*create)(RRDSET *st, const char *id, const char *filename, collected_number multiplier,
+                          collected_number divisor, RRD_ALGORITHM algorithm);
+    void(*init)(RRDDIM* rd);
+    void(*destroy)(RRDDIM *rd);
+};
+
+// ------------------------------------------------------------------------
+// function pointers for all APIs provided by a storge engine
+typedef struct storage_engine_api {
+    struct storage_engine_ops engine_ops;
+    struct rrdset_ops set_ops;
+    struct rrddim_ops dim_ops;
+    struct rrddim_collect_ops collect_ops;
+    struct rrddim_query_ops query_ops;
+} STORAGE_ENGINE_API;
+
+struct storage_engine {
+    RRD_MEMORY_MODE id;
+    const char* name;
+    STORAGE_ENGINE_API api;
+
+    // True if this storage engine only supports a single host per instance
+    bool instance_per_host;
+    STORAGE_ENGINE_INSTANCE* multidb_instance;
+};
+
+// Abstract structure to be extended by implementations
+struct storage_engine_instance {
+    STORAGE_ENGINE* engine;
+};
+
+STORAGE_ENGINE* engine_get(RRD_MEMORY_MODE mmode);
+STORAGE_ENGINE* engine_find(const char* name);
+
+// Iterator over existing engines
+STORAGE_ENGINE* engine_foreach_init();
+STORAGE_ENGINE* engine_foreach_next(STORAGE_ENGINE* it);
+
+// ------------------------------------------------------------------------
+// Retreive or create a storage engine instance for mmode and host
+// If this engine supports multidb (instance_per_host is false), a global instance
+// is returned.
+// If force_new is true, a new instance will be created regardless of instance_per_host.
+STORAGE_ENGINE_INSTANCE* engine_new(STORAGE_ENGINE* engine, RRDHOST *host, bool force_new);
+void engine_delete(STORAGE_ENGINE_INSTANCE* engine);
+
+#endif

--- a/ml/Dimension.h
+++ b/ml/Dimension.h
@@ -45,7 +45,7 @@ private:
     RRDDIM *RD;
     RRDDIM *AnomalyRateRD;
 
-    struct rrddim_volatile::rrddim_query_ops *Ops;
+    struct rrddim_query_ops *Ops;
 
     std::string ID;
 };

--- a/ml/Query.h
+++ b/ml/Query.h
@@ -40,7 +40,7 @@ public:
 private:
     RRDDIM *RD;
 
-    struct rrddim_volatile::rrddim_query_ops *Ops;
+    struct rrddim_query_ops *Ops;
     struct rrddim_query_handle Handle;
 };
 

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -3,6 +3,10 @@
 #include "query.h"
 #include "web/api/formatters/rrd2json.h"
 #include "rrdr.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
+#include "database/rrddim_mem.h"
 
 #include "average/average.h"
 #include "incremental_sum/incremental_sum.h"

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -580,9 +580,10 @@ static inline void do_dimension_fixedstep(
         // read the value from the database
         //storage_number n = rd->values[slot];
 #ifdef NETDATA_INTERNAL_CHECKS
+        struct mem_query_handle* mem_handle = (struct mem_query_handle*)handle.handle;
         if ((rd->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE) &&
-            (rrdset_time2slot(st, now) != (long unsigned)handle.slotted.slot)) {
-            error("INTERNAL CHECK: Unaligned query for %s, database slot: %lu, expected slot: %lu", rd->id, (long unsigned)handle.slotted.slot, rrdset_time2slot(st, now));
+            (rrdset_time2slot(st, now) != (long unsigned)(mem_handle->slot))) {
+            error("INTERNAL CHECK: Unaligned query for %s, database slot: %lu, expected slot: %lu", rd->id, (long unsigned)mem_handle->slot, rrdset_time2slot(st, now));
         }
 #endif
         db_now = now; // this is needed to set db_now in case the next_metric implementation does not set it
@@ -601,8 +602,9 @@ static inline void do_dimension_fixedstep(
             calculated_number value = NAN;
             if(likely(now >= db_now && does_storage_number_exist(n))) {
 #if defined(NETDATA_INTERNAL_CHECKS) && defined(ENABLE_DBENGINE)
-                if ((rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) && (now != handle.rrdeng.now)) {
-                    error("INTERNAL CHECK: Unaligned query for %s, database time: %ld, expected time: %ld", rd->id, (long)handle.rrdeng.now, (long)now);
+                struct rrdeng_query_handle* rrd_handle = (struct rrdeng_query_handle*)handle.handle;
+                if ((rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) && (now != rrd_handle->now)) {
+                    error("INTERNAL CHECK: Unaligned query for %s, database time: %ld, expected time: %ld", rd->id, (long)rrd_handle->now, (long)now);
                 }
 #endif
                 if (options & RRDR_OPTION_ANOMALY_BIT)

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -49,6 +49,13 @@ typedef enum rrdr_result_flags {
     RRDR_RESULT_OPTION_VARIABLE_STEP = 0x00000004, // the query uses variable-step time-frames
 } RRDR_RESULT_FLAGS;
 
+// RRDR region info
+typedef struct rrdr_region_info {
+    time_t start_time;
+    int update_every;
+    unsigned points;
+} RRDR_REGION_INFO;
+
 typedef struct rrdresult {
     struct rrdset *st;         // the chart this result refers to
 
@@ -111,6 +118,48 @@ extern RRDR *rrd2rrdr(
     RRDSET *st, long points_requested, long long after_requested, long long before_requested,
     RRDR_GROUPING group_method, long resampling_time_requested, RRDR_OPTIONS options, const char *dimensions,
     struct context_param *context_param_list);
+
+extern RRDR *rrd2rrdr_fixedstep(
+        RRDSET *st
+        , long points_requested
+        , long long after_requested
+        , long long before_requested
+        , RRDR_GROUPING group_method
+        , long resampling_time_requested
+        , RRDR_OPTIONS options
+        , const char *dimensions
+        , int update_every
+        , time_t first_entry_t
+        , time_t last_entry_t
+        , int absolute_period_requested
+        , struct context_param *context_param_list
+);
+
+extern RRDR *rrd2rrdr_variablestep(
+        RRDSET *st
+        , long points_requested
+        , long long after_requested
+        , long long before_requested
+        , RRDR_GROUPING group_method
+        , long resampling_time_requested
+        , RRDR_OPTIONS options
+        , const char *dimensions
+        , int update_every
+        , time_t first_entry_t
+        , time_t last_entry_t
+        , int absolute_period_requested
+        , struct rrdr_region_info *region_info_array
+        , struct context_param *context_param_list
+);
+
+extern int rrdr_convert_before_after_to_absolute(
+        long long *after_requestedp
+        , long long *before_requestedp
+        , int update_every
+        , time_t first_entry_t
+        , time_t last_entry_t
+        , RRDR_OPTIONS options
+);
 
 #include "query.h"
 


### PR DESCRIPTION
Following the idea discussed here:
https://github.com/netdata/netdata/discussions/12216

This PR allows adding arbitrary memory modes (storage engines).

##### Summary

These commits do the following (in commit order):
* Move `rrddim_collect_ops` and `rrddim_query_ops` out of the `rrddim_volatile` structure, allowing them to be used outside of the context of this structure. Later, we plan to use these structures to allow storage engines to expose their collection and query APIs.
* Make `rrddim_collect_handle` and `rrddim_query_handle` opaque structures instead of a union, allowing for arbitrary handle types, later provided by arbitrary memory modes/storage engines.
* Add a new API layer to interact with storage engines (memory modes) and use it to instantiate "dbengine".
* Use the new API layer to create/delete `RRDSET`
* Use the new API layer to create/delete `RRDDIM` and to store and query metrics
* Add a new API call to perform rrdset queries.

##### Test Plan

These changes don't add any new memory modes/storage engines for now, and only refactor existing features, so they are expected to be covered by existing unit tests.
