### PR TITLE
Remove Ubuntu 21.10 from CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -177,11 +177,6 @@ include:
     test:
       ebpf-core: true
   - <<: *ubuntu
-    version: "21.10"
-    packages:
-      <<: *ubuntu_packages
-      repo_distro: ubuntu/impish
-  - <<: *ubuntu
     version: "20.04"
     packages:
       <<: *ubuntu_packages

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -67,7 +67,6 @@ to work on these platforms with minimal user effort.
 | Red Hat Enterprise Linux | 8.x | x86\_64, AArch64 | |
 | Red Hat Enterprise Linux | 7.x | x86\_64 | |
 | Ubuntu | 22.04 | x86\_64, ARMv7, AArch64 | |
-| Ubuntu | 21.10 | x86\_64, i386, ARMv7, AArch64 | |
 | Ubuntu | 20.04 | x86\_64, i386, ARMv7, AArch64 | |
 | Ubuntu | 18.04 | x86\_64, i386, ARMv7, AArch64 | |
 
@@ -147,15 +146,13 @@ This is a list of platforms that we have supported in the recent past but no lon
 | -------- | ------- | ----- |
 | Alpine Linux | 3.12 | EOL as of 2022-05-01 |
 | Alpine Linux | 3.11 | EOL as of 2021-11-01 |
-| Fedora | 34 | EOL as of 2022-06-07 |
 | Debian | 9.x | EOL as of 2022-06-30 |
+| Fedora | 34 | EOL as of 2022-06-07 |
 | Fedora | 33 | EOL as of 2021-11-30 |
-| Fedora | 32 | EOL as of 2021-05-25 |
 | FreeBSD | 11-STABLE | EOL as of 2021-10-30 |
 | openSUSE | Leap 15.2 | EOL as of 2021-12-01 |
+| Ubuntu | 21.10 | EOL as of 2022-07-31 |
 | Ubuntu | 21.04 | EOL as of 2022-01-01 |
-| Ubuntu | 20.10 | EOL as of 2021-07-22 |
-| Ubuntu | 16.04 | EOL as of 2021-04-02 |
 
 ## Static builds
 


### PR DESCRIPTION
##### Summary

To be merged on 2022-07-31 when it goes EOL upstream.

##### Test Plan

n/a

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Ubuntu 21.10 (Impish Indra) will no longer receive official support from the Netdata team, and we will stop publishing packages for it.
</details>
