### PR TITLE
Trace rwlocks of netdata

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -679,63 +679,7 @@ void post_conf_load(char **user)
     appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "cloud base url", DEFAULT_CLOUD_BASE_URL);
 }
 
-struct clock {
-    clockid_t clockid;
-    const char *name;
-};
-
-#define HISTOGRAM_SIZE 10000
-#define ITERATIONS 10000000
-
 int main(int argc, char **argv) {
-    struct clock clocks[] = {
-        {CLOCK_BOOTTIME, "CLOCK_BOOTTIME now_boottime_*()"},
-        {CLOCK_MONOTONIC, "CLOCK_MONOTONIC now_monotonic_high_precision_*()"},
-        {CLOCK_MONOTONIC_COARSE, "CLOCK_MONOTONIC_COARSE now_monotonic_*()"},
-        {CLOCK_MONOTONIC_RAW, "CLOCK_MONOTONIC_RAW"},
-        {CLOCK_REALTIME, "CLOCK_REALTIME now_realtime_*()" },
-        {CLOCK_REALTIME_COARSE, "CLOCK_REALTIME_COARSE" },
-        {0, NULL }
-    };
-
-    int current_clock;
-    for(current_clock = 0; clocks[current_clock].name ; current_clock++) {
-        printf("\n\nTesting %s ...\n", clocks[current_clock].name);
-
-        usec_t histogram[HISTOGRAM_SIZE + 1] = { 0 };
-        size_t count, total;
-        usec_t us, oldus, delta, min, max, start, end;
-        start = oldus = now_usec(clocks[current_clock].clockid);
-        for (count = 0; count < ITERATIONS; count++) {
-            us = now_usec(clocks[current_clock].clockid);
-            delta = us - oldus;
-            if (count == 0)
-                min = max = delta;
-            else {
-                if (delta < min)
-                    min = delta;
-                if (delta > max)
-                    max = delta;
-            }
-            oldus = us;
-
-            if (delta > HISTOGRAM_SIZE)
-                delta = HISTOGRAM_SIZE;
-            histogram[delta]++;
-        }
-        total = count;
-
-        end = now_usec(clocks[current_clock].clockid);
-        delta = end - start;
-        printf("%zu iterations in %llu usec, min %llu, max %llu, average %llu\n", count, delta, min, max, delta / total);
-
-        for (count = 0; count <= HISTOGRAM_SIZE; count++)
-            if (histogram[count])
-                printf(
-                    "   %04zu usec : %llu (%.02f%%)\n", count, histogram[count], (float)(histogram[count] * 100.0) / (float)total);
-    }
-    exit(0);
-
     int i;
     int config_loaded = 0;
     int dont_fork = 0;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -679,7 +679,63 @@ void post_conf_load(char **user)
     appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "cloud base url", DEFAULT_CLOUD_BASE_URL);
 }
 
