### PR TITLE
chore(cgroups.plugin): remove "enable new cgroups detected at run time" config option

### DIFF
--- a/build_external/scenarios/aclk-testing/agent_netdata.conf
+++ b/build_external/scenarios/aclk-testing/agent_netdata.conf
@@ -201,7 +201,6 @@
 	# path to /sys/fs/cgroup/devices = /sys/fs/cgroup/devices
 	# max cgroups to allow = 1000
 	# max cgroups depth to monitor = 0
-	# enable new cgroups detected at run time = yes
 	# enable by default cgroups matching =  !*/init.scope  !/system.slice/run-*.scope  *.scope  /machine.slice/*.service  !*/vcpu*  !*/emulator  !*.mount  !*.partition  !*.service  !*.socket  !*.slice  !*.swap  !*.user  !/  !/docker  !/libvirt  !/lxc  !/lxc/*/*  !/lxc.monitor  !/lxc.pivot  !/lxc.payload  !/machine  !/qemu  !/system  !/systemd  !/user  * 
 	# search for cgroups in subpaths matching =  !*/init.scope  !*-qemu  !*.libvirt-qemu  !/init.scope  !/system  !/systemd  !/user  !/user.slice  !/lxc/*/*  !/lxc.monitor  !/lxc.payload/*/*  * 
 	# script to get cgroup names = /usr/libexec/netdata/plugins.d/cgroup-name.sh

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -42,8 +42,6 @@ static int cgroup_unified_exist = CONFIG_BOOLEAN_AUTO;
 
 static int cgroup_search_in_devices = 1;
 
-static int cgroup_enable_new_cgroups_detected_at_runtime = 1;
-
 static int cgroup_check_for_new_every = 10;
 static int cgroup_update_every = 1;
 static int cgroup_containers_chart_priority = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS;
@@ -412,8 +410,6 @@ void read_cgroup_plugin_configuration() {
 
     cgroup_root_max = (int)config_get_number("plugin:cgroups", "max cgroups to allow", cgroup_root_max);
     cgroup_max_depth = (int)config_get_number("plugin:cgroups", "max cgroups depth to monitor", cgroup_max_depth);
-
-    cgroup_enable_new_cgroups_detected_at_runtime = config_get_boolean("plugin:cgroups", "enable new cgroups detected at run time", cgroup_enable_new_cgroups_detected_at_runtime);
 
     enabled_cgroup_paths = simple_pattern_create(
             config_get("plugin:cgroups", "enable by default cgroups matching",
@@ -874,9 +870,6 @@ struct discovery_thread {
 // ---------------------------------------------------------------------------------------------
 
 static inline int matches_enabled_cgroup_paths(char *id) {
-    if (!cgroup_enable_new_cgroups_detected_at_runtime) {
-        return 0;
-    }
     return simple_pattern_matches(enabled_cgroup_paths, id);
 }
 


### PR DESCRIPTION
##### Summary

This option is useless/does nothing after #12778

##### Test Plan

ci

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
