### PR TITLE
Fix cgroups netdev chart labels

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -487,7 +487,7 @@ static inline void netdev_rename_cgroup(struct netdev *d, struct netdev_rename *
     snprintfz(buffer, RRD_ID_LENGTH_MAX, "net %s", r->container_device);
     d->chart_family = strdupz(buffer);
 
-    rrdlabels_migrate_to_these(d->chart_labels, r->chart_labels);
+    rrdlabels_copy(d->chart_labels, r->chart_labels);
 
     d->priority = NETDATA_CHART_PRIO_CGROUP_NET_IFACE;
     d->flipped = 1;


### PR DESCRIPTION
##### Summary
Network interface chart labels are replaced by cgroup labels. We need to keep the existing chart labels and add cgroup labels.

Fixes #13198

##### Test Plan
Run a docker container. Check if there is the type label in cgroup network interface charts.