### PR TITLE
Add user plugin dirs to environment

### DIFF
--- a/collectors/plugins.d/README.md
+++ b/collectors/plugins.d/README.md
@@ -151,7 +151,7 @@ available for the plugin to use.
 |`NETDATA_USER_CONFIG_DIR`|The directory where all Netdata-related user configuration should be stored. If the plugin requires custom user configuration, this is the place the user has saved it (normally under `/etc/netdata`).|
 |`NETDATA_STOCK_CONFIG_DIR`|The directory where all Netdata -related stock configuration should be stored. If the plugin is shipped with configuration files, this is the place they can be found (normally under `/usr/lib/netdata/conf.d`).|
 |`NETDATA_PLUGINS_DIR`|The directory where all Netdata plugins are stored.|
-|`NETDATA_USER_PLUGINS_DIR`|The list of directories where custom plugins are stored.|
+|`NETDATA_USER_PLUGINS_DIRS`|The list of directories where custom plugins are stored.|
 |`NETDATA_WEB_DIR`|The directory where the web files of Netdata are saved.|
 |`NETDATA_CACHE_DIR`|The directory where the cache files of Netdata are stored. Use this directory if the plugin requires a place to store data. A new directory should be created for the plugin for this purpose, inside this directory.|
 |`NETDATA_LOG_DIR`|The directory where the log files are stored. By default the `stderr` output of the plugin will be saved in the `error.log` file of Netdata.|

--- a/collectors/plugins.d/README.md
+++ b/collectors/plugins.d/README.md
@@ -151,6 +151,7 @@ available for the plugin to use.
 |`NETDATA_USER_CONFIG_DIR`|The directory where all Netdata-related user configuration should be stored. If the plugin requires custom user configuration, this is the place the user has saved it (normally under `/etc/netdata`).|
 |`NETDATA_STOCK_CONFIG_DIR`|The directory where all Netdata -related stock configuration should be stored. If the plugin is shipped with configuration files, this is the place they can be found (normally under `/usr/lib/netdata/conf.d`).|
 |`NETDATA_PLUGINS_DIR`|The directory where all Netdata plugins are stored.|
+|`NETDATA_USER_PLUGINS_DIR`|The list of directories where custom plugins are stored.|
 |`NETDATA_WEB_DIR`|The directory where the web files of Netdata are saved.|
 |`NETDATA_CACHE_DIR`|The directory where the cache files of Netdata are stored. Use this directory if the plugin requires a place to store data. A new directory should be created for the plugin for this purpose, inside this directory.|
 |`NETDATA_LOG_DIR`|The directory where the log files are stored. By default the `stderr` output of the plugin will be saved in the `error.log` file of Netdata.|

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -848,25 +848,17 @@ void set_global_environment()
     setenv("NETDATA_HOST_PREFIX", netdata_configured_host_prefix, 1);
 
     {
-        size_t len = 0;
+        BUFFER *user_plugin_dirs = buffer_create(FILENAME_MAX);
 
         for (size_t i = 1; i < PLUGINSD_MAX_DIRECTORIES && plugin_directories[i]; i++) {
             if (i > 1)
-                len++;
-            len += strlen(plugin_directories[i]);
+                buffer_strcat(user_plugin_dirs, " ");
+            buffer_strcat(user_plugin_dirs, plugin_directories[i]);
         }
 
-        char *user_plugins_dir = callocz(1, len + 1);
+        setenv("NETDATA_USER_PLUGINS_DIR", buffer_tostring(user_plugin_dirs), 1);
 
-        for (size_t i = 1; i < PLUGINSD_MAX_DIRECTORIES && plugin_directories[i]; i++) {
-            if (i > 1)
-                strcat(user_plugins_dir, " ");
-            strcat(user_plugins_dir, plugin_directories[i]);
-        }
-
-        setenv("NETDATA_USER_PLUGINS_DIR", user_plugins_dir, 1);
-
-        freez(user_plugins_dir);
+        buffer_free(user_plugin_dirs);
     }
 
     analytics_data.data_length = 0;

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -848,17 +848,17 @@ void set_global_environment()
     setenv("NETDATA_HOST_PREFIX", netdata_configured_host_prefix, 1);
 
     {
-        BUFFER *user_plugin_dirs = buffer_create(FILENAME_MAX);
+        BUFFER *user_plugins_dirs = buffer_create(FILENAME_MAX);
 
         for (size_t i = 1; i < PLUGINSD_MAX_DIRECTORIES && plugin_directories[i]; i++) {
             if (i > 1)
-                buffer_strcat(user_plugin_dirs, " ");
-            buffer_strcat(user_plugin_dirs, plugin_directories[i]);
+                buffer_strcat(user_plugins_dirs, " ");
+            buffer_strcat(user_plugins_dirs, plugin_directories[i]);
         }
 
-        setenv("NETDATA_USER_PLUGINS_DIR", buffer_tostring(user_plugin_dirs), 1);
+        setenv("NETDATA_USER_PLUGINS_DIRS", buffer_tostring(user_plugins_dirs), 1);
 
-        buffer_free(user_plugin_dirs);
+        buffer_free(user_plugins_dirs);
     }
 
     analytics_data.data_length = 0;

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -847,6 +847,28 @@ void set_global_environment()
     setenv("HOME", verify_required_directory(netdata_configured_home_dir), 1);
     setenv("NETDATA_HOST_PREFIX", netdata_configured_host_prefix, 1);
 
+    {
+        size_t len = 0;
+
+        for (size_t i = 1; i < PLUGINSD_MAX_DIRECTORIES && plugin_directories[i]; i++) {
+            if (i > 1)
+                len++;
+            len += strlen(plugin_directories[i]);
+        }
+
+        char *user_plugins_dir = callocz(1, len + 1);
+
+        for (size_t i = 1; i < PLUGINSD_MAX_DIRECTORIES && plugin_directories[i]; i++) {
+            if (i > 1)
+                strcat(user_plugins_dir, " ");
+            strcat(user_plugins_dir, plugin_directories[i]);
+        }
+
+        setenv("NETDATA_USER_PLUGINS_DIR", user_plugins_dir, 1);
+
+        freez(user_plugins_dir);
+    }
+
     analytics_data.data_length = 0;
     analytics_set_data(&analytics_data.netdata_config_stream_enabled, "null");
     analytics_set_data(&analytics_data.netdata_config_memory_mode, "null");


### PR DESCRIPTION
##### Summary
We will expose the list of custom plugin directories as an environment variable.

Closes #13201

##### Test Plan
Run a custom plugin that reads the `NETDATA_USER_PLUGINS_DIR` environment variable. It should provide the list of directories (except the first one) configured using the `plugins` option in the `[directories]` section of `netdata.conf`.
```python
import os
self.info("NETDATA_USER_PLUGINS_DIR = ", os.environ['NETDATA_USER_PLUGINS_DIR'])
```