### PR TITLE
chore(cgroups.plugin): reduce the CPU time required for cgroup-network-helper.sh

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network-helper.sh
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh
@@ -226,6 +226,7 @@ netnsid_find_all_interfaces_for_cgroup() {
         for p in $(< "${c}/cgroup.procs" )
         do
             netnsid_find_all_interfaces_for_pid "${p}"
+            return 0
         done
     else
         debug "Cannot find file '${c}/cgroup.procs', not searching for netnsid interfaces."

--- a/collectors/cgroups.plugin/cgroup-network-helper.sh
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh
@@ -218,16 +218,8 @@ netnsid_find_all_interfaces_for_pid() {
 netnsid_find_all_interfaces_for_cgroup() {
     local c="${1}" # the cgroup path
 
-    # for each pid of the cgroup
-    # find any tun/tap devices linked to the pid
-    if [ -f "${c}/cgroup.procs" ]
-    then
-        local p
-        for p in $(< "${c}/cgroup.procs" )
-        do
-            netnsid_find_all_interfaces_for_pid "${p}"
-            return 0
-        done
+    if [ -f "${c}/cgroup.procs" ]; then
+        netnsid_find_all_interfaces_for_pid "$(head -n 1 "${c}/cgroup.procs" 2 >/dev/null)"
     else
         debug "Cannot find file '${c}/cgroup.procs', not searching for netnsid interfaces."
     fi


### PR DESCRIPTION
##### Summary

There is no need to call `lsns` for every task in a cgroup when finding network interfaces. This small change significantly reduces the CPU time.

- I have a server with 50 docker containers
- 1st "spike" is our current code.
- 2nd is this PR.

 
<img width="1355" alt="Screenshot 2022-04-19 at 12 26 33" src="https://user-images.githubusercontent.com/22274335/163973945-fb6d2224-bc3d-4689-b1cf-03d634bf7755.png">


##### Test Plan

Check `netdata` process CPU usage (should be lower), check containers on the dashboard (should have network interfaces).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
