### PR TITLE
fix(cgroups.plugin): improve check for uninitialized containers in k8s

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2580,7 +2580,7 @@ static inline void discovery_process_first_time_seen_cgroup(struct cgroup *cg) {
         // could be:
         //   6 (before runc, seen on GKE)
         //   runc:[0:PARENT], runc:[1:CHILD], runc:[2:INIT]
-        if (!strncmp(comm, "runc:[", 6) || isdigit(comm[0])) {
+        if (isdigit(comm[0]) || !strncmp(comm, "runc:[", 6) || !strcmp(comm, "exe")) {
             cg->first_time_seen = 1;
             return;
         }

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2577,9 +2577,8 @@ static inline void discovery_process_first_time_seen_cgroup(struct cgroup *cg) {
 
     if (is_inside_k8s && !k8s_get_container_first_proc_comm(cg->id, comm)) {
         // container initialization may take some time when CPU % is high
-        // could be:
-        //   6 (before runc, seen on GKE)
-        //   runc:[0:PARENT], runc:[1:CHILD], runc:[2:INIT]
+        // skip processes that are parent of an entrypoint (http://terenceli.github.io/%E6%8A%80%E6%9C%AF/2021/12/28/runc-internals-3)
+        // 'isdigit' for 6 (before runc, seen on GKE).
         if (isdigit(comm[0]) || !strncmp(comm, "runc:[", 6) || !strcmp(comm, "exe")) {
             cg->first_time_seen = 1;
             return;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2567,10 +2567,6 @@ static inline void discovery_find_all_cgroups_v2() {
     }
 }
 
-// could be runc:[0:PARENT], runc:[1:CHILD], runc:[2:INIT]
-#define CGROUP_RUNC_COMM_PREFIX "runc:["
-#define CGROUP_RUNC_COMM_PREFIX_LENGTH 6
-
 static inline void discovery_process_first_time_seen_cgroup(struct cgroup *cg) {
     if (!cg->first_time_seen) {
         return;
@@ -2581,7 +2577,10 @@ static inline void discovery_process_first_time_seen_cgroup(struct cgroup *cg) {
 
     if (is_inside_k8s && !k8s_get_container_first_proc_comm(cg->id, comm)) {
         // container initialization may take some time when CPU % is high
-        if (!strncmp(comm, CGROUP_RUNC_COMM_PREFIX, CGROUP_RUNC_COMM_PREFIX_LENGTH)) {
+        // could be:
+        //   6 (before runc, seen on GKE)
+        //   runc:[0:PARENT], runc:[1:CHILD], runc:[2:INIT]
+        if (!strncmp(comm, "runc:[", 6) || isdigit(comm[0])) {
             cg->first_time_seen = 1;
             return;
         }

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2567,6 +2567,10 @@ static inline void discovery_find_all_cgroups_v2() {
     }
 }
 
+// could be runc:[0:PARENT], runc:[1:CHILD], runc:[2:INIT]
+#define CGROUP_RUNC_COMM_PREFIX "runc:["
+#define CGROUP_RUNC_COMM_PREFIX_LENGTH 6
+
 static inline void discovery_process_first_time_seen_cgroup(struct cgroup *cg) {
     if (!cg->first_time_seen) {
         return;
@@ -2577,8 +2581,7 @@ static inline void discovery_process_first_time_seen_cgroup(struct cgroup *cg) {
 
     if (is_inside_k8s && !k8s_get_container_first_proc_comm(cg->id, comm)) {
         // container initialization may take some time when CPU % is high
-        // TODO: not sure run-level 2 is enough (just came across this problem on an AWS K8s cluster)
-        if (!strcmp(comm, "runc:[2:INIT]")) {
+        if (!strncmp(comm, CGROUP_RUNC_COMM_PREFIX, CGROUP_RUNC_COMM_PREFIX_LENGTH)) {
             cg->first_time_seen = 1;
             return;
         }


### PR DESCRIPTION
##### Summary

Uninitialized containers processing postponing is important because:

 - K8s API won't return data (pod/container name, etc) for them, and spending `pending_renames` makes no sense.
 - we don't really know if that is a pause container (which we should skip) or not.

After #12865 we don't disable K8s pod/container if fail to rename them. It means that identifying pause containers becomes crucial - if we fail, we collect metrics from them.

##### Test Plan

Start a lot of pods (I did 400), check that all containers discovered/renamed and there are no pause containers being collected.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
