### PR TITLE
Draft: kickstart and netdata-updater for Linux Mint

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -105,11 +105,15 @@ telemetry_event() {
   fi
 
   if [ -z "${HOST_NAME}" ] || [ -z "${HOST_VERSION}" ] || [ -z "${HOST_ID}" ]; then
-    if [ -f "/etc/lsb-release" ]; then
+    lsb_release="/etc/lsb-release"
+    if [ -f "/etc/upstream-release/lsb-release" ]
+    then lsb_release="/etc/upstream-release/lsb-release"
+    fi
+    if [ -f "${lsb_release}" ]; then
       DISTRIB_ID="unknown"
       DISTRIB_RELEASE="unknown"
       DISTRIB_CODENAME="unknown"
-      eval "$(grep -E "^(DISTRIB_ID|DISTRIB_RELEASE|DISTRIB_CODENAME)=" < /etc/lsb-release)"
+      eval "$(grep -E "^(DISTRIB_ID|DISTRIB_RELEASE|DISTRIB_CODENAME)=" < "${lsb_release}")"
       if [ -z "${HOST_NAME}" ]; then HOST_NAME="${DISTRIB_ID}"; fi
       if [ -z "${HOST_VERSION}" ]; then HOST_VERSION="${DISTRIB_RELEASE}"; fi
       if [ -z "${HOST_ID}" ]; then HOST_ID="${DISTRIB_CODENAME}"; fi
@@ -406,6 +410,13 @@ get_system_info() {
       if [ -n "${os_release_file}" ]; then
         # shellcheck disable=SC1090
         . "${os_release_file}"
+
+	if [ -n "$ID_LIKE" ]
+	then ID="$ID_LIKE"
+	fi
+	if [ -n "$UBUNTU_CODENAME" ]
+	then VERSION_CODENAME="$UBUNTU_CODENAME"
+	fi
 
         DISTRO="${ID}"
         SYSVERSION="${VERSION_ID}"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -454,6 +454,9 @@ update_binpkg() {
   . "${os_release_file}"
 
   DISTRO="${ID}"
+  if [ -n "$ID_LIKE" ]
+  then DISTRO="$ID_LIKE"
+  fi
 
   supported_compat_names="debian ubuntu centos fedora opensuse"
 


### PR DESCRIPTION
##### Summary

This add native Linux Mint support to the `kickstart.sh` and `netdata-updater.`sh packager scripts.

##### Test Plan

Unsure yet ('-_-).

Feedback wanted:
- [ ] some hints how to write tests on this change?
- [ ] opinion about `/etc/upstream-release/lsb-release` / `/etc/lsb-release` or `/etc/os-release` (both of the latter are being used)?

##### Additional Information

As far as I know, only Linux Mint uses `/etc/upstream-release/lsb-release`.

<details> <summary>For users: How does this change affect me?</summary>
If you use Linux Mint, you will be able to use the [kickstart installer method](https://learn.netdata.cloud/docs/agent/packaging/installer/methods/kickstart) and add nodes to a (netdata cloud) room with the script.
</details>
