### PR TITLE
fix conditions for nightly build triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
     name: Trigger artifact builds
     runs-on: ubuntu-latest
     needs: update-changelogs
-    if: ${{ needs.update-changelogs.outputs.run }} == 'true'
+    if: needs.update-changelogs.outputs.run == 'true'
     steps:
       - name: Checkout
         id: checkout
@@ -146,7 +146,7 @@ jobs:
     name: Trigger docker builds
     runs-on: ubuntu-latest
     needs: update-changelogs
-    if: ${{ needs.update-changelogs.outputs.run }} == 'true'
+    if: needs.update-changelogs.outputs.run == 'true'
     steps:
       - name: Checkout
         id: checkout
@@ -181,7 +181,7 @@ jobs:
     name: Trigger package builds
     runs-on: ubuntu-latest
     needs: update-changelogs
-    if: ${{ needs.update-changelogs.outputs.run }} == 'true'
+    if: needs.update-changelogs.outputs.run == 'true'
     steps:
       - name: Checkout
         id: checkout


### PR DESCRIPTION
##### Summary
Nightly builds are triggered even when there are no changes in master, causing unnecessary development build artefacts created.
The script [prepare-release-base.sh](https://github.com/netdata/netdata/blob/master/.github/scripts/prepare-release-base.sh) works correctly, but the conditions were wrong.

##### Test Plan
Tested locally by running the workflow with dispatch option, and verifying it did not trigger the builds.

##### Additional Information
This PR fixes the issue described in https://github.com/netdata/internal/issues/73