### PR TITLE
fix: remove thread num from web server CPU usage chart

### DIFF
--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -331,7 +331,7 @@ static void web_server_tmr_callback(void *timer_data) {
         char title[100 + 1];
 
         snprintfz(id, 100, "web_thread%d_cpu", worker_private->id + 1);
-        snprintfz(title, 100, "Netdata web server thread No %d CPU usage", worker_private->id + 1);
+        snprintfz(title, 100, "Netdata web server thread CPU usage");
 
         st = rrdset_create_localhost(
                 "netdata"


### PR DESCRIPTION
##### Summary

Fixes part of #12641

##### Test Plan


Check `netdata.web_thread%d_cpu` charts title.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
