### PR TITLE
Consider ZFS ARC shrincable as cache on FreeBSD

### DIFF
--- a/collectors/freebsd.plugin/freebsd_kstat_zfs.c
+++ b/collectors/freebsd.plugin/freebsd_kstat_zfs.c
@@ -5,6 +5,8 @@
 
 extern struct arcstats arcstats;
 
+unsigned long long zfs_arcstats_shrinkable_cache_size_bytes = 0;
+
 // --------------------------------------------------------------------------------------------------------------------
 // kstat.zfs.misc.arcstats
 
@@ -212,6 +214,12 @@ int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt) {
     // not used: GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.arc_meta_min", mibs.arc_meta_min, arcstats.arc_meta_min);
     // missing mib: GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.arc_need_free", mibs.arc_need_free, arcstats.arc_need_free);
     // missing mib: GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.arc_sys_free", mibs.arc_sys_free, arcstats.arc_sys_free);
+
+    if (arcstats.size > arcstats.c_min) {
+        zfs_arcstats_shrinkable_cache_size_bytes = arcstats.size - arcstats.c_min;
+    } else {
+        zfs_arcstats_shrinkable_cache_size_bytes = 0;
+    }
 
     generate_charts_arcstats("freebsd.plugin", "zfs", show_zero_charts, update_every);
     generate_charts_arc_summary("freebsd.plugin", "zfs", show_zero_charts, update_every);

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -1026,10 +1026,8 @@ int do_system_ram(int update_every, usec_t dt) {
             rd_free     = rrddim_add(st, "free",     NULL, system_pagesize, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);
             rd_active   = rrddim_add(st, "active",   NULL, system_pagesize, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);
             rd_inactive = rrddim_add(st, "inactive", NULL, system_pagesize, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);
-            rd_wired    = rrddim_add(st, "wired",    NULL, system_pagesize, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);
-#if __FreeBSD_version < 1200016
-            rd_cache    = rrddim_add(st, "cache",    NULL, system_pagesize, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);
-#endif
+            rd_wired    = rrddim_add(st, "wired",    NULL, 1, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);
+            rd_cache    = rrddim_add(st, "cache",    NULL, 1, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);
 #if defined(NETDATA_COLLECT_LAUNDRY)
             rd_laundry  = rrddim_add(st, "laundry",  NULL, system_pagesize, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);
 #endif
@@ -1040,9 +1038,11 @@ int do_system_ram(int update_every, usec_t dt) {
         rrddim_set_by_pointer(st, rd_free,     vmmeter_data.v_free_count);
         rrddim_set_by_pointer(st, rd_active,   vmmeter_data.v_active_count);
         rrddim_set_by_pointer(st, rd_inactive, vmmeter_data.v_inactive_count);
-        rrddim_set_by_pointer(st, rd_wired,    vmmeter_data.v_wire_count);
+        rrddim_set_by_pointer(st, rd_wired,    vmmeter_data.v_wire_count * system_pagesize - zfs_arcstats_shrinkable_cache_size_bytes);
 #if __FreeBSD_version < 1200016
-        rrddim_set_by_pointer(st, rd_cache,    vmmeter_data.v_cache_count);
+        rrddim_set_by_pointer(st, rd_cache,    vmmeter_data.v_cache_count * system_pagesize + zfs_arcstats_shrinkable_cache_size_bytes);
+#else
+        rrddim_set_by_pointer(st, rd_cache,    zfs_arcstats_shrinkable_cache_size_bytes);
 #endif
 #if defined(NETDATA_COLLECT_LAUNDRY)
         rrddim_set_by_pointer(st, rd_laundry,  vmmeter_data.v_laundry_count);

--- a/collectors/freebsd.plugin/plugin_freebsd.h
+++ b/collectors/freebsd.plugin/plugin_freebsd.h
@@ -49,4 +49,7 @@ extern int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt);
 extern int do_kstat_zfs_misc_zio_trim(int update_every, usec_t dt);
 extern int do_ipfw(int update_every, usec_t dt);
 
+// metrics that need to be shared among data collectors
+extern unsigned long long zfs_arcstats_shrinkable_cache_size_bytes;
+
 #endif /* NETDATA_PLUGIN_FREEBSD_H */

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -1,18 +1,6 @@
 
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-    alarm: used_ram_to_ignore
-       on: system.ram
-    class: Utilization
-     type: System
-component: Memory
-       os: freebsd
-    hosts: *
-     calc: ($zfs.arc_size.arcsz = nan)?(0):($zfs.arc_size.arcsz - $zfs.arc_size.min)
-    every: 10s
-     info: amount of memory reported as used, \
-           but it is actually capable for resizing itself based on the system needs (eg. ZFS ARC)
-
     alarm: ram_in_use
        on: system.ram
     class: Utilization
@@ -66,7 +54,7 @@ host labels: _is_k8s_node = false
 component: Memory
        os: freebsd
     hosts: *
-     calc: ($active + $wired + $laundry + $buffers - $used_ram_to_ignore) * 100 / ($active + $wired + $laundry + $buffers - $used_ram_to_ignore + $cache + $free + $inactive)
+     calc: ($active + $wired + $laundry + $buffers) * 100 / ($active + $wired + $laundry + $buffers - $used_ram_to_ignore + $cache + $free + $inactive)
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
@@ -82,7 +70,7 @@ component: Memory
 component: Memory
        os: freebsd
     hosts: *
-     calc: ($free + $inactive + $used_ram_to_ignore) * 100 / ($free + $active + $inactive + $wired + $cache + $laundry + $buffers)
+     calc: ($free + $inactive + $cache) * 100 / ($free + $active + $inactive + $wired + $cache + $laundry + $buffers)
     units: %
     every: 10s
      warn: $this < (($status >= $WARNING)  ? (15) : (10))


### PR DESCRIPTION
##### Summary
ZFS ARC is included in the wired memory class on FreeBSD. It is misleading because all the memory allocated over the `kstat.zfs.misc.arcstats.c_min` value can be reused. We move the reusable memory from `wired` to `cache`.

Fixes #12864

##### Test Plan
1. Create a ZFS pool.
2. Do some significant I/O operations on it to make the ARC cache use more memory than defined as a minimum limit.
3. Check if the `cache` dimension in the `system.ram` chart shows the amount exceeding the limit.
