### PR TITLE
Use a separate thread for slow mountpoints in the diskspace plugin

### DIFF
--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -523,9 +523,11 @@ void *diskspace_slow_worker(void *ptr)
 
     struct basic_mountinfo *slow_mountinfo_root = NULL;
 
+    int slow_update_every = update_every > SLOW_UPDATE_EVERY ? update_every : SLOW_UPDATE_EVERY;
+
     netdata_thread_cleanup_push(diskspace_slow_worker_cleanup, ptr);
 
-    usec_t step = (update_every > SLOW_UPDATE_EVERY ? update_every : SLOW_UPDATE_EVERY) * USEC_PER_SEC;
+    usec_t step = slow_update_every * USEC_PER_SEC;
     heartbeat_t hb;
     heartbeat_init(&hb);
 
@@ -551,7 +553,7 @@ void *diskspace_slow_worker(void *ptr)
 
         struct basic_mountinfo *bmi;
         for(bmi = slow_mountinfo_root; bmi; bmi = bmi->next) {
-            do_slow_disk_space_stats(bmi, update_every);
+            do_slow_disk_space_stats(bmi, slow_update_every);
             
             if(unlikely(netdata_exit)) break;
         }
@@ -632,7 +634,6 @@ void *diskspace_main(void *ptr) {
         /* usec_t hb_dt = */ heartbeat_next(&hb, step);
 
         if(unlikely(netdata_exit)) break;
-
 
         // --------------------------------------------------------------------------
         // this is smart enough not to reload it every time

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -166,9 +166,9 @@ static void free_basic_mountinfo(struct basic_mountinfo *bmi)
         freez(bmi->root);
         freez(bmi->mount_point);
         freez(bmi->filesystem);
-    }
 
-    freez(bmi);
+        freez(bmi);
+    }
 };
 
 static void free_basic_mountinfo_list(struct basic_mountinfo *root)
@@ -198,11 +198,7 @@ static void calculate_values_and_show_charts(
     fsblkcnt_t btotal         = buff_statvfs->f_blocks;
     fsblkcnt_t bavail_root    = buff_statvfs->f_bfree;
     fsblkcnt_t breserved_root = bavail_root - bavail;
-    fsblkcnt_t bused;
-    if(likely(btotal >= bavail_root))
-        bused = btotal - bavail_root;
-    else
-        bused = bavail_root - btotal;
+    fsblkcnt_t bused = likely(btotal >= bavail_root) ? btotal - bavail_root : bavail_root - btotal;
 
 #ifdef NETDATA_INTERNAL_CHECKS
     if(unlikely(btotal != bavail + breserved_root + bused))

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -321,6 +321,9 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
     static SIMPLE_PATTERN *excluded_mountpoints = NULL;
     static SIMPLE_PATTERN *excluded_filesystems = NULL;
+
+    usec_t slow_timeout = MAX_STAT_USEC * update_every;
+
     int do_space, do_inodes;
 
     if(unlikely(!dict_mountpoints)) {
@@ -394,7 +397,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
                 }
             }
 
-            if ((now_monotonic_high_precision_usec() - start_time) > MAX_STAT_USEC)
+            if ((now_monotonic_high_precision_usec() - start_time) > slow_timeout)
                 slow = 1;
         }
 
@@ -460,7 +463,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
         return;
     }
 
-    if ((now_monotonic_high_precision_usec() - start_time) > MAX_STAT_USEC)
+    if ((now_monotonic_high_precision_usec() - start_time) > slow_timeout)
         m->slow = 1;
 
     m->shown_error = 0;

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -18,11 +18,12 @@ static struct mountinfo *disk_mountinfo_root = NULL;
 static int check_for_new_mountpoints_every = 15;
 static int cleanup_mount_points = 1;
 
