### PR TITLE
Add squeue-based Slurm data collector

### DIFF
--- a/collectors/python.d.plugin/Makefile.am
+++ b/collectors/python.d.plugin/Makefile.am
@@ -99,6 +99,7 @@ include retroshare/Makefile.inc
 include riakkv/Makefile.inc
 include samba/Makefile.inc
 include sensors/Makefile.inc
+include slurm/Makefile.inc
 include smartd_log/Makefile.inc
 include spigotmc/Makefile.inc
 include springboot/Makefile.inc

--- a/collectors/python.d.plugin/python.d.conf
+++ b/collectors/python.d.plugin/python.d.conf
@@ -97,6 +97,7 @@ nginx_log: no
 # riakkv: yes
 # samba: yes
 # sensors: yes
+slurm: no
 # smartd_log: yes
 # spigotmc: yes
 # springboot: yes

--- a/collectors/python.d.plugin/slurm/Makefile.inc
+++ b/collectors/python.d.plugin/slurm/Makefile.inc
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_python_DATA       += slurm/slurm.chart.py
+dist_pythonconfig_DATA += slurm/slurm.conf
+
+# do not install these files, but include them in the distribution
+dist_noinst_DATA       += slurm/README.md slurm/Makefile.inc
+

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -13,7 +13,17 @@ Executes `squeue` to grab information from the slurm queue.
 ## Configuring slurm
 
 Slurm monitoring is disabled by default. 
+### Example
 
+```yaml
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
 ## Metrics and Alerts produced by this collector
 
 | Chart      | Metrics     | Alert                    |

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -10,14 +10,12 @@ Monitors slurm queue statistics using the squeue tool.
 
 Execute `squeue` to grab information from the slurm queue.
 
-It produces only a single chart:
+## Configuring slurm
 
-1.  **Slurm Queue**
+Slurm monitoring is enabled by default. 
 
-    -   jobs
+## Metrics and Alerts produced by this collector
 
-Configuration is not needed.
-
----
-
-
+| Chart      | Metrics     | Alert                    |
+| ---------- | ----------- | ------------------------ |
+| Slurm Queue | jobs | Triggers no alert |

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -11,7 +11,7 @@ Monitors slurm queue statistics using the [`squeue`](https://slurm.schedmd.com/s
 
 ## Configuring slurm
 
-#### Prerequiistes
+#### Prerequisites
 The slurm collector requires `squeue` to be installed and configured properly.
 
 Slurm monitoring is disabled by default. To enable the collector:  

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -6,9 +6,7 @@ sidebar_label: "Slurm Queue"
 
 # Slurm queue monitoring with Netdata
 
-Monitors slurm queue statistics using the squeue tool.  
-
-Executes `squeue` to grab information from the slurm queue.
+Monitors slurm queue statistics using the [`squeue`](https://slurm.schedmd.com/squeue.html) tool. Currently, only the number of pending and running jobs are collected.
 
 ## Configuring slurm
 

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -13,6 +13,7 @@ Executes `squeue` to grab information from the slurm queue.
 ## Configuring slurm
 
 Slurm monitoring is disabled by default. 
+
 ### Example
 
 ```yaml
@@ -24,6 +25,8 @@ Slurm monitoring is disabled by default.
 #     priority: 60000         # the JOB's order on the dashboard
 #     penalty: yes            # the JOB's penalty
 #     autodetection_retry: 0  # the JOB's re-check interval in seconds
+```
+
 ## Metrics and Alerts produced by this collector
 
 | Chart      | Metrics     | Alert                    |

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -8,21 +8,28 @@ sidebar_label: "Slurm Queue"
 
 Monitors slurm queue statistics using the [`squeue`](https://slurm.schedmd.com/squeue.html) tool. Currently, only the number of pending and running jobs are collected.
 
-Notice that this plugin requires `squeue` to be installed and configured properly.
 
 ## Configuring slurm
 
-Slurm monitoring is disabled by default. It may be enabled by modifying [../python.d.conf](../python.d.conf) from
+#### Prerequiistes
+The slurm collector requires `squeue` to be installed and configured properly.
 
-```yaml
-slurm: no
-```
+Slurm monitoring is disabled by default. To enable the collector:  
+1. Navigate to the [Netdata config directory](https://learn.netdata.cloud/docs/configure/nodes#the-netdata-config-directory).
+   ```bash
+   cd /etc/netdata
+   ```
+2. Use the [`edit-config`](https://learn.netdata.cloud/docs/configure/nodes#use-edit-config-to-edit-configuration-files) script to edit `python.d.conf`.
+   ```bash
+   sudo ./edit-config python.d.conf
+   ```
+3. Enable the slurm collector by setting `slurm` to `yes`. 
 
-to
-
-```yaml
-slurm: yes
-```
+   ```yaml
+   slurm: yes
+   ```
+   
+ 4. Save the changes and restart the Agent with `sudo systemctl restart netdata` or the [appropriate method](https://learn.netdata.cloud/docs/configure/start-stop-restart)for your system.
 
 ### Example
 
@@ -35,7 +42,8 @@ squeue:
     update_every: 1         # the JOB's data collection frequency (in seconds)
 ```
 
