### PR TITLE
Add cargo/rustc/bazel/buck to apps_groups.conf

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -227,7 +227,7 @@ dnsdist: dnsdist
 # installation / compilation / debugging
 
 build: cc1 cc1plus as gcc* cppcheck ld make cmake automake autoconf autoreconf
-build: git gdb valgrind*
+build: cargo rustc bazel buck git gdb valgrind*
 
 # -----------------------------------------------------------------------------
 # antivirus


### PR DESCRIPTION
##### Summary

Adds a couple more binaries to the build group. The names are ubiquitous enough to have them in the build group.
 
##### Test Plan

Install the agent, use one of the binaries added and check the apps.cpu chart.
