### PR TITLE
Don't expose the chart definition to streaming if there is no metadata change

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -399,6 +399,7 @@ struct rrddim_volatile {
 // volatile state per chart
 struct rrdset_volatile {
     char *old_title;
+    char *old_units;
     char *old_context;
     uuid_t hash_id;
     struct label *new_labels;

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -855,6 +855,7 @@ RRDSET *rrdset_create_custom(
     st->state->is_ar_chart = strcmp(st->id, ML_ANOMALY_RATES_CHART_ID) == 0;
 
     st->units = units ? strdupz(units) : strdupz("");
+    st->state->old_units = strdupz(st->units);
     json_fix_string(st->units);
 
     st->context = context ? strdupz(context) : strdupz(st->id);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -561,8 +561,6 @@ RRDSET *rrdset_create_custom(
     RRDSET *st = rrdset_find_on_create(host, fullid);
     if (st) {
         int mark_rebuild = 0;
-        rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
-        rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
         if (rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)) {
             rrdset_flag_clear(st, RRDSET_FLAG_ARCHIVED);
             changed_from_archived_to_active = 1;
@@ -678,6 +676,11 @@ RRDSET *rrdset_create_custom(
             int rc = update_chart_metadata(st->chart_uuid, st, id, name);
             if (unlikely(rc))
                 error_report("Failed to update chart metadata in the database");
+
+            if (!changed_from_archived_to_active) {
+                rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
+                rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
+            }
         }
         /* Fall-through during switch from archived to active so that the host lock is taken and health is linked */
         if (!changed_from_archived_to_active)


### PR DESCRIPTION
##### Summary
Only clear the RRDSET_FLAG_UPSTREAM_EXPOSED chart flag if the chart metadata has changed
- Handle change of units as well

##### Test Plan
- There is already code that detects chart metadata change, so the RRDSET_FLAG_UPSTREAM_EXPOSED will be cleared only when such a change is detected