### PR TITLE
Correctly propagate errors and warnings up to the kickstart script from scripts it calls.

### DIFF
--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -2,6 +2,9 @@
 
 echo ">>> Installing Netdata..."
 /netdata/packaging/installer/kickstart.sh --dont-wait --build-only --disable-telemetry || exit 1
+echo "::group::Environment File Contents"
+cat /etc/netdata/.environment
+echo "::endgroup::"
 echo ">>> Updating Netdata..."
 export NETDATA_NIGHTLIES_BASEURL="http://localhost:8080/artifacts/" # Pull the tarball from the local web server.
 /netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update || exit 1

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Next unused error code: I0012
+
 export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 uniquepath() {
   path=""
@@ -38,6 +40,21 @@ fi
 cd "${NETDATA_SOURCE_DIR}" || exit 1
 
 # -----------------------------------------------------------------------------
+# load the required functions
+
+if [ -f "${INSTALLER_DIR}/packaging/installer/functions.sh" ]; then
+  # shellcheck source=packaging/installer/functions.sh
+  . "${INSTALLER_DIR}/packaging/installer/functions.sh" || exit 1
+else
+  # shellcheck source=packaging/installer/functions.sh
+  . "${NETDATA_SOURCE_DIR}/packaging/installer/functions.sh" || exit 1
+fi
+
+# Used to enable saved warnings support in functions.sh
+# shellcheck disable=SC2034
+NETDATA_SAVE_WARNINGS=1
+
+# -----------------------------------------------------------------------------
 # figure out an appropriate temporary directory
 _cannot_use_tmpdir() {
   testfile="$(TMPDIR="${1}" mktemp -q -t netdata-test.XXXXXXXXXX)"
@@ -62,9 +79,7 @@ _cannot_use_tmpdir() {
 if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}"; then
   if _cannot_use_tmpdir /tmp; then
     if _cannot_use_tmpdir "${PWD}"; then
-      echo >&2
-      echo >&2 "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
-      exit 1
+      fatal "UUnable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." I0000
     else
       TMPDIR="${PWD}"
     fi
@@ -75,35 +90,17 @@ fi
 
 # -----------------------------------------------------------------------------
 # set up handling for deferred error messages
-NETDATA_DEFERRED_ERRORS=""
-
-defer_error() {
-  NETDATA_DEFERRED_ERRORS="${NETDATA_DEFERRED_ERRORS}\n* ${1}"
-}
-
-defer_error_highlighted() {
-  NETDATA_DEFERRED_ERRORS="${TPUT_YELLOW}${TPUT_BOLD}${NETDATA_DEFERRED_ERRORS}\n* ${1}${TPUT_RESET}"
-}
+#
+# This leverages the saved warnings functionality shared with some functions from functions.sh
 
 print_deferred_errors() {
-  if [ -n "${NETDATA_DEFERRED_ERRORS}" ]; then
-    echo >&2
-    echo >&2 "The following non-fatal errors were encountered during the installation process:"
-    printf '%s' >&2 "${NETDATA_DEFERRED_ERRORS}"
-    echo >&2
+  if [ -n "${SAVED_WARNINGS}" ]; then
+    printf >&2 "\n"
+    printf >&2 "%s\n" "The following warnings and non-fatal errors were encountered during the installation process:"
+    printf >&2 "%s\n" "${SAVED_WARNINGS}"
+    printf >&2 "\n"
   fi
 }
-
-# -----------------------------------------------------------------------------
-# load the required functions
-
-if [ -f "${INSTALLER_DIR}/packaging/installer/functions.sh" ]; then
-  # shellcheck source=packaging/installer/functions.sh
-  . "${INSTALLER_DIR}/packaging/installer/functions.sh" || exit 1
-else
-  # shellcheck source=packaging/installer/functions.sh
-  . "${NETDATA_SOURCE_DIR}/packaging/installer/functions.sh" || exit 1
-fi
 
 download_go() {
   download_file "${1}" "${2}" "go.d plugin" "go"
@@ -159,7 +156,7 @@ banner_nonroot_install() {
 
   ${TPUT_RED}${TPUT_BOLD}Sorry! This will fail!${TPUT_RESET}
 
-  You are attempting to install netdata as non-root, but you plan
+  You are attempting to install netdata as a non-root user, but you plan
   to install it in system paths.
 
   Please set an installation prefix, like this:
@@ -346,7 +343,7 @@ while [ -n "${1}" ]; do
     "--one-time-build") NETDATA_CONFIGURE_OPTIONS="$(echo "${NETDATA_CONFIGURE_OPTIONS%--disable-dependency-tracking)}" | sed 's/$/ --disable-dependency-tracking/g')" ;;
     "--disable-cloud")
       if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
-        echo "Cloud explicitly enabled, ignoring --disable-cloud."
+        warning "Cloud explicitly enabled, ignoring --disable-cloud."
       else
         NETDATA_DISABLE_CLOUD=1
         NETDATA_CONFIGURE_OPTIONS="$(echo "${NETDATA_CONFIGURE_OPTIONS%--disable-cloud)}" | sed 's/$/ --disable-cloud/g')"
@@ -354,7 +351,7 @@ while [ -n "${1}" ]; do
       ;;
     "--require-cloud")
       if [ -n "${NETDATA_DISABLE_CLOUD}" ]; then
-        echo "Cloud explicitly disabled, ignoring --require-cloud."
+        warning "Cloud explicitly disabled, ignoring --require-cloud."
       else
         NETDATA_REQUIRE_CLOUD=1
         NETDATA_CONFIGURE_OPTIONS="$(echo "${NETDATA_CONFIGURE_OPTIONS%--enable-cloud)}" | sed 's/$/ --enable-cloud/g')"
@@ -379,7 +376,8 @@ while [ -n "${1}" ]; do
       exit 1
       ;;
     *)
-      run_failed "I cannot understand option '$1'."
+      echo >&2 "Unrecognized option '${1}'."
+      exit_reason "Unrecognized option '${1}'." I000E
       usage
       exit 1
       ;;
@@ -434,8 +432,8 @@ if [ "$(uname -s)" = "Linux" ] && [ -f /proc/meminfo ]; then
     if [ "${target_ram}" -gt "${total_ram}" ] && [ "${proc_count}" -gt 1 ] && [ -z "${SKIP_RAM_CHECK}" ]; then
       target_ram="$(echo "${target_ram}" | awk '{$1/=1024*1024*1024;printf "%.2fGiB\n",$1}')"
       total_ram="$(echo "${total_ram}" | awk '{$1/=1024*1024*1024;printf "%.2fGiB\n",$1}')"
-      run_failed "Netdata needs ${target_ram} of RAM to safely install, but this system only has ${total_ram}."
-      run_failed "Insufficient RAM available for an install. Try reducing the number of processes used for the install using the \$MAKEOPTS variable."
+      run_failed "Netdata needs ${target_ram} of RAM to safely install, but this system only has ${total_ram}. Try reducing the number of processes used for the install using the \$MAKEOPTS variable."
+      exit_reason "Insufficent RAM to safely install." I000F
       exit 2
     fi
   fi
@@ -451,8 +449,8 @@ fi
 if [ "$(id -u)" -ne 0 ]; then
   if [ -z "${NETDATA_PREFIX}" ]; then
     netdata_banner
-	progress "wrong command line options!"
     banner_nonroot_install "${@}"
+    exit_reason "Attempted install as non-root user to /." I0010
     exit 1
   else
     banner_root_notify "${@}"
@@ -535,18 +533,7 @@ if [ ! "$have_autotools" ]; then
   if [ -f configure ]; then
     echo "Will skip autoreconf step"
   else
-    netdata_banner
-	progress "autotools v2.60 required"
-    cat << "EOF"
-
--------------------------------------------------------------------------------
-autotools 2.60 or later is required
-
-Sorry, you do not seem to have autotools 2.60 or later, which is
-required to build from the git sources of netdata.
-
-EOF
-    exit 1
+    fatal "Could not find a usable version of GNU autotools, which is required for building Netdata. Version 2.60 or later of GNU autotools is required." I0001
   fi
 fi
 
@@ -558,6 +545,7 @@ if [ ${DONOTWAIT} -eq 0 ]; then
   fi
   read -r REPLY
   if [ "$REPLY" != '' ]; then
+    exit_reason "User did not accept install attempt." I0011
     exit 1
   fi
 
