### PR TITLE
Use explicit typecast to enum rrdset_flags

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -489,8 +489,8 @@ typedef enum rrdset_flags {
 #define rrdset_flag_clear(st, flag) __atomic_and_fetch(&((st)->flags), ~flag, __ATOMIC_SEQ_CST)
 #else
 #define rrdset_flag_check(st, flag) ((st)->flags & (flag))
-#define rrdset_flag_set(st, flag)   (st)->flags |= (flag)
-#define rrdset_flag_clear(st, flag) (st)->flags &= ~(flag)
+#define rrdset_flag_set(st, flag)   (st)->flags = (RRDSET_FLAGS)((st)->flags | flag)
+#define rrdset_flag_clear(st, flag) (st)->flags = (RRDSET_FLAGS)((st)->flags & ~(flag))
 #endif
 #define rrdset_flag_check_noatomic(st, flag) ((st)->flags & (flag))
 


### PR DESCRIPTION
specifications say
An enumerator can be promoted to an integer value. However,
converting an integer to an enumerator requires an explicit
cast, and the results are not defined.

Therefore The bitwise OR operation you are performing results
in an int, which you then attempt to assign to a variable of
type rrdset_flags without a cast.

Fixes
| ml/Host.cc:167:9: error: assigning to 'RRDSET_FLAGS' (aka 'rrdset_flags') from incompatible type 'int'
|         rrdset_flag_set(RS, RRDSET_FLAG_ANOMALY_DETECTION);
|         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Upstream-Status: Pending

Signed-off-by: Khem Raj <raj.khem@gmail.com>

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
