### PR TITLE
One way allocator to double the speed of parallel context queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,8 @@ set(LIBNETDATA_FILES
         libnetdata/log/log.h
         libnetdata/os.c
         libnetdata/os.h
+        libnetdata/onewayalloc/onewayalloc.c
+        libnetdata/onewayalloc/onewayalloc.h
         libnetdata/popen/popen.c
         libnetdata/popen/popen.h
         libnetdata/procfile/procfile.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -159,6 +159,8 @@ LIBNETDATA_FILES = \
     libnetdata/locks/locks.h \
     libnetdata/log/log.c \
     libnetdata/log/log.h \
+    libnetdata/onewayalloc/onewayalloc.c \
+    libnetdata/onewayalloc/onewayalloc.h \
     libnetdata/popen/popen.c \
     libnetdata/popen/popen.h \
     libnetdata/procfile/procfile.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1769,6 +1769,7 @@ AC_CONFIG_FILES([
     libnetdata/eval/Makefile
     libnetdata/locks/Makefile
     libnetdata/log/Makefile
+    libnetdata/onewayalloc/Makefile
     libnetdata/popen/Makefile
     libnetdata/procfile/Makefile
     libnetdata/simple_pattern/Makefile

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1732,7 +1732,8 @@ static int test_dbengine_check_rrdr(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DIMS]
     update_every = REGION_UPDATE_EVERY[current_region];
     long points = (time_end - time_start) / update_every;
     for (i = 0 ; i < CHARTS ; ++i) {
-        RRDR *r = rrd2rrdr(st[i], points, time_start + update_every, time_end, RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL, 0);
+        ONEWAYALLOC *owa = onewayalloc_create(0);
+        RRDR *r = rrd2rrdr(owa, st[i], points, time_start + update_every, time_end, RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL, 0);
         if (!r) {
             fprintf(stderr, "    DB-engine unittest %s: empty RRDR ### E R R O R ###\n", st[i]->name);
             return ++errors;
@@ -1766,8 +1767,9 @@ static int test_dbengine_check_rrdr(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DIMS]
                     }
                 }
             }
-            rrdr_free(r);
+            rrdr_free(owa, r);
         }
+        onewayalloc_destroy(owa);
     }
     return errors;
 }
@@ -1851,7 +1853,8 @@ int test_dbengine(void)
     long points = (time_end[REGIONS - 1] - time_start[0]) / update_every; // cover all time regions with RRDR
     long point_offset = (time_start[current_region] - time_start[0]) / update_every;
     for (i = 0 ; i < CHARTS ; ++i) {
-        RRDR *r = rrd2rrdr(st[i], points, time_start[0] + update_every, time_end[REGIONS - 1], RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL, 0);
+        ONEWAYALLOC *owa = onewayalloc_create(0);
+        RRDR *r = rrd2rrdr(owa, st[i], points, time_start[0] + update_every, time_end[REGIONS - 1], RRDR_GROUPING_AVERAGE, 0, 0, NULL, NULL, 0);
         if (!r) {
             fprintf(stderr, "    DB-engine unittest %s: empty RRDR ### E R R O R ###\n", st[i]->name);
             ++errors;
@@ -1888,8 +1891,9 @@ int test_dbengine(void)
                     }
                 }
             }
-            rrdr_free(r);
+            rrdr_free(owa, r);
         }
+        onewayalloc_destroy(owa);
     }
 error_out:
     rrd_wrlock();

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -89,7 +89,7 @@ extern void db_unlock(void);
 extern void db_lock(void);
 extern void delete_dimension_uuid(uuid_t *dimension_uuid);
 extern void sql_store_chart_label(uuid_t *chart_uuid, int source_type, char *label, char *value);
-extern void sql_build_context_param_list(struct context_param **param_list, RRDHOST *host, char *context, char *chart);
+extern void sql_build_context_param_list(ONEWAYALLOC  *owa, struct context_param **param_list, RRDHOST *host, char *context, char *chart);
 extern void store_claim_id(uuid_t *host_id, uuid_t *claim_id);
 extern int update_node_id(uuid_t *host_id, uuid_t *node_id);
 extern int get_node_id(uuid_t *host_id, uuid_t *node_id);

--- a/libnetdata/Makefile.am
+++ b/libnetdata/Makefile.am
@@ -17,6 +17,7 @@ SUBDIRS = \
     health \
     locks \
     log \
