### PR TITLE
Return rc->last_update from alarms_values api

### DIFF
--- a/health/health_json.c
+++ b/health/health_json.c
@@ -165,6 +165,10 @@ static inline void health_rrdcalc_values2json_nolock(RRDHOST *host, BUFFER *wb, 
     buffer_rrd_value(wb, rc->value);
     buffer_strcat(wb, ",\n");
 
+    buffer_strcat(wb, "\t\t\t\"when\":");
+    buffer_sprintf(wb, "%lu", (unsigned long)rc->last_updated);
+    buffer_strcat(wb, ",\n");
+
     buffer_sprintf(wb,
                    "\t\t\t\"status\": \"%s\"\n"
                    , rrdcalc_status2string(rc->status));


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Adds the `last_updated` timestamp of the alert to the `/api/v1/alarms_values` endpoint.

The time refers to the last calculated time of that alert, i.e. it should be the time that the value was updated.

![image](https://user-images.githubusercontent.com/1905463/169482541-2c58c7ca-aea1-48ad-9717-3e799aab070d.png)

Requested by FE to aid in an ongoing project, cc @jacekkolasa 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Raise an alert and visit `/api/v1/alarms_values` endpoint. It should have a new `when` field.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
