### PR TITLE
feat(dbengine): make dbengine page cache undumpable and dedupuble

### DIFF
--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -356,7 +356,7 @@ static void pg_cache_evict_unsafe(struct rrdengine_instance *ctx, struct rrdeng_
 {
     struct page_cache_descr *pg_cache_descr = descr->pg_cache_descr;
 
-    freez(pg_cache_descr->page);
+    dbengine_page_free(pg_cache_descr->page);
     pg_cache_descr->page = NULL;
     pg_cache_descr->flags &= ~RRD_PAGE_POPULATED;
     pg_cache_release_pages_unsafe(ctx, 1);
@@ -1222,7 +1222,7 @@ void free_page_cache(struct rrdengine_instance *ctx)
                 /* Check rrdenglocking.c */
                 pg_cache_descr = descr->pg_cache_descr;
                 if (pg_cache_descr->flags & RRD_PAGE_POPULATED) {
-                    freez(pg_cache_descr->page);
+                    dbengine_page_free(pg_cache_descr->page);
                     bytes_freed += RRDENG_BLOCK_SIZE;
                 }
                 rrdeng_destroy_pg_cache_descr(ctx, pg_cache_descr);

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -12,19 +12,13 @@ rrdeng_stats_t global_flushing_pressure_page_deletions = 0;
 static unsigned pages_per_extent = MAX_PAGES_PER_EXTENT;
 
 void *dbengine_page_alloc() {
-#ifdef MADV_MERGEABLE
-    return mymmap(NULL, RRDENG_BLOCK_SIZE, MAP_PRIVATE, enable_ksm);
-#else
-    return mallocz(RRDENG_BLOCK_SIZE);
-#endif
+    void *page = netdata_mmap(NULL, RRDENG_BLOCK_SIZE, MAP_PRIVATE, enable_ksm);
+    if(!page) fatal("Cannot allocate dbengine page cache page, with mmap()");
+    return page;
 }
 
 void dbengine_page_free(void *page) {
-#ifdef MADV_MERGEABLE
     munmap(page, RRDENG_BLOCK_SIZE);
-#else
-    freez(page);
-#endif
 }
 
 static void sanity_check(void)

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -227,6 +227,9 @@ struct rrdengine_instance {
     struct rrdengine_statistics stats;
 };
 
+extern void *dbengine_page_alloc(void);
+extern void dbengine_page_free(void *page);
+
 extern int init_rrd_files(struct rrdengine_instance *ctx);
 extern void finalize_rrd_files(struct rrdengine_instance *ctx);
 extern void rrdeng_test_quota(struct rrdengine_worker_config* wc);

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -202,7 +202,7 @@ void rrdeng_store_metric_flush_current_page(RRDDIM *rd)
             /* handle->prev_descr = descr;*/
         }
     } else {
-        freez(descr->pg_cache_descr->page);
+        dbengine_page_free(descr->pg_cache_descr->page);
         rrdeng_destroy_pg_cache_descr(ctx, descr->pg_cache_descr);
         freez(descr);
     }
