### PR TITLE
Remove unnescesary ‘cleanup’ code.

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -981,35 +981,6 @@ install_netdata_updater() {
   return 0
 }
 
-cleanup_old_netdata_updater() {
-  if [ -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh ]; then
-    echo >&2 "Removing updater from deprecated location"
-    rm -f "${NETDATA_PREFIX}"/usr/libexec/netdata-updater.sh
-  fi
-
-  if issystemd && [ -n "$(get_systemd_service_dir)" ] ; then
-    systemctl disable netdata-updater.timer
-    rm -f "$(get_systemd_service_dir)/netdata-updater.timer"
-    rm -f "$(get_systemd_service_dir)/netdata-updater.service"
-  fi
-
-  if [ -d /etc/cron.daily ]; then
-    rm -f /etc/cron.daily/netdata-updater.sh
-    rm -f /etc/cron.daily/netdata-updater
-  fi
-
-  if [ -d /etc/periodic/daily ]; then
-    rm -f /etc/periodic/daily/netdata-updater.sh
-    rm -f /etc/periodic/daily/netdata-updater
-  fi
-
-  if [ -d /etc/cron.d ]; then
-    rm -f /etc/cron.d/netdata-updater
-  fi
-
-  return 0
-}
-
 set_netdata_updater_channel() {
   sed -i -e "s/^RELEASE_CHANNEL=.*/RELEASE_CHANNEL=\"${RELEASE_CHANNEL}\"/" "${NETDATA_USER_CONFIG_DIR}/.environment"
 }

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -154,7 +154,6 @@ set_netdata_updater_channel || run_failed "Cannot set netdata updater tool relea
 
 # -----------------------------------------------------------------------------
 progress "Install (but not enable) netdata updater tool"
-cleanup_old_netdata_updater || run_failed "Cannot cleanup old netdata updater tool."
 install_netdata_updater || run_failed "Cannot install netdata updater tool."
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION


##### Summary

This was causing the updater to be unconditionally disabled on static builds, and we don’t actually _need_ any of it anymore since we’ve already decoupled the auto-update handling state from the installation process (in fact, this should have been removed then, but it got missed somehow).

##### Test Plan

1. Prepare a static build using the code in this branch by running `packaging/makeslf/build-static.sh <arch>` from the root of the repository (where `<arch>` is one of `x86_64`, `armv7l`, `aarch64`, or `ppc64le` as appropriate to the system you will be testing on, note that this requires a working Docker install on the build system). This will produce a static build archive in the `artifacts` directory.
2. On the test system, run the kickstart script as outlined in our documentation, but add the option `--static-only` to force use of a static build.
3. Run the static build archive from step 1 on the test system (it’s a self-extracting tarball, similar to a SHAR file).
4. Verify that `/etc/cron.daily/netdata-updater.sh` or `/etc/periodic/daily/netdata-updater.sh` still exists.

The test system should ideally be a VM, though the exact distro does not matter much provided it comes with a usable cron implementation _other_ than systemd timer units.

##### Additional Information

This resolves the issue outlined in https://github.com/netdata/netdata/issues/13102, but will not actually be ‘live’ until nightlies have been published after this is merged.

<details> <summary>For users: How does this change affect me?</summary>
Auto updates will not be disabled on static builds by just updating the install.
</details>
