### PR TITLE
Show error when clock synchronization state is unavailable

### DIFF
--- a/collectors/timex.plugin/plugin_timex.c
+++ b/collectors/timex.plugin/plugin_timex.c
@@ -67,8 +67,15 @@ void *timex_main(void *ptr)
 
         struct timex timex_buf = {};
         int sync_state = 0;
+        static int prev_sync_state = 0;
 
         sync_state = ADJUST_TIMEX(&timex_buf);
+
+        if (sync_state == -1 && prev_sync_state != -1) {
+            error("Cannot get clock synchronization state");
+        }
+
+        prev_sync_state = sync_state;
 
         collected_number divisor = USEC_PER_MS;
         if (timex_buf.status & STA_NANO)

--- a/collectors/timex.plugin/plugin_timex.c
+++ b/collectors/timex.plugin/plugin_timex.c
@@ -71,7 +71,7 @@ void *timex_main(void *ptr)
 
         sync_state = ADJUST_TIMEX(&timex_buf);
         
-        int non_seq_failure = sync_state == -1 && prev_sync_state != -1;
+        int non_seq_failure = (sync_state == -1 && prev_sync_state != -1);
         prev_sync_state = sync_state;
 
         if (non_seq_failure) {

--- a/collectors/timex.plugin/plugin_timex.c
+++ b/collectors/timex.plugin/plugin_timex.c
@@ -70,12 +70,14 @@ void *timex_main(void *ptr)
         static int prev_sync_state = 0;
 
         sync_state = ADJUST_TIMEX(&timex_buf);
-
-        if (sync_state == -1 && prev_sync_state != -1) {
-            error("Cannot get clock synchronization state");
-        }
-
+        
+        int non_seq_failure = sync_state == -1 && prev_sync_state != -1;
         prev_sync_state = sync_state;
+
+        if (non_seq_failure) {
+            error("Cannot get clock synchronization state");
+            continue;
+        }
 
         collected_number divisor = USEC_PER_MS;
         if (timex_buf.status & STA_NANO)


### PR DESCRIPTION
##### Summary
SSIA

Edit: Ilya's suggestion: we won't collect data as well if the call is failed.

##### Test Plan

Check the `timex.plugin` collects data if the ADJUST_TIMEX call doesn't fail.