### PR TITLE
Check for host labels when linking alerts for children

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -116,6 +116,31 @@ static inline int rrdcalc_test_additional_restriction(RRDCALC *rc, RRDSET *st){
     if (rc->plugin_match && !simple_pattern_matches(rc->plugin_pattern, st->plugin_name))
         return 0;
 
+    if (rc->labels) {
+        int labels_count=1;
+        int labels_match=0;
+        char *s = rc->labels;
+        while (*s) {
+            if (*s==' ')
+                labels_count++;
+            s++;
+        }
+        RRDHOST *host = st->rrdhost;
+        char cmp[CONFIG_FILE_LINE_MAX+1];
+        struct label *move = host->labels.head;
+        while(move) {
+            snprintf(cmp, CONFIG_FILE_LINE_MAX, "%s=%s", move->key, move->value);
+            if (simple_pattern_matches(rc->splabels, move->key) ||
+                simple_pattern_matches(rc->splabels, cmp)) {
+                labels_match++;
+            }
+            move = move->next;
+        }
+
+        if (labels_match != labels_count)
+            return 0;
+    }
+
     return 1;
 }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #12994 

This PR adds a check during alerts linking with charts for the host's labels. 

The alert will be linked to the chart only if all host labels are matched to the ones in the alert.

The check comes during charts linking to alerts. By that time, labels from the child _should_ have already been propagated to the parent.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

1) Setup a parent and a child.
2) Pick an alert on the parent that would normally be linked for the child.
3) Find a child label, e.g. `_system_cores = 4`
4) Add this host label to the alert's `host label:` parameter, sligthly different, e.g. `_system_cores = 3`.
5) Without this PR notice that the alert appears in `/host/child/api/v1/alarms?all`.
6) Repeat the same with this PR. The alert should be missing.
7) Try various combinations with e.g. 2 host labels.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
