### PR TITLE
fix(ci): properly handle "schedule" event in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       ref: ${{ steps.target.outputs.ref }}
       version: ${{ steps.target.outputs.version }}
+      type: ${{ steps.target.outputs.type }}
       run: ${{ steps.target.outputs.run }}
     steps:
       - name: Checkout
@@ -119,17 +120,17 @@ jobs:
           repo: ${{ github.repository }}
           workflow: Build
           ref: ${{ needs.update-changelogs.outputs.ref }}
-          inputs: '{"version": "${{ needs.update-changelogs.outputs.version }}", "type": "${{ github.event.inputs.type }}"}'
+          inputs: '{"version": "${{ needs.update-changelogs.outputs.version }}", "type": "${{ needs.update-changelogs.outputs.type }}"}'
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: 'danger'
           SLACK_FOOTER: ''
           SLACK_ICON_EMOJI: ':github-actions:'
-          SLACK_TITLE: 'Failed to trigger ${{ github.event.inputs.type }} artifact builds:'
+          SLACK_TITLE: 'Failed to trigger ${{ needs.update-changelogs.outputs.type }} artifact builds:'
           SLACK_USERNAME: 'GitHub Actions'
           SLACK_MESSAGE: |-
-              ${{ github.repository }}: Failed to trigger ${{ github.event.inputs.type }} artifact builds.
+              ${{ github.repository }}: Failed to trigger ${{ needs.update-changelogs.outputs.type }} artifact builds.
               Checkout: ${{ steps.checkout.outcome }}
               Trigger build: ${{ steps.trigger.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -161,10 +162,10 @@ jobs:
           SLACK_COLOR: 'danger'
           SLACK_FOOTER: ''
           SLACK_ICON_EMOJI: ':github-actions:'
-          SLACK_TITLE: 'Failed to trigger ${{ github.event.inputs.type }} Docker builds:'
+          SLACK_TITLE: 'Failed to trigger ${{ needs.update-changelogs.outputs.type }} Docker builds:'
           SLACK_USERNAME: 'GitHub Actions'
           SLACK_MESSAGE: |-
-              ${{ github.repository }}: Failed to trigger ${{ github.event.inputs.type }} Docker builds.
+              ${{ github.repository }}: Failed to trigger ${{ needs.update-changelogs.outputs.type }} Docker builds.
               Checkout: ${{ steps.checkout.outcome }}
               Trigger build: ${{ steps.trigger.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -189,17 +190,17 @@ jobs:
           repo: ${{ github.repository }}
           workflow: Packages
           ref: ${{ needs.update-changelogs.outputs.ref }}
-          inputs: '{"version": "${{ needs.update-changelogs.outputs.version }}", "type": "${{ github.event.inputs.type }}"}'
+          inputs: '{"version": "${{ needs.update-changelogs.outputs.version }}", "type": "${{ needs.update-changelogs.outputs.type }}"}'
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: 'danger'
           SLACK_FOOTER: ''
           SLACK_ICON_EMOJI: ':github-actions:'
-          SLACK_TITLE: 'Failed to trigger ${{ github.event.inputs.type }} package builds:'
+          SLACK_TITLE: 'Failed to trigger ${{ needs.update-changelogs.outputs.type }} package builds:'
           SLACK_USERNAME: 'GitHub Actions'
           SLACK_MESSAGE: |-
-              ${{ github.repository }}: Failed to trigger ${{ github.event.inputs.type }} package builds.
+              ${{ github.repository }}: Failed to trigger ${{ needs.update-changelogs.outputs.type }} package builds.
               Checkout: ${{ steps.checkout.outcome }}
               Trigger build: ${{ steps.trigger.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
##### Summary

Fixes: #12517

We should use "update-changelogs" job outputs, the current code works only when the workflow is triggered by a dispatch event.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>

Fixed publishing of native packages.

</details>
