### PR TITLE
fix(kickstart.sh): use `$ROOTCMD` when setting auto updates

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -936,11 +936,11 @@ set_auto_updates() {
     # This first case is for catching using a new kickstart script with an old build. It can be safely removed after v1.34.0 is released.
     if ! grep -q '\-\-enable-auto-updates' ${updater}; then
       echo
-    elif ! ${updater} --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
+    elif ! ${ROOTCMD} ${updater} --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
       warning "Failed to enable auto updates. Netdata will still work, but you will need to update manually."
     fi
   else
-    ${updater} --disable-auto-updates
+    ${ROOTCMD} ${updater} --disable-auto-updates
   fi
 }
 


### PR DESCRIPTION
##### Summary

Fixes: #12527

##### Test Plan

Run the kickstart script with `--auto-update` parameter, ensure auto-updating is enabled.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
