### PR TITLE
fix(cgroups.plugin): remove "search for cgroups under PATH" conf option to fix memory leak

### DIFF
--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -45,13 +45,6 @@ Netdata rescans these directories for added or removed cgroups every `check for 
 
 Since cgroups are hierarchical, for each of the directories shown above, Netdata walks through the subdirectories recursively searching for cgroups (each subdirectory is another cgroup).
 
-For each of the directories found, Netdata provides a configuration variable:
-
-```
-[plugin:cgroups]
-	search for cgroups under PATH = yes | no
-```
-
 To provide a sane default for this setting, Netdata uses the following pattern list (patterns starting with `!` give a negative match and their order is important: the first matching a path will be used):
 
 ```

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1925,15 +1925,7 @@ static inline int find_dir_in_subdirs(const char *base, const char *this, void (
                 if(*r == '\0') r = "/";
 
                 // do not decent in directories we are not interested
-                int def = simple_pattern_matches(enabled_cgroup_paths, r);
-
-                // we check for this option here
-                // so that the config will not have settings
-                // for leaf directories
-                char option[FILENAME_MAX + 1];
-                snprintfz(option, FILENAME_MAX, "search for cgroups under %s", r);
-                option[FILENAME_MAX] = '\0';
-                enabled = config_get_boolean("plugin:cgroups", option, def);
+                enabled = simple_pattern_matches(enabled_cgroup_paths, r);
             }
 
             if(enabled) {


### PR DESCRIPTION
##### Summary

We create a "search for cgroups under PATH" entry for every directory, but we **never** remove these entries, which is a memory leak. Fixing it properly looks tricky and I think not worth it. So this PR just removes the option.

##### Test Plan

Add several containers, ensure there is no "search for cgroups under PATH" under "[plugin:cgroups]".

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
