### PR TITLE
Adjust timex.plugin information to be less cryptic

### DIFF
--- a/collectors/timex.plugin/README.md
+++ b/collectors/timex.plugin/README.md
@@ -6,7 +6,7 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/timex
 
 # timex.plugin
 
-This plugin monitors the system kernel clock synchronization state on Linux nodes.
+This plugin monitors the system kernel clock synchronization state.
 
 This plugin creates two charts:
 

--- a/collectors/timex.plugin/README.md
+++ b/collectors/timex.plugin/README.md
@@ -13,7 +13,7 @@ This plugin creates two charts:
 -   System clock synchronization state according to the system kernel
 -   Computed time offset between local system and reference clock
 
-This is obtained from the information provided by the ntp_adjtime() system call.
+This is obtained from the information provided by the [ntp_adjtime()](https://man7.org/linux/man-pages/man2/adjtimex.2.html) system call.
 An unsynchronized clock may indicate a hardware clock error, or an issue with UTC synchronization.
 
 ## Configuration

--- a/collectors/timex.plugin/README.md
+++ b/collectors/timex.plugin/README.md
@@ -6,12 +6,15 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/timex
 
 # timex.plugin
 
-This plugin monitors the system clock synchronization state on Linux nodes.
+This plugin monitors the system kernel clock synchronization state on Linux nodes.
 
 This plugin creates two charts:
 
--   System clock synchronization state
+-   System clock synchronization state according to the system kernel
 -   Computed time offset between local system and reference clock
+
+This is obtained from the information provided by the ntp_adjtime() system call.
+An unsynchronized clock may indicate a hardware clock error, or an issue with UTC synchronization.
 
 ## Configuration
 

--- a/health/health.d/timex.conf
+++ b/health/health.d/timex.conf
@@ -13,5 +13,5 @@ component: Clock
     every: 10s
      warn: $system.uptime.uptime > 17 * 60 AND $this == 0
     delay: down 5m
-     info: the system time is not synchronized to a reliable server
+     info: when set to 0, the system kernel believes the system clock not properly synchronized
        to: silent

--- a/health/health.d/timex.conf
+++ b/health/health.d/timex.conf
@@ -13,5 +13,5 @@ component: Clock
     every: 10s
      warn: $system.uptime.uptime > 17 * 60 AND $this == 0
     delay: down 5m
-     info: when set to 0, the system kernel believes the system clock not properly synchronized
+     info: when set to 0, the system kernel believes the system clock is not properly synchronized to a reliable server
        to: silent

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1310,8 +1310,8 @@ netdataDashboard.context = {
     },
 
     'system.clock_sync_state': {
-        info:'<p>The system clock synchronization state. '+
-        'It is strongly recommended having the clock in sync with reliable NTP servers. Otherwise, '+
+        info:'<p>The system clock synchronization state as provided by the ntp_adjtime() system call. '+
+        'This reflects the status of the system kernel regarding clock synchronization.'+ 
         'it leads to unpredictable problems. '+
         'It can take several minutes (usually up to 17) before NTP daemon selects a server to synchronize with. '+
         '<p><b>State map</b>: 0 - not synchronized, 1 - synchronized.</p>'

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1311,8 +1311,7 @@ netdataDashboard.context = {
 
     'system.clock_sync_state': {
         info:'<p>The system clock synchronization state as provided by the <a href="https://man7.org/linux/man-pages/man2/adjtimex.2.html" target="_blank">ntp_adjtime()</a> system call. '+
-        'This reflects the status of the system kernel regarding clock synchronization. '+ 
-        'it leads to unpredictable problems. '+
+        'An unsynchronized clock may be the result of synchronization issues by the NTP daemon. '+
         'It can take several minutes (usually up to 17) before NTP daemon selects a server to synchronize with. '+
         '<p><b>State map</b>: 0 - not synchronized, 1 - synchronized.</p>'
     },

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1310,7 +1310,7 @@ netdataDashboard.context = {
     },
 
     'system.clock_sync_state': {
-        info:'<p>The system clock synchronization state as provided by the ntp_adjtime() system call. '+
+        info:'<p>The system clock synchronization state as provided by the <a href="https://man7.org/linux/man-pages/man2/adjtimex.2.html" target="_blank">ntp_adjtime()</a> system call. '+
         'This reflects the status of the system kernel regarding clock synchronization. '+ 
         'it leads to unpredictable problems. '+
         'It can take several minutes (usually up to 17) before NTP daemon selects a server to synchronize with. '+

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1311,7 +1311,7 @@ netdataDashboard.context = {
 
     'system.clock_sync_state': {
         info:'<p>The system clock synchronization state as provided by the <a href="https://man7.org/linux/man-pages/man2/adjtimex.2.html" target="_blank">ntp_adjtime()</a> system call. '+
-        'An unsynchronized clock may be the result of synchronization issues by the NTP daemon. '+
+        'An unsynchronized clock may be the result of synchronization issues by the NTP daemon or a hardware clock fault. '+
         'It can take several minutes (usually up to 17) before NTP daemon selects a server to synchronize with. '+
         '<p><b>State map</b>: 0 - not synchronized, 1 - synchronized.</p>'
     },

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1311,7 +1311,7 @@ netdataDashboard.context = {
 
     'system.clock_sync_state': {
         info:'<p>The system clock synchronization state as provided by the ntp_adjtime() system call. '+
-        'This reflects the status of the system kernel regarding clock synchronization.'+ 
+        'This reflects the status of the system kernel regarding clock synchronization. '+ 
         'it leads to unpredictable problems. '+
         'It can take several minutes (usually up to 17) before NTP daemon selects a server to synchronize with. '+
         '<p><b>State map</b>: 0 - not synchronized, 1 - synchronized.</p>'


### PR DESCRIPTION
##### Summary
Adjusts the timex plugin dashboard info description, clock_sync error description and readme.md to be more clear about the source of the alarm. This does not change the source of the alarm itself

##### Additional Information

Fixes: #12405 