### PR TITLE
feat(cgroups.plugin): add CPU throttling charts

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -677,7 +677,7 @@ struct cpuacct_stat {
     char *filename;
 
     unsigned long long user;           // v1, v2(user_usec)
-    unsigned long long system;         // v1, v2(system_user)
+    unsigned long long system;         // v1, v2(system_usec)
 };
 
 // https://www.kernel.org/doc/Documentation/cgroup-v1/cpuacct.txt

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -948,8 +948,8 @@ static inline void cgroup_read_cpuacct_cpu_stat(struct cpuacct_cpu_stat *cp){
             cp->throttled_time = str2ull(procfile_lineword(ff, i, 1));
         }
     }
-    cp->nr_periods_delta = (cp->nr_periods - nr_periods_last) >= 0 ? cp->nr_periods - nr_periods_last : 0;
-    cp->nr_throttled_delta = (cp->nr_throttled - nr_throttled_last) >= 0 ? cp->nr_throttled - nr_throttled_last : 0;
+    cp->nr_periods_delta = cp->nr_periods >= nr_periods_last ? cp->nr_periods - nr_periods_last : 0;
+    cp->nr_throttled_delta = cp->nr_throttled >= nr_throttled_last ? cp->nr_throttled - nr_throttled_last : 0;
 
     cp->updated = 1;
 
@@ -1009,8 +1009,8 @@ static inline void cgroup2_read_cpuacct_stat(struct cpuacct_stat *cp) {
             cp->throttled_time = str2ull(procfile_lineword(ff, i, 1));
         }
     }
-    cp->nr_periods_delta = (cp->nr_periods - nr_periods_last) >= 0 ? cp->nr_periods - nr_periods_last : 0;
-    cp->nr_throttled_delta = (cp->nr_throttled - nr_throttled_last) >= 0 ? cp->nr_throttled - nr_throttled_last : 0;
+    cp->nr_periods_delta = cp->nr_periods >= nr_periods_last ? cp->nr_periods - nr_periods_last : 0;
+    cp->nr_throttled_delta = cp->nr_throttled >= nr_throttled_last ? cp->nr_throttled - nr_throttled_last : 0;
 
     cp->updated = 1;
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -844,14 +844,6 @@ struct discovery_thread {
 
 // ----------------------------------------------------------------------------
 
-static inline int is_cgroup_v1(struct cgroup *cg) {
-    return !(cg->options & CGROUP_OPTIONS_IS_UNIFIED);
-}
-
-static inline int is_cgroup_v2(struct cgroup *cg) {
-    return !is_cgroup_v1(cg);
-}
-
 static unsigned long long calc_delta(unsigned long long curr, unsigned long long prev) {
     if (prev > curr) {
         return 0;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2013,7 +2013,6 @@ static inline void update_filenames()
                 if(likely(stat(filename, &buf) != -1)) {
                     cg->cpuacct_cpu_stat.filename = strdupz(filename);
                     cg->cpuacct_cpu_stat.enabled = cgroup_enable_cpuacct_cpu_throttling;
-                    info("CGRPUP: THROTTLE filename: %s", filename);
                     debug(D_CGROUP, "cpu.stat filename for cgroup '%s': '%s'", cg->id, cg->cpuacct_cpu_stat.filename);
                 }
                 else

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -3890,8 +3890,8 @@ netdataDashboard.context = {
     },
 
     'cgroup.throttled': {
-        info: 'The number of times tasks in a cgroup have been throttled. '+ 
-        'The tasks have not been allowed to run because they have exhausted all of the available time as specified by their CPUquota.'
+        info: 'The percentage of runnable periods when tasks in a cgroup have been throttled. '+ 
+        'The tasks have not been allowed to run because they have exhausted all of the available time as specified by their CPU quota.'
     },
 
     'cgroup.throttled_duration': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -3889,6 +3889,16 @@ netdataDashboard.context = {
         '<a href="https://en.wikipedia.org/wiki/CPU_modes#Mode_types" target="_blank">user and kernel</a> modes.'
     },
 
+    'cgroup.throttled': {
+        info: 'The number of times tasks in a cgroup have been throttled. '+ 
+        'The tasks have not been allowed to run because they have exhausted all of the available time as specified by their quota.'
+    },
+
+    'cgroup.throttled_duration': {
+        info: 'The total time duration for which tasks in a cgroup have been throttled. '+
+        'When an application has used its allotted CPU quota for a given period, it gets throttled until the next period.'
+    },
+
     'cgroup.cpu_per_core': {
         info: 'Total CPU utilization per core within the system-wide CPU resources.'
     },

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -3891,7 +3891,7 @@ netdataDashboard.context = {
 
     'cgroup.throttled': {
         info: 'The number of times tasks in a cgroup have been throttled. '+ 
-        'The tasks have not been allowed to run because they have exhausted all of the available time as specified by their quota.'
+        'The tasks have not been allowed to run because they have exhausted all of the available time as specified by their CPUquota.'
     },
 
     'cgroup.throttled_duration': {


### PR DESCRIPTION
##### Summary

This PR adds two new charts:
 - CPU Throttled Runnable Periods
 - CPU Throttled Time Duration

Fixes: #12595
Closes: netdata/netdata-cloud#375

##### Test Plan

Install this PR, run a container with a CPU limit, and ensure the charts have values for both cgroups v1 and v2.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
