### PR TITLE
Improve handling of release channel selection in kickstart.sh.

### DIFF
--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -50,8 +50,12 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--dont-wait`: Synonym for `--non-interactive`
 - `--dry-run`: Show what the installer would do, but don’t actually do any of it.
 - `--dont-start-it`: Don’t auto-start the daemon after installing. This parameter is not guaranteed to work.
-- `--nightly-channel`: Use a nightly build instead of a stable release (this is the default).
-- `--stable-channel`: Use a stable release instead of a nightly build.
+- `--release-channel`: Specify a particular release channel to install from. Currently supported release channels are:
+    - `nightly`: Installs a nightly build (this is currently the default).
+    - `stable`: Installs a stable release.
+    - `default`: Explicitly request whatever the current default is.
+- `--nightly-channel`: Synonym for `--release-channel nightly`.
+- `--stable-channel`: Synonym for `--release-channel stable`.
 - `--auto-update`: Enable automatic updates (this is the default).
 - `--no-updates`: Disable automatic updates.
 - `--disable-telemetry`: Disable anonymous statistics.


### PR DESCRIPTION
##### Summary

- Added a new option named `--nightly-channel` for symmetry with `--stable-channel`.
- Added a new option named `--release-channel` for a future-proof way to explicitly specify a particular release channel.
- Added a third release channel value named `default` to indicate that the user has indicated no preference for a specific release channel.
- Decoupled the selected release channel from the one indicated in telemetry events, allowing us to differentiate between the default channel being selected because the user explicitly asked for it, and it being selected because the user indicated no preference.

##### Test Plan

Simple testing to verify the behavior of the new options and ensure that release channel selection is working correctly is sufficient.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Users will be able to more readily explicitly select a particular release channel.
</details>
