### PR TITLE
Configurable storage engine for Netdata agents: step 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,6 +637,10 @@ set(RRD_PLUGIN_FILES
         database/rrdsetvar.h
         database/rrdvar.c
         database/rrdvar.h
+        database/storage_engine.c
+        database/storage_engine.h
+        database/ram/rrddim_mem.c
+        database/ram/rrddim_mem.h
         database/sqlite/sqlite_functions.c
         database/sqlite/sqlite_functions.h
         database/sqlite/sqlite_aclk.c
@@ -1025,7 +1029,7 @@ IF(ENABLE_EXPORTING_PROMETHEUS_REMOTE_WRITE)
     message(STATUS "prometheus remote write exporting: enabled")
 
     find_package(Protobuf REQUIRED)
-    
+
     function(PROTOBUF_REMOTE_WRITE_GENERATE_CPP SRCS HDRS)
         if(NOT ARGN)
             message(SEND_ERROR "Error: PROTOBUF_REMOTE_WRITE_GENERATE_CPP() called without any proto files")

--- a/Makefile.am
+++ b/Makefile.am
@@ -446,6 +446,10 @@ RRD_PLUGIN_FILES = \
     database/rrdsetvar.h \
     database/rrdvar.c \
     database/rrdvar.h \
+    database/storage_engine.c \
+    database/storage_engine.h \
+    database/ram/rrddim_mem.c \
+    database/ram/rrddim_mem.h \
     database/sqlite/sqlite_functions.c \
     database/sqlite/sqlite_functions.h \
     database/sqlite/sqlite_aclk.c \

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "rrddim_mem.h"
+
+// ----------------------------------------------------------------------------
+// RRDDIM legacy data collection functions
+
+void rrddim_collect_init(RRDDIM *rd) {
+    rd->values[rd->rrdset->current_entry] = SN_EMPTY_SLOT;
+    rd->state->handle = calloc(1, sizeof(struct mem_collect_handle));
+}
+void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number) {
+    (void)point_in_time;
+    rd->values[rd->rrdset->current_entry] = number;
+}
+int rrddim_collect_finalize(RRDDIM *rd) {
+    free((struct mem_collect_handle*)rd->state->handle);
+    return 0;
+}
+
+// ----------------------------------------------------------------------------
+// RRDDIM legacy database query functions
+
+void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time) {
+    handle->rd = rd;
+    handle->start_time = start_time;
+    handle->end_time = end_time;
+    struct mem_query_handle* h = calloc(1, sizeof(struct mem_query_handle));
+    h->slot = rrdset_time2slot(rd->rrdset, start_time);
+    h->last_slot = rrdset_time2slot(rd->rrdset, end_time);
+    h->finished = 0;
+    handle->handle = (STORAGE_QUERY_HANDLE *)h;
+}
+
+storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time) {
+    RRDDIM *rd = handle->rd;
+    struct mem_query_handle* h = (struct mem_query_handle*)handle->handle;
+    long entries = rd->rrdset->entries;
+    long slot = h->slot;
+
+    (void)current_time;
+    if (unlikely(h->slot == h->last_slot))
+        h->finished = 1;
+    storage_number n = rd->values[slot++];
+
+    if(unlikely(slot >= entries)) slot = 0;
+    h->slot = slot;
+
+    return n;
+}
+
+int rrddim_query_is_finished(struct rrddim_query_handle *handle) {
+    struct mem_query_handle* h = (struct mem_query_handle*)handle->handle;
+    return h->finished;
+}
+
+void rrddim_query_finalize(struct rrddim_query_handle *handle) {
+    freez(handle->handle);
+}
+
+time_t rrddim_query_latest_time(RRDDIM *rd) {
+    return rrdset_last_entry_t_nolock(rd->rrdset);
+}
+
+time_t rrddim_query_oldest_time(RRDDIM *rd) {
+    return rrdset_first_entry_t_nolock(rd->rrdset);
+}

