### PR TITLE
Tweak static build process to improve build speed and debuggability.

### DIFF
--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -7,7 +7,7 @@
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
-  export CFLAGS="-static -O3 -I/openssl-static/include"
+  export CFLAGS="-static -O2 -I/openssl-static/include"
 else
   export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include"
 fi
@@ -51,12 +51,6 @@ if run readelf -l "${NETDATA_INSTALL_PATH}"/bin/netdata | grep 'INTERP'; then
   printf >&2 "Ooops. %s is not a statically linked binary!\n" "${NETDATA_INSTALL_PATH}"/bin/netdata
   ldd "${NETDATA_INSTALL_PATH}"/bin/netdata
   exit 1
-fi
-
-if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
-  run strip "${NETDATA_INSTALL_PATH}"/bin/netdata
-  run strip "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/apps.plugin
-  run strip "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/cgroup-network
 fi
 
 # shellcheck disable=SC2015


### PR DESCRIPTION
##### Summary

- Switch from `-O3` to `-O2` for optimization CFLAGS, bringing us in-line with all of our other builds. This should help avoid strange edge cases specific to static builds resulting from the build process.
- Stop stripping binaries in static builds so that we can get proper symbolic backtraces when the agent crashes in the static builds.

##### Test Plan

CI passes correctly on this PR.

Static builds created with this PR can produce proper symbolic backtraces when run under GDB.

##### Additional Information

Relevant to: https://github.com/netdata/netdata/issues/12505

<details> <summary>For users: How does this change affect me?</summary>
Static builds will have a marginally larger runtime memory footprint, a slightly higher disk space requirement, and may run marginally slower (but should be no slower than the other install types already were), but in exchange debugging of crashes when using static builds will be simpler.
</details>