### PR TITLE
Fix a compilation warning

### DIFF
--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -952,6 +952,7 @@ int alert_hash_and_store_config(
 #else
     UNUSED(hash_id);
     UNUSED(cfg);
+    UNUSED(store_hash);
 #endif
 
     return 1;


### PR DESCRIPTION
##### Summary
Fixes the following warning
```
database/sqlite/sqlite_health.c: In function 'alert_hash_and_store_config':
database/sqlite/sqlite_health.c:904:9: warning: unused parameter 'store_hash' [-Wunused-parameter]
  904 |     int store_hash)
      |     ~~~~^~~~~~~~~~
```

##### Test Plan
Build Netdata
```
sudo CFLAGS="-Og -ggdb -Wall -Wextra -Wformat-signedness -fno-omit-frame-pointer -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTiFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1" ./netdata-installer.sh --enable-plugin-nfacct --enable-plugin-freeipmi --use-system-protobuf --disable-cloud --disable-ml --disable-go --disable-lto --dont-wait --dont-start-it
```
There should be the only warning left unfixed
```
database/sqlite/sqlite3.c: In function 'pager_playback':
database/sqlite/sqlite3.c:55579:5: warning: 'memset' writing 4 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
55579 |     memset(&zSuper[-4], 0, 4);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
database/sqlite/sqlite3.c:55561:21: note: destination object '*pPager.pTmpSpace' of size [0, 9223372036854775807]
55561 |     zSuper = &pPager->pTmpSpace[4];
      |               ~~~~~~^~~~~~~~~~~
```