### PR TITLE
Remove Alpine 3.12 from CI.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -19,8 +19,6 @@ include:
     version: "3.14"
   - <<: *alpine
     version: "3.13"
-  - <<: *alpine
-    version: "3.12"
 
   - distro: archlinux
     version: latest

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -82,7 +82,6 @@ with minimal user effort.
 | -------- | ------- | ------------------------ | ----- |
 | Alpine Linux | 3.14 | No | |
 | Alpine Linux | 3.13 | No | |
-| Alpine Linux | 3.12 | No | |
 | Arch Linux | Latest | No | We officially recommend the community packages available for Arch Linux |
 | Manjaro Linux | Latest | No | We officially recommend the community packages available for Arch Linux |
 
@@ -143,6 +142,7 @@ This is a list of platforms that we have supported in the recent past but no lon
 
 | Platform | Version | Notes |
 | -------- | ------- | ----- |
+| Alpine Linux | 3.12 | EOL as of 2022-05-01 |
 | Alpine Linux | 3.11 | EOL as of 2021-11-01 |
 | Alpine Linux | 3.10 | EOL as of 2021-05-01 |
 | Fedora | 33 | EOL as of 2021-11-30 |


### PR DESCRIPTION

##### Summary

It went EOL upstream on 2022-05-01.

##### Test Plan

n/a

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
The Netdata team will no longer provide official support for Alpine Linux 3.12.
</details>
