### PR TITLE
Don’t pull in GCC for build if Clang is already present.

### DIFF
--- a/packaging/installer/dependencies/freebsd.sh
+++ b/packaging/installer/dependencies/freebsd.sh
@@ -9,7 +9,6 @@ DONT_WAIT=0
 
 package_tree="
   git
-  gcc
   autoconf
   autoconf-archive
   autogen

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1341,9 +1341,9 @@ packages() {
   require_cmd git || suitable_package git
   require_cmd find || suitable_package find
 
-  require_cmd gcc ||
+  require_cmd gcc || require_cmd clang ||
     require_cmd gcc-multilib || suitable_package gcc
-  require_cmd g++ || suitable_package gxx
+  require_cmd g++ || require_cmd clang++ || suitable_package gxx
 
   require_cmd make || suitable_package make
   require_cmd autoconf || suitable_package autoconf


### PR DESCRIPTION
##### Summary

This relaxes our dependency handling for local builds to not install GCC if we see an existing install of Clang. We don’t actually have any issues building with Clang, so we should just use it if it’s present.

This will have the biggest impact for FreeBSD users, who will no longer need GCC installed to install Netdata.

##### Test Plan

Testable by verifying whether the `install-required-pkgs.sh` script tries to install GCC on a system that has Clang installed already.

##### Additional Information

Relevant to (but does not completely fix): https://github.com/netdata/netdata/issues/13230

<details> <summary>For users: How does this change affect me?</summary>
Once this is merged, users will be able to install on FreeBSD without GCC being installed.
</details>
