### PR TITLE
statsd sets should count unique values

### DIFF
--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -601,7 +601,7 @@ static inline void statsd_process_set(STATSD_METRIC *m, const char *value) {
     else {
         void *t = dictionary_get(m->set.dict, value);
         if (unlikely(!t)) {
-            dictionary_set(m->set.dict, value, NULL, 1);
+            dictionary_set(m->set.dict, value, "", 1);
             m->set.unique++;
         }
 


### PR DESCRIPTION
Ancient bug in statsd SETs.
Passing a NULL as the value to the dictionary means the comparison for NULL on dictionary_get() is always NULL.
Yes, I know... since 2017...