### PR TITLE
feat(proc/proc_net_dev): add dim per phys link state to the "Interface Physical Link State" chart

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -183,7 +183,8 @@ static struct netdev {
     RRDDIM *rd_operstate_testing;
     RRDDIM *rd_operstate_dormant;
     RRDDIM *rd_operstate_up;
-    RRDDIM *rd_carrier;
+    RRDDIM *rd_carrier_up;
+    RRDDIM *rd_carrier_down;
     RRDDIM *rd_mtu;
 
     char *filename_speed;
@@ -250,7 +251,8 @@ static void netdev_charts_release(struct netdev *d) {
     d->rd_duplex_full = NULL;
     d->rd_duplex_half = NULL;
     d->rd_duplex_unknown = NULL;
-    d->rd_carrier     = NULL;
+    d->rd_carrier_up = NULL;
+    d->rd_carrier_down = NULL;
     d->rd_mtu         = NULL;
 
     d->rd_operstate_unknown = NULL;
@@ -1099,11 +1101,13 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
                 rrdset_update_rrdlabels(d->st_carrier, d->chart_labels);
 
-                d->rd_carrier = rrddim_add(d->st_carrier, "carrier",  NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
+                d->rd_carrier_up = rrddim_add(d->st_carrier, "up",  NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
+                d->rd_carrier_down = rrddim_add(d->st_carrier, "down",  NULL,  1, 1, RRD_ALGORITHM_ABSOLUTE);
             }
             else rrdset_next(d->st_carrier);
 
-            rrddim_set_by_pointer(d->st_carrier, d->rd_carrier, (collected_number)d->carrier);
+            rrddim_set_by_pointer(d->st_carrier, d->rd_carrier_up, (collected_number)(d->carrier == 1));
+            rrddim_set_by_pointer(d->st_carrier, d->rd_carrier_down, (collected_number)(d->carrier == 1));
             rrdset_done(d->st_carrier);
         }
 

--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -1107,7 +1107,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
             else rrdset_next(d->st_carrier);
 
             rrddim_set_by_pointer(d->st_carrier, d->rd_carrier_up, (collected_number)(d->carrier == 1));
-            rrddim_set_by_pointer(d->st_carrier, d->rd_carrier_down, (collected_number)(d->carrier == 1));
+            rrddim_set_by_pointer(d->st_carrier, d->rd_carrier_down, (collected_number)(d->carrier != 1));
             rrdset_done(d->st_carrier);
         }
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1133,8 +1133,7 @@ const netOperstateInfo = '<p>The current ' +
     '<b>Testing</b> - the interface is in testing mode, e.g. cable test. It can’t be used for normal traffic until tests complete. ' +
     '<b>Dormant</b> - the interface is L1 up, but waiting for an external event, e.g. for a protocol to establish. ' +
     '<b>Up</b> - the interface is ready to pass packets and can be used.</p>'
-const netCarrierInfo = '<p>The current physical link state of the interface.</p>' +
-    '<p><b>State map</b>: 0 - down, 1 - up.</p>'
+const netCarrierInfo = 'The current physical link state of the interface.'
 const netSpeedInfo = 'The interface\'s latest or current speed that the network adapter ' +
     '<a href="https://en.wikipedia.org/wiki/Autonegotiation" target="_blank">negotiated</a> with the device it is connected to. ' +
     'This does not give the max supported speed of the NIC.'


### PR DESCRIPTION
##### Summary

This PR adds 'up' and 'down' dimensions instead of 'state'. This will allow showing the number of interfaces in the up/down states automatically on the Cloud. 

##### Test Plan

Check the "Interface Physical Link State" charts.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
