### PR TITLE
Add Alpine 3.16 to CI and platform support document.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -14,6 +14,8 @@ include:
     jsonc_removal: |
       apk del json-c-dev
   - <<: *alpine
+    version: "3.16"
+  - <<: *alpine
     version: "3.15"
   - <<: *alpine
     version: "3.14"

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -50,7 +50,7 @@ to work on these platforms with minimal user effort.
 
 | Platform | Version | Official Native Packages | Notes |
 | -------- | ------- | ------------------------ | ----- |
-| Alpine Linux | 3.15 | No | The latest release of Alpine Linux is guaranteed to remain at **Core** tier due to usage for our Docker images |
+| Alpine Linux | 3.16 | No | The latest release of Alpine Linux is guaranteed to remain at **Core** tier due to usage for our Docker images |
 | Alma Linux | 8.x | x86\_64, AArch64 | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives |
 | CentOS | 7.x | x86\_64 | |
 | Docker | 19.03 or newer | x86\_64, i386, ARMv7, AArch64, POWER8+ | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker |
@@ -80,6 +80,7 @@ with minimal user effort.
 
 | Platform | Version | Official Native Packages | Notes |
 | -------- | ------- | ------------------------ | ----- |
+| Alpine Linux | 3.15 | No | |
 | Alpine Linux | 3.14 | No | |
 | Alpine Linux | 3.13 | No | |
 | Arch Linux | Latest | No | We officially recommend the community packages available for Arch Linux |


### PR DESCRIPTION
##### Summary

SSIA

##### Test Plan

CI passes on this PR.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
As of mergint this PR, Alpine 3.16 will be officially supported by the Netdata team, and Alpine 3.15 will be demoted to the intermediate support tier.
</details>

Associated PR updating bases for the Docker images and static builds: https://github.com/netdata/helper-images/pull/165