### PR TITLE
chore(ci): adjust ACLK label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,9 +10,10 @@
 #
 # Please keep the labels sorted and deduplicated.
 
-ACLK:
+area/ACLK:
   - aclk/*
   - aclk/**/*
+  - database/sqlite/sqlite_aclk*
   - mqtt_websockets
 
 area/claim:


### PR DESCRIPTION
##### Summary

This PR:
 - changes 'ACLK' label to 'area/ACLK'.
 - adds 'database/sqlite/sqlite_aclk*' path for 'area/ACLK'.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
