### PR TITLE
Add more sqlite unittests

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1532,8 +1532,66 @@ int test_sqlite(void) {
         fprintf(stderr,"Failed to test SQLite: Update with LIMIT failed\n");
         return 1;
     }
+
+    BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE);
+    char *uuid_str = "0000_000";
+
+    buffer_sprintf(sql, TABLE_ACLK_CHART, uuid_str);
+    rc = sqlite3_exec(db_meta, buffer_tostring(sql), 0, 0, NULL);
+    buffer_flush(sql);
+    if (rc != SQLITE_OK)
+        goto error;
+
+    buffer_sprintf(sql, TABLE_ACLK_CHART_PAYLOAD, uuid_str);
+    rc = sqlite3_exec(db_meta, buffer_tostring(sql), 0, 0, NULL);
+    buffer_flush(sql);
+    if (rc != SQLITE_OK)
+        goto error;
+
+    buffer_sprintf(sql, TABLE_ACLK_CHART_LATEST, uuid_str);
+    rc = sqlite3_exec(db_meta, buffer_tostring(sql), 0, 0, NULL);
+    if (rc != SQLITE_OK)
+        goto error;
+    buffer_flush(sql);
+
+    buffer_sprintf(sql, INDEX_ACLK_CHART, uuid_str, uuid_str);
+    rc = sqlite3_exec(db_meta, buffer_tostring(sql), 0, 0, NULL);
+    if (rc != SQLITE_OK)
+        goto error;
+    buffer_flush(sql);
+
+    buffer_sprintf(sql, INDEX_ACLK_CHART_LATEST, uuid_str, uuid_str);
+    rc = sqlite3_exec(db_meta, buffer_tostring(sql), 0, 0, NULL);
+    if (rc != SQLITE_OK)
+        goto error;
+    buffer_flush(sql);
+
+    buffer_sprintf(sql, TRIGGER_ACLK_CHART_PAYLOAD, uuid_str, uuid_str, uuid_str);
+    rc = sqlite3_exec(db_meta, buffer_tostring(sql), 0, 0, NULL);
+    if (rc != SQLITE_OK)
+        goto error;
+    buffer_flush(sql);
+
+    buffer_sprintf(sql, TABLE_ACLK_ALERT, uuid_str);
+    rc = sqlite3_exec(db_meta, buffer_tostring(sql), 0, 0, NULL);
+    if (rc != SQLITE_OK)
+        goto error;
+    buffer_flush(sql);
+
+    buffer_sprintf(sql, INDEX_ACLK_ALERT, uuid_str, uuid_str);
+    rc = sqlite3_exec(db_meta, buffer_tostring(sql), 0, 0, NULL);
+    if (rc != SQLITE_OK)
+        goto error;
+    buffer_flush(sql);
+
+    buffer_free(sql);
     fprintf(stderr,"SQLite is OK\n");
     return 0;
+error:
+    fprintf(stderr,"SQLite statement failed: %s\n", buffer_tostring(sql));
+    buffer_free(sql);
+    fprintf(stderr,"SQLite tests failed\n");
+    return 1;
 }
 
 


### PR DESCRIPTION
##### Summary
This adds additional unit tests for sqlite to check that nothing breaks with certain SQL statements (especially when we update the sqlite version)

##### Test Plan
- Run unittests with `netdata -W unittest`
