### PR TITLE
Fix coverity 378625

### DIFF
--- a/web/api/health/health_cmdapi.c
+++ b/web/api/health/health_cmdapi.c
@@ -199,6 +199,7 @@ int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, c
         BUFFER *jsonb = buffer_create(200);
         health_silencers2json(jsonb);
         health_silencers2file(jsonb);
+        buffer_free(jsonb);
     }
 
     return ret;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Frees the `jsonb` buffer.

> CID 378625 (https://github.com/netdata/netdata/issues/1 of 1): Resource leak (RESOURCE_LEAK)15. leaked_storage: Variable jsonb going out of scope leaks the storage it points to.