### PR TITLE
Removee invalid function call from installer script.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1859,7 +1859,6 @@ echo >&2
 
 # -----------------------------------------------------------------------------
 progress "Installing (but not enabling) the netdata updater tool"
-cleanup_old_netdata_updater || run_failed "Cannot cleanup old netdata updater tool."
 install_netdata_updater || run_failed "Cannot install netdata updater tool."
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

This got missed in #13013 when the function got removed.

Thankfully it’s just a cosmetic issue in this case.

##### Test Plan

Run the installer script from this branch, and note that it no longer complains about being unable to remove the old updater code.