### PR TITLE
73x times faster metrics correlations at the agent

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -625,6 +625,7 @@ static void get_netdata_configured_variables() {
     // --------------------------------------------------------------------
     // metric correlations
     enable_metric_correlations = config_get_boolean(CONFIG_SECTION_GLOBAL, "enable metric correlations", enable_metric_correlations);
+    default_metric_correlations_method = mc_string_to_method(config_get(CONFIG_SECTION_GLOBAL, "metric correlations method", mc_method_to_string(default_metric_correlations_method)));
 
     // --------------------------------------------------------------------
     // get various system parameters

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -895,6 +895,9 @@ int main(int argc, char **argv) {
                         }
 #endif
 #ifdef ENABLE_DBENGINE
+                        else if(strcmp(optarg, "mctest") == 0) {
+                            return mc_unittest();
+                        }
                         else if(strcmp(optarg, "dicttest") == 0) {
                             return dictionary_unittest(10000);
                         }

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -221,7 +221,11 @@ static int rrdset_metric_correlations(BUFFER *wb, RRDSET *st,
     for(i = 0, d = base_rrdr->st->dimensions ; d && i < base_rrdr->d; i++, d = d->next) {
 
         // skip the not evaluated ones
-        if(likely(!(base_rrdr->od[i] & RRDR_DIMENSION_SELECTED) || !(high_rrdr->od[i] & RRDR_DIMENSION_SELECTED)))
+        if(unlikely(!(base_rrdr->od[i] & RRDR_DIMENSION_SELECTED) || !(high_rrdr->od[i] & RRDR_DIMENSION_SELECTED)))
+            continue;
+
+        // skip the dimensions that are just zero
+        if(unlikely(!(base_rrdr->od[i] & RRDR_DIMENSION_NONZERO) && !(high_rrdr->od[i] & RRDR_DIMENSION_NONZERO)))
             continue;
 
         // copy the baseline points of the dimension to a contiguous array
@@ -238,7 +242,7 @@ static int rrdset_metric_correlations(BUFFER *wb, RRDSET *st,
 
         // fprintf(stderr, "kstwo %d = %s:%s:%f\n", gettid(), st->name, d->name, prob);
 
-        if(i) buffer_sprintf(wb, ",\n");
+        if(correlated_dimensions) buffer_sprintf(wb, ",\n");
         buffer_sprintf(wb, "\t\t\t\t\"%s\": %f", d->name, prob);
         correlated_dimensions++;
     }

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -320,9 +320,9 @@ int metric_correlations(RRDHOST *host, BUFFER *wb,
     }
 
     // if the user didn't give a timeout
-    // assume 20 seconds
+    // assume 60 seconds
     if(!timeout_ms)
-        timeout_ms = 30 * MSEC_PER_SEC;
+        timeout_ms = 60 * MSEC_PER_SEC;
 
     // if the timeout is less than 1 second
     // make it at least 1 second

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -157,7 +157,7 @@ static int rrdset_metric_correlations(BUFFER *wb, RRDSET *st,
                                       long long baseline_after, long long baseline_before,
                                       long long highlight_after, long long highlight_before,
                                       long long max_points, uint32_t shifts, int timeout_ms) {
-    RRDR_OPTIONS options = RRDR_OPTION_NULL2ZERO;
+    RRDR_OPTIONS options = RRDR_OPTION_NULL2ZERO | RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_ALLOW_PAST | RRDR_OPTION_NONZERO;
     int group_method = RRDR_GROUPING_AVERAGE;
     long group_time = 0;
     struct context_param  *context_param_list = NULL;

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -6,6 +6,7 @@
 #define MAX_POINTS 10000
 int enable_metric_correlations = CONFIG_BOOLEAN_YES;
 int metric_correlations_version = 1;
+METRIC_CORRELATIONS_METHOD default_metric_correlations_method = METRIC_CORRELATIONS_VOLUME;
 
 typedef struct mc_stats {
     size_t db_points;
@@ -31,7 +32,7 @@ METRIC_CORRELATIONS_METHOD mc_string_to_method(const char *method) {
         if(strcmp(method, metric_correlations_methods[i].name) == 0)
             return metric_correlations_methods[i].value;
 
-    return METRIC_CORRELATIONS_VOLUME;
+    return default_metric_correlations_method;
 }
 
 const char *mc_method_to_string(METRIC_CORRELATIONS_METHOD method) {

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -4,7 +4,7 @@
 #include "KolmogorovSmirnovDist.h"
 
 #define MAX_POINTS 10000
-int enable_metric_correlations = CONFIG_BOOLEAN_NO;
+int enable_metric_correlations = CONFIG_BOOLEAN_YES;
 int metric_correlations_version = 1;
 
 struct charts {

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -47,10 +47,14 @@ static inline int binary_search_bigger_than(const double arr[], int left, int ri
         // so, binary search the next available value
 
         right = orig_right;
+
+        // for constant metrics, let's skip everything
+        if(unlikely(arr[right] == K)) return right + 1;
+
         while(left <= right) {
             int middle = left + (right - left) / 2;
 
-            if(arr[middle] == K)
+            if(likely(arr[middle] == K))
                 left = middle + 1;
 
             else

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -21,10 +21,11 @@ struct per_dim {
     long int highlight_diffs[MAX_POINTS];
 };
 
-#define DOUBLE_TO_INT_MULTIPLIER 100000.0
+#define DOUBLE_TO_INT_MULTIPLIER 1000000.0
 
 static inline int binary_search_bigger_than(const long int arr[], int left, int size, long int K) {
-    // binary search to find K in the array
+    // binary search to find the index the smallest index
+    // of the first value in the array that is greater than K
 
     int right = size;
     while(left < right) {

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -259,7 +259,7 @@ int metric_correlations(RRDHOST *host, BUFFER *wb,
     if (enable_metric_correlations == CONFIG_BOOLEAN_NO) {
         error("Metric correlations: not enabled.");
         buffer_strcat(wb, "{\"error\": \"Metric correlations functionality is not enabled.\" }");
-        return HTTP_RESP_BAD_REQUEST;
+        return HTTP_RESP_FORBIDDEN;
     }
 
     if (highlight_before <= highlight_after || baseline_before <= baseline_after) {

--- a/database/metric_correlations.h
+++ b/database/metric_correlations.h
@@ -20,5 +20,6 @@ extern int metric_correlations (RRDHOST *host, BUFFER *wb, METRIC_CORRELATIONS_M
 
 extern METRIC_CORRELATIONS_METHOD mc_string_to_method(const char *method);
 extern const char *mc_method_to_string(METRIC_CORRELATIONS_METHOD method);
+extern int mc_unittest(void);
 
 #endif //NETDATA_METRIC_CORRELATIONS_H

--- a/database/metric_correlations.h
+++ b/database/metric_correlations.h
@@ -11,6 +11,6 @@ typedef enum {
     METRIC_CORRELATIONS_VOLUME = 2,
 } METRIC_CORRELATIONS_METHOD;
 
-extern int metric_correlations (RRDHOST *host, BUFFER *wb, METRIC_CORRELATIONS_METHOD method, long long selected_after, long long selected_before, long long reference_after, long long reference_before, long long max_points, int timeout_ms);
+extern int metric_correlations (RRDHOST *host, BUFFER *wb, METRIC_CORRELATIONS_METHOD method, long long selected_after, long long selected_before, long long reference_after, long long reference_before, long long points, RRDR_OPTIONS options, int timeout_ms);
 
 #endif //NETDATA_METRIC_CORRELATIONS_H

--- a/database/metric_correlations.h
+++ b/database/metric_correlations.h
@@ -6,6 +6,11 @@
 extern int enable_metric_correlations;
 extern int metric_correlations_version;
 
-extern int metric_correlations (RRDHOST *host, BUFFER *wb, long long selected_after, long long selected_before, long long reference_after, long long reference_before, long long max_points, int timeout_ms);
+typedef enum {
+    METRIC_CORRELATIONS_KS2    = 1,
+    METRIC_CORRELATIONS_VOLUME = 2,
+} METRIC_CORRELATIONS_METHOD;
+
+extern int metric_correlations (RRDHOST *host, BUFFER *wb, METRIC_CORRELATIONS_METHOD method, long long selected_after, long long selected_before, long long reference_after, long long reference_before, long long max_points, int timeout_ms);
 
 #endif //NETDATA_METRIC_CORRELATIONS_H

--- a/database/metric_correlations.h
+++ b/database/metric_correlations.h
@@ -6,6 +6,6 @@
 extern int enable_metric_correlations;
 extern int metric_correlations_version;
 
-extern int metric_correlations (RRDHOST *host, BUFFER *wb, long long selected_after, long long selected_before, long long reference_after, long long reference_before, long long max_points, long timeout);
+extern int metric_correlations (RRDHOST *host, BUFFER *wb, long long selected_after, long long selected_before, long long reference_after, long long reference_before, long long max_points, int timeout_ms);
 
 #endif //NETDATA_METRIC_CORRELATIONS_H

--- a/database/metric_correlations.h
+++ b/database/metric_correlations.h
@@ -5,13 +5,14 @@
 
 #include "web/api/queries/query.h"
 
-extern int enable_metric_correlations;
-extern int metric_correlations_version;
-
 typedef enum {
     METRIC_CORRELATIONS_KS2    = 1,
     METRIC_CORRELATIONS_VOLUME = 2,
 } METRIC_CORRELATIONS_METHOD;
+
+extern int enable_metric_correlations;
+extern int metric_correlations_version;
+extern METRIC_CORRELATIONS_METHOD default_metric_correlations_method;
 
 extern int metric_correlations (RRDHOST *host, BUFFER *wb, METRIC_CORRELATIONS_METHOD method, RRDR_GROUPING group,
                                long long baseline_after, long long baseline_before,

--- a/database/metric_correlations.h
+++ b/database/metric_correlations.h
@@ -6,6 +6,6 @@
 extern int enable_metric_correlations;
 extern int metric_correlations_version;
 
-void metric_correlations (RRDHOST *host, BUFFER *wb, long long selected_after, long long selected_before, long long reference_after, long long reference_before, long long max_points);
+extern int metric_correlations (RRDHOST *host, BUFFER *wb, long long selected_after, long long selected_before, long long reference_after, long long reference_before, long long max_points, long timeout);
 
 #endif //NETDATA_METRIC_CORRELATIONS_H

--- a/database/metric_correlations.h
+++ b/database/metric_correlations.h
@@ -3,6 +3,8 @@
 #ifndef NETDATA_METRIC_CORRELATIONS_H
 #define NETDATA_METRIC_CORRELATIONS_H 1
 
+#include "web/api/queries/query.h"
+
 extern int enable_metric_correlations;
 extern int metric_correlations_version;
 
@@ -11,6 +13,12 @@ typedef enum {
     METRIC_CORRELATIONS_VOLUME = 2,
 } METRIC_CORRELATIONS_METHOD;
 
-extern int metric_correlations (RRDHOST *host, BUFFER *wb, METRIC_CORRELATIONS_METHOD method, long long selected_after, long long selected_before, long long reference_after, long long reference_before, long long points, RRDR_OPTIONS options, int timeout_ms);
+extern int metric_correlations (RRDHOST *host, BUFFER *wb, METRIC_CORRELATIONS_METHOD method, RRDR_GROUPING group,
+                               long long baseline_after, long long baseline_before,
+                               long long after, long long before,
+                               long long points, RRDR_OPTIONS options, int timeout);
+
+extern METRIC_CORRELATIONS_METHOD mc_string_to_method(const char *method);
+extern const char *mc_method_to_string(METRIC_CORRELATIONS_METHOD method);
 
 #endif //NETDATA_METRIC_CORRELATIONS_H

--- a/health/health.c
+++ b/health/health.c
@@ -855,10 +855,12 @@ void *health_main(void *ptr) {
                     /* time_t old_db_timestamp = rc->db_before; */
                     int value_is_null = 0;
 
-                    int ret = rrdset2value_api_v1(rc->rrdset, NULL, &rc->value, rc->dimensions, 1, rc->after,
-                                                  rc->before, rc->group, 0, rc->options, &rc->db_after,
-                                                  &rc->db_before, &value_is_null, 0
-                    );
+                    int ret = rrdset2value_api_v1(rc->rrdset, NULL, &rc->value, rc->dimensions, 1,
+                                                  rc->after, rc->before, rc->group,
+                                                  0, rc->options,
+                                                  &rc->db_after,&rc->db_before,
+                                                  NULL, NULL,
+                                                  &value_is_null, 0);
 
                     if (unlikely(ret != 200)) {
                         // database lookup failed

--- a/libnetdata/storage_number/storage_number.h
+++ b/libnetdata/storage_number/storage_number.h
@@ -23,6 +23,8 @@ typedef double calculated_number;
 #define LONG_DOUBLE_MODIFIER "f"
 typedef double LONG_DOUBLE;
 
+#define CALCULATED_NUMBER_MAX DBL_MAX
+
 #else // NETDATA_WITHOUT_LONG_DOUBLE
 
 typedef long double calculated_number;
@@ -32,6 +34,8 @@ typedef long double calculated_number;
 
 #define LONG_DOUBLE_MODIFIER "Lf"
 typedef long double LONG_DOUBLE;
+
+#define CALCULATED_NUMBER_MAX LDBL_MAX
 
 #endif // NETDATA_WITHOUT_LONG_DOUBLE
 

--- a/web/api/badges/web_buffer_svg.c
+++ b/web/api/badges/web_buffer_svg.c
@@ -1101,8 +1101,12 @@ int web_client_api_request_v1_badge(RRDHOST *host, struct web_client *w, char *u
 
         // if the collected value is too old, don't calculate its value
         if (rrdset_last_entry_t(st) >= (now_realtime_sec() - (st->update_every * st->gap_when_lost_iterations_above)))
-            ret = rrdset2value_api_v1(st, w->response.data, &n, (dimensions) ? buffer_tostring(dimensions) : NULL
-                                      , points, after, before, group, 0, options, NULL, &latest_timestamp, &value_is_null, 0);
+            ret = rrdset2value_api_v1(st, w->response.data, &n,
+                                      (dimensions) ? buffer_tostring(dimensions) : NULL,
+                                      points, after, before, group, 0, options,
+                                      NULL, &latest_timestamp,
+                                      NULL, NULL,
+                                      &value_is_null, 0);
 
         // if the value cannot be calculated, show empty badge
         if (ret != HTTP_RESP_OK) {

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -35,7 +35,7 @@ static int fill_formatted_callback(const char *name, const char *value, RRDLABEL
 }
 
 void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value,
-    QUERY_PARAMS *rrdset_query_data)
+    RRDR_GROUPING group_method, QUERY_PARAMS *rrdset_query_data)
 {
     struct context_param *context_param_list = rrdset_query_data->context_param_list;
     char *chart_label_key = rrdset_query_data->chart_label_key;
@@ -76,7 +76,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                        "   %slast_entry%s: %u,\n"
                        "   %sbefore%s: %u,\n"
                        "   %safter%s: %u,\n"
-                       "   %sdimension_names%s: ["
+                       "   %sgroup%s: %s%s%s,\n"
+                       "   %soptions%s: %s"
                    , kq, kq
                    , kq, kq, sq, context_mode && temp_rd?r->st->context:r->st->id, sq
                    , kq, kq, sq, context_mode && temp_rd?r->st->context:r->st->name, sq
@@ -86,7 +87,13 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                    , kq, kq, (uint32_t) (context_param_list ? context_param_list->last_entry_t : rrdset_last_entry_t_nolock(r->st))
                    , kq, kq, (uint32_t)r->before
                    , kq, kq, (uint32_t)r->after
-                   , kq, kq);
+                   , kq, kq, sq, web_client_api_request_v1_data_group_to_string(group_method), sq
+                   , kq, kq, sq);
+
+    web_client_api_request_v1_data_options_to_string(wb, options);
+
+    buffer_sprintf(wb, "%s,\n   %sdimension_names%s: [", sq, kq, kq);
+
     if (should_lock)
         rrdset_unlock(r->st);
 

--- a/web/api/formatters/json_wrapper.h
+++ b/web/api/formatters/json_wrapper.h
@@ -4,9 +4,11 @@
 #define NETDATA_API_FORMATTER_JSON_WRAPPER_H
 
 #include "rrd2json.h"
+#include "web/api/queries/query.h"
+
 
 extern void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value,
-    QUERY_PARAMS *query_params);
+    RRDR_GROUPING group_method, QUERY_PARAMS *query_params);
 extern void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
 
 #endif //NETDATA_API_FORMATTER_JSON_WRAPPER_H

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -178,8 +178,6 @@ int rrdset2value_api_v1(
     }
 
     if(rrdr_rows(r) == 0) {
-        rrdr_free(owa, r);
-
         if(db_after)  *db_after  = 0;
         if(db_before) *db_before = 0;
         if(value_is_null) *value_is_null = 1;

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -264,7 +264,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_SSV:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, group_method, query_params);
             rrdr2ssv(r, wb, options, "", " ", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -277,7 +277,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_SSV_COMMA:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, group_method, query_params);
             rrdr2ssv(r, wb, options, "", ",", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -290,7 +290,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_JS_ARRAY:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, group_method, query_params);
             rrdr2ssv(r, wb, options, "[", ",", "]", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 0);
         }
@@ -303,7 +303,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_CSV:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, group_method, query_params);
             rrdr2csv(r, wb, format, options, "", ",", "\\n", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -316,7 +316,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_CSV_MARKDOWN:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, group_method, query_params);
             rrdr2csv(r, wb, format, options, "", "|", "\\n", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -329,7 +329,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_CSV_JSON_ARRAY:
         wb->contenttype = CT_APPLICATION_JSON;
         if(options & RRDR_OPTION_JSON_WRAP) {
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, group_method, query_params);
             buffer_strcat(wb, "[\n");
             rrdr2csv(r, wb, format, options + RRDR_OPTION_LABEL_QUOTES, "[", ",", "]", ",\n", temp_rd);
             buffer_strcat(wb, "\n]");
@@ -346,7 +346,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_TSV:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, group_method, query_params);
             rrdr2csv(r, wb, format, options, "", "\t", "\\n", "", temp_rd);
             rrdr_json_wrapper_end(r, wb, format, options, 1);
         }
@@ -359,7 +359,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_HTML:
         if(options & RRDR_OPTION_JSON_WRAP) {
             wb->contenttype = CT_APPLICATION_JSON;
-            rrdr_json_wrapper_begin(r, wb, format, options, 1, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 1, group_method, query_params);
             buffer_strcat(wb, "<html>\\n<center>\\n<table border=\\\"0\\\" cellpadding=\\\"5\\\" cellspacing=\\\"5\\\">\\n");
             rrdr2csv(r, wb, format, options, "<tr><td>", "</td><td>", "</td></tr>\\n", "", temp_rd);
             buffer_strcat(wb, "</table>\\n</center>\\n</html>\\n");
@@ -377,7 +377,7 @@ int rrdset2anything_api_v1(
         wb->contenttype = CT_APPLICATION_X_JAVASCRIPT;
 
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, group_method, query_params);
 
         rrdr2json(r, wb, options, 1, query_params->context_param_list);
 
@@ -389,7 +389,7 @@ int rrdset2anything_api_v1(
         wb->contenttype = CT_APPLICATION_JSON;
 
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, group_method, query_params);
 
         rrdr2json(r, wb, options, 1, query_params->context_param_list);
 
@@ -400,7 +400,7 @@ int rrdset2anything_api_v1(
     case DATASOURCE_JSONP:
         wb->contenttype = CT_APPLICATION_X_JAVASCRIPT;
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, group_method, query_params);
 
         rrdr2json(r, wb, options, 0, query_params->context_param_list);
 
@@ -413,7 +413,7 @@ int rrdset2anything_api_v1(
         wb->contenttype = CT_APPLICATION_JSON;
 
         if(options & RRDR_OPTION_JSON_WRAP)
-            rrdr_json_wrapper_begin(r, wb, format, options, 0, query_params);
+            rrdr_json_wrapper_begin(r, wb, format, options, 0, group_method, query_params);
 
         rrdr2json(r, wb, options, 0, query_params->context_param_list);
 

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -162,6 +162,8 @@ int rrdset2value_api_v1(
         , uint32_t options
         , time_t *db_after
         , time_t *db_before
+        , size_t *db_points_read
+        , size_t *result_points_generated
         , int *value_is_null
         , int timeout
 ) {
@@ -176,6 +178,12 @@ int rrdset2value_api_v1(
         ret = HTTP_RESP_INTERNAL_SERVER_ERROR;
         goto cleanup;
     }
+
+    if(db_points_read)
+        *db_points_read += r->internal.db_points_read;
+
+    if(result_points_generated)
+        *result_points_generated += r->internal.result_points_generated;
 
     if(rrdr_rows(r) == 0) {
         if(db_after)  *db_after  = 0;

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -92,6 +92,8 @@ extern int rrdset2value_api_v1(
         , uint32_t options
         , time_t *db_after
         , time_t *db_before
+        , size_t *db_points_read
+        , size_t *result_points_generated
         , int *value_is_null
         , int timeout
 );

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -1192,7 +1192,7 @@
             "schema": {
               "type": "number",
               "format": "integer",
-              "default": 1000
+              "default": 500
             }
           },
           {
@@ -1206,7 +1206,7 @@
                 "ks2",
                 "volume"
               ],
-              "default": "ks2"
+              "default": "volume"
             }
           },
           {

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -1241,7 +1241,8 @@
                   "unaligned",
                   "allow_past",
                   "nonzero",
-                  "anomaly-bit"
+                  "anomaly-bit",
+                  "raw"
                 ]
               },
               "default": [

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -319,7 +319,8 @@
                   "match-ids",
                   "match-names",
                   "showcustomvars",
-                  "allow_past"
+                  "allow_past",
+                  "anomaly-bit"
                 ]
               },
               "default": [
@@ -484,7 +485,8 @@
                   "absolute-sum",
                   "null2zero",
                   "percentage",
-                  "unaligned"
+                  "unaligned",
+                  "anomaly-bit"
                 ]
               },
               "default": [
@@ -908,7 +910,7 @@
     "/alarms_values": {
       "get": {
         "summary": "Get a list of active or raised alarms on the server",
-        "description": "The alarms_values endpoint returns the list of all raised or enabled alarms on the netdata server. Called without any parameters, the raised alarms in state WARNING or CRITICAL are returned. By passing \"?all\", all the enabled alarms are returned. This option output differs from `/alarms` in the number of variables delivered. This endpoint gives to user `id`, `value`, `last_updated` time and alarm `status`.",
+        "description": "The alarms_values endpoint returns the list of all raised or enabled alarms on the netdata server. Called without any parameters, the raised alarms in state WARNING or CRITICAL are returned. By passing \"?all\", all the enabled alarms are returned. This option output differs from `/alarms` in the number of variables delivered. This endpoint gives to user `id`, `value`, `last_updated` time, and alarm `status`.",
         "parameters": [
           {
             "name": "all",
@@ -1129,6 +1131,153 @@
           }
         }
       }
+    },
+    "/metric_correlations": {
+      "get": {
+        "summary": "Analyze all the metrics to find their correlations",
+        "description": "Given two time-windows (baseline, highlight), it goes through all the available metrics, querying both windows and tries to find how these two windows relate to each other. It supports multiple algorithms to do so. The result is a list of all metrics evaluated, weighted for 0.0 (the two windows are more different) to 1.0 (the two windows are similar). The algorithm adjusts automatically the baseline window to be a power of two multiple of the highlighted (1, 2, 4, 8, etc).",
+        "parameters": [
+          {
+            "name": "baseline_after",
+            "in": "query",
+            "description": "This parameter can either be an absolute timestamp specifying the starting point of baseline window, or a relative number of seconds (negative, relative to parameter baseline_before). Netdata will assume it is a relative number if it is less that 3 years (in seconds).",
+            "required": false,
+            "allowEmptyValue": false,
+            "schema": {
+              "type": "number",
+              "format": "integer",
+              "default": -300
+            }
+          },
+          {
+            "name": "baseline_before",
+            "in": "query",
+            "description": "This parameter can either be an absolute timestamp specifying the ending point of the baseline window, or a relative number of seconds (negative), relative to the last collected timestamp. Netdata will assume it is a relative number if it is less than 3 years (in seconds).",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "integer",
+              "default": -60
+            }
+          },
+          {
+            "name": "highlight_after",
+            "in": "query",
+            "description": "This parameter can either be an absolute timestamp specifying the starting point of highlighted window, or a relative number of seconds (negative, relative to parameter highlight_before). Netdata will assume it is a relative number if it is less that 3 years (in seconds).",
+            "required": false,
+            "allowEmptyValue": false,
+            "schema": {
+              "type": "number",
+              "format": "integer",
+              "default": -60
+            }
+          },
+          {
+            "name": "highlight_before",
+            "in": "query",
+            "description": "This parameter can either be an absolute timestamp specifying the ending point of the highlighted window, or a relative number of seconds (negative), relative to the last collected timestamp. Netdata will assume it is a relative number if it is less than 3 years (in seconds).",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "points",
+            "in": "query",
+            "description": "The number of points to be evaluated for the highlighted window. The baseline window will be adjusted automatically to receive a proportional amount of points.",
+            "required": false,
+            "allowEmptyValue": false,
+            "schema": {
+              "type": "number",
+              "format": "integer",
+              "default": 1000
+            }
+          },
+          {
+            "name": "method",
+            "in": "query",
+            "description": "the algorithm to run",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ks2",
+                "volume"
+              ],
+              "default": "ks2"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Cancel the query if to takes more that this amount of milliseconds.",
+            "required": false,
+            "allowEmptyValue": false,
+            "schema": {
+              "type": "number",
+              "format": "integer",
+              "default": 60000
+            }
+          },
+          {
+            "name": "options",
+            "in": "query",
+            "description": "Options that affect data generation.",
+            "required": false,
+            "allowEmptyValue": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "min2max",
+                  "abs",
+                  "absolute",
+                  "absolute-sum",
+                  "null2zero",
+                  "percentage",
+                  "unaligned",
+                  "allow_past",
+                  "nonzero",
+                  "anomaly-bit"
+                ]
+              },
+              "default": [
+                "null2zero",
+                "allow_past",
+                "nonzero",
+                "unaligned"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON object with weights for each chart and dimension.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/metric_correlations"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The given parameters are invalid."
+          },
+          "403": {
+            "description": "metrics correlations are not enabled on this Netdata Agent."
+          },
+          "404": {
+            "description": "No charts could be found, or the method that correlated the metrics did not produce any result."
+          },
+          "504": {
+            "description": "Timeout - the query took too long and has been cancelled."
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -1267,7 +1416,7 @@
           "stream_compression": {
             "type": "boolean",
             "description": "Stream transmission compression method.",
-            "example": "true"
+            "example": true
           },
           "labels": {
             "type": "object",
@@ -2135,7 +2284,7 @@
         "type": "object",
         "properties": {
           "aclk-available": {
-            "type": "boolean",
+            "type": "string",
             "description": "Describes whether this agent is capable of connection to the Cloud. False means agent has been built without ACLK component either on purpose (user choice) or due to missing dependency."
           },
           "aclk-version": {
@@ -2153,7 +2302,7 @@
             "type": "boolean",
             "description": "Informs whether this agent has been added to a space in the cloud (User has to perform claiming). If false (user didn't perform claiming) agent will never attempt any cloud connection."
           },
-          "claimed-id": {
+          "claimed_id": {
             "type": "string",
             "format": "uuid",
             "description": "Unique ID this agent uses to identify when connecting to cloud"
@@ -2169,6 +2318,59 @@
               "Old",
               "New"
             ]
+          }
+        }
+      },
+      "metric_correlations": {
+        "type": "object",
+        "properties": {
+          "correlated_charts": {
+            "type": "object",
+            "description": "An object containing chart objects with their metrics correlations.",
+            "properties": {
+              "chart-id1": {
+                "type": "object",
+                "properties": {
+                  "context": {
+                    "type": "string"
+                  },
+                  "dimensions": {
+                    "type": "object",
+                    "properties": {
+                      "dimension1-name": {
+                        "type": "number"
+                      },
+                      "dimension2-name": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              },
+              "chart-id2": {
+                "type": "object",
+                "properties": {
+                  "context": {
+                    "type": "string"
+                  },
+                  "dimensions": {
+                    "type": "object",
+                    "properties": {
+                      "dimension1-name": {
+                        "type": "number"
+                      },
+                      "dimension2-name": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "total_dimensions_count": {
+            "description": "The number of dimensions correlated",
+            "type": "integer"
           }
         }
       }

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -280,6 +280,7 @@ paths:
                 - match-names
                 - showcustomvars
                 - allow_past
+                - anomaly-bit
             default:
               - seconds
               - jsonwrap
@@ -427,6 +428,7 @@ paths:
                 - null2zero
                 - percentage
                 - unaligned
+                - anomaly-bit
             default:
               - absolute
         - name: label
@@ -913,6 +915,137 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/aclk_state"
+  /metric_correlations:
+    get:
+      summary: Analyze all the metrics to find their correlations
+      description: Given two time-windows (baseline, highlight), it goes
+        through all the available metrics, querying both windows and tries to find
+        how these two windows relate to each other. It supports
+        multiple algorithms to do so. The result is a list of all
+        metrics evaluated, weighted for 0.0 (the two windows are
+        more different) to 1.0 (the two windows are similar).
+        The algorithm adjusts automatically the baseline window to be
+        a power of two multiple of the highlighted (1, 2, 4, 8, etc).
+      parameters:
+        - name: baseline_after
+          in: query
+          description: This parameter can either be an absolute timestamp specifying the
+            starting point of baseline window, or a relative number of
+            seconds (negative, relative to parameter baseline_before). Netdata will
+            assume it is a relative number if it is less that 3 years (in seconds).
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+            default: -300
+        - name: baseline_before
+          in: query
+          description: This parameter can either be an absolute timestamp specifying the
+            ending point of the baseline window, or a relative number of
+            seconds (negative), relative to the last collected timestamp.
+            Netdata will assume it is a relative number if it is less than 3
+            years (in seconds).
+          required: false
+          schema:
+            type: number
+            format: integer
+            default: -60
+        - name: highlight_after
+          in: query
+          description: This parameter can either be an absolute timestamp specifying the
+            starting point of highlighted window, or a relative number of
+            seconds (negative, relative to parameter highlight_before). Netdata will
+            assume it is a relative number if it is less that 3 years (in seconds).
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+            default: -60
+        - name: highlight_before
+          in: query
+          description: This parameter can either be an absolute timestamp specifying the
+            ending point of the highlighted window, or a relative number of
+            seconds (negative), relative to the last collected timestamp.
+            Netdata will assume it is a relative number if it is less than 3
+            years (in seconds).
+          required: false
+          schema:
+            type: number
+            format: integer
+            default: 0
+        - name: points
+          in: query
+          description: The number of points to be evaluated for the highlighted window.
+            The baseline window will be adjusted automatically to receive a proportional
+            amount of points.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+            default: 1000
+        - name: method
+          in: query
+          description: the algorithm to run
+          required: false
+          schema:
+            type: string
+            enum:
+              - ks2
+              - volume
+            default: ks2
+        - name: timeout
+          in: query
+          description: Cancel the query if to takes more that this amount of milliseconds.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+            default: 60000
+        - name: options
+          in: query
+          description: Options that affect data generation.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - min2max
+                - abs
+                - absolute
+                - absolute-sum
+                - null2zero
+                - percentage
+                - unaligned
+                - allow_past
+                - nonzero
+                - anomaly-bit
+            default:
+              - null2zero
+              - allow_past
+              - nonzero
+              - unaligned
+      responses:
+        "200":
+          description: JSON object with weights for each chart and dimension.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/metric_correlations"
+        "400":
+          description: The given parameters are invalid.
+        "403":
+          description: metrics correlations are not enabled on this Netdata Agent.
+        "404":
+          description: No charts could be found, or the method
+            that correlated the metrics did not produce any result.
+        "504":
+          description: Timeout - the query took too long and has been cancelled.
 servers:
   - url: https://registry.my-netdata.io/api/v1
   - url: http://registry.my-netdata.io/api/v1
@@ -1696,3 +1829,37 @@ components:
           enum:
             - Old
             - New
+    metric_correlations:
+      type: object
+      properties:
+        correlated_charts:
+          type: object
+          description: An object containing chart objects with their metrics correlations.
+          properties:
+            chart-id1:
+              type: object
+              properties:
+                context:
+                  type: string
+                dimensions:
+                  type: object
+                  properties:
+                    dimension1-name:
+                      type: number
+                    dimension2-name:
+                      type: number
+            chart-id2:
+              type: object
+              properties:
+                context:
+                  type: string
+                dimensions:
+                  type: object
+                  properties:
+                    dimension1-name:
+                      type: number
+                    dimension2-name:
+                      type: number
+        total_dimensions_count:
+          description: The number of dimensions correlated
+          type: integer

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -1025,6 +1025,7 @@ paths:
                 - allow_past
                 - nonzero
                 - anomaly-bit
+                - raw
             default:
               - null2zero
               - allow_past

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -985,7 +985,7 @@ paths:
           schema:
             type: number
             format: integer
-            default: 1000
+            default: 500
         - name: method
           in: query
           description: the algorithm to run
@@ -995,7 +995,7 @@ paths:
             enum:
               - ks2
               - volume
-            default: ks2
+            default: volume
         - name: timeout
           in: query
           description: Cancel the query if to takes more that this amount of milliseconds.

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -857,6 +857,14 @@ static int rrdr_convert_before_after_to_absolute(
         after_requested = tmp;
     }
 
+    // we need to make sure that the query is at least aligned
+    // with the database update every, otherwise when the user
+    // requests just 1 point for the entire duration, it may not
+    // be created (the last 1 point may be misaligned with the
+    // query).
+    before_requested -= before_requested % update_every;
+    after_requested  -= after_requested % update_every;
+
     *before_requestedp = before_requested;
     *after_requestedp = after_requested;
 

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -280,6 +280,16 @@ RRDR_GROUPING web_client_api_request_v1_data_group(const char *name, RRDR_GROUPI
     return def;
 }
 
+const char *web_client_api_request_v1_data_group_to_string(RRDR_GROUPING group) {
+    int i;
+
+    for(i = 0; api_v1_data_groups[i].name ; i++)
+        if(unlikely(group == api_v1_data_groups[i].value))
+            return api_v1_data_groups[i].name;
+
+    return "unknown";
+}
+
 // ----------------------------------------------------------------------------
 
 static void rrdr_disable_not_selected_dimensions(RRDR *r, RRDR_OPTIONS options, const char *dims,
@@ -791,49 +801,36 @@ static void rrd2rrdr_log_request_response_metadata(RRDR *r
 #endif // NETDATA_INTERNAL_CHECKS
 
 // Returns 1 if an absolute period was requested or 0 if it was a relative period
-static int rrdr_convert_before_after_to_absolute(
-        long long *after_requestedp
-        , long long *before_requestedp
-        , int update_every
-        , time_t first_entry_t
-        , time_t last_entry_t
-        , RRDR_OPTIONS options
-) {
+int rrdr_relative_window_to_absolute(long long *after, long long *before, int update_every, long points) {
+    time_t now = now_realtime_sec();
+
     int absolute_period_requested = -1;
     long long after_requested, before_requested;
 
-    before_requested = *before_requestedp;
-    after_requested = *after_requestedp;
-
-    if(before_requested == 0 && after_requested == 0) {
-        // dump the all the data
-        before_requested = last_entry_t;
-        after_requested = first_entry_t;
-        absolute_period_requested = 0;
-    }
+    before_requested = *before;
+    after_requested = *after;
 
     // allow relative for before (smaller than API_RELATIVE_TIME_MAX)
     if(ABS(before_requested) <= API_RELATIVE_TIME_MAX) {
-        if(ABS(before_requested) % update_every) {
-            // make sure it is multiple of st->update_every
-            if(before_requested < 0) before_requested = before_requested - update_every -
-                                                        before_requested % update_every;
-            else before_requested = before_requested + update_every - before_requested % update_every;
-        }
-        if(before_requested > 0) before_requested = first_entry_t + before_requested;
-        else                     before_requested = last_entry_t  + before_requested; //last_entry_t is not really now_t
-        //TODO: fix before_requested to be relative to now_t
+        // if the user asked for a positive relative time,
+        // flip it to a negative
+        if(before_requested > 0)
+            before_requested = -before_requested;
+
+        before_requested = now + before_requested;
         absolute_period_requested = 0;
     }
 
     // allow relative for after (smaller than API_RELATIVE_TIME_MAX)
     if(ABS(after_requested) <= API_RELATIVE_TIME_MAX) {
-        if(after_requested == 0) after_requested = -update_every;
-        if(ABS(after_requested) % update_every) {
-            // make sure it is multiple of st->update_every
-            if(after_requested < 0) after_requested = after_requested - update_every - after_requested % update_every;
-            else after_requested = after_requested + update_every - after_requested % update_every;
-        }
+        if(after_requested > 0)
+            after_requested = -after_requested;
+
+        // if the user didn't give an after, use the number of points
+        // to give a sane default
+        if(after_requested == 0)
+            after_requested = -(points * update_every);
+
         after_requested = before_requested + after_requested;
         absolute_period_requested = 0;
     }
@@ -841,32 +838,46 @@ static int rrdr_convert_before_after_to_absolute(
     if(absolute_period_requested == -1)
         absolute_period_requested = 1;
 
-    // make sure they are within our timeframe
-    if(before_requested > last_entry_t)  before_requested = last_entry_t;
-    if(before_requested < first_entry_t && !(options & RRDR_OPTION_ALLOW_PAST))
-        before_requested = first_entry_t;
-
-    if(after_requested > last_entry_t)  after_requested = last_entry_t;
-    if(after_requested < first_entry_t && !(options & RRDR_OPTION_ALLOW_PAST))
-        after_requested = first_entry_t;
-
-    // check if they are reversed
-    if(after_requested > before_requested) {
-        time_t tmp = before_requested;
+    // check if the parameters are flipped
+    if(after_requested >= before_requested) {
+        long long t = before_requested;
         before_requested = after_requested;
-        after_requested = tmp;
+        after_requested = t;
     }
 
-    // we need to make sure that the query is at least aligned
+    // we need to make sure that the query is aligned
     // with the database update every, otherwise when the user
     // requests just 1 point for the entire duration, it may not
     // be created (the last 1 point may be misaligned with the
     // query).
-    before_requested -= before_requested % update_every;
-    after_requested  -= after_requested % update_every;
+    if(before_requested % update_every)
+        before_requested += update_every - (before_requested % update_every);
 
-    *before_requestedp = before_requested;
-    *after_requestedp = after_requested;
+    if(after_requested % update_every)
+        after_requested += update_every - (after_requested % update_every);
+
+    // if the query requests future data
+    // shift the query back to be in the present time
+    // (this may also happen because of the rules above)
+    if(before_requested > now) {
+        long long delta = before_requested - now;
+        if(delta % update_every)
+            delta += update_every - (delta % update_every);
+        before_requested -= delta;
+        after_requested  -= delta;
+    }
+
+    // if the query requests last second data and
+    // the update every is 1 second, shift it a
+    // second in the past to make sure we have the
+    // data available
+    if(update_every == 1 && before_requested == now) {
+        before_requested -= update_every;
+        after_requested  -= update_every;
+    }
+
+    *before = before_requested;
+    *after = after_requested;
 
     return absolute_period_requested;
 }
@@ -889,25 +900,25 @@ static RRDR *rrd2rrdr_fixedstep(
         , int timeout
 ) {
     int aligned = !(options & RRDR_OPTION_NOT_ALIGNED);
+    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
 
     // the duration of the chart
     time_t duration = before_requested - after_requested;
     long available_points = duration / update_every;
 
-    RRDDIM *temp_rd = context_param_list ? context_param_list->rd : NULL;
-
     if(duration <= 0 || available_points <= 0)
-        return rrdr_create(owa, st, 1, context_param_list);
+        return NULL;
 
-    // check the number of wanted points in the result
-    if(unlikely(points_requested < 0)) points_requested = -points_requested;
-    if(unlikely(points_requested > available_points)) points_requested = available_points;
-    if(unlikely(points_requested == 0)) points_requested = available_points;
+    if(unlikely(points_requested > available_points))
+        points_requested = available_points;
 
     // calculate the desired grouping of source data points
     long group = available_points / points_requested;
     if(unlikely(group <= 0)) group = 1;
-    if(unlikely(available_points % points_requested > points_requested / 2)) group++; // rounding to the closest integer
+
+    // round "group" to the closest integer
+    if(unlikely(available_points % points_requested > points_requested / 2))
+        group++;
 
     // resampling_time_requested enforces a certain grouping multiple
     calculated_number resampling_divisor = 1.0;
@@ -963,7 +974,7 @@ static RRDR *rrd2rrdr_fixedstep(
     if(aligned) {
         // alignment has been requested, so align the values
         before_requested -= before_requested % (group * update_every);
-        after_requested  -= after_requested % (group * update_every);
+        after_requested  -= after_requested  % (group * update_every);
     }
 
     // we align the request on requested_before
@@ -975,7 +986,6 @@ static RRDR *rrd2rrdr_fixedstep(
 
         before_wanted = last_entry_t - (last_entry_t % ( ((aligned)?group:1) * update_every ));
     }
-    //size_t before_slot = rrdset_time2slot(st, before_wanted);
 
     // we need to estimate the number of points, for having
     // an integer number of values per point
@@ -997,7 +1007,6 @@ static RRDR *rrd2rrdr_fixedstep(
             after_wanted = first_entry_t - (first_entry_t % ( ((aligned)?group:1) * update_every )) + ( ((aligned)?group:1) * update_every );
         }
     }
-    //size_t after_slot = rrdset_time2slot(st, after_wanted);
 
     // check if they are reversed
     if(unlikely(after_wanted > before_wanted)) {
@@ -1667,25 +1676,43 @@ RRDR *rrd2rrdr(
     int rrd_update_every;
     int absolute_period_requested;
 
+    if(unlikely(points_requested < 0))
+        points_requested = -points_requested;
+
+    if(unlikely(!points_requested))
+        points_requested = 1;
+
     time_t first_entry_t;
     time_t last_entry_t;
     if (context_param_list) {
         first_entry_t = context_param_list->first_entry_t;
-        last_entry_t = context_param_list->last_entry_t;
-    } else {
+        last_entry_t  = context_param_list->last_entry_t;
+    }
+    else {
         rrdset_rdlock(st);
         first_entry_t = rrdset_first_entry_t_nolock(st);
-        last_entry_t = rrdset_last_entry_t_nolock(st);
+        last_entry_t  = rrdset_last_entry_t_nolock(st);
         rrdset_unlock(st);
     }
 
     rrd_update_every = st->update_every;
-    absolute_period_requested = rrdr_convert_before_after_to_absolute(&after_requested, &before_requested,
-                                                                      rrd_update_every, first_entry_t,
-                                                                      last_entry_t, options);
-    if (options & RRDR_OPTION_ALLOW_PAST)
+    absolute_period_requested = rrdr_relative_window_to_absolute(&after_requested, &before_requested,
+                                                                 rrd_update_every, points_requested);
+
+    if(options & RRDR_OPTION_ALLOW_PAST) {
         if (first_entry_t > after_requested)
             first_entry_t = after_requested;
+
+        if (last_entry_t < before_requested)
+            last_entry_t = before_requested;
+    }
+    else {
+        if(after_requested < first_entry_t)
+            after_requested = first_entry_t;
+
+        if(before_requested > last_entry_t)
+            before_requested = last_entry_t;
+    }
 
     if (context_param_list && !(context_param_list->flags & CONTEXT_FLAGS_ARCHIVE)) {
         rebuild_context_param_list(owa, context_param_list, after_requested);
@@ -1707,22 +1734,21 @@ RRDR *rrd2rrdr(
                 if (rrd_update_every != region_info_array[0].update_every) {
                     rrd_update_every = region_info_array[0].update_every;
                     /* recalculate query alignment */
-                    absolute_period_requested =
-                            rrdr_convert_before_after_to_absolute(&after_requested, &before_requested, rrd_update_every,
-                                                                  first_entry_t, last_entry_t, options);
+                    absolute_period_requested = rrdr_relative_window_to_absolute(&after_requested, &before_requested,
+                                                                                 rrd_update_every, points_requested);
                 }
                 freez(region_info_array);
             }
             return rrd2rrdr_fixedstep(owa, st, points_requested, after_requested, before_requested, group_method,
                                       resampling_time_requested, options, dimensions, rrd_update_every,
                                       first_entry_t, last_entry_t, absolute_period_requested, context_param_list, timeout);
-        } else {
+        }
+        else {
             if (rrd_update_every != (uint16_t)max_interval) {
                 rrd_update_every = (uint16_t) max_interval;
                 /* recalculate query alignment */
-                absolute_period_requested = rrdr_convert_before_after_to_absolute(&after_requested, &before_requested,
-                                                                                  rrd_update_every, first_entry_t,
-                                                                                  last_entry_t, options);
+                absolute_period_requested = rrdr_relative_window_to_absolute(&after_requested, &before_requested,
+                                                                             rrd_update_every, points_requested);
             }
             return rrd2rrdr_variablestep(owa, st, points_requested, after_requested, before_requested, group_method,
                                          resampling_time_requested, options, dimensions, rrd_update_every,

--- a/web/api/queries/query.h
+++ b/web/api/queries/query.h
@@ -20,5 +20,6 @@ typedef enum rrdr_grouping {
 extern const char *group_method2string(RRDR_GROUPING group);
 extern void web_client_api_v1_init_grouping(void);
 extern RRDR_GROUPING web_client_api_request_v1_data_group(const char *name, RRDR_GROUPING def);
+extern const char *web_client_api_request_v1_data_group_to_string(RRDR_GROUPING group);
 
 #endif //NETDATA_API_DATA_QUERY_H

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -83,12 +83,8 @@ inline static void rrdr_unlock_rrdset(RRDR *r) {
     }
 }
 
-inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r)
-{
-    if(unlikely(!r)) {
-        error("NULL value given!");
-        return;
-    }
+inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r) {
+    if(unlikely(!r)) return;
 
     rrdr_unlock_rrdset(r);
     onewayalloc_freez(owa, r->t);

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -25,6 +25,7 @@ typedef enum rrdr_options {
     RRDR_OPTION_CUSTOM_VARS  = 0x00010000, // when wrapping response in a JSON, return custom variables in response
     RRDR_OPTION_ALLOW_PAST   = 0x00020000, // The after parameter can extend in the past before the first entry
     RRDR_OPTION_ANOMALY_BIT  = 0x00040000, // Return the anomaly bit stored in each collected_number
+    RRDR_OPTION_RETURN_RAW   = 0x00080000, // Return raw data for aggregating across multiple nodes
 } RRDR_OPTIONS;
 
 typedef enum rrdr_value_flag {
@@ -113,6 +114,8 @@ extern RRDR *rrd2rrdr(
     RRDSET *st, long points_requested, long long after_requested, long long before_requested,
     RRDR_GROUPING group_method, long resampling_time_requested, RRDR_OPTIONS options, const char *dimensions,
     struct context_param *context_param_list, int timeout);
+
+extern int rrdr_relative_window_to_absolute(long long *after, long long *before, int update_every, long points);
 
 #include "query.h"
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -36,9 +36,9 @@ static struct {
         , {"match_names"     , 0    , RRDR_OPTION_MATCH_NAMES}
         , {"match-names"     , 0    , RRDR_OPTION_MATCH_NAMES}
         , {"showcustomvars"  , 0    , RRDR_OPTION_CUSTOM_VARS}
-        , {"allow_past"      , 0    , RRDR_OPTION_ALLOW_PAST}
         , {"anomaly-bit"     , 0    , RRDR_OPTION_ANOMALY_BIT}
-        , {                  NULL, 0, 0}
+        , {"raw"             , 0    , RRDR_OPTION_RETURN_RAW}
+        , {NULL              , 0    , 0}
 };
 
 static struct {
@@ -162,8 +162,8 @@ void web_client_api_v1_management_init(void) {
 	api_secret = get_mgmt_api_key();
 }
 
-inline uint32_t web_client_api_request_v1_data_options(char *o) {
-    uint32_t ret = 0x00000000;
+inline RRDR_OPTIONS web_client_api_request_v1_data_options(char *o) {
+    RRDR_OPTIONS ret = 0x00000000;
     char *tok;
 
     while(o && *o && (tok = mystrsep(&o, ", |"))) {
@@ -180,6 +180,19 @@ inline uint32_t web_client_api_request_v1_data_options(char *o) {
     }
 
     return ret;
+}
+
+void web_client_api_request_v1_data_options_to_string(BUFFER *wb, RRDR_OPTIONS options) {
+    RRDR_OPTIONS used = 0; // to prevent adding duplicates
+    int added = 0;
+    for(int i = 0; api_v1_data_options[i].name ; i++) {
+        if (unlikely((api_v1_data_options[i].value & options) && !(api_v1_data_options[i].value & used))) {
+            if(added) buffer_strcat(wb, ",");
+            buffer_strcat(wb, api_v1_data_options[i].name);
+            used |= api_v1_data_options[i].value;
+            added++;
+        }
+    }
 }
 
 inline uint32_t web_client_api_request_v1_data_format(char *name) {
@@ -1319,11 +1332,12 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
     if (!netdata_ready)
         return HTTP_RESP_BACKEND_FETCH_FAILED;
 
-    long long baseline_after = 300, baseline_before = -60, highlight_after = -60, highlight_before = 0, points = 1000;
-    RRDR_OPTIONS options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_ALLOW_PAST | RRDR_OPTION_NONZERO | RRDR_OPTION_NULL2ZERO;
+    long long baseline_after = 0, baseline_before = 0, after = 0, before = 0, points = 0;
+    RRDR_OPTIONS options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_NONZERO | RRDR_OPTION_NULL2ZERO | RRDR_OPTION_ALLOW_PAST;
     METRIC_CORRELATIONS_METHOD method = METRIC_CORRELATIONS_KS2;
-    int timeout = 20000;
- 
+    RRDR_GROUPING group = RRDR_GROUPING_AVERAGE;
+    int timeout = 0;
+
     while (url) {
         char *value = mystrsep(&url, "&");
         if (!value || !*value)
@@ -1341,11 +1355,11 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
         else if (!strcmp(name, "baseline_before"))
             baseline_before = (long long) strtoul(value, NULL, 0);
 
-        else if (!strcmp(name, "highlight_after"))
-            highlight_after = (long long) strtoul(value, NULL, 0);
+        else if (!strcmp(name, "after") || !strcmp(name, "highlight_after"))
+            after = (long long) strtoul(value, NULL, 0);
 
-        else if (!strcmp(name, "highlight_before"))
-            highlight_before = (long long) strtoul(value, NULL, 0);
+        else if (!strcmp(name, "before") || !strcmp(name, "highlight_before"))
+            before = (long long) strtoul(value, NULL, 0);
 
         else if (!strcmp(name, "points") || !strcmp(name, "max_points"))
             points = (long long) strtoul(value, NULL, 0);
@@ -1353,12 +1367,15 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
         else if (!strcmp(name, "timeout"))
             timeout = (int) strtoul(value, NULL, 0);
 
-        else if(!strcmp(name, "method")) {
-            if(!strcmp(value, "volume")) method = METRIC_CORRELATIONS_VOLUME;
-            else method = METRIC_CORRELATIONS_KS2;
-        }
+        else if(!strcmp(name, "group"))
+            group = web_client_api_request_v1_data_group(value, RRDR_GROUPING_AVERAGE);
+
         else if(!strcmp(name, "options"))
             options |= web_client_api_request_v1_data_options(value);
+
+        else if(!strcmp(name, "method"))
+            method = mc_string_to_method(value);
+
     }
 
     BUFFER *wb = w->response.data;
@@ -1366,13 +1383,7 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
     wb->contenttype = CT_APPLICATION_JSON;
     buffer_no_cacheable(wb);
 
-    if(!highlight_after || !highlight_before) {
-        buffer_strcat(wb, "{\"error\": \"Missing or invalid required highlight after and before parameters.\" }");
-        return HTTP_RESP_BAD_REQUEST;
-    }
-
-    return metric_correlations(host, wb, method, baseline_after, baseline_before,
-                               highlight_after, highlight_before, points, options, timeout);
+    return metric_correlations(host, wb, method, group, baseline_after, baseline_before, after, before, points, options, timeout);
 }
 
 static struct api_command {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1334,7 +1334,7 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
 
     long long baseline_after = 0, baseline_before = 0, after = 0, before = 0, points = 0;
     RRDR_OPTIONS options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_NONZERO | RRDR_OPTION_NULL2ZERO | RRDR_OPTION_ALLOW_PAST;
-    METRIC_CORRELATIONS_METHOD method = METRIC_CORRELATIONS_KS2;
+    METRIC_CORRELATIONS_METHOD method = METRIC_CORRELATIONS_VOLUME;
     RRDR_GROUPING group = RRDR_GROUPING_AVERAGE;
     int timeout = 0;
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1334,12 +1334,16 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
 
         if (!strcmp(name, "baseline_after"))
             baseline_after = (long long) strtoul(value, NULL, 0);
+
         else if (!strcmp(name, "baseline_before"))
             baseline_before = (long long) strtoul(value, NULL, 0);
+
         else if (!strcmp(name, "highlight_after"))
             highlight_after = (long long) strtoul(value, NULL, 0);
+
         else if (!strcmp(name, "highlight_before"))
             highlight_before = (long long) strtoul(value, NULL, 0);
+
         else if (!strcmp(name, "max_points"))
             max_points = (long long) strtoul(value, NULL, 0);
         
@@ -1350,11 +1354,10 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
     wb->contenttype = CT_APPLICATION_JSON;
     buffer_no_cacheable(wb);
 
-    if (!highlight_after || !highlight_before)
+    if(!highlight_after || !highlight_before)
         buffer_strcat(wb, "{\"error\": \"Missing or invalid required highlight after and before parameters.\" }");
-    else {
+    else
         metric_correlations(host, wb, baseline_after, baseline_before, highlight_after, highlight_before, max_points);
-    }
 
     return HTTP_RESP_OK;
 }

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1334,7 +1334,7 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
 
     long long baseline_after = 0, baseline_before = 0, after = 0, before = 0, points = 0;
     RRDR_OPTIONS options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_NONZERO | RRDR_OPTION_NULL2ZERO | RRDR_OPTION_ALLOW_PAST;
-    METRIC_CORRELATIONS_METHOD method = METRIC_CORRELATIONS_VOLUME;
+    METRIC_CORRELATIONS_METHOD method = default_metric_correlations_method;
     RRDR_GROUPING group = RRDR_GROUPING_AVERAGE;
     int timeout = 0;
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1320,6 +1320,7 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
         return HTTP_RESP_BACKEND_FETCH_FAILED;
 
     long long baseline_after = 0, baseline_before = 0, highlight_after = 0, highlight_before = 0, max_points = 0;
+    METRIC_CORRELATIONS_METHOD method = METRIC_CORRELATIONS_KS2;
     long timeout = 0;
  
     while (url) {
@@ -1351,6 +1352,11 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
         else if (!strcmp(name, "timeout"))
             timeout = (long long) strtoul(value, NULL, 0);
 
+        else if(!strcmp(name, "method")) {
+            if(!strcmp(value, "volume")) method = METRIC_CORRELATIONS_VOLUME;
+            else method = METRIC_CORRELATIONS_KS2;
+        }
+
     }
 
     BUFFER *wb = w->response.data;
@@ -1363,7 +1369,7 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
         return HTTP_RESP_BAD_REQUEST;
     }
 
-    return metric_correlations(host, wb, baseline_after, baseline_before, highlight_after, highlight_before, max_points, timeout);
+    return metric_correlations(host, wb, method, baseline_after, baseline_before, highlight_after, highlight_before, max_points, timeout);
 }
 
 static struct api_command {

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -9,7 +9,9 @@
 #include "web/api/health/health_cmdapi.h"
 
 #define MAX_CHART_LABELS_FILTER (32)
-extern uint32_t web_client_api_request_v1_data_options(char *o);
+extern RRDR_OPTIONS web_client_api_request_v1_data_options(char *o);
+extern void web_client_api_request_v1_data_options_to_string(BUFFER *wb, RRDR_OPTIONS options);
+
 extern uint32_t web_client_api_request_v1_data_format(char *name);
 extern uint32_t web_client_api_request_v1_data_google_format(char *name);
 

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -26,6 +26,7 @@ extern int web_enable_gzip, web_gzip_level, web_gzip_strategy;
 // HTTP_CODES 5XX Server Errors
 #define HTTP_RESP_INTERNAL_SERVER_ERROR 500
 #define HTTP_RESP_BACKEND_FETCH_FAILED 503
+#define HTTP_RESP_GATEWAY_TIMEOUT 504
 
 extern int respect_web_browser_do_not_track_policy;
 extern char *web_x_frame_options;


### PR DESCRIPTION
This PR improves the performance of metrics correlations by a factor of 73.

The biggest problem of it was this function:

```c
int find_index(double arr[], long int n, double K, long int start)
{
    for (long int i = start; i < n; i++) {
        if (K<arr[i]){
            return i;
        }
    }
    return n;
}
```

It has been replaced with a binary search function, which alone saved 75% of CPU resources required.

Then the next big problem was comparisons of `double` numbers. So, I multiplied the `double` pair diffs by 1 million (to have 6 digits precision) and divided the final `min` and `max` by 1 million, so that we only compare `long int` numbers. This saved 15% more (compared to the original).

Then a number of additional optimizations have been done to optimize the whole logic further:

1. The need to replace NANs with zeros has been replaced with the option `RRDR_OPTION_NULL2ZERO` so that the query engine will do it.
2. Loops to copy data around have been eliminated
3. Loops to calculate min and max have been eliminated

The current code in the master, has another important issue. The baseline is 4x bigger than the highlight, but the code requests the same number of points for both the highlight and the baseline. This is now fixed. The new code tries to have the same duration for each point of the result. So, it first does the highlight query to find the number of points returned and then it does the baseline query requesting 4 times the number of points of the highlight. The code is smart enough to adapt the baseline window to be power of 2 compared to the highlight and respecting the maximum buffers the code has. So, the old code, also gives wrong results.

Overall, for a given test I made for 30 minutes of metrics correlations, by observations are like follows:

1. The original time to run metric correlations was about 8 seconds.
2. The time to do the queries to collect the data was about 700 ms (just 9% of the total time).
3. The new time to run metric correlations is about 800 ms (for the same timeframe, the same dataset).
4. So, 7300ms before vs 100ms now. 73x times faster.

Now metrics correlations is just about 12% more resource hungry than running metrics correlations on the cloud. It is really nothing. If we accumulated into this the CPU time the agent needs to prepare JSON responses for all data queries and send them over to the cloud, the agent version is now really a lot more efficient for the agent itself.

I also enabled metric correlations at the agent, by default.