### PR TITLE
bind to localhost by default

### DIFF
--- a/system/netdata.conf
+++ b/system/netdata.conf
@@ -17,3 +17,5 @@
     page cache size = 32
     dbengine multihost disk space = 256
 
+    # by default do not expose the netdata port
+    bind to = localhost


### PR DESCRIPTION
##### Summary

Bind netdata web interface to localhost by default.

This is to prevent unintentional exposure of sensitive data if the service is publicly reachable (assuming there is no firewall to prevent this).

##### Additional Information

The netdata debian package was once already configured this way. See https://github.com/netdata/netdata/pull/8468

However, it seems the configuration was dropped when the default configuration for the build systems were merged.