### PR TITLE
fix memory leaks and mismatches of the use of the z functions for allocations

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -725,11 +725,6 @@ PARSER_RC metalog_pluginsd_host(char **words, void *user, PLUGINSD_ACTION  *plug
     return PARSER_RC_OK;
 }
 
-static void pluginsd_thread_cleanup(void *ptr) {
-    PARSER_USER_OBJECT *user = (PARSER_USER_OBJECT *)ptr;
-
-}
-
 static void pluginsd_process_thread_cleanup(void *ptr) {
     PARSER *parser = (PARSER *)ptr;
     parser_destroy(parser);

--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -290,7 +290,7 @@ int update_zfs_pool_state_chart(char *name, void *pool_p, void *update_every_p)
         }
     } else {
         disable_zfs_pool_state(pool);
-        struct deleted_zfs_pool *new = calloc(1, sizeof(struct deleted_zfs_pool));
+        struct deleted_zfs_pool *new = callocz(1, sizeof(struct deleted_zfs_pool));
         new->name = strdupz(name);
         new->next = deleted_zfs_pools;
         deleted_zfs_pools = new;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1235,7 +1235,7 @@ int main(int argc, char **argv) {
     // initialize rrd, registry, health, rrdpush, etc.
 
     netdata_anonymous_statistics_enabled=-1;
-    struct rrdhost_system_info *system_info = calloc(1, sizeof(struct rrdhost_system_info));
+    struct rrdhost_system_info *system_info = callocz(1, sizeof(struct rrdhost_system_info));
     get_system_info(system_info);
     system_info->hops = 0;
     get_install_type(&system_info->install_type, &system_info->prebuilt_arch, &system_info->prebuilt_dist);

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -424,7 +424,6 @@ static int scan_metalog_files(struct metalog_instance *ctx)
     size_t count __maybe_unused = metalog_parser_object.count;
 
     debug(D_METADATALOG, "Parsing count=%u", (unsigned)count);
-after_failed_to_parse:
 
     freez(metalogfiles);
     return matched_files;

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -375,19 +375,15 @@ static int scan_metalog_files(struct metalog_instance *ctx)
     struct metalog_pluginsd_state metalog_parser_state;
     metalog_pluginsd_state_init(&metalog_parser_state, ctx);
 
-    PARSER_USER_OBJECT metalog_parser_object;
-    metalog_parser_object.enabled = cd.enabled;
-    metalog_parser_object.host = ctx->rrdeng_ctx->host;
-    metalog_parser_object.cd = &cd;
-    metalog_parser_object.trust_durations = 0;
-    metalog_parser_object.private = &metalog_parser_state;
+    PARSER_USER_OBJECT metalog_parser_object = {
+        .enabled = cd.enabled,
+        .host = ctx->rrdeng_ctx->host,
+        .cd = &cd,
+        .trust_durations = 0,
+        .private = &metalog_parser_state
+    };
 
     PARSER *parser = parser_init(metalog_parser_object.host, &metalog_parser_object, NULL, PARSER_INPUT_SPLIT);
-    if (unlikely(!parser)) {
-        error("Failed to initialize metadata log parser.");
-        failed_to_load = matched_files;
-        goto after_failed_to_parse;
-    }
     parser_add_keyword(parser, PLUGINSD_KEYWORD_HOST, metalog_pluginsd_host);
     parser_add_keyword(parser, PLUGINSD_KEYWORD_GUID, pluginsd_guid);
     parser_add_keyword(parser, PLUGINSD_KEYWORD_CONTEXT, pluginsd_context);
@@ -431,7 +427,6 @@ static int scan_metalog_files(struct metalog_instance *ctx)
 after_failed_to_parse:
 
     freez(metalogfiles);
-
     return matched_files;
 }
 

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -540,7 +540,7 @@ void rrdeng_load_metric_init(RRDDIM *rd, struct rrddim_query_handle *rrdimm_hand
     rrdimm_handle->start_time = start_time;
     rrdimm_handle->end_time = end_time;
 
-    handle = calloc(1, sizeof(struct rrdeng_query_handle));
+    handle = callocz(1, sizeof(struct rrdeng_query_handle));
     handle->next_page_time = start_time;
     handle->now = start_time;
     handle->position = 0;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -674,6 +674,10 @@ void rrdeng_load_metric_finalize(struct rrddim_query_handle *rrdimm_handle)
 #endif
         pg_cache_put(ctx, descr);
     }
+
+    // whatever is allocated at rrdeng_load_metric_init() should be freed here
+    freez(handle);
+    rrdimm_handle->handle = NULL;
 }
 
 time_t rrdeng_metric_latest_time(RRDDIM *rd)

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -287,7 +287,7 @@ inline uint32_t rrdcalc_get_unique_id(RRDHOST *host, const char *chart, const ch
 char *alarm_name_with_dim(char *name, size_t namelen, const char *dim, size_t dimlen) {
     char *newname,*move;
 
-    newname = malloc(namelen + dimlen + 2);
+    newname = mallocz(namelen + dimlen + 2);
     if(newname) {
         move = newname;
         memcpy(move, name, namelen);

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -288,18 +288,14 @@ char *alarm_name_with_dim(char *name, size_t namelen, const char *dim, size_t di
     char *newname,*move;
 
     newname = mallocz(namelen + dimlen + 2);
-    if(newname) {
-        move = newname;
-        memcpy(move, name, namelen);
-        move += namelen;
+    move = newname;
+    memcpy(move, name, namelen);
+    move += namelen;
 
-        *move++ = '_';
-        memcpy(move, dim, dimlen);
-        move += dimlen;
-        *move = '\0';
-    } else {
-        newname = name;
-    }
+    *move++ = '_';
+    memcpy(move, dim, dimlen);
+    move += dimlen;
+    *move = '\0';
 
     return newname;
 }

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -169,30 +169,30 @@ static time_t rrddim_query_oldest_time(RRDDIM *rd) {
 
 void rrdcalc_link_to_rrddim(RRDDIM *rd, RRDSET *st, RRDHOST *host) {
     RRDCALC *rrdc;
+    
     for (rrdc = host->alarms_with_foreach; rrdc ; rrdc = rrdc->next) {
         if (simple_pattern_matches(rrdc->spdim, rd->id) || simple_pattern_matches(rrdc->spdim, rd->name)) {
             if (rrdc->hash_chart == st->hash_name || !strcmp(rrdc->chart, st->name) || !strcmp(rrdc->chart, st->id)) {
                 char *name = alarm_name_with_dim(rrdc->name, strlen(rrdc->name), rd->name, strlen(rd->name));
-                if (name) {
-                    if(rrdcalc_exists(host, st->name, name, 0, 0)){
-                        freez(name);
-                        continue;
-                    }
+                if(rrdcalc_exists(host, st->name, name, 0, 0)) {
+                    freez(name);
+                    continue;
+                }
 
-                    netdata_rwlock_wrlock(&host->health_log.alarm_log_rwlock);
-                    RRDCALC *child = rrdcalc_create_from_rrdcalc(rrdc, host, name, rd->name);
-                    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
+                netdata_rwlock_wrlock(&host->health_log.alarm_log_rwlock);
+                RRDCALC *child = rrdcalc_create_from_rrdcalc(rrdc, host, name, rd->name);
+                netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
 
-                    if (child) {
-                        rrdcalc_add_to_host(host, child);
-                        RRDCALC *rdcmp  = (RRDCALC *) avl_insert_lock(&(host)->alarms_idx_health_log,(avl_t *)child);
-                        if (rdcmp != child) {
-                            error("Cannot insert the alarm index ID %s",child->name);
-                        }
-                    } else {
-                        error("Cannot allocate a new alarm.");
-                        rrdc->foreachcounter--;
+                if (child) {
+                    rrdcalc_add_to_host(host, child);
+                    RRDCALC *rdcmp  = (RRDCALC *) avl_insert_lock(&(host)->alarms_idx_health_log,(avl_t *)child);
+                    if (rdcmp != child) {
+                        error("Cannot insert the alarm index ID %s",child->name);
                     }
+                }
+                else {
+                    error("Cannot allocate a new alarm.");
+                    rrdc->foreachcounter--;
                 }
             }
         }

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -33,16 +33,7 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, PARSER_INPUT_TYPE fl
     PARSER *parser;
 
     parser = callocz(1, sizeof(*parser));
-
-    if (unlikely(!parser))
-        return NULL;
-
     parser->plugins_action = callocz(1, sizeof(PLUGINSD_ACTION));
-    if (unlikely(!parser->plugins_action)) {
-        freez(parser);
-        return NULL;
-    }
-
     parser->user = user;
     parser->input = input;
     parser->flags = flags;
@@ -181,7 +172,6 @@ void parser_destroy(PARSER *parser)
     }
 
     freez(parser->plugins_action);
-
     freez(parser);
     return;
 }

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -38,6 +38,7 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, PARSER_INPUT_TYPE fl
     parser->input = input;
     parser->flags = flags;
     parser->host = host;
+
 #ifdef ENABLE_HTTPS
     parser->bytesleft = 0;
     parser->readfrom = NULL;
@@ -173,7 +174,6 @@ void parser_destroy(PARSER *parser)
 
     freez(parser->plugins_action);
     freez(parser);
-    return;
 }
 
 

--- a/web/api/queries/des/des.c
+++ b/web/api/queries/des/des.c
@@ -70,7 +70,7 @@ static inline void set_beta(RRDR *r, struct grouping_des *g) {
 }
 
 void *grouping_create_des(RRDR *r) {
-    struct grouping_des *g = (struct grouping_des *)malloc(sizeof(struct grouping_des));
+    struct grouping_des *g = (struct grouping_des *)mallocz(sizeof(struct grouping_des));
     set_alpha(r, g);
     set_beta(r, g);
     g->level = 0.0;


### PR DESCRIPTION
there are a few cases where we mix and match allocations and deallocations with the `z` functions...

Also there were the following memory leaks:

1. for every dbengine data query, there was a memory leak
2. on plugins exit (that are joined by their parents threads), there was a memory leak
3. on streaming receiver exit (that are joined by their parent threads), there was a memory leak

There are certain jobs that are hard to detect memory leaks:

1. Database queries that span multiple submodules of netdata
2. Streaming clients (senders) that connect and disconnect all the time
3. Streaming parents (receivers) that get connections and disconnections all the time
4. Streaming proxies (receivers and senders), a special case that spawn threads to implement both functions

Special care is needed for threads that can be cancelled at any time (like streaming threads). We have to use pthread push and pop functions to ensure there are no allocations left back.

Please establish a process to test all these cases for memory leaks. Prior to any stable release all these cases need to be tested with `valgrind` or any other similar tool, to make sure netdata is free of memory leaks.