### PR TITLE
Migrate data when machine GUID changes

### DIFF
--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -30,7 +30,7 @@ PARSER_RC metalog_pluginsd_host_action(
     }
 
     if (likely(!uuid_parse(machine_guid, state->host_uuid))) {
-        int rc = sql_store_host(&state->host_uuid, hostname, registry_hostname, update_every, os, timezone, tags);
+        int rc = sql_store_host(&state->host_uuid, hostname, registry_hostname, update_every, os, timezone, tags, 1);
         if (unlikely(rc)) {
             errno = 0;
             error("Failed to store host %s with UUID %s in the database", hostname, machine_guid);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -308,7 +308,8 @@ RRDHOST *rrdhost_create(const char *hostname,
     }
 
     if (likely(!uuid_parse(host->machine_guid, host->host_uuid))) {
-        int rc = sql_store_host(&host->host_uuid, hostname, registry_hostname, update_every, os, timezone, tags);
+        int rc = sql_store_host(&host->host_uuid, hostname, registry_hostname, update_every, os, timezone, tags,
+                                host->system_info->hops);
         if (unlikely(rc))
             error_report("Failed to store machine GUID to the database");
         sql_load_node_id(host);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -760,6 +760,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         fatal("Failed to initialize dbengine");
     }
 #endif
+    migrate_localhost(&localhost->host_uuid);
     sql_aclk_sync_init();
     rrd_unlock();
 

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -29,6 +29,23 @@ static int column_exists_in_table(const char *table, const char *column)
     return exists;
 }
 
+const char *database_migrate_v1_v2[] = {
+    "ALTER TABLE host ADD hops INTEGER;",
+    NULL
+};
+
+static int do_migration_v1_v2(sqlite3 *database, const char *name)
+{
+    UNUSED(database);
+    UNUSED(name);
+    info("Running database migration %s", name);
+
+    if (!column_exists_in_table("host", "hops"))
+        return init_database_batch(DB_CHECK_NONE, 0, &database_migrate_v1_v2[0]);
+    return 0;
+}
+
+
 static int do_migration_noop(sqlite3 *database, const char *name)
 {
     UNUSED(database);
@@ -42,6 +59,7 @@ static struct database_func_migration_list {
     int (*func)(sqlite3 *database, const char *name);
 } migration_action[] = {
     {.name = "v0 to v1",  .func = do_migration_noop},
+    {.name = "v1 to v2",  .func = do_migration_v1_v2},
     // the terminator of this array
     {.name = NULL, .func = NULL}
 };

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -47,21 +47,12 @@ static struct database_func_migration_list {
 };
 
 
-static int perform_database_migration_cb(void *data, int argc, char **argv, char **column)
-{
-    int *status = data;
-    UNUSED(argc);
-    UNUSED(column);
-    *status = str2uint32_t(argv[0]);
-    return 0;
-}
-
 int perform_database_migration(sqlite3 *database, int target_version)
 {
     int user_version = 0;
     char *err_msg = NULL;
 
-    int rc = sqlite3_exec(database, "PRAGMA user_version;", perform_database_migration_cb, (void *) &user_version, &err_msg);
+    int rc = sqlite3_exec(database, "PRAGMA user_version;", return_int_cb, (void *) &user_version, &err_msg);
     if (rc != SQLITE_OK) {
         info("Error checking the database version; %s", err_msg);
         sqlite3_free(err_msg);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -7,7 +7,7 @@
 
 const char *database_config[] = {
     "CREATE TABLE IF NOT EXISTS host(host_id blob PRIMARY KEY, hostname text, "
-    "registry_hostname text, update_every int, os text, timezone text, tags text);",
+    "registry_hostname text, update_every int, os text, timezone text, tags text, hops INT);",
     "CREATE TABLE IF NOT EXISTS chart(chart_id blob PRIMARY KEY, host_id blob, type text, id text, name text, "
     "family text, context text, title text, unit text, plugin text, module text, priority int, update_every int, "
     "chart_type int, memory_mode int, history_entries);",

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -735,7 +735,7 @@ uuid_t *create_chart_uuid(RRDSET *st, const char *id, const char *name)
 
 int sql_store_host(
     uuid_t *host_uuid, const char *hostname, const char *registry_hostname, int update_every, const char *os,
-    const char *tzone, const char *tags)
+    const char *tzone, const char *tags, int hops)
 {
     static __thread sqlite3_stmt *res = NULL;
     int rc;
@@ -780,6 +780,10 @@ int sql_store_host(
         goto bind_fail;
 
     rc = sqlite3_bind_text(res, 7, tags, -1, SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK))
+        goto bind_fail;
+
+    rc = sqlite3_bind_int(res, 8, hops);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -345,7 +345,7 @@ static int attempt_database_fix()
     return sql_init_database(DB_CHECK_FIX_DB | DB_CHECK_CONT, 0);
 }
 
-static int init_database_batch(int rebuild, int init_type, const char *batch[])
+int init_database_batch(int rebuild, int init_type, const char *batch[])
 {
     int rc;
     char *err_msg = NULL;

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -437,7 +437,10 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
     char buf[1024 + 1] = "";
     const char *list[2] = { buf, NULL };
 
-    int target_version = perform_database_migration(db_meta, DB_METADATA_VERSION);
+    int target_version = DB_METADATA_VERSION;
+
+    if (likely(!memory))
+        target_version = perform_database_migration(db_meta, DB_METADATA_VERSION);
 
     // https://www.sqlite.org/pragma.html#pragma_auto_vacuum
     // PRAGMA schema.auto_vacuum = 0 | NONE | 1 | FULL | 2 | INCREMENTAL;

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -27,7 +27,8 @@ typedef enum db_check_action_type {
 #define SQL_MAX_RETRY (100)
 #define SQLITE_INSERT_DELAY (50)        // Insert delay in case of lock
 
-#define SQL_STORE_HOST "insert or replace into host (host_id,hostname,registry_hostname,update_every,os,timezone,tags) values (?1,?2,?3,?4,?5,?6,?7);"
+#define SQL_STORE_HOST "insert or replace into host (host_id,hostname,registry_hostname,update_every,os,timezone,tags, hops) " \
+        "values (?1,?2,?3,?4,?5,?6,?7,?8);"
 
 #define SQL_STORE_CHART "insert or replace into chart (chart_id, host_id, type, id, " \
     "name, family, context, title, unit, plugin, module, priority, update_every , chart_type , memory_mode , " \
@@ -60,7 +61,8 @@ typedef enum db_check_action_type {
 extern int sql_init_database(db_check_action_type_t rebuild, int memory);
 extern void sql_close_database(void);
 
-extern int sql_store_host(uuid_t *guid, const char *hostname, const char *registry_hostname, int update_every, const char *os, const char *timezone, const char *tags);
+extern int sql_store_host(uuid_t *guid, const char *hostname, const char *registry_hostname, int update_every, const char *os,
+                          const char *timezone, const char *tags, int hops);
 extern int sql_store_chart(
     uuid_t *chart_uuid, uuid_t *host_uuid, const char *type, const char *id, const char *name, const char *family,
     const char *context, const char *title, const char *units, const char *plugin, const char *module, long priority,

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -105,4 +105,5 @@ extern int sql_set_dimension_option(uuid_t *dim_uuid, char *option);
 char *get_hostname_by_node_id(char *node_id);
 void free_temporary_host(RRDHOST *host);
 int init_database_batch(int rebuild, int init_type, const char *batch[]);
+void migrate_localhost(uuid_t *host_uuid);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -104,4 +104,5 @@ extern void compute_chart_hash(RRDSET *st);
 extern int sql_set_dimension_option(uuid_t *dim_uuid, char *option);
 char *get_hostname_by_node_id(char *node_id);
 void free_temporary_host(RRDHOST *host);
+int init_database_batch(int rebuild, int init_type, const char *batch[]);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
When the machine GUID of an agent changes, a new entry is created in the host table and node_instance table. This causes a second registration to the cloud. This new instance is marked with `live=false` causing confusion. 

This PR adds functionality to detect a machine GUID change and migrate all the data from the old machine guid to the new one. It will clean up the host and node instance tables and update the chart table with the new host machine UUID


##### Test Plan
- Setup agent / claim to the cloud
- Start agent, view cloud dashboard
- Stop agent and change the agent machine GUID
- Restart the agent

Fixes #12890