### PR TITLE
chore(cgroups.plugin): improve cgroups name resolution in k8s

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -114,7 +114,7 @@ function add_lbl_prefix() {
   echo "${new_labels:0:-1}" # trim last ','
 }
 
-function k8s_is_container_pause() {
+function k8s_is_pause_container() {
   local cgroup_path="${1}"
 
   local file
@@ -221,7 +221,7 @@ function k8s_get_kubepod_name() {
   [ -n "$pod_uid" ] && info "${fn}: cgroup '$id' is a pod(uid:$pod_uid)"
   [ -n "$cntr_id" ] && info "${fn}: cgroup '$id' is a container(id:$cntr_id)"
 
-  if [ -n "$cntr_id" ] && k8s_is_container_pause "$cgroup_path"; then
+  if [ -n "$cntr_id" ] && k8s_is_pause_container "$cgroup_path"; then
     return 1
   fi
 

--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -383,17 +383,17 @@ function k8s_get_name() {
     else
       info "${fn}: cgroup '${id}' has chart name '${NAME}'"
     fi
-    NAME_NOT_FOUND=0
+    EXIT_CODE=$EXIT_SUCCESS
     ;;
   2)
     warning "${fn}: cannot find the name of cgroup with id '${id}'. Setting name to ${id} and asking for retry."
     NAME="${id}"
-    NAME_NOT_FOUND=2
+    EXIT_CODE=$EXIT_RETRY
     ;;
   *)
     warning "${fn}: cannot find the name of cgroup with id '${id}'. Setting name to ${id} and disabling it."
     NAME="${id}"
-    NAME_NOT_FOUND=3
+    EXIT_CODE=$EXIT_DISABLE
     ;;
   esac
 }
@@ -407,7 +407,7 @@ function docker_get_name() {
   fi
   if [ -z "${NAME}" ]; then
     warning "cannot find the name of docker container '${id}'"
-    NAME_NOT_FOUND=2
+    EXIT_CODE=$EXIT_RETRY
     NAME="${id:0:12}"
   else
     info "docker container '${id}' is named '${NAME}'"
@@ -432,7 +432,7 @@ function podman_get_name() {
 
   if [ -z "${NAME}" ]; then
     warning "cannot find the name of podman container '${id}'"
-    NAME_NOT_FOUND=2
+    EXIT_CODE=$EXIT_RETRY
     NAME="${id:0:12}"
   else
     info "podman container '${id}' is named '${NAME}'"
@@ -454,7 +454,10 @@ DOCKER_HOST="${DOCKER_HOST:=/var/run/docker.sock}"
 PODMAN_HOST="${PODMAN_HOST:=/run/podman/podman.sock}"
 CGROUP_PATH="${1}" # the path as it is (e.g. '/docker/efcf4c409')
 CGROUP="${2}"      # the modified path (e.g. 'docker_efcf4c409')
-NAME_NOT_FOUND=0
+EXIT_SUCCESS=0
+EXIT_RETRY=2
+EXIT_DISABLE=3
+EXIT_CODE=$EXIT_SUCCESS
 NAME=
 
 # -----------------------------------------------------------------------------
@@ -536,4 +539,4 @@ fi
 info "cgroup '${CGROUP}' is called '${NAME}'"
 echo "${NAME}"
 
-exit ${NAME_NOT_FOUND}
+exit ${EXIT_CODE}

--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -241,9 +241,7 @@ function k8s_get_kubepod_name() {
     [ -f "$tmp_kube_containers_file" ] &&
     labels=$(grep "$cntr_id" "$tmp_kube_containers_file" 2>/dev/null); then
     IFS= read -r kube_system_uid 2>/dev/null <"$tmp_kube_system_ns_uid_file"
-    info "${fn}: K8S CACHE HIT (cgroup $cgroup_path)"
   else
-    info "${fn}: K8S CACHE MISS (cgroup $cgroup_path)"
     IFS= read -r kube_system_uid 2>/dev/null <"$tmp_kube_system_ns_uid_file"
     local kube_system_ns
     local pods

--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -221,7 +221,10 @@ function k8s_get_kubepod_name() {
   [ -n "$pod_uid" ] && info "${fn}: cgroup '$id' is a pod(uid:$pod_uid)"
   [ -n "$cntr_id" ] && info "${fn}: cgroup '$id' is a container(id:$cntr_id)"
 
-  if [ -n "$cntr_id" ] && k8s_is_pause_container "$cgroup_path"; then
+  if [ -n "$cntr_id" ] &&
+    [ -z "$KUBERNETES_SERVICE_HOST" ] &&
+    [ -z "$KUBERNETES_SERVICE_PORT" ] &&
+    k8s_is_pause_container "$cgroup_path"; then
     return 1
   fi
 

--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -221,10 +221,7 @@ function k8s_get_kubepod_name() {
   [ -n "$pod_uid" ] && info "${fn}: cgroup '$id' is a pod(uid:$pod_uid)"
   [ -n "$cntr_id" ] && info "${fn}: cgroup '$id' is a container(id:$cntr_id)"
 
-  if [ -n "$cntr_id" ] &&
-    [ -z "$KUBERNETES_SERVICE_HOST" ] &&
-    [ -z "$KUBERNETES_SERVICE_PORT" ] &&
-    k8s_is_pause_container "$cgroup_path"; then
+  if [ -n "$cntr_id" ] && k8s_is_pause_container "$cgroup_path"; then
     return 1
   fi
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -274,7 +274,7 @@ void read_cgroup_plugin_configuration() {
     if(cgroup_check_for_new_every < cgroup_update_every)
         cgroup_check_for_new_every = cgroup_update_every;
     
-    cgroup_renaming_tries = config_get_number("plugin:cgroups", "cgroup renaming tries", cgroup_renaming_tries)
+    cgroup_renaming_tries = config_get_number("plugin:cgroups", "cgroup renaming tries", cgroup_renaming_tries);
     if (cgroup_renaming_tries < 1) {
         cgroup_renaming_tries = 1;
     }

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -4573,7 +4573,7 @@ void *cgroups_main(void *ptr) {
 
     struct rusage thread;
 
-    if is_inside_k8s() {
+    if (is_inside_k8s()) {
         cgroup_enable_cpuacct_cpu_shares = CONFIG_BOOLEAN_YES;
         // 2 was not enough on an AWS K8s cluster when: CPU % is high, many containers are created in a short time.
         cgroup_renaming_tries = 4;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1772,7 +1772,7 @@ static inline struct cgroup *cgroup_add(const char *id) {
             debug(D_CGROUP, "cgroup '%s' with chart id '%s' (title: '%s') does not match systemd services groups", cg->id, cg->chart_id, cg->chart_title);
     }
 
-    if (cg->enanbled && user_configurable) {
+    if (cg->enabled && user_configurable) {
         // allow the user to enable/disable this individually
         char option[FILENAME_MAX + 1];
         snprintfz(option, FILENAME_MAX, "enable cgroup %s", cg->chart_title);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -867,6 +867,9 @@ struct discovery_thread {
     int exited;
 } discovery_thread;
 
+static int is_inside_k8s() {
+    return (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL)
+}
 // ----------------------------------------------------------------------------
 
 static unsigned long long calc_delta(unsigned long long curr, unsigned long long prev) {
@@ -4570,8 +4573,10 @@ void *cgroups_main(void *ptr) {
 
     struct rusage thread;
 
-    if (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL) {
+    if is_inside_k8s() {
         cgroup_enable_cpuacct_cpu_shares = CONFIG_BOOLEAN_YES;
+        // 2 was not enough on an AWS K8s cluster when: CPU % is high, many containers are created in a short time.
+        cgroup_renaming_tries = 4;
     }
 
     // when ZERO, attempt to do it

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1617,7 +1617,7 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
     char command[CGROUP_CHARTID_LINE_MAX + 1];
 
     // TODO: use cg->id when the renaming script is fixed
-    snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->intermediate_id);
+    snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s' '%s'", cgroups_rename_script, cg->id, cg->intermediate_id);
 
     debug(D_CGROUP, "executing command \"%s\" for cgroup '%s'", command, cg->chart_id);
     FILE *fp = mypopen(command, &cgroup_pid);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -868,7 +868,7 @@ struct discovery_thread {
 } discovery_thread;
 
 static int is_inside_k8s() {
-    return (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL)
+    return (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL);
 }
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
##### Summary

This PR adds the following improvements:

- do not query K8s API for [pause](https://github.com/kubernetes/kubernetes/tree/master/build/pause) containers (a container that holds the network namespace for the pod).
- cache (store on the host filesystem) `/api/v1/pods` response and check it before querying K8s API (only for containers).
- simplifies renaming code.

---

##### Test Plan

- K8s (requires adding debug logging messages)
  - check pause container identification logic.
  - check that cache works (hit/miss).
- run N docker containers, check name resolution works.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
