### PR TITLE
Dictionaries with reference counters and full deletion support during traversal

### DIFF
--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -390,7 +390,7 @@ static void dictionary_metric_insert_callback(const char *name, void *value, voi
         netdata_mutex_init(&m->histogram.ext->mutex);
     }
 
-    __atomic_fetch_add(&index->metrics, 1, __ATOMIC_SEQ_CST);
+    __atomic_fetch_add(&index->metrics, 1, __ATOMIC_RELAXED);
 }
 
 static void dictionary_metric_delete_callback(const char *name, void *value, void *data) {

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -46,9 +46,9 @@ static struct global_statistics {
 };
 
 void rrdr_query_completed(uint64_t db_points_read, uint64_t result_points_generated) {
-    __atomic_fetch_add(&global_statistics.rrdr_queries_made, 1, __ATOMIC_SEQ_CST);
-    __atomic_fetch_add(&global_statistics.rrdr_db_points_read, db_points_read, __ATOMIC_SEQ_CST);
-    __atomic_fetch_add(&global_statistics.rrdr_result_points_generated, result_points_generated, __ATOMIC_SEQ_CST);
+    __atomic_fetch_add(&global_statistics.rrdr_queries_made, 1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&global_statistics.rrdr_db_points_read, db_points_read, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&global_statistics.rrdr_result_points_generated, result_points_generated, __ATOMIC_RELAXED);
 }
 
 void finished_web_request_statistics(uint64_t dt,
@@ -58,45 +58,44 @@ void finished_web_request_statistics(uint64_t dt,
                                      uint64_t compressed_content_size) {
     uint64_t old_web_usec_max = global_statistics.web_usec_max;
     while(dt > old_web_usec_max)
-        __atomic_compare_exchange(&global_statistics.web_usec_max, &old_web_usec_max, &dt, 1, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+        __atomic_compare_exchange(&global_statistics.web_usec_max, &old_web_usec_max, &dt, 1, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
 
-    __atomic_fetch_add(&global_statistics.web_requests, 1, __ATOMIC_SEQ_CST);
-    __atomic_fetch_add(&global_statistics.web_usec, dt, __ATOMIC_SEQ_CST);
-    __atomic_fetch_add(&global_statistics.bytes_received, bytes_received, __ATOMIC_SEQ_CST);
-    __atomic_fetch_add(&global_statistics.bytes_sent, bytes_sent, __ATOMIC_SEQ_CST);
-    __atomic_fetch_add(&global_statistics.content_size, content_size, __ATOMIC_SEQ_CST);
-    __atomic_fetch_add(&global_statistics.compressed_content_size, compressed_content_size, __ATOMIC_SEQ_CST);
+    __atomic_fetch_add(&global_statistics.web_requests, 1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&global_statistics.web_usec, dt, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&global_statistics.bytes_received, bytes_received, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&global_statistics.bytes_sent, bytes_sent, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&global_statistics.content_size, content_size, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&global_statistics.compressed_content_size, compressed_content_size, __ATOMIC_RELAXED);
 }
 
 uint64_t web_client_connected(void) {
-    __atomic_fetch_add(&global_statistics.connected_clients, 1, __ATOMIC_SEQ_CST);
-    return __atomic_fetch_add(&global_statistics.web_client_count, 1, __ATOMIC_SEQ_CST);
+    __atomic_fetch_add(&global_statistics.connected_clients, 1, __ATOMIC_RELAXED);
+    return __atomic_fetch_add(&global_statistics.web_client_count, 1, __ATOMIC_RELAXED);
 }
 
 void web_client_disconnected(void) {
-    __atomic_fetch_sub(&global_statistics.connected_clients, 1, __ATOMIC_SEQ_CST);
+    __atomic_fetch_sub(&global_statistics.connected_clients, 1, __ATOMIC_RELAXED);
 }
 
 
 static inline void global_statistics_copy(struct global_statistics *gs, uint8_t options) {
-    gs->connected_clients            = __atomic_fetch_add(&global_statistics.connected_clients, 0, __ATOMIC_SEQ_CST);
-    gs->web_requests                 = __atomic_fetch_add(&global_statistics.web_requests, 0, __ATOMIC_SEQ_CST);
-    gs->web_usec                     = __atomic_fetch_add(&global_statistics.web_usec, 0, __ATOMIC_SEQ_CST);
-    gs->web_usec_max                 = __atomic_fetch_add(&global_statistics.web_usec_max, 0, __ATOMIC_SEQ_CST);
-    gs->bytes_received               = __atomic_fetch_add(&global_statistics.bytes_received, 0, __ATOMIC_SEQ_CST);
-    gs->bytes_sent                   = __atomic_fetch_add(&global_statistics.bytes_sent, 0, __ATOMIC_SEQ_CST);
-    gs->content_size                 = __atomic_fetch_add(&global_statistics.content_size, 0, __ATOMIC_SEQ_CST);
-    gs->compressed_content_size      = __atomic_fetch_add(&global_statistics.compressed_content_size, 0, __ATOMIC_SEQ_CST);
-    gs->web_client_count             = __atomic_fetch_add(&global_statistics.web_client_count, 0, __ATOMIC_SEQ_CST);
+    gs->connected_clients            = __atomic_fetch_add(&global_statistics.connected_clients, 0, __ATOMIC_RELAXED);
+    gs->web_requests                 = __atomic_fetch_add(&global_statistics.web_requests, 0, __ATOMIC_RELAXED);
+    gs->web_usec                     = __atomic_fetch_add(&global_statistics.web_usec, 0, __ATOMIC_RELAXED);
+    gs->web_usec_max                 = __atomic_fetch_add(&global_statistics.web_usec_max, 0, __ATOMIC_RELAXED);
+    gs->bytes_received               = __atomic_fetch_add(&global_statistics.bytes_received, 0, __ATOMIC_RELAXED);
+    gs->bytes_sent                   = __atomic_fetch_add(&global_statistics.bytes_sent, 0, __ATOMIC_RELAXED);
+    gs->content_size                 = __atomic_fetch_add(&global_statistics.content_size, 0, __ATOMIC_RELAXED);
+    gs->compressed_content_size      = __atomic_fetch_add(&global_statistics.compressed_content_size, 0, __ATOMIC_RELAXED);
+    gs->web_client_count             = __atomic_fetch_add(&global_statistics.web_client_count, 0, __ATOMIC_RELAXED);
 
-    gs->rrdr_queries_made            = __atomic_fetch_add(&global_statistics.rrdr_queries_made, 0, __ATOMIC_SEQ_CST);
-    gs->rrdr_db_points_read          = __atomic_fetch_add(&global_statistics.rrdr_db_points_read, 0, __ATOMIC_SEQ_CST);
-    gs->rrdr_result_points_generated = __atomic_fetch_add(&global_statistics.rrdr_result_points_generated, 0, __ATOMIC_SEQ_CST);
+    gs->rrdr_queries_made            = __atomic_fetch_add(&global_statistics.rrdr_queries_made, 0, __ATOMIC_RELAXED);
+    gs->rrdr_db_points_read          = __atomic_fetch_add(&global_statistics.rrdr_db_points_read, 0, __ATOMIC_RELAXED);
+    gs->rrdr_result_points_generated = __atomic_fetch_add(&global_statistics.rrdr_result_points_generated, 0, __ATOMIC_RELAXED);
 
     if(options & GLOBAL_STATS_RESET_WEB_USEC_MAX) {
         uint64_t n = 0;
-        __atomic_compare_exchange(&global_statistics.web_usec_max, (uint64_t *) &gs->web_usec_max, &n, 1, __ATOMIC_SEQ_CST,
-                                  __ATOMIC_SEQ_CST);
+        __atomic_compare_exchange(&global_statistics.web_usec_max, (uint64_t *) &gs->web_usec_max, &n, 1, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
     }
 }
 

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -611,20 +611,15 @@ void rrdlabels_add_pair(DICTIONARY *dict, const char *string, RRDLABEL_SRC ls) {
 // rrdlabels_get_to_buffer_or_null()
 
 void rrdlabels_get_value_to_buffer_or_null(DICTIONARY *labels, BUFFER *wb, const char *key, const char *quote, const char *null) {
-    // Get a read lock on the dictionary
-    // to copy the value into the buffer
-    void *v;
-    dfe_start_read(labels, v) {
-        RRDLABEL *lb = dictionary_get_having_read_lock(labels, key);
+    void *acquired_item = dictionary_acquire_item(labels, key);
+    RRDLABEL *lb = dictionary_acquired_item_value(labels, acquired_item);
 
-        if(lb && lb->value)
-            buffer_sprintf(wb, "%s%s%s", quote, lb->value, quote);
-        else
-            buffer_strcat(wb, null);
+    if(lb && lb->value)
+        buffer_sprintf(wb, "%s%s%s", quote, lb->value, quote);
+    else
+        buffer_strcat(wb, null);
 
-        break;
-    }
-    dfe_done(v);
+    dictionary_acquired_item_release(labels, acquired_item);
 }
 
 

--- a/libnetdata/dictionary/README.md
+++ b/libnetdata/dictionary/README.md
@@ -22,7 +22,7 @@ Dictionaries are **ordered**, meaning that the order they have been added is pre
 
 Dictionaries guarantee **uniqueness** of all items added to them, meaning that only one item with a given name can exist in the dictionary at any given time.
 
-Dictionaries are extremely fast in all operations. They are indexing the keys with `JudyHS` and they utilize a double-linked-list for the traversal operations. Deletion is the most expensive operation, usually somewhat slower than insertion.
+Dictionaries are extremely fast in all operations. They are indexing the keys with `JudyHS` (or `AVL` when `libJudy` is not available) and they utilize a double-linked-list for the traversal operations. Deletion is the most expensive operation, usually somewhat slower than insertion.
 
 ## Memory management
 
@@ -31,13 +31,13 @@ Dictionaries come with 2 memory management options:
 - **Clone** (copy) the name and/or the value to memory allocated by the dictionary.
 - **Link** the name and/or the value, without allocating any memory about them.
 
-In **clone** mode, the dictionary guarantees that all operations on the dictionary items will automatically take care of the memory used by the name and/or the value. In case the value is an object needs to have user allocated memory, the following callback functions can be registered:
+In **clone** mode, the dictionary guarantees that all operations on the dictionary items will automatically take care of the memory used by the name and/or the value. In case the value is an object that needs to have user allocated memory, the following callback functions can be registered:
 
    1.`dictionary_register_insert_callback()` that will be called just after the insertion of an item to the dictionary, or after the replacement of the value of a dictionary item (but while the dictionary is write-locked - if locking is enabled).
    2. `dictionary_register_delete_callback()` that will be called just prior to the deletion of an item from the dictionary, or prior to the replacement of the value of a dictionary item (but while the dictionary is write-locked - if locking is enabled).
    3. `dictionary_register_conflict_callback()` that will be called when `DICTIONARY_FLAG_DONT_OVERWRITE_VALUE` is set and another value is attempted to be inserted for the same key. 
 
-In **link** mode, the name and/or the value are just linked to the dictionary item, and it is the user's responsibility to free the memory used after an item is deleted from the dictionary.
+In **link** mode, the name and/or the value are just linked to the dictionary item, and it is the user's responsibility to free the memory they use after an item is deleted from the dictionary or when the dictionary is destroyed.
 
 By default, **clone** mode is used for both the name and the value.
 
@@ -63,7 +63,7 @@ The dictionary supports the following operations supported by the hash table:
 
 Use `dictionary_create()` to create a dictionary.
 
-Use `dictionary_destroy()` to destroy a dictionary. When destroyed, a dictionary frees all the memory it has allocated on its own. The exception is the registration of a deletion callback function that can be called on deletion of an item, which may free additional resources. 
+Use `dictionary_destroy()` to destroy a dictionary. When destroyed, a dictionary frees all the memory it has allocated on its own. This can be complemented by the registration of a deletion callback function that can be called upon deletion of each item in the dictionary, which may free additional resources. 
 
 ### dictionary_set()
 
@@ -72,7 +72,7 @@ This call is used to:
 - **add** an item to the dictionary.
 - **reset** the value of an existing item in the dictionary.
 
-If **resetting** is not desired, add `DICTIONARY_FLAG_DONT_OVERWRITE_VALUE` to the flags when creating the dictionary. In this case, `dictionary_set()` will return the value of the original item found in the dictionary instead of resetting it and the value passed to the call will be ignored.
+If **resetting** is not desired, add `DICTIONARY_FLAG_DONT_OVERWRITE_VALUE` to the flags when creating the dictionary. In this case, `dictionary_set()` will return the value of the original item found in the dictionary instead of resetting it and the value passed to the call will be ignored. Optionally a conflict callback function can be registered, to manipulate (probably merge or extend) the original value, based on the new value attempted to be added to the dictionary.
 
 For **multi-threaded** operation, the `dictionary_set()` calls get an exclusive write lock on the dictionary.
 
@@ -89,11 +89,11 @@ Where:
 * `value` is a pointer to the value associated with this item. In **clone** mode, if `value` is `NULL`, a new memory allocation will be made of `value_len` size and will be initialized to zero.
 * `value_len` is the size of the `value` data. If `value_len` is zero, no allocation will be done and the dictionary item will permanently have the `NULL` value.
 
-> **IMPORTANT**<br/>There is also an **unsafe** version (without locks) of this call. This is to be used when traversing the dictionary. It should never be called without an active lock on the dictionary, which can only be acquired while traversing.
+> **IMPORTANT**<br/>There is also an **unsafe** version (without locks) of this call. This is to be used when traversing the dictionary in write mode. It should never be called without an active lock on the dictionary, which can only be acquired while traversing.
 
 ### dictionary_get()
 
-This call is used to get the value of an item, given its name. It utilizes the JudyHS hash table for making the lookup.
+This call is used to get the value of an item, given its name. It utilizes the `JudyHS` hash table for making the lookup.
 
 For **multi-threaded** operation, the `dictionary_get()` call gets a shared read lock on the dictionary.
 
@@ -114,7 +114,7 @@ Where:
 
 This call is used to delete an item from the dictionary, given its name.
 
-If there is a delete callback registered to the dictionary (`dictionary_register_delete_callback()`), it is called prior to the actual deletion of the item. 
+If there is a deletion callback registered to the dictionary (`dictionary_register_delete_callback()`), it is called prior to the actual deletion of the item. 
 
 For **multi-threaded** operation, the `dictionary_del()` calls get an exclusive write lock on the dictionary.
 
@@ -133,27 +133,28 @@ Where:
 
 ## Traversal
 
-Dictionaries offer 2 ways to traverse the entire dictionary:
+Dictionaries offer 3 ways to traverse the entire dictionary:
 
 - **walkthrough**, implemented by setting a callback function to be called for every item.
+- **sorted walkthrough**, which first sorts the dictionary and then call a callback function for every item.
 - **foreach**, a way to traverse the dictionary with a for-next loop.
 
-Both of these methods are available in **read** or **write** mode. In **read** mode only lookups are allowed to the dictionary. In **write** both lookups but also deletion of the currently working item is also allowed.
+All these methods are available in **read** or **write** mode. In **read** mode only lookups are allowed to the dictionary. In **write** lookups but also insertions and deletions are allowed.
 
-While traversing the dictionary with any of these methods, all calls to the dictionary have to use the `_unsafe` versions of the function calls, otherwise deadlock may arise.
+While traversing the dictionary with any of these methods, all calls to the dictionary have to use the `_unsafe` versions of the function calls, otherwise deadlocks may arise.
 
 > **IMPORTANT**<br/>The dictionary itself does not check to ensure that a user is actually using the right lock mode (read or write) while traversing the dictionary for each of the unsafe calls.
 
 ### walkthrough (callback)
 
-There are 2 calls:
+There are 4 calls:
 
-- `dictionary_walkthrough_read()` that acquires a shared read lock, and it calls a callback function for every item of the dictionary. The callback function may use the unsafe versions of the `dictionary_get()` calls to lookup other items in the dictionary, but it should not add or remove item from the dictionary.
-- `dictionary_walkthrough_write()` that acquires an exclusive write lock, and it calls a callback function for every item of the dictionary. This is to be used when items need to be added to the dictionary, or when the current item may need to be deleted. If the callback function deletes any other items, the behavior may be undefined (actually, the item next to the one currently working should not be deleted - a pointer to it is held by the traversal function to move on traversing the dictionary).
+- `dictionary_walkthrough_read()` and `dictionary_sorted_walkthrough_read()` that acquire a shared read lock, and they call a callback function for every item of the dictionary. The callback function may use the unsafe versions of the `dictionary_get()` calls to lookup other items in the dictionary, but it should not attempt to add or remove items to/from the dictionary.
+- `dictionary_walkthrough_write()` and `dictionary_sorted_walkthrough_write()` that acquire an exclusive write lock, and they call a callback function for every item of the dictionary. This is to be used when items need to be added to or removed from the dictionary. **IMPORTANT: Although the plain version can be used to delete any or all the items from the dictionary, including the currently working one, the sorted version MUST NEVER be used to delete items from the dictionary. The sorted version maintains an ephemeral copy of pointers to the items in the dictionary, which will be invalid if items after the current one are deleted.** 
 
-The items are traversed in the same order they have been added to the dictionary (or the reverse order if the flag `DICTIONARY_FLAG_ADD_IN_FRONT` is set during dictionary creation).
+The non sorted versions traverse the items in the same order they have been added to the dictionary (or the reverse order if the flag `DICTIONARY_FLAG_ADD_IN_FRONT` is set during dictionary creation). The sorted versions first alphabetically sort the items based on their name, and then they traverse them in the sorted order.
 
-The callback function returns an `int`. If this value is negative, traversal of the dictionary is stopped immediately and the negative value is returned to the caller. If the returned value of all callbacks is zero or positive, the walkthrough functions return the sum of the return values of all callbacks. So, if you are just interested to know how many items fall into some condition, write a callback function that returns 1 when the item satisfies that condition and 0 when it does not and the walkthrough function will return how many tested positive.
+The callback function returns an `int`. If this value is negative, traversal of the dictionary is stopped immediately and the negative value is returned to the caller. If the returned value of all callback calls is zero or positive, the walkthrough functions return the sum of the return values of all callbacks. So, if you are just interested to know how many items fall into some condition, write a callback function that returns 1 when the item satisfies that condition and 0 when it does not and the walkthrough function will return how many tested positive.
 
 ### foreach (for-next loop)
 
@@ -186,14 +187,14 @@ else
     something else;
 ```
 
-In the above, the `if(x)` condition will work as expected. It will do the foreach loop when x is 1, otherwise it will run `something else`.
+In the above, the `if(x == 1)` condition will work as expected. It will do the foreach loop when x is 1, otherwise it will run `something else`.
 
 There are 2 versions of `dfe_start`:
 
 - `dfe_start_read()` that acquires a shared read lock to the dictionary.
 - `dfe_start_write()` that acquires an exclusive write lock to the dictionary.
 
-While in the loop, depending on the read or write versions of `dfe_start`, the caller may lookup or manipulate the dictionary. The rules are the same with the walkthrough callback functions.
+While in the loop, depending on the read or write versions of `dfe_start`, the caller may lookup or manipulate the dictionary. The rules are the same with the unsorted walkthrough callback functions.
 
 PS: DFE is Dictionary For Each.
 

--- a/libnetdata/dictionary/dictionary.c
+++ b/libnetdata/dictionary/dictionary.c
@@ -413,6 +413,11 @@ static size_t hashtable_destroy_unsafe(DICTIONARY *dict) {
 }
 
 static inline NAME_VALUE **hashtable_insert_unsafe(DICTIONARY *dict, const char *name, size_t name_len) {
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(!(dict->flags & DICTIONARY_FLAG_EXCLUSIVE_ACCESS)))
+        error("DICTIONARY: INTERNAL ERROR: inserting to the index without exclusive access to the dictionary.");
+#endif
+
     JError_t J_Error;
     Pvoid_t *Rc = JudyHSIns(&dict->JudyHSArray, (void *)name, name_len, &J_Error);
     if (unlikely(Rc == PJERR)) {
@@ -431,8 +436,12 @@ static inline NAME_VALUE **hashtable_insert_unsafe(DICTIONARY *dict, const char 
 }
 
 static inline int hashtable_delete_unsafe(DICTIONARY *dict, const char *name, size_t name_len, NAME_VALUE *nv) {
-    (void)nv;
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(!(dict->flags & DICTIONARY_FLAG_EXCLUSIVE_ACCESS)))
+        error("DICTIONARY: INTERNAL ERROR: deleting from the index without exclusive access to the dictionary.");
+#endif
 
+    (void)nv;
     if(unlikely(!dict->JudyHSArray)) return 0;
 
     JError_t J_Error;
@@ -487,6 +496,11 @@ static inline void hashtable_inserted_name_value_unsafe(DICTIONARY *dict, const 
 // linked list management
 
 static inline void linkedlist_namevalue_link_unsafe(DICTIONARY *dict, NAME_VALUE *nv) {
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(!(dict->flags & DICTIONARY_FLAG_EXCLUSIVE_ACCESS)))
+        error("DICTIONARY: INTERNAL ERROR: adding item to the linked-list without exclusive access to the dictionary.");
+#endif
+
     if (unlikely(!dict->first_item)) {
         // we are the only ones here
         nv->next = NULL;
@@ -514,6 +528,11 @@ static inline void linkedlist_namevalue_link_unsafe(DICTIONARY *dict, NAME_VALUE
 }
 
 static inline void linkedlist_namevalue_unlink_unsafe(DICTIONARY *dict, NAME_VALUE *nv) {
+#ifdef NETDATA_INTERNAL_CHECKS
+    if(unlikely(!(dict->flags & DICTIONARY_FLAG_EXCLUSIVE_ACCESS)))
+        error("DICTIONARY: INTERNAL ERROR: removing item from the linked-list without exclusive access to the dictionary.");
+#endif
+
     if(nv->next) nv->next->prev = nv->prev;
     if(nv->prev) nv->prev->next = nv->next;
     if(dict->first_item == nv) dict->first_item = nv->next;

--- a/libnetdata/dictionary/dictionary.h
+++ b/libnetdata/dictionary/dictionary.h
@@ -168,7 +168,7 @@ typedef DICTFE_CONST struct dictionary_foreach {
     char rw;                    // the lock mode 'r' or 'w'
     usec_t started_ut;          // the time the caller started iterating (now_realtime_usec())
     DICTIONARY *dict;           // the dictionary upon we work
-    void *last_position_index;  // the internal position index, to remember the position we are at
+    void *last_item;            // the item we work on, to remember the position we are at
 } DICTFE;
 
 #define dfe_start_read(dict, value) dfe_start_rw(dict, value, 'r')

--- a/libnetdata/dictionary/dictionary.h
+++ b/libnetdata/dictionary/dictionary.h
@@ -46,7 +46,10 @@ typedef enum dictionary_flags {
     DICTIONARY_FLAG_NAME_LINK_DONT_CLONE   = (1 << 2), // don't copy the name, just point to the one provided (default: copy)
     DICTIONARY_FLAG_DONT_OVERWRITE_VALUE   = (1 << 3), // don't overwrite values of dictionary items (default: overwrite)
     DICTIONARY_FLAG_ADD_IN_FRONT           = (1 << 4), // add dictionary items at the front of the linked list (default: at the end)
-    DICTIONARY_FLAG_RESERVED1              = (1 << 5), // this is reserved for DICTIONARY_FLAG_REFERENCE_COUNTERS
+
+    // to change the value of the following, you also need to change the corresponding #defines in dictionary.c
+    DICTIONARY_FLAG_RESERVED1              = (1 << 28), // this is reserved for DICTIONARY_FLAG_REFERENCE_COUNTERS
+    DICTIONARY_FLAG_RESERVED2              = (1 << 29), // this is reserved for DICTIONARY_FLAG_EXCLUSIVE_ACCESS
 } DICTIONARY_FLAGS;
 
 // Create a dictionary

--- a/libnetdata/dictionary/dictionary.h
+++ b/libnetdata/dictionary/dictionary.h
@@ -49,6 +49,7 @@ typedef enum dictionary_flags {
 
     // to change the value of the following, you also need to change the corresponding #defines in dictionary.c
     DICTIONARY_FLAG_RESERVED1              = (1 << 29), // this is reserved for DICTIONARY_FLAG_EXCLUSIVE_ACCESS
+    DICTIONARY_FLAG_RESERVED2              = (1 << 30), // this is reserved for DICTIONARY_FLAG_DESTROYED
 } DICTIONARY_FLAGS;
 
 // Create a dictionary

--- a/libnetdata/dictionary/dictionary.h
+++ b/libnetdata/dictionary/dictionary.h
@@ -97,6 +97,12 @@ extern void *dictionary_get(DICTIONARY *dict, const char *name);
 // returns -1 if the item was not found in the index
 extern int dictionary_del(DICTIONARY *dict, const char *name);
 
+extern void *dictionary_acquire_item_unsafe(DICTIONARY *dict, const char *name);
+extern void *dictionary_acquire_item(DICTIONARY *dict, const char *name);
+extern void *dictionary_acquired_item_value(DICTIONARY *dict, void *item);
+extern void dictionary_acquired_item_release(DICTIONARY *dict, void *item);
+extern void dictionary_acquired_item_release_unsafe(DICTIONARY *dict, void *item);
+
 // UNSAFE functions, without locks
 // to be used when the user is traversing with the right lock type
 // Read lock is acquired by dictionary_walktrhough_read() and dfe_start_read()

--- a/libnetdata/dictionary/dictionary.h
+++ b/libnetdata/dictionary/dictionary.h
@@ -48,8 +48,9 @@ typedef enum dictionary_flags {
     DICTIONARY_FLAG_ADD_IN_FRONT           = (1 << 4), // add dictionary items at the front of the linked list (default: at the end)
 
     // to change the value of the following, you also need to change the corresponding #defines in dictionary.c
-    DICTIONARY_FLAG_RESERVED1              = (1 << 29), // this is reserved for DICTIONARY_FLAG_EXCLUSIVE_ACCESS
-    DICTIONARY_FLAG_RESERVED2              = (1 << 30), // this is reserved for DICTIONARY_FLAG_DESTROYED
+    DICTIONARY_FLAG_RESERVED1              = (1 << 29), // reserved for DICTIONARY_FLAG_EXCLUSIVE_ACCESS
+    DICTIONARY_FLAG_RESERVED2              = (1 << 30), // reserved for DICTIONARY_FLAG_DESTROYED
+    DICTIONARY_FLAG_RESERVED3              = (1 << 31), // reserved for DICTIONARY_FLAG_DEFER_ALL_DELETIONS
 } DICTIONARY_FLAGS;
 
 // Create a dictionary
@@ -164,6 +165,7 @@ typedef DICTFE_CONST struct dictionary_foreach {
                                 // same as the return value of dictfe_start() and dictfe_next()
 
     // the following are for internal use only - to keep track of the point we are
+    char rw;                    // the lock mode 'r' or 'w'
     usec_t started_ut;          // the time the caller started iterating (now_realtime_usec())
     DICTIONARY *dict;           // the dictionary upon we work
     void *last_position_index;  // the internal position index, to remember the position we are at
@@ -190,9 +192,8 @@ extern void * dictionary_foreach_next(DICTFE *dfe);
 extern usec_t dictionary_foreach_done(DICTFE *dfe);
 
 // Get statistics about the dictionary
-// If DICTIONARY_FLAG_WITH_STATISTICS is not set, these return zero
-extern size_t dictionary_stats_allocated_memory(DICTIONARY *dict);
-extern size_t dictionary_stats_entries(DICTIONARY *dict);
+extern long int dictionary_stats_allocated_memory(DICTIONARY *dict);
+extern long int dictionary_stats_entries(DICTIONARY *dict);
 extern size_t dictionary_stats_inserts(DICTIONARY *dict);
 extern size_t dictionary_stats_searches(DICTIONARY *dict);
 extern size_t dictionary_stats_deletes(DICTIONARY *dict);

--- a/libnetdata/dictionary/dictionary.h
+++ b/libnetdata/dictionary/dictionary.h
@@ -48,8 +48,7 @@ typedef enum dictionary_flags {
     DICTIONARY_FLAG_ADD_IN_FRONT           = (1 << 4), // add dictionary items at the front of the linked list (default: at the end)
 
     // to change the value of the following, you also need to change the corresponding #defines in dictionary.c
-    DICTIONARY_FLAG_RESERVED1              = (1 << 28), // this is reserved for DICTIONARY_FLAG_REFERENCE_COUNTERS
-    DICTIONARY_FLAG_RESERVED2              = (1 << 29), // this is reserved for DICTIONARY_FLAG_EXCLUSIVE_ACCESS
+    DICTIONARY_FLAG_RESERVED1              = (1 << 29), // this is reserved for DICTIONARY_FLAG_EXCLUSIVE_ACCESS
 } DICTIONARY_FLAGS;
 
 // Create a dictionary
@@ -161,7 +160,6 @@ typedef DICTFE_CONST struct dictionary_foreach {
     usec_t started_ut;          // the time the caller started iterating (now_realtime_usec())
     DICTIONARY *dict;           // the dictionary upon we work
     void *last_position_index;  // the internal position index, to remember the position we are at
-    void *next_position_index;  // the internal position index, of the next item
 } DICTFE;
 
 #define dfe_start_read(dict, value) dfe_start_rw(dict, value, 'r')

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -6,7 +6,7 @@
 int web_server_is_multithreaded = 1;
 
 const char *program_name = "";
-uint64_t debug_flags = DEBUG;
+uint64_t debug_flags = 0;
 
 int access_log_syslog = 1;
 int error_log_syslog = 1;
@@ -691,7 +691,7 @@ void debug_int( const char *file, const char *function, const unsigned long line
     log_date(date, LOG_DATE_LENGTH);
 
     va_start( args, fmt );
-    printf("%s: %s DEBUG : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
+    printf("%s: %s DEBUG : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
     vprintf(fmt, args);
     va_end( args );
     putchar('\n');
@@ -727,8 +727,11 @@ void info_int( const char *file, const char *function, const unsigned long line,
     log_lock();
 
     va_start( args, fmt );
-    if(debug_flags) fprintf(stderr, "%s: %s INFO  : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
-    else            fprintf(stderr, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
+#ifdef NETDATA_INTERNAL_CHECKS
+    fprintf(stderr, "%s: %s INFO  : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
+#else
+    fprintf(stderr, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
+#endif
     vfprintf( stderr, fmt, args );
     va_end( args );
 
@@ -783,8 +786,11 @@ void error_int( const char *prefix, const char *file, const char *function, cons
     log_lock();
 
     va_start( args, fmt );
-    if(debug_flags) fprintf(stderr, "%s: %s %-5.5s : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
-    else            fprintf(stderr, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
+#ifdef NETDATA_INTERNAL_CHECKS
+    fprintf(stderr, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
+#else
+    fprintf(stderr, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
+#endif
     vfprintf( stderr, fmt, args );
     va_end( args );
 
@@ -826,8 +832,11 @@ void fatal_int( const char *file, const char *function, const unsigned long line
     log_lock();
 
     va_start( args, fmt );
-    if(debug_flags) fprintf(stderr, "%s: %s FATAL : %s : (%04lu@%-10.10s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
-    else            fprintf(stderr, "%s: %s FATAL : %s : ", date, program_name, thread_tag);
+#ifdef NETDATA_INTERNAL_CHECKS
+    fprintf(stderr, "%s: %s FATAL : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
+#else
+    fprintf(stderr, "%s: %s FATAL : %s : ", date, program_name, thread_tag);
+#endif
     vfprintf( stderr, fmt, args );
     va_end( args );
 

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -85,7 +85,7 @@ static inline void debug_dummy(void) {}
 #define internal_error(condition, args...) do { if(unlikely(condition)) error_int("INTERNAL ERROR", __FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
 #else
 #define debug(type, args...) debug_dummy()
-#define internal_checks_error(args...) debug_dummy()
+#define internal_error(args...) debug_dummy()
 #endif
 
 #define info(args...)    info_int(__FILE__, __FUNCTION__, __LINE__, ##args)

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -47,10 +47,6 @@ extern "C" {
 #define D_ACLK_SYNC         0x0000000800000000
 #define D_SYSTEM            0x8000000000000000
 
-//#define DEBUG (D_WEB_CLIENT_ACCESS|D_LISTENER|D_RRD_STATS)
-//#define DEBUG 0xffffffff
-#define DEBUG (0)
-
 extern int web_server_is_multithreaded;
 
 extern uint64_t debug_flags;
@@ -86,8 +82,10 @@ static inline void debug_dummy(void) {}
 
 #ifdef NETDATA_INTERNAL_CHECKS
 #define debug(type, args...) do { if(unlikely(debug_flags & type)) debug_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
+#define internal_error(condition, args...) do { if(unlikely(condition)) error_int("INTERNAL ERROR", __FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
 #else
 #define debug(type, args...) debug_dummy()
+#define internal_checks_error(args...) debug_dummy()
 #endif
 
 #define info(args...)    info_int(__FILE__, __FUNCTION__, __LINE__, ##args)


### PR DESCRIPTION
This PR:

1. Relaxes the use of atomic operations for statistics (they are faster)
   
2. Implements reference counters to protect the dictionary items while they are traversed. In case an item is deleted while it is being used, the deletion is deferred until its reference counter becomes zero. While an item is marked for deletion, it is not in the index (it can be added again, and is not found while searching), but it remains in the linked list, although it is not offered to other callers traversing the dictionary.
   
3. Added public interface to acquire and release item from the dictionary. 

This is the first step to make the dictionaries more generic for using them in long-standing objects like RRDSETs, RRDDIMs, RRDHOSTs, etc.

Another current benefit is that with this version, a caller traversing the dictionary may delete any or all items in the dictionary, including the item currently working on (previously, only the current item could be deleted - the behavior was undefined if other items were deleted). Now, deletion of all not-used item is immediate while deletion of used items (including the current item) are deferred until the items are released, which happens automatically upon moving to the next item while traversing, or if the release function is called.

This means that items of the dictionary are protected while they are being used, even when the dictionary is totally unlocked for other uses.