### PR TITLE
Fix labels unit test

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -888,6 +888,10 @@ int main(int argc, char **argv) {
                             if(test_dbengine()) return 1;
 #endif
                             if(test_sqlite()) return 1;
+                            if (dictionary_unittest(10000))
+                                return 1;
+                            if (rrdlabels_unittest())
+                                return 1;
                             fprintf(stderr, "\n\nALL TESTS PASSED\n\n");
                             return 0;
                         }

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -1043,8 +1043,9 @@ int rrdlabels_unittest_add_pairs() {
     errors += rrdlabels_unittest_add_a_pair("\"tag=1\": country:\"Gre\\\"ece\"", "tag_1", "country:Gre_ece");
     errors += rrdlabels_unittest_add_a_pair("\"tag=1\" = country:\"Gre\\\"ece\"", "tag_1", "country:Gre_ece");
 
-    errors += rrdlabels_unittest_add_a_pair("\t'LABE=L'\t=\t\"World\" peace", "labe_l", "World_peace");
+    errors += rrdlabels_unittest_add_a_pair("\t'LABE=L'\t=\t\"World\" peace", "labe_l", "World peace");
     errors += rrdlabels_unittest_add_a_pair("\t'LA\\'B:EL'\t=\tcountry:\"World\":\"Europe\":\"Greece\"", "la_b_el", "country:World:Europe:Greece");
+    errors += rrdlabels_unittest_add_a_pair("\t'LA\\'B:EL'\t=\tcountry\\\"World\"\\\"Europe\"\\\"Greece\"", "la_b_el", "country/World/Europe/Greece");
 
     errors += rrdlabels_unittest_add_a_pair("NAME=\"VALUE\"", "name", "VALUE");
     errors += rrdlabels_unittest_add_a_pair("\"NAME\" : \"VALUE\"", "name", "VALUE");
@@ -1113,22 +1114,22 @@ int rrdlabels_unittest_sanitization() {
 
     errors += rrdlabels_unittest_sanitize_value("", "");
     errors += rrdlabels_unittest_sanitize_value("1", "1");
-    errors += rrdlabels_unittest_sanitize_value("  hello   world   ", "hello_world");
+    errors += rrdlabels_unittest_sanitize_value("  hello   world   ", "hello world");
 
     // 2-byte UTF-8
     errors += rrdlabels_unittest_sanitize_value(" Ελλάδα ", "Ελλάδα");
     errors += rrdlabels_unittest_sanitize_value("aŰbŲcŴ", "aŰbŲcŴ");
-    errors += rrdlabels_unittest_sanitize_value("Ű b Ų c Ŵ", "Ű_b_Ų_c_Ŵ");
+    errors += rrdlabels_unittest_sanitize_value("Ű b Ų c Ŵ", "Ű b Ų c Ŵ");
 
     // 3-byte UTF-8
     errors += rrdlabels_unittest_sanitize_value("‱", "‱");
     errors += rrdlabels_unittest_sanitize_value("a‱b", "a‱b");
-    errors += rrdlabels_unittest_sanitize_value("a ‱ b", "a_‱_b");
+    errors += rrdlabels_unittest_sanitize_value("a ‱ b", "a ‱ b");
 
     // 4-byte UTF-8
     errors += rrdlabels_unittest_sanitize_value("𩸽", "𩸽");
     errors += rrdlabels_unittest_sanitize_value("a𩸽b", "a𩸽b");
-    errors += rrdlabels_unittest_sanitize_value("a 𩸽 b", "a_𩸽_b");
+    errors += rrdlabels_unittest_sanitize_value("a 𩸽 b", "a 𩸽 b");
 
     // mixed multi-byte
     errors += rrdlabels_unittest_sanitize_value("Ű‱𩸽‱Ű", "Ű‱𩸽‱Ű");


### PR DESCRIPTION
##### Summary
Fix the unit test after the latest changes in the sanitization function

##### Test Plan
- Run `netdata -W rrdlabelstest` before and after the PR
