### PR TITLE
Don't do fatal on error writing the health api management key.

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -137,15 +137,24 @@ char *get_mgmt_api_key(void) {
 
         // save it
         fd = open(api_key_filename, O_WRONLY|O_CREAT|O_TRUNC, 444);
-        if(fd == -1)
-            fatal("Cannot create unique management API key file '%s'. Please fix this.", api_key_filename);
+        if(fd == -1) {
+            error("Cannot create unique management API key file '%s'. Please fix this.", api_key_filename);
+            goto temp_key;
+        }
 
-        if(write(fd, guid, GUID_LEN) != GUID_LEN)
-            fatal("Cannot write the unique management API key file '%s'. Please fix this.", api_key_filename);
+        if(write(fd, guid, GUID_LEN) != GUID_LEN) {
+            error("Cannot write the unique management API key file '%s'. Please fix this.", api_key_filename);
+            close(fd);
+            goto temp_key;
+        }
 
         close(fd);
     }
 
+    return guid;
+
+temp_key:
+    info("You can still continue to use the alarm management API using the authorization token %s during this Netdata session only.", guid);
     return guid;
 }
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -138,12 +138,12 @@ char *get_mgmt_api_key(void) {
         // save it
         fd = open(api_key_filename, O_WRONLY|O_CREAT|O_TRUNC, 444);
         if(fd == -1) {
-            error("Cannot create unique management API key file '%s'. Please fix this.", api_key_filename);
+            error("Cannot create unique management API key file '%s'. Please adjust config parameter 'netdata management api key file' to a proper path and file.", api_key_filename);
             goto temp_key;
         }
 
         if(write(fd, guid, GUID_LEN) != GUID_LEN) {
-            error("Cannot write the unique management API key file '%s'. Please fix this.", api_key_filename);
+            error("Cannot write the unique management API key file '%s'. Please adjust config parameter 'netdata management api key file' to a proper path and file with enough space left.", api_key_filename);
             close(fd);
             goto temp_key;
         }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->
Fixes #12568 

If for any reason there is trouble committing the Health API management key to disk, don't exit, but instead inform the user to fix the problem and provide the produced api key in the log file. This can be used to access the management API, but only during this session of Netdata.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Specify a readonly path to save the key (e.g. `/root/something` if running as a normal user) in field `netdata management api key file` under `registry` in `netdata.conf`. Using this PR the agent will keep running, and the printed key can be used to access the API.
