### PR TITLE
faster execution of external programs

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -486,9 +486,8 @@ void call_the_helper(pid_t pid, const char *cgroup) {
         (void)custom_popene(&cgroup_pid, environment, POPEN_FLAG_CREATE_PIPE | POPEN_FLAG_CLOSE_FD, &fp, PLUGINS_DIR "/cgroup-network-helper.sh", "cgroup-network-helper.sh", "--cgroup", cgroup, NULL);
     }
     else {
-        char buffer[101];
-        snprintf(buffer, 100, "%d", pid);
-        buffer[100] = 0;
+        char buffer[100];
+        snprintfz(buffer, 100, "%d", pid);
         (void)custom_popene(&cgroup_pid, environment, POPEN_FLAG_CREATE_PIPE | POPEN_FLAG_CLOSE_FD, &fp, PLUGINS_DIR "/cgroup-network-helper.sh", "cgroup-network-helper.sh", "--pid", buffer, NULL);
     }
 

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -483,13 +483,13 @@ void call_the_helper(pid_t pid, const char *cgroup) {
 
     // fp = mypopene(command, &cgroup_pid, environment);
     if(cgroup) {
-        (void)custom_popene(&cgroup_pid, environment, POPEN_FLAG_CREATE_PIPE | POPEN_FLAG_CLOSE_FD, &fp, PLUGINS_DIR "/cgroup-network-helper.sh", "--cgroup", cgroup, NULL);
+        (void)custom_popene(&cgroup_pid, environment, POPEN_FLAG_CREATE_PIPE | POPEN_FLAG_CLOSE_FD, &fp, PLUGINS_DIR "/cgroup-network-helper.sh", "cgroup-network-helper.sh", "--cgroup", cgroup, NULL);
     }
     else {
         char buffer[101];
         snprintf(buffer, 100, "%d", pid);
         buffer[100] = 0;
-        (void)custom_popene(&cgroup_pid, environment, POPEN_FLAG_CREATE_PIPE | POPEN_FLAG_CLOSE_FD, &fp, PLUGINS_DIR "/cgroup-network-helper.sh", "--pid", buffer, NULL);
+        (void)custom_popene(&cgroup_pid, environment, POPEN_FLAG_CREATE_PIPE | POPEN_FLAG_CLOSE_FD, &fp, PLUGINS_DIR "/cgroup-network-helper.sh", "cgroup-network-helper.sh", "--pid", buffer, NULL);
     }
 
     if(fp) {

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1441,16 +1441,20 @@ static inline void read_cgroup_network_interfaces(struct cgroup *cg) {
     char command[CGROUP_NETWORK_INTERFACE_MAX_LINE + 1];
 
     if(!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
-        snprintfz(command, CGROUP_NETWORK_INTERFACE_MAX_LINE, "exec %s --cgroup '%s%s'", cgroups_network_interface_script, cgroup_cpuacct_base, cg->id);
+        // snprintfz(command, CGROUP_NETWORK_INTERFACE_MAX_LINE, "exec %s --cgroup '%s%s'", cgroups_network_interface_script, cgroup_cpuacct_base, cg->id);
+        snprintfz(command, CGROUP_NETWORK_INTERFACE_MAX_LINE, "%s%s", cgroup_cpuacct_base, cg->id);
     }
     else {
-        snprintfz(command, CGROUP_NETWORK_INTERFACE_MAX_LINE, "exec %s --cgroup '%s%s'", cgroups_network_interface_script, cgroup_unified_base, cg->id);
+        // snprintfz(command, CGROUP_NETWORK_INTERFACE_MAX_LINE, "exec %s --cgroup '%s%s'", cgroups_network_interface_script, cgroup_unified_base, cg->id);
+        snprintfz(command, CGROUP_NETWORK_INTERFACE_MAX_LINE, "%s%s", cgroup_unified_base, cg->id);
     }
 
-    debug(D_CGROUP, "executing command '%s' for cgroup '%s'", command, cg->id);
-    FILE *fp = mypopen(command, &cgroup_pid);
+    debug(D_CGROUP, "executing command %s --cgroup '%s' for cgroup '%s'", cgroups_network_interface_script, command, cg->id);
+    FILE *fp;
+    // fp = mypopen(command, &cgroup_pid);
+    (void)custom_popene(&cgroup_pid, environ, POPEN_FLAG_CREATE_PIPE | POPEN_FLAG_CLOSE_FD, &fp, cgroups_network_interface_script, cgroups_network_interface_script, "--cgroup", command, NULL);
     if(!fp) {
-        error("CGROUP: cannot popen(\"%s\", \"r\").", command);
+        error("CGROUP: cannot popen(%s --cgroup \"%s\", \"r\").", cgroups_network_interface_script, command);
         return;
     }
 
@@ -1577,13 +1581,15 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
     debug(D_CGROUP, "looking for the name of cgroup '%s' with chart id '%s' and title '%s'", cg->id, cg->chart_id, cg->chart_title);
 
     pid_t cgroup_pid;
-    char command[CGROUP_CHARTID_LINE_MAX + 1];
+    // char command[CGROUP_CHARTID_LINE_MAX + 1];
 
     // TODO: use cg->id when the renaming script is fixed
-    snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->intermediate_id);
+    // snprintfz(command, CGROUP_CHARTID_LINE_MAX, "exec %s '%s'", cgroups_rename_script, cg->intermediate_id);
 
-    debug(D_CGROUP, "executing command \"%s\" for cgroup '%s'", command, cg->chart_id);
-    FILE *fp = mypopen(command, &cgroup_pid);
+    debug(D_CGROUP, "executing command %s \"%s\" for cgroup '%s'", cgroups_rename_script, cg->intermediate_id, cg->chart_id);
+    FILE *fp;
+    // fp = mypopen(command, &cgroup_pid);
+    (void)custom_popene(&cgroup_pid, environ, POPEN_FLAG_CREATE_PIPE | POPEN_FLAG_CLOSE_FD, &fp, cgroups_rename_script, cgroups_rename_script, cg->intermediate_id, NULL);
     if(fp) {
         // debug(D_CGROUP, "reading from command '%s' for cgroup '%s'", command, cg->id);
         char buffer[CGROUP_CHARTID_LINE_MAX + 1];
@@ -1624,7 +1630,7 @@ static inline void cgroup_get_chart_name(struct cgroup *cg) {
         }
     }
     else
-        error("CGROUP: cannot popen(\"%s\", \"r\").", command);
+        error("CGROUP: cannot popen(%s \"%s\", \"r\").", cgroups_rename_script, cg->intermediate_id);
 }
 
 static inline struct cgroup *cgroup_add(const char *id) {

--- a/libnetdata/popen/popen.h
+++ b/libnetdata/popen/popen.h
@@ -8,6 +8,12 @@
 #define PIPE_READ 0
 #define PIPE_WRITE 1
 
+/* custom_popene flag definitions */
+#define POPEN_FLAG_CREATE_PIPE 1 // Create a pipe like popen() when set, otherwise set stdout to /dev/null
+#define POPEN_FLAG_CLOSE_FD 2 // Close all file descriptors other than STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO
+
+extern int custom_popene(volatile pid_t *pidptr, char **env, uint8_t flags, FILE **fpp, const char *command, ...);
+
 extern FILE *mypopen(const char *command, volatile pid_t *pidptr);
 extern FILE *mypopene(const char *command, volatile pid_t *pidptr, char **env);
 extern int mypclose(FILE *fp, pid_t pid);


### PR DESCRIPTION
in k8s, when hundreds of containers start and stop, netdata uses a lot of CPU to call external programs like `cgroup-network` and `cgroup-name.sh`.

The call `mypopen()` runs all external commands using `/bin/sh -c "command to be run"`. This means that it spawns twice for every command.

This PR changes this logic, so that the external command to be run, is executed directly, without `/bin/sh`.

The results are as follows:

* Running `cgroup-network` that is a C program is 4 times faster
* Running `cgroup-name.sh` that is a BASH program is 2 times faster