@@ -565,44 +553,8 @@ fi
 
 build_error() {
   netdata_banner
-  progress "sorry, it failed to build..."
-  cat << EOF
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Sorry! netdata failed to build...
-
-You may need to check these:
-
-1. The package uuid-dev (or libuuid-devel) has to be installed.
-
-   If your system cannot find libuuid, although it is installed
-   run me with the option:  --libs-are-really-here
-
-2. The package zlib1g-dev (or zlib-devel) has to be installed.
-
-   If your system cannot find zlib, although it is installed
-   run me with the option:  --libs-are-really-here
-
-3. The package json-c-dev (or json-c-devel) has to be installed.
-
-   If your system cannot find json-c, although it is installed
-   run me with the option:  --libs-are-really-here
-
-4. You need basic build tools installed, like:
-
-   gcc make autoconf automake pkg-config
-
-   Autoconf version 2.60 or higher is required.
-
-If you still cannot get it to build, ask for help at github:
-
-   https://github.com/netdata/netdata/issues
-
-
-EOF
   trap - EXIT
-  exit 1
+  fatal "Netdata failed to build for an unknown reason." I0002
 }
 
 if [ ${LIBS_ARE_HERE} -eq 1 ]; then
@@ -655,7 +607,7 @@ bundle_protobuf() {
 
   if [ -n "${USE_SYSTEM_PROTOBUF}" ]; then
     echo "Skipping protobuf"
-    defer_error "You have requested use of a system copy of protobuf. This should work, but it is not recommended as it's very likely to break if you upgrade the currently installed version of protobuf."
+    warning "You have requested use of a system copy of protobuf. This should work, but it is not recommended as it's very likely to break if you upgrade the currently installed version of protobuf."
     return 0
   fi
 
@@ -678,12 +630,10 @@ bundle_protobuf() {
       run_ok "protobuf built and prepared."
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-bundled-protobuf"
     else
-      run_failed "Failed to build protobuf."
-      defer_error_highlighted "Failed to build protobuf. You may not be able to connect this node to Netdata Cloud."
+      run_failed "Failed to build protobuf. Netdata Cloud support will not be available in this build."
     fi
   else
-    run_failed "Unable to fetch sources for protobuf."
-    defer_error_highlighted "Unable to fetch sources for protobuf. You may not be able to connect this node to Netdata Cloud."
+    run_failed "Unable to fetch sources for protobuf. Netdata Cloud support will not be available in this build."
   fi
 
   [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
@@ -763,23 +713,19 @@ bundle_judy() {
       run_ok "libJudy built and prepared."
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-bundled-libJudy"
     else
-      run_failed "Failed to build libJudy."
       if [ -n "${NETDATA_BUILD_JUDY}" ]; then
         [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
-
-        exit 1
+        fatal "failed to build libJudy." I0003
       else
-        defer_error_highlighted "Failed to build libJudy. dbengine support will be disabled."
+        run_failed "Failed to build libJudy, dbengine support will be disabled."
       fi
     fi
   else
-    run_failed "Unable to fetch sources for libJudy."
     if [ -n "${NETDATA_BUILD_JUDY}" ]; then
       [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
-
-      exit 1
+      fatal "Unable to fetch sources for libJudy, which is required for this build of Netdata." I0004
     else
-      defer_error_highlighted "Unable to fetch sources for libJudy. dbengine support will be disabled."
+      run_failed "Unable to fetch sources for libJudy, which is required for this build of Netdata."
     fi
   fi
 
@@ -796,12 +742,12 @@ build_jsonc() {
     env_cmd="env CFLAGS=-fPIC CXXFLAGS= LDFLAGS="
   fi
 
-  cd "${1}" > /dev/null || exit 1
+  cd "${1}" > /dev/null || return 1
   # shellcheck disable=SC2086
   run ${env_cmd} cmake -DBUILD_SHARED_LIBS=OFF .
   # shellcheck disable=SC2086
   run ${env_cmd} ${make} ${MAKEOPTS}
-  cd - > /dev/null || exit 1
+  cd - > /dev/null || return 1
 }
 
 copy_jsonc() {
@@ -822,7 +768,6 @@ bundle_jsonc() {
 
   if [ -z "$(command -v cmake)" ]; then
     run_failed "Could not find cmake, which is required to build JSON-C. The install process will continue, but Netdata Cloud support will be disabled."
-    defer_error_highlighted "Could not find cmake, which is required to build JSON-C. The install process will continue, but Netdata Cloud support will be disabled."
     return 0
   fi
 
@@ -846,12 +791,10 @@ bundle_jsonc() {
       rm -rf "${tmp}"; then
       run_ok "JSON-C built and prepared."
     else
-      run_failed "Failed to build JSON-C."
-      defer_error_highlighted "Failed to build JSON-C. Netdata Cloud support will be disabled."
+      run_failed "Failed to build JSON-C, Netdata Cloud support will be disabled in this build."
     fi
   else
-    run_failed "Unable to fetch sources for JSON-C."
-    defer_error_highlighted "Unable to fetch sources for JSON-C. Netdata Cloud support will be disabled."
+    run_failed "Unable to fetch sources for JSON-C, Netdata Cloud support will be disabled in this build."
   fi
 
   [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
@@ -891,13 +834,13 @@ detect_libc() {
       cmd=$(ldd "$ls_path" | grep -w libc | cut -d" " -f 3)
       if bash -c "${cmd}" 2>&1 | grep -q -i "GNU C Library"; then
         echo >&2 " Detected GLIBC"
-        libc="glibc"    
-      fi    
-    fi    
+        libc="glibc"
+      fi
+    fi
   fi
 
   if [ -z "$libc" ]; then
-    echo >&2 " ERROR: Cannot detect a supported libc on your system!"
+    warning "Cannot detect a supported libc on your system, eBPF support will be disabled."
     return 1
   fi
 
@@ -917,11 +860,11 @@ rename_libbpf_packaging() {
 
 
 build_libbpf() {
-  cd "${1}/src" > /dev/null || exit 1
+  cd "${1}/src" > /dev/null || return 1
   mkdir root build
   # shellcheck disable=SC2086
   run env CFLAGS=-fPIC CXXFLAGS= LDFLAGS= BUILD_STATIC_ONLY=y OBJDIR=build DESTDIR=.. ${make} ${MAKEOPTS} install
-  cd - > /dev/null || exit 1
+  cd - > /dev/null || return 1
 }
 
 copy_libbpf() {
@@ -975,19 +918,17 @@ bundle_libbpf() {
       rm -rf "${tmp}"; then
       run_ok "libbpf built and prepared."
     else
-      run_failed "Failed to build libbpf."
       if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 0 ]; then
-        exit 1
+        fatal "failed to build libbpf." I0005
       else
-        defer_error_highlighted "Failed to build libbpf. You may not be able to use eBPF plugin."
+        run_failed "Failed to build libbpf. eBPF support will be disabled"
       fi
     fi
   else
-    run_failed "Unable to fetch sources for libbpf."
     if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 0 ]; then
-      exit 1
+      fatal "Failed to fetch sources for libbpf." I0006
     else
-      defer_error_highlighted "Unable to fetch sources for libbpf. You may not be able to use eBPF plugin."
+      run_failed "Unable to fetch sources for libbpf. eBPF support will be disabled"
     fi
   fi
 
@@ -1024,21 +965,19 @@ bundle_ebpf_co_re() {
       rm -rf "${tmp}"; then
       run_ok "libbpf built and prepared."
     else
-      run_failed "Failed to get eBPF CO-RE files."
       if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 0 ]; then
-        exit 1
+        fatal "Failed to get eBPF CO-RE files." I0007
       else
-        defer_error_highlighted "Failed to get CO-RE. You will not be able to use eBPF plugin."
+        run_failed "Failed to get eBPF CO-RE files. eBPF support will be disabled"
         NETDATA_DISABLE_EBPF=1
         NETDATA_CONFIGURE_OPTIONS="$(echo "${NETDATA_CONFIGURE_OPTIONS%--disable-ebpf)}" | sed 's/$/ --disable-ebpf/g')"
       fi
     fi
   else
-    run_failed "Unable to fetch sources for libbpf."
     if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 0 ]; then
-      exit 1
+      fatal "Failed to fetch eBPF CO-RE files." I0008
     else
-      defer_error_highlighted "Unable to fetch sources for eBPF CO-RE. You will not be able to use eBPF plugin."
+      run_failed "Failed to fetch eBPF CO-RE files. eBPF support will be disabled"
       NETDATA_DISABLE_EBPF=1
       NETDATA_CONFIGURE_OPTIONS="$(echo "${NETDATA_CONFIGURE_OPTIONS%--disable-ebpf)}" | sed 's/$/ --disable-ebpf/g')"
     fi
@@ -1075,21 +1014,26 @@ echo >&2
 progress "Run autotools to configure the build environment"
 
 if [ "$have_autotools" ]; then
-  run autoreconf -ivf || exit 1
+  if ! run autoreconf -ivf; then
+    fatal "Failed to prepare Netdata sources." I0009
+  fi
 fi
 
 # shellcheck disable=SC2086
-run ./configure \
-  --prefix="${NETDATA_PREFIX}/usr" \
-  --sysconfdir="${NETDATA_PREFIX}/etc" \
-  --localstatedir="${NETDATA_PREFIX}/var" \
-  --libexecdir="${NETDATA_PREFIX}/usr/libexec" \
-  --libdir="${NETDATA_PREFIX}/usr/lib" \
-  --with-zlib \
-  --with-math \
-  --with-user=netdata \
-  ${NETDATA_CONFIGURE_OPTIONS} \
-  CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" || exit 1
+if ! run ./configure \
+         --prefix="${NETDATA_PREFIX}/usr" \
+         --sysconfdir="${NETDATA_PREFIX}/etc" \
+         --localstatedir="${NETDATA_PREFIX}/var" \
+         --libexecdir="${NETDATA_PREFIX}/usr/libexec" \
+         --libdir="${NETDATA_PREFIX}/usr/lib" \
+         --with-zlib \
+         --with-math \
+         --with-user=netdata \
+         ${NETDATA_CONFIGURE_OPTIONS} \
+         CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"; then
+  fatal "Failed to configure Netdata sources." I000A
+fi
+
 
 [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
 
@@ -1107,7 +1051,9 @@ run $make clean
 progress "Compile netdata"
 
 # shellcheck disable=SC2086
-run $make ${MAKEOPTS} || exit 1
+if ! run $make ${MAKEOPTS}; then
+  fatal "Failed to build Netdata." I000B
+fi
 
 [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
 
@@ -1200,7 +1146,9 @@ touch "${NETDATA_PREFIX}/etc/netdata/.installer-cleanup-of-stock-configs-done"
 # -----------------------------------------------------------------------------
 progress "Install netdata"
 
-run $make install || exit 1
+if ! run $make install; then
+  fatal "Failed to install Netdata." I000C
+fi
 
 # -----------------------------------------------------------------------------
 progress "Fix generated files permissions"
@@ -1308,7 +1256,9 @@ progress "Fix permissions of netdata directories (using user '${NETDATA_USER}')"
 
 if [ ! -d "${NETDATA_RUN_DIR}" ]; then
   # this is needed if NETDATA_PREFIX is not empty
-  run mkdir -p "${NETDATA_RUN_DIR}" || exit 1
+  if ! run mkdir -p "${NETDATA_RUN_DIR}"; then
+    warning "Failed to create ${NETDATA_RUN_DIR}, it must becreated by hand or the Netdata Agent will not be able to be started."
+  fi
 fi
 
 # --- stock conf dir ----
@@ -1339,7 +1289,9 @@ run find "${NETDATA_WEB_DIR}" -type d -exec chmod 0775 {} \;
 for x in "${NETDATA_LIB_DIR}" "${NETDATA_CACHE_DIR}" "${NETDATA_LOG_DIR}"; do
   if [ ! -d "${x}" ]; then
     echo >&2 "Creating directory '${x}'"
-    run mkdir -p "${x}" || exit 1
+    if ! run mkdir -p "${x}"; then
+      warning "Failed to create ${x}, it must be created by hand or the Netdata Agent will not be able to be started."
+    fi
   fi
 
   run chown -R "${NETDATA_USER}:${NETDATA_GROUP}" "${x}"
@@ -1353,7 +1305,9 @@ run chmod 755 "${NETDATA_LOG_DIR}"
 
 if [ ! -d "${NETDATA_CLAIMING_DIR}" ]; then
   echo >&2 "Creating directory '${NETDATA_CLAIMING_DIR}'"
-  run mkdir -p "${NETDATA_CLAIMING_DIR}" || exit 1
+  if ! run mkdir -p "${NETDATA_CLAIMING_DIR}"; then
+    warning "failed to create ${NETDATA_CLAIMING_DIR}, it will need to be created manually."
+  fi
 fi
 run chown -R "${NETDATA_USER}:${NETDATA_GROUP}" "${NETDATA_CLAIMING_DIR}"
 run chmod 770 "${NETDATA_CLAIMING_DIR}"
@@ -1564,7 +1518,6 @@ install_go() {
 
   if [ ! -f "${tmp}/${GO_PACKAGE_BASENAME}" ] || [ ! -f "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/${GO_PACKAGE_BASENAME}" ]; then
     run_failed "go.d plugin download failed, go.d plugin will not be available"
-    defer_error "go.d plugin download failed, go.d plugin will not be available"
     echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
     echo >&2
     [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
@@ -1581,8 +1534,7 @@ install_go() {
     echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
     echo >&2
 
-    run_failed "go.d.plugin package files checksum validation failed."
-    defer_error "go.d.plugin package files checksum validation failed, go.d.plugin will not be available"
+    run_failed "go.d.plugin package files checksum validation failed. go.d.plugin will not be available."
     [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
     return 0
   fi
@@ -1608,20 +1560,21 @@ install_go
 
 should_install_ebpf() {
   if [ "${NETDATA_DISABLE_EBPF:=0}" -eq 1 ]; then
-    run_failed "eBPF explicitly disabled."
-    defer_error "eBPF explicitly disabled."
+    run_failed "eBPF has been explicitly disabled, it will not be available in this install."
     return 1
   fi
 
   if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
-    run_failed "Currently eBPF is only supported on Linux on X86_64."
-    defer_error "Currently eBPF is only supported on Linux on X86_64."
+    if [ "${NETDATA_DISABLE_EBPF:=1}" -eq 0 ]; then
+      run_failed "Currently eBPF is only supported on Linux on X86_64."
+    fi
+
     return 1
   fi
 
   # Check Kernel Config
   if ! run "${INSTALLER_DIR}"/packaging/check-kernel-config.sh; then
-    echo >&2 "Warning: Kernel unsupported or missing required config (eBPF may not work on your system)"
+    warning "Kernel unsupported or missing required config (eBPF may not work on your system)"
   fi
 
   return 0
@@ -1777,7 +1730,7 @@ if [ ${DONOTSTART} -eq 1 ]; then
   create_netdata_conf "${NETDATA_PREFIX}/etc/netdata/netdata.conf"
 else
   if ! restart_netdata "${NETDATA_PREFIX}/usr/sbin/netdata" "${@}"; then
-    fatal "Cannot start netdata!"
+    fatal "Cannot start netdata!" I000D
   fi
 
   started=1

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -277,12 +277,12 @@ warning() {
 }
 
 run_ok() {
-  printf >&2 "%s OK %s %s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${1}"
+  printf >&2 "%s OK %s %s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${1:-''}"
 }
 
 run_failed() {
-  printf >&2 "%s FAILED %s %s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${1}"
-  if [ -n "${NETDATA_SAVE_WARNINGS}" ] && [ -n "${1}" ]; then
+  printf >&2 "%s FAILED %s %s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${1:-''}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ] && [ -n "${1:-''}" ]; then
     SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
   fi
 }

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -255,7 +255,7 @@ exit_reason() {
     if [ -n "${NETDATA_PROPAGATE_WARNINGS}" ]; then
       export EXIT_REASON
       export EXIT_CODE
-      export SAVED_WARNINGS
+      export NETDATA_WARNINGS="${NETDATA_WARNINGS}${SAVED_WARNINGS}"
     fi
   fi
 }

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# next unused error code: L0003
+
 # make sure we have a UID
 [ -z "${UID}" ] && UID="$(id -u)"
 # -----------------------------------------------------------------------------
@@ -42,6 +44,7 @@ setup_terminal() {
       TPUT_RESET="$(tput sgr 0)"
       # shellcheck disable=SC2034
       TPUT_BLACK="$(tput setaf 0)"
+      # shellcheck disable=SC2034
       TPUT_RED="$(tput setaf 1)"
       TPUT_GREEN="$(tput setaf 2)"
       # shellcheck disable=SC2034
@@ -99,7 +102,7 @@ get() {
   elif command -v wget > /dev/null 2>&1; then
     wget -T 15 -O - "${url}"
   else
-    fatal "I need curl or wget to proceed, but neither is available on this system."
+    fatal "I need curl or wget to proceed, but neither is available on this system." "L0002"
   fi
 }
 
@@ -245,17 +248,43 @@ find_processors() {
 }
 
 # -----------------------------------------------------------------------------
+exit_reason() {
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    EXIT_REASON="${1}"
+    EXIT_CODE="${2}"
+    if [ -n "${NETDATA_PROPAGATE_WARNINGS}" ]; then
+      export EXIT_REASON
+      export EXIT_CODE
+      export SAVED_WARNINGS
+    fi
+  fi
+}
+
 fatal() {
-  printf >&2 "%s ABORTED %s %s \n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${*}"
+  printf >&2 "%s ABORTED %s %s \n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${1}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+  fi
+  exit_reason "${1}" "${2}"
   exit 1
 }
 
+warning() {
+  printf >&2 "%s WARNING %s %s\n\n" "%{TPUT_BGYELLOW}${TPUT_BLACK}${TPUT_BOLD}" "${TPUT_RESET}" "${1}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+  fi
+}
+
 run_ok() {
-  printf >&2 "%s OK %s %s \n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${*}"
+  printf >&2 "%s OK %s %s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${1}"
 }
 
 run_failed() {
-  printf >&2 "%s FAILED %s %s \n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${*}"
+  printf >&2 "%s FAILED %s %s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}" "${1}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ] && [ -n "${1}" ]; then
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+  fi
 }
 
 ESCAPED_PRINT_METHOD=
@@ -299,6 +328,9 @@ run() {
   if [ ${ret} -ne 0 ]; then
     run_failed
     printf >> "${run_logfile}" "FAILED with exit code %s\n" "${ret}"
+    if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+      SAVED_WARNINGS="${SAVED_WARNINGS}\n  - Command '${*}' failed with exit code ${ret}."
+    fi
   else
     run_ok
     printf >> "${run_logfile}" "OK\n"
@@ -430,14 +462,14 @@ install_non_systemd_init() {
         run chkconfig netdata on &&
         return 0
     else
-      echo >&2 "I don't know what init file to install on system '${key}'. Open a github issue to help us fix it."
+      warning "Could not determine what type of init script to install on this system."
       return 1
     fi
   elif [ -f /etc/init.d/netdata ]; then
     echo >&2 "file '/etc/init.d/netdata' already exists."
     return 0
   else
-    echo >&2 "I don't know what init file to install on system '${key}'. Open a github issue to help us fix it."
+    warning "Could not determine what type of init script to install on this system."
   fi
 
   return 1
@@ -507,7 +539,7 @@ install_netdata_service() {
           ${ENABLE_NETDATA_IF_PREVIOUSLY_ENABLED} &&
           return 0
       else
-        echo >&2 "no systemd directory; cannot install netdata.service"
+        warning "Could not find a systemd service directory, unable to install Netdata systemd service."
       fi
     else
       install_non_systemd_init
@@ -559,7 +591,7 @@ stop_netdata_on_pid() {
   printf >&2 "Stopping netdata on pid %s ..." "${pid}"
   while [ -n "${pid}" ] && [ ${ret} -eq 0 ]; do
     if [ ${count} -gt 24 ]; then
-      echo >&2 "Cannot stop the running netdata on pid ${pid}."
+      warning "Cannot stop netdata agent with PID ${pid}."
       return 1
     fi
 
@@ -584,7 +616,7 @@ stop_netdata_on_pid() {
 
   echo >&2
   if [ ${ret} -eq 0 ]; then
-    echo >&2 "SORRY! CANNOT STOP netdata ON PID ${pid} !"
+    warning "Failed to stop netdata agent process with PID ${pid}."
     return 1
   fi
 
@@ -687,7 +719,7 @@ restart_netdata() {
 
   if [ ${started} -eq 0 ]; then
     # still not started... another forced attempt, just run the binary
-    echo >&2 "Netdata service still not started, attempting another forced restart by running '${netdata} ${*}'"
+    warning "Netdata service still not started, attempting another forced restart by running '${netdata} ${*}'"
     run stop_all_netdata
     run "${netdata}" "${@}"
     return $?
@@ -798,7 +830,7 @@ portable_add_user() {
     run sysadminctl -addUser "${username}" && return 0
   fi
 
-  echo >&2 "Failed to add ${username} user account !"
+  warning "Failed to add ${username} user account!"
 
   return 1
 }
@@ -834,7 +866,7 @@ portable_add_group() {
     dseditgroup -o create "${groupname}" && return 0
   fi
 
-  echo >&2 "Failed to add ${groupname} user group !"
+  warning >&2 "Failed to add ${groupname} user group !"
   return 1
 }
 
@@ -845,7 +877,8 @@ portable_add_user_to_group() {
   # Check if group exist
   if ! cut -d ':' -f 1 < /etc/group | grep "^${groupname}$" > /dev/null 2>&1; then
     echo >&2 "Group '${groupname}' does not exist."
-    return 1
+    # Don’t treat this as a failure, if the group does not exist we should not be trying to add the user to it.
+    return 0
   fi
 
   # Check if user is in group
@@ -876,7 +909,8 @@ portable_add_user_to_group() {
     if command -v dseditgroup 1> /dev/null 2>&1; then
       dseditgroup -u "${username}" "${groupname}" && return 0
     fi
-    echo >&2 "Failed to add user ${username} to group ${groupname} !"
+
+    warning >&2 "Failed to add user ${username} to group ${groupname}!"
     return 1
   fi
 }
@@ -889,7 +923,7 @@ safe_sha256sum() {
   elif command -v shasum > /dev/null 2>&1; then
     shasum -a 256 "$@"
   else
-    fatal "I could not find a suitable checksum binary to use"
+    fatal "I could not find a suitable checksum binary to use" "L0001"
   fi
 }
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1496,12 +1496,18 @@ build_and_install() {
     opts="${opts} --disable-cloud"
   fi
 
+  export NETDATA_SAVE_WARNINGS=1
+  export NETDATA_PROPAGATE_WARNINGS=1
   # shellcheck disable=SC2086
   run ${ROOTCMD} ./netdata-installer.sh ${opts}
 
   case $? in
     1)
-      fatal "netdata-installer.sh failed to run correctly." F0007
+      if [ -n "${EXIT_REASON}" ]; then
+        fatal "netdata-installer.sh failed to run: ${EXIT_REASON}" "${EXIT_CODE}"
+      else
+        fatal "netdata-installer.sh failed to run correctly." I0000
+      fi
       ;;
     2)
       fatal "Insufficient RAM to install netdata." F0008

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -687,6 +687,8 @@ uninstall() {
       return 0
     else
       progress "Found existing netdata-uninstaller. Running it.."
+      export NETDATA_SAVE_WARNINGS=1
+      export NETDATA_PROPAGATE_WARNINGS=1
       if ! run ${ROOTCMD} "${uninstaller}" $FLAGS; then
         warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
       fi
@@ -700,6 +702,8 @@ uninstall() {
       progress "Downloading netdata-uninstaller ..."
       download "${uninstaller_url}" "${tmpdir}/netdata-uninstaller.sh"
       chmod +x "${tmpdir}/netdata-uninstaller.sh"
+      export NETDATA_SAVE_WARNINGS=1
+      export NETDATA_PROPAGATE_WARNINGS=1
       if ! run ${ROOTCMD} "${tmpdir}/netdata-uninstaller.sh" $FLAGS; then
         warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
       fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -644,11 +644,17 @@ update() {
       return 0
     fi
 
+    export NETDATA_SAVE_WARNINGS=1
+    export NETDATA_PROPAGATE_WARNINGS=1
     if run ${ROOTCMD} "${updater}" --not-running-from-cron; then
       progress "Updated existing install at ${ndprefix}"
       return 0
     else
-      fatal "Failed to update existing Netdata install at ${ndprefix}" F0100
+      if [ -n "${EXIT_REASON}" ]; then
+        fatal "Failed to update existing Netdata install at ${ndprefix}: ${EXIT_REASON}" "${EXIT_CODE}"
+      else
+        fatal "Failed to update existing Netdata install at ${ndprefix}." U0000
+      fi
     fi
   else
     warning "Could not find a usable copy of the updater script."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -35,8 +35,8 @@ NETDATA_ONLY_BUILD=0
 NETDATA_ONLY_NATIVE=0
 NETDATA_ONLY_STATIC=0
 NETDATA_REQUIRE_CLOUD=1
+NETDATA_WARNINGS=""
 RELEASE_CHANNEL="nightly"
-WARNINGS=""
 
 if [ -n "$DISABLE_TELEMETRY" ]; then
   NETDATA_DISABLE_TELEMETRY="${DISABLE_TELEMETRY}"
@@ -342,9 +342,9 @@ cleanup() {
 }
 
 deferred_warnings() {
-  if [ -n "${WARNINGS}" ]; then
+  if [ -n "${NETDATA_WARNINGS}" ]; then
     printf >&2 "%s\n" "The following non-fatal warnings or errors were encountered:"
-    echo >&2 "${WARNINGS}"
+    echo >&2 "${NETDATA_WARNINGS}"
     printf >&2 "\n"
   fi
 }
@@ -417,7 +417,8 @@ run() {
   if [ ${ret} -ne 0 ]; then
     printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} FAILED ${TPUT_RESET}"
     printf "%s\n" "FAILED with exit code ${ret}" >> "${run_logfile}"
-    WARNINGS="${WARNINGS}\n  - Command \"${*}\" failed with exit code ${ret}."
+    # shellcheck disable=SC2089
+    NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - Command \"${*}\" failed with exit code ${ret}."
   else
     printf >&2 "%s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD} OK ${TPUT_RESET}"
     printf "OK\n" >> "${run_logfile}"
@@ -428,7 +429,7 @@ run() {
 
 warning() {
   printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*}"
-  WARNINGS="${WARNINGS}\n  - ${*}"
+  NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - ${*}"
 }
 
 _cannot_use_tmpdir() {
@@ -646,6 +647,8 @@ update() {
 
     export NETDATA_SAVE_WARNINGS=1
     export NETDATA_PROPAGATE_WARNINGS=1
+    # shellcheck disable=SC2090
+    export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
     if run ${ROOTCMD} "${updater}" --not-running-from-cron; then
       progress "Updated existing install at ${ndprefix}"
       return 0
@@ -689,6 +692,8 @@ uninstall() {
       progress "Found existing netdata-uninstaller. Running it.."
       export NETDATA_SAVE_WARNINGS=1
       export NETDATA_PROPAGATE_WARNINGS=1
+      # shellcheck disable=SC2090
+      export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
       if ! run ${ROOTCMD} "${uninstaller}" $FLAGS; then
         warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
       fi
@@ -704,6 +709,8 @@ uninstall() {
       chmod +x "${tmpdir}/netdata-uninstaller.sh"
       export NETDATA_SAVE_WARNINGS=1
       export NETDATA_PROPAGATE_WARNINGS=1
+      # shellcheck disable=SC2090
+      export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
       if ! run ${ROOTCMD} "${tmpdir}/netdata-uninstaller.sh" $FLAGS; then
         warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
       fi
@@ -1508,6 +1515,8 @@ build_and_install() {
 
   export NETDATA_SAVE_WARNINGS=1
   export NETDATA_PROPAGATE_WARNINGS=1
+  # shellcheck disable=SC2090
+  export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
   # shellcheck disable=SC2086
   run ${ROOTCMD} ./netdata-installer.sh ${opts}
 

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -10,6 +10,8 @@
 #
 # Author: Paweł Krupa <paulfantom@gmail.com>
 # Author: Pavlos Emm. Katsoulakis <paul@netdata.cloud>
+#
+# Next unused error code: R0005
 
 usage="$(basename "$0") [-h] [-f ] -- program to calculate the answer to life, the universe and everything
 
@@ -51,17 +53,57 @@ while :; do
   esac
 done
 
+if [ -n "${script_source}" ]; then
+  script_name="$(basename "${script_source}")"
+else
+  script_name="netdata-updater.sh"
+fi
+
+info() {
+  echo >&3 "$(date) : INFO: ${script_name}: " "${1}"
+}
+
+error() {
+  echo >&3 "$(date) : ERROR: ${script_name}: " "${1}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+  fi
+}
+
+fatal() {
+  echo >&3 "$(date) : FATAL: ${script_name}: FAILED TO UPDATE NETDATA: " "${1}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+  fi
+  exit_reason "${1}" "${2}"
+  exit 1
+}
+
+exit_reason() {
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    EXIT_REASON="${1}"
+    EXIT_CODE="${2}"
+    if [ -n "${NETDATA_PROPAGATE_WARNINGS}" ]; then
+      export EXIT_REASON
+      export EXIT_CODE
+      export SAVED_WARNINGS
+    fi
+  fi
+}
+
 if [ "$YES" != "1" ]; then
   echo >&2 "This script will REMOVE netdata from your system."
   echo >&2 "Run it again with --yes to do it."
+  exit_reason "User did not accept uninstalling." R0001
   exit 1
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-  echo >&2 "This script SHOULD be run as root or otherwise it won't delete all installed components."
+  error "This script SHOULD be run as root or otherwise it won't delete all installed components."
   key="n"
   read -r 1 -p "Do you want to continue as non-root user [y/n] ? " key
   if [ "$key" != "y" ] && [ "$key" != "Y" ]; then
+    exit_reason "User cancelled uninstall." R0002
     exit 1
   fi
 fi
@@ -107,7 +149,7 @@ create_tmp_directory() {
   if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}"; then
     if _cannot_use_tmpdir /tmp; then
       if _cannot_use_tmpdir "${PWD}"; then
-        fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." F0400
+        fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." R0003
       else
         TMPDIR="${PWD}"
       fi
@@ -325,14 +367,6 @@ setup_terminal() {
 }
 setup_terminal || echo > /dev/null
 
-run_ok() {
-  printf >&2 "%s OK %s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}"
-}
-
-run_failed() {
-  printf >&2 "%s FAILED %s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}"
-}
-
 ESCAPED_PRINT_METHOD=
 if printf "%s " test > /dev/null 2>&1; then
   ESCAPED_PRINT_METHOD="printfq"
@@ -373,10 +407,11 @@ run() {
 
   ret=$?
   if [ ${ret} -ne 0 ]; then
-    run_failed
+    printf >&2 "%s FAILED %s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}"
     printf >> "${run_logfile}" "FAILED with exit code %s\n" "${ret}"
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - Command \"${*}\" failed with exit code ${ret}."
   else
-    run_ok
+    printf >&2 "%s OK %s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}"
     printf >> "${run_logfile}" "OK\n"
   fi
 
@@ -387,14 +422,14 @@ portable_del_group() {
   groupname="${1}"
 
   # Check if group exist
-  echo >&2 "Removing ${groupname} user group ..."
+  info "Removing ${groupname} user group ..."
 
   # Linux
   if command -v groupdel 1> /dev/null 2>&1; then
     if grep -q "${groupname}" /etc/group; then
       run groupdel "${groupname}" && return 0
     else
-      echo >&2 "Group ${groupname} already removed in a previous step."
+      info "Group ${groupname} already removed in a previous step."
       return 0
     fi
   fi
@@ -404,12 +439,12 @@ portable_del_group() {
     if dseditgroup -o read netdata 1> /dev/null 2>&1; then
       run dseditgroup -o delete "${groupname}" && return 0
     else
-      echo >&2 "Could not find group ${groupname}, nothing to do"
+      info "Could not find group ${groupname}, nothing to do"
       return 0
     fi
   fi
 
-  echo >&2 "Group ${groupname} was not automatically removed, you might have to remove it manually"
+  error "Group ${groupname} was not automatically removed, you might have to remove it manually"
   return 1
 }
 
@@ -453,7 +488,7 @@ issystemd() {
 
 portable_del_user() {
   username="${1}"
-  echo >&2 "Deleting ${username} user account ..."
+  info "Deleting ${username} user account ..."
 
   # Linux
   if command -v userdel 1> /dev/null 2>&1; then
@@ -465,7 +500,7 @@ portable_del_user() {
     run sysadminctl -deleteUser "${username}" && return 0
   fi
 
-  echo >&2 "User ${username} could not be deleted from system, you might have to remove it manually"
+  error "User ${username} could not be deleted from system, you might have to remove it manually"
   return 1
 }
 
@@ -474,7 +509,7 @@ portable_del_user_from_group() {
   username="${2}"
 
   # username is not in group
-  echo >&2 "Deleting ${username} user from ${groupname} group ..."
+  info "Deleting ${username} user from ${groupname} group ..."
 
   # Linux
   if command -v gpasswd 1> /dev/null 2>&1; then
@@ -496,16 +531,16 @@ portable_del_user_from_group() {
     run dseditgroup -o delete -u "${username}" "${groupname}" && return 0
   fi
 
-  echo >&2 "Failed to delete user ${username} from group ${groupname} !"
+  error "Failed to delete user ${username} from group ${groupname} !"
   return 1
 }
 
 quit_msg() {
   echo
   if [ "$FILE_REMOVAL_STATUS" -eq 0 ]; then
-    echo >&2 "Something went wrong :("
+    fatal "Failed to completely remove Netdata from this system." R0004
   else
-    echo >&2 "Netdata files were successfully removed from your system"
+    info "Netdata files were successfully removed from your system"
   fi
 }
 
@@ -513,7 +548,7 @@ rm_file() {
   FILE="$1"
   if [ -f "${FILE}" ]; then
     if user_input "Do you want to delete this file '$FILE' ? "; then
-	  run rm -v "${FILE}"
+      run rm -v "${FILE}"
     fi
   fi
 }
@@ -559,10 +594,10 @@ stop_netdata_on_pid() {
 
   pidisnetdata "${pid}" || return 0
 
-  printf >&2 "Stopping netdata on pid %s ..." "${pid}"
+  info "Stopping netdata on pid ${pid} ..."
   while [ -n "$pid" ] && [ ${ret} -eq 0 ]; do
     if [ ${count} -gt 24 ]; then
-      echo >&2 "Cannot stop the running netdata on pid ${pid}."
+      error "Cannot stop the running netdata on pid ${pid}."
       return 1
     fi
 
@@ -587,11 +622,11 @@ stop_netdata_on_pid() {
 
   echo >&2
   if [ ${ret} -eq 0 ]; then
-    echo >&2 "SORRY! CANNOT STOP netdata ON PID ${pid} !"
+    error "SORRY! CANNOT STOP netdata ON PID ${pid} !"
     return 1
   fi
 
-  echo >&2 "netdata on pid ${pid} stopped."
+  info "netdata on pid ${pid} stopped."
   return 0
 }
 
@@ -657,7 +692,7 @@ trap quit_msg EXIT
 . "${ENVIRONMENT_FILE}" || exit 1
 
 #### STOP NETDATA
-echo >&2 "Stopping a possibly running netdata..."
+info "Stopping a possibly running netdata..."
 stop_all_netdata
 
 #### REMOVE NETDATA FILES

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -66,14 +66,14 @@ info() {
 error() {
   echo >&3 "$(date) : ERROR: ${script_name}: " "${1}"
   if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
-    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+    NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - ${1}"
   fi
 }
 
 fatal() {
   echo >&3 "$(date) : FATAL: ${script_name}: FAILED TO UPDATE NETDATA: " "${1}"
   if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
-    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+    NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - ${1}"
   fi
   exit_reason "${1}" "${2}"
   exit 1
@@ -86,7 +86,7 @@ exit_reason() {
     if [ -n "${NETDATA_PROPAGATE_WARNINGS}" ]; then
       export EXIT_REASON
       export EXIT_CODE
-      export SAVED_WARNINGS
+      export NETDATA_WARNINGS
     fi
   fi
 }
@@ -409,7 +409,7 @@ run() {
   if [ ${ret} -ne 0 ]; then
     printf >&2 "%s FAILED %s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}"
     printf >> "${run_logfile}" "FAILED with exit code %s\n" "${ret}"
-    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - Command \"${*}\" failed with exit code ${ret}."
+    NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - Command \"${*}\" failed with exit code ${ret}."
   else
     printf >&2 "%s OK %s\n\n" "${TPUT_BGGREEN}${TPUT_WHITE}${TPUT_BOLD}" "${TPUT_RESET}"
     printf >> "${run_logfile}" "OK\n"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -28,7 +28,7 @@
 # Author: Pavlos Emm. Katsoulakis <paul@netdata.cloud>
 # Author: Austin S. Hemmelgarn <austin@netdata.cloud>
 
-# Next unused error code: U0014
+# Next unused error code: U001A
 
 set -e
 
@@ -529,7 +529,7 @@ update_build() {
 
   RUN_INSTALLER=0
   ndtmpdir=$(create_tmp_directory)
-  cd "$ndtmpdir" || exit 1
+  cd "$ndtmpdir" || fatal "Failed to change current working directory to ${ndtmpdir}" U0016
 
   install_build_dependencies
 
@@ -547,7 +547,7 @@ update_build() {
       NEW_CHECKSUM="$(safe_sha256sum netdata-latest.tar.gz 2> /dev/null | cut -d' ' -f1)"
       tar -xf netdata-latest.tar.gz >&3 2>&3
       rm netdata-latest.tar.gz >&3 2>&3
-      cd "$(find . -maxdepth 1 -name "netdata-${path_version}*" | head -n 1)" || exit 1
+      cd "$(find . -maxdepth 1 -name "netdata-${path_version}*" | head -n 1)" || fatal "Failed to switch to build directory" U0017
       RUN_INSTALLER=1
     fi
   fi
@@ -574,7 +574,7 @@ update_build() {
 
     if [ ! -x ./netdata-installer.sh ]; then
       if [ "$(find . -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ] && [ -x "$(find . -mindepth 1 -maxdepth 1 -type d)/netdata-installer.sh" ]; then
-        cd "$(find . -mindepth 1 -maxdepth 1 -type d)" || exit 1
+        cd "$(find . -mindepth 1 -maxdepth 1 -type d)" || fatal "Failed to switch to build directory" U0018
       fi
     fi
 
@@ -622,7 +622,7 @@ update_static() {
   PREVDIR="$(pwd)"
 
   info "Entering ${ndtmpdir}"
-  cd "${ndtmpdir}" || exit 1
+  cd "${ndtmpdir}" || fatal "Failed to change current working directory to ${ndtmpdir}" U0019
 
   if update_available; then
     sysarch="$(uname -m)"
@@ -827,12 +827,12 @@ fi
 
 if [ -r "${ENVIRONMENT_FILE}" ] ; then
   # shellcheck source=/dev/null
-  . "${ENVIRONMENT_FILE}" || exit 1
+  . "${ENVIRONMENT_FILE}" || fatal "Failed to source ${ENVIRONMENT_FILE}" U0014
 fi
 
 if [ -r "$(dirname "${ENVIRONMENT_FILE}")/.install-type" ]; then
   # shellcheck source=/dev/null
-  . "$(dirname "${ENVIRONMENT_FILE}")/.install-type" || exit 1
+  . "$(dirname "${ENVIRONMENT_FILE}")/.install-type" || fatal "Failed to source $(dirname "${ENVIRONMENT_FILE}")/.install-type" U0015
 fi
 
 while [ -n "${1}" ]; do

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -456,7 +456,7 @@ get_latest_version() {
 }
 
 validate_environment_file() {
-  if [ -n "${NETDATA_PREFIX}" ] && [ -n "${REINSTALL_OPTIONS}" ]; then
+  if [ -n "${NETDATA_PREFIX+SET_BUT_NULL}" ] && [ -n "${REINSTALL_OPTIONS}" ]; then
     return 0
   else
     fatal "Environment file located at ${ENVIRONMENT_FILE} is not valid, unable to update." U0007

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -28,6 +28,8 @@
 # Author: Pavlos Emm. Katsoulakis <paul@netdata.cloud>
 # Author: Austin S. Hemmelgarn <austin@netdata.cloud>
 
+# Next unused error code: U0014
+
 set -e
 
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
@@ -55,16 +57,35 @@ else
 fi
 
 info() {
-  echo >&3 "$(date) : INFO: ${script_name}: " "${@}"
+  echo >&3 "$(date) : INFO: ${script_name}: " "${1}"
 }
 
 error() {
-  echo >&3 "$(date) : ERROR: ${script_name}: " "${@}"
+  echo >&3 "$(date) : ERROR: ${script_name}: " "${1}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+  fi
 }
 
 fatal() {
-  echo >&3 "$(date) : FATAL: ${script_name}: FAILED TO UPDATE NETDATA: " "${@}"
+  echo >&3 "$(date) : FATAL: ${script_name}: FAILED TO UPDATE NETDATA: " "${1}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+  fi
+  exit_reason "${1}" "${2}"
   exit 1
+}
+
+exit_reason() {
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    EXIT_REASON="${1}"
+    EXIT_CODE="${2}"
+    if [ -n "${NETDATA_PROPAGATE_WARNINGS}" ]; then
+      export EXIT_REASON
+      export EXIT_CODE
+      export SAVED_WARNINGS
+    fi
+  fi
 }
 
 issystemd() {
@@ -158,8 +179,7 @@ enable_netdata_updater() {
       updater_type="$(_get_scheduler_type)"
       ;;
     *)
-      error "Unrecognized updater type ${updater_type} requested. Supported types are 'systemd', 'interval', and 'crontab'."
-      exit 1
+      fatal "Unrecognized updater type ${updater_type} requested. Supported types are 'systemd', 'interval', and 'crontab'." U0001
       ;;
   esac
 
@@ -172,8 +192,7 @@ enable_netdata_updater() {
         info "If the update process fails, the failure will be logged to the systemd journal just like a regular service failure."
         info "Successful updates should produce empty logs."
       else
-        error "Systemd-based auto-update scheduling requested, but this does not appear to be a systemd system."
-        error "Auto-updates have NOT been enabled."
+        error "Systemd-based auto-update scheduling requested, but this does not appear to be a systemd system. Auto-updates have NOT been enabled."
         return 1
       fi
       ;;
@@ -185,8 +204,7 @@ enable_netdata_updater() {
         info "If the update process fails and you have email notifications set up correctly for cron on this system, you should receive an email notification of the failure."
         info "Successful updates will not send an email."
       else
-        error "Interval-based auto-update scheduling requested, but I could not find an interval scheduling directory."
-        error "Auto-updates have NOT been enabled."
+        error "Interval-based auto-update scheduling requested, but I could not find an interval scheduling directory. Auto-updates have NOT been enabled."
         return 1
       fi
       ;;
@@ -200,14 +218,12 @@ enable_netdata_updater() {
         info "If the update process fails and you have email notifications set up correctly for cron on this system, you should receive an email notification of the failure."
         info "Successful updates will not send an email."
       else
-        error "Crontab-based auto-update scheduling requested, but there is no '/etc/cron.d'."
-        error "Auto-updates have NOT been enabled."
+        error "Crontab-based auto-update scheduling requested, but there is no '/etc/cron.d'. Auto-updates have NOT been enabled."
         return 1
       fi
       ;;
     *)
-      error "Unable to determine what type of auto-update scheduling to use."
-      error "Auto-updates have NOT been enabled."
+      error "Unable to determine what type of auto-update scheduling to use. Auto-updates have NOT been enabled."
       return 1
   esac
 
@@ -251,7 +267,7 @@ safe_sha256sum() {
   elif command -v shasum > /dev/null 2>&1; then
     shasum -a 256 "$@"
   else
-    fatal "I could not find a suitable checksum binary to use"
+    fatal "I could not find a suitable checksum binary to use" U0002
   fi
 }
 
@@ -294,7 +310,7 @@ create_tmp_directory() {
       if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
         if _cannot_use_tmpdir /tmp ; then
           if _cannot_use_tmpdir "${PWD}" ; then
-            fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again."
+            fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." U0003
           else
             TMPDIR="${PWD}"
           fi
@@ -334,9 +350,9 @@ download() {
   if [ ${ret} -eq 0 ]; then
     return 0
   elif [ ${ret} -eq 255 ]; then
-    fatal "I need curl or wget to proceed, but neither is available on this system."
+    fatal "I need curl or wget to proceed, but neither is available on this system." U0004
   else
-    fatal "Cannot download ${url}"
+    fatal "Cannot download ${url}" U0005
   fi
 }
 
@@ -349,7 +365,7 @@ get_netdata_latest_tag() {
   elif command -v wget >/dev/null 2>&1; then
     tag=$(wget --max-redirect=0 "${url}" 2>&1 | grep Location | cut -d ' ' -f2 | grep -m 1 -o '[^/]*$')
   else
-    fatal "I need curl or wget to proceed, but neither of them are available on this system."
+    fatal "I need curl or wget to proceed, but neither of them are available on this system." U0006
   fi
 
   echo "${tag}" >"${dest}"
@@ -443,7 +459,7 @@ validate_environment_file() {
   if [ -n "${RELEASE_CHANNEL}" ] && [ -n "${NETDATA_PREFIX}" ] && [ -n "${REINSTALL_OPTIONS}" ] && [ -n "${IS_NETDATA_STATIC_BINARY}" ]; then
     return 0
   else
-    error "Environment file located at ${ENVIRONMENT_FILE} is not valid, unable to update."
+    fatal "Environment file located at ${ENVIRONMENT_FILE} is not valid, unable to update." U0007
   fi
 }
 
@@ -526,7 +542,7 @@ update_build() {
       info "Newest version is already installed"
     else
       if ! grep netdata-latest.tar.gz sha256sum.txt | safe_sha256sum -c - >&3 2>&3; then
-        fatal "Tarball checksum validation failed. Stopping netdata upgrade and leaving tarball in ${ndtmpdir}\nUsually this is a result of an older copy of the tarball or checksum file being cached somewhere upstream and can be resolved by retrying in an hour."
+        fatal "Tarball checksum validation failed. Stopping netdata upgrade and leaving tarball in ${ndtmpdir}\nUsually this is a result of an older copy of the tarball or checksum file being cached somewhere upstream and can be resolved by retrying in an hour." U0008
       fi
       NEW_CHECKSUM="$(safe_sha256sum netdata-latest.tar.gz 2> /dev/null | cut -d' ' -f1)"
       tar -xf netdata-latest.tar.gz >&3 2>&3
@@ -550,7 +566,7 @@ update_build() {
       do_not_start="--dont-start-it"
     fi
 
-    env="TMPDIR='${TMPDIR}'"
+    env="/bin/env TMPDIR=${TMPDIR}"
 
     if [ -n "${NETDATA_SELECTED_DASHBOARD}" ]; then
       env="${env} NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"
@@ -573,7 +589,17 @@ update_build() {
     fi
 
     info "Re-installing netdata..."
-    eval "${env} ./netdata-installer.sh ${REINSTALL_OPTIONS} --dont-wait ${do_not_start}" >&3 2>&3 || fatal "FAILED TO COMPILE/INSTALL NETDATA"
+    export NETDATA_SAVE_WARNINGS=1
+    export NETDATA_PROPAGATE_WARNINGS=1
+    # shellcheck disable=SC2086
+    if ! ${env} ./netdata-installer.sh ${REINSTALL_OPTIONS} --dont-wait ${do_not_start} >&3 2>&3; then
+      if [ -n "${EXIT_REASON}" ]; then
+        fatal "Failed to rebuild existing netdata install: ${EXIT_REASON}" "U${EXIT_CODE}"
+      else
+        fatal "Failed to rebuild existing netdata reinstall." UI0000
+      fi
+    fi
+    eval "${env} ./netdata-installer.sh ${REINSTALL_OPTIONS} --dont-wait ${do_not_start}" >&3 2>&3 || fatal "FAILED TO COMPILE/INSTALL NETDATA" U0009
 
     # We no longer store checksum info here. but leave this so that we clean up all environment files upon next update.
     sed -i '/NETDATA_TARBALL/d' "${ENVIRONMENT_FILE}"
@@ -602,7 +628,7 @@ update_static() {
     download "${NETDATA_TARBALL_CHECKSUM_URL}" "${ndtmpdir}/sha256sum.txt"
     download "${NETDATA_TARBALL_URL}" "${ndtmpdir}/netdata-${sysarch}-latest.gz.run"
     if ! grep "netdata-${sysarch}-latest.gz.run" "${ndtmpdir}/sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-      fatal "Static binary checksum validation failed. Stopping netdata installation and leaving binary in ${ndtmpdir}\nUsually this is a result of an older copy of the file being cached somewhere and can be resolved by simply retrying in an hour."
+      fatal "Static binary checksum validation failed. Stopping netdata installation and leaving binary in ${ndtmpdir}\nUsually this is a result of an older copy of the file being cached somewhere and can be resolved by simply retrying in an hour." U000A
     fi
 
     if [ -e /opt/netdata/etc/netdata/.install-type ] ; then
@@ -637,7 +663,7 @@ update_binpkg() {
   elif [ -s "/usr/lib/os-release" ] && [ -r "/usr/lib/os-release" ]; then
     os_release_file="/usr/lib/os-release"
   else
-    fatal "Cannot find an os-release file ..." F0401
+    fatal "Cannot find an os-release file ..." U000B
   fi
 
   # shellcheck disable=SC1090
@@ -733,20 +759,20 @@ update_binpkg() {
 
   if [ -n "${repo_subcmd}" ]; then
     # shellcheck disable=SC2086
-    env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts} || fatal "Failed to update repository metadata."
+    env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts} || fatal "Failed to update repository metadata." U000C
   fi
 
   for repopkg in netdata-repo netdata-repo-edge; do
     if ${pkg_installed_check} ${repopkg} > /dev/null 2>&1; then
       # shellcheck disable=SC2086
-      env ${env} ${pm_cmd} ${upgrade_cmd} ${pkg_install_opts} ${repopkg} || fatal "Failed to update Netdata repository config."
+      env ${env} ${pm_cmd} ${upgrade_cmd} ${pkg_install_opts} ${repopkg} || fatal "Failed to update Netdata repository config." U000D
       # shellcheck disable=SC2086
-      env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts} || fatal "Failed to update repository metadata."
+      env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts} || fatal "Failed to update repository metadata." U000E
     fi
   done
 
   # shellcheck disable=SC2086
-  env ${env} ${pm_cmd} ${upgrade_cmd} ${pkg_install_opts} netdata || fatal "Failed to update Netdata package."
+  env ${env} ${pm_cmd} ${upgrade_cmd} ${pkg_install_opts} netdata || fatal "Failed to update Netdata package." U000F
 }
 
 # Simple function to encapsulate original updater behavior.
@@ -793,7 +819,7 @@ if [ "${ENVIRONMENT_FILE}" = "THIS_SHOULD_BE_REPLACED_BY_INSTALLER_SCRIPT" ]; th
     elif [ -r "${itpath}" ]; then
       ENVIRONMENT_FILE="$(dirname "${itpath}")/.environment"
     else
-      fatal "Cannot find environment file or install type file, unable to update."
+      fatal "Cannot find environment file or install type file, unable to update." U0010
     fi
   fi
 fi
@@ -854,7 +880,7 @@ export NETDATA_LIB_DIR="${NETDATA_LIB_DIR:-${NETDATA_PREFIX}/var/lib/netdata}"
 export NETDATA_NIGHTLIES_BASEURL="${NETDATA_NIGHTLIES_BASEURL:-https://storage.googleapis.com/netdata-nightlies}"
 
 if echo "$INSTALL_TYPE" | grep -qv ^binpkg && [ "${INSTALL_UID}" != "$(id -u)" ]; then
-  fatal "You are running this script as user with uid $(id -u). We recommend to run this script as root (user with uid 0)"
+  fatal "You are running this script as user with uid $(id -u). We recommend to run this script as root (user with uid 0)" U0011
 fi
 
 self_update
@@ -884,13 +910,13 @@ case "${INSTALL_TYPE}" in
       if validate_environment_file; then
         update_legacy
       else
-        fatal "This script does not support updating custom installations without valid environment files."
+        fatal "This script does not support updating custom installations without valid environment files." U0012
       fi
       ;;
     oci)
-      fatal "This script does not support updating Netdata inside our official Docker containers, please instead update the container itself."
+      fatal "This script does not support updating Netdata inside our official Docker containers, please instead update the container itself." U0013
       ;;
     *)
-      fatal "Unrecognized installation type (${INSTALL_TYPE}), unable to update."
+      fatal "Unrecognized installation type (${INSTALL_TYPE}), unable to update." U0014
       ;;
 esac

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -63,14 +63,14 @@ info() {
 error() {
   echo >&3 "$(date) : ERROR: ${script_name}: " "${1}"
   if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
-    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+    NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - ${1}"
   fi
 }
 
 fatal() {
   echo >&3 "$(date) : FATAL: ${script_name}: FAILED TO UPDATE NETDATA: " "${1}"
   if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
-    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
+    NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - ${1}"
   fi
   exit_reason "${1}" "${2}"
   exit 1
@@ -83,7 +83,7 @@ exit_reason() {
     if [ -n "${NETDATA_PROPAGATE_WARNINGS}" ]; then
       export EXIT_REASON
       export EXIT_CODE
-      export SAVED_WARNINGS
+      export NETDATA_WARNINGS
     fi
   fi
 }
@@ -591,6 +591,7 @@ update_build() {
     info "Re-installing netdata..."
     export NETDATA_SAVE_WARNINGS=1
     export NETDATA_PROPAGATE_WARNINGS=1
+    export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
     # shellcheck disable=SC2086
     if ! ${env} ./netdata-installer.sh ${REINSTALL_OPTIONS} --dont-wait ${do_not_start} >&3 2>&3; then
       if [ -n "${EXIT_REASON}" ]; then

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -456,7 +456,7 @@ get_latest_version() {
 }
 
 validate_environment_file() {
-  if [ -n "${RELEASE_CHANNEL}" ] && [ -n "${NETDATA_PREFIX}" ] && [ -n "${REINSTALL_OPTIONS}" ] && [ -n "${IS_NETDATA_STATIC_BINARY}" ]; then
+  if [ -n "${NETDATA_PREFIX}" ] && [ -n "${REINSTALL_OPTIONS}" ]; then
     return 0
   else
     fatal "Environment file located at ${ENVIRONMENT_FILE} is not valid, unable to update." U0007
@@ -889,12 +889,12 @@ self_update
 # shellcheck disable=SC2153
 case "${INSTALL_TYPE}" in
     *-build)
-      validate_environment_file || exit 1
+      validate_environment_file
       set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
       update_build && exit 0
       ;;
     *-static*)
-      validate_environment_file || exit 1
+      validate_environment_file
       set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
       update_static && exit 0
       ;;
@@ -902,13 +902,13 @@ case "${INSTALL_TYPE}" in
       update_binpkg && exit 0
       ;;
     "") # Fallback case for no `.install-type` file. This just works like the old install type detection.
-      validate_environment_file || exit 1
+      validate_environment_file
       update_legacy
       ;;
     custom)
       # At this point, we _should_ have a valid `.environment` file, but it's best to just check.
       # If we do, then behave like the legacy updater.
-      if validate_environment_file; then
+      if validate_environment_file && [ -n "${IS_NETDATA_STATIC_BINARY}" ]; then
         update_legacy
       else
         fatal "This script does not support updating custom installations without valid environment files." U0012

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -566,7 +566,7 @@ update_build() {
       do_not_start="--dont-start-it"
     fi
 
-    env="/bin/env TMPDIR=${TMPDIR}"
+    env="env TMPDIR=${TMPDIR}"
 
     if [ -n "${NETDATA_SELECTED_DASHBOARD}" ]; then
       env="${env} NETDATA_SELECTED_DASHBOARD=${NETDATA_SELECTED_DASHBOARD}"


### PR DESCRIPTION
##### Summary

This significantly reworks how the kickstart script handles tracking of warnings and errors from `netdata-installer.sh`, `netdata-updater.sh`, and `netdata-uninstaller.sh`. At a high level, these changes mean that:

- Any errors or warnings generated by these scripts while running will be included (in the correct chronological order) in the warning summary printed by the kickstart script at the end of a run.
- Fatal errors in these scripts will be properly logged by the kickstart script, including the error message generated by the script.
- A handful of cases (mostly in `netdata-installer.sh` which were functionally fatal errors but were not handled as such will be handled correctly as fatal errors now.
- A handful of cases that should have been warnings instead of fatal errors have been corrected to not be fatal and to provide useful warnings.
- The old deferred error handling in `netdata-installer.sh` has been folded into the warning/error code, thus eliminating a number of extra function calls.
- A handful of excessively long and largely out of date banners have been removed and instead replaced with much more concise error messages.
- Telemetry events sent from the kickstart script will be properly differentiated for cases where `netdata-installer.sh` or `netdata-updater.sh` run into fatal errors.

##### Test Plan

Full testing will require intentionally creating situations that would trigger errors in `netdata-installer.sh` or `netdata-updater.sh` and then running the kickstart script from this PR in a way that would trigger those errors, while utilizing the copy of the installer or updater from this PR.

##### Additional Information

Fixes: #12632 

This adds five new sets of `error_code` values for the telemetry events sent by the kickstart script:

- `Lxxx` codes indicate a fatal error in a function in `packaging/installer/functions.sh` (probably called by the installer).
- `Ixxxx` codes indicate a fatal error in `netdata-installer.sh.
- `Uxxx` codes indicate a fatal error in the `netdata-updater.sh.
- `UIxxxx` codes indicate a fatal error in `netdata-installer.sh` when it was invoked by `netdata-updater.sh` (the numerical values match with those for the `Ixxxx` codes).
- `Rxxxx` codes indicate a fatal error in `netdata-uninstaller.sh`. These should never be seen, as none of the cases of fatal errors in the uninstaller currently translate to a fatal error in the kickstart script.

<details> <summary>For users: How does this change affect me?</summary>
Users will be able to see a complete list of errors and warnings encountered during a run of the kickstart script, not just those which were generated by the kickstart script itself.
</details>
