### PR TITLE
Fix issues with DEB postinstall script.

### DIFF
--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -16,7 +16,7 @@ dpkg-maintscript-helper dir_to_symlink \
   /var/lib/netdata/www/static /usr/share/netdata/www/static 1.18.1~ netdata -- "$@"
 
 case "$1" in
-  configure)
+  configure|recnfigure)
     if [ -z "$2" ]; then
       if ! getent group netdata > /dev/null; then
         addgroup --quiet --system netdata

--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -17,41 +17,38 @@ dpkg-maintscript-helper dir_to_symlink \
 
 case "$1" in
   configure|recnfigure)
-    if [ -z "$2" ]; then
-      if ! getent group netdata > /dev/null; then
-        addgroup --quiet --system netdata
+    if ! getent group netdata > /dev/null; then
+      addgroup --quiet --system netdata
+    fi
+
+    if ! getent passwd netdata > /dev/null; then
+      adduser --quiet --system --ingroup netdata --home /var/lib/netdata --no-create-home netdata
+    fi
+
+    for item in docker nginx varnish haproxy adm nsd proxy squid ceph nobody I2C; do
+      if getent group $item > /dev/null 2>&1; then
+        usermod -a -G $item netdata
       fi
+    done
 
-      if ! getent passwd netdata > /dev/null; then
-        adduser --quiet --system --ingroup netdata --home /var/lib/netdata --no-create-home netdata
-      fi
+    if ! dpkg-statoverride --list /var/lib/netdata > /dev/null 2>&1; then
+      dpkg-statoverride --update --add netdata netdata 0755 /var/lib/netdata
+    fi
 
-      for item in docker nginx varnish haproxy adm nsd proxy squid ceph nobody I2C; do
-        if getent group $item > /dev/null 2>&1; then
-          usermod -a -G $item netdata
-        fi
-      done
+    if ! dpkg-statoverride --list /var/lib/netdata/www > /dev/null 2>&1; then
+      dpkg-statoverride --update --add root netdata 0755 /var/lib/netdata/www
+    fi
 
-      if ! dpkg-statoverride --list /var/lib/netdata > /dev/null 2>&1; then
-        dpkg-statoverride --update --add netdata netdata 0755 /var/lib/netdata
-      fi
+    if ! dpkg-statoverride --list /var/cache/netdata > /dev/null 2>&1; then
+      dpkg-statoverride --update --add netdata netdata 0755 /var/cache/netdata
+    fi
 
-      if ! dpkg-statoverride --list /var/lib/netdata/www > /dev/null 2>&1; then
-        dpkg-statoverride --update --add root netdata 0755 /var/lib/netdata/www
-      fi
+    if ! dpkg-statoverride --list /var/run/netdata > /dev/null 2>&1; then
+      dpkg-statoverride --update --add netdata netdata 0755 /var/run/netdata
+    fi
 
-      if ! dpkg-statoverride --list /var/cache/netdata > /dev/null 2>&1; then
-        dpkg-statoverride --update --add netdata netdata 0755 /var/cache/netdata
-      fi
-
-      if ! dpkg-statoverride --list /var/run/netdata > /dev/null 2>&1; then
-        dpkg-statoverride --update --add netdata netdata 0755 /var/run/netdata
-      fi
-
-      if ! dpkg-statoverride --list /var/log/netdata > /dev/null 2>&1; then
-        dpkg-statoverride --update --add netdata adm 02750 /var/log/netdata
-      fi
-
+    if ! dpkg-statoverride --list /var/log/netdata > /dev/null 2>&1; then
+      dpkg-statoverride --update --add netdata adm 02750 /var/log/netdata
     fi
 
     dpkg-statoverride --force --update --add root netdata 0775 /var/lib/netdata/registry > /dev/null 2>&1

--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -59,7 +59,12 @@ case "$1" in
     chown -R root:netdata /usr/libexec/netdata/plugins.d
     setcap cap_dac_read_search,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin
     setcap cap_dac_read_search+ep /usr/libexec/netdata/plugins.d/slabinfo.plugin
-    capsh --supports=cap_perfmon 2>/dev/null && setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin || setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin
+
+    if capsh --supports=cap_perfmon 2>/dev/null; then
+        setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin
+    else
+        setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin
+    fi
 
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network
     chmod 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin


### PR DESCRIPTION
##### Summary

- Run configuration for both configure _and_ reconfigure hooks. This allows users to run `dpkg-reconfigure netdata` to fix any issues with group membership and/or file permissions.
- Use a proper if/then/else construct for handling the file capabilities for the perf plugin. This ensures we get the behavior we want, and should also get rid of the warnings we see on install/update on some systems.
- Run all configuration regardless of whether the configuration hook is happening as part of an install or an upgrade. This ensures that changes we make to configuration always get applied. See [the deb-postinst manpage](https://man7.org/linux/man-pages/man5/deb-postinst.5.html) for info on why the ommit for this particular change works.

##### Test Plan

1. Build a package from this PR.
2. In the test environment, install an older version of Netdata (such as a nightly from at least a couple of weeks ago).
3. Pass the package from step 1 directly to APT to upgrade Netdata to the version in the package.
4. Confirm that the `netdata` user is in all the supplementary groups it is supposed to be in.

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/13247