### PR TITLE
Allow usage of new MQTT 5 implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,6 +817,11 @@ set(ACLK_FILES
         mqtt_websockets/src/include/mqtt_wss_log.h
         mqtt_websockets/src/ws_client.c
         mqtt_websockets/src/include/ws_client.h
+        mqtt_websockets/src/mqtt_ng.c
+        mqtt_websockets/src/include/mqtt_ng.h
+        mqtt_websockets/src/common_public.c
+        mqtt_websockets/src/include/common_public.h
+        mqtt_websockets/src/include/common_internal.h
         mqtt_websockets/c-rbuf/src/ringbuffer.c
         mqtt_websockets/c-rbuf/include/ringbuffer.h
         mqtt_websockets/c-rbuf/src/ringbuffer_internal.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -628,6 +628,11 @@ ACLK_FILES = \
     mqtt_websockets/src/include/mqtt_wss_log.h \
     mqtt_websockets/src/ws_client.c \
     mqtt_websockets/src/include/ws_client.h \
+    mqtt_websockets/src/mqtt_ng.c \
+    mqtt_websockets/src/include/mqtt_ng.h \
+    mqtt_websockets/src/common_public.c \
+    mqtt_websockets/src/include/common_public.h \
+    mqtt_websockets/src/include/common_internal.h \
     mqtt_websockets/c-rbuf/src/ringbuffer.c \
     mqtt_websockets/c-rbuf/include/ringbuffer.h \
     mqtt_websockets/c-rbuf/src/ringbuffer_internal.h \

--- a/aclk/README.md
+++ b/aclk/README.md
@@ -50,10 +50,12 @@ You can configure following keys in the `netdata.conf` section `[cloud]`:
 [cloud]
   statistics = yes
   query thread count = 2
+  mqtt5 = no
 ```
 
 - `statistics` enables/disables ACLK related statistics and their charts. You can disable this to save some space in the database and slightly reduce memory usage of Netdata Agent.
 - `query thread count` specifies the number of threads to process cloud queries. Increasing this setting is useful for nodes with many children (streaming), which can expect to handle more queries (and/or more complicated queries).
+- `mqtt5` enables the new MQTT5 protocol implementation in the Agent. Currently a technical preview.
 
 ## Disable the ACLK
 

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -172,7 +172,7 @@ void aclk_mqtt_wss_log_cb(mqtt_wss_log_type_t log_type, const char* str)
         case MQTT_WSS_LOG_ERROR:
         case MQTT_WSS_LOG_FATAL:
         case MQTT_WSS_LOG_WARN:
-            error("%s", str);
+            error_report("%s", str);
             return;
         case MQTT_WSS_LOG_INFO:
             info("%s", str);

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1124,7 +1124,6 @@ void aclk_send_node_instances()
             node_state_update.claim_id = localhost->aclk_state.claimed_id;
             query->data.bin_payload.payload = generate_node_instance_connection(&query->data.bin_payload.size, &node_state_update);
             rrdhost_aclk_state_unlock(localhost);
-            freez(list->hostname);
             info("Queuing status update for node=%s, live=%d, hops=%d",(char*)node_state_update.node_id,
                  list->live,
                  list->hops);
@@ -1152,6 +1151,7 @@ void aclk_send_node_instances()
             freez(node_instance_creation.machine_guid);
             aclk_queue_query(create_query);
         }
+        freez(list->hostname);
 
         list++;
     }

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -12,6 +12,7 @@
 #include "aclk_rx_msgs.h"
 #include "aclk_collector_list.h"
 #include "https_client.h"
+#include "schema-wrappers/schema_wrappers.h"
 
 #include "aclk_proxy.h"
 

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1139,6 +1139,8 @@ void aclk_send_node_instances()
             };
             node_instance_creation.machine_guid = mallocz(UUID_STR_LEN);
             uuid_unparse_lower(list->host_id, (char*)node_instance_creation.machine_guid);
+            create_query->data.bin_payload.topic = ACLK_TOPICID_CREATE_NODE;
+            create_query->data.bin_payload.msg_name = "CreateNodeInstance";
             rrdhost_aclk_state_lock(localhost);
             node_instance_creation.claim_id = localhost->aclk_state.claimed_id,
             create_query->data.bin_payload.payload = generate_node_instance_creation(&create_query->data.bin_payload.size, &node_instance_creation);

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -392,7 +392,7 @@ static inline void queue_connect_payloads(void)
 
 static inline void mqtt_connected_actions(mqtt_wss_client client)
 {
-    const char *topic = aclk_get_topic(ACLK_TOPICID_COMMAND);
+    char *topic = (char*)aclk_get_topic(ACLK_TOPICID_COMMAND);
 
     if (!topic)
         error("Unable to fetch topic for COMMAND (to subscribe)");
@@ -401,7 +401,7 @@ static inline void mqtt_connected_actions(mqtt_wss_client client)
 
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
     if (aclk_use_new_cloud_arch) {
-        topic = aclk_get_topic(ACLK_TOPICID_CMD_NG_V1);
+        topic = (char*)aclk_get_topic(ACLK_TOPICID_CMD_NG_V1);
         if (!topic)
             error("Unable to fetch topic for protobuf COMMAND (to subscribe)");
         else
@@ -1095,7 +1095,7 @@ void aclk_host_state_update(RRDHOST *host, int cmd)
 
     info("Queuing status update for node=%s, live=%d, hops=%u",(char*)node_state_update.node_id, cmd,
          host->system_info->hops);
-    freez(node_state_update.node_id);
+    freez((void*)node_state_update.node_id);
     query->data.bin_payload.msg_name = "UpdateNodeInstanceConnection";
     query->data.bin_payload.topic = ACLK_TOPICID_NODE_CONN;
     aclk_queue_query(query);
@@ -1128,7 +1128,7 @@ void aclk_send_node_instances()
             info("Queuing status update for node=%s, live=%d, hops=%d",(char*)node_state_update.node_id,
                  list->live,
                  list->hops);
-            freez(node_state_update.node_id);
+            freez((void*)node_state_update.node_id);
             query->data.bin_payload.msg_name = "UpdateNodeInstanceConnection";
             query->data.bin_payload.topic = ACLK_TOPICID_NODE_CONN;
             aclk_queue_query(query);

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -800,10 +800,12 @@ void *aclk_main(void *ptr)
     if (wait_till_agent_claim_ready())
         goto exit;
 
+    use_mqtt_5 = config_get_boolean(CONFIG_SECTION_CLOUD, "mqtt5", CONFIG_BOOLEAN_NO);
+
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
-    if (!(mqttwss_client = mqtt_wss_new("mqtt_wss", aclk_mqtt_wss_log_cb, msg_callback, puback_callback))) {
+    if (!(mqttwss_client = mqtt_wss_new("mqtt_wss", aclk_mqtt_wss_log_cb, msg_callback, puback_callback, use_mqtt_5))) {
 #else
-    if (!(mqttwss_client = mqtt_wss_new("mqtt_wss", aclk_mqtt_wss_log_cb, msg_callback_old_protocol, puback_callback))) {
+    if (!(mqttwss_client = mqtt_wss_new("mqtt_wss", aclk_mqtt_wss_log_cb, msg_callback_old_protocol, puback_callback, use_mqtt_5))) {
 #endif
         error("Couldn't initialize MQTT_WSS network library");
         goto exit;

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1237,7 +1237,7 @@ char *ng_aclk_state(void)
         "Protocols Supported: Legacy\n"
 #endif
     );
-    buffer_sprintf(wb, "Protocol Used: %s\nClaimed: ", aclk_use_new_cloud_arch ? "Protobuf" : "Legacy");
+    buffer_sprintf(wb, "Protocol Used: %s\nMQTT Version: %d\nClaimed: ", aclk_use_new_cloud_arch ? "Protobuf" : "Legacy", use_mqtt_5 ? 5 : 3);
 
     char *agent_id = is_agent_claimed();
     if (agent_id == NULL)
@@ -1436,6 +1436,9 @@ char *ng_aclk_state_json(void)
 
     tmp = json_object_new_string(aclk_use_new_cloud_arch ? "Protobuf" : "Legacy");
     json_object_object_add(msg, "used-cloud-protocol", tmp);
+
+    tmp = json_object_new_int(use_mqtt_5 ? 5 : 3);
+    json_object_object_add(msg, "mqtt-version", tmp);
 
     tmp = json_object_new_int(aclk_rcvd_cloud_msgs);
     json_object_object_add(msg, "received-app-layer-msgs", tmp);

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1044,6 +1044,7 @@ void aclk_del_collector(RRDHOST *host, const char *plugin_name, const char *modu
     aclk_queue_query(query);
 }
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 void aclk_host_state_update(RRDHOST *host, int cmd)
 {
     uuid_t node_id;
@@ -1100,7 +1101,6 @@ void aclk_host_state_update(RRDHOST *host, int cmd)
     aclk_queue_query(query);
 }
 
-#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 void aclk_send_node_instances()
 {
     struct node_instance_list *list_head = get_node_list();

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1100,6 +1100,7 @@ void aclk_host_state_update(RRDHOST *host, int cmd)
     aclk_queue_query(query);
 }
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 void aclk_send_node_instances()
 {
     struct node_instance_list *list_head = get_node_list();
@@ -1156,6 +1157,7 @@ void aclk_send_node_instances()
     }
     freez(list_head);
 }
+#endif
 
 void aclk_send_bin_msg(char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname)
 {

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -43,9 +43,8 @@ int aclk_update_chart(RRDHOST *host, char *chart_name, int create);
 void aclk_add_collector(RRDHOST *host, const char *plugin_name, const char *module_name);
 void aclk_del_collector(RRDHOST *host, const char *plugin_name, const char *module_name);
 
-void aclk_host_state_update(RRDHOST *host, int cmd);
-
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
+void aclk_host_state_update(RRDHOST *host, int cmd);
 void aclk_send_node_instances(void);
 #endif
 

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -45,7 +45,9 @@ void aclk_del_collector(RRDHOST *host, const char *plugin_name, const char *modu
 
 void aclk_host_state_update(RRDHOST *host, int cmd);
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 void aclk_send_node_instances(void);
+#endif
 
 void aclk_send_bin_msg(char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname);
 

--- a/aclk/aclk_alarm_api.c
+++ b/aclk/aclk_alarm_api.c
@@ -24,7 +24,8 @@ void aclk_send_alarm_log_entry(struct alarm_log_entry *log_entry)
 
     aclk_send_bin_msg(payload, payload_size, ACLK_TOPICID_ALARM_LOG, "AlarmLogEntry");
 
-    freez(payload);
+    if (!use_mqtt_5)
+        freez(payload);
 }
 
 void aclk_send_provide_alarm_cfg(struct provide_alarm_configuration *cfg)

--- a/aclk/aclk_api.c
+++ b/aclk/aclk_api.c
@@ -16,6 +16,7 @@ int aclk_disable_runtime = 0;
 int aclk_disable_single_updates = 0;
 
 int aclk_stats_enabled;
+int use_mqtt_5 = 0;
 
 #define ACLK_IMPL_KEY_NAME "aclk implementation"
 

--- a/aclk/aclk_api.c
+++ b/aclk/aclk_api.c
@@ -69,6 +69,8 @@ struct label *add_aclk_host_labels(struct label *label) {
             break;
     }
 
+    int mqtt5 = config_get_boolean(CONFIG_SECTION_CLOUD, "mqtt5", CONFIG_BOOLEAN_NO);
+    label = add_label_to_list(label, "_mqtt_version", mqtt5 ? "5" : "3", LABEL_SOURCE_AUTO);
     label = add_label_to_list(label, "_aclk_impl", "Next Generation", LABEL_SOURCE_AUTO);
     label = add_label_to_list(label, "_aclk_proxy", proxy_str, LABEL_SOURCE_AUTO);
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL

--- a/aclk/aclk_api.h
+++ b/aclk/aclk_api.h
@@ -21,6 +21,7 @@ extern int aclk_stats_enabled;
 extern int aclk_alert_reloaded;
 
 extern int aclk_ng;
+extern int use_mqtt_5;
 
 #ifdef ENABLE_ACLK
 void *aclk_starter(void *ptr);

--- a/aclk/aclk_api.h
+++ b/aclk/aclk_api.h
@@ -37,7 +37,9 @@ int aclk_update_alarm(RRDHOST *host, ALARM_ENTRY *ae);
 void aclk_add_collector(RRDHOST *host, const char *plugin_name, const char *module_name);
 void aclk_del_collector(RRDHOST *host, const char *plugin_name, const char *module_name);
 
+#ifdef ENABLE_NEW_CLOUD_PROTOCOL
 void aclk_host_state_update(RRDHOST *host, int connect);
+#endif
 
 #define NETDATA_ACLK_HOOK                                                                                              \
     { .name = "ACLK_Main",                                                                                             \

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -292,22 +292,6 @@ static int alarm_state_update_query(struct aclk_query_thread *query_thr, aclk_qu
 }
 
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
-static int register_node(struct aclk_query_thread *query_thr, aclk_query_t query) {
-    // TODO create a pending registrations list
-    // with some timeouts to detect registration requests that
-    // go unanswered from the cloud
-    aclk_generate_node_registration(query_thr->client, &query->data.node_creation);
-    return 0;
-}
-
-static int node_state_update(struct aclk_query_thread *query_thr, aclk_query_t query) {
-    // TODO create a pending registrations list
-    // with some timeouts to detect registration requests that
-    // go unanswered from the cloud
-    aclk_generate_node_state_update(query_thr->client, &query->data.node_update);
-    return 0;
-}
-
 static int send_bin_msg(struct aclk_query_thread *query_thr, aclk_query_t query)
 {
     // this will be simplified when legacy support is removed
@@ -324,8 +308,8 @@ aclk_query_handler aclk_query_handlers[] = {
     { .type = CHART_NEW,            .name = "chart_new",                .fnc = chart_query              },
     { .type = CHART_DEL,            .name = "chart_delete",             .fnc = info_metadata            },
 #ifdef ENABLE_NEW_CLOUD_PROTOCOL
-    { .type = REGISTER_NODE,        .name = "register_node",            .fnc = register_node            },
-    { .type = NODE_STATE_UPDATE,    .name = "node_state_update",        .fnc = node_state_update        },
+    { .type = REGISTER_NODE,        .name = "register_node",            .fnc = send_bin_msg             },
+    { .type = NODE_STATE_UPDATE,    .name = "node_state_update",        .fnc = send_bin_msg             },
     { .type = CHART_DIMS_UPDATE,    .name = "chart_and_dim_update",     .fnc = send_bin_msg             },
     { .type = CHART_CONFIG_UPDATED, .name = "chart_config_updated",     .fnc = send_bin_msg             },
     { .type = CHART_RESET,          .name = "reset_chart_messages",     .fnc = send_bin_msg             },

--- a/aclk/aclk_query_queue.c
+++ b/aclk/aclk_query_queue.c
@@ -121,16 +121,7 @@ void aclk_query_free(aclk_query_t query)
         break;
 
     case NODE_STATE_UPDATE:
-        freez((void*)query->data.node_update.claim_id);
-        freez((void*)query->data.node_update.node_id);
-        break;
-
     case REGISTER_NODE:
-        freez((void*)query->data.node_creation.claim_id);
-        freez((void*)query->data.node_creation.hostname);
-        freez((void*)query->data.node_creation.machine_guid);
-        break;
-
     case CHART_DIMS_UPDATE:
     case CHART_CONFIG_UPDATED:
     case CHART_RESET:

--- a/aclk/aclk_query_queue.c
+++ b/aclk/aclk_query_queue.c
@@ -130,7 +130,8 @@ void aclk_query_free(aclk_query_t query)
     case ALARM_LOG_HEALTH:
     case ALARM_PROVIDE_CFG:
     case ALARM_SNAPSHOT:
-        freez(query->data.bin_payload.payload);
+        if (!use_mqtt_5)
+            freez(query->data.bin_payload.payload);
         break;
 
     default:

--- a/aclk/aclk_query_queue.h
+++ b/aclk/aclk_query_queue.h
@@ -77,8 +77,6 @@ struct aclk_query {
         struct aclk_query_metadata metadata_alarms;
         struct aclk_query_http_api_v2 http_api_v2;
         struct aclk_query_chart_add_del chart_add_del;
-        node_instance_creation_t node_creation;
-        node_instance_connection_t node_update;
         struct aclk_bin_payload bin_payload;
         json_object *alarm_update;
     } data;

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -129,7 +129,7 @@ static int aclk_send_message_with_bin_payload(mqtt_wss_client client, json_objec
 
     if (unlikely(!topic || topic[0] != '/')) {
         error ("Full topic required!");
-        return 500;
+        return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
 
     str = json_object_to_json_string_ext(msg, JSON_C_TO_STRING_PLAIN);
@@ -160,12 +160,12 @@ static int aclk_send_message_with_bin_payload(mqtt_wss_client client, json_objec
         if (rc == MQTT_WSS_ERR_BLOCK_TIMEOUT) {
             error("Timeout sending binpacked message");
             freez(full_msg);
-            return 503;
+            return HTTP_RESP_BACKEND_FETCH_FAILED;
         }
         if (rc == MQTT_WSS_ERR_TX_BUF_TOO_SMALL) {
             error("Message is bigger than allowed maximum");
             freez(full_msg);
-            return 403;
+            return HTTP_RESP_FORBIDDEN;
         }
     }
 
@@ -372,13 +372,13 @@ void aclk_http_msg_v2(mqtt_wss_client client, const char *topic, const char *msg
     json_object_put(msg);
 
     switch (rc) {
-    case 403:
+    case HTTP_RESP_FORBIDDEN:
         aclk_http_msg_v2_err(client, topic, msg_id, rc, CLOUD_EC_REQ_REPLY_TOO_BIG, CLOUD_EMSG_REQ_REPLY_TOO_BIG, payload, payload_len);
         break;
-    case 500:
+    case HTTP_RESP_INTERNAL_SERVER_ERROR:
         aclk_http_msg_v2_err(client, topic, msg_id, rc, CLOUD_EC_FAIL_TOPIC, CLOUD_EMSG_FAIL_TOPIC, payload, payload_len);
         break;
-    case 503:
+    case HTTP_RESP_BACKEND_FETCH_FAILED:
         aclk_http_msg_v2_err(client, topic, msg_id, rc, CLOUD_EC_SND_TIMEOUT, CLOUD_EMSG_SND_TIMEOUT, payload, payload_len);
         break;
     }

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -50,7 +50,7 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
     }
 
     if (use_mqtt_5)
-        mqtt_wss_publish5(client, topic, NULL, msg, NULL, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
+        mqtt_wss_publish5(client, (char*)topic, NULL, msg, &freez, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
     else
         mqtt_wss_publish_pid(client, topic, msg, msg_len,  MQTT_WSS_PUB_QOS1, &packet_id);
 
@@ -499,7 +499,8 @@ uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable
     }
 
     pid = aclk_send_bin_message_subtopic_pid(client, msg, len, ACLK_TOPICID_AGENT_CONN, "UpdateAgentConnection");
-    freez(msg);
+    if (!use_mqtt_5)
+        freez(msg);
     if (localhost->aclk_state.prev_claimed_id) {
         freez(localhost->aclk_state.prev_claimed_id);
         localhost->aclk_state.prev_claimed_id = NULL;

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -531,30 +531,6 @@ char *aclk_generate_lwt(size_t *size) {
 
     return msg;
 }
-
-void aclk_generate_node_registration(mqtt_wss_client client, node_instance_creation_t *node_creation) {
-    size_t len;
-    char *msg = generate_node_instance_creation(&len, node_creation);
-    if (!msg) {
-        error("Error generating nodeinstance::create::v1::CreateNodeInstance");
-        return;
-    }
-
-    aclk_send_bin_message_subtopic_pid(client, msg, len, ACLK_TOPICID_CREATE_NODE, "CreateNodeInstance");
-    freez(msg);
-}
-
-void aclk_generate_node_state_update(mqtt_wss_client client, node_instance_connection_t *node_connection) {
-    size_t len;
-    char *msg = generate_node_instance_connection(&len, node_connection);
-    if (!msg) {
-        error("Error generating nodeinstance::v1::UpdateNodeInstanceConnection");
-        return;
-    }
-
-    aclk_send_bin_message_subtopic_pid(client, msg, len, ACLK_TOPICID_NODE_CONN, "UpdateNodeInstanceConnection");
-    freez(msg);
-}
 #endif /* ENABLE_NEW_CLOUD_PROTOCOL */
 
 #ifndef __GNUC__

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -154,7 +154,7 @@ static int aclk_send_message_with_bin_payload(mqtt_wss_client client, json_objec
 #endif */
 
     if (use_mqtt_5)
-        mqtt_wss_publish5(client, topic, NULL, payload_len ? full_msg : str, NULL, len, MQTT_WSS_PUB_QOS1, &packet_id);
+        mqtt_wss_publish5(client, (char*)topic, NULL, (char*)(payload_len ? full_msg : str), NULL, len, MQTT_WSS_PUB_QOS1, &packet_id);
     else {
         rc = mqtt_wss_publish_pid_block(client, topic, payload_len ? full_msg : str, len,  MQTT_WSS_PUB_QOS1, &packet_id, 5000);
         if (rc == MQTT_WSS_ERR_BLOCK_TIMEOUT) {

--- a/aclk/aclk_tx_msgs.h
+++ b/aclk/aclk_tx_msgs.h
@@ -28,9 +28,6 @@ int aclk_send_app_layer_disconnect(mqtt_wss_client client, const char *message);
 // new protobuf msgs
 uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable);
 char *aclk_generate_lwt(size_t *size);
-
-void aclk_generate_node_registration(mqtt_wss_client client, node_instance_creation_t *node_creation);
-void aclk_generate_node_state_update(mqtt_wss_client client, node_instance_connection_t *node_connection);
 #endif
 
 #endif

--- a/aclk/schema-wrappers/node_creation.h
+++ b/aclk/schema-wrappers/node_creation.h
@@ -8,9 +8,9 @@ extern "C" {
 #endif
 
 typedef struct {
-    const char* claim_id;
-    const char* machine_guid;
-    const char* hostname;
+    char* claim_id;
+    char* machine_guid;
+    char* hostname;
 
     int32_t hops;
 } node_instance_creation_t;

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -682,9 +682,9 @@ static int rrdpush_receive(struct receiver_state *rpt)
 
     cd.version = rpt->stream_version;
 
-#if defined(ENABLE_ACLK)
+#if defined(ENABLE_NEW_CLOUD_PROTOCOL)
     // in case we have cloud connection we inform cloud
-    // new slave connected
+    // new child connected
     if (netdata_cloud_setting)
         aclk_host_state_update(rpt->host, 1);
 #endif
@@ -696,9 +696,9 @@ static int rrdpush_receive(struct receiver_state *rpt)
     error("STREAM %s [receive from [%s]:%s]: disconnected (completed %zu updates).", rpt->hostname, rpt->client_ip,
           rpt->client_port, count);
 
-#if defined(ENABLE_ACLK)
+#if defined(ENABLE_NEW_CLOUD_PROTOCOL)
     // in case we have cloud connection we inform cloud
-    // new slave connected
+    // new child connected
     if (netdata_cloud_setting)
         aclk_host_state_update(rpt->host, 0);
 #endif


### PR DESCRIPTION
##### Summary

Allows usage of the new MQTT 5 custom client. https://github.com/netdata/netdata/issues/12481
By default disabled for now until it is polished and stability is tested well enough.

Main benefit -> removed max publish size limit. The published data don't all have to fit into a fixed size buffer anymore.
As a result also memory usage is reduced.

Currently implements only the bits and pieces of MQTT5 which we actually use. In future more will be implemented (topic aliases might be useful for us).

Following PRs need to implement smarter query thread that actually throttles when there is too much data pending.

##### Test Plan
Absolutely most important piece to test is this by accident doesn't break the current MQTT by setting `mqtt5 = no`.

Then you can go ahead and have fun with this new implementation

```
netdata.conf
[cloud]
    mqtt5 = yes
```


##### Additional Information
Some additional info can be found here:
Fixes #12481

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ACLK (cloud connection)
- Can they see the change or is it an under the hood? If they can see it, where? Under the hood
- How is the user impacted by the change? Better Agent<->Cloud performance especially for bigger setups. Lowered memory consumption.
- What are there any benefits of the change? lower mem consumption, removed message size limit
-->
</details>
