### PR TITLE
fix(python.d): urllib3 import collection for py3.10+

### DIFF
--- a/collectors/python.d.plugin/python_modules/urllib3/_collections.py
+++ b/collectors/python.d.plugin/python_modules/urllib3/_collections.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: MIT
 from __future__ import absolute_import
-from collections import Mapping, MutableMapping
+
+try:
+    from collections import Mapping, MutableMapping
+except ImportError:
+    from collections.abc import Mapping, MutableMapping
+
 try:
     from threading import RLock
 except ImportError:  # Platform-specific: No threads available

--- a/collectors/python.d.plugin/python_modules/urllib3/util/selectors.py
+++ b/collectors/python.d.plugin/python_modules/urllib3/util/selectors.py
@@ -12,7 +12,13 @@ import select
 import socket
 import sys
 import time
-from collections import namedtuple, Mapping
+
+from collections import namedtuple
+
+try:
+    from collections import Mapping
+except ImportError:
+    from collections.abc import Mapping
 
 try:
     monotonic = time.monotonic


### PR DESCRIPTION
##### Summary

Fixes: #13134

> **Warning**
> The correct fix is to vendor a recent version of urllib3.

This is a quick fix that can go into the nightly release.

---

```py
Python 3.9.2 (default, Feb 28 2021, 17:03:44)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import Mapping
<stdin>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```

Netdata docker image python version: 

```cmd
$ docker exec ndtest python3 --version
Python 3.10.4
``` 


##### Test Plan

Build a docker image, run python.d.plugin in debug mode, and ensure there are no "cannot import name 'Mapping' from 'collections'" errors.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
