### PR TITLE
Update error message to remove confusion

### DIFF
--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -358,7 +358,7 @@ int security_test_certificate(SSL *ssl) {
 int security_location_for_context(SSL_CTX *ctx, char *file, char *path) {
     struct stat statbuf;
     if (stat(file, &statbuf)) {
-        info("Netdata does not have the parent's SSL certificate, so it will use the default OpenSSL configuration to validate certificates!");
+        info("Netdata does not have the parent's SSL certificate, so it will use internal default configuration to validate certificates!");
         return 0;
     }
 

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -358,7 +358,7 @@ int security_test_certificate(SSL *ssl) {
 int security_location_for_context(SSL_CTX *ctx, char *file, char *path) {
     struct stat statbuf;
     if (stat(file, &statbuf)) {
-        info("Netdata does not have the parent's SSL certificate, so it will use netdata internal default configuration to validate certificates!");
+        info("Netdata does not have the parent's SSL certificate, so it will use the netdata internal default configuration to validate certificates!");
         return 0;
     }
 

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -358,7 +358,7 @@ int security_test_certificate(SSL *ssl) {
 int security_location_for_context(SSL_CTX *ctx, char *file, char *path) {
     struct stat statbuf;
     if (stat(file, &statbuf)) {
-        info("Netdata does not have the parent's SSL certificate, so it will use internal default configuration to validate certificates!");
+        info("Netdata does not have the parent's SSL certificate, so it will use netdata internal default configuration to validate certificates!");
         return 0;
     }
 


### PR DESCRIPTION
##### Summary
Fixes #13283 

Update error message to avoid confusions.

##### Test Plan
1. No test needed, we are only updating an info message.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Streaming
- Can they see the change or is it an under the hood? If they can see it, where? Only when streaming is configured with `TLS`.
- How is the user impacted by the change?  We remove confusions from users
- What are there any benefits of the change? Clear message error.
</details>
