### PR TITLE
Temporarily disable updates for static builds.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -622,7 +622,7 @@ update_build() {
 }
 
 update_static() {
-  warning "Due to nown issues with updates on static builds, updates for this system are temporarily disabled. They should start working again automatically once this issue is fixed."
+  warning "Due to known issues with updates on static builds, updates for this system are temporarily disabled. They should start working again automatically once this issue is fixed."
   return 0
 
   ndtmpdir="$(create_tmp_directory)"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -622,6 +622,9 @@ update_build() {
 }
 
 update_static() {
+  warning "Due to nown issues with updates on static builds, updates for this system are temporarily disabled. They should start working again automatically once this issue is fixed."
+  return 0
+
   ndtmpdir="$(create_tmp_directory)"
   PREVDIR="$(pwd)"
 


### PR DESCRIPTION
##### Summary

This temporarily disables updates using the netdata-updater.sh script for static installs. This is being done to prevent any further issues caused by a bug we have identified in the static installer code which was causing automatic updates to be unconditionally disabled.

Once the aforementioned bug is fixed, this PR will be reverted to re-enable updates for static installs.

##### Test Plan

With the code in this PR, attempting to run the updater script on a system with a static install should print a warning informing the user that updates have been temporarily disabled and then exit without updating.