+    onewayalloc \
     popen \
     procfile \
     simple_pattern \

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -342,6 +342,7 @@ extern char *netdata_configured_host_prefix;
 #include "json/json.h"
 #include "health/health.h"
 #include "string/utf8.h"
+#include "onewayalloc/onewayalloc.h"
 
 // BEWARE: Outside of the C code this also exists in alarm-notify.sh
 #define DEFAULT_CLOUD_BASE_URL "https://app.netdata.cloud"

--- a/libnetdata/onewayalloc/Makefile.am
+++ b/libnetdata/onewayalloc/Makefile.am
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+AUTOMAKE_OPTIONS = subdir-objects
+MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+
+dist_noinst_DATA = \
+    README.md \
+    $(NULL)

--- a/libnetdata/onewayalloc/README.md
+++ b/libnetdata/onewayalloc/README.md
@@ -1,10 +1,70 @@
 <!--
-title: "circular_buffer"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/libnetdata/circular_buffer/README.md
+title: "One Way Allocator"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/libnetdata/onewayallocator/README.md
 -->
 
-# Circular Buffer
+# One Way Allocator
 
-`struct circular_buffer` is an adaptive circular buffer. It will start at an initial size
-and grow up to a maximum size as it fills. Two indices within the structure track the current
-`read` and `write` position for data.
+This is a very fast single-threaded-only memory allocator, that minimized system calls
+when a lot of memory allocations needs to be made to perform a task, which all of them
+can be freed together when the task finishes.
+
+It has been designed to be used for netdata context queries.
+
+For netdata to perform a context query, it builds a virtual chart, a chart that contains
+all the dimensions of the charts having the same context. This process requires allocating
+several structures for each of the dimensions to attach them to the virtual chart. All
+these data can be freed immediately after the query finishes.
+
+## How it works
+
+1. The caller calls `ONEWAYALLOC *owa = onewayalloc_create(sizehint)` to create an OWA.
+   Internally this allocates the first memory buffer with size >= `sizehint`.
+   If `sizehint` is zero, it will allocate 1 hardware page (usually 4kb).
+   No need to check for success or failure. As with `mallocz()` in netdata, a `fatal()`
+   will be called if the allocation fails - although this will never fail, since Linux
+   does not really check if there is memory available for `mmap()` calls.
+   
+2. The caller can then perform any number of the following calls to acquire memory:
+   - `onewayalloc_mallocz(owa, size)` to just get a buffer of `size`
+   - `onewayalloc_strdupz(owa, string)` similar to `strdup()`
+   - `onewayalloc_memdupz(owa, ptr, size)` similar to `malloc()` and then `memcpy()`
+   
+3. Once the caller has done all the work with the allocated buffers, all memory allocated 
+   can be freed with `onewayalloc_destroy(owa)`.
+
+## How faster it is?
+
+On modern hardware, for any single query the performance improvement is marginal and not
+noticeable at all.
+
+We performed the following tests using the same huge context query (1000 charts,
+100 dimensions each = 100k dimensions)
+
+1. using `mallocz()`, 1 caller, 256 queries (sequential)
+2. using `mallocz()`, 256 callers, 1 query each (parallel)
+3. using `OWA`, 1 caller, 256 queries (sequential)
+4. using `OWA`, 256 callers, 1 query each (parallel)
+
+Netdata was configured to use 24 web threads on the 24 core server we used.
+
+The results are as follows:
+
+### sequential test
+
+branch|transactions|time to complete|transaction rate|average response time|min response time|max response time
+:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+`malloc()`|256|322.35s|0.79/sec|1.26s|1.01s|1.87s
+`OWA`|256|310.19s|0.83/sec|1.21s|1.04s|1.63s
+
+For a single query, the improvement is just marginal and not noticeable at all.
+
+### parallel test
+
+branch|transactions|time to complete|transaction rate|average response time|min response time|max response time
+:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+`malloc()`|256|84.72s|3.02/sec|68.43s|50.20s|84.71s
+`OWA`|256|39.35s|6.51/sec|34.48s|20.55s|39.34s
+
+For parallel workload, like the one executed by netdata.cloud, `OWA` provides a 54% overall speed improvement (more than double the overall
+user-experienced speed, including the data query itself).

