### PR TITLE
Do not store metric if not actually collected

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1212,9 +1212,6 @@ static inline size_t rrdset_done_interpolate(
 
             if(unlikely(!store_this_entry)) {
                 (void) ml_is_anomalous(rd, 0, false);
-
-                rd->state->collect_ops.store_metric(rd, next_store_ut, SN_EMPTY_SLOT);
-//                rd->values[current_entry] = SN_EMPTY_SLOT;
                 continue;
             }
 
@@ -1248,9 +1245,6 @@ static inline size_t rrdset_done_interpolate(
                           , current_entry
                 );
                 #endif
-
-//                rd->values[current_entry] = SN_EMPTY_SLOT;
-                rd->state->collect_ops.store_metric(rd, next_store_ut, SN_EMPTY_SLOT);
                 rd->last_stored_value = NAN;
             }
 


### PR DESCRIPTION
##### Summary
Avoid storing an entry with SN_EMPTY_SLOT if the RD has not been updated or there is an indication to not store the entry

##### Test Plan
- Obsoleting a single dimension on a chart and running a data query on it, should not report data being collected (with NULL values)

##### Additional Information
Storing an entry with SN_EMPTY_SLOT will generate NULL values when a query runs on that data (it would do so anyway if there was a collection gap)  but it will also update the collected _end_time_ for the dimension which is not what we want)
