### PR TITLE
Faster queries

### DIFF
--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -49,10 +49,12 @@ struct rrdeng_query_handle {
     time_t next_page_time;
     time_t now;
     unsigned position;
+    unsigned entries;
     storage_number *page;
     usec_t page_end_time;
     uint32_t page_length;
     usec_t dt;
+    time_t dt_sec;
 };
 
 typedef enum {

--- a/libnetdata/storage_number/storage_number.h
+++ b/libnetdata/storage_number/storage_number.h
@@ -80,7 +80,7 @@ typedef uint32_t storage_number;
 #define did_storage_number_reset(value)  ((((storage_number) (value)) & SN_EXISTS_RESET) != 0)
 
 storage_number pack_storage_number(calculated_number value, uint32_t flags);
-calculated_number unpack_storage_number(storage_number value);
+static inline calculated_number unpack_storage_number(storage_number value) __attribute__((const));
 
 int print_calculated_number(char *str, calculated_number value);
 
@@ -97,5 +97,42 @@ int print_calculated_number(char *str, calculated_number value);
 // Maximum acceptable rate of increase for counters. With a rate of 10% netdata can safely detect overflows with a
 // period of at least every other 10 samples.
 #define MAX_INCREMENTAL_PERCENT_RATE 10
+
+
+static inline calculated_number unpack_storage_number(storage_number value) {
+    extern calculated_number unpack_storage_number_lut10x[4 * 8];
+
+    if(!value) return 0;
+
+    int sign = 1, exp = 0;
+    int factor = 0;
+
+    // bit 32 = 0:positive, 1:negative
+    if(unlikely(value & (1 << 31)))
+        sign = -1;
+
+    // bit 31 = 0:divide, 1:multiply
+    if(unlikely(value & (1 << 30)))
+        exp = 1;
+
+    // bit 27 SN_EXISTS_100
+    if(unlikely(value & (1 << 26)))
+        factor = 1;
+
+    // bit 26 SN_EXISTS_RESET
+    // bit 25 SN_ANOMALY_BIT
+
+    // bit 30, 29, 28 = (multiplier or divider) 0-7 (8 total)
+    int mul = (value & ((1<<29)|(1<<28)|(1<<27))) >> 27;
+
+    // bit 24 to bit 1 = the value, so remove all other bits
+    value ^= value & ((1<<31)|(1<<30)|(1<<29)|(1<<28)|(1<<27)|(1<<26)|(1<<25)|(1<<24));
+
+    calculated_number n = value;
+
+    // fprintf(stderr, "UNPACK: %08X, sign = %d, exp = %d, mul = %d, factor = %d, n = " CALCULATED_NUMBER_FORMAT "\n", value, sign, exp, mul, factor, n);
+
+    return sign * unpack_storage_number_lut10x[(factor * 16) + (exp * 8) + mul] * n;
+}
 
 #endif /* NETDATA_STORAGE_NUMBER_H */

--- a/web/api/queries/average/average.c
+++ b/web/api/queries/average/average.c
@@ -29,11 +29,9 @@ void grouping_free_average(RRDR *r) {
 }
 
 void grouping_add_average(RRDR *r, calculated_number value) {
-    if(likely(!isnan(value))) {
-        struct grouping_average *g = (struct grouping_average *)r->internal.grouping_data;
-        g->sum += value;
-        g->count++;
-    }
+    struct grouping_average *g = (struct grouping_average *)r->internal.grouping_data;
+    g->sum += value;
+    g->count++;
 }
 
 calculated_number grouping_flush_average(RRDR *r,  RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {

--- a/web/api/queries/average/average.c
+++ b/web/api/queries/average/average.c
@@ -10,9 +10,8 @@ struct grouping_average {
     size_t count;
 };
 
-void *grouping_create_average(RRDR *r) {
-    (void)r;
-    return callocz(1, sizeof(struct grouping_average));
+void grouping_create_average(RRDR *r) {
+    r->internal.grouping_data = callocz(1, sizeof(struct grouping_average));
 }
 
 // resets when switches dimensions

--- a/web/api/queries/average/average.h
+++ b/web/api/queries/average/average.h
@@ -6,7 +6,7 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void *grouping_create_average(RRDR *r);
+extern void grouping_create_average(RRDR *r);
 extern void grouping_reset_average(RRDR *r);
 extern void grouping_free_average(RRDR *r);
 extern void grouping_add_average(RRDR *r, calculated_number value);

--- a/web/api/queries/des/des.c
+++ b/web/api/queries/des/des.c
@@ -99,28 +99,26 @@ void grouping_free_des(RRDR *r) {
 void grouping_add_des(RRDR *r, calculated_number value) {
     struct grouping_des *g = (struct grouping_des *)r->internal.grouping_data;
 
-    if(calculated_number_isnumber(value)) {
-        if(likely(g->count > 0)) {
-            // we have at least a number so far
+    if(likely(g->count > 0)) {
+        // we have at least a number so far
 
-            if(unlikely(g->count == 1)) {
-                // the second value we got
-                g->trend = value - g->trend;
-                g->level = value;
-            }
-
-            // for the values, except the first
-            calculated_number last_level = g->level;
-            g->level = (g->alpha * value) + (g->alpha_other * (g->level + g->trend));
-            g->trend = (g->beta * (g->level - last_level)) + (g->beta_other * g->trend);
-        }
-        else {
-            // the first value we got
-            g->level = g->trend = value;
+        if(unlikely(g->count == 1)) {
+            // the second value we got
+            g->trend = value - g->trend;
+            g->level = value;
         }
 
-        g->count++;
+        // for the values, except the first
+        calculated_number last_level = g->level;
+        g->level = (g->alpha * value) + (g->alpha_other * (g->level + g->trend));
+        g->trend = (g->beta * (g->level - last_level)) + (g->beta_other * g->trend);
     }
+    else {
+        // the first value we got
+        g->level = g->trend = value;
+    }
+
+    g->count++;
 
     //fprintf(stderr, "value: " CALCULATED_NUMBER_FORMAT ", level: " CALCULATED_NUMBER_FORMAT ", trend: " CALCULATED_NUMBER_FORMAT "\n", value, g->level, g->trend);
 }

--- a/web/api/queries/des/des.c
+++ b/web/api/queries/des/des.c
@@ -69,14 +69,14 @@ static inline void set_beta(RRDR *r, struct grouping_des *g) {
     //info("beta for chart '%s' is " CALCULATED_NUMBER_FORMAT, r->st->name, g->beta);
 }
 
-void *grouping_create_des(RRDR *r) {
+void grouping_create_des(RRDR *r) {
     struct grouping_des *g = (struct grouping_des *)mallocz(sizeof(struct grouping_des));
     set_alpha(r, g);
     set_beta(r, g);
     g->level = 0.0;
     g->trend = 0.0;
     g->count = 0;
-    return g;
+    r->internal.grouping_data = g;
 }
 
 // resets when switches dimensions

--- a/web/api/queries/des/des.h
+++ b/web/api/queries/des/des.h
@@ -8,7 +8,7 @@
 
 extern void grouping_init_des(void);
 
-extern void *grouping_create_des(RRDR *r);
+extern void grouping_create_des(RRDR *r);
 extern void grouping_reset_des(RRDR *r);
 extern void grouping_free_des(RRDR *r);
 extern void grouping_add_des(RRDR *r, calculated_number value);

--- a/web/api/queries/incremental_sum/incremental_sum.c
+++ b/web/api/queries/incremental_sum/incremental_sum.c
@@ -31,17 +31,15 @@ void grouping_free_incremental_sum(RRDR *r) {
 }
 
 void grouping_add_incremental_sum(RRDR *r, calculated_number value) {
-    if(!isnan(value)) {
-        struct grouping_incremental_sum *g = (struct grouping_incremental_sum *)r->internal.grouping_data;
+    struct grouping_incremental_sum *g = (struct grouping_incremental_sum *)r->internal.grouping_data;
 
-        if(unlikely(!g->count)) {
-            g->first = value;
-            g->count++;
-        }
-        else {
-            g->last = value;
-            g->count++;
-        }
+    if(unlikely(!g->count)) {
+        g->first = value;
+        g->count++;
+    }
+    else {
+        g->last = value;
+        g->count++;
     }
 }
 

--- a/web/api/queries/incremental_sum/incremental_sum.c
+++ b/web/api/queries/incremental_sum/incremental_sum.c
@@ -11,9 +11,8 @@ struct grouping_incremental_sum {
     size_t count;
 };
 
-void *grouping_create_incremental_sum(RRDR *r) {
-    (void)r;
-    return callocz(1, sizeof(struct grouping_incremental_sum));
+void grouping_create_incremental_sum(RRDR *r) {
+    r->internal.grouping_data = callocz(1, sizeof(struct grouping_incremental_sum));
 }
 
 // resets when switches dimensions

--- a/web/api/queries/incremental_sum/incremental_sum.h
+++ b/web/api/queries/incremental_sum/incremental_sum.h
@@ -6,7 +6,7 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void *grouping_create_incremental_sum(RRDR *r);
+extern void grouping_create_incremental_sum(RRDR *r);
 extern void grouping_reset_incremental_sum(RRDR *r);
 extern void grouping_free_incremental_sum(RRDR *r);
 extern void grouping_add_incremental_sum(RRDR *r, calculated_number value);

--- a/web/api/queries/max/max.c
+++ b/web/api/queries/max/max.c
@@ -10,9 +10,8 @@ struct grouping_max {
     size_t count;
 };
 
-void *grouping_create_max(RRDR *r) {
-    (void)r;
-    return callocz(1, sizeof(struct grouping_max));
+void grouping_create_max(RRDR *r) {
+    r->internal.grouping_data = callocz(1, sizeof(struct grouping_max));
 }
 
 // resets when switches dimensions

--- a/web/api/queries/max/max.c
+++ b/web/api/queries/max/max.c
@@ -29,13 +29,11 @@ void grouping_free_max(RRDR *r) {
 }
 
 void grouping_add_max(RRDR *r, calculated_number value) {
-    if(!isnan(value)) {
-        struct grouping_max *g = (struct grouping_max *)r->internal.grouping_data;
+    struct grouping_max *g = (struct grouping_max *)r->internal.grouping_data;
 
-        if(!g->count || calculated_number_fabs(value) > calculated_number_fabs(g->max)) {
-            g->max = value;
-            g->count++;
-        }
+    if(!g->count || calculated_number_fabs(value) > calculated_number_fabs(g->max)) {
+        g->max = value;
+        g->count++;
     }
 }
 

--- a/web/api/queries/max/max.h
+++ b/web/api/queries/max/max.h
@@ -6,7 +6,7 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void *grouping_create_max(RRDR *r);
+extern void grouping_create_max(RRDR *r);
 extern void grouping_reset_max(RRDR *r);
 extern void grouping_free_max(RRDR *r);
 extern void grouping_add_max(RRDR *r, calculated_number value);

--- a/web/api/queries/median/median.c
+++ b/web/api/queries/median/median.c
@@ -13,14 +13,14 @@ struct grouping_median {
     LONG_DOUBLE series[];
 };
 
-void *grouping_create_median(RRDR *r) {
+void grouping_create_median(RRDR *r) {
     long entries = r->group;
     if(entries < 0) entries = 0;
 
     struct grouping_median *g = (struct grouping_median *)callocz(1, sizeof(struct grouping_median) + entries * sizeof(LONG_DOUBLE));
     g->series_size = (size_t)entries;
 
-    return g;
+    r->internal.grouping_data = g;
 }
 
 // resets when switches dimensions

--- a/web/api/queries/median/median.c
+++ b/web/api/queries/median/median.c
@@ -41,10 +41,8 @@ void grouping_add_median(RRDR *r, calculated_number value) {
     if(unlikely(g->next_pos >= g->series_size)) {
         error("INTERNAL ERROR: median buffer overflow on chart '%s' - next_pos = %zu, series_size = %zu, r->group = %ld.", r->st->name, g->next_pos, g->series_size, r->group);
     }
-    else {
-        if(calculated_number_isnumber(value))
-            g->series[g->next_pos++] = (LONG_DOUBLE)value;
-    }
+    else
+        g->series[g->next_pos++] = (LONG_DOUBLE)value;
 }
 
 calculated_number grouping_flush_median(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {

--- a/web/api/queries/median/median.h
+++ b/web/api/queries/median/median.h
@@ -6,7 +6,7 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void *grouping_create_median(RRDR *r);
+extern void grouping_create_median(RRDR *r);
 extern void grouping_reset_median(RRDR *r);
 extern void grouping_free_median(RRDR *r);
 extern void grouping_add_median(RRDR *r, calculated_number value);

--- a/web/api/queries/min/min.c
+++ b/web/api/queries/min/min.c
@@ -10,9 +10,8 @@ struct grouping_min {
     size_t count;
 };
 
-void *grouping_create_min(RRDR *r) {
-    (void)r;
-    return callocz(1, sizeof(struct grouping_min));
+void grouping_create_min(RRDR *r) {
+    r->internal.grouping_data = callocz(1, sizeof(struct grouping_min));
 }
 
 // resets when switches dimensions

--- a/web/api/queries/min/min.c
+++ b/web/api/queries/min/min.c
@@ -29,13 +29,11 @@ void grouping_free_min(RRDR *r) {
 }
 
 void grouping_add_min(RRDR *r, calculated_number value) {
-    if(!isnan(value)) {
-        struct grouping_min *g = (struct grouping_min *)r->internal.grouping_data;
+    struct grouping_min *g = (struct grouping_min *)r->internal.grouping_data;
 
-        if(!g->count || calculated_number_fabs(value) < calculated_number_fabs(g->min)) {
-            g->min = value;
-            g->count++;
-        }
+    if(!g->count || calculated_number_fabs(value) < calculated_number_fabs(g->min)) {
+        g->min = value;
+        g->count++;
     }
 }
 

--- a/web/api/queries/min/min.h
+++ b/web/api/queries/min/min.h
@@ -6,7 +6,7 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void *grouping_create_min(RRDR *r);
+extern void grouping_create_min(RRDR *r);
 extern void grouping_reset_min(RRDR *r);
 extern void grouping_free_min(RRDR *r);
 extern void grouping_add_min(RRDR *r, calculated_number value);

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -28,7 +28,7 @@ static struct {
 
     // Allocate all required structures for a query.
     // This is called once for each netdata query.
-    void *(*create)(struct rrdresult *r);
+    void (*create)(struct rrdresult *r);
 
     // Cleanup collected values, but don't destroy the structures.
     // This is called when the query engine switches dimensions,
@@ -1115,7 +1115,7 @@ static RRDR *rrd2rrdr_fixedstep(
     }
 
     // allocate any memory required by the grouping method
-    r->internal.grouping_data = r->internal.grouping_create(r);
+    r->internal.grouping_create(r);
 
 
     // -------------------------------------------------------------------------
@@ -1507,7 +1507,7 @@ static RRDR *rrd2rrdr_variablestep(
     }
 
     // allocate any memory required by the grouping method
-    r->internal.grouping_data = r->internal.grouping_create(r);
+    r->internal.grouping_create(r);
 
 
     // -------------------------------------------------------------------------

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -465,7 +465,9 @@ static inline void do_dimension_variablestep(
                 }
             }
             // add this value to grouping
-            r->internal.grouping_add(r, value);
+            if(likely(!isnan(value)))
+                r->internal.grouping_add(r, value);
+
             values_in_group++;
             db_points_read++;
         }
@@ -649,10 +651,11 @@ static inline void do_dimension_fixedstep(
 
                 if(unlikely(did_storage_number_reset(n)))
                     group_value_flags |= RRDR_VALUE_RESET;
+
+                grouping_add(r, value);
             }
 
             // add this value for grouping
-            grouping_add(r, value);
             values_in_group++;
             db_points_read++;
 

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -83,7 +83,7 @@ typedef struct rrdresult {
         long resampling_group;
         calculated_number resampling_divisor;
 
-        void *(*grouping_create)(struct rrdresult *r);
+        void (*grouping_create)(struct rrdresult *r);
         void (*grouping_reset)(struct rrdresult *r);
         void (*grouping_free)(struct rrdresult *r);
         void (*grouping_add)(struct rrdresult *r, calculated_number value);

--- a/web/api/queries/ses/ses.c
+++ b/web/api/queries/ses/ses.c
@@ -71,13 +71,11 @@ void grouping_free_ses(RRDR *r) {
 void grouping_add_ses(RRDR *r, calculated_number value) {
     struct grouping_ses *g = (struct grouping_ses *)r->internal.grouping_data;
 
-    if(calculated_number_isnumber(value)) {
-        if(unlikely(!g->count))
-            g->level = value;
+    if(unlikely(!g->count))
+        g->level = value;
 
-        g->level = g->alpha * value + g->alpha_other * g->level;
-        g->count++;
-    }
+    g->level = g->alpha * value + g->alpha_other * g->level;
+    g->count++;
 }
 
 calculated_number grouping_flush_ses(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {

--- a/web/api/queries/ses/ses.c
+++ b/web/api/queries/ses/ses.c
@@ -48,11 +48,11 @@ static inline void set_alpha(RRDR *r, struct grouping_ses *g) {
     g->alpha_other = 1.0 - g->alpha;
 }
 
-void *grouping_create_ses(RRDR *r) {
+void grouping_create_ses(RRDR *r) {
     struct grouping_ses *g = (struct grouping_ses *)callocz(1, sizeof(struct grouping_ses));
     set_alpha(r, g);
     g->level = 0.0;
-    return g;
+    r->internal.grouping_data = g;
 }
 
 // resets when switches dimensions

--- a/web/api/queries/ses/ses.h
+++ b/web/api/queries/ses/ses.h
@@ -8,7 +8,7 @@
 
 extern void grouping_init_ses(void);
 
-extern void *grouping_create_ses(RRDR *r);
+extern void grouping_create_ses(RRDR *r);
 extern void grouping_reset_ses(RRDR *r);
 extern void grouping_free_ses(RRDR *r);
 extern void grouping_add_ses(RRDR *r, calculated_number value);

--- a/web/api/queries/stddev/stddev.c
+++ b/web/api/queries/stddev/stddev.c
@@ -14,9 +14,8 @@ struct grouping_stddev {
     calculated_number m_oldM, m_newM, m_oldS, m_newS;
 };
 
-void *grouping_create_stddev(RRDR *r) {
-    UNUSED (r);
-    return callocz(1, sizeof(struct grouping_stddev));
+void grouping_create_stddev(RRDR *r) {
+    r->internal.grouping_data = callocz(1, sizeof(struct grouping_stddev));
 }
 
 // resets when switches dimensions

--- a/web/api/queries/stddev/stddev.c
+++ b/web/api/queries/stddev/stddev.c
@@ -34,22 +34,20 @@ void grouping_free_stddev(RRDR *r) {
 void grouping_add_stddev(RRDR *r, calculated_number value) {
     struct grouping_stddev *g = (struct grouping_stddev *)r->internal.grouping_data;
 
-    if(calculated_number_isnumber(value)) {
-        g->count++;
+    g->count++;
 
-        // See Knuth TAOCP vol 2, 3rd edition, page 232
-        if (g->count == 1) {
-            g->m_oldM = g->m_newM = value;
-            g->m_oldS = 0.0;
-        }
-        else {
-            g->m_newM = g->m_oldM + (value - g->m_oldM) / g->count;
-            g->m_newS = g->m_oldS + (value - g->m_oldM) * (value - g->m_newM);
+    // See Knuth TAOCP vol 2, 3rd edition, page 232
+    if (g->count == 1) {
+        g->m_oldM = g->m_newM = value;
+        g->m_oldS = 0.0;
+    }
+    else {
+        g->m_newM = g->m_oldM + (value - g->m_oldM) / g->count;
+        g->m_newS = g->m_oldS + (value - g->m_oldM) * (value - g->m_newM);
 
-            // set up for next iteration
-            g->m_oldM = g->m_newM;
-            g->m_oldS = g->m_newS;
-        }
+        // set up for next iteration
+        g->m_oldM = g->m_newM;
+        g->m_oldS = g->m_newS;
     }
 }
 

--- a/web/api/queries/stddev/stddev.h
+++ b/web/api/queries/stddev/stddev.h
@@ -6,7 +6,7 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void *grouping_create_stddev(RRDR *r);
+extern void grouping_create_stddev(RRDR *r);
 extern void grouping_reset_stddev(RRDR *r);
 extern void grouping_free_stddev(RRDR *r);
 extern void grouping_add_stddev(RRDR *r, calculated_number value);

--- a/web/api/queries/sum/sum.c
+++ b/web/api/queries/sum/sum.c
@@ -10,9 +10,8 @@ struct grouping_sum {
     size_t count;
 };
 
-void *grouping_create_sum(RRDR *r) {
-    (void)r;
-    return callocz(1, sizeof(struct grouping_sum));
+void grouping_create_sum(RRDR *r) {
+    r->internal.grouping_data = callocz(1, sizeof(struct grouping_sum));
 }
 
 // resets when switches dimensions

--- a/web/api/queries/sum/sum.c
+++ b/web/api/queries/sum/sum.c
@@ -29,11 +29,9 @@ void grouping_free_sum(RRDR *r) {
 }
 
 void grouping_add_sum(RRDR *r, calculated_number value) {
-    if(!isnan(value)) {
-        struct grouping_sum *g = (struct grouping_sum *)r->internal.grouping_data;
-        g->sum += value;
-        g->count++;
-    }
+    struct grouping_sum *g = (struct grouping_sum *)r->internal.grouping_data;
+    g->sum += value;
+    g->count++;
 }
 
 calculated_number grouping_flush_sum(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {

--- a/web/api/queries/sum/sum.h
+++ b/web/api/queries/sum/sum.h
@@ -6,7 +6,7 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void *grouping_create_sum(RRDR *r);
+extern void grouping_create_sum(RRDR *r);
 extern void grouping_reset_sum(RRDR *r);
 extern void grouping_free_sum(RRDR *r);
 extern void grouping_add_sum(RRDR *r, calculated_number value);


### PR DESCRIPTION
Minor query engine optimizations that give about 5% additional performance increase.

Each commit is doing one thing, so it is easier to check it by reviewing the individual commits.

1. `rrdeng_load_metric_next()` was doing 2 calculations about page size and current timestamp for every point, which are now cached for the lifetime of each page.
2. `unpack_storage_number()` is now inlined (it is defined in the header file)
3. the grouping functions were doing a check for every point to verify the number is not `NAN`, but the same check was also done at the query engine.

Fixed also a discrepancy in the way the grouping functions were created and destroyed. Nothing about performance. Just a tiny issue for uniformity.
