### PR TITLE
Add hostname in the worker structure to avoid constant lookups

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -624,6 +624,8 @@ void aclk_database_worker(void *arg)
                                 snprintfz(threadname, NETDATA_THREAD_NAME_MAX, "AS_%s", wc->host->hostname);
                                 uv_thread_set_name_np(wc->thread, threadname);
                                 wc->host->dbsync_worker = wc;
+                                if (unlikely(!wc->hostname))
+                                    wc->hostname = strdupz(wc->host->hostname);
                                 aclk_del_worker_thread(wc);
                                 wc->node_info_send = 1;
                             }
@@ -676,6 +678,7 @@ void aclk_database_worker(void *arg)
     rrd_rdlock();
     if (likely(wc->host))
         wc->host->dbsync_worker = NULL;
+    freez(wc->hostname);
     freez(wc);
     rrd_unlock();
 
@@ -745,13 +748,17 @@ void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id)
         return;
 
     struct aclk_database_worker_config *wc = callocz(1, sizeof(struct aclk_database_worker_config));
-    if (likely(host))
-        host->dbsync_worker = (void *) wc;
+    if (node_id && !uuid_is_null(*node_id))
+        uuid_unparse_lower(*node_id, wc->node_id);
+    if (likely(host)) {
+        host->dbsync_worker = (void *)wc;
+        wc->hostname = strdupz(host->hostname);
+    }
+    else
+        wc->hostname = get_hostname_by_node_id(wc->node_id);
     wc->host = host;
     strcpy(wc->uuid_str, uuid_str);
     strcpy(wc->host_guid, host_guid);
-    if (node_id && !uuid_is_null(*node_id))
-        uuid_unparse_lower(*node_id, wc->node_id);
     wc->chart_updates = 0;
     wc->alert_updates = 0;
     wc->retry_count = 0;

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -170,6 +170,7 @@ struct aclk_database_worker_config {
     char uuid_str[GUID_LEN + 1];
     char node_id[GUID_LEN + 1];
     char host_guid[GUID_LEN + 1];
+    char *hostname;                 // hostname to avoid constant lookups
     uint64_t chart_sequence_id;     // last chart_sequence_id
     time_t chart_timestamp;         // last chart timestamp
     time_t cleanup_after;           // Start a cleanup after this timestamp

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -437,33 +437,28 @@ void aclk_send_alarm_health_log(char *node_id)
     if (unlikely(!node_id))
         return;
 
-    char *hostname= NULL;
+    struct aclk_database_worker_config *wc = find_inactive_wc_by_node_id(node_id);
 
-    struct aclk_database_worker_config *wc  = NULL;
+    if (likely(!wc)) {
+        rrd_rdlock();
+        RRDHOST *host = find_host_by_node_id(node_id);
+        rrd_unlock();
+        if (likely(host))
+            wc = (struct aclk_database_worker_config *)host->dbsync_worker;
+    }
+
+    if (!wc) {
+        log_access("ACLK REQ [%s (N/A)]: HEALTH LOG REQUEST RECEIVED FOR INVALID NODE", node_id);
+        return;
+    }
+
+    log_access("ACLK REQ [%s (%s)]: HEALTH LOG REQUEST RECEIVED", node_id, wc->hostname ? wc->hostname : "N/A");
+
     struct aclk_database_cmd cmd;
     memset(&cmd, 0, sizeof(cmd));
     cmd.opcode = ACLK_DATABASE_ALARM_HEALTH_LOG;
 
-    rrd_rdlock();
-    RRDHOST *host = find_host_by_node_id(node_id);
-    if (likely(host)) {
-        wc = (struct aclk_database_worker_config *)host->dbsync_worker;
-        hostname = host->hostname;
-    }
-    else
-        hostname = get_hostname_by_node_id(node_id);
-    rrd_unlock();
-
-    log_access("ACLK REQ [%s (%s)]: HEALTH LOG request received", node_id, hostname ? hostname : "N/A");
-    if (unlikely(!host))
-        freez(hostname);
-
-    if (wc)
-        aclk_database_enq_cmd(wc, &cmd);
-    else {
-        if (aclk_worker_enq_cmd(node_id, &cmd))
-            log_access("ACLK STA [%s (N/A)]: ACLK synchronization thread is not active.", node_id);
-    }
+    aclk_database_enq_cmd(wc, &cmd);
     return;
 }
 
@@ -549,7 +544,7 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
     wc->alert_sequence_id = last_sequence;
 
     aclk_send_alarm_log_health(&alarm_log);
-    log_access("ACLK RES [%s (%s)]: HEALTH LOG SENT from %"PRIu64" to %"PRIu64, wc->node_id, wc->host ? wc->host->hostname : "N/A", first_sequence, last_sequence);
+    log_access("ACLK RES [%s (%s)]: HEALTH LOG SENT from %"PRIu64" to %"PRIu64, wc->node_id, wc->hostname ? wc->hostname : "N/A", first_sequence, last_sequence);
 
     rc = sqlite3_finalize(res);
     if (unlikely(rc != SQLITE_OK))

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1951,12 +1951,6 @@ char *get_hostname_by_node_id(char *node)
     char  *hostname = NULL;
     int rc;
 
-    rrd_rdlock();
-    RRDHOST *host = find_host_by_node_id(node);
-    rrd_unlock();
-    if (host)
-        return strdupz(host->hostname);
-
     if (unlikely(!db_meta)) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
             error_report("Database has not been initialized");


### PR DESCRIPTION
##### Summary
Adds the hostname in the worker structures to avoid constant lookups to map the node id to the hostname

##### Test Plan
- Agent should work as before
