### PR TITLE
Don't send alert events without wc->host

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -135,6 +135,9 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
     if (unlikely(!claim_id))
         return;
 
+    if (unlikely(!wc->host))
+        return;
+
     BUFFER *sql = buffer_create(1024);
 
     if (wc->alerts_start_seq_id != 0) {

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -135,8 +135,10 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
     if (unlikely(!claim_id))
         return;
 
-    if (unlikely(!wc->host))
+    if (unlikely(!wc->host)) {
+        freez(claim_id);
         return;
+    }
 
     BUFFER *sql = buffer_create(1024);
 

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -272,7 +272,7 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
         db_execute(buffer_tostring(sql));
     } else {
         if (log_first_sequence_id)
-            log_access("OG [%s (%s)]: Sent alert events, first sequence_id %"PRIu64", last sequence_id %"PRIu64, wc->node_id, wc->host ? wc->host->hostname : "N/A", log_first_sequence_id, log_last_sequence_id);
+            log_access("OG [%s (%s)]: Sent alert events, first sequence_id %"PRIu64", last sequence_id %"PRIu64, wc->node_id, wc->host->hostname, log_first_sequence_id, log_last_sequence_id);
         log_first_sequence_id = 0;
         log_last_sequence_id = 0;
     }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Don't try to send alert events if `wc->host` is not yet connected. If that happens, it is better to wait for the next iteration of the function (when eventually `wc->host` will be ok... ?) instead of sending an event with missing timezone data.

Fixes #12539 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Since it's hard to reproduce, basic testing of alerts still going to the cloud after this change should be ok.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->
