### PR TITLE
fix(ebpf.plugin): allow 'socket' module to be enabled in ebpf.d.conf

### DIFF
--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -57,7 +57,8 @@
     oomkill = yes
     process = yes
     shm = yes
-    socket = no # Disabled while we are fixing race condition
+    # 'socket' is disabled while we are fixing race condition (https://github.com/netdata/netdata/issues/12027)
+    socket = no
     softirq = yes
     sync = yes
     swap = no


### PR DESCRIPTION
##### Summary

It seems inline comments are not supported at all.

The following doesn't work:

```ini
socket = yes # Disabled while we are fixing race condition
```

##### Test Plan

Set `socket` to `yes`, check ebpf network charts on the dashboard.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
