### PR TITLE
Update configuration about removal of python web_log module

### DIFF
--- a/collectors/python.d.plugin/python.d.conf
+++ b/collectors/python.d.plugin/python.d.conf
@@ -107,5 +107,5 @@ nginx_log: no
 # uwsgi: yes
 # varnish: yes
 # w1sensor: yes
-# web_log: yes
+# web_log deprecated and replaced by equivalent go.d.plugin module
 # zscores: no


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Python `web_log` module has been deprecated and replace by the equivalent Go plugin module, the Python plugin configuration should be updated to reflect that. 

Also, I am not sure about how the following parts should be changed:

```
# apache_cache has been replaced by web_log
apache_cache: no
...
# gunicorn_log has been replaced by web_log
gunicorn_log: no
...
# nginx_log has been replaced by web_log
nginx_log: no
```

Any suggestions?

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

--