### PR TITLE
Remove Fedora 34 from CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -89,11 +89,6 @@ include:
     packages:
       <<: *fedora_packages
       repo_distro: fedora/35
-  - <<: *fedora
-    version: "34"
-    packages:
-      <<: *fedora_packages
-      repo_distro: fedora/34
 
   - &opensuse
     distro: opensuse

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -59,7 +59,6 @@ to work on these platforms with minimal user effort.
 | Debian | 9.x | x86\_64, i386, ARMv7, AArch64 | |
 | Fedora | 36 | x86\_64, ARMv7, AArch64 | |
 | Fedora | 35 | x86\_64, ARMv7, AArch64 | |
-| Fedora | 34 | x86\_64, ARMv7, AArch64 | |
 | openSUSE | Leap 15.3 | x86\_64, AArch64 | |
 | Oracle Linux | 8.x | x86\_64, AArch64 | |
 | Red Hat Enterprise Linux | 7.x | x86\_64 | |
@@ -144,12 +143,11 @@ This is a list of platforms that we have supported in the recent past but no lon
 | Platform | Version | Notes |
 | -------- | ------- | ----- |
 | Alpine Linux | 3.11 | EOL as of 2021-11-01 |
-| Alpine Linux | 3.10 | EOL as of 2021-05-01 |
+| Fedora 34 | EOL as of 2022-06-07 |
 | Fedora | 33 | EOL as of 2021-11-30 |
 | Fedora | 32 | EOL as of 2021-05-25 |
 | FreeBSD | 11-STABLE | EOL as of 2021-10-30 |
 | openSUSE | Leap 15.2 | EOL as of 2021-12-01 |
-| openSUSE | Leap 15.1 | EOL as of 2021-01-31 |
 | Ubuntu | 21.04 | EOL as of 2022-01-01 |
 | Ubuntu | 20.10 | EOL as of 2021-07-22 |
 | Ubuntu | 16.04 | EOL as of 2021-04-02 |


### PR DESCRIPTION
##### Summary

To be merged when it goes EOL on 2022-06-07.

##### Test Plan

n/a

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
End of official support for Fedora 34.
</details>
