### PR TITLE
collectors: apps.plugin: apps_groups: update net, aws, ha groups

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -128,9 +128,10 @@ email: dovecot imapd pop3d amavis* zmstat* zmmailboxdmgr saslauthd opendkim post
 
 ppp: ppp*
 vpn: openvpn pptp* cjdroute gvpe tincd wireguard
-wifi: hostapd wpa_supplicant NetworkManager
+wifi: hostapd wpa_supplicant
 routing: ospfd* ospf6d* bgpd bfdd fabricd isisd eigrpd sharpd staticd ripd ripngd pimd pbrd nhrpd ldpd zebra vrrpd vtysh bird*
 modem: ModemManager
+netmanager: NetworkManager nm* systemd-networkd networkctl netplan
 tor: tor
 
 # -----------------------------------------------------------------------------
@@ -138,7 +139,7 @@ tor: tor
 
 camo: *camo*
 balancer: ipvs_* haproxy
-ha: corosync hs_logd ha_logd stonithd pacemakerd lrmd crmd
+ha: corosync hs_logd ha_logd stonithd pacemakerd lrmd crmd keepalived
 
 # -----------------------------------------------------------------------------
 # telephony
@@ -182,7 +183,7 @@ heapster: heapster
 # -----------------------------------------------------------------------------
 # AWS
 
-aws-s3: '*aws s3*'
+aws-s3: '*aws s3*' s3cmd s5cmd
 aws: aws
 
 # -----------------------------------------------------------------------------
@@ -354,4 +355,3 @@ gremlin: gremlin*
 # load testing tools
 
 locust: locust
-


### PR DESCRIPTION
* added [keepalived](https://github.com/acassen/keepalived) to `ha` group
* added [s3cmd](https://github.com/s3tools/s3cmd) & [s5cmd](https://github.com/peak/s5cmd) tools to `aws-s3` group
* created `netmanager` group, cause `wifi` group was bemused me once - what wifi on my server? Ah, this is [NetworkManager](https://gitlab.freedesktop.org/NetworkManager/NetworkManager) 🤔
* also added [netplan](https://github.com/canonical/netplan) & [systemd-networkd](https://www.freedesktop.org/software/systemd/man/systemd-networkd.service.html#) to `netmanagers`