### PR TITLE
query engine optimizations and cleanup

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -630,19 +630,25 @@ static inline void do_dimension_fixedstep(
         }
 
         for ( ; now <= db_now ; now += dt) {
-            if(likely(now >= db_now && does_storage_number_exist(n))) {
+            if(likely(does_storage_number_exist(n))) {
+
 #if defined(NETDATA_INTERNAL_CHECKS) && defined(ENABLE_DBENGINE)
-                struct rrdeng_query_handle* rrd_handle = (struct rrdeng_query_handle*)handle.handle;
-                if ((rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) && (now != rrd_handle->now)) {
-                    error("INTERNAL CHECK: Unaligned query for %s, database time: %ld, expected time: %ld", rd->id, (long)rrd_handle->now, (long)now);
+                if(now >= db_now) {
+                    struct rrdeng_query_handle *rrd_handle = (struct rrdeng_query_handle *)handle.handle;
+                    if ((rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) && (now != rrd_handle->now))
+                        error(
+                            "INTERNAL CHECK: Unaligned query for %s, database time: %ld, expected time: %ld",
+                            rd->id,
+                            (long)rrd_handle->now,
+                            (long)now);
                 }
 #endif
+
                 if(likely(value != 0.0))
                     values_in_group_non_zero++;
 
                 if(unlikely(did_storage_number_reset(n)))
                     group_value_flags |= RRDR_VALUE_RESET;
-
             }
 
             // add this value for grouping

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -599,11 +599,28 @@ static inline void do_dimension_fixedstep(
 #endif
 
         db_now = now; // this is needed to set db_now in case the next_metric implementation does not set it
+
         storage_number n;
-        if (unlikely(rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE && now <= first_time_t))
+        calculated_number value;
+
+        if (unlikely(rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE && now <= first_time_t)) {
             n = SN_EMPTY_SLOT;
-        else
+            value = NAN;
+        }
+        else {
+            // load the metric value
             n = next_metric(&handle, &db_now);
+
+            // and unpack it
+            if(likely(does_storage_number_exist(n))) {
+                if (options & RRDR_OPTION_ANOMALY_BIT)
+                    value = (n & SN_ANOMALY_BIT) ? 0.0 : 100.0;
+                else
+                    value = unpack_storage_number(n);
+            }
+            else
+                value = NAN;
+        }
 
         if(unlikely(db_now > before_wanted)) {
 #ifdef NETDATA_INTERNAL_CHECKS
@@ -613,8 +630,6 @@ static inline void do_dimension_fixedstep(
         }
 
         for ( ; now <= db_now ; now += dt) {
-            calculated_number value = NAN;
-
             if(likely(now >= db_now && does_storage_number_exist(n))) {
 #if defined(NETDATA_INTERNAL_CHECKS) && defined(ENABLE_DBENGINE)
                 struct rrdeng_query_handle* rrd_handle = (struct rrdeng_query_handle*)handle.handle;
@@ -622,11 +637,6 @@ static inline void do_dimension_fixedstep(
                     error("INTERNAL CHECK: Unaligned query for %s, database time: %ld, expected time: %ld", rd->id, (long)rrd_handle->now, (long)now);
                 }
 #endif
-                if (options & RRDR_OPTION_ANOMALY_BIT)
-                    value = (n & SN_ANOMALY_BIT) ? 0.0 : 100.0;
-                else
-                    value = unpack_storage_number(n);
-
                 if(likely(value != 0.0))
                     values_in_group_non_zero++;
 
@@ -657,21 +667,21 @@ static inline void do_dimension_fixedstep(
                 // store the specific point options
                 *rrdr_value_options_ptr = group_value_flags;
 
-                // store the value
-                value = grouping_flush(r, rrdr_value_options_ptr);
-                r->v[rrdr_o_v_index] = value;
+                // store the group value
+                calculated_number group_value = grouping_flush(r, rrdr_value_options_ptr);
+                r->v[rrdr_o_v_index] = group_value;
 
                 if(likely(points_added || dim_id_in_rrdr)) {
                     // find the min/max across all dimensions
 
-                    if(unlikely(value < min)) min = value;
-                    if(unlikely(value > max)) max = value;
+                    if(unlikely(group_value < min)) min = group_value;
+                    if(unlikely(group_value > max)) max = group_value;
 
                 }
                 else {
                     // runs only when dim_id_in_rrdr == 0 && points_added == 0
                     // so, on the first point added for the query.
-                    min = max = value;
+                    min = max = group_value;
                 }
 
                 points_added++;


### PR DESCRIPTION
1. move number unpacking close to metric_next
2. fix `value` variable shadowing by introducing the `group_value` variable
3. don't miss group flags when iterating at the inner loop