### PR TITLE
Cache invariant components in static builds to reduce build times.

### DIFF
--- a/.github/scripts/build-static.sh
+++ b/.github/scripts/build-static.sh
@@ -22,7 +22,7 @@ prepare_build() {
 build_static() {
   progress "Building static ${BUILDARCH}"
   (
-    USER="" USE_EXISTING_DOCKER_IMAGE='yes' ./packaging/makeself/build-static.sh "${BUILDARCH}"
+    USER="" ./packaging/makeself/build-static.sh "${BUILDARCH}"
   ) >&2
 }
 

--- a/.github/scripts/build-static.sh
+++ b/.github/scripts/build-static.sh
@@ -22,7 +22,7 @@ prepare_build() {
 build_static() {
   progress "Building static ${BUILDARCH}"
   (
-    USER="" ./packaging/makeself/build-static.sh "${BUILDARCH}"
+    USER="" USE_EXISTING_DOCKER_IMAGE='yes' ./packaging/makeself/build-static.sh "${BUILDARCH}"
   ) >&2
 }
 

--- a/.github/scripts/get-static-cache-key.sh
+++ b/.github/scripts/get-static-cache-key.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-platform="${1}"
-arch="${2}"
+arch="${1}"
+platform="$(packaging/makeself/uname2platform.sh "${arch}")"
 
 docker pull --platform "${platform}" netdata/static-builder
 

--- a/.github/scripts/get-static-cache-key.sh
+++ b/.github/scripts/get-static-cache-key.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+platform="${1}"
+arch="${2}"
+
+docker pull --platform "${platform}" netdata/static-builder
+
+# shellcheck disable=SC2046
+cat $(find packaging/makeself/jobs -type f ! -regex '.*\(netdata\|-makeself\).*') > /tmp/static-cache-key-data
+
+docker run -it --rm --platform "${platform}" netdata/static-builder sh -c 'apk list -I 2>/dev/null' >> /tmp/static-cache-key-data
+
+h="$(sha256sum /tmp/static-cache-key-data | cut -f 1 -d ' ')"
+
+echo "::set-output name=key::static-${arch}-${h}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,11 +87,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - {arch: 'x86_64', platform: 'linux/amd64'}
-          - {arch: 'armv7l', platform: 'linux/arm/v7'}
-          - {arch: 'aarch64', platform: 'linux/arm64/v8'}
-          - {arch: 'ppc64le', platform: 'linux/ppc64le'}
+        arch:
+          - x86_64
+          - armv7l
+          - aarch64
+          - ppc64le
     steps:
       - name: Checkout
         id: checkout
@@ -106,7 +106,7 @@ jobs:
           sed -i 's/^RELEASE_CHANNEL="nightly" *#/RELEASE_CHANNEL="stable" #/' netdata-installer.sh packaging/makeself/install-or-update.sh
       - name: Get Cache Key
         id: cache-key
-        run: .github/scripts/get-static-cache-key.sh ${{ matrix.platform }} ${{ matrix.arch }}
+        run: .github/scripts/get-static-cache-key.sh ${{ matrix.arch }}
       - name: Cache
         id: cache
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,11 +87,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch:
-          - 'x86_64'
-          - 'armv7l'
-          - 'aarch64'
-          - 'ppc64le'
+        include:
+          - {arch: 'x86_64', platform: 'linux/amd64'}
+          - {arch: 'armv7l', platform: 'linux/arm/v7'}
+          - {arch: 'aarch64', platform: 'linux/arm64/v8'}
+          - {arch: 'ppc64le', platform: 'linux/ppc64le'}
     steps:
       - name: Checkout
         id: checkout
@@ -104,6 +104,15 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.type != 'nightly'
         run: |
           sed -i 's/^RELEASE_CHANNEL="nightly" *#/RELEASE_CHANNEL="stable" #/' netdata-installer.sh packaging/makeself/install-or-update.sh
+      - name: Get Cache Key
+        id: cache-key
+        run: .github/scripts/get-static-cache-key.sh ${{ matrix.platform }} ${{ matrix.arch }}
+      - name: Cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: artifacts/cache
+          key: ${{ steps.cache-key.outputs.key }}
       - name: Build
         id: build
         run: .github/scripts/build-static.sh ${{ matrix.arch }}

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -26,8 +26,11 @@ if [ "${BUILDARCH}" != "$(uname -m)" ] && [ "$(uname -m)" = 'x86_64' ] && [ -z "
     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
 fi
 
-if [ "${USE_EXISTING_DOCKER_IMAGE}" != 'yes' ] && docker inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
-    docker image rm "${DOCKER_IMAGE_NAME}" || exit 1
+if docker inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
+    img_platform="$(docker image inspect netdata/static-builder --format '{{.Os}}/{{.Architecture}}/{{.Variant}}')"
+    if [ "${img_platform%'/'}" != "${platform}" ]; then
+        docker image rm "${DOCKER_IMAGE_NAME}" || exit 1
+    fi
 fi
 
 if ! docker inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -36,11 +36,11 @@ fi
 
 # Run the build script inside the container
 if [ -t 1 ]; then
-  run docker run -e BUILDARCH="${BUILDARCH}" -a stdin -a stdout -a stderr -i -t -v "$(pwd)":/netdata:rw \
+  run docker run --rm -e BUILDARCH="${BUILDARCH}" -a stdin -a stdout -a stderr -i -t -v "$(pwd)":/netdata:rw \
     "${DOCKER_IMAGE_NAME}" \
     /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 else
-  run docker run -e BUILDARCH="${BUILDARCH}" -v "$(pwd)":/netdata:rw \
+  run docker run --rm -e BUILDARCH="${BUILDARCH}" -v "$(pwd)":/netdata:rw \
     -e GITHUB_ACTIONS="${GITHUB_ACTIONS}" "${DOCKER_IMAGE_NAME}" \
     /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 fi

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -9,16 +9,11 @@ BUILDARCH="${1}"
 
 set -e
 
-case ${BUILDARCH} in
-  x86_64) platform=linux/amd64 ;;
-  armv7l) platform=linux/arm/v7 ;;
-  aarch64) platform=linux/arm64/v8 ;;
-  ppc64le) platform=linux/ppc64le ;;
-  *)
-    echo "Unknown target architecture '${BUILDARCH}'."
+platform="$("$(dirname "${0}")/uname2platform.sh" "${BUILDARCH}")"
+
+if [ -z "${platform}" ]; then
     exit 1
