### PR TITLE
chore(apps.plugin): change cpu_guest chart context

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3768,7 +3768,7 @@ static void send_charts_updates_to_netdata(struct target *root, const char *type
     }
 
     if(show_guest_time) {
-        fprintf(stdout, "CHART %s.cpu_guest '' '%s CPU Guest Time (100%% = 1 core)' 'percentage' cpu %s.cpu_system stacked 20022 %d\n", type, title, type, update_every);
+        fprintf(stdout, "CHART %s.cpu_guest '' '%s CPU Guest Time (100%% = 1 core)' 'percentage' cpu %s.cpu_guest stacked 20022 %d\n", type, title, type, update_every);
         for (w = root; w; w = w->next) {
             if(unlikely(w->exposed))
                 fprintf(stdout, "DIMENSION %s '' absolute 1 %llu\n", w->name, time_factor * RATES_DETAIL / 100LLU);


### PR DESCRIPTION
##### Summary

`cpu_system` and `cpu_guest` charts have the same context - `cpu_system`.
https://github.com/netdata/netdata/blob/528378baf9f6f844790f16d069e7a7ad7a9a8e40/collectors/apps.plugin/apps_plugin.c#L3764

https://github.com/netdata/netdata/blob/528378baf9f6f844790f16d069e7a7ad7a9a8e40/collectors/apps.plugin/apps_plugin.c#L3771

This PR changes the` cpu_guest` chart context.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
