### PR TITLE
Statistics on bytes recvd and sent

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -822,6 +822,7 @@ void *aclk_main(void *ptr)
         stats_thread = callocz(1, sizeof(struct aclk_stats_thread));
         stats_thread->thread = mallocz(sizeof(netdata_thread_t));
         stats_thread->query_thread_count = query_threads.count;
+        stats_thread->client = mqttwss_client;
         aclk_stats_thread_prepare(query_threads.count, proto_hdl_cnt);
         netdata_thread_create(
             stats_thread->thread, ACLK_STATS_THREAD_NAME, NETDATA_THREAD_OPTION_JOINABLE, aclk_stats_main_thread,

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -277,8 +277,8 @@ static void aclk_stats_mqtt_wss(struct mqtt_wss_stats *stats)
             "netdata", "aclk_openssl_bytes", NULL, "aclk", NULL, "Received and Sent bytes.", "B/s",
             "netdata", "stats", 200011, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
-        rd_sent  = rrddim_add(st, "sent", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_INCREMENTAL);
-        rd_recvd = rrddim_add(st, "received", NULL, -11, localhost->rrd_update_every, RRD_ALGORITHM_INCREMENTAL);
+        rd_sent  = rrddim_add(st, "sent", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_recvd = rrddim_add(st, "received", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
     } else
         rrdset_next(st);
 

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -277,8 +277,8 @@ static void aclk_stats_mqtt_wss(struct mqtt_wss_stats *stats)
             "netdata", "aclk_openssl_bytes", NULL, "aclk", NULL, "Received and Sent bytes.", "B/s",
             "netdata", "stats", 200011, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
-        rd_sent  = rrddim_add(st, "sent", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-        rd_recvd = rrddim_add(st, "received", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_sent  = rrddim_add(st, "sent", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_recvd = rrddim_add(st, "received", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     } else
         rrdset_next(st);
 

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -266,19 +266,24 @@ static void aclk_stats_mqtt_wss(struct mqtt_wss_stats *stats)
     static RRDSET *st = NULL;
     static RRDDIM *rd_sent = NULL;
     static RRDDIM *rd_recvd = NULL;
+    static uint64_t sent = 0;
+    static uint64_t recvd = 0;
+
+    sent += stats->bytes_tx;
+    recvd += stats->bytes_rx;
 
     if (unlikely(!st)) {
         st = rrdset_create_localhost(
-            "netdata", "aclk_openssl_written", NULL, "aclk", NULL, "Sent bytes.", "B/s",
+            "netdata", "aclk_openssl_bytes", NULL, "aclk", NULL, "Received and Sent bytes.", "B/s",
             "netdata", "stats", 200011, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
 
-        rd_sent  = rrddim_add(st, "sent", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
-        rd_recvd = rrddim_add(st, "received", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
+        rd_sent  = rrddim_add(st, "sent", NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_INCREMENTAL);
+        rd_recvd = rrddim_add(st, "received", NULL, -11, localhost->rrd_update_every, RRD_ALGORITHM_INCREMENTAL);
     } else
         rrdset_next(st);
 
-    rrddim_set_by_pointer(st, rd_sent, stats->bytes_tx);
-    rrddim_set_by_pointer(st, rd_recvd, -stats->bytes_rx);
+    rrddim_set_by_pointer(st, rd_sent, sent);
+    rrddim_set_by_pointer(st, rd_recvd, recvd);
 
     rrdset_done(st);
 }

--- a/aclk/aclk_stats.h
+++ b/aclk/aclk_stats.h
@@ -6,6 +6,7 @@
 #include "daemon/common.h"
 #include "libnetdata/libnetdata.h"
 #include "aclk_query_queue.h"
+#include "mqtt_wss_client.h"
 
 #define ACLK_STATS_THREAD_NAME "ACLK_Stats"
 
@@ -22,6 +23,7 @@ int aclk_cloud_req_http_type_to_idx(const char *name);
 struct aclk_stats_thread {
     netdata_thread_t *thread;
     int query_thread_count;
+    mqtt_wss_client client;
 };
 
 // preserve between samples


### PR DESCRIPTION
##### Summary
Adds info about bytes written/read from OpenSSL_write and openssl_read. This will also be used in following PRs to react to situations where more data is produced that can be sent. For example:
- send low priority data only when connection idle (or near idle) e.g. aclk events
- reduce amount of children we expose to cloud if we see the link cannot handle it anymore, instead of kicking random messages

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
