### PR TITLE
Fix Build on MacOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -292,6 +292,26 @@ freebsd*)
 darwin*)
     build_target=macos
     LDFLAGS="${LDFLAGS} -framework CoreFoundation -framework IOKit"
+    # -----------------------------------------------------------------------------
+    # Pull in OpenSSL properly if on macOS
+    if brew --prefix > /dev/null 2>&1; then
+      if brew --prefix --installed openssl > /dev/null 2>&1; then
+        HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl)
+      elif brew --prefix --installed openssl@3 > /dev/null 2>&1; then
+        HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@3)
+      elif brew --prefix --installed openssl@1.1 > /dev/null 2>&1; then
+        HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@1.1)
+      fi
+      if test -n "${HOMEBREW_OPENSSL_PREFIX}"; then
+        OPTIONAL_OS_DEP_CFLAGS="${CFLAGS} -I${HOMEBREW_OPENSSL_PREFIX}/include"
+        CFLAGS="${CFLAGS} ${OPTIONAL_OS_DEP_CFLAGS}"
+        LDFLAGS="${LDFLAGS} -L${HOMEBREW_OPENSSL_PREFIX}/lib"
+      fi
+      HOMEBREW_PREFIX=$(brew --prefix)
+      OPTIONAL_OS_DEP_CFLAGS="${OPTIONAL_OS_DEP_CFLAGS} -I${HOMEBREW_PREFIX}/include"
+      CFLAGS="${CFLAGS} -I${HOMEBREW_PREFIX}/include"
+      LDFLAGS="${LDFLAGS} -L${HOMEBREW_PREFIX}/lib"
+    fi
     ;;
 *)
     build_target=linux

--- a/configure.ac
+++ b/configure.ac
@@ -303,7 +303,7 @@ darwin*)
         HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@1.1)
       fi
       if test -n "${HOMEBREW_OPENSSL_PREFIX}"; then
-        OPTIONAL_OS_DEP_CFLAGS="${CFLAGS} -I${HOMEBREW_OPENSSL_PREFIX}/include"
+        OPTIONAL_OS_DEP_CFLAGS="-I${HOMEBREW_OPENSSL_PREFIX}/include"
         CFLAGS="${CFLAGS} ${OPTIONAL_OS_DEP_CFLAGS}"
         LDFLAGS="${LDFLAGS} -L${HOMEBREW_OPENSSL_PREFIX}/lib"
       fi

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -29,27 +29,6 @@ if [ "${NETDATA_SOURCE_DIR}" != "${INSTALLER_DIR}" ] && [ "${INSTALLER_DIR}" != 
 fi
 
 # -----------------------------------------------------------------------------
-# Pull in OpenSSL properly if on macOS
-if [ "$(uname -s)" = 'Darwin' ]; then
-  if brew --prefix > /dev/null 2>&1; then
-    if brew --prefix --installed openssl > /dev/null 2>&1; then
-      HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl)
-    elif brew --prefix --installed openssl@3 > /dev/null 2>&1; then
-      HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@3)
-    elif brew --prefix --installed openssl@1.1 > /dev/null 2>&1; then
-      HOMEBREW_OPENSSL_PREFIX=$(brew --prefix --installed openssl@1.1)
-    fi
-    if [ -n "${HOMEBREW_OPENSSL_PREFIX}" ]; then
-      export CFLAGS="${CFLAGS} -I${HOMEBREW_OPENSSL_PREFIX}/include"
-      export LDFLAGS="${LDFLAGS} -L${HOMEBREW_OPENSSL_PREFIX}/lib"
-    fi
-    HOMEBREW_PREFIX=$(brew --prefix)
-    export CFLAGS="${CFLAGS} -I${HOMEBREW_PREFIX}/include"
-    export LDFLAGS="${LDFLAGS} -L${HOMEBREW_PREFIX}/lib"
-  fi
-fi
-
-# -----------------------------------------------------------------------------
 # reload the user profile
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
##### Summary
This PR https://github.com/netdata/netdata/pull/12048 silently broke the case where there is a system protobuf copy installed in `/usr/local/include` and bundled protobuf is requested (the default option and sane one if built from source). This was done by adding the system's include path into `CFLAGS` which proceeds every other flag due to:

`CFLAGS="${CFLAGS} ${OPTIONAL_PROTOBUF_CFLAGS} ...` in `configure.ac`

This is wrong for multiple reasons and introduces hidden bugs.

Fixes https://github.com/netdata/netdata/issues/12516
Stacked on top of (review that first) https://github.com/netdata/netdata/pull/12552
This is split into 2 PRs also because reviewers who have FreeBSD and reviewers who have MacOS testing ability might be not the same people. (+ of course 1PR one job rule)

##### Test Plan

Ensure you have system protobuf installed `brew install protobuf` then the folder `/usr/local/include/google/protobuf` should exist. (assuming homebrew installed into default paths)

Use `netdata/netdata master` (IMPORTANT before https://github.com/netdata/netdata/commit/88da52d77a8358e9404ffd8703233078f7be7f8c got merged as that is a workaround that will break in future - it hides the issue but doesn't permanently fix it) and install using bundled protobuf (default) like this: ./netdata-installer.sh --disable-telemetry --install /tmp --dont-start-it . The compilation will fail (assuming your system proto version is different than bundled one).

Use this branch. The same test should succeed.

<details> <summary>For users: How does this change affect me?</summary>

```
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
   -> build system
- Can they see the change or is it an under the hood? If they can see it, where?
   -> building/installing netdata from source using homebrew on MacOS
- How is the user impacted by the change?
   -> netdata will work instead of not work
- What are there any benefits of the change?
   -> all the netdata benefits you couldn't have before because you were unable to install netdata on MacOs
```

</details>
