### PR TITLE
Remove per chart configuration.

### DIFF
--- a/database/rrd.c
+++ b/database/rrd.c
@@ -139,8 +139,7 @@ const char *rrdset_type_name(RRDSET_TYPE chart_type) {
 // ----------------------------------------------------------------------------
 // RRD - cache directory
 
-char *rrdset_cache_dir(RRDHOST *host, const char *id, const char *config_section) {
-    UNUSED(config_section);
+char *rrdset_cache_dir(RRDHOST *host, const char *id) {
     char *ret = NULL;
 
     char b[FILENAME_MAX + 1];

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -459,7 +459,6 @@ struct rrdset_volatile {
 // and may lead to missing information.
 
 typedef enum rrdset_flags {
-    RRDSET_FLAG_ENABLED             = 1 << 0, // enables or disables a chart
     RRDSET_FLAG_DETAIL              = 1 << 1, // if set, the data set should be considered as a detail of another
                                               // (the master data set should be the one that has the same family and is not detail)
     RRDSET_FLAG_DEBUG               = 1 << 2, // enables or disables debugging for a chart
@@ -511,7 +510,7 @@ struct rrdset {
                                                     // since the config always has a higher priority
                                                     // (the user overwrites the name of the charts)
 
-    char *config_section;                           // the config section for the chart
+    void *unused_ptr;                               // Unused field (previously it held the config section of the chart)
 
     char *type;                                     // the type of graph RRD_TYPE_* (a category, for determining graphing options)
     char *family;                                   // grouping sets under the same family
@@ -1120,8 +1119,8 @@ extern void rrdset_is_obsolete(RRDSET *st);
 extern void rrdset_isnot_obsolete(RRDSET *st);
 
 // checks if the RRDSET should be offered to viewers
-#define rrdset_is_available_for_viewers(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_HIDDEN) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
-#define rrdset_is_available_for_exporting_and_alarms(st) (rrdset_flag_check(st, RRDSET_FLAG_ENABLED) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
+#define rrdset_is_available_for_viewers(st) (!rrdset_flag_check(st, RRDSET_FLAG_HIDDEN) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
+#define rrdset_is_available_for_exporting_and_alarms(st) (!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
 #define rrdset_is_archived(st) (rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
 
 // get the total duration in seconds of the round robin database
@@ -1339,7 +1338,7 @@ extern int alarm_compare_name(void *a, void *b);
 extern avl_tree_lock rrdhost_root_index;
 
 extern char *rrdset_strncpyz_name(char *to, const char *from, size_t length);
-extern char *rrdset_cache_dir(RRDHOST *host, const char *id, const char *config_section);
+extern char *rrdset_cache_dir(RRDHOST *host, const char *id);
 
 #define rrddim_free(st, rd) rrddim_free_custom(st, rd, 0)
 extern void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated);

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -43,9 +43,10 @@ inline int rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name) {
 
     debug(D_RRD_CALLS, "rrddim_set_name() from %s.%s to %s.%s", st->name, rd->name, st->name, name);
 
-    char varname[CONFIG_MAX_NAME + 1];
-    snprintfz(varname, CONFIG_MAX_NAME, "dim %s name", rd->id);
-    rd->name = config_set_default(st->config_section, varname, name);
+    if (rd->name)
+        freez((void *) rd->name);
+
+    rd->name = strdupz(name);
     rd->hash_name = simple_hash(rd->name);
 
     if (!st->state->is_ar_chart)

--- a/exporting/tests/exporting_fixtures.c
+++ b/exporting/tests/exporting_fixtures.c
@@ -58,7 +58,6 @@ int setup_rrdhost()
     st->rrdhost = localhost;
     strcpy(st->id, "chart_id");
     st->name = strdupz("chart_name");
-    st->flags |= RRDSET_FLAG_ENABLED;
     st->rrd_memory_mode |= RRD_MEMORY_MODE_SAVE;
     st->update_every = 1;
 

--- a/health/health.c
+++ b/health/health.c
@@ -514,11 +514,6 @@ static inline int rrdcalc_isrunnable(RRDCALC *rc, time_t now, time_t *next_run) 
         return 0;
     }
 
-    if(unlikely(!rrdset_flag_check(rc->rrdset, RRDSET_FLAG_ENABLED))) {
-        debug(D_HEALTH, "Health not running alarm '%s.%s'. The chart is not enabled", rc->chart?rc->chart:"NOCHART", rc->name);
-        return 0;
-    }
-
     if(unlikely(rrdset_flag_check(rc->rrdset, RRDSET_FLAG_ARCHIVED))) {
         debug(D_HEALTH, "Health not running alarm '%s.%s'. The chart has been marked as archived", rc->chart?rc->chart:"NOCHART", rc->name);
         return 0;

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -136,11 +136,7 @@ static inline int should_send_chart_matching(RRDSET *st) {
     if (rrdset_flag_check(st, RRDSET_FLAG_ANOMALY_DETECTION))
         return ml_streaming_enabled();
 
-    if(unlikely(!rrdset_flag_check(st, RRDSET_FLAG_ENABLED))) {
-        rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_SEND);
-        rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_IGNORE);
-    }
-    else if(!rrdset_flag_check(st, RRDSET_FLAG_UPSTREAM_SEND|RRDSET_FLAG_UPSTREAM_IGNORE)) {
+    if(!rrdset_flag_check(st, RRDSET_FLAG_UPSTREAM_SEND|RRDSET_FLAG_UPSTREAM_IGNORE)) {
         RRDHOST *host = st->rrdhost;
 
         if(simple_pattern_matches(host->rrdpush_send_charts_matching, st->id) ||

--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -52,7 +52,6 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
         "\t\t\t\"priority\": %ld,\n"
         "\t\t\t\"plugin\": \"%s\",\n"
         "\t\t\t\"module\": \"%s\",\n"
-        "\t\t\t\"enabled\": %s,\n"
         "\t\t\t\"units\": \"%s\",\n"
         "\t\t\t\"data_url\": \"/api/v1/data?chart=%s\",\n"
         "\t\t\t\"chart_type\": \"%s\",\n",
@@ -66,7 +65,6 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
         st->priority,
         st->plugin_name ? st->plugin_name : "",
         st->module_name ? st->module_name : "",
-        rrdset_flag_check(st, RRDSET_FLAG_ENABLED) ? "true" : "false",
         st->units,
         st->name,
         rrdset_type_name(st->chart_type));


### PR DESCRIPTION
##### Summary

After https://github.com/netdata/netdata/pull/12209 per-chart configuration was used for (a) enabling/disabling a chart, and (b) renaming dimensions.

Regarding the first use case: We already have component-specific configuration options|flags to finely control how a chart should behave. Eg. `send charts matching` in streaming, `charts to skip from training` in ML, etc. If we really need the concept of a disabled chart, we can
add a host-level simple pattern to match these charts.

Regarding the second use case: It's not obvious why we'd need to provide support for remapping dimension names through a chart-specific configuration from the core agent. If the need arises, we could add such support at the right place, ie. a exporter/streaming config section.

This will allow each flag to act indepentendly from each other and avoid managing flag-state manually at various places, eg:

```
    if(unlikely(!rrdset_flag_check(st, RRDSET_FLAG_ENABLED))) {
        rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_SEND);
        rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_IGNORE);
    } ...
```

##### Test Plan

CI build jobs