### PR TITLE
fix: Netdata segfault because of 2 timex.plugin threads

### DIFF
--- a/daemon/static_threads_linux.c
+++ b/daemon/static_threads_linux.c
@@ -10,15 +10,6 @@ extern void *timex_main(void *ptr);
 
 const struct netdata_static_thread static_threads_linux[] = {
     {
-        .name = "PLUGIN[timex]",
-        .config_section = CONFIG_SECTION_PLUGINS,
-        .config_name = "timex",
-        .enabled = 1,
-        .thread = NULL,
-        .init_routine = NULL,
-        .start_routine = timex_main
-    },
-    {
         .name = "PLUGIN[tc]",
         .config_section = CONFIG_SECTION_PLUGINS,
         .config_name = "tc",


### PR DESCRIPTION
##### Summary

ssia, big thanks to @vlvkobal for finding the root cause.

Closes: #12507

##### Test Plan

Install this PR, ensure there is only one TIMEX thread running.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
