### PR TITLE
Assorted cleanup in the OpenRC init script.

### DIFF
--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -24,7 +24,7 @@
 extra_started_commands="reload rotate save"
 command_prefix="@sbindir_POST@"
 command="${command_prefix}/netdata"
-command_args="-P ${NETDATA_PIDFILE}${NETDATA_EXTRA_ARGS}"
+command_args="-P ${NETDATA_PIDFILE} ${NETDATA_EXTRA_ARGS}"
 command_args_foreground="-D"
 start_stop_daemon_args="-u ${NETDATA_OWNER}"
 required_files="/etc/netdata/netdata.conf"

--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -27,7 +27,6 @@ command="${command_prefix}/netdata"
 command_args="-P ${NETDATA_PIDFILE} ${NETDATA_EXTRA_ARGS}"
 command_args_foreground="-D"
 start_stop_daemon_args="-u ${NETDATA_OWNER}"
-required_files="/etc/netdata/netdata.conf"
 if [ "${NETDATA_FORCE_EXIT}" -eq 1 ]; then
     retry="TERM/${NETDATA_WAIT_EXIT_TIMEOUT}/KILL/1"
 else

--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -15,9 +15,13 @@
 # to exit.
 : "${NETDATA_FORCE_EXIT:=0}"
 
+# When set to 1, we use netdatacli for reload/rotate/save commands instead of s-s-d.
+: "${NETDATA_USE_NETDATACLI:=0}"
+
 extra_started_commands="reload rotate save"
 pidfile="@localstatedir_POST@/run/netdata/netdata.pid"
-command="@sbindir_POST@/netdata"
+command_prefix="@sbindir_POST@"
+command="${command_prefix}/netdata"
 command_args="-P ${pidfile} ${NETDATA_EXTRA_ARGS}"
 start_stop_daemon_args="-u ${NETDATA_OWNER}"
 required_files="/etc/netdata/netdata.conf"
