### PR TITLE
Fix memory leaks on Netdata exit

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1105,6 +1105,7 @@ void aclk_send_node_instances()
             uuid_unparse_lower(list->node_id, (char*)query->data.node_update.node_id);
             query->data.node_update.queryable = 1;
             query->data.node_update.session_id = aclk_session_newarch;
+            freez(list->hostname);
             info("Queuing status update for node=%s, live=%d, hops=%d",(char*)query->data.node_update.node_id,
                  list->live,
                  list->hops);

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -41,6 +41,7 @@ void aclk_env_t_destroy(aclk_env_t *env) {
         for (size_t i = 0; i < env->transport_count; i++) {
             if(env->transports[i]) {
                 aclk_transport_desc_t_destroy(env->transports[i]);
+                freez(env->transports[i]);
                 env->transports[i] = NULL;
             }
         }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -250,6 +250,8 @@ void cancel_main_threads() {
     else
         info("All threads finished.");
 
+    for (i = 0; static_threads[i].name != NULL ; i++)
+        freez(static_threads[i].thread);
     free(static_threads);
 }
 

--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -159,6 +159,7 @@ int create_data_file(struct rrdengine_datafile *datafile)
     if (unlikely(ret)) {
         fatal("posix_memalign:%s", strerror(ret));
     }
+    memset(superblock, 0, sizeof(*superblock));
     (void) strncpy(superblock->magic_number, RRDENG_DF_MAGIC, RRDENG_MAGIC_SZ);
     (void) strncpy(superblock->version, RRDENG_DF_VER, RRDENG_VER_SZ);
     superblock->tier = 1;

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -210,6 +210,7 @@ int create_journal_file(struct rrdengine_journalfile *journalfile, struct rrdeng
     if (unlikely(ret)) {
         fatal("posix_memalign:%s", strerror(ret));
     }
+    memset(superblock, 0, sizeof(*superblock));
     (void) strncpy(superblock->magic_number, RRDENG_JF_MAGIC, RRDENG_MAGIC_SZ);
     (void) strncpy(superblock->version, RRDENG_JF_VER, RRDENG_VER_SZ);
 

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -120,6 +120,9 @@ inline void rrdcalctemplate_free(RRDCALCTEMPLATE *rt) {
     freez(rt->name);
     freez(rt->exec);
     freez(rt->recipient);
+    freez(rt->classification);
+    freez(rt->component);
+    freez(rt->type);
     freez(rt->context);
     freez(rt->source);
     freez(rt->units);

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -516,6 +516,7 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
         case RRD_MEMORY_MODE_RAM:
             debug(D_RRD_CALLS, "Unmapping dimension '%s'.", rd->name);
             freez((void *)rd->id);
+            freez((void *)rd->name);
             freez(rd->cache_filename);
             freez(rd->state);
             munmap(rd, rd->memsize);
@@ -526,6 +527,7 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
         case RRD_MEMORY_MODE_DBENGINE:
             debug(D_RRD_CALLS, "Removing dimension '%s'.", rd->name);
             freez((void *)rd->id);
+            freez((void *)rd->name);
             freez(rd->cache_filename);
             freez(rd->state);
             freez(rd);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -395,6 +395,13 @@ void rrdset_free(RRDSET *st) {
     netdata_rwlock_destroy(&st->state->labels.labels_rwlock);
 
     // free directly allocated members
+    freez((void *)st->name);
+    freez(st->type);
+    freez(st->family);
+    freez(st->title);
+    freez(st->units);
+    freez(st->context);
+    freez(st->cache_dir);
     freez(st->config_section);
     freez(st->plugin_name);
     freez(st->module_name);

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -665,7 +665,6 @@ static int health_readfile(const char *filename, void *data) {
             if(rc) {
                 if(!alert_hash_and_store_config(rc->config_hash_id, alert_cfg, sql_store_hashes) || ignore_this || !rrdcalc_add_alarm_from_config(host, rc)) {
                     rrdcalc_free(rc);
-                    alert_config_free(alert_cfg);
                 }
                // health_add_alarms_loop(host, rc, ignore_this) ;
             }
@@ -673,7 +672,6 @@ static int health_readfile(const char *filename, void *data) {
             if(rt) {
                 if (!alert_hash_and_store_config(rt->config_hash_id, alert_cfg, sql_store_hashes) || ignore_this || !rrdcalctemplate_add_template_from_config(host, rt)) {
                     rrdcalctemplate_free(rt);
-                    alert_config_free(alert_cfg);
                 }
                 rt = NULL;
             }
@@ -691,6 +689,8 @@ static int health_readfile(const char *filename, void *data) {
             rc->old_status = RRDCALC_STATUS_UNINITIALIZED;
             rc->warn_repeat_every = host->health_default_warn_repeat_every;
             rc->crit_repeat_every = host->health_default_crit_repeat_every;
+            if (alert_cfg)
+                alert_config_free(alert_cfg);
             alert_cfg = callocz(1, sizeof(struct alert_config));
 
             if(rrdvar_fix_name(rc->name))
@@ -704,7 +704,6 @@ static int health_readfile(const char *filename, void *data) {
 //                health_add_alarms_loop(host, rc, ignore_this) ;
                 if(!alert_hash_and_store_config(rc->config_hash_id, alert_cfg, sql_store_hashes) || ignore_this || !rrdcalc_add_alarm_from_config(host, rc)) {
                     rrdcalc_free(rc);
-                    alert_config_free(alert_cfg);
                 }
 
                 rc = NULL;
@@ -713,7 +712,6 @@ static int health_readfile(const char *filename, void *data) {
             if(rt) {
                 if(!alert_hash_and_store_config(rt->config_hash_id, alert_cfg, sql_store_hashes) || ignore_this || !rrdcalctemplate_add_template_from_config(host, rt)) {
                     rrdcalctemplate_free(rt);
-                    alert_config_free(alert_cfg);
                 }
             }
 
@@ -726,6 +724,8 @@ static int health_readfile(const char *filename, void *data) {
             rt->delay_multiplier = 1.0;
             rt->warn_repeat_every = host->health_default_warn_repeat_every;
             rt->crit_repeat_every = host->health_default_crit_repeat_every;
+            if (alert_cfg)
+                alert_config_free(alert_cfg);
             alert_cfg = callocz(1, sizeof(struct alert_config));
 
             if(rrdvar_fix_name(rt->name))

--- a/streaming/compression.c
+++ b/streaming/compression.c
@@ -46,6 +46,7 @@ static void lz4_compressor_destroy(struct compressor_state **state)
             if (s->data->stream)
                 LZ4_freeStream(s->data->stream);
             freez(s->data->stream_buffer);
+            freez(s->data);
         }
         freez(s->buffer);
         freez(s);
@@ -154,6 +155,7 @@ static void lz4_decompressor_destroy(struct decompressor_state **state)
             if (s->data->stream)
                 LZ4_freeStreamDecode(s->data->stream);
             freez(s->data->stream_buffer);
+            freez(s->data);
         }
         freez(s->buffer);
         freez(s);


### PR DESCRIPTION
##### Summary
In order to make memory leak debug easier, we fix memory leaks in
- [x] dimensions and charts (introduces in #12209)
- [x] database file initialization
- [x] static threads cleanup
- [x] compression
- [x] health alerts
- [x] health alert configuration

There are also errors connected with `uv_thread_create`. It seems they are caused by the library itself, I'm not sure though.

Fixes #12510

##### Test Plan

Build Netdata, run it with Valgrind, press Ctrl+C. Check if there are no memory leaks on Netdata exit, except those connected with `uv_thread_create`.