### PR TITLE
Rename the chart of real memory usage in FreeBSD

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1703,6 +1703,11 @@ netdataDashboard.context = {
         info: 'Committed Memory, is the sum of all memory which has been allocated by processes.'
     },
 
+    'mem.real': {
+        colors: NETDATA.colors[3],
+        info: 'Total amount of real (physical) memory used.'
+    },
+
     'mem.oom_kill': {
         info: 'The number of processes killed by '+
         '<a href="https://en.wikipedia.org/wiki/Out_of_memory" target="_blank">Out of Memory</a> Killer. '+


### PR DESCRIPTION
##### Summary
Using the notion of committed memory (`mem.committed` chart) is confusing on FreeBSD. As far as we use `vmtotal.t_rm` as the data source, we need to reflect its meaning in the chart name and info.

Closes #13231

##### Test Plan
Check the `mem.real` chart on FreeBSD.