### PR TITLE
Double runtime testing timeouts in CI.

### DIFF
--- a/.github/scripts/docker-test.sh
+++ b/.github/scripts/docker-test.sh
@@ -6,7 +6,7 @@ wait_for() {
   host="${1}"
   port="${2}"
   name="${3}"
-  timeout="30"
+  timeout="60"
 
   if command -v nc > /dev/null ; then
     netcat="nc"
@@ -19,7 +19,7 @@ wait_for() {
 
   printf "Waiting for %s on %s:%s ... " "${name}" "${host}" "${port}"
 
-  sleep 30
+  sleep 60
 
   i=0
   while ! ${netcat} -z "${host}" "${port}"; do

--- a/.github/scripts/docker-test.sh
+++ b/.github/scripts/docker-test.sh
@@ -6,7 +6,8 @@ wait_for() {
   host="${1}"
   port="${2}"
   name="${3}"
-  timeout="60"
+  timeout_count="18"
+  timeout_interval="5"
 
   if command -v nc > /dev/null ; then
     netcat="nc"
@@ -23,8 +24,8 @@ wait_for() {
 
   i=0
   while ! ${netcat} -z "${host}" "${port}"; do
-    sleep 1
-    if [ "$i" -gt "$timeout" ]; then
+    sleep "${timeout_interval}"
+    if [ "$i" -gt "${timeout_count}" ]; then
       printf "Timed out!\n"
       return 1
     fi

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -67,7 +67,8 @@ wait_for() {
   host="${1}"
   port="${2}"
   name="${3}"
-  timeout="60"
+  timeout_count="18"
+  timeout_interval="5"
 
   if command -v nc > /dev/null ; then
     netcat="nc"
@@ -84,8 +85,8 @@ wait_for() {
 
   i=0
   while ! ${netcat} -z "${host}" "${port}"; do
-    sleep 1
-    if [ "$i" -gt "$timeout" ]; then
+    sleep "${timeout_interval}"
+    if [ "$i" -gt "${timeout_count}" ]; then
       printf "Timed out!\n"
       return 1
     fi

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -67,7 +67,7 @@ wait_for() {
   host="${1}"
   port="${2}"
   name="${3}"
-  timeout="30"
+  timeout="60"
 
   if command -v nc > /dev/null ; then
     netcat="nc"
@@ -80,7 +80,7 @@ wait_for() {
 
   printf "Waiting for %s on %s:%s ... " "${name}" "${host}" "${port}"
 
-  sleep 30
+  sleep 60
 
   i=0
   while ! ${netcat} -z "${host}" "${port}"; do


### PR DESCRIPTION
##### Summary

Something appears to have changed in the hosted GHA runners causing startup times for the Netdata agent to vary significantly more than they had previously, which is in turn causing random failures in our runtime testing CI.

This double sboth the initial wait for agent startup, as well as the subsequent timeout for checking for the agent to be live in hopes of mitigating this issue.

##### Test Plan

n/a