### PR TITLE
fix virtualization detection on FreeBSD

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -44,9 +44,11 @@ if [ -z "${VIRTUALIZATION}" ]; then
     [ -n "$VIRTUALIZATION" ] && VIRT_DETECTION="dmidecode"
   fi
 
-  if [ -z "${VIRTUALIZATION}" ] && [ "${KERNEL_NAME}" = "FreeBSD" ]; then
-    VIRTUALIZATION=$(sysctl kern.vm_guest 2>/dev/null | cut -d: -f 2 | awk '{$1=$1};1')
-    [ -n "$VIRTUALIZATION" ] && VIRT_DETECTION="sysctl"
+  if [ -z "${VIRTUALIZATION}" ] || [ "$VIRTUALIZATION" = "unknown" ]; then
+    if [ "${KERNEL_NAME}" = "FreeBSD" ]; then
+      VIRTUALIZATION=$(sysctl kern.vm_guest 2>/dev/null | cut -d: -f 2 | awk '{$1=$1};1')
+      [ -n "$VIRTUALIZATION" ] && VIRT_DETECTION="sysctl"
+    fi
   fi
 
   if [ -z "${VIRTUALIZATION}" ]; then


### PR DESCRIPTION
##### Summary

ssia

##### Test Plan

It will be tested by @cpipilas 

```
wget -q -O system-info.sh https://raw.githubusercontent.com/ilyam8/netdata/fix_virtualization_detection_on_freebsd/daemon/system-info.sh; sh system-info.sh | grep -i virt; rm system-info.sh
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
