### PR TITLE
ci: add issues to the Agent Board project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,6 +4,7 @@ on:
   issues:
     types:
       - opened
+      - transferred
 
 jobs:
   add-to-project:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add issues to Agent Board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.0.5
+        with:
+          project-url: https://github.com/orgs/netdata/projects/32
+          github-token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}


### PR DESCRIPTION
##### Summary

This PR adds [actions/add-to-project](https://github.com/actions/add-to-project#usage) GHA to automatically add all new **issues** to the [Agent Board](https://github.com/orgs/netdata/projects/32) project.

> **Note** the GHA supports adding PRs to projects too. This PR enables the GHA only for issues.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
