### PR TITLE
Add user netdata to secondary group in DEB package

### DIFF
--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 set -e
 
@@ -25,6 +25,14 @@ case "$1" in
       if ! getent passwd netdata > /dev/null; then
         adduser --quiet --system --ingroup netdata --home /var/lib/netdata --no-create-home netdata
       fi
+
+      set -- docker nginx varnish haproxy adm nsd proxy squid ceph nobody I2C
+      for item
+        do
+          if getent group $item > /dev/null 2>&1; then
+          usermod -a -G $item netdata
+        fi
+      done
 
       if ! dpkg-statoverride --list /var/lib/netdata > /dev/null 2>&1; then
         dpkg-statoverride --update --add netdata netdata 0755 /var/lib/netdata


### PR DESCRIPTION
##### Summary

Fixes #13090

##### Test Plan

N/A

##### Additional Information
There was a bug preventing netdata agent from reading some logs. This change should fix this misbehavior.

<details> <summary>For users: How does this change affect me?</summary>
Netdata should read some applications' logs
</details>
