### PR TITLE
Configurable storage engine for Netdata agents: step 3

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -2,6 +2,9 @@
 
 #include "common.h"
 #include "buildinfo.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 struct analytics_data analytics_data;
 extern void analytics_exporting_connectors (BUFFER *b);

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "common.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 #define GLOBAL_STATS_RESET_WEB_USEC_MAX 0x01
 
@@ -455,7 +458,7 @@ static void dbengine_statistics_charts(void) {
 
         rrdhost_foreach_read(host) {
             if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && !rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
-                if (&multidb_ctx == host->rrdeng_ctx) {
+                if (host->rrdeng_ctx == host->rrdeng_ctx->engine->context) {
                     if (counted_multihost_db)
                         continue; /* Only count multi-host DB once */
                     counted_multihost_db = 1;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -3,6 +3,10 @@
 #include "common.h"
 #include "buildinfo.h"
 #include "static_threads.h"
+#include "database/storage_engine.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 int netdata_zero_metrics_enabled;
 int netdata_anonymous_statistics_enabled;
@@ -54,13 +58,18 @@ void netdata_cleanup_and_exit(int ret) {
 
         // free the database
         info("EXIT: freeing database memory...");
-#ifdef ENABLE_DBENGINE
-        rrdeng_prepare_exit(&multidb_ctx);
-#endif
+        for (STORAGE_ENGINE* eng = storage_engine_foreach_init(); eng; eng = storage_engine_foreach_next(eng)) {
+            if (eng->context && eng->api.engine_ops.exit)
+                eng->api.engine_ops.exit(eng->context);
+        }
+
         rrdhost_free_all();
-#ifdef ENABLE_DBENGINE
-        rrdeng_exit(&multidb_ctx);
-#endif
+        for (STORAGE_ENGINE* eng = storage_engine_foreach_init(); eng; eng = storage_engine_foreach_next(eng)) {
+            if (eng->context && eng->api.engine_ops.exit) {
+                eng->api.engine_ops.destroy(eng->context);
+                eng->context = NULL;
+            }
+        }
     }
     sql_close_database();
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -59,13 +59,13 @@ void netdata_cleanup_and_exit(int ret) {
         // free the database
         info("EXIT: freeing database memory...");
         for (STORAGE_ENGINE* eng = storage_engine_foreach_init(); eng; eng = storage_engine_foreach_next(eng)) {
-            if (eng->context && eng->api.engine_ops.exit)
+            if (eng->context)
                 eng->api.engine_ops.exit(eng->context);
         }
 
         rrdhost_free_all();
         for (STORAGE_ENGINE* eng = storage_engine_foreach_init(); eng; eng = storage_engine_foreach_next(eng)) {
-            if (eng->context && eng->api.engine_ops.exit) {
+            if (eng->context) {
                 eng->api.engine_ops.destroy(eng->context);
                 eng->context = NULL;
             }

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "common.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengineapi.h"
+#endif
 
 static int check_number_printing(void) {
     struct {
@@ -1166,7 +1169,7 @@ int run_test(struct test *test)
     RRDSET *st = rrdset_create_localhost("netdata", name, name, "netdata", NULL, "Unit Testing", "a value", "unittest", NULL, 1
                                          , test->update_every, RRDSET_TYPE_LINE);
     RRDDIM *rd = rrddim_add(st, "dim1", NULL, test->multiplier, test->divisor, test->algorithm);
-    
+
     RRDDIM *rd2 = NULL;
     if(test->feed2)
         rd2 = rrddim_add(st, "dim2", NULL, test->multiplier, test->divisor, test->algorithm);

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -1335,13 +1335,8 @@ error_after_loop_init:
  */
 void rrdengine_main(void)
 {
-    STORAGE_ENGINE_INSTANCE* ctx;
-
     sanity_check();
-    ctx = rrdeng_init(storage_engine_get(RRD_MEMORY_MODE_DBENGINE), NULL);
-    if (!ctx) {
-        exit(1);
-    }
+    STORAGE_ENGINE_INSTANCE* ctx = rrdeng_init(storage_engine_get(RRD_MEMORY_MODE_DBENGINE), NULL);
     rrdeng_exit(ctx);
     fprintf(stderr, "Hello world!");
     exit(0);

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -1335,13 +1335,12 @@ error_after_loop_init:
  */
 void rrdengine_main(void)
 {
-    int ret;
-    struct rrdengine_instance *ctx;
+    STORAGE_ENGINE_INSTANCE* ctx;
 
     sanity_check();
-    ret = rrdeng_init(NULL, &ctx, "/tmp", RRDENG_MIN_PAGE_CACHE_SIZE_MB, RRDENG_MIN_DISK_SPACE_MB);
-    if (ret) {
-        exit(ret);
+    ctx = rrdeng_init(storage_engine_get(RRD_MEMORY_MODE_DBENGINE), NULL);
+    if (!ctx) {
+        exit(1);
     }
     rrdeng_exit(ctx);
     fprintf(stderr, "Hello world!");

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -13,6 +13,7 @@
 #include <openssl/evp.h>
 #include "daemon/common.h"
 #include "../rrd.h"
+#include "../storage_engine.h"
 #include "rrddiskprotocol.h"
 #include "rrdenginelib.h"
 #include "datafile.h"
@@ -226,6 +227,7 @@ extern rrdeng_stats_t global_flushing_pressure_page_deletions; /* number of dele
 #define QUIESCED    (2) /* is set after all threads have finished running */
 
 struct rrdengine_instance {
+    STORAGE_ENGINE_INSTANCE parent;
     struct metalog_instance *metalog_ctx;
     struct rrdengine_worker_config worker_config;
     struct completion rrdengine_completion;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "rrdengine.h"
-
-/* Default global database instance */
-struct rrdengine_instance multidb_ctx;
+#include "../storage_engine.h"
 
 int db_engine_use_malloc = 0;
 int default_rrdeng_page_fetch_timeout = 3;
@@ -13,9 +11,16 @@ int default_multidb_disk_quota_mb = 256;
 /* Default behaviour is to unblock data collection if the page cache is full of dirty pages by dropping metrics */
 uint8_t rrdeng_drop_metrics_under_page_cache_pressure = 1;
 
+void *rrdeng_create_page(struct rrdengine_instance *ctx, uuid_t *id, struct rrdeng_page_descr **ret_descr);
+void rrdeng_commit_page(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr,
+                               Word_t page_correlation_id);
+void *rrdeng_get_latest_page(struct rrdengine_instance *ctx, uuid_t *id, void **handle);
+void *rrdeng_get_page(struct rrdengine_instance *ctx, uuid_t *id, usec_t point_in_time, void **handle);
+void rrdeng_put_page(struct rrdengine_instance *ctx, void *handle);
+
 static inline struct rrdengine_instance *get_rrdeng_ctx_from_host(RRDHOST *host)
 {
-    return host->rrdeng_ctx;
+    return (struct rrdengine_instance*) host->rrdeng_ctx;
 }
 
 /* This UUID is not unique across hosts */
@@ -71,7 +76,7 @@ void rrdeng_metric_init(RRDDIM *rd)
     pg_cache = &ctx->pg_cache;
 
     rrdeng_generate_legacy_uuid(rd->id, rd->rrdset->id, &legacy_uuid);
-    if (host != localhost && host->rrdeng_ctx == &multidb_ctx)
+    if (host != localhost && host->rrdeng_ctx->engine && host->rrdeng_ctx == host->rrdeng_ctx->engine->context)
         is_multihost_child = 1;
 
     uv_rwlock_rdlock(&pg_cache->metrics_index.lock);
@@ -200,15 +205,11 @@ void rrdeng_store_metric_next(RRDDIM *rd, usec_t point_in_time, NETDATA_DOUBLE n
     storage_number number = pack_storage_number(n, flags);
 
     struct rrdeng_collect_handle *handle = (struct rrdeng_collect_handle *)rd->state->handle;
-    struct rrdengine_instance *ctx;
-    struct page_cache *pg_cache;
-    struct rrdeng_page_descr *descr;
+    struct rrdengine_instance *ctx = handle->ctx;
+    struct page_cache *pg_cache = &ctx->pg_cache;
+    struct rrdeng_page_descr *descr = handle->descr;
     storage_number *page;
     uint8_t must_flush_unaligned_page = 0, perfect_page_alignment = 0;
-
-    ctx = handle->ctx;
-    pg_cache = &ctx->pg_cache;
-    descr = handle->descr;
 
     if (descr) {
         /* Make alignment decisions */
@@ -841,10 +842,11 @@ void *rrdeng_get_page(struct rrdengine_instance *ctx, uuid_t *id, usec_t point_i
  * You must not change the indices of the statistics or user code will break.
  * You must not exceed RRDENG_NR_STATS or it will crash.
  */
-void rrdeng_get_37_statistics(struct rrdengine_instance *ctx, unsigned long long *array)
+void rrdeng_get_37_statistics(STORAGE_ENGINE_INSTANCE* context, unsigned long long *array)
 {
-    if (ctx == NULL)
+    if (context == NULL)
         return;
+    struct rrdengine_instance* ctx = (struct rrdengine_instance*) context;
 
     struct page_cache *pg_cache = &ctx->pg_cache;
 
@@ -895,19 +897,23 @@ void rrdeng_put_page(struct rrdengine_instance *ctx, void *handle)
     pg_cache_put(ctx, (struct rrdeng_page_descr *)handle);
 }
 
-/*
- * Returns 0 on success, negative on error
- */
-int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_path, unsigned page_cache_mb,
-                unsigned disk_space_mb)
+
+STORAGE_ENGINE_INSTANCE*
+rrdeng_init(STORAGE_ENGINE* eng, RRDHOST *host)
 {
     struct rrdengine_instance *ctx;
     int error;
-    uint32_t max_open_files;
 
-    max_open_files = rlimit_nofile.rlim_cur / 4;
+    bool is_legacy = is_legacy_child(host->machine_guid);
+    if (!is_legacy && eng->context) {
+        if (host->rrd_memory_mode == eng->id && host->rrdeng_ctx == NULL) {
+            host->rrdeng_ctx = eng->context;
+        }
+        return eng->context;
+    }
 
     /* reserve RRDENG_FD_BUDGET_PER_INSTANCE file descriptors for this instance */
+    uint32_t max_open_files = rlimit_nofile.rlim_cur / 4;
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, RRDENG_FD_BUDGET_PER_INSTANCE);
     if (rrdeng_reserved_file_descriptors > max_open_files) {
         error(
@@ -916,15 +922,18 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
 
         rrd_stat_atomic_add(&global_fs_errors, 1);
         rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
-        return UV_EMFILE;
+        return NULL;//UV_EMFILE;
     }
+    char dbfiles_path[FILENAME_MAX + 1];
 
-    if (NULL == ctxp) {
-        ctx = &multidb_ctx;
-        memset(ctx, 0, sizeof(*ctx));
-    } else {
-        *ctxp = ctx = callocz(1, sizeof(*ctx));
-    }
+    snprintfz(dbfiles_path, FILENAME_MAX, "%s/dbengine", host->cache_dir);
+    mkdir(dbfiles_path, 0775);
+
+    int page_cache_mb = default_rrdeng_page_cache_mb;
+    int disk_space_mb = default_rrdeng_disk_quota_mb;
+
+    ctx = callocz(1, sizeof(*ctx));
+    ctx->parent.engine = eng;
     ctx->global_compress_alg = RRD_LZ4;
     if (page_cache_mb < RRDENG_MIN_PAGE_CACHE_SIZE_MB)
         page_cache_mb = RRDENG_MIN_PAGE_CACHE_SIZE_MB;
@@ -946,6 +955,15 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
     ctx->quiesce = NO_QUIESCE;
     ctx->metalog_ctx = NULL; /* only set this after the metadata log has finished initializing */
     ctx->host = host;
+
+    // Attach context as the global context
+    if (!is_legacy && !eng->context) {
+        eng->context = (STORAGE_ENGINE_INSTANCE *)ctx;
+    }
+    // Attach context as the host context
+    if (host->rrd_memory_mode == eng->id && host->rrdeng_ctx == NULL) {
+        host->rrdeng_ctx = eng->context;
+    }
 
     memset(&ctx->worker_config, 0, sizeof(ctx->worker_config));
     ctx->worker_config.ctx = ctx;
@@ -971,30 +989,30 @@ int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_p
         goto error_after_rrdeng_worker;
     }
 
-    return 0;
+    return (STORAGE_ENGINE_INSTANCE *)ctx;
 
 error_after_rrdeng_worker:
     finalize_rrd_files(ctx);
 error_after_init_rrd_files:
     free_page_cache(ctx);
-    if (ctx != &multidb_ctx) {
+    if ((STORAGE_ENGINE_INSTANCE *)ctx != eng->context) {
         freez(ctx);
-        *ctxp = NULL;
     }
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
-    return UV_EIO;
+    return NULL;//UV_EIO;
 }
 
 /*
  * Returns 0 on success, 1 on error
  */
-int rrdeng_exit(struct rrdengine_instance *ctx)
+void rrdeng_exit(STORAGE_ENGINE_INSTANCE* context)
 {
     struct rrdeng_cmd cmd;
 
-    if (NULL == ctx) {
-        return 1;
+    if (NULL == context) {
+        return;
     }
+    struct rrdengine_instance* ctx = (struct rrdengine_instance*)context;
 
     /* TODO: add page to page cache */
     cmd.opcode = RRDENG_SHUTDOWN;
@@ -1005,21 +1023,18 @@ int rrdeng_exit(struct rrdengine_instance *ctx)
     finalize_rrd_files(ctx);
     //metalog_exit(ctx->metalog_ctx);
     free_page_cache(ctx);
-
-    if (ctx != &multidb_ctx) {
-        freez(ctx);
-    }
+    freez(ctx);
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
-    return 0;
 }
 
-void rrdeng_prepare_exit(struct rrdengine_instance *ctx)
+void rrdeng_prepare_exit(STORAGE_ENGINE_INSTANCE* context)
 {
     struct rrdeng_cmd cmd;
 
-    if (NULL == ctx) {
+    if (NULL == context) {
         return;
     }
+    struct rrdengine_instance* ctx = (struct rrdengine_instance*)context;
 
     completion_init(&ctx->rrdengine_completion);
     cmd.opcode = RRDENG_QUIESCE;

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -19,20 +19,12 @@ extern int default_rrdeng_page_cache_mb;
 extern int default_rrdeng_disk_quota_mb;
 extern int default_multidb_disk_quota_mb;
 extern uint8_t rrdeng_drop_metrics_under_page_cache_pressure;
-extern struct rrdengine_instance multidb_ctx;
 
 struct rrdeng_region_info {
     time_t start_time;
     int update_every;
     unsigned points;
 };
-
-extern void *rrdeng_create_page(struct rrdengine_instance *ctx, uuid_t *id, struct rrdeng_page_descr **ret_descr);
-extern void rrdeng_commit_page(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr,
-                               Word_t page_correlation_id);
-extern void *rrdeng_get_latest_page(struct rrdengine_instance *ctx, uuid_t *id, void **handle);
-extern void *rrdeng_get_page(struct rrdengine_instance *ctx, uuid_t *id, usec_t point_in_time, void **handle);
-extern void rrdeng_put_page(struct rrdengine_instance *ctx, void *handle);
 
 extern void rrdeng_generate_legacy_uuid(const char *dim_id, char *chart_id, uuid_t *ret_uuid);
 extern void rrdeng_convert_legacy_uuid_to_multihost(char machine_guid[GUID_LEN + 1], uuid_t *legacy_uuid,
@@ -54,14 +46,13 @@ extern int rrdeng_load_metric_is_finished(struct rrddim_query_handle *rrdimm_han
 extern void rrdeng_load_metric_finalize(struct rrddim_query_handle *rrdimm_handle);
 extern time_t rrdeng_metric_latest_time(RRDDIM *rd);
 extern time_t rrdeng_metric_oldest_time(RRDDIM *rd);
-extern void rrdeng_get_37_statistics(struct rrdengine_instance *ctx, unsigned long long *array);
+extern void rrdeng_get_37_statistics(STORAGE_ENGINE_INSTANCE *ctx, unsigned long long *array);
 
 /* must call once before using anything */
-extern int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_path, unsigned page_cache_mb,
-                       unsigned disk_space_mb);
+extern STORAGE_ENGINE_INSTANCE* rrdeng_init(STORAGE_ENGINE* eng, RRDHOST *host);
 
-extern int rrdeng_exit(struct rrdengine_instance *ctx);
-extern void rrdeng_prepare_exit(struct rrdengine_instance *ctx);
+extern void rrdeng_exit(STORAGE_ENGINE_INSTANCE *ctx);
+extern void rrdeng_prepare_exit(STORAGE_ENGINE_INSTANCE *ctx);
 extern int rrdeng_metric_latest_time_by_uuid(uuid_t *dim_uuid, time_t *first_entry_t, time_t *last_entry_t);
 
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -1,6 +1,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "rrddim_mem.h"
+#include "../storage_engine.h"
+
+STORAGE_ENGINE_INSTANCE* rrddim_storage_engine_instance_new(STORAGE_ENGINE* engine, RRDHOST *host) {
+    (void)engine; (void)host;
+    return NULL;
+}
+
+void rrddim_storage_engine_instance_exit(STORAGE_ENGINE_INSTANCE* context) {
+    (void)context;
+}
+
+void rrddim_storage_engine_instance_destroy(STORAGE_ENGINE_INSTANCE* context) {
+    (void)context;
+}
 
 // ----------------------------------------------------------------------------
 // RRDDIM legacy data collection functions

--- a/database/ram/rrddim_mem.h
+++ b/database/ram/rrddim_mem.h
@@ -19,6 +19,10 @@ struct mem_query_handle {
     size_t last_slot;
 };
 
+STORAGE_ENGINE_INSTANCE* rrddim_storage_engine_instance_new(STORAGE_ENGINE* engine, RRDHOST *host);
+void rrddim_storage_engine_instance_exit(STORAGE_ENGINE_INSTANCE* context);
+void rrddim_storage_engine_instance_destroy(STORAGE_ENGINE_INSTANCE* context);
+
 extern void rrddim_collect_init(RRDDIM *rd);
 extern void rrddim_collect_store_metric(RRDDIM *rd, usec_t point_in_time, NETDATA_DOUBLE number, SN_FLAGS flags);
 extern int rrddim_collect_finalize(RRDDIM *rd);

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -28,31 +28,10 @@ int gap_when_lost_iterations_above = 1;
 // RRD - memory modes
 
 inline const char *rrd_memory_mode_name(RRD_MEMORY_MODE id) {
-    switch(id) {
-        case RRD_MEMORY_MODE_RAM:
-            return RRD_MEMORY_MODE_RAM_NAME;
-
-        case RRD_MEMORY_MODE_MAP:
-            return RRD_MEMORY_MODE_MAP_NAME;
-
-        case RRD_MEMORY_MODE_NONE:
-            return RRD_MEMORY_MODE_NONE_NAME;
-
-        case RRD_MEMORY_MODE_SAVE:
-            return RRD_MEMORY_MODE_SAVE_NAME;
-
-        case RRD_MEMORY_MODE_ALLOC:
-            return RRD_MEMORY_MODE_ALLOC_NAME;
-
-        case RRD_MEMORY_MODE_DBENGINE:
-            return RRD_MEMORY_MODE_DBENGINE_NAME;
-    }
-
     STORAGE_ENGINE* eng = storage_engine_get(id);
     if (eng) {
         return eng->name;
     }
-
     return RRD_MEMORY_MODE_SAVE_NAME;
 }
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -18,6 +18,7 @@ typedef struct rrdcalc RRDCALC;
 typedef struct rrdcalctemplate RRDCALCTEMPLATE;
 typedef struct alarm_entry ALARM_ENTRY;
 typedef struct context_param CONTEXT_PARAM;
+typedef struct storage_engine_instance STORAGE_ENGINE_INSTANCE;
 
 typedef void *ml_host_t;
 typedef void *ml_dimension_t;
@@ -854,9 +855,7 @@ struct rrdhost {
     avl_tree_lock rrdfamily_root_index;             // the host's chart families index
     avl_tree_lock rrdvar_root_index;                // the host's chart variables index
 
-#ifdef ENABLE_DBENGINE
-    struct rrdengine_instance *rrdeng_ctx;          // DB engine instance for this host
-#endif
+    STORAGE_ENGINE_INSTANCE *rrdeng_ctx;          // DB engine instance for this host
     uuid_t  host_uuid;                              // Global GUID for this host
     uuid_t  *node_id;                               // Cloud node_id
 
@@ -1321,9 +1320,6 @@ extern void set_host_properties(
 // ----------------------------------------------------------------------------
 // RRD DB engine declarations
 
-#ifdef ENABLE_DBENGINE
-#include "database/engine/rrdengineapi.h"
-#endif
 #include "sqlite/sqlite_functions.h"
 #include "sqlite/sqlite_aclk.h"
 #include "sqlite/sqlite_aclk_chart.h"

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -19,6 +19,7 @@ typedef struct rrdcalctemplate RRDCALCTEMPLATE;
 typedef struct alarm_entry ALARM_ENTRY;
 typedef struct context_param CONTEXT_PARAM;
 typedef struct storage_engine_instance STORAGE_ENGINE_INSTANCE;
+typedef struct storage_engine STORAGE_ENGINE;
 
 typedef void *ml_host_t;
 typedef void *ml_dimension_t;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -714,9 +714,6 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         return 1;
     }
 
-    for (STORAGE_ENGINE* eng = storage_engine_foreach_init(); eng; eng = storage_engine_foreach_next(eng)) {
-        storage_engine_new(eng, localhost);
-    }
     if (likely(system_info))
        migrate_localhost(&localhost->host_uuid);
     sql_aclk_sync_init();

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -715,12 +715,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
     }
 
     for (STORAGE_ENGINE* eng = storage_engine_foreach_init(); eng; eng = storage_engine_foreach_next(eng)) {
-        STORAGE_ENGINE_INSTANCE* ret = storage_engine_new(eng, localhost);
-        if (!ret) {
-            error(
-                "Host '%s' with machine guid '%s' failed to initialize multi-host storage engine instance at '%s'.",
-                localhost->hostname, localhost->machine_guid, localhost->cache_dir);
-        }
+        storage_engine_new(eng, localhost);
     }
     if (likely(system_info))
        migrate_localhost(&localhost->host_uuid);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -2,6 +2,10 @@
 
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
+#include "storage_engine.h"
+#ifdef ENABLE_DBENGINE
+#include "engine/rrdenginelib.h"
+#endif
 
 RRDHOST *localhost = NULL;
 size_t rrd_hosts_available = 0;
@@ -334,41 +338,8 @@ RRDHOST *rrdhost_create(const char *hostname,
     else
         error_report("Host machine GUID %s is not valid", host->machine_guid);
 
-    if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-#ifdef ENABLE_DBENGINE
-        char dbenginepath[FILENAME_MAX + 1];
-        int ret;
-
-        snprintfz(dbenginepath, FILENAME_MAX, "%s/dbengine", host->cache_dir);
-        ret = mkdir(dbenginepath, 0775);
-        if (ret != 0 && errno != EEXIST)
-            error("Host '%s': cannot create directory '%s'", host->hostname, dbenginepath);
-        else ret = 0; // succeed
-        if (is_legacy) // initialize legacy dbengine instance as needed
-            ret = rrdeng_init(host, &host->rrdeng_ctx, dbenginepath, default_rrdeng_page_cache_mb,
-                              default_rrdeng_disk_quota_mb); // may fail here for legacy dbengine initialization
-        else
-            host->rrdeng_ctx = &multidb_ctx;
-        if (ret) { // check legacy or multihost initialization success
-            error(
-                "Host '%s': cannot initialize host with machine guid '%s'. Failed to initialize DB engine at '%s'.",
-                host->hostname, host->machine_guid, host->cache_dir);
-            rrdhost_free(host);
-            host = NULL;
-            //rrd_hosts_available++; //TODO: maybe we want this?
-
-            return host;
-        }
-
-#else
-        fatal("RRD_MEMORY_MODE_DBENGINE is not supported in this platform.");
-#endif
-    }
-    else {
-#ifdef ENABLE_DBENGINE
-        host->rrdeng_ctx = &multidb_ctx;
-#endif
-    }
+    // Create engine
+    host->rrdeng_ctx = storage_engine_new(storage_engine_get(host->rrd_memory_mode), host);
 
     // ------------------------------------------------------------------------
     // link it and add it to the index
@@ -671,10 +642,8 @@ restart_after_removal:
             info("Host '%s' with machine guid '%s' is obsolete - cleaning up.", host->hostname, host->machine_guid);
 
             if (rrdhost_flag_check(host, RRDHOST_FLAG_DELETE_ORPHAN_HOST)
-#ifdef ENABLE_DBENGINE
                 /* don't delete multi-host DB host files */
-                && !(host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && host->rrdeng_ctx == &multidb_ctx)
-#endif
+                && !(host->rrdeng_ctx->engine && host->rrdeng_ctx->engine->context == host->rrdeng_ctx)
             )
                 rrdhost_delete_charts(host);
             else
@@ -745,25 +714,16 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         return 1;
     }
 
-#ifdef ENABLE_DBENGINE
-    char dbenginepath[FILENAME_MAX + 1];
-    int ret;
-    snprintfz(dbenginepath, FILENAME_MAX, "%s/dbengine", localhost->cache_dir);
-    ret = mkdir(dbenginepath, 0775);
-    if (ret != 0 && errno != EEXIST)
-        error("Host '%s': cannot create directory '%s'", localhost->hostname, dbenginepath);
-    else  // Unconditionally create multihost db to support on demand host creation
-        ret = rrdeng_init(NULL, NULL, dbenginepath, default_rrdeng_page_cache_mb, default_multidb_disk_quota_mb);
-    if (ret) {
-        error(
-            "Host '%s' with machine guid '%s' failed to initialize multi-host DB engine instance at '%s'.",
-            localhost->hostname, localhost->machine_guid, localhost->cache_dir);
-        rrdhost_free(localhost);
-        localhost = NULL;
-        rrd_unlock();
-        fatal("Failed to initialize dbengine");
+    for (STORAGE_ENGINE* eng = storage_engine_foreach_init(); eng; eng = storage_engine_foreach_next(eng)) {
+        if (eng->api.engine_ops.create) {
+            STORAGE_ENGINE_INSTANCE* ret = storage_engine_new(eng, localhost);
+            if (!ret) {
+                error(
+                    "Host '%s' with machine guid '%s' failed to initialize multi-host storage engine instance at '%s'.",
+                    localhost->hostname, localhost->machine_guid, localhost->cache_dir);
+            }
+        }
     }
-#endif
     if (likely(system_info))
        migrate_localhost(&localhost->host_uuid);
     sql_aclk_sync_init();
@@ -910,12 +870,12 @@ void rrdhost_free(RRDHOST *host) {
     // ------------------------------------------------------------------------
     // release its children resources
 
-#ifdef ENABLE_DBENGINE
-    if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-        if (host->rrdeng_ctx != &multidb_ctx)
-            rrdeng_prepare_exit(host->rrdeng_ctx);
+    STORAGE_ENGINE* eng = host->rrdeng_ctx->engine;
+    if (host->rrdeng_ctx != eng->context) {
+        if (eng && eng->api.engine_ops.exit)
+            eng->api.engine_ops.exit(host->rrdeng_ctx);
     }
-#endif
+
     while(host->rrdset_root)
         rrdset_free(host->rrdset_root);
 
@@ -946,10 +906,11 @@ void rrdhost_free(RRDHOST *host) {
 
     health_alarm_log_free(host);
 
-#ifdef ENABLE_DBENGINE
-    if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && host->rrdeng_ctx != &multidb_ctx)
-        rrdeng_exit(host->rrdeng_ctx);
-#endif
+    if (host->rrdeng_ctx != eng->context) {
+        if (eng && eng->api.engine_ops.destroy)
+            eng->api.engine_ops.destroy(host->rrdeng_ctx);
+        host->rrdeng_ctx = NULL;
+    }
 
     // ------------------------------------------------------------------------
     // remove it from the indexes
@@ -1265,10 +1226,8 @@ void rrdhost_cleanup_all(void) {
     RRDHOST *host;
     rrdhost_foreach_read(host) {
         if (host != localhost && rrdhost_flag_check(host, RRDHOST_FLAG_DELETE_ORPHAN_HOST) && !host->receiver
-#ifdef ENABLE_DBENGINE
             /* don't delete multi-host DB host files */
-            && !(host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && host->rrdeng_ctx == &multidb_ctx)
-#endif
+            && !(host->rrdeng_ctx->engine && host->rrdeng_ctx->engine->context == host->rrdeng_ctx)
         )
             rrdhost_delete_charts(host);
         else
@@ -1351,7 +1310,7 @@ restart_after_removal:
                 rrdvar_free_remaining_variables(host, &st->rrdvar_root_index);
 
                 rrdset_flag_clear(st, RRDSET_FLAG_OBSOLETE);
-                
+
                 if (st->dimensions) {
                     /* If the chart still has dimensions don't delete it from the metadata log */
                     continue;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -715,13 +715,11 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
     }
 
     for (STORAGE_ENGINE* eng = storage_engine_foreach_init(); eng; eng = storage_engine_foreach_next(eng)) {
-        if (eng->api.engine_ops.create) {
-            STORAGE_ENGINE_INSTANCE* ret = storage_engine_new(eng, localhost);
-            if (!ret) {
-                error(
-                    "Host '%s' with machine guid '%s' failed to initialize multi-host storage engine instance at '%s'.",
-                    localhost->hostname, localhost->machine_guid, localhost->cache_dir);
-            }
+        STORAGE_ENGINE_INSTANCE* ret = storage_engine_new(eng, localhost);
+        if (!ret) {
+            error(
+                "Host '%s' with machine guid '%s' failed to initialize multi-host storage engine instance at '%s'.",
+                localhost->hostname, localhost->machine_guid, localhost->cache_dir);
         }
     }
     if (likely(system_info))
@@ -907,7 +905,7 @@ void rrdhost_free(RRDHOST *host) {
     health_alarm_log_free(host);
 
     if (host->rrdeng_ctx != eng->context) {
-        if (eng && eng->api.engine_ops.destroy)
+        if (eng)
             eng->api.engine_ops.destroy(host->rrdeng_ctx);
         host->rrdeng_ctx = NULL;
     }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -3,6 +3,10 @@
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
 #include <sched.h>
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrddiskprotocol.h"
+#include "database/engine/rrdengineapi.h"
+#endif
 
 void __rrdset_check_rdlock(RRDSET *st, const char *file, const char *function, const unsigned long line) {
     debug(D_RRD_CALLS, "Checking read lock on chart '%s'", st->id);

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -2,6 +2,9 @@
 
 #include "sqlite_functions.h"
 #include "sqlite_aclk_chart.h"
+#ifdef ENABLE_DBENGINE
+#include "../engine/rrdengineapi.h"
+#endif
 
 #ifdef ENABLE_ACLK
 #include "../../aclk/aclk_charts_api.h"

--- a/database/storage_engine.c
+++ b/database/storage_engine.c
@@ -6,51 +6,29 @@
 #include "engine/rrdengineapi.h"
 #endif
 
-/** Empty create op for engines not using a context */
-STORAGE_ENGINE_INSTANCE* create_op_null(STORAGE_ENGINE* engine, RRDHOST *host) {
-    (void)engine; (void)host;
-    return NULL;
-}
-
-/** Empty exit op for engines not using a context */
-void exit_op_null(STORAGE_ENGINE_INSTANCE* context) {
-    (void)context;
-}
-
-/** Empty destroy op for engines not using a context */
-void destroy_op_null(STORAGE_ENGINE_INSTANCE* context) {
-    (void)context;
-}
-
-#define engine_ops_null { \
-    .create = create_op_null, \
-    .exit = exit_op_null, \
-    .destroy = destroy_op_null \
-}
-
-#define im_collect_ops { \
-    .init = rrddim_collect_init,\
-    .store_metric = rrddim_collect_store_metric,\
-    .finalize = rrddim_collect_finalize\
-}
-
-#define im_query_ops { \
-    .init = rrddim_query_init, \
-    .next_metric = rrddim_query_next_metric, \
-    .is_finished = rrddim_query_is_finished, \
-    .finalize = rrddim_query_finalize, \
-    .latest_time = rrddim_query_latest_time, \
-    .oldest_time = rrddim_query_oldest_time \
-}
-
 static STORAGE_ENGINE engines[] = {
     {
         .id = RRD_MEMORY_MODE_NONE,
         .name = RRD_MEMORY_MODE_NONE_NAME,
         .api = {
-            .engine_ops = engine_ops_null,
-            .collect_ops = im_collect_ops,
-            .query_ops = im_query_ops
+            .engine_ops = {
+                .create = rrddim_storage_engine_instance_new,
+                .exit = rrddim_storage_engine_instance_exit,
+                .destroy = rrddim_storage_engine_instance_destroy
+            },
+            .collect_ops = {
+                .init = rrddim_collect_init,
+                .store_metric = rrddim_collect_store_metric,
+                .finalize = rrddim_collect_finalize
+            },
+            .query_ops = {
+                .init = rrddim_query_init,
+                .next_metric = rrddim_query_next_metric,
+                .is_finished = rrddim_query_is_finished,
+                .finalize = rrddim_query_finalize,
+                .latest_time = rrddim_query_latest_time,
+                .oldest_time = rrddim_query_oldest_time
+            }
         },
         .context = NULL
     },
@@ -58,9 +36,24 @@ static STORAGE_ENGINE engines[] = {
         .id = RRD_MEMORY_MODE_RAM,
         .name = RRD_MEMORY_MODE_RAM_NAME,
         .api = {
-            .engine_ops = engine_ops_null,
-            .collect_ops = im_collect_ops,
-            .query_ops = im_query_ops
+            .engine_ops = {
+                .create = rrddim_storage_engine_instance_new,
+                .exit = rrddim_storage_engine_instance_exit,
+                .destroy = rrddim_storage_engine_instance_destroy
+            },
+            .collect_ops = {
+                .init = rrddim_collect_init,
+                .store_metric = rrddim_collect_store_metric,
+                .finalize = rrddim_collect_finalize
+            },
+            .query_ops = {
+                .init = rrddim_query_init,
+                .next_metric = rrddim_query_next_metric,
+                .is_finished = rrddim_query_is_finished,
+                .finalize = rrddim_query_finalize,
+                .latest_time = rrddim_query_latest_time,
+                .oldest_time = rrddim_query_oldest_time
+            }
         },
         .context = NULL
     },
@@ -68,9 +61,24 @@ static STORAGE_ENGINE engines[] = {
         .id = RRD_MEMORY_MODE_MAP,
         .name = RRD_MEMORY_MODE_MAP_NAME,
         .api = {
-            .engine_ops = engine_ops_null,
-            .collect_ops = im_collect_ops,
-            .query_ops = im_query_ops
+            .engine_ops = {
+                .create = rrddim_storage_engine_instance_new,
+                .exit = rrddim_storage_engine_instance_exit,
+                .destroy = rrddim_storage_engine_instance_destroy
+            },
+            .collect_ops = {
+                .init = rrddim_collect_init,
+                .store_metric = rrddim_collect_store_metric,
+                .finalize = rrddim_collect_finalize
+            },
+            .query_ops = {
+                .init = rrddim_query_init,
+                .next_metric = rrddim_query_next_metric,
+                .is_finished = rrddim_query_is_finished,
+                .finalize = rrddim_query_finalize,
+                .latest_time = rrddim_query_latest_time,
+                .oldest_time = rrddim_query_oldest_time
+            }
         },
         .context = NULL
     },
@@ -78,9 +86,24 @@ static STORAGE_ENGINE engines[] = {
         .id = RRD_MEMORY_MODE_SAVE,
         .name = RRD_MEMORY_MODE_SAVE_NAME,
         .api = {
-            .engine_ops = engine_ops_null,
-            .collect_ops = im_collect_ops,
-            .query_ops = im_query_ops
+            .engine_ops = {
+                .create = rrddim_storage_engine_instance_new,
+                .exit = rrddim_storage_engine_instance_exit,
+                .destroy = rrddim_storage_engine_instance_destroy
+            },
+            .collect_ops = {
+                .init = rrddim_collect_init,
+                .store_metric = rrddim_collect_store_metric,
+                .finalize = rrddim_collect_finalize
+            },
+            .query_ops = {
+                .init = rrddim_query_init,
+                .next_metric = rrddim_query_next_metric,
+                .is_finished = rrddim_query_is_finished,
+                .finalize = rrddim_query_finalize,
+                .latest_time = rrddim_query_latest_time,
+                .oldest_time = rrddim_query_oldest_time
+            }
         },
         .context = NULL
     },
@@ -88,9 +111,24 @@ static STORAGE_ENGINE engines[] = {
         .id = RRD_MEMORY_MODE_ALLOC,
         .name = RRD_MEMORY_MODE_ALLOC_NAME,
         .api = {
-            .engine_ops = engine_ops_null,
-            .collect_ops = im_collect_ops,
-            .query_ops = im_query_ops
+            .engine_ops = {
+                .create = rrddim_storage_engine_instance_new,
+                .exit = rrddim_storage_engine_instance_exit,
+                .destroy = rrddim_storage_engine_instance_destroy
+            },
+            .collect_ops = {
+                .init = rrddim_collect_init,
+                .store_metric = rrddim_collect_store_metric,
+                .finalize = rrddim_collect_finalize
+            },
+            .query_ops = {
+                .init = rrddim_query_init,
+                .next_metric = rrddim_query_next_metric,
+                .is_finished = rrddim_query_is_finished,
+                .finalize = rrddim_query_finalize,
+                .latest_time = rrddim_query_latest_time,
+                .oldest_time = rrddim_query_oldest_time
+            }
         },
         .context = NULL
     },

--- a/database/storage_engine.c
+++ b/database/storage_engine.c
@@ -172,7 +172,7 @@ STORAGE_ENGINE_INSTANCE* storage_engine_new(STORAGE_ENGINE* eng, RRDHOST *host)
 void storage_engine_delete(STORAGE_ENGINE_INSTANCE* instance) {
     if (instance) {
         STORAGE_ENGINE* eng = instance->engine;
-        if (eng && eng->api.engine_ops.destroy) {
+        if (eng) {
             eng->api.engine_ops.destroy(instance);
         }
     }

--- a/database/storage_engine.c
+++ b/database/storage_engine.c
@@ -157,26 +157,26 @@ static STORAGE_ENGINE engines[] = {
             }
         },
         .context = NULL
-    },
+    }
 #endif
-    { .id = RRD_MEMORY_MODE_NONE, .name = NULL }
 };
+
+const size_t engine_count = sizeof(engines) / sizeof(engines[0]);
 
 STORAGE_ENGINE* storage_engine_find(const char* name)
 {
-    for (STORAGE_ENGINE* it = engines; it->name; it++) {
-        if (strcmp(it->name, name) == 0)
-            return it;
-    }
+    for (size_t i = 0; i != engine_count; i++)
+        if (strcmp(engines[i].name, name) == 0)
+            return &engines[i];
+
     return NULL;
 }
 
 STORAGE_ENGINE* storage_engine_get(RRD_MEMORY_MODE mmode)
 {
-    for (STORAGE_ENGINE* it = engines; it->name; it++) {
-        if (it->id == mmode)
-            return it;
-    }
+    for (size_t i = 0; i != engine_count; i++)
+        if (engines[i].id == mmode)
+            return &engines[i];
     return NULL;
 }
 
@@ -188,11 +188,8 @@ STORAGE_ENGINE* storage_engine_foreach_init()
 
 STORAGE_ENGINE* storage_engine_foreach_next(STORAGE_ENGINE* it)
 {
-    if (!it || !it->name)
-        return NULL;
-
     it++;
-    return it->name ? it : NULL;
+    return (it >= &engines[engine_count]) ? NULL : it;
 }
 
 STORAGE_ENGINE_INSTANCE* storage_engine_new(STORAGE_ENGINE* eng, RRDHOST *host)

--- a/database/storage_engine.c
+++ b/database/storage_engine.c
@@ -6,10 +6,26 @@
 #include "engine/rrdengineapi.h"
 #endif
 
+/** Empty create op for engines not using a context */
+STORAGE_ENGINE_INSTANCE* create_op_null(STORAGE_ENGINE* engine, RRDHOST *host) {
+    (void)engine; (void)host;
+    return NULL;
+}
+
+/** Empty exit op for engines not using a context */
+void exit_op_null(STORAGE_ENGINE_INSTANCE* context) {
+    (void)context;
+}
+
+/** Empty destroy op for engines not using a context */
+void destroy_op_null(STORAGE_ENGINE_INSTANCE* context) {
+    (void)context;
+}
+
 #define engine_ops_null { \
-    .create = NULL, \
-    .exit = NULL, \
-    .destroy = NULL \
+    .create = create_op_null, \
+    .exit = exit_op_null, \
+    .destroy = destroy_op_null \
 }
 
 #define im_collect_ops { \
@@ -145,9 +161,7 @@ STORAGE_ENGINE_INSTANCE* storage_engine_new(STORAGE_ENGINE* eng, RRDHOST *host)
 {
     STORAGE_ENGINE_INSTANCE* instance = host->rrdeng_ctx;
     if (!instance && eng) {
-        if (eng->api.engine_ops.create) {
-            instance = eng->api.engine_ops.create(eng, host);
-        }
+        instance = eng->api.engine_ops.create(eng, host);
         if (instance) {
             instance->engine = eng;
         }

--- a/database/storage_engine.h
+++ b/database/storage_engine.h
@@ -6,10 +6,20 @@
 #include "rrd.h"
 
 typedef struct storage_engine STORAGE_ENGINE;
+typedef struct storage_engine_instance STORAGE_ENGINE_INSTANCE;
+
+// ------------------------------------------------------------------------
+// function pointers that handle storage engine instance creation and destruction
+struct storage_engine_ops {
+    STORAGE_ENGINE_INSTANCE*(*create)(STORAGE_ENGINE* engine, RRDHOST *host);
+    void(*exit)(STORAGE_ENGINE_INSTANCE*);
+    void(*destroy)(STORAGE_ENGINE_INSTANCE*);
+};
 
 // ------------------------------------------------------------------------
 // function pointers for all APIs provided by a storge engine
 typedef struct storage_engine_api {
+    struct storage_engine_ops engine_ops;
     struct rrddim_collect_ops collect_ops;
     struct rrddim_query_ops query_ops;
 } STORAGE_ENGINE_API;
@@ -18,6 +28,12 @@ struct storage_engine {
     RRD_MEMORY_MODE id;
     const char* name;
     STORAGE_ENGINE_API api;
+    STORAGE_ENGINE_INSTANCE* context;
+};
+
+// Abstract structure to be extended by implementations
+struct storage_engine_instance {
+    STORAGE_ENGINE* engine;
 };
 
 extern STORAGE_ENGINE* storage_engine_get(RRD_MEMORY_MODE mmode);
@@ -26,5 +42,10 @@ extern STORAGE_ENGINE* storage_engine_find(const char* name);
 // Iterator over existing engines
 extern STORAGE_ENGINE* storage_engine_foreach_init();
 extern STORAGE_ENGINE* storage_engine_foreach_next(STORAGE_ENGINE* it);
+
+// ------------------------------------------------------------------------
+// Retreive or create a storage engine instance for host
+STORAGE_ENGINE_INSTANCE* storage_engine_new(STORAGE_ENGINE* engine, RRDHOST *host);
+void storage_engine_delete(STORAGE_ENGINE_INSTANCE* engine);
 
 #endif

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -4,6 +4,9 @@
 #include "web/api/formatters/rrd2json.h"
 #include "rrdr.h"
 #include "database/ram/rrddim_mem.h"
+#ifdef ENABLE_DBENGINE
+#include "database/engine/rrdengine.h"
+#endif
 
 #include "average/average.h"
 #include "countif/countif.h"


### PR DESCRIPTION
Following the idea discussed here:
https://github.com/netdata/netdata/discussions/12216

This change introduces the new storage engine API for managing global and per-host storage engine contexts.

##### Summary

These commits allows storage engines to provide API functions to manage a global context and per-host contexts.
* In-memory engines don't use a context object. These engines provide a null function to signal that they don't use a context.
* dbengine uses a global context

##### Test Plan

These changes don't add any new memory modes/storage engines for now, and only refactor existing features, so they are expected to be covered by existing unit tests.
