### PR TITLE
Added Alma Linux 9 and RHEL 9 support to CI and packaging.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -27,17 +27,24 @@ include:
     env_prep: |
       pacman --noconfirm -Syu && pacman --noconfirm -Sy grep libffi
 
-  - distro: almalinux
-    version: "8"
+  - &alma
+    distro: almalinux
+    version: "9"
     base_image: almalinux
     jsonc_removal: |
       dnf remove -y json-c-devel
-    packages:
+    packages: &alma_packages
       type: rpm
-      repo_distro: el/8
+      repo_distro: el/9
       arches:
         - amd64
         - arm64
+  - <<: *alma
+    version: "8"
+    packages:
+      <<: *alma_packages
+      repo_distro: el/8
+
   - distro: centos
     version: "7"
     packages:

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -36,6 +36,10 @@ install_centos() {
 
   pkg_version="$(echo "${VERSION}" | tr - .)"
 
+  if [ "${PKGMGR}" = "dnf" ]; then
+    opts="--allowerasing"
+  fi
+
   # Install EPEL (needed for `jq`
   "$PKGMGR" install -y epel-release || exit 1
 
@@ -43,7 +47,7 @@ install_centos() {
   "$PKGMGR" install -y /netdata/artifacts/netdata-"${pkg_version}"-*.rpm
 
   # Install testing tools
-  "$PKGMGR" install -y curl nc jq || exit 1
+  "$PKGMGR" install -y ${opts} curl nc jq || exit 1
 }
 
 install_suse_like() {

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -127,7 +127,9 @@ BuildRequires: git-core
 BuildRequires: autoconf
 %if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1140
 BuildRequires: autoconf-archive
+%if 0%{?rhel} <= 8
 BuildRequires: autogen
+%endif
 %endif
 BuildRequires: automake
 BuildRequires: cmake

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -51,6 +51,7 @@ to work on these platforms with minimal user effort.
 | Platform | Version | Official Native Packages | Notes |
 | -------- | ------- | ------------------------ | ----- |
 | Alpine Linux | 3.16 | No | The latest release of Alpine Linux is guaranteed to remain at **Core** tier due to usage for our Docker images |
+| Alma Linux | 9.x | x86\_64, AArch64 | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives |
 | Alma Linux | 8.x | x86\_64, AArch64 | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives |
 | CentOS | 7.x | x86\_64 | |
 | Docker | 19.03 or newer | x86\_64, i386, ARMv7, AArch64, POWER8+ | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker |
@@ -62,8 +63,9 @@ to work on these platforms with minimal user effort.
 | Fedora | 34 | x86\_64, ARMv7, AArch64 | |
 | openSUSE | Leap 15.3 | x86\_64, AArch64 | |
 | Oracle Linux | 8.x | x86\_64, AArch64 | |
-| Red Hat Enterprise Linux | 7.x | x86\_64 | |
+| Red Hat Enterprise Linux | 9.x | x86\_64, AArch64 | |
 | Red Hat Enterprise Linux | 8.x | x86\_64, AArch64 | |
+| Red Hat Enterprise Linux | 7.x | x86\_64 | |
 | Ubuntu | 22.04 | x86\_64, ARMv7, AArch64 | |
 | Ubuntu | 21.10 | x86\_64, i386, ARMv7, AArch64 | |
 | Ubuntu | 20.04 | x86\_64, i386, ARMv7, AArch64 | |

--- a/packaging/installer/dependencies/centos.sh
+++ b/packaging/installer/dependencies/centos.sh
@@ -10,7 +10,6 @@ declare -a package_tree=(
   make
   autoconf
   autoconf-archive
-  autogen
   automake
   libatomic
   libtool
@@ -106,7 +105,22 @@ validate_tree_centos() {
 
   echo >&2 " > CentOS Version: $(os_version) ..."
 
-  if [[ $(os_version) =~ ^8(\..*)?$ ]]; then
+  if [[ $(os_version) =~ ^9(\..*)?$ ]]; then
+    package_manager=dnf
+    echo >&2 " > Checking for config-manager ..."
+    if ! dnf config-manager --help &> /dev/null; then
+      if prompt "config-manager not found, shall I install it?"; then
+        dnf ${opts} install 'dnf-command(config-manager)'
+      fi
+    fi
+
+    echo >&2 " > Checking for CRB ..."
+    if ! dnf repolist | grep CRB; then
+      if prompt "CRB not found, shall I install it?"; then
+        dnf ${opts} config-manager --set-enabled crb
+      fi
+    fi
+  elif [[ $(os_version) =~ ^8(\..*)?$ ]]; then
     package_manager=dnf
     echo >&2 " > Checking for config-manager ..."
     if ! dnf config-manager --help &> /dev/null; then
@@ -128,7 +142,7 @@ validate_tree_centos() {
     echo >&2 " > Installing Judy-devel directly ..."
     dnf ${opts} install http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64.rpm
     dnf makecache --refresh
-elif [[ $(os_version) =~ ^7(\..*)?$ ]]; then
+  elif [[ $(os_version) =~ ^7(\..*)?$ ]]; then
     package_manager=yum
     echo >&2 " > Checking for EPEL ..."
     if ! rpm -qa | grep epel-release > /dev/null; then

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -660,6 +660,8 @@ declare -A pkg_autogen=(
   # exceptions
   ['centos-6']="WARNING|"
   ['rhel-6']="WARNING|"
+  ['centos-9']="NOTREQUIRED|"
+  ['rhel-9']="NOTREQUIRED|"
 )
 
 declare -A pkg_automake=(
@@ -1601,7 +1603,21 @@ validate_tree_centos() {
 
   echo >&2 " > CentOS Version: ${version} ..."
 
-  if [[ "${version}" =~ ^8(\..*)?$ ]]; then
+  if [[ "${version}" =~ ^9(\..*)?$ ]]; then
+    echo >&2 " > Checking for config-manager ..."
+    if ! run ${sudo} dnf config-manager --help; then
+      if prompt "config-manager not found, shall I install it?"; then
+        run ${sudo} dnf ${opts} install 'dnf-command(config-manager)'
+      fi
+    fi
+
+    echo >&2 " > Checking for CRB ..."
+    if ! run dnf ${sudo} repolist | grep CRB; then
+      if prompt "CRB not found, shall I install it?"; then
+        run ${sudo} dnf ${opts} config-manager --set-enabled crb
+      fi
+    fi
+  elif [[ "${version}" =~ ^8(\..*)?$ ]]; then
     echo >&2 " > Checking for config-manager ..."
     if ! run ${sudo} yum config-manager --help; then
       if prompt "config-manager not found, shall I install it?"; then


### PR DESCRIPTION
##### Summary

This adds RHEL 9 and Alma Linux 9 to CI, packaging, and our official support list.

##### Test Plan

n/a

##### Additional Information

Fixes: #13057 

<details> <summary>For users: How does this change affect me?</summary>
Once merged, Alma Linux 9 and RHEL 9 will be officially supported by the Netdata Agent.
</details>