### PR TITLE
Ci coverage

### DIFF
--- a/.github/scripts/check-updater.sh
+++ b/.github/scripts/check-updater.sh
@@ -17,7 +17,18 @@ check_successful_update() {
   ) >&2
 }
 
-steps="check_successful_update"
+check_autoupdate_enabled() {
+  progress "Check autoupdate still enabled after update"
+  (
+    if [ -f /etc/periodic/daily/netdata-updater ] || [ -f /etc/cron.daily/netdata-updater ]; then
+      echo "Update successful!"
+    else
+      exit 1
+    fi
+  ) >&2
+}
+
+steps="check_successful_update check_autoupdate_enabled"
 
 _main() {
   for step in $steps; do

--- a/.github/scripts/ci-support-pkgs.sh
+++ b/.github/scripts/ci-support-pkgs.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# This script installs supporting packages needed for CI, which provide following:
+# cron, pidof
+
+set -e
+
+if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/fedora-release ] || [ -f /etc/almalinux-release ]; then
+    # Alma, Fedora, CentOS, Redhat
+    dnf install -y procps-ng cronie cronie-anacron || yum install -y procps-ng cronie cronie-anacron
+elif [ -f /etc/arch-release ]; then
+    # Arch
+    pacman -S --noconfirm cronie
+fi

--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+echo ">>> Installing CI support packages..."
+/netdata/.github/scripts/ci-support-pkgs.sh
 echo ">>> Installing Netdata..."
 /netdata/packaging/installer/kickstart.sh --dont-wait --build-only --disable-telemetry || exit 1
 echo "::group::Environment File Contents"


### PR DESCRIPTION
##### Summary
Following changes are implemented:
1. Improve CI coverage to make sure autoupdate is still enabled, after netdata upgrade.
2. Fixed unknown command `pidof` during CI.

##### Test Plan
Verify the new testcase exists in the updater-check job in the build.yml workflow.
The log should show something like:

`
>>> Updating Netdata...
>>> Checking if update was successful...
Check netdata version after update ...  [ OK ]
Check autoupdate still enabled after update ... [ OK ]
🎉 All Done!`

The errors related to missing `pidof` command should be gone as well.


##### Additional Information
We had an issue recently where the updater broke the autoupdate process, and we needed to CI coverage, to prevent this from happening in the future.

Issue: https://github.com/netdata/netdata/issues/13105
