### PR TITLE
chore: make logs less noisy on child reconnect

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -153,7 +153,7 @@ int rrdset_set_name(RRDSET *st, const char *name) {
     strncpyz(new_name, sanitized_name, CONFIG_MAX_VALUE);
 
     if(rrdset_index_find_name(host, new_name, 0)) {
-        info("RRDSET: chart name '%s' on host '%s' already exists.", new_name, host->hostname);
+        debug(D_RRD_CALLS, "RRDSET: chart name '%s' on host '%s' already exists.", new_name, host->hostname);
         if(!strcmp(st->id, full_name) && !st->name) {
             unsigned i = 1;
 


### PR DESCRIPTION
##### Summary

We have a huge amount of log messages on child reconnect

https://github.com/netdata/netdata/blob/edea331caf2dc0d407a6c746ac71f57914d25318/database/rrdset.c#L156

This log message doesn't provide much value and is mainly just a noise. This PR changes it severity level to debug.

##### Test Plan

CI checks.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
