### PR TITLE
Delay children chart obsoletion check

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -795,11 +795,13 @@ struct rrdhost {
     volatile size_t connected_senders;              // when remote hosts are streaming to this
                                                     // host, this is the counter of connected clients
 
+    time_t senders_connect_time;                    // the time the last sender was connected
+    time_t senders_last_chart_command;              // the time of the last CHART streaming command
     time_t senders_disconnected_time;               // the time the last sender was disconnected
 
     struct receiver_state *receiver;
     netdata_mutex_t receiver_lock;
-    time_t trigger_chart_obsoletion_check;          // set when child connects, will instruct parent to
+    int trigger_chart_obsoletion_check;             // set when child connects, will instruct parent to
                                                     // trigger a check for obsoleted charts since previous connect
 
     // ------------------------------------------------------------------------

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1533,7 +1533,7 @@ void rrdset_check_obsoletion(RRDHOST *host)
 {
     RRDSET *st;
     time_t last_entry_t;
-    rrdset_foreach_write(st, host) {
+    rrdset_foreach_read(st, host) {
         last_entry_t = rrdset_last_entry_t(st);
         if (last_entry_t && last_entry_t < host->senders_connect_time) {
             rrdset_is_obsolete(st);
@@ -1565,7 +1565,7 @@ void rrd_cleanup_obsolete_charts()
             host->trigger_chart_obsoletion_check &&
             host->senders_last_chart_command &&
             host->senders_last_chart_command + 120 < now_realtime_sec()) {
-            rrdhost_wrlock(host);
+            rrdhost_rdlock(host);
             rrdset_check_obsoletion(host);
             rrdhost_unlock(host);
             host->trigger_chart_obsoletion_check = 0;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1532,8 +1532,10 @@ restart_after_removal:
 void rrdset_check_obsoletion(RRDHOST *host)
 {
     RRDSET *st;
+    time_t last_entry_t;
     rrdset_foreach_write(st, host) {
-        if (rrdset_last_entry_t(st) < host->trigger_chart_obsoletion_check) {
+        last_entry_t = rrdset_last_entry_t(st);
+        if (last_entry_t && last_entry_t < host->senders_connect_time) {
             rrdset_is_obsolete(st);
         }
     }
@@ -1561,7 +1563,8 @@ void rrd_cleanup_obsolete_charts()
 
         if (host != localhost &&
             host->trigger_chart_obsoletion_check &&
-            host->trigger_chart_obsoletion_check + 120 < now_realtime_sec()) {
+            host->senders_last_chart_command &&
+            host->senders_last_chart_command + 120 < now_realtime_sec()) {
             rrdhost_wrlock(host);
             rrdset_check_obsoletion(host);
             rrdhost_unlock(host);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -551,6 +551,10 @@ RRDSET *rrdset_create_custom(
         return NULL;
     }
 
+    if (host != localhost) {
+        host->senders_last_chart_command = now_realtime_sec();
+    }
+
     // ------------------------------------------------------------------------
     // check if it already exists
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #12939

In some cases, especially when an agent is under load, the `rrdset_check_obsoletion` might kick in sooner than needed (even with a 2 minute delay). If it does, it might mark charts as obsolete when in fact their complete definition has not yet been transmitted in full. Moreover the check for cleaning up obsolete charts might as well be triggered.

This PR extends the time for the `rrdset_check_obsoletion` every time a chart definition is received. It will then trigger the check 2 minutes after the last definition.

There's also a check for `rrdset_last_entry_t` being 0 not to trigger any check on that chart. This will make sure the check is not run for the chart since most likely the chart is still being defined.

There are also 2 new timestamps for the host structure. `senders_connect_time` marks the time the child was connected, and `senders_last_chart_command` the time the last chart definition was received. Both could be also used in other situations, e.g. to inform the cloud after the child has finished chart definitions.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

There shouldn't be any functional changes.

1) Connect a child to a parent.
2) Disconnect and kill the child. Remove a chart previously monitored by the child (e.g. a mount point).
3) Start the child.
4) After a while, the parent should mark the missing chart as obsolete, and in turn any alerts raised on that chart should be removed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
