### PR TITLE
Remove sync warning

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1193,10 +1193,10 @@ static void read_collector_values(int *disable_apps, int *disable_cgroups, int u
     how_to_load(value);
 
     btf_path = appconfig_get(&collector_config, EBPF_GLOBAL_SECTION, EBPF_CFG_PROGRAM_PATH,
-                             EBPF_DEFAULT_BTF_FILE);
+                             EBPF_DEFAULT_BTF_PATH);
 
 #ifdef LIBBPF_MAJOR_VERSION
-    default_btf = ebpf_load_btf_file(btf_path, "vmlinux");
+    default_btf = ebpf_load_btf_file(btf_path, EBPF_DEFAULT_BTF_FILE);
 #endif
 
     value = appconfig_get(&collector_config, EBPF_GLOBAL_SECTION, EBPF_CFG_TYPE_FORMAT, EBPF_CFG_DEFAULT_PROGRAM);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1172,23 +1172,6 @@ static inline void epbf_update_load_mode(char *str)
     ebpf_set_load_mode(load);
 }
 
-#ifdef LIBBPF_MAJOR_VERSION
-/**
- * Set default btf file
- *
- * Load the default BTF file on environment.
- */
-static void ebpf_set_default_btf_file()
-{
-    char path[PATH_MAX + 1];
-    snprintfz(path, PATH_MAX, "%s/vmlinux", btf_path);
-    default_btf = ebpf_parse_btf_file(path);
-    if (!default_btf)
-        info("Your environment does not have BTF file %s/vmlinux. The plugin will work with 'legacy' code.",
-             btf_path);
-}
-#endif
-
 /**
  * Read collector values
  *
@@ -1213,7 +1196,7 @@ static void read_collector_values(int *disable_apps, int *disable_cgroups, int u
                              EBPF_DEFAULT_BTF_FILE);
 
 #ifdef LIBBPF_MAJOR_VERSION
-    ebpf_set_default_btf_file();
+    default_btf = ebpf_load_btf_file(btf_path, "vmlinux");
 #endif
 
     value = appconfig_get(&collector_config, EBPF_GLOBAL_SECTION, EBPF_CFG_TYPE_FORMAT, EBPF_CFG_DEFAULT_PROGRAM);

--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -21,6 +21,7 @@
     cgroups = no
     update every = 5
     pid table size = 32768
+    btf path = /sys/kernel/btf/
 
 #
 # eBPF Programs

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -44,13 +44,41 @@ struct config sync_config = { .first_section = NULL,
         .rwlock = AVL_LOCK_INITIALIZER } };
 
 ebpf_sync_syscalls_t local_syscalls[] = {
-    {.syscall = NETDATA_SYSCALLS_SYNC, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL},
-    {.syscall = NETDATA_SYSCALLS_SYNCFS, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL},
-    {.syscall = NETDATA_SYSCALLS_MSYNC, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL},
-    {.syscall = NETDATA_SYSCALLS_FSYNC, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL},
-    {.syscall = NETDATA_SYSCALLS_FDATASYNC, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL},
-    {.syscall = NETDATA_SYSCALLS_SYNC_FILE_RANGE, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL},
-    {.syscall = NULL, .enabled = CONFIG_BOOLEAN_NO, .objects = NULL, .probe_links = NULL}
+    {.syscall = NETDATA_SYSCALLS_SYNC, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL,
+#ifdef LIBBPF_MAJOR_VERSION
+     .sync_obj = NULL
+#endif
+    },
+    {.syscall = NETDATA_SYSCALLS_SYNCFS, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL,
+#ifdef LIBBPF_MAJOR_VERSION
+     .sync_obj = NULL
+#endif
+    },
+    {.syscall = NETDATA_SYSCALLS_MSYNC, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL,
+#ifdef LIBBPF_MAJOR_VERSION
+     .sync_obj = NULL
+#endif
+    },
+    {.syscall = NETDATA_SYSCALLS_FSYNC, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL,
+#ifdef LIBBPF_MAJOR_VERSION
+     .sync_obj = NULL
+#endif
+    },
+    {.syscall = NETDATA_SYSCALLS_FDATASYNC, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL,
+#ifdef LIBBPF_MAJOR_VERSION
+     .sync_obj = NULL
+#endif
+    },
+    {.syscall = NETDATA_SYSCALLS_SYNC_FILE_RANGE, .enabled = CONFIG_BOOLEAN_YES, .objects = NULL, .probe_links = NULL,
+#ifdef LIBBPF_MAJOR_VERSION
+     .sync_obj = NULL
+#endif
+    },
+    {.syscall = NULL, .enabled = CONFIG_BOOLEAN_NO, .objects = NULL, .probe_links = NULL,
+#ifdef LIBBPF_MAJOR_VERSION
+     .sync_obj = NULL
+#endif
+    }
 };
 
 netdata_ebpf_targets_t sync_targets[] = { {.name = NETDATA_SYSCALLS_SYNC, .mode = EBPF_LOAD_TRAMPOLINE},

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -843,9 +843,13 @@ void ebpf_adjust_thread_load(ebpf_module_t *mod, struct btf *file)
 }
 
 /**
+ * Parse BTF file
  *
- * @param filename
- * @return
+ * Parse a specific BTF file present on filesystem
+ *
+ * @param filename  the file that will be parsed.
+ *
+ * @return It returns a pointer for the file on success and NULL otherwise.
  */
 struct btf *ebpf_parse_btf_file(const char *filename)
 {
@@ -860,7 +864,7 @@ struct btf *ebpf_parse_btf_file(const char *filename)
 }
 
 /**
- * Set default btf file
+ * Load default btf file
  *
  * Load the default BTF file on environment.
  *
@@ -877,6 +881,51 @@ struct btf *ebpf_load_btf_file(char *path, char *filename)
              path, filename);
 
     return ret;
+}
+
+/**
+ * Find BTF attach type
+ *
+ * Search type fr current btf file.
+ *
+ * @param file     is the structure for the btf file already parsed.
+ */
+static inline const struct btf_type *ebpf_find_btf_attach_type(struct btf *file)
+{
+    int id = btf__find_by_name_kind(file, "bpf_attach_type", BTF_KIND_ENUM);
+    if (id < 0) {
+        fprintf(stderr, "Cannot find 'bpf_attach_type'");
+
+        return NULL;
+    }
+
+    return btf__type_by_id(file, id);
+}
+
+/**
+ * Is function inside BTF
+ *
+ * Look for a specific function inside the given BTF file.
+ *
+ * @param file     is the structure for the btf file already parsed.
+ * @param function is the function that we want to find.
+ */
+int ebpf_is_function_inside_btf(struct btf *file, char *function)
+{
+    const struct btf_type *type = ebpf_find_btf_attach_type(file);
+    if (!type)
+        return -1;
+
+    const struct btf_enum *e = btf_enum(type);
+    int i, id;
+    for (id = -1, i = 0; i < btf_vlen(type); i++, e++) {
+        if (!strcmp(btf__name_by_offset(file, e->name_off), "BPF_TRACE_FENTRY")) {
+            id = btf__find_by_name_kind(file, function, BTF_KIND_FUNC);
+            break;
+        }
+    }
+
+    return (id > 0) ? 1 : 0;
 }
 #endif
 

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -858,6 +858,26 @@ struct btf *ebpf_parse_btf_file(const char *filename)
 
     return bf;
 }
