### PR TITLE
Optimize the dimensions option store to the metadata database

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -170,6 +170,7 @@ typedef enum rrddim_flags {
     RRDDIM_FLAG_ACLK                            = (1 << 4),
 
     RRDDIM_FLAG_PENDING_FOREACH_ALARM           = (1 << 5), // set when foreach alarm has not been initialized yet
+    RRDDIM_FLAG_META_HIDDEN                     = (1 << 6), // Status of hidden option in the metadata database
 } RRDDIM_FLAGS;
 
 #define rrddim_flag_check(rd, flag) (__atomic_load_n(&((rd)->flags), __ATOMIC_SEQ_CST) & (flag))

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -472,9 +472,11 @@ int rrddim_hide(RRDSET *st, const char *id) {
         error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, st->name, st->id, host->hostname);
         return 1;
     }
-    (void) sql_set_dimension_option(&rd->state->metric_uuid, "hidden");
+    if (!rrddim_flag_check(rd, RRDDIM_FLAG_META_HIDDEN))
+        (void)sql_set_dimension_option(&rd->state->metric_uuid, "hidden");
 
     rrddim_flag_set(rd, RRDDIM_FLAG_HIDDEN);
+    rrddim_flag_set(rd, RRDDIM_FLAG_META_HIDDEN);
     return 0;
 }
 
@@ -487,9 +489,11 @@ int rrddim_unhide(RRDSET *st, const char *id) {
         error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, st->name, st->id, host->hostname);
         return 1;
     }
-    (void) sql_set_dimension_option(&rd->state->metric_uuid, NULL);
+    if (rrddim_flag_check(rd, RRDDIM_FLAG_META_HIDDEN))
+        (void)sql_set_dimension_option(&rd->state->metric_uuid, NULL);
 
     rrddim_flag_clear(rd, RRDDIM_FLAG_HIDDEN);
+    rrddim_flag_clear(rd, RRDDIM_FLAG_META_HIDDEN);
     return 0;
 }
 


### PR DESCRIPTION
##### Summary
Use a flag on the dimension to "cache" the hidden state of the dimension that was stored last in the database to avoid updating it needlessly.

##### Test Plan
- The dimension count in the database containing the "hidden" option should be the same before and after this PR
  - connecting to the `netdata-meta.db` using e.g the sqlite3 CLI and running 
    `select count(*) from dimension where options = "hidden";` should return the same count of dimensions before and 
   after running this PR.
   You can even do an 
   `update dimension set options = null where options = "hidden";` 
   and restart the agent. The count of dimensions should be the same.
