### PR TITLE
Add a timeout parameter to data queries

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1732,7 +1732,7 @@ static int test_dbengine_check_rrdr(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DIMS]
     update_every = REGION_UPDATE_EVERY[current_region];
     long points = (time_end - time_start) / update_every;
     for (i = 0 ; i < CHARTS ; ++i) {
-        RRDR *r = rrd2rrdr(st[i], points, time_start + update_every, time_end, RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL);
+        RRDR *r = rrd2rrdr(st[i], points, time_start + update_every, time_end, RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL, 0);
         if (!r) {
             fprintf(stderr, "    DB-engine unittest %s: empty RRDR ### E R R O R ###\n", st[i]->name);
             return ++errors;
@@ -1851,7 +1851,7 @@ int test_dbengine(void)
     long points = (time_end[REGIONS - 1] - time_start[0]) / update_every; // cover all time regions with RRDR
     long point_offset = (time_start[current_region] - time_start[0]) / update_every;
     for (i = 0 ; i < CHARTS ; ++i) {
-        RRDR *r = rrd2rrdr(st[i], points, time_start[0] + update_every, time_end[REGIONS - 1], RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL);
+        RRDR *r = rrd2rrdr(st[i], points, time_start[0] + update_every, time_end[REGIONS - 1], RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL, 0);
         if (!r) {
             fprintf(stderr, "    DB-engine unittest %s: empty RRDR ### E R R O R ###\n", st[i]->name);
             ++errors;

--- a/health/health.c
+++ b/health/health.c
@@ -830,7 +830,7 @@ void *health_main(void *ptr) {
 
                     int ret = rrdset2value_api_v1(rc->rrdset, NULL, &rc->value, rc->dimensions, 1, rc->after,
                                                   rc->before, rc->group, 0, rc->options, &rc->db_after,
-                                                  &rc->db_before, &value_is_null
+                                                  &rc->db_before, &value_is_null, 0
                     );
 
                     if (unlikely(ret != 200)) {

--- a/web/api/badges/web_buffer_svg.c
+++ b/web/api/badges/web_buffer_svg.c
@@ -1102,7 +1102,7 @@ int web_client_api_request_v1_badge(RRDHOST *host, struct web_client *w, char *u
         // if the collected value is too old, don't calculate its value
         if (rrdset_last_entry_t(st) >= (now_realtime_sec() - (st->update_every * st->gap_when_lost_iterations_above)))
             ret = rrdset2value_api_v1(st, w->response.data, &n, (dimensions) ? buffer_tostring(dimensions) : NULL
-                                      , points, after, before, group, 0, options, NULL, &latest_timestamp, &value_is_null);
+                                      , points, after, before, group, 0, options, NULL, &latest_timestamp, &value_is_null, 0);
 
         // if the value cannot be calculated, show empty badge
         if (ret != HTTP_RESP_OK) {

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -167,9 +167,10 @@ int rrdset2value_api_v1(
         , time_t *db_after
         , time_t *db_before
         , int *value_is_null
+        , int timeout
 ) {
 
-    RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions, NULL);
+    RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions, NULL, timeout);
 
     if(!r) {
         if(value_is_null) *value_is_null = 1;
@@ -218,12 +219,13 @@ int rrdset2anything_api_v1(
         , struct context_param *context_param_list
         , char *chart_label_key
         , int max_anomaly_rates
-) {
-
+        , int timeout
+)
+{
     if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE))
         st->last_accessed_time = now_realtime_sec();
 
-    RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions?buffer_tostring(dimensions):NULL, context_param_list);
+    RRDR *r = rrd2rrdr(st, points, after, before, group_method, group_time, options, dimensions?buffer_tostring(dimensions):NULL, context_param_list, timeout);
     if(!r) {
         buffer_strcat(wb, "Cannot generate output with these parameters on this chart.");
         return HTTP_RESP_INTERNAL_SERVER_ERROR;

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -231,6 +231,11 @@ int rrdset2anything_api_v1(
         return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
 
+    if (r->result_options & RRDR_RESULT_OPTION_CANCEL) {
+        rrdr_free(r);
+        return HTTP_RESP_BACKEND_FETCH_FAILED;
+    }
+
     if (st && st->state && st->state->is_ar_chart)
         ml_process_rrdr(r, max_anomaly_rates);
 

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -68,6 +68,7 @@ extern int rrdset2anything_api_v1(
         , struct context_param *context_param_list
         , char *chart_label_key
         , int max_anomaly_rates
+        , int timeout
 );
 
 extern int rrdset2value_api_v1(
@@ -84,6 +85,7 @@ extern int rrdset2value_api_v1(
         , time_t *db_after
         , time_t *db_before
         , int *value_is_null
+        , int timeout
 );
 
 extern void build_context_param_list(struct context_param **param_list, RRDSET *st);

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -232,6 +232,18 @@
             }
           },
           {
+            "name": "timeout",
+            "in": "query",
+            "description": "Specify a timeout value in milliseconds after which the agent will abort the query and return a 503 error. A value of 0 indicates no timeout.",
+            "required": false,
+            "allowEmptyValue": false,
+            "schema": {
+              "type": "number",
+              "format": "integer",
+              "default": 0
+            }
+          },
+          {
             "name": "format",
             "in": "query",
             "description": "The format of the data to be returned.",

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -202,6 +202,16 @@ paths:
             type: number
             format: integer
             default: 0
+        - name: timeout
+          in: query
+          description: Specify a timeout value in milliseconds after which the agent will    
+            abort the query and return a 503 error. A value of 0 indicates no timeout.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+            default: 0
         - name: format
           in: query
           description: The format of the data to be returned.

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -844,6 +844,7 @@ static RRDR *rrd2rrdr_fixedstep(
         , time_t last_entry_t
         , int absolute_period_requested
         , struct context_param *context_param_list
+        , int timeout
 ) {
     int aligned = !(options & RRDR_OPTION_NOT_ALIGNED);
 
@@ -1217,6 +1218,7 @@ static RRDR *rrd2rrdr_variablestep(
         , int absolute_period_requested
         , struct rrdeng_region_info *region_info_array
         , struct context_param *context_param_list
+        , int timeout
 ) {
     int aligned = !(options & RRDR_OPTION_NOT_ALIGNED);
 
@@ -1591,6 +1593,7 @@ RRDR *rrd2rrdr(
         , RRDR_OPTIONS options
         , const char *dimensions
         , struct context_param *context_param_list
+        , int timeout
 )
 {
     int rrd_update_every;
@@ -1644,7 +1647,7 @@ RRDR *rrd2rrdr(
             }
             return rrd2rrdr_fixedstep(st, points_requested, after_requested, before_requested, group_method,
                                       resampling_time_requested, options, dimensions, rrd_update_every,
-                                      first_entry_t, last_entry_t, absolute_period_requested, context_param_list);
+                                      first_entry_t, last_entry_t, absolute_period_requested, context_param_list, timeout);
         } else {
             if (rrd_update_every != (uint16_t)max_interval) {
                 rrd_update_every = (uint16_t) max_interval;
@@ -1655,11 +1658,11 @@ RRDR *rrd2rrdr(
             }
             return rrd2rrdr_variablestep(st, points_requested, after_requested, before_requested, group_method,
                                          resampling_time_requested, options, dimensions, rrd_update_every,
-                                         first_entry_t, last_entry_t, absolute_period_requested, region_info_array, context_param_list);
+                                         first_entry_t, last_entry_t, absolute_period_requested, region_info_array, context_param_list, timeout);
         }
     }
 #endif
     return rrd2rrdr_fixedstep(st, points_requested, after_requested, before_requested, group_method,
                               resampling_time_requested, options, dimensions,
-                              rrd_update_every, first_entry_t, last_entry_t, absolute_period_requested, context_param_list);
+                              rrd_update_every, first_entry_t, last_entry_t, absolute_period_requested, context_param_list, timeout);
 }

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -110,7 +110,7 @@ extern RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *contex
 extern RRDR *rrd2rrdr(
     RRDSET *st, long points_requested, long long after_requested, long long before_requested,
     RRDR_GROUPING group_method, long resampling_time_requested, RRDR_OPTIONS options, const char *dimensions,
-    struct context_param *context_param_list);
+    struct context_param *context_param_list, int timeout);
 
 #include "query.h"
 

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -47,6 +47,7 @@ typedef enum rrdr_result_flags {
     RRDR_RESULT_OPTION_RELATIVE      = 0x00000002, // the query uses relative time-frames
                                                    // (should not to be cached by browsers and proxies)
     RRDR_RESULT_OPTION_VARIABLE_STEP = 0x00000004, // the query uses variable-step time-frames
+    RRDR_RESULT_OPTION_CANCEL        = 0x00000008, // the query needs to be cancelled
 } RRDR_RESULT_FLAGS;
 
 typedef struct rrdresult {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -415,6 +415,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     char *after_str = NULL;
     char *group_time_str = NULL;
     char *points_str = NULL;
+    char *timeout_str = NULL;
     char *max_anomaly_rates_str = NULL;
     char *context = NULL;
     char *chart_label_key = NULL;
@@ -447,6 +448,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         else if(!strcmp(name, "after")) after_str = value;
         else if(!strcmp(name, "before")) before_str = value;
         else if(!strcmp(name, "points")) points_str = value;
+        else if(!strcmp(name, "timeout")) timeout_str = value;
         else if(!strcmp(name, "gtime")) group_time_str = value;
         else if(!strcmp(name, "group")) {
             group = web_client_api_request_v1_data_group(value, RRDR_GROUPING_AVERAGE);
@@ -576,6 +578,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     long long before = (before_str && *before_str)?str2l(before_str):0;
     long long after  = (after_str  && *after_str) ?str2l(after_str):-600;
     int       points = (points_str && *points_str)?str2i(points_str):0;
+    int       timeout = (timeout_str && *timeout_str)?str2i(timeout_str): 0;
     long      group_time = (group_time_str && *group_time_str)?str2l(group_time_str):0;
     int       max_anomaly_rates = (max_anomaly_rates_str && *max_anomaly_rates_str) ? str2i(max_anomaly_rates_str) : 0;
 
@@ -623,7 +626,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     ret = rrdset2anything_api_v1(st, w->response.data, dimensions, format,
                                  points, after, before, group, group_time,
                                  options, &last_timestamp_in_data, context_param_list,
-                                 chart_label_key, max_anomaly_rates);
+                                 chart_label_key, max_anomaly_rates, timeout);
 
     free_context_param_list(&context_param_list);
 


### PR DESCRIPTION
##### Summary
Add a `timeout` parameter to the `/api/v1/data` endpoint. This is used from the cloud (at least for now) to let the agent know that if a query cannot be executed within the specified time, the cloud will give up and timeout anyway. 

The agent will attempt to cancel the query if execution takes more than `timeout` milliseconds and return a 503 error to the caller. 

##### Test Plan
- Run a data request that returns a lot of points e.g.  `/api/v1/data?context=cpu.cpu&after=-86400`
- Try running with `/api/v1/data?context=cpu.cpu&after=-86400&timeout=1`
   -You may need to request more data if your system can process the request is fast. Notice a 503 error in your browser and a 
     message similar to the following 
     `QUERY CANCELED RUNTIME EXCEEDED 1.68 ms (LIMIT 1 ms)`
     in the agents `access.log` 
