### PR TITLE
fix: re-add setuid bit to ioping after installing Debian package

### DIFF
--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -63,6 +63,7 @@ case "$1" in
 
     # Workaround for other plugins not installed directly by this package
     chmod -f 4750 /usr/libexec/netdata/plugins.d/freeipmi.plugin || true
+    chmod -f 4750 /usr/libexec/netdata/plugins.d/ioping || true
 
     ;;
 esac


### PR DESCRIPTION
##### Summary

Fixes: #12579

ssia, I guess it gets reset after we do

https://github.com/netdata/netdata/blob/6086e2477608441fe11ec7d4fee124cbf31fa6d7/contrib/debian/netdata.postinst#L53

should re-add after if the ioping binary exists.

##### Test Plan

Install deb package, ensure setuid bit is not removed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
