### PR TITLE
chore(kickstart.sh): remove unused `--auto-update` option when using static/build install method

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1482,10 +1482,6 @@ build_and_install() {
     opts="${opts} --dont-wait"
   fi
 
-  if [ "${NETDATA_AUTO_UPDATES}" -eq 1 ]; then
-    opts="${opts} --auto-update"
-  fi
-
   if [ "${RELEASE_CHANNEL}" = "stable" ]; then
     opts="${opts} --stable-channel"
   fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1396,7 +1396,7 @@ try_static_install() {
 
   progress "Installing netdata"
   # shellcheck disable=SC2086
-  if ! run ${ROOTCMD} sh "${tmpdir}/netdata-${SYSARCH}-latest.gz.run" ${opts} -- ${NETDATA_AUTO_UPDATES:+--auto-update} ${NETDATA_INSTALLER_OPTIONS}; then
+  if ! run ${ROOTCMD} sh "${tmpdir}/netdata-${SYSARCH}-latest.gz.run" ${opts} -- ${NETDATA_INSTALLER_OPTIONS}; then
     warning "Failed to install static build of Netdata on ${SYSARCH}."
     run rm -rf /opt/netdata
     return 2


### PR DESCRIPTION
##### Summary

Passing it does nothing after https://github.com/netdata/netdata/pull/12296. Enabling auto updates is handled by

https://github.com/netdata/netdata/blob/a7af7e343e93199b03c5ec7ec261ccdce3fc6ef6/packaging/installer/kickstart.sh#L1060

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
