### PR TITLE
Fix compilation warnings

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1293,8 +1293,7 @@ extern avl_tree_lock rrdhost_root_index;
 extern char *rrdset_strncpyz_name(char *to, const char *from, size_t length);
 extern char *rrdset_cache_dir(RRDHOST *host, const char *id);
 
-#define rrddim_free(st, rd) rrddim_free_custom(st, rd, 0)
-extern void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated);
+extern void rrddim_free(RRDSET *st, RRDDIM *rd);
 
 extern int rrddim_compare(void* a, void* b);
 extern int rrdset_compare(void* a, void* b);

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -373,9 +373,8 @@ void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
 {
     ml_delete_dimension(rd);
 
-#ifndef ENABLE_ACLK
     UNUSED(db_rotated);
-#endif
+    
     debug(D_RRD_CALLS, "rrddim_free() %s.%s", st->name, rd->name);
 
     if (!rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -369,11 +369,9 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
 // ----------------------------------------------------------------------------
 // RRDDIM remove / free a dimension
 
-void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
+void rrddim_free(RRDSET *st, RRDDIM *rd)
 {
     ml_delete_dimension(rd);
-
-    UNUSED(db_rotated);
     
     debug(D_RRD_CALLS, "rrddim_free() %s.%s", st->name, rd->name);
 

--- a/ml/Dimension.h
+++ b/ml/Dimension.h
@@ -48,7 +48,7 @@ public:
     }
 
     virtual ~RrdDimension() {
-        rrddim_free_custom(AnomalyRateRD->rrdset, AnomalyRateRD, 0);
+        rrddim_free(AnomalyRateRD->rrdset, AnomalyRateRD);
     }
 
 private:

--- a/ml/ml.h
+++ b/ml/ml.h
@@ -10,9 +10,9 @@ extern "C" {
 #include "daemon/common.h"
 #include "web/api/queries/rrdr.h"
 
-// This is an internal DBEngine function redeclared here so that we can free
+// This is a DBEngine function redeclared here so that we can free
 // the anomaly rate dimension, whenever its backing dimension is freed.
-extern void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated);
+extern void rrddim_free(RRDSET *st, RRDDIM *rd);
 
 typedef void* ml_host_t;
 typedef void* ml_dimension_t;

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -268,7 +268,7 @@ inline int parser_action(PARSER *parser, char *input)
 
     uint32_t command_hash = simple_hash(command);
 
-    size_t worker_job_id;
+    size_t worker_job_id = 0;
     while(tmp_keyword) {
         if (command_hash == tmp_keyword->keyword_hash &&
                 (!strcmp(command, tmp_keyword->keyword))) {


### PR DESCRIPTION
##### Summary
SSIA

```text
database/rrddim.c: In function 'rrddim_free_custom':
database/rrddim.c:372:53: warning: unused parameter 'db_rotated' [-Wunused-parameter]
  372 | void rrddim_free_custom(RRDSET *st, RRDDIM *rd, int db_rotated)
      |                                                 ~~~~^~~~~~~~~~
```
```text
parser/parser.c: In function 'parser_action':
parser/parser.c:292:9: warning: 'worker_job_id' may be used uninitialized [-Wmaybe-uninitialized]
  292 |         worker_is_busy(worker_job_id);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
parser/parser.c:271:12: note: 'worker_job_id' was declared here
  271 |     size_t worker_job_id;
      |            ^~~~~~~~~~~~~
```