### PR TITLE
Allocate buffer and release on callback when executing agent CLI commands

### DIFF
--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -387,6 +387,7 @@ static void pipe_write_cb(uv_write_t* req, int status)
 
     uv_close((uv_handle_t *)client, pipe_close_cb);
     --clients;
+    freez(client->data);
     info("Command Clients = %u\n", clients);
 }
 
@@ -411,7 +412,7 @@ static inline void add_string_to_command_reply(char *reply_string, unsigned *rep
 static void send_command_reply(struct command_context *cmd_ctx, cmd_status_t status, char *message)
 {
     int ret;
-    char reply_string[MAX_COMMAND_LENGTH] = {'\0', };
+    char *reply_string = mallocz(message ? (strlen(message) + MAX_EXIT_STATUS_LENGTH + 2) : MAX_COMMAND_LENGTH);
     char exit_status_string[MAX_EXIT_STATUS_LENGTH + 1] = {'\0', };
     unsigned reply_string_size = 0;
     uv_buf_t write_buf;
@@ -428,6 +429,7 @@ static void send_command_reply(struct command_context *cmd_ctx, cmd_status_t sta
     }
 
     cmd_ctx->write_req.data = client;
+    client->data = reply_string;
     write_buf.base = reply_string;
     write_buf.len = reply_string_size;
     ret = uv_write(&cmd_ctx->write_req, (uv_stream_t *)client, &write_buf, 1, pipe_write_cb);


### PR DESCRIPTION
Fixes #12397

##### Summary
- The allocated buffer should remain valid until the callback function is called

##### Test Plan
- n/a

<details> <summary>For users: How does this change affect me?</summary>
- Avoid memory corruption / agent crash
</details>
