### PR TITLE
Add options to kickstart.sh for explicitly passing options to installer code.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -140,6 +140,8 @@ USAGE: kickstart.sh [options]
   --no-cleanup               Don't do any cleanup steps. This is intended to help with debugging the installer.
   --uninstall                Uninstall an existing installation of Netdata.
   --reinstall-clean          Clean reinstall Netdata.
+  --local-build-options      Specify additional options to pass to the installer code when building locally. Only valid if --build-only is also specified.
+  --static-install-options   Specify additional options to pass to the static installer code. Only valid if --static-only is also specified.
 
 Additionally, this script may use the following environment variables:
 
@@ -151,7 +153,6 @@ Additionally, this script may use the following environment variables:
                              you need special options for one of those to work, or have a different tool to do
                              the same thing on your system, you can specify it here.
   DISABLE_TELEMETRY          If set to a value other than 0, behave as if \`--disable-telemetry\` was specified.
-  NETDATA_INSTALLER_OPTIONS: Specifies extra options to pass to the static installer or local build script.
 
 HEREDOC
 }
@@ -1657,6 +1658,10 @@ install_on_freebsd() {
 
 setup_terminal || echo > /dev/null
 
+if [ -n "${NETDATA_INSTALLER_OPTIONS}" ]; then
+    warning "Explicitly specifying additional installer options with NETDATA_INSTALLER_OPTIONS is deprecated. Please instead pass the options to the script using either --local-build-options or --static-install-options as appropriate."
+fi
+
 while [ -n "${1}" ]; do
   case "${1}" in
     "--help")
@@ -1762,13 +1767,37 @@ while [ -n "${1}" ]; do
           ;;
       esac
       ;;
+    "--local-build-options")
+      LOCAL_BUILD_OPTIONS="${2}"
+      shift 1
+      ;;
+    "--static-install-options")
+      STATIC_INSTALL_OPTIONS="${2}"
+      shift 1
+      ;;
     *)
-      warning "Passing unrecognized option '${1}' to installer script. If this is intended, please add it to \$NETDATA_INSTALLER_OPTIONS instead."
+      warning "Passing unrecognized option '${1}' to installer script. This behavior is deprecated and will be removed in the near future. If you intended to pass this option to the installer code, please use either --local-build-options or --static-install-options to specify it instead."
       NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} ${1}"
       ;;
   esac
   shift 1
 done
+
+if [ -n "${LOCAL_BUILD_OPTIONS}" ]; then
+  if [ "${NETDATA_ONLY_BUILD}" -eq 1 ]; then
+    NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} ${LOCAL_BUILD_OPTIONS}"
+  else
+    fatal "Specifying local build options is only supported when the --build-only option is also specified." F0401
+  fi
+fi
+
+if [ -n "${STATIC_INSTALL_OPTIONS}" ]; then
+  if [ "${NETDATA_ONLY_STATIC}" -eq 1 ]; then
+    NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} ${STATIC_INSTALL_OPTIONS}"
+  else
+    fatal "Specifying installer options options is only supported when the --static-only option is also specified." F0402
+  fi
+fi
 
 check_claim_opts
 confirm_root_support

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -67,6 +67,8 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--old-install-prefix`: Specify the custom local build's installation prefix that should be removed.
 - `--uninstall`: Uninstall an existing installation of Netdata.
 - `--reinstall-clean`: Performs an uninstall of Netdata and clean installation.
+- `--local-build-options`: Specify additional options to pass to the installer code when building locally. Only valid if `--build-only` is also specified.
+- `--static-install-options`: Specify additional options to pass to the static installer code. Only valid if --static-only is also specified.
 
 Additionally, the following environment variables may be used to further customize how the script runs (most users
 should not need to use special values for any of these):
@@ -78,7 +80,6 @@ should not need to use special values for any of these):
   we try to use sudo, doas, or pkexec (in that order of preference), but if you need special options for one of
   those to work, or have a different tool to do the same thing on your system, you can specify it here.
 - `DISABLE_TELEMETRY`: If set to a value other than 0, behave as if `--disable-telemetry` was specified.
-- `NETDATA_INSTALLER_OPTIONS`: Specifies extra options to pass to the static installer or local build script.
 
 ### Connect node to Netdata Cloud during installation
 


### PR DESCRIPTION
##### Summary

This provides a consistent way for users to pass options to either `netdata-installer.sh` (for local builds) or the static installer code (for static installs). It also deprecates all existing methods of doing this, which will ultimately enable us to eventually have `kickstart.sh` explicitly reject unrecognized options passed to it.

The newly added options are:

- `--local-build-options`: Used to specify additional options to be passed to `netdata-installer.sh`. The argument immediately following it will be appended to the list of options being passed to `netdata-installer.sh`. Requires that `--build-only` also be passed to `kickstart.sh`
- `--static-install-options`: Used to specify additional options to be passed to the static installer. The argument immediately following it will be appended to the list of options being passed to the static installer. Requires that `--static-only` also be passed to `kickstart.sh`

##### Test Plan

This can be tested by simply trying the new options with the kickstart script from this PR.

##### Additional Information

First half of implementing https://github.com/netdata/netdata/issues/12630. The other half will have to wait for a couple of months after this is merged so that we can ensure that people see the deprecation warnings and update their tooling around the script to ensure things keep working.

<details> <summary>For users: How does this change affect me?</summary>
Users who have either been relying on the kickstart script passing unrecognized options to the installer code, or on using `$NETDATA_INSTALLER_OPTIONS` to do so will need to update their usage of `kickstart.sh` to instead pass those options using the new `--local-build-options` or `--static-install-options` options for `kickstart.sh`, as well as needing to explicitly ask for either a local build or static install (required for using these new options).
</details>
