### PR TITLE
Fix alignment in charts endpoint

### DIFF
--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -14,7 +14,7 @@ void chart_labels2json(RRDSET *st, BUFFER *wb, size_t indentation)
 
     tabs[0] = '\0';
     while (indentation) {
-        strcat(tabs, "\t");
+        strcat(tabs, "\t\t");
         indentation--;
     }
 


### PR DESCRIPTION
##### Summary
Our current json output for chart labels is not aligned, because we are missing a tab:

```c
                        "green": null,
			"red": null,
			"alarms": {

			},
			"chart_labels": {
		"123caniuse":"testing",
		"myconstant":"never_change",
		"ourconstant":"we talk about",
		"yourconstant":"you define"
			}
```

This PR is fixing this issue aligning the JSON:

```c
                        "green": null,
			"red": null,
			"alarms": {

			},
			"chart_labels": {
				"123caniuse":"testing",
				"myconstant":"never_change",
				"ourconstant":"we talk about",
				"yourconstant":"you define"
			}
```

##### Test Plan

1. Before to compile this branch, start your `netdata` and access http://localhost:19999/api/v1/charts?all, you will have chart labels not aligned.
2. Compile this branch
3. Access the link again https://localhost:19999/api/v1/charts?all (press Ctrl+R) and you will see that chart labels are now aligned.

##### Additional Information
<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? API
- Can they see the change or is it an under the hood? If they can see it, where? It is not visible for uses
- How is the user impacted by the change?  When users work directly with API,  they will have data better organized.
- What are there any benefits of the change? It keeps the JSON cleaner.
</details>
