### PR TITLE
Send collectors to the cloud

### DIFF
--- a/aclk/schema-wrappers/node_info.cc
+++ b/aclk/schema-wrappers/node_info.cc
@@ -56,8 +56,8 @@ static int generate_node_info(nodeinstance::info::v1::NodeInfo *info, struct acl
     if (data->custom_info)
         info->set_custom_info(data->custom_info);
 
-    for (size_t i = 0; i < data->service_count; i++)
-        info->add_services(data->services[i]);
+    for (size_t i = 0; i < data->collector_count; i++)
+        info->add_collectors(data->collectors[i]);
 
     if (data->machine_guid)
         info->set_machine_guid(data->machine_guid);

--- a/aclk/schema-wrappers/node_info.h
+++ b/aclk/schema-wrappers/node_info.h
@@ -49,8 +49,8 @@ struct aclk_node_info {
 
     char *custom_info;
 
-    char **services;
-    size_t service_count;
+    char **collectors;
+    size_t collector_count;
 
     char *machine_guid;
 

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -60,8 +60,8 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     node_info.data.virtualization_type = host->system_info->virtualization ? host->system_info->virtualization : "unknown";
     node_info.data.container_type = host->system_info->container ? host->system_info->container : "unknown";
     node_info.data.custom_info = config_get(CONFIG_SECTION_WEB, "custom dashboard_info.js", "");
-    node_info.data.services = NULL;   // char **
-    node_info.data.service_count = 0;
+    node_info.data.collectors = NULL;   // char **
+    node_info.data.collector_count = 0;
     node_info.data.machine_guid = wc->host_guid;
 
     struct capability node_caps[] = {

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -7,6 +7,66 @@
 #include "../../aclk/aclk_charts_api.h"
 #endif
 
+struct collector {
+    char *plugin;
+    char *module;
+};
+
+struct array_printer {
+    int c;
+    char **collectors;
+};
+
+int store_collectors(void *entry, void *data) {
+    char name[500];
+    struct collector *col=(struct collector *) entry;
+    struct array_printer *ap = (struct array_printer *)data;
+    ap->collectors = reallocz(ap->collectors, sizeof(ap->collectors) * (ap->c + 1));
+    snprintfz(name, 499, "%s:%s", col->plugin ? col->plugin : "", col->module ? col->module : "");
+    ap->collectors[ap->c] = strdupz(name);
+    (ap->c)++;
+    return 0;
+}
+
+char **collectors_from_charts(RRDHOST *host, size_t *count) {
+    DICTIONARY *dict = dictionary_create(DICTIONARY_FLAG_SINGLE_THREADED);
+    RRDSET *st;
+    char name[500];
+
+    time_t now = now_realtime_sec();
+    rrdhost_rdlock(host);
+    rrdset_foreach_read(st, host) {
+        if (rrdset_is_available_for_viewers(st)) {
+            struct collector col = {
+                    .plugin = st->plugin_name ? st->plugin_name : "",
+                    .module = st->module_name ? st->module_name : ""
+            };
+            snprintfz(name, 499, "%s:%s", col.plugin, col.module);
+            dictionary_set(dict, name, &col, sizeof(struct collector));
+            st->last_accessed_time = now;
+        }
+    }
+    rrdhost_unlock(host);
+
+    struct array_printer ap;
+    ap.c = 0;
+    ap.collectors = NULL;
+
+    dictionary_get_all(dict, store_collectors, &ap);
+    dictionary_destroy(dict);
+
+    *count = ap.c;
+    return ap.collectors;
+}
+
+void free_collectors_from_charts(char **collectors, size_t count)
+{
+    for (size_t i=0;i<count;i++)
+        freez(collectors[i]);
+
+    freez(collectors);
+}
+
 void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
 {
     UNUSED(cmd);
@@ -60,8 +120,7 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     node_info.data.virtualization_type = host->system_info->virtualization ? host->system_info->virtualization : "unknown";
     node_info.data.container_type = host->system_info->container ? host->system_info->container : "unknown";
     node_info.data.custom_info = config_get(CONFIG_SECTION_WEB, "custom dashboard_info.js", "");
-    node_info.data.collectors = NULL;   // char **
-    node_info.data.collector_count = 0;
+    node_info.data.collectors = collectors_from_charts(host, &node_info.data.collector_count);
     node_info.data.machine_guid = wc->host_guid;
 
     struct capability node_caps[] = {
@@ -84,6 +143,7 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     rrd_unlock();
     freez(node_info.claim_id);
     freez(host_version);
+    free_collectors_from_charts(node_info.data.collectors, node_info.data.collector_count);
 #else
     UNUSED(wc);
 #endif


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR gathers a list of collectors (per host) and sends them to the cloud via the `UpdateNodeInfo` message.

The produced part of the `UpdateNodeInfo` message looks like:

```
       "collectors" => [
            [ 0] "freebsd.plugin:vm.stats.sys.v_soft",
            [ 1] "freebsd.plugin:vm.vmtotal",
            [ 2] "freebsd.plugin:net.inet.ip.stats",
            [ 3] "freebsd.plugin:net.isr",
            [ 4] "freebsd.plugin:vm.stats.vm.v_swappgs",
            [ 5] "freebsd.plugin:net.inet.icmp.stats",
            [ 6] "idlejitter.plugin:",
            [ 7] "freebsd.plugin:kern.ipc.msq",
            [ 8] "freebsd.plugin:net.inet6.icmp6.stats",
            [ 9] "freebsd.plugin:kern.ipc.sem",
            [10] "statsd.plugin:stats",
            [11] "freebsd.plugin:kern.ipc.shm",
            [12] "freebsd.plugin:system.ram",
            [13] "freebsd.plugin:getifaddrs",
            [14] "freebsd.plugin:kern.cp_times",
            [15] "freebsd.plugin:uptime",
            [16] "freebsd.plugin:net.inet6.ip6.stats",
            [17] "freebsd.plugin:vm.stats.sys.v_intr",
            [18] "freebsd.plugin:vm.stats.sys.v_swtch",
            [19] "freebsd.plugin:net.inet.tcp.states",
            [20] "freebsd.plugin:hw.intrcnt",
            [21] "freebsd.plugin:vm.stats.vm.v_pgfaults",
            [22] "freebsd.plugin:getmntinfo",
            [23] "freebsd.plugin:net.inet.tcp.stats",
            [24] "freebsd.plugin:dev.cpu.0.freq",
            [25] "freebsd.plugin:devstat",
            [26] "freebsd.plugin:kern.cp_time",
            [27] "freebsd.plugin:net.inet.udp.stats",
            [28] "freebsd.plugin:vm.swap_info"
        ]
```
The `:` character is used as a separator between modules and plugins and the above format has been discussed with BE.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

No easy way to check that the message is updated with the collectors, unless the `aclk-log` (ACLK_LOG_CONVERSATION_DIR) feature is used that dumps the messages to disk.

We will get an okay from Cloud BE before merging.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

We might or might not need to adjust when the `UpdateNodeInfo` goes out. If it goes too early then the list of collectors might be less than the reality. There is however logic to re-send these messages at later times so it might not be an issue. We should look if there is need to re-send e.g. when a chart (and it's collector) dissapears.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
It will provide info on the services supported by this agent on the cloud.
</details>
