### PR TITLE
Add a parameter for how many worker threads the libuv library needs to pre-initialize

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1093,6 +1093,7 @@ int main(int argc, char **argv) {
 
         // prepare configuration environment variables for the plugins
 
+        setenv("UV_THREADPOOL_SIZE", config_get(CONFIG_SECTION_GLOBAL, "libuv worker threads", "16"), 1);
         get_netdata_configured_variables();
         set_global_environment();
 

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -1186,6 +1186,7 @@ void rrdeng_worker(void* arg)
 
     fatal_assert(0 == uv_timer_start(&timer_req, timer_cb, TIMER_PERIOD_MS, TIMER_PERIOD_MS));
     shutdown = 0;
+    int set_name = 0;
     while (likely(shutdown == 0 || rrdeng_threads_alive(wc))) {
         uv_run(loop, UV_RUN_DEFAULT);
         rrdeng_cleanup_finished_threads(wc);
@@ -1230,6 +1231,10 @@ void rrdeng_worker(void* arg)
                 break;
             case RRDENG_READ_EXTENT:
                 do_read_extent(wc, cmd.read_extent.page_cache_descr, cmd.read_extent.page_count, 1);
+                if (unlikely(!set_name)) {
+                    set_name = 1;
+                    uv_thread_set_name_np(ctx->worker_config.thread, "DBENGINE");
+                }
                 break;
             case RRDENG_COMMIT_PAGE:
                 do_commit_transaction(wc, STORE_DATA, NULL);

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -946,7 +946,7 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
     /* wait for worker thread to initialize */
     completion_wait_for(&ctx->rrdengine_completion);
     completion_destroy(&ctx->rrdengine_completion);
-    uv_thread_set_name_np(ctx->worker_config.thread, "DBENGINE");
+    uv_thread_set_name_np(ctx->worker_config.thread, "LIBUV_WORKER");
     if (ctx->worker_config.error) {
         goto error_after_rrdeng_worker;
     }


### PR DESCRIPTION
##### Summary
Add a new parameter in the global config `libuv worker threads"` to set the number of libuv worker threads that should be automatically pre initialized by the library. The default is 16

##### Test Plan
- Start an agent before the PR. The default threads that the library uses is 4
  - You should be able to use `gdb` to access the thread names. You should see 5 threads with the name `DBENGINE`
  
After the PR, the thread name will be `LIBUV_WORKER` and you should be able to see 16 threads with the LIBUV_WORKER name and one thread with the DBENGINE name

There is no other effect on the code