@@ -39,18 +43,33 @@ start_pre() {
 
 reload() {
     ebegin "Reloading Netdata health configuration"
-    start-stop-daemon --signal SIGUSR2 --pidfile "${pidfile}"
-    eend $? "Failed to reload Netdata health configuration"
+    if [ "${NETDATA_USE_NETDATACLI}" = 1 ]; then
+        "${command_prefix}/netdatacli" reload-health >/dev/null
+        eend $? "Failed to reload Netdata health configuration"
+    else
+        start-stop-daemon --signal SIGUSR2 --pidfile "${pidfile}"
+        eend $? "Failed to reload Netdata health configuration"
+    fi
 }
 
 rotate() {
     ebegin "Reopening Netdata log files"
-    start-stop-daemon --signal SIGHUP --pidfile "${pidfile}"
-    eend $? "Failed to reopen Netdata log files"
+    if [ "${NETDATA_USE_NETDATACLI}" = 1 ]; then
+        "${command_prefix}/netdatacli" reopen-logs >/dev/null
+        eend $? "Failed to reopen Netdata log files"
+    else
+        start-stop-daemon --signal SIGHUP --pidfile "${pidfile}"
+        eend $? "Failed to reopen Netdata log files"
+    fi
 }
 
 save() {
     ebegin "Saving Netdata database"
-    start-stop-daemon --signal SIGUSR1 --pidfile "${pidfile}"
-    eend $? "Failed to save Netdata database"
+    if [ "${NETDATA_USE_NETDATACLI}" = 1 ]; then
+        "${command_prefix}/netdatacli" save-database >/dev/null
+        eend $? "Failed to save Netdata database"
+    else
+        start-stop-daemon --signal SIGUSR1 --pidfile "${pidfile}"
+        eend $? "Failed to save Netdata database"
+    fi
 }

--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -38,15 +38,15 @@ start_pre() {
 }
 
 reload() {
-    ebegin "Reloading Netdata"
+    ebegin "Reloading Netdata health configuration"
     start-stop-daemon --signal SIGUSR2 --pidfile "${pidfile}"
-    eend $? "Failed to reload Netdata"
+    eend $? "Failed to reload Netdata health configuration"
 }
 
 rotate() {
-    ebegin "Logrotating Netdata"
+    ebegin "Reopening Netdata log files"
     start-stop-daemon --signal SIGHUP --pidfile "${pidfile}"
-    eend $? "Failed to logrotate Netdata"
+    eend $? "Failed to reopen Netdata log files"
 }
 
 save() {

--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -48,35 +48,42 @@ start_pre() {
     fi
 }
 
-reload() {
-    ebegin "Reloading Netdata health configuration"
+run_cmd() {
+    cmd="${1}"
+    msg="${2}"
+    failmsg="${3}"
+    signal="${4}"
+
+    ebegin "${msg}"
     if [ "${NETDATA_USE_NETDATACLI}" = 1 ]; then
-        "${command_prefix}/netdatacli" reload-health >/dev/null
-        eend $? "Failed to reload Netdata health configuration"
+        "${command_prefix}/netdatacli" "${cmd}" >/dev/null
+        eend $? "${failmsg}"
+    elif [ "${supervisor}" = "supervise-daemon" ]; then
+        supervise-daemon "${RC_SVCNAME}" --signal "${signal}"
+        eend $? "${failmsg}"
     else
-        start-stop-daemon --signal SIGUSR2 --pidfile "${pidfile}"
-        eend $? "Failed to reload Netdata health configuration"
+        start-stop-daemon --signal "${signal}" --pidfile "${pidfile}"
+        eend $? "${failmsg}"
     fi
+}
+
+reload() {
+    run_cmd reload-health \
+            "Reloading Netdata health configuration" \
+            "Failed to reload Netdata health configuration" \
+            SIGUSR2
 }
 
 rotate() {
-    ebegin "Reopening Netdata log files"
-    if [ "${NETDATA_USE_NETDATACLI}" = 1 ]; then
-        "${command_prefix}/netdatacli" reopen-logs >/dev/null
-        eend $? "Failed to reopen Netdata log files"
-    else
-        start-stop-daemon --signal SIGHUP --pidfile "${pidfile}"
-        eend $? "Failed to reopen Netdata log files"
-    fi
+    run_cmd reopen-logs \
+            "Reopening Netdata log files" \
+            "Failed to reopen Netdata log files" \
+            SIGHUP
 }
 
 save() {
-    ebegin "Saving Netdata database"
-    if [ "${NETDATA_USE_NETDATACLI}" = 1 ]; then
-        "${command_prefix}/netdatacli" save-database >/dev/null
-        eend $? "Failed to save Netdata database"
-    else
-        start-stop-daemon --signal SIGUSR1 --pidfile "${pidfile}"
-        eend $? "Failed to save Netdata database"
-    fi
+    run_cmd save-database \
+            "Saving Netdata database" \
+            "Failed to save Netdata database" \
+            SIGUSR1
 }

--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -18,11 +18,14 @@
 # When set to 1, we use netdatacli for reload/rotate/save commands instead of s-s-d.
 : "${NETDATA_USE_NETDATACLI:=0}"
 
+# Specifies the pidfile to use when running in the background.
+: "${NETDATA_PIDFILE:=@localstatedir_POST@/run/netdata/netdata.pid}"
+
 extra_started_commands="reload rotate save"
-pidfile="@localstatedir_POST@/run/netdata/netdata.pid"
 command_prefix="@sbindir_POST@"
 command="${command_prefix}/netdata"
-command_args="-P ${pidfile} ${NETDATA_EXTRA_ARGS}"
+command_args="-P ${NETDATA_PIDFILE}${NETDATA_EXTRA_ARGS}"
+command_args_foreground="-D"
 start_stop_daemon_args="-u ${NETDATA_OWNER}"
 required_files="/etc/netdata/netdata.conf"
 if [ "${NETDATA_FORCE_EXIT}" -eq 1 ]; then
@@ -39,6 +42,10 @@ depend() {
 
 start_pre() {
     checkpath -o ${NETDATA_OWNER} -d @localstatedir_POST@/cache/netdata @localstatedir_POST@/run/netdata
+
+    if [ -z "${supervisor}" ]; then
+        pidfile="${NETDATA_PIDFILE}"
+    fi
 }
 
 reload() {

--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -15,10 +15,6 @@
 # to exit.
 : "${NETDATA_FORCE_EXIT:=0}"
 
-# Netdata will use these services, only if they
-# are enabled to start.
-: "${NETDATA_START_AFTER_SERVICES:=apache2 squid nginx mysql named opensips upsd hostapd postfix lm_sensors}"
-
 extra_started_commands="reload rotate save"
 pidfile="@localstatedir_POST@/run/netdata/netdata.pid"
 command="@sbindir_POST@/netdata"
@@ -34,7 +30,7 @@ fi
 depend() {
     use logger
     need net
-    after ${NETDATA_START_AFTER_SERVICES}
+    after apache2 squid nginx mysql named opensips upsd hostapd postfix lm_sensors
 }
 
 start_pre() {


### PR DESCRIPTION
##### Summary

- Get rid of `NETDATA_START_AFTER_SERVICES`. OpenRC already provides a robust configuration system for managing service dependencies, including overrides. The variable itself thus provides no real benefit but makes the script somewhat harder to read, so this PR removes it and just sets the default `after` list to what we had been using as the default value of the variable.
- Add less ambiguous and more accurate descriptions for the `reload`, `rotate`, and `save` commands. This way they concretely describe exactly what they are doing using standard terminology typically seen in other OpenRC scripts.
- Add the ability to use `netdatacli` for the above mentioned commands instead of `start-stop-daemon`. This is controlled by a new variable called `NETDATA_USE_NETDATACLI` variable, which, if set to 1, uses `netdatacli`. The variable defaults to a value of `0`, preserving the existing behavior as the default behavior.
- Consolidate the duplicated code from the `reload`, `rotate`, and `save` commands. The functions are about 90% identical, so this significantly reduces code duplication.
- Add a handful of tweaks to make it easier to work with OpenRC's native process supervision mechanism (`supervise-daemon`), including:
    - Explicitly indicating that Netdata must be started with the `-D` argument to make it run in the foreground.
    - Only setting the `pidfile` variable if not using `supervise-daemon`. This is needed because of how `supervise-daemon` expects PID file handling to work (namely, it expects to be the one managing the PID file for the service, not the command it’s running).
    - Properly support using `supervise-daemon` equivalents for the `reload`, `rotate`, and `save` commands.
- Removed a pointless dependence on the existence of `/etc/netdata/netdata.conf` that’s been causing issues for users who are using static builds.

##### Test Plan

Basic testing involves installing from this PR branch on a system that uses OpenRC (such as Alpine Linux or a default Gentoo install) and verifying that the script still works. Note that this cannot be done properly in a Docker container.

##### Additional Information

This fixes three of the four most glaring issues with our OpenRC init script. The final issue is our `need net` dependency, which is [generally considered a bad thing](https://github.com/OpenRC/openrc/blob/master/service-script-guide.md#be-wary-of-need-net-dependencies). Properly resolving that is far more complicated though and will be handled in a separate PR.

Fixes: #13860

<details> <summary>For users: How does this change affect me?</summary>
<ul>
<li><code>NETDATA_START_AFTER_SERVICES</code> is no longer supported. Instead use `rc_after` in `/etc/conf.d/netdata` like you would for any other service.</li>
<li><code>NETDATA_USE_NETDATACLI</code> can now be set to a value of 1 to avoid using start-stop-daemon, simplifying usage of Netdata with OpenRC’s native process supervision.</li>
</ul>
</details>
