### PR TITLE
Autodetect channel for specific version

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -89,6 +89,21 @@ main() {
   progress "Using ${tmpdir} as a temporary directory."
   cd "${tmpdir}" || fatal "Failed to change current working directory to ${tmpdir}." F000A
 
+  if [ -n "${INSTALL_VERSION}" ]; then
+    if echo "${INSTALL_VERSION}" | grep -E -o "^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$" > /dev/null 2>&1; then
+      NEW_SELECTED_RELEASE_CHANNEL="stable"
+    else
+      NEW_SELECTED_RELEASE_CHANNEL="nightly"
+    fi
+
+    if [ "${NETDATA_ONLY_STATIC}" = 1 ] || [ "${NETDATA_ONLY_BUILD}" = 1 ]; then
+      if ! [ "${NEW_SELECTED_RELEASE_CHANNEL}" = "${SELECTED_RELEASE_CHANNEL}" ]; then
+          warning "Selected release channel does not match this version and it will be changed automatically."
+          SELECTED_RELEASE_CHANNEL="${NEW_SELECTED_RELEASE_CHANNEL}"
+      fi
+    fi
+  fi
+
   case "${SYSTYPE}" in
     Linux) install_on_linux ;;
     Darwin) install_on_macos ;;
@@ -1300,6 +1315,20 @@ try_package_install() {
       return 2
       ;;
   esac
+
+  if [ -n "${INSTALL_VERSION}" ]; then
+    if echo "${INSTALL_VERSION}" | grep -q "nightly"; then
+      new_release="-edge"
+    else
+      new_release=
+    fi
+
+    if { [ -n "${new_release}" ] && [ -z "${release}" ]; } || { [ -z "${new_release}" ] && [ -n "${release}" ]; }; then
+      warning "Selected release channel does not match this version and it will be changed automatically."
+    fi
+
+    release="${new_release}"
+  fi
 
   repoconfig_name="netdata-repo${release}"
   repoconfig_file="${repoconfig_name}${pkg_vsep}${REPOCONFIG_VERSION}${pkg_suffix}.${pkg_type}"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -96,11 +96,9 @@ main() {
       NEW_SELECTED_RELEASE_CHANNEL="nightly"
     fi
 
-    if [ "${NETDATA_ONLY_STATIC}" = 1 ] || [ "${NETDATA_ONLY_BUILD}" = 1 ]; then
-      if ! [ "${NEW_SELECTED_RELEASE_CHANNEL}" = "${SELECTED_RELEASE_CHANNEL}" ]; then
-          warning "Selected release channel does not match this version and it will be changed automatically."
-          SELECTED_RELEASE_CHANNEL="${NEW_SELECTED_RELEASE_CHANNEL}"
-      fi
+    if ! [ "${NEW_SELECTED_RELEASE_CHANNEL}" = "${SELECTED_RELEASE_CHANNEL}" ]; then
+        warning "Selected release channel does not match this version and it will be changed automatically."
+        SELECTED_RELEASE_CHANNEL="${NEW_SELECTED_RELEASE_CHANNEL}"
     fi
   fi
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->
Autodetect channel (nightly or stable) for specific version of netdata.
If passed `--stable-channel` flag will be ignored.

##### Test Plan
Install specific version of netdata with `kickstart.sh --install-version`, even if version is only for nightly or stable channel the script should autodetect channel and install netdata with the specific version without issues.
<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
