### PR TITLE
fix crashes due to misaligned allocations

### DIFF
--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -1,7 +1,9 @@
 #include "onewayalloc.h"
 
 static size_t OWA_NATURAL_PAGE_SIZE = 0;
-static size_t OWA_NATURAL_ALIGNMENT = sizeof(int*);
+
+// https://www.gnu.org/software/libc/manual/html_node/Aligned-Memory-Blocks.html
+#define OWA_NATURAL_ALIGNMENT  (sizeof(void *) * 2)
 
 typedef struct owa_page {
     size_t stats_pages;
@@ -36,7 +38,7 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
 
     // make sure the new page will fit both the requested size
     // and the OWA_PAGE structure at its beginning
-    size_hint += sizeof(OWA_PAGE);
+    size_hint += natural_alignment(sizeof(OWA_PAGE));
 
     // prefer the user size if it is bigger than our size
     if(size_hint > size) size = size_hint;


### PR DESCRIPTION
gcc 12 makes netdata crash if memory allocations that include function pointers are not 16-byte aligned.

According to GNU documentation, on 64-bit systems, malloc returns 16-byte aligned memories (8-byte on 32-bit systems).

So, this fix makes OWA align to `sizeof(void *) * 2` to comply with the GNU libraries.