### PR TITLE
Fix existing install detection for FreeBSD and macOS.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -807,7 +807,10 @@ detect_existing_install() {
     fi
 
     if [ -n "${ndpath}" ]; then
-      ndprefix="$(dirname "$(dirname "${ndpath}")")"
+      case "${ndpath}" in
+        */usr/bin/netdata|*/usr/sbin/netdata) ndprefix="$(dirname "$(dirname "$(dirname "${ndpath}")")")" ;;
+        *) ndprefix="$(dirname "$(dirname "${ndpath}")")" ;;
+      esac
     fi
 
     if echo "${ndprefix}" | grep -Eq '^/usr$'; then


### PR DESCRIPTION
##### Summary

Due to issues relating to https://github.com/netdata/netdata/issues/13242, install type detection for existing installs is broken on some systems. This fixes things so that the detection works correctly on such systems without needing to fix the root cause.

##### Test Plan

This can be tested by running the kickstart.sh script on a FreeBSD or macOS system that has an existing install of the agent created by running the kickstart script.

Using the kickstart script in the master branch, this will throw an error due to not being able to identify the install type.

Using the kickstart script from this PR, it will correctly detect the install type and proceed normally.

##### Additional Information

Relevant to (but does not completely fix): https://github.com/netdata/netdata/issues/13230

<details> <summary>For users: How does this change affect me?</summary>
Using the kickstart script to update or claim existing installs on FreeBSD and macOS systems will now work correctly.
</details>
