### PR TITLE
Explicitly use debhelper to enable systemd service

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -23,21 +23,14 @@ HAVE_EBPF = 1
 endif
 
 %:
-	# For jessie and beyond
-	#
-	dh $@ --with autoreconf,systemd
-
-	# For wheezy or other non-systemd distributions use the following. You
-	# should also see contrib/README.md which gives details of updates to
-	# make to debian/control.
-	#
-	#dh $@ --with autoreconf
+	dh $@
 
 override_dh_installinit:
 	echo "SystemD Version: $(SYSTEMD_VERSION)"
 	echo "Using SystemD Unit: $(SYSTEMD_UNIT)"
 	cp -v $(SYSTEMD_UNIT) debian/netdata.service
 
+	dh_systemd_enable
 	dh_installinit
 
 override_dh_auto_configure:


### PR DESCRIPTION

##### Summary

For some reason, even with moving to compat 10 in #12488, `dh_systemd_enable` isn't called automatically by `dh_installinit`. This patch explicitly calls `dh_systemd_enable` to make sure the service is enabled on install. 

This also cleans up the general call to `dh` dropping the `--with`parameters that are enabled by default in compat >= 10.

Fixes #12250.

##### Test Plan

- Build a new `.deb` from scratch.
- Verify that the `postinst` in `control.tar.xz` inside the package has a section marked `dh_systemd_enable`, that uses the `deb_systemd_helper` to enable the service.
- Possibly: install the debian on a fresh machine and verify the service is enabled by checking `systemctl status netdata`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

For users: How does this change affect me?

- Enables the Netdata systemd service upon first install of the Debian package.
- Does **not** enable the service on existing installs, because debhelper cannot know if a sysadmin has manually disabled the service. If instead we want the service to always be enabled on reinstall/upgrade, we need another / additional change.
