### PR TITLE
Summarize encountered errors and warnings at end of kickstart script run.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -344,7 +344,8 @@ cleanup() {
 deferred_warnings() {
   if [ -n "${WARNINGS}" ]; then
     printf >&2 "%s\n" "The following non-fatal warnings or errors were encountered:"
-    printf >&2 "%s\n\n" "${WARNINGS}"
+    echo >&2 "${WARNINGS}"
+    printf >&2 "\n"
   fi
 }
 
@@ -416,7 +417,7 @@ run() {
   if [ ${ret} -ne 0 ]; then
     printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET}"
     printf "%s\n" "FAILED with exit code ${ret}" >> "${run_logfile}"
-    WARNINGS="${WARNINGS}\n- Command \"${*}\" failed with exit code ${ret}."
+    WARNINGS="${WARNINGS}\n  - Command \"${*}\" failed with exit code ${ret}."
   else
     printf >&2 "%s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD} OK ${TPUT_RESET}"
     printf "OK\n" >> "${run_logfile}"
@@ -427,7 +428,7 @@ run() {
 
 warning() {
   printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*}"
-  WARNINGS="${WARNINGS}\n- ${*}"
+  WARNINGS="${WARNINGS}\n  - ${*}"
 }
 
 _cannot_use_tmpdir() {

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -36,6 +36,7 @@ NETDATA_ONLY_NATIVE=0
 NETDATA_ONLY_STATIC=0
 NETDATA_REQUIRE_CLOUD=1
 RELEASE_CHANNEL="nightly"
+WARNINGS=""
 
 if [ -n "$DISABLE_TELEMETRY" ]; then
   NETDATA_DISABLE_TELEMETRY="${DISABLE_TELEMETRY}"
@@ -62,6 +63,8 @@ fi
 main() {
   if [ "${ACTION}" = "uninstall" ]; then
     uninstall
+    printf >&2 "Finished uninstalling the Netdata Agent."
+    deferred_warnings
     cleanup
     trap - EXIT
     exit 0
@@ -100,6 +103,7 @@ main() {
   set_auto_updates
 
   printf >&2 "%s\n\n" "Successfully installed the Netdata Agent."
+  deferred_warnings
   success_banner
   telemetry_event INSTALL_SUCCESS "" ""
   cleanup
@@ -252,6 +256,8 @@ trap_handler() {
   code="${1}"
   lineno="${2}"
 
+  deferred_warnings
+
   printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ERROR ${TPUT_RESET} Installer exited unexpectedly (${code}-${lineno})"
 
   case "${code}" in
@@ -335,7 +341,15 @@ cleanup() {
   fi
 }
 
+deferred_warnings() {
+  if [ -n "${WARNINGS}" ]; then
+    printf >&2 "%s\n" "The following non-fatal warnings or errors were encountered:"
+    printf >&2 "%s\n\n" "${WARNINGS}"
+  fi
+}
+
 fatal() {
+  deferred_warnings
   printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${1}"
   printf >&2 "%s\n" "For community support, you can connect with us on:"
   support_list
@@ -343,14 +357,6 @@ fatal() {
   cleanup
   trap - EXIT
   exit 1
-}
-
-run_ok() {
-  printf >&2 "%s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD} OK ${TPUT_RESET}"
-}
-
-run_failed() {
-  printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET}"
 }
 
 ESCAPED_PRINT_METHOD=
@@ -408,10 +414,11 @@ run() {
   fi
 
   if [ ${ret} -ne 0 ]; then
-    run_failed
+    printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET}"
     printf "%s\n" "FAILED with exit code ${ret}" >> "${run_logfile}"
+    WARNINGS="${WARNINGS}\n- Command \"${*}\" failed with exit code ${ret}."
   else
-    run_ok
+    printf >&2 "%s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD} OK ${TPUT_RESET}"
     printf "OK\n" >> "${run_logfile}"
   fi
 
@@ -420,6 +427,7 @@ run() {
 
 warning() {
   printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*}"
+  WARNINGS="${WARNINGS}\n- ${*}"
 }
 
 _cannot_use_tmpdir() {
@@ -815,6 +823,7 @@ handle_existing_install() {
         progress "Not attempting to claim existing install at ${ndprefix} (no claiming token provided)."
       fi
 
+      deferred_warnings
       success_banner
       cleanup
       trap - EXIT
@@ -1036,6 +1045,7 @@ claim() {
   esac
 
   if [ -z "${NETDATA_NEW_INSTALL}" ]; then
+    deferred_warnings
     printf >&2 "%s\n" "For community support, you can connect with us on:"
     support_list
     cleanup


### PR DESCRIPTION
##### Summary

This way users will be more likely to see them, and we will have an easier time actually helping users who encounter issues.

The actual code currently collects any messages passed to the `warning` function, as well as any commands that failed when run by the `run` function. If any such errors arise, they will be printed when the script exits in most cases as a summarized list sorted by the order in which they occurred during execution.

##### Test Plan

The relevant code can easily be triggered by passing an option to the kickstart script that would normally be passed to `netdata-installer.sh`.

##### Additional Information

Fixes: #12631

This also inlines a couple of one-line functions that are only invoked in a single location, slightly simplifying the surrounding code.

<details> <summary>For users: How does this change affect me?</summary>
Any errors or warnings encountered when running the installer will be presented as a list at the end of the script.
</details>