### PR TITLE
Delete ML-related data of a host in the proper order.

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -848,6 +848,10 @@ void rrdhost_free(RRDHOST *host) {
 
     rrd_check_wrlock();     // make sure the RRDs are write locked
 
+    rrdhost_wrlock(host);
+    ml_delete_host(host);
+    rrdhost_unlock(host);
+
     // ------------------------------------------------------------------------
     // clean up streaming
     rrdpush_sender_thread_stop(host); // stop a possibly running thread
@@ -936,8 +940,6 @@ void rrdhost_free(RRDHOST *host) {
     if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && host->rrdeng_ctx != &multidb_ctx)
         rrdeng_exit(host->rrdeng_ctx);
 #endif
-
-    ml_delete_host(host);
 
     // ------------------------------------------------------------------------
     // remove it from the indexes

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -90,7 +90,10 @@ void ml_delete_dimension(RRDDIM *RD) {
         return;
 
     Host *H = static_cast<Host *>(RD->rrdset->rrdhost->ml_host);
-    H->removeDimension(D);
+    if (!H)
+        delete D;
+    else
+        H->removeDimension(D);
 
     RD->state->ml_dimension = nullptr;
 }


### PR DESCRIPTION
##### Summary

Initialization of ML-related structures and threads should happen
when the underlying RRD objects have been fully initialized. Destruction
should happen in the opposite way, ie. before deleting an RRD host/dimension.

##### Test Plan

Reproducing the linked issue is difficult because we need a setup that frequently frees streaming RRD hosts with ML enabled.

I've tested a parent/child setup with ML-enabled by running & killing the parent and/or the child several times, without managing to crash either of them.

##### Additional Information

Resolves https://github.com/netdata/netdata/issues/12648