### PR TITLE
fix: printing a warning msg in installer

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -270,7 +270,7 @@ fatal() {
 }
 
 warning() {
-  printf >&2 "%s WARNING %s %s\n\n" "%{TPUT_BGYELLOW}${TPUT_BLACK}${TPUT_BOLD}" "${TPUT_RESET}" "${1}"
+  printf >&2 "%s WARNING %s %s\n\n" "${TPUT_BGYELLOW}${TPUT_BLACK}${TPUT_BOLD}" "${TPUT_RESET}" "${1}"
   if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
     SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${1}"
   fi


### PR DESCRIPTION
##### Summary

Fixing a typo in `warning()`.

https://github.com/netdata/netdata/blob/3f45709706a59b431b76443b0fbe23c9115768a8/packaging/installer/functions.sh#L272-L273

The output is:

```sh
Press ENTER to build and install netdata to '/opt/netdata' >
Skipping protobuf
%{TPUT_BGYELLOW} WARNING  You have requested use of a system copy of protobuf. This should work, but it is not recommended as it's very likely to break if you upgrade the currently installed version of protobuf.
```

##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
