### PR TITLE
fix(cgroups.plugin): set CPU prev usage before first usage.

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -3588,6 +3588,7 @@ void update_cgroup_charts(int update_every) {
                                 rrddim_add(cg->st_cpu_limit, "used", NULL, 1, system_hz, RRD_ALGORITHM_ABSOLUTE);
                             else
                                 rrddim_add(cg->st_cpu_limit, "used", NULL, 1, 1000000, RRD_ALGORITHM_ABSOLUTE);
+                            cg->prev_cpu_usage = (calculated_number)(cg->cpuacct_stat.user + cg->cpuacct_stat.system) * 100;
                         }
                         else
                             rrdset_next(cg->st_cpu_limit);


### PR DESCRIPTION
##### Summary

Otherwise, it is 0 when we calculate cpu_used the first time. The value is not stored locally but (looks like) transferred when streaming.

https://github.com/netdata/netdata/blob/e7e5e61d655ab44dcf8748fcac60dc02182a0d40/collectors/cgroups.plugin/sys_fs_cgroup.c#L3596-L3597

##### Test Plan

Test manually.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
