### PR TITLE
fix!: do not replace a hyphen in the chart name with an underscore

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -125,7 +125,7 @@ char *rrdset_strncpyz_name(char *to, const char *from, size_t length) {
     char c, *p = to;
 
     while (length-- && (c = *from++)) {
-        if(c != '.' && !isalnum(c))
+        if(c != '.' && c != '-' && !isalnum(c))
             c = '_';
 
         *p++ = c;


### PR DESCRIPTION
##### Summary

There is no real reason why we need to replace `-` with `_` in chart names. At the moment there is no way to split the chart name into logical entities because [we have no separator](https://github.com/netdata/netdata/blob/8e46581d822180b2bf6874372492e44203a1406e/database/rrdset.c#L124-L137). 

- Allowing `-` is nice, we will be able to do the following: `it-em1_it-em2_it-em3_...` and splitting by `_` will result in a valid value.
- Also using `-` is a pretty common pattern and mangling original names is wrong imo.

⚠️  This PR is a breaking change for:
 - memory mode `save` and `map`: metrics for charts with `-` will be lost.
 - exporting: metrics for charts with `-` will have different `chart` label values.

❗ But:
- The only charts with `-` are [cgroups](https://github.com/netdata/netdata/tree/master/collectors/cgroups.plugin#cgroupsplugin) (containers) that have `-` in their names.
- No metrics are lost if using memory mode dbengine.
- No need to change alarms, they work

This is a good change because it makes the chart name/chart label value better if we split it by `_`:

- current (doesn't work)

```yaml
cgroup_k8s_cntr_kube_system_kube_dns_798f8cc6fb_55xr6_dnsmasq.cpu_limit
- cgroup
- k8s 
- cntr
- kube
- system
- kube
- dns
- 798f8cc6fb
- 55xr6
- dnsmasq
```

- this PR

```yaml

cgroup_k8s_cntr_kube-system_kube-dns-798f8cc6fb-55xr6_dnsmasq.cpu_limit
- cgroup
- k8s
- cntr
- kube-system               # namespace
- kube-dns-798f8cc6fb-55xr6 # pod name
- dnsmasq                   # container name
```

##### Test Plan

- check UI works and IDs have `-`.
- ensure no metrics are lost when using memory mode dbengine.
- ensure alarms work.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
