### PR TITLE
fix RAM calculation on macOS in system-info

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -338,7 +338,7 @@ if [ "${KERNEL_NAME}" = FreeBSD ]; then
   TOTAL_RAM="$(sysctl -n hw.physmem)"
 elif [ "${KERNEL_NAME}" = Darwin ]; then
   RAM_DETECTION="sysctl"
-  TOTAL_RAM="$(sysctl -n hw.physmem)"
+  TOTAL_RAM="$(sysctl -n hw.memsize)"
 elif [ -r /proc/meminfo ]; then
   RAM_DETECTION="procfs"
   TOTAL_RAM="$(grep -F MemTotal /proc/meminfo | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | cut -f 1 -d ' ')"


### PR DESCRIPTION
##### Summary

Need to use `hw.memsize` (int64), it seems `hw.physmem` variable type is int32, so its max value is 2147483648.

We use the correct variable in kickstart

https://github.com/netdata/netdata/blob/f5a49bd9ab48b0e5569165cb7f6dcb5362048bd6/packaging/installer/kickstart.sh#L237-L238

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
