### PR TITLE
Use prebuilt builder images for static builds.

### DIFF
--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -20,46 +20,25 @@ case ${BUILDARCH} in
     ;;
 esac
 
-DOCKER_CONTAINER_NAME="netdata-package-${BUILDARCH}-static-alpine315"
+DOCKER_IMAGE_NAME="netdata/static-builder"
 
 if [ "${BUILDARCH}" != "$(uname -m)" ] && [ "$(uname -m)" = 'x86_64' ] && [ -z "${SKIP_EMULATION}" ]; then
     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
 fi
 
-if ! docker inspect "${DOCKER_CONTAINER_NAME}" > /dev/null 2>&1; then
-  # To run interactively:
-  #   docker run -it netdata-package-x86_64-static /bin/sh
-  # (add -v host-dir:guest-dir:rw arguments to mount volumes)
-  #
-  # To remove images in order to re-create:
-  #   docker rm -v $(sudo docker ps -a -q -f status=exited)
-  #   docker rmi netdata-package-x86_64-static
-  #
-  # This command maps the current directory to
-  #   /usr/src/netdata.git
-  # inside the container and runs the script install-alpine-packages.sh
-  # (also inside the container)
-  #
-  if docker inspect alpine:3.15 > /dev/null 2>&1; then
-    run docker image remove alpine:3.15
-    run docker pull --platform=${platform}  alpine:3.15
-  fi
-
-  run docker run --platform=${platform} -v "$(pwd)":/netdata:rw alpine:3.15 \
-    /bin/sh /netdata/packaging/makeself/install-alpine-packages.sh
-
-  # save the changes made permanently
-  id=$(docker ps -l -q)
-  run docker commit "${id}" "${DOCKER_CONTAINER_NAME}"
+if docker inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
+    docker image rm "${DOCKER_IMAGE_NAME}" || exit 1
 fi
+
+docker pull --platform "${platform}" "${DOCKER_IMAGE_NAME}"
 
 # Run the build script inside the container
 if [ -t 1 ]; then
   run docker run -e BUILDARCH="${BUILDARCH}" -a stdin -a stdout -a stderr -i -t -v "$(pwd)":/netdata:rw \
-    "${DOCKER_CONTAINER_NAME}" \
+    "${DOCKER_IMAGE_NAME}" \
     /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 else
   run docker run -e BUILDARCH="${BUILDARCH}" -v "$(pwd)":/netdata:rw \
-    -e GITHUB_ACTIONS="${GITHUB_ACTIONS}" "${DOCKER_CONTAINER_NAME}" \
+    -e GITHUB_ACTIONS="${GITHUB_ACTIONS}" "${DOCKER_IMAGE_NAME}" \
     /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 fi


### PR DESCRIPTION
##### Summary

This switches to using a pre-generated Docker image for our static builds.

This has two advantages:

- It provides a marginal improvement in build times when running under QEMU userspace emulation like we do for our alt-arch static builds.
- It avoids the complex cleanup needed on developer systems by the current code.

##### Test Plan

CI passes on this PR.

##### Additional Information

Fixes: #12817 

<details> <summary>For users: How does this change affect me?</summary>
No user visible changes.
</details>
