### PR TITLE
fix(freebsd.plugin): fix wired/cached/avail memory calculation on FreeBSD with ZFS

### DIFF
--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -1044,9 +1044,9 @@ int do_system_ram(int update_every, usec_t dt) {
         rrddim_set_by_pointer(st, rd_free,     vmmeter_data.v_free_count);
         rrddim_set_by_pointer(st, rd_active,   vmmeter_data.v_active_count);
         rrddim_set_by_pointer(st, rd_inactive, vmmeter_data.v_inactive_count);
-        rrddim_set_by_pointer(st, rd_wired,    vmmeter_data.v_wire_count * system_pagesize - zfs_arcstats_shrinkable_cache_size_bytes);
+        rrddim_set_by_pointer(st, rd_wired,    (unsigned long long)vmmeter_data.v_wire_count * (unsigned long long)system_pagesize - zfs_arcstats_shrinkable_cache_size_bytes);
 #if __FreeBSD_version < 1200016
-        rrddim_set_by_pointer(st, rd_cache,    vmmeter_data.v_cache_count * system_pagesize + zfs_arcstats_shrinkable_cache_size_bytes);
+        rrddim_set_by_pointer(st, rd_cache,    (unsigned long long)vmmeter_data.v_cache_count * (unsigned long long)system_pagesize + zfs_arcstats_shrinkable_cache_size_bytes);
 #else
         rrddim_set_by_pointer(st, rd_cache,    zfs_arcstats_shrinkable_cache_size_bytes);
 #endif

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -1077,9 +1077,9 @@ int do_system_ram(int update_every, usec_t dt) {
         else rrdset_next(st_mem_available);
 
 #if __FreeBSD_version < 1200016
-        rrddim_set_by_pointer(st_mem_available, rd_avail, vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + (vmmeter_data.v_cache_count * system_pagesize + zfs_arcstats_shrinkable_cache_size_bytes));
+        rrddim_set_by_pointer(st_mem_available, rd_avail, vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + vmmeter_data.v_cache_count + zfs_arcstats_shrinkable_cache_size_bytes / system_pagesize);
 #else
-        rrddim_set_by_pointer(st_mem_available, rd_avail, vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + zfs_arcstats_shrinkable_cache_size_bytes);
+        rrddim_set_by_pointer(st_mem_available, rd_avail, vmmeter_data.v_inactive_count + vmmeter_data.v_free_count + zfs_arcstats_shrinkable_cache_size_bytes / system_pagesize);
 #endif
 
         rrdset_done(st_mem_available);


### PR DESCRIPTION
##### Summary

Fixes: #13172

##### Test Plan

Install on FreeBSD with ZFS, check the `system.ram` and `mem.available` charts.

- wired

<img width="1156" alt="Screenshot 2022-06-20 at 20 38 09" src="https://user-images.githubusercontent.com/22274335/174654193-2b112d06-b4a6-4d9c-9b88-8ea4a4b7d77c.png">

- avail (51TB => 13GB)

<img width="1295" alt="Screenshot 2022-06-20 at 20 57 31" src="https://user-images.githubusercontent.com/22274335/174656554-4a942f33-b470-49db-b63a-a6f35de010f4.png">

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
