### PR TITLE
add CAP_SYS_RAWIO to Netdata's systemd unit CapabilityBoundingSet

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -43,7 +43,7 @@ CapabilityBoundingSet=CAP_DAC_OVERRIDE
 # is required for apps plugin
 CapabilityBoundingSet=CAP_DAC_READ_SEARCH
 # is required for freeipmi plugin
-CapabilityBoundingSet=CAP_FOWNER
+CapabilityBoundingSet=CAP_FOWNER CAP_SYS_RAWIO
 # is required for apps, perf and slabinfo plugins
 CapabilityBoundingSet=CAP_SETPCAP
 # is required for perf plugin


### PR DESCRIPTION
##### Summary

[Needed](https://github.com/netdata/netdata/issues/10044#issuecomment-1156445663) for freeimpi plugin.

<details>
<summary>CAP_SYS_RAWIO</summary>

- Perform I/O port operations ([iopl(2)](https://man7.org/linux/man-pages/man2/iopl.2.html) and [ioperm(2)](https://man7.org/linux/man-pages/man2/ioperm.2.html));
- access /proc/kcore;
- employ the FIBMAP ioctl(2) operation;
- open devices for accessing x86 model-specific registers (MSRs, see [msr(4)](https://man7.org/linux/man-pages/man4/msr.4.html));
- update /proc/sys/vm/mmap_min_addr;
- create memory mappings at addresses below the value specified by /proc/sys/vm/mmap_min_addr;
- map files in /proc/bus/pci;
- open /dev/mem and /dev/kmem;
- perform various SCSI device commands;
- perform certain operations on [hpsa(4)](https://man7.org/linux/man-pages/man4/hpsa.4.html) and [cciss(4)](https://man7.org/linux/man-pages/man4/cciss.4.html) devices;
- perform a range of device-specific operations on other devices.

</details>

##### Test Plan

CI is enough.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
