### PR TITLE
fix `[global statistics]` section in netdata.conf

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -1495,7 +1495,7 @@ void *global_statistics_main(void *ptr)
     netdata_thread_cleanup_push(global_statistics_cleanup, ptr);
 
     int update_every =
-        (int)config_get_number("CONFIG_SECTION_GLOBAL_STATISTICS", "update every", localhost->rrd_update_every);
+        (int)config_get_number(CONFIG_SECTION_GLOBAL_STATISTICS, "update every", localhost->rrd_update_every);
     if (update_every < localhost->rrd_update_every)
         update_every = localhost->rrd_update_every;
 

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -4,8 +4,6 @@
 
 #define GLOBAL_STATS_RESET_WEB_USEC_MAX 0x01
 
-#define CONFIG_SECTION_GLOBAL_STATISTICS "global statistics"
-
 #define WORKER_JOB_GLOBAL             0
 #define WORKER_JOB_REGISTRY           1
 #define WORKER_JOB_WORKERS            2

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -844,6 +844,7 @@ void appconfig_generate(struct config *root, BUFFER *wb, int only_changed)
                || !strcmp(co->name, CONFIG_SECTION_STREAM)
                || !strcmp(co->name, CONFIG_SECTION_HOST_LABEL)
                || !strcmp(co->name, CONFIG_SECTION_ML)
+               || !strcmp(co->name, CONFIG_SECTION_GLOBAL_STATISTICS)
                     )
                 pri = 0;
             else if(!strncmp(co->name, "plugin:", 7)) pri = 1;

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -95,6 +95,7 @@
 #define CONFIG_SECTION_PROMETHEUS "prometheus:exporter"
 #define CONFIG_SECTION_HOST_LABEL "host labels"
 #define EXPORTING_CONF            "exporting.conf"
+#define CONFIG_SECTION_GLOBAL_STATISTICS "global statistics"
 
 // these are used to limit the configuration names and values lengths
 // they are not enforced by config.c functions (they will strdup() all strings, no matter of their length)


### PR DESCRIPTION
##### Summary

See "Test Plan"

##### Test Plan

- master

```ini
# per chart configuration

[CONFIG_SECTION_GLOBAL_STATISTICS]
	# update every = 1
```

- this PR

```ini
[global statistics]
	# update every = 1


# per plugin configuration
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
