### PR TITLE
Fix Valgrind errors

### DIFF
--- a/aclk/aclk_alarm_api.c
+++ b/aclk/aclk_alarm_api.c
@@ -23,6 +23,8 @@ void aclk_send_alarm_log_entry(struct alarm_log_entry *log_entry)
     char *payload = generate_alarm_log_entry(&payload_size, log_entry);
 
     aclk_send_bin_msg(payload, payload_size, ACLK_TOPICID_ALARM_LOG, "AlarmLogEntry");
+
+    freez(payload);
 }
 
 void aclk_send_provide_alarm_cfg(struct provide_alarm_configuration *cfg)

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -364,7 +364,7 @@ void aclk_stats_upd_online(int online) {
 }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-static usec_t pub_time[UINT16_MAX] = {0};
+static usec_t pub_time[UINT16_MAX + 1] = {0};
 void aclk_stats_msg_published(uint16_t id)
 {
     ACLK_STATS_LOCK;

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -364,7 +364,7 @@ void aclk_stats_upd_online(int online) {
 }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-static usec_t pub_time[UINT16_MAX];
+static usec_t pub_time[UINT16_MAX] = {0};
 void aclk_stats_msg_published(uint16_t id)
 {
     ACLK_STATS_LOCK;

--- a/aclk/schema-wrappers/alarm_stream.cc
+++ b/aclk/schema-wrappers/alarm_stream.cc
@@ -176,8 +176,10 @@ char *generate_alarm_log_entry(size_t *len, struct alarm_log_entry *data)
 
     *len = PROTO_COMPAT_MSG_SIZE(le);
     char *bin = (char*)mallocz(*len);
-    if (!le.SerializeToArray(bin, *len))
+    if (!le.SerializeToArray(bin, *len)) {
+        freez(bin);
         return NULL;
+    }
 
     return bin;
 }

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -81,6 +81,7 @@ void * wal_get_transaction_buffer(struct rrdengine_worker_config* wc, unsigned s
     if (NULL == ctx->commit_log.buf) {
         buf_size = ALIGN_BYTES_CEILING(size);
         ret = posix_memalign((void *)&ctx->commit_log.buf, RRDFILE_ALIGNMENT, buf_size);
+        memset(ctx->commit_log.buf, 0, buf_size);
         if (unlikely(ret)) {
             fatal("posix_memalign:%s", strerror(ret));
         }

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -81,10 +81,10 @@ void * wal_get_transaction_buffer(struct rrdengine_worker_config* wc, unsigned s
     if (NULL == ctx->commit_log.buf) {
         buf_size = ALIGN_BYTES_CEILING(size);
         ret = posix_memalign((void *)&ctx->commit_log.buf, RRDFILE_ALIGNMENT, buf_size);
-        memset(ctx->commit_log.buf, 0, buf_size);
         if (unlikely(ret)) {
             fatal("posix_memalign:%s", strerror(ret));
         }
+        memset(ctx->commit_log.buf, 0, buf_size);
         buf_pos = ctx->commit_log.buf_pos = 0;
         ctx->commit_log.buf_size =  buf_size;
     }

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -731,6 +731,7 @@ static int do_flush_pages(struct rrdengine_worker_config* wc, int force, struct 
         break;
     }
     ret = posix_memalign((void *)&xt_io_descr->buf, RRDFILE_ALIGNMENT, ALIGN_BYTES_CEILING(size_bytes));
+    memset(xt_io_descr->buf, 0, ALIGN_BYTES_CEILING(size_bytes));
     if (unlikely(ret)) {
         fatal("posix_memalign:%s", strerror(ret));
         /* freez(xt_io_descr);*/

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -731,11 +731,11 @@ static int do_flush_pages(struct rrdengine_worker_config* wc, int force, struct 
         break;
     }
     ret = posix_memalign((void *)&xt_io_descr->buf, RRDFILE_ALIGNMENT, ALIGN_BYTES_CEILING(size_bytes));
-    memset(xt_io_descr->buf, 0, ALIGN_BYTES_CEILING(size_bytes));
     if (unlikely(ret)) {
         fatal("posix_memalign:%s", strerror(ret));
         /* freez(xt_io_descr);*/
     }
+    memset(xt_io_descr->buf, 0, ALIGN_BYTES_CEILING(size_bytes));
     (void) memcpy(xt_io_descr->descr_array, eligible_pages, sizeof(struct rrdeng_page_descr *) * count);
     xt_io_descr->descr_count = count;
 


### PR DESCRIPTION
##### Summary
Fixes
- [x] leaks in alarm_log_entry
- [x] array initialization in ACLK stats
- [x] buffer initialization in rrdengine

Fixes #12618

##### Test Plan
1. Build Netdata
```
sudo CFLAGS="-Og -ggdb -Wall -Wextra -Wformat-signedness -fno-omit-frame-pointer -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTiFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1" ./netdata-installer.sh --use-system-protobuf --disable-lto --dont-wait --dont-start-it
```
2. Run it with Valgrind
```
sudo valgrind --leak-check=yes /usr/sbin/netdata -P /var/run/netdata/netdata.pid -D -W set global process scheduling policy keep -W set global OOM score keep
```
3. Press Ctrl+C and check if there are no errors mentioned above in the Valgrind output.