### PR TITLE
Reduce alert events sent to the cloud.

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -632,6 +632,8 @@ void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id)
     db_execute(buffer_tostring(sql));
     buffer_flush(sql);
 
+    log_access("This runs");
+    
     buffer_sprintf(sql, INDEX_ACLK_ALERT, uuid_str, uuid_str);
     db_execute(buffer_tostring(sql));
 

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -632,8 +632,6 @@ void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id)
     db_execute(buffer_tostring(sql));
     buffer_flush(sql);
 
-    log_access("This runs");
-    
     buffer_sprintf(sql, INDEX_ACLK_ALERT, uuid_str, uuid_str);
     db_execute(buffer_tostring(sql));
 

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -628,7 +628,7 @@ void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id)
     db_execute(buffer_tostring(sql));
     buffer_flush(sql);
 
-    buffer_sprintf(sql, TABLE_ACLK_ALERT, uuid_str, uuid_str, uuid_str);
+    buffer_sprintf(sql, TABLE_ACLK_ALERT, uuid_str);
     db_execute(buffer_tostring(sql));
     buffer_flush(sql);
 

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -103,9 +103,9 @@ static inline char *get_str_from_uuid(uuid_t *uuid)
 
 #define TABLE_ACLK_ALERT "CREATE TABLE IF NOT EXISTS aclk_alert_%s (sequence_id INTEGER PRIMARY KEY, " \
         "alert_unique_id, date_created, date_submitted, date_cloud_ack, " \
-        "unique(alert_unique_id)); " \
-        "insert into aclk_alert_%s (alert_unique_id, date_created) " \
-        "select unique_id alert_unique_id, strftime('%%s') date_created from health_log_%s where new_status <> 0 and new_status <> -2 order by unique_id asc on conflict (alert_unique_id) do nothing;"
+        "unique(alert_unique_id)); "
+        /* "insert into aclk_alert_%s (alert_unique_id, date_created) " \ */
+        /* "select unique_id alert_unique_id, strftime('%%s') date_created from health_log_%s where new_status <> 0 and new_status <> -2 order by unique_id asc on conflict (alert_unique_id) do nothing;" */
 
 #define INDEX_ACLK_CHART "CREATE INDEX IF NOT EXISTS aclk_chart_index_%s ON aclk_chart_%s (unique_id);"
 

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -104,8 +104,6 @@ static inline char *get_str_from_uuid(uuid_t *uuid)
 #define TABLE_ACLK_ALERT "CREATE TABLE IF NOT EXISTS aclk_alert_%s (sequence_id INTEGER PRIMARY KEY, " \
         "alert_unique_id, date_created, date_submitted, date_cloud_ack, " \
         "unique(alert_unique_id)); "
-        /* "insert into aclk_alert_%s (alert_unique_id, date_created) " \ */
-        /* "select unique_id alert_unique_id, strftime('%%s') date_created from health_log_%s where new_status <> 0 and new_status <> -2 order by unique_id asc on conflict (alert_unique_id) do nothing;" */
 
 #define INDEX_ACLK_CHART "CREATE INDEX IF NOT EXISTS aclk_chart_index_%s ON aclk_chart_%s (unique_id);"
 

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -103,7 +103,9 @@ static inline char *get_str_from_uuid(uuid_t *uuid)
 
 #define TABLE_ACLK_ALERT "CREATE TABLE IF NOT EXISTS aclk_alert_%s (sequence_id INTEGER PRIMARY KEY, " \
         "alert_unique_id, date_created, date_submitted, date_cloud_ack, " \
-        "unique(alert_unique_id)); "
+        "unique(alert_unique_id));"
+        /* "insert into aclk_alert_%s (alert_unique_id, date_created) " \ */
+        /* "select unique_id alert_unique_id, strftime('%%s') date_created from health_log_%s where new_status <> 0 and new_status <> -2 and config_hash_id is not null and updated_by_id = 0 order by unique_id asc on conflict (alert_unique_id) do nothing;" */
 
 #define INDEX_ACLK_CHART "CREATE INDEX IF NOT EXISTS aclk_chart_index_%s ON aclk_chart_%s (unique_id);"
 

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -104,8 +104,6 @@ static inline char *get_str_from_uuid(uuid_t *uuid)
 #define TABLE_ACLK_ALERT "CREATE TABLE IF NOT EXISTS aclk_alert_%s (sequence_id INTEGER PRIMARY KEY, " \
         "alert_unique_id, date_created, date_submitted, date_cloud_ack, " \
         "unique(alert_unique_id));"