--- a/libnetdata/onewayalloc/README.md
+++ b/libnetdata/onewayalloc/README.md
@@ -1,0 +1,10 @@
+<!--
+title: "circular_buffer"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/libnetdata/circular_buffer/README.md
+-->
+
+# Circular Buffer
+
+`struct circular_buffer` is an adaptive circular buffer. It will start at an initial size
+and grow up to a maximum size as it fills. Two indices within the structure track the current
+`read` and `write` position for data.

--- a/libnetdata/onewayalloc/README.md
+++ b/libnetdata/onewayalloc/README.md
@@ -26,9 +26,10 @@ these data can be freed immediately after the query finishes.
    does not really check if there is memory available for `mmap()` calls.
    
 2. The caller can then perform any number of the following calls to acquire memory:
-   - `onewayalloc_mallocz(owa, size)` to just get a buffer of `size`
-   - `onewayalloc_strdupz(owa, string)` similar to `strdup()`
-   - `onewayalloc_memdupz(owa, ptr, size)` similar to `malloc()` and then `memcpy()`
+   - `onewayalloc_mallocz(owa, size)`, similar to `mallocz()`
+   - `onewayalloc_callocz(owa, nmemb, size)`, similar to `callocz()`
+   - `onewayalloc_strdupz(owa, string)`, similar to `strdupz()`
+   - `onewayalloc_memdupz(owa, ptr, size)`, similar to `mallocz()` and then `memcpy()`
    
 3. Once the caller has done all the work with the allocated buffers, all memory allocated 
    can be freed with `onewayalloc_destroy(owa)`.

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -105,8 +105,9 @@ void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {
 }
 
 char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s) {
-    char *d = onewayalloc_mallocz((OWA_PAGE *)owa, strlen(s) + 1);
-    strcpy(d, s);
+    size_t size = strlen(s) + 1;
+    char *d = onewayalloc_mallocz((OWA_PAGE *)owa, size);
+    memcpy(d, s, size);
     return d;
 }
 

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -1,7 +1,7 @@
 #include "onewayalloc.h"
 
 static size_t PAGE_SIZE = 0;
