### PR TITLE
Adjust alarms count

### DIFF
--- a/health/health_json.c
+++ b/health/health_json.c
@@ -355,7 +355,6 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
                 continue;
             if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
                 continue;
-
             if(unlikely((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status))
                 numberOfAlarms++;
         }

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -340,6 +340,8 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
             for(rc = host->alarms; rc ; rc = rc->next) {
                 if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
                     continue;
+                if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
+                    continue;
                 if(unlikely(rc->rrdset && rc->rrdset->hash_context == simple_hash(tok)
                             && !strcmp(rc->rrdset->context, tok)
                             && ((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status)))
@@ -350,6 +352,8 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
     else {
         for(rc = host->alarms; rc ; rc = rc->next) {
             if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+                continue;
+            if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
                 continue;
 
             if(unlikely((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status))


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Adjust `/api/v1/alarm_count` to match `/api/v1/alarms`.

When we fill the alarms in `health_alarms2json_fill_alarms` we take into account `rrdset_is_available_for_exporting_and_alarms`. Same consideration should be taken when counting them via `health_aggregate_alarms` to match the number of `WARNING` and `CRITICAL` (when of course we don't use the `all` parameter in `/api/v1/alarms`).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Will be tested via set team to see if it fixes a discrepancy in tests. cc @dimko 