### PR TITLE
Add mem.available chart to FreeBSD

### DIFF
--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -1067,9 +1067,9 @@ int do_system_ram(int update_every, usec_t dt) {
                     "MiB",
                     "freebsd.plugin",
                     "system.ram",
-                    NETDATA_CHART_PRIO_SYSTEM_RAM,
+                    NETDATA_CHART_PRIO_MEM_SYSTEM_AVAILABLE,
                     update_every,
-                    RRDSET_TYPE_STACKED
+                    RRDSET_TYPE_AREA
             );
 
             rd_avail   = rrddim_add(st_mem_available, "MemAvailable", "avail", system_pagesize, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -1005,9 +1005,9 @@ int do_system_ram(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------
 
-        static RRDSET *st = NULL;
+        static RRDSET *st = NULL, *st_mem_available = NULL;
         static RRDDIM *rd_free = NULL, *rd_active = NULL, *rd_inactive = NULL, *rd_wired = NULL,
-                      *rd_cache = NULL, *rd_buffers = NULL;
+            *rd_cache = NULL, *rd_buffers = NULL, *rd_avail = NULL;
 
 #if defined(NETDATA_COLLECT_LAUNDRY)
         static RRDDIM *rd_laundry = NULL;
@@ -1055,6 +1055,34 @@ int do_system_ram(int update_every, usec_t dt) {
 #endif
         rrddim_set_by_pointer(st, rd_buffers,  vfs_bufspace_count);
         rrdset_done(st);
+
+        if (unlikely(!st_mem_available)) {
+            st = rrdset_create_localhost(
+                    "mem",
+                    "available",
+                    NULL,
+                    "system",
+                    NULL,
+                    "Available RAM for applications",
+                    "MiB",
+                    "freebsd.plugin",
+                    "system.ram",
+                    NETDATA_CHART_PRIO_SYSTEM_RAM,
+                    update_every,
+                    RRDSET_TYPE_STACKED
+            );
+
+            rd_avail   = rrddim_add(st_mem_available, "MemAvailable", "avail", system_pagesize, MEGA_FACTOR, RRD_ALGORITHM_ABSOLUTE);
+        }
+        else rrdset_next(st_mem_available);
+
+#if __FreeBSD_version < 1200016
+        rrddim_set_by_pointer(st_mem_available, rd_avail,    vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + (vmmeter_data.v_cache_count * system_pagesize + zfs_arcstats_shrinkable_cache_size_bytes));
+#else
+        rrddim_set_by_pointer(st_mem_available, rd_avail,    vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + zfs_arcstats_shrinkable_cache_size_bytes);
+#endif
+
+        rrdset_done(st_mem_available);
     }
 
     return 0;

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -1007,7 +1007,7 @@ int do_system_ram(int update_every, usec_t dt) {
 
         static RRDSET *st = NULL, *st_mem_available = NULL;
         static RRDDIM *rd_free = NULL, *rd_active = NULL, *rd_inactive = NULL, *rd_wired = NULL,
-            *rd_cache = NULL, *rd_buffers = NULL, *rd_avail = NULL;
+                      *rd_cache = NULL, *rd_buffers = NULL, *rd_avail = NULL;
 
 #if defined(NETDATA_COLLECT_LAUNDRY)
         static RRDDIM *rd_laundry = NULL;
@@ -1077,9 +1077,9 @@ int do_system_ram(int update_every, usec_t dt) {
         else rrdset_next(st_mem_available);
 
 #if __FreeBSD_version < 1200016
-        rrddim_set_by_pointer(st_mem_available, rd_avail,    vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + (vmmeter_data.v_cache_count * system_pagesize + zfs_arcstats_shrinkable_cache_size_bytes));
+        rrddim_set_by_pointer(st_mem_available, rd_avail, vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + (vmmeter_data.v_cache_count * system_pagesize + zfs_arcstats_shrinkable_cache_size_bytes));
 #else
-        rrddim_set_by_pointer(st_mem_available, rd_avail,    vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + zfs_arcstats_shrinkable_cache_size_bytes);
+        rrddim_set_by_pointer(st_mem_available, rd_avail, vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + zfs_arcstats_shrinkable_cache_size_bytes);
 #endif
 
         rrdset_done(st_mem_available);

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -1057,7 +1057,7 @@ int do_system_ram(int update_every, usec_t dt) {
         rrdset_done(st);
 
         if (unlikely(!st_mem_available)) {
-            st = rrdset_create_localhost(
+            st_mem_available = rrdset_create_localhost(
                     "mem",
                     "available",
                     NULL,

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -54,7 +54,7 @@ host labels: _is_k8s_node = false
 component: Memory
        os: freebsd
     hosts: *
-     calc: ($active + $wired + $laundry + $buffers) * 100 / ($active + $wired + $laundry + $buffers - $used_ram_to_ignore + $cache + $free + $inactive)
+     calc: ($active + $wired + $laundry + $buffers) * 100 / ($active + $wired + $laundry + $buffers + $cache + $free + $inactive)
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
@@ -70,7 +70,7 @@ component: Memory
 component: Memory
        os: freebsd
     hosts: *
-     calc: $avail * 100 / ($free + $active + $inactive + $wired + $cache + $laundry + $buffers)
+     calc: $avail * 100 / ($system.ram.free + $system.ram.active + $system.ram.inactive + $system.ram.wired + $system.ram.cache + $system.ram.laundry + $system.ram.buffers)
     units: %
     every: 10s
      warn: $this < (($status >= $WARNING)  ? (15) : (10))

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -64,13 +64,13 @@ component: Memory
        to: sysadmin
 
     alarm: ram_available
-       on: system.ram
+       on: mem.available
     class: Utilization
      type: System
 component: Memory
        os: freebsd
     hosts: *
-     calc: ($free + $inactive + $cache) * 100 / ($free + $active + $inactive + $wired + $cache + $laundry + $buffers)
+     calc: $avail * 100 / ($free + $active + $inactive + $wired + $cache + $laundry + $buffers)
     units: %
     every: 10s
      warn: $this < (($status >= $WARNING)  ? (15) : (10))

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1734,7 +1734,12 @@ netdataDashboard.context = {
     },
 
     'mem.available': {
-        info: 'Available Memory is estimated by the kernel, as the amount of RAM that can be used by userspace processes, without causing swapping.'
+        info: function (os) {
+            if (os === "freebsd")
+                return 'The amount of memory that can be used by user-space processes without causing swapping. Calculated as the sum of free, cached, and inactive memory.';
+            else
+                return 'Available Memory is estimated by the kernel, as the amount of RAM that can be used by userspace processes, without causing swapping.';
+        }
     },
 
     'mem.writeback': {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes https://github.com/netdata/netdata-cloud/issues/352

`mem.available` is one of those special charts that we use in the node list in the cloud. It is however missing from FreeBSD. This PR adds it, so that it can be displayed in the cloud.

The relevant alert is also changed to use the new chart.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Compile on FreeBSD. Note the new chart, and the alerts `ram_available` and `ram_in_use` should be displaying correct values.