### PR TITLE
feat: add k8s_cluster_name host tag (GKE only)

### DIFF
--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -43,15 +43,15 @@ LABELS="$POD_LABELS\nk8s_cluster_id:$KUBE_SYSTEM_NS_UID"
 
 GCP_META_HEADER="Metadata-Flavor: Google"
 GCP_META_URL="http://metadata/computeMetadata/v1"
-GCP_CLUSTER_NAME=""
+GKE_CLUSTER_NAME=""
 
 if id=$(curl --fail -s -m 5 --noproxy "*" -H "$GCP_META_HEADER" "$GCP_META_URL/project/project-id"); then
   loc=$(curl --fail -s -m 5 --noproxy "*" -H "$GCP_META_HEADER" "$GCP_META_URL/instance/attributes/cluster-location")
   name=$(curl --fail -s -m 5 --noproxy "*" -H "$GCP_META_HEADER" "$GCP_META_URL/instance/attributes/cluster-name")
-  [ -n "$id" ] && [ -n "$loc" ] && [ -n "$name" ] && GCP_CLUSTER_NAME="gke_${id}_${loc}_${name}"
+  [ -n "$id" ] && [ -n "$loc" ] && [ -n "$name" ] && GKE_CLUSTER_NAME="gke_${id}_${loc}_${name}"
 fi
 
-[ -n "$GCP_CLUSTER_NAME" ] && LABELS+="\nk8s_cluster_name:$GCP_CLUSTER_NAME"
+[ -n "$GKE_CLUSTER_NAME" ] && LABELS+="\nk8s_cluster_name:$GKE_CLUSTER_NAME"
 
 echo -e "$LABELS"
 

--- a/daemon/get-kubernetes-labels.sh.in
+++ b/daemon/get-kubernetes-labels.sh.in
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# Checks if netdata is running in a kubernetes pod and fetches that pod's labels
+# Checks if netdata is running in a kubernetes pod and fetches:
+#   - pod's labels
+#   - kubernetes cluster name (GKE only)
 
 if [ -z "${KUBERNETES_SERVICE_HOST}" ] || [ -z "${KUBERNETES_PORT_443_TCP_PORT}" ] || [ -z "${MY_POD_NAMESPACE}" ] || [ -z "${MY_POD_NAME}" ]; then
   exit 0
@@ -37,5 +39,20 @@ if ! KUBE_SYSTEM_NS_UID=$(jq -r '.metadata.uid' <<< "$KUBE_SYSTEM_NS_DATA" 2>&1)
   exit 1
 fi
 
-echo -e "$POD_LABELS\nk8s_cluster_id:$KUBE_SYSTEM_NS_UID"
+LABELS="$POD_LABELS\nk8s_cluster_id:$KUBE_SYSTEM_NS_UID"
+
+GCP_META_HEADER="Metadata-Flavor: Google"
+GCP_META_URL="http://metadata/computeMetadata/v1"
+GCP_CLUSTER_NAME=""
+
+if id=$(curl --fail -s -m 5 --noproxy "*" -H "$GCP_META_HEADER" "$GCP_META_URL/project/project-id"); then
+  loc=$(curl --fail -s -m 5 --noproxy "*" -H "$GCP_META_HEADER" "$GCP_META_URL/instance/attributes/cluster-location")
+  name=$(curl --fail -s -m 5 --noproxy "*" -H "$GCP_META_HEADER" "$GCP_META_URL/instance/attributes/cluster-name")
+  [ -n "$id" ] && [ -n "$loc" ] && [ -n "$name" ] && GCP_CLUSTER_NAME="gke_${id}_${loc}_${name}"
+fi
+
+[ -n "$GCP_CLUSTER_NAME" ] && LABELS+="\nk8s_cluster_name:$GCP_CLUSTER_NAME"
+
+echo -e "$LABELS"
+
 exit 0


### PR DESCRIPTION
##### Summary

Part of netdata/product#2382. The cluster name format is: `gke_${projectID}_${location}_${cluster-name}`.

##### Test Plan

Install this PR on a GKE cluster, and check the "host_labels" (/api/v1/info).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
