### PR TITLE
Fill missing removed events after a crash

### DIFF
--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -447,8 +447,6 @@ void sql_inject_removed_status(char *uuid_str, uint32_t alarm_id, uint32_t alarm
     if (!alarm_id || !alarm_event_id || !unique_id || !max_unique_id)
         return;
 
-    info ("Injecting a removed event for alarm_id [%u], with alarm_event_id [%u], updating unique_id [%u], with new unique_id [%u]", alarm_id, alarm_event_id + 1, unique_id, max_unique_id);
-
     sqlite3_stmt *res = NULL;
 
     snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_INJECT_REMOVED(uuid_str, uuid_str));


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

In a normal agent lifecycle, during agent shutdown and alert reload, the agent creates (while unlinking alerts) removed alert events for every alert currently in memory.

When the agent starts up again, it picks up from that removed event and creates new uninitialized, and the clear, etc.

If when it starts some of those alerts are no longer evaluated, we're left with not updated removed events in the database. Those not-updated removed events are then propagated to the cloud. (And in effect any raised alerts from these will be removed since they will no longer be evaluated).

In case of an agent crash though, we lose that intermediate state of removed alert events. This PR tries to detect this case and inject removed events in the database for all alerts that are missing it. This happens right before the alert events are loaded in the memory during a host's initialization. After this process completes, the events are loaded normally, and newer health events should continue as planned.

The injected removed events will inherit some of the data from the last event id for that alert. The existing entry (before the new removed) will also be updated to retain the chain of alerts.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

The tests can be done by checking `/api/v1/alarms_log` or by checking the `health_log_xxxx` table (the latter should provide more clarity).

1) Create a new clean agent.
2) Find a way to crash the agent after a few health loops.
3) Before restarting, check the `health_log` table. It should have entries for all alerts, but the latest statuses of each should not be `new_status = -2` (removed).
4) If the agent is started without this PR, the table will be filled with new Uninitialised/undefined, then cleared, etc statuses. Also the chain of updated_by_id will be broken.
5) With this PR, when the agent restarts it should fill the missing removed events and continue with the new from then on.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->

This change should lead to having less stuck alerts on the cloud, caused by cases when an agent crashes.

</details>