+struct clock {
+    clockid_t clockid;
+    const char *name;
+};
+
+#define HISTOGRAM_SIZE 10000
+#define ITERATIONS 10000000
+
 int main(int argc, char **argv) {
+    struct clock clocks[] = {
+        {CLOCK_BOOTTIME, "CLOCK_BOOTTIME now_boottime_*()"},
+        {CLOCK_MONOTONIC, "CLOCK_MONOTONIC now_monotonic_high_precision_*()"},
+        {CLOCK_MONOTONIC_COARSE, "CLOCK_MONOTONIC_COARSE now_monotonic_*()"},
+        {CLOCK_MONOTONIC_RAW, "CLOCK_MONOTONIC_RAW"},
+        {CLOCK_REALTIME, "CLOCK_REALTIME now_realtime_*()" },
+        {CLOCK_REALTIME_COARSE, "CLOCK_REALTIME_COARSE" },
+        {0, NULL }
+    };
+
+    int current_clock;
+    for(current_clock = 0; clocks[current_clock].name ; current_clock++) {
+        printf("\n\nTesting %s ...\n", clocks[current_clock].name);
+
+        usec_t histogram[HISTOGRAM_SIZE + 1] = { 0 };
+        size_t count, total;
+        usec_t us, oldus, delta, min, max, start, end;
+        start = oldus = now_usec(clocks[current_clock].clockid);
+        for (count = 0; count < ITERATIONS; count++) {
+            us = now_usec(clocks[current_clock].clockid);
+            delta = us - oldus;
+            if (count == 0)
+                min = max = delta;
+            else {
+                if (delta < min)
+                    min = delta;
+                if (delta > max)
+                    max = delta;
+            }
+            oldus = us;
+
+            if (delta > HISTOGRAM_SIZE)
+                delta = HISTOGRAM_SIZE;
+            histogram[delta]++;
+        }
+        total = count;
+
+        end = now_usec(clocks[current_clock].clockid);
+        delta = end - start;
+        printf("%zu iterations in %llu usec, min %llu, max %llu, average %llu\n", count, delta, min, max, delta / total);
+
+        for (count = 0; count <= HISTOGRAM_SIZE; count++)
+            if (histogram[count])
+                printf(
+                    "   %04zu usec : %llu (%.02f%%)\n", count, histogram[count], (float)(histogram[count] * 100.0) / (float)total);
+    }
+    exit(0);
+
     int i;
     int config_loaded = 0;
     int dont_fork = 0;
@@ -1087,8 +1143,9 @@ int main(int argc, char **argv) {
         if(i > 0)
             mallopt(M_ARENA_MAX, 1);
 #endif
-        test_clock_boottime();
-        test_clock_monotonic_coarse();
+
+        // initialize the system clocks
+        clocks_init();
 
         // prepare configuration environment variables for the plugins
 

--- a/libnetdata/Makefile.am
+++ b/libnetdata/Makefile.am
@@ -17,7 +17,6 @@ SUBDIRS = \
     health \
     locks \
     log \
-    onewayalloc \
     popen \
     procfile \
     simple_pattern \

--- a/libnetdata/Makefile.am
+++ b/libnetdata/Makefile.am
@@ -17,6 +17,7 @@ SUBDIRS = \
     health \
     locks \
     log \
+    onewayalloc \
     popen \
     procfile \
     simple_pattern \

--- a/libnetdata/avl/avl.c
+++ b/libnetdata/avl/avl.c
@@ -374,7 +374,7 @@ void avl_destroy_lock(avl_tree_lock *tree) {
 #ifdef AVL_LOCK_WITH_MUTEX
     lock = pthread_mutex_destroy(&tree->mutex);
 #else
-    lock = pthread_rwlock_destroy(&tree->rwlock);
+    lock = netdata_rwlock_destroy(&tree->rwlock);
 #endif
 
     if(lock != 0)

--- a/libnetdata/avl/avl.c
+++ b/libnetdata/avl/avl.c
@@ -372,7 +372,7 @@ void avl_destroy_lock(avl_tree_lock *tree) {
     int lock;
 
 #ifdef AVL_LOCK_WITH_MUTEX
-    lock = pthread_mutex_destroy(&tree->mutex);
+    lock = netdata_mutex_destroy(&tree->mutex);
 #else
     lock = netdata_rwlock_destroy(&tree->rwlock);
 #endif

--- a/libnetdata/clocks/clocks.h
+++ b/libnetdata/clocks/clocks.h
@@ -133,7 +133,6 @@ extern int now_boottime_timeval(struct timeval *tv);
 extern time_t now_boottime_sec(void);
 extern usec_t now_boottime_usec(void);
 
-
 extern usec_t timeval_usec(struct timeval *tv);
 extern msec_t timeval_msec(struct timeval *tv);
 
@@ -152,17 +151,12 @@ extern usec_t heartbeat_monotonic_dt_to_now_usec(heartbeat_t *hb);
 
 extern int sleep_usec(usec_t usec);
 
-/*
- * When running a binary with CLOCK_BOOTTIME defined on a system with a linux kernel older than Linux 2.6.39 the
- * clock_gettime(2) system call fails with EINVAL. In that case it must fall-back to CLOCK_MONOTONIC.
- */
-void test_clock_boottime(void);
+extern void clocks_init(void);
 
-/*
- * When running a binary with CLOCK_MONOTONIC_COARSE defined on a system with a linux kernel older than Linux 2.6.32 the
- * clock_gettime(2) system call fails with EINVAL. In that case it must fall-back to CLOCK_MONOTONIC.
- */
-void test_clock_monotonic_coarse(void);
+// lower level functions - avoid using directly
+extern time_t now_sec(clockid_t clk_id);
+extern usec_t now_usec(clockid_t clk_id);
+extern int now_timeval(clockid_t clk_id, struct timeval *tv);
 
 extern collected_number uptime_msec(char *filename);
 

--- a/libnetdata/locks/README.md
+++ b/libnetdata/locks/README.md
@@ -2,4 +2,99 @@
 custom_edit_url: https://github.com/netdata/netdata/edit/master/libnetdata/locks/README.md
 -->
 
+## How to trace netdata locks
+
+To enable tracing rwlocks in netdata, compile netdata by setting `CFLAGS="-DNETDATA_TRACE_RWLOCKS=1"`, like this:
+
+```
+CFLAGS="-O1 -ggdb -DNETDATA_TRACE_RWLOCKS=1"  ./netdata-installer.sh
+```
+
+During compilation, the compiler will log:
+
+```
+libnetdata/locks/locks.c:105:2: warning: #warning NETDATA_TRACE_RWLOCKS ENABLED - EXPECT A LOT OF OUTPUT [-Wcpp]
+  105 | #warning NETDATA_TRACE_RWLOCKS ENABLED - EXPECT A LOT OF OUTPUT
+      |  ^~~~~~~
+```
+
+Once compiled, netdata will do the following:
+
+Every call to `netdata_rwlock_*()` is now measured in time.
+
+### logging of slow locks/unlocks
+
+If any call takes more than 10 usec, it will be logged like this:
+
+```
+RW_LOCK ON LOCK 0x0x7fbe1f2e5190: 4157038, 'ACLK_Query_2' (function build_context_param_list() 99@web/api/formatters/rrd2json.c) WAITED to UNLOCK for 29 usec.
+```
+
+The time can be changed by setting this `-DNETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC=20` (or whatever number) to the CFLAGS.
+
+### logging of long hold times
+
+If any lock is holded for more than 10000 usec, it will be logged like this:
+
+```
+RW_LOCK ON LOCK 0x0x55a20afc1b20: 4187198, 'ANALYTICS' (function analytics_gather_mutable_meta_data() 532@daemon/analytics.c) holded a 'R' for 13232 usec.
+```
+
+The time can be changed by setting this `-DNETDATA_TRACE_RWLOCKS_HOLD_TIME_TO_IGNORE_USEC=20000` (or whatever number) to the CFLAGS.
+
+### logging for probable pauses (predictive)
+
+The library maintains a linked-list of all the lock holders (one entry per thread).  For this linked-list a mutex is used. So every call to the r/w locks now also has  a mutex lock.
+
+If any call is expected to pause the caller (ie the caller is attempting a read lock while there is a write lock in place and vice versa), the library will log something like this:
+
+```
+RW_LOCK ON LOCK 0x0x5651c9fcce20: 4190039 'HEALTH' (function init_pending_foreach_alarms() 661@health/health.c) WANTS a 'W' lock (while holding 1 rwlocks and 1 mutexes).
+There are 7 readers and 0 writers are holding the lock:
+     => 1: RW_LOCK: process 4190091 'WEB_SERVER[static14]' (function web_client_api_request_v1_data() 526@web/api/web_api_v1.c) is having 1 'R' lock for 709847 usec.
+     => 2: RW_LOCK: process 4190079 'WEB_SERVER[static6]' (function web_client_api_request_v1_data() 526@web/api/web_api_v1.c) is having 1 'R' lock for 709869 usec.
+     => 3: RW_LOCK: process 4190084 'WEB_SERVER[static10]' (function web_client_api_request_v1_data() 526@web/api/web_api_v1.c) is having 1 'R' lock for 709948 usec.
+     => 4: RW_LOCK: process 4190076 'WEB_SERVER[static3]' (function web_client_api_request_v1_data() 526@web/api/web_api_v1.c) is having 1 'R' lock for 710190 usec.
+     => 5: RW_LOCK: process 4190092 'WEB_SERVER[static15]' (function web_client_api_request_v1_data() 526@web/api/web_api_v1.c) is having 1 'R' lock for 710195 usec.
+     => 6: RW_LOCK: process 4190077 'WEB_SERVER[static4]' (function web_client_api_request_v1_data() 526@web/api/web_api_v1.c) is having 1 'R' lock for 710208 usec.
+     => 7: RW_LOCK: process 4190044 'WEB_SERVER[static1]' (function web_client_api_request_v1_data() 526@web/api/web_api_v1.c) is having 1 'R' lock for 710221 usec.
+```
+
+And each of the above is paired with a `GOT` log, like this:
+
+```
+RW_LOCK ON LOCK 0x0x5651c9fcce20: 4190039 'HEALTH' (function init_pending_foreach_alarms() 661@health/health.c) GOT a 'W' lock (while holding 2 rwlocks and 1 mutexes).
+There are 0 readers and 1 writers are holding the lock:
+     => 1: RW_LOCK: process 4190039 'HEALTH' (function init_pending_foreach_alarms() 661@health/health.c) is having 1 'W' lock for 36 usec.
+```
+
+Keep in mind that the lock and log are not atomic. The list of callers is indicative (and sometimes just empty because the original holders of the lock, unlocked it until we had the chance to print their names).
+
+### POSIX compliance check
+
+The library may also log messages about POSIX unsupported cases, like this:
+
+```
+RW_LOCK FATAL ON LOCK 0x0x622000109290: 3609368 'PLUGIN[proc]' (function __rrdset_check_rdlock() 10@database/rrdset.c) attempts to acquire a 'W' lock.
+But it is not supported by POSIX because: ALREADY HAS THIS LOCK
+At this attempt, the task is holding 1 rwlocks and 1 mutexes.
+There are 1 readers and 0 writers are holding the lock requested now:
+     => 1: RW_LOCK: process 3609368 'PLUGIN[proc]' (function rrdset_done() 1398@database/rrdset.c) is having 1 'R' lock for 0 usec.
+```
+
+### nested read locks
+
+When compiled with `-DNETDATA_TRACE_RWLOCKS_LOG_NESTED=1` the library will also detect nested read locks and print them like this:
+
+```
+RW_LOCK ON LOCK 0x0x7ff6ea46d190: 4140225 'WEB_SERVER[static14]' (function rrdr_json_wrapper_begin() 34@web/api/formatters/json_wrapper.c) NESTED READ LOCK REQUEST a 'R' lock (while holding 1 rwlocks and 1 mutexes).
+There are 5 readers and 0 writers are holding the lock:
+   => 1: RW_LOCK: process 4140225 'WEB_SERVER[static14]' (function rrdr_lock_rrdset() 70@web/api/queries/rrdr.c) is having 1 'R' lock for 216667 usec.
+   => 2: RW_LOCK: process 4140211 'WEB_SERVER[static6]' (function rrdr_lock_rrdset() 70@web/api/queries/rrdr.c) is having 1 'R' lock for 220001 usec.
+   => 3: RW_LOCK: process 4140218 'WEB_SERVER[static8]' (function rrdr_lock_rrdset() 70@web/api/queries/rrdr.c) is having 1 'R' lock for 220001 usec.
+   => 4: RW_LOCK: process 4140224 'WEB_SERVER[static13]' (function rrdr_lock_rrdset() 70@web/api/queries/rrdr.c) is having 1 'R' lock for 220001 usec.
+   => 5: RW_LOCK: process 4140227 'WEB_SERVER[static16]' (function rrdr_lock_rrdset() 70@web/api/queries/rrdr.c) is having 1 'R' lock for 220001 usec.
+```
+
+
 

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -101,6 +101,7 @@ int __netdata_mutex_unlock(netdata_mutex_t *mutex) {
 }
 
 #ifdef NETDATA_TRACE_RWLOCKS
+#warning NETDATA_TRACE_RWLOCKS ENABLED - EXPECT A LOT OF OUTPUT
 
 int netdata_mutex_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                              const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -55,6 +55,13 @@ int __netdata_mutex_init(netdata_mutex_t *mutex) {
     return ret;
 }
 
+int __netdata_mutex_destroy(netdata_mutex_t *mutex) {
+    int ret = pthread_mutex_destroy(mutex);
+    if(unlikely(ret != 0))
+        error("MUTEX_LOCK: failed to destroy (code %d).", ret);
+    return ret;
+}
+
 int __netdata_mutex_lock(netdata_mutex_t *mutex) {
     netdata_thread_disable_cancelability();
 
@@ -108,6 +115,23 @@ int netdata_mutex_init_debug(const char *file __maybe_unused, const char *functi
     int ret = __netdata_mutex_init(mutex);
 
     debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+
+    return ret;
+}
+
+int netdata_mutex_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
+                             const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
+    usec_t start = 0;
+    (void)start;
+
+    if(unlikely(debug_flags & D_LOCKS)) {
+        start = now_boottime_usec();
+        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    }
+
+    int ret = __netdata_mutex_destroy(mutex);
+
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
 
     return ret;
 }

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -229,7 +229,7 @@ int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock) {
 void not_supported_by_posix_rwlocks(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, char locktype, const char *reason) {
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     fprintf(stderr,
-            "RW_LOCK FATAL ON LOCK 0x%08x: %zu, '%s' (function %s() %llu@%s) attempts to acquire a '%c' lock but is not supported by POSIX because: %s\n"
+            "RW_LOCK FATAL ON LOCK 0x%08x: %zu '%s' (function %s() %llu@%s) attempts to acquire a '%c' lock but is not supported by POSIX because: %s\n"
             "There are %zu readers and %zu writers are holding the lock:\n",
             (uintptr_t)rwlock,
             gettid(), netdata_thread_tag(),
@@ -256,7 +256,7 @@ void not_supported_by_posix_rwlocks(const char *file, const char *function, cons
 static void log_rwlock_lockers(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, const char *reason, char locktype) {
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     fprintf(stderr,
-            "RW_LOCK ON LOCK 0x%08x: %zu, '%s' (function %s() %llu@%s) %s a '%c' lock.\n"
+            "RW_LOCK ON LOCK 0x%08x: %zu '%s' (function %s() %llu@%s) %s a '%c' lock.\n"
             "There are %zu readers and %zu writers are holding the lock:\n",
             (uintptr_t)rwlock,
             gettid(), netdata_thread_tag(),

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -405,7 +405,7 @@ static void remove_rwlock_locker(const char *file __maybe_unused, const char *fu
                     locker->callers, locker->lock);
         }
         else {
-            if(end_s - locker->start_s > NETDATA_TRACE_RWLOCKS_HOLD_TIME_TO_IGNORE_USEC)
+            if(end_s - locker->start_s >= NETDATA_TRACE_RWLOCKS_HOLD_TIME_TO_IGNORE_USEC)
                 fprintf(stderr,
                         "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) holded a '%c' for %llu usec.\n",
                         rwlock,
@@ -523,7 +523,7 @@ int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *fun
 
     }
 
-    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+    if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
                 "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED for a READ lock for %llu usec.\n",
                 rwlock,
@@ -560,7 +560,7 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
         if(log) log_rwlock_lockers(file, function, line, rwlock, "GOT", 'W');
     }
 
-    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+    if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
                 "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED for a WRITE lock for %llu usec.\n",
                 rwlock,
@@ -586,7 +586,7 @@ int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *fun
     int ret = __netdata_rwlock_unlock(rwlock);
     usec_t end_s = now_monotonic_high_precision_usec();
 
-    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+    if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
                 "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED to UNLOCK for %llu usec.\n",
                 rwlock,
@@ -616,7 +616,7 @@ int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *
     if(!ret)
         locker = update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'R');
 
-    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+    if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
                 "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED to TRYREAD for %llu usec.\n",
                 rwlock,
@@ -644,7 +644,7 @@ int netdata_rwlock_trywrlock_debug(const char *file __maybe_unused, const char *
     if(!ret)
         locker = update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'W');
 
-    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+    if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
                 "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED to TRYWRITE for %llu usec.\n",
                 rwlock,

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -118,29 +118,29 @@ int __netdata_mutex_unlock(netdata_mutex_t *mutex) {
 
 int netdata_mutex_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                              const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     int ret = __netdata_mutex_init(mutex);
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) = %d, from %lu@%s, %s()", mutex, ret, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(%p) = %d, from %lu@%s, %s()", mutex, ret, line, file, function);
 
     return ret;
 }
 
 int netdata_mutex_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                              const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     int ret = __netdata_mutex_destroy(mutex);
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) = %d, from %lu@%s, %s()", mutex, ret, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(%p) = %d, from %lu@%s, %s()", mutex, ret, line, file, function);
 
     return ret;
 }
 
 int netdata_mutex_lock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                              const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_mutex_lock(mutex);
@@ -150,14 +150,14 @@ int netdata_mutex_lock_debug(const char *file __maybe_unused, const char *functi
     (void)start_s;
     (void)end_s;
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
 
 int netdata_mutex_trylock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_mutex_trylock(mutex);
@@ -167,14 +167,14 @@ int netdata_mutex_trylock_debug(const char *file __maybe_unused, const char *fun
     (void)start_s;
     (void)end_s;
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
 
 int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_mutex_unlock(mutex);
@@ -184,7 +184,7 @@ int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *func
     (void)start_s;
     (void)end_s;
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
@@ -280,10 +280,7 @@ int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock) {
 void not_supported_by_posix_rwlocks(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, char locktype, const char *reason) {
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     fprintf(stderr,
-            "RW_LOCK FATAL ON LOCK 0x%p: %d '%s' (function %s() %lu@%s) attempts to acquire a '%c' lock.\n"
-            "But it is not supported by POSIX because: %s\n"
-            "At this attempt, the task is holding %zu rwlocks and %zu mutexes.\n"
-            "There are %zu readers and %zu writers are holding the lock requested now:\n",
+            "RW_LOCK FATAL ON LOCK %p: %d '%s' (function %s() %lu@%s) attempts to acquire a '%c' lock, but it is not supported by POSIX because: %s. At this attempt, the task is holding %zu rwlocks and %zu mutexes. There are %zu readers and %zu writers holding this lock:\n",
             rwlock,
             gettid(), netdata_thread_tag(),
             function, line, file,
@@ -297,8 +294,8 @@ void not_supported_by_posix_rwlocks(const char *file, const char *function, cons
     netdata_rwlock_locker *p;
     for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
         fprintf(stderr,
-                "     => %i: RW_LOCK: process %d '%s' (function %s() %lu@%s) is having %zu '%c' lock for %llu usec.\n",
-                i,
+                "     => %i: RW_LOCK %p: process %d '%s' (function %s() %lu@%s) is having %zu '%c' lock for %llu usec.\n",
+                i, rwlock,
                 p->pid, p->tag,
                 p->function, p->line, p->file,
                 p->callers, p->lock,
@@ -310,8 +307,7 @@ void not_supported_by_posix_rwlocks(const char *file, const char *function, cons
 static void log_rwlock_lockers(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, const char *reason, char locktype) {
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     fprintf(stderr,
-            "RW_LOCK ON LOCK 0x%p: %d '%s' (function %s() %lu@%s) %s a '%c' lock (while holding %zu rwlocks and %zu mutexes).\n"
-            "There are %zu readers and %zu writers are holding the lock:\n",
+            "RW_LOCK ON LOCK %p: %d '%s' (function %s() %lu@%s) %s a '%c' lock (while holding %zu rwlocks and %zu mutexes). There are %zu readers and %zu writers holding this lock:\n",
             rwlock,
             gettid(), netdata_thread_tag(),
             function, line, file,
@@ -324,8 +320,8 @@ static void log_rwlock_lockers(const char *file, const char *function, const uns
     netdata_rwlock_locker *p;
     for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
         fprintf(stderr,
-                "     => %i: RW_LOCK: process %d '%s' (function %s() %lu@%s) is having %zu '%c' lock for %llu usec.\n",
-                i,
+                "     => %i: RW_LOCK %p: process %d '%s' (function %s() %lu@%s) is having %zu '%c' lock for %llu usec.\n",
+                i, rwlock,
                 p->pid, p->tag,
                 p->function, p->line, p->file,
                 p->callers, p->lock,
@@ -360,14 +356,14 @@ static void remove_rwlock_locker(const char *file __maybe_unused, const char *fu
 
     if(locker->callers == 0)
         fprintf(stderr,
-                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) callers should be positive but it is zero\n",
+                "RW_LOCK ON LOCK %p: %d, '%s' (function %s() %lu@%s) callers should be positive but it is zero\n",
                 rwlock,
                 locker->pid, locker->tag,
                 locker->function, locker->line, locker->file);
 
     if(locker->callers > 1 && locker->lock != 'R')
         fprintf(stderr,
-                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) only 'R' locks support multiple holders, but here we have %zu callers holding a '%c' lock.\n",
+                "RW_LOCK ON LOCK %p: %d, '%s' (function %s() %lu@%s) only 'R' locks support multiple holders, but here we have %zu callers holding a '%c' lock.\n",
                 rwlock,
                 locker->pid, locker->tag,
                 locker->function, locker->line, locker->file,
@@ -398,7 +394,7 @@ static void remove_rwlock_locker(const char *file __maybe_unused, const char *fu
 
         if(!doit) {
             fprintf(stderr,
-                    "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) with %zu x '%c' lock is not found.\n",
+                    "RW_LOCK ON LOCK %p: %d, '%s' (function %s() %lu@%s) with %zu x '%c' lock is not found.\n",
                     rwlock,
                     locker->pid, locker->tag,
                     locker->function, locker->line, locker->file,
@@ -407,7 +403,7 @@ static void remove_rwlock_locker(const char *file __maybe_unused, const char *fu
         else {
             if(end_s - locker->start_s >= NETDATA_TRACE_RWLOCKS_HOLD_TIME_TO_IGNORE_USEC)
                 fprintf(stderr,
-                        "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) holded a '%c' for %llu usec.\n",
+                        "RW_LOCK ON LOCK %p: %d, '%s' (function %s() %lu@%s) holded a '%c' for %llu usec.\n",
                         rwlock,
                         locker->pid, locker->tag,
                         locker->function, locker->line, locker->file,
@@ -454,7 +450,7 @@ static netdata_rwlock_locker *update_or_add_rwlock_locker(const char *file, cons
 
 int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                  const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     if(rwlock->readers)
         error("RW_LOCK: destroying a rwlock with %zu readers in it", rwlock->readers);
@@ -472,14 +468,14 @@ int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *fu
             error("RW_LOCK: internal error - empty rwlock with %zu writers in it", rwlock->writers);
     }
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) = %d, from %lu@%s, %s()", rwlock, ret, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(%p) = %d, from %lu@%s, %s()", rwlock, ret, line, file, function);
 
     return ret;
 }
 
 int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                               const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     int ret = __netdata_rwlock_init(rwlock);
     if(!ret) {
@@ -489,7 +485,7 @@ int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *funct
         rwlock->writers = 0;
     }
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) = %d, from %lu@%s, %s()", rwlock, ret, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(%p) = %d, from %lu@%s, %s()", rwlock, ret, line, file, function);
 
     return ret;
 }
@@ -497,7 +493,7 @@ int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *funct
 int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
 
@@ -525,13 +521,13 @@ int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *fun
 
     if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
-                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED for a READ lock for %llu usec.\n",
+                "RW_LOCK ON LOCK %p: %d, '%s' (function %s() %lu@%s) WAITED for a READ lock for %llu usec.\n",
                 rwlock,
                 gettid(), netdata_thread_tag(),
                 function, line, file,
                 end_s - start_s);
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
@@ -539,7 +535,7 @@ int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *fun
 int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
     if(locker)
@@ -562,13 +558,13 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
 
     if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
-                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED for a WRITE lock for %llu usec.\n",
+                "RW_LOCK ON LOCK %p: %d, '%s' (function %s() %lu@%s) WAITED for a WRITE lock for %llu usec.\n",
                 rwlock,
                 gettid(), netdata_thread_tag(),
                 function, line, file,
                 end_s - start_s);
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
@@ -576,7 +572,7 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
 int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
     if(unlikely(!locker))
@@ -588,7 +584,7 @@ int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *fun
 
     if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
-                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED to UNLOCK for %llu usec.\n",
+                "RW_LOCK ON LOCK %p: %d, '%s' (function %s() %lu@%s) WAITED to UNLOCK for %llu usec.\n",
                 rwlock,
                 gettid(), netdata_thread_tag(),
                 function, line, file,
@@ -596,14 +592,14 @@ int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *fun
 
     if(likely(!ret && locker)) remove_rwlock_locker(file, function, line, rwlock, locker);
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
 
 int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                    const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
     if(locker && locker->lock == 'W')
@@ -618,20 +614,20 @@ int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *
 
     if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
-                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED to TRYREAD for %llu usec.\n",
+                "RW_LOCK ON LOCK %p: %d, '%s' (function %s() %lu@%s) WAITED to TRYREAD for %llu usec.\n",
                 rwlock,
                 gettid(), netdata_thread_tag(),
                 function, line, file,
                 end_s - start_s);
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
 
 int netdata_rwlock_trywrlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                    const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
     if(locker)
@@ -646,13 +642,13 @@ int netdata_rwlock_trywrlock_debug(const char *file __maybe_unused, const char *
 
     if(end_s - start_s >= NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
         fprintf(stderr,
-                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED to TRYWRITE for %llu usec.\n",
+                "RW_LOCK ON LOCK %p: %d, '%s' (function %s() %lu@%s) WAITED to TRYWRITE for %llu usec.\n",
                 rwlock,
                 gettid(), netdata_thread_tag(),
                 function, line, file,
                 end_s - start_s);
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -150,19 +150,18 @@ int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *func
     return ret;
 }
 
-
 // ----------------------------------------------------------------------------
-// r/w lock
+// rwlock
 
 int __netdata_rwlock_destroy(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_destroy(rwlock);
+    int ret = pthread_rwlock_destroy(&rwlock->rwlock_t);
     if(unlikely(ret != 0))
         error("RW_LOCK: failed to destroy lock (code %d)", ret);
     return ret;
 }
 
 int __netdata_rwlock_init(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_init(rwlock, NULL);
+    int ret = pthread_rwlock_init(&rwlock->rwlock_t, NULL);
     if(unlikely(ret != 0))
         error("RW_LOCK: failed to initialize lock (code %d)", ret);
     return ret;
@@ -171,7 +170,7 @@ int __netdata_rwlock_init(netdata_rwlock_t *rwlock) {
 int __netdata_rwlock_rdlock(netdata_rwlock_t *rwlock) {
     netdata_thread_disable_cancelability();
 
-    int ret = pthread_rwlock_rdlock(rwlock);
+    int ret = pthread_rwlock_rdlock(&rwlock->rwlock_t);
     if(unlikely(ret != 0)) {
         netdata_thread_enable_cancelability();
         error("RW_LOCK: failed to obtain read lock (code %d)", ret);
@@ -183,7 +182,7 @@ int __netdata_rwlock_rdlock(netdata_rwlock_t *rwlock) {
 int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock) {
     netdata_thread_disable_cancelability();
 
-    int ret = pthread_rwlock_wrlock(rwlock);
+    int ret = pthread_rwlock_wrlock(&rwlock->rwlock_t);
     if(unlikely(ret != 0)) {
         error("RW_LOCK: failed to obtain write lock (code %d)", ret);
         netdata_thread_enable_cancelability();
@@ -193,7 +192,7 @@ int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock) {
 }
 
 int __netdata_rwlock_unlock(netdata_rwlock_t *rwlock) {
-    int ret = pthread_rwlock_unlock(rwlock);
+    int ret = pthread_rwlock_unlock(&rwlock->rwlock_t);
     if(unlikely(ret != 0))
         error("RW_LOCK: failed to release lock (code %d)", ret);
     else
@@ -205,7 +204,7 @@ int __netdata_rwlock_unlock(netdata_rwlock_t *rwlock) {
 int __netdata_rwlock_tryrdlock(netdata_rwlock_t *rwlock) {
     netdata_thread_disable_cancelability();
 
-    int ret = pthread_rwlock_tryrdlock(rwlock);
+    int ret = pthread_rwlock_tryrdlock(&rwlock->rwlock_t);
     if(ret != 0)
         netdata_thread_enable_cancelability();
 
@@ -215,13 +214,176 @@ int __netdata_rwlock_tryrdlock(netdata_rwlock_t *rwlock) {
 int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock) {
     netdata_thread_disable_cancelability();
 
-    int ret = pthread_rwlock_trywrlock(rwlock);
+    int ret = pthread_rwlock_trywrlock(&rwlock->rwlock_t);
     if(ret != 0)
         netdata_thread_enable_cancelability();
 
     return ret;
 }
 
+#ifdef NETDATA_INTERNAL_CHECKS
+
+// ----------------------------------------------------------------------------
+// lockers list
+
+void not_supported_by_posix_rwlocks(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, char locktype, const char *reason) {
+    __netdata_mutex_lock(&rwlock->lockers_mutex);
+    fprintf(stderr,
+            "RW_LOCK FATAL ON LOCK 0x%08x: %zu, '%s' (function %s() %llu@%s) attempts to acquire a '%c' lock but is not supported by POSIX because: %s\n"
+            "There are %zu readers and %zu writers are holding the lock:\n",
+            (uintptr_t)rwlock,
+            gettid(), netdata_thread_tag(),
+            function, line, file,
+            locktype,
+            reason,
+            rwlock->readers, rwlock->writers);
+
+    int i;
+    usec_t now = now_monotonic_usec();
+    netdata_rwlock_locker *p;
+    for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
+        fprintf(stderr,
+                "     => %i: RW_LOCK: process %zu '%s' (function %s() %llu@%s) is having %zu '%c' lock for %llu usec.\n",
+                i,
+                p->pid, p->tag,
+                p->function, p->line, p->file,
+                p->callers, p->lock,
+                (now - p->start_s));
+    }
+    __netdata_mutex_unlock(&rwlock->lockers_mutex);
+}
+
+static void log_rwlock_lockers(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, const char *reason, char locktype) {
+    __netdata_mutex_lock(&rwlock->lockers_mutex);
+    fprintf(stderr,
+            "RW_LOCK ON LOCK 0x%08x: %zu, '%s' (function %s() %llu@%s) %s a '%c' lock.\n"
+            "There are %zu readers and %zu writers are holding the lock:\n",
+            (uintptr_t)rwlock,
+            gettid(), netdata_thread_tag(),
+            function, line, file,
+            reason, locktype,
+            rwlock->readers, rwlock->writers);
+
+    int i;
+    usec_t now = now_monotonic_usec();
+    netdata_rwlock_locker *p;
+    for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
+        fprintf(stderr,
+                "     => %i: RW_LOCK: process %zu '%s' (function %s() %llu@%s) is having %zu '%c' lock for %llu usec.\n",
+                i,
+                p->pid, p->tag,
+                p->function, p->line, p->file,
+                p->callers, p->lock,
+                (now - p->start_s));
+    }
+    __netdata_mutex_unlock(&rwlock->lockers_mutex);
+}
+
+static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, char lock_type) {
+    netdata_rwlock_locker *p = mallocz(sizeof(netdata_rwlock_locker));
+    p->pid = gettid();
+    p->tag = netdata_thread_tag();
+    p->lock = lock_type;
+    p->file = file;
+    p->function = function;
+    p->line = line;
+    p->callers = 1;
+    p->start_s = now_monotonic_usec();
+
+    __netdata_mutex_lock(&rwlock->lockers_mutex);
+    p->next = rwlock->lockers;
+    rwlock->lockers = p;
+    if(lock_type == 'R') rwlock->readers++;
+    if(lock_type == 'W') rwlock->writers++;
+    __netdata_mutex_unlock(&rwlock->lockers_mutex);
+
+    return p;
+}
+
+static void remove_rwlock_locker(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, netdata_rwlock_locker *locker) {
+    if(locker->callers == 0)
+        fprintf(stderr,
+                "RW_LOCK ON LOCK 0x%08x: %d, '%s' (function %s() %lu@%s) callers should be positive but it is zero\n",
+                (uintptr_t)rwlock,
+                locker->pid, locker->tag,
+                locker->function, locker->line, locker->file);
+
+    if(locker->callers > 1 && locker->lock != 'R')
+        fprintf(stderr,
+                "RW_LOCK ON LOCK 0x%08x: %d, '%s' (function %s() %lu@%s) only 'R' locks support nesting, but here we have %zu on '%c' lock.\n",
+                (uintptr_t)rwlock,
+                locker->pid, locker->tag,
+                locker->function, locker->line, locker->file,
+                locker->callers, locker->lock);
+
+    __netdata_mutex_lock(&rwlock->lockers_mutex);
+    locker->callers--;
+
+    if(!locker->callers) {
+        int doit = 0;
+
+        if (rwlock->lockers == locker) {
+            rwlock->lockers = locker->next;
+            doit = 1;
+        } else {
+            netdata_rwlock_locker *p;
+            for (p = rwlock->lockers; p && p->next != locker; p = p->next)
+                ;
+            if (p && p->next == locker) {
+                p->next = locker->next;
+                doit = 1;
+            }
+        }
+        if(doit) {
+            if(locker->lock == 'R') rwlock->readers--;
+            if(locker->lock == 'W') rwlock->writers--;
+        }
+
+        if(!doit) {
+            fprintf(stderr,
+                    "RW_LOCK ON LOCK 0x%08x: %d, '%s' (function %s() %lu@%s) with %zu '%c' lock is not found.\n",
+                    (uintptr_t)rwlock,
+                    locker->pid, locker->tag,
+                    locker->function, locker->line, locker->file,
+                    locker->callers, locker->lock);
+        }
+        else {
+            freez(locker);
+        }
+    }
+
+    __netdata_mutex_unlock(&rwlock->lockers_mutex);
+}
+
+static netdata_rwlock_locker *find_rwlock_locker(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+    pid_t pid = gettid();
+    netdata_rwlock_locker *p;
+
+    __netdata_mutex_lock(&rwlock->lockers_mutex);
+    for(p = rwlock->lockers; p ;p = p->next) {
+        if(p->pid == pid) break;
+    }
+    __netdata_mutex_unlock(&rwlock->lockers_mutex);
+
+    return p;
+}
+
+static void update_or_add_rwlock_locker(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, netdata_rwlock_locker *locker, char locktype) {
+    if(!locker) {
+        (void)add_rwlock_locker(file, function, line, rwlock, locktype);
+    }
+    else if(locker->lock == 'R' && locktype == 'R') {
+        __netdata_mutex_lock(&rwlock->lockers_mutex);
+        locker->callers++;
+        __netdata_mutex_unlock(&rwlock->lockers_mutex);
+    }
+    else {
+        not_supported_by_posix_rwlocks(file, function, line, rwlock, locktype, "DEADLOCK - WANTS TO CHANGE LOCK TYPE BUT ALREADY HAS THIS LOCKED");
+    }
+}
+
+// ----------------------------------------------------------------------------
+// debug versions of rwlock
 
 int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                  const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
@@ -233,7 +395,21 @@ int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *fu
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
+    if(rwlock->readers)
+        error("RW_LOCK: destroying a rwlock with %zu readers in it", rwlock->readers);
+    if(rwlock->writers)
+        error("RW_LOCK: destroying a rwlock with %zu writers in it", rwlock->writers);
+
     int ret = __netdata_rwlock_destroy(rwlock);
+    if(!ret) {
+        while (rwlock->lockers)
+            remove_rwlock_locker(file, function, line, rwlock, rwlock->lockers);
+
+        if (rwlock->readers)
+            error("RW_LOCK: internal error - empty rwlock with %zu readers in it", rwlock->readers);
+        if (rwlock->writers)
+            error("RW_LOCK: internal error - empty rwlock with %zu writers in it", rwlock->writers);
+    }
 
     debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
 
@@ -251,6 +427,12 @@ int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *funct
     }
 
     int ret = __netdata_rwlock_init(rwlock);
+    if(!ret) {
+        __netdata_mutex_init(&rwlock->lockers_mutex);
+        rwlock->lockers = NULL;
+        rwlock->readers = 0;
+        rwlock->writers = 0;
+    }
 
     debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
 
@@ -267,7 +449,22 @@ int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *fun
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
+    netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
+    if(locker && locker->lock == 'R') {
+        log_rwlock_lockers(file, function, line, rwlock, "NESTED READ LOCK REQUEST", 'R');
+    }
+
+    int log = 0;
+    if(rwlock->writers) {
+        log_rwlock_lockers(file, function, line, rwlock, "WANTS", 'R');
+        log = 1;
+    }
+
     int ret = __netdata_rwlock_rdlock(rwlock);
+    if(!ret) {
+        update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'R');
+        if(log) log_rwlock_lockers(file, function, line, rwlock, "GOT", 'R');
+    }
 
     debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
 
@@ -284,7 +481,21 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
+    netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
+    if(locker)
+        not_supported_by_posix_rwlocks(file, function, line, rwlock, 'W', "DEADLOCK - WANTS A WRITE LOCK BUT ALREADY HAVE THIS LOCKED");
+
+    int log = 0;
+    if(rwlock->readers) {
+        log_rwlock_lockers(file, function, line, rwlock, "WANTS", 'W');
+        log = 1;
+    }
+
     int ret = __netdata_rwlock_wrlock(rwlock);
+    if(!ret){
+        update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'W');
+        if(log) log_rwlock_lockers(file, function, line, rwlock, "GOT", 'W');
+    }
 
     debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
 
@@ -301,7 +512,13 @@ int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *fun
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
+    netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
+    if(unlikely(!locker))
+        not_supported_by_posix_rwlocks(file, function, line, rwlock, 'U', "UNLOCK WITHOUT LOCK");
+
     int ret = __netdata_rwlock_unlock(rwlock);
+
+    if(likely(!ret && locker)) remove_rwlock_locker(file, function, line, rwlock, locker);
 
     debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
 
@@ -318,7 +535,13 @@ int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
+    netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
+    if(locker && locker->lock == 'W')
+        not_supported_by_posix_rwlocks(file, function, line, rwlock, 'R', "DEADLOCK - WANTS A READ LOCK BUT IT HAS A WRITE LOCK ALREADY");
+
     int ret = __netdata_rwlock_tryrdlock(rwlock);
+    if(!ret)
+        update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'R');
 
     debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
 
@@ -335,9 +558,17 @@ int netdata_rwlock_trywrlock_debug(const char *file __maybe_unused, const char *
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
+    netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
+    if(locker)
+        not_supported_by_posix_rwlocks(file, function, line, rwlock, 'W', "ALREADY HAS THIS LOCK");
+
     int ret = __netdata_rwlock_trywrlock(rwlock);
+    if(!ret)
+        update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'W');
 
     debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
 
     return ret;
 }
+
+#endif // NETDATA_INTERNAL_CHECKS

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -278,7 +278,7 @@ int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock) {
 void not_supported_by_posix_rwlocks(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, char locktype, const char *reason) {
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     fprintf(stderr,
-            "RW_LOCK FATAL ON LOCK 0x%p: %u '%s' (function %s() %lu@%s) attempts to acquire a '%c' lock.\n"
+            "RW_LOCK FATAL ON LOCK 0x%p: %d '%s' (function %s() %lu@%s) attempts to acquire a '%c' lock.\n"
             "But it is not supported by POSIX because: %s\n"
             "At this attempt, the task is holding %zu rwlocks and %zu mutexes.\n"
             "There are %zu readers and %zu writers are holding the lock requested now:\n",
@@ -295,7 +295,7 @@ void not_supported_by_posix_rwlocks(const char *file, const char *function, cons
     netdata_rwlock_locker *p;
     for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
         fprintf(stderr,
-                "     => %i: RW_LOCK: process %u '%s' (function %s() %lu@%s) is having %zu '%c' lock for %llu usec.\n",
+                "     => %i: RW_LOCK: process %d '%s' (function %s() %lu@%s) is having %zu '%c' lock for %llu usec.\n",
                 i,
                 p->pid, p->tag,
                 p->function, p->line, p->file,
@@ -308,7 +308,7 @@ void not_supported_by_posix_rwlocks(const char *file, const char *function, cons
 static void log_rwlock_lockers(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, const char *reason, char locktype) {
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     fprintf(stderr,
-            "RW_LOCK ON LOCK 0x%p: %u '%s' (function %s() %lu@%s) %s a '%c' lock (while holding %zu rwlocks and %zu mutexes).\n"
+            "RW_LOCK ON LOCK 0x%p: %d '%s' (function %s() %lu@%s) %s a '%c' lock (while holding %zu rwlocks and %zu mutexes).\n"
             "There are %zu readers and %zu writers are holding the lock:\n",
             rwlock,
             gettid(), netdata_thread_tag(),
@@ -322,7 +322,7 @@ static void log_rwlock_lockers(const char *file, const char *function, const uns
     netdata_rwlock_locker *p;
     for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
         fprintf(stderr,
-                "     => %i: RW_LOCK: process %u '%s' (function %s() %lu@%s) is having %zu '%c' lock for %llu usec.\n",
+                "     => %i: RW_LOCK: process %d '%s' (function %s() %lu@%s) is having %zu '%c' lock for %llu usec.\n",
                 i,
                 p->pid, p->tag,
                 p->function, p->line, p->file,

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -2,6 +2,18 @@
 
 #include "../libnetdata.h"
 
+#ifdef NETDATA_TRACE_RWLOCKS
+
+#ifndef NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC
+#define NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC 10
+#endif
+
+#ifndef NETDATA_TRACE_RWLOCKS_HOLD_TIME_TO_IGNORE_USEC
+#define NETDATA_TRACE_RWLOCKS_HOLD_TIME_TO_IGNORE_USEC 10000
+#endif
+
+#endif // NETDATA_TRACE_RWLOCKS
+
 // ----------------------------------------------------------------------------
 // automatic thread cancelability management, based on locks
 
@@ -101,89 +113,78 @@ int __netdata_mutex_unlock(netdata_mutex_t *mutex) {
 }
 
 #ifdef NETDATA_TRACE_RWLOCKS
+
 #warning NETDATA_TRACE_RWLOCKS ENABLED - EXPECT A LOT OF OUTPUT
 
 int netdata_mutex_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                              const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    usec_t start = 0;
-    (void)start;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) from %lu@%s, %s()", mutex, line, file, function);
-    }
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) from %lu@%s, %s()", mutex, line, file, function);
 
     int ret = __netdata_mutex_init(mutex);
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) = %d, from %lu@%s, %s()", mutex, ret, line, file, function);
 
     return ret;
 }
 
 int netdata_mutex_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                              const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    usec_t start = 0;
-    (void)start;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) from %lu@%s, %s()", mutex, line, file, function);
-    }
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) from %lu@%s, %s()", mutex, line, file, function);
 
     int ret = __netdata_mutex_destroy(mutex);
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) = %d, from %lu@%s, %s()", mutex, ret, line, file, function);
 
     return ret;
 }
 
 int netdata_mutex_lock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                              const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    usec_t start = 0;
-    (void)start;
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
 
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
-    }
-
+    usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_mutex_lock(mutex);
+    usec_t end_s = now_monotonic_high_precision_usec();
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
+    // remove compiler unused variables warning
+    (void)start_s;
+    (void)end_s;
+
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
 
 int netdata_mutex_trylock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    usec_t start = 0;
-    (void)start;
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
 
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
-    }
-
+    usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_mutex_trylock(mutex);
+    usec_t end_s = now_monotonic_high_precision_usec();
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
+    // remove compiler unused variables warning
+    (void)start_s;
+    (void)end_s;
+
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
 
 int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
-    usec_t start = 0;
-    (void)start;
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
 
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
-    }
-
+    usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_mutex_unlock(mutex);
+    usec_t end_s = now_monotonic_high_precision_usec();
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
+    // remove compiler unused variables warning
+    (void)start_s;
+    (void)end_s;
+
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
@@ -292,7 +293,7 @@ void not_supported_by_posix_rwlocks(const char *file, const char *function, cons
             rwlock->readers, rwlock->writers);
 
     int i;
-    usec_t now = now_monotonic_usec();
+    usec_t now = now_monotonic_high_precision_usec();
     netdata_rwlock_locker *p;
     for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
         fprintf(stderr,
@@ -319,7 +320,7 @@ static void log_rwlock_lockers(const char *file, const char *function, const uns
             rwlock->readers, rwlock->writers);
 
     int i;
-    usec_t now = now_monotonic_usec();
+    usec_t now = now_monotonic_high_precision_usec();
     netdata_rwlock_locker *p;
     for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
         fprintf(stderr,
@@ -342,7 +343,7 @@ static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *fu
     p->function = function;
     p->line = line;
     p->callers = 1;
-    p->start_s = now_monotonic_usec();
+    p->start_s = now_monotonic_high_precision_usec();
 
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     p->next = rwlock->lockers;
@@ -355,6 +356,8 @@ static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *fu
 }
 
 static void remove_rwlock_locker(const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock, netdata_rwlock_locker *locker) {
+    usec_t end_s = now_monotonic_high_precision_usec();
+
     if(locker->callers == 0)
         fprintf(stderr,
                 "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) callers should be positive but it is zero\n",
@@ -395,13 +398,21 @@ static void remove_rwlock_locker(const char *file __maybe_unused, const char *fu
 
         if(!doit) {
             fprintf(stderr,
-                    "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) with %zu '%c' lock is not found.\n",
+                    "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) with %zu x '%c' lock is not found.\n",
                     rwlock,
                     locker->pid, locker->tag,
                     locker->function, locker->line, locker->file,
                     locker->callers, locker->lock);
         }
         else {
+            if(end_s - locker->start_s > NETDATA_TRACE_RWLOCKS_HOLD_TIME_TO_IGNORE_USEC)
+                fprintf(stderr,
+                        "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) holded a '%c' for %llu usec.\n",
+                        rwlock,
+                        locker->pid, locker->tag,
+                        locker->function, locker->line, locker->file,
+                        locker->lock, end_s - locker->start_s);
+
             freez(locker);
         }
     }
@@ -422,17 +433,19 @@ static netdata_rwlock_locker *find_rwlock_locker(const char *file __maybe_unused
     return p;
 }
 
-static void update_or_add_rwlock_locker(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, netdata_rwlock_locker *locker, char locktype) {
+static netdata_rwlock_locker *update_or_add_rwlock_locker(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, netdata_rwlock_locker *locker, char locktype) {
     if(!locker) {
-        (void)add_rwlock_locker(file, function, line, rwlock, locktype);
+        return add_rwlock_locker(file, function, line, rwlock, locktype);
     }
     else if(locker->lock == 'R' && locktype == 'R') {
         __netdata_mutex_lock(&rwlock->lockers_mutex);
         locker->callers++;
         __netdata_mutex_unlock(&rwlock->lockers_mutex);
+        return locker;
     }
     else {
         not_supported_by_posix_rwlocks(file, function, line, rwlock, locktype, "DEADLOCK - WANTS TO CHANGE LOCK TYPE BUT ALREADY HAS THIS LOCKED");
+        return locker;
     }
 }
 
@@ -441,13 +454,7 @@ static void update_or_add_rwlock_locker(const char *file, const char *function, 
 
 int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                  const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-    (void)start;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     if(rwlock->readers)
         error("RW_LOCK: destroying a rwlock with %zu readers in it", rwlock->readers);
@@ -465,20 +472,14 @@ int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *fu
             error("RW_LOCK: internal error - empty rwlock with %zu writers in it", rwlock->writers);
     }
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) = %d, from %lu@%s, %s()", rwlock, ret, line, file, function);
 
     return ret;
 }
 
 int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                               const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-    (void)start;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     int ret = __netdata_rwlock_init(rwlock);
     if(!ret) {
@@ -488,25 +489,23 @@ int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *funct
         rwlock->writers = 0;
     }
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) = %d, from %lu@%s, %s()", rwlock, ret, line, file, function);
 
     return ret;
 }
 
 int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-    (void)start;
 
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
+
+#ifdef NETDATA_TRACE_RWLOCKS_LOG_NESTED
     if(locker && locker->lock == 'R') {
         log_rwlock_lockers(file, function, line, rwlock, "NESTED READ LOCK REQUEST", 'R');
     }
+#endif // NETDATA_TRACE_RWLOCKS_LOG_NESTED
 
     int log = 0;
     if(rwlock->writers) {
@@ -514,26 +513,33 @@ int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *fun
         log = 1;
     }
 
+    usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_rwlock_rdlock(rwlock);
+    usec_t end_s = now_monotonic_high_precision_usec();
+
     if(!ret) {
-        update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'R');
+        locker = update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'R');
         if(log) log_rwlock_lockers(file, function, line, rwlock, "GOT", 'R');
+
     }
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
+    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+        fprintf(stderr,
+                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED for a READ lock for %llu usec.\n",
+                rwlock,
+                gettid(), netdata_thread_tag(),
+                function, line, file,
+                end_s - start_s);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
 
 int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-    (void)start;
 
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
     if(locker)
@@ -545,11 +551,22 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
         log = 1;
     }
 
+    usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_rwlock_wrlock(rwlock);
+    usec_t end_s = now_monotonic_high_precision_usec();
+
     if(!ret){
-        update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'W');
+        locker = update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'W');
         if(log) log_rwlock_lockers(file, function, line, rwlock, "GOT", 'W');
     }
+
+    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+        fprintf(stderr,
+                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED for a WRITE lock for %llu usec.\n",
+                rwlock,
+                gettid(), netdata_thread_tag(),
+                function, line, file,
+                end_s - start_s);
 
     debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
 
@@ -558,69 +575,84 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
 
 int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-    (void)start;
 
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
     if(unlikely(!locker))
         not_supported_by_posix_rwlocks(file, function, line, rwlock, 'U', "UNLOCK WITHOUT LOCK");
 
+    usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_rwlock_unlock(rwlock);
+    usec_t end_s = now_monotonic_high_precision_usec();
+
+    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+        fprintf(stderr,
+                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED to UNLOCK for %llu usec.\n",
+                rwlock,
+                gettid(), netdata_thread_tag(),
+                function, line, file,
+                end_s - start_s);
 
     if(likely(!ret && locker)) remove_rwlock_locker(file, function, line, rwlock, locker);
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
 
 int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                    const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-    (void)start;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
     if(locker && locker->lock == 'W')
         not_supported_by_posix_rwlocks(file, function, line, rwlock, 'R', "DEADLOCK - WANTS A READ LOCK BUT IT HAS A WRITE LOCK ALREADY");
 
+    usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_rwlock_tryrdlock(rwlock);
-    if(!ret)
-        update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'R');
+    usec_t end_s = now_monotonic_high_precision_usec();
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
+    if(!ret)
+        locker = update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'R');
+
+    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+        fprintf(stderr,
+                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED to TRYREAD for %llu usec.\n",
+                rwlock,
+                gettid(), netdata_thread_tag(),
+                function, line, file,
+                end_s - start_s);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
 
 int netdata_rwlock_trywrlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
                                    const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-    usec_t start = 0;
