### PR TITLE
user configurable sqlite PRAGMAs

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -416,6 +416,11 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
     snprintfz(buf, 1024, "PRAGMA journal_size_limit=%lld;", config_get_number(CONFIG_SECTION_SQLITE, "journal size limit", 16777216));
     if(init_database_batch(rebuild, 0, list)) return 1;
 
+    // PRAGMA schema.cache_size = pages;
+    // PRAGMA schema.cache_size = -kibibytes;
+    snprintfz(buf, 1024, "PRAGMA cache_size=%lld;", config_get_number(CONFIG_SECTION_SQLITE, "cache size", -2000));
+    if(init_database_batch(rebuild, 0, list)) return 1;
+
     if (init_database_batch(rebuild, 0, &database_config[0]))
         return 1;
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -5,8 +5,6 @@
 #define DB_METADATA_VERSION "1"
 
 const char *database_config[] = {
-    "PRAGMA auto_vacuum=incremental; PRAGMA synchronous=1 ; PRAGMA journal_mode=WAL; PRAGMA temp_store=MEMORY;",
-    "PRAGMA journal_size_limit=16777216;",
     "CREATE TABLE IF NOT EXISTS host(host_id blob PRIMARY KEY, hostname text, "
     "registry_hostname text, update_every int, os text, timezone text, tags text);",
     "CREATE TABLE IF NOT EXISTS chart(chart_id blob PRIMARY KEY, host_id blob, type text, id text, name text, "
@@ -394,6 +392,29 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
         return 1;
 
     info("SQLite database %s initialization", sqlite_database);
+
+    char buf[1024 + 1] = "";
+    const char *list[2] = { buf, NULL };
+
+    // PRAGMA schema.auto_vacuum = 0 | NONE | 1 | FULL | 2 | INCREMENTAL;
+    snprintfz(buf, 1024, "PRAGMA auto_vacuum=%s;", config_get(CONFIG_SECTION_SQLITE, "auto vacuum", "INCREMENTAL"));
+    if(init_database_batch(rebuild, 0, list)) return 1;
+
+    // PRAGMA schema.synchronous = 0 | OFF | 1 | NORMAL | 2 | FULL | 3 | EXTRA;
+    snprintfz(buf, 1024, "PRAGMA synchronous=%s;", config_get(CONFIG_SECTION_SQLITE, "synchronous", "NORMAL"));
+    if(init_database_batch(rebuild, 0, list)) return 1;
+
+    // PRAGMA schema.journal_mode = DELETE | TRUNCATE | PERSIST | MEMORY | WAL | OFF
+    snprintfz(buf, 1024, "PRAGMA journal_mode=%s;", config_get(CONFIG_SECTION_SQLITE, "journal mode", "WAL"));
+    if(init_database_batch(rebuild, 0, list)) return 1;
+
+    // PRAGMA temp_store = 0 | DEFAULT | 1 | FILE | 2 | MEMORY;
+    snprintfz(buf, 1024, "PRAGMA temp_store=%s;", config_get(CONFIG_SECTION_SQLITE, "temp store", "MEMORY"));
+    if(init_database_batch(rebuild, 0, list)) return 1;
+
+    // PRAGMA schema.journal_size_limit = N ;
+    snprintfz(buf, 1024, "PRAGMA journal_size_limit=%lld;", config_get_number(CONFIG_SECTION_SQLITE, "journal size limit", 16777216));
+    if(init_database_batch(rebuild, 0, list)) return 1;
 
     if (init_database_batch(rebuild, 0, &database_config[0]))
         return 1;

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -805,50 +805,38 @@ void appconfig_generate(struct config *root, BUFFER *wb, int only_changed)
     struct section *co;
     struct config_option *cv;
 
-    for(i = 0; i < 3 ;i++) {
-        switch(i) {
-            case 0:
-                buffer_strcat(wb,
-                    "# netdata configuration\n"
-                    "#\n"
-                    "# You can download the latest version of this file, using:\n"
-                    "#\n"
-                    "#  wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf\n"
-                    "# or\n"
-                    "#  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf\n"
-                    "#\n"
-                    "# You can uncomment and change any of the options below.\n"
-                    "# The value shown in the commented settings, is the default value.\n"
-                    "#\n"
-                    "\n# global netdata configuration\n");
-                break;
+    buffer_strcat(wb,
+                  "# netdata configuration\n"
+                  "#\n"
+                  "# You can download the latest version of this file, using:\n"
+                  "#\n"
+                  "#  wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf\n"
+                  "# or\n"
+                  "#  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf\n"
+                  "#\n"
+                  "# You can uncomment and change any of the options below.\n"
+                  "# The value shown in the commented settings, is the default value.\n"
+                  "#\n"
+                  "\n# global netdata configuration\n");
 
-            case 1:
-                buffer_strcat(wb, "\n\n# per plugin configuration\n");
-                break;
-
-            case 2:
-                buffer_strcat(wb, "\n\n# per chart configuration\n");
-                break;
-        }
-
+    for(i = 0; i <= 13 ;i++) {
         appconfig_wrlock(root);
         for(co = root->first_section; co ; co = co->next) {
-            if(!strcmp(co->name, CONFIG_SECTION_GLOBAL)
-               || !strcmp(co->name, CONFIG_SECTION_WEB)
-               || !strcmp(co->name, CONFIG_SECTION_STATSD)
-               || !strcmp(co->name, CONFIG_SECTION_PLUGINS)
-               || !strcmp(co->name, CONFIG_SECTION_CLOUD)
-               || !strcmp(co->name, CONFIG_SECTION_REGISTRY)
-               || !strcmp(co->name, CONFIG_SECTION_HEALTH)
-               || !strcmp(co->name, CONFIG_SECTION_STREAM)
-               || !strcmp(co->name, CONFIG_SECTION_HOST_LABEL)
-               || !strcmp(co->name, CONFIG_SECTION_ML)
-               || !strcmp(co->name, CONFIG_SECTION_GLOBAL_STATISTICS)
-                    )
-                pri = 0;
-            else if(!strncmp(co->name, "plugin:", 7)) pri = 1;
-            else pri = 2;
+            if(!strcmp(co->name, CONFIG_SECTION_GLOBAL))                 pri = 0;
+            else if(!strcmp(co->name, CONFIG_SECTION_HOST_LABEL))        pri = 1;
+            else if(!strcmp(co->name, CONFIG_SECTION_SQLITE))            pri = 2;
+            else if(!strcmp(co->name, CONFIG_SECTION_CLOUD))             pri = 3;
+            else if(!strcmp(co->name, CONFIG_SECTION_ML))                pri = 4;
+            else if(!strcmp(co->name, CONFIG_SECTION_HEALTH))            pri = 5;
+            else if(!strcmp(co->name, CONFIG_SECTION_STREAM))            pri = 6;
+            else if(!strcmp(co->name, CONFIG_SECTION_WEB))               pri = 7;
+            // by default, new sections will get pri = 8 (set at the end, below)
+            else if(!strcmp(co->name, CONFIG_SECTION_REGISTRY))          pri = 9;
+            else if(!strcmp(co->name, CONFIG_SECTION_GLOBAL_STATISTICS)) pri = 10;
+            else if(!strcmp(co->name, CONFIG_SECTION_STATSD))            pri = 11;
+            else if(!strcmp(co->name, CONFIG_SECTION_PLUGINS))           pri = 12;
+            else if(!strncmp(co->name, "plugin:", 7))                    pri = 13; // << change the loop too if you change this
+            else pri = 8; // this is used for any new (currently unknown) sections
 
             if(i == pri) {
                 int loaded = 0;

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -83,6 +83,7 @@
 #define CONFIG_FILENAME "netdata.conf"
 
 #define CONFIG_SECTION_GLOBAL     "global"
+#define CONFIG_SECTION_SQLITE     "sqlite"
 #define CONFIG_SECTION_WEB        "web"
 #define CONFIG_SECTION_STATSD     "statsd"
 #define CONFIG_SECTION_PLUGINS    "plugins"


### PR DESCRIPTION
This PR allows the users to configure how they want to configure sqlite for netdata.
The following section is added to `netdata.conf`:

```
[sqlite]
	# auto vacuum = INCREMENTAL
	# synchronous = NORMAL
	# journal mode = WAL
	# temp store = MEMORY
	# journal size limit = 16777216
	# cache size = -2000
```

The idea behind this, is that depending of the role of a netdata agent (child, proxy, parent), users may need to change various optimization settings for sqlite.

This PR gives them the ability to do so.