### PR TITLE
fix: use `/proc/cpuinfo` for CPU freq detection as a last resort

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -280,6 +280,12 @@ elif [ -r /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq ]; then
 
   value="$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq)"
   CPU_FREQ="$((value * 1000))"
+elif [ -r /proc/cpuinfo ]; then
+  if (echo "${CPU_INFO_SOURCE}" | grep -qv procfs); then
+    CPU_INFO_SOURCE="${CPU_INFO_SOURCE} procfs"
+  fi
+  value=$(grep "cpu MHz" /proc/cpuinfo 2>/dev/null | grep -o "[0-9\.]*" | awk '{print int($0*1000000)}')
+  [ -n "$value" ] && CPU_FREQ="$value"
 fi
 
 freq_units="$(echo "${CPU_FREQ}" | cut -f 2 -d ' ')"

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -284,7 +284,7 @@ elif [ -r /proc/cpuinfo ]; then
   if (echo "${CPU_INFO_SOURCE}" | grep -qv procfs); then
     CPU_INFO_SOURCE="${CPU_INFO_SOURCE} procfs"
   fi
-  value=$(grep "cpu MHz" /proc/cpuinfo 2>/dev/null | grep -o "[0-9\.]*" | awk '{print int($0*1000000)}')
+  value=$(grep "cpu MHz" /proc/cpuinfo 2>/dev/null | grep -o "[0-9]*" | head -n 1 | awk '{print int($0*1000000)}')
   [ -n "$value" ] && CPU_FREQ="$value"
 fi
 


### PR DESCRIPTION
##### Summary

ssia, I discovered (during PT call with @cboydstun 😄) that my Netdata container CPU freq is "unknown" on the Cloud. The container is on DO Debian 11 droplet.

##### Test Plan

- master branch

```bash
bash-5.1# wget -q -O system-info.sh https://raw.githubusercontent.com/netdata/netdata/master/daemon/system-info.sh; sh system-info.sh | grep -i freq; rm system-info.sh
NETDATA_SYSTEM_CPU_FREQ=unknown
```

- this PR

```bash
bash-5.1# wget -q -O system-info.sh https://raw.githubusercontent.com/ilyam8/netdata/cpu_freq_add_proccpuinfo/daemon/system-info.sh; sh system-info.sh | grep -i freq; rm system-info.sh
NETDATA_SYSTEM_CPU_FREQ=2494000000
```


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>