### PR TITLE
feat(netdata-updater): add `--force-update` parameter

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -464,6 +464,10 @@ validate_environment_file() {
 }
 
 update_available() {
+  if [ "$NETDATA_UPDATER_FORCE_UPDATE" = "1" ]; then
+     info "Force update requested"
+     return 0
+  fi
   basepath="$(dirname "$(dirname "$(dirname "${NETDATA_LIB_DIR}")")")"
   searchpath="${basepath}/bin:${basepath}/sbin:${basepath}/usr/bin:${basepath}/usr/sbin:${PATH}"
   searchpath="${basepath}/netdata/bin:${basepath}/netdata/sbin:${basepath}/netdata/usr/bin:${basepath}/netdata/usr/sbin:${searchpath}"
@@ -790,6 +794,9 @@ while [ -n "${1}" ]; do
     shift 1
   elif [ "${1}" = "--no-updater-self-update" ]; then
     NETDATA_NO_UPDATER_SELF_UPDATE=1
+    shift 1
+  elif [ "${1}" = "--force-update" ]; then
+    NETDATA_UPDATER_FORCE_UPDATE=1
     shift 1
   elif [ "${1}" = "--tmpdir-path" ]; then
     NETDATA_TMPDIR_PATH="${2}"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -464,7 +464,7 @@ validate_environment_file() {
 }
 
 update_available() {
-  if [ "$NETDATA_UPDATER_FORCE_UPDATE" = "1" ]; then
+  if [ "$NETDATA_FORCE_UPDATE" = "1" ]; then
      info "Force update requested"
      return 0
   fi
@@ -796,7 +796,7 @@ while [ -n "${1}" ]; do
     NETDATA_NO_UPDATER_SELF_UPDATE=1
     shift 1
   elif [ "${1}" = "--force-update" ]; then
-    NETDATA_UPDATER_FORCE_UPDATE=1
+    NETDATA_FORCE_UPDATE=1
     shift 1
   elif [ "${1}" = "--tmpdir-path" ]; then
     NETDATA_TMPDIR_PATH="${2}"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -536,7 +536,9 @@ update_build() {
   if update_available; then
     download "${NETDATA_TARBALL_CHECKSUM_URL}" "${ndtmpdir}/sha256sum.txt" >&3 2>&3
     download "${NETDATA_TARBALL_URL}" "${ndtmpdir}/netdata-latest.tar.gz"
-    if [ -n "${NETDATA_TARBALL_CHECKSUM}" ] && grep "${NETDATA_TARBALL_CHECKSUM}" sha256sum.txt >&3 2>&3; then
+    if [ -n "${NETDATA_TARBALL_CHECKSUM}" ] &&
+      grep "${NETDATA_TARBALL_CHECKSUM}" sha256sum.txt >&3 2>&3 &&
+      [ "$NETDATA_FORCE_UPDATE" != "1" ]; then
       info "Newest version is already installed"
     else
       if ! grep netdata-latest.tar.gz sha256sum.txt | safe_sha256sum -c - >&3 2>&3; then


### PR DESCRIPTION
##### Summary

This will be quite handy when testing the changes in the updater script. Update forcing works for static and from source builds.

##### Test Plan

Run the new version with the `--force-update` option, see it updates Netdata even if there is no new version available:

 - static isntall.
 - from the source install.

##### Additional Information

@netdata/agent-sre I am not sure that the modification behavior of the `update_available` function is the correct change. If you think we shouldn't do it please comment, I will move out checking `NETDATA_FORCE_UPDATE` from it.
