### PR TITLE
Properly limit repository configuration dependencies.

### DIFF
--- a/packaging/repoconfig/netdata-repo.spec
+++ b/packaging/repoconfig/netdata-repo.spec
@@ -19,7 +19,7 @@ Source7:        netdata-edge.repo.ol
 
 BuildArch:      noarch
 
-%if 0%{?centos_ver} < 8
+%if 0%{?centos_ver} && 0%{?centos_ver} < 8
 Requires:       yum-plugin-priorities
 %endif
 


### PR DESCRIPTION
##### Summary

We should only depend on yum-plugin-priorities on older CentOS systems and no other platforms.

##### Test Plan

n/a

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Installation using native packages on RPM systems other than CentOS works again.
</details>
