### PR TITLE
feat(cgroups.plugin): add filtering by cgroups names and improve renaming in k8s

### DIFF
--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -28,7 +28,7 @@ Linux exposes resource usage reporting and provides dynamic configuration for cg
 under `/sys/fs/cgroup`. Netdata reads `/proc/self/mountinfo` to detect the exact mount point of cgroups. Netdata also
 allows manual configuration of this mount point, using these settings:
 
-```
+```text
 [plugin:cgroups]
 	check for new cgroups every = 10
 	path to /sys/fs/cgroup/cpuacct = /sys/fs/cgroup/cpuacct
@@ -47,7 +47,7 @@ recursively searching for cgroups (each subdirectory is another cgroup).
 To provide a sane default for this setting, Netdata uses the following pattern list (patterns starting with `!` give a
 negative match and their order is important: the first matching a path will be used):
 
-```
+```text
 [plugin:cgroups]
 	search for cgroups in subpaths matching =  !*/init.scope  !*-qemu  !/init.scope  !/system  !/systemd  !/user  !/user.slice  *
 ```
@@ -62,7 +62,7 @@ others are enabled.
 Netdata automatically detects cgroups version. If detection fails Netdata assumes v1.
 To switch to v2 manually add:
 
-```
+```text
 [plugin:cgroups]
 	use unified cgroups = yes
 	path to unified cgroups = /sys/fs/cgroup
@@ -78,21 +78,21 @@ following [pattern list](https://learn.netdata.cloud/docs/agent/libnetdata/simpl
 
 - checks the pattern against the path of the cgroup
 
-  ```
+  ```text
   [plugin:cgroups]
   	enable by default cgroups matching =  !*/init.scope  *.scope  !*/vcpu*  !*/emulator  !*.mount  !*.partition  !*.service  !*.slice  !*.swap  !*.user  !/  !/docker  !/libvirt  !/lxc  !/lxc/*/ns  !/lxc/*/ns/*  !/machine  !/qemu  !/system  !/systemd  !/user  *
   ```
 
 - checks the pattern against the name of the cgroup (as you see it on the dashboard)
 
-  ```
+  ```text
   [plugin:cgroups]
   	enable by default cgroups names matching = *
   ```
 
 Renaming is configured with the following options:
 
-```
+```text
 [plugin:cgroups]
 	run script to rename cgroups matching =  *.scope  *docker*  *lxc*  *qemu*  !/  !*.mount  !*.partition  !*.service  !*.slice  !*.swap  !*.user  *
 	script to get cgroup names = /usr/libexec/netdata/plugins.d/cgroup-name.sh
@@ -126,7 +126,7 @@ ignored. Metrics that will start having values, after Netdata is started, will b
 automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a
 chart instead of `auto` to enable it permanently. For example:
 
-```
+```text
 [plugin:cgroups]
 	enable memory (used mem including cache) = yes
 ```
@@ -148,16 +148,16 @@ Netdata monitors **systemd services**. Example:
 
 Support per distribution:
 
