### PR TITLE
Also run repoconfig package builds when distro list is changed.

### DIFF
--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - packaging/repoconfig/**
       - .github/workflows/repoconfig-packages.yml
+      - .github/data/distros.yml
   push:
     branches:
       - master
     paths:
       - packaging/repoconfig/**
       - .github/workflows/repoconfig-packages.yml
+      - .github/data/distros.yml
 env:
   DISABLE_TELEMETRY: 1
   REPO_PREFIX: netdata/netdata


### PR DESCRIPTION
##### Summary

This ensures that newly added distros get repoconfig packages promptly.

##### Test Plan

n/a