### PR TITLE
Remove warnings when openssl 3 is used.

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -93,7 +93,7 @@ static int load_private_key()
                                               NULL, NULL);
 
     if (!aclk_dctx) {
-        error("Claimed agent cannot establish ACLK - no suitable potential decoders found.");
+        error("Loading private key (from claiming) failed - no OpenSSL Decoders found");
         goto biofailed;
     }
 

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -99,7 +99,7 @@ static int load_private_key()
 
     // this is necesseary to avoid RSA key with wrong size
     if (!OSSL_DECODER_from_bio(aclk_dctx, key_bio)) {
-        error("Claimed agent cannot establish ACLK - Decode failure.");
+        error("Decoding private key (from claiming) failed - invalid format.");
         goto biofailed;
     }
 #else

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -458,7 +458,11 @@ static int private_decrypt(RSA *p_key, unsigned char * enc_data, int data_len, u
     return result;
 }
 
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
+int aclk_get_mqtt_otp(EVP_PKEY *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_pass, url_t *target)
+#else
 int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_pass, url_t *target)
+#endif
 {
     unsigned char *challenge;
     int challenge_bytes;

--- a/aclk/aclk_otp.h
+++ b/aclk/aclk_otp.h
@@ -8,7 +8,11 @@
 #include "https_client.h"
 #include "aclk_util.h"
 
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
+int aclk_get_mqtt_otp(EVP_PKEY *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_pass, url_t *target);
+#else
 int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_pass, url_t *target);
+#endif
 int aclk_get_env(aclk_env_t *env, const char *aclk_hostname, int aclk_port);
 
 #endif /* ACLK_OTP_H */

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -26,9 +26,16 @@
 
 #  include <openssl/ssl.h>
 #  include <openssl/err.h>
+#  include <openssl/evp.h>
+#  include <openssl/pem.h>
 #  if (SSLEAY_VERSION_NUMBER >= OPENSSL_VERSION_097) && (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110)
 #   include <openssl/conf.h>
 #  endif
+
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
+#include <openssl/core_names.h>
+#include <openssl/decoder.h>
+#endif
 
 struct netdata_ssl{
     SSL *conn; //SSL connection

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -22,6 +22,7 @@
 #define OPENSSL_VERSION_097 0x0907000L
 #define OPENSSL_VERSION_110 0x10100000L
 #define OPENSSL_VERSION_111 0x10101000L
+#define OPENSSL_VERSION_300 0x30000000L
 
 #  include <openssl/ssl.h>
 #  include <openssl/err.h>


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/13139

This PR is adjusting our ACLK code to use the high-level functions instead the low level functions that were deprecated when OpenSSL 3.0 was released, this will help us to avoid possible lost connection between agents and cloud when functions are removed.

We are not using only high-level interface, because low-level interface is faster when it is available. The functions were not removed from OpenSSL tree, instead they are only used [internally](https://github.com/openssl/openssl/blob/master/crypto/pem/pem_all.c)
##### Test Plan

1. Compile this branch on a distribution that runs `OpenSSL 3.0` or newer. Another option is to compile the library and install on your environment. Verify that we do not have warnings during this step.
2. Start agent
3. Claim the agent if the host is not claimed. 
4. Verify that cloud is working as expected.
5. Run next command to be sure we do not have any errors:
```sh
root@ubuntu2204:/home/thiago/Netdata/netdata# grep -r ACLK /var/log/netdata/error.log
``` 

##### Additional Information

| Distribution | OpenSSL version |
|--------------|-----------------|
|Slackware current | OpenSSL 1.1.1o 3 May 2022|
|CentOS 7.9 | OpenSSL 1.0.2k-fips  26 Jan 2017 |
|Ubuntu 22.04 | OpenSSL 3.0.3 3 May 2022 |

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ACLK/Cloud
- Can they see the change or is it an under the hood? If they can see it, where? Users won't have warnings while Netdata is compiled.
- How is the user impacted by the change? Cloud will continue running if functions are removed.
- What are there any benefits of the change? Agents monitored on cloud independent of OpenSSL version.
</details>
