### PR TITLE
Fix coverity on receiver setsockopt

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -612,7 +612,8 @@ static int rrdpush_receive(struct receiver_state *rpt)
     struct timeval timeout;
     timeout.tv_sec = 120;
     timeout.tv_usec = 0;
-    setsockopt (rpt->fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof timeout);
+    if (unlikely(setsockopt(rpt->fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof timeout) != 0))
+        error("STREAM %s [receive from [%s]:%s]: cannot set timeout for socket %d", rpt->host->hostname, rpt->client_ip, rpt->client_port, rpt->fd);
 
     // convert the socket to a FILE *
     FILE *fp = fdopen(rpt->fd, "r");


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Adds a check on the return value on `setsockopt` to fix coverity report:

```
>>>     CID 352524:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "setsockopt(rpt->fd, 1, 20, &timeout, 16U)" without checking return value. This library function may fail and return an error code.
```

Thanks to @thiagoftsm for reporting!