### PR TITLE
fix implicit declaration of function 'appconfig_section_option_destroy_non_loaded'

### DIFF
--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -183,6 +183,7 @@ extern void appconfig_generate(struct config *root, BUFFER *wb, int only_changed
 extern int appconfig_section_compare(void *a, void *b);
 
 extern void appconfig_section_destroy_non_loaded(struct config *root, const char *section);
+extern void appconfig_section_option_destroy_non_loaded(struct config *root, const char *section, const char *name);
 
 extern int config_parse_duration(const char* string, int* result);
 


### PR DESCRIPTION
##### Summary

Forgot to add it in https://github.com/netdata/netdata/pull/12746

```c
In file included from collectors/cgroups.plugin/sys_fs_cgroup.h:6,
                 from collectors/cgroups.plugin/sys_fs_cgroup.c:3:
collectors/cgroups.plugin/sys_fs_cgroup.c: In function 'cleanup_all_cgroups':
./daemon/common.h:30:54: warning: implicit declaration of function 'appconfig_section_option_destroy_non_loaded'; did you mean 'appconfig_section_destroy_non_loaded'? [-Wimplicit-function-declaration]
   30 | #define config_section_option_destroy(section, name) appconfig_section_option_destroy_non_loaded(&netdata_config, section, name)
      |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./daemon/common.h:30:54: note: in definition of macro 'config_section_option_destroy'
   30 | #define config_section_option_destroy(section, name) appconfig_section_option_destroy_non_loaded(&netdata_config, section, name)
```

##### Test Plan

No warning during compilation

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
