### PR TITLE
Set trust durations to have data from children properly aligned

### DIFF
--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -353,7 +353,7 @@ size_t streaming_parser(struct receiver_state *rpt, struct plugind *cd, FILE *fp
         .host = rpt->host,
         .opaque = rpt,
         .cd = cd,
-        .trust_durations = 0
+        .trust_durations = 1
     };
 
     PARSER *parser = parser_init(rpt->host, &user, fp, PARSER_INPUT_SPLIT);


### PR DESCRIPTION
Fixes #12603
##### Summary
Set the trust durations parameter properly to make sure that data received via streaming is properly aligned with the chart update every. 

##### Test Plan
- Set up parent with multiple children, claim parent to cloud
- Occasionally you may notice charts being not properly aligned in the overview screen (especially with update every > 1)
- Apply the PR and observe the improved behavior
