### PR TITLE
feat: disable cloud if `NETDATA_DISABLE_CLOUD` is set to 1

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1282,6 +1282,11 @@ int main(int argc, char **argv) {
     }
 #endif
 
+    char *nd_disable_cloud = getenv("NETDATA_DISABLE_CLOUD");
+    if (nd_disable_cloud && !strncmp(nd_disable_cloud, "1", 1)) {
+        appconfig_set_default(&cloud_config, "global", "enabled", "false");
+    }
+
     if(!config_loaded)
     {
         load_netdata_conf(NULL, 0);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1292,7 +1292,7 @@ int main(int argc, char **argv) {
 
     char *nd_disable_cloud = getenv("NETDATA_DISABLE_CLOUD");
     if (nd_disable_cloud && !strncmp(nd_disable_cloud, "1", 1)) {
-        appconfig_set_default(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", "false");
+        appconfig_set(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", "false");
     }
 
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1282,16 +1282,17 @@ int main(int argc, char **argv) {
     }
 #endif
 
-    char *nd_disable_cloud = getenv("NETDATA_DISABLE_CLOUD");
-    if (nd_disable_cloud && !strncmp(nd_disable_cloud, "1", 1)) {
-        appconfig_set_default(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", "false");
-    }
 
     if(!config_loaded)
     {
         load_netdata_conf(NULL, 0);
         post_conf_load(&user);
         load_cloud_conf(0);
+    }
+
+    char *nd_disable_cloud = getenv("NETDATA_DISABLE_CLOUD");
+    if (nd_disable_cloud && !strncmp(nd_disable_cloud, "1", 1)) {
+        appconfig_set_default(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", "false");
     }
 
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1284,7 +1284,7 @@ int main(int argc, char **argv) {
 
     char *nd_disable_cloud = getenv("NETDATA_DISABLE_CLOUD");
     if (nd_disable_cloud && !strncmp(nd_disable_cloud, "1", 1)) {
-        appconfig_set_default(&cloud_config, "global", "enabled", "false");
+        appconfig_set_default(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", "false");
     }
 
     if(!config_loaded)


### PR DESCRIPTION
##### Summary

Fixes: #12736

The main (and probably only) reason for this feature I have in mind is to be able to disable Cloud (read as remove Cloud UI elements from the dashboard) when using the Docker version of Netdata.

With that said, maybe we better update the [entrypoint file](https://github.com/netdata/netdata/blob/master/packaging/docker/run.sh), but not sure.


##### Test Plan

- Build a docker image with enabled Cloud.
  - `docker run -d --name nd -p 19999:19999 --env NETDATA_DISABLE_CLOUD=1 ilyam8/netdata-test`.
  - `docker run -d --name nd -p 19999:19999 ilyam8/netdata-test`.
- Build a docker image with disabled Cloud.
  - `docker run -d --name nd -p 19999:19999 --env NETDATA_DISABLE_CLOUD=1 ilyam8/netdata-test`.
  - `docker run -d --name nd -p 19999:19999 ilyam8/netdata-test`.

In all cases check the dashboard and look for Cloud UI elements.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
