### PR TITLE
Add type label for network interfaces

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -741,11 +741,13 @@ int do_proc_net_dev(int update_every, usec_t dt) {
             char buffer[FILENAME_MAX + 1];
 
             snprintfz(buffer, FILENAME_MAX, path_to_sys_devices_virtual_net, d->name);
-            if(likely(access(buffer, R_OK) == 0)) {
+            if (likely(access(buffer, R_OK) == 0)) {
                 d->virtual = 1;
-            }
-            else
+                rrdlabels_add(d->chart_labels, "type", "virtual", RRDLABEL_SRC_AUTO);
+            } else {
                 d->virtual = 0;
+                rrdlabels_add(d->chart_labels, "type", "real", RRDLABEL_SRC_AUTO);
+            }
 
             if(likely(!d->virtual)) {
                 // set the filename to get the interface speed


### PR DESCRIPTION
##### Summary
SSIA

Closes #13128

##### Test Plan
Check the `http://localhost:19999/api/v1/chart?chart=net.<interface name>` endpoint. `chart_labels` should contain `"type":"virtual"` or `"type":"real"`.