-        /* "insert into aclk_alert_%s (alert_unique_id, date_created) " \ */
-        /* "select unique_id alert_unique_id, strftime('%%s') date_created from health_log_%s where new_status <> 0 and new_status <> -2 and config_hash_id is not null and updated_by_id = 0 order by unique_id asc on conflict (alert_unique_id) do nothing;" */
 
 #define INDEX_ACLK_CHART "CREATE INDEX IF NOT EXISTS aclk_chart_index_%s ON aclk_chart_%s (unique_id);"
 

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -410,8 +410,6 @@ void sql_queue_existing_alerts_to_aclk(RRDHOST *host)
 
     db_execute(buffer_tostring(sql));
 
-    log_access("Sent existing");
-    
     buffer_free(sql);
 }
 

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -88,14 +88,12 @@ int should_send_to_cloud(RRDHOST *host, ALARM_ENTRY *ae)
     }
 
     if (uuid_compare(ae->config_hash_id, config_hash_id)) {
-        log_access("Checking %u, diff uuid", ae->unique_id);
         send = 1;
         goto done;
     }
 
     //same status, same config
     if (ae->new_status == RRDCALC_STATUS_CLEAR) {
-        log_access("Checking %u same status clear", ae->unique_id);
         send = 0;
         goto done;
     }
@@ -105,11 +103,9 @@ int should_send_to_cloud(RRDHOST *host, ALARM_ENTRY *ae)
         time_t when = removed_when(ae->alarm_id, ae->unique_id, unique_id, uuid_str);
 
         if (when && (when + (time_t)MAX_REMOVED_PERIOD) < ae->when) {
-            log_access("Checking %u over max period when [%ld] ae when [%ld], add [%ld]", ae->unique_id, when, ae->when, when+MAX_REMOVED_PERIOD);
             send = 1;
             goto done;
         } else {
-            log_access("Checking %u under max period or no removed when", ae->unique_id);
             send = 0;
             goto done;
         }
@@ -149,14 +145,11 @@ int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae, int skip_filter)
         return 1;
 
     if (ae->flags & HEALTH_ENTRY_FLAG_ACLK_QUEUED) {
-        //log_access("IS queued");
-        log_access ("MC Will skip %u (%s) %d already queued", ae->unique_id, ae->name, ae->new_status);
         return 0;
     }
 
     if (!skip_filter) {
         if (!should_send_to_cloud(host, ae)) {
-            log_access ("MC Will skip %u (%s) %d from filter", ae->unique_id, ae->name, ae->new_status);
             return 0;
         }
     }
@@ -195,7 +188,6 @@ int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae, int skip_filter)
     }
 
     ae->flags |= HEALTH_ENTRY_FLAG_ACLK_QUEUED;
-    log_access("queued %u", ae->unique_id);
 
 bind_fail:
     if (unlikely(sqlite3_finalize(res_alert) != SQLITE_OK))

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -507,35 +507,6 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
         }
     }
 
-    /* if (unlikely(!first_sequence)) { */
-    /*     sql_queue_existing_alerts_to_aclk(host); */
-    /*     rc = sqlite3_finalize(res); */
-    /*     if (unlikely(rc != SQLITE_OK)) */
-    /*         error_report("Failed to reset statement to get health log statistics from the database, rc = %d", rc); */
-
-    /*     //re-read */
-    /*     rc = sqlite3_prepare_v2(db_meta, buffer_tostring(sql), -1, &res, 0); */
-    /*     if (rc != SQLITE_OK) { */
-    /*         error_report("Failed to prepare statement to get health log statistics from the database"); */
-    /*         buffer_free(sql); */
-    /*         freez(claim_id); */
-    /*         return; */
-    /*     } */
-
-    /*     while (sqlite3_step(res) == SQLITE_ROW) { */
-    /*         first_sequence = sqlite3_column_bytes(res, 0) > 0 ? (uint64_t) sqlite3_column_int64(res, 0) : 0; */
-    /*         if (sqlite3_column_bytes(res, 1) > 0) { */
-    /*             first_timestamp.tv_sec = sqlite3_column_int64(res, 1); */
-    /*         } */
-
-    /*         last_sequence = sqlite3_column_bytes(res, 2) > 0 ? (uint64_t) sqlite3_column_int64(res, 2) : 0; */
-    /*         if (sqlite3_column_bytes(res, 3) > 0) { */
-    /*             last_timestamp.tv_sec = sqlite3_column_int64(res, 3); */
-    /*         } */
-    /*     } */
-        
-    /* } */
-
     struct alarm_log_entries log_entries;
     log_entries.first_seq_id = first_sequence;
     log_entries.first_when = first_timestamp;

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -29,9 +29,9 @@ time_t removed_when(uint32_t alarm_id, uint32_t before_unique_id, uint32_t after
         when = (time_t) sqlite3_column_int64(res, 0);
     }
 
