### PR TITLE
More checks to disable ksm

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -750,7 +750,7 @@ RRDSET *rrdset_create_custom(
             (memory_mode == RRD_MEMORY_MODE_RAM) ? NULL : fullfilename,
             size,
             ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE),
-            0);
+            1);
 
         if(st) {
             memset(&st->avl, 0, sizeof(avl_t));

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1004,8 +1004,11 @@ void *netdata_mmap(const char *filename, size_t size, int flags, int ksm) {
     if(unlikely((flags & MAP_SHARED) && (!filename || !*filename)))
         fatal("MAP_SHARED requested, without a filename to netdata_mmap()");
 
-    // don't enable ksm is the global setting is disabled
-    if(unlikely(!enable_ksm)) ksm = 0;
+    // don't enable ksm if filename is not null (memory mode not ram or dbengine)
+    // and either flags is MAP_SHARED (memory mode map)
+    // or ksm is disabled by default
+    if (filename && (flags & MAP_SHARED || !enable_ksm || !ksm))
+        ksm = 0;
 
     // KSM only merges anonymous (private) pages, never pagecache (file) pages
     // but MAP_PRIVATE without MAP_ANONYMOUS it fails too, so we need it always


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR tries to revert a check of whether or not to use ksm that I think changed a bit since https://github.com/netdata/netdata/pull/12765

Before https://github.com/netdata/netdata/pull/12765 I believe ksm was always enabled for dbengine and ram modes based mostly on the check on `filename` variable. Not sure if that was intentional or not, and why calls to `mymmap` then for dimensions had ksm 1, but for charts 0 (and is same after that PR). (Perhaps the solution might be to just pass 1 or really the configuration option, when calling for charts and or dimensions).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Setup a parent in memory mode RAM.
Also enable ram mode for children in stream.conf
Enable `memory deduplication (ksm)`
This needs a large number of children to reproduce. In my tests ~150-200 children are enough to reproduce, i.e. after a while (~1-2 minutes), the parent will stop with errors of not being able to allocate memory.
With this PR, ksm practically also runs for charts, so in my tests 200 children are ok now.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
