### PR TITLE
Properly handle interactivity in the updater code.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -696,11 +696,17 @@ update() {
       return 0
     fi
 
+    if [ "${INTERACTIVE}" -eq 0 ]; then
+        opts="--non-interactive"
+    else
+        opts="--interactive"
+    fi
+
     export NETDATA_SAVE_WARNINGS=1
     export NETDATA_PROPAGATE_WARNINGS=1
     # shellcheck disable=SC2090
     export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
-    if run ${ROOTCMD} "${updater}" --not-running-from-cron; then
+    if run ${ROOTCMD} "${updater}" ${opts} --not-running-from-cron; then
       progress "Updated existing install at ${ndprefix}"
       return 0
     else

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -848,6 +848,8 @@ while [ -n "${1}" ]; do
     --not-running-from-cron) NETDATA_NOT_RUNNING_FROM_CRON=1 ;;
     --no-updater-self-update) NETDATA_NO_UPDATER_SELF_UPDATE=1 ;;
     --force-update) NETDATA_FORCE_UPDATE=1 ;;
+    --non-interactive) INTERACTIVE=0 ;;
+    --interactive) INTERACTIVE=1 ;;
     --tmpdir-path)
         NETDATA_TMPDIR_PATH="${2}"
         shift 1

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -28,7 +28,7 @@
 # Author: Pavlos Emm. Katsoulakis <paul@netdata.cloud>
 # Author: Austin S. Hemmelgarn <austin@netdata.cloud>
 
-# Next unused error code: U001A
+# Next unused error code: U001B
 
 set -e
 
@@ -844,27 +844,28 @@ if [ -r "$(dirname "${ENVIRONMENT_FILE}")/.install-type" ]; then
 fi
 
 while [ -n "${1}" ]; do
-  if [ "${1}" = "--not-running-from-cron" ]; then
-    NETDATA_NOT_RUNNING_FROM_CRON=1
-    shift 1
-  elif [ "${1}" = "--no-updater-self-update" ]; then
-    NETDATA_NO_UPDATER_SELF_UPDATE=1
-    shift 1
-  elif [ "${1}" = "--force-update" ]; then
-    NETDATA_FORCE_UPDATE=1
-    shift 1
-  elif [ "${1}" = "--tmpdir-path" ]; then
-    NETDATA_TMPDIR_PATH="${2}"
-    shift 2
-  elif [ "${1}" = "--enable-auto-updates" ]; then
-    enable_netdata_updater "${2}"
-    exit $?
-  elif [ "${1}" = "--disable-auto-updates" ]; then
-    disable_netdata_updater
-    exit $?
-  else
-    break
-  fi
+  case "${1}" in
+    --not-running-from-cron) NETDATA_NOT_RUNNING_FROM_CRON=1 ;;
+    --no-updater-self-update) NETDATA_NO_UPDATER_SELF_UPDATE=1 ;;
+    --force-update) NETDATA_FORCE_UPDATE=1 ;;
+    --tmpdir-path)
+        NETDATA_TMPDIR_PATH="${2}"
+        shift 1
+        ;;
+    --enable-auto-updates)
+        enable_netdata_updater "${2}"
+        exit $?
+        ;;
+    --disable-auto-updates)
+        disable_netdata_updater
+        exit $?
+        ;;
+    *)
+        fatal "Unrecognized option ${1}" U001A
+        ;;
+  esac
+
+  shift 1
 done
 
 # Random sleep to alleviate stampede effect of Agents upgrading


### PR DESCRIPTION
##### Summary

This adds options to override the default interactivity of the updater code, and leverages those to pass the interactivity of the kickstart script through to the updater when it is invoked from the kickstart script.

It also tidies up the option parsing code in the updater so that it’s easier to maintain going forwards.

##### Test Plan

Verify that the new `--non-interactive` option does not result in any prompting in the updater when run manually from a terminal.

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/13071