### PR TITLE
fix: use NETDATA_LISTENER_PORT in docker healtcheck

### DIFF
--- a/packaging/docker/health.sh
+++ b/packaging/docker/health.sh
@@ -4,7 +4,8 @@
 
 if [ -z "${NETDATA_HEALTHCHECK_TARGET}" ] ; then
     # If users didn't request something else, query `/api/v1/info`.
-    NETDATA_HEALTHCHECK_TARGET="http://localhost:19999/api/v1/info"
+    PORT=${NETDATA_LISTENER_PORT:-19999}
+    NETDATA_HEALTHCHECK_TARGET="http://localhost:${PORT}/api/v1/info"
 fi
 
 case "${NETDATA_HEALTHCHECK_TARGET}" in


### PR DESCRIPTION
##### Summary

The port in healthcheck is hardcoded

https://github.com/netdata/netdata/blob/e36fbebaa205c1c3c2304a8395e74a118bcca17b/packaging/docker/health.sh#L7

This is a problem when NETDATA_LISTENER_PORT is set to a non-default value.

https://github.com/netdata/netdata/blob/e36fbebaa205c1c3c2304a8395e74a118bcca17b/packaging/docker/run.sh#L62

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
