### PR TITLE
Update default value for "host anomaly rate threshold"

### DIFF
--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -42,7 +42,7 @@ void Config::readMLConfig(void) {
     unsigned MaxKMeansIters = config_get_number(ConfigSectionML, "maximum number of k-means iterations", 1000);
 
     double DimensionAnomalyScoreThreshold = config_get_float(ConfigSectionML, "dimension anomaly score threshold", 0.99);
-    double HostAnomalyRateThreshold = config_get_float(ConfigSectionML, "host anomaly rate threshold", 0.01);
+    double HostAnomalyRateThreshold = config_get_float(ConfigSectionML, "host anomaly rate threshold", 0.02);
 
     double ADMinWindowSize = config_get_float(ConfigSectionML, "minimum window size", 30);
     double ADMaxWindowSize = config_get_float(ConfigSectionML, "maximum window size", 600);


### PR DESCRIPTION
Update default value for "host anomaly rate threshold"

##### Summary
The current default value for "host anomaly rate threshold" of 0.01 (1%) is too sensitive and background nosie levels of anomaly rate have been anecdotally found to been in the <2% range. Therefore this PR proposes updating the default value to 2% to not detect spurious anomaly events.


##### Test Plan

Test on staging once build with change is available to confirm expected behavior.

##### Additional Information

- Which area of Netdata is affected by the change? 
-- **Anomaly Advisor**
- Can they see the change or is it an under the hood? If they can see it, where? 
-- **The change is under the hood, but the visible change for users will be a reduction in the number of anomaly events**
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-- **The user will see less spurious anomaly events which are triggered by background anomaly levels of 1-1.5% anomaly rate, the anomaly events detected will be true anomaly events making troubleshooting using anomaly advisor more meaningful and intuitive.**

