### PR TITLE
feat(cgroups.plugin): add k8s cluster name label (GKE only)

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -145,7 +145,8 @@ function k8s_gcp_get_cluster_name() {
   url="http://metadata/computeMetadata/v1"
   if id=$(curl --fail -s -m 3 --noproxy "*" -H "$header" "$url/project/project-id") &&
     loc=$(curl --fail -s -m 3 --noproxy "*" -H "$header" "$url/instance/attributes/cluster-location") &&
-    name=$(curl --fail -s -m 3 --noproxy "*" -H "$header" "$url/instance/attributes/cluster-name"); then
+    name=$(curl --fail -s -m 3 --noproxy "*" -H "$header" "$url/instance/attributes/cluster-name") &&
+    [ -n "$id" ] && [ -n "$loc" ] && [ -n "$name" ]; then
     echo "gke_${id}_${loc}_${name}"
     return 0
   fi

--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -252,6 +252,7 @@ function k8s_get_kubepod_name() {
   local labels
 
   if [ -n "$cntr_id" ] &&
+    [ -f "$tmp_kube_cluster_name" ] &&
     [ -f "$tmp_kube_system_ns_uid_file" ] &&
     [ -f "$tmp_kube_containers_file" ] &&
     labels=$(grep "$cntr_id" "$tmp_kube_containers_file" 2>/dev/null); then
@@ -260,6 +261,7 @@ function k8s_get_kubepod_name() {
   else
     IFS= read -r kube_system_uid 2>/dev/null <"$tmp_kube_system_ns_uid_file"
     IFS= read -r kube_cluster_name 2>/dev/null <"$tmp_kube_containers_file"
+    [ -z "$kube_cluster_name" ] && ! kube_cluster_name=$(k8s_gcp_get_cluster_name) && kube_cluster_name="unknown"
 
     local kube_system_ns
     local pods
@@ -275,12 +277,6 @@ function k8s_get_kubepod_name() {
         # FIX: check HTTP response code
         if ! kube_system_ns=$(curl -sSk -H "$header" "$url" 2>&1); then
           warning "${fn}: error on curl '${url}': ${kube_system_ns}."
-        fi
-      fi
-
-      if [ -z "$kube_cluster_name" ]; then
-        if ! kube_cluster_name=$(k8s_gcp_get_cluster_name); then
-          kube_cluster_name="unknown"
         fi
       fi
 


### PR DESCRIPTION
##### Summary

This PR adds `k8s_cluster_name` for K8s pod/containers cgroups. Works only on GKE.

This PR unblocks netdata/dashboard#395.

The end result is having a proper K8s cluster name instead of ID:

<img width="311" alt="Screenshot 2022-05-09 at 17 49 04" src="https://user-images.githubusercontent.com/22274335/167436223-83812117-55cc-4732-b165-721a374373f0.png">

cc @hugovalente-pm 

##### Test Plan

Install this branch on a GKE cluster, and check cgroups charts labels.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
