### PR TITLE
Don’t use realpath to find kickstart source path.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -16,7 +16,16 @@ DISCUSSIONS_URL="https://github.com/netdata/netdata/discussions"
 DOCS_URL="https://learn.netdata.cloud/docs/"
 FORUM_URL="https://community.netdata.cloud/"
 KICKSTART_OPTIONS="${*}"
-KICKSTART_SOURCE="$(realpath "$0")"
+KICKSTART_SOURCE="$(
+    self=${0}
+    while [ -L "${self}" ]
+    do
+        cd "${self%/*}" || exit 1
+        self=$(readlink "${self}")
+    done
+    cd "${self%/*}" || exit 1
+    echo "$(pwd -P)/${self##*/}"
+)"
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
 PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 PUBLIC_CLOUD_URL="https://app.netdata.cloud"


### PR DESCRIPTION
##### Summary

It doesn’t work on macOS and leads to a bogus error message being printed.

The replacement code is POSIX-compliant other than requiring a usable `readlink` command (which is present on all platforms we care about). 

##### Test Plan

Running the kickstart script on macOS no longer produces a line reading `/tmp/netdata-kickstart.sh: line 19: realpath: command not found` at the top of the output.

##### Additional Information

Discovered in https://github.com/netdata/netdata/issues/13185