### PR TITLE
Expose anomaly-bit option to health.

### DIFF
--- a/health/health_config.c
+++ b/health/health_config.c
@@ -433,6 +433,9 @@ static inline int health_parse_db_lookup(
         else if(!strcasecmp(key, "unaligned")) {
             *options |= RRDR_OPTION_NOT_ALIGNED;
         }
+        else if(!strcasecmp(key, "anomaly-bit")) {
+            *options |= RRDR_OPTION_ANOMALY_BIT;
+        }
         else if(!strcasecmp(key, "match-ids") || !strcasecmp(key, "match_ids")) {
             *options |= RRDR_OPTION_MATCH_IDS;
         }

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -496,6 +496,11 @@ void buffer_data_options2string(BUFFER *wb, uint32_t options) {
         if(count++) buffer_strcat(wb, " ");
         buffer_strcat(wb, "unaligned");
     }
+
+    if(options & RRDR_OPTION_ANOMALY_BIT) {
+        if(count++) buffer_strcat(wb, " ");
+        buffer_strcat(wb, "anomaly-bit");
+    }
 }
 
 static inline int check_host_and_call(RRDHOST *host, struct web_client *w, char *url, int (*func)(RRDHOST *, struct web_client *, char *)) {


### PR DESCRIPTION
##### Summary

This will allow DB lookups to use the stored anomaly-bit values, eg:

> lookup: average -10m unaligned anomaly-bit of user,system,softirq,irq,guest

##### Test Plan

CI jobs

##### Additional Information

Resolves https://github.com/netdata/product/issues/2796 