--- a/database/ram/rrddim_mem.h
+++ b/database/ram/rrddim_mem.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_RRDDIMMEM_H
+#define NETDATA_RRDDIMMEM_H
+
+#include "database/rrd.h"
+
+struct mem_collect_handle {
+    long slot;
+    long entries;
+};
+struct mem_query_handle {
+    long slot;
+    long last_slot;
+    uint8_t finished;
+};
+
+extern void rrddim_collect_init(RRDDIM *rd);
+extern void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number);
+extern int rrddim_collect_finalize(RRDDIM *rd);
+
+extern void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time);
+extern storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time);
+extern int rrddim_query_is_finished(struct rrddim_query_handle *handle);
+extern void rrddim_query_finalize(struct rrddim_query_handle *handle);
+extern time_t rrddim_query_latest_time(RRDDIM *rd);
+extern time_t rrddim_query_oldest_time(RRDDIM *rd);
+
+#endif

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -2,6 +2,7 @@
 #define NETDATA_RRD_INTERNALS 1
 
 #include "rrd.h"
+#include "storage_engine.h"
 
 // ----------------------------------------------------------------------------
 // globals
@@ -47,24 +48,19 @@ inline const char *rrd_memory_mode_name(RRD_MEMORY_MODE id) {
             return RRD_MEMORY_MODE_DBENGINE_NAME;
     }
 
+    STORAGE_ENGINE* eng = storage_engine_get(id);
+    if (eng) {
+        return eng->name;
+    }
+
     return RRD_MEMORY_MODE_SAVE_NAME;
 }
 
 RRD_MEMORY_MODE rrd_memory_mode_id(const char *name) {
-    if(unlikely(!strcmp(name, RRD_MEMORY_MODE_RAM_NAME)))
-        return RRD_MEMORY_MODE_RAM;
-
-    else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_MAP_NAME)))
-        return RRD_MEMORY_MODE_MAP;
-
-    else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_NONE_NAME)))
-        return RRD_MEMORY_MODE_NONE;
-
-    else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_ALLOC_NAME)))
-        return RRD_MEMORY_MODE_ALLOC;
-
-    else if(unlikely(!strcmp(name, RRD_MEMORY_MODE_DBENGINE_NAME)))
-        return RRD_MEMORY_MODE_DBENGINE;
+    STORAGE_ENGINE* eng = storage_engine_find(name);
+    if (eng) {
+        return eng->id;
+    }
 
     return RRD_MEMORY_MODE_SAVE;
 }

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -405,19 +405,6 @@ struct rrdset_volatile {
     bool is_ar_chart;
 };
 
-// RRDDIM legacy data collection structures
-
-struct mem_collect_handle {
-    long slot;
-    long entries;
-};
-
-struct mem_query_handle {
-    long slot;
-    long last_slot;
-    uint8_t finished;
-};
-
 // ----------------------------------------------------------------------------
 // these loop macros make sure the linked list is accessed with the right lock
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -2,6 +2,10 @@
 
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
+#include "database/rrddim_mem.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 // ----------------------------------------------------------------------------
 // RRDDIM index
@@ -95,74 +99,6 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
     rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
     return 1;
 }
