### PR TITLE
fix(python.d/mongodb): set `serverSelectionTimeoutMS` for pymongo4+

### DIFF
--- a/collectors/python.d.plugin/mongodb/mongodb.chart.py
+++ b/collectors/python.d.plugin/mongodb/mongodb.chart.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from sys import exc_info
 
 try:
-    from pymongo import MongoClient, ASCENDING, DESCENDING
+    from pymongo import MongoClient, ASCENDING, DESCENDING, version_tuple
     from pymongo.errors import PyMongoError
 
     PYMONGO = True
@@ -750,7 +750,7 @@ class Service(SimpleService):
             CONN_PARAM_HOST: conf.get(CONN_PARAM_HOST, DEFAULT_HOST),
             CONN_PARAM_PORT: conf.get(CONN_PARAM_PORT, DEFAULT_PORT),
         }
-        if hasattr(MongoClient, 'server_selection_timeout'):
+        if hasattr(MongoClient, 'server_selection_timeout') or version_tuple[0] >= 4:
             params[CONN_PARAM_SERVER_SELECTION_TIMEOUT_MS] = conf.get('timeout', DEFAULT_TIMEOUT)
 
         params.update(self.build_ssl_connection_params())


### PR DESCRIPTION
##### Summary

Checking #13134 I noticed that python.d/mongodb module hangs for 30 seconds. 

The reason is that [`serverSelectionTimeoutMS`](https://pymongo.readthedocs.io/en/stable/api/pymongo/errors.html?highlight=serverselectiontimeoutms#pymongo.errors.ServerSelectionTimeoutError) is not set.

> If there is no suitable server for an operation PyMongo tries for serverSelectionTimeoutMS (default 30 seconds) to find one, then throws this exception.

The following check no longer works for pymongo4+ ([v4 breaking changes](https://pymongo.readthedocs.io/en/stable/changelog.html#breaking-changes-in-4-0))

https://github.com/netdata/netdata/blob/6bed6b1519b2937b1b58324deb9243480a68eded/collectors/python.d.plugin/mongodb/mongodb.chart.py#L753-L754

This PR fixes the problem. 



##### Test Plan

Tested manually in a docker container.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
