### PR TITLE
revert to default of `host anomaly rate threshold=0.01`

### DIFF
--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -42,7 +42,7 @@ void Config::readMLConfig(void) {
     unsigned MaxKMeansIters = config_get_number(ConfigSectionML, "maximum number of k-means iterations", 1000);
 
     double DimensionAnomalyScoreThreshold = config_get_float(ConfigSectionML, "dimension anomaly score threshold", 0.99);
-    double HostAnomalyRateThreshold = config_get_float(ConfigSectionML, "host anomaly rate threshold", 0.02);
+    double HostAnomalyRateThreshold = config_get_float(ConfigSectionML, "host anomaly rate threshold", 0.01);
 
     double ADMinWindowSize = config_get_float(ConfigSectionML, "minimum window size", 30);
     double ADMaxWindowSize = config_get_float(ConfigSectionML, "maximum window size", 600);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR reverts the default for `host anomaly rate threshold` to `0.01` from `0.02`. 

The default of this param is 1% because the default of `dimension anomaly score threshold` is `0.99`. This means that typically around 1% of metrics will randomly (naturally) by flipping between anomalous and normal. This is why when the node anomaly rate is above 1% we consider a node level anomaly.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
