### PR TITLE
Fix coverity issue 378617,378615

### DIFF
--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -112,9 +112,9 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
     now_realtime_timeval(&w->tv_ready);
 
     if (query->timeout) {
-        double in_queue = ((int) dt_usec(&w->tv_in, &w->tv_ready)) / 1000.0;
+        int in_queue = (int) (dt_usec(&w->tv_in, &w->tv_ready) / 1000);
         if (in_queue > query->timeout) {
-            log_access("QUERY CANCELED: QUEUE TIME EXCEEDED %0.2f ms (LIMIT %d ms)", in_queue, query->timeout);
+            log_access("QUERY CANCELED: QUEUE TIME EXCEEDED %d ms (LIMIT %d ms)", in_queue, query->timeout);
             retval = 1;
             w->response.code = HTTP_RESP_BACKEND_FETCH_FAILED;
             aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, w->response.code, CLOUD_EC_SND_TIMEOUT, CLOUD_EMSG_SND_TIMEOUT, NULL, 0);

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -112,7 +112,7 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
     now_realtime_timeval(&w->tv_ready);
 
     if (query->timeout) {
-        double in_queue = (int)dt_usec(&w->tv_in, &w->tv_ready) / 1000;
+        double in_queue = ((int) dt_usec(&w->tv_in, &w->tv_ready)) / 1000.0;
         if (in_queue > query->timeout) {
             log_access("QUERY CANCELED: QUEUE TIME EXCEEDED %0.2f ms (LIMIT %d ms)", in_queue, query->timeout);
             retval = 1;

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -67,8 +67,8 @@ inline static void rrdr_lock_rrdset(RRDR *r) {
         return;
     }
 
-    rrdset_rdlock(r->st);
     r->has_st_lock = 1;
+    rrdset_rdlock(r->st);
 }
 
 inline static void rrdr_unlock_rrdset(RRDR *r) {

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -67,8 +67,8 @@ inline static void rrdr_lock_rrdset(RRDR *r) {
         return;
     }
 
-    r->has_st_lock = 1;
     rrdset_rdlock(r->st);
+    r->has_st_lock = 1;
 }
 
 inline static void rrdr_unlock_rrdset(RRDR *r) {
@@ -78,8 +78,8 @@ inline static void rrdr_unlock_rrdset(RRDR *r) {
     }
 
     if(likely(r->has_st_lock)) {
-        rrdset_unlock(r->st);
         r->has_st_lock = 0;
+        rrdset_unlock(r->st);
     }
 }
 


### PR DESCRIPTION
##### Summary

```   	
CID 378617 (#1 of 1): Result is not floating-point (UNINTENDED_INTEGER_DIVISION)
CID 378615 (#1 of 1): Data race condition (MISSING_LOCK)
```

##### Test Plan
- Coverity warning should disappear
