### PR TITLE
Autodetect coverity install path to increase robustness

### DIFF
--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -87,7 +87,8 @@ debugrun() {
 
 scanit() {
   progress "Scanning using coverity"
-  export PATH="${PATH}:${INSTALL_DIR}/${COVERITY_BUILD_VERSION}/bin/"
+  COVERITY_PATH=$(find /opt/ -maxdepth 1 -name 'cov*linux*')
+  export PATH=${PATH}:${INSTALL_DIR}/${COVERITY_PATH}/bin/
   covbuild="${COVERITY_BUILD_PATH}"
   [ -z "${covbuild}" ] && covbuild="$(which cov-build 2> /dev/null || command -v cov-build 2> /dev/null)"
 
@@ -146,7 +147,8 @@ installit() {
 
     run sudo tar -z -x -f "${TMP_DIR}/${COVERITY_BUILD_VERSION}.tar.gz" || exit 1
     rm "${TMP_DIR}/${COVERITY_BUILD_VERSION}.tar.gz"
-    export PATH=${PATH}:${INSTALL_DIR}/${COVERITY_BUILD_VERSION}/bin/
+    COVERITY_PATH=$(find /opt/ -maxdepth 1 -name 'cov*linux*')
+    export PATH=${PATH}:${INSTALL_DIR}/${COVERITY_PATH}/bin/
   elif find . -name "*.tar.gz" > /dev/null 2>&1; then
     fatal "Downloaded coverity tool tarball does not appear to be the version we were expecting, exiting."
   else


### PR DESCRIPTION
##### Summary
Coverity Scan is broken, due to the fact that the folder name (after extraction from tar.gz file) is not matching the file name.

##### Test Plan
Allow github action for coverity scan to complete, and observe that it picked up the correct path for the executable.

