### PR TITLE
Cleanup the node instance table on startup

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -62,6 +62,7 @@ const char *database_cleanup[] = {
     "delete from chart where chart_id not in (select chart_id from dimension);",
     "delete from host where host_id not in (select host_id from chart);",
     "delete from chart_label where chart_id not in (select chart_id from chart);",
+    "DELETE FROM node_instance WHERE host_id NOT IN (SELECT host_id FROM host);",
     NULL
 };
 


### PR DESCRIPTION
##### Summary
If the host has been deleted from the database, cleanup the related node instance entries from the database

##### Test Plan
- Should be self explanatory