### PR TITLE
feat(cgroups.plugin): add k8s_qos_class label

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -286,8 +286,8 @@ function k8s_get_kubepod_name() {
   if [ -n "$cntr_id" ]; then
     if labels=$(grep "$cntr_id" <<< "$containers" 2> /dev/null); then
       labels+=',kind="container"'
+      labels+=",qos_class=\"$qos_class\""
       [ -n "$kube_system_uid" ] && [ "$kube_system_uid" != "null" ] && labels+=",cluster_id=\"$kube_system_uid\""
-      [ -n "$qos_class" ] && labels+=",qos_class=\"$qos_class\""
       name="cntr"
       name+="_$(get_lbl_val "$labels" namespace)"
       name+="_$(get_lbl_val "$labels" pod_name)"
@@ -299,8 +299,8 @@ function k8s_get_kubepod_name() {
     if labels=$(grep "$pod_uid" -m 1 <<< "$containers" 2> /dev/null); then
       labels="${labels%%,container_*}"
       labels+=',kind="pod"'
+      labels+=",qos_class=\"$qos_class\""
       [ -n "$kube_system_uid" ] && [ "$kube_system_uid" != "null" ] && labels+=",cluster_id=\"$kube_system_uid\""
-      [ -n "$qos_class" ] && labels+=",qos_class=\"$qos_class\""
       name="pod"
       name+="_$(get_lbl_val "$labels" namespace)"
       name+="_$(get_lbl_val "$labels" pod_name)"

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -273,6 +273,13 @@ function k8s_get_kubepod_name() {
     return 1
   fi
 
+  local qos_class
+  if [[ $clean_id =~ .+(besteffort|burstable) ]]; then
+    qos_class="${BASH_REMATCH[1]}"
+  else
+    qos_class="guaranteed"
+  fi
+
   # available labels:
   # namespace, pod_name, pod_uid, container_name, container_id, node_name
   local labels
@@ -280,6 +287,7 @@ function k8s_get_kubepod_name() {
     if labels=$(grep "$cntr_id" <<< "$containers" 2> /dev/null); then
       labels+=',kind="container"'
       [ -n "$kube_system_uid" ] && [ "$kube_system_uid" != "null" ] && labels+=",cluster_id=\"$kube_system_uid\""
+      [ -n "$qos_class" ] && labels+=",qos_class=\"$qos_class\""
       name="cntr"
       name+="_$(get_lbl_val "$labels" namespace)"
       name+="_$(get_lbl_val "$labels" pod_name)"
@@ -292,6 +300,7 @@ function k8s_get_kubepod_name() {
       labels="${labels%%,container_*}"
       labels+=',kind="pod"'
       [ -n "$kube_system_uid" ] && [ "$kube_system_uid" != "null" ] && labels+=",cluster_id=\"$kube_system_uid\""
+      [ -n "$qos_class" ] && labels+=",qos_class=\"$qos_class\""
       name="pod"
       name+="_$(get_lbl_val "$labels" namespace)"
       name+="_$(get_lbl_val "$labels" pod_name)"


### PR DESCRIPTION
##### Summary

This PR adds [k8s_qos_class](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#qos-classes) label to pod/container charts in Kubernetes.

##### Test Plan

- install this PR in k8s.
- query api/v1/charts.
- check all the cgroups charts have "k8s_qos_class" label.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
