### PR TITLE
Delay health until obsoletions check is complete

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1398,7 +1398,7 @@ void rrd_cleanup_obsolete_charts()
         if (host != localhost &&
             host->trigger_chart_obsoletion_check &&
             host->senders_last_chart_command &&
-            host->senders_last_chart_command + 120 < now_realtime_sec()) {
+            host->senders_last_chart_command + host->health_delay_up_to < now_realtime_sec()) {
             rrdhost_rdlock(host);
             rrdset_check_obsoletion(host);
             rrdhost_unlock(host);

--- a/health/health.c
+++ b/health/health.c
@@ -787,6 +787,11 @@ void *health_main(void *ptr) {
                 host->health_delay_up_to = 0;
             }
 
+            //wait unitl cleanup of obsolete charts on children is complete
+            if (host != localhost)
+                if (unlikely(host->trigger_chart_obsoletion_check == 1))
+                    continue;
+
             if(likely(!host->health_log_fp) && (loop == 1 || loop % cleanup_sql_every_loop == 0))
                 sql_health_alarm_log_cleanup(host);
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR delays starting of health for children until the chart obsoletion check is completed.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