-static size_t NATURAL_ALIGNMENT = sizeof(size_t);
+static size_t NATURAL_ALIGNMENT = sizeof(int*);
 
 typedef struct owa_page {
     size_t stats_pages;

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -113,16 +113,19 @@ char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s) {
 
 void *onewayalloc_memdupz(ONEWAYALLOC *owa, const void *src, size_t size) {
     void *mem = onewayalloc_mallocz((OWA_PAGE *)owa, size);
+    // memcpy() is way faster than strcpy() since it does not check for '\0'
     memcpy(mem, src, size);
     return mem;
 }
 
 void onewayalloc_destroy(ONEWAYALLOC *owa) {
+    if(!owa) return;
+
     OWA_PAGE *head = (OWA_PAGE *)owa;
 
-    info("OWA: %zu allocations of %zu total bytes, in %zu pages of %zu total bytes",
-         head->stats_mallocs_made, head->stats_mallocs_size,
-         head->stats_pages, head->stats_pages_size);
+    //info("OWA: %zu allocations of %zu total bytes, in %zu pages of %zu total bytes",
+    //     head->stats_mallocs_made, head->stats_mallocs_size,
+    //     head->stats_pages, head->stats_pages_size);
 
     OWA_PAGE *page = head;
     while(page) {

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -125,10 +125,11 @@ void *onewayalloc_memdupz(ONEWAYALLOC *owa, const void *src, size_t size) {
     return mem;
 }
 
-void onewayalloc_freez(ONEWAYALLOC *owa, const void *ptr) {
+void onewayalloc_freez(ONEWAYALLOC *owa __maybe_unused, const void *ptr __maybe_unused) {
+#ifdef NETDATA_INTERNAL_CHECKS
     // allow the caller to call us for a mallocz() allocation
     // so try to find it in our memory and if it is not there
-    // call freez(ptr)
+    // log an error
 
     OWA_PAGE *head = (OWA_PAGE *)owa;
     OWA_PAGE *page;
@@ -147,8 +148,10 @@ void onewayalloc_freez(ONEWAYALLOC *owa, const void *ptr) {
 
     // not found - it is not ours
     // let's free it with the system allocator
-    info("ONEWAYALLOC: freeing address 0x%p that is not allocated by OWA", ptr);
-    freez((void *)ptr);
+    error("ONEWAYALLOC: request to free address 0x%p that is not allocated by this OWA", ptr);
+#endif
+
+    return;
 }
 
 void onewayalloc_destroy(ONEWAYALLOC *owa) {

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -1,0 +1,77 @@
+#include "onewayalloc.h"
+
+static size_t PAGE_SIZE = 0;
+
+typedef struct owa_page {
+    size_t size;        // the total size of the page
+    size_t offset;      // the first free byte of the page
+    struct owa_page *next;     // the next page on the list
+    struct owa_page *last;     // the last page on the list - we currently allocate on this
+} OWA_PAGE;
+
+static inline size_t alignment(size_t size) {
+    size_t wanted = sizeof(size_t);
+
+    if(unlikely(size % wanted))
+        size = size + wanted - (size % wanted);
+
+    return size;
+}
+
+ONEWAYALLOC *onewayalloc_create(size_t size_hint) {
+    if(unlikely(!PAGE_SIZE)) PAGE_SIZE = sysconf(_SC_PAGE_SIZE);
+
+    size_t size = PAGE_SIZE;
+    if(size_hint > size) size = ((PAGE_SIZE / size_hint) + 1) * PAGE_SIZE;
+
+    void *mem = netdata_mmap(NULL, size, MAP_ANONYMOUS|MAP_PRIVATE, 0);
+    if(!mem) fatal("Cannot allocate onewayalloc buffer of size %zu", size);
+
+    OWA_PAGE *page = (OWA_PAGE *)mem;
+    page->size = size;
+    page->offset = alignment(sizeof(OWA_PAGE));
+    page->next = NULL;
+    page->last = page;
+
+    return (ONEWAYALLOC *)page;
+}
+
+void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {
+    OWA_PAGE *head = (OWA_PAGE *)owa;
+    OWA_PAGE *page = head->last;
+
+    // make sure the size is aligned
+    size = alignment(size);
+
+    if(unlikely(page->size - page->offset < size)) {
+        // we don't have enough space to fit the data
+        // let's get another page
+        page = page->last = head->last = onewayalloc_create((size > page->size)?size:page->size);
+    }
+
+    char *mem = (char *)page;
+    mem = &mem[page->offset];
+    page->offset += size;
+
+    return (void *)mem;
+}
+
+char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s) {
+    char *d = onewayalloc_mallocz((OWA_PAGE *)owa, strlen(s) + 1);
+    strcpy(d, s);
+    return d;
+}
+
+void *onewayalloc_memdupz(ONEWAYALLOC *owa, const void *src, size_t size) {
+    void *mem = onewayalloc_mallocz((OWA_PAGE *)owa, size);
+    memcpy(mem, src, size);
+    return mem;
+}
+
+void onewayalloc_destroy(ONEWAYALLOC *ptr) {
+    OWA_PAGE *page = (OWA_PAGE *)ptr;
+    if(page->next)
+        onewayalloc_destroy((ONEWAYALLOC *)page->next);
+
+    munmap(page, page->size);
+}

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -104,6 +104,13 @@ void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {
     return (void *)mem;
 }
 
+void *onewayalloc_callocz(ONEWAYALLOC *owa, size_t nmemb, size_t size) {
+    size_t total = nmemb * size;
+    void *mem = onewayalloc_mallocz(owa, total);
+    memset(mem, 0, total);
+    return mem;
+}
+
 char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s) {
     size_t size = strlen(s) + 1;
     char *d = onewayalloc_mallocz((OWA_PAGE *)owa, size);

--- a/libnetdata/onewayalloc/onewayalloc.h
+++ b/libnetdata/onewayalloc/onewayalloc.h
@@ -1,0 +1,15 @@
+#ifndef ONEWAYALLOC_H
+#define ONEWAYALLOC_H 1
+
+#include "../libnetdata.h"
+
+typedef void ONEWAYALLOC;
+
+extern ONEWAYALLOC *onewayalloc_create(size_t size_hint);
+extern void onewayalloc_destroy(ONEWAYALLOC *owa);
+
+extern void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size);
+extern char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s);
+extern void *onewayalloc_memdupz(ONEWAYALLOC *owa, const void *src, size_t size);
+
+#endif // ONEWAYALLOC_H

--- a/libnetdata/onewayalloc/onewayalloc.h
+++ b/libnetdata/onewayalloc/onewayalloc.h
@@ -12,5 +12,6 @@ extern void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size);
 extern void *onewayalloc_callocz(ONEWAYALLOC *owa, size_t nmemb, size_t size);
 extern char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s);
 extern void *onewayalloc_memdupz(ONEWAYALLOC *owa, const void *src, size_t size);
+extern void onewayalloc_freez(ONEWAYALLOC *owa, const void *ptr);
 
 #endif // ONEWAYALLOC_H

--- a/libnetdata/onewayalloc/onewayalloc.h
+++ b/libnetdata/onewayalloc/onewayalloc.h
@@ -9,6 +9,7 @@ extern ONEWAYALLOC *onewayalloc_create(size_t size_hint);
 extern void onewayalloc_destroy(ONEWAYALLOC *owa);
 
 extern void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size);
