### PR TITLE
Trigger queue removed alerts on health log exchange with cloud

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -34,7 +34,7 @@ time_t last_disconnect_time = 0;
 time_t next_connection_attempt = 0;
 float last_backoff_value = 0;
 
-int aclk_alert_reloaded = 1; //1 on startup, and again on health_reload
+int aclk_alert_reloaded = 0; //1 on health log exchange, and again on health_reload
 
 time_t aclk_block_until = 0;
 

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -557,6 +557,8 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
 
     freez(claim_id);
     buffer_free(sql);
+
+    aclk_alert_reloaded = 1;
 #endif
 
     return;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Right now, "orphan" removed events are queued to go to cloud either when the agent starts, or after a health reload. This also includes the events for a child's database as well as the parent's in a parent - child setup.

The removed events are triggered to go out after a couple of health loops to ensure only those left without an update really go out.

However, if a child delays connection to a parent after a restart, it could miss the window of opportunity when the removed alerts are queued. This PR will instead stop trying to do it on agent startup and instead will trigger when the health log is exchanged with the cloud. Again the actual queuing will happen after a couple of health loops after that trigger.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

We need a claimed parent for this. On a single setup startup there should be a `Queued removed alerts.` for that host. Connect a child after that point, and after a while again a `Queued removed alerts.` should appear for the child.

Note that when triggered, it will try to queue for all hosts. There will be a follow up to optimize this behavior.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
