### PR TITLE
Fix typo in release base prep script.

### DIFF
--- a/.github/scripts/prepare-release-base.sh
+++ b/.github/scripts/prepare-release-base.sh
@@ -153,7 +153,7 @@ elif [ "${EVENT_TYPE}" = 'minor' ] && [ "${EVENT_VERSION}" != "nightly" ]; then
     echo "::set-output name=ref::${EVENT_VERSION}"
     echo "::set-output name=type::release"
     echo "::set-output name=branch::master"
-    echo "::set-output name=new-branch:${branch_name}"
+    echo "::set-output name=new-branch::${branch_name}"
     echo "::set-output name=version::$(tr -d 'v' < packaging/version)"
 elif [ "${EVENT_TYPE}" = 'major' ] && [ "${EVENT_VERSION}" != "nightly" ]; then
     echo "::notice::Preparing a major release build."


### PR DESCRIPTION
##### Summary

This fixes a single character omission typo in the release prep script.

The typo itself was causing a workflow command issued by the script to not actually be processed, which in turn meant that minor releases would not end up creating a release branch like they should.

##### Test Plan

n/a