### PR TITLE
Ebpf issues

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -231,8 +231,6 @@ static void ebpf_exit(int sig)
 
     if (ebpf_modules[EBPF_MODULE_DCSTAT_IDX].enabled) {
         ebpf_modules[EBPF_MODULE_DCSTAT_IDX].enabled = 0;
-        clean_dcstat_pid_structures();
-        freez(dcstat_pid);
     }
 
     if (ebpf_modules[EBPF_MODULE_SWAP_IDX].enabled) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -219,34 +219,6 @@ static void ebpf_exit(int sig)
         return;
     }
 
-    if (ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled) {
-        ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled = 0;
-    }
-
-    if (ebpf_modules[EBPF_MODULE_CACHESTAT_IDX].enabled) {
-        ebpf_modules[EBPF_MODULE_CACHESTAT_IDX].enabled = 0;
-    }
-
-    if (ebpf_modules[EBPF_MODULE_DCSTAT_IDX].enabled) {
-        ebpf_modules[EBPF_MODULE_DCSTAT_IDX].enabled = 0;
-    }
-
-    if (ebpf_modules[EBPF_MODULE_SWAP_IDX].enabled) {
-        ebpf_modules[EBPF_MODULE_SWAP_IDX].enabled = 0;
-    }
-
-    if (ebpf_modules[EBPF_MODULE_VFS_IDX].enabled) {
-        ebpf_modules[EBPF_MODULE_VFS_IDX].enabled = 0;
-    }
-
-    if (ebpf_modules[EBPF_MODULE_FD_IDX].enabled) {
-        ebpf_modules[EBPF_MODULE_FD_IDX].enabled = 0;
-    }
-
-    if (ebpf_modules[EBPF_MODULE_SHM_IDX].enabled) {
-        ebpf_modules[EBPF_MODULE_SHM_IDX].enabled = 0;
-    }
-
     ebpf_close_cgroup_shm();
 
     ebpf_clean_cgroup_pids();

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -221,7 +221,6 @@ static void ebpf_exit(int sig)
 
     ebpf_close_cgroup_shm();
 
