### PR TITLE
Fix coverity cids 378596 378604 378618 378619 & 378625

### DIFF
--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -699,9 +699,9 @@ static inline void statsd_process_dictionary(STATSD_METRIC *m, const char *value
                 m->dictionary.base = t;
                 m->dictionary.unique++;
             }
-            t->count++;
         }
 
+        t->count++;
         m->events++;
         m->count++;
     }
@@ -818,7 +818,7 @@ static void statsd_process_metric(const char *name, const char *value, const cha
             statsd_parse_field_trim(tagkey, tagkey_end);
             statsd_parse_field_trim(tagvalue, tagvalue_end);
 
-            if(tagvalue && *tagkey && *tagvalue) {
+            if(tagkey && tagvalue && *tagkey && *tagvalue) {
                 if (!m->units[0] && strcmp(tagkey, "units") == 0)
                     strncpyz(m->units, tagvalue, STATSD_MAX_UNITS_LENGTH);
 

--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -1590,13 +1590,14 @@ static inline void statsd_readdir(const char *user_path, const char *stock_path,
 // extract chart type and chart id from metric name
 static inline void statsd_get_metric_type_and_id(STATSD_METRIC *m, char *type, char *id, char *context, const char *metrictype, size_t len) {
     char *s;
+
     snprintfz(type, len, "%s_%s", STATSD_CHART_PREFIX, m->name);
-    if(sizeof(STATSD_CHART_PREFIX) + 2 < len) {
+    if(sizeof(STATSD_CHART_PREFIX) + 2 < len)
         for(s = &type[sizeof(STATSD_CHART_PREFIX) + 2]; *s ;s++)
-            if(unlikely(*s == '.' || *s == '_')) {
-                *s++ = '\0';
-                break;
-            }
+            if(unlikely(*s == '.' || *s == '_')) break;
+
+    if(*s == '.' || *s == '_') {
+        *s++ = '\0';
         snprintfz(id, len, "%s_%s", s, metrictype);
     }
     else {

--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -1590,7 +1590,6 @@ static inline void statsd_readdir(const char *user_path, const char *stock_path,
 // extract chart type and chart id from metric name
 static inline void statsd_get_metric_type_and_id(STATSD_METRIC *m, char *type, char *id, char *context, const char *metrictype, size_t len) {
     char *s;
-    info("DES Haha");
     snprintfz(type, len, "%s_%s", STATSD_CHART_PREFIX, m->name);
     if(sizeof(STATSD_CHART_PREFIX) + 2 < len) {
         for(s = &type[sizeof(STATSD_CHART_PREFIX) + 2]; *s ;s++)

--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -699,9 +699,9 @@ static inline void statsd_process_dictionary(STATSD_METRIC *m, const char *value
                 m->dictionary.base = t;
                 m->dictionary.unique++;
             }
+            t->count++;
         }
 
-        t->count++;
         m->events++;
         m->count++;
     }
@@ -818,7 +818,7 @@ static void statsd_process_metric(const char *name, const char *value, const cha
             statsd_parse_field_trim(tagkey, tagkey_end);
             statsd_parse_field_trim(tagvalue, tagvalue_end);
 
-            if(tagkey && tagkey && tagvalue && *tagvalue) {
+            if(tagvalue && *tagkey && *tagvalue) {
                 if (!m->units[0] && strcmp(tagkey, "units") == 0)
                     strncpyz(m->units, tagvalue, STATSD_MAX_UNITS_LENGTH);
 
@@ -1590,14 +1590,14 @@ static inline void statsd_readdir(const char *user_path, const char *stock_path,
 // extract chart type and chart id from metric name
 static inline void statsd_get_metric_type_and_id(STATSD_METRIC *m, char *type, char *id, char *context, const char *metrictype, size_t len) {
     char *s;
-
+    info("DES Haha");
     snprintfz(type, len, "%s_%s", STATSD_CHART_PREFIX, m->name);
-    if(sizeof(STATSD_CHART_PREFIX) + 2 < len)
+    if(sizeof(STATSD_CHART_PREFIX) + 2 < len) {
         for(s = &type[sizeof(STATSD_CHART_PREFIX) + 2]; *s ;s++)
-            if(unlikely(*s == '.' || *s == '_')) break;
-
-    if(*s == '.' || *s == '_') {
-        *s++ = '\0';
+            if(unlikely(*s == '.' || *s == '_')) {
+                *s++ = '\0';
+                break;
+            }
         snprintfz(id, len, "%s_%s", s, metrictype);
     }
     else {

--- a/web/api/health/health_cmdapi.c
+++ b/web/api/health/health_cmdapi.c
@@ -199,6 +199,7 @@ int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, c
         BUFFER *jsonb = buffer_create(200);
         health_silencers2json(jsonb);
         health_silencers2file(jsonb);
+        buffer_free(jsonb);
     }
 
     return ret;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR tries to fix some coverity reports, i.e 378596 378604 378618 378619 & 378625.

> CID 378625 (#1 of 1): Resource leak (RESOURCE_LEAK)15. leaked_storage: Variable jsonb going out of scope leaks the storage it points to. https://github.com/netdata/netdata/blob/5c5cf7ea4a621657cfc4bcbd302c9fda7098249d/web/api/health/health_cmdapi.c#L199

> CID 378596 (#1 of 1): Same on both sides (CONSTANT_EXPRESSION_RESULT)pointless_expression: The expression tagkey && tagkey does not accomplish anything because it evaluates to either of its identical operands, tagkey. https://github.com/netdata/netdata/blob/5c5cf7ea4a621657cfc4bcbd302c9fda7098249d/collectors/statsd.plugin/statsd.c#L821

> CID 378604 (#1 of 1): Pointer to local outside scope (RETURN_LOCAL)16. use_invalid: Using t, which points to an out-of-scope variable tmp. https://github.com/netdata/netdata/blob/5c5cf7ea4a621657cfc4bcbd302c9fda7098249d/collectors/statsd.plugin/statsd.c#L704

For the above, I think accessing `t->count++;` should happen inside the `if (unlikely(!t)) {` but I'm not sure if the counter should only increase if `if(!t->name) {` or not.

> CID 378618 (#1 of 1): Dereference before null check (REVERSE_INULL)check_after_deref: Null-checking tagkey suggests that it may be null, but it has already been dereferenced on all paths leading to the check. https://github.com/netdata/netdata/blob/5c5cf7ea4a621657cfc4bcbd302c9fda7098249d/collectors/statsd.plugin/statsd.c#L821

> CID 378619 (#1 of 1): Uninitialized pointer read (UNINIT)3. uninit_use: Using uninitialized value s. https://github.com/netdata/netdata/blob/5c5cf7ea4a621657cfc4bcbd302c9fda7098249d/collectors/statsd.plugin/statsd.c#L1599

I think that `type` is checked for the first occurance of `.` or `_` (after the initial `_` one), and if found use it for the final `id`. Reverted, will be handled by #13023 

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

Comments are most welocome!

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
