### PR TITLE
Restore a broken symbolic link

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,1 @@
 .gitignore
-
-# Jupyter notebook checkpoints
-.ipynb_checkpoints
-# Jupyter notebooks
-.ipynb


### PR DESCRIPTION
##### Summary

A symbolic link (`.dockerignore` -> `.gitignore`) was broken in #12313. The PR restores it. @andrewm4894, if you want to change the file, you should copy the contents of `.gitignore` and then change `.dockerignore`.