### PR TITLE
Add an option to use malloc for page cache instead of mmap

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -584,6 +584,7 @@ static void get_netdata_configured_variables() {
     // ------------------------------------------------------------------------
     // get default Database Engine page cache size in MiB
 
+    db_engine_use_malloc = config_get_boolean(CONFIG_SECTION_GLOBAL, "page cache uses malloc", CONFIG_BOOLEAN_NO);
     default_rrdeng_page_cache_mb = (int) config_get_number(CONFIG_SECTION_GLOBAL, "page cache size", default_rrdeng_page_cache_mb);
     if(default_rrdeng_page_cache_mb < RRDENG_MIN_PAGE_CACHE_SIZE_MB) {
         error("Invalid page cache size %d given. Defaulting to %d.", default_rrdeng_page_cache_mb, RRDENG_MIN_PAGE_CACHE_SIZE_MB);

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -4,6 +4,7 @@
 /* Default global database instance */
 struct rrdengine_instance multidb_ctx;
 
+int db_engine_use_malloc = 0;
 int default_rrdeng_page_cache_mb = 32;
 int default_rrdeng_disk_quota_mb = 256;
 int default_multidb_disk_quota_mb = 256;

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -12,6 +12,7 @@
 
 #define RRDENG_FD_BUDGET_PER_INSTANCE (50)
 
+extern int db_engine_use_malloc;
 extern int default_rrdeng_page_cache_mb;
 extern int default_rrdeng_disk_quota_mb;
 extern int default_multidb_disk_quota_mb;


### PR DESCRIPTION
Fixes #13133

##### Summary
Add a config option `page cache uses malloc` to switch from using mmap to malloc. In some cases mmap will fail whereas malloc works just fine. 

In in the netdata.conf `[global]` section

add the following so that the agent will use malloc instead of mmap (the default is `no`) 

`page cache uses malloc = yes`

##### Test Plan
- Agent should work as this change affects only how the metric page is allocated / deallocated