### PR TITLE
Disable automake dependency tracking in our various one-time builds.

### DIFF
--- a/.github/scripts/build-artifacts.sh
+++ b/.github/scripts/build-artifacts.sh
@@ -33,6 +33,7 @@ build_dist() {
       --with-zlib \
       --with-math \
       --with-user=netdata \
+      --disable-dependency-tracking \
       CFLAGS=-O2
     make dist
     mv "${BASENAME}.tar.gz" artifacts/

--- a/.github/scripts/build-dist.sh
+++ b/.github/scripts/build-dist.sh
@@ -32,6 +32,7 @@ build_dist() {
       --with-zlib \
       --with-math \
       --with-user=netdata \
+      --disable-dependency-tracking \
       CFLAGS=-O2
     make dist
     mv "${BASENAME}.tar.gz" artifacts/

--- a/.github/scripts/run_install_with_dist_file.sh
+++ b/.github/scripts/run_install_with_dist_file.sh
@@ -33,7 +33,7 @@ docker run \
   -v "${PWD}:/netdata" \
   -w /netdata \
   "ubuntu:latest" \
-  /bin/bash -c "./install-required-packages.sh --dont-wait --non-interactive netdata && apt install wget && ./netdata-installer.sh --dont-wait --require-cloud --disable-telemetry --install /tmp && echo \"Validating netdata instance is running\" && wget -O - 'http://127.0.0.1:19999/api/v1/info' | grep version"
+  /bin/bash -c "./install-required-packages.sh --dont-wait --non-interactive netdata && apt install wget && ./netdata-installer.sh --dont-wait --require-cloud --disable-telemetry --install /tmp --one-time-build && echo \"Validating netdata instance is running\" && wget -O - 'http://127.0.0.1:19999/api/v1/info' | grep version"
 popd || exit 1
 
 echo "All Done!"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,23 +321,23 @@ jobs:
         id: build-basic
         run: |
           docker run --security-opt seccomp=unconfined -w /netdata sha256:${{ steps.load.outputs.image }} \
-              /bin/sh -c 'autoreconf -ivf && ./configure && make -j2'
+              /bin/sh -c 'autoreconf -ivf && ./configure --disable-dependency-tracking && make -j2'
       - name: netdata-installer on ${{ matrix.distro }}, disable cloud
         id: build-no-cloud
         run: |
           docker run --security-opt seccomp=unconfined -w /netdata sha256:${{ steps.load.outputs.image }} \
-              /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --disable-cloud'
+              /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --disable-cloud --one-time-build'
       - name: netdata-installer on ${{ matrix.distro }}, require cloud
         id: build-cloud
         run: |
           docker run --security-opt seccomp=unconfined -w /netdata sha256:${{ steps.load.outputs.image }} \
-              /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud'
+              /bin/sh -c './netdata-installer.sh --dont-wait --dont-start-it --require-cloud --one-time-build'
       - name: netdata-installer on ${{ matrix.distro }}, require cloud, no JSON-C
         id: build-no-jsonc
         if: matrix.jsonc_removal != ''
         run: |
           docker run --security-opt seccomp=unconfined -w /netdata sha256:${{ steps.load.outputs.image }} \
-              /bin/sh -c '/rmjsonc.sh && ./netdata-installer.sh --dont-wait --dont-start-it --require-cloud'
+              /bin/sh -c '/rmjsonc.sh && ./netdata-installer.sh --dont-wait --dont-start-it --require-cloud --one-time-build'
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
           apk del openssl openssl-dev;
           apk add libressl libressl-dev;
           autoreconf -ivf;
-          ./configure;
+          ./configure --disable-dependency-trackiong;
           make;'
   clang-checks:
     name: Clang
@@ -51,7 +51,7 @@ jobs:
       - name: Prepare environment
         run: ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata
       - name: Build netdata
-        run: ./netdata-installer.sh --dont-start-it --disable-telemetry --dont-wait --install /tmp/install
+        run: ./netdata-installer.sh --dont-start-it --disable-telemetry --dont-wait --install /tmp/install --one-time-build
       - name: Check that repo is clean
         run: |
           git status --porcelain=v1 > /tmp/porcelain

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Configure
         run: |
           autoreconf -ivf
-          ./configure --disable-ml
+          ./configure --disable-ml --disable-dependency-tracking
       # XXX: Work-around for bug with libbson-1.0 in Ubuntu 18.04
       # See: https://bugs.launchpad.net/ubuntu/+source/libmongoc/+bug/1790771
       #      https://jira.mongodb.org/browse/CDRIVER-2818

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -343,6 +343,7 @@ while [ -n "${1}" ]; do
     "--enable-ebpf") NETDATA_DISABLE_EBPF=0 ;;
     "--disable-ebpf") NETDATA_DISABLE_EBPF=1 NETDATA_CONFIGURE_OPTIONS="$(echo "${NETDATA_CONFIGURE_OPTIONS%--disable-ebpf)}" | sed 's/$/ --disable-ebpf/g')" ;;
     "--skip-available-ram-check") SKIP_RAM_CHECK=1 ;;
