### PR TITLE
Fix compilation warnings

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -2267,9 +2267,8 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
     for (i = 0 ; i < DSET_CHARTS ; ++i) {
         stored_metrics_nr += chart_threads[i]->stored_metrics_nr;
     }
-    unsigned long queries_nr = 0, queried_metrics_nr = 0;
+    unsigned long queried_metrics_nr = 0;
     for (i = 0 ; i < QUERY_THREADS ; ++i) {
-        queries_nr += query_threads[i]->queries_nr;
         queried_metrics_nr += query_threads[i]->queried_metrics_nr;
     }
     fprintf(stderr, "%u metrics were stored (dataset size of %lu MiB) in %u charts by 1 writer thread per chart.\n",

--- a/libnetdata/worker_utilization/worker_utilization.c
+++ b/libnetdata/worker_utilization/worker_utilization.c
@@ -69,7 +69,7 @@ void worker_register_job_name(size_t job_id, const char *name) {
         error("WORKER_UTILIZATION: job_id %zu is too big. Max is %zu", job_id, (size_t)(WORKER_UTILIZATION_MAX_JOB_TYPES - 1));
         return;
     }
-    if (worker->per_job_type[job_id].name && *worker->per_job_type[job_id].name) {
+    if (*worker->per_job_type[job_id].name) {
         error("WORKER_UTILIZATION: duplicate job registration: worker '%s' job id %zu is '%s', ignoring '%s'", worker->workname, job_id, worker->per_job_type[job_id].name, name);
         return;
     }

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -45,18 +45,18 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, PARSER_INPUT_TYPE fl
 #endif
 
     if (unlikely(!(flags & PARSER_NO_PARSE_INIT))) {
-        int rc = parser_add_keyword(parser, PLUGINSD_KEYWORD_FLUSH, pluginsd_flush);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_CHART, pluginsd_chart);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_DIMENSION, pluginsd_dimension);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_DISABLE, pluginsd_disable);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_VARIABLE, pluginsd_variable);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_LABEL, pluginsd_label);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_OVERWRITE, pluginsd_overwrite);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_END, pluginsd_end);
-        rc += parser_add_keyword(parser, "CLABEL_COMMIT", pluginsd_clabel_commit);
-        rc += parser_add_keyword(parser, "CLABEL", pluginsd_clabel);
-        rc += parser_add_keyword(parser, PLUGINSD_KEYWORD_BEGIN, pluginsd_begin);
-        rc += parser_add_keyword(parser, "SET", pluginsd_set);
+        parser_add_keyword(parser, PLUGINSD_KEYWORD_FLUSH, pluginsd_flush);
+        parser_add_keyword(parser, PLUGINSD_KEYWORD_CHART, pluginsd_chart);
+        parser_add_keyword(parser, PLUGINSD_KEYWORD_DIMENSION, pluginsd_dimension);
+        parser_add_keyword(parser, PLUGINSD_KEYWORD_DISABLE, pluginsd_disable);
+        parser_add_keyword(parser, PLUGINSD_KEYWORD_VARIABLE, pluginsd_variable);
+        parser_add_keyword(parser, PLUGINSD_KEYWORD_LABEL, pluginsd_label);
+        parser_add_keyword(parser, PLUGINSD_KEYWORD_OVERWRITE, pluginsd_overwrite);
+        parser_add_keyword(parser, PLUGINSD_KEYWORD_END, pluginsd_end);
+        parser_add_keyword(parser, "CLABEL_COMMIT", pluginsd_clabel_commit);
+        parser_add_keyword(parser, "CLABEL", pluginsd_clabel);
+        parser_add_keyword(parser, PLUGINSD_KEYWORD_BEGIN, pluginsd_begin);
+        parser_add_keyword(parser, "SET", pluginsd_set);
     }
 
     return parser;


### PR DESCRIPTION
##### Summary
There are some compilation warnings on mac OS
```
libnetdata/worker_utilization/worker_utilization.c:72:38: warning: address of array 'worker->per_job_type[job_id].name' will always evaluate to 'true' [-Wpointer-bool-conversion]
    if (worker->per_job_type[job_id].name && *worker->per_job_type[job_id].name) {
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~ ~~

daemon/unit_test.c:2270:19: warning: variable 'queries_nr' set but not used [-Wunused-but-set-variable]
    unsigned long queries_nr = 0, queried_metrics_nr = 0;
                  ^
parser/parser.c:48:13: warning: variable 'rc' set but not used [-Wunused-but-set-variable]
        int rc = parser_add_keyword(parser, PLUGINSD_KEYWORD_FLUSH, pluginsd_flush);
            ^
```

##### Test Plan
Build Netdata with `sudo CFLAGS="-O1 -ggdb -Wall -Wextra -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1" ./netdata-installer.sh --install /usr/local --use-system-protobuf --disable-go --disable-lto --dont-wait` on macOS. There shouldn't be any compilation warnings.