### PR TITLE
Ignore obsolete charts/dims in prediction thread.

### DIFF
--- a/ml/Dimension.h
+++ b/ml/Dimension.h
@@ -30,6 +30,16 @@ public:
         return SS.str();
     }
 
+    bool isActive() const {
+        if (rrdset_flag_check(RD->rrdset, RRDSET_FLAG_OBSOLETE))
+            return false;
+
+        if (rrddim_flag_check(RD, RRDDIM_FLAG_OBSOLETE))
+            return false;
+
+        return true;
+    }
+
     void setAnomalyRateRD(RRDDIM *ARRD) { AnomalyRateRD = ARRD; }
     RRDDIM *getAnomalyRateRD() const { return AnomalyRateRD; }
 

--- a/ml/Host.h
+++ b/ml/Host.h
@@ -127,6 +127,7 @@ private:
     size_t NumAnomalousDimensions{0};
     size_t NumNormalDimensions{0};
     size_t NumTrainedDimensions{0};
+    size_t NumActiveDimensions{0};
 
     unsigned AnomalyRateTimer{0};
 


### PR DESCRIPTION
##### Summary

Teach prediction thread to ignore obsolete charts/dims. This will allow `/ml_info` to return back the correct numbers a user would expect to see.

##### Test Plan

CI & staging

##### Additional Information

Fixes https://github.com/netdata/netdata-cloud/issues/363

TODO: create a follow-up PR to teach training thread to schedule dims for training without considering obsolete charts/dims.