### PR TITLE
feat(netdata-updater): add the script name when logging

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -49,15 +49,15 @@ else
 fi
 
 info() {
-  echo >&3 "$(date) : INFO: " "${@}"
+  echo >&3 "$(date) : INFO: $(basename "$0"): " "${@}"
 }
 
 error() {
-  echo >&3 "$(date) : ERROR: " "${@}"
+  echo >&3 "$(date) : ERROR: $(basename "$0"): " "${@}"
 }
 
 fatal() {
-  error "FAILED TO UPDATE NETDATA : ${1}"
+  echo >&3 "$(date) : FATAL: $(basename "$0"): FAILED TO UPDATE NETDATA: " "${@}"
   exit 1
 }
 


### PR DESCRIPTION
##### Summary

Due to the fact that `kickstart.sh` internally calls `netdata-updater.sh` and the increased number of problems with installing/updating it is not easy to spot where the problem is by checking the logs.

After this PR

```cmd
$ sudo /opt/netdata/usr/libexec/netdata/netdata-updater.sh
Wed Mar 30 07:47:24 UTC 2022 : INFO: netdata-updater.sh:  Checking if a newer version of the updater script is available.
Wed Mar 30 07:47:24 UTC 2022 : INFO: netdata-updater.sh:  Running on a terminal - (this script also supports running headless from crontab)
Wed Mar 30 07:47:24 UTC 2022 : INFO: netdata-updater.sh:  Fetching dependency handling script...
Wed Mar 30 07:47:24 UTC 2022 : INFO: netdata-updater.sh:  Running dependency handling script...
Loading /etc/os-release ...

/etc/os-release information:
NAME            : Debian GNU/Linux
VERSION         : 11 (bullseye)
ID              : debian
ID_LIKE         :
VERSION_ID      : 11

We detected these:
Distribution    : debian
Version         : 11
Codename        : 11 (bullseye)
Package Manager : install_apt_get
Packages Tree   : debian
Detection Method: /etc/os-release
Default Python v: 2 (will install python3 too)

Searching for distro_sdk ...
Searching for autoconf_archive ...
 > Checking if package 'autoconf-archive' is installed...
Searching for libz_dev ...
 > Checking if package 'zlib1g-dev' is installed...
Searching for libuuid_dev ...
 > Checking if package 'uuid-dev' is installed...
Searching for libmnl_dev ...
 > Checking if package 'libmnl-dev' is installed...
Searching for json_c_dev ...
 > Checking if package 'libjson-c-dev' is installed...
Searching for libuv ...
 > Checking if package 'libuv1-dev' is installed...
Searching for lz4 ...
 > Checking if package 'liblz4-dev' is installed...
Searching for openssl ...
 > Checking if package 'libssl-dev' is installed...
Searching for judy ...
 > Checking if package 'libjudy-dev' is installed...
Searching for libelf ...
 > Checking if package 'libelf-dev' is installed...

All required packages are already installed. Now proceed to the next step.

Wed Mar 30 07:47:24 UTC 2022 : INFO: netdata-updater.sh:  Current Version: 00103300100251
Wed Mar 30 07:47:24 UTC 2022 : INFO: netdata-updater.sh:  Latest Version: 00103300100250
Wed Mar 30 07:47:24 UTC 2022 : INFO: netdata-updater.sh:  Newest version (current=00103300100251 >= latest=00103300100250) is already installed
```

##### Test Plan

- run the script, ensure its logging messages contain the script name.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
