### PR TITLE
Adjust the dimension liveness status check

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1274,7 +1274,9 @@ extern void rrddim_isnot_obsolete(RRDSET *st, RRDDIM *rd);
 
 extern collected_number rrddim_set_by_pointer(RRDSET *st, RRDDIM *rd, collected_number value);
 extern collected_number rrddim_set(RRDSET *st, const char *id, collected_number value);
+#if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
 extern time_t calc_dimension_liveness(RRDDIM *rd, time_t now);
+#endif
 extern long align_entries_to_pagesize(RRD_MEMORY_MODE mode, long entries);
 
 // ----------------------------------------------------------------------------

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1274,7 +1274,7 @@ extern void rrddim_isnot_obsolete(RRDSET *st, RRDDIM *rd);
 
 extern collected_number rrddim_set_by_pointer(RRDSET *st, RRDDIM *rd, collected_number value);
 extern collected_number rrddim_set(RRDSET *st, const char *id, collected_number value);
-
+extern time_t calc_dimension_liveness(RRDDIM *rd, time_t now);
 extern long align_entries_to_pagesize(RRD_MEMORY_MODE mode, long entries);
 
 // ----------------------------------------------------------------------------

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -181,7 +181,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
             debug(D_METADATALOG, "DIMENSION [%s] metadata updated", rd->id);
             (void)sql_store_dimension(&rd->state->metric_uuid, rd->rrdset->chart_uuid, rd->id, rd->name, rd->multiplier, rd->divisor,
                                       rd->algorithm);
-
+            queue_dimension_to_aclk(rd, calc_dimension_liveness(rd, now_realtime_sec()));
             rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
             rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
         }

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -141,9 +141,6 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
     RRDHOST *host = st->rrdhost;
     rrdset_wrlock(st);
 
-    rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
-    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
-
     RRDDIM *rd = rrddim_find(st, id);
     if(unlikely(rd)) {
         debug(D_RRD_CALLS, "Cannot create rrd dimension '%s/%s', it already exists.", st->id, name?name:"<NONAME>");
@@ -168,10 +165,16 @@ RRDDIM *rrddim_add_custom(RRDSET *st, const char *id, const char *name, collecte
             debug(D_METADATALOG, "DIMENSION [%s] metadata updated", rd->id);
             (void)sql_store_dimension(&rd->state->metric_uuid, rd->rrdset->chart_uuid, rd->id, rd->name, rd->multiplier, rd->divisor,
                                       rd->algorithm);
+
+            rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
+            rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
         }
         rrdset_unlock(st);
         return rd;
     }
+
+    rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
+    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
 
     char filename[FILENAME_MAX + 1];
     char fullfilename[FILENAME_MAX + 1];

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1489,7 +1489,7 @@ restart_after_removal:
                         }
 #if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
                         else
-                            queue_dimension_to_aclk(rd);
+                            queue_dimension_to_aclk(rd, rd->last_collected_time.tv_sec);
 #endif
                     }
                     last = rd;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1798,12 +1798,8 @@ after_second_database_work:
 
 #if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
         if (likely(!st->state->is_ar_chart)) {
-            if (!rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN) && likely(rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
-                int live =
-                    ((mark - rd->last_collected_time.tv_sec) < RRDSET_MINIMUM_DIM_LIVE_MULTIPLIER * rd->update_every);
-                if (unlikely(live != rd->state->aclk_live_status))
-                    queue_dimension_to_aclk(rd);
-            }
+            if (!rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN) && likely(rrdset_flag_check(st, RRDSET_FLAG_ACLK)))
+                queue_dimension_to_aclk(rd, calc_dimension_liveness(rd, mark));
         }
 #endif
         if(unlikely(!rd->updated))
@@ -1906,7 +1902,7 @@ after_second_database_work:
                         } else {
                             /* Do not delete this dimension */
 #if defined(ENABLE_ACLK) && defined(ENABLE_NEW_CLOUD_PROTOCOL)
-                            queue_dimension_to_aclk(rd);
+                            queue_dimension_to_aclk(rd, calc_dimension_liveness(rd, mark));
 #endif
                             last = rd;
                             rd = rd->next;

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -58,18 +58,30 @@ bind_fail:
     return send_status;
 }
 
-static int aclk_add_chart_payload(struct aclk_database_worker_config *wc, uuid_t *uuid, char *claim_id,
-                                  ACLK_PAYLOAD_TYPE payload_type, void *payload, size_t payload_size, time_t *send_status)
+static int aclk_add_chart_payload(
+    struct aclk_database_worker_config *wc,
+    uuid_t *uuid,
+    char *claim_id,
+    ACLK_PAYLOAD_TYPE payload_type,
+    void *payload,
+    size_t payload_size,
+    time_t *send_status,
+    int check_sent)
 {
     static __thread sqlite3_stmt *res_chart = NULL;
     int rc;
     time_t date_submitted;
 
-    date_submitted = payload_sent(wc->uuid_str, uuid, payload, payload_size);
-    if (send_status)
-        *send_status = date_submitted;
-    if (date_submitted)
+    if (unlikely(!payload))
         return 0;
+
+    if (check_sent) {
+        date_submitted = payload_sent(wc->uuid_str, uuid, payload, payload_size);
+        if (send_status)
+            *send_status = date_submitted;
+        if (date_submitted)
+            return 0;
+    }
 
     if (unlikely(!res_chart)) {
         char sql[ACLK_SYNC_QUERY_SIZE];

--- a/database/sqlite/sqlite_aclk_chart.h
+++ b/database/sqlite/sqlite_aclk_chart.h
@@ -16,9 +16,19 @@ extern sqlite3 *db_meta;
 #define RRDSET_MINIMUM_DIM_LIVE_MULTIPLIER   (3)
 #endif
 
+#ifndef RRDSET_MINIMUM_DIM_OFFLINE_MULTIPLIER
+#define RRDSET_MINIMUM_DIM_OFFLINE_MULTIPLIER (30)
+#endif
+
 #ifndef ACLK_MAX_DIMENSION_CLEANUP
 #define ACLK_MAX_DIMENSION_CLEANUP (500)
 #endif
+
+struct aclk_chart_dimension_data {
+    uuid_t uuid;
+    char *payload;
+    size_t payload_size;
+};
 
 struct aclk_chart_sync_stats {
     int        updates;
@@ -37,7 +47,7 @@ struct aclk_chart_sync_stats {
 };
 
 extern int queue_chart_to_aclk(RRDSET *st);
-extern void queue_dimension_to_aclk(RRDDIM *rd);
+extern void queue_dimension_to_aclk(RRDDIM *rd, time_t last_updated);
 extern void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id);
 int aclk_add_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 int aclk_add_dimension_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);


### PR DESCRIPTION
Fixes #12909
Fixes #12662

##### Summary
Adjust the dimension collected state calculation to avoid sending too many messages
when switching from collected to non collected state. 

Switching from collected to non collected state will produce a message after MIN(rrdset_free_obsolete_time, 30 * chart_update_every) seconds. This will also result in reduced network and disk I/O

##### Test Plan
- Any application monitored by apps plugin that starts and stops frequently will generate dimensions that switch from 
  collected to non collected in a short period of time. 
  This will generate separate messages to go to the cloud. Notice messages 
  in the access.log as CHARTS SENT messages
- Apply the PR and notice less messages being generated (recorded in the metadata database and sent to the cloud)


