### PR TITLE
Use live charts to count the total number of dimensions.

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -416,12 +416,16 @@ void analytics_metrics(void)
     rrdset_foreach_read(st, localhost)
     {
         rrdset_rdlock(st);
-        rrddim_foreach_read(rd, st)
-        {
-            if (rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN) || rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE))
-                continue;
-            dimensions++;
+
+        if (rrdset_is_available_for_viewers(st)) {
+            rrddim_foreach_read(rd, st)
+            {
+                if (rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN) || rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE))
+                    continue;
+                dimensions++;
+            }
         }
+
         rrdset_unlock(st);
     }
     {


### PR DESCRIPTION
##### Summary

The discrepancy was noticed on a node that had ML enabled. There's a dedicated, hidden chart that tracks anomaly rates. However, the dims in that chart are not hidden because they are meant to be queried by the `/data` endpoint.

##### Test Plan

Compare `metrics-count` and `charts-count` of `/api/v1/info` against `charts_count` and `dimensions_count` of `/api/v1/charts` with/without ML.

##### Additional Information

Fixes https://github.com/netdata/netdata/issues/12476.
