### PR TITLE
fix for negative per job busy time

### DIFF
--- a/libnetdata/worker_utilization/worker_utilization.c
+++ b/libnetdata/worker_utilization/worker_utilization.c
@@ -196,7 +196,6 @@ void workers_foreach(const char *workname, void (*callback)(void *data, pid_t pi
             usec_t dt = now - worker_last_action_timestamp;
             busy_time += dt;
             per_job_type_busy_time[worker_job_id] += dt;
-            p->per_job_type[worker_job_id].statistics_last_busy_time += dt;
             jobs_running = 1;
         }
 


### PR DESCRIPTION
There are cases that per job busy time is negative:

![image](https://user-images.githubusercontent.com/2662304/167685776-57717f2f-e94e-4ead-bb08-054748435889.png)

The problem is that we were adding the same busy time twice while the worker was busy, but when the worker switched state and we found out the actual work time, the chart presented a negative value.

Fixed it: we should not persist the busy time of in-flight busy workers. It is recalculated on every iteration already.