### PR TITLE
Suppress warning when freeing a NULL pointer in onewayalloc_freez

### DIFF
--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -133,6 +133,9 @@ void onewayalloc_freez(ONEWAYALLOC *owa __maybe_unused, const void *ptr __maybe_
     // so try to find it in our memory and if it is not there
     // log an error
 
+    if (unlikely(!ptr))
+        return;
+
     OWA_PAGE *head = (OWA_PAGE *)owa;
     OWA_PAGE *page;
     size_t seeking = (size_t)ptr;


### PR DESCRIPTION
##### Summary
Trying to free a NULL pointer in onewayalloc_freez should be a no op. 

Now it will log an error message 

```
ONEWAYALLOC: request to free address 0x(nil) that is not allocated by this OWA
```
This can be triggered when running a context query on a node that is offline (e.g. a child that has disconnected from the parent)

Checking for correctness of the pointer passed to the onewayalloc_freez function is only triggered when compiling with
NETDATA_INTERNAL_CHECKS

##### Test Plan
- Setup parent - child and start both (parent should be compiled with NETDATA_INTERNAL_CHECKS)
- Then stop child and parent
- Start only parent
  Run a context query on the parent and you would notice the warning in the error log e.g
  `http://127.0.0.1:19999/host/<child>/api/v1/data?context=cpu.cpu`
- Apply the PR and retry

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