-|      system      | systemd services<br/>charts shown |     `tree`<br/>`/sys/fs/cgroup`      | comments                  |
-|:----------------:|:---------------------------------:|:------------------------------------:|:--------------------------|
-|    Arch Linux    |                YES                |                                      |                           |
-|      Gentoo      |                NO                 |                                      | can be enabled, see below |
-| Ubuntu 16.04 LTS |                YES                |                                      |                           |
-|   Ubuntu 16.10   |                YES                | [here](http://pastebin.com/PiWbQEXy) |                           |
-|    Fedora 25     |                YES                | [here](http://pastebin.com/ax0373wF) |                           |
-|     Debian 8     |                NO                 |                                      | can be enabled, see below |
-|       AMI        |                NO                 | [here](http://pastebin.com/FrxmptjL) | not a systemd system      |
-| CentOS 7.3.1611  |                NO                 | [here](http://pastebin.com/SpzgezAg) | can be enabled, see below |
+|      system      | charts shown |        `/sys/fs/cgroup` tree         | comments                  |
+|:----------------:|:------------:|:------------------------------------:|:--------------------------|
+|    Arch Linux    |     YES      |                                      |                           |
+|      Gentoo      |      NO      |                                      | can be enabled, see below |
+| Ubuntu 16.04 LTS |     YES      |                                      |                           |
+|   Ubuntu 16.10   |     YES      | [here](http://pastebin.com/PiWbQEXy) |                           |
+|    Fedora 25     |     YES      | [here](http://pastebin.com/ax0373wF) |                           |
+|     Debian 8     |      NO      |                                      | can be enabled, see below |
+|       AMI        |      NO      | [here](http://pastebin.com/FrxmptjL) | not a systemd system      |
+| CentOS 7.3.1611  |      NO      | [here](http://pastebin.com/SpzgezAg) | can be enabled, see below |
 
 ### Monitored systemd service metrics
 
@@ -199,7 +199,7 @@ sed -e 's|^#Default\(.*\)Accounting=.*$|Default\1Accounting=yes|g' /etc/systemd/
 
 To see the changes it made, run this:
 
-```
+```sh
 # diff /etc/systemd/system.conf /tmp/system.conf
 40,44c40,44
 < #DefaultCPUAccounting=no
@@ -235,7 +235,7 @@ Now, when you run `systemd-cgtop`, services will start reporting usage (if it do
 In case memory accounting is missing, you will need to enable it at your kernel, by appending the following kernel boot
 options and rebooting:
 
-```
+```sh
 cgroup_enable=memory swapaccount=1
 ```
 
@@ -245,7 +245,7 @@ DigitalOcean debian images you may have to set it at `/etc/default/grub.d/50-clo
 
 Which systemd services are monitored by Netdata is determined by the following pattern list:
 
-```
+```text
 [plugin:cgroups]
 	cgroups to match as systemd services =  !/system.slice/*/*.service  /system.slice/*.service
 ```
@@ -308,5 +308,3 @@ cannot find, but immediately:
 
 Network interfaces are monitored by means of
 the [proc plugin](/collectors/proc.plugin/README.md#monitored-network-interface-metrics).
-
-

--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -162,16 +162,16 @@ Netdata monitors **systemd services**. Example:
 
 Support per distribution:
 
-|system|systemd services<br/>charts shown|`tree`<br/>`/sys/fs/cgroup`|comments|
-|:----:|:-------------------------------:|:-------------------------:|:-------|
-|Arch Linux|YES|||
-|Gentoo|NO||can be enabled, see below|
-|Ubuntu 16.04 LTS|YES|||
-|Ubuntu 16.10|YES|[here](http://pastebin.com/PiWbQEXy)||
-|Fedora 25|YES|[here](http://pastebin.com/ax0373wF)||
-|Debian 8|NO||can be enabled, see below|
-|AMI|NO|[here](http://pastebin.com/FrxmptjL)|not a systemd system|
-|CentOS 7.3.1611|NO|[here](http://pastebin.com/SpzgezAg)|can be enabled, see below|
+|      system      | systemd services<br/>charts shown |     `tree`<br/>`/sys/fs/cgroup`      | comments                  |
+|:----------------:|:---------------------------------:|:------------------------------------:|:--------------------------|
+|    Arch Linux    |                YES                |                                      |                           |
+|      Gentoo      |                NO                 |                                      | can be enabled, see below |
+| Ubuntu 16.04 LTS |                YES                |                                      |                           |
+|   Ubuntu 16.10   |                YES                | [here](http://pastebin.com/PiWbQEXy) |                           |
+|    Fedora 25     |                YES                | [here](http://pastebin.com/ax0373wF) |                           |
+|     Debian 8     |                NO                 |                                      | can be enabled, see below |
+|       AMI        |                NO                 | [here](http://pastebin.com/FrxmptjL) | not a systemd system      |
+| CentOS 7.3.1611  |                NO                 | [here](http://pastebin.com/SpzgezAg) | can be enabled, see below |
 
 ### Monitored systemd service metrics
 

--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -228,9 +228,7 @@ sudo systemctl daemon-reexec
 (`systemctl daemon-reload` does not reload the configuration of the server - so you have to
 execute `systemctl daemon-reexec`).
 
-Now, when you run `systemd-cgtop`, services will start reporting usage (if it does not, restart a service - any service
-
-- to wake it up). Refresh your Netdata dashboard, and you will have the charts too.
+Now, when you run `systemd-cgtop`, services will start reporting usage (if it does not, restart any service to wake it up). Refresh your Netdata dashboard, and you will have the charts too.
 
 In case memory accounting is missing, you will need to enable it at your kernel, by appending the following kernel boot
 options and rebooting:

--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -137,8 +137,7 @@ metrics for all internal Netdata plugins.
 ### alarms
 
 CPU and memory limits are watched and used to rise alarms. Memory usage for every cgroup is checked against `ram`
-and `ram+swap` limits. CPU usage for every cgroup is checked against `cpuset.cpus` and `cpu.cfs_period_us`
-+ `cpu.cfs_quota_us` pair assigned for the cgroup. Configuration for the alarms is available in `health.d/cgroups.conf`
+and `ram+swap` limits. CPU usage for every cgroup is checked against `cpuset.cpus` and `cpu.cfs_period_us` + `cpu.cfs_quota_us` pair assigned for the cgroup. Configuration for the alarms is available in `health.d/cgroups.conf`
 file.
 
 ## Monitoring systemd services

--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -7,11 +7,15 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/cgrou
 
 You can monitor containers and virtual machines using **cgroups**.
 
-cgroups (or control groups), are a Linux kernel feature that provides accounting and resource usage limiting for processes. When cgroups are bundled with namespaces (i.e. isolation), they form what we usually call **containers**.
+cgroups (or control groups), are a Linux kernel feature that provides accounting and resource usage limiting for
+processes. When cgroups are bundled with namespaces (i.e. isolation), they form what we usually call **containers**.
 
-cgroups are hierarchical, meaning that cgroups can contain child cgroups, which can contain more cgroups, etc. All accounting is reported (and resource usage limits are applied) also in a hierarchical way.
+cgroups are hierarchical, meaning that cgroups can contain child cgroups, which can contain more cgroups, etc. All
+accounting is reported (and resource usage limits are applied) also in a hierarchical way.
 
-To visualize cgroup metrics Netdata provides configuration for cherry picking the cgroups of interest. By default (without any configuration) Netdata should pick **systemd services**, all kinds of **containers** (lxc, docker, etc) and **virtual machines** spawn by managers that register them with cgroups (qemu, libvirt, etc).
+To visualize cgroup metrics Netdata provides configuration for cherry picking the cgroups of interest. By default (
+without any configuration) Netdata should pick **systemd services**, all kinds of **containers** (lxc, docker, etc)
+and **virtual machines** spawn by managers that register them with cgroups (qemu, libvirt, etc).
 
 ## configuring Netdata for cgroups
 
@@ -28,7 +32,9 @@ Below we see, how this works.
 
 ### how Netdata finds the available cgroups
 
-Linux exposes resource usage reporting and provides dynamic configuration for cgroups, using virtual files (usually) under `/sys/fs/cgroup`. Netdata reads `/proc/self/mountinfo` to detect the exact mount point of cgroups. Netdata also allows manual configuration of this mount point, using these settings:
+Linux exposes resource usage reporting and provides dynamic configuration for cgroups, using virtual files (usually)
+under `/sys/fs/cgroup`. Netdata reads `/proc/self/mountinfo` to detect the exact mount point of cgroups. Netdata also
+allows manual configuration of this mount point, using these settings:
 
 ```
 [plugin:cgroups]
@@ -43,16 +49,21 @@ Netdata rescans these directories for added or removed cgroups every `check for 
 
 ### hierarchical search for cgroups
 
-Since cgroups are hierarchical, for each of the directories shown above, Netdata walks through the subdirectories recursively searching for cgroups (each subdirectory is another cgroup).
+Since cgroups are hierarchical, for each of the directories shown above, Netdata walks through the subdirectories
+recursively searching for cgroups (each subdirectory is another cgroup).
 
-To provide a sane default for this setting, Netdata uses the following pattern list (patterns starting with `!` give a negative match and their order is important: the first matching a path will be used):
+To provide a sane default for this setting, Netdata uses the following pattern list (patterns starting with `!` give a
+negative match and their order is important: the first matching a path will be used):
 
 ```
 [plugin:cgroups]
 	search for cgroups in subpaths matching =  !*/init.scope  !*-qemu  !/init.scope  !/system  !/systemd  !/user  !/user.slice  *
 ```
 
-So, we disable checking for **child cgroups** in systemd internal cgroups ([systemd services are monitored by Netdata](#monitoring-systemd-services)), user cgroups (normally used for desktop and remote user sessions), qemu virtual machines (child cgroups of virtual machines) and `init.scope`. All others are enabled.
+So, we disable checking for **child cgroups** in systemd internal
+cgroups ([systemd services are monitored by Netdata](#monitoring-systemd-services)), user cgroups (normally used for
+desktop and remote user sessions), qemu virtual machines (child cgroups of virtual machines) and `init.scope`. All
+others are enabled.
 
 ### unified cgroups (cgroups v2) support
 
@@ -64,7 +75,8 @@ Basic unified cgroups metrics are supported. To use them instead of v1 cgroups a
 	path to unified cgroups = /sys/fs/cgroup
 ```
 
-Unified cgroups use same name pattern matching as v1 cgroups. `cgroup_enable_systemd_services_detailed_memory` is currently unsupported when using unified cgroups.
+Unified cgroups use same name pattern matching as v1 cgroups. `cgroup_enable_systemd_services_detailed_memory` is
+currently unsupported when using unified cgroups.
 
 ### enabled cgroups
 
@@ -75,16 +87,21 @@ To check if the cgroup is enabled, Netdata uses this setting:
 	enable cgroup NAME = yes | no
 ```
 
-To provide a sane default, Netdata uses the following pattern list (it checks the pattern against the path of the cgroup):
+To provide a sane default, Netdata uses the following pattern list (it checks the pattern against the path of the
+cgroup):
 
 ```
 [plugin:cgroups]
 	enable by default cgroups matching =  !*/init.scope  *.scope  !*/vcpu*  !*/emulator  !*.mount  !*.partition  !*.service  !*.slice  !*.swap  !*.user  !/  !/docker  !/libvirt  !/lxc  !/lxc/*/ns  !/lxc/*/ns/*  !/machine  !/qemu  !/system  !/systemd  !/user  *
 ```
 
-The above provides the default `yes` or `no` setting for the cgroup. However, there is an additional step. In many cases the cgroups found in the `/sys/fs/cgroup` hierarchy are just random numbers and in many cases these numbers are ephemeral: they change across reboots or sessions.
+The above provides the default `yes` or `no` setting for the cgroup. However, there is an additional step. In many cases
+the cgroups found in the `/sys/fs/cgroup` hierarchy are just random numbers and in many cases these numbers are
+ephemeral: they change across reboots or sessions.
 
-So, we need to somehow map the paths of the cgroups to names, to provide consistent Netdata configuration (i.e. there is no point to say `enable cgroup 1234 = yes | no`, if `1234` is a random number that changes over time - we need a name for the cgroup first, so that `enable cgroup NAME = yes | no` will be consistent).
+So, we need to somehow map the paths of the cgroups to names, to provide consistent Netdata configuration (i.e. there is
+no point to say `enable cgroup 1234 = yes | no`, if `1234` is a random number that changes over time - we need a name
+for the cgroup first, so that `enable cgroup NAME = yes | no` will be consistent).
 
 For this mapping Netdata provides 2 configuration options:
 
@@ -94,32 +111,48 @@ For this mapping Netdata provides 2 configuration options:
 	script to get cgroup names = /usr/libexec/netdata/plugins.d/cgroup-name.sh
 ```
 
-The whole point for the additional pattern list, is to limit the number of times the script will be called. Without this pattern list, the script might be called thousands of times, depending on the number of cgroups available in the system.
+The whole point for the additional pattern list, is to limit the number of times the script will be called. Without this
+pattern list, the script might be called thousands of times, depending on the number of cgroups available in the system.
 
-The above pattern list is matched against the path of the cgroup. For matched cgroups, Netdata calls the script [cgroup-name.sh](https://raw.githubusercontent.com/netdata/netdata/master/collectors/cgroups.plugin/cgroup-name.sh.in) to get its name. This script queries `docker`, `kubectl`, `podman`, or applies heuristics to find give a name for the cgroup.
+The above pattern list is matched against the path of the cgroup. For matched cgroups, Netdata calls the
+script [cgroup-name.sh](https://raw.githubusercontent.com/netdata/netdata/master/collectors/cgroups.plugin/cgroup-name.sh.in)
+to get its name. This script queries `docker`, `kubectl`, `podman`, or applies heuristics to find give a name for the
+cgroup.
 
 #### Note on Podman container names
 
-Podman's security model is a lot more restrictive than Docker's, so Netdata will not be able to detect container names out of the box unless they were started by the same user as Netdata itself.
+Podman's security model is a lot more restrictive than Docker's, so Netdata will not be able to detect container names
+out of the box unless they were started by the same user as Netdata itself.
 
-If Podman is used in "rootful" mode, it's also possible to use `podman system service` to grant Netdata access to container names. To do this, ensure `podman system service` is running and Netdata has access to `/run/podman/podman.sock` (the default permissions as specified by upstream are `0600`, with owner `root`, so you will have to adjust the configuration).
+If Podman is used in "rootful" mode, it's also possible to use `podman system service` to grant Netdata access to
+container names. To do this, ensure `podman system service` is running and Netdata has access
+to `/run/podman/podman.sock` (the default permissions as specified by upstream are `0600`, with owner `root`, so you
+will have to adjust the configuration).
 
-[docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) can also be used to give Netdata restricted access to the socket. Note that `PODMAN_HOST` in Netdata's environment should be set to the proxy's URL in this case.
+[docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) can also be used to give Netdata restricted
+access to the socket. Note that `PODMAN_HOST` in Netdata's environment should be set to the proxy's URL in this case.
 
 ### charts with zero metrics
 
-By default, Netdata will enable monitoring metrics only when they are not zero. If they are constantly zero they are ignored. Metrics that will start having values, after Netdata is started, will be detected and charts will be automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a chart instead of `auto` to enable it permanently. For example:
+By default, Netdata will enable monitoring metrics only when they are not zero. If they are constantly zero they are
+ignored. Metrics that will start having values, after Netdata is started, will be detected and charts will be
+automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a
+chart instead of `auto` to enable it permanently. For example:
 
 ```
 [plugin:cgroups]
 	enable memory (used mem including cache) = yes
 ```
 
-You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero metrics for all internal Netdata plugins.
+You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero
+metrics for all internal Netdata plugins.
 
 ### alarms
 
-CPU and memory limits are watched and used to rise alarms. Memory usage for every cgroup is checked against `ram` and `ram+swap` limits. CPU usage for every cgroup is checked against `cpuset.cpus` and `cpu.cfs_period_us` + `cpu.cfs_quota_us` pair assigned for the cgroup. Configuration for the alarms is available in `health.d/cgroups.conf` file.
+CPU and memory limits are watched and used to rise alarms. Memory usage for every cgroup is checked against `ram`
+and `ram+swap` limits. CPU usage for every cgroup is checked against `cpuset.cpus` and `cpu.cfs_period_us`
++ `cpu.cfs_quota_us` pair assigned for the cgroup. Configuration for the alarms is available in `health.d/cgroups.conf`
+file.
 
 ## Monitoring systemd services
 
@@ -142,34 +175,35 @@ Support per distribution:
 
 ### Monitored systemd service metrics
 
-- CPU utilization
-- Used memory
-- RSS memory
-- Mapped memory
-- Cache memory
-- Writeback memory
-- Memory minor page faults
-- Memory major page faults
-- Memory charging activity
-- Memory uncharging activity
-- Memory limit failures
-- Swap memory used
-- Disk read bandwidth
-- Disk write bandwidth
-- Disk read operations
-- Disk write operations
-- Throttle disk read bandwidth
-- Throttle disk write bandwidth
-- Throttle disk read operations
-- Throttle disk write operations
-- Queued disk read operations
-- Queued disk write operations
-- Merged disk read operations
-- Merged disk write operations
+- CPU utilization
+- Used memory
+- RSS memory
+- Mapped memory
+- Cache memory
+- Writeback memory
+- Memory minor page faults
+- Memory major page faults
+- Memory charging activity
+- Memory uncharging activity
+- Memory limit failures
+- Swap memory used
+- Disk read bandwidth
+- Disk write bandwidth
+- Disk read operations
+- Disk write operations
+- Throttle disk read bandwidth
+- Throttle disk write bandwidth
+- Throttle disk read operations
+- Throttle disk write operations
+- Queued disk read operations
+- Queued disk write operations
+- Merged disk read operations
+- Merged disk write operations
 
 ### how to enable cgroup accounting on systemd systems that is by default disabled
 
-You can verify there is no accounting enabled, by running `systemd-cgtop`. The program will show only resources for cgroup `/`, but all services will show nothing.
+You can verify there is no accounting enabled, by running `systemd-cgtop`. The program will show only resources for
+cgroup `/`, but all services will show nothing.
 
 To enable cgroup accounting, execute this:
 
@@ -205,17 +239,22 @@ sudo cp /tmp/system.conf /etc/systemd/system.conf
 sudo systemctl daemon-reexec
 ```
 
-(`systemctl daemon-reload` does not reload the configuration of the server - so you have to execute `systemctl daemon-reexec`).
+(`systemctl daemon-reload` does not reload the configuration of the server - so you have to
+execute `systemctl daemon-reexec`).
 
-Now, when you run `systemd-cgtop`, services will start reporting usage (if it does not, restart a service - any service - to wake it up). Refresh your Netdata dashboard, and you will have the charts too.
+Now, when you run `systemd-cgtop`, services will start reporting usage (if it does not, restart a service - any service
+- to wake it up). Refresh your Netdata dashboard, and you will have the charts too.
 
-In case memory accounting is missing, you will need to enable it at your kernel, by appending the following kernel boot options and rebooting:
+In case memory accounting is missing, you will need to enable it at your kernel, by appending the following kernel boot
+options and rebooting:
 
 ```
 cgroup_enable=memory swapaccount=1
 ```
 
-You can add the above, directly at the `linux` line in your `/boot/grub/grub.cfg` or appending them to the `GRUB_CMDLINE_LINUX` in `/etc/default/grub` (in which case you will have to run `update-grub` before rebooting). On DigitalOcean debian images you may have to set it at `/etc/default/grub.d/50-cloudimg-settings.cfg`.
+You can add the above, directly at the `linux` line in your `/boot/grub/grub.cfg` or appending them to
+the `GRUB_CMDLINE_LINUX` in `/etc/default/grub` (in which case you will have to run `update-grub` before rebooting). On
+DigitalOcean debian images you may have to set it at `/etc/default/grub.d/50-cloudimg-settings.cfg`.
 
 Which systemd services are monitored by Netdata is determined by the following pattern list:
 
@@ -228,53 +267,59 @@ Which systemd services are monitored by Netdata is determined by the following p
 
 ## Monitoring ephemeral containers
 
-Netdata monitors containers automatically when it is installed at the host, or when it is installed in a container that has access to the `/proc` and `/sys` filesystems of the host.
+Netdata monitors containers automatically when it is installed at the host, or when it is installed in a container that
+has access to the `/proc` and `/sys` filesystems of the host.
 
 Netdata prior to v1.6 had 2 issues when such containers were monitored:
 
-1.  network interface alarms where triggering when containers were stopped
+1. network interface alarms where triggering when containers were stopped
 
-2.  charts were never cleaned up, so after some time dozens of containers were showing up on the dashboard, and they were occupying memory.
+2. charts were never cleaned up, so after some time dozens of containers were showing up on the dashboard, and they were
+   occupying memory.
 
 ### the current Netdata
 
 network interfaces and cgroups (containers) are now self-cleaned.
 
-So, when a network interface or container stops, Netdata might log a few errors in error.log complaining about files it cannot find, but immediately:
+So, when a network interface or container stops, Netdata might log a few errors in error.log complaining about files it
+cannot find, but immediately:
 
-1.  it will detect this is a removed container or network interface
-2.  it will freeze/pause all alarms for them
-3.  it will mark their charts as obsolete
-4.  obsolete charts are not be offered on new dashboard sessions (so hit F5 and the charts are gone)
-5.  existing dashboard sessions will continue to see them, but of course they will not refresh
-6.  obsolete charts will be removed from memory, 1 hour after the last user viewed them (configurable with `[global].cleanup obsolete charts after seconds = 3600` (at `netdata.conf`).
-7.  when obsolete charts are removed from memory they are also deleted from disk (configurable with `[global].delete obsolete charts files = yes`)
+1. it will detect this is a removed container or network interface
+2. it will freeze/pause all alarms for them
+3. it will mark their charts as obsolete
+4. obsolete charts are not be offered on new dashboard sessions (so hit F5 and the charts are gone)
+5. existing dashboard sessions will continue to see them, but of course they will not refresh
+6. obsolete charts will be removed from memory, 1 hour after the last user viewed them (configurable
+   with `[global].cleanup obsolete charts after seconds = 3600` (at `netdata.conf`).
+7. when obsolete charts are removed from memory they are also deleted from disk (configurable
+   with `[global].delete obsolete charts files = yes`)
 
 ### Monitored container metrics
 
-- CPU usage
-- CPU usage within the limits
-- CPU usage per core
-- Memory usage
-- Writeback memory
-- Memory activity
-- Memory page faults
-- Used memory
-- Used RAM within the limits
-- Memory utilization
-- Memory limit failures
-- I/O bandwidth (all disks)
-- Serviced I/O operations (all disks)
-- Throttle I/O bandwidth (all disks)
-- Throttle serviced I/O operations (all disks)
-- Queued I/O operations (all disks)
-- Merged I/O operations (all disks)
-- CPU pressure
-- Memory pressure
-- Memory full pressure
-- I/O pressure
-- I/O full pressure
-  
-Network interfaces are monitored by means of the [proc plugin](/collectors/proc.plugin/README.md#monitored-network-interface-metrics).
+- CPU usage
+- CPU usage within the limits
+- CPU usage per core
+- Memory usage
+- Writeback memory
+- Memory activity
+- Memory page faults
+- Used memory
+- Used RAM within the limits
+- Memory utilization
+- Memory limit failures
+- I/O bandwidth (all disks)
+- Serviced I/O operations (all disks)
+- Throttle I/O bandwidth (all disks)
+- Throttle serviced I/O operations (all disks)
+- Queued I/O operations (all disks)
+- Merged I/O operations (all disks)
+- CPU pressure
+- Memory pressure
+- Memory full pressure
+- I/O pressure
+- I/O full pressure
+
+Network interfaces are monitored by means of
+the [proc plugin](/collectors/proc.plugin/README.md#monitored-network-interface-metrics).
 
 

--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -115,7 +115,7 @@ The whole point for the additional pattern list, is to limit the number of times
 pattern list, the script might be called thousands of times, depending on the number of cgroups available in the system.
 
 The above pattern list is matched against the path of the cgroup. For matched cgroups, Netdata calls the
-script [cgroup-name.sh](https://raw.githubusercontent.com/netdata/netdata/master/collectors/cgroups.plugin/cgroup-name.sh.in)
+script [cgroup-name.sh](https://raw.githubusercontent.com/netdata/netdata/master/collectors/cgroups.plugin/cgroup-name.sh)
 to get its name. This script queries `docker`, `kubectl`, `podman`, or applies heuristics to find give a name for the
 cgroup.
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1912,19 +1912,25 @@ static inline void convert_cgroup_to_systemd_service(struct cgroup *cg) {
 
     // skip to the last slash
     size_t len = strlen(s);
-    while (len--)
-        if (unlikely(s[len] == '/'))
+    while (len--) {
+        if (unlikely(s[len] == '/')) {
             break;
-    if (len)
+        }
+    }
+    if (len) {
         s = &s[len + 1];
+    }
 
     // remove extension
     len = strlen(s);
-    while (len--)
-        if (unlikely(s[len] == '.'))
+    while (len--) {
+        if (unlikely(s[len] == '.')) {
             break;
-    if (len)
+        }
+    }
+    if (len) {
         s[len] = '\0';
+    }
 
     freez(cg->chart_title);
     cg->chart_title = cgroup_title_strdupz(s);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -4707,7 +4707,6 @@ void *cgroups_main(void *ptr) {
     usec_t step = cgroup_update_every * USEC_PER_SEC;
     usec_t find_every = cgroup_check_for_new_every * USEC_PER_SEC, find_dt = 0;
 
-    int init_discovery = 1;
     while(!netdata_exit) {
         usec_t hb_dt = heartbeat_next(&hb, step);
         if(unlikely(netdata_exit)) break;
@@ -4718,7 +4717,6 @@ void *cgroups_main(void *ptr) {
             discovery_thread.start_discovery = 1;
             find_dt = 0;
             cgroups_check = 0;
-            init_discovery = 0;
         }
 
         uv_mutex_lock(&cgroup_root_mutex);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2113,7 +2113,7 @@ static inline void discovery_update_filenames() {
                 else
                     debug(D_CGROUP, "cpuacct.usage_percpu file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
-            if(unlikely(cgroup_enable_cpuacct_cpu_throttling && !cg->cpuacct_cpu_throttling.filename && is_cgroup_systemd_service(cg))) {
+            if(unlikely(cgroup_enable_cpuacct_cpu_throttling && !cg->cpuacct_cpu_throttling.filename && !is_cgroup_systemd_service(cg))) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpu.stat", cgroup_cpuacct_base, cg->id);
                 if(likely(stat(filename, &buf) != -1)) {
                     cg->cpuacct_cpu_throttling.filename = strdupz(filename);
@@ -2604,7 +2604,7 @@ static inline void discovery_process_cgroup(struct cgroup *cg) {
         return;
     }
 
-    if (!(cg->enabled && (cg->enabled = matches_enabled_cgroup_paths(cg->id)))) {
+    if (!(cg->enabled = matches_enabled_cgroup_paths(cg->id))) {
         return;
     }
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -907,7 +907,7 @@ static int k8s_is_container(const char *id) {
     const char *p = id;
     const char *pp = NULL;
     int i = 0;
-    size_t l = strlen("pod");
+    size_t l = 3; // pod
     while ((p = strstr(p, "pod"))) {
         i++;
         p += l;
@@ -2504,6 +2504,7 @@ static inline void discovery_find_all_cgroups_v1() {
             error("CGROUP: disabled cpu statistics.");
         }
     }
+
     if (cgroup_enable_blkio_io || cgroup_enable_blkio_ops || cgroup_enable_blkio_throttle_io ||
         cgroup_enable_blkio_throttle_ops || cgroup_enable_blkio_merged_ops || cgroup_enable_blkio_queued_ops) {
         if (discovery_find_dir_in_subdirs(cgroup_blkio_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
@@ -2513,6 +2514,7 @@ static inline void discovery_find_all_cgroups_v1() {
             error("CGROUP: disabled blkio statistics.");
         }
     }
+
     if (cgroup_enable_memory || cgroup_enable_detailed_memory || cgroup_enable_swap || cgroup_enable_memory_failcnt) {
         if (discovery_find_dir_in_subdirs(cgroup_memory_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
             cgroup_enable_memory = cgroup_enable_detailed_memory = cgroup_enable_swap = cgroup_enable_memory_failcnt =
@@ -2520,6 +2522,7 @@ static inline void discovery_find_all_cgroups_v1() {
             error("CGROUP: disabled memory statistics.");
         }
     }
+
     if (cgroup_search_in_devices) {
         if (discovery_find_dir_in_subdirs(cgroup_devices_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
             cgroup_search_in_devices = 0;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2541,7 +2541,7 @@ static inline void discovery_process_first_time_seen_cgroup(struct cgroup *cg) {
     }
     cg->first_time_seen = 0;
 
-    char comm[TASK_COMM_LEN] = "";
+    char comm[TASK_COMM_LEN];
 
     if (is_inside_k8s && !k8s_get_container_first_proc_comm(cg->id, comm)) {
         // container initialization may take some time when CPU % is high

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2589,6 +2589,10 @@ static int discovery_is_cgroup_duplicate(struct cgroup *cg) {
 }
 
 static inline void discovery_process_cgroup(struct cgroup *cg) {
+    if (!cg) {
+        debug(D_CGROUP, "discovery_process_cgroup() received NULL");
+        return;
+    }
     if (!cg->available || cg->processed) {
         return;
     }

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1826,7 +1826,6 @@ static inline void discovery_rename_cgroup(struct cgroup *cg) {
     debug(D_CGROUP, "looking for the name of cgroup '%s' with chart id '%s' and title '%s'", cg->id, cg->chart_id, cg->chart_title);
     debug(D_CGROUP, "executing command %s \"%s\" for cgroup '%s'", cgroups_rename_script, cg->intermediate_id, cg->chart_id);
     pid_t cgroup_pid;
-    char command[CGROUP_CHARTID_LINE_MAX + 1];
 
     FILE *fp;
     (void)mypopen_raw_default_flags_and_environment(&cgroup_pid, &fp, cgroups_rename_script, cg->id, cg->intermediate_id);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -974,7 +974,7 @@ static int k8s_get_container_first_proc_comm(const char *id, char *comm) {
         return 1;
     }
 
-    strncpy(comm, proc_comm, TASK_COMM_LEN);
+    strncpyz(comm, proc_comm, TASK_COMM_LEN);
     return 0;
 }
 
@@ -1905,9 +1905,9 @@ static void is_cgroup_procs_exist(netdata_ebpf_cgroup_shm_body_t *out, char *id)
 }
 
 static inline void convert_cgroup_to_systemd_service(struct cgroup *cg) {
-    char buffer[CGROUP_CHARTID_LINE_MAX + 1];
+    char buffer[CGROUP_CHARTID_LINE_MAX];
     cg->options |= CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE;
-    strncpy(buffer, cg->id, CGROUP_CHARTID_LINE_MAX);
+    strncpyz(buffer, cg->id, CGROUP_CHARTID_LINE_MAX);
     char *s = buffer;
 
     // skip to the last slash

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -9,6 +9,8 @@
 // ----------------------------------------------------------------------------
 // cgroup globals
 
+static int is_inside_k8s = 0;
+
 static long system_page_size = 4096; // system will be queried via sysconf() in configuration()
 
 static int cgroup_enable_cpuacct_stat = CONFIG_BOOLEAN_AUTO;
@@ -41,6 +43,9 @@ static int cgroup_unified_exist = CONFIG_BOOLEAN_AUTO;
 static int cgroup_search_in_devices = 1;
 
 static int cgroup_enable_new_cgroups_detected_at_runtime = 1;
+
+static int cgroup_renaming_tries = 2;
+
 static int cgroup_check_for_new_every = 10;
 static int cgroup_update_every = 1;
 static int cgroup_containers_chart_priority = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS;
@@ -60,8 +65,9 @@ static int cgroup_root_count = 0;
 static int cgroup_root_max = 1000;
 static int cgroup_max_depth = 0;
 
-static SIMPLE_PATTERN *enabled_cgroup_patterns = NULL;
 static SIMPLE_PATTERN *enabled_cgroup_paths = NULL;
+static SIMPLE_PATTERN *enabled_cgroup_names = NULL;
+static SIMPLE_PATTERN *search_cgroup_paths = NULL;
 static SIMPLE_PATTERN *enabled_cgroup_renames = NULL;
 static SIMPLE_PATTERN *systemd_services_cgroups = NULL;
 
@@ -270,6 +276,11 @@ void read_cgroup_plugin_configuration() {
     cgroup_check_for_new_every = (int)config_get_number("plugin:cgroups", "check for new cgroups every", (long long)cgroup_check_for_new_every * (long long)cgroup_update_every);
     if(cgroup_check_for_new_every < cgroup_update_every)
         cgroup_check_for_new_every = cgroup_update_every;
+    
+    cgroup_renaming_tries = config_get_number("plugin:cgroups", "cgroup renaming tries", cgroup_renaming_tries);
+    if (cgroup_renaming_tries < 1) {
+        cgroup_renaming_tries = 1;
+    }
 
     cgroup_use_unified_cgroups = config_get_boolean_ondemand("plugin:cgroups", "use unified cgroups", CONFIG_BOOLEAN_AUTO);
     if(cgroup_use_unified_cgroups == CONFIG_BOOLEAN_AUTO)
@@ -411,7 +422,7 @@ void read_cgroup_plugin_configuration() {
 
     cgroup_enable_new_cgroups_detected_at_runtime = config_get_boolean("plugin:cgroups", "enable new cgroups detected at run time", cgroup_enable_new_cgroups_detected_at_runtime);
 
-    enabled_cgroup_patterns = simple_pattern_create(
+    enabled_cgroup_paths = simple_pattern_create(
             config_get("plugin:cgroups", "enable by default cgroups matching",
             // ----------------------------------------------------------------
 
@@ -453,7 +464,12 @@ void read_cgroup_plugin_configuration() {
                     " * "                                  // enable anything else
             ), NULL, SIMPLE_PATTERN_EXACT);
 
-    enabled_cgroup_paths = simple_pattern_create(
+    enabled_cgroup_names = simple_pattern_create(
+            config_get("plugin:cgroups", "enable by default cgroups matching names",
+                    " * "
+            ), NULL, SIMPLE_PATTERN_EXACT);
+
+    search_cgroup_paths = simple_pattern_create(
             config_get("plugin:cgroups", "search for cgroups in subpaths matching",
                     " !*/init.scope "                      // ignore init.scope
                     " !*-qemu "                            //  #345
@@ -730,6 +746,9 @@ struct cgroup_network_interface {
 struct cgroup {
     uint32_t options;
 
+    int first_time_seen;    // set when first time seen by the discovery worker
+    int skip;               // set when should be skipped by the discovery worker (e.g.: 'pause' container in K8s)
+
     char available;      // found in the filesystem
     char enabled;        // enabled in the config
 
@@ -859,7 +878,114 @@ struct discovery_thread {
     int exited;
 } discovery_thread;
 
-// ----------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------
+
+static inline int matches_enabled_cgroup_paths(char *id) {
+    if (!cgroup_enable_new_cgroups_detected_at_runtime) {
+        return 0;
+    }
+    return simple_pattern_matches(enabled_cgroup_paths, id);
+}
+
+static inline int matches_enabled_cgroup_names(char *name) {
+    return simple_pattern_matches(enabled_cgroup_names, name);
+}
+
+static inline int matches_enabled_cgroup_renames(char *id) {
+    return simple_pattern_matches(enabled_cgroup_renames, id);
+}
+
+static inline int matches_systemd_services_cgroups(char *id) {
+    return simple_pattern_matches(systemd_services_cgroups, id);
+}
+
+static inline int matches_search_cgroup_paths(const char *dir) {
+    return simple_pattern_matches(search_cgroup_paths, dir);
+}
+
+static inline int is_cgroup_systemd_service(struct cgroup *cg) {
+    return (cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE);
+}
+
+// ---------------------------------------------------------------------------------------------
+static int k8s_is_container(const char *id) {
+    // examples:
+    // https://github.com/netdata/netdata/blob/0fc101679dcd12f1cb8acdd07bb4c85d8e553e53/collectors/cgroups.plugin/cgroup-name.sh#L121-L147
+    const char *p = id;
+    const char *pp = NULL;
+    int i = 0;
+    size_t l = strlen("pod");
+    while ((p = strstr(p, "pod"))) {
+        i++;
+        p += l;
+        pp = p;
+    }
+    return !(i < 2 || !pp || !(pp = strchr(pp, '/')) || !pp++ || !*pp);
+}
+
+#define TASK_COMM_LEN 16
+
+static int k8s_get_container_first_proc_comm(const char *id, char *comm) {
+    if (!k8s_is_container(id)) {
+        return 1;
+    }
+
+    static procfile *ff = NULL;
+
+    char filename[FILENAME_MAX + 1];
+    snprintfz(filename, FILENAME_MAX, "%s/%s/cgroup.procs", cgroup_cpuacct_base, id);
+
+    ff = procfile_reopen(ff, filename, NULL, PROCFILE_FLAG_DEFAULT);
+    if (unlikely(!ff)) {
+        debug(D_CGROUP, "CGROUP: k8s_is_pause_container(): cannot open file '%s'.", filename);
+        return 1;
+    }
+
+    ff = procfile_readall(ff);
+    if (unlikely(!ff)) {
+        debug(D_CGROUP, "CGROUP: k8s_is_pause_container(): cannot read file '%s'.", filename);
+        return 1;
+    }
+
+    unsigned long lines = procfile_lines(ff);
+    if (likely(lines < 2)) {
+        return 1;
+    }
+
+    char *pid = procfile_lineword(ff, 0, 0);
+    if (!pid || !*pid) {
+        return 1;
+    }
+
+    snprintfz(filename, FILENAME_MAX, "%s/proc/%s/comm", netdata_configured_host_prefix, pid);
+
+    ff = procfile_reopen(ff, filename, NULL, PROCFILE_FLAG_DEFAULT);
+    if (unlikely(!ff)) {
+        debug(D_CGROUP, "CGROUP: k8s_is_pause_container(): cannot open file '%s'.", filename);
+        return 1;
+    }
+
+    ff = procfile_readall(ff);
+    if (unlikely(!ff)) {
+        debug(D_CGROUP, "CGROUP: k8s_is_pause_container(): cannot read file '%s'.", filename);
+        return 1;
+    }
+
+    lines = procfile_lines(ff);
+    if (unlikely(lines != 2)) {
+        return 1;
+    }
+
+    char *proc_comm = procfile_lineword(ff, 0, 0);
+    if (!proc_comm || !*proc_comm) {
+        return 1;
+    }
+
+    strncpy(comm, proc_comm, TASK_COMM_LEN);
+    return 0;
+}
+
+// ---------------------------------------------------------------------------------------------
 
 static unsigned long long calc_delta(unsigned long long curr, unsigned long long prev) {
     if (prev > curr) {
@@ -873,6 +999,15 @@ static unsigned long long calc_percentage(unsigned long long value, unsigned lon
         return 0;
     }
     return (calculated_number)value / (calculated_number)total * 100;
+}
+
+static int calc_cgroup_depth(const char *id) {
+    int depth = 0;
+    const char *s;
+    for (s = id; *s; s++) {
+        depth += unlikely(*s == '/');
+    }
+    return depth;
 }
 
 // ----------------------------------------------------------------------------
@@ -1429,7 +1564,7 @@ memory_next:
     }
 }
 
-static inline void cgroup_read(struct cgroup *cg) {
+static inline void read_cgroup(struct cgroup *cg) {
     debug(D_CGROUP, "reading metrics for cgroups '%s'", cg->id);
     if(!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
         cgroup_read_cpuacct_stat(&cg->cpuacct_stat);
@@ -1457,14 +1592,15 @@ static inline void cgroup_read(struct cgroup *cg) {
     }
 }
 
-static inline void read_all_cgroups(struct cgroup *root) {
+static inline void read_all_discovered_cgroups(struct cgroup *root) {
     debug(D_CGROUP, "reading metrics for all cgroups");
 
     struct cgroup *cg;
-
-    for(cg = root; cg ; cg = cg->next)
-        if(cg->enabled && !cg->pending_renames)
-            cgroup_read(cg);
+    for (cg = root; cg; cg = cg->next) {
+        if (cg->enabled && !cg->pending_renames) {
+            read_cgroup(cg);
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -1582,8 +1718,7 @@ static inline void substitute_dots_in_id(char *s) {
     }
 }
 
-char *parse_k8s_data(struct label **labels, char *data)
-{
+char *k8s_parse_resolved_name(struct label **labels, char *data) {
     char *name = mystrsep(&data, " ");
     
     if (!data) {
@@ -1609,181 +1744,6 @@ char *parse_k8s_data(struct label **labels, char *data)
     }
 
     return name;
-}
-
-static inline void cgroup_get_chart_name(struct cgroup *cg) {
-    debug(D_CGROUP, "looking for the name of cgroup '%s' with chart id '%s' and title '%s'", cg->id, cg->chart_id, cg->chart_title);
-
-    pid_t cgroup_pid;
-    // TODO: use cg->id when the renaming script is fixed
-    debug(D_CGROUP, "executing command %s \"%s\" for cgroup '%s'", cgroups_rename_script, cg->intermediate_id, cg->chart_id);
-    FILE *fp;
-    (void)mypopen_raw_default_flags_and_environment(&cgroup_pid, &fp, cgroups_rename_script, cg->intermediate_id);
-    if(fp) {
-        // debug(D_CGROUP, "reading from command '%s' for cgroup '%s'", command, cg->id);
-        char buffer[CGROUP_CHARTID_LINE_MAX + 1];
-        char *s = fgets(buffer, CGROUP_CHARTID_LINE_MAX, fp);
-        // debug(D_CGROUP, "closing command for cgroup '%s'", cg->id);
-        int name_error = mypclose(fp, cgroup_pid);
-        // debug(D_CGROUP, "closed command for cgroup '%s'", cg->id);
-
-        if(s && *s && *s != '\n') {
-            debug(D_CGROUP, "cgroup '%s' should be renamed to '%s'", cg->chart_id, s);
-
-            s = trim(s);
-            if (s) {
-                if(likely(name_error==0))
-                    cg->pending_renames = 0;
-                else if (unlikely(name_error==3)) {
-                    debug(D_CGROUP, "cgroup '%s' disabled based due to rename command output", cg->chart_id);
-                    cg->enabled = 0;
-                }
-
-                if (likely(cg->pending_renames < 2)) {
-                    char *name = s;
-
-                    if (!strncmp(s, "k8s_", 4)) {
-                        free_label_list(cg->chart_labels);
-                        name = parse_k8s_data(&cg->chart_labels, s);
-                    }
-
-                    freez(cg->chart_title);
-                    cg->chart_title = cgroup_title_strdupz(name);
-
-                    freez(cg->chart_id);
-                    cg->chart_id = cgroup_chart_id_strdupz(name);
-                    substitute_dots_in_id(cg->chart_id);
-                    cg->hash_chart = simple_hash(cg->chart_id);
-                }
-            }
-        }
-    }
-    else
-        error("CGROUP: cannot popen(%s \"%s\", \"r\").", cgroups_rename_script, cg->intermediate_id);
-}
-
-static inline struct cgroup *cgroup_add(const char *id) {
-    if(!id || !*id) id = "/";
-    debug(D_CGROUP, "adding to list, cgroup with id '%s'", id);
-
-    if(cgroup_root_count >= cgroup_root_max) {
-        info("CGROUP: maximum number of cgroups reached (%d). Not adding cgroup '%s'", cgroup_root_count, id);
-        return NULL;
-    }
-
-    int def = simple_pattern_matches(enabled_cgroup_patterns, id)?cgroup_enable_new_cgroups_detected_at_runtime:0;
-    struct cgroup *cg = callocz(1, sizeof(struct cgroup));
-
-    cg->id = strdupz(id);
-    cg->hash = simple_hash(cg->id);
-
-    cg->chart_title = cgroup_title_strdupz(id);
-
-    cg->intermediate_id = cgroup_chart_id_strdupz(id);
-
-    cg->chart_id = cgroup_chart_id_strdupz(id);
-    substitute_dots_in_id(cg->chart_id);
-    cg->hash_chart = simple_hash(cg->chart_id);
-
-    if(cgroup_use_unified_cgroups) cg->options |= CGROUP_OPTIONS_IS_UNIFIED;
-
-    if(!discovered_cgroup_root)
-        discovered_cgroup_root = cg;
-    else {
-        // append it
-        struct cgroup *e;
-        for(e = discovered_cgroup_root; e->discovered_next ;e = e->discovered_next) ;
-        e->discovered_next = cg;
-    }
-
-    cgroup_root_count++;
-
-    // fix the chart_id and title by calling the external script
-    if(simple_pattern_matches(enabled_cgroup_renames, cg->id)) {
-
-        cg->pending_renames = 2;
-        cgroup_get_chart_name(cg);
-
-        debug(D_CGROUP, "cgroup '%s' renamed to '%s' (title: '%s')", cg->id, cg->chart_id, cg->chart_title);
-    }
-    else
-        debug(D_CGROUP, "cgroup '%s' will not be renamed - it matches the list of disabled cgroup renames (will be shown as '%s')", cg->id, cg->chart_id);
-
-    int user_configurable = 1;
-
-    // check if this cgroup should be a systemd service
-    if(cgroup_enable_systemd_services) {
-        if(simple_pattern_matches(systemd_services_cgroups, cg->id) ||
-                simple_pattern_matches(systemd_services_cgroups, cg->chart_id)) {
-            debug(D_CGROUP, "cgroup '%s' with chart id '%s' (title: '%s') matches systemd services cgroups", cg->id, cg->chart_id, cg->chart_title);
-
-            char buffer[CGROUP_CHARTID_LINE_MAX + 1];
-            cg->options |= CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE;
-
-            strncpy(buffer, cg->id, CGROUP_CHARTID_LINE_MAX);
-            char *s = buffer;
-
-            // skip to the last slash
-            size_t len = strlen(s);
-            while(len--) if(unlikely(s[len] == '/')) break;
-            if(len) s = &s[len + 1];
-
-            // remove extension
-            len = strlen(s);
-            while(len--) if(unlikely(s[len] == '.')) break;
-            if(len) s[len] = '\0';
-
-            freez(cg->chart_title);
-            cg->chart_title = cgroup_title_strdupz(s);
-
-            cg->enabled = 1;
-            user_configurable = 0;
-
-            debug(D_CGROUP, "cgroup '%s' renamed to '%s' (title: '%s')", cg->id, cg->chart_id, cg->chart_title);
-        }
-        else
-            debug(D_CGROUP, "cgroup '%s' with chart id '%s' (title: '%s') does not match systemd services groups", cg->id, cg->chart_id, cg->chart_title);
-    }
-
-    if(user_configurable) {
-        // allow the user to enable/disable this individually
-        char option[FILENAME_MAX + 1];
-        snprintfz(option, FILENAME_MAX, "enable cgroup %s", cg->chart_title);
-        cg->enabled = (char) config_get_boolean("plugin:cgroups", option, def);
-    }
-
-    // detect duplicate cgroups
-    if(cg->enabled) {
-        struct cgroup *t;
-        for (t = discovered_cgroup_root; t; t = t->discovered_next) {
-            if (t != cg && t->enabled && t->hash_chart == cg->hash_chart && !strcmp(t->chart_id, cg->chart_id)) {
-                // TODO: use it after refactoring if system.slice might be scanned before init.scope/system.slice
-                //
-                // if (!strncmp(t->id, "/system.slice/", 14) && !strncmp(cg->id, "/init.scope/system.slice/", 25)) {
-                //     error("CGROUP: chart id '%s' already exists with id '%s' and is enabled. Swapping them by enabling cgroup with id '%s' and disabling cgroup with id '%s'.",
-                //           cg->chart_id, t->id, cg->id, t->id);
-                //     t->enabled = 0;
-                //     t->options |= CGROUP_OPTIONS_DISABLED_DUPLICATE;
-                // }
-                // else {}
-                //
-                // https://github.com/netdata/netdata/issues/797#issuecomment-241248884
-                error("CGROUP: chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.",
-                        cg->chart_id, t->id, cg->id);
-                cg->enabled = 0;
-                cg->options |= CGROUP_OPTIONS_DISABLED_DUPLICATE;
-
-                break;
-            }
-        }
-    }
-
-    if(cg->enabled && !cg->pending_renames && !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE))
-        read_cgroup_network_interfaces(cg);
-
-    debug(D_CGROUP, "ADDED CGROUP: '%s' with chart id '%s' and title '%s' as %s (default was %s)", cg->id, cg->chart_id, cg->chart_title, (cg->enabled)?"enabled":"disabled", (def)?"enabled":"disabled");
-
-    return cg;
 }
 
 static inline void free_pressure(struct pressure *res) {
@@ -1862,8 +1822,149 @@ static inline void cgroup_free(struct cgroup *cg) {
     cgroup_root_count--;
 }
 
-// find if a given cgroup exists
-static inline struct cgroup *cgroup_find(const char *id) {
+// ----------------------------------------------------------------------------
+
+static inline void discovery_rename_cgroup(struct cgroup *cg) {
+    if (!cg->pending_renames) {
+        return;
+    }
+    cg->pending_renames--;
+
+    debug(D_CGROUP, "looking for the name of cgroup '%s' with chart id '%s' and title '%s'", cg->id, cg->chart_id, cg->chart_title);
+    debug(D_CGROUP, "executing command %s \"%s\" for cgroup '%s'", cgroups_rename_script, cg->intermediate_id, cg->chart_id);
+    pid_t cgroup_pid;
+    char command[CGROUP_CHARTID_LINE_MAX + 1];
+
+    FILE *fp;
+    (void)mypopen_raw_default_flags_and_environment(&cgroup_pid, &fp, cgroups_rename_script, cg->id, cg->intermediate_id);
+    if (!fp) {
+        error("CGROUP: cannot popen(%s \"%s\", \"r\").", cgroups_rename_script, cg->intermediate_id);
+        cg->pending_renames = 0;
+        return;
+    }
+
+    char buffer[CGROUP_CHARTID_LINE_MAX + 1];
+    char *new_name = fgets(buffer, CGROUP_CHARTID_LINE_MAX, fp);
+    int exit_code = mypclose(fp, cgroup_pid);
+
+    switch (exit_code) {
+        case 0:
+            cg->pending_renames = 0;
+            break;
+        case 3:
+            cg->pending_renames = 0;
+            cg->skip = 1;
+            break;
+        default:
+            if (!cg->pending_renames && is_inside_k8s) {
+                cg->skip = 1;
+            }
+    }
+
+    if (cg->pending_renames || cg->skip) {
+        return;
+    }
+    if (!(new_name && *new_name && *new_name != '\n')) {
+        return;
+    }
+    new_name = trim(new_name);
+    if (!(new_name)) {
+        return;
+    }
+    char *name = new_name;
+    if (!strncmp(new_name, "k8s_", 4)) {
+        free_label_list(cg->chart_labels);
+        name = k8s_parse_resolved_name(&cg->chart_labels, new_name);
+    }
+    freez(cg->chart_title);
+    cg->chart_title = cgroup_title_strdupz(name);
+    freez(cg->chart_id);
+    cg->chart_id = cgroup_chart_id_strdupz(name);
+    substitute_dots_in_id(cg->chart_id);
+    cg->hash_chart = simple_hash(cg->chart_id);
+}
+
+static void is_cgroup_procs_exist(netdata_ebpf_cgroup_shm_body_t *out, char *id) {
+    struct stat buf;
+
+    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_cpuset_base, id);
+    if (likely(stat(out->path, &buf) == 0)) {
+        return;
+    }
+
+    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_blkio_base, id);
+    if (likely(stat(out->path, &buf) == 0)) {
+        return;
+    }
+
+    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_memory_base, id);
+    if (likely(stat(out->path, &buf) == 0)) {
+        return;
+    }
+
+    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_devices_base, id);
+    if (likely(stat(out->path, &buf) == 0)) {
+        return;
+    }
+
+    out->path[0] = '\0';
+    out->enabled = 0;
+}
+
+static inline void convert_cgroup_to_systemd_service(struct cgroup *cg) {
+    char buffer[CGROUP_CHARTID_LINE_MAX + 1];
+    cg->options |= CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE;
+    strncpy(buffer, cg->id, CGROUP_CHARTID_LINE_MAX);
+    char *s = buffer;
+
+    // skip to the last slash
+    size_t len = strlen(s);
+    while (len--)
+        if (unlikely(s[len] == '/'))
+            break;
+    if (len)
+        s = &s[len + 1];
+
+    // remove extension
+    len = strlen(s);
+    while (len--)
+        if (unlikely(s[len] == '.'))
+            break;
+    if (len)
+        s[len] = '\0';
+
+    freez(cg->chart_title);
+    cg->chart_title = cgroup_title_strdupz(s);
+}
+
+static inline struct cgroup *discovery_cgroup_add(const char *id) {
+    debug(D_CGROUP, "adding to list, cgroup with id '%s'", id);
+
+    struct cgroup *cg = callocz(1, sizeof(struct cgroup));
+    cg->id = strdupz(id);
+    cg->hash = simple_hash(cg->id);
+    cg->chart_title = cgroup_title_strdupz(id);
+    cg->intermediate_id = cgroup_chart_id_strdupz(id);
+    cg->chart_id = cgroup_chart_id_strdupz(id);
+    substitute_dots_in_id(cg->chart_id);
+    cg->hash_chart = simple_hash(cg->chart_id);
+    if (cgroup_use_unified_cgroups) {
+        cg->options |= CGROUP_OPTIONS_IS_UNIFIED;
+    }
+
+    if (!discovered_cgroup_root)
+        discovered_cgroup_root = cg;
+    else {
+        struct cgroup *t;
+        for (t = discovered_cgroup_root; t->discovered_next; t = t->discovered_next) {
+        }
+        t->discovered_next = cg;
+    }
+
+    return cg;
+}
+
+static inline struct cgroup *discovery_cgroup_find(const char *id) {
     debug(D_CGROUP, "searching for cgroup '%s'", id);
 
     uint32_t hash = simple_hash(id);
@@ -1878,55 +1979,38 @@ static inline struct cgroup *cgroup_find(const char *id) {
     return cg;
 }
 
-// ----------------------------------------------------------------------------
-// detect running cgroups
-
-// callback for find_file_in_subdirs()
-static inline void found_subdir_in_dir(const char *dir) {
+static inline void discovery_find_cgroup_in_dir_callback(const char *dir) {
+    if (!dir || !*dir) {
+        dir = "/";
+    }
     debug(D_CGROUP, "examining cgroup dir '%s'", dir);
 
-    struct cgroup *cg = cgroup_find(dir);
-    if(!cg) {
-        if(*dir && cgroup_max_depth > 0) {
-            int depth = 0;
-            const char *s;
-
-            for(s = dir; *s ;s++)
-                if(unlikely(*s == '/'))
-                    depth++;
-
-            if(depth > cgroup_max_depth) {
-                info("CGROUP: '%s' is too deep (%d, while max is %d)", dir, depth, cgroup_max_depth);
-                return;
-            }
-        }
-        // debug(D_CGROUP, "will add dir '%s' as cgroup", dir);
-        cg = cgroup_add(dir);
-    }
-
-    if(cg) {
-        // delay renaming of the cgroup and looking for network interfaces to deal with the docker lag when starting the container
-        if(unlikely(cg->pending_renames == 1)) {
-            // fix the chart_id and title by calling the external script
-            if(simple_pattern_matches(enabled_cgroup_renames, cg->id)) {
-
-                cgroup_get_chart_name(cg);
-                cg->pending_renames = 0;
-
-                if(cg->enabled && !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE))
-                    read_cgroup_network_interfaces(cg);
-
-                debug(D_CGROUP, "cgroup '%s' renamed to '%s' (title: '%s')", cg->id, cg->chart_id, cg->chart_title);
-            }
-            else
-                debug(D_CGROUP, "cgroup '%s' will not be renamed - it matches the list of disabled cgroup renames (will be shown as '%s')", cg->id, cg->chart_id);
-        }
-
+    struct cgroup *cg = discovery_cgroup_find(dir);
+    if (cg) {
         cg->available = 1;
+        return;
     }
+
+    if (cgroup_root_count >= cgroup_root_max) {
+        info("CGROUP: maximum number of cgroups reached (%d). Not adding cgroup '%s'", cgroup_root_count, dir);
+        return;
+    }
+
+    if (cgroup_max_depth > 0) {
+        int depth = calc_cgroup_depth(dir);
+        if (depth > cgroup_max_depth) {
+            info("CGROUP: '%s' is too deep (%d, while max is %d)", dir, depth, cgroup_max_depth);
+            return;
+        }
+    }
+
+    cg = discovery_cgroup_add(dir);
+    cg->available = 1;
+    cg->first_time_seen = 1;
+    cgroup_root_count++;
 }
 
-static inline int find_dir_in_subdirs(const char *base, const char *this, void (*callback)(const char *)) {
+static inline int discovery_find_dir_in_subdirs(const char *base, const char *this, void (*callback)(const char *)) {
     if(!this) this = base;
     debug(D_CGROUP, "searching for directories in '%s' (base '%s')", this?this:"", base);
 
@@ -1962,7 +2046,7 @@ static inline int find_dir_in_subdirs(const char *base, const char *this, void (
                 if(*r == '\0') r = "/";
 
                 // do not decent in directories we are not interested
-                enabled = simple_pattern_matches(enabled_cgroup_paths, r);
+                enabled = matches_search_cgroup_paths(r);
             }
 
             if(enabled) {
@@ -1970,7 +2054,7 @@ static inline int find_dir_in_subdirs(const char *base, const char *this, void (
                 strcpy(s, this);
                 strcat(s, "/");
                 strcat(s, de->d_name);
-                int ret2 = find_dir_in_subdirs(base, s, callback);
+                int ret2 = discovery_find_dir_in_subdirs(base, s, callback);
                 if(ret2 > 0) ret += ret2;
                 freez(s);
             }
@@ -1981,28 +2065,19 @@ static inline int find_dir_in_subdirs(const char *base, const char *this, void (
     return ret;
 }
 
-static inline void mark_all_cgroups_as_not_available() {
+static inline void discovery_mark_all_cgroups_as_unavailable() {
     debug(D_CGROUP, "marking all cgroups as not available");
-
     struct cgroup *cg;
-
-    // mark all as not available
-    for(cg = discovered_cgroup_root; cg ; cg = cg->discovered_next) {
+    for (cg = discovered_cgroup_root; cg; cg = cg->discovered_next) {
         cg->available = 0;
     }
 }
 
-static inline void update_filenames()
-{
+static inline void discovery_update_filenames() {
     struct cgroup *cg;
     struct stat buf;
     for(cg = discovered_cgroup_root; cg ; cg = cg->discovered_next) {
-        // fprintf(stderr, " >>> CGROUP '%s' (%u - %s) with name '%s'\n", cg->id, cg->hash, cg->available?"available":"stopped", cg->name);
-
-        if(unlikely(cg->pending_renames))
-            cg->pending_renames--;
-
-        if(unlikely(!cg->available || cg->pending_renames))
+        if(unlikely(!cg->available || !cg->enabled || cg->pending_renames))
             continue;
 
         debug(D_CGROUP, "checking paths for cgroup '%s'", cg->id);
@@ -2028,7 +2103,7 @@ static inline void update_filenames()
                     debug(D_CGROUP, "cpuacct.stat file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely(cgroup_enable_cpuacct_usage && !cg->cpuacct_usage.filename && !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE))) {
+            if(unlikely(cgroup_enable_cpuacct_usage && !cg->cpuacct_usage.filename && !is_cgroup_systemd_service(cg))) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpuacct.usage_percpu", cgroup_cpuacct_base, cg->id);
                 if(likely(stat(filename, &buf) != -1)) {
                     cg->cpuacct_usage.filename = strdupz(filename);
@@ -2038,7 +2113,7 @@ static inline void update_filenames()
                 else
                     debug(D_CGROUP, "cpuacct.usage_percpu file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
-            if(unlikely(cgroup_enable_cpuacct_cpu_throttling && !cg->cpuacct_cpu_throttling.filename && !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE))) {
+            if(unlikely(cgroup_enable_cpuacct_cpu_throttling && !cg->cpuacct_cpu_throttling.filename && is_cgroup_systemd_service(cg))) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpu.stat", cgroup_cpuacct_base, cg->id);
                 if(likely(stat(filename, &buf) != -1)) {
                     cg->cpuacct_cpu_throttling.filename = strdupz(filename);
@@ -2050,7 +2125,7 @@ static inline void update_filenames()
             }
             if (unlikely(
                     cgroup_enable_cpuacct_cpu_shares && !cg->cpuacct_cpu_shares.filename &&
-                    !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE))) {
+                    !is_cgroup_systemd_service(cg))) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpu.shares", cgroup_cpuacct_base, cg->id);
                 if (likely(stat(filename, &buf) != -1)) {
                     cg->cpuacct_cpu_shares.filename = strdupz(filename);
@@ -2061,7 +2136,7 @@ static inline void update_filenames()
                     debug(D_CGROUP, "cpu.shares file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely((cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed && (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE)))) {
+            if(unlikely((cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed && (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !is_cgroup_systemd_service(cg)))) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.stat", cgroup_memory_base, cg->id);
                 if(likely(stat(filename, &buf) != -1)) {
                     cg->memory.filename_detailed = strdupz(filename);
@@ -2270,7 +2345,7 @@ static inline void update_filenames()
                     debug(D_CGROUP, "cpu.weight file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely((cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed && (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE)))) {
+            if(unlikely((cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed && (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !is_cgroup_systemd_service(cg)))) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.stat", cgroup_unified_base, cg->id);
                 if(likely(stat(filename, &buf) != -1)) {
                     cg->memory.filename_detailed = strdupz(filename);
@@ -2346,7 +2421,7 @@ static inline void update_filenames()
     }
 }
 
-static inline void cleanup_all_cgroups() {
+static inline void discovery_cleanup_all_cgroups() {
     struct cgroup *cg = discovered_cgroup_root, *last = NULL;
 
     for(; cg ;) {
@@ -2369,9 +2444,6 @@ static inline void cleanup_all_cgroups() {
             else
                 last->discovered_next = cg->discovered_next;
 
-            char option[FILENAME_MAX + 1];
-            snprintfz(option, FILENAME_MAX, "enable cgroup %s", cg->chart_title);
-            config_section_option_destroy("plugin:cgroups", option);
             cgroup_free(cg);
 
             if(!last)
@@ -2386,49 +2458,19 @@ static inline void cleanup_all_cgroups() {
     }
 }
 
-static inline void copy_discovered_cgroups()
-{
+static inline void discovery_copy_discovered_cgroups_to_reader() {
     debug(D_CGROUP, "copy discovered cgroups to the main group list");
 
     struct cgroup *cg;
 
-    for(cg = discovered_cgroup_root; cg ; cg = cg->discovered_next) {
+    for (cg = discovered_cgroup_root; cg; cg = cg->discovered_next) {
         cg->next = cg->discovered_next;
     }
 
     cgroup_root = discovered_cgroup_root;
 }
 
-static void is_there_cgroup_procs(netdata_ebpf_cgroup_shm_body_t *out, char *id)
-{
-    struct stat buf;
-
-    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_cpuset_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
-        return;
-    }
-
-    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_blkio_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
-        return;
-    }
-
-    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_memory_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
-        return;
-    }
-
-    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_devices_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
-        return;
-    }
-
-    out->path[0] = '\0';
-    out->enabled = 0;
-}
-
-static inline void share_cgroups()
-{
+static inline void discovery_share_cgroups_with_ebpf() {
     struct cgroup *cg;
     int count;
     struct stat buf;
@@ -2438,9 +2480,9 @@ static inline void share_cgroups()
     }
     sem_wait(shm_mutex_cgroup_ebpf);
 
-    for (cg = cgroup_root, count = 0; cg ; cg = cg->next, count++) {
+    for (cg = cgroup_root, count = 0; cg; cg = cg->next, count++) {
         netdata_ebpf_cgroup_shm_body_t *ptr = &shm_cgroup_ebpf.body[count];
-        char *prefix = (cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE) ? "" : "cgroup_";
+        char *prefix = (is_cgroup_systemd_service(cg)) ? "" : "cgroup_";
         snprintfz(ptr->name, CGROUP_EBPF_NAME_SHARED_LENGTH - 1, "%s%s", prefix, cg->chart_title);
         ptr->hash = simple_hash(ptr->name);
         ptr->options = cg->options;
@@ -2452,7 +2494,7 @@ static inline void share_cgroups()
                 ptr->enabled = 0;
             }
         } else {
-            is_there_cgroup_procs(ptr, cg->id);
+            is_cgroup_procs_exist(ptr, cg->id);
         }
 
         debug(D_CGROUP, "cgroup shared: NAME=%s, ENABLED=%d", ptr->name, ptr->enabled);
@@ -2462,63 +2504,139 @@ static inline void share_cgroups()
     sem_post(shm_mutex_cgroup_ebpf);
 }
 
-static inline void find_all_cgroups() {
+static inline void discovery_find_all_cgroups_v1() {
+    if (cgroup_enable_cpuacct_stat || cgroup_enable_cpuacct_usage) {
+        if (discovery_find_dir_in_subdirs(cgroup_cpuacct_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
+            cgroup_enable_cpuacct_stat = cgroup_enable_cpuacct_usage = CONFIG_BOOLEAN_NO;
+            error("CGROUP: disabled cpu statistics.");
+        }
+    }
+    if (cgroup_enable_blkio_io || cgroup_enable_blkio_ops || cgroup_enable_blkio_throttle_io ||
+        cgroup_enable_blkio_throttle_ops || cgroup_enable_blkio_merged_ops || cgroup_enable_blkio_queued_ops) {
+        if (discovery_find_dir_in_subdirs(cgroup_blkio_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
+            cgroup_enable_blkio_io = cgroup_enable_blkio_ops = cgroup_enable_blkio_throttle_io =
+                cgroup_enable_blkio_throttle_ops = cgroup_enable_blkio_merged_ops = cgroup_enable_blkio_queued_ops =
+                    CONFIG_BOOLEAN_NO;
+            error("CGROUP: disabled blkio statistics.");
+        }
+    }
+    if (cgroup_enable_memory || cgroup_enable_detailed_memory || cgroup_enable_swap || cgroup_enable_memory_failcnt) {
+        if (discovery_find_dir_in_subdirs(cgroup_memory_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
+            cgroup_enable_memory = cgroup_enable_detailed_memory = cgroup_enable_swap = cgroup_enable_memory_failcnt =
+                CONFIG_BOOLEAN_NO;
+            error("CGROUP: disabled memory statistics.");
+        }
+    }
+    if (cgroup_search_in_devices) {
+        if (discovery_find_dir_in_subdirs(cgroup_devices_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
+            cgroup_search_in_devices = 0;
+            error("CGROUP: disabled devices statistics.");
+        }
+    }
+}
+
+static inline void discovery_find_all_cgroups_v2() {
+    if (discovery_find_dir_in_subdirs(cgroup_unified_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
+        cgroup_unified_exist = CONFIG_BOOLEAN_NO;
+        error("CGROUP: disabled unified cgroups statistics.");
+    }
+}
+
+static inline void discovery_process_first_time_seen_cgroup(struct cgroup *cg) {
+    if (!cg->first_time_seen) {
+        return;
+    }
+    cg->first_time_seen = 0;
+
+    char comm[TASK_COMM_LEN] = "";
+
+    if (is_inside_k8s && !k8s_get_container_first_proc_comm(cg->id, comm)) {
+        if (!strcmp(comm, "runc:[2:INIT]")) {
+            cg->first_time_seen = 1;
+            return;
+        }
+        if (!strcmp(comm, "pause")) {
+            cg->skip = 1;
+            return;
+        }
+    }
+
+    if (cgroup_enable_systemd_services && matches_systemd_services_cgroups(cg->id)) {
+        convert_cgroup_to_systemd_service(cg);
+        return;
+    }
+
+    if (matches_enabled_cgroup_renames(cg->id)) {
+        cg->pending_renames = cgroup_renaming_tries;
+        if (is_inside_k8s && k8s_is_container(cg->id) && cg->pending_renames < 8) {
+            cg->pending_renames = 8;
+        }
+    }
+}
+
+static inline void discovery_process_cgroup(struct cgroup *cg) {
+    if (!cg->available || cg->skip) {
+        return;
+    }
+
+    if (cg->first_time_seen) {
+        discovery_process_first_time_seen_cgroup(cg);
+        if (unlikely(cg->first_time_seen || cg->skip)) {
+            return;
+        }
+    }
+
+    if (cg->pending_renames) {
+        discovery_rename_cgroup(cg);
+        if (unlikely(cg->pending_renames || cg->skip)) {
+            return;
+        }
+    }
+
+    cg->skip = 1;
+
+    if (is_cgroup_systemd_service(cg)) {
+        cg->enabled = 1;
+        return;
+    }
+
+    if (!(cg->enabled = matches_enabled_cgroup_names(cg->chart_title))) {
+        return;
+    }
+
+    if (!(cg->enabled && (cg->enabled = matches_enabled_cgroup_paths(cg->id)))) {
+        return;
+    }
+
+    if (cg->enabled) {
+        read_cgroup_network_interfaces(cg);
+    }
+}
+
+static inline void discovery_find_all_cgroups() {
     debug(D_CGROUP, "searching for cgroups");
 
-    mark_all_cgroups_as_not_available();
-    if(!cgroup_use_unified_cgroups) {
-        if(cgroup_enable_cpuacct_stat || cgroup_enable_cpuacct_usage) {
-            if(find_dir_in_subdirs(cgroup_cpuacct_base, NULL, found_subdir_in_dir) == -1) {
-                cgroup_enable_cpuacct_stat =
-                cgroup_enable_cpuacct_usage = CONFIG_BOOLEAN_NO;
-                error("CGROUP: disabled cpu statistics.");
-            }
-        }
+    discovery_mark_all_cgroups_as_unavailable();
 
-        if(cgroup_enable_blkio_io || cgroup_enable_blkio_ops || cgroup_enable_blkio_throttle_io || cgroup_enable_blkio_throttle_ops || cgroup_enable_blkio_merged_ops || cgroup_enable_blkio_queued_ops) {
-            if(find_dir_in_subdirs(cgroup_blkio_base, NULL, found_subdir_in_dir) == -1) {
-                cgroup_enable_blkio_io =
-                cgroup_enable_blkio_ops =
-                cgroup_enable_blkio_throttle_io =
-                cgroup_enable_blkio_throttle_ops =
-                cgroup_enable_blkio_merged_ops =
-                cgroup_enable_blkio_queued_ops = CONFIG_BOOLEAN_NO;
-                error("CGROUP: disabled blkio statistics.");
-            }
-        }
-
-        if(cgroup_enable_memory || cgroup_enable_detailed_memory || cgroup_enable_swap || cgroup_enable_memory_failcnt) {
-            if(find_dir_in_subdirs(cgroup_memory_base, NULL, found_subdir_in_dir) == -1) {
-                cgroup_enable_memory =
-                cgroup_enable_detailed_memory =
-                cgroup_enable_swap =
-                cgroup_enable_memory_failcnt = CONFIG_BOOLEAN_NO;
-                error("CGROUP: disabled memory statistics.");
-            }
-        }
-
-        if(cgroup_search_in_devices) {
-            if(find_dir_in_subdirs(cgroup_devices_base, NULL, found_subdir_in_dir) == -1) {
-                cgroup_search_in_devices = 0;
-                error("CGROUP: disabled devices statistics.");
-            }
-        }
-    }
-    else {
-        if (find_dir_in_subdirs(cgroup_unified_base, NULL, found_subdir_in_dir) == -1) {
-            cgroup_unified_exist = CONFIG_BOOLEAN_NO;
-            error("CGROUP: disabled unified cgroups statistics.");
-        }
+    if (!cgroup_use_unified_cgroups) {
+        discovery_find_all_cgroups_v1();
+    } else {
+        discovery_find_all_cgroups_v2();
     }
 
-    update_filenames();
+    struct cgroup *cg;
+    for (cg = discovered_cgroup_root; cg; cg = cg->discovered_next) {
+        discovery_process_cgroup(cg);
+    }
+
+    discovery_update_filenames();
 
     uv_mutex_lock(&cgroup_root_mutex);
-    cleanup_all_cgroups();
-    copy_discovered_cgroups();
+    discovery_cleanup_all_cgroups();
+    discovery_copy_discovered_cgroups_to_reader();
     uv_mutex_unlock(&cgroup_root_mutex);
 
-    share_cgroups();
+    discovery_share_cgroups_with_ebpf();
 
     debug(D_CGROUP, "done searching for cgroups");
 }
@@ -2537,7 +2655,7 @@ void cgroup_discovery_worker(void *ptr)
         if (unlikely(netdata_exit))
             break;
 
-        find_all_cgroups();
+        discovery_find_all_cgroups();
     }
 
     discovery_thread.exited = 1;
@@ -3123,7 +3241,7 @@ void update_systemd_services_charts(
     // update the values
     struct cgroup *cg;
     for(cg = cgroup_root; cg ; cg = cg->next) {
-        if(unlikely(!cg->enabled || cg->pending_renames || !(cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE)))
+        if(unlikely(!cg->enabled || cg->pending_renames || !is_cgroup_systemd_service(cg)))
             continue;
 
         if(likely(do_cpu && cg->cpuacct_stat.updated)) {
@@ -3525,7 +3643,7 @@ void update_cgroup_charts(int update_every) {
         if(unlikely(!cg->enabled || cg->pending_renames))
             continue;
 
-        if(likely(cgroup_enable_systemd_services && cg->options & CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE)) {
+        if(likely(cgroup_enable_systemd_services && is_cgroup_systemd_service(cg))) {
             if(cg->cpuacct_stat.updated && cg->cpuacct_stat.enabled == CONFIG_BOOLEAN_YES) services_do_cpu++;
 
             if(cgroup_enable_systemd_services_detailed_memory && cg->memory.updated_detailed && cg->memory.enabled_detailed) services_do_mem_detailed++;
@@ -4542,7 +4660,13 @@ void *cgroups_main(void *ptr) {
     struct rusage thread;
 
     if (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL) {
+        is_inside_k8s = 1;
+    }
+
+    if (is_inside_k8s) {
         cgroup_enable_cpuacct_cpu_shares = CONFIG_BOOLEAN_YES;
+        // 2 was not enough on an AWS K8s cluster when: CPU % is high, many containers are created in a short time.
+        cgroup_renaming_tries = 4;
     }
 
     // when ZERO, attempt to do it
@@ -4583,20 +4707,22 @@ void *cgroups_main(void *ptr) {
     usec_t step = cgroup_update_every * USEC_PER_SEC;
     usec_t find_every = cgroup_check_for_new_every * USEC_PER_SEC, find_dt = 0;
 
+    int init_discovery = 1;
     while(!netdata_exit) {
         usec_t hb_dt = heartbeat_next(&hb, step);
         if(unlikely(netdata_exit)) break;
 
         find_dt += hb_dt;
-        if(unlikely(find_dt >= find_every || cgroups_check)) {
+        if (unlikely(find_dt >= find_every || (!is_inside_k8s && cgroups_check))) {
             uv_cond_signal(&discovery_thread.cond_var);
             discovery_thread.start_discovery = 1;
             find_dt = 0;
             cgroups_check = 0;
+            init_discovery = 0;
         }
 
         uv_mutex_lock(&cgroup_root_mutex);
-        read_all_cgroups(cgroup_root);
+        read_all_discovered_cgroups(cgroup_root);
         update_cgroup_charts(cgroup_update_every);
         uv_mutex_unlock(&cgroup_root_mutex);
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.h
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.h
@@ -39,6 +39,6 @@ typedef struct netdata_ebpf_cgroup_shm {
 
 #include "../proc.plugin/plugin_proc.h"
 
-extern char *parse_k8s_data(struct label **labels, char *data);
+extern char *k8s_parse_resolved_name(struct label **labels, char *data);
 
 #endif //NETDATA_SYS_FS_CGROUP_H

--- a/collectors/cgroups.plugin/tests/test_cgroups_plugin.c
+++ b/collectors/cgroups.plugin/tests/test_cgroups_plugin.c
@@ -8,7 +8,7 @@ int netdata_zero_metrics_enabled = 1;
 struct config netdata_config;
 char *netdata_configured_primary_plugins_dir = NULL;
 
-static void test_parse_k8s_data(void **state)
+static void test_k8s_parse_resolved_name(void **state)
 {
     UNUSED(state);
 
@@ -89,7 +89,7 @@ static void test_parse_k8s_data(void **state)
             expect_value(__wrap_add_label_to_list, label_source, LABEL_SOURCE_KUBERNETES);    
         }
 
-        char *name = parse_k8s_data(&labels, data);
+        char *name = k8s_parse_resolved_name(&labels, data);
 
         assert_string_equal(name, test_data[i].name);
         assert_ptr_equal(labels, 0xff);
@@ -101,10 +101,10 @@ static void test_parse_k8s_data(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_parse_k8s_data),
+        cmocka_unit_test(test_k8s_parse_resolved_name),
     };
 
-    int test_res = cmocka_run_group_tests_name("test_parse_k8s_data", tests, NULL, NULL);
+    int test_res = cmocka_run_group_tests_name("test_k8s_parse_resolved_name", tests, NULL, NULL);
 
     return test_res;
 }


### PR DESCRIPTION
##### Summary

So many changes in one PR because the goal was to fix the following problem:

- Netdata loses some containers on a K8s cluster when:
  - the CPU % of the node is high (100% in our case).
  - A lot of containers are created in a short time. 

The changes address that problem. After this patch, the amount of CPU time needed for cgroup name resolution is ~40% less.

`enable by default cgroups names matching` is just a nice addition that came naturally 😄 

---

This PR:

- **[feat]**: Adds `enable by default cgroups names matching` filter. It matches the name of the cgroup (as you see it on the dashboard). It is much easier to filter specific containers, e.g.: `!nginx2 *`.
- **[feat]**: K8s: wait for container initialization (`runc:[2:INIT]` may take a while) and don't try to rename/collect uninitialized containers.
- **[feat]**: K8s: identify [pause containers](https://docs.mirantis.com/mke/3.4/ref-arch/pause-containers.html) and don't try to rename/collect their data. Every pod has a pause container, so it is up to 50% fewer cgroup-rename.sh calls.
- **[feat]**: K8s: bump renaming tries to 9 for containers. In addition to a new, the renaming script returns labels. There is (close to) 0 sense to collect a cgroup metrics if we don't know its [name/labels](https://github.com/netdata/netdata/blob/3f45709706a59b431b76443b0fbe23c9115768a8/collectors/cgroups.plugin/cgroup-name.sh#L283-L310). We did some tests on a K8s cluster with 100% CPU and it may take 60-70 seconds until K8s api returns data for the container.
- **[feat]**: K8s: cache (store on the host filesystem) /api/v1/pods response and check it before querying K8s API (only for containers). This allows querying the K8s API **much** less frequently.
- **[feat]**: K8s: a cgroup (container) removal doesn't trigger discovery anymore, we run discovery only every `check for new cgroups every`. This behavior is better in K8s.
- **[chore]**: removes `enable cgroup X` option. Not really useful in general. Filtering (enabling/disabling) specific containers is easier using new `enable by default cgroups names matching` feature.
- **[chore]**: a small refactoring of discovery logic + formatting the readme file.

##### Test Plan

- K8s (requires adding debug logging messages)
  - check pause container identification logic.
  - check that cache works (hit/miss).
- run N docker containers, check name resolution works.
- test `enable by default cgroups names matching` filter.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
