### PR TITLE
fix(cgroups.plugin): remove "enable cgroup X" config option on cgroup deletion

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2318,6 +2318,9 @@ static inline void cleanup_all_cgroups() {
             else
                 last->discovered_next = cg->discovered_next;
 
+            char option[FILENAME_MAX + 1];
+            snprintfz(option, FILENAME_MAX, "enable cgroup %s", cg->chart_title);
+            config_section_option_destroy("plugin:cgroups", option);
             cgroup_free(cg);
 
             if(!last)

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -27,6 +27,8 @@
 
 #define config_generate(buffer, only_changed) appconfig_generate(&netdata_config, buffer, only_changed)
 
+#define config_section_option_destroy(section, name) appconfig_section_option_destroy_non_loaded(&netdata_config, section, name)
+
 // ----------------------------------------------------------------------------
 // netdata include files
 

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -273,14 +273,15 @@ void appconfig_section_option_destroy_non_loaded(struct config *root, const char
     struct config_option *cv;
 
     cv = appconfig_option_index_find(co, name, simple_hash(name));
-    if (unlikely(!(cv && appconfig_option_index_del(co, cv)))) {
+
+    if (cv && cv->flags & CONFIG_VALUE_LOADED) {
         config_section_unlock(co);
-        error("Could not destroy section option '%s -> %s'. The option not found.", section, name);
         return;
     }
 
-    if (cv->flags & CONFIG_VALUE_LOADED) {
+    if (unlikely(!(cv && appconfig_option_index_del(co, cv)))) {
         config_section_unlock(co);
+        error("Could not destroy section option '%s -> %s'. The option not found.", section, name);
         return;
     }
 


### PR DESCRIPTION
##### Summary

We add `enable cgroup X = yes/no` option to the `plugin:cgroup` section for every discovered cgroup. But we never remove it. This PR fixes the problem. 

##### Test Plan

```cmd
$ docker run -d --rm --name nginx1 nginx > /dev/null
$ docker run -d --rm --name nginx2 nginx > /dev/null
$ curl -s "localhost:19999/netdata.conf" | grep "enable cgroup nginx"
	# enable cgroup nginx1 = yes
	# enable cgroup nginx2 = yes
$ docker stop nginx2 > /dev/null
$ curl -s "localhost:19999/netdata.conf" | grep "enable cgroup nginx"
	# enable cgroup nginx1 = yes
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
