### PR TITLE
some config updates for ml

### DIFF
--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -32,7 +32,7 @@ void Config::readMLConfig(void) {
     unsigned MinTrainSamples = config_get_number(ConfigSectionML, "minimum num samples to train", 1 * 3600);
     unsigned TrainEvery = config_get_number(ConfigSectionML, "train every", 1 * 3600);
 
-    unsigned DBEngineAnomalyRateEvery = config_get_number(ConfigSectionML, "dbengine anomaly rate every", 60);
+    unsigned DBEngineAnomalyRateEvery = config_get_number(ConfigSectionML, "dbengine anomaly rate every", 30);
 
     unsigned DiffN = config_get_number(ConfigSectionML, "num samples to diff", 1);
     unsigned SmoothN = config_get_number(ConfigSectionML, "num samples to smooth", 3);
@@ -58,8 +58,8 @@ void Config::readMLConfig(void) {
      * Clamp
      */
 
-    MaxTrainSamples = clamp(MaxTrainSamples, 1 * 3600u, 6 * 3600u);
-    MinTrainSamples = clamp(MinTrainSamples, 1 * 3600u, 6 * 3600u);
+    MaxTrainSamples = clamp(MaxTrainSamples, 1 * 3600u, 24 * 3600u);
+    MinTrainSamples = clamp(MinTrainSamples, 1 * 900u, 6 * 3600u);
     TrainEvery = clamp(TrainEvery, 1 * 3600u, 6 * 3600u);
 
     DBEngineAnomalyRateEvery = clamp(DBEngineAnomalyRateEvery, 1 * 30u, 15 * 60u);


### PR DESCRIPTION
- set `dbengine anomaly rate every` to 30 by default to provide better sorting functionality for anomaly advisor.
- increase upper clamp on `MaxTrainSamples` to 24 hours for those who might like a larger training window on a parent.
- decrease lower clamp on `MinTrainSamples` to 15 minutes to enable faster training of initial models.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Some updates to config options/limits. 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

I have created a node with 30s and one with default of 60s and comparisons of some important metrics can be seen below. Basically it seems like they are very similar profiles. But a 30s aggregation vs a 60s aggregation gives much better sorting performance in terms of quality for the Anomaly Advisor in Netdata Cloud. 

<img width="713" alt="image" src="https://user-images.githubusercontent.com/2178292/165713201-20f81c8c-bc2e-481d-9a42-b3efb6b2689e.png">
<img width="708" alt="image" src="https://user-images.githubusercontent.com/2178292/165713504-f7936022-d7ed-4cdc-8721-8df6a63afaf0.png">
<img width="710" alt="image" src="https://user-images.githubusercontent.com/2178292/165713720-977956a4-04a5-40ac-95f7-ccb376893fac.png">
<img width="716" alt="image" src="https://user-images.githubusercontent.com/2178292/165713829-8ea68523-35af-4ba7-be66-6301dc03acec.png">

We have also previously validated that the ml functionality works fine with a training window of 24 hours so users should be able to extend their training windows to 24 hours if they are ok with the impact of this on their agent or if running such ML on a parent node. 

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
This should increase the quality of the sorting from Anomaly Advisor since more granular aggregations of 30s will be more accurate in typical use cases. 