### PR TITLE
Rename --install option for kickstart.sh

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -161,6 +161,10 @@ banner_nonroot_install() {
 
   Please set an installation prefix, like this:
 
+      $PROGRAM ${@} --install-prefix /tmp
+
+  or
+
       $PROGRAM ${@} --install /tmp
 
   or, run the installer as root:
@@ -199,7 +203,8 @@ usage() {
 USAGE: ${PROGRAM} [options]
        where options include:
 
-  --install <path>           Install netdata in <path>. Ex. --install /opt will put netdata in /opt/netdata.
+  --install <path>           Install netdata in <path>. Ex. --install /opt will put netdata in /opt/netdata, this option is deprecated and will be removed in the future version, please use --install-prefix instead.
+  --install-prefix <path>           Install netdata in <path>. Ex. --install-prefix /opt will put netdata in /opt/netdata.
   --dont-start-it            Do not (re)start netdata after installation.
   --dont-wait                Run installation in non-interactive mode.
   --stable-channel           Use packages from GitHub release pages instead of nightly updates.
@@ -367,6 +372,10 @@ while [ -n "${1}" ]; do
       NETDATA_BUILD_JUDY=1
       ;;
     "--install")
+      NETDATA_PREFIX="${2}/netdata"
+      shift 1
+      ;;
+    "--install-prefix")
       NETDATA_PREFIX="${2}/netdata"
       shift 1
       ;;

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -203,7 +203,7 @@ usage() {
 USAGE: ${PROGRAM} [options]
        where options include:
 
-  --install <path>           Install netdata in <path>. Ex. --install /opt will put netdata in /opt/netdata, this option is deprecated and will be removed in the future version, please use --install-prefix instead.
+  --install <path>           Install netdata in <path>. Ex. --install /opt will put netdata in /opt/netdata, this option is deprecated and will be removed in a future version, please use --install-prefix instead.
   --install-prefix <path>           Install netdata in <path>. Ex. --install-prefix /opt will put netdata in /opt/netdata.
   --dont-start-it            Do not (re)start netdata after installation.
   --dont-wait                Run installation in non-interactive mode.

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1743,7 +1743,7 @@ while [ -n "${1}" ]; do
       NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --disable-telemetry"
       ;;
     "--install")
-      warning "--install flag is deprecated and will be removed in the future version. Please use --install-prefix instead."
+      warning "--install flag is deprecated and will be removed in a future version. Please use --install-prefix instead."
       INSTALL_PREFIX="${2}"
       shift 1
       ;;

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -135,7 +135,8 @@ USAGE: kickstart.sh [options]
   --reinstall-even-if-unsafe Even try to reinstall if we don't think we can do so safely (implies --reinstall).
   --disable-cloud            Disable support for Netdata Cloud (default: detect)
   --require-cloud            Only install if Netdata Cloud can be enabled. Overrides --disable-cloud.
-  --install <path>           Specify an installation prefix for local builds (default: autodetect based on system type).
+  --install <path>           This option is deprecated and will be removed in the future version, use --install-prefix instead.
+  --install-prefix <path>           Specify an installation prefix for local builds (default: autodetect based on system type).
   --old-install-prefix <path>       Specify an old local builds installation prefix for uninstall/reinstall (if it's not default).
   --claim-token              Use a specified token for claiming to Netdata Cloud.
   --claim-rooms              When claiming, add the node to the specified rooms.
@@ -920,11 +921,11 @@ EOF
 
 confirm_install_prefix() {
   if [ -n "${INSTALL_PREFIX}" ] && [ "${NETDATA_ONLY_BUILD}" -ne 1 ]; then
-    fatal "The \`--install\` option is only supported together with the \`--build-only\` option." F0204
+    fatal "The \`--install-prefix\` and \`--install\` options are only supported together with the \`--build-only\` option." F0204
   fi
 
   if [ -n "${INSTALL_PREFIX}" ]; then
-    NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --install ${INSTALL_PREFIX}"
+    NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --install-prefix ${INSTALL_PREFIX}"
   else
     case "${SYSTYPE}" in
       Darwin)
@@ -1742,6 +1743,12 @@ while [ -n "${1}" ]; do
       NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --disable-telemetry"
       ;;
     "--install")
