### PR TITLE
buffer overflow detected by the compiler

### DIFF
--- a/parser/parser.c
+++ b/parser/parser.c
@@ -238,7 +238,7 @@ inline int parser_action(PARSER *parser, char *input)
 {
     PARSER_RC   rc = PARSER_RC_OK;
     char *words[PLUGINSD_MAX_WORDS] = { NULL };
-    char command[PLUGINSD_LINE_MAX];
+    char command[PLUGINSD_LINE_MAX + 1];
     keyword_function action_function;
     keyword_function *action_function_list = NULL;
 

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -9,7 +9,7 @@ static inline int find_keyword(char *str, char *keyword, int max_size, int (*cus
     while (unlikely(custom_isspace(*s))) s++;
     keyword_start = s;
 
-    while (likely(*s && !custom_isspace(*s)) && max_size > 0) {
+    while (likely(*s && !custom_isspace(*s)) && max_size > 1) {
         *keyword++ = *s++;
         max_size--;
     }


### PR DESCRIPTION
```
n function 'find_keyword',
    inlined from 'parser_action' at parser/parser.c:261:9:
parser/parser.c:16:14: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
   16 |     *keyword = '\0';
      |     ~~~~~~~~~^~~~~~
parser/parser.c: In function 'parser_action':
parser/parser.c:241:10: note: at offset 1024 into destination object 'command' of size 1024
  241 |     char command[PLUGINSD_LINE_MAX];
      |          ^~~~~~~
```

gcc version 12.1.0 (GCC)