### PR TITLE
procfile: more comfortable initial settings and faster/fewer reallocs

### DIFF
--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -233,12 +233,15 @@ extern __thread size_t log_thread_memory_allocations;
 #define mallocz(size) mallocz_int(__FILE__, __FUNCTION__, __LINE__, size)
 #define reallocz(ptr, size) reallocz_int(__FILE__, __FUNCTION__, __LINE__, ptr, size)
 #define freez(ptr) freez_int(__FILE__, __FUNCTION__, __LINE__, ptr)
+#define log_allocations() log_allocations_int(__FILE__, __FUNCTION__, __LINE__)
 
 extern char *strdupz_int(const char *file, const char *function, const unsigned long line, const char *s);
 extern void *callocz_int(const char *file, const char *function, const unsigned long line, size_t nmemb, size_t size);
 extern void *mallocz_int(const char *file, const char *function, const unsigned long line, size_t size);
 extern void *reallocz_int(const char *file, const char *function, const unsigned long line, void *ptr, size_t size);
 extern void freez_int(const char *file, const char *function, const unsigned long line, void *ptr);
+extern void log_allocations_int(const char *file, const char *function, const unsigned long line);
+
 #else // NETDATA_LOG_ALLOCATIONS
 extern char *strdupz(const char *s) MALLOCLIKE NEVERNULL;
 extern void *callocz(size_t nmemb, size_t size) MALLOCLIKE NEVERNULL;


### PR DESCRIPTION
Speedup `procfile` reads significantly on big files.
On my `/proc/kallsyms` (used by ebpf) this PR is 20% times faster, from 140 ms to 116 ms.

Test:

compile with `-DNETDATA_LOG_ALLOCATIONS=1`. For the master before this PR, copy libnetdata.c and libnetdata.h from this PR to get the same interface for the memory logs.

```c
int main(int argc, char **argv) {
    usec_t start = now_realtime_usec();
    procfile *ff = procfile_open("/proc/kallsyms", " \t", PROCFILE_FLAG_DEFAULT);
    if(unlikely(!ff)) {
        error("Cannot open %s%s", netdata_configured_host_prefix, NETDATA_KALLSYMS);
        exit(1);
    }

    ff = procfile_readall(ff);

    usec_t end = now_realtime_usec();
    printf("file read in %llu usec\n", end-start);

    log_allocations();

    procfile_close(ff);
    exit(0);
}
```

The current master needs 140ms and does 45k reallocs:

```
file read in 140056 usec
MAIN MEMORY ALLOCATIONS: (0695@daemon/main.c:main): Allocated 19159 KiB (+19618992 B), mmapped 0 KiB (+0 B): print : malloc 3 (+3), calloc 0 (+0), realloc 45840 (+45840), strdup 0 (+0), free 0 (+0)
```

With this PR it needs 116 ms and does 54 reallocs:

```
file read in 116450 usec
MAIN MEMORY ALLOCATIONS: (0695@daemon/main.c:main): Allocated 23285 KiB (+23843359 B), mmapped 0 KiB (+0 B): print : malloc 3 (+3), calloc 0 (+0), realloc 54 (+54), strdup 0 (+0), free 0 (+0)
```
