### PR TITLE
Remove on pull_request trigger

### DIFF
--- a/.github/workflows/cloud_regression.yml
+++ b/.github/workflows/cloud_regression.yml
@@ -10,16 +10,6 @@ on:
       - '**.h'
       - 'mqtt_websockets/**'
       - 'aclk/aclk-schemas/**'
-  pull_request_target:
-    branches: [master]
-    paths:
-      - 'CMakeLists.txt'
-      - '**.c'
-      - '**.cc'
-      - '**.cpp'
-      - '**.h'
-      - 'mqtt_websockets/**'
-      - 'aclk/aclk-schemas/**'
 jobs:
   trigger_cloud_regression_tests:
     runs-on: ubuntu-latest
@@ -31,7 +21,7 @@ jobs:
           PR_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
         id: output-workflow-dispatch-params
         run: |
-          if [ ${{ github.event_name }} == 'pull_request' ]; then
+          if [ ${{ github.event_name }} == 'pull_request_target' ]; then
             NETDATA_CUSTOM_REPO="$PR_REPO_NAME"
             NETDATA_CUSTOM_BRANCH="$PR_BRANCH_NAME"
             NETDATA_CUSTOM_PR_NUMBER="${{ github.event.number }}"


### PR DESCRIPTION
Remove the on pull_request_target trigger for the Cloud tests workflow.
Also fix the pull request event evaluation, in case it's to be used again in the future.

We're triggering too many github actions due to the many pushes on PR branches. 

E2E cloud regression will be only triggered for pushes against master for now, until we re-evaluate the process.