### PR TITLE
More safe permissions for configuration files

### DIFF
--- a/system/edit-config.in
+++ b/system/edit-config.in
@@ -51,7 +51,7 @@ edit() {
     exit 1
   fi
 
-  make_it_safer()
+  make_it_safer
 
   "${EDITOR}" "${1}"
   exit $?

--- a/system/edit-config.in
+++ b/system/edit-config.in
@@ -13,6 +13,10 @@ fi
 [ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="@configdir_POST@"
 [ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
 
+make_it_safer() {
+  find "${NETDATA_USER_CONFIG_DIR}"/*/ -type f ! -perm 640 -name "*.conf" -exec chmod o-rwx {} + -exec chown root:netdata {} +
+}
+
 if [ -z "${file}" ]; then
   cat << EOF
 
@@ -33,6 +37,7 @@ EOF
 
   cd "${NETDATA_STOCK_CONFIG_DIR}" || exit 1
   ls >&2 -R ./*.conf ./*/*.conf
+  make_it_safer()
   exit 1
 
 fi
@@ -45,6 +50,8 @@ edit() {
     echo >&2 "Cannot write to ${1}! Aborting ..."
     exit 1
   fi
+
+  make_it_safer()
 
   "${EDITOR}" "${1}"
   exit $?


### PR DESCRIPTION
##### Summary

Tighten the permissions and set root:netdata ownership to /etc/netdata/*/*.conf files during edit-config.sh run.

##### Test Plan

N/A

##### Additional Information

This fix does not allow fully eliminate potential insecure configuration files permissions but makes a step towards this goal.
Another part (to be implemented yet) is to add such permissions checking to agent.