-    ebpf_clean_cgroup_pids();
     /*
     int ret = fork();
     if (ret < 0) // error

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -247,8 +247,6 @@ static void ebpf_exit(int sig)
 
     if (ebpf_modules[EBPF_MODULE_FD_IDX].enabled) {
         ebpf_modules[EBPF_MODULE_FD_IDX].enabled = 0;
-        clean_fd_pid_structures();
-        freez(fd_pid);
     }
 
     if (ebpf_modules[EBPF_MODULE_SHM_IDX].enabled) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -251,8 +251,6 @@ static void ebpf_exit(int sig)
 
     if (ebpf_modules[EBPF_MODULE_SHM_IDX].enabled) {
         ebpf_modules[EBPF_MODULE_SHM_IDX].enabled = 0;
-        clean_shm_pid_structures();
-        freez(shm_pid);
     }
 
     ebpf_close_cgroup_shm();

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -233,8 +233,6 @@ static void ebpf_exit(int sig)
 
     if (ebpf_modules[EBPF_MODULE_SWAP_IDX].enabled) {
         ebpf_modules[EBPF_MODULE_SWAP_IDX].enabled = 0;
-        clean_swap_pid_structures();
-        freez(swap_pid);
     }
 
     if (ebpf_modules[EBPF_MODULE_VFS_IDX].enabled) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -227,8 +227,6 @@ static void ebpf_exit(int sig)
 
     if (ebpf_modules[EBPF_MODULE_CACHESTAT_IDX].enabled) {
         ebpf_modules[EBPF_MODULE_CACHESTAT_IDX].enabled = 0;
-        clean_cachestat_pid_structures();
-        freez(cachestat_pid);
     }
 
     if (ebpf_modules[EBPF_MODULE_DCSTAT_IDX].enabled) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -237,8 +237,6 @@ static void ebpf_exit(int sig)
 
     if (ebpf_modules[EBPF_MODULE_VFS_IDX].enabled) {
         ebpf_modules[EBPF_MODULE_VFS_IDX].enabled = 0;
-        clean_vfs_pid_structures();
-        freez(vfs_pid);
     }
 
     if (ebpf_modules[EBPF_MODULE_FD_IDX].enabled) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -221,8 +221,6 @@ static void ebpf_exit(int sig)
 
     if (ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled) {
         ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled = 0;
-        clean_socket_apps_structures();
-        freez(socket_bandwidth_curr);
     }
 
     if (ebpf_modules[EBPF_MODULE_CACHESTAT_IDX].enabled) {

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -433,8 +433,6 @@ extern size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep
 
 extern void collect_data_for_all_processes(int tbl_pid_stats_fd);
 
-extern void clean_global_memory();
-
 extern ebpf_process_stat_t **global_process_stats;
 extern ebpf_process_publish_apps_t **current_apps_data;
 extern netdata_publish_cachestat_t **cachestat_pid;

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -294,20 +294,6 @@ static inline int ebpf_cachestat_load_and_attach(struct cachestat_bpf *obj, ebpf
  *****************************************************************/
 
 /**
- * Clean PID structures
- *
- * Clean the allocated structures.
- */
-void clean_cachestat_pid_structures() {
-    struct pid_stat *pids = root_of_pids;
-    while (pids) {
-        freez(cachestat_pid[pids->pid]);
-
-        pids = pids->next;
-    }
-}
-
-/**
  * Clean up the main thread.
  *
  * @param ptr thread data.

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -324,7 +324,8 @@ static void ebpf_cachestat_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else if (bpf_obj)

--- a/collectors/ebpf.plugin/ebpf_cachestat.h
+++ b/collectors/ebpf.plugin/ebpf_cachestat.h
@@ -82,7 +82,6 @@ typedef struct netdata_publish_cachestat {
 } netdata_publish_cachestat_t;
 
 extern void *ebpf_cachestat_thread(void *ptr);
-extern void clean_cachestat_pid_structures();
 
 extern struct config cachestat_config;
 extern netdata_ebpf_targets_t cachestat_targets[];

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -134,26 +134,6 @@ static inline void ebpf_clean_specific_cgroup_pids(struct pid_on_target2 *pt)
 }
 
 /**
- * Cleanup link list
- */
-void ebpf_clean_cgroup_pids()
-{
-    if (!ebpf_cgroup_pids)
-        return;
-
-    ebpf_cgroup_target_t *ect = ebpf_cgroup_pids;
-    while (ect) {
-        ebpf_cgroup_target_t *next_cgroup = ect->next;
-
-        ebpf_clean_specific_cgroup_pids(ect->pids);
-        freez(ect);
-
-        ect = next_cgroup;
-    }
-    ebpf_cgroup_pids = NULL;
-}
-
-/**
  * Remove Cgroup Update Target Update List
  *
  * Remove from cgroup target and update the link list

--- a/collectors/ebpf.plugin/ebpf_cgroup.h
+++ b/collectors/ebpf.plugin/ebpf_cgroup.h
@@ -63,7 +63,6 @@ typedef struct ebpf_cgroup_target {
 extern void ebpf_map_cgroup_shared_memory();
 extern void ebpf_parse_cgroup_shm_data();
 extern void ebpf_close_cgroup_shm();
-extern void ebpf_clean_cgroup_pids();
 extern void ebpf_create_charts_on_systemd(char *id, char *title, char *units, char *family, char *charttype, int order,
                                           char *algorithm, char *context, char *module, int update_every);
 

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -298,7 +298,8 @@ static void ebpf_dcstat_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else if (bpf_obj)

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -252,20 +252,6 @@ void dcstat_update_publish(netdata_publish_dcstat_t *out, uint64_t cache_access,
  *****************************************************************/
 
 /**
- * Clean PID structures
- *
- * Clean the allocated structures.
- */
-void clean_dcstat_pid_structures() {
-    struct pid_stat *pids = root_of_pids;
-    while (pids) {
-        freez(dcstat_pid[pids->pid]);
-
-        pids = pids->next;
-    }
-}
-
-/**
  *  Clean names
  *
  *  Clean the optional names allocated during startup.

--- a/collectors/ebpf.plugin/ebpf_dcstat.h
+++ b/collectors/ebpf.plugin/ebpf_dcstat.h
@@ -77,7 +77,6 @@ typedef struct netdata_publish_dcstat {
 
 extern void *ebpf_dcstat_thread(void *ptr);
 extern void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr);
-extern void clean_dcstat_pid_structures();
 extern struct config dcstat_config;
 extern netdata_ebpf_targets_t dc_targets[];
 

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -465,7 +465,8 @@ static void ebpf_disk_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -78,7 +78,8 @@ static void ebpf_fd_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -48,20 +48,6 @@ netdata_fd_stat_t **fd_pid = NULL;
  *****************************************************************/
 
 /**
- * Clean PID structures
- *
- * Clean the allocated structures.
- */
-void clean_fd_pid_structures() {
-    struct pid_stat *pids = root_of_pids;
-    while (pids) {
-        freez(fd_pid[pids->pid]);
-
-        pids = pids->next;
-    }
-}
-
-/**
  * Clean up the main thread.
  *
  * @param ptr thread data.

--- a/collectors/ebpf.plugin/ebpf_fd.h
+++ b/collectors/ebpf.plugin/ebpf_fd.h
@@ -79,7 +79,6 @@ extern void *ebpf_fd_thread(void *ptr);
 extern void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr);
 extern struct config fd_config;
 extern netdata_fd_stat_t **fd_pid;
-extern void clean_fd_pid_structures();
 
 #endif /* NETDATA_EBPF_FD_H */
 

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -381,7 +381,8 @@ void ebpf_filesystem_cleanup_ebpf_data()
                 bpf_link__destroy(probe_links[j]);
                 j++;
             }
