### PR TITLE
Add support for installing static builds on systems without usable internet connections.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1691,33 +1691,33 @@ prepare_offline_install_source() {
       set_static_archive_urls "${SELECTED_RELEASE_CHANNEL}" "${arch}"
 
       progress "Fetching ${NETDATA_STATIC_ARCHIVE_URL}"
-      if ! download "${NETDATA_STATIC_ARCHIVE_URL}" "${1}/netdata-${arch}-latest.gz.run"; then
+      if ! download "${NETDATA_STATIC_ARCHIVE_URL}" "netdata-${arch}-latest.gz.run"; then
         warning "Failed to download static installer archive for ${arch}."
       fi
     done
 
     progress "Fetching ${NETDATA_STATIC_ARCHIVE_CHECKSUM_URL}"
-    if ! download "${NETDATA_STATIC_ARCHIVE_CHECKSUM_URL}" "${1}/sha256sums.txt"; then
+    if ! download "${NETDATA_STATIC_ARCHIVE_CHECKSUM_URL}" "sha256sums.txt"; then
       fatal "Failed to download checksum file." F0506
     fi
   fi
 
   progress "Verifying checksums."
-  if ! safe_sha256sum --ignore-missing -c "${1}/sha256sums.txt"; then
+  if ! safe_sha256sum --ignore-missing -c "./sha256sums.txt"; then
     fatal "Checksums for offline install files are incorrect. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0507
   fi
 
   progress "Preparing install script."
-  cat > "${1}/install.sh" <<-EOF
+  cat > "install.sh" <<-EOF
 	#!/bin/sh
 	dir=\$(CDPATH= cd -- "\$(dirname -- "$0")" && pwd)
 	"\${dir}/kickstart.sh --offline-install-source "\${dir}" \${@}
 	EOF
-  chmod +x "${1}/install.sh"
+  chmod +x "install.sh"
 
   progress "Copying kickstart script."
-  cp "${KICKSTART_SOURCE}" "${1}/kickstart.sh"
-  chmod +x "${1}/install.sh"
+  cp "${KICKSTART_SOURCE}" "kickstart.sh"
+  chmod +x "install.sh"
 
   progress "Finished preparing ofline install source directory at ${1}. You can now copy this directory to a target system and then run the script ‘install.sh’ from it to install on that system."
   deferred_warnings

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1716,7 +1716,7 @@ prepare_offline_install_source() {
 
   if [ "${DRY_RUN}" -ne 1 ]; then
     progress "Verifying checksums."
-    if ! safe_sha256sum --ignore-missing -c "./sha256sums.txt"; then
+    if ! grep -e "$(find . -name '*.gz.run')" sha256sums.txt | safe_sha256sum -c -; then
       fatal "Checksums for offline install files are incorrect. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0507
     fi
   else

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1422,20 +1422,20 @@ set_static_archive_urls() {
   elif [ "${1}" = "stable" ]; then
     if [ -n "${INSTALL_VERSION}" ]; then
       export NETDATA_STATIC_ARCHIVE_OLD_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-v${INSTALL_VERSION}.gz.run"
-      export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-${SYSARCH}-v${INSTALL_VERSION}.gz.run"
+      export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-${arch}-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
       latest="$(get_redirect "https://github.com/netdata/netdata/releases/latest")"
-      export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/${latest}/netdata-${SYSARCH}-latest.gz.run"
+      export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/${latest}/netdata-${arch}-latest.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/${latest}/sha256sums.txt"
     fi
   else
     if [ -n "${INSTALL_VERSION}" ]; then
-      export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-${SYSARCH}-v${INSTALL_VERSION}.gz.run"
+      export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-${arch}-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_OLD_URL="${NETDATA_TARBALL_BASEURL}/netdata-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/sha256sums.txt"
     else
-      export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-${SYSARCH}-latest.gz.run"
+      export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-${arch}-latest.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/sha256sums.txt"
     fi
   fi
@@ -1726,7 +1726,7 @@ prepare_offline_install_source() {
 
   if [ "${DRY_RUN}" -ne 1 ]; then
     progress "Verifying checksums."
-    if ! grep -e "$(find . -name '*.gz.run')" sha256sums.txt | safe_sha256sum -c -; then
+    if ! grep -e "$(find . -name '*.gz.run')" sha255sums.txt | safe_sha256sum -c -; then
       fatal "Checksums for offline install files are incorrect. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0507
     fi
   else

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2004,8 +2004,10 @@ while [ -n "${1}" ]; do
   shift 1
 done
 
-if [ "${NETDATA_ONLY_NATIVE}" -eq 1 ] && [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
-  fatal "Native packages are not supported with offline installs." F0502
+if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
+  if [ "${NETDATA_ONLY_NATIVE}" -eq 1 ] || [ "${NETDATA_ONLY_BUILD}" ]; then
+    fatal "Offline installs are only supported for static builds currently." F0502
+  fi
 fi
 
 if [ -n "${LOCAL_BUILD_OPTIONS}" ]; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1451,7 +1451,7 @@ try_static_install() {
 
   # Check status code first, so that we can provide nicer fallback for dry runs.
   if check_for_remote_file "${NETDATA_STATIC_ARCHIVE_URL}"; then
-    if [ -n "${OFFLINE_INSTALL_SOURCE}" ]; then
+    if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
       netdata_agent="$(basename "${NETDATA_STATIC_ARCHIVE_URL#"file://"}")"
     elif [ -n "${INSTALL_VERSION}" ]; then
       if [ "${SELECTED_RELEASE_CHANNEL}" = "stable" ]; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1726,7 +1726,7 @@ prepare_offline_install_source() {
 
   if [ "${DRY_RUN}" -ne 1 ]; then
     progress "Verifying checksums."
-    if ! grep -e "$(find . -name '*.gz.run')" sha255sums.txt | safe_sha256sum -c -; then
+    if ! grep -e "$(find . -name '*.gz.run')" sha256sums.txt | safe_sha256sum -c -; then
       fatal "Checksums for offline install files are incorrect. Usually this is a result of an older copy of the file being cached somewhere upstream and can be resolved by retrying in an hour." F0507
     fi
   else

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -132,38 +132,39 @@ usage() {
 USAGE: kickstart.sh [options]
        where options include:
 
-  --non-interactive          Do not prompt for user input. (default: prompt if there is a controlling terminal)
-  --interactive              Prompt for user input even if there is no controlling terminal.
-  --dont-start-it            Do not start the agent by default (only for static installs or local builds)
-  --dry-run                  Report what we would do with the given options on this system, but don’t actually do anything.
-  --release-channel          Specify the release channel to use for the install (default: ${DEFAULT_RELEASE_CHANNEL})
-  --stable-channel           Equivalent to "--release-channel stable"
-  --nightly-channel          Equivalent to "--release-channel nightly"
-  --no-updates               Do not enable automatic updates (default: enable automatic updates using the best supported scheduling method)
-  --auto-update              Enable automatic updates.
-  --auto-update-type         Specify a particular scheduling type for auto-updates (valid types: systemd, interval, crontab)
-  --disable-telemetry        Opt-out of anonymous statistics.
-  --repositories-only        Only install appropriate repository configuration packages (only for native install).
-  --native-only              Only install if native binary packages are available.
-  --static-only              Only install if a static build is available.
-  --build-only               Only install using a local build.
-  --reinstall                Explicitly reinstall instead of updating any existing install.
-  --reinstall-even-if-unsafe Even try to reinstall if we don't think we can do so safely (implies --reinstall).
-  --disable-cloud            Disable support for Netdata Cloud (default: detect)
-  --require-cloud            Only install if Netdata Cloud can be enabled. Overrides --disable-cloud.
-  --install <path>           This option is deprecated and will be removed in a future version, use --install-prefix instead.
-  --install-prefix <path>           Specify an installation prefix for local builds (default: autodetect based on system type).
-  --old-install-prefix <path>       Specify an old local builds installation prefix for uninstall/reinstall (if it's not default).
-  --install-version <version>       Specify the version of Netdata to install.
-  --claim-token              Use a specified token for claiming to Netdata Cloud.
-  --claim-rooms              When claiming, add the node to the specified rooms.
-  --claim-only               If there is an existing install, only try to claim it, not update it.
-  --claim-*                  Specify other options for the claiming script.
-  --no-cleanup               Don't do any cleanup steps. This is intended to help with debugging the installer.
-  --uninstall                Uninstall an existing installation of Netdata.
-  --reinstall-clean          Clean reinstall Netdata.
-  --local-build-options      Specify additional options to pass to the installer code when building locally. Only valid if --build-only is also specified.
-  --static-install-options   Specify additional options to pass to the static installer code. Only valid if --static-only is also specified.
+  --non-interactive                Do not prompt for user input. (default: prompt if there is a controlling terminal)
+  --interactive                    Prompt for user input even if there is no controlling terminal.
+  --dont-start-it                  Do not start the agent by default (only for static installs or local builds)
+  --dry-run                        Report what we would do with the given options on this system, but don’t actually do anything.
+  --release-channel                Specify the release channel to use for the install (default: ${DEFAULT_RELEASE_CHANNEL})
+  --stable-channel                 Equivalent to "--release-channel stable"
+  --nightly-channel                Equivalent to "--release-channel nightly"
+  --no-updates                     Do not enable automatic updates (default: enable automatic updates using the best supported scheduling method)
+  --auto-update                    Enable automatic updates.
+  --auto-update-type               Specify a particular scheduling type for auto-updates (valid types: systemd, interval, crontab)
+  --disable-telemetry              Opt-out of anonymous statistics.
+  --repositories-only              Only install appropriate repository configuration packages (only for native install).
+  --native-only                    Only install if native binary packages are available.
+  --static-only                    Only install if a static build is available.
+  --build-only                     Only install using a local build.
+  --reinstall                      Explicitly reinstall instead of updating any existing install.
+  --reinstall-even-if-unsafe       Even try to reinstall if we don't think we can do so safely (implies --reinstall).
+  --disable-cloud                  Disable support for Netdata Cloud (default: detect)
+  --require-cloud                  Only install if Netdata Cloud can be enabled. Overrides --disable-cloud.
+  --install <path>                 This option is deprecated and will be removed in a future version, use --install-prefix instead.
+  --install-prefix <path>          Specify an installation prefix for local builds (default: autodetect based on system type).
+  --old-install-prefix <path>      Specify an old local builds installation prefix for uninstall/reinstall (if it's not default).
+  --install-version <version>      Specify the version of Netdata to install.
+  --claim-token                    Use a specified token for claiming to Netdata Cloud.
+  --claim-rooms                    When claiming, add the node to the specified rooms.
+  --claim-only                     If there is an existing install, only try to claim it, not update it.
+  --claim-*                        Specify other options for the claiming script.
+  --no-cleanup                     Don't do any cleanup steps. This is intended to help with debugging the installer.
+  --uninstall                      Uninstall an existing installation of Netdata.
+  --reinstall-clean                Clean reinstall Netdata.
+  --local-build-options            Specify additional options to pass to the installer code when building locally. Only valid if --build-only is also specified.
+  --static-install-options         Specify additional options to pass to the static installer code. Only valid if --static-only is also specified.
+  --prepare-offline-install-source Instead of insallling the agent, prepare a directory that can be used to install on another system without needing to download anything.
 
 Additionally, this script may use the following environment variables:
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -495,7 +495,10 @@ check_for_remote_file() {
 download() {
   url="${1}"
   dest="${2}"
-  if command -v curl > /dev/null 2>&1; then
+
+  if echo "${url}" | grep -Eq "^file:///"; then
+    run cp "${url%file://}" "${dest}" || return 1
+  elif command -v curl > /dev/null 2>&1; then
     run curl --fail -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}" || return 1
   elif command -v wget > /dev/null 2>&1; then
     run wget -T 15 -O "${dest}" "${url}" || return 1

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1404,7 +1404,11 @@ set_static_archive_urls() {
     arch="${2}"
   fi
 
-  if [ "${1}" = "stable" ]; then
+  if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
+    path="$(cd "${NETDATA_OFFLINE_INSTALL_SOURCE}" || exit 1; pwd)"
+    export NETDATA_STATIC_ARCHIVE_URL="file://${path}/netdata-${arch}-latest.gz.run"
+    export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="file://${path}/sha256sums.txt"
+  elif [ "${1}" = "stable" ]; then
     if [ -n "${INSTALL_VERSION}" ]; then
       export NETDATA_STATIC_ARCHIVE_OLD_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-${SYSARCH}-v${INSTALL_VERSION}.gz.run"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1710,7 +1710,7 @@ prepare_offline_install_source() {
   progress "Preparing install script."
   cat > "install.sh" <<-EOF
 	#!/bin/sh
-	dir=\$(CDPATH= cd -- "\$(dirname -- "$0")" && pwd)
+	dir=\$(CDPATH= cd -- "\$(dirname -- "\$0")" && pwd)
 	"\${dir}/kickstart.sh --offline-install-source "\${dir}" \${@}
 	EOF
   chmod +x "install.sh"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -164,7 +164,7 @@ USAGE: kickstart.sh [options]
   --reinstall-clean                Clean reinstall Netdata.
   --local-build-options            Specify additional options to pass to the installer code when building locally. Only valid if --build-only is also specified.
   --static-install-options         Specify additional options to pass to the static installer code. Only valid if --static-only is also specified.
-  --prepare-offline-install-source Instead of insallling the agent, prepare a directory that can be used to install on another system without needing to download anything.
+  --prepare-offline-install-source Instead of installing the agent, prepare a directory that can be used to install on another system without needing to download anything.
 
 Additionally, this script may use the following environment variables:
 
@@ -1760,7 +1760,7 @@ prepare_offline_install_source() {
     progress "Would save release channel information to offline install source directory"
   fi
 
-  progress "Finished preparing ofline install source directory at ${1}. You can now copy this directory to a target system and then run the script ‘install.sh’ from it to install on that system."
+  progress "Finished preparing offline install source directory at ${1}. You can now copy this directory to a target system and then run the script ‘install.sh’ from it to install on that system."
 }
 
 # ======================================================================

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2038,7 +2038,13 @@ if [ -n "${STATIC_INSTALL_OPTIONS}" ]; then
   fi
 fi
 
-if [ "${NETDATA_AUTO_UPDATES}" = "default" ] || [ "${NETDATA_AUTO_UPDATES}" = "1" ]; then
+if [ "${NETDATA_AUTO_UPDATES}" = "default" ]; then
+  if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
+    AUTO_UPDATE=0
+  else
+    AUTO_UPDATE=1
+  fi
+elif [ "${NETDATA_AUTO_UPDATES}" = 1 ]; then
   AUTO_UPDATE=1
 else
   AUTO_UPDATE=0

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -76,6 +76,7 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--reinstall-clean`: Performs an uninstall of Netdata and clean installation.
 - `--local-build-options`: Specify additional options to pass to the installer code when building locally. Only valid if `--build-only` is also specified.
 - `--static-install-options`: Specify additional options to pass to the static installer code. Only valid if --static-only is also specified.
+- `--prepare-offline-install-source`: Instead of insallling the agent, prepare a directory that can be used to install on another system without needing to download anything. See our [offline installation documentation](/packaging/installer/methods/offline.md) for more info.
 
 Additionally, the following environment variables may be used to further customize how the script runs (most users
 should not need to use special values for any of these):

--- a/packaging/installer/methods/offline.md
+++ b/packaging/installer/methods/offline.md
@@ -6,75 +6,53 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/instal
 
 # Install Netdata on offline systems
 
-The Netdata Agent installs on offline or air gapped systems with a few additional steps.
+Our kickstart install script provides support for installing the Netdata Agent on systems which do not have a
+usable internet connection by prefetching all of the required files so that they can be copied to the target system.
+Currently, we only support using static installs with this method. There are tentative plans to support building
+locally on offline systems as well, but there is currently no estimate of when this functionality may be implemented.
 
-By default, the `kickstart.sh` and `kickstart-static64.sh` download Netdata assets, like the precompiled binary and a
-few dependencies, using the system's internet connection, but the Agent installer can also use equivalent files already
-present on the local filesystem.
+Users who wish to use native packages on offline systems may be able to do so using whatever tooling their
+distribution already provides for offline package management (such as `apt-offline` on Debian or Ubuntu systems),
+but this is not officially supported.
 
-First, download the required files. If you're using `kickstart.sh`, you need the Netdata tarball, the checksums, the
-go.d plugin binary, and the go.d plugin configuration. If you're using `kickstart-static64.sh`, you need only the
-Netdata tarball and checksums.
+## Preparing the offline installation source
 
-Download the files you need to a system of yours that's connected to the internet. Use the commands below, or visit the
-[latest Netdata release page](https://github.com/netdata/netdata/releases/latest) and [latest go.d plugin release
-page](https://github.com/netdata/go.d.plugin/releases) to download the required files manually.
+The first step to installing Netdata on an offline system is to prepare the offline installation source. This can
+be as a regular user from any internet connected system that has the following tools available:
 
-**If you're using `kickstart.sh`**, use the following commands:
+- cURL or wget
+- sha256sum or shasum
+- A standard POSIX compliant shell
 
-```bash
-cd /tmp
-
-curl -s https://my-netdata.io/kickstart.sh > kickstart.sh
-
-# Netdata tarball
-curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*tar.gz" | cut -d '"' -f 4 | wget -qi -
-
-# Netdata checksums
-curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*txt" | cut -d '"' -f 4 | wget -qi -
-
-# Netdata dependency handling script
-wget -q - https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh
-
-# go.d plugin 
-# For binaries for OS types and architectures not listed on [go.d releases](https://github.com/netdata/go.d.plugin/releases/latest), kindly open a github issue and we will do our best to serve your request
-export OS=$(uname -s | tr '[:upper:]' '[:lower:]') ARCH=$(uname -m | sed -e 's/i386/386/g' -e 's/i686/386/g' -e 's/x86_64/amd64/g' -e 's/aarch64/arm64/g' -e 's/armv64/arm64/g' -e 's/armv6l/arm/g' -e 's/armv7l/arm/g' -e 's/armv5tel/arm/g') && curl -s https://api.github.com/repos/netdata/go.d.plugin/releases/latest | grep "browser_download_url.*${OS}-${ARCH}.tar.gz" | cut -d '"' -f 4 | wget -qi -
-
-# go.d configuration 
-curl -s https://api.github.com/repos/netdata/go.d.plugin/releases/latest | grep "browser_download_url.*config.tar.gz" | cut -d '"' -f 4 | wget -qi -
-```
-
-**If you're using `kickstart-static64.sh`**, use the following commands:
+To prepare the offline installation source, simply run:
 
 ```bash
-cd /tmp
-
-curl -s https://my-netdata.io/kickstart-static64.sh > kickstart-static64.sh
-
-# Netdata static64 tarball
-curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*gz.run" | cut -d '"' -f 4 | wget -qi -
-
-# Netdata checksums
-curl -s https://api.github.com/repos/netdata/netdata/releases/latest | grep "browser_download_url.*txt" | cut -d '"' -f 4 | wget -qi -
+wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh --prepare-offline-install-source ./netdata-offline
 ```
 
-Move downloaded files to the `/tmp` directory on the offline system in whichever way your defined policy allows (if
-any).
-
-Now you can run either the `kickstart.sh` or `kickstart-static64.sh` scripts using the `--local-files` option. This
-option requires you to specify the location and names of the files you just downloaded. 
-
-> When using `--local-files`, the `kickstart.sh` or `kickstart-static64.sh` scripts won't download any Netdata assets
-> from the internet. But, you may still need a connection to install dependencies using your system's package manager.
-> The scripts will warn you if your system doesn't have all the dependencies.
+or
 
 ```bash
-# kickstart.sh
-bash kickstart.sh --local-files /tmp/netdata-(version-number-here).tar.gz /tmp/sha256sums.txt /tmp/go.d.plugin-(version-number-here).(OS)-(architecture).tar.gz /tmp/config.tar.gz /tmp/install-required-packages.sh
-
-# kickstart-static64.sh
-bash kickstart-static64.sh --local-files /tmp/netdata-(version-number-here).gz.run /tmp/sha256sums.txt
+curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --prepare-offline-install-source ./netdata-offline
 ```
+
+> The exact name used for the directory does not matter, you can specify any other name you want in place of `./netdata-offline`.
+
+This will create a directory called `netdata-offline` in the current directory and place all the files required for an offline install in it.
+
+If you want to use a specific release channel (nightly or stable), it _must_ be specified on this step using the
+apporpriate option for the kickstart script.
+
+## Installing on the target system
+
+Once you have prepared the offline install source, you need to copy the offline install source directory to the
+target system. This can be done in any manner you like, as long as filenames are not changed.
+
+After copying the files, simply run the `install.sh` script located in the
+offline install source directory. It accepts all the [same options as the kickstart
+script](/packaging/installer/methods/kickstart.md#optional-parameters-to-alter-your-installation) for further
+customization of the installation, though it will default to not enabling automatic updates (as they are not
+supported on offline installs).
 
 ## What's next?
 


### PR DESCRIPTION
##### Summary

This works in three steps:

1. The user creates an offline install source directory using the new `--prepare-offline-install-source` option for the kickstart script.
2. The user exposes that directory to the target system (either by copying it, or by sharing it in some other way).
3. The user runs the `install.sh` script from that directory on the target system, with whatever other install options they want to use.

The offline install source directory consists of:

- The static install archives for the selected version of Netdata (we unconditionally download all architectures at the moment because it’s simpler).
- The checksum file for the static install archives (we verify the checksums as part of creating the offline install source).
- A copy of the kickstart script that was used to create the directory.
- A stub script called `install.sh` which invokes the copy of the kickstart script with the correct value for the new `--offline-install-source` option to make it use the contents of the directory for the install.
- A file called `channel` that stores the release channel (used to set it automatically during the install).

The required changes in the actual installation code are relatively trivial, simply involving modifying `download` and `check_for_remote_file` to accept `file:///` URLs and `set_static_archive_urls` to generate such URLs when an offline install source has been specified.

##### Test Plan

Testing follows the general outline above. The `--prepare-offline-install-source` option takes exactly one argument, specifying the name of the directory to use (it will be created if it does not exist). Creation of the offline install source directory is expected to work on any platform with a working POSIX compliant shell, `wget` or `curl`, and `sha256sum` or `shasum`. Actual installation is expected to work on any platform which we provide static builds for (currently Linux systems running on 64-bit x86, ARMv7l, AArch64, or POWER8+).

##### Additional Information

Fixes: https://github.com/netdata/product/issues/2314
Fixes: #12111
Supersedes: https://github.com/netdata/netdata/pull/12802

Implementing this for local builds is theoretically possible, but would require significant changes to `netdata-installer.sh`.

<details> <summary>For users: How does this change affect me?</summary>
This enables support for installation of static builds on systems which do not have a usable internet connection.
</details>
