### PR TITLE
Add additional metadata to the data response

### DIFF
--- a/web/api/formatters/json_wrapper.h
+++ b/web/api/formatters/json_wrapper.h
@@ -5,7 +5,8 @@
 
 #include "rrd2json.h"
 
-extern void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value, struct context_param *context_param_list, char *chart_key);
+extern void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value,
+    QUERY_PARAMS *query_params);
 extern void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
 
 #endif //NETDATA_API_FORMATTER_JSON_WRAPPER_H

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -5,14 +5,14 @@
 
 #include "web/api/web_api_v1.h"
 
-typedef struct rrdset_query_data {
+typedef struct query_params {
     struct context_param *context_param_list;
     BUFFER *wb;
     char *chart_label_key;
     int max_anomaly_rates;
     int timeout;
     int show_dimensions;
-} RRDSET_QUERY_DATA;
+} QUERY_PARAMS;
 
 
 #include "web/api/exporters/allmetrics.h"
@@ -67,8 +67,8 @@ extern void rrdr_buffer_print_format(BUFFER *wb, uint32_t format);
 extern int rrdset2anything_api_v1(
           ONEWAYALLOC *owa
         , RRDSET *st
-        , BUFFER *wb
-        , BUFFER *dimensions
+        ,
+    QUERY_PARAMS *query_params, BUFFER *dimensions
         , uint32_t format
         , long points
         , long long after
@@ -77,10 +77,6 @@ extern int rrdset2anything_api_v1(
         , long group_time
         , uint32_t options
         , time_t *latest_timestamp
-        , struct context_param *context_param_list
-        , char *chart_label_key
-        , int max_anomaly_rates
-        , int timeout
 );
 
 extern int rrdset2value_api_v1(

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -4,6 +4,17 @@
 #define NETDATA_RRD2JSON_H 1
 
 #include "web/api/web_api_v1.h"
+
+typedef struct rrdset_query_data {
+    struct context_param *context_param_list;
+    BUFFER *wb;
+    char *chart_label_key;
+    int max_anomaly_rates;
+    int timeout;
+    int show_dimensions;
+} RRDSET_QUERY_DATA;
+
+
 #include "web/api/exporters/allmetrics.h"
 #include "web/api/queries/rrdr.h"
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -647,10 +647,15 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         buffer_strcat(w->response.data, "(");
     }
 
-    ret = rrdset2anything_api_v1(owa, st, w->response.data, dimensions, format,
-                                 points, after, before, group, group_time,
-                                 options, &last_timestamp_in_data, context_param_list,
-                                 chart_label_key, max_anomaly_rates, timeout);
+    QUERY_PARAMS query_params = {
+        .context_param_list = context_param_list,
+        .timeout = timeout,
+        .max_anomaly_rates = max_anomaly_rates,
+        .show_dimensions = show_dimensions,
+        .wb = w->response.data};
+
+    ret = rrdset2anything_api_v1(owa, st, &query_params, dimensions, format,
+            points, after, before, group, group_time, options, &last_timestamp_in_data);
 
     free_context_param_list(owa, &context_param_list);
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -422,6 +422,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
     char *chart_labels_filter = NULL;
 
     int group = RRDR_GROUPING_AVERAGE;
+    int show_dimensions = 0;
     uint32_t format = DATASOURCE_JSON;
     uint32_t options = 0x00000000;
 
@@ -447,6 +448,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
             buffer_strcat(dimensions, "|");
             buffer_strcat(dimensions, value);
         }
+        else if(!strcmp(name, "show_dimensions")) show_dimensions = 1;
         else if(!strcmp(name, "after")) after_str = value;
         else if(!strcmp(name, "before")) before_str = value;
         else if(!strcmp(name, "points")) points_str = value;


### PR DESCRIPTION
##### Summary
This is the first part of enhancing the data API call to include additional information that will be used
by the cloud to make dashboard chart refreshes faster. 

The additional metadata will be available if both `show_dimensions=1` and `option=jsonwrap` is passed.

The output in that case will include the following fields

`full_dimension_list` array of `2-element array` with the dimension id and dimension name
`full_chart_list` array of `2-element array` with the chart_id and chart name
`full_chart_labels`  array of `2-element array` with the chart_label_key and chart_label_value

Example:
```
"full_dimension_list": [["softirq","softirq"],["irq","irq"],["iowait","iowait"],["guest","guest"],["system","system"],["user","user"],["nice","nice"],["guest_nice","guest_nice"],["steal","steal"],["idle","idle"]],
```

##### Test Plan
- Apply PR and run an api/v1/data query but also supply `show_dimensions=1&option=jsonwrap`
  e.g.
  `http://127.0.0.1:19999/api/v1/data?context=cpu.cpu&options=jsonwrap&after=-60&show_dimensions=1&dimension=user`

```
   "api": 1,
   "id": "cpu.cpu",
   "name": "cpu.cpu",
   "view_update_every": 1,
   "update_every": 1,
   "first_entry": 1653900405,
   "last_entry": 1653921124,
   "before": 1653921124,
   "after": 1653921065,
   "dimension_names": ["user", "user", "user", "user", "user", "user", "user", "user", "user", "user", "user", "user"],
   "dimension_ids": ["user", "user", "user", "user", "user", "user", "user", "user", "user", "user", "user", "user"],
   "full_dimension_list": [["softirq","softirq"],["irq","irq"],["iowait","iowait"],["guest","guest"],["system","system"],["user","user"],["nice","nice"],["guest_nice","guest_nice"],["steal","steal"],["idle","idle"]],
   "full_chart_list": [["cpu.cpu5","cpu.cpu5"],["cpu.cpu11","cpu.cpu11"],["cpu.cpu7","cpu.cpu7"],["cpu.cpu10","cpu.cpu10"],["cpu.cpu9","cpu.cpu9"],["cpu.cpu1","cpu.cpu1"],["cpu.cpu4","cpu.cpu4"],["cpu.cpu0","cpu.cpu0"],["cpu.cpu2","cpu.cpu2"],["cpu.cpu3","cpu.cpu3"],["cpu.cpu6","cpu.cpu6"],["cpu.cpu8","cpu.cpu8"]],
   "full_chart_labels": [],
   "chart_ids": ["cpu.cpu11", "cpu.cpu10", "cpu.cpu9", "cpu.cpu8", "cpu.cpu7", "cpu.cpu6", "cpu.cpu5", "cpu.cpu4", "cpu.cpu3", "cpu.cpu2", "cpu.cpu1", "cpu.cpu0"],
   "latest_values": [1, 3.030303, 5, 0.9803922, 1.010101, 2.0408163, 2, 1.010101, 1.0309278, 1, 2, 2],
   "view_latest_values": [1, 3.030303, 5, 0.9803922, 1.010101, 2.040816, 2, 1.010101, 1.0309278, 1, 2, 2],
   "dimensions": 12,
   "points": 60,
   "format": "json",
```