### PR TITLE
Add eBPF CO-RE version and checksum files to distfile list.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,8 @@ dist_noinst_DATA = \
     packaging/check-kernel-config.sh \
     packaging/ebpf.checksums \
     packaging/ebpf.version \
+    packaging/ebpf-co-re.checksums \
+    packaging/ebpf-co-re.version \
     packaging/go.d.checksums \
     packaging/go.d.version \
     packaging/installer/README.md \


### PR DESCRIPTION
##### Summary

These were somehow missed when they were originally added.

##### Test Plan

n/a

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/12478

<details> <summary>For users: How does this change affect me?</summary>
With this change, eBPF will work correctly on newer kernels.
</details>
