### PR TITLE
Initialize the metadata database when performing dbengine stress test

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -777,17 +777,17 @@ int main(int argc, char **argv) {
                         char* stresstest_string = "stresstest=";
 #endif
                         if(strcmp(optarg, "sqlite-check") == 0) {
-                            sql_init_database(DB_CHECK_INTEGRITY);
+                            sql_init_database(DB_CHECK_INTEGRITY, 0);
                             return 0;
                         }
 
                         if(strcmp(optarg, "sqlite-fix") == 0) {
-                            sql_init_database(DB_CHECK_FIX_DB);
+                            sql_init_database(DB_CHECK_FIX_DB, 0);
                             return 0;
                         }
 
                         if(strcmp(optarg, "sqlite-compact") == 0) {
-                            sql_init_database(DB_CHECK_RECLAIM_SPACE);
+                            sql_init_database(DB_CHECK_RECLAIM_SPACE, 0);
                             return 0;
                         }
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -340,12 +340,12 @@ int help(int exitcode) {
             "  -W sqlite-compact        Reclaim metadata database unused space and exit.\n\n"
 #ifdef ENABLE_DBENGINE
             "  -W createdataset=N       Create a DB engine dataset of N seconds and exit.\n\n"
-            "  -W stresstest=A,B,C,D,E,F\n"
+            "  -W stresstest=A,B,C,D,E,F,G\n"
             "                           Run a DB engine stress test for A seconds,\n"
             "                           with B writers and C readers, with a ramp up\n"
             "                           time of D seconds for writers, a page cache\n"
             "                           size of E MiB, an optional disk space limit\n"
-            "                           of F MiB and exit.\n\n"
+            "                           of F MiB, G libuv workers (default 16) and exit.\n\n"
 #endif
             "  -W set section option value\n"
             "                           set netdata.conf option from the command line.\n\n"
@@ -567,7 +567,7 @@ static void get_netdata_configured_variables() {
 
 }
 
-static int load_netdata_conf(char *filename, char overwrite_used) {
+int load_netdata_conf(char *filename, char overwrite_used) {
     errno = 0;
 
     int ret = 0;
@@ -835,7 +835,7 @@ int main(int argc, char **argv) {
                         else if(strncmp(optarg, stresstest_string, strlen(stresstest_string)) == 0) {
                             char *endptr;
                             unsigned test_duration_sec = 0, dset_charts = 0, query_threads = 0, ramp_up_seconds = 0,
-                            page_cache_mb = 0, disk_space_mb = 0;
+                            page_cache_mb = 0, disk_space_mb = 0, workers = 16;
 
                             optarg += strlen(stresstest_string);
                             test_duration_sec = (unsigned)strtoul(optarg, &endptr, 0);
@@ -849,7 +849,15 @@ int main(int argc, char **argv) {
                                 page_cache_mb = (unsigned)strtoul(endptr + 1, &endptr, 0);
                             if (',' == *endptr)
                                 disk_space_mb = (unsigned)strtoul(endptr + 1, &endptr, 0);
+                            if (',' == *endptr)
+                                workers = (unsigned)strtoul(endptr + 1, &endptr, 0);
 
+                            if (workers > 1024)
+                                workers = 1024;
+
+                            char workers_str[16];
+                            snprintf(workers_str, 15, "%u", workers);
+                            setenv("UV_THREADPOOL_SIZE", workers_str, 1);
                             dbengine_stress_test(test_duration_sec, dset_charts, query_threads, ramp_up_seconds,
                                                  page_cache_mb, disk_space_mb);
                             return 0;

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -2190,6 +2190,7 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
 
     fprintf(stderr, "Initializing localhost with hostname 'dbengine-stress-test'\n");
 
+    (void) sql_init_database(DB_CHECK_NONE, 1);
     host = dbengine_rrdhost_find_or_create("dbengine-stress-test");
     if (NULL == host)
         return;

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -437,7 +437,6 @@ uint8_t pg_cache_punch_hole(struct rrdengine_instance *ctx, struct rrdeng_page_d
     ret = JudyLDel(&page_index->JudyL_array, (Word_t)(descr->start_time / USEC_PER_SEC), PJE0);
     if (unlikely(0 == ret)) {
         uv_rwlock_wrunlock(&page_index->lock);
-        error("Page under deletion was not in index.");
         if (unlikely(debug_flags & D_RRDENGINE)) {
             print_page_descr(descr);
         }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -698,7 +698,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
     if (gap_when_lost_iterations_above < 1)
         gap_when_lost_iterations_above = 1;
 
-    if (unlikely(sql_init_database(DB_CHECK_NONE))) {
+    if (unlikely(sql_init_database(DB_CHECK_NONE, 0))) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
             fatal("Failed to initialize SQLite");
         info("Skipping SQLITE metadata initialization since memory mode is not db engine");

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -303,7 +303,7 @@ static int attempt_database_fix()
         error_report("Failed to close database, rc = %d", rc);
     info("Attempting to fix database");
     db_meta = NULL;
-    return sql_init_database(DB_CHECK_FIX_DB | DB_CHECK_CONT);
+    return sql_init_database(DB_CHECK_FIX_DB | DB_CHECK_CONT, 0);
 }
 
 static int init_database_batch(int rebuild, int init_type, const char *batch[])
@@ -334,13 +334,17 @@ static int init_database_batch(int rebuild, int init_type, const char *batch[])
  * Initialize the SQLite database
  * Return 0 on success
  */
-int sql_init_database(db_check_action_type_t rebuild)
+int sql_init_database(db_check_action_type_t rebuild, int memory)
 {
     char *err_msg = NULL;
     char sqlite_database[FILENAME_MAX + 1];
     int rc;
 
-    snprintfz(sqlite_database, FILENAME_MAX, "%s/netdata-meta.db", netdata_configured_cache_dir);
+    if (likely(!memory))
+        snprintfz(sqlite_database, FILENAME_MAX, "%s/netdata-meta.db", netdata_configured_cache_dir);
+    else
+        strcpy(sqlite_database, ":memory:");
+
     rc = sqlite3_open(sqlite_database, &db_meta);
     if (rc != SQLITE_OK) {
         error_report("Failed to initialize database at %s, due to \"%s\"", sqlite_database, sqlite3_errstr(rc));

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -56,7 +56,7 @@ typedef enum db_check_action_type {
         return 1;                                                                                                      \
     }
 
-extern int sql_init_database(db_check_action_type_t rebuild);
+extern int sql_init_database(db_check_action_type_t rebuild, int memory);
 extern void sql_close_database(void);
 
 extern int sql_store_host(uuid_t *guid, const char *hostname, const char *registry_hostname, int update_every, const char *os, const char *timezone, const char *tags);


### PR DESCRIPTION
##### Summary
When the dbengine stress test runs, there are a lot of errors because the metadata database is not initialized
This PR will create an in-memory database to store the metadata while the test is running

##### Test Plan
- Run a small stress test using e.g `netdata -W stresstest=120,2000,64,120,32,128`
  - Notice a lot of warning messages / errors e.g
```
2022-05-09 21:06:15: netdata ERROR : MAIN : Database has not been initialized
2022-05-09 21:06:15: netdata ERROR : MAIN : Failed to prepare statement to lookup chart UUID in the database  
2022-05-09 21:06:15: netdata ERROR : MAIN : Failed to bind prepare statement to lookup dimension UUID in the database
``` 
- Apply the PR and rerun the test
