### PR TITLE
Speed up BUFFER increases (minimize reallocs)

### DIFF
--- a/libnetdata/buffer/buffer.c
+++ b/libnetdata/buffer/buffer.c
@@ -420,16 +420,19 @@ void buffer_increase(BUFFER *b, size_t free_size_required) {
     buffer_overflow_check(b);
 
     size_t left = b->size - b->len;
-
     if(left >= free_size_required) return;
 
-    size_t increase = free_size_required - left;
-    if(increase < WEB_DATA_LENGTH_INCREASE_STEP) increase = WEB_DATA_LENGTH_INCREASE_STEP;
+    size_t wanted = free_size_required - left;
+    size_t minimum = WEB_DATA_LENGTH_INCREASE_STEP;
+    if(minimum > wanted) wanted = minimum;
 
-    debug(D_WEB_BUFFER, "Increasing data buffer from size %zu to %zu.", b->size, b->size + increase);
+    size_t optimal = b->size / 2;
+    if(optimal > wanted) wanted = optimal;
 
-    b->buffer = reallocz(b->buffer, b->size + increase + sizeof(BUFFER_OVERFLOW_EOF) + 2);
-    b->size += increase;
+    debug(D_WEB_BUFFER, "Increasing data buffer from size %zu to %zu.", b->size, b->size + wanted);
+
+    b->buffer = reallocz(b->buffer, b->size + wanted + sizeof(BUFFER_OVERFLOW_EOF) + 2);
+    b->size += wanted;
 
     buffer_overflow_init(b);
     buffer_overflow_check(b);

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -55,6 +55,7 @@ extern const char *buffer_tostring(BUFFER *wb);
 extern void buffer_reset(BUFFER *wb);
 
 extern void buffer_strcat(BUFFER *wb, const char *txt);
+extern void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len);
 extern void buffer_rrd_value(BUFFER *wb, calculated_number value);
 
 extern void buffer_date(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);


### PR DESCRIPTION
Optimize BUFFER increases for large web requests.

This PR makes buffer increases about 25% faster for large buffers.

In the following test case, using the BUFFER of the master, it finishes in 65 ms. With this PR it finishes in 50 ms.

Test:

```c
int main(int argc, char **argv) {
    BUFFER *wb = buffer_create(1024);

    const char *string = "012345678901234567890123456789012345678901234567890123456789";
    size_t size_of_string = strlen(string);
    size_t total = 0;

    usec_t start = now_realtime_usec();
    while(total < 40*1024*1024) {
        buffer_sprintf(wb, "%s", string);
        total += size_of_string;
    }
    usec_t end = now_realtime_usec();
    printf("Buffer of %zu bytes finished in %llu usec\n", buffer_strlen(wb), end-start);

    log_allocations();

    buffer_free(wb);
    exit(0);
}
```

Test results from master:

```
Buffer of 41943060 bytes finished in 65844 usec
MAIN MEMORY ALLOCATIONS: (0697@daemon/main.c:main): Allocated 40961 KiB (+41944078 B), mmapped 0 KiB (+0 B): : malloc 1 (+1), calloc 1 (+1), realloc 40920 (+40920), strdup 0 (+0), free 0 (+0)
```

Test results from this PR:

```
Buffer of 41943060 bytes finished in 50036 usec
MAIN MEMORY ALLOCATIONS: (0697@daemon/main.c:main): Allocated 49152 KiB (+50331702 B), mmapped 0 KiB (+0 B): : malloc 1 (+1), calloc 1 (+1), realloc 15 (+15), strdup 0 (+0), free 0 (+0)
```


---

## real-life effect

Running a parallel test with on a context with 1000 charts, 100 dimensions each, like this:

```
siege --verbose --concurrent=255 --benchmark --reps=1 "http://localhost:19999/api/v1/data?context=example.random&before=0&after=-60&points=60&options=jsonwrap"
```

This PR provides a 10% benefit.

The master:

```
Transactions:                255 hits
Availability:             100.00 %
Elapsed time:             131.46 secs
Data transferred:        2384.86 MB
Response time:            110.83 secs
Transaction rate:           1.94 trans/sec
Throughput:            18.14 MB/sec
Concurrency:              214.98
Successful transactions:         255
Failed transactions:               0
Longest transaction:          131.46
Shortest transaction:          93.43
```

This PR:

```
Transactions:                255 hits
Availability:             100.00 %
Elapsed time:             119.09 secs
Data transferred:        2384.76 MB
Response time:             97.45 secs
Transaction rate:           2.14 trans/sec
Throughput:            20.02 MB/sec
Concurrency:              208.66
Successful transactions:         255
Failed transactions:               0
Longest transaction:          119.09
Shortest transaction:          83.44
```