### PR TITLE
Switch to Alma Linux for RHEL compatible support.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -27,9 +27,9 @@ include:
     env_prep: |
       pacman --noconfirm -Syu && pacman --noconfirm -Sy grep libffi
 
-  - distro: rockylinux
+  - distro: almalinux
     version: "8"
-    base_image: rockylinux/rockylinux
+    base_image: almalinux
     jsonc_removal: |
       dnf remove -y json-c-devel
     packages:

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -101,7 +101,7 @@ case "${DISTRO}" in
   fedora | oraclelinux)
     install_fedora_like
     ;;
-  centos | rockylinux)
+  centos | rockylinux | almalinux)
     install_centos
     ;;
   opensuse)

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -51,18 +51,20 @@ to work on these platforms with minimal user effort.
 | Platform | Version | Official Native Packages | Notes |
 | -------- | ------- | ------------------------ | ----- |
 | Alpine Linux | 3.15 | No | The latest release of Alpine Linux is guaranteed to remain at **Core** tier due to usage for our Docker images |
+| Alma Linux | 8.x | x86\_64, AArch64 | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives |
 | CentOS | 7.x | x86\_64 | |
-| CentOS | 8.x | x86\_64, AArch64 | Includes Rocky Linux 8.x support, which will be our primary platform long-term for RHEL compatiblitiy |
 | Docker | 19.03 or newer | x86\_64, i386, ARMv7, AArch64, POWER8+ | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker |
 | Debian | 11.x | x86\_64, i386, ARMv7, AArch64 | |
 | Debian | 10.x | x86\_64, i386, ARMv7, AArch64 | |
 | Debian | 9.x | x86\_64, i386, ARMv7, AArch64 | |
+| Fedora | 36 | x86\_64, ARMv7, AArch64 | |
 | Fedora | 35 | x86\_64, ARMv7, AArch64 | |
 | Fedora | 34 | x86\_64, ARMv7, AArch64 | |
 | openSUSE | Leap 15.3 | x86\_64, AArch64 | |
 | Oracle Linux | 8.x | x86\_64, AArch64 | |
 | Red Hat Enterprise Linux | 7.x | x86\_64 | |
 | Red Hat Enterprise Linux | 8.x | x86\_64, AArch64 | |
+| Ubuntu | 22.04 | x86\_64, ARMv7, AArch64 | |
 | Ubuntu | 21.10 | x86\_64, i386, ARMv7, AArch64 | |
 | Ubuntu | 20.04 | x86\_64, i386, ARMv7, AArch64 | |
 | Ubuntu | 18.04 | x86\_64, i386, ARMv7, AArch64 | |


### PR DESCRIPTION
##### Summary

This PR switches from using Rocky Linux for RHEL compatible support to using Alma Linux instead. This should translate to no user-visible changes, but is preferable for us for two reasons:

- Alma Linux has commercial support options, while Rocky does not. This is generally indicative of much better long-term staying power for a distro.
- Alma Linux has better cross-architecture support, which is beneficial to us long-term.

##### Test Plan

CI passes on this PR.

##### Additional Information

This PR also recynchronizes the platform support document with our list of currently supported platforms, as it’s gotten a bit out of sync.

<details> <summary>For users: How does this change affect me?</summary>
No user-visible changes.
</details>
