### PR TITLE
fix virtualization detection when `systemd-detect-virt` is not available

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -50,6 +50,7 @@ if [ -z "${VIRTUALIZATION}" ]; then
   if [ -z "${VIRTUALIZATION}" ]; then
     # Output from the command is outside of spec
     VIRTUALIZATION="unknown"
+    VIRT_DETECTION="none"
   else
     VIRTUALIZATION=$(virtualization_normalize_name $VIRTUALIZATION)
   fi

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -15,16 +15,11 @@ ARCHITECTURE="$(uname -m)"
 virtualization_normalize_name() {
   vname="$1"
   case "$vname" in
-  "User-mode Linux")
-    vname="uml"
-    ;;
-  "Windows Subsystem for Linux")
-    vname="wsl"
-    ;;
+  "User-mode Linux") vname="uml" ;;
+  "Windows Subsystem for Linux") vname="wsl" ;;
   esac
 
-  vname=$(echo "$vname" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
-  echo "$vname"
+  echo "$vname" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g'
 }
 
 CONTAINER="unknown"

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -41,7 +41,7 @@ if [ -z "${VIRTUALIZATION}" ]; then
     CONTAINER=${CONTAINER:-$(systemd-detect-virt -c)}
     CONT_DETECTION="systemd-detect-virt"
   else
-    if command -v lscpu 2> /dev/null; then
+    if command -v lscpu >/dev/null 2>&1; then
       VIRTUALIZATION=$(lscpu | grep "Hypervisor vendor" | cut -d: -f 2 | awk '{$1=$1};1')
       VIRT_DETECTION="lscpu"
     elif [ -n "$(command -v dmidecode)" ] && dmidecode -s system-product-name 2> /dev/null | grep -q "VMware\|Virtual\|KVM\|Bochs"; then

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -14,8 +14,6 @@ ARCHITECTURE="$(uname -m)"
 # lscpu: https://github.com/util-linux/util-linux/blob/581b77da7aa4a5205902857184d555bed367e3e0/sys-utils/lscpu.c#L52
 virtualization_normalize_name() {
   vname="$1"
-  vname=$(echo "$vname" | tr '[:upper:]' '[:lower:]')
-
   case "$vname" in
   "User-mode Linux")
     vname="uml"
@@ -25,7 +23,7 @@ virtualization_normalize_name() {
     ;;
   esac
 
-  vname=$(echo "$vname" | sed 's/ /-/g')
+  vname=$(echo "$vname" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
   echo "$vname"
 }
 


### PR DESCRIPTION
##### Summary

This PR improves virtualization detection:

- Removes (not really useful) `grep -q "^flags.*hypervisor" /proc/cpuinfo` check.
- Adds using the "Hypervisor vendor" field from `lscpu` output.

The "Hypervisor vendor" field provides more or less the same data as `systemd-detect-virt -v`:

- [systemd-detect-virt]( https://github.com/systemd/systemd/blob/df423851fcc05cf02281d11aab6aee7b476c1c3b/src/basic/virt.c#L999) known virtualization technologies values.
- [lscpu](https://github.com/util-linux/util-linux/blob/581b77da7aa4a5205902857184d555bed367e3e0/sys-utils/lscpu.c#L52) hypervisor vendors table.

##### Test Plan

Check "virtualization" on a Netdata container in GKE:

- master

```bash
# wget -q -O system-info.sh https://raw.githubusercontent.com/netdata/netdata/master/daemon/system-info.sh; sh system-info.sh | grep -i virt; rm system-info.sh
NETDATA_SYSTEM_VIRTUALIZATION=hypervisor
NETDATA_SYSTEM_VIRT_DETECTION=/proc/cpuinfo
```

- this PR

```bash
# wget -q -O system-info.sh https://raw.githubusercontent.com/ilyam8/netdata/fix_virtualization_detection/daemon/system-info.sh; sh system-info.sh | grep -i virt; rm system-info.sh
NETDATA_SYSTEM_VIRTUALIZATION=kvm
NETDATA_SYSTEM_VIRT_DETECTION=lscpu
```



##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