-    (void)start;
-
-    if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_monotonic_usec();
-        debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
-    }
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
     if(locker)
         not_supported_by_posix_rwlocks(file, function, line, rwlock, 'W', "ALREADY HAS THIS LOCK");
 
+    usec_t start_s = now_monotonic_high_precision_usec();
     int ret = __netdata_rwlock_trywrlock(rwlock);
-    if(!ret)
-        update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'W');
+    usec_t end_s = now_monotonic_high_precision_usec();
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
+    if(!ret)
+        locker = update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'W');
+
+    if(end_s - start_s > NETDATA_TRACE_RWLOCKS_WAIT_TIME_TO_IGNORE_USEC)
+        fprintf(stderr,
+                "RW_LOCK ON LOCK 0x%p: %d, '%s' (function %s() %lu@%s) WAITED to TRYWRITE for %llu usec.\n",
+                rwlock,
+                gettid(), netdata_thread_tag(),
+                function, line, file,
+                end_s - start_s);
+
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -108,13 +108,13 @@ int netdata_mutex_init_debug(const char *file __maybe_unused, const char *functi
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) from %lu@%s, %s()", mutex, line, file, function);
     }
 
     int ret = __netdata_mutex_init(mutex);
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -125,13 +125,13 @@ int netdata_mutex_destroy_debug(const char *file __maybe_unused, const char *fun
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) from %lu@%s, %s()", mutex, line, file, function);
     }
 
     int ret = __netdata_mutex_destroy(mutex);
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -142,13 +142,13 @@ int netdata_mutex_lock_debug(const char *file __maybe_unused, const char *functi
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
     }
 
     int ret = __netdata_mutex_lock(mutex);
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -159,13 +159,13 @@ int netdata_mutex_trylock_debug(const char *file __maybe_unused, const char *fun
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
     }
 
     int ret = __netdata_mutex_trylock(mutex);
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -176,13 +176,13 @@ int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *func
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) from %lu@%s, %s()", mutex, line, file, function);
     }
 
     int ret = __netdata_mutex_unlock(mutex);
 
