### PR TITLE
chore(ci): add the root dir markdown files to area/docs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -48,6 +48,7 @@ area/database:
   - database/**/*
 
 area/docs:
+  - "*.md"
   - "**/*.md"
   - "**/*.mdx"
   - diagrams/*


### PR DESCRIPTION
##### Summary

Noticed that we don't mark the repo readme file as area/docs in https://github.com/netdata/netdata/pull/12742.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