-    rc = sqlite3_reset(res);
+    rc = sqlite3_finalize(res);
     if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to reset statement when trying to find removed gap, rc = %d", rc);
+        error_report("Failed to finalize statement when trying to find removed gap, rc = %d", rc);
 
     return when;
 }
@@ -67,7 +67,7 @@ int should_send_to_cloud(RRDHOST *host, ALARM_ENTRY *ae)
     if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement when trying to filter alert events.");
         send = 1;
-        goto done;
+        return send;
     }
 
     rc = sqlite3_step(res);
@@ -112,9 +112,9 @@ int should_send_to_cloud(RRDHOST *host, ALARM_ENTRY *ae)
     }
      
 done:
-    rc = sqlite3_reset(res);
+    rc = sqlite3_finalize(res);
     if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to reset statement when trying to filter alert events, rc = %d", rc);
+        error_report("Failed to finalize statement when trying to filter alert events, rc = %d", rc);
 
     return send;
 }

--- a/database/sqlite/sqlite_aclk_alert.h
+++ b/database/sqlite/sqlite_aclk_alert.h
@@ -26,5 +26,6 @@ void sql_process_queue_removed_alerts_to_aclk(struct aclk_database_worker_config
 void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_process_send_alarm_snapshot(char *node_id, char *claim_id, uint64_t snapshot_id, uint64_t sequence_id);
 int get_proto_alert_status(RRDHOST *host, struct proto_alert_status *proto_alert_status);
+extern int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae, int skip_filter);
 
 #endif //NETDATA_SQLITE_ACLK_ALERT_H

--- a/database/sqlite/sqlite_aclk_chart.h
+++ b/database/sqlite/sqlite_aclk_chart.h
@@ -35,7 +35,6 @@ struct aclk_chart_sync_stats {
 extern int queue_chart_to_aclk(RRDSET *st);
 extern int queue_dimension_to_aclk(RRDDIM *rd);
 extern void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id);
-extern int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae);
 int aclk_add_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 int aclk_add_dimension_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 int aclk_send_chart_config(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);

--- a/health/health.c
+++ b/health/health.c
@@ -767,7 +767,7 @@ void *health_main(void *ptr) {
                             rc->value = NAN;
 #if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
                             if (netdata_cloud_setting && likely(!aclk_alert_reloaded))
-                                sql_queue_removed_alerts_to_aclk(host);
+                                sql_queue_alarm_to_aclk(host, ae, 1);
 #endif
                         }
                     }

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -162,7 +162,7 @@ inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae) {
 
 #ifdef ENABLE_ACLK
     if (netdata_cloud_setting) {
-        sql_queue_alarm_to_aclk(host, ae);
+        sql_queue_alarm_to_aclk(host, ae, 0);
     }
 #endif
 }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

The purpose of this PR is to reduce the number of alert events sent to the cloud. Right now the agent does not apply any specific rules on which alert events to send, thus in some situations (mostly during restarts) will send events that are of no use to the cloud experience.

This PR tries to skip consecutive same alert events if:

* The alert configuration has not changed
* There is a less than 15 minutes difference between a REMOVED event and a new WARNING or CRITICAL status. If the new status is CLEAR we skip this check.

It will also handle better the case of an agent claimed while running. On the first start streaming request for batch_id 1 and start sequence 1, it will try to queue the existing alerts to the cloud. The relevant query there also takes into account the alert events having a config hash (https://github.com/netdata/netdata/issues/12369).

The REMOVED events created on chart obsoletion will also be queued immediately, skipping the filter check above.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Test will be done together with the set team to make sure we don't miss anything important, and to cover extra cases. It will be converted to proper PR after this.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->


Should reduce the amount of traffic between agent and cloud, and also the burden on the cloud.
</details>
