### PR TITLE
Fix coverity issue 378598

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -134,6 +134,10 @@ void load_claiming_state(void)
     netdata_cloud_setting = 0;
 #else
     uuid_t uuid;
+
+    // Propagate into aclk and registry. Be kind of atomic...
+    appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "cloud base url", DEFAULT_CLOUD_BASE_URL);
+
     rrdhost_aclk_state_lock(localhost);
     if (localhost->aclk_state.claimed_id) {
         if (aclk_connected)
@@ -147,9 +151,6 @@ void load_claiming_state(void)
         aclk_kill_link = 1;
     }
     aclk_disable_runtime = 0;
-
-    // Propagate into aclk and registry. Be kind of atomic...
-    appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "cloud base url", DEFAULT_CLOUD_BASE_URL);
 
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s/cloud.d/claimed_id", netdata_configured_varlib_dir);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Coverity issue 378598 is:

> CID 378598 (#1 of 1): Thread deadlock (ORDER_REVERSAL)5. lock_order: Calling appconfig_get acquires lock netdata_rwlock_t.rwlock_t while holding lock rrdhost.aclk_state_lock

In https://github.com/netdata/netdata/blob/5c5cf7ea4a621657cfc4bcbd302c9fda7098249d/claim/claim.c#L152

Moving `appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "cloud base url", DEFAULT_CLOUD_BASE_URL);` before `rrdhost_aclk_state_lock(localhost);` should be okay and not cause trouble.

If I understand correctly, call to `appconfig_get` is that so the relavant cloud.conf config will be created if it doesn't exist?

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Should not break any claiming procedure.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