-            bpf_object__close(efp->objects);
+            if (efp->objects)
+                bpf_object__close(efp->objects);
         }
     }
 }

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -179,7 +179,8 @@ static void hardirq_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -74,7 +74,8 @@ static void mdflush_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -247,7 +247,8 @@ static void ebpf_mount_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else if (bpf_obj)

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -60,7 +60,8 @@ static void oomkill_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -1093,20 +1093,6 @@ static void process_collector(ebpf_module_t *em)
  *
  *****************************************************************/
 
-void clean_global_memory() {
-    int pid_fd = process_maps[NETDATA_PROCESS_PID_TABLE].map_fd;
-    struct pid_stat *pids = root_of_pids;
-    while (pids) {
-        uint32_t pid = pids->pid;
-        freez(global_process_stats[pid]);
-
-        bpf_map_delete_elem(pid_fd, &pid);
-        freez(current_apps_data[pid]);
-
-        pids = pids->next;
-    }
-}
-
 /**
  * Process disable tracepoints
  *
@@ -1150,10 +1136,6 @@ static void ebpf_process_cleanup(void *ptr)
 
     ebpf_cleanup_publish_syscall(process_publish_aggregated);
     freez(process_hash_values);
-
-    clean_global_memory();
-    freez(global_process_stats);
-    freez(current_apps_data);
 
     ebpf_process_disable_tracepoints();
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -1146,7 +1146,8 @@ static void ebpf_process_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 
     freez(cgroup_thread.thread);

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -274,7 +274,8 @@ static void ebpf_shm_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else if (bpf_obj)

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -243,18 +243,6 @@ static inline int ebpf_shm_load_and_attach(struct shm_bpf *obj, ebpf_module_t *e
  *****************************************************************/
 
 /**
- * Clean shm structure
- */
-void clean_shm_pid_structures() {
-    struct pid_stat *pids = root_of_pids;
-    while (pids) {
-        freez(shm_pid[pids->pid]);
-
-        pids = pids->next;
-    }
-}
-
-/**
  * Clean up the main thread.
  *
  * @param ptr thread data.

--- a/collectors/ebpf.plugin/ebpf_shm.h
+++ b/collectors/ebpf.plugin/ebpf_shm.h
@@ -56,7 +56,6 @@ extern netdata_publish_shm_t **shm_pid;
 
 extern void *ebpf_shm_thread(void *ptr);
 extern void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr);
-extern void clean_shm_pid_structures();
 extern netdata_ebpf_targets_t shm_targets[];
 
 extern struct config shm_config;

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2930,7 +2930,8 @@ static void ebpf_socket_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
     finalized_threads = 1;
 }

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2827,15 +2827,6 @@ static void clean_hostnames(ebpf_network_viewer_hostname_list_t *hostnames)
     }
 }
 
-void clean_socket_apps_structures() {
-    struct pid_stat *pids = root_of_pids;
-    while (pids) {
-        freez(socket_bandwidth_curr[pids->pid]);
-
-        pids = pids->next;
-    }
-}
-
 /**
  * Cleanup publish syscall
  *

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -362,7 +362,6 @@ extern void update_listen_table(uint16_t value, uint16_t proto, netdata_passive_
 extern void parse_network_viewer_section(struct config *cfg);
 extern void fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_ip_list_t *in, char *table);
 extern void parse_service_name_section(struct config *cfg);
-extern void clean_socket_apps_structures();
 
 extern ebpf_socket_publish_apps_t **socket_bandwidth_curr;
 extern struct config socket_config;

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -97,7 +97,8 @@ static void softirq_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -196,18 +196,6 @@ static inline int ebpf_swap_load_and_attach(struct swap_bpf *obj, ebpf_module_t 
  *****************************************************************/
 
 /**
- * Clean swap structure
- */
-void clean_swap_pid_structures() {
-    struct pid_stat *pids = root_of_pids;
-    while (pids) {
-        freez(swap_pid[pids->pid]);
-
-        pids = pids->next;
-    }
-}
-
-/**
  * Clean up the main thread.
  *
  * @param ptr thread data.

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -226,7 +226,8 @@ static void ebpf_swap_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else if (bpf_obj)

--- a/collectors/ebpf.plugin/ebpf_swap.h
+++ b/collectors/ebpf.plugin/ebpf_swap.h
@@ -46,7 +46,6 @@ extern netdata_publish_swap_t **swap_pid;
 
 extern void *ebpf_swap_thread(void *ptr);
 extern void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr);
-extern void clean_swap_pid_structures();
 
 extern struct config swap_config;
 extern netdata_ebpf_targets_t swap_targets[];

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -459,7 +459,8 @@ void ebpf_sync_cleanup_objects()
                 bpf_link__destroy(w->probe_links[j]);
                 j++;
             }
-            bpf_object__close(w->objects);
+            if (w->objects)
+                bpf_object__close(w->objects);
         }
 #ifdef LIBBPF_MAJOR_VERSION
         else if (w->sync_obj)

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -78,7 +78,8 @@ static void ebpf_vfs_cleanup(void *ptr)
             bpf_link__destroy(probe_links[i]);
             i++;
         }
-        bpf_object__close(objects);
+        if (objects)
+            bpf_object__close(objects);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -50,20 +50,6 @@ static int read_thread_closed = 1;
  *****************************************************************/
 
 /**
- * Clean PID structures
- *
- * Clean the allocated structures.
- */
-void clean_vfs_pid_structures() {
-    struct pid_stat *pids = root_of_pids;
-    while (pids) {
-        freez(vfs_pid[pids->pid]);
-
-        pids = pids->next;
-    }
-}
-
-/**
 * Clean up the main thread.
 *
 * @param ptr thread data.

--- a/collectors/ebpf.plugin/ebpf_vfs.h
+++ b/collectors/ebpf.plugin/ebpf_vfs.h
@@ -156,7 +156,6 @@ extern netdata_publish_vfs_t **vfs_pid;
 
 extern void *ebpf_vfs_thread(void *ptr);
 extern void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr);
-extern void clean_vfs_pid_structures();
 
 extern struct config vfs_config;
 


### PR DESCRIPTION
##### Summary
Fixes #12775

We are bringing for eBPF the same logic used with `apps` .

##### Test Plan

1. Compile this PR
2. Run netdata
3. wait few minutes
4. Stop the netdata, you should not have segmentation fault repoted.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ebpf
- Can they see the change or is it an under the hood? If they can see it, where? When netdata is stopped, users won't receive errors.
- How is the user impacted by the change? No possible core-dumps
- What are there any benefits of the change? We are removing errors from user systems
</details>
