### PR TITLE
fixed coveriry 379136 379135 379134 379133

### DIFF
--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -87,6 +87,8 @@ static void register_result_destroy(DICTIONARY *results) {
 }
 
 static void register_result(DICTIONARY *results, RRDSET *st, RRDDIM *d, calculated_number value) {
+    if(!calculated_number_isnumber(value)) return;
+
     struct register_result t = {
         .st = st,
         .chart_id = st->id,
@@ -553,8 +555,7 @@ static int rrdset_metric_correlations_volume(RRDSET *st, DICTIONARY *results,
         else if(isgreater(highlight_average, 0.0) || isless(highlight_average, 0.0))
             pcent = highlight_average;
 
-        if(!isnan(pcent))
-            register_result(results, st, d, pcent);
+        register_result(results, st, d, pcent);
     }
 
     return correlated_dimensions;
@@ -615,6 +616,10 @@ static size_t spread_results_evenly(DICTIONARY *results) {
         if(likely(slots[i] != last_value))
             slots[unique_values++] = last_value = slots[i];
     }
+
+    // this cannot happen, but coverity thinks otherwise...
+    if(!unique_values)
+        unique_values = dimensions;
 
     // calculate the weight of each slot, using the number of unique values
     calculated_number slot_weight = 1.0 / (calculated_number)unique_values;

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -970,7 +970,7 @@ int rrdlabels_unittest_add_a_pair_callback(const char *name, const char *value, 
         t->errors++;
     }
     else if(strcmp(value, t->expected_value) != 0) {
-        fprintf(stderr, "values don't match, found \"%s\", expected \"%s\"", value, t->expected_value?t->expected_value:"(null)");
+        fprintf(stderr, "values don't match, found \"%s\", expected \"%s\"", value, t->expected_value);
         t->errors++;
     }
 

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -831,8 +831,10 @@ static int rrdlabels_log_label_to_buffer_callback(const char *name, void *value,
     buffer_sprintf(wb, "Label: %s: \"%s\" (", name, lb->value);
 
     size_t sources = 0;
-    if(lb->label_source & RRDLABEL_SRC_AUTO)
-        buffer_sprintf(wb, "%sauto", sources++?",":"");
+    if(lb->label_source & RRDLABEL_SRC_AUTO) {
+        buffer_sprintf(wb, "auto");
+        sources++;
+    }
 
     if(lb->label_source & RRDLABEL_SRC_CONFIG)
         buffer_sprintf(wb, "%snetdata.conf", sources++?",":"");
@@ -968,7 +970,7 @@ int rrdlabels_unittest_add_a_pair_callback(const char *name, const char *value, 
         t->errors++;
     }
     else if(strcmp(value, t->expected_value) != 0) {
-        fprintf(stderr, "values don't match, found \"%s\", expected \"%s\"", value?value:"(null)", t->expected_value?t->expected_value:"(null)");
+        fprintf(stderr, "values don't match, found \"%s\", expected \"%s\"", value, t->expected_value?t->expected_value:"(null)");
         t->errors++;
     }
 

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -255,7 +255,7 @@ int rrdset2anything_api_v1(
         return HTTP_RESP_BACKEND_FETCH_FAILED;
     }
 
-    if (st && st->state && st->state->is_ar_chart)
+    if (st->state && st->state->is_ar_chart)
         ml_process_rrdr(r, query_params->max_anomaly_rates);
 
     RRDDIM *temp_rd = query_params->context_param_list ? query_params->context_param_list->rd : NULL;


### PR DESCRIPTION
All of them are false alarms, but anyway let's fix them

```
________________________________________________________________________________________________________
*** CID 379136:  Control flow issues  (DEADCODE)
/database/rrdlabels.c: 971 in rrdlabels_unittest_add_a_pair_callback()
965         }
966         else if(value == NULL || t->expected_value == NULL) {
967             fprintf(stderr, "value is wrong, found \"%s\", expected \"%s\"", value?value:"(null)", t->expected_value?t->expected_value:"(null)");
968             t->errors++;
969         }
970         else if(strcmp(value, t->expected_value) != 0) {
>>>     CID 379136:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach the expression ""(null)"" inside this statement: "fprintf(stderr, "values don...".
971             fprintf(stderr, "values don't match, found \"%s\", expected \"%s\"", value?value:"(null)", t->expected_value?t->expected_value:"(null)");
972             t->errors++;
973         }
974     
975         return 1;
976     }

** CID 379135:  Null pointer dereferences  (REVERSE_INULL)
/web/api/formatters/rrd2json.c: 258 in rrdset2anything_api_v1()


________________________________________________________________________________________________________
*** CID 379135:  Null pointer dereferences  (REVERSE_INULL)
/web/api/formatters/rrd2json.c: 258 in rrdset2anything_api_v1()
252     
253         if (r->result_options & RRDR_RESULT_OPTION_CANCEL) {
254             rrdr_free(owa, r);
255             return HTTP_RESP_BACKEND_FETCH_FAILED;
256         }
257     
>>>     CID 379135:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "st" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
258         if (st && st->state && st->state->is_ar_chart)
259             ml_process_rrdr(r, query_params->max_anomaly_rates);
260     
261         RRDDIM *temp_rd = query_params->context_param_list ? query_params->context_param_list->rd : NULL;
262     
263         if(r->result_options & RRDR_RESULT_OPTION_RELATIVE)

** CID 379134:  Control flow issues  (DEADCODE)
/database/rrdlabels.c: 835 in rrdlabels_log_label_to_buffer_callback()


________________________________________________________________________________________________________
*** CID 379134:  Control flow issues  (DEADCODE)
/database/rrdlabels.c: 835 in rrdlabels_log_label_to_buffer_callback()
829         RRDLABEL *lb = (RRDLABEL *)value;
830     
831         buffer_sprintf(wb, "Label: %s: \"%s\" (", name, lb->value);
832     
833         size_t sources = 0;
834         if(lb->label_source & RRDLABEL_SRC_AUTO)
>>>     CID 379134:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach the expression "","" inside this statement: "buffer_sprintf(wb, "%sauto"...".
835             buffer_sprintf(wb, "%sauto", sources++?",":"");
836     
837         if(lb->label_source & RRDLABEL_SRC_CONFIG)
838             buffer_sprintf(wb, "%snetdata.conf", sources++?",":"");
839     
840         if(lb->label_source & RRDLABEL_SRC_K8S)

** CID 379133:  Incorrect expression  (DIVIDE_BY_ZERO)
/database/metric_correlations.c: 620 in spread_results_evenly()


________________________________________________________________________________________________________
*** CID 379133:  Incorrect expression  (DIVIDE_BY_ZERO)
/database/metric_correlations.c: 620 in spread_results_evenly()
614         for(size_t i = 0; i < dimensions ;i++) {
615             if(likely(slots[i] != last_value))
616                 slots[unique_values++] = last_value = slots[i];
617         }
618     
619         // calculate the weight of each slot, using the number of unique values
>>>     CID 379133:  Incorrect expression  (DIVIDE_BY_ZERO)
>>>     In expression "1. / (calculated_number)unique_values", division by expression "unique_values" which may be zero has undefined behavior.
620         calculated_number slot_weight = 1.0 / (calculated_number)unique_values;
621     
622         dfe_start_read(results, t) {
623             int slot = binary_search_bigger_than_calculated_number(slots, 0, (int)unique_values, t->value);
624             calculated_number v = slot * slot_weight;
625             if(unlikely(v > 1.0)) v = 1.0;
```