### PR TITLE
fix: keep virtualization unknown if all used commands are not available

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -30,28 +30,25 @@ if [ -z "${VIRTUALIZATION}" ]; then
   VIRTUALIZATION="unknown"
   VIRT_DETECTION="none"
 
-  if [ -n "$(command -v systemd-detect-virt 2> /dev/null)" ]; then
+  if command -v systemd-detect-virt >/dev/null 2>&1; then
     VIRTUALIZATION="$(systemd-detect-virt -v)"
     VIRT_DETECTION="systemd-detect-virt"
     CONTAINER=${CONTAINER:-$(systemd-detect-virt -c)}
     CONT_DETECTION="systemd-detect-virt"
-  else
-    if command -v lscpu >/dev/null 2>&1; then
-      VIRTUALIZATION=$(lscpu | grep "Hypervisor vendor" | cut -d: -f 2 | awk '{$1=$1};1')
-      VIRT_DETECTION="lscpu"
-    elif [ -n "$(command -v dmidecode)" ] && dmidecode -s system-product-name 2> /dev/null | grep -q "VMware\|Virtual\|KVM\|Bochs"; then
-      VIRTUALIZATION="$(dmidecode -s system-product-name)"
-      VIRT_DETECTION="dmidecode"
-    else
-      VIRTUALIZATION="none"
-    fi
+  elif command -v lscpu >/dev/null 2>&1; then
+    VIRTUALIZATION=$(lscpu | grep "Hypervisor vendor:" | cut -d: -f 2 | awk '{$1=$1};1')
+    [ -n "$VIRTUALIZATION" ] && VIRT_DETECTION="lscpu"
+    [ -z "$VIRTUALIZATION" ] && lscpu | grep -q "Virtualization:" && VIRTUALIZATION="none"
+  elif command -v dmidecode >/dev/null 2>&1; then
+    VIRTUALIZATION=$(dmidecode -s system-product-name 2>/dev/null | grep "VMware\|Virtual\|KVM\|Bochs")
+    [ -n "$VIRTUALIZATION" ] && VIRT_DETECTION="dmidecode"
   fi
 
   if [ -z "${VIRTUALIZATION}" ]; then
     # Output from the command is outside of spec
     VIRTUALIZATION="unknown"
     VIRT_DETECTION="none"
-  else
+  elif [ "$VIRTUALIZATION" != "none" ] && [ "$VIRTUALIZATION" != "unknown" ]; then
     VIRTUALIZATION=$(virtualization_normalize_name $VIRTUALIZATION)
   fi
 else

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -44,6 +44,11 @@ if [ -z "${VIRTUALIZATION}" ]; then
     [ -n "$VIRTUALIZATION" ] && VIRT_DETECTION="dmidecode"
   fi
 
+  if [ -z "${VIRTUALIZATION}" ] && [ "${KERNEL_NAME}" = "FreeBSD" ]; then
+    VIRTUALIZATION=$(sysctl kern.vm_guest 2>/dev/null | cut -d: -f 2 | awk '{$1=$1};1')
+    [ -n "$VIRTUALIZATION" ] && VIRT_DETECTION="sysctl"
+  fi
+
   if [ -z "${VIRTUALIZATION}" ]; then
     # Output from the command is outside of spec
     VIRTUALIZATION="unknown"


### PR DESCRIPTION
##### Summary

We need this because we don't query Cloud instance metadata for bare metal hosts:

https://github.com/netdata/netdata/blob/675bd3e01a0366610b2a82cbca22fbf2489ca5cf/daemon/system-info.sh#L434-L436

For virtualization detection we use:
 - `systemd-detect-virt`
 - `lscpu`
 - `dmidecode`
 
If none of those commands are available on the system we shouldn't assume that the host is a bare-metal host.

---

Also, this PR adds virtualization detection for FreeBSD using `sysctl kern.vm_guest` thx to @cpipilas 

##### Test Plan

Run updated system-info script on:
 - bare-metal host
 - qemu vm
 - freebsd vm on AWS
 - linux vm on GCP (k8s host)

and check the output (virtualization and cloud_* data).

---

@cpipilas I think after this PR a lot of "bare metal" hosts will appears as "unknown" on the Cloud. But that is closer to the truth I guess.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
