### PR TITLE
Fix Plugins (ebpf, apps) memory leak

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -2933,7 +2933,7 @@ static size_t zero_all_targets(struct target *root) {
             while(pid_on_target) {
                 pid_on_target_to_free = pid_on_target;
                 pid_on_target = pid_on_target->next;
-                free(pid_on_target_to_free);
+                freez(pid_on_target_to_free);
             }
 
             w->root_pid = NULL;

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1928,6 +1928,9 @@ int main(int argc, char **argv)
         ebpf_exit(5);
     }
 
+    netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
+    if(verify_netdata_host_prefix() == -1) ebpf_exit(6);
+
     ebpf_allocate_common_vectors();
 
 #ifdef LIBBPF_MAJOR_VERSION

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -134,7 +134,7 @@ size_t zero_all_targets(struct target *root)
             while (pid_on_target) {
                 struct pid_on_target *pid_on_target_to_free = pid_on_target;
                 pid_on_target = pid_on_target->next;
-                free(pid_on_target_to_free);
+                freez(pid_on_target_to_free);
             }
 
             w->root_pid = NULL;


### PR DESCRIPTION
##### Summary
This PR is fixing an ancient bug for `apps.plugin` and `ebpf.plugin`, we are allocating memory with `mallocz` ([apps](https://github.com/netdata/netdata/blob/e6f1aeb54c5b17f7ad5315fd97c6e1dcdd03207e/collectors/apps.plugin/apps_plugin.c#L3097) and [ebpf](https://github.com/netdata/netdata/blob/e6f1aeb54c5b17f7ad5315fd97c6e1dcdd03207e/collectors/ebpf.plugin/ebpf_apps.c#L1078) , but we are cleaning memory with `free` instead `freez`.

This PR is also initializing the variable `netdata_configured_host_prefix` that is not properly initialized inside `ebpf.plugin`

##### Test Plan

1. Compile this `branch` and let it running in a computer without user iteration, in this scenario memory usage for `apps` and `ebpf` are almost static, only small changes can happen.
2. Run the following command to get the data:
```sh
$ curl -o query.txt "http://localhost:19999/api/v1/data?chart=apps.mem&dimension=ebpf.plugin,apps.plugin&after=-36000"
```
3. Now compile this branch on a computer running applications that creates threads/process, you will have a small increase instead constant memory increase, because this is expecting according the algorithm used by both plugins. 
4. Repeat step 2 renaming the file.

##### Additional Information
We should consider this a first step in the direction of the final solution, because right now both collectors are collecting the same data, in the perfect scenario the integration with `apps.plugin` will have a shared memory with only `apps.plugin` filling the common structure like the integration with `cgroup.plugin`.

This PR was tested with the following scenarios:

| Scenario | Description | Result |
|-------------|-----------------|----------|
|Current master | Normal work with clion and firefox | [master.txt](https://github.com/netdata/netdata/files/8841013/master.txt)  |
| This PR | Normal work with clion and firefox | [pr.txt](https://github.com/netdata/netdata/files/8841017/pr.txt) |
| Isolated computer | I closed all graphic software, except X server and KDE. |  [pr_no_process.txt](https://github.com/netdata/netdata/files/8841024/pr_no_process.txt) |

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? `ebpf` and `apps` plugins.
- Can they see the change or is it an under the hood? If they can see it, where? Yes, acessing the chart `apps.mem`
- How is the user impacted by the change?  It is expected that plugins will use less memory.
- What are there any benefits of the change? Two plugins using less memory.
</details>
