### PR TITLE
Avoid clearing already unset flags.

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -872,14 +872,6 @@ RRDSET *rrdset_create_custom(
     else
         rrdset_flag_clear(st, RRDSET_FLAG_ENABLED);
 
-    rrdset_flag_clear(st, RRDSET_FLAG_DETAIL);
-    rrdset_flag_clear(st, RRDSET_FLAG_DEBUG);
-    rrdset_flag_clear(st, RRDSET_FLAG_OBSOLETE);
-    rrdset_flag_clear(st, RRDSET_FLAG_EXPORTING_SEND);
-    rrdset_flag_clear(st, RRDSET_FLAG_EXPORTING_IGNORE);
-    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_SEND);
-    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_IGNORE);
-    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
     rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
 
     // if(!strcmp(st->id, "disk_util.dm-0")) {


### PR DESCRIPTION
##### Summary

If memory mode is save, map or ram the set's flags are initialized to 0.
Otherwise, the set is calloc'd which will make the set have 0 flags.

##### Test Plan

CI jobs.