+    "--one-time-build") NETDATA_CONFIGURE_OPTIONS="$(echo "${NETDATA_CONFIGURE_OPTIONS%--disable-dependency-tracking)}" | sed 's/$/ --disable-dependency-tracking/g')" ;;
     "--disable-cloud")
       if [ -n "${NETDATA_REQUIRE_CLOUD}" ]; then
         echo "Cloud explicitly enabled, ignoring --disable-cloud."
@@ -711,7 +712,7 @@ build_judy() {
     run ${env_cmd} autoheader &&
     run ${env_cmd} automake --add-missing --force --copy --include-deps &&
     run ${env_cmd} autoconf &&
-    run ${env_cmd} ./configure &&
+    run ${env_cmd} ./configure --disable-dependency-tracking &&
     run ${env_cmd} ${make} ${MAKEOPTS} -C src &&
     run ${env_cmd} ar -r src/libJudy.a src/Judy*/*.o; then
     cd - > /dev/null || return 1

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN chmod +x netdata-installer.sh && \
    cp -rp /deps/* /usr/local/ && \
    /bin/echo -e "INSTALL_TYPE='oci'\nPREBUILT_ARCH='$(uname -m)'" > ./system/.install-type && \
    ./netdata-installer.sh --dont-wait --dont-start-it --use-system-protobuf ${EXTRA_INSTALL_OPTS} \
-   "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
+   --one-time-build "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
 
 # files to one directory
 RUN mkdir -p /app/usr/sbin/ \

--- a/packaging/makeself/jobs/50-bash-5.1.16.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.1.16.install.sh
@@ -20,7 +20,8 @@ run ./configure \
   --enable-array-variables \
   --disable-progcomp \
   --disable-profiling \
-  --disable-nls
+  --disable-nls \
+  --disable-dependency-tracking
 
 run make clean
 run make -j "$(nproc)"

--- a/packaging/makeself/jobs/50-curl-7.82.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.82.0.install.sh
@@ -37,7 +37,8 @@ run ./configure \
   --enable-ipv6 \
   --enable-cookies \
   --with-ca-fallback \
-  --with-openssl
+  --with-openssl \
+  --disable-dependency-tracking
 
 # Curl autoconf does not honour the curl_LDFLAGS environment variable
 run sed -i -e "s/LDFLAGS =/LDFLAGS = -all-static/" src/Makefile

--- a/packaging/makeself/jobs/50-fping-5.1.install.sh
+++ b/packaging/makeself/jobs/50-fping-5.1.install.sh
@@ -17,7 +17,8 @@ export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 run ./configure \
   --prefix="${NETDATA_INSTALL_PATH}" \
   --enable-ipv4 \
-  --enable-ipv6
+  --enable-ipv6 \
+  --disable-dependency-tracking
 
 cat > doc/Makefile << EOF
 all:

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -32,7 +32,8 @@ run ./netdata-installer.sh \
   --dont-start-it \
   --require-cloud \
   --use-system-protobuf \
-  --dont-scrub-cflags-even-though-it-may-break-things
+  --dont-scrub-cflags-even-though-it-may-break-things \
+  --one-time-build
 
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Finishing netdata install" || true


### PR DESCRIPTION
##### Summary

This should provide a marginal improvement to build performance in CI, especially for builds that require QEMU userspace emulation.

##### Test Plan

CI passes correctly on this PR.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
No user visible changes.
</details>