+
+/**
+ * Set default btf file
+ *
+ * Load the default BTF file on environment.
+ *
+ * @param path     is the fullpath
+ * @param filename is the file inside BTF path.
+ */
+struct btf *ebpf_load_btf_file(char *path, char *filename)
+{
+    char fullpath[PATH_MAX + 1];
+    snprintfz(fullpath, PATH_MAX, "%s/%s", path, filename);
+    struct btf *ret = ebpf_parse_btf_file(fullpath);
+    if (!ret)
+        info("Your environment does not have BTF file %s/%s. The plugin will work with 'legacy' code.",
+             path, filename);
+
+    return ret;
+}
 #endif
 
 /**

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -287,6 +287,7 @@ extern void ebpf_select_host_prefix(char *output, size_t length, char *syscall, 
 #ifdef LIBBPF_MAJOR_VERSION
 extern void ebpf_adjust_thread_load(ebpf_module_t *mod, struct btf *file);
 extern struct btf *ebpf_parse_btf_file(const char *filename);
+extern struct btf *ebpf_load_btf_file(char *path, char *filename);
 #endif
 
 #endif /* NETDATA_EBPF_H */

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -289,6 +289,7 @@ extern void ebpf_select_host_prefix(char *output, size_t length, char *syscall, 
 extern void ebpf_adjust_thread_load(ebpf_module_t *mod, struct btf *file);
 extern struct btf *ebpf_parse_btf_file(const char *filename);
 extern struct btf *ebpf_load_btf_file(char *path, char *filename);
+extern int ebpf_is_function_inside_btf(struct btf *file, char *function);
 #endif
 
 #endif /* NETDATA_EBPF_H */

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -275,7 +275,8 @@ extern int ebpf_enable_tracing_values(char *subsys, char *eventname);
 extern int ebpf_disable_tracing_values(char *subsys, char *eventname);
 
 // BTF Section
-#define EBPF_DEFAULT_BTF_FILE "/sys/kernel/btf"
+#define EBPF_DEFAULT_BTF_FILE "vmlinux"
+#define EBPF_DEFAULT_BTF_PATH "/sys/kernel/btf"
 #define EBPF_DEFAULT_ERROR_MSG "Cannot open or load BPF file for thread"
 
 // BTF helpers


### PR DESCRIPTION
##### Summary
This PR is fixing warnings reported [here](https://github.com/netdata/netdata/pull/12760#issuecomment-11185521280).

##### Test Plan

1. Compile this PR 
2. Run `netdata`.
3. After few seconds, run next command and verify warnings were removed:

```sh
$ grep libbpf /var/log/netdata/error.log
```

##### Additional Information
This PR must be tested on kernel `5.7` or newer and your kernel needs to have BTF enabled.

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ebpf.plugin
- Can they see the change or is it an under the hood? If they can see it, where? This is only visible inside logs.
- How is the user impacted by the change?  We won't have `libbpf` warnings inside the `error.log`
- What are there any benefits of the change? The PR removes of unnecessary error.
</details>