### PR TITLE
Remove obsolete --use-system-lws option from netdata-installer.sh help

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -239,7 +239,6 @@ USAGE: ${PROGRAM} [options]
   --enable-ml                Enable anomaly detection with machine learning. Default: autodetect.
   --disable-ml               Explicitly disable anomaly detection with machine learning.
   --disable-x86-sse          Disable SSE instructions & optimizations. Default: enabled.
-  --use-system-lws           Use a system copy of libwebsockets instead of bundled copy. Default: bundled.
   --use-system-protobuf      Use a system copy of libprotobuf instead of bundled copy. Default: bundled.
   --zlib-is-really-here
   --libs-are-really-here     If you see errors about missing zlib or libuuid but you know it is available, you might


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

`--use-system-lws` doesn't exist within the installer script anymore, so it should be removed from the help prompt.