### PR TITLE
Re-enable updates for systems using static builds.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -622,9 +622,6 @@ update_build() {
 }
 
 update_static() {
-  warning "Due to known issues with updates on static builds, updates for this system are temporarily disabled. They should start working again automatically once this issue is fixed."
-  return 0
-
   ndtmpdir="$(create_tmp_directory)"
   PREVDIR="$(pwd)"
 


### PR DESCRIPTION
Reverts netdata/netdata#13100

Fixes: https://github.com/netdata/netdata/issues/13102 (as the last step in doing so).