### PR TITLE
cleanup and optimize rrdeng_load_metric_next()

### DIFF
--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -52,6 +52,7 @@ struct rrdeng_query_handle {
     storage_number *page;
     usec_t page_end_time;
     uint32_t page_length;
+    usec_t dt;
 };
 
 typedef enum {

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -554,7 +554,7 @@ void rrdeng_load_metric_init(RRDDIM *rd, struct rrddim_query_handle *rrdimm_hand
         handle->next_page_time = INVALID_TIME;
 }
 
-static int rrdend_load_page_next(struct rrddim_query_handle *rrdimm_handle, unsigned *position_ptr) {
+static int rrdeng_load_page_next(struct rrddim_query_handle *rrdimm_handle, unsigned *position_ptr) {
     struct rrdeng_query_handle *handle = (struct rrdeng_query_handle *)rrdimm_handle->handle;
 
     struct rrdengine_instance *ctx = handle->ctx;
@@ -632,7 +632,7 @@ storage_number rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle
 
     if (unlikely(!descr || position >= (handle->page_length / sizeof(storage_number)))) {
         // We need to get a new page
-        if(rrdend_load_page_next(rrdimm_handle, &position))
+        if(rrdeng_load_page_next(rrdimm_handle, &position))
             goto no_more_metrics;
 
         descr = handle->descr;


### PR DESCRIPTION
I noticed that `rrdeng_load_metric_next()` was way too heavy. Using `perf top` while stressing netdata, I found out that `rrdeng_load_metric_next()` was about 5 times heavier than `unpack_storage_number()`.

In this PR, `rrdeng_load_metric_next()` is split into 2 functions:

1. `rrdeng_load_metric_next()` that fetches the next metric
2. `rrdeng_load_page_next()` that is called by the above when a new page needs to be loaded

The interesting part was in the following code:

```c
    entries = page_length / sizeof(storage_number);

    if (entries > 1) {
        usec_t dt;

        dt = (page_end_time - descr->start_time) / (entries - 1);
        current_position_time = descr->start_time + position * dt;
    } else {
        current_position_time = descr->start_time;
    }
```

The code above calculates the time of the current point in the database, but in order to do so, it calculates the page length and the duration of each point in the database, which is... fixed for the entire page but it does it... for every point!

After the rearrangement and the cleanup of the code, the weight of `rrdeng_load_metric_next()` in `perf top` is the same with `unpack_storage_number()`, which drastically improved the performance of the query engine.

## Tests

Get context `net.net` for 5 days, using 24 workers doing 1000 fetches each, using the command:

```sh
siege --concurrent=24 --reps=1000 --no-parser --benchmark "http://localhost:19999/api/v1/data?context=net.net&before=0&after=-$[86400*5]&options=jsonwrap,unaligned&points=10"
```

Current master (repeated many times, all like this):

```
Transactions:              24000 hits
Availability:             100.00 %
Elapsed time:              31.83 secs
Data transferred:          14.95 MB
Response time:              0.03 secs
Transaction rate:         754.01 trans/sec
Throughput:             0.47 MB/sec
Concurrency:               23.41
Successful transactions:       24000
Failed transactions:               0
Longest transaction:            0.14
Shortest transaction:           0.00
```

This PR (again repeated many times, all like this):

```
Transactions:              24000 hits
Availability:             100.00 %
Elapsed time:              21.15 secs
Data transferred:          14.93 MB
Response time:              0.02 secs
Transaction rate:        1134.75 trans/sec
Throughput:             0.71 MB/sec
Concurrency:               23.39
Successful transactions:       24000
Failed transactions:               0
Longest transaction:            0.08
Shortest transaction:           0.00
```

- The duration of the test improved by 34% (from 31.83 secs to 21.15 secs)
- The transaction rate improved by 50% (from 754 to 1134 transactions/sec)