-Please consider that too frequent updates can lead to performance issues with `squeue` as described [here](https://slurm.schedmd.com/squeue.html#SECTION_PERFORMANCE).
+## Known issues
+Please consider that too frequent updates can lead to performance issues with `squeue` as described [in the slurm documentation](https://slurm.schedmd.com/squeue.html#SECTION_PERFORMANCE).
 
 ## Metrics and Alerts produced by this collector
 

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -10,19 +10,27 @@ Monitors slurm queue statistics using the [`squeue`](https://slurm.schedmd.com/s
 
 ## Configuring slurm
 
-Slurm monitoring is disabled by default. 
+Slurm monitoring is disabled by default. It may be enabled by modifying [../python.d.conf](../python.d.conf) from
+
+```yaml
+slurm: no
+```
+
+to
+
+```yaml
+slurm: yes
+```
 
 ### Example
 
+As of now, the slurm plugin only has the default options, cf. [../README.md](../README.md).
+For instance, you can increase the collection frequency from 10 seconds (the default) to 1 second by
+
 ```yaml
-# job_name:
-#     name: myname            # the JOB's name as it will appear at the
-#                             # dashboard (by default is the job_name)
-#                             # JOBs sharing a name are mutually exclusive
-#     update_every: 1         # the JOB's data collection frequency
-#     priority: 60000         # the JOB's order on the dashboard
-#     penalty: yes            # the JOB's penalty
-#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+squeue:
+    name: "Slurm Queue"     # the JOB's name as it will appear on the dashboard
+    update_every: 1         # the JOB's data collection frequency (in seconds)
 ```
 
 ## Metrics and Alerts produced by this collector

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -8,6 +8,8 @@ sidebar_label: "Slurm Queue"
 
 Monitors slurm queue statistics using the [`squeue`](https://slurm.schedmd.com/squeue.html) tool. Currently, only the number of pending and running jobs are collected.
 
+Notice that this plugin requires `squeue` to be installed and configured properly.
+
 ## Configuring slurm
 
 Slurm monitoring is disabled by default. It may be enabled by modifying [../python.d.conf](../python.d.conf) from
@@ -32,6 +34,8 @@ squeue:
     name: "Slurm Queue"     # the JOB's name as it will appear on the dashboard
     update_every: 1         # the JOB's data collection frequency (in seconds)
 ```
+
+Please consider that too frequent updates can lead to performance issues with `squeue` as described [here](https://slurm.schedmd.com/squeue.html#SECTION_PERFORMANCE).
 
 ## Metrics and Alerts produced by this collector
 

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -29,7 +29,7 @@ Slurm monitoring is disabled by default. To enable the collector:
    slurm: yes
    ```
    
- 4. Save the changes and restart the Agent with `sudo systemctl restart netdata` or the [appropriate method](https://learn.netdata.cloud/docs/configure/start-stop-restart)for your system.
+ 4. Save the changes and restart the Agent with `sudo systemctl restart netdata` or the [appropriate method](https://learn.netdata.cloud/docs/configure/start-stop-restart) for your system.
 
 ### Example
 

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -1,0 +1,27 @@
+<!--
+title: "Postfix monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/postfix/README.md
+sidebar_label: "Postfix"
+-->
+
+# Postfix monitoring with Netdata
+
+Monitors MTA email queue statistics using postqueue tool.  
+
+Execute `postqueue -p` to grab postfix queue.
+
+It produces only two charts:
+
+1.  **Postfix Queue Emails**
+
+    -   emails
+
+2.  **Postfix Queue Emails Size** in KB
+
+    -   size
+
+Configuration is not needed.
+
+---
+
+

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -33,7 +33,7 @@ Slurm monitoring is disabled by default. To enable the collector:
 
 ### Example
 
-As of now, the slurm plugin only has the default options, cf. [../README.md](../README.md).
+The slurm plugin currently supports only the default configuration options, see [python.d documentation](https://learn.netdata.cloud/docs/agent/collectors/python.d.plugin).
 For instance, you can increase the collection frequency from 10 seconds (the default) to 1 second by
 
 ```yaml

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -12,7 +12,7 @@ Execute `squeue` to grab information from the slurm queue.
 
 ## Configuring slurm
 
-Slurm monitoring is enabled by default. 
+Slurm monitoring is disabled by default. 
 
 ## Metrics and Alerts produced by this collector
 

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -8,7 +8,7 @@ sidebar_label: "Slurm Queue"
 
 Monitors slurm queue statistics using the squeue tool.  
 
-Execute `squeue` to grab information from the slurm queue.
+Executes `squeue` to grab information from the slurm queue.
 
 ## Configuring slurm
 

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -1,24 +1,20 @@
 <!--
-title: "Postfix monitoring with Netdata"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/postfix/README.md
-sidebar_label: "Postfix"
+title: "Slurm queue monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/slurm/README.md
+sidebar_label: "Slurm Queue"
 -->
 
-# Postfix monitoring with Netdata
+# Slurm queue monitoring with Netdata
 
-Monitors MTA email queue statistics using postqueue tool.  
+Monitors slurm queue statistics using the squeue tool.  
 
-Execute `postqueue -p` to grab postfix queue.
+Execute `squeue -o %all` to grab squeue queue.
 
-It produces only two charts:
+It produces only a single chart:
 
-1.  **Postfix Queue Emails**
+1.  **Slurm Queue**
 
-    -   emails
-
-2.  **Postfix Queue Emails Size** in KB
-
-    -   size
+    -   jobs
 
 Configuration is not needed.
 

--- a/collectors/python.d.plugin/slurm/README.md
+++ b/collectors/python.d.plugin/slurm/README.md
@@ -8,7 +8,7 @@ sidebar_label: "Slurm Queue"
 
 Monitors slurm queue statistics using the squeue tool.  
 
-Execute `squeue -o %all` to grab squeue queue.
+Execute `squeue` to grab information from the slurm queue.
 
 It produces only a single chart:
 

--- a/collectors/python.d.plugin/slurm/slurm.chart.py
+++ b/collectors/python.d.plugin/slurm/slurm.chart.py
@@ -5,7 +5,7 @@
 
 from bases.FrameworkServices.ExecutableService import ExecutableService
 
-SQUEUE_COMMAND = "squeue -o %all"
+SQUEUE_COMMAND = "squeue -O state"
 
 ORDER = [
     "slurmjobs",

--- a/collectors/python.d.plugin/slurm/slurm.chart.py
+++ b/collectors/python.d.plugin/slurm/slurm.chart.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Description: slurm netdata python.d module
+# Author: Max Berrendorf (mberr)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from bases.FrameworkServices.ExecutableService import ExecutableService
+
+SQUEUE_COMMAND = "squeue -o %all"
+
+ORDER = [
+    "slurmjobs",
+]
+
+CHARTS = {
+    "slurmjobs": {
+        "options": [None, "Slurm Queue", "job", "queue", "slurm.total", "line"],
+        "lines": [
+            # ['total', None, 'absolute'],
+            ["running", None, "absolute"],
+            ["pending", None, "absolute"],
+        ],
+    },
+}
+
+
+class Service(ExecutableService):
+    def __init__(self, configuration=None, name=None):
+        ExecutableService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.command = SQUEUE_COMMAND
+
+    def _get_data(self):
+        """
+        Format data received from shell command
+        :return: dict
+        """
+        try:
+            # _get_raw_data returns a list of lines
+            raw_lines = self._get_raw_data()
+            # first line is the header
+            # comment: we could use pandas to easily parse this, and perform the subsequent operations
+            header, *data = [line.strip().split("|") for line in raw_lines]
+            # build dictionaries for each line
+            data = [dict(zip(header, line)) for line in data]
+            return {
+                "total": len(data),
+                "running": sum(1 for entry in data if entry["STATE"] == "RUNNING"),
+                "pending": sum(1 for entry in data if entry["STATE"] == "PENDING"),
+            }
+        except (ValueError, AttributeError):
+            return None

--- a/collectors/python.d.plugin/slurm/slurm.conf
+++ b/collectors/python.d.plugin/slurm/slurm.conf
@@ -68,4 +68,4 @@
 # AUTO-DETECTION JOBS
 
 local:
-  command: 'squeue -o %all'
+  command: 'squeue -O state'

--- a/collectors/python.d.plugin/slurm/slurm.conf
+++ b/collectors/python.d.plugin/slurm/slurm.conf
@@ -1,71 +1,9 @@
 # netdata python.d.plugin configuration for slurm
-#
-# This file is in YaML format. Generally the format is:
-#
-# name: value
-#
-# There are 2 sections:
-#  - global variables
-#  - one or more JOBS
-#
-# JOBS allow you to collect values from multiple sources.
-# Each source will have its own set of charts.
-#
-# JOB parameters have to be indented (using spaces only, example below).
-
-# ----------------------------------------------------------------------
-# Global Variables
-# These variables set the defaults for all JOBs, however each JOB
-# may define its own, overriding the defaults.
-
-# update_every sets the default data collection frequency.
-# If unset, the python.d.plugin default is used.
-# update_every: 10
-
-# priority controls the order of charts at the netdata dashboard.
-# Lower numbers move the charts towards the top of the page.
-# If unset, the default for python.d.plugin is used.
-# priority: 60000
-
-# penalty indicates whether to apply penalty to update_every in case of failures.
-# Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
-# penalty: yes
-
-# autodetection_retry sets the job re-check interval in seconds.
-# The job is not deleted if check fails.
-# Attempts to start the job are made once every autodetection_retry.
-# This feature is disabled by default.
-# autodetection_retry: 0
-
-# ----------------------------------------------------------------------
-# JOBS (data collection sources)
-#
-# The default JOBS share the same *name*. JOBS with the same name
-# are mutually exclusive. Only one of them will be allowed running at
-# any time. This allows autodetection to try several alternatives and
-# pick the one that works.
-#
-# Any number of jobs is supported.
-#
-# All python.d.plugin JOBS (for all its modules) support a set of
-# predefined parameters. These are:
-#
-# job_name:
-#     name: myname            # the JOB's name as it will appear at the
-#                             # dashboard (by default is the job_name)
-#                             # JOBs sharing a name are mutually exclusive
-#     update_every: 1         # the JOB's data collection frequency
-#     priority: 60000         # the JOB's order on the dashboard
-#     penalty: yes            # the JOB's penalty
-#     autodetection_retry: 0  # the JOB's re-check interval in seconds
-#
-# Additionally to the above, postfix also supports the following:
-#
-#     command: 'postqueue -p' # the command to run
-#
+# For more information, see ../../example/example.conf
 
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
 
-local:
-  command: 'squeue -O state'
+squeue:
+    name: "Slurm Queue"     # the JOB's name as it will appear on the dashboard
+    update_every: 10        # the JOB's data collection frequency (in seconds)

--- a/collectors/python.d.plugin/slurm/slurm.conf
+++ b/collectors/python.d.plugin/slurm/slurm.conf
@@ -1,0 +1,71 @@
+# netdata python.d.plugin configuration for slurm
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 10
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# penalty indicates whether to apply penalty to update_every in case of failures.
+# Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
+# penalty: yes
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, postfix also supports the following:
+#
+#     command: 'postqueue -p' # the command to run
+#
+
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+
+local:
+  command: 'squeue -o %all'

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -690,7 +690,7 @@ netdataDashboard.menu = {
     'slurm': {
         title: 'slurm',
         icon: '<i class="fas fa-list"></i>',
-        info: undefined
+        info: 'Charts showing the status of the Slurm queue (extracted via squeue).'
     },
 };
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -686,6 +686,12 @@ netdataDashboard.menu = {
         icon: '<i class="fas fa-shield-alt"></i>',
         info: 'Netdata keeps track of the current jail status by reading the Fail2ban log file.'
     },
+
+    'slurm': {
+        title: 'slurm',
+        icon: '<i class="fas fa-list"></i>',
+        info: undefined
+    },
 };
 
 


### PR DESCRIPTION
##### Summary
This PR adds a simple data collector to extract information about the queue in [slurm](https://slurm.schedmd.com/). It is based on parsing the output of [`squeue`](https://slurm.schedmd.com/squeue.html), and currently only extracts the number of running and pending jobs in the queue.

##### Test Plan
I am not yet sure how to test this change. Basically we would need:
* a running slurm (client) providing the `squeue` command
* a slurm control daemon which provides the contents for `squeue`

##### Additional Information
We use `netdata` to monitor several machines running a compute cluster managed by Slurm. It would thus be nice to also see the utilization of the overall system in a dashboard.

I am not familiar with the structure of `netdata`, and have oriented myself at the `postfix` example in `python.d`. Let me know if there is anything missing / could be solved in a better way.