### PR TITLE
fix(cgroups.plugin): do not add network devices if cgroup proc is in the host net ns

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -29,7 +29,7 @@ struct iface {
 
 unsigned int calc_num_ifaces(struct iface *root) {
     unsigned int num = 0;
-    for (struct iface *h = root; h != NULL; h = h->next) {
+    for (struct iface *h = root; h; h = h->next) {
         num++;
     }
     return num;
@@ -461,9 +461,9 @@ void detect_veth_interfaces(pid_t pid) {
     // and we can't really identify which ifaces belong to the cgroup (e.g. Proxmox VM).
     if (host_dev_num == cgroup_dev_num) {
         unsigned int m = 0;
-        for (h = host; h != NULL; h = h->next) {
-            for (c = cgroup; c != NULL; c = c->next) {
-                if (h->ifindex == c->ifindex && h->iflink == c->iflink) {
+        for (h = host; h; h = h->next) {
+            for (c = cgroup; c; c = c->next) {
+                if (h->ifndex == c->ifindex && h->iflink == c->iflink) {
                     m++;
                     break;
                 }

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -457,7 +457,7 @@ void detect_veth_interfaces(pid_t pid) {
     // host ifaces == guest ifaces => we are still in the host namespace
     // and we can't really identify which ifaces belong to the cgroup (e.g. Proxmox VM).
     if (host->count == cgroup->count) {
-        int m = 0;
+        unsigned int m = 0;
         for (h = host; h; h = h->next) {
             for (c = cgroup; c; c = c->next) {
                 if (h->ifindex == c->ifindex && h->iflink == c->iflink) {

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -24,10 +24,16 @@ struct iface {
     unsigned int ifindex;
     unsigned int iflink;
 
-    unsigned int count; // total number of ifaces in the list, only the head element contains the valid number
-
     struct iface *next;
 };
+
+unsigned int calc_num_ifaces(struct iface *root) {
+    unsigned int num = 0;
+    for (h = root; h != NULL; h = h->next) {
+        num++;
+    }
+    return num;
+}
 
 unsigned int read_iface_iflink(const char *prefix, const char *iface) {
     if(!prefix) prefix = "";
@@ -81,10 +87,8 @@ struct iface *read_proc_net_dev(const char *scope __maybe_unused, const char *pr
 
     size_t lines = procfile_lines(ff), l;
     struct iface *root = NULL;
-    unsigned int count = 0;
     for(l = 2; l < lines ;l++) {
         if (unlikely(procfile_linewords(ff, l) < 1)) continue;
-        count++;
 
         struct iface *t = callocz(1, sizeof(struct iface));
         t->device = strdupz(procfile_lineword(ff, l, 0));
@@ -97,9 +101,6 @@ struct iface *read_proc_net_dev(const char *scope __maybe_unused, const char *pr
 #ifdef NETDATA_INTERNAL_CHECKS
         info("added %s interface '%s', ifindex %u, iflink %u", scope, t->device, t->ifindex, t->iflink);
 #endif
-    }
-    if (root) {
-        root->count = count;
     }
 
     procfile_close(ff);
@@ -454,19 +455,21 @@ void detect_veth_interfaces(pid_t pid) {
         goto cleanup;
     }
 
+     unsigned int host_dev_num = calc_num_ifaces(host);
+     unsigned int cgroup_dev_num = calc_num_ifaces(cgroup);
     // host ifaces == guest ifaces => we are still in the host namespace
     // and we can't really identify which ifaces belong to the cgroup (e.g. Proxmox VM).
-    if (host->count == cgroup->count) {
+    if (host_dev_num == cgroup_dev_num) {
         unsigned int m = 0;
         for (h = host; h != NULL; h = h->next) {
             for (c = cgroup; c != NULL; c = c->next) {
                 if (h->ifindex == c->ifindex && h->iflink == c->iflink) {
-                    m += 1;
+                    m++;
                     break;
                 }
             }
         }
-        if (host->count == m) {
+        if (host_dev_num == m) {
             goto cleanup;
         }
     }

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -463,7 +463,7 @@ void detect_veth_interfaces(pid_t pid) {
         unsigned int m = 0;
         for (h = host; h; h = h->next) {
             for (c = cgroup; c; c = c->next) {
-                if (h->ifndex == c->ifindex && h->iflink == c->iflink) {
+                if (h->ifindex == c->ifindex && h->iflink == c->iflink) {
                     m++;
                     break;
                 }

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -458,8 +458,8 @@ void detect_veth_interfaces(pid_t pid) {
     // and we can't really identify which ifaces belong to the cgroup (e.g. Proxmox VM).
     if (host->count == cgroup->count) {
         unsigned int m = 0;
-        for (h = host; h; h = h->next) {
-            for (c = cgroup; c; c = c->next) {
+        for (h = host; h != NULL; h = h->next) {
+            for (c = cgroup; c != NULL; c = c->next) {
                 if (h->ifindex == c->ifindex && h->iflink == c->iflink) {
                     m += 1;
                     break;

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -447,6 +447,22 @@ void detect_veth_interfaces(pid_t pid) {
         goto cleanup;
     }
 
+    // host ifaces == guest ifaces => we are still in the host namespace
+    // and we can't really identify which ifaces belong to the cgroup (e.g. Proxmox VM).
+    int i = 0, m = 0;
+    for (h = host; h; h = h->next) {
+        i++;
+        for (c = cgroup; c; c = c->next) {
+            if (h->ifindex == c->ifindex && h->iflink == c->iflink) {
+                m += 1;
+                break;
+            }
+        }
+    }
+    if (i == m) {
+        goto cleanup;
+    }
+
     for(h = host; h ; h = h->next) {
         if(iface_is_eligible(h)) {
             for (c = cgroup; c; c = c->next) {

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -29,7 +29,7 @@ struct iface {
 
 unsigned int calc_num_ifaces(struct iface *root) {
     unsigned int num = 0;
-    for (h = root; h != NULL; h = h->next) {
+    for (struct iface *h = root; h != NULL; h = h->next) {
         num++;
     }
     return num;


### PR DESCRIPTION
##### Summary

[detect_veth_interfaces()](https://github.com/netdata/netdata/blob/7ae0a2e21d9fcd965c2bde20869b586ea5c1483a/collectors/cgroups.plugin/cgroup-network.c#L410) works correctly only when the cgroup proc (cgroup.procs) is not in the host network namespace.

The bug was discovered when we installed Netdata on a Proxmox host with several VMs.

```bash
$ readlink /proc/self/ns/net
net:[4026532008]
$ nsenter -t $(cat /sys/fs/cgroup/qemu.slice/103.scope/cgroup.procs) -n readlink /proc/self/ns/net
net:[4026532008]
$ ps -o comm= --pid $(cat /sys/fs/cgroup/qemu.slice/103.scope/cgroup.procs)
kvm
```

The end result is adding all double-linked host interfaces to the last discovered VM cgroup.

<details>
<summary>Screenshot</summary>

<img width="1648" alt="Screenshot 2022-04-30 at 13 49 57" src="https://user-images.githubusercontent.com/22274335/166102461-39f71c52-808e-4680-8a8e-b248cdaad190.png">

</details>

<details>
<summary>Screenshot when the patch applied</summary>

<img width="1587" alt="Screenshot 2022-04-30 at 13 55 01" src="https://user-images.githubusercontent.com/22274335/166102586-fb5315fd-1453-4c9e-975e-59b92786d5be.png">

</details>


##### Test Plan

Check VM cgroups network interfaces.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
