### PR TITLE
fix(installer): non interpreted new lines when printing deferred errors

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -96,8 +96,8 @@ fi
 print_deferred_errors() {
   if [ -n "${SAVED_WARNINGS}" ]; then
     printf >&2 "\n"
-    printf >&2 "%s\n" "The following warnings and non-fatal errors were encountered during the installation process:"
-    printf >&2 "%s\n" "${SAVED_WARNINGS}"
+    printf >&2 "%b\n" "The following warnings and non-fatal errors were encountered during the installation process:"
+    printf >&2 "%b\n" "${SAVED_WARNINGS}"
     printf >&2 "\n"
   fi
 }


### PR DESCRIPTION
##### Summary

- current

```cmd
	The following warnings and non-fatal errors were encountered during the installation process:
\n  - You have requested use of a system copy of protobuf. This should work, but it is not recommended as it's very likely to break if you upgrade the currently installed version of protobuf.\n  - eBPF has been explicitly disabled, it will not be available in this install.
```

- this PR

```cmd
The following warnings and non-fatal errors were encountered during the installation process:

  - You have requested use of a system copy of protobuf. This should work, but it is not recommended as it's very likely to break if you upgrade the currently installed version of protobuf.
  - eBPF has been explicitly disabled, it will not be available in this install.
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
