### PR TITLE
Add configuration for dbengine page fetch timeout and retry count

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1231,6 +1231,7 @@ int main(int argc, char **argv) {
         // initialize the log files
         open_all_log_files();
 
+#ifdef ENABLE_DBENGINE
         default_rrdeng_page_fetch_timeout = (int) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine page fetch timeout", PAGE_CACHE_FETCH_WAIT_TIMEOUT);
         if (default_rrdeng_page_fetch_timeout < 1) {
             info("\"dbengine page fetch timeout\" found in netdata.conf cannot be %d, using 1", default_rrdeng_page_fetch_timeout);
@@ -1242,6 +1243,7 @@ int main(int argc, char **argv) {
             info("\"dbengine page fetch retries\" found in netdata.conf cannot be %d, using 1", default_rrdeng_page_fetch_retries);
             default_rrdeng_page_fetch_retries = 1;
         }
+#endif
 
         get_system_timezone();
         // --------------------------------------------------------------------

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -584,6 +584,14 @@ static void get_netdata_configured_variables() {
     // ------------------------------------------------------------------------
     // get default Database Engine page cache size in MiB
 
+    default_rrdeng_page_fetch_timeout = (int) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine page fetch timeout", PAGE_CACHE_FETCH_WAIT_TIMEOUT);
+    if (default_rrdeng_page_fetch_timeout < 1)
+        default_rrdeng_page_fetch_timeout = 1;
+
+    default_rrdeng_page_fetch_retries = (int) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine page fetch retries", MAX_PAGE_CACHE_FETCH_RETRIES);
+    if (default_rrdeng_page_fetch_retries < 1)
+        default_rrdeng_page_fetch_retries = 1;
+
     db_engine_use_malloc = config_get_boolean(CONFIG_SECTION_GLOBAL, "page cache uses malloc", CONFIG_BOOLEAN_NO);
     default_rrdeng_page_cache_mb = (int) config_get_number(CONFIG_SECTION_GLOBAL, "page cache size", default_rrdeng_page_cache_mb);
     if(default_rrdeng_page_cache_mb < RRDENG_MIN_PAGE_CACHE_SIZE_MB) {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -584,14 +584,6 @@ static void get_netdata_configured_variables() {
     // ------------------------------------------------------------------------
     // get default Database Engine page cache size in MiB
 
-    default_rrdeng_page_fetch_timeout = (int) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine page fetch timeout", PAGE_CACHE_FETCH_WAIT_TIMEOUT);
-    if (default_rrdeng_page_fetch_timeout < 1)
-        default_rrdeng_page_fetch_timeout = 1;
-
-    default_rrdeng_page_fetch_retries = (int) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine page fetch retries", MAX_PAGE_CACHE_FETCH_RETRIES);
-    if (default_rrdeng_page_fetch_retries < 1)
-        default_rrdeng_page_fetch_retries = 1;
-
     db_engine_use_malloc = config_get_boolean(CONFIG_SECTION_GLOBAL, "page cache uses malloc", CONFIG_BOOLEAN_NO);
     default_rrdeng_page_cache_mb = (int) config_get_number(CONFIG_SECTION_GLOBAL, "page cache size", default_rrdeng_page_cache_mb);
     if(default_rrdeng_page_cache_mb < RRDENG_MIN_PAGE_CACHE_SIZE_MB) {
@@ -1238,6 +1230,18 @@ int main(int argc, char **argv) {
         error_log_limit_unlimited();
         // initialize the log files
         open_all_log_files();
+
+        default_rrdeng_page_fetch_timeout = (int) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine page fetch timeout", PAGE_CACHE_FETCH_WAIT_TIMEOUT);
+        if (default_rrdeng_page_fetch_timeout < 1) {
+            info("\"dbengine page fetch timeout\" found in netdata.conf cannot be %d, using 1", default_rrdeng_page_fetch_timeout);
+            default_rrdeng_page_fetch_timeout = 1;
+        }
+
+        default_rrdeng_page_fetch_retries = (int) config_get_number(CONFIG_SECTION_GLOBAL, "dbengine page fetch retries", MAX_PAGE_CACHE_FETCH_RETRIES);
+        if (default_rrdeng_page_fetch_retries < 1) {
+            info("\"dbengine page fetch retries\" found in netdata.conf cannot be %d, using 1", default_rrdeng_page_fetch_retries);
+            default_rrdeng_page_fetch_retries = 1;
+        }
 
         get_system_timezone();
         // --------------------------------------------------------------------

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -1067,9 +1067,9 @@ pg_cache_lookup_next(struct rrdengine_instance *ctx, struct pg_cache_page_index 
     int retry_count = 0;
     while (1) {
         descr = find_first_page_in_time_range(page_index, start_time, end_time);
-        if (NULL == descr || 0 == descr->page_length || retry_count == MAX_PAGE_CACHE_RETRY_WAIT) {
+        if (NULL == descr || 0 == descr->page_length || retry_count == default_rrdeng_page_fetch_retries) {
             /* non-empty page not found */
-            if (retry_count == MAX_PAGE_CACHE_RETRY_WAIT)
+            if (retry_count == default_rrdeng_page_fetch_retries)
                 error_report("Page cache timeout while waiting for page %p : returning FAIL", descr);
             uv_rwlock_rdunlock(&page_index->lock);
 
@@ -1115,7 +1115,7 @@ pg_cache_lookup_next(struct rrdengine_instance *ctx, struct pg_cache_page_index 
         if (!(flags & RRD_PAGE_POPULATED))
             page_not_in_cache = 1;
 
-        if (pg_cache_timedwait_event_unsafe(descr, 1) == UV_ETIMEDOUT) {
+        if (pg_cache_timedwait_event_unsafe(descr, default_rrdeng_page_fetch_timeout) == UV_ETIMEDOUT) {
             error_report("Page cache timeout while waiting for page %p : retry count = %d", descr, retry_count);
             ++retry_count;
         }

--- a/database/engine/pagecache.h
+++ b/database/engine/pagecache.h
@@ -11,7 +11,8 @@ struct extent_info;
 struct rrdeng_page_descr;
 
 #define INVALID_TIME (0)
-#define MAX_PAGE_CACHE_RETRY_WAIT (3)
+#define MAX_PAGE_CACHE_FETCH_RETRIES (3)
+#define PAGE_CACHE_FETCH_WAIT_TIMEOUT (3)
 
 /* Page flags */
 #define RRD_PAGE_DIRTY          (1LU << 0)

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -5,6 +5,8 @@
 struct rrdengine_instance multidb_ctx;
 
 int db_engine_use_malloc = 0;
+int default_rrdeng_page_fetch_timeout = 3;
+int default_rrdeng_page_fetch_retries = 3;
 int default_rrdeng_page_cache_mb = 32;
 int default_rrdeng_disk_quota_mb = 256;
 int default_multidb_disk_quota_mb = 256;

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -13,6 +13,8 @@
 #define RRDENG_FD_BUDGET_PER_INSTANCE (50)
 
 extern int db_engine_use_malloc;
+extern int default_rrdeng_page_fetch_timeout;
+extern int default_rrdeng_page_fetch_retries;
 extern int default_rrdeng_page_cache_mb;
 extern int default_rrdeng_disk_quota_mb;
 extern int default_multidb_disk_quota_mb;


### PR DESCRIPTION

##### Summary
Right now the default page fetch wait timeout is set to 1 seconds with a maximum of 3 retries. The agent will rarely need to reform a page cache retry except under extreme load. For example running netdata using valgrind may produce timeouts and in that case you will see in the error.log messages like

```
Page cache timeout while waiting for page 0x5555593ee9e0 : retry count = 0
``` 

This PR will change the default timeout to 3 seconds with a number of retries remaining to 3.

Both options can be changed by by adding the following in `netdata.conf` under the `[global]` section

```
dbengine page fetch timeout = 3
dbengine page fetch retries = 3
```
