### PR TITLE
fix(cgroups.plugin): use correct identifier when registering the main thread "chart" worker job

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -4734,7 +4734,7 @@ void *cgroups_main(void *ptr) {
     worker_register("CGROUPS");
     worker_register_job_name(WORKER_CGROUPS_LOCK, "lock");
     worker_register_job_name(WORKER_CGROUPS_READ, "read");
-    worker_register_job_name(WORKER_CGROUPS_READ, "chart");
+    worker_register_job_name(WORKER_CGROUPS_CHART, "chart");
 
     netdata_thread_cleanup_push(cgroup_main_cleanup, ptr);
 


### PR DESCRIPTION
##### Summary

ssia

https://github.com/netdata/netdata/blob/44b9fd0e13f861886ac3e428582c5f9de2c5104c/collectors/cgroups.plugin/sys_fs_cgroup.c#L4892-L4904

##### Test Plan

ci

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
