### PR TITLE
Get rid of extra semicolon in Graphite exporting

### DIFF
--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -100,8 +100,7 @@ int format_host_labels_graphite_plaintext(struct instance *instance, RRDHOST *ho
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
 
-    buffer_strcat(instance->labels_buffer, ";");
-    rrdlabels_to_buffer(host->host_labels, instance->labels_buffer, "", "=", "", ";",
+    rrdlabels_to_buffer(host->host_labels, instance->labels_buffer, ";", "=", "", "",
                         exporting_labels_filter_callback, instance,
                         NULL, sanitize_graphite_label_value);
 


### PR DESCRIPTION
##### Summary
There is an extra semicolon after the metric name in the Graphite exporting output.
```text
netdata.arch-linux.system.processes.running; 2.3000000 1656516736
netdata.arch-linux.system.processes.blocked; 0.0000000 1656516736
```
That is happening when no labels are exported. The bug was introduced in #13070. We should remove the semicolon for empty label sets.

Fixes #13205

##### Test Plan
1. Configure a Graphite exporting instance.
2. Set `send automatic labels = no`.
3. Check with `nc` if there are no semicolons after the metric names.