### PR TITLE
Cleanup chart hash and map tables on startup

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -60,6 +60,8 @@ const char *database_cleanup[] = {
     "delete from chart where chart_id not in (select chart_id from dimension);",
     "delete from host where host_id not in (select host_id from chart);",
     "delete from chart_label where chart_id not in (select chart_id from chart);",
+    "DELETE FROM chart_hash_map WHERE chart_id NOT IN (SELECT chart_id FROM chart);",
+    "DELETE FROM chart_hash WHERE hash_id NOT IN (SELECT hash_id FROM chart_hash_map);",
     "DELETE FROM node_instance WHERE host_id NOT IN (SELECT host_id FROM host);",
     NULL
 };


### PR DESCRIPTION
##### Summary
Perform a cleanup during startup on the chart_hash and chart_hash_map tables. 

In a following PR this will also happen while the agent is running

##### Test Plan
- If there are stale entries, restarting the agent will remove them. Check the entries in those tables before and after applying the PR
  `select count(*) from chart_hash;`
  `select count(*) from chart_hash_map;`
