### PR TITLE
Fix the static build code in light of CVE-2022-24765

### DIFF
--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -45,8 +45,8 @@ if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
     run docker pull --platform=${platform}  alpine:3.15
   fi
 
-  run docker run --platform=${platform} -v "$(pwd)":/usr/src/netdata.git:rw alpine:3.15 \
-    /bin/sh /usr/src/netdata.git/packaging/makeself/install-alpine-packages.sh
+  run docker run --platform=${platform} -v "$(pwd)":/netdata:rw alpine:3.15 \
+    /bin/sh /netdata/packaging/makeself/install-alpine-packages.sh
 
   # save the changes made permanently
   id=$(docker ps -l -q)
@@ -55,15 +55,11 @@ fi
 
 # Run the build script inside the container
 if [ -t 1 ]; then
-  run docker run -e BUILDARCH="${BUILDARCH}" -a stdin -a stdout -a stderr -i -t -v "$(pwd)":/usr/src/netdata.git:rw \
+  run docker run -e BUILDARCH="${BUILDARCH}" -a stdin -a stdout -a stderr -i -t -v "$(pwd)":/netdata:rw \
     "${DOCKER_CONTAINER_NAME}" \
-    /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
+    /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 else
-  run docker run -e BUILDARCH="${BUILDARCH}" -v "$(pwd)":/usr/src/netdata.git:rw \
+  run docker run -e BUILDARCH="${BUILDARCH}" -v "$(pwd)":/netdata:rw \
     -e GITHUB_ACTIONS="${GITHUB_ACTIONS}" "${DOCKER_CONTAINER_NAME}" \
-    /bin/sh /usr/src/netdata.git/packaging/makeself/build.sh "${@}"
-fi
-
-if [ "${USER}" ]; then
-  sudo chown -R "${USER}" .
+    /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 fi

--- a/packaging/makeself/build.sh
+++ b/packaging/makeself/build.sh
@@ -27,16 +27,11 @@ done
 # the required packages. build-x86_64-static.sh will do this for you
 # using docker.
 
-cd "$(dirname "$0")" || exit 1
+mkdir -p /usr/src
+cp -va /netdata /usr/src/netdata
+chown -R root:root /usr/src/netdata
 
-# if we don't run inside the netdata repo
-# download it and run from it
-if [ ! -f ../../netdata-installer.sh ]; then
-  git clone https://github.com/netdata/netdata.git netdata.git || exit 1
-  cd netdata.git/makeself || exit 1
-  ./build.sh "$@"
-  exit $?
-fi
+cd /usr/src/netdata/packaging/makeself || exit 1
 
 git clean -dxf
 git submodule foreach --recursive git clean -dxf
@@ -64,3 +59,7 @@ if ! ./run-all-jobs.sh "$@"; then
   printf >&2 "Build failed."
   exit 1
 fi
+
+mkdir -p /netdata/artifacts
+cp -va /usr/src/netdata/artifacts/* /netdata/artifacts/
+chown -R "$(stat -c '%u:%g' /netdata)" /netdata/artifacts/


### PR DESCRIPTION
##### Summary

Also, fix handling of the source directory in the builds so that we don’t leave behind a dirty source directory.

##### Test Plan

Static build CI passes on this PR.

##### Additional Information
<details> <summary>For users: How does this change affect me?</summary>
  No user visible changes.
</details>
