### PR TITLE
Add a 2 minute timeout to stream receiver socket

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -610,7 +610,7 @@ static int rrdpush_receive(struct receiver_state *rpt)
         error("STREAM %s [receive from [%s]:%s]: cannot remove the non-blocking flag from socket %d", rpt->host->hostname, rpt->client_ip, rpt->client_port, rpt->fd);
 
     struct timeval timeout;
-    timeout.tv_sec = 600;
+    timeout.tv_sec = 120;
     timeout.tv_usec = 0;
     setsockopt (rpt->fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof timeout);
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -609,6 +609,11 @@ static int rrdpush_receive(struct receiver_state *rpt)
     if(sock_delnonblock(rpt->fd) < 0)
         error("STREAM %s [receive from [%s]:%s]: cannot remove the non-blocking flag from socket %d", rpt->host->hostname, rpt->client_ip, rpt->client_port, rpt->fd);
 
+    struct timeval timeout;
+    timeout.tv_sec = 600;
+    timeout.tv_usec = 0;
+    setsockopt (rpt->fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof timeout);
+
     // convert the socket to a FILE *
     FILE *fp = fdopen(rpt->fd, "r");
     if(!fp) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR adds a 10 minute timeout on the receiver socket for streaming connections.

When this is set, after 10 minutes of no received data from a child it will exit the parser, and declare the child ORPHAN. This could be useful in cases where the child disappears from the network before sending a disconnect.

The default timeout without setting it, is I believe 0, which can cause the connection to remain open. (If anyone knows, please advise).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->
Setup a child and parent. 

Disconnect the child from the network, and observe what happens with and without this PR. With this PR after 10 minutes of inactivity the receiving thread should stop, and the child be considered ORPHAN. If the child returns during this 10 minute span, it should continue normally to stream.
