### PR TITLE
storage engine: add comment to specify end-of-list marker

### DIFF
--- a/database/storage_engine.c
+++ b/database/storage_engine.c
@@ -83,6 +83,7 @@ static STORAGE_ENGINE engines[] = {
         }
     },
 #endif
+    // End-of-list identified by name = NULL
     { .id = RRD_MEMORY_MODE_NONE, .name = NULL }
 };
 


### PR DESCRIPTION
##### Summary

This removes RRD_MEMORY_MODE_NONE as end-of-list marker that was introduced with the storage engine API.

##### Test Plan

This was not currently used to check for end-of-list so this change is of no consequence.
