### PR TITLE
Fix coverity issues

### DIFF
--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -9,7 +9,7 @@
 #define DEFAULT_EXCLUDED_FILESYSTEMS "*gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl autofs"
 #define CONFIG_SECTION_DISKSPACE "plugin:proc:diskspace"
 
-#define MAX_STAT_USEC 10000
+#define MAX_STAT_USEC 10000LU
 #define SLOW_UPDATE_EVERY 5
 
 static netdata_thread_t *diskspace_slow_thread = NULL;

--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -593,7 +593,6 @@ static inline void statsd_process_set(STATSD_METRIC *m, const char *value) {
     if(unlikely(m->reset)) {
         if(likely(m->set.dict)) {
             dictionary_destroy(m->set.dict);
-            dictionary_register_insert_callback(m->set.dict, dictionary_metric_set_value_insert_callback, m);
             m->set.dict = NULL;
         }
         statsd_reset_metric(m);
@@ -601,6 +600,7 @@ static inline void statsd_process_set(STATSD_METRIC *m, const char *value) {
 
     if (unlikely(!m->set.dict)) {
         m->set.dict   = dictionary_create(STATSD_DICTIONARY_OPTIONS);
+        dictionary_register_insert_callback(m->set.dict, dictionary_metric_set_value_insert_callback, m);
         m->set.unique = 0;
     }
 


### PR DESCRIPTION
##### Summary
Fix two coverity issues

- CID 378821 : Use after free (USE_AFTER_FREE)
```
/collectors/statsd.plugin/statsd.c: 596 in statsd_process_set()
590             return;
591         }
592     
593         if(unlikely(m->reset)) {
594             if(likely(m->set.dict)) {
595                 dictionary_destroy(m->set.dict);
>>>     CID 378821:  Memory - illegal accesses  (USE_AFTER_FREE)
>>>     Calling "dictionary_register_insert_callback" dereferences freed pointer "(*m).set.dict".
596                 dictionary_register_insert_callback(m->set.dict, dictionary_metric_set_value_insert_callback, m);
597                 m->set.dict = NULL;
598             }
599             statsd_reset_metric(m);
600         }
601     
```
- CID 379185 : Unintentional integer overflow (OVERFLOW_BEFORE_WIDEN)
```
319     static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
320         const char *disk = mi->persistent_id;
321     
322         static SIMPLE_PATTERN *excluded_mountpoints = NULL;
323         static SIMPLE_PATTERN *excluded_filesystems = NULL;
324     
>>>     CID 379185:  Integer handling issues  (OVERFLOW_BEFORE_WIDEN)
>>>     Potentially overflowing expression "10000 * update_every" with type "int" (32 bits, signed) is evaluated using 32-bit arithmetic, and then used in a context that expects an expression of type "usec_t" (64 bits, unsigned).
325         usec_t slow_timeout = MAX_STAT_USEC * update_every;
326     
327         int do_space, do_inodes;
328     
329         if(unlikely(!dict_mountpoints)) {
330             SIMPLE_PREFIX_MODE mode = SIMPLE_PATTERN_EXACT;
```

##### Test Plan
- Coverity issues vanish
