### PR TITLE
Use memset to mark the empty words in the quoted_strings_splitter function

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -39,7 +39,7 @@ inline int config_isspace(char c)
 inline int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char), char *recover_input, char **recover_location, int max_recover)
 {
     char *s = str, quote = 0;
-    int i = 0, j, rec = 0;
+    int i = 0, rec = 0;
     char *recover = recover_input;
 
     // skip all white space
@@ -112,9 +112,7 @@ inline int quoted_strings_splitter(char *str, char **words, int max_words, int (
     }
 
     // terminate the words
-    j = i;
-    while (likely(j < max_words))
-        words[j++] = NULL;
+     memset(&words[i], 0, (max_words - i) * sizeof (char *));
 
     return i;
 }


### PR DESCRIPTION
##### Summary
Avoid setting NULL with a loop (use memset) 

**callgrind reports**

Before the change 


```
 4,554,049 ( 1.05%)              s++;
         .               }
         .           
         .               // terminate the words
   603,032 ( 0.14%)      j = i;
33,120,826 ( 7.63%)      while (likely(j < max_words))
41,346,952 ( 9.53%)          words[j++] = NULL;
         .           
   301,516 ( 0.07%)      return i;
 1,507,580 ( 0.35%)  }

```

after the change

```
 4,503,586 ( 1.22%)              s++;
         .               }
         .           
         .               // terminate the words
 3,597,036 ( 0.97%)       memset(&words[i], 0, (max_words - i) * sizeof (char *));
 8,362,886 ( 2.26%)  => ???:0x000000000014ee00 (299,753x)
         .           
   299,753 ( 0.08%)      return i;
 1,498,765 ( 0.40%)  }
```

Further optimizations may be possible

##### Test Plan
- It should not affect the agent

