### PR TITLE
Pause alert pushes to the cloud

### DIFF
--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -174,6 +174,7 @@ struct aclk_database_worker_config {
     uint64_t alerts_batch_id; // batch id for alerts to use
     uint64_t alerts_start_seq_id; // cloud has asked to start streaming from
     uint64_t alert_sequence_id; // last alert sequence_id
+    int pause_alert_updates;
     uint32_t chart_payload_count;
     uint64_t alerts_snapshot_id; //will contain the snapshot_id value if snapshot was requested
     uint64_t alerts_ack_sequence_id; //last sequence_id ack'ed from cloud via sendsnapshot message


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR introduces a per worker thread variable called `pause_alert_updates`. When the main function (`aclk_push_alert_event`) that pushes alert events to the cloud detects that there where no events to push, it will set it to 0, and will not check again for alerts to push.

Other functions that queue alert events will set it to 1, thus enabling the `aclk_push_alert_event` to work again. 

This will prevent checking sqlite each second for each worker thread for new alerts to push.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

All is needed is an agent claimed to the cloud. Functionality should be the same for a single agent or a claimed agent with children since the check is per worker thread.

To be more obvious, a `log_access("Pushing");` or similar logging can be inserted in `aclk_push_alert_event` to reveal when it works.

