### PR TITLE
Fix and improve netdata-updater.sh script

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -58,6 +58,10 @@ info() {
   echo >&3 "$(date) : INFO: ${script_name}: " "${@}"
 }
 
+warning() {
+  echo >&3 "$(date) : WARNING: ${script_name}: " "${@}"
+}
+
 error() {
   echo >&3 "$(date) : ERROR: ${script_name}: " "${@}"
 }
@@ -650,17 +654,13 @@ update_binpkg() {
   if str_in_list "${DISTRO}" "${supported_compat_names}"; then
     DISTRO_COMPAT_NAME="${DISTRO}"
   else
-    case "${DISTRO}" in
-      opensuse-leap)
-        DISTRO_COMPAT_NAME="opensuse"
-        ;;
-      rhel)
-        DISTRO_COMPAT_NAME="centos"
-        ;;
-      *)
-        DISTRO_COMPAT_NAME="unknown"
-        ;;
-    esac
+    DISTRO_COMPAT_NAME="unknown"
+    for compat_id in ${ID_LIKE}; do
+      if str_in_list "${compat_id}" "${supported_compat_names}"; then
+        DISTRO_COMPAT_NAME="${compat_id}"
+        break
+      fi
+    done
   fi
 
   if [ "${INTERACTIVE}" = "0" ]; then

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -654,13 +654,17 @@ update_binpkg() {
   if str_in_list "${DISTRO}" "${supported_compat_names}"; then
     DISTRO_COMPAT_NAME="${DISTRO}"
   else
-    DISTRO_COMPAT_NAME="unknown"
-    for compat_id in ${ID_LIKE}; do
-      if str_in_list "${compat_id}" "${supported_compat_names}"; then
-        DISTRO_COMPAT_NAME="${compat_id}"
-        break
-      fi
-    done
+    case "${DISTRO}" in
+      opensuse-leap)
+        DISTRO_COMPAT_NAME="opensuse"
+        ;;
+      almalinux|rocky|rhel)
+        DISTRO_COMPAT_NAME="centos"
+        ;;
+      *)
+        DISTRO_COMPAT_NAME="unknown"
+        ;;
+    esac
   fi
 
   if [ "${INTERACTIVE}" = "0" ]; then


### PR DESCRIPTION
##### Summary

Minor fix and improvement of netdata-updater.sh script

1. Added missing warning() function
2. Added Alma and Rocky distros as CentOS compatibility distro

##### Test Plan

Not needed.

##### Additional Information

I'm using Netdata with [rockylinux ](https://rockylinux.org/) and noticed that netdata-updater.sh throws errors like that

```
/etc/cron.daily/netdata-updater:

/tmp/netdata-updater-DxSyUpT6B8/netdata-updater.sh: line 729: warning: command not found

```
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
