### PR TITLE
Add `-pipe` to CFLAGS in most cases for builds.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -576,17 +576,18 @@ build_protobuf() {
   env_cmd=''
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
+    # shellcheck disable=SC2089
     env_cmd="env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS="
   fi
 
   cd "${1}" > /dev/null || return 1
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086,SC2090
   if ! run ${env_cmd} ./configure --disable-shared --without-zlib --disable-dependency-tracking --with-pic; then
     cd - > /dev/null || return 1
     return 1
   fi
 
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086,SC2090
   if ! run ${env_cmd} $make ${MAKEOPTS}; then
     cd - > /dev/null || return 1
     return 1
@@ -651,6 +652,7 @@ build_judy() {
   libtoolize="libtoolize"
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
+    # shellcheck disable=SC2089
     env_cmd="env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS="
   fi
 
@@ -659,7 +661,7 @@ build_judy() {
   fi
 
   cd "${1}" > /dev/null || return 1
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086,SC2090
   if run ${env_cmd} ${libtoolize} --force --copy &&
     run ${env_cmd} aclocal &&
     run ${env_cmd} autoheader &&
@@ -742,13 +744,14 @@ build_jsonc() {
   env_cmd=''
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
+    # shellcheck disable=SC2089
     env_cmd="env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS="
   fi
 
   cd "${1}" > /dev/null || return 1
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086,SC2090
   run ${env_cmd} cmake -DBUILD_SHARED_LIBS=OFF .
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086,SC2090
   run ${env_cmd} ${make} ${MAKEOPTS}
   cd - > /dev/null || return 1
 }

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -576,19 +576,16 @@ build_protobuf() {
   env_cmd=''
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
-    # shellcheck disable=SC2089
     env_cmd="env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS="
   fi
 
   cd "${1}" > /dev/null || return 1
-  # shellcheck disable=SC2086,SC2090
-  if ! run ${env_cmd} ./configure --disable-shared --without-zlib --disable-dependency-tracking --with-pic; then
+  if ! run eval "${env_cmd} ./configure --disable-shared --without-zlib --disable-dependency-tracking --with-pic"; then
     cd - > /dev/null || return 1
     return 1
   fi
 
-  # shellcheck disable=SC2086,SC2090
-  if ! run ${env_cmd} $make ${MAKEOPTS}; then
+  if ! run eval "${env_cmd} ${make} ${MAKEOPTS}"; then
     cd - > /dev/null || return 1
     return 1
   fi
@@ -652,7 +649,6 @@ build_judy() {
   libtoolize="libtoolize"
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
-    # shellcheck disable=SC2089
     env_cmd="env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS="
   fi
 
@@ -661,15 +657,14 @@ build_judy() {
   fi
 
   cd "${1}" > /dev/null || return 1
-  # shellcheck disable=SC2086,SC2090
-  if run ${env_cmd} ${libtoolize} --force --copy &&
-    run ${env_cmd} aclocal &&
-    run ${env_cmd} autoheader &&
-    run ${env_cmd} automake --add-missing --force --copy --include-deps &&
-    run ${env_cmd} autoconf &&
-    run ${env_cmd} ./configure --disable-dependency-tracking &&
-    run ${env_cmd} ${make} ${MAKEOPTS} -C src &&
-    run ${env_cmd} ar -r src/libJudy.a src/Judy*/*.o; then
+  if run eval "${env_cmd} ${libtoolize} --force --copy" &&
+    run eval "${env_cmd} aclocal" &&
+    run eval "${env_cmd} autoheader" &&
+    run eval "${env_cmd} automake --add-missing --force --copy --include-deps" &&
+    run eval "${env_cmd} autoconf" &&
+    run eval "${env_cmd} ./configure" &&
+    run eval "${env_cmd} ${make} ${MAKEOPTS} -C src" &&
+    run eval "${env_cmd} ar -r src/libJudy.a src/Judy*/*.o"; then
     cd - > /dev/null || return 1
   else
     cd - > /dev/null || return 1
@@ -744,15 +739,12 @@ build_jsonc() {
   env_cmd=''
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
-    # shellcheck disable=SC2089
     env_cmd="env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS="
   fi
 
-  cd "${1}" > /dev/null || return 1
-  # shellcheck disable=SC2086,SC2090
-  run ${env_cmd} cmake -DBUILD_SHARED_LIBS=OFF .
-  # shellcheck disable=SC2086,SC2090
-  run ${env_cmd} ${make} ${MAKEOPTS}
+  cd "${1}" > /dev/null || exit 1
+  run eval "${env_cmd} cmake -DBUILD_SHARED_LIBS=OFF ."
+  run eval "${env_cmd} ${make} ${MAKEOPTS}"
   cd - > /dev/null || return 1
 }
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -129,7 +129,7 @@ renice 19 $$ > /dev/null 2> /dev/null
 # you can set CFLAGS before running installer
 # shellcheck disable=SC2269
 LDFLAGS="${LDFLAGS}"
-CFLAGS="${CFLAGS--O2}"
+CFLAGS="${CFLAGS-"-O2 -pipe"}"
 [ "z${CFLAGS}" = "z-O3" ] && CFLAGS="-O2"
 # shellcheck disable=SC2269
 ACLK="${ACLK}"
@@ -576,7 +576,7 @@ build_protobuf() {
   env_cmd=''
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
-    env_cmd="env CFLAGS=-fPIC CXXFLAGS= LDFLAGS="
+    env_cmd="env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS="
   fi
 
   cd "${1}" > /dev/null || return 1
@@ -651,7 +651,7 @@ build_judy() {
   libtoolize="libtoolize"
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
-    env_cmd="env CFLAGS=-fPIC CXXFLAGS= LDFLAGS="
+    env_cmd="env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS="
   fi
 
   if [ "$(uname)" = "Darwin" ]; then
@@ -742,7 +742,7 @@ build_jsonc() {
   env_cmd=''
 
   if [ -z "${DONT_SCRUB_CFLAGS_EVEN_THOUGH_IT_MAY_BREAK_THINGS}" ]; then
-    env_cmd="env CFLAGS=-fPIC CXXFLAGS= LDFLAGS="
+    env_cmd="env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS="
   fi
 
   cd "${1}" > /dev/null || return 1
@@ -866,7 +866,7 @@ build_libbpf() {
   cd "${1}/src" > /dev/null || return 1
   mkdir root build
   # shellcheck disable=SC2086
-  run env CFLAGS=-fPIC CXXFLAGS= LDFLAGS= BUILD_STATIC_ONLY=y OBJDIR=build DESTDIR=.. ${make} ${MAKEOPTS} install
+  run env CFLAGS='-fPIC -pipe' CXXFLAGS='-fPIC -pipe' LDFLAGS= BUILD_STATIC_ONLY=y OBJDIR=build DESTDIR=.. ${make} ${MAKEOPTS} install
   cd - > /dev/null || return 1
 }
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -26,8 +26,8 @@ WORKDIR /opt/netdata.git
 RUN chmod +x netdata-installer.sh && \
    cp -rp /deps/* /usr/local/ && \
    /bin/echo -e "INSTALL_TYPE='oci'\nPREBUILT_ARCH='$(uname -m)'" > ./system/.install-type && \
-   ./netdata-installer.sh --dont-wait --dont-start-it --use-system-protobuf ${EXTRA_INSTALL_OPTS} \
-   --one-time-build "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
+   CFLAGS="-O2 -pipe" ./netdata-installer.sh --dont-wait --dont-start-it --use-system-protobuf \
+   ${EXTRA_INSTALL_OPTS} --one-time-build "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
 
 # files to one directory
 RUN mkdir -p /app/usr/sbin/ \

--- a/packaging/makeself/jobs/20-openssl.install.sh
+++ b/packaging/makeself/jobs/20-openssl.install.sh
@@ -9,7 +9,7 @@
 
 version="$(cat "$(dirname "${0}")/../openssl.version")"
 
-export CFLAGS='-fno-lto'
+export CFLAGS='-fno-lto -pipe'
 export LDFLAGS='-static'
 export PKG_CONFIG="pkg-config --static"
 

--- a/packaging/makeself/jobs/50-bash-5.1.16.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.1.16.install.sh
@@ -10,6 +10,7 @@
 fetch "bash-5.1.16" "http://ftp.gnu.org/gnu/bash/bash-5.1.16.tar.gz" \
     5bac17218d3911834520dad13cd1f85ab944e1c09ae1aba55906be1f8192f558
 
+export CFLAGS="-pipe"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
 run ./configure \

--- a/packaging/makeself/jobs/50-curl-7.82.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.82.0.install.sh
@@ -10,7 +10,7 @@
 fetch "curl-7.82.0" "https://curl.haxx.se/download/curl-7.82.0.tar.gz" \
     910cc5fe279dc36e2cca534172c94364cf3fcf7d6494ba56e6c61a390881ddce
 
-export CFLAGS="-I/openssl-static/include"
+export CFLAGS="-I/openssl-static/include -pipe"
 export LDFLAGS="-static -L/openssl-static/lib"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"

--- a/packaging/makeself/jobs/50-fping-5.1.install.sh
+++ b/packaging/makeself/jobs/50-fping-5.1.install.sh
@@ -10,7 +10,7 @@
 fetch "fping-5.1" "https://fping.org/dist/fping-5.1.tar.gz" \
     1ee5268c063d76646af2b4426052e7d81a42b657e6a77d8e7d3d2e60fd7409fe
 
-export CFLAGS="-static -I/openssl-static/include"
+export CFLAGS="-static -I/openssl-static/include -pipe"
 export LDFLAGS="-static -L/openssl-static/lib"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 

--- a/packaging/makeself/jobs/50-ioping-1.2.install.sh
+++ b/packaging/makeself/jobs/50-ioping-1.2.install.sh
@@ -10,7 +10,7 @@
 fetch "ioping-1.2" "https://github.com/koct9i/ioping/archive/v1.2.tar.gz" \
     d3e4497c653a1e96df67c72ce2b70da18e9f5e3b93179a5bb57a6e30ceacfa75
 
-export CFLAGS="-static"
+export CFLAGS="-static -pipe"
 
 run make clean
 run make -j "$(nproc)"

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -7,9 +7,9 @@
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
-  export CFLAGS="-static -O2 -I/openssl-static/include"
+  export CFLAGS="-static -O2 -I/openssl-static/include -pipe"
 else
-  export CFLAGS="-static -O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include"
+  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include"
 fi
 
 export LDFLAGS="-static -L/openssl-static/lib"


### PR DESCRIPTION
##### Summary

This trades marginally higher memory usage at build time (on the order of a few hundred kB in the worst case scenario) for improved build times by avoiding using temporary files for passing data from the compiler to commands it invokes.

##### Test Plan

CI passes on this PR, with builds taking slightly less time than otherwise.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Install and update times are improved for local builds.
</details>
