### PR TITLE
fix centos gpg key issue

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1025,7 +1025,7 @@ netdata_avail_check() {
       ;;
     centos|fedora|ol)
       # shellcheck disable=SC2086
-      ${pm_cmd} search -v netdata | grep -qE 'Repo *: netdata(-edge)?$'
+      ${pm_cmd} search --nogpgcheck -v netdata | grep -qE 'Repo *: netdata(-edge)?$'
       return $?
       ;;
     opensuse)


### PR DESCRIPTION
##### Summary
This fixes a similar issue with gpg keys as reported in https://github.com/netdata/netdata/issues/12154, but for Centos8, AlmaLinux and RockyLinux

##### Test Plan
Verify kickstart works as expected (native install) on CentOS8, Alma and Rocky.

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
