### PR TITLE
fix(proc/net/dev): exclude Proxmox bridge interfaces 

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network-helper.sh
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh
@@ -219,7 +219,7 @@ netnsid_find_all_interfaces_for_cgroup() {
     local c="${1}" # the cgroup path
 
     if [ -f "${c}/cgroup.procs" ]; then
-        netnsid_find_all_interfaces_for_pid "$(head -n 1 "${c}/cgroup.procs" 2 >/dev/null)"
+        netnsid_find_all_interfaces_for_pid "$(head -n 1 "${c}/cgroup.procs" 2>/dev/null)"
     else
         debug "Cannot find file '${c}/cgroup.procs', not searching for netnsid interfaces."
     fi

--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -655,7 +655,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
         do_carrier      = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "carrier for all interfaces", CONFIG_BOOLEAN_AUTO);
         do_mtu          = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "mtu for all interfaces", CONFIG_BOOLEAN_AUTO);
 
-        disabled_list = simple_pattern_create(config_get(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "disable by default interfaces matching", "lo fireqos* *-ifb"), NULL, SIMPLE_PATTERN_EXACT);
+        disabled_list = simple_pattern_create(config_get(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "disable by default interfaces matching", "lo fireqos* *-ifb fwpr* fwbr* fwln*"), NULL, SIMPLE_PATTERN_EXACT);
     }
 
     if(unlikely(!ff)) {


### PR DESCRIPTION
##### Summary

Proxmox networking is the following: 

- `fwbr<VMID>i<network interface X>` is the firewall bridge where the filtering happens.
- `fwpr<VMID>i<network interface X>` is the bridge in the device.
- `fwln<VMID>i<network interface X>` is the bridge out device.
- `tap<VMID>i<network interface X>` is the connector port for the guest (VM).
- `veth<VMID>i<network interface X>` is the connector port for the guest (LXC).

<details>
<summary>brctl show</summary>

```cmd
brctl show
bridge name	bridge id		STP enabled	interfaces
docker0		    8000.024277c16a36	no
fwbr101i0		8000.12482e7ef46e	no		fwln101i0
 						                    tap101i0
fwbr102i0		8000.de83bf7b6c17	no		fwln102i0
 						                    tap102i0
fwbr103i0		8000.faf93a98e77d	no		fwln103i0
 						                    tap103i0
fwbr105i0		8000.120651255bdf	no		fwln105i0
 						                    veth105i0
vmbr0		    8000.d85ed30ec5e6	no		enp5s0
 						                    fwpr101p0
 						                    fwpr102p0
vmbr1		    8000.ea3212ab5102	no		fwpr103p0
 					                        fwpr105p0
```

</details>

I think we need only the guest interface (`veth` for container and `tap` for VMs) because all these `fw*` show the same number of packets/bytes (assuming no filtering is enabled)).

Associating `fw*` with a VM/container [doesn't work anyway](https://github.com/netdata/netdata/pull/12788).

---

In addition, this PR fixes a small bug in the cgroup-network-help.sh script.


##### Test Plan

Check for any `fwpr* fwbr* fwln*` interfaces on the dashboard.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
