### PR TITLE
ML-related changes to address issue/discussion comments.

### DIFF
--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -128,9 +128,6 @@ void Config::readMLConfig(void) {
 
     // Always exclude anomaly_detection charts from training.
     Cfg.ChartsToSkip = "anomaly_detection.* ";
-    Cfg.ChartsToSkip += config_get(ConfigSectionML, "charts to skip from training",
-            "!system.* !cpu.* !mem.* !disk.* !disk_* "
-            "!ip.* !ipv4.* !ipv6.* !net.* !net_* !netfilter.* "
-            "!services.* !apps.* !groups.* !user.* !ebpf.* !netdata.* *");
+    Cfg.ChartsToSkip += config_get(ConfigSectionML, "charts to skip from training", "netdata.*");
     Cfg.SP_ChartsToSkip = simple_pattern_create(ChartsToSkip.c_str(), NULL, SIMPLE_PATTERN_EXACT);
 }

--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -38,6 +38,7 @@ void Config::readMLConfig(void) {
     unsigned SmoothN = config_get_number(ConfigSectionML, "num samples to smooth", 3);
     unsigned LagN = config_get_number(ConfigSectionML, "num samples to lag", 5);
 
+    double RandomSamplingRatio = config_get_float(ConfigSectionML, "random sampling ratio", 1.0 / LagN);
     unsigned MaxKMeansIters = config_get_number(ConfigSectionML, "maximum number of k-means iterations", 1000);
 
     double DimensionAnomalyScoreThreshold = config_get_float(ConfigSectionML, "dimension anomaly score threshold", 0.99);
@@ -67,6 +68,7 @@ void Config::readMLConfig(void) {
     SmoothN = clamp(SmoothN, 0u, 5u);
     LagN = clamp(LagN, 0u, 5u);
 
+    RandomSamplingRatio = clamp(RandomSamplingRatio, 0.2, 1.0);
     MaxKMeansIters = clamp(MaxKMeansIters, 500u, 1000u);
 
     DimensionAnomalyScoreThreshold = clamp(DimensionAnomalyScoreThreshold, 0.01, 5.00);
@@ -112,6 +114,7 @@ void Config::readMLConfig(void) {
     Cfg.SmoothN = SmoothN;
     Cfg.LagN = LagN;
 
+    Cfg.RandomSamplingRatio = RandomSamplingRatio;
     Cfg.MaxKMeansIters = MaxKMeansIters;
 
     Cfg.DimensionAnomalyScoreThreshold = DimensionAnomalyScoreThreshold;

--- a/ml/Config.h
+++ b/ml/Config.h
@@ -21,6 +21,7 @@ public:
     unsigned SmoothN;
     unsigned LagN;
 
+    double RandomSamplingRatio;
     unsigned MaxKMeansIters;
 
     double DimensionAnomalyScoreThreshold;
@@ -39,6 +40,7 @@ public:
     SIMPLE_PATTERN *SP_ChartsToSkip;
 
     std::string AnomalyDBPath;
+    std::vector<uint32_t> RandomNums;
 
     void readMLConfig();
 };

--- a/ml/Dimension.cc
+++ b/ml/Dimension.cc
@@ -125,8 +125,13 @@ MLResult TrainableDimension::trainModel() {
     if (!CNs)
         return MLResult::MissingData;
 
-    SamplesBuffer SB = SamplesBuffer(CNs, N, 1, Cfg.DiffN, Cfg.SmoothN, Cfg.LagN);
+    unsigned TargetNumSamples = Cfg.MaxTrainSamples * Cfg.RandomSamplingRatio;
+    double SamplingRatio = std::min(static_cast<double>(TargetNumSamples) / N, 1.0);
+
+    SamplesBuffer SB = SamplesBuffer(CNs, N, 1, Cfg.DiffN, Cfg.SmoothN, Cfg.LagN,
+                                     SamplingRatio, Cfg.RandomNums);
     KM.train(SB, Cfg.MaxKMeansIters);
+
     Trained = true;
     ConstantModel = true;
 
@@ -162,7 +167,8 @@ std::pair<MLResult, bool> PredictableDimension::predict() {
     CalculatedNumber *TmpCNs = new CalculatedNumber[N * (Cfg.LagN + 1)]();
     std::memcpy(TmpCNs, CNs.data(), N * sizeof(CalculatedNumber));
 
-    SamplesBuffer SB = SamplesBuffer(TmpCNs, N, 1, Cfg.DiffN, Cfg.SmoothN, Cfg.LagN);
+    SamplesBuffer SB = SamplesBuffer(TmpCNs, N, 1, Cfg.DiffN, Cfg.SmoothN, Cfg.LagN,
+                                     1.0, Cfg.RandomNums);
     AnomalyScore = computeAnomalyScore(SB);
     delete[] TmpCNs;
 

--- a/ml/Dimension.h
+++ b/ml/Dimension.h
@@ -76,10 +76,6 @@ public:
 
     bool isTrained() const { return Trained; }
 
-    double updateTrainingDuration(double Duration) {
-        return TrainingDuration.exchange(Duration);
-    }
-
 private:
     std::pair<CalculatedNumber *, size_t> getCalculatedNumbers();
 
@@ -94,7 +90,6 @@ private:
     KMeans KM;
 
     std::atomic<bool> Trained{false};
-    std::atomic<double> TrainingDuration{0.0};
 };
 
 class PredictableDimension : public TrainableDimension {

--- a/ml/Host.cc
+++ b/ml/Host.cc
@@ -358,7 +358,7 @@ void TrainableHost::trainDimension(Dimension *D, const TimePoint &NowTP) {
 }
 
 void TrainableHost::train() {
-    Duration<double> MaxSleepFor = Seconds{updateEvery()};
+    Duration<double> MaxSleepFor = Seconds{10 * updateEvery()};
 
     while (!netdata_exit) {
         TimePoint NowTP = SteadyClock::now();

--- a/ml/Host.cc
+++ b/ml/Host.cc
@@ -477,15 +477,18 @@ void DetectableHost::detectOnce() {
 void DetectableHost::detect() {
     std::this_thread::sleep_for(Seconds{10});
 
+    heartbeat_t HB;
+    heartbeat_init(&HB);
+
     while (!netdata_exit) {
+        heartbeat_next(&HB, updateEvery() * USEC_PER_SEC);
+
         TimePoint StartTP = SteadyClock::now();
         detectOnce();
         TimePoint EndTP = SteadyClock::now();
 
         Duration<double> Dur = EndTP - StartTP;
         updateDetectionChart(getRH(), Dur.count() * 1000);
-
-        std::this_thread::sleep_for(Seconds{updateEvery()});
     }
 }
 

--- a/ml/Host.cc
+++ b/ml/Host.cc
@@ -305,6 +305,7 @@ void RrdHost::getConfigAsJson(nlohmann::json &Json) const {
     Json["smooth-n"] = Cfg.SmoothN;
     Json["lag-n"] = Cfg.LagN;
 
+    Json["random-sampling-ratio"] = Cfg.RandomSamplingRatio;
     Json["max-kmeans-iters"] = Cfg.MaxKMeansIters;
 
     Json["dimension-anomaly-score-threshold"] = Cfg.DimensionAnomalyScoreThreshold;

--- a/ml/Host.h
+++ b/ml/Host.h
@@ -70,9 +70,22 @@ public:
 
     void train();
 
+    void updateResourceUsage() {
+        std::lock_guard<std::mutex> Lock(ResourceUsageMutex);
+        getrusage(RUSAGE_THREAD, &ResourceUsage);
+    }
+
+    void getResourceUsage(struct rusage *RU) {
+        std::lock_guard<std::mutex> Lock(ResourceUsageMutex);
+        memcpy(RU, &ResourceUsage, sizeof(struct rusage));
+    }
+
 private:
     std::pair<Dimension *, Duration<double>> findDimensionToTrain(const TimePoint &NowTP);
     void trainDimension(Dimension *D, const TimePoint &NowTP);
+
+    std::mutex ResourceUsageMutex;
+    struct rusage ResourceUsage;
 };
 
 class DetectableHost : public TrainableHost {

--- a/ml/kmeans/SamplesBuffer.cc
+++ b/ml/kmeans/SamplesBuffer.cc
@@ -130,7 +130,13 @@ std::vector<DSample> SamplesBuffer::preprocess() {
     DSamples.reserve(OutN);
     Preprocessed = true;
 
+    uint32_t MaxMT = std::numeric_limits<uint32_t>::max();
+    uint32_t CutOff = static_cast<double>(MaxMT) * SamplingRatio;
+
     for (size_t Idx = NumSamples - OutN; Idx != NumSamples; Idx++) {
+        if (RandNums[Idx] > CutOff)
+            continue;
+
         DSample DS;
         DS.set_size(NumDimsPerSample * (LagN + 1));
 

--- a/ml/kmeans/SamplesBuffer.h
+++ b/ml/kmeans/SamplesBuffer.h
@@ -80,9 +80,11 @@ class SamplesBuffer {
 public:
     SamplesBuffer(CalculatedNumber *CNs,
                   size_t NumSamples, size_t NumDimsPerSample,
-                  size_t DiffN = 1, size_t SmoothN = 3, size_t LagN = 3) :
+                  size_t DiffN, size_t SmoothN, size_t LagN,
+                  double SamplingRatio, std::vector<uint32_t> &RandNums) :
         CNs(CNs), NumSamples(NumSamples), NumDimsPerSample(NumDimsPerSample),
         DiffN(DiffN), SmoothN(SmoothN), LagN(LagN),
+        SamplingRatio(SamplingRatio), RandNums(RandNums),
         BytesPerSample(NumDimsPerSample * sizeof(CalculatedNumber)),
         Preprocessed(false) {};
 
@@ -129,6 +131,9 @@ private:
     size_t DiffN;
     size_t SmoothN;
     size_t LagN;
+    double SamplingRatio;
+    std::vector<uint32_t> &RandNums;
+
     size_t BytesPerSample;
     bool Preprocessed;
 };

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -32,6 +32,9 @@ void ml_init(void) {
     // Read config values
     Cfg.readMLConfig();
 
+    if (!Cfg.EnableAnomalyDetection)
+        return;
+
     // Generate random numbers to efficiently sample the features we need
     // for KMeans clustering.
     std::random_device RD;
@@ -39,7 +42,7 @@ void ml_init(void) {
 
     Cfg.RandomNums.reserve(Cfg.MaxTrainSamples);
     for (size_t Idx = 0; Idx != Cfg.MaxTrainSamples; Idx++)
-        Cfg.RandomNums[Idx] = Gen();
+        Cfg.RandomNums.push_back(Gen());
 }
 
 void ml_new_host(RRDHOST *RH) {

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -4,6 +4,8 @@
 #include "Dimension.h"
 #include "Host.h"
 
+#include <random>
+
 using namespace ml;
 
 bool ml_capable() {
@@ -27,7 +29,17 @@ bool ml_enabled(RRDHOST *RH) {
  */
 
 void ml_init(void) {
+    // Read config values
     Cfg.readMLConfig();
+
+    // Generate random numbers to efficiently sample the features we need
+    // for KMeans clustering.
+    std::random_device RD;
+    std::mt19937 Gen(RD());
+
+    Cfg.RandomNums.reserve(Cfg.MaxTrainSamples);
+    for (size_t Idx = 0; Idx != Cfg.MaxTrainSamples; Idx++)
+        Cfg.RandomNums[Idx] = Gen();
 }
 
 void ml_new_host(RRDHOST *RH) {


### PR DESCRIPTION
##### Summary

Relevant changes to address comments in:

- https://github.com/netdata/netdata/issues/12173
- https://github.com/netdata/netdata/issues/12177
- https://github.com/netdata/netdata/discussions/12350

At a high-level:

- Allow sleeping for more than one second in the training thread.
- Use a heartbeat for the prediction thread.
- Use getrusage for training/prediction CPU usage.
- Skip only `netdata.*` charts from training.
- Random sampling of extracted features.

Each commit in this PR constitutes a standalone change to make review easier.

##### Test Plan

Local testing + CI jobs + staging environment 
