### PR TITLE
Run the /net/dev module of the proc plugin in a separate thread

### DIFF
--- a/collectors/proc.plugin/plugin_proc.h
+++ b/collectors/proc.plugin/plugin_proc.h
@@ -8,7 +8,9 @@
 #define PLUGIN_PROC_CONFIG_NAME "proc"
 #define PLUGIN_PROC_NAME PLUGIN_PROC_CONFIG_NAME ".plugin"
 
-extern int do_proc_net_dev(int update_every, usec_t dt);
+#define THREAD_NETDEV_NAME "PLUGIN[proc netdev]"
+extern void *netdev_main(void *ptr);
+
 extern int do_proc_net_wireless(int update_every, usec_t dt);
 extern int do_proc_diskstats(int update_every, usec_t dt);
 extern int do_proc_mdstat(int update_every, usec_t dt);

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -988,6 +988,7 @@ static struct worker_utilization all_workers_utilization[] = {
     { .name = "STATSD",      .family = "workers plugin statsd",           .priority = 1000000 },
     { .name = "STATSDFLUSH", .family = "workers plugin statsd flush",     .priority = 1000000 },
     { .name = "PROC",        .family = "workers plugin proc",             .priority = 1000000 },
+    { .name = "NETDEV",      .family = "workers plugin proc netdev",      .priority = 1000000 },
     { .name = "FREEBSD",     .family = "workers plugin freebsd",          .priority = 1000000 },
     { .name = "MACOS",       .family = "workers plugin macos",            .priority = 1000000 },
     { .name = "CGROUPS",     .family = "workers plugin cgroups",          .priority = 1000000 },


### PR DESCRIPTION
##### Summary
The `/net/dev` module of the `proc` plugin can spend quite a lot of time processing files and that can cause gaps in `proc` plugin's charts. We'll run the module in a separate thread.

Fixes #12984

##### Test Plan
1) Check if charts for network interfaces are working.
2) Check for `workers plugin proc netdev` charts in Netdata Monitoring.
3) Check if a separate thread `"PLUGIN[proc net"` exists (in gdb).