### PR TITLE
Fix telegram-bot rate limit

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1352,7 +1352,6 @@ send_telegram() {
           "https://api.telegram.org/bot${bottoken}/sendMessage?chat_id=${chatid}")
 
         notify_telegram=0
-        attempt_counter=$((attempt_counter + 1))
 
         if [ "${httpcode}" = "200" ]; then
           info "sent telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}'"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1339,21 +1339,31 @@ send_telegram() {
 
   if [ "${SEND_TELEGRAM}" = "YES" ] && [ -n "${bottoken}" ] && [ -n "${chatids}" ] && [ -n "${message}" ]; then
     for chatid in ${chatids}; do
-      # https://core.telegram.org/bots/api#sendmessage
-      httpcode=$(docurl ${disableNotification} \
-        --data-urlencode "parse_mode=HTML" \
-        --data-urlencode "disable_web_page_preview=true" \
-        --data-urlencode "text=${emoji} ${message}" \
-        "https://api.telegram.org/bot${bottoken}/sendMessage?chat_id=${chatid}")
+      successful=0
 
-      if [ "${httpcode}" = "200" ]; then
-        info "sent telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}'"
-        sent=$((sent + 1))
-      elif [ "${httpcode}" = "401" ]; then
-        error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}': Wrong bot token."
-      else
-        error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}' with HTTP response status code ${httpcode}."
-      fi
+      while [ ${successful} -eq 0 ]; do
+        # https://core.telegram.org/bots/api#sendmessage
+        httpcode=$(docurl ${disableNotification} \
+          --data-urlencode "parse_mode=HTML" \
+          --data-urlencode "disable_web_page_preview=true" \
+          --data-urlencode "text=${emoji} ${message}" \
+          "https://api.telegram.org/bot${bottoken}/sendMessage?chat_id=${chatid}")
+
+        successful=1
+
+        if [ "${httpcode}" = "200" ]; then
+          info "sent telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}'"
+          sent=$((sent + 1))
+        elif [ "${httpcode}" = "401" ]; then
+          error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}': Wrong bot token."
+        elif [ "${httpcode}" = "429" ]; then
+          error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}': rate limit exceeded, retrying after 1s."
+          successful=0
+          sleep 1
+        else
+          error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}' with HTTP response status code ${httpcode}."
+        fi
+      done
     done
 
     [ ${sent} -gt 0 ] && return 0

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1340,8 +1340,9 @@ send_telegram() {
   if [ "${SEND_TELEGRAM}" = "YES" ] && [ -n "${bottoken}" ] && [ -n "${chatids}" ] && [ -n "${message}" ]; then
     for chatid in ${chatids}; do
       successful=0
+      attempt_counter=0
 
-      while [ ${successful} -eq 0 ]; do
+      while [ ${successful} -eq 0 ] && [ ${attempt_counter} -lt 60 ]; do
         # https://core.telegram.org/bots/api#sendmessage
         httpcode=$(docurl ${disableNotification} \
           --data-urlencode "parse_mode=HTML" \
@@ -1350,6 +1351,7 @@ send_telegram() {
           "https://api.telegram.org/bot${bottoken}/sendMessage?chat_id=${chatid}")
 
         successful=1
+        attempt_counter=$((attempt_counter + 1))
 
         if [ "${httpcode}" = "200" ]; then
           info "sent telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}'"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1339,10 +1339,11 @@ send_telegram() {
 
   if [ "${SEND_TELEGRAM}" = "YES" ] && [ -n "${bottoken}" ] && [ -n "${chatids}" ] && [ -n "${message}" ]; then
     for chatid in ${chatids}; do
-      successful=0
-      attempt_counter=0
+      notify_telegram=1
+      notify_retries=0
+      notify_retries_limit=${TELEGRAM_RETRIES_ON_LIMIT:-0}
 
-      while [ ${successful} -eq 0 ] && [ ${attempt_counter} -lt 60 ]; do
+      while [ ${notify_telegram} -eq 1 ]; do
         # https://core.telegram.org/bots/api#sendmessage
         httpcode=$(docurl ${disableNotification} \
           --data-urlencode "parse_mode=HTML" \
@@ -1350,7 +1351,7 @@ send_telegram() {
           --data-urlencode "text=${emoji} ${message}" \
           "https://api.telegram.org/bot${bottoken}/sendMessage?chat_id=${chatid}")
 
-        successful=1
+        notify_telegram=0
         attempt_counter=$((attempt_counter + 1))
 
         if [ "${httpcode}" = "200" ]; then
@@ -1359,9 +1360,14 @@ send_telegram() {
         elif [ "${httpcode}" = "401" ]; then
           error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}': Wrong bot token."
         elif [ "${httpcode}" = "429" ]; then
-          error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}': rate limit exceeded, retrying after 1s."
-          successful=0
-          sleep 1
+          if [ "$notify_retries" -lt "$notify_retries_limit" ]; then
+            error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}': rate limit exceeded, retrying after 1s."
+            notify_retries=$((notify_retries + 1))
+            notify_telegram=1
+            sleep 1
+          else
+            error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}': rate limit exceeded."
+          fi
         else
           error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}' with HTTP response status code ${httpcode}."
         fi

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1340,8 +1340,7 @@ send_telegram() {
   if [ "${SEND_TELEGRAM}" = "YES" ] && [ -n "${bottoken}" ] && [ -n "${chatids}" ] && [ -n "${message}" ]; then
     for chatid in ${chatids}; do
       notify_telegram=1
-      notify_retries=0
-      notify_retries_limit=${TELEGRAM_RETRIES_ON_LIMIT:-0}
+      notify_retries=${TELEGRAM_RETRIES_ON_LIMIT:-0}
 
       while [ ${notify_telegram} -eq 1 ]; do
         # https://core.telegram.org/bots/api#sendmessage
@@ -1359,9 +1358,9 @@ send_telegram() {
         elif [ "${httpcode}" = "401" ]; then
           error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}': Wrong bot token."
         elif [ "${httpcode}" = "429" ]; then
-          if [ "$notify_retries" -lt "$notify_retries_limit" ]; then
+          if [ "$notify_retries" -gt 0 ]; then
             error "failed to send telegram notification for: ${host} ${chart}.${name} is ${status} to '${chatid}': rate limit exceeded, retrying after 1s."
-            notify_retries=$((notify_retries + 1))
+            notify_retries=$((notify_retries - 1))
             notify_telegram=1
             sleep 1
           else

--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -443,6 +443,11 @@ SEND_TELEGRAM="YES"
 # Without it, netdata cannot send telegram messages.
 TELEGRAM_BOT_TOKEN=""
 
+# If an API limit error is returned on sending a message, Netdata will retry this number of times before giving up.
+# Setting the number to 0 makes Netdata do no retries (which is the default).
+# See https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
+TELEGRAM_RETRIES_ON_LIMIT="0"
+
 # To get your chat ID send the command /getid to telegram bot @myidbot
 # (https://t.me/myidbot). Each user also needs to open a conversation with the
 # bot that will be sending notifications.


### PR DESCRIPTION
##### Summary
When sending too many messages in telegram bot - we can encounter rate limit and get 429 error. As a result, the message will be lost. With this proposal we'll never lose a message but try send it again after 1 second until this message could be sended or another error will appear.

FAQ about telegram limits: https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
