### PR TITLE
Fix ebpf exit

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -296,8 +296,10 @@ static void ebpf_exit(int sig)
      */
 
 #ifdef LIBBPF_MAJOR_VERSION
-    if (default_btf)
+    if (default_btf) {
         btf__free(default_btf);
+        default_btf = NULL;
+    }
 #endif
 
     char filename[FILENAME_MAX + 1];

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -212,6 +212,7 @@ void clean_loaded_events()
 static void ebpf_exit(int sig)
 {
     close_ebpf_plugin = 1;
+    static int remove_pid = 0;
 
     // When both threads were not finished case I try to go in front this address, the collector will crash
     if (!thread_finished) {
@@ -302,9 +303,13 @@ static void ebpf_exit(int sig)
     }
 #endif
 
-    char filename[FILENAME_MAX + 1];
-    ebpf_pid_file(filename, FILENAME_MAX);
-    unlink(filename);
+    if (!remove_pid) {
+        remove_pid = 1;
+        char filename[FILENAME_MAX + 1];
+        ebpf_pid_file(filename, FILENAME_MAX);
+        if (unlink(filename))
+            error("Cannot remove PID file %s", filename);
+    }
 
     exit(sig);
 }


### PR DESCRIPTION
##### Summary
Fixes #12589 

I will run more tests on other environments, but on `Manjaro  21.1` kernel `5.13.0-35-generic` the problem appears to be fixed..

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
