### PR TITLE
chore(fping.plugin): bump default fping version to 5.1

### DIFF
--- a/collectors/fping.plugin/fping.plugin.in
+++ b/collectors/fping.plugin/fping.plugin.in
@@ -16,7 +16,7 @@ if [ "${1}" = "install" ]
     then
     [ "${UID}" != 0 ] && echo >&2 "Please run me as root. This will install a single binary file: /usr/local/bin/fping." && exit 1
 
-    [ -z "${2}" ] && fping_version="5.0" || fping_version="${2}"
+    [ -z "${2}" ] && fping_version="5.1" || fping_version="${2}"
 
     run() {
         printf >&2 " > "


### PR DESCRIPTION
##### Summary

Bump `fping` version to [v5.1](https://github.com/schweikert/fping/releases/tag/v5.1) which contains some Netdata-related fixes.

---

The static build was updated in #12461.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
