### PR TITLE
Fix disabled apps (ebpf.plugin)

### DIFF
--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1091,6 +1091,9 @@ static inline void aggregate_pid_on_target(struct target *w, struct pid_stat *p,
  */
 void collect_data_for_all_processes(int tbl_pid_stats_fd)
 {
+    if (unlikely(!all_pids))
+        return;
+
     struct pid_stat *pids = root_of_pids; // global list of all processes running
     while (pids) {
         if (pids->updated_twice) {

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -377,7 +377,7 @@ void *ebpf_oomkill_thread(void *ptr)
     ebpf_module_t *em = (ebpf_module_t *)ptr;
     em->maps = oomkill_maps;
 
-    if (unlikely(!all_pids)) {
+    if (unlikely(!all_pids || !em->apps_charts)) {
         // When we are not running integration with apps, we won't fill necessary variables for this thread to run, so
         // we need to disable it.
         if (em->enabled)

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -377,6 +377,15 @@ void *ebpf_oomkill_thread(void *ptr)
     ebpf_module_t *em = (ebpf_module_t *)ptr;
     em->maps = oomkill_maps;
 
+    if (unlikely(!all_pids)) {
+        // When we are not running integration with apps, we won't fill necessary variables for this thread to run, so
+        // we need to disable it.
+        if (em->enabled)
+            info("Disabling OOMKILL thread, because apps integration is completely disabled.");
+
+        em->enabled = 0;
+    }
+
     if (!em->enabled) {
         goto endoomkill;
     }

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -579,6 +579,9 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
  */
 static void ebpf_create_apps_charts(struct target *root)
 {
+    if (unlikely(!all_pids))
+        return;
+
     struct target *w;
     int newly_added = 0;
 

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -971,6 +971,9 @@ void ebpf_update_module_using_config(ebpf_module_t *modules)
     modules->apps_charts = appconfig_get_boolean(modules->cfg, EBPF_GLOBAL_SECTION, EBPF_CFG_APPLICATION,
                                                  modules->apps_charts);
 
+    modules->cgroup_charts = appconfig_get_boolean(modules->cfg, EBPF_GLOBAL_SECTION, EBPF_CFG_CGROUP,
+                                                   modules->cgroup_charts);
+
     modules->pid_map_size = (uint32_t)appconfig_get_number(modules->cfg, EBPF_GLOBAL_SECTION, EBPF_CFG_PID_SIZE,
                                                            modules->pid_map_size);
 


### PR DESCRIPTION
##### Summary
This PR is fixing some issues we had when `apps.plugin` was disabled:

- When integration with `apps` plugin was set `ebpf.plugin` was crashing with errors like:
```sh
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/opt/netdata/usr/libexec/netdata/plugins.d/ebpf.plugin 1'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000563b3cbafef1 in clean_vfs_pid_structures () at collectors/ebpf.plugin/ebpf_vfs.c:60
60	        freez(vfs_pid[pids->pid]);
[Current thread is 1 (Thread 0x7f78d1d83780 (LWP 1358834))]
(gdb) bt
#0  0x0000563b3cbafef1 in clean_vfs_pid_structures () at collectors/ebpf.plugin/ebpf_vfs.c:60
#1  0x0000563b3cb99699 in ebpf_exit (sig=sig@entry=0) at collectors/ebpf.plugin/ebpf.c:248
#2  0x0000563b3cb9a675 in main (argc=<optimized out>, argv=<optimized out>) at collectors/ebpf.plugin/ebpf.c:1978
```
- When `apps` was disabled and `cgroup` enabled, plugin closed because `oomkill` thread tried to write a dimension for a site that was not created.

##### Test Plan

###### Without change confir

1. Compile this branch
2. Start ebpf.plugin without any change to be sure nothing was missed.

###### Disable everything

1. Change your `/etc/netdata/ebpf.d.conf` and set: 
```conf
[global]
    apps = no
    cgroups = no
```
2. Restart `netdata`.  After few minutes, you should have ebpf.plugin running normally without any chart integrated with `apps` or `cgroup`.

###### Enable only `cgroup`.

1. Change your `/etc/netdata/ebpf.d.conf` and set: 
```conf
[global]
    apps = no
    cgroups = yes
```
2. Restart `netdata`.  After few minutes, you should have ebpf.plugin running normally without charts integrated with `apps`, but you will have `cgroup` charts.

##### Additional Information
This PR was successfully tested on the following scenarios:

| Distribution | Cgroup Version | Apps | Cgroup |
|-----------------|----------------------|---------|------------|
| Slackware Current | v1 | yes | yes |
| Slackware Current | v1 | yes | no |
| Slackware Current | v1 | no | no |
| Slackware Current | v1 | no | yes |
| Arch Linux | v2 | yes | yes |
| Arch Linux | v2 | yes | no |
| Arch Linux | v2 | no | no |
| Arch Linux | v2 | no | yes |


<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ebpf.plugin
- Can they see the change or is it an under the hood? If they can see it, where? When they disable apps integration, ebpf.plugin won't crash and global charts will be available.
- How is the user impacted by the change?  They have plugin running as expected. 
- What are there any benefits of the change?  This allow users to collect eBPF data when integrations are disabled.
</details>
