### PR TITLE
just a simple fix to avoid recompiling protobuf all the time

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -618,6 +618,13 @@ bundle_protobuf() {
 
   PROTOBUF_PACKAGE_VERSION="$(cat packaging/protobuf.version)"
 
+  if [ -f ${PWD}/externaldeps/protobuf/.version ] && [ "${PROTOBUF_PACKAGE_VERSION}" = "$(< "${PWD}/externaldeps/protobuf/.version")" ]
+  then
+    echo >&2 "Found compiled protobuf, same version"
+    NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-bundled-protobuf"
+    return 0
+  fi
+
   tmp="$(mktemp -d -t netdata-protobuf-XXXXXX)"
   PROTOBUF_PACKAGE_BASENAME="protobuf-cpp-${PROTOBUF_PACKAGE_VERSION}.tar.gz"
 
@@ -629,6 +636,7 @@ bundle_protobuf() {
     if run tar --no-same-owner -xf "${tmp}/${PROTOBUF_PACKAGE_BASENAME}" -C "${tmp}" &&
       build_protobuf "${tmp}/protobuf-${PROTOBUF_PACKAGE_VERSION}" &&
       copy_protobuf "${tmp}/protobuf-${PROTOBUF_PACKAGE_VERSION}" &&
+      echo "${PROTOBUF_PACKAGE_VERSION}" >"${PWD}/externaldeps/protobuf/.version" &&
       rm -rf "${tmp}"; then
       run_ok "protobuf built and prepared."
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-bundled-protobuf"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -618,9 +618,9 @@ bundle_protobuf() {
 
   PROTOBUF_PACKAGE_VERSION="$(cat packaging/protobuf.version)"
 
-  if [ -f ${PWD}/externaldeps/protobuf/.version ] && [ "${PROTOBUF_PACKAGE_VERSION}" = "$(< "${PWD}/externaldeps/protobuf/.version")" ]
+  if [ -f "${PWD}/externaldeps/protobuf/.version" ] && [ "${PROTOBUF_PACKAGE_VERSION}" = "$(< "${PWD}/externaldeps/protobuf/.version")" ]
   then
-    echo >&2 "Found compiled protobuf, same version"
+    echo >&2 "Found compiled protobuf, same version, not compiling it again. Remove file '${PWD}/externaldeps/protobuf/.version' to recompile."
     NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-bundled-protobuf"
     return 0
   fi

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -618,7 +618,7 @@ bundle_protobuf() {
 
   PROTOBUF_PACKAGE_VERSION="$(cat packaging/protobuf.version)"
 
-  if [ -f "${PWD}/externaldeps/protobuf/.version" ] && [ "${PROTOBUF_PACKAGE_VERSION}" = "$(< "${PWD}/externaldeps/protobuf/.version")" ]
+  if [ -f "${PWD}/externaldeps/protobuf/.version" ] && [ "${PROTOBUF_PACKAGE_VERSION}" = "$(cat "${PWD}/externaldeps/protobuf/.version")" ]
   then
     echo >&2 "Found compiled protobuf, same version, not compiling it again. Remove file '${PWD}/externaldeps/protobuf/.version' to recompile."
     NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS} --with-bundled-protobuf"


### PR DESCRIPTION
We really lose a lot of time recompiling protobuf every time and there is really nothing we can do to prevent this, apart from disabling protobuf or using the system default. Both of these options are problematic, because then we are testing a version of netdata that is not the final one.

This PR adds a simple check: if a compiled protobuf exists and it is the same version to the one we need, don't compile it again. Just skip protobuf downloading and compilation.