### PR TITLE
fix(kickstart.sh): handle the case when `tput colors` doesn't return a number

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -339,7 +339,7 @@ setup_terminal() {
   test -t 2 || return 1
 
   if command -v tput > /dev/null 2>&1; then
-    if [ $(($(tput colors 2> /dev/null))) -ge 8 ]; then
+    if num_colors=$(tput colors 2> /dev/null) && [ "${num_colors:-0}" -ge 8 ]; then
       # Enable colors
       TPUT_RESET="$(tput sgr 0)"
       TPUT_WHITE="$(tput setaf 7)"


### PR DESCRIPTION
##### Summary

Fixes: #12960

##### Test Plan

Manually test new `if` condition in the command line.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
