### PR TITLE
Fix temporary directory handling for dependency handling script in updater.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -126,9 +126,9 @@ install_build_dependencies() {
   fi
 
   info "Fetching dependency handling script..."
-  download "${PACKAGES_SCRIPT}" "${TMPDIR}/install-required-packages.sh" || true
+  download "${PACKAGES_SCRIPT}" "./install-required-packages.sh" || true
 
-  if [ ! -s "${TMPDIR}/install-required-packages.sh" ]; then
+  if [ ! -s "./install-required-packages.sh" ]; then
     error "Downloaded dependency installation script is empty."
   else
     info "Running dependency handling script..."
@@ -136,7 +136,7 @@ install_build_dependencies() {
     opts="--dont-wait --non-interactive"
 
     # shellcheck disable=SC2086
-    if ! "${bash}" "${TMPDIR}/install-required-packages.sh" ${opts} netdata >&3 2>&3; then
+    if ! "${bash}" "./install-required-packages.sh" ${opts} netdata >&3 2>&3; then
       error "Installing build dependencies failed. The update should still work, but you might be missing some features."
     fi
   fi
@@ -505,11 +505,11 @@ set_tarball_urls() {
 update_build() {
   [ -z "${logfile}" ] && info "Running on a terminal - (this script also supports running headless from crontab)"
 
-  install_build_dependencies
-
   RUN_INSTALLER=0
   ndtmpdir=$(create_tmp_directory)
   cd "$ndtmpdir" || exit 1
+
+  install_build_dependencies
 
   if update_available; then
     download "${NETDATA_TARBALL_CHECKSUM_URL}" "${ndtmpdir}/sha256sum.txt" >&3 2>&3


### PR DESCRIPTION
##### Summary

This ensures that we are actually using the temporary directory we created when trying to pull in build dependencies in the updater.

##### Test Plan

This can be verified by running the copy of the updater script from this PR on macOS, or in an environment where `$TMPDIR` is not set and `/` is read-only.

##### Additional Information

Fixes: #12515 

<details> <summary>For users: How does this change affect me?</summary>
Users on macOS will be able to successfully run the updater script again.
</details>