-    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -291,7 +291,7 @@ void not_supported_by_posix_rwlocks(const char *file, const char *function, cons
             rwlock->readers, rwlock->writers);
 
     int i;
-    usec_t now = now_boottime_usec();
+    usec_t now = now_monotonic_usec();
     netdata_rwlock_locker *p;
     for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
         fprintf(stderr,
@@ -318,7 +318,7 @@ static void log_rwlock_lockers(const char *file, const char *function, const uns
             rwlock->readers, rwlock->writers);
 
     int i;
-    usec_t now = now_boottime_usec();
+    usec_t now = now_monotonic_usec();
     netdata_rwlock_locker *p;
     for(i = 1, p = rwlock->lockers; p ;p = p->next, i++) {
         fprintf(stderr,
@@ -341,7 +341,7 @@ static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *fu
     p->function = function;
     p->line = line;
     p->callers = 1;
-    p->start_s = now_boottime_usec();
+    p->start_s = now_monotonic_usec();
 
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     p->next = rwlock->lockers;
@@ -444,7 +444,7 @@ int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *fu
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
@@ -464,7 +464,7 @@ int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *fu
             error("RW_LOCK: internal error - empty rwlock with %zu writers in it", rwlock->writers);
     }
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_destroy(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -475,7 +475,7 @@ int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *funct
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
@@ -487,7 +487,7 @@ int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *funct
         rwlock->writers = 0;
     }
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_init(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -498,7 +498,7 @@ int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *fun
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
@@ -519,7 +519,7 @@ int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *fun
         if(log) log_rwlock_lockers(file, function, line, rwlock, "GOT", 'R');
     }
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_rdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -530,7 +530,7 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
@@ -550,7 +550,7 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
         if(log) log_rwlock_lockers(file, function, line, rwlock, "GOT", 'W');
     }
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -561,7 +561,7 @@ int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *fun
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
@@ -573,7 +573,7 @@ int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *fun
 
     if(likely(!ret && locker)) remove_rwlock_locker(file, function, line, rwlock, locker);
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_unlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -584,7 +584,7 @@ int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
@@ -596,7 +596,7 @@ int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *
     if(!ret)
         update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'R');
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_tryrdlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }
@@ -607,7 +607,7 @@ int netdata_rwlock_trywrlock_debug(const char *file __maybe_unused, const char *
     (void)start;
 
     if(unlikely(debug_flags & D_LOCKS)) {
-        start = now_boottime_usec();
+        start = now_monotonic_usec();
         debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) from %lu@%s, %s()", rwlock, line, file, function);
     }
 
