### PR TITLE
Make sure registered static threads are unique.

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -786,8 +786,13 @@ int main(int argc, char **argv) {
                         }
 
                         if(strcmp(optarg, "unittest") == 0) {
-                            if(unit_test_buffer()) return 1;
-                            if(unit_test_str2ld()) return 1;
+                            if (unit_test_static_threads())
+                                return 1;
+                            if (unit_test_buffer())
+                                return 1;
+                            if (unit_test_str2ld())
+                                return 1;
+
                             // No call to load the config file on this code-path
                             post_conf_load(&user);
                             get_netdata_configured_variables();

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -404,6 +404,42 @@ int unit_test_buffer() {
     return 0;
 }
 
+int unit_test_static_threads() {
+    struct netdata_static_thread *static_threads = static_threads_get();
+
+    /*
+     * make sure enough static threads have been registered
+     */
+    if (!static_threads) {
+        fprintf(stderr, "empty static_threads array\n");
+        return 1;
+    }
+
+    int n;
+    for (n = 0; static_threads[n].start_routine != NULL; n++) {}
+
+    if (n < 2) {
+        fprintf(stderr, "only %d static threads registered", n);
+        return 1;
+    }
+
+    /*
+     * verify that each thread's start routine is unique.
+     */
+    for (int i = 0; i != n - 1; i++) {
+        for (int j = i + 1; j != n; j++) {
+            if (static_threads[i].start_routine != static_threads[j].start_routine)
+                continue;
+
+            fprintf(stderr, "Found duplicate threads with name: %s\n", static_threads[i].name);
+            return 1;
+        }
+    }
+
+    free(static_threads);
+    return 0;
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 struct feed_values {

--- a/daemon/unit_test.h
+++ b/daemon/unit_test.h
@@ -8,6 +8,7 @@ extern int unit_test(long delay, long shift);
 extern int run_all_mockup_tests(void);
 extern int unit_test_str2ld(void);
 extern int unit_test_buffer(void);
+extern int unit_test_static_threads(void);
 extern int test_sqlite(void);
 #ifdef ENABLE_DBENGINE
 extern int test_dbengine(void);


### PR DESCRIPTION
##### Summary

Proactively catch https://github.com/netdata/netdata/pull/12512 in the future.

##### Test Plan

- CI jobs
- Register the same static thread twice, build/run the agent with internal checks.

##### Additional Information

The implementation is O(N^2) but it shouldn't matter because we only have a handful of static threads, and the code runs only when building the agent with internal checks enabled.