### PR TITLE
When sending a dimension for the first time, make sure there is a non zero created_at timestamp

### DIFF
--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -1093,6 +1093,11 @@ void queue_dimension_to_aclk(RRDDIM *rd, time_t last_updated)
     if (likely(rd->state->aclk_live_status == live))
         return;
 
+    time_t created_at = rd->state->query_ops.oldest_time(rd);
+
+    if (unlikely(!created_at && rd->updated))
+       created_at = rd->last_collected_time.tv_sec;
+
     rd->state->aclk_live_status = live;
 
     struct aclk_database_worker_config *wc = rd->rrdset->rrdhost->dbsync_worker;
@@ -1110,7 +1115,7 @@ void queue_dimension_to_aclk(RRDDIM *rd, time_t last_updated)
     dim_payload.name = rd->name;
     dim_payload.id = rd->id;
     dim_payload.chart_id = rd->rrdset->id;
-    dim_payload.created_at.tv_sec = rd->state->query_ops.oldest_time(rd);
+    dim_payload.created_at.tv_sec = created_at;
     dim_payload.last_timestamp.tv_sec = last_updated;
 
     size_t size = 0;


### PR DESCRIPTION
##### Summary

On a fresh claimed agent some of the dimension may be sent to the cloud with a create_at (oldest collected time) of 0. This is not valid especially if the dimension has been marked as "updated". It is not obvious (yet) as how this can happen so this is a workaround to make sure we submit a valid created_at timestamp.

The side effects is that some dimensions have be transmitted with a (0, 0) timestamps which causes a deletion of the chart on the cloud (and those charts do not appear in the cloud anymore)

##### Test Plan
- Claim agent to the cloud
- Delete the dbengine files and metadata database (under var/cache/netdata/dbengine and var/cache/netdata/netdata-meta.db)
- Start the agent
  - When sync completes (a few seconds) , all charts should be visible on the cloud

