### PR TITLE
workers fixes and improvements

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -196,7 +196,7 @@ static void global_statistics_charts(void) {
                     "netdata"
                     , "clients"
                     , NULL
-                    , "netdata"
+                    , "api"
                     , NULL
                     , "Netdata Web Clients"
                     , "connected clients"
@@ -227,7 +227,7 @@ static void global_statistics_charts(void) {
                     "netdata"
                     , "requests"
                     , NULL
-                    , "netdata"
+                    , "api"
                     , NULL
                     , "Netdata Web Requests"
                     , "requests/s"
@@ -259,13 +259,13 @@ static void global_statistics_charts(void) {
                     "netdata"
                     , "net"
                     , NULL
-                    , "netdata"
+                    , "api"
                     , NULL
                     , "Netdata Network Traffic"
                     , "kilobits/s"
                     , "netdata"
                     , "stats"
-                    , 130000
+                    , 130400
                     , localhost->rrd_update_every
                     , RRDSET_TYPE_AREA
             );
@@ -293,13 +293,13 @@ static void global_statistics_charts(void) {
                     "netdata"
                     , "response_time"
                     , NULL
-                    , "netdata"
+                    , "api"
                     , NULL
                     , "Netdata API Response Time"
                     , "milliseconds/request"
                     , "netdata"
                     , "stats"
-                    , 130400
+                    , 130500
                     , localhost->rrd_update_every
                     , RRDSET_TYPE_LINE
             );
@@ -342,13 +342,13 @@ static void global_statistics_charts(void) {
                     "netdata"
                     , "compression_ratio"
                     , NULL
-                    , "netdata"
+                    , "api"
                     , NULL
                     , "Netdata API Responses Compression Savings Ratio"
                     , "percentage"
                     , "netdata"
                     , "stats"
-                    , 130500
+                    , 130600
                     , localhost->rrd_update_every
                     , RRDSET_TYPE_LINE
             );
@@ -395,7 +395,7 @@ static void global_statistics_charts(void) {
                     , "queries/s"
                     , "netdata"
                     , "stats"
-                    , 130500
+                    , 131000
                     , localhost->rrd_update_every
                     , RRDSET_TYPE_LINE
             );
@@ -428,7 +428,7 @@ static void global_statistics_charts(void) {
                     , "points/s"
                     , "netdata"
                     , "stats"
-                    , 130501
+                    , 131001
                     , localhost->rrd_update_every
                     , RRDSET_TYPE_AREA
             );
@@ -499,7 +499,7 @@ static void dbengine_statistics_charts(void) {
                         "percentage",
                         "netdata",
                         "stats",
-                        130502,
+                        132000,
                         localhost->rrd_update_every,
                         RRDSET_TYPE_LINE);
 
@@ -539,7 +539,7 @@ static void dbengine_statistics_charts(void) {
                         "percentage",
                         "netdata",
                         "stats",
-                        130503,
+                        132003,
                         localhost->rrd_update_every,
                         RRDSET_TYPE_LINE);
 
@@ -592,7 +592,7 @@ static void dbengine_statistics_charts(void) {
                         "pages",
                         "netdata",
                         "stats",
-                        130504,
+                        132004,
                         localhost->rrd_update_every,
                         RRDSET_TYPE_LINE);
 
@@ -635,7 +635,7 @@ static void dbengine_statistics_charts(void) {
                         "pages",
                         "netdata",
                         "stats",
-                        130505,
+                        132005,
                         localhost->rrd_update_every,
                         RRDSET_TYPE_LINE);
 
@@ -673,7 +673,7 @@ static void dbengine_statistics_charts(void) {
                         "MiB/s",
                         "netdata",
                         "stats",
-                        130506,
+                        132006,
                         localhost->rrd_update_every,
                         RRDSET_TYPE_LINE);
 
@@ -705,7 +705,7 @@ static void dbengine_statistics_charts(void) {
                         "operations/s",
                         "netdata",
                         "stats",
-                        130507,
+                        132007,
                         localhost->rrd_update_every,
                         RRDSET_TYPE_LINE);
 
@@ -738,7 +738,7 @@ static void dbengine_statistics_charts(void) {
                         "errors/s",
                         "netdata",
                         "stats",
-                        130508,
+                        132008,
                         localhost->rrd_update_every,
                         RRDSET_TYPE_LINE);
 
@@ -773,7 +773,7 @@ static void dbengine_statistics_charts(void) {
                         "descriptors",
                         "netdata",
                         "stats",
-                        130509,
+                        132009,
                         localhost->rrd_update_every,
                         RRDSET_TYPE_LINE);
 
@@ -810,7 +810,7 @@ static void dbengine_statistics_charts(void) {
                         "MiB",
                         "netdata",
                         "stats",
-                        130510,
+                        132010,
                         localhost->rrd_update_every,
                         RRDSET_TYPE_STACKED);
 
@@ -884,6 +884,8 @@ static void update_heartbeat_charts() {
 // ---------------------------------------------------------------------------------------------------------------------
 // worker utilization
 
+#define WORKERS_MIN_PERCENT_DEFAULT 10000.0
+
 struct worker_job_type {
     char name[WORKER_UTILIZATION_MAX_JOB_NAME_LENGTH + 1];
     size_t jobs_started;
@@ -898,6 +900,7 @@ struct worker_thread {
     int enabled;
 
     int cpu_enabled;
+    double cpu;
 
     kernel_uint_t utime;
     kernel_uint_t stime;
@@ -932,6 +935,11 @@ struct worker_utilization {
     double workers_min_busy_time;
     double workers_max_busy_time;
 
+    size_t workers_cpu_registered;
+    double workers_cpu_min;
+    double workers_cpu_max;
+    double workers_cpu_total;
+
     struct worker_thread *threads;
 
     RRDSET *st_workers_time;
@@ -939,7 +947,6 @@ struct worker_utilization {
     RRDDIM *rd_workers_time_min;
     RRDDIM *rd_workers_time_max;
 
-    size_t workers_cpu_enabled;
     RRDSET *st_workers_cpu;
     RRDDIM *rd_workers_cpu_avg;
     RRDDIM *rd_workers_cpu_min;
@@ -951,7 +958,77 @@ struct worker_utilization {
 
     RRDSET *st_workers_jobs_per_job_type;
     RRDSET *st_workers_busy_per_job_type;
+
+    RRDDIM *rd_total_cpu_utilizaton;
 };
+
+static struct worker_utilization all_workers_utilization[] = {
+    { .name = "STATS",       .family = "workers global statistics",       .priority = 1000000 },
+    { .name = "HEALTH",      .family = "workers health alarms",           .priority = 1000000 },
+    { .name = "MLTRAIN",     .family = "workers ML training",             .priority = 1000000 },
+    { .name = "MLDETECT",    .family = "workers ML detection",            .priority = 1000000 },
+    { .name = "STREAMRCV",   .family = "workers streaming receive",       .priority = 1000000 },
+    { .name = "STREAMSND",   .family = "workers streaming send",          .priority = 1000000 },
+    { .name = "DBENGINE",    .family = "workers dbengine instances",      .priority = 1000000 },
+    { .name = "WEB",         .family = "workers web server",              .priority = 1000000 },
+    { .name = "ACLKQUERY",   .family = "workers aclk query",              .priority = 1000000 },
+    { .name = "ACLKSYNC",    .family = "workers aclk host sync",          .priority = 1000000 },
+    { .name = "PLUGINSD",    .family = "workers plugins.d",               .priority = 1000000 },
+    { .name = "STATSD",      .family = "workers plugin statsd",           .priority = 1000000 },
+    { .name = "STATSDFLUSH", .family = "workers plugin statsd flush",     .priority = 1000000 },
+    { .name = "PROC",        .family = "workers plugin proc",             .priority = 1000000 },
+    { .name = "FREEBSD",     .family = "workers plugin freebsd",          .priority = 1000000 },
+    { .name = "MACOS",       .family = "workers plugin macos",            .priority = 1000000 },
+    { .name = "CGROUPS",     .family = "workers plugin cgroups",          .priority = 1000000 },
+    { .name = "CGROUPSDISC", .family = "workers plugin cgroups find",     .priority = 1000000 },
+    { .name = "DISKSPACE",   .family = "workers plugin diskspace",        .priority = 1000000 },
+    { .name = "TC",          .family = "workers plugin tc",               .priority = 1000000 },
+    { .name = "TIMEX",       .family = "workers plugin timex",            .priority = 1000000 },
+    { .name = "IDLEJITTER",  .family = "workers plugin idlejitter",       .priority = 1000000 },
+
+    // has to be terminated with a NULL
+    { .name = NULL,          .family = NULL       }
+};
+
+static void workers_total_cpu_utilization_chart(void) {
+    size_t i, cpu_enabled = 0;
+    for(i = 0; all_workers_utilization[i].name ;i++)
+        if(all_workers_utilization[i].workers_cpu_registered) cpu_enabled++;
+
+    if(!cpu_enabled) return;
+
+    static RRDSET *st = NULL;
+
+    if(!st) {
+        st = rrdset_create_localhost(
+            "netdata",
+            "workers_cpu",
+            NULL,
+            "workers",
+            "netdata.workers.cpu_total",
+            "Netdata Workers CPU Utilization (100% = 1 core)",
+            "%",
+            "netdata",
+            "stats",
+            999000,
+            localhost->rrd_update_every,
+            RRDSET_TYPE_STACKED);
+    }
+
+    rrdset_next(st);
+
+    for(i = 0; all_workers_utilization[i].name ;i++) {
+        struct worker_utilization *wu = &all_workers_utilization[i];
+        if(!wu->workers_cpu_registered) continue;
+
+        if(!wu->rd_total_cpu_utilizaton)
+            wu->rd_total_cpu_utilizaton = rrddim_add(st, wu->name_lowercase, NULL, 1, 10000ULL, RRD_ALGORITHM_ABSOLUTE);
+
+        rrddim_set_by_pointer(st, wu->rd_total_cpu_utilizaton, (collected_number)((double)wu->workers_cpu_total * 10000.0));
+    }
+
+    rrdset_done(st);
+}
 
 static void workers_utilization_update_chart(struct worker_utilization *wu) {
     if(!wu->workers_registered) return;
@@ -1000,19 +1077,25 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
 
     rrdset_next(wu->st_workers_time);
 
+    if(unlikely(wu->workers_min_busy_time == WORKERS_MIN_PERCENT_DEFAULT)) wu->workers_min_busy_time = 0.0;
+
     if(wu->rd_workers_time_min)
         rrddim_set_by_pointer(wu->st_workers_time, wu->rd_workers_time_min, (collected_number)((double)wu->workers_min_busy_time * 10000.0));
 
     if(wu->rd_workers_time_max)
         rrddim_set_by_pointer(wu->st_workers_time, wu->rd_workers_time_max, (collected_number)((double)wu->workers_max_busy_time * 10000.0));
 
-    rrddim_set_by_pointer(wu->st_workers_time, wu->rd_workers_time_avg, (collected_number)((double)wu->workers_total_busy_time * 100.0 * 10000.0 / (double)wu->workers_total_duration));
+    if(wu->workers_total_duration == 0)
+        rrddim_set_by_pointer(wu->st_workers_time, wu->rd_workers_time_avg, 0);
+    else
+        rrddim_set_by_pointer(wu->st_workers_time, wu->rd_workers_time_avg, (collected_number)((double)wu->workers_total_busy_time * 100.0 * 10000.0 / (double)wu->workers_total_duration));
+
     rrdset_done(wu->st_workers_time);
 
     // ----------------------------------------------------------------------
 
 #ifdef __linux__
-    if(wu->workers_cpu_enabled || wu->st_workers_cpu) {
+    if(wu->workers_cpu_registered || wu->st_workers_cpu) {
         if(unlikely(!wu->st_workers_cpu)) {
             char name[RRD_ID_LENGTH_MAX + 1];
             snprintfz(name, RRD_ID_LENGTH_MAX, "workers_cpu_%s", wu->name_lowercase);
@@ -1047,31 +1130,19 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
 
         rrdset_next(wu->st_workers_cpu);
 
-        size_t count = 0;
-        calculated_number min = 1000.0, max = 0.0, total = 0.0;
-        struct worker_thread *wt;
-        for(wt = wu->threads; wt ; wt = wt->next) {
-            if(!wt->cpu_enabled) continue;
-            count++;
-
-            usec_t delta = wt->collected_time - wt->collected_time_old;
-            calculated_number utime = (calculated_number)(wt->utime - wt->utime_old) / (calculated_number)system_hz * 100.0 * (calculated_number)USEC_PER_SEC / (calculated_number)delta;
-            calculated_number stime = (calculated_number)(wt->stime - wt->stime_old) / (calculated_number)system_hz * 100.0 * (calculated_number)USEC_PER_SEC / (calculated_number)delta;
-            calculated_number cpu_util = utime + stime;
-
-            total += cpu_util;
-            if(cpu_util < min) min = cpu_util;
-            if(cpu_util > max) max = cpu_util;
-        }
-        if(unlikely(min == 1000.0)) min = 0.0;
+        if(unlikely(wu->workers_cpu_min == WORKERS_MIN_PERCENT_DEFAULT)) wu->workers_cpu_min = 0.0;
 
         if(wu->rd_workers_cpu_min)
-            rrddim_set_by_pointer(wu->st_workers_cpu, wu->rd_workers_cpu_min, (collected_number)(min * 10000ULL));
+            rrddim_set_by_pointer(wu->st_workers_cpu, wu->rd_workers_cpu_min, (collected_number)(wu->workers_cpu_min * 10000ULL));
 
         if(wu->rd_workers_cpu_max)
-            rrddim_set_by_pointer(wu->st_workers_cpu, wu->rd_workers_cpu_max, (collected_number)(max * 10000ULL));
+            rrddim_set_by_pointer(wu->st_workers_cpu, wu->rd_workers_cpu_max, (collected_number)(wu->workers_cpu_max * 10000ULL));
 
-        rrddim_set_by_pointer(wu->st_workers_cpu, wu->rd_workers_cpu_avg, (collected_number)( total * 10000ULL / (calculated_number)count ));
+        if(wu->workers_cpu_registered == 0)
+            rrddim_set_by_pointer(wu->st_workers_cpu, wu->rd_workers_cpu_avg, 0);
+        else
+            rrddim_set_by_pointer(wu->st_workers_cpu, wu->rd_workers_cpu_avg, (collected_number)( wu->workers_cpu_total * 10000ULL / (calculated_number)wu->workers_cpu_registered ));
+
         rrdset_done(wu->st_workers_cpu);
     }
 #endif
@@ -1203,9 +1274,13 @@ static void workers_utilization_reset_statistics(struct worker_utilization *wu) 
     wu->workers_total_busy_time = 0;
     wu->workers_total_duration = 0;
     wu->workers_total_jobs_started = 0;
-    wu->workers_min_busy_time = 100.0;
+    wu->workers_min_busy_time = WORKERS_MIN_PERCENT_DEFAULT;
     wu->workers_max_busy_time = 0;
-    wu->workers_cpu_enabled = 0;
+
+    wu->workers_cpu_registered = 0;
+    wu->workers_cpu_min = WORKERS_MIN_PERCENT_DEFAULT;
+    wu->workers_cpu_max = 0;
+    wu->workers_cpu_total = 0;
 
     size_t i;
     for(i = 0; i < WORKER_UTILIZATION_MAX_JOB_TYPES ;i++) {
@@ -1339,39 +1414,21 @@ static void worker_utilization_charts_callback(void *ptr, pid_t pid __maybe_unus
 
     // find its CPU utilization
     if((!read_thread_cpu_time_from_proc_stat(pid, &wt->utime, &wt->stime))) {
-        wt->cpu_enabled = 1;
         wt->collected_time = now_realtime_usec();
+        usec_t delta = wt->collected_time - wt->collected_time_old;
+
+        double utime = (double)(wt->utime - wt->utime_old) / (double)system_hz * 100.0 * (double)USEC_PER_SEC / (double)delta;
+        double stime = (double)(wt->stime - wt->stime_old) / (double)system_hz * 100.0 * (double)USEC_PER_SEC / (double)delta;
+        double cpu = utime + stime;
+        wt->cpu = cpu;
+        wt->cpu_enabled = 1;
+
+        wu->workers_cpu_total += cpu;
+        if(cpu < wu->workers_cpu_min) wu->workers_cpu_min = cpu;
+        if(cpu > wu->workers_cpu_max) wu->workers_cpu_max = cpu;
     }
-    wu->workers_cpu_enabled += wt->cpu_enabled;
+    wu->workers_cpu_registered += wt->cpu_enabled;
 }
-
-static struct worker_utilization all_workers_utilization[] = {
-    { .name = "STATS",       .family = "workers global statistics",       .priority = 1000000 },
-    { .name = "HEALTH",      .family = "workers health alarms",           .priority = 1000000 },
-    { .name = "MLTRAIN",     .family = "workers ML training",             .priority = 1000000 },
-    { .name = "MLDETECT",    .family = "workers ML detection",            .priority = 1000000 },
-    { .name = "STREAMRCV",   .family = "workers streaming receive",       .priority = 1000000 },
-    { .name = "STREAMSND",   .family = "workers streaming send",          .priority = 1000000 },
-    { .name = "DBENGINE",    .family = "workers dbengine instances",      .priority = 1000000 },
-    { .name = "WEB",         .family = "workers web server",              .priority = 1000000 },
-    { .name = "ACLKQUERY",   .family = "workers aclk query",              .priority = 1000000 },
-    { .name = "ACLKSYNC",    .family = "workers aclk host sync",          .priority = 1000000 },
-    { .name = "PLUGINSD",    .family = "workers plugins.d",               .priority = 1000000 },
-    { .name = "STATSD",      .family = "workers plugin statsd",           .priority = 1000000 },
-    { .name = "STATSDFLUSH", .family = "workers plugin statsd flush",     .priority = 1000000 },
-    { .name = "PROC",        .family = "workers plugin proc",             .priority = 1000000 },
-    { .name = "FREEBSD",     .family = "workers plugin freebsd",          .priority = 1000000 },
-    { .name = "MACOS",       .family = "workers plugin macos",            .priority = 1000000 },
-    { .name = "CGROUPS",     .family = "workers plugin cgroups",          .priority = 1000000 },
-    { .name = "CGROUPSDISC", .family = "workers plugin cgroups find",     .priority = 1000000 },
-    { .name = "DISKSPACE",   .family = "workers plugin diskspace",        .priority = 1000000 },
-    { .name = "TC",          .family = "workers plugin tc",               .priority = 1000000 },
-    { .name = "TIMEX",       .family = "workers plugin timex",            .priority = 1000000 },
-    { .name = "IDLEJITTER",  .family = "workers plugin idlejitter",       .priority = 1000000 },
-
-    // has to be terminated with a NULL
-    { .name = NULL,          .family = NULL       }
-};
 
 static void worker_utilization_charts(void) {
     static size_t iterations = 0;
@@ -1388,6 +1445,8 @@ static void worker_utilization_charts(void) {
 
         workers_threads_cleanup(&all_workers_utilization[i]);
     }
+
+    workers_total_cpu_utilization_chart();
 }
 
 static void worker_utilization_finish(void) {
@@ -1443,6 +1502,11 @@ void *global_statistics_main(void *ptr)
     usec_t step = update_every * USEC_PER_SEC;
     heartbeat_t hb;
     heartbeat_init(&hb);
+
+    // keep the randomness at zero
+    // to make sure we are not close to any other thread
+    hb.randomness = 0;
+
     while (!netdata_exit) {
         worker_is_idle();
         heartbeat_next(&hb, step);

--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -259,7 +259,8 @@ void heartbeat_statistics(usec_t *min_ptr, usec_t *max_ptr, usec_t *average_ptr,
             count++;
         }
     }
-    average = total / count;
+    if(count)
+        average = total / count;
 
     if(min_ptr) *min_ptr = min;
     if(max_ptr) *max_ptr = max;

--- a/libnetdata/worker_utilization/README.md
+++ b/libnetdata/worker_utilization/README.md
@@ -5,8 +5,16 @@ custom_edit_url: https://github.com/netdata/netdata/edit/master/libnetdata/onewa
 
 # Worker Utilization
 
-This library is to be used when there are 1 or more worker threads accepting requests of some kind and servicing them.
-The goal is to provide a very simple way to monitor worker threads utilization, as a percentage of the time they are busy and the amount of requests served.
+This library is to be used when there are 1 or more worker threads accepting requests
+of some kind and servicing them. The goal is to provide a very simple way to monitor
+worker threads utilization, as a percentage of the time they are busy and the amount
+of requests served.
+
+## Design goals
+
+1. Minimal, if any, impact on the performance of the workers
+2. Easy to be integrated into any kind of worker
+3. No state of any kind at the worker side
 
 ## How to use
 
@@ -19,40 +27,64 @@ void worker_register(const char *name);
 This will create the necessary structures for the library to work.
 No need to keep a pointer to them. They are allocated as `__thread` variables.
 
+Then job types need to be defined. Job types are anything a worker does that can be
+counted and their execution time needs to be reported. The library is fast enough to
+be integrated even on workers that perform hundreds of thousands of actions per second.
+
+Job types are defined like this:
+
+```c
+void worker_register_job_type(size_t id, const char *name);
+```
+
+`id` is a number starting from zero. The library is compiled with a fixed size of 50
+ids (0 to 49). More can be allocated by setting `WORKER_UTILIZATION_MAX_JOB_TYPES` in
+`worker_utilization.h`. `name` can be any string up to 22 characters. This can be
+changed by setting `WORKER_UTILIZATION_MAX_JOB_NAME_LENGTH` in `worker_utilization.h`.
+
+Each thread that calls `worker_register(name)` will allocate about 3kB for maintaining
+the information required.
+
 When the thread stops, call:
 
 ```c
-void worker_unregister(void)
+void worker_unregister(void);
 ```
 
 Again, no parameters, or return values.
 
+> IMPORTANT: cancellable threads need to add a call to `worker_unregister()` to the
+> `pop` function that cleans up the thread. Failure to do so, will result in about
+> 3kB of memory leak for every thread that is stopped.
+
 When you are about to do some work in the working thread, call:
 
 ```c
-void worker_is_busy(void)
+void worker_is_busy(size_t id);
 ```
 
 When you finish doing the job, call:
 
 ```c
-void worker_is_idle(void)
+void worker_is_idle(void);
 ```
 
-Calls to `worker_is_busy()` can be made one after another (without calling
+Calls to `worker_is_busy(id)` can be made one after another (without calling
 `worker_is_idle()` between them) to switch jobs without losing any time between
 them and eliminating one of the 2 clock calls involved.
 
 ## Implementation details
 
-Totally lockless, extremely fast, it should not introduce any kind of problems to the workers.
-Every time `worker_is_busy()` or `worker_is_idle()` are called, a call to `now_realtime_usec()`
-is done and a couple of variables are updated. That's it!
+Totally lockless, extremely fast, it should not introduce any kind of problems to the
+workers. Every time `worker_is_busy(id)` or `worker_is_idle()` are called, a call to
+`now_realtime_usec()` is done and a couple of variables are updated. That's it!
 
-The worker does not need to update the variables regularly. Based on the last status of the worker,
-the statistics collector of netdata will calculate if the thread is busy or idle all the time or
-part of the time. Works well for both thousands of jobs per second and unlimited working time
-(being totally busy with a single request for ages).
+The worker does not need to update the variables regularly. Based on the last status
+of the worker, the statistics collector of netdata will calculate if the thread is
+busy or idle all the time or part of the time. Works well for both thousands of jobs
+per second and unlimited working time (being totally busy with a single request for
+ages).
 
-The statistics collector is called by the global statistics thread of netdata. So, even if the workers
-are extremely busy with their jobs, netdata will be able to know how busy they are.
+The statistics collector is called by the global statistics thread of netdata. So,
+even if the workers are extremely busy with their jobs, netdata will be able to know
+how busy they are.


### PR DESCRIPTION
1. Eliminated division by zero when running workers exit all together, but the statistics thread is still running
2. Eliminated division by zero when all threads calling `heartbeat_next()` exit, but the statistics thread is still running
3. Updated documentation of workers utilization
4. Added a chart to show the absolute total CPU utilization of all workers together (100% = 1 core)
5. Moved API statistics to the `api` family (were in `netdata` family)
6. When a worker was busy for a long time, the busy time chart of the worker was reflecting this, but the job busy time chart was not. At the job busy time, time was accumulated when the worker switched state. Fixed it, so that the job busy time shows the busy time of running jobs too.