@@ -724,7 +724,7 @@ void *rrdeng_create_page(struct rrdengine_instance *ctx, uuid_t *id, struct rrde
 
     descr = pg_cache_create_descr();
     descr->id = id; /* TODO: add page type: metric, log, something? */
-    page = mallocz(RRDENG_BLOCK_SIZE); /*TODO: add page size */
+    page = dbengine_page_alloc(); /*TODO: add page size */
     rrdeng_page_descr_mutex_lock(ctx, descr);
     pg_cache_descr = descr->pg_cache_descr;
     pg_cache_descr->page = page;

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -244,12 +244,11 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
 
     if(memory_mode == RRD_MEMORY_MODE_SAVE || memory_mode == RRD_MEMORY_MODE_MAP ||
        memory_mode == RRD_MEMORY_MODE_RAM) {
-        rd = (RRDDIM *)mymmap(
-                  (memory_mode == RRD_MEMORY_MODE_RAM) ? NULL : fullfilename
-                , size
-                , ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE)
-                , 1
-        );
+        rd = (RRDDIM *)netdata_mmap(
+            (memory_mode == RRD_MEMORY_MODE_RAM) ? NULL : fullfilename,
+            size,
+            ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE),
+            1);
 
         if(likely(rd)) {
             // we have a file mapped for rd

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -744,12 +744,11 @@ RRDSET *rrdset_create_custom(
     snprintfz(fullfilename, FILENAME_MAX, "%s/main.db", cache_dir);
     if(memory_mode == RRD_MEMORY_MODE_SAVE || memory_mode == RRD_MEMORY_MODE_MAP ||
        memory_mode == RRD_MEMORY_MODE_RAM) {
-        st = (RRDSET *) mymmap(
-                  (memory_mode == RRD_MEMORY_MODE_RAM) ? NULL : fullfilename
-                , size
-                , ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE)
-                , 0
-        );
+        st = (RRDSET *)netdata_mmap(
+            (memory_mode == RRD_MEMORY_MODE_RAM) ? NULL : fullfilename,
+            size,
+            ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE),
+            0);
 
         if(st) {
             memset(&st->avl, 0, sizeof(avl_t));

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -944,117 +944,112 @@ static int memory_file_open(const char *filename, size_t size) {
     return fd;
 }
 
-// mmap_shared is used for memory mode = map
-static void *memory_file_mmap(const char *filename, size_t size, int flags) {
-    // info("memory_file_mmap('%s', %zu", filename, size);
-    static int log_madvise = 1;
+static inline int madvise_sequential(void *mem, size_t len) {
+    static int logger = 1;
+    int ret = madvise(mem, len, MADV_SEQUENTIAL);
 
-    int fd = -1;
-    if(filename) {
-        fd = memory_file_open(filename, size);
-        if(fd == -1) return MAP_FAILED;
-    }
+    if (ret != 0 && logger-- > 0) error("madvise(MADV_SEQUENTIAL) failed.");
+    return ret;
+}
+static inline int madvise_dontfork(void *mem, size_t len) {
+    static int logger = 1;
+    int ret = madvise(mem, len, MADV_DONTFORK);
 
-    void *mem = mmap(NULL, size, PROT_READ | PROT_WRITE, flags, fd, 0);
-    if (mem != MAP_FAILED) {
-#ifdef NETDATA_LOG_ALLOCATIONS
-        mmap_accounting(size);
+    if (ret != 0 && logger-- > 0) error("madvise(MADV_DONTFORK) failed.");
+    return ret;
+}
+static inline int madvise_willneed(void *mem, size_t len) {
+    static int logger = 1;
+    int ret = madvise(mem, len, MADV_WILLNEED);
+
+    if (ret != 0 && logger-- > 0) error("madvise(MADV_WILLNEED) failed.");
+    return ret;
+}
+static inline int madvise_dontdump(void *mem, size_t len) {
+    static int logger = 1;
+    int ret = madvise(mem, len, MADV_DONTDUMP);
+
+    if (ret != 0 && logger-- > 0) error("madvise(MADV_DONTDUMP) failed.");
+    return ret;
+}
+static inline int madvise_mergeable(void *mem, size_t len) {
+#ifdef MADV_MERGEABLE
+    static int logger = 1;
+    int ret = madvise(mem, len, MADV_MERGEABLE);
+
+    if (ret != 0 && logger-- > 0) error("madvise(MADV_MERGEABLE) failed.");
+    return ret;
+#else
+    return 0;
 #endif
-        int advise = MADV_SEQUENTIAL | MADV_DONTFORK;
-        if (flags & MAP_SHARED) advise |= MADV_WILLNEED;
-
-        if (madvise(mem, size, advise) != 0 && log_madvise) {
-            error("Cannot advise the kernel about shared memory usage.");
-            log_madvise--;
-        }
-    }
-
-    if(fd != -1)
-        close(fd);
-
-    return mem;
 }
 
-#ifdef MADV_MERGEABLE
-static void *memory_file_mmap_ksm(const char *filename, size_t size, int flags) {
-    // info("memory_file_mmap_ksm('%s', %zu", filename, size);
-    static int log_madvise_1 = 1, log_madvise_2 = 1, log_madvise_3 = 1, log_madvise_4 = 1;
+void *netdata_mmap(const char *filename, size_t size, int flags, int ksm) {
+    // info("netdata_mmap('%s', %zu", filename, size);
+
+    // MAP_SHARED is used in memory mode map
+    // MAP_PRIVATE is used in memory mode ram and save
+
+    if(unlikely(!(flags & MAP_SHARED) && !(flags & MAP_PRIVATE)))
+        fatal("Neither MAP_SHARED or MAP_PRIVATE were given to netdata_mmap()");
+
+    if(unlikely((flags & MAP_SHARED) && (flags & MAP_PRIVATE)))
+        fatal("Both MAP_SHARED and MAP_PRIVATE were given to netdata_mmap()");
+
+    if(unlikely((flags & MAP_SHARED) && (!filename || !*filename)))
+        fatal("MAP_SHARED requested, without a filename to netdata_mmap()");
+
+    // don't enable ksm is the global setting is disabled
+    if(unlikely(!enable_ksm)) ksm = 0;
+
+    // KSM only merges anonymous (private) pages, never pagecache (file) pages
+    // but MAP_PRIVATE without MAP_ANONYMOUS it fails too, so we need it always
+    if((flags & MAP_PRIVATE)) flags |= MAP_ANONYMOUS;
 
     int fd = -1;
-    if(filename) {
+    void *mem = MAP_FAILED;
+
+    if(filename && *filename) {
+        // open/create the file to be used
         fd = memory_file_open(filename, size);
-        if(fd == -1) return MAP_FAILED;
+        if(fd == -1) goto cleanup;
     }
 
-    void *mem = mmap(NULL, size, PROT_READ | PROT_WRITE, flags | MAP_ANONYMOUS, -1, 0);
+    int fd_for_mmap = fd;
+    if(fd != -1 && (flags & MAP_PRIVATE)) {
+        // this is MAP_PRIVATE allocation
+        // no need for mmap() to use our fd
+        // we will copy the file into the memory allocated
+        fd_for_mmap = -1;
+    }
+
+    mem = mmap(NULL, size, PROT_READ | PROT_WRITE, flags, fd_for_mmap, 0);
     if (mem != MAP_FAILED) {
+
 #ifdef NETDATA_LOG_ALLOCATIONS
         mmap_accounting(size);
 #endif
-        if(fd != -1) {
+
+        // if we have a file open, but we didn't give it to mmap(),
+        // we have to read the file into the memory block we allocated
+        if(fd != -1 && fd_for_mmap == -1) {
             if (lseek(fd, 0, SEEK_SET) == 0) {
                 if (read(fd, mem, size) != (ssize_t) size)
-                    error("Cannot read from file '%s'", filename);
+                    info("Cannot read from file '%s'", filename);
             }
-            else error("Cannot seek to beginning of file '%s'.", filename);
+            else info("Cannot seek to beginning of file '%s'.", filename);
         }
 
-        if (madvise(mem, size, MADV_SEQUENTIAL) != 0 && log_madvise_1) {
-            error("Cannot advise the kernel about the memory usage MADV_SEQUENTIAL.");
-            log_madvise_1--;
-        }
-
-        if (madvise(mem, size, MADV_DONTFORK) != 0 && log_madvise_2) {
-            error("Cannot advise the kernel about the memory usage MADV_DONTFORK.");
-            log_madvise_2--;
-        }
-
-        if (madvise(mem, size, MADV_MERGEABLE) != 0 && log_madvise_3) {
-            error("Cannot advise the kernel about the memory usage MADV_MERGEABLE.");
-            log_madvise_3--;
-        }
-
-        if (madvise(mem, size, MADV_DONTDUMP) != 0 && log_madvise_4) {
-            error("Cannot advise the kernel about the memory usage MADV_DONTDUMP.");
-            log_madvise_4--;
-        }
+        madvise_sequential(mem, size);
+        madvise_dontfork(mem, size);
+        madvise_dontdump(mem, size);
+        if(flags & MAP_SHARED) madvise_willneed(mem, size);
+        if(ksm) madvise_mergeable(mem, size);
     }
 
-    if(fd != -1)
-        close(fd);
-
-    return mem;
-}
-#else
-static void *memory_file_mmap_ksm(const char *filename, size_t size, int flags) {
-    // info("memory_file_mmap_ksm FALLBACK ('%s', %zu", filename, size);
-
-    if(filename)
-        return memory_file_mmap(filename, size, flags);
-
-    // when KSM is not available and no filename is given (memory mode = ram),
-    // we just report failure
-    return MAP_FAILED;
-}
-#endif
-
-void *mymmap(const char *filename, size_t size, int flags, int ksm) {
-    void *mem = NULL;
-
-    if (filename && (flags & MAP_SHARED || !enable_ksm || !ksm))
-        // memory mode = map | save
-        // when KSM is not enabled
-        // MAP_SHARED is used for memory mode = map (no KSM possible)
-        mem = memory_file_mmap(filename, size, flags);
-
-    else
-        // memory mode = save | ram
-        // when KSM is enabled
-        // for memory mode = ram, the filename is NULL
-        mem = memory_file_mmap_ksm(filename, size, flags);
-
+cleanup:
+    if(fd != -1) close(fd);
     if(mem == MAP_FAILED) return NULL;
-
     errno = 0;
     return mem;
 }

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -250,7 +250,7 @@ extern void freez(void *ptr);
 extern void json_escape_string(char *dst, const char *src, size_t size);
 extern void json_fix_string(char *s);
 
-extern void *mymmap(const char *filename, size_t size, int flags, int ksm);
+extern void *netdata_mmap(const char *filename, size_t size, int flags, int ksm);
 extern int memory_file_save(const char *filename, void *mem, size_t size);
 
 extern int fd_is_valid(int fd);


### PR DESCRIPTION
##### Summary

Fixes: #12744

This PR replaces DBengine page cache allocation/deallocation calls with `mmap()`/`munmap()` when available.

Used options:

- `MADV_DONTFORK`, to prevent these pages from being copied on `fork()`.
- `MADV_MERGEABLE`, to enable these pages to be deduped with KSM (this can half the cache size impact on the system).
- `MADV_DONTDUMP`, to prevent these pages from being included in coredumps.

##### Test Plan

Start/stop Netdata, keep it running in a stressed env (15-20 children instances), and ensure there are no segfaults.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
