### PR TITLE
Fix checking of enviornment file in updater.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -456,7 +456,7 @@ get_latest_version() {
 }
 
 validate_environment_file() {
-  if [ -n "${NETDATA_PREFIX+SET_BUT_NULL}" ] && [ -n "${REINSTALL_OPTIONS}" ]; then
+  if [ -n "${NETDATA_PREFIX+SET_BUT_NULL}" ] && [ -n "${REINSTALL_OPTIONS+SET_BUT_NULL}" ]; then
     return 0
   else
     fatal "Environment file located at ${ENVIRONMENT_FILE} is not valid, unable to update." U0007


### PR DESCRIPTION
##### Summary

We should check that `${REINSTALL_OPTIONS}` is defined, not that it is defined to a non-empty string.

##### Test Plan

Updater runs correctly on systems where `REINSTALL_OPTIONS` is empty in the `.environment` file instead of running into a fatal error.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
The updater will work correctly again in a couple of cases it was broken for.
</details>
