### PR TITLE
add k8s_state dashboard_info

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -6833,4 +6833,192 @@ netdataDashboard.context = {
         info: '<p>The number of banned IP addresses.</p>'
     },
 
+    // ------------------------------------------------------------------------
+    // K8s state: Node.
+
+    'k8s_state.node_allocatable_cpu_requests_utilization': {
+        info: 'The percentage of allocated CPU resources used by Pod requests. '+
+        'A Pod is scheduled to run on a Node only if the Node has enough CPU resources available to satisfy the Pod CPU request.'
+    },
+    'k8s_state.node_allocatable_cpu_requests_used': {
+        info: 'The amount of allocated CPU resources used by Pod requests. ' +
+        '1000 millicpu is equivalent to '+
+        '<a href="https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#cpu-units" target="_blank">1 physical or virtual CPU core</a>.'
+    },
+    'k8s_state.node_allocatable_cpu_limits_utilization': {
+        info: 'The percentage of allocated CPU resources used by Pod limits. '+
+        'Total limits may be over 100 percent (overcommitted).'
+    },
+    'k8s_state.node_allocatable_cpu_limits_used': {
+        info: 'The amount of allocated CPU resources used by Pod limits. ' +
+        '1000 millicpu is equivalent to '+
+        '<a href="https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#cpu-units" target="_blank">1 physical or virtual CPU core</a>.'
+    },
+    'k8s_state.node_allocatable_mem_requests_utilization': {
+        info: 'The percentage of allocated memory resources used by Pod requests. '+
+        'A Pod is scheduled to run on a Node only if the Node has enough memory resources available to satisfy the Pod memory request.'
+    },
+    'k8s_state.node_allocatable_mem_requests_used': {
+        info: 'The amount of allocated memory resources used by Pod requests.'
+    },
+    'k8s_state.node_allocatable_mem_limits_utilization': {
+        info: 'The percentage of allocated memory resources used by Pod limits. '+
+        'Total limits may be over 100 percent (overcommitted).'
+    },
+    'k8s_state.node_allocatable_mem_limits_used': {
+        info: 'The amount of allocated memory resources used by Pod limits.'
+    },
+    'k8s_state.node_allocatable_pods_utilization': {
+        info: 'Pods limit utilization.'
+    },
+    'k8s_state.node_allocatable_pods_usage': {
+        info: '<p>Pods limit usage.</p>'+
+        '<p><b>Available</b> - the number of Pods available for scheduling. '+
+        '<b>Allocated</b> - the number of Pods that have been scheduled.</p>'
+    },
+    'k8s_state.node_condition': {
+        info: 'Health status. '+
+        'If the status of the Ready condition remains False for longer than the <code>pod-eviction-timeout</code> (the default is 5 minutes), '+
+        'then the node controller triggers API-initiated eviction for all Pods assigned to that node. '+
+        '<a href="https://kubernetes.io/docs/concepts/architecture/nodes/#condition" target="_blank">More info.</a>'
+    },
+    'k8s_state.node_pods_readiness': {
+        info: 'The percentage of Pods that are ready to serve requests.'
+    },
+    'k8s_state.node_pods_readiness_state': {
+        info: '<p>Pods readiness state.</p>'+
+        '<p><b>Ready</b> - the Pod has passed its readiness probe and ready to serve requests. '+
+        '<b>Unready</b> - the Pod has not passed its readiness probe yet.</p>'
+    },
+    'k8s_state.node_pods_condition': {
+        info: '<p>Pods state. '+
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions" target="_blank">More info.</a></p>'+
+        '<b>PodReady</b> -  the Pod is able to serve requests and should be added to the load balancing pools of all matching Services. '+
+        '<b>PodScheduled</b> - the Pod has been scheduled to a node. '+
+        '<b>PodInitialized</b> - all init containers have completed successfully. '+
+        '<b>ContainersReady</b> - all containers in the Pod are ready.</p>'
+    },
+    'k8s_state.node_pods_phase': {
+        info: '<p>Pods phase. The phase of a Pod is a high-level summary of where the Pod is in its lifecycle. '+
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase" target="_blank">More info.</a></p>'+
+        '<p><b>Running</b> - the Pod has been bound to a node, and all of the containers have been created. '+
+        'At least one container is still running, or is in the process of starting or restarting. ' +
+        '<b>Failed</b> - all containers in the Pod have terminated, and at least one container has terminated in failure. '+
+        'That is, the container either exited with non-zero status or was terminated by the system. ' +
+        '<b>Succedeed</b> - all containers in the Pod have terminated in success, and will not be restarted. ' +
+        '<b>Pending</b> - the Pod has been accepted by the Kubernetes cluster, but one or more of the containers has not been set up and made ready to run.</p>'
+    },
+    'k8s_state.node_containers': {
+        info: 'The total number of containers and init containers.'
+    },
+    'k8s_state.node_containers_state': {
+        info: '<p>The number of containers in different lifecycle states. '+
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states" target="_blank">More info.</a></p>'+
+        '<p><b>Running</b> - a container is executing without issues. '+
+        '<b>Waiting</b> - a container is still running the operations it requires in order to complete start up. '+
+        '<b>Terminated</b> - a container began execution and then either ran to completion or failed for some reason.</p>'
+    },
+    'k8s_state.node_init_containers_state': {
+        info: '<p>The number of init containers in different lifecycle states. '+
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states" target="_blank">More info.</a></p>'+
+        '<p><b>Running</b> - a container is executing without issues. '+
+        '<b>Waiting</b> - a container is still running the operations it requires in order to complete start up. '+
+        '<b>Terminated</b> - a container began execution and then either ran to completion or failed for some reason.</p>'
+    },
+    'k8s_state.node_age': {
+        info: 'The lifetime of the Node.'
+    },
+
+    // K8s state: Pod.
+
+    'k8s_state.pod_cpu_requests_used': {
+        info: 'The overall CPU resource requests for a Pod. '+
+        'This is the sum of the CPU requests for all the Containers in the Pod. '+
+        'Provided the system has CPU time free, a container is guaranteed to be allocated as much CPU as it requests. '+
+        '1000 millicpu is equivalent to '+
+        '<a href="https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#cpu-units" target="_blank">1 physical or virtual CPU core</a>.'
+    },
+    'k8s_state.pod_cpu_limits_used': {
+        info: 'The overall CPU resource limits for a Pod. '+
+        'This is the sum of the CPU limits for all the Containers in the Pod. '+
+        'If set, containers cannot use more CPU than the configured limit. '+
+        '1000 millicpu is equivalent to '+
+        '<a href="https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#cpu-units" target="_blank">1 physical or virtual CPU core</a>.'
+    },
+    'k8s_state.pod_mem_requests_used': {
+        info: 'The overall memory resource requests for a Pod. '+
+        'This is the sum of the memory requests for all the Containers in the Pod.'
+    },
+    'k8s_state.pod_mem_limits_used': {
+        info: 'The overall memory resource limits for a Pod. '+
+        'This is the sum of the memory limits for all the Containers in the Pod. '+
+        'If set, containers cannot use more RAM than the configured limit.'
+    },
+    'k8s_state.pod_condition': {
+        info: 'The current state of the Pod. ' +
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions" target="_blank">More info.</a></p>'+
+        '<p><b>PodReady</b> - the Pod is able to serve requests and should be added to the load balancing pools of all matching Services. ' +
+        '<b>PodScheduled</b> - the Pod has been scheduled to a node. ' +
+        '<b>PodInitialized</b> - all init containers have completed successfully. ' +
+        '<b>ContainersReady</b> - all containers in the Pod are ready. '
+    },
+    'k8s_state.pod_phase': {
+        info: 'High-level summary of where the Pod is in its lifecycle. ' +
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase" target="_blank">More info.</a></p>'+
+        '<p><b>Running</b> - the Pod has been bound to a node, and all of the containers have been created. '+
+        'At least one container is still running, or is in the process of starting or restarting. ' +
+        '<b>Failed</b> - all containers in the Pod have terminated, and at least one container has terminated in failure. '+
+        'That is, the container either exited with non-zero status or was terminated by the system. ' +
+        '<b>Succedeed</b> - all containers in the Pod have terminated in success, and will not be restarted. ' +
+        '<b>Pending</b> - the Pod has been accepted by the Kubernetes cluster, but one or more of the containers has not been set up and made ready to run. '+
+        'This includes time a Pod spends waiting to be scheduled as well as the time spent downloading container images over the network. '
+    },
+    'k8s_state.pod_age': {
+        info: 'The <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-lifetime" target="_blank">lifetime</a> of the Pod. '
+    },
+    'k8s_state.pod_containers': {
+        info: 'The number of containers and init containers belonging to the Pod.'
+    },
+    'k8s_state.pod_containers_state': {
+        info: 'The state of each container inside this Pod. '+
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states" target="_blank">More info.</a> '+
+        '<p><b>Running</b> - a container is executing without issues. '+
+        '<b>Waiting</b> - a container is still running the operations it requires in order to complete start up. '+
+        '<b>Terminated</b> - a container began execution and then either ran to completion or failed for some reason.</p>'
+    },
+    'k8s_state.pod_init_containers_state': {
+        info: 'The state of each init container inside this Pod. '+
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states" target="_blank">More info.</a> '+
+        '<p><b>Running</b> - a container is executing without issues. '+
+        '<b>Waiting</b> - a container is still running the operations it requires in order to complete start up. '+
+        '<b>Terminated</b> - a container began execution and then either ran to completion or failed for some reason.</p>'
+    },
+
+    // K8s state: Pod container.
+
+    'k8s_state.pod_container_readiness_state': {
+        info: 'Specifies whether the container has passed its readiness probe. '+
+        'Kubelet uses readiness probes to know when a container is ready to start accepting traffic.'
+    },
+    'k8s_state.pod_container_restarts': {
+        info: 'The number of times the container has been restarted.'
+    },
+    'k8s_state.pod_container_state': {
+        info: 'Current state of the container. '+
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states" target="_blank">More info.</a> '+
+        '<p><b>Running</b> - a container is executing without issues. '+
+        '<b>Waiting</b> - a container is still running the operations it requires in order to complete start up. '+
+        '<b>Terminated</b> - a container began execution and then either ran to completion or failed for some reason.</p>'
+    },
+    'k8s_state.pod_container_waiting_state_reason': {
+        info: 'Reason the container is not yet running. '+
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-state-waiting" target="_blank">More info.</a> '
+    },
+    'k8s_state.pod_container_terminated_state_reason': {
+        info: 'Reason from the last termination of the container. '+
+        '<a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-state-terminated" target="_blank">More info.</a>'
+    },
+
+    // ------------------------------------------------------------------------
+
 };


### PR DESCRIPTION
##### Summary

This PR adds charts description for [k8s_state](https://github.com/netdata/go.d.plugin/tree/master/modules/k8s_state#kubernetes-cluster-state-monitoring-with-netdata).

##### Test Plan

Tested using [npm run start:node-view](https://github.com/netdata/dashboard#available-scripts) (container with the dashboard on a local machine, Netdata with k8s_state charts in remote).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
