### PR TITLE
fix(updater): fix updating when using `--force-update` and new version of the updater script is available

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -422,7 +422,7 @@ self_update() {
       export ENVIRONMENT_FILE="${ENVIRONMENT_FILE}"
       force_update=""
       [ "$NETDATA_FORCE_UPDATE" = "1" ] && force_update="--force-update"
-      exec ./netdata-updater.sh --not-running-from-cron --no-updater-self-update --tmpdir-path "$(pwd)" "$force_update"
+      exec ./netdata-updater.sh --not-running-from-cron --no-updater-self-update "$force_update" --tmpdir-path "$(pwd)"
     else
       error "Failed to download newest version of updater script, continuing with current version."
     fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -420,7 +420,9 @@ self_update() {
     if _safe_download "https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/netdata-updater.sh" ./netdata-updater.sh; then
       chmod +x ./netdata-updater.sh || exit 1
       export ENVIRONMENT_FILE="${ENVIRONMENT_FILE}"
-      exec ./netdata-updater.sh --not-running-from-cron --no-updater-self-update --tmpdir-path "$(pwd)"
+      force_update=""
+      [ "$NETDATA_FORCE_UPDATE" = "1" ] && force_update="--force-update"
+      exec ./netdata-updater.sh --not-running-from-cron --no-updater-self-update --tmpdir-path "$(pwd)" "$force_update"
     else
       error "Failed to download newest version of updater script, continuing with current version."
     fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -553,6 +553,10 @@ update_build() {
       NEW_CHECKSUM="$(safe_sha256sum netdata-latest.tar.gz 2> /dev/null | cut -d' ' -f1)"
       tar -xf netdata-latest.tar.gz >&3 2>&3
       rm netdata-latest.tar.gz >&3 2>&3
+      if [ -z "$path_version" ]; then
+        latest_tag="$(get_latest_version)"
+        path_version="$(echo "${latest_tag}" | cut -f 1 -d "-")"
+      fi
       cd "$(find . -maxdepth 1 -type d -name "netdata-${path_version}*" | head -n 1)" || fatal "Failed to switch to build directory" U0017
       RUN_INSTALLER=1
     fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -553,7 +553,7 @@ update_build() {
       NEW_CHECKSUM="$(safe_sha256sum netdata-latest.tar.gz 2> /dev/null | cut -d' ' -f1)"
       tar -xf netdata-latest.tar.gz >&3 2>&3
       rm netdata-latest.tar.gz >&3 2>&3
-      cd "$(find . -maxdepth 1 -name "netdata-${path_version}*" | head -n 1)" || fatal "Failed to switch to build directory" U0017
+      cd "$(find . -maxdepth 1 -type d -name "netdata-${path_version}*" | head -n 1)" || fatal "Failed to switch to build directory" U0017
       RUN_INSTALLER=1
     fi
   fi


### PR DESCRIPTION
##### Summary

It appears we have several bugs:

- we don't pass `--force-update` when `exec`uting downloaded `netdata-updater.sh`

https://github.com/netdata/netdata/blob/b67c1026bae0411e863a227214fd4175ff109d0f/packaging/installer/netdata-updater.sh#L420-L423

- at this point, we have another problems

https://github.com/netdata/netdata/blob/b67c1026bae0411e863a227214fd4175ff109d0f/packaging/installer/netdata-updater.sh#L553-L554

1. `netdata-updater.sh` is in the `pwd` (self_update()).
2. `path_version` is not set (because of `--force-update`).

Which results in trying to  `cd` into `netdata-updater.sh`.


##### Test Plan

To test this PR manually I did:

- created web server that returns the exact `netdata-updater.sh` as in this PR.
- changed `self_update()` so it always downloads the script from my server.
- executed `netdata-updater.sh --force-update`.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
