### PR TITLE
Add a SQLite database checkpoint command

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -569,6 +569,8 @@ void aclk_database_worker(void *arg)
                         cmd.completion = NULL;
                         wc->node_info_send = aclk_database_enq_cmd_noblock(wc, &cmd);
                     }
+                    if (localhost == wc->host)
+                        (void) sqlite3_wal_checkpoint(db_meta, NULL);
                     break;
                 default:
                     debug(D_ACLK_SYNC, "%s: default.", __func__);


### PR DESCRIPTION
##### Summary
- Adds a database checkpoint command (best effort ; in passive mode) to prevent the WAL file size from growing

[Checkpoint](https://www.sqlite.org/c3ref/wal_checkpoint_v2.html)
_Checkpoint as many frames as possible without waiting for any database readers or writers to finish, then sync the database file if all frames in the log were checkpointed. The [busy-handler callback](https://www.sqlite.org/c3ref/busy_handler.html) is never invoked in the SQLITE_CHECKPOINT_PASSIVE mode. On the other hand, passive mode might leave the checkpoint unfinished if there are concurrent readers or writers._

##### Test Plan
- N/A
