### PR TITLE
fix: use internal defaults for sched policy/oom score in native packages

### DIFF
--- a/system/netdata.conf
+++ b/system/netdata.conf
@@ -16,7 +16,3 @@
     # the default database size - 1 hour
     history = 3600
 
-    # some defaults to run netdata with least priority
-    process scheduling policy = idle
-    OOM score = 1000
-


### PR DESCRIPTION
##### Summary

Both debian/rpm packages use [system/netdata.conf](https://github.com/netdata/netdata/blob/master/system/netdata.conf). We have changed both CPU scheduling policy and OOM score in https://github.com/netdata/netdata/pull/12271. 

##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
