### PR TITLE
Fix the retry count and netdata_exit check when running an sqlite3_step command

### DIFF
--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -24,6 +24,7 @@ typedef enum db_check_action_type {
     DB_CHECK_CONT = 0x00008
 } db_check_action_type_t;
 
+#define SQL_MAX_RETRY (100)
 #define SQLITE_INSERT_DELAY (50)        // Insert delay in case of lock
 
 #define SQL_STORE_HOST "insert or replace into host (host_id,hostname,registry_hostname,update_every,os,timezone,tags) values (?1,?2,?3,?4,?5,?6,?7);"


### PR DESCRIPTION
##### Summary
The condition for checking netdata_exit was wrong so basically it would just attempt to run the sqlite3_step command only once.  

This PR will properly check the `netdata_exit` and also add a retry count up to SQL_MAX_RETRY (future PRs will add more checks)

##### Test Plan
- Should be obvious but you can try the following
   - Start the agent
   - Open the metadata database using `sqlite3`  (the netdata-meta.db file) and do
   ```
    BEGIN TRANSACTION; 
    UPDATE chart SET chart_id = chart_id LIMIT 1;
    ```
    Notice there is no `COMMIT;` so this will lock the database. Notice that commands that fail do not get a retry count
-  Apply the PR and retest, you can see attempts similar to 
   ```
   2022-05-31 10:17:01: netdata ERROR : HEALTH : Failed to insert/update, rc = 5 -- attempt 1
   2022-05-31 10:17:01: netdata ERROR : HEALTH : Failed to insert/update, rc = 5 -- attempt 2
   2022-05-31 10:17:01: netdata ERROR : HEALTH : Failed to insert/update, rc = 5 -- attempt 3
   2022-05-31 10:17:01: netdata ERROR : HEALTH : Failed to insert/update, rc = 5 -- attempt 4
    ```


  