### PR TITLE
Initialize chart label key parameter correctly

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -652,6 +652,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         .timeout = timeout,
         .max_anomaly_rates = max_anomaly_rates,
         .show_dimensions = show_dimensions,
+        .chart_label_key = chart_label_key,
         .wb = w->response.data};
 
     ret = rrdset2anything_api_v1(owa, st, &query_params, dimensions, format,


### PR DESCRIPTION
##### Summary
Passes the chart label key parameter correctly so that it will be handled by the json wrapper correctly
and populate the result set with the necessary metadata

##### Test Plan
- Agent claimed to the cloud will correctly display K8S charts
