### PR TITLE
Configurable storage engine for Netdata agents: step 4

### DIFF
--- a/database/ram/rrddim_mem.h
+++ b/database/ram/rrddim_mem.h
@@ -15,6 +15,17 @@ struct mem_query_handle {
     uint8_t finished;
 };
 
+extern RRDDIM* rrddim_init_map(RRDSET *st, const char *id, const char *filename, collected_number multiplier,
+                          collected_number divisor, RRD_ALGORITHM algorithm);
+extern RRDDIM* rrddim_init_ram(RRDSET *st, const char *id, const char *filename, collected_number multiplier,
+                          collected_number divisor, RRD_ALGORITHM algorithm);
+extern RRDDIM* rrddim_init_save(RRDSET *st, const char *id, const char *filename, collected_number multiplier,
+                          collected_number divisor, RRD_ALGORITHM algorithm);
+
+extern RRDSET* rrdset_init_map(const char *id, const char *fullid, const char *filename, long entries, int update_every);
+extern RRDSET* rrdset_init_ram(const char *id, const char *fullid, const char *filename, long entries, int update_every);
+extern RRDSET* rrdset_init_save(const char *id, const char *fullid, const char *filename, long entries, int update_every);
+
 STORAGE_ENGINE_INSTANCE* rrddim_storage_engine_instance_new(STORAGE_ENGINE* engine, RRDHOST *host);
 void rrddim_storage_engine_instance_exit(STORAGE_ENGINE_INSTANCE* context);
 void rrddim_storage_engine_instance_destroy(STORAGE_ENGINE_INSTANCE* context);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1062,6 +1062,11 @@ extern void rrdset_done(RRDSET *st);
 extern void rrdset_is_obsolete(RRDSET *st);
 extern void rrdset_isnot_obsolete(RRDSET *st);
 
+static inline void last_updated_time_align(RRDSET *st) {
+    st->last_updated.tv_sec -= st->last_updated.tv_sec % st->update_every;
+    st->last_updated.tv_usec = 0;
+}
+
 // checks if the RRDSET should be offered to viewers
 #define rrdset_is_available_for_viewers(st) (!rrdset_flag_check(st, RRDSET_FLAG_HIDDEN) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
 #define rrdset_is_available_for_exporting_and_alarms(st) (!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -3,6 +3,7 @@
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
 #include <sched.h>
+#include "storage_engine.h"
 #ifdef ENABLE_DBENGINE
 #include "database/engine/rrddiskprotocol.h"
 #include "database/engine/rrdengineapi.h"
@@ -326,11 +327,6 @@ static inline void last_collected_time_align(RRDSET *st) {
         st->last_collected_time.tv_usec = 500000;
 }
 
-static inline void last_updated_time_align(RRDSET *st) {
-    st->last_updated.tv_sec -= st->last_updated.tv_sec % st->update_every;
-    st->last_updated.tv_usec = 0;
-}
-
 // ----------------------------------------------------------------------------
 // RRDSET - free a chart
 
