### PR TITLE
use ks2 as MC default

### DIFF
--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -6,7 +6,7 @@
 #define MAX_POINTS 10000
 int enable_metric_correlations = CONFIG_BOOLEAN_YES;
 int metric_correlations_version = 1;
-METRIC_CORRELATIONS_METHOD default_metric_correlations_method = METRIC_CORRELATIONS_VOLUME;
+METRIC_CORRELATIONS_METHOD default_metric_correlations_method = METRIC_CORRELATIONS_KS2;
 
 typedef struct mc_stats {
     size_t db_points;

--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -1206,7 +1206,7 @@
                 "ks2",
                 "volume"
               ],
-              "default": "volume"
+              "default": "ks2"
             }
           },
           {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

The aim of this PR is to use `ks2` as the default for metric correlations instead of `volume`. 

[Here](https://drive.google.com/file/d/124G-THUZlhQNTXeQzm8hZubfmsweHZKx/view?usp=sharing) is a video of some examples why i think ks2 should be the default over volume.

Basically, ks2 will capture a wider range of changes than volume will be able to. As such just using volume will bias towards a subset of changes that the ks2 algo will capture anyway. 

So while i like that we should have volume as a dropdown option in the FE and it will be the default at first for cross node MC where we have a larger amount of selected nodes. I don't think it should be the default and replace ks2.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
