### PR TITLE
Remove pinned page reference

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -796,7 +796,7 @@ static void dbengine_statistics_charts(void) {
                 static RRDDIM *rd_index_metadata = NULL;
                 static RRDDIM *rd_pages_metadata = NULL;
 
-                collected_number cached_pages, pinned_pages, API_producers, populated_pages, cache_metadata, pages_on_disk,
+                collected_number API_producers, populated_pages, cache_metadata, pages_on_disk,
                     page_cache_descriptors, index_metadata, pages_metadata;
 
                 if (unlikely(!st_ram_usage)) {
@@ -827,13 +827,6 @@ static void dbengine_statistics_charts(void) {
                 populated_pages = (collected_number)stats_array[3];
                 page_cache_descriptors = (collected_number)stats_array[27];
 
-                if (API_producers * 2 > populated_pages) {
-                    pinned_pages = API_producers;
-                } else {
-                    pinned_pages = API_producers * 2;
-                }
-                cached_pages = populated_pages - pinned_pages;
-
                 cache_metadata = page_cache_descriptors * sizeof(struct page_cache_descr);
 
                 pages_metadata = pages_on_disk * sizeof(struct rrdeng_page_descr);
@@ -841,8 +834,8 @@ static void dbengine_statistics_charts(void) {
                 /* This is an empirical estimation for Judy array indexing and extent structures */
                 index_metadata = pages_on_disk * 58;
 
-                rrddim_set_by_pointer(st_ram_usage, rd_cached, cached_pages);
-                rrddim_set_by_pointer(st_ram_usage, rd_pinned, pinned_pages);
+                rrddim_set_by_pointer(st_ram_usage, rd_cached, populated_pages - API_producers);
+                rrddim_set_by_pointer(st_ram_usage, rd_pinned, API_producers);
                 rrddim_set_by_pointer(st_ram_usage, rd_cache_metadata, cache_metadata);
                 rrddim_set_by_pointer(st_ram_usage, rd_pages_metadata, pages_metadata);
                 rrddim_set_by_pointer(st_ram_usage, rd_index_metadata, index_metadata);

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -238,7 +238,6 @@ static void pg_cache_release_pages(struct rrdengine_instance *ctx, unsigned numb
  */
 unsigned long pg_cache_hard_limit(struct rrdengine_instance *ctx)
 {
-    /* it's twice the number of producers since we pin 2 pages per producer */
     return ctx->max_cache_pages + (unsigned long)ctx->metric_API_max_producers;
 }
 
@@ -248,7 +247,6 @@ unsigned long pg_cache_hard_limit(struct rrdengine_instance *ctx)
  */
 unsigned long pg_cache_soft_limit(struct rrdengine_instance *ctx)
 {
-    /* it's twice the number of producers since we pin 2 pages per producer */
     return ctx->cache_pages_low_watermark + (unsigned long)ctx->metric_API_max_producers;
 }
 

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -239,7 +239,7 @@ static void pg_cache_release_pages(struct rrdengine_instance *ctx, unsigned numb
 unsigned long pg_cache_hard_limit(struct rrdengine_instance *ctx)
 {
     /* it's twice the number of producers since we pin 2 pages per producer */
-    return ctx->max_cache_pages + 2 * (unsigned long)ctx->metric_API_max_producers;
+    return ctx->max_cache_pages + (unsigned long)ctx->metric_API_max_producers;
 }
 
 /*
@@ -249,7 +249,7 @@ unsigned long pg_cache_hard_limit(struct rrdengine_instance *ctx)
 unsigned long pg_cache_soft_limit(struct rrdengine_instance *ctx)
 {
     /* it's twice the number of producers since we pin 2 pages per producer */
-    return ctx->cache_pages_low_watermark + 2 * (unsigned long)ctx->metric_API_max_producers;
+    return ctx->cache_pages_low_watermark + (unsigned long)ctx->metric_API_max_producers;
 }
 
 /*

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -35,7 +35,7 @@ struct rrdengine_instance;
 #define RRDENG_FILE_NUMBER_PRINT_TMPL "%1.1u-%10.10u"
 
 struct rrdeng_collect_handle {
-    struct rrdeng_page_descr *descr, *prev_descr;
+    struct rrdeng_page_descr *descr;
     unsigned long page_correlation_id;
     struct rrdengine_instance *ctx;
     // set to 1 when this dimension is not page aligned with the other dimensions in the chart

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -279,12 +279,10 @@ void rrdeng_store_metric_next(RRDDIM *rd, usec_t point_in_time, storage_number n
 int rrdeng_store_metric_finalize(RRDDIM *rd)
 {
     struct rrdeng_collect_handle *handle;
-    struct rrdengine_instance *ctx;
     struct pg_cache_page_index *page_index;
     uint8_t can_delete_metric = 0;
 
     handle = (struct rrdeng_collect_handle *)rd->state->handle;
-    ctx = handle->ctx;
     page_index = rd->state->page_index;
     rrdeng_store_metric_flush_current_page(rd);
     uv_rwlock_wrlock(&page_index->lock);


### PR DESCRIPTION
##### Summary
- Remove the pinned page reference as it is not used (reduce a bit the memory needed per collected metric)
- Remove it from the page cache statistics calculation

The prev_used handle was not used

##### Test Plan
- Agent should work as expected. You will notice a difference in the calculation of dbengine statistics (dbengine_ram) under the netdata section for `cache` and `collectors`. The collectors will now report half the amount of the memory used as they take into account only the active collected page as a page get filled and moves to the page cache. The memory will now be reported under `cache` 
<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
