### PR TITLE
fix(cgroups.plugin): run renaming script only for containers in k8s

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -492,7 +492,9 @@ void read_cgroup_plugin_configuration() {
                     " *docker* "
                     " *lxc* "
                     " *qemu* "
-                    " *kubepods* "                        // #3396 kubernetes
+                    " /kubepods/pod*/* "                   // k8s containers
+                    " /kubepods/*/pod*/* "                 // k8s containers
+                    " !/kubepods* "                        // all other k8s cgroups
                     " *.libvirt-qemu "                    // #3010
                     " * "
             ), NULL, SIMPLE_PATTERN_EXACT);


### PR DESCRIPTION
##### Summary

No reason to execute the script for everything except сontainers (e.g. pods), because it is filtered by the "enable by default cgroups matching" option.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