-    ;;
-esac
+fi
 
 DOCKER_IMAGE_NAME="netdata/static-builder"
 

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -26,11 +26,13 @@ if [ "${BUILDARCH}" != "$(uname -m)" ] && [ "$(uname -m)" = 'x86_64' ] && [ -z "
     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
 fi
 
-if docker inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
+if [ "${USE_EXISTING_DOCKER_IMAGE}" != 'yes' ] && docker inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
     docker image rm "${DOCKER_IMAGE_NAME}" || exit 1
 fi
 
-docker pull --platform "${platform}" "${DOCKER_IMAGE_NAME}"
+if ! docker inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
+    docker pull --platform "${platform}" "${DOCKER_IMAGE_NAME}"
+fi
 
 # Run the build script inside the container
 if [ -t 1 ]; then

--- a/packaging/makeself/functions.sh
+++ b/packaging/makeself/functions.sh
@@ -40,6 +40,7 @@ fetch() {
   if [ -d "${cache}/${dir}" ]; then
     echo "Found cached copy of build directory for ${key}, using it."
     cp -a "${cache}/${dir}" "${NETDATA_MAKESELF_PATH}/tmp/"
+    CACHE_HIT=1
   else
     echo "No cached copy of build directory for ${key} found, fetching sources instead."
 
@@ -62,6 +63,8 @@ fetch() {
     cd "${NETDATA_MAKESELF_PATH}/tmp"
     run tar -zxpf "${tar}"
     cd -
+
+    CACHE_HIT=0
   fi
 
   run cd "${NETDATA_MAKESELF_PATH}/tmp/${dir}"
@@ -73,13 +76,15 @@ store_cache() {
 
     cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/${key}"
 
-    if [ -d "${cache}" ]; then
-        rm -rf "${cache}"
+    if [ "${CACHE_HIT:-0}" -eq 0 ]; then
+        if [ -d "${cache}" ]; then
+            rm -rf "${cache}"
+        fi
+
+        mkdir -p "${cache}"
+
+        cp -a "${src}" "${cache}"
     fi
-
-    mkdir -p "${cache}"
-
-    cp -a "${src}" "${cache}"
 }
 
 # -----------------------------------------------------------------------------

--- a/packaging/makeself/jobs/20-openssl.install.sh
+++ b/packaging/makeself/jobs/20-openssl.install.sh
@@ -26,15 +26,20 @@ cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/openssl"
 if [ -d "${cache}" ]; then
   echo "Found cached copy of build directory for openssl, using it."
   cp -a "${cache}/openssl" "${NETDATA_MAKESELF_PATH}/tmp/"
+  CACHE_HIT=1
 else
   echo "No cached copy of build directory for openssl found, fetching sources instead."
   run git clone --branch "${version}" --single-branch --depth 1 git://git.openssl.org/openssl.git "${NETDATA_MAKESELF_PATH}/tmp/openssl"
+  CACHE_HIT=0
 fi
 
 cd "${NETDATA_MAKESELF_PATH}/tmp/openssl" || exit 1
 
-run ./config -static no-tests --prefix=/openssl-static --openssldir=/opt/netdata/etc/ssl
-run make -j "$(nproc)"
+if [ "${CACHE_HIT:-0}" -eq 0 ]; then
+    run ./config -static no-tests --prefix=/openssl-static --openssldir=/opt/netdata/etc/ssl
+    run make -j "$(nproc)"
+fi
+
 run make -j "$(nproc)" install_sw
 
 store_cache openssl "${NETDATA_MAKESELF_PATH}/tmp/openssl"

--- a/packaging/makeself/jobs/20-openssl.install.sh
+++ b/packaging/makeself/jobs/20-openssl.install.sh
@@ -13,15 +13,31 @@ export CFLAGS='-fno-lto -pipe'
 export LDFLAGS='-static'
 export PKG_CONFIG="pkg-config --static"
 
-# Might be bind-mounted
-if [ ! -d "${NETDATA_MAKESELF_PATH}/tmp/openssl" ]; then
+if [ -d "${NETDATA_MAKESELF_PATH}/tmp/openssl" ]; then
+  rm -rf "${NETDATA_MAKESELF_PATH}/tmp/openssl"
+fi
+
+if [ -d "${NETDATA_MAKESELF_PATH}/tmp/openssl" ]; then
+  rm -rf "${NETDATA_MAKESELF_PATH}/tmp/openssl"
+fi
+
+cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/openssl"
+
+if [ -d "${cache}" ]; then
+  echo "Found cached copy of build directory for openssl, using it."
+  cp -a "${cache}/openssl" "${NETDATA_MAKESELF_PATH}/tmp/"
+else
+  echo "No cached copy of build directory for openssl found, fetching sources instead."
   run git clone --branch "${version}" --single-branch --depth 1 git://git.openssl.org/openssl.git "${NETDATA_MAKESELF_PATH}/tmp/openssl"
 fi
+
 cd "${NETDATA_MAKESELF_PATH}/tmp/openssl" || exit 1
 
 run ./config -static no-tests --prefix=/openssl-static --openssldir=/opt/netdata/etc/ssl
 run make -j "$(nproc)"
 run make -j "$(nproc)" install_sw
+
+store_cache openssl "${NETDATA_MAKESELF_PATH}/tmp/openssl"
 
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/makeself/jobs/50-bash-5.1.16.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.1.16.install.sh
@@ -4,11 +4,13 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
+version="5.1.16"
+
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::building bash" || true
 
-fetch "bash-5.1.16" "http://ftp.gnu.org/gnu/bash/bash-5.1.16.tar.gz" \
-    5bac17218d3911834520dad13cd1f85ab944e1c09ae1aba55906be1f8192f558
+fetch "bash-${version}" "http://ftp.gnu.org/gnu/bash/bash-${version}.tar.gz" \
+    5bac17218d3911834520dad13cd1f85ab944e1c09ae1aba55906be1f8192f558 bash
 
 export CFLAGS="-pipe"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
@@ -34,6 +36,8 @@ install:
 EOF
 
 run make install
+
+store_cache bash "${NETDATA_MAKESELF_PATH}/tmp/bash-${version}"
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/bin/bash

--- a/packaging/makeself/jobs/50-bash-5.1.16.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.1.16.install.sh
@@ -15,25 +15,27 @@ fetch "bash-${version}" "http://ftp.gnu.org/gnu/bash/bash-${version}.tar.gz" \
 export CFLAGS="-pipe"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
-run ./configure \
-  --prefix="${NETDATA_INSTALL_PATH}" \
-  --without-bash-malloc \
-  --enable-static-link \
-  --enable-net-redirections \
-  --enable-array-variables \
-  --disable-progcomp \
-  --disable-profiling \
-  --disable-nls \
-  --disable-dependency-tracking
+if [ "${CACHE_HIT:-0}" -eq 0 ]; then
+    run ./configure \
+        --prefix="${NETDATA_INSTALL_PATH}" \
+        --without-bash-malloc \
+        --enable-static-link \
+        --enable-net-redirections \
+        --enable-array-variables \
+        --disable-progcomp \
+        --disable-profiling \
+        --disable-nls \
+        --disable-dependency-tracking
 
-run make clean
-run make -j "$(nproc)"
+    run make clean
+    run make -j "$(nproc)"
 
-cat > examples/loadables/Makefile << EOF
-all:
-clean:
-install:
-EOF
+    cat > examples/loadables/Makefile <<-EOF
+	all:
+	clean:
+	install:
+	EOF
+fi
 
 run make install
 

--- a/packaging/makeself/jobs/50-curl-7.82.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.82.0.install.sh
@@ -17,36 +17,39 @@ export LDFLAGS="-static -L/openssl-static/lib"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
-run autoreconf -fi
+if [ "${CACHE_HIT:-0}" -eq 0 ]; then
+    run autoreconf -fi
 
-run ./configure \
-  --prefix="${NETDATA_INSTALL_PATH}" \
-  --enable-optimize \
-  --disable-shared \
-  --enable-static \
-  --enable-http \
-  --disable-ldap \
-  --disable-ldaps \
-  --enable-proxy \
-  --disable-dict \
-  --disable-telnet \
-  --disable-tftp \
-  --disable-pop3 \
-  --disable-imap \
-  --disable-smb \
-  --disable-smtp \
-  --disable-gopher \
-  --enable-ipv6 \
-  --enable-cookies \
-  --with-ca-fallback \
-  --with-openssl \
-  --disable-dependency-tracking
+    run ./configure \
+        --prefix="${NETDATA_INSTALL_PATH}" \
+        --enable-optimize \
+        --disable-shared \
+        --enable-static \
+        --enable-http \
+        --disable-ldap \
+        --disable-ldaps \
+        --enable-proxy \
+        --disable-dict \
+        --disable-telnet \
+        --disable-tftp \
+        --disable-pop3 \
+        --disable-imap \
+        --disable-smb \
+        --disable-smtp \
+        --disable-gopher \
+        --enable-ipv6 \
+        --enable-cookies \
+        --with-ca-fallback \
+        --with-openssl \
+        --disable-dependency-tracking
 
-# Curl autoconf does not honour the curl_LDFLAGS environment variable
-run sed -i -e "s/LDFLAGS =/LDFLAGS = -all-static/" src/Makefile
+    # Curl autoconf does not honour the curl_LDFLAGS environment variable
+    run sed -i -e "s/LDFLAGS =/LDFLAGS = -all-static/" src/Makefile
 
-run make clean
-run make -j "$(nproc)"
+    run make clean
+    run make -j "$(nproc)"
+fi
+
 run make install
 
 store_cache curl "${NETDATA_MAKESELF_PATH}/tmp/curl-${version}"

--- a/packaging/makeself/jobs/50-curl-7.82.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.82.0.install.sh
@@ -4,11 +4,13 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
+version="7.82.0"
+
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building cURL" || true
 
-fetch "curl-7.82.0" "https://curl.haxx.se/download/curl-7.82.0.tar.gz" \
-    910cc5fe279dc36e2cca534172c94364cf3fcf7d6494ba56e6c61a390881ddce
+fetch "curl-${version}" "https://curl.haxx.se/download/curl-${version}.tar.gz" \
+    910cc5fe279dc36e2cca534172c94364cf3fcf7d6494ba56e6c61a390881ddce curl
 
 export CFLAGS="-I/openssl-static/include -pipe"
 export LDFLAGS="-static -L/openssl-static/lib"
@@ -46,6 +48,8 @@ run sed -i -e "s/LDFLAGS =/LDFLAGS = -all-static/" src/Makefile
 run make clean
 run make -j "$(nproc)"
 run make install
+
+store_cache curl "${NETDATA_MAKESELF_PATH}/tmp/curl-${version}"
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/bin/curl

--- a/packaging/makeself/jobs/50-fping-5.1.install.sh
+++ b/packaging/makeself/jobs/50-fping-5.1.install.sh
@@ -32,7 +32,7 @@ run make clean
 run make -j "$(nproc)"
 run make install
 
-store_cache fping "${NETDATA_MAKESELF_PATH}/tmp/fping"
+store_cache fping "${NETDATA_MAKESELF_PATH}/tmp/fping-${version}"
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/bin/fping

--- a/packaging/makeself/jobs/50-fping-5.1.install.sh
+++ b/packaging/makeself/jobs/50-fping-5.1.install.sh
@@ -4,11 +4,13 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
+version="5.1"
+
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building fping" || true
 
-fetch "fping-5.1" "https://fping.org/dist/fping-5.1.tar.gz" \
-    1ee5268c063d76646af2b4426052e7d81a42b657e6a77d8e7d3d2e60fd7409fe
+fetch "fping-${version}" "https://fping.org/dist/fping-${version}.tar.gz" \
+    1ee5268c063d76646af2b4426052e7d81a42b657e6a77d8e7d3d2e60fd7409fe fping
 
 export CFLAGS="-static -I/openssl-static/include -pipe"
 export LDFLAGS="-static -L/openssl-static/lib"
@@ -29,6 +31,8 @@ EOF
 run make clean
 run make -j "$(nproc)"
 run make install
+
+store_cache fping "${NETDATA_MAKESELF_PATH}/tmp/fping"
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/bin/fping

--- a/packaging/makeself/jobs/50-fping-5.1.install.sh
+++ b/packaging/makeself/jobs/50-fping-5.1.install.sh
@@ -16,20 +16,23 @@ export CFLAGS="-static -I/openssl-static/include -pipe"
 export LDFLAGS="-static -L/openssl-static/lib"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 
-run ./configure \
-  --prefix="${NETDATA_INSTALL_PATH}" \
-  --enable-ipv4 \
-  --enable-ipv6 \
-  --disable-dependency-tracking
+if [ "${CACHE_HIT:-0}" -eq 0 ]; then
+    run ./configure \
+        --prefix="${NETDATA_INSTALL_PATH}" \
+        --enable-ipv4 \
+        --enable-ipv6 \
+        --disable-dependency-tracking
 
-cat > doc/Makefile << EOF
-all:
-clean:
-install:
-EOF
+    cat > doc/Makefile <<-EOF
+	all:
+	clean:
+	install:
+	EOF
 
-run make clean
-run make -j "$(nproc)"
+    run make clean
+    run make -j "$(nproc)"
+fi
+
 run make install
 
 store_cache fping "${NETDATA_MAKESELF_PATH}/tmp/fping-${version}"

--- a/packaging/makeself/jobs/50-ioping-1.2.install.sh
+++ b/packaging/makeself/jobs/50-ioping-1.2.install.sh
@@ -4,11 +4,13 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
+version='1.2'
+
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building ioping" || true
 
-fetch "ioping-1.2" "https://github.com/koct9i/ioping/archive/v1.2.tar.gz" \
-    d3e4497c653a1e96df67c72ce2b70da18e9f5e3b93179a5bb57a6e30ceacfa75
+fetch "ioping-${version}" "https://github.com/koct9i/ioping/archive/v${version}.tar.gz" \
+    d3e4497c653a1e96df67c72ce2b70da18e9f5e3b93179a5bb57a6e30ceacfa75 ioping
 
 export CFLAGS="-static -pipe"
 
@@ -16,6 +18,8 @@ run make clean
 run make -j "$(nproc)"
 run mkdir -p "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/
 run install -o root -g root -m 4750 ioping "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/
+
+store_cache ioping "${NETDATA_MAKESELF_PATH}/tmp/ioping-${version}"
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   run strip "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/ioping

--- a/packaging/makeself/jobs/50-ioping-1.2.install.sh
+++ b/packaging/makeself/jobs/50-ioping-1.2.install.sh
@@ -14,8 +14,11 @@ fetch "ioping-${version}" "https://github.com/koct9i/ioping/archive/v${version}.
 
 export CFLAGS="-static -pipe"
 
-run make clean
-run make -j "$(nproc)"
+if [ "${CACHE_HIT:-0}" -eq 0 ]; then
+    run make clean
+    run make -j "$(nproc)"
+fi
+
 run mkdir -p "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/
 run install -o root -g root -m 4750 ioping "${NETDATA_INSTALL_PATH}"/usr/libexec/netdata/plugins.d/
 

--- a/packaging/makeself/uname2platform.sh
+++ b/packaging/makeself/uname2platform.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e
+
+BUILDARCH="${1}"
+
+case "${BUILDARCH}" in
+  x86_64) echo "linux/amd64" ;;
+  armv7l) echo "linux/arm/v7" ;;
+  aarch64) echo "linux/arm64/v8" ;;
+  ppc64le) echo "linux/ppc64le" ;;
+  *)
+    echo "Unknown target architecture '${BUILDARCH}'." >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
##### Summary

This adds support for build caching of the components used in our static builds that change only infrequently (OpenSSL, bash, cURL, fping, and ioping). This consists of two parts:

- Support in the static build code itself for caching these components. Cached data is stored in `artifacts/cache` in the build environment, is scoped by architecture, and is keyed by the version of the component itself.
- Use of `actions/cache@v3` in CI to cache this data across CI builds. Keying of these caches is based on the hash of the list of packages and versions in the build environment and the contents of the files responsible for actually building these components.

##### Test Plan

CI on this PR works correctly.

##### Additional Information

Effective speedup in CI is roughly 50%, based on comparing static build jobs in https://github.com/netdata/netdata/runs/6405398151 (with an empty cache) and https://github.com/netdata/netdata/runs/6407152560 (with a cache hit).

<details> <summary>For users: How does this change affect me?</summary>
No user visible changes.
</details>