### PR TITLE
chore(ebpf.plugin): re-enable socket module by default

### DIFF
--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -57,7 +57,7 @@
     oomkill = yes
     process = yes
     shm = yes
-    socket = no # Disabled while we are fixing race condition
+    socket = yes
     softirq = yes
     sync = yes
     swap = no


### PR DESCRIPTION
##### Summary

This PR enables socket thread because #12027 (the reason we disabled it) has been fixed.

##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