+extern void *onewayalloc_callocz(ONEWAYALLOC *owa, size_t nmemb, size_t size);
 extern char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s);
 extern void *onewayalloc_memdupz(ONEWAYALLOC *owa, const void *src, size_t size);
 

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -12,9 +12,9 @@ static inline void free_single_rrdrim(ONEWAYALLOC *owa, RRDDIM *temp_rd, int arc
     if (unlikely(archive_mode)) {
         temp_rd->rrdset->counter--;
         if (!temp_rd->rrdset->counter) {
-            freez((char *)temp_rd->rrdset->name);
-            freez(temp_rd->rrdset->context);
-            freez(temp_rd->rrdset);
+            onewayalloc_freez(owa, (char *)temp_rd->rrdset->name);
+            onewayalloc_freez(owa, temp_rd->rrdset->context);
+            onewayalloc_freez(owa, temp_rd->rrdset);
         }
     }
 

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -90,8 +90,6 @@ void build_context_param_list(ONEWAYALLOC *owa, struct context_param **param_lis
         rd->id = onewayalloc_strdupz(owa, rd1->id);
         rd->name = onewayalloc_strdupz(owa, rd1->name);
         rd->state = onewayalloc_memdupz(owa, rd1->state, sizeof(*rd->state));
-        memcpy(&rd->state->collect_ops, &rd1->state->collect_ops, sizeof(struct rrddim_collect_ops));
-        memcpy(&rd->state->query_ops, &rd1->state->query_ops, sizeof(struct rrddim_query_ops));
         rd->next = (*param_list)->rd;
         (*param_list)->rd = rd;
     }

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -88,7 +88,7 @@ extern int rrdset2value_api_v1(
         , int timeout
 );
 
-extern void build_context_param_list(struct context_param **param_list, RRDSET *st);
+extern void build_context_param_list(ONEWAYALLOC *owa, struct context_param **param_list, RRDSET *st);
 extern void rebuild_context_param_list(struct context_param *context_param_list, time_t after_requested);
 extern void free_context_param_list(struct context_param **param_list);
 

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -54,7 +54,8 @@ extern void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
 extern void rrdr_buffer_print_format(BUFFER *wb, uint32_t format);
 
 extern int rrdset2anything_api_v1(
-          RRDSET *st
+          ONEWAYALLOC *owa
+        , RRDSET *st
         , BUFFER *wb
         , BUFFER *dimensions
         , uint32_t format
@@ -89,7 +90,7 @@ extern int rrdset2value_api_v1(
 );
 
 extern void build_context_param_list(ONEWAYALLOC *owa, struct context_param **param_list, RRDSET *st);
-extern void rebuild_context_param_list(struct context_param *context_param_list, time_t after_requested);
-extern void free_context_param_list(struct context_param **param_list);
+extern void rebuild_context_param_list(ONEWAYALLOC *owa, struct context_param *context_param_list, time_t after_requested);
+extern void free_context_param_list(ONEWAYALLOC *owa, struct context_param **param_list);
 
 #endif /* NETDATA_RRD2JSON_H */

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -831,7 +831,8 @@ static int rrdr_convert_before_after_to_absolute(
 }
 
 static RRDR *rrd2rrdr_fixedstep(
-        RRDSET *st
+          ONEWAYALLOC *owa
+        , RRDSET *st
         , long points_requested
         , long long after_requested
         , long long before_requested
@@ -855,7 +856,7 @@ static RRDR *rrd2rrdr_fixedstep(
     RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
 
     if(duration <= 0 || available_points <= 0)
-        return rrdr_create(st, 1, context_param_list);
+        return rrdr_create(owa, st, 1, context_param_list);
 
     // check the number of wanted points in the result
     if(unlikely(points_requested < 0)) points_requested = -points_requested;
@@ -1013,7 +1014,7 @@ static RRDR *rrd2rrdr_fixedstep(
     // initialize our result set
     // this also locks the chart for us
 
-    RRDR *r = rrdr_create(st, points_wanted, context_param_list);
+    RRDR *r = rrdr_create(owa, st, points_wanted, context_param_list);
     if(unlikely(!r)) {
         #ifdef NETDATA_INTERNAL_CHECKS
         error("INTERNAL CHECK: Cannot create RRDR for %s, after=%u, before=%u, duration=%u, points=%ld", st->id, (uint32_t)after_wanted, (uint32_t)before_wanted, (uint32_t)duration, points_wanted);
@@ -1216,7 +1217,8 @@ static RRDR *rrd2rrdr_fixedstep(
 
 #ifdef ENABLE_DBENGINE
 static RRDR *rrd2rrdr_variablestep(
-        RRDSET *st
+        ONEWAYALLOC *owa
+        , RRDSET *st
         , long points_requested
         , long long after_requested
         , long long before_requested
@@ -1242,7 +1244,7 @@ static RRDR *rrd2rrdr_variablestep(
 
     if(duration <= 0 || available_points <= 0) {
         freez(region_info_array);
-        return rrdr_create(st, 1, context_param_list);
+        return rrdr_create(owa, st, 1, context_param_list);
     }
 
     // check the number of wanted points in the result
@@ -1401,7 +1403,7 @@ static RRDR *rrd2rrdr_variablestep(
     // initialize our result set
     // this also locks the chart for us
 
-    RRDR *r = rrdr_create(st, points_wanted, context_param_list);
+    RRDR *r = rrdr_create(owa, st, points_wanted, context_param_list);
     if(unlikely(!r)) {
         #ifdef NETDATA_INTERNAL_CHECKS
         error("INTERNAL CHECK: Cannot create RRDR for %s, after=%u, before=%u, duration=%u, points=%ld", st->id, (uint32_t)after_wanted, (uint32_t)before_wanted, (uint32_t)duration, points_wanted);
@@ -1608,7 +1610,8 @@ static RRDR *rrd2rrdr_variablestep(
 #endif //#ifdef ENABLE_DBENGINE
 
 RRDR *rrd2rrdr(
-        RRDSET *st
+          ONEWAYALLOC *owa
+        , RRDSET *st
         , long points_requested
         , long long after_requested
         , long long before_requested
@@ -1644,7 +1647,7 @@ RRDR *rrd2rrdr(
             first_entry_t = after_requested;
 
     if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
-        rebuild_context_param_list(context_param_list, after_requested);
+        rebuild_context_param_list(owa, context_param_list, after_requested);
         st = context_param_list->rd ? context_param_list->rd->rrdset : NULL;
         if (unlikely(!st))
             return NULL;
@@ -1669,7 +1672,7 @@ RRDR *rrd2rrdr(
                 }
                 freez(region_info_array);
             }
-            return rrd2rrdr_fixedstep(st, points_requested, after_requested, before_requested, group_method,
+            return rrd2rrdr_fixedstep(owa, st, points_requested, after_requested, before_requested, group_method,
                                       resampling_time_requested, options, dimensions, rrd_update_every,
                                       first_entry_t, last_entry_t, absolute_period_requested, context_param_list, timeout);
         } else {
@@ -1680,13 +1683,13 @@ RRDR *rrd2rrdr(
                                                                                   rrd_update_every, first_entry_t,
                                                                                   last_entry_t, options);
             }
-            return rrd2rrdr_variablestep(st, points_requested, after_requested, before_requested, group_method,
+            return rrd2rrdr_variablestep(owa, st, points_requested, after_requested, before_requested, group_method,
                                          resampling_time_requested, options, dimensions, rrd_update_every,
                                          first_entry_t, last_entry_t, absolute_period_requested, region_info_array, context_param_list, timeout);
         }
     }
 #endif
-    return rrd2rrdr_fixedstep(st, points_requested, after_requested, before_requested, group_method,
+    return rrd2rrdr_fixedstep(owa, st, points_requested, after_requested, before_requested, group_method,
                               resampling_time_requested, options, dimensions,
                               rrd_update_every, first_entry_t, last_entry_t, absolute_period_requested, context_param_list, timeout);
 }

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -83,7 +83,7 @@ inline static void rrdr_unlock_rrdset(RRDR *r) {
     }
 }
 
-inline void rrdr_free(RRDR *r)
+inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r)
 {
     if(unlikely(!r)) {
         error("NULL value given!");
@@ -91,21 +91,21 @@ inline void rrdr_free(RRDR *r)
     }
 
     rrdr_unlock_rrdset(r);
-    freez(r->t);
-    freez(r->v);
-    freez(r->o);
-    freez(r->od);
-    freez(r);
+    onewayalloc_freez(owa, r->t);
+    onewayalloc_freez(owa, r->v);
+    onewayalloc_freez(owa, r->o);
+    onewayalloc_freez(owa, r->od);
+    onewayalloc_freez(owa, r);
 }
 
-RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param_list)
+RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, struct context_param *context_param_list)
 {
     if (unlikely(!st)) {
         error("NULL value given!");
         return NULL;
     }
 
-    RRDR *r = callocz(1, sizeof(RRDR));
+    RRDR *r = onewayalloc_callocz(owa, 1, sizeof(RRDR));
     r->st = st;
 
     if (!context_param_list || !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
@@ -126,10 +126,10 @@ RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param
 
     r->n = n;
 
-    r->t = callocz((size_t)n, sizeof(time_t));
-    r->v = mallocz(n * r->d * sizeof(calculated_number));
-    r->o = mallocz(n * r->d * sizeof(RRDR_VALUE_FLAGS));
-    r->od = mallocz(r->d * sizeof(RRDR_DIMENSION_FLAGS));
+    r->t = onewayalloc_callocz(owa, (size_t)n, sizeof(time_t));
+    r->v = onewayalloc_mallocz(owa, n * r->d * sizeof(calculated_number));
+    r->o = onewayalloc_mallocz(owa, n * r->d * sizeof(RRDR_VALUE_FLAGS));
+    r->od = onewayalloc_mallocz(owa, r->d * sizeof(RRDR_DIMENSION_FLAGS));
 
     // set the hidden flag on hidden dimensions
     int c;

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -102,13 +102,14 @@ typedef struct rrdresult {
 #define rrdr_rows(r) ((r)->rows)
 
 #include "database/rrd.h"
-extern void rrdr_free(RRDR *r);
-extern RRDR *rrdr_create(struct rrdset *st, long n, struct context_param *context_param_list);
+extern void rrdr_free(ONEWAYALLOC *owa, RRDR *r);
+extern RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, struct context_param *context_param_list);
 
 #include "../web_api_v1.h"
 #include "web/api/queries/query.h"
 
 extern RRDR *rrd2rrdr(
+    ONEWAYALLOC *owa,
     RRDSET *st, long points_requested, long long after_requested, long long before_requested,
     RRDR_GROUPING group_method, long resampling_time_requested, RRDR_OPTIONS options, const char *dimensions,
     struct context_param *context_param_list, int timeout);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -542,7 +542,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
             st = context_param_list->rd->rrdset;
         else {
             if (!chart_label_key && !chart_labels_filter)
-                sql_build_context_param_list(&context_param_list, host, context, NULL);
+                sql_build_context_param_list(owa, &context_param_list, host, context, NULL);
         }
     }
     else {
@@ -552,7 +552,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         if (likely(st))
             st->last_accessed_time = now_realtime_sec();
         else
-            sql_build_context_param_list(&context_param_list, host, NULL, chart);
+            sql_build_context_param_list(owa, &context_param_list, host, NULL, chart);
     }
 
     if (!st) {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -512,6 +512,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     fix_google_param(outFileName);
 
     RRDSET *st = NULL;
+    ONEWAYALLOC *owa = onewayalloc_create(0);
 
     if((!chart || !*chart) && (!context)) {
         buffer_sprintf(w->response.data, "No chart id is given at the request.");
@@ -519,7 +520,6 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     }
 
     struct context_param  *context_param_list = NULL;
-    ONEWAYALLOC *owa = onewayalloc_create(0);
 
     if (context && !chart) {
         RRDSET *st1;

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -559,7 +559,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         if (likely(context_param_list && context_param_list->rd && context_param_list->rd->rrdset))
             st = context_param_list->rd->rrdset;
         else {
-            free_context_param_list(&context_param_list);
+            free_context_param_list(owa, &context_param_list);
             context_param_list = NULL;
         }
     }
@@ -633,12 +633,12 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         buffer_strcat(w->response.data, "(");
     }
 
-    ret = rrdset2anything_api_v1(st, w->response.data, dimensions, format,
+    ret = rrdset2anything_api_v1(owa, st, w->response.data, dimensions, format,
                                  points, after, before, group, group_time,
                                  options, &last_timestamp_in_data, context_param_list,
                                  chart_label_key, max_anomaly_rates, timeout);
 
-    free_context_param_list(&context_param_list);
+    free_context_param_list(owa, &context_param_list);
 
     if(format == DATASOURCE_DATATABLE_JSONP) {
         if(google_timestamp < last_timestamp_in_data)


### PR DESCRIPTION
Context queries do a gazillion of `mallocz()`, `strdupz()` and `freez()` to create the virtual chart that takes all the dimensions of the context.

This PR adds a `one way allocator`, a set of functions that allocate large blocks using `mmap()` (the fastest possible) and then calls to `onewayalloc_mallocz()` returns blocks of memory within the mmap allocated buffer.

It allocates more and more mmap buffers as needed, transparently, but it takes into account the amount of memory already allocated, to minimize future allocations.

- Allocation are done using `mmap()` with flags: `MAP_ANOMYMOYS|MAP_PRIVATE`. KSM is disabled for them, since this is expected to be short lived
- Allocations are aligned to the CPU `sizeof(size_t)` size. So, the minimum allocation is for that size and all the allocations are always multiple of that. However the caller may request whatever size (the alignment is transparent).
- No locks and no threading support - use this only when you need a super fast allocator for a task
- No `realloc()` support - just allocate a new one
- No `free()` support to deallocate the individual allocations made with this
- To release the memory, destroy the whole OWA when you finish

## How much less allocations?

Tested with a context query, on 1000 charts, having 100 dimensions each (go.d.plugin, `example` module). The result is this: 

```
OWA: 400001 allocations of 60069032 total bytes, in 22 pages of 63832064 total bytes
```

So, for 100k dimensions total (1000 charts x 100 dimensions each), the code is performing 400k allocations of 60MB total. The OWA allocator did only 22 `mmap()` allocations, of 63MB (a little more, due to the forward looking optimizer).

The reduction of system calls is astonishing (400k vs 22)!

## How faster it is?

On modern hardware, for any single query the performance improvement is marginal and not noticeable at all.

We performed the following tests using the same huge context query (1000 charts, 100 dimensions each = 100k dimensions)

1. current `master` branch, 1 caller, 256 queries (sequential)
2. current `master` branch, 256 callers, 1 query each (parallel)
3. This PR, 1 caller, 256 queries (sequential)
4. This PR, 256 callers, 1 query each (parallel)

Netdata was configured to use 24 web threads on the 24 core server we used.

The results are as follows:

### sequential test

branch|transactions|time to complete|transaction rate|average response time|min response time|max response time
:---:|:---:|:---:|:---:|:---:|:---:|:---:|
`master`|256|322.35s|0.79/sec|1.26s|1.01s|1.87s
this PR|256|310.19s|0.83/sec|1.21s|1.04s|1.63s

For a single query, the improvement is just marginal and not noticeable at all.

### parallel test

branch|transactions|time to complete|transaction rate|average response time|min response time|max response time
:---:|:---:|:---:|:---:|:---:|:---:|:---:|
`master`|256|84.72s|3.02/sec|68.43s|50.20s|84.71s
this PR|256|39.35s|6.51/sec|34.48s|20.55s|39.34s

This PR provides a 54% overall speed improvement (more than double the overall user-experienced speed, including the data query itself).

---

## TODO

The query engine that uses this PR is currently messy. The SQLite parts of it have not been updated to use OWA. So, if this is used in production and the SQLite code kicks in, there will be memory leaks (the code that frees malloc() allocations is commented, since it is not supported by OWA.

So, to merge this PR, the sqlite code needs to be updated too.
