### PR TITLE
fix(cgroup.plugin): read k8s_cluster_name label from the correct file

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -261,7 +261,7 @@ function k8s_get_kubepod_name() {
     IFS= read -r kube_cluster_name 2>/dev/null <"$tmp_kube_cluster_name"
   else
     IFS= read -r kube_system_uid 2>/dev/null <"$tmp_kube_system_ns_uid_file"
-    IFS= read -r kube_cluster_name 2>/dev/null <"$tmp_kube_containers_file"
+    IFS= read -r kube_cluster_name 2>/dev/null <"$tmp_kube_cluster_name"
     [ -z "$kube_cluster_name" ] && ! kube_cluster_name=$(k8s_gcp_get_cluster_name) && kube_cluster_name="unknown"
 
     local kube_system_ns


### PR DESCRIPTION
##### Summary

Quite by accident, I noticed some cgroup charts have wrong `k8s_cluster_name` value in our K8s cluster:

> "k8s_cluster_name": "namespace=",

The following `IFS= read...` lines should be the same:

https://github.com/netdata/netdata/blob/446ac867e414da2c920e8ea7dbc9f7c9a7faebd1/collectors/cgroups.plugin/cgroup-name.sh#L260-L264

As you can see we read `k8s_cluster_name` from the wrong file in the `else` branch

---



##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
