### PR TITLE
Remove warnings while compiling ML on FreeBSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -260,7 +260,7 @@ ML_FILES += \
     $(NULL)
 
 # Disable warnings from dlib library
-ml/kmeans/dlib/dlib/all/source.$(OBJEXT) : CXXFLAGS += -Wno-sign-compare -Wno-type-limits
+ml/kmeans/dlib/dlib/all/source.$(OBJEXT) : CXXFLAGS += -Wno-sign-compare -Wno-type-limits -Wno-aggressive-loop-optimizations
 
 endif
 


### PR DESCRIPTION
##### Summary
This PR is removing the following warnings when we compile Netdata on FreeBSD:

```sh
[/home/thiago/Netdata/netdata]# gmake -j2 
In file included from ml/kmeans/dlib/dlib/all/../dnn/../matrix.h:11,
                 from ml/kmeans/dlib/dlib/all/../dnn/tensor.h:8,
                 from ml/kmeans/dlib/dlib/all/../dnn/cpu_dlib.h:9,
                 from ml/kmeans/dlib/dlib/all/../dnn/cpu_dlib.cpp:8,
                 from ml/kmeans/dlib/dlib/all/source.cpp:82:
ml/kmeans/dlib/dlib/all/../dnn/../matrix/matrix_la.h: In function 'long int dlib::svd4(dlib::svd_u_mode, bool, const dlib::matrix_exp<EXP>&, dlib::matrix<typename EXP::type, uM, uN, MM1, L1>&, dlib::matrix<typename EXP::type, qN, qX, MM2, L1>&, dlib::matrix<typename EXP::type, vM, vN, MM3, L1>&) [with EXP = dlib::matrix_op<dlib::op_trans<dlib::matrix_op<dlib::op_trans<dlib::matrix<double, 1, 2> > > > >; long int qN = 1; long int qX = 1; long int uM = 1; long int uN = 1; long int vM = 2; long int vN = 1; MM1 = dlib::memory_manager_stateless_kernel_1<char>; MM2 = dlib::memory_manager_stateless_kernel_1<char>; MM3 = dlib::memory_manager_stateless_kernel_1<char>; L1 = dlib::row_major_layout]':
ml/kmeans/dlib/dlib/all/../dnn/../matrix/matrix_la.h:225:32: warning: iteration 1 invokes undefined behavior [-Waggressive-loop-optimizations]
  225 |             y = abs(q(i)) + abs(e(i));
      |                             ~~~^~~~~~
ml/kmeans/dlib/dlib/all/../dnn/../matrix/matrix_la.h:163:20: note: within this loop
  163 |         for (i=0; i<n; i++)
      |                   ~^~
 OK 
```

##### Test Plan

1. Compile master branch on FreeBSD (probably MacOS) and you will have the specified warning.
2. Now clone this PR on FreeBSD environment and compile it, you should not have any warning.
3. Run `netdata` during few minutes and verify that ML is working as expected.

##### Additional Information
This PR was compiled on:

| OS | Does ML work? |
|------|----------------------|
|FreeBSD  13.1-RELEASE-p0| yes |
|Slackware current | yes |
| CentOS 7.x | yes |

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Installation script
- Can they see the change or is it an under the hood? If they can see it, where? When compile netdata on FreeBSD warning won't be present
- How is the user impacted by the change?  It hides unnecessary warning.
- What are there any benefits of the change?  Users could have the wrong impression that ML is not working.
</details>