@@ -409,21 +405,10 @@ void rrdset_free(RRDSET *st) {
     freez(st->state);
     freez(st->chart_uuid);
 
-    switch(st->rrd_memory_mode) {
-        case RRD_MEMORY_MODE_SAVE:
-        case RRD_MEMORY_MODE_MAP:
-        case RRD_MEMORY_MODE_RAM:
-            debug(D_RRD_CALLS, "Unmapping stats '%s'.", st->name);
-            munmap(st, st->memsize);
-            break;
-
-        case RRD_MEMORY_MODE_ALLOC:
-        case RRD_MEMORY_MODE_NONE:
-        case RRD_MEMORY_MODE_DBENGINE:
-            freez(st);
-            break;
-    }
-
+    STORAGE_ENGINE* engine = (host->rrdeng_ctx && st->rrd_memory_mode == host->rrdeng_ctx->engine->id)
+        ? host->rrdeng_ctx->engine
+        : storage_engine_get(st->rrd_memory_mode);
+    engine->api.set_ops.destroy(st);
 }
 
 void rrdset_save(RRDSET *st) {
@@ -740,99 +725,18 @@ RRDSET *rrdset_create_custom(
     unsigned long size = sizeof(RRDSET);
     char *cache_dir = rrdset_cache_dir(host, fullid);
 
-    time_t now = now_realtime_sec();
-
     // ------------------------------------------------------------------------
     // load it or allocate it
 
     debug(D_RRD_CALLS, "Creating RRD_STATS for '%s.%s'.", type, id);
 
     snprintfz(fullfilename, FILENAME_MAX, "%s/main.db", cache_dir);
-    if(memory_mode == RRD_MEMORY_MODE_SAVE || memory_mode == RRD_MEMORY_MODE_MAP ||
-       memory_mode == RRD_MEMORY_MODE_RAM) {
-        st = (RRDSET *)netdata_mmap(
-            (memory_mode == RRD_MEMORY_MODE_RAM) ? NULL : fullfilename,
-            size,
-            ((memory_mode == RRD_MEMORY_MODE_MAP) ? MAP_SHARED : MAP_PRIVATE),
-            0);
-
-        if(st) {
-            memset(&st->avl, 0, sizeof(avl_t));
-            memset(&st->avlname, 0, sizeof(avl_t));
-            memset(&st->rrdvar_root_index, 0, sizeof(avl_tree_lock));
-            memset(&st->dimensions_index, 0, sizeof(avl_tree_lock));
-            memset(&st->rrdset_rwlock, 0, sizeof(netdata_rwlock_t));
-
-            st->name = NULL;
-            st->type = NULL;
-            st->family = NULL;
-            st->title = NULL;
-            st->units = NULL;
-            st->context = NULL;
-            st->cache_dir = NULL;
-            st->plugin_name = NULL;
-            st->module_name = NULL;
-            st->dimensions = NULL;
-            st->rrdfamily = NULL;
-            st->rrdhost = NULL;
-            st->next = NULL;
-            st->variables = NULL;
-            st->alarms = NULL;
-            st->flags = 0x00000000;
-            st->exporting_flags = NULL;
-
-            if(memory_mode == RRD_MEMORY_MODE_RAM) {
-                memset(st, 0, size);
-            }
-            else {
-                if(strcmp(st->magic, RRDSET_MAGIC) != 0) {
-                    info("Initializing file %s.", fullfilename);
-                    memset(st, 0, size);
-                }
-                else if(strcmp(st->id, fullid) != 0) {
-                    error("File %s contents are not for chart %s. Clearing it.", fullfilename, fullid);
-                    // munmap(st, size);
-                    // st = NULL;
-                    memset(st, 0, size);
-                }
-                else if(st->memsize != size || st->entries != entries) {
-                    error("File %s does not have the desired size. Clearing it.", fullfilename);
-                    memset(st, 0, size);
-                }
-                else if(st->update_every != update_every) {
-                    error("File %s does not have the desired update frequency. Clearing it.", fullfilename);
-                    memset(st, 0, size);
-                }
-                else if((now - st->last_updated.tv_sec) > update_every * entries) {
-                    info("File %s is too old. Clearing it.", fullfilename);
-                    memset(st, 0, size);
-                }
-                else if(st->last_updated.tv_sec > now + update_every) {
-                    error("File %s refers to the future by %zd secs. Resetting it to now.", fullfilename, (ssize_t)(st->last_updated.tv_sec - now));
-                    st->last_updated.tv_sec = now;
-                }
-
-                // make sure the database is aligned
-                if(st->last_updated.tv_sec) {
-                    st->update_every = update_every;
-                    last_updated_time_align(st);
-                }
-            }
-
-            // make sure we have the right memory mode
-            // even if we cleared the memory
-            st->rrd_memory_mode = memory_mode;
-        }
+    STORAGE_ENGINE* engine = storage_engine_get(memory_mode);
+    if (unlikely(!engine)) {
+        fatal("Can't find memory mode %s", rrd_memory_mode_name(memory_mode));
+        return NULL;
     }
-
-    if(unlikely(!st)) {
-        st = callocz(1, size);
-        if (memory_mode == RRD_MEMORY_MODE_DBENGINE)
-            st->rrd_memory_mode = RRD_MEMORY_MODE_DBENGINE;
-        else
-            st->rrd_memory_mode = (memory_mode == RRD_MEMORY_MODE_NONE) ? RRD_MEMORY_MODE_NONE : RRD_MEMORY_MODE_ALLOC;
-    }
-
+    st = engine->api.set_ops.create(id, fullid, fullfilename, entries, update_every);
     st->plugin_name = plugin?strdupz(plugin):NULL;
     st->module_name = module?strdupz(module):NULL;
 

--- a/database/storage_engine.h
+++ b/database/storage_engine.h
@@ -17,9 +17,27 @@ struct storage_engine_ops {
 };
 
 // ------------------------------------------------------------------------
+// function pointers that handle RRDSET creation, destruction and query
+struct rrdset_ops {
+    RRDSET*(*create)(const char *id, const char *fullid, const char *filename, long entries, int update_every);
+    void(*destroy)(RRDSET *rd);
+};
+
+// ------------------------------------------------------------------------
+// function pointers that handle RRDDIM creation and destruction
+struct rrddim_ops {
+    RRDDIM*(*create)(RRDSET *st, const char *id, const char *filename, collected_number multiplier,
+                          collected_number divisor, RRD_ALGORITHM algorithm);
+    void(*init)(RRDDIM* rd);
+    void(*destroy)(RRDDIM *rd);
+};
+
+// ------------------------------------------------------------------------
 // function pointers for all APIs provided by a storge engine
 typedef struct storage_engine_api {
     struct storage_engine_ops engine_ops;
+    struct rrdset_ops set_ops;
+    struct rrddim_ops dim_ops;
     struct rrddim_collect_ops collect_ops;
     struct rrddim_query_ops query_ops;
 } STORAGE_ENGINE_API;


### PR DESCRIPTION
Following the idea discussed here:
https://github.com/netdata/netdata/discussions/12216

This change introduces the new storage engine API to create, initialize and destroy rrdset and rrddim using per-engine implementations. 

##### Summary

These commits allow storage engines to provide API functions to manage the creation and destruction of rrdset and rrddim instances.
* Add the new API and implementations for existing engines (not used yet in this commit)
* Use the new APIs for RRDSET
* Use the new APIs for RRDDIM

Implementation of the new APIs follows the existing behavior & code.

##### Test Plan

These changes don't add any new memory modes/storage engines for now, and only refactor existing features, so they are expected to be covered by existing unit tests.