@@ -619,7 +619,7 @@ int netdata_rwlock_trywrlock_debug(const char *file __maybe_unused, const char *
     if(!ret)
         update_or_add_rwlock_locker(file, function, line, rwlock, locker, 'W');
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_boottime_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_trywrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
 
     return ret;
 }

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -568,7 +568,7 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
                 function, line, file,
                 end_s - start_s);
 
-    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, now_monotonic_usec() - start, line, file, function);
+    debug(D_LOCKS, "RW_LOCK: netdata_rwlock_wrlock(0x%p) = %d in %llu usec, from %lu@%s, %s()", rwlock, ret, end_s - start_s, line, file, function);
 
     return ret;
 }

--- a/libnetdata/locks/locks.h
+++ b/libnetdata/locks/locks.h
@@ -51,6 +51,7 @@ typedef struct netdata_rwlock_t {
 #endif // NETDATA_TRACE_RWLOCKS
 
 extern int __netdata_mutex_init(netdata_mutex_t *mutex);
+extern int __netdata_mutex_destroy(netdata_mutex_t *mutex);
 extern int __netdata_mutex_lock(netdata_mutex_t *mutex);
 extern int __netdata_mutex_trylock(netdata_mutex_t *mutex);
 extern int __netdata_mutex_unlock(netdata_mutex_t *mutex);
@@ -69,6 +70,7 @@ extern void netdata_thread_enable_cancelability(void);
 #ifdef NETDATA_TRACE_RWLOCKS
 
 extern int netdata_mutex_init_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+extern int netdata_mutex_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
 extern int netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
 extern int netdata_mutex_trylock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
 extern int netdata_mutex_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
@@ -82,6 +84,7 @@ extern int netdata_rwlock_tryrdlock_debug( const char *file, const char *functio
 extern int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
 
 #define netdata_mutex_init(mutex)    netdata_mutex_init_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
+#define netdata_mutex_destroy(mutex) netdata_mutex_init_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_lock(mutex)    netdata_mutex_lock_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_trylock(mutex) netdata_mutex_trylock_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_unlock(mutex)  netdata_mutex_unlock_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
@@ -97,6 +100,7 @@ extern int netdata_rwlock_trywrlock_debug( const char *file, const char *functio
 #else // !NETDATA_TRACE_RWLOCKS
 
 #define netdata_mutex_init(mutex)    __netdata_mutex_init(mutex)
+#define netdata_mutex_destroy(mutex) __netdata_mutex_destroy(mutex)
 #define netdata_mutex_lock(mutex)    __netdata_mutex_lock(mutex)
 #define netdata_mutex_trylock(mutex) __netdata_mutex_trylock(mutex)
 #define netdata_mutex_unlock(mutex)  __netdata_mutex_unlock(mutex)

--- a/libnetdata/locks/locks.h
+++ b/libnetdata/locks/locks.h
@@ -9,7 +9,7 @@
 typedef pthread_mutex_t netdata_mutex_t;
 #define NETDATA_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
 
-#ifdef NETDATA_INTERNAL_CHECKS
+#ifdef NETDATA_TRACE_RWLOCKS
 typedef struct netdata_rwlock_locker {
     pid_t pid;
     const char *tag;
@@ -30,15 +30,15 @@ typedef struct netdata_rwlock_t {
     netdata_rwlock_locker *lockers;
 } netdata_rwlock_t;
 
-#define NETDATA_RWLOCK_INITIALIZER { \
-        .rwlock_t = PTHREAD_RWLOCK_INITIALIZER, \
-        .readers = 0, \
-        .writers = 0, \
+#define NETDATA_RWLOCK_INITIALIZER {                \
+        .rwlock_t = PTHREAD_RWLOCK_INITIALIZER,     \
+        .readers = 0,                               \
+        .writers = 0,                               \
         .lockers_mutex = NETDATA_MUTEX_INITIALIZER, \
-        .lockers = NULL \
+        .lockers = NULL                             \
     }
 
-#else // NETDATA_INTERNAL_CHECKS
+#else // NETDATA_TRACE_RWLOCKS
 
 typedef struct netdata_rwlock_t {
     pthread_rwlock_t rwlock_t;
@@ -48,7 +48,7 @@ typedef struct netdata_rwlock_t {
         .rwlock_t = PTHREAD_RWLOCK_INITIALIZER \
     }
 
-#endif // NETDATA_INTERNAL_CHECKS
+#endif // NETDATA_TRACE_RWLOCKS
 
 extern int __netdata_mutex_init(netdata_mutex_t *mutex);
 extern int __netdata_mutex_lock(netdata_mutex_t *mutex);
@@ -66,7 +66,7 @@ extern int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock);
 extern void netdata_thread_disable_cancelability(void);
 extern void netdata_thread_enable_cancelability(void);
 
-#ifdef NETDATA_INTERNAL_CHECKS
+#ifdef NETDATA_TRACE_RWLOCKS
 
 extern int netdata_mutex_init_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
 extern int netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
@@ -94,7 +94,7 @@ extern int netdata_rwlock_trywrlock_debug( const char *file, const char *functio
 #define netdata_rwlock_tryrdlock(rwlock) netdata_rwlock_tryrdlock_debug(__FILE__, __FUNCTION__, __LINE__, rwlock)
 #define netdata_rwlock_trywrlock(rwlock) netdata_rwlock_trywrlock_debug(__FILE__, __FUNCTION__, __LINE__, rwlock)
 
-#else // !NETDATA_INTERNAL_CHECKS
+#else // !NETDATA_TRACE_RWLOCKS
 
 #define netdata_mutex_init(mutex)    __netdata_mutex_init(mutex)
 #define netdata_mutex_lock(mutex)    __netdata_mutex_lock(mutex)
@@ -109,6 +109,6 @@ extern int netdata_rwlock_trywrlock_debug( const char *file, const char *functio
 #define netdata_rwlock_tryrdlock(rwlock)  __netdata_rwlock_tryrdlock(rwlock)
 #define netdata_rwlock_trywrlock(rwlock)  __netdata_rwlock_trywrlock(rwlock)
 
-#endif // NETDATA_INTERNAL_CHECKS
+#endif // NETDATA_TRACE_RWLOCKS
 
 #endif //NETDATA_LOCKS_H

--- a/libnetdata/locks/locks.h
+++ b/libnetdata/locks/locks.h
@@ -19,6 +19,7 @@ typedef struct netdata_rwlock_locker {
     unsigned long line;
     size_t callers;
     usec_t start_s;
+    struct netdata_rwlock_t **all_caller_locks;
     struct netdata_rwlock_locker *next;
 } netdata_rwlock_locker;
 

--- a/libnetdata/locks/locks.h
+++ b/libnetdata/locks/locks.h
@@ -23,11 +23,11 @@ typedef struct netdata_rwlock_locker {
 } netdata_rwlock_locker;
 
 typedef struct netdata_rwlock_t {
-    pthread_rwlock_t rwlock_t;
-    size_t readers;
-    size_t writers;
-    netdata_mutex_t lockers_mutex;
-    netdata_rwlock_locker *lockers;
+    pthread_rwlock_t rwlock_t;       // the lock
+    size_t readers;                  // the number of reader on the lock
+    size_t writers;                  // the number of writers on the lock
+    netdata_mutex_t lockers_mutex;   // a mutex to protect the linked list of the lock holding threads
+    netdata_rwlock_locker *lockers;  // the linked list of the lock holding threads
 } netdata_rwlock_t;
 
 #define NETDATA_RWLOCK_INITIALIZER {                \

--- a/spawn/spawn_server.c
+++ b/spawn/spawn_server.c
@@ -312,8 +312,8 @@ void spawn_server(void)
 {
     int error;
 
-    test_clock_boottime();
-    test_clock_monotonic_coarse();
+    // initialize the system clocks
+    clocks_init();
 
     // close all open file descriptors, except the standard ones
     // the caller may have left open files (lxc-attach has this issue)


### PR DESCRIPTION
## tracing R/W locks

Allows tracing rwlocks in netdata.

compile with `-DNETDATA_TRACE_RWLOCKS=1`.

Then in error log you may find lines like this:

```
RW_LOCK ON LOCK 0xd3e3a300: 2706979, 'SERVICE' (function service_main() 35@daemon/service.c) WANTS a 'W' lock.
     => 1: RW_LOCK: process 2706977 'HEALTH' (function health_main() 750@health/health.c) is having 1 'R' lock for 2406668 usec.
```

To help solve the issue #12770

---

## clocks performance

I did some tests on the performance on clocks, to understand which clock should be used to report usage in locks.

Here is the test:

<details><summary>click to see the test code</summary>

```c

struct clock {
    clockid_t clockid;
    const char *name;
};

#define HISTOGRAM_SIZE 10000
#define ITERATIONS 10000000

int main(int argc, char **argv) {
    struct clock clocks[] = {
        {CLOCK_BOOTTIME, "CLOCK_BOOTTIME now_boottime_*()"},
        {CLOCK_MONOTONIC, "CLOCK_MONOTONIC now_monotonic_high_precision_*()"},
        {CLOCK_MONOTONIC_COARSE, "CLOCK_MONOTONIC_COARSE now_monotonic_*()"},
        {CLOCK_MONOTONIC_RAW, "CLOCK_MONOTONIC_RAW"},
        {CLOCK_REALTIME, "CLOCK_REALTIME now_realtime_*()" },
        {CLOCK_REALTIME_COARSE, "CLOCK_REALTIME_COARSE" },
        {0, NULL }
    };

    int current_clock;
    for(current_clock = 0; clocks[current_clock].name ; current_clock++) {
        printf("\n\nTesting %s ...\n", clocks[current_clock].name);

        usec_t histogram[HISTOGRAM_SIZE + 1] = { 0 };
        size_t count, total;
        usec_t us, oldus, delta, min, max, start, end;
        start = oldus = now_usec(clocks[current_clock].clockid);
        for (count = 0; count < ITERATIONS; count++) {
            us = now_usec(clocks[current_clock].clockid);
            delta = us - oldus;
            if (count == 0)
                min = max = delta;
            else {
                if (delta < min)
                    min = delta;
                if (delta > max)
                    max = delta;
            }
            oldus = us;

            if (delta > HISTOGRAM_SIZE)
                delta = HISTOGRAM_SIZE;
            histogram[delta]++;
        }
        total = count;

        end = now_usec(clocks[current_clock].clockid);
        delta = end - start;
        printf("%zu iterations in %llu usec, min %llu, max %llu, average %llu\n", count, delta, min, max, delta / total);

        for (count = 0; count <= HISTOGRAM_SIZE; count++)
            if (histogram[count])
                printf(
                    "   %04zu usec : %llu (%.02f%%)\n", count, histogram[count], (float)(histogram[count] * 100.0) / (float)total);
    }
    exit(0);
}
```

</details>

<details><summary>click to see the results</summary>

```
Testing CLOCK_BOOTTIME now_boottime_*() ...
10000000 iterations in 249612 usec, min 0, max 18, average 0
   0000 usec : 9750582 (97.51%)
   0001 usec : 249356 (2.49%)
   0002 usec : 39 (0.00%)
   0003 usec : 5 (0.00%)
   0004 usec : 6 (0.00%)
   0005 usec : 3 (0.00%)
   0006 usec : 1 (0.00%)
   0008 usec : 1 (0.00%)
   0013 usec : 1 (0.00%)
   0014 usec : 2 (0.00%)
   0017 usec : 3 (0.00%)
   0018 usec : 1 (0.00%)


Testing CLOCK_MONOTONIC now_monotonic_high_precision_*() ...
10000000 iterations in 245320 usec, min 0, max 8, average 0
   0000 usec : 9754769 (97.55%)
   0001 usec : 245167 (2.45%)
   0002 usec : 49 (0.00%)
   0003 usec : 10 (0.00%)
   0004 usec : 3 (0.00%)
   0005 usec : 1 (0.00%)
   0008 usec : 1 (0.00%)


Testing CLOCK_MONOTONIC_COARSE now_monotonic_*() ...
10000000 iterations in 86667 usec, min 0, max 3334, average 0
   0000 usec : 9999974 (100.00%)
   3333 usec : 17 (0.00%)
   3334 usec : 9 (0.00%)


Testing CLOCK_MONOTONIC_RAW ...
10000000 iterations in 250710 usec, min 0, max 785, average 0
   0000 usec : 9750915 (97.51%)
   0001 usec : 249019 (2.49%)
   0002 usec : 42 (0.00%)
   0003 usec : 8 (0.00%)
   0004 usec : 5 (0.00%)
   0005 usec : 3 (0.00%)
   0006 usec : 2 (0.00%)
   0007 usec : 1 (0.00%)
   0008 usec : 1 (0.00%)
   0013 usec : 1 (0.00%)
   0014 usec : 1 (0.00%)
   0709 usec : 1 (0.00%)
   0785 usec : 1 (0.00%)


Testing CLOCK_REALTIME now_realtime_*() ...
10000000 iterations in 245326 usec, min 0, max 10, average 0
   0000 usec : 9754758 (97.55%)
   0001 usec : 245184 (2.45%)
   0002 usec : 49 (0.00%)
   0003 usec : 4 (0.00%)
   0004 usec : 2 (0.00%)
   0005 usec : 1 (0.00%)
   0009 usec : 1 (0.00%)
   0010 usec : 1 (0.00%)


Testing CLOCK_REALTIME_COARSE ...
10000000 iterations in 86667 usec, min 0, max 3334, average 0
   0000 usec : 9999974 (100.00%)
   3333 usec : 17 (0.00%)
   3334 usec : 9 (0.00%)
```

</details>

The `now_monotonic_*()` functions of netdata, are 3 times faster than `now_boottime_*()` and `now_realtime_*()`. The `CLOCK_MONOTONIC_COARSE` clock is used when available, which has some insignificant error as you can see in the results.

---

UPDATE: it turned out the `clock_monotonic_*()` is a bit fuzzy and gives frequent errors. So, I changed the locks to use `clock_monotonic_high_precision_usec()` when tracing is enabled. When tracing is not enabled, we don't use any timing functions in locks.