### PR TITLE
Fix package build filtering on PRs.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -46,7 +46,7 @@ jobs:
           import json
           import re
           FULL_CI_REGEX = '/actions run full ci'
-          ALWAYS_RUN_ARCHES = ["amd64"]
+          ALWAYS_RUN_ARCHES = ["amd64", "x86_64"]
           PR_BODY = """${{ github.event.pull_request.body }}"""
           yaml = YAML(typ='safe')
           entries = list()


### PR DESCRIPTION
##### Summary

Changes added as part of https://github.com/netdata/netdata/pull/13240 resulted in the job filtering for native package builds on PRs to not work correctly.

This fixes it.

##### Test Plan

CI on this PR includes Fedora, Alma, Oracle, and openSUSE package build jobs.