### PR TITLE
Allow for an easy way to do metadata migrations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,6 +658,8 @@ set(RRD_PLUGIN_FILES
         database/ram/rrddim_mem.h
         database/sqlite/sqlite_functions.c
         database/sqlite/sqlite_functions.h
+        database/sqlite/sqlite_db_migration.c
+        database/sqlite/sqlite_db_migration.h
         database/sqlite/sqlite_aclk.c
         database/sqlite/sqlite_aclk.h
         database/sqlite/sqlite_health.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -454,6 +454,8 @@ RRD_PLUGIN_FILES = \
     database/ram/rrddim_mem.h \
     database/sqlite/sqlite_functions.c \
     database/sqlite/sqlite_functions.h \
+    database/sqlite/sqlite_db_migration.c \
+    database/sqlite/sqlite_db_migration.h \
     database/sqlite/sqlite_aclk.c \
     database/sqlite/sqlite_aclk.h \
     database/sqlite/sqlite_health.c \

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "sqlite_db_migration.h"
+
+static int do_migration_noop(sqlite3 *database, const char *name)
+{
+    UNUSED(database);
+    UNUSED(name);
+    info("Running database migration %s", name);
+    return 0;
+}
+
+static struct database_func_migration_list {
+    char *name;
+    int (*func)(sqlite3 *database, const char *name);
+} migration_action[] = {
+    {.name = "v0 to v1",  .func = do_migration_noop},
+    // the terminator of this array
+    {.name = NULL, .func = NULL}
+};
+
+
+static int perform_database_migration_cb(void *data, int argc, char **argv, char **column)
+{
+    int *status = data;
+    UNUSED(argc);
+    UNUSED(column);
+    *status = str2uint32_t(argv[0]);
+    return 0;
+}
+
+int perform_database_migration(sqlite3 *database, int target_version)
+{
+    int user_version = 0;
+    char *err_msg = NULL;
+
+    int rc = sqlite3_exec(database, "PRAGMA user_version;", perform_database_migration_cb, (void *) &user_version, &err_msg);
+    if (rc != SQLITE_OK) {
+        info("Error checking the database version; %s", err_msg);
+        sqlite3_free(err_msg);
+    }
+
+    if (likely(user_version == target_version)) {
+        info("Metadata database version is %d", target_version);
+        return target_version;
+    }
+
+    info("Database version is %d, current version is %d. Running migration ...", user_version, target_version);
+    for (int i = user_version; migration_action[i].func && i < target_version; i++) {
+        rc = (migration_action[i].func)(database, migration_action[i].name);
+        if (unlikely(rc)) {
+            error_report("Database migration from version %d to version %d failed", i, i + 1);
+            return i;
+        }
+    }
+    return target_version;
+}

--- a/database/sqlite/sqlite_db_migration.h
+++ b/database/sqlite/sqlite_db_migration.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef NETDATA_SQLITE_DB_MIGRATION_H
+#define NETDATA_SQLITE_DB_MIGRATION_H
+
+#include "daemon/common.h"
+#include "sqlite3.h"
+
+
+int perform_database_migration(sqlite3 *database, int target_version);
+
+#endif //NETDATA_SQLITE_DB_MIGRATION_H


### PR DESCRIPTION

##### Summary
This PR adds an easy way to do metadata migration by checking the user_version recorded in the sqlite database
(set by using `PRAGMA user_version`)

It will then call a series of functions that need to perform the actions needed. 

The current version of the database schema is 1 (agents running older versions might have a version of 0). 
Version 0 and 1 are identical (additional tables added but existing tables have not been changed)

This PR will run dummy migration code (noop) from v0 to v1 (if needed) and it will simply set the user version to 1 just as the current agent does.

##### Test Plan
- Run the agent as usual, notice a `Metadata database version is 1` message as the agent starts in the error.log
- Stop the agent 
- Connect to the database via the sqlite CLI (eg `sqlite3 /var/cache/netdata/netdata-meta.db`) and execute
  `PRAGMA user_version=0;`
- Start the agent and notice 
  ```
  Database version is 0, current version is 1. Running migration ...
  Running database migration v0 to v1
  ```
