### PR TITLE
'apt-get upgrade' has been replaced with 'apt-get --upgrade-only inst…

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -675,7 +675,7 @@ update_binpkg() {
     debian)
       pm_cmd="apt-get"
       repo_subcmd="update"
-      upgrade_cmd="upgrade"
+      upgrade_cmd="--only-upgrade install"
       pkg_install_opts="${interactive_opts}"
       repo_update_opts="${interactive_opts}"
       pkg_installed_check="dpkg -s"
@@ -684,7 +684,7 @@ update_binpkg() {
     ubuntu)
       pm_cmd="apt-get"
       repo_subcmd="update"
-      upgrade_cmd="upgrade"
+      upgrade_cmd="--only-upgrade install"
       pkg_install_opts="${interactive_opts}"
       repo_update_opts="${interactive_opts}"
       pkg_installed_check="dpkg -s"


### PR DESCRIPTION
'apt-get upgrade' has been replaced with 'apt-get --upgrade-only install' for Debian/Ubuntu

##### Summary

'apt-get upgrade' has been replaced with 'apt-get --upgrade-only install' for Debian/Ubuntu
Fixes [Bug]: updater installs the newest version of all currently installed packages on Debian #12700
##### Test Plan

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->

This change affects netdata-updater.sh on Debian and Ubuntu systems

</details>
