### PR TITLE
Clean sqlite prepared statements on thread shutdown

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -99,6 +99,10 @@ static void add_stmt_to_list(sqlite3_stmt *res)
     static sqlite3_stmt *statements[MAX_OPEN_STATEMENTS];
 
     if (unlikely(!res)) {
+        if (idx)
+            info("Finilizing %d statements", idx);
+        else
+            info("No statements pending to finalize");
         while (idx > 0) {
             int rc;
             rc = sqlite3_finalize(statements[--idx]);


### PR DESCRIPTION
##### Summary
- Allocate thread keys to track the prepared statememts
- Finalize the statements on thread shutdown

##### Test Plan
- Setup parent - child
  - Compile with `NETDATA_INTERNAL_CHECKS` 
  - Start child and parent and notice messages on the parent error.log that assign prepared statements to keys
  - Stop the child
    - Observe that the statements are released

Example:
```
2022-06-22 00:03:46: netdata INFO  : STREAM_RECEIVER[ubuntu1804,[192.168.122.103]:53024] : Thread 483819: Using key 1 on statement 0x55961c5d74d8
2022-06-22 00:03:46: netdata INFO  : STREAM_RECEIVER[ubuntu1804,[192.168.122.103]:53024] : Thread 483819: Using key 2 on statement 0x55961c64dd48
2022-06-22 00:03:46: netdata INFO  : STREAM_RECEIVER[ubuntu1804,[192.168.122.103]:53024] : Thread 483819: Using key 3 on statement 0x55961c49e5b8
2022-06-22 00:03:46: netdata INFO  : STREAM_RECEIVER[ubuntu1804,[192.168.122.103]:53024] : Thread 483819: Using key 4 on statement 0x55961c86b368
2022-06-22 00:03:46: netdata INFO  : STREAM_RECEIVER[ubuntu1804,[192.168.122.103]:53024] : Thread 483819: Using key 5 on statement 0x55961c86b4a8
2022-06-22 00:03:46: netdata INFO  : STREAM_RECEIVER[ubuntu1804,[192.168.122.103]:53024] : Thread 483819: Using key 6 on statement 0x55961c86c2e8
2022-06-22 00:03:46: netdata INFO  : STREAM_RECEIVER[ubuntu1804,[192.168.122.103]:53024] : Thread 483819: Using key 7 on statement 0x55961c86c428
2022-06-22 00:03:47: netdata INFO  : STREAM_RECEIVER[ubuntu1804,[192.168.122.103]:53024] : Thread 483819: Using key 8 on statement 0x55961c86c6f8
2022-06-22 00:03:47: netdata INFO  : STREAM_RECEIVER[ubuntu1804,[192.168.122.103]:53024] : Thread 483819: Using key 9 on statement 0x55961c86c958
```

and when the child disconnects
```
2022-06-22 00:04:06: netdata INFO  : MAIN : Thread 483819: Cleaning prepared statement on 0x55961c5d74d8
2022-06-22 00:04:06: netdata INFO  : MAIN : Thread 483819: Cleaning prepared statement on 0x55961c64dd48
2022-06-22 00:04:06: netdata INFO  : MAIN : Thread 483819: Cleaning prepared statement on 0x55961c49e5b8
2022-06-22 00:04:06: netdata INFO  : MAIN : Thread 483819: Cleaning prepared statement on 0x55961c86b368
2022-06-22 00:04:06: netdata INFO  : MAIN : Thread 483819: Cleaning prepared statement on 0x55961c86b4a8
2022-06-22 00:04:06: netdata INFO  : MAIN : Thread 483819: Cleaning prepared statement on 0x55961c86c2e8
2022-06-22 00:04:06: netdata INFO  : MAIN : Thread 483819: Cleaning prepared statement on 0x55961c86c428
2022-06-22 00:04:06: netdata INFO  : MAIN : Thread 483819: Cleaning prepared statement on 0x55961c86c6f8
2022-06-22 00:04:06: netdata INFO  : MAIN : Thread 483819: Cleaning prepared statement on 0x55961c86c958
```

