### PR TITLE
Prevent command_to_be_logged from overflowing

### DIFF
--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1111,14 +1111,13 @@ char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len) {
 }
 
 int vsnprintfz(char *dst, size_t n, const char *fmt, va_list args) {
+    if(unlikely(!n)) return 0;
+
     int size = vsnprintf(dst, n, fmt, args);
+    dst[n - 1] = '\0';
 
-    if (unlikely((size_t) size > n)) {
-        // truncated
-        size = (int)n;
-    }
+    if (unlikely((size_t) size > n)) size = (int)n;
 
-    dst[size] = '\0';
     return size;
 }
 

--- a/libnetdata/popen/popen.c
+++ b/libnetdata/popen/popen.c
@@ -95,7 +95,7 @@ static inline void convert_argv_to_string(char *dst, size_t size, const char *sp
 static int custom_popene(volatile pid_t *pidptr, char **env, uint8_t flags, FILE **fpp, const char *command, const char *spawn_argv[]) {
     // create a string to be logged about the command we are running
     char command_to_be_logged[2048];
-    convert_argv_to_string(command_to_be_logged, sizeof(command_to_be_logged) - 1, spawn_argv);
+    convert_argv_to_string(command_to_be_logged, sizeof(command_to_be_logged), spawn_argv);
     // info("custom_popene() running command: %s", command_to_be_logged);
 
     FILE *fp = NULL;

--- a/libnetdata/popen/popen.c
+++ b/libnetdata/popen/popen.c
@@ -95,7 +95,7 @@ static inline void convert_argv_to_string(char *dst, size_t size, const char *sp
 static int custom_popene(volatile pid_t *pidptr, char **env, uint8_t flags, FILE **fpp, const char *command, const char *spawn_argv[]) {
     // create a string to be logged about the command we are running
     char command_to_be_logged[2048];
-    convert_argv_to_string(command_to_be_logged, sizeof(command_to_be_logged), spawn_argv);
+    convert_argv_to_string(command_to_be_logged, sizeof(command_to_be_logged) - 1, spawn_argv);
     // info("custom_popene() running command: %s", command_to_be_logged);
 
     FILE *fp = NULL;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR tries to prevent the variable `command_to_be_logged` from overflowing. If it happens, it can result in corruption and random crashes.

I believe this is the crash reported in #12880.

The analytics commands tend to be more than 2048 bytes that the variable `command_to_be_logged` is defined. During tests the crash is pretty reproducible when analytics tries to execute the external script with many parameters that span more than 2048 bytes. It is more evident in FreeBSD/arm.

The crash is actually reported in line https://github.com/netdata/netdata/blob/4616491f1a2561285197126fe4683edc71001455/daemon/analytics.c#L1018 but actually is caused by previous corruption.

With either this patch, or by using `popen` instead of `mypopen`, I could no longer trigger the crash.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Try it if possible on FreeBSD arm. Most likely it's the most finicky system to observe. Let it run at least for 2 minutes until the agent tries to send a `META_START` event. It should crash. Using this PR it should not.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
