### PR TITLE
feat(proc/cgroups.plugin): add PSI stall time charts

### DIFF
--- a/collectors/cgroups.plugin/tests/test_doubles.c
+++ b/collectors/cgroups.plugin/tests/test_doubles.c
@@ -142,9 +142,9 @@ void rrdset_done(RRDSET *st)
     UNUSED(st);
 }
 
-void update_pressure_chart(struct pressure_chart *chart)
+void update_pressure_charts(struct pressure_charts *charts)
 {
-    UNUSED(chart);
+    UNUSED(charts);
 }
 
 void netdev_rename_device_add(

--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -8,22 +8,36 @@
 // linux calculates this every 2 seconds, see kernel/sched/psi.c PSI_FREQ
 #define MIN_PRESSURE_UPDATE_EVERY 2
 
+static int pressure_update_every = 0;
 
 static struct pressure resources[PRESSURE_NUM_RESOURCES] = {
-        {
-            .some = { .id = "cpu_pressure", .title = "CPU Pressure" },
-        },
-        {
-            .some = { .id = "memory_some_pressure", .title = "Memory Pressure" },
-            .full = { .id = "memory_full_pressure", .title = "Memory Full Pressure" },
-        },
-        {
-            .some = { .id = "io_some_pressure", .title = "I/O Pressure" },
-            .full = { .id = "io_full_pressure", .title = "I/O Full Pressure" },
-        },
+    {
+        .some =
+            {.share_time = {.id = "cpu_some_pressure", .title = "CPU some pressure"},
+             .total_time = {.id = "cpu_some_pressure_stall_time", .title = "CPU some pressure stall time"}},
+        .full =
+            {.share_time = {.id = "cpu_full_pressure", .title = "CPU full pressure"},
+             .total_time = {.id = "cpu_full_pressure_stall_time", .title = "CPU full pressure stall time"}},
+    },
+    {
+        .some =
+            {.share_time = {.id = "memory_some_pressure", .title = "Memory some pressure"},
+             .total_time = {.id = "memory_some_pressure_stall_time", .title = "Memory some pressure stall time"}},
+        .full =
+            {.share_time = {.id = "memory_full_pressure", .title = "Memory full pressure"},
+             .total_time = {.id = "memory_full_presure_stall_time", .title = "Memory full pressure stall time"}},
+    },
+    {
+        .some =
+            {.share_time = {.id = "io_some_pressure", .title = "I/O some pressure"},
+             .total_time = {.id = "io_some_pressure_stall_time", .title = "I/O some pressure stall time"}},
+        .full =
+            {.share_time = {.id = "io_full_pressure", .title = "I/O full pressure"},
+             .total_time = {.id = "io_full_pressure_stall_time", .title = "I/O full pressure stall time"}},
+    },
 };
 
-static struct {
+static struct resource_info {
     procfile *pf;
     const char *name;       // metric file name
     const char *family;     // webui section name
@@ -34,12 +48,70 @@ static struct {
         { .name = "io",     .family = "disk",   .section_priority = NETDATA_CHART_PRIO_SYSTEM_IO },
 };
 
-void update_pressure_chart(struct pressure_chart *chart) {
-    rrddim_set_by_pointer(chart->st, chart->rd10, (collected_number)(chart->value10 * 100));
-    rrddim_set_by_pointer(chart->st, chart->rd60, (collected_number) (chart->value60 * 100));
-    rrddim_set_by_pointer(chart->st, chart->rd300, (collected_number) (chart->value300 * 100));
+void update_pressure_charts(struct pressure_charts *pcs) {
+    if (pcs->share_time.st) {
+        rrddim_set_by_pointer(
+            pcs->share_time.st, pcs->share_time.rd10, (collected_number)(pcs->share_time.value10 * 100));
+        rrddim_set_by_pointer(
+            pcs->share_time.st, pcs->share_time.rd60, (collected_number)(pcs->share_time.value60 * 100));
+        rrddim_set_by_pointer(
+            pcs->share_time.st, pcs->share_time.rd300, (collected_number)(pcs->share_time.value300 * 100));
+        rrdset_done(pcs->share_time.st);
+    }
+    if (pcs->total_time.st) {
+        rrddim_set_by_pointer(
+            pcs->total_time.st, pcs->total_time.rdtotal, (collected_number)(pcs->total_time.value_total));
+        rrdset_done(pcs->total_time.st);
+    }
+}
 
-    rrdset_done(chart->st);
+static void proc_pressure_do_resource(procfile *ff, struct pressure_charts *pcs, struct resource_info ri, int some) {
+    if (unlikely(!pcs->share_time.st)) {
+        pcs->share_time.st = rrdset_create_localhost(
+            "system",
+            pcs->share_time.id,
+            NULL,
+            ri.family,
+            NULL,
+            pcs->share_time.title,
+            "percentage",
+            PLUGIN_PROC_NAME,
+            PLUGIN_PROC_MODULE_PRESSURE_NAME,
+            ri.section_priority + (some ? 40 : 50),
+            pressure_update_every,
+            RRDSET_TYPE_LINE);
+        pcs->share_time.rd10 =
+            rrddim_add(pcs->share_time.st, some ? "some 10" : "full 10", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+        pcs->share_time.rd60 =
+            rrddim_add(pcs->share_time.st, some ? "some 60" : "full 60", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+        pcs->share_time.rd300 =
+            rrddim_add(pcs->share_time.st, some ? "some 300" : "full 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+    } else {
+        rrdset_next(pcs->share_time.st);
+    }
+    pcs->share_time.value10 = strtod(procfile_lineword(ff, some ? 0 : 1, 2), NULL);
+    pcs->share_time.value60 = strtod(procfile_lineword(ff, some ? 0 : 1, 4), NULL);
+    pcs->share_time.value300 = strtod(procfile_lineword(ff, some ? 0 : 1, 6), NULL);
+
+    if (unlikely(!pcs->total_time.st)) {
+        pcs->total_time.st = rrdset_create_localhost(
+            "system",
+            pcs->total_time.id,
+            NULL,
+            ri.family,
+            NULL,
+            pcs->total_time.title,
+            "ms",
+            PLUGIN_PROC_NAME,
+            PLUGIN_PROC_MODULE_PRESSURE_NAME,
+            ri.section_priority + (some ? 45 : 55),
+            pressure_update_every,
+            RRDSET_TYPE_LINE);
+        pcs->total_time.rdtotal = rrddim_add(pcs->total_time.st, "time", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+    } else {
+        rrdset_next(pcs->total_time.st);
+    }
+    pcs->total_time.value_total = str2ull(procfile_lineword(ff, some ? 0 : 1, 8)) / 1000;
 }
 
 int do_proc_pressure(int update_every, usec_t dt) {
@@ -50,6 +122,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
     static char *base_path = NULL;
 
     update_every = (update_every < MIN_PRESSURE_UPDATE_EVERY) ? MIN_PRESSURE_UPDATE_EVERY : update_every;
+    pressure_update_every = update_every;
 
     if (next_pressure_dt <= dt) {
         next_pressure_dt = update_every * USEC_PER_SEC;
@@ -80,11 +153,10 @@ int do_proc_pressure(int update_every, usec_t dt) {
             snprintfz(config_key, CONFIG_MAX_NAME, "enable %s some pressure", resource_info[i].name);
             do_some = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, config_key, CONFIG_BOOLEAN_YES);
             resources[i].some.enabled = do_some;
-            if (resources[i].full.id) {
-                snprintfz(config_key, CONFIG_MAX_NAME, "enable %s full pressure", resource_info[i].name);
-                do_full = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, config_key, CONFIG_BOOLEAN_YES);
-                resources[i].full.enabled = do_full;
-            }
+
+            snprintfz(config_key, CONFIG_MAX_NAME, "enable %s full pressure", resource_info[i].name);
+            do_full = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, config_key, CONFIG_BOOLEAN_YES);
+            resources[i].full.enabled = do_full;
 
             ff = procfile_open(filename, " =", PROCFILE_FLAG_DEFAULT);
             if (unlikely(!ff)) {
@@ -108,65 +180,13 @@ int do_proc_pressure(int update_every, usec_t dt) {
             continue;
         }
 
-        struct pressure_chart *chart;
         if (do_some) {
-            chart = &resources[i].some;
-            if (unlikely(!chart->st)) {
-                chart->st = rrdset_create_localhost(
-                        "system"
-                        , chart->id
-                        , NULL
-                        , resource_info[i].family
-                        , NULL
-                        , chart->title
-                        , "percentage"
-                        , PLUGIN_PROC_NAME
-                        , PLUGIN_PROC_MODULE_PRESSURE_NAME
-                        , resource_info[i].section_priority + 40
-                        , update_every
-                        , RRDSET_TYPE_LINE
-                );
-                chart->rd10 = rrddim_add(chart->st, "some 10", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
-                chart->rd60 = rrddim_add(chart->st, "some 60", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
-                chart->rd300 = rrddim_add(chart->st, "some 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
-            } else {
-                rrdset_next(chart->st);
-            }
-
-            chart->value10 = strtod(procfile_lineword(ff, 0, 2), NULL);
-            chart->value60 = strtod(procfile_lineword(ff, 0, 4), NULL);
-            chart->value300 = strtod(procfile_lineword(ff, 0, 6), NULL);
-            update_pressure_chart(chart);
+            proc_pressure_do_resource(ff, &resources[i].some, resource_info[i], 1);
+            update_pressure_charts(&resources[i].some);
         }
-
         if (do_full && lines > 2) {
-            chart = &resources[i].full;
-            if (unlikely(!chart->st)) {
-                chart->st = rrdset_create_localhost(
-                        "system"
-                        , chart->id
-                        , NULL
-                        , resource_info[i].family
-                        , NULL
-                        , chart->title
-                        , "percentage"
-                        , PLUGIN_PROC_NAME
-                        , PLUGIN_PROC_MODULE_PRESSURE_NAME
-                        , resource_info[i].section_priority + 45
-                        , update_every
-                        , RRDSET_TYPE_LINE
-                );
-                chart->rd10 = rrddim_add(chart->st, "full 10", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
-                chart->rd60 = rrddim_add(chart->st, "full 60", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
-                chart->rd300 = rrddim_add(chart->st, "full 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
-            } else {
-                rrdset_next(chart->st);
-            }
-
-            chart->value10 = strtod(procfile_lineword(ff, 1, 2), NULL);
-            chart->value60 = strtod(procfile_lineword(ff, 1, 4), NULL);
-            chart->value300 = strtod(procfile_lineword(ff, 1, 6), NULL);
-            update_pressure_chart(chart);
+            proc_pressure_do_resource(ff, &resources[i].full, resource_info[i], 0);
+            update_pressure_charts(&resources[i].full);
         }
     }
 

--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -25,7 +25,7 @@ static struct pressure resources[PRESSURE_NUM_RESOURCES] = {
              .total_time = {.id = "memory_some_pressure_stall_time", .title = "Memory some pressure stall time"}},
         .full =
             {.share_time = {.id = "memory_full_pressure", .title = "Memory full pressure"},
-             .total_time = {.id = "memory_full_presure_stall_time", .title = "Memory full pressure stall time"}},
+             .total_time = {.id = "memory_full_pressure_stall_time", .title = "Memory full pressure stall time"}},
     },
     {
         .some =

--- a/collectors/proc.plugin/proc_pressure.h
+++ b/collectors/proc.plugin/proc_pressure.h
@@ -9,23 +9,35 @@ struct pressure {
     int updated;
     char *filename;
 
-    struct pressure_chart {
+    struct pressure_charts {
         int enabled;
 
-        const char *id;
-        const char *title;
+        struct pressure_share_time_chart {
+            const char *id;
+            const char *title;
 
-        double value10;
-        double value60;
-        double value300;
+            double value10;
+            double value60;
+            double value300;
 
-        RRDSET *st;
-        RRDDIM *rd10;
-        RRDDIM *rd60;
-        RRDDIM *rd300;
+            RRDSET *st;
+            RRDDIM *rd10;
+            RRDDIM *rd60;
+            RRDDIM *rd300;
+        } share_time;
+
+        struct pressure_total_time_chart {
+            const char *id;
+            const char *title;
+
+            unsigned long long value_total;
+
+            RRDSET *st;
+            RRDDIM *rdtotal;
+        } total_time;
     } some, full;
 };
 
-extern void update_pressure_chart(struct pressure_chart *chart);
+extern void update_pressure_charts(struct pressure_charts *charts);
 
 #endif //NETDATA_PROC_PRESSURE_H

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1309,29 +1309,61 @@ netdataDashboard.context = {
         height: 0.7
     },
 
-    'system.cpu_pressure': {
-        info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a> ' +
-            'identifies and quantifies the disruptions caused by resource contentions. ' +
-            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on CPU. ' +
-            'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    'system.cpu_some_pressure': {
+        info: 'CPU <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. '+
+            '<b>Some</b> indicates the share of time in which at least <b>some tasks</b> are stalled on CPU. ' +
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'system.cpu_some_pressure_stall_time': {
+        info: 'The amount of time some processes have been waiting for CPU time.'
+    },
+    'system.cpu_full_pressure': {
+        info: 'CPU <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. ' +
+            '<b>Full</b> indicates the share of time in which <b>all non-idle tasks</b> are stalled on CPU resource simultaneously. ' +
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'system.cpu_full_pressure_stall_time': {
+        info: 'The amount of time all non-idle processes have been stalled due to CPU congestion.'
     },
 
     'system.memory_some_pressure': {
-        info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a> ' +
-            'identifies and quantifies the disruptions caused by resource contentions. ' +
-            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on memory. ' +
-            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on memory simultaneously. ' +
-            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. ' +
-            'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+        info: 'Memory <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. '+
+            '<b>Some</b> indicates the share of time in which at least <b>some tasks</b> are stalled on memory. ' +
+            'In this state the CPU is still doing productive work. '+
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'system.memory_some_pressure_stall_time': {
+        info: 'The amount of time some processes have been waiting due to memory congestion.'
+    },
+    'system.memory_full_pressure': {
+        info: 'Memory <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. ' +
+            '<b>Full</b> indicates the share of time in which <b>all non-idle tasks</b> are stalled on memory resource simultaneously. ' +
+            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. '+
+            'This has severe impact on performance. '+
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'system.memory_full_pressure_stall_time': {
+        info: 'The amount of time all non-idle processes have been stalled due to memory congestion.'
     },
 
     'system.io_some_pressure': {
-        info: '<a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a> ' +
-            'identifies and quantifies the disruptions caused by resource contentions. ' +
-            'The "some" line indicates the share of time in which at least <b>some</b> tasks are stalled on I/O. ' +
-            'The "full" line indicates the share of time in which <b>all non-idle</b> tasks are stalled on I/O simultaneously. ' +
-            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. ' +
-            'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+        info: 'I/O <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. '+
+            '<b>Some</b> indicates the share of time in which at least <b>some tasks</b> are stalled on I/O. ' +
+            'In this state the CPU is still doing productive work. '+
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'system.io_some_pressure_stall_time': {
+        info: 'The amount of time some processes have been waiting due to I/O congestion.'
+    },
+    'system.io_full_pressure': {
+        info: 'I/O <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. ' +
+            '<b>Full</b> line indicates the share of time in which <b>all non-idle tasks</b> are stalled on I/O resource simultaneously. ' +
+            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. '+
+            'This has severe impact on performance. '+
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'system.io_full_pressure_stall_time': {
+        info: 'The amount of time all non-idle processes have been stalled due to I/O congestion.'
     },
 
     'system.io': {
@@ -4037,10 +4069,22 @@ netdataDashboard.context = {
         info: 'Total CPU utilization per core within the system-wide CPU resources.'
     },
 
-    'cgroup.cpu_pressure': {
+    'cgroup.cpu_some_pressure': {
         info: 'CPU <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. '+
-        '<b>Some</b> indicates the share of time in which at least some tasks are stalled on CPU. '+
-        'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+            '<b>Some</b> indicates the share of time in which at least <b>some tasks</b> are stalled on CPU. ' +
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'cgroup.cpu_some_pressure_stall_time': {
+        info: 'The amount of time some processes have been waiting for CPU time.'
+    },
+
+    'cgroup.cpu_full_pressure': {
+        info: 'CPU <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. ' +
+            '<b>Full</b> indicates the share of time in which <b>all non-idle tasks</b> are stalled on CPU resource simultaneously. ' +
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'cgroup.cpu_full_pressure_stall_time': {
+        info: 'The amount of time all non-idle processes have been stalled due to CPU congestion.'
     },
 
     'cgroup.mem_utilization': {
@@ -4126,18 +4170,25 @@ netdataDashboard.context = {
         '<b>Swap</b> - major page faults.</p>'
     },
 
-    'cgroup.memory_pressure': {
+    'cgroup.memory_some_pressure': {
         info: 'Memory <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. '+
-        '<b>Some</b> indicates the share of time in which at least some tasks are stalled on memory. '+
-        'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+            '<b>Some</b> indicates the share of time in which at least <b>some tasks</b> are stalled on memory. ' +
+            'In this state the CPU is still doing productive work. '+
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'cgroup.memory_some_pressure_stall_time': {
+        info: 'The amount of time some processes have been waiting due to memory congestion.'
     },
 
     'cgroup.memory_full_pressure': {
-        info: 'Memory <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. '+
-        '<b>Full</b> indicates the share of time in which all non-idle tasks are stalled on memory simultaneously. '+
-        'In this state actual CPU cycles are going to waste, '+
-        'and a workload that spends extended time in this state is considered to be thrashing. '+
-        'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+        info: 'Memory <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. ' +
+            '<b>Full</b> indicates the share of time in which <b>all non-idle tasks</b> are stalled on memory resource simultaneously. ' +
+            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. '+
+            'This has severe impact on performance. '+
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'cgroup.memory_full_pressure_stall_time': {
+        info: 'The amount of time all non-idle processes have been stalled due to memory congestion.'
     },
 
     'cgroup.io': {
@@ -4197,18 +4248,25 @@ netdataDashboard.context = {
         info: 'The number of I/O operations performed on specific devices as seen by the throttling policy.'
     },
 
-    'cgroup.io_pressure': {
+    'cgroup.io_some_pressure': {
         info: 'I/O <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. '+
-        '<b>Some</b> indicates the share of time in which at least some tasks are stalled on I/O. '+
-        'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+            '<b>Some</b> indicates the share of time in which at least <b>some tasks</b> are stalled on I/O. ' +
+            'In this state the CPU is still doing productive work. '+
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'cgroup.io_some_pressure_stall_time': {
+        info: 'The amount of time some processes have been waiting due to I/O congestion.'
     },
 
     'cgroup.io_full_pressure': {
-        info: 'I/O <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. '+
-        '<b>Full</b> indicates the share of time in which all non-idle tasks are stalled on I/O simultaneously. '+
-        'In this state actual CPU cycles are going to waste, '+
-        'and a workload that spends extended time in this state is considered to be thrashing. '+
-        'The ratios (in %) are tracked as recent trends over 10-, 60-, and 300-second windows.'
+        info: 'I/O <a href="https://www.kernel.org/doc/html/latest/accounting/psi.html" target="_blank">Pressure Stall Information</a>. ' +
+            '<b>Full</b> line indicates the share of time in which <b>all non-idle tasks</b> are stalled on I/O resource simultaneously. ' +
+            'In this state actual CPU cycles are going to waste, and a workload that spends extended time in this state is considered to be thrashing. '+
+            'This has severe impact on performance. '+
+            'The ratios are tracked as recent trends over 10-, 60-, and 300-second windows.'
+    },
+    'cgroup.io_full_pressure_stall_time': {
+        info: 'The amount of time all non-idle processes have been stalled due to I/O congestion.'
     },
 
     'cgroup.swap_read': {


### PR DESCRIPTION
##### Summary

Closes: #12882

This PR:

- adds [PSI](https://www.kernel.org/doc/html/latest/accounting/psi.html) total stall time for CPU, memory, I/O resources:

  - per host.
  - per cgroup (v2 only).

  <br>

  > The total absolute stall time (in us) is tracked and exported as well, to allow detection of latency spikes which wouldn’t necessarily make a dent in the time averages, or to average trends over custom time frames.

- adds collecting `full` for CPU. Despite the [PSI doc](https://www.kernel.org/doc/html/latest/accounting/psi.html) saying the CPU resource has only `some`, our Proxmox server has both:

  ```cmd
  $ cat /proc/pressure/cpu
  some avg10=0.00 avg60=0.00 avg300=0.00 total=775799775
  full avg10=0.00 avg60=0.00 avg300=0.00 total=651201120
  ```

##### Test Plan

Install this branch on a host with PSI and cgroups v2, check PSI charts.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
