### PR TITLE
use aclk_parse_otp_error on /env error

### DIFF
--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -860,6 +860,8 @@ int aclk_get_env(aclk_env_t *env, const char* aclk_hostname, int aclk_port) {
     }
     if (resp.http_code != 200) {
         error("The HTTP code not 200 OK (Got %d)", resp.http_code);
+        if (resp.payload_size)
+            aclk_parse_otp_error(resp.payload);
         https_req_response_free(&resp);
         buffer_free(buf);
         return 1;


### PR DESCRIPTION
##### Summary

Env endpoint can now return the same HTTP payload in case of error as challenge and password endpoint.

##### Test Plan
`aclk_otp.c` line 846 change the URL so the `cap` is some garbage. For example `cap=sadfsdfsad`. Cloud will return the error payload. We should now honor it also when `/env` endpoint returns it.

For now, only testing cloud env has this working properly (prod/staging is missing fix on cloud side as of now).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
