### PR TITLE
query engine fixes for alarms and dashboards

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -808,6 +808,10 @@ int rrdr_relative_window_to_absolute(long long *after, long long *before, int up
         if(after_requested == 0)
             after_requested = -(points * update_every);
 
+        // since the query engine now returns inclusive timestamps
+        // it is awkward to return 6 points when after=-5 is given
+        // so for relative queries we add 1 second, to give
+        // more predictable results to users.
         after_requested = before_requested + after_requested + 1;
         absolute_period_requested = 0;
     }


### PR DESCRIPTION
## Problem 1

The alignment of `before` was going beyond the database on relative queries (like health ones), resulting in random alarm values.

Generally, health queries should be defined `unaligned`, so this was only visible on aligned ones.

Now, instead of aligning ahead, the query engine aligns `before` to the past, so that data are always available.


## Problem 2

The new query engine returns data for the specified timestamp including the `after` and `before` timestamp.

This was awkward for relative queries. For example a query with `after=-3&before=0` it was returning 4 points. It is fixed to now return -1 points on relative queries.

Absolute queries still return inclusive timestamps.

## Problem 3

The new query engine respected the number of points more than the time-frame. So, it was under conditions returning data for a smaller duration than the requested. Now, if the points requested are not enough to cover the entire time-frame, it may return more points.

## Problem 4

Some debug logs were accidentally reporting wrong values. Fixed them.