### PR TITLE
Resolve coverity related to memory and structure dereference

### DIFF
--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -38,7 +38,7 @@ inline RRDDIM *rrddim_find(RRDSET *st, const char *id) {
 // RRDDIM rename a dimension
 
 inline int rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name) {
-    if(unlikely(!name || !*name || !strcmp(rd->name, name)))
+    if(unlikely(!name || !*name || (rd->name && !strcmp(rd->name, name))))
         return 0;
 
     debug(D_RRD_CALLS, "rrddim_set_name() from %s.%s to %s.%s", st->name, rd->name, st->name, name);

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -353,6 +353,7 @@ void aclk_send_chart_event(struct aclk_database_worker_config *wc, struct aclk_d
         if (rc != SQLITE_OK) {
             error_report("Failed to prepare statement when trying to send a chart update via ACLK");
             freez(claim_id);
+            freez(hostname);
             return;
         }
     }
@@ -774,7 +775,6 @@ void aclk_start_streaming(char *node_id, uint64_t sequence_id, time_t created_at
                         freez(chart_reset.claim_id);
                         wc->chart_reset_count = -1;
                     }
-                    return;
                 } else {
                     struct aclk_database_cmd cmd;
                     memset(&cmd, 0, sizeof(cmd));
@@ -797,12 +797,11 @@ void aclk_start_streaming(char *node_id, uint64_t sequence_id, time_t created_at
                         wc->chart_updates = 1;
                     }
                 }
-                freez(hostname);
             } else {
                 hostname = get_hostname_by_node_id(node_id);
                 log_access("ACLK STA [%s (%s)]: ACLK synchronization thread is not active.", node_id, hostname ? hostname : "N/A");
-                freez(hostname);
             }
+            freez(hostname);
             return;
         }
         host = host->next;


### PR DESCRIPTION
##### Summary
Resolve coverity issues
- Variable "hostname" going out of scope leaks the storage it points to.
- Null-checking "rd->name" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.

##### Test Plan
- Run coverity to verify the issues are resolved