-
-// ----------------------------------------------------------------------------
-// RRDDIM legacy data collection functions
-
-static void rrddim_collect_init(RRDDIM *rd) {
-    rd->state->handle = callocz(1, sizeof(struct mem_collect_handle));
-    rd->values[rd->rrdset->current_entry] = SN_EMPTY_SLOT;
-}
-static void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, storage_number number) {
-    (void)point_in_time;
-
-    rd->values[rd->rrdset->current_entry] = number;
-}
-static int rrddim_collect_finalize(RRDDIM *rd) {
-    freez(rd->state->handle);
-    return 0;
-}
-
-
-// ----------------------------------------------------------------------------
-// RRDDIM legacy database query functions
-
-static void rrddim_query_init(RRDDIM *rd, struct rrddim_query_handle *handle, time_t start_time, time_t end_time) {
-    handle->rd = rd;
-    handle->start_time = start_time;
-    handle->end_time = end_time;
-    struct mem_query_handle* mem_handle = callocz(1, sizeof(struct mem_query_handle));
-    mem_handle->slot = rrdset_time2slot(rd->rrdset, start_time);
-    mem_handle->last_slot = rrdset_time2slot(rd->rrdset, end_time);
-    mem_handle->finished = 0;
-    handle->handle = (STORAGE_QUERY_HANDLE *)mem_handle;
-}
-
-static storage_number rrddim_query_next_metric(struct rrddim_query_handle *handle, time_t *current_time) {
-    RRDDIM *rd = handle->rd;
-    struct mem_query_handle* mem_handle = (struct mem_query_handle*)handle->handle;
-    long entries = rd->rrdset->entries;
-    long slot = mem_handle->slot;
-
-    (void)current_time;
-    if (unlikely(mem_handle->slot == mem_handle->last_slot))
-        mem_handle->finished = 1;
-    storage_number n = rd->values[slot++];
-
-    if(unlikely(slot >= entries)) slot = 0;
-    mem_handle->slot = slot;
-
-    return n;
-}
-
-static int rrddim_query_is_finished(struct rrddim_query_handle *handle) {
-    struct mem_query_handle* mem_handle = (struct mem_query_handle*)handle->handle;
-    return mem_handle->finished;
-}
-
-static void rrddim_query_finalize(struct rrddim_query_handle *handle) {
-    freez(handle->handle);
-    return;
-}
-
-static time_t rrddim_query_latest_time(RRDDIM *rd) {
-    return rrdset_last_entry_t_nolock(rd->rrdset);
-}
-
-static time_t rrddim_query_oldest_time(RRDDIM *rd) {
-    return rrdset_first_entry_t_nolock(rd->rrdset);
-}
-
 
 // ----------------------------------------------------------------------------
 // RRDDIM create a dimension

