### PR TITLE
Add a chart label filter parameter in context data queries

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -36,7 +36,7 @@ inline int config_isspace(char c)
 }
 
 // split a text into words, respecting quotes
-static inline int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char), char *recover_input, char **recover_location, int max_recover)
+inline int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char), char *recover_input, char **recover_location, int max_recover)
 {
     char *s = str, quote = 0;
     int i = 0, j, rec = 0;

--- a/collectors/plugins.d/plugins_d.h
+++ b/collectors/plugins.d/plugins_d.h
@@ -66,5 +66,6 @@ extern int pluginsd_initialize_plugin_directories();
 
 extern int config_isspace(char c);
 extern int pluginsd_space(char c);
+int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char), char *recover_input, char **recover_location, int max_recover);
 
 #endif /* NETDATA_PLUGINS_D_H */

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -240,6 +240,7 @@ extern void rrdset_add_label_to_new_list(RRDSET *st, char *key, char *value, LAB
 extern void rrdset_finalize_labels(RRDSET *st);
 extern void rrdset_update_labels(RRDSET *st, struct label *labels);
 extern int rrdset_contains_label_keylist(RRDSET *st, char *key);
+extern int rrdset_matches_label_keys(RRDSET *st, char *key, char *words[], uint32_t *hash_key_list, int *word_count, int size);
 extern struct label *rrdset_lookup_label_key(RRDSET *st, char *key, uint32_t key_hash);
 
 // ----------------------------------------------------------------------------

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -200,6 +200,28 @@
             }
           },
           {
+            "name": "chart_label_key",
+            "in": "query",
+            "description": "Specify the chart label keys that need to match for context queries as comma separated values. At least one matching key is needed to match the corresponding chart.",
+            "required": false,
+            "allowEmptyValue": false,
+            "schema": {
+              "type": "string",
+              "format": "key1,key2,key3"
+            }
+          },
+          {
+            "name": "chart_labels_filter",
+            "in": "query",
+            "description": "Specify the chart label keys and values to match for context queries. All keys/values need to match for the chart to be included in the query. The labels are specified as key1:value1,key2:value2",
+            "required": false,
+            "allowEmptyValue": false,
+            "schema": {
+              "type": "string",
+              "format": "key1:value1,key2:value2,key3:value3"
+            }
+          },
+          {
             "name": "group",
             "in": "query",
             "description": "The grouping method. If multiple collected values are to be grouped in order to return fewer points, this parameters defines the method of grouping. methods supported \"min\", \"max\", \"average\", \"sum\", \"incremental-sum\". \"max\" is actually calculated on the absolute value collected (so it works for both positive and negative dimensions to return the most extreme value in either direction).",

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -170,6 +170,24 @@ paths:
             type: number
             format: integer
             default: 20
+        - name: chart_label_key
+          in: query
+          description: Specify the chart label keys that need to match for context queries as comma separated values.
+                At least one matching key is needed to match the corresponding chart.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: string
+            format: key1,key2,key3
+        - name: chart_labels_filter
+          in: query
+          description: Specify the chart label keys and values to match for context queries. All keys/values need to 
+              match for the chart to be included in the query. The labels are specified as key1:value1,key2:value2
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: string
+            format: key1:value1,key2:value2,key3:value3
         - name: group
           in: query
           description: The grouping method. If multiple collected values are to be grouped

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -173,7 +173,7 @@ paths:
         - name: chart_label_key
           in: query
           description: Specify the chart label keys that need to match for context queries as comma separated values.
-                At least one matching key is needed to match the corresponding chart.
+            At least one matching key is needed to match the corresponding chart.
           required: false
           allowEmptyValue: false
           schema:
@@ -181,8 +181,8 @@ paths:
             format: key1,key2,key3
         - name: chart_labels_filter
           in: query
-          description: Specify the chart label keys and values to match for context queries. All keys/values need to 
-              match for the chart to be included in the query. The labels are specified as key1:value1,key2:value2
+          description: Specify the chart label keys and values to match for context queries. All keys/values need to
+            match for the chart to be included in the query. The labels are specified as key1:value1,key2:value2
           required: false
           allowEmptyValue: false
           schema:

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -8,6 +8,7 @@
 #include "web/api/formatters/rrd2json.h"
 #include "web/api/health/health_cmdapi.h"
 
+#define MAX_CHART_LABELS_FILTER (32)
 extern uint32_t web_client_api_request_v1_data_options(char *o);
 extern uint32_t web_client_api_request_v1_data_format(char *name);
 extern uint32_t web_client_api_request_v1_data_google_format(char *name);


### PR DESCRIPTION
##### Summary
This PR will add a `chart_labels_filter` parameter in data queries. This will apply in context queries when a list of chart label keys and values need to match in order for the chart to be included in that data query

Adds the description in swagger (also adds previously missing description for `chart_label_key` 

##### Test Plan
- Setup an agent that monitors a k8s cluster 
   - Execute a context query e.g
     `/api/v1/data?chart_label_key=k8s_cluster_id&context=cgroup.net_packets`
   This should return results
- Apply the PR and assuming your k8s_cluster_id is `dcbda642-4c3b-11ea-b701-4201ac100014` execute a modified query using
  `/api/v1/data?chart_label_key=k8s_cluster_id&context=cgroup.net_packets&chart_labels_filter=k8s_cluster_id:dcbda642-4c3b-11ea-b701-4201ac100014` 

Note the `chart_labels_filter=k8s_cluster_id:dcbda642-4c3b-11ea-b701-4201ac100014` specifies that the key
`k8s_cluster_id` should exist with the value `dcbda642-4c3b-11ea-b701-4201ac100014`

If you now specify an invalid `k8s_cluster_id` you should not get any results back
