### PR TITLE
Initialize a pointer and add a check for it

### DIFF
--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -1589,14 +1589,14 @@ static inline void statsd_readdir(const char *user_path, const char *stock_path,
 
 // extract chart type and chart id from metric name
 static inline void statsd_get_metric_type_and_id(STATSD_METRIC *m, char *type, char *id, char *context, const char *metrictype, size_t len) {
-    char *s;
+    char *s = NULL;
 
     snprintfz(type, len, "%s_%s", STATSD_CHART_PREFIX, m->name);
     if(sizeof(STATSD_CHART_PREFIX) + 2 < len)
         for(s = &type[sizeof(STATSD_CHART_PREFIX) + 2]; *s ;s++)
             if(unlikely(*s == '.' || *s == '_')) break;
 
-    if(*s == '.' || *s == '_') {
+    if(s && (*s == '.' || *s == '_')) {
         *s++ = '\0';
         snprintfz(id, len, "%s_%s", s, metrictype);
     }


### PR DESCRIPTION
##### Summary
There is a compilation warning introduced in #12980
```text
collectors/statsd.plugin/statsd.c: In function 'statsd_get_metric_type_and_id':
collectors/statsd.plugin/statsd.c:1600:14: warning: 's' may be used uninitialized [-Wmaybe-uninitialized]
 1600 |         *s++ = '\0';
      |         ~~~~~^~~~~~
collectors/statsd.plugin/statsd.c:1592:11: note: 's' was declared here
 1592 |     char *s;
      |           ^
```
The PR fixes it.