### PR TITLE
feat(apps.plugin): add caddy to apps_groups.conf

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -103,7 +103,7 @@ fail2ban: fail2ban*
 # -----------------------------------------------------------------------------
 # web/ftp servers
 
-httpd: apache* httpd nginx* lighttpd hiawatha
+httpd: apache* httpd nginx* lighttpd hiawatha caddy
 proxy: squid* c-icap squidGuard varnish*
 php: php* lsphp*
 ftpd: proftpd in.tftpd vsftpd


### PR DESCRIPTION
##### Summary
Caddy is quit widely used and also in the Netdata setup document

I guess its nice to have it

##### Test Plan
I tested on one of my Netdata instance
Before it was in others, then I tried group under caddy (which is now missing), then httpd
<img width="1555" alt="image" src="https://user-images.githubusercontent.com/12656264/163064846-703b2c44-9fa3-4659-a4c3-ba02f340fa89.png">
