### PR TITLE
Write the entire request with parameters in the access.log file

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1011,7 +1011,7 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
 
                 // copy the URL - we are going to overwrite parts of it
                 // TODO -- ideally we we should avoid copying buffers around
-                strncpyz(w->last_url, w->decoded_url, NETDATA_WEB_REQUEST_URL_SIZE);
+                snprintfz(w->last_url, NETDATA_WEB_REQUEST_URL_SIZE, "%s%s", w->decoded_url,  w->decoded_query_string);
 #ifdef ENABLE_HTTPS
                 if ( (!web_client_check_unix(w)) && (netdata_srv_ctx) ) {
                     if ((w->ssl.conn) && ((w->ssl.flags & NETDATA_SSL_NO_HANDSHAKE) && (web_client_is_using_ssl_force(w) || web_client_is_using_ssl_default(w)) && (w->mode != WEB_CLIENT_MODE_STREAM))  ) {


### PR DESCRIPTION
##### Summary
The `/api/v1/data` query now logs just /api/v1/data in the access.log

With this PR it will record the parameters as well 

e.g.
`/api/v1/data?chart=cpu.cpu8_softnet_stat`

##### Test Plan
- Apply the PR and check the `access.log` while viewing the agent dashboard
