### PR TITLE
Better check for IOMainPort on MacOS

### DIFF
--- a/collectors/macos.plugin/macos_fw.c
+++ b/collectors/macos.plugin/macos_fw.c
@@ -78,7 +78,7 @@ int do_macos_iokit(int update_every, usec_t dt) {
     // NEEDED BY: do_bandwidth
     struct ifaddrs *ifa, *ifap;
 
-#if !__is_identifier(IOMainPort) /* macOS >= 12.0 */
+#if !defined(MAC_OS_VERSION_12_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_12_0)
 #define IOMainPort IOMasterPort
 #endif
 


### PR DESCRIPTION
##### Summary
`__is_identifier()` works only in clang. We need a more robust check for `IOMainPort()`. IOKit SDK version checking is proved to be more reliable and portable than `__is_identifier()`.

Fixes #12560

##### Test Plan
Build Netdata on macOS.