### PR TITLE
Fix coverity 378587

### DIFF
--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -30,9 +30,10 @@ static inline size_t natural_alignment(size_t size) {
 static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     if(unlikely(!OWA_NATURAL_PAGE_SIZE)) {
         long int page_size = sysconf(_SC_PAGE_SIZE);
-        if (page_size == -1)
-            fatal("Cannot allocate onewayalloc buffer, sysconf failed.");
-        OWA_NATURAL_PAGE_SIZE = page_size;
+        if (unlikely(page_size == -1))
+            OWA_NATURAL_PAGE_SIZE = 4096;
+        else
+            OWA_NATURAL_PAGE_SIZE = page_size;
     }
 
     // our default page size

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -28,8 +28,12 @@ static inline size_t natural_alignment(size_t size) {
 // any number of times, for any amount of memory.
 
 static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
-    if(unlikely(!OWA_NATURAL_PAGE_SIZE))
-        OWA_NATURAL_PAGE_SIZE = sysconf(_SC_PAGE_SIZE);
+    if(unlikely(!OWA_NATURAL_PAGE_SIZE)) {
+        long int page_size = sysconf(_SC_PAGE_SIZE);
+        if (page_size == -1)
+            fatal("Cannot allocate onewayalloc buffer, sysconf failed.");
+        OWA_NATURAL_PAGE_SIZE = page_size;
+    }
 
     // our default page size
     size_t size = OWA_NATURAL_PAGE_SIZE;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Coverity reports:

> CID 378587 (#1 of 1): Improper use of negative value (NEGATIVE_RETURNS)9. negative_returns: size is passed to a parameter that cannot be negative. At line: (https://github.com/netdata/netdata/blob/ef7cbc0e21d9bf9afcce4a8cc977379ccf64420e/libnetdata/onewayalloc/onewayalloc.c#L55)

`size` is assigned from `OWA_NATURAL_PAGE_SIZE` which is assigned by the return of `sysconf(_SC_PAGE_SIZE);`

`sysconf` might return -1 on error. Check the value and fatal if that's the case.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Since onewayalloc is used throughout, basic test of agent is running should be enough.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
