### PR TITLE
Make heartbeat a static chart

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -854,37 +854,42 @@ static void dbengine_statistics_charts(void) {
 }
 
 static void update_heartbeat_charts() {
-    RRDSET *st = rrdset_create_localhost(
-        "netdata"
-        , "heartbeat"
-        , NULL
-        , "heartbeat"
-        , NULL
-        , "System clock jitter"
-        , "microseconds"
-        , "netdata"
-        , "stats"
-        , 900000
-        , localhost->rrd_update_every
-        , RRDSET_TYPE_AREA
-    );
+    static RRDSET *st_heartbeat = NULL;
+    static RRDDIM *rd_heartbeat_min = NULL;
+    static RRDDIM *rd_heartbeat_max = NULL;
+    static RRDDIM *rd_heartbeat_avg = NULL;
 
-    RRDDIM *rd_min = rrddim_add(st, "min", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_max = rrddim_add(st, "max", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_avg = rrddim_add(st, "average", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    if (unlikely(!st_heartbeat)) {
+        st_heartbeat = rrdset_create_localhost(
+            "netdata"
+            , "heartbeat"
+            , NULL
+            , "heartbeat"
+            , NULL
+            , "System clock jitter"
+            , "microseconds"
+            , "netdata"
+            , "stats"
+            , 900000
+            , localhost->rrd_update_every
+            , RRDSET_TYPE_AREA);
 
-    rrdset_next(st);
+        rd_heartbeat_min = rrddim_add(st_heartbeat, "min", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_heartbeat_max = rrddim_add(st_heartbeat, "max", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_heartbeat_avg = rrddim_add(st_heartbeat, "average", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    } else
+        rrdset_next(st_heartbeat);
 
     usec_t min, max, average;
     size_t count;
 
     heartbeat_statistics(&min, &max, &average, &count);
 
-    rrddim_set_by_pointer(st, rd_min, (collected_number)min);
-    rrddim_set_by_pointer(st, rd_max, (collected_number)max);
-    rrddim_set_by_pointer(st, rd_avg, (collected_number)average);
+    rrddim_set_by_pointer(st_heartbeat, rd_heartbeat_min, (collected_number)min);
+    rrddim_set_by_pointer(st_heartbeat, rd_heartbeat_max, (collected_number)max);
+    rrddim_set_by_pointer(st_heartbeat, rd_heartbeat_avg, (collected_number)average);
 
-    rrdset_done(st);
+    rrdset_done(st_heartbeat);
 }
 
 // ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

`update_heartbeat_charts()` is called inside the loop, every second. The `heartbeat` chart is then created every time. This PR changes it so that it is a static variable, and behaves as other similar charts.

Unless there is a specific reason for that behavior, it is perhaps better to turn it into a static one.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Make sure the `heartbeat` chart works as before the PR.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
