### PR TITLE
Fix handling of temp directory in kickstart when uninstalling.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -101,9 +101,7 @@ main() {
       ;;
   esac
 
-  tmpdir="$(create_tmp_directory)"
-  progress "Using ${tmpdir} as a temporary directory."
-  cd "${tmpdir}" || fatal "Failed to change current working directory to ${tmpdir}." F000A
+  set_tmpdir
 
   if [ -n "${INSTALL_VERSION}" ]; then
     if echo "${INSTALL_VERSION}" | grep -E -o "^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$" > /dev/null 2>&1; then
@@ -373,7 +371,8 @@ success_banner() {
 }
 
 cleanup() {
-  if [ -z "${NO_CLEANUP}" ]; then
+  if [ -z "${NO_CLEANUP}" ] && [ -n "${tmpdir}" ]; then
+    cd || true
     ${ROOTCMD} rm -rf "${tmpdir}"
   fi
 }
@@ -504,6 +503,14 @@ create_tmp_directory() {
   fi
 
   mktemp -d -t netdata-kickstart-XXXXXXXXXX
+}
+
+set_tmpdir() {
+  if [ -z "${tmpdir}" ]; then
+    tmpdir="$(create_tmp_directory)"
+    progress "Using ${tmpdir} as a temporary directory."
+    cd "${tmpdir}" || fatal "Failed to change current working directory to ${tmpdir}." F000A
+  fi
 }
 
 check_for_remote_file() {
@@ -710,6 +717,7 @@ update() {
 }
 
 uninstall() {
+  set_tmpdir
   get_system_info
   detect_existing_install
 


### PR DESCRIPTION
##### Summary

This makes temporary directory creation idempotent, and ensures it’s invoked in each place that needs it. It also tidies up the cleanup code so that it only tries to remove the temporary directory if one was created.

##### Test Plan

Easily tested by trying to uninstall or do a clean reinstall with the kickstart script on a system that does not have a usable uninstaller script locally.

Without this PR, the uninstall process will try to use `/` as a temporary directory to download the uninstaller script and fail as a result if not run as `root`.

With this PR, the uninstall process will work correctly.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Uninstalls and clean reinstalls with the kickstart script work correctly again as a non-root user.
</details>
