### PR TITLE
Check for chart obsoletion on children re-connections

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -846,6 +846,8 @@ struct rrdhost {
 
     struct receiver_state *receiver;
     netdata_mutex_t receiver_lock;
+    time_t trigger_chart_obsoletion_check;          // set when child connects, will instruct parent to
+                                                    // trigger a check for obsoleted charts since previous connect
 
     // ------------------------------------------------------------------------
     // health monitoring options

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1533,7 +1533,7 @@ void rrdset_check_obsoletion(RRDHOST *host)
     RRDSET *st;
     rrdset_foreach_write(st, host) {
         if (rrdset_last_entry_t(st) < host->trigger_chart_obsoletion_check) {
-            rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE);
+            rrdset_is_obsolete(st);
         }
     }
 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1528,6 +1528,16 @@ restart_after_removal:
     }
 }
 
+void rrdset_check_obsoletion(RRDHOST *host)
+{
+    RRDSET *st;
+    rrdset_foreach_write(st, host) {
+        if (rrdset_last_entry_t(st) < host->trigger_chart_obsoletion_check) {
+            rrdset_flag_set(st, RRDSET_FLAG_OBSOLETE);
+        }
+    }
+}
+
 void rrd_cleanup_obsolete_charts()
 {
     rrd_rdlock();
@@ -1546,6 +1556,15 @@ void rrd_cleanup_obsolete_charts()
                 aclk_update_chart(host, "dummy-chart", 0);
 #endif
             rrdhost_unlock(host);
+        }
+
+        if (host != localhost &&
+            host->trigger_chart_obsoletion_check &&
+            host->trigger_chart_obsoletion_check + 120 < now_realtime_sec()) {
+            rrdhost_wrlock(host);
+            rrdset_check_obsoletion(host);
+            rrdhost_unlock(host);
+            host->trigger_chart_obsoletion_check = 0;
         }
     }
 

--- a/health/health.c
+++ b/health/health.c
@@ -808,7 +808,6 @@ void *health_main(void *ptr) {
 #endif
                         }
                     }
-                    continue;
                 }
 
                 if (unlikely(!rrdcalc_isrunnable(rc, now, &next_run))) {

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -640,6 +640,7 @@ static int rrdpush_receive(struct receiver_state *rpt)
                 rpt->host->hostname);
         }
     }
+    rpt->host->trigger_chart_obsoletion_check = now_realtime_sec();
     rrdhost_unlock(rpt->host);
 
     // call the plugins.d processor to receive the metrics
@@ -680,6 +681,7 @@ static int rrdpush_receive(struct receiver_state *rpt)
             if(health_enabled == CONFIG_BOOLEAN_AUTO)
                 rpt->host->health_enabled = 0;
         }
+        rpt->host->trigger_chart_obsoletion_check = 0;
         rrdhost_unlock(rpt->host);
         if (rpt->host->receiver == rpt) {
             rrdpush_sender_thread_stop(rpt->host);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

When a child is connected and streams to a parent, the parent has a set of the streamed charts from the child. However, if the child at some point disconnects, and during that disconnection time a chart it has disappear, then on re-connection, the parent will have no information that that specific chart has been gone.

If a chart is gone during the child being connected to the parent, the child will inform the parent about that chart's obsoletion, but not in the above case.

If in addition, there is a raised alert on the gone chart, then the alert will remain on the parent, until the parent restarts. The same alert will also remain on the cloud since there won't be any event after that.

This PR adds a small check on the parent, after a child is connected. It will go through the charts for this host, and if some are not updated after the child's connection, it will set them as OBSOLETE. The check will happen 2 minutes after the child's connection.

We might, or not need to do the same for separate dimensions...

Also the check will run on first child's connect, when it's not really needed. If there is an easy way to check if it is a fresh (for this parent's session) connection, we can skip it. But it shouldn't make much difference.

With this PR, a `continue` statement when a REMOVED event is created because of chart obsoletion, is removed. This is to allow to mark the `rc` as not `RRDCALC_FLAG_RUNNABLE` to prevent it from being calculated.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Tests can be conducted by examining what happens to a raised alert when this situation occurs.

1) Setup a child -> parent setup.
2) On the child, have a mount point (e.g. a usb device) with very little space left to trigger an alert on the parent.
3) Stop the child and remove the usb device.
4) Start the child again.

Without this PR, the raised alert will remain on the agent.

With this PR, after a while, the alert will be removed from the parent (and a REMOVED event will be transmitted to the cloud). If the chart re-appears then the alert should be raised again normally.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
