### PR TITLE
fix(kickstart.sh): detect existing "custom" installation under /opt

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -616,10 +616,10 @@ detect_existing_install() {
     if [ -z "$ndpath" ]; then
       # static build
       if [ -x /opt/netdata/bin/netdata ]; then
-            ndpath="/opt/netdata/bin/netdata"
+        ndpath="/opt/netdata/bin/netdata"
       # build from source with /opt install-prefix (fairly common case)
       elif [ -x /opt/netdata/usr/sbin/netdata ]; then
-            ndpath="/opt/netdata/usr/sbin/netdata"
+        ndpath="/opt/netdata/usr/sbin/netdata"
       fi
     fi
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -613,8 +613,14 @@ detect_existing_install() {
 
     ndpath="$(PATH="${searchpath}" command -v netdata 2>/dev/null)"
 
-    if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ]; then
-      ndpath="/opt/netdata/bin/netdata"
+    if [ -z "$ndpath" ]; then
+      # static build
+      if [ -x /opt/netdata/bin/netdata ]; then
+            ndpath="/opt/netdata/bin/netdata"
+      # build from source with /opt install-prefix (fairly common case)
+      elif [ -x /opt/netdata/usr/sbin/netdata ]; then
+            ndpath="/opt/netdata/usr/sbin/netdata"
+      fi
     fi
 
     if [ -n "${ndpath}" ]; then


### PR DESCRIPTION
##### Summary

That is a pretty common case when we (at least I do it always) build Netdata from source using `--install /opt`.

- before this PR we can't detect an existing installation and **are trying to install Netdata**

  <details>
  <summary>kickstart log</summary>

  ```cmd
  $ sudo ./kickstart.sh

   --- Using /tmp/netdata-kickstart-XJzUdAUZWl as a temporary directory. ---
   --- Checking for existing installations of Netdata... ---
   --- No existing installations of netdata found, assuming this is a fresh install. ---
   --- Attempting to install using native packages... ---
   --- Checking for availability of repository configuration package. ---
  [/tmp/netdata-kickstart-XJzUdAUZWl]# curl --fail -q -sSL --connect-timeout 10 --retry 3 --output /tmp/netdata-kickstart-XJzUdAUZWl/netdata-repo-edge_1-1_all.deb https://packagecloud.io/netdata/netdata-repoconfig/packages/debian/bullseye/netdata-repo-edge_1-1_all.deb/download.deb
   OK

  [/tmp/netdata-kickstart-XJzUdAUZWl]# env apt-get update
  Hit:1 http://security.debian.org/debian-security bullseye-security InRelease
  Hit:2 http://deb.debian.org/debian bullseye InRelease
  Hit:3 http://deb.debian.org/debian bullseye-updates InRelease
  Hit:4 http://deb.debian.org/debian bullseye-backports InRelease
  Hit:5 https://download.docker.com/linux/debian bullseye InRelease
  Hit:6 https://apt.releases.hashicorp.com bullseye InRelease
  Hit:7 https://repos-droplet.digitalocean.com/apt/droplet-agent main InRelease
  0% [Connected to packagecloud.io (52.52.85.114)]^C ERROR  Installer exited unexpectedly (2-0)
  ```

  </details>

- after this PR we find an existing install and **are NOT trying to install Netdata**

  <details>
  <summary>kickstart logs</summary>

  ```cmd
  $ sudo ./kickstart.sh
  
   --- Using /tmp/netdata-kickstart-X9GNfsxoPL as a temporary directory. ---
   --- Checking for existing installations of Netdata... ---
   ABORTED  Found an existing netdata install at /opt/netdata, but the install type is 'custom', which is not supported, refusing to proceed.
  ```

  </details>


---

@netdata/agent-sre If that is expected behavior I am ok with won't fix that.

##### Test Plan

Run the script, ensure it finds an existing install, and doesn't try to install Netdata.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
