### PR TITLE
chore(netdata-installer): remove a call to 'cleanup_old_netdata_updater()' because it is no longer exists

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1859,7 +1859,6 @@ echo >&2
 
 # -----------------------------------------------------------------------------
 progress "Installing (but not enabling) the netdata updater tool"
-cleanup_old_netdata_updater || run_failed "Cannot cleanup old netdata updater tool."
 install_netdata_updater || run_failed "Cannot install netdata updater tool."
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

Was installing Netdata from git and noticed

```bash
Uninstall script copied to: /opt/netdata/usr/libexec/netdata/netdata-uninstaller.sh

 --- Installing (but not enabling) the netdata updater tool ---
./netdata-installer.sh: 1862: cleanup_old_netdata_updater: not found
 FAILED  Cannot cleanup old netdata updater tool.

Update script is located at /opt/netdata/usr/libexec/netdata/netdata-updater.sh
```

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