+// a copy of basic mountinfo fields
 struct basic_mountinfo {
-    char *persistent_id;    // a calculated persistent id for the mount point
-    char *root;             // root: root of the mount within the filesystem.
-    char *mount_point;      // mount point: mount point relative to the process's root.
-    char *filesystem;       // filesystem type: name of filesystem in the form "type[.subtype]".
+    char *persistent_id;    
+    char *root;             
+    char *mount_point;      
+    char *filesystem;       
 
     struct basic_mountinfo *next;
 };

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -163,7 +163,7 @@ static void add_basic_mountinfo(struct basic_mountinfo **root, struct mountinfo 
 
 static void free_basic_mountinfo(struct basic_mountinfo *bmi)
 {
-    if (!bmi) {
+    if (bmi) {
         freez(bmi->persistent_id);
         freez(bmi->root);
         freez(bmi->mount_point);
@@ -581,6 +581,9 @@ void *diskspace_slow_worker(void *ptr)
     }
 
     netdata_thread_cleanup_pop(1);
+
+    free_basic_mountinfo_list(slow_mountinfo_root);
+
     return NULL;
 }
 
@@ -596,6 +599,8 @@ static void diskspace_main_cleanup(void *ptr) {
         netdata_thread_join(*diskspace_slow_thread, NULL);
         freez(diskspace_slow_thread);
     }
+
+    free_basic_mountinfo_list(slow_mountinfo_tmp_root);
 
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -109,18 +109,18 @@ int mount_point_is_protected(char *mount_point)
 static void calculate_values_and_show_charts(
     struct mountinfo *mi,
     struct mount_point_metadata *m,
-    struct statvfs buff_statvfs,
+    struct statvfs *buff_statvfs,
     int update_every)
 {
     const char *family = mi->mount_point;
     const char *disk = mi->persistent_id;
 
     // logic found at get_fs_usage() in coreutils
-    unsigned long bsize = (buff_statvfs.f_frsize) ? buff_statvfs.f_frsize : buff_statvfs.f_bsize;
+    unsigned long bsize = (buff_statvfs->f_frsize) ? buff_statvfs->f_frsize : buff_statvfs->f_bsize;
 
-    fsblkcnt_t bavail         = buff_statvfs.f_bavail;
-    fsblkcnt_t btotal         = buff_statvfs.f_blocks;
-    fsblkcnt_t bavail_root    = buff_statvfs.f_bfree;
+    fsblkcnt_t bavail         = buff_statvfs->f_bavail;
+    fsblkcnt_t btotal         = buff_statvfs->f_blocks;
+    fsblkcnt_t bavail_root    = buff_statvfs->f_bfree;
     fsblkcnt_t breserved_root = bavail_root - bavail;
     fsblkcnt_t bused;
     if(likely(btotal >= bavail_root))
@@ -135,9 +135,9 @@ static void calculate_values_and_show_charts(
 
     // --------------------------------------------------------------------------
 
-    fsfilcnt_t favail         = buff_statvfs.f_favail;
-    fsfilcnt_t ftotal         = buff_statvfs.f_files;
-    fsfilcnt_t favail_root    = buff_statvfs.f_ffree;
+    fsfilcnt_t favail         = buff_statvfs->f_favail;
+    fsfilcnt_t ftotal         = buff_statvfs->f_files;
+    fsfilcnt_t favail_root    = buff_statvfs->f_ffree;
     fsfilcnt_t freserved_root = favail_root - favail;
     fsfilcnt_t fused          = ftotal - favail_root;
 
@@ -374,7 +374,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
     }
     m->shown_error = 0;
 
-    calculate_values_and_show_charts(mi, m, buff_statvfs, update_every);
+    calculate_values_and_show_charts(mi, m, &buff_statvfs, update_every);
 }
 
 static void diskspace_main_cleanup(void *ptr) {


### PR DESCRIPTION
##### Summary
`stat()` and `statvfs()` calls are blocking. That causes gaps in diskspace charts, especially if there are network filesystems mounted to a system. We will check for the time needed to process mountpoints and if the calls are slow, process the "slow" mountpoints in a separate thread with a much longer `update_every`.

Fixes #10150

##### Test Plan
1. Insert `if (!strcmp(mi->mount_point, "/tmp") || !strcmp(mi->mount_point, "/run")) sleep(4);` before or after `stat()`, `statvfs()` calls.
2. Check if `disk_space.` and `disk_inodes.`charts for `/tmp` and `/run` mountpoints work and `update_every` is more than 5 for them.