### PR TITLE
Use printf instead of echo for printing collected warnings in kickstart.sh.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -381,8 +381,9 @@ cleanup() {
 deferred_warnings() {
   if [ -n "${NETDATA_WARNINGS}" ]; then
     printf >&2 "%s\n" "The following non-fatal warnings or errors were encountered:"
-    echo >&2 "${NETDATA_WARNINGS}"
-    printf >&2 "\n"
+    # shellcheck disable=SC2059
+    printf >&2 "${NETDATA_WARNINGS}"
+    printf >&2 "\n\n"
   fi
 }
 


### PR DESCRIPTION
##### Summary

This ensures that the formatting is done properly.

##### Test Plan

Differences can be observed by simply running the script before and after the changes.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Warnings listed at the end of execution of the kickstart script will be properly formatted.
</details>