--- a/database/storage_engine.c
+++ b/database/storage_engine.c
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "storage_engine.h"
+#include "ram/rrddim_mem.h"
+#ifdef ENABLE_DBENGINE
+#include "engine/rrdengineapi.h"
+#endif
+
+#define im_collect_ops { \
+    .init = rrddim_collect_init,\
+    .store_metric = rrddim_collect_store_metric,\
+    .finalize = rrddim_collect_finalize\
+}
+
+#define im_query_ops { \
+    .init = rrddim_query_init, \
+    .next_metric = rrddim_query_next_metric, \
+    .is_finished = rrddim_query_is_finished, \
+    .finalize = rrddim_query_finalize, \
+    .latest_time = rrddim_query_latest_time, \
+    .oldest_time = rrddim_query_oldest_time \
+}
+
+static STORAGE_ENGINE engines[] = {
+    {
+        .id = RRD_MEMORY_MODE_NONE,
+        .name = RRD_MEMORY_MODE_NONE_NAME,
+        .api = {
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        }
+    },
+    {
+        .id = RRD_MEMORY_MODE_RAM,
+        .name = RRD_MEMORY_MODE_RAM_NAME,
+        .api = {
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        }
+    },
+    {
+        .id = RRD_MEMORY_MODE_MAP,
+        .name = RRD_MEMORY_MODE_MAP_NAME,
+        .api = {
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        }
+    },
+    {
+        .id = RRD_MEMORY_MODE_SAVE,
+        .name = RRD_MEMORY_MODE_SAVE_NAME,
+        .api = {
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        }
+    },
+    {
+        .id = RRD_MEMORY_MODE_ALLOC,
+        .name = RRD_MEMORY_MODE_ALLOC_NAME,
+        .api = {
+            .collect_ops = im_collect_ops,
+            .query_ops = im_query_ops
+        }
+    },
+#ifdef ENABLE_DBENGINE
+    {
+        .id = RRD_MEMORY_MODE_DBENGINE,
+        .name = RRD_MEMORY_MODE_DBENGINE_NAME,
+        .api = {
+            .collect_ops = {
+                .init = rrdeng_store_metric_init,
+                .store_metric = rrdeng_store_metric_next,
+                .finalize = rrdeng_store_metric_finalize
+            },
+            .query_ops = {
+                .init = rrdeng_load_metric_init,
+                .next_metric = rrdeng_load_metric_next,
+                .is_finished = rrdeng_load_metric_is_finished,
+                .finalize = rrdeng_load_metric_finalize,
+                .latest_time = rrdeng_metric_latest_time,
+                .oldest_time = rrdeng_metric_oldest_time
+            }
+        }
+    },
+#endif
+    { .id = RRD_MEMORY_MODE_NONE, .name = NULL }
+};
+
+STORAGE_ENGINE* storage_engine_find(const char* name)
+{
+    for (STORAGE_ENGINE* it = engines; it->name; it++) {
+        if (strcmp(it->name, name) == 0)
+            return it;
+    }
+    return NULL;
+}
+
+STORAGE_ENGINE* storage_engine_get(RRD_MEMORY_MODE mmode)
+{
+    for (STORAGE_ENGINE* it = engines; it->name; it++) {
+        if (it->id == mmode)
+            return it;
+    }
+    return NULL;
+}
+
+STORAGE_ENGINE* storage_engine_foreach_init()
+{
+    // Assuming at least one engine exists
+    return &engines[0];
+}
+
+STORAGE_ENGINE* storage_engine_foreach_next(STORAGE_ENGINE* it)
+{
+    if (!it || !it->name)
+        return NULL;
+
+    it++;
+    return it->name ? it : NULL;
+}

--- a/database/storage_engine.h
+++ b/database/storage_engine.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_STORAGEENGINEAPI_H
+#define NETDATA_STORAGEENGINEAPI_H
+
+#include "rrd.h"
+
+typedef struct storage_engine STORAGE_ENGINE;
+
+// ------------------------------------------------------------------------
+// function pointers for all APIs provided by a storge engine
+typedef struct storage_engine_api {
+    struct rrddim_collect_ops collect_ops;
+    struct rrddim_query_ops query_ops;
+} STORAGE_ENGINE_API;
+
+struct storage_engine {
+    RRD_MEMORY_MODE id;
+    const char* name;
+    STORAGE_ENGINE_API api;
+};
+
+extern STORAGE_ENGINE* storage_engine_get(RRD_MEMORY_MODE mmode);
+extern STORAGE_ENGINE* storage_engine_find(const char* name);
+
+// Iterator over existing engines
+extern STORAGE_ENGINE* storage_engine_foreach_init();
+extern STORAGE_ENGINE* storage_engine_foreach_next(STORAGE_ENGINE* it);
+
+#endif

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -3,6 +3,7 @@
 #include "query.h"
 #include "web/api/formatters/rrd2json.h"
 #include "rrdr.h"
+#include "database/ram/rrddim_mem.h"
 
 #include "average/average.h"
 #include "incremental_sum/incremental_sum.h"


### PR DESCRIPTION
Following the idea discussed here:
https://github.com/netdata/netdata/discussions/12216

This change introduces the new storage engine API for `rrddim_collect` and `rrddim_query`  operations. It introduces the new compile-time list of storage engines and APIs to find an engine by name or id.

##### Summary

These commits do the following (in commit order):
* Add the new storage engine API, and use it to find an engine id by name or name from id.
* Use the new API for dimension collection and query

##### Test Plan

These changes don't add any new memory modes/storage engines for now, and only refactor existing features, so they are expected to be covered by existing unit tests.
