### PR TITLE
Set a page wait timeout and retry count

### DIFF
--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -1067,10 +1067,13 @@ pg_cache_lookup_next(struct rrdengine_instance *ctx, struct pg_cache_page_index 
 
     page_not_in_cache = 0;
     uv_rwlock_rdlock(&page_index->lock);
+    int retry_count = 0;
     while (1) {
         descr = find_first_page_in_time_range(page_index, start_time, end_time);
-        if (NULL == descr || 0 == descr->page_length) {
+        if (NULL == descr || 0 == descr->page_length || retry_count == MAX_PAGE_CACHE_RETRY_WAIT) {
             /* non-empty page not found */
+            if (retry_count == MAX_PAGE_CACHE_RETRY_WAIT)
+                error_report("Page cache timeout while waiting for page %p : returning FAIL", descr);
             uv_rwlock_rdunlock(&page_index->lock);
 
             pg_cache_release_pages(ctx, 1);
@@ -1114,7 +1117,11 @@ pg_cache_lookup_next(struct rrdengine_instance *ctx, struct pg_cache_page_index 
             print_page_cache_descr(descr);
         if (!(flags & RRD_PAGE_POPULATED))
             page_not_in_cache = 1;
-        pg_cache_wait_event_unsafe(descr);
+
+        if (pg_cache_timedwait_event_unsafe(descr, 1) == UV_ETIMEDOUT) {
+            error_report("Page cache timeout while waiting for page %p : retry count = %d", descr, retry_count);
+            ++retry_count;
+        }
         rrdeng_page_descr_mutex_unlock(ctx, descr);
 
         /* reset scan to find again */

--- a/database/engine/pagecache.h
+++ b/database/engine/pagecache.h
@@ -11,6 +11,7 @@ struct extent_info;
 struct rrdeng_page_descr;
 
 #define INVALID_TIME (0)
+#define MAX_PAGE_CACHE_RETRY_WAIT (3)
 
 /* Page flags */
 #define RRD_PAGE_DIRTY          (1LU << 0)


### PR DESCRIPTION

##### Summary
- Use a timeout when waiting for the page request
- Add a retry count before giving up (caller will assume the page is empty or doesn't exist)

##### Test Plan
- Change should be obvious