### PR TITLE
fix: don't kill Netdata PIDs if successfully stopped Netdata

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -640,39 +640,46 @@ netdata_pids() {
 }
 
 stop_all_netdata() {
+  stop_success=0
 
   if [ "${UID}" -eq 0 ]; then
-    uname="$(uname 2> /dev/null)"
+    uname="$(uname 2>/dev/null)"
 
     # Any of these may fail, but we need to not bail if they do.
     if issystemd; then
       if systemctl stop netdata; then
+        stop_success=1
         sleep 5
       fi
     elif [ "${uname}" = "Darwin" ]; then
       if launchctl stop netdata; then
+        stop_success=1
         sleep 5
       fi
     elif [ "${uname}" = "FreeBSD" ]; then
       if /etc/rc.d/netdata stop; then
+        stop_success=1
         sleep 5
       fi
     else
       if service netdata stop; then
+        stop_success=1
         sleep 5
       fi
     fi
   fi
 
-  if [ -n "$(netdata_pids)" ] && [ -n "$(command -v netdatacli)" ]; then
-    netdatacli shutdown-agent
-    sleep 20
-  fi
+  if [ "$stop_success" = "0" ]; then
+    if [ -n "$(netdata_pids)" ] && [ -n "$(command -v netdatacli)" ]; then
+      netdatacli shutdown-agent
+      sleep 20
+    fi
 
-  for p in $(netdata_pids); do
-    # shellcheck disable=SC2086
-    stop_netdata_on_pid ${p}
-  done
+    for p in $(netdata_pids); do
+      # shellcheck disable=SC2086
+      stop_netdata_on_pid ${p}
+    done
+  fi
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

When Netdata is running in a docker container, using the host PID namespace is a requirement for associating network interfaces with cgroups.

It means that our installer/uninstaller scripts kill all Netdata containers running on the host (a pretty common setup when developing: Netdata installed on the host + a bunch of containers).



##### Test Plan

Run the installer, and check that docker containers don't get restarted.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
