### PR TITLE
Only try to update repo metadata in updater script if needed.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -772,7 +772,9 @@ update_binpkg() {
       # shellcheck disable=SC2086
       env ${env} ${pm_cmd} ${upgrade_cmd} ${pkg_install_opts} ${repopkg} || fatal "Failed to update Netdata repository config." U000D
       # shellcheck disable=SC2086
-      env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts} || fatal "Failed to update repository metadata." U000E
+      if [ -n "${repo_subcmd}" ]; then
+        env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts} || fatal "Failed to update repository metadata." U000E
+      fi
     fi
   done
 


### PR DESCRIPTION
##### Summary

We attempt to update repository metadata twice in the updater script when updating a system that was installed using native packages, once before updating the repository config packages, and once after updating them.

The first attempt was properly guarded so that it only happened if the package manager supported doing so, but the second attempt would run unconditionally, thus causing issues for YUM-based systems (which do not support explicitly updating repository metadata independent of other operations).

##### Test Plan

Attempt to run the updater script on a CentOS 7 system which has netdata installed using native packages.

Without the changes in this PR, it will crash after updating the repository config packages.

With the changes in this PR, it will run correctly.

##### Additional Information

Fixes: #12953 

<details> <summary>For users: How does this change affect me?</summary>
Once this PR is merged, the updater script will work correctly again on YUM-based systems that were installed using native packages.
</details>
