### PR TITLE
Update reconnect node with kickstart info

### DIFF
--- a/claim/README.md
+++ b/claim/README.md
@@ -492,16 +492,12 @@ sudo rm -rf cloud.d/
 This node no longer has access to the credentials it was used when connecting to Netdata Cloud via the ACLK.
 You will still be able to see this node in your War Rooms in an **unreachable** state.
 
-If you want to reconnect this node, you need to create a new identity by adding `-id=$(uuidgen)` to
-the claiming script parameters (not yet supported on the kickstart script). Make sure that you have the `uuidgen-runtime` package installed, as it is used to run the command `uuidgen`. For example:
+If you want to reconnect this node, you need to:
+1. Ensure that the `/var/lib/netdata/cloud.d` directory doesn't exist.
+2. Ensure that the `uuidgen-runtime` package is installed. Run ```echo "$(uuidgen)"``` and validate you get back a UUID.
+3. Copy the kickstart.sh command to add a node from your space and add to the end of it `--claim-id "$(uuidgen)"` 
+4. Restart the agent
 
-**Claiming script**
-
-```bash
-sudo netdata-claim.sh -token=TOKEN -rooms=ROOM1,ROOM2 -url=https://app.netdata.cloud -id=$(uuidgen)
-```
-
-The agent _must be restarted_ after this change.
 
 ## Connecting reference
 In the sections below, you can find reference material for the kickstart script, claiming script, connecting via the Agent's command line

--- a/claim/README.md
+++ b/claim/README.md
@@ -494,9 +494,10 @@ You will still be able to see this node in your War Rooms in an **unreachable** 
 
 If you want to reconnect this node, you need to:
 1. Ensure that the `/var/lib/netdata/cloud.d` directory doesn't exist.
-2. Ensure that the `uuidgen-runtime` package is installed. Run ```echo "$(uuidgen)"``` and validate you get back a UUID.
-3. Copy the kickstart.sh command to add a node from your space and add to the end of it `--claim-id "$(uuidgen)"` 
-4. Restart the agent
+2. Stop the agent.
+3. Ensure that the `uuidgen-runtime` package is installed. Run ```echo "$(uuidgen)"``` and validate you get back a UUID.
+4. Copy the kickstart.sh command to add a node from your space and add to the end of it `--claim-id "$(uuidgen)"`. Run the command and look for the message `Node was successfully claimed.`
+5. Start the agent
 
 
 ## Connecting reference


### PR DESCRIPTION
##### Summary
The information on how to disconnect and reconnect a node was obsolete. `kickstart.sh` has supported this option for a while now. 

##### Test Plan

Validate the info is correct.