+      warning "--install flag is deprecated and will be removed in the future version."
+      warning "Please use --install-prefix instead."
+      INSTALL_PREFIX="${2}"
+      shift 1
+      ;;
+    "--install-prefix")
       INSTALL_PREFIX="${2}"
       shift 1
       ;;

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -135,7 +135,7 @@ USAGE: kickstart.sh [options]
   --reinstall-even-if-unsafe Even try to reinstall if we don't think we can do so safely (implies --reinstall).
   --disable-cloud            Disable support for Netdata Cloud (default: detect)
   --require-cloud            Only install if Netdata Cloud can be enabled. Overrides --disable-cloud.
-  --install <path>           This option is deprecated and will be removed in the future version, use --install-prefix instead.
+  --install <path>           This option is deprecated and will be removed in a future version, use --install-prefix instead.
   --install-prefix <path>           Specify an installation prefix for local builds (default: autodetect based on system type).
   --old-install-prefix <path>       Specify an old local builds installation prefix for uninstall/reinstall (if it's not default).
   --claim-token              Use a specified token for claiming to Netdata Cloud.
@@ -1743,8 +1743,7 @@ while [ -n "${1}" ]; do
       NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --disable-telemetry"
       ;;
     "--install")
-      warning "--install flag is deprecated and will be removed in the future version."
-      warning "Please use --install-prefix instead."
+      warning "--install flag is deprecated and will be removed in the future version. Please use --install-prefix instead."
       INSTALL_PREFIX="${2}"
       shift 1
       ;;

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -63,7 +63,8 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--disable-cloud`: For local builds, don’t build any of the cloud code at all. For native packages and static builds,
     use runtime configuration to disable cloud support.
 - `--require-cloud`: Only install if Netdata Cloud can be enabled. Overrides `--disable-cloud`.
-- `--install`: Specify an installation prefix for local builds (by default, we use a sane prefix based on the type of system).
+- `--install`: Specify an installation prefix for local builds (by default, we use a sane prefix based on the type of system), this option is deprecated and will be removed in the future version, please use `--install-prefix` instead.
+- `--install-prefix`: Specify an installation prefix for local builds (by default, we use a sane prefix based on the type of system).
 - `--old-install-prefix`: Specify the custom local build's installation prefix that should be removed.
 - `--uninstall`: Uninstall an existing installation of Netdata.
 - `--reinstall-clean`: Performs an uninstall of Netdata and clean installation.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -63,7 +63,7 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--disable-cloud`: For local builds, don’t build any of the cloud code at all. For native packages and static builds,
     use runtime configuration to disable cloud support.
 - `--require-cloud`: Only install if Netdata Cloud can be enabled. Overrides `--disable-cloud`.
-- `--install`: Specify an installation prefix for local builds (by default, we use a sane prefix based on the type of system), this option is deprecated and will be removed in the future version, please use `--install-prefix` instead.
+- `--install`: Specify an installation prefix for local builds (by default, we use a sane prefix based on the type of system), this option is deprecated and will be removed in a future version, please use `--install-prefix` instead.
 - `--install-prefix`: Specify an installation prefix for local builds (by default, we use a sane prefix based on the type of system).
 - `--old-install-prefix`: Specify the custom local build's installation prefix that should be removed.
 - `--uninstall`: Uninstall an existing installation of Netdata.


### PR DESCRIPTION
##### Summary
Add the new --install-prefix option and add a deprecation warning to the existing --install option. #12659

##### Test Plan
Tested with `./kickstart.sh --install-prefix /test --build-only `pointed to netdata-installer.sh from local path.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
