### PR TITLE
Accept a data query timeout parameter from the cloud

### DIFF
--- a/aclk/aclk_query_queue.h
+++ b/aclk/aclk_query_queue.h
@@ -67,7 +67,7 @@ struct aclk_query {
 
     struct timeval created_tv;
     usec_t created;
-
+    int timeout;
     aclk_query_t next;
 
     // TODO maybe remove?

--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -17,6 +17,7 @@ struct aclk_request {
     char *callback_topic;
     char *payload;
     int version;
+    int timeout;
     int min_version;
     int max_version;
 };
@@ -55,6 +56,10 @@ static int cloud_to_agent_parse(JSON_ENTRY *e)
         case JSON_NUMBER:
             if (!strcmp(e->name, "version")) {
                 data->version = e->data.number;
+                break;
+            }
+            if (!strcmp(e->name, "timeout")) {
+                data->timeout = e->data.number;
                 break;
             }
             if (!strcmp(e->name, "min-version")) {
@@ -160,6 +165,7 @@ static int aclk_handle_cloud_http_request_v2(struct aclk_request *cloud_to_agent
 
     // aclk_queue_query takes ownership of data pointer
     query->callback_topic = cloud_to_agent->callback_topic;
+    query->timeout = cloud_to_agent->timeout;
     // for clarity and code readability as when we process the request
     // it would be strange to get URL from `dedup_id`
     query->data.http_api_v2.query = query->dedup_id;


### PR DESCRIPTION
##### Summary
The cloud now sends a `timeout` parameter in the incoming query header (in milliseconds). If a query remains in the incoming queue for more than `timeout` milliseconds then it will be cancelled immediately (with an appropriate error code back to the cloud)


##### Test Plan
- Should be easy to check by adding an artificial delay in the aclk_query message processing to "fake" a long queue wait time