### PR TITLE
Null terminate string if file read was not successful

### DIFF
--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -567,6 +567,7 @@ bool rrddim_memory_load_or_create_map_save(RRDSET *st, RRDDIM *rd, RRD_MEMORY_MO
     now_realtime_timeval(&now);
 
     int reset = 0;
+    rd_on_file->magic[sizeof(RRDDIMENSION_MAGIC_V019)] = '\0';
     if(strcmp(rd_on_file->magic, RRDDIMENSION_MAGIC_V019) != 0) {
         info("Initializing file %s.", fullfilename);
         memset(rd_on_file, 0, size);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1912,6 +1912,7 @@ bool rrdset_memory_load_or_create_map_save(RRDSET *st, RRD_MEMORY_MODE memory_mo
 
     time_t now = now_realtime_sec();
 
+    st_on_file->magic[sizeof(RRDSET_MAGIC_V019)] = '\0';
     if(strcmp(st_on_file->magic, RRDSET_MAGIC_V019) != 0) {
         info("Initializing file '%s'.", fullfilename);
         memset(st_on_file, 0, size);


### PR DESCRIPTION
##### Summary
Fixes

```
*** CID 379225:  Memory - illegal accesses  (STRING_NULL)
/database/rrdset.c: 1915 in rrdset_memory_load_or_create_map_save()
1909             0);
1910     
1911         if(!st_on_file) return false;
1912     
1913         time_t now = now_realtime_sec();
1914     
>>>     CID 379225:  Memory - illegal accesses  (STRING_NULL)
>>>     Passing unterminated string "st_on_file->magic" to "strcmp", which expects a null-terminated string.
1915         if(strcmp(st_on_file->magic, RRDSET_MAGIC_V019) != 0) {
1916             info("Initializing file '%s'.", fullfilename);
1917             memset(st_on_file, 0, size);
1918         }
1919         else if(strncmp(st_on_file->id, st->id, RRD_ID_LENGTH_MAX_V019) != 0) {
1920             error("File '%s' contents are not for chart '%s'. Clearing it.", fullfilename, st->id);
```

```
*** CID 379222:  Memory - illegal accesses  (STRING_NULL)
/database/rrddim.c: 570 in rrddim_memory_load_or_create_map_save()
564         if(unlikely(!rd_on_file)) return false;
565     
566         struct timeval now;
567         now_realtime_timeval(&now);
568     
569         int reset = 0;
>>>     CID 379222:  Memory - illegal accesses  (STRING_NULL)
>>>     Passing unterminated string "rd_on_file->magic" to "strcmp", which expects a null-terminated string.
570         if(strcmp(rd_on_file->magic, RRDDIMENSION_MAGIC_V019) != 0) {
571             info("Initializing file %s.", fullfilename);
572             memset(rd_on_file, 0, size);
573             reset = 1;
574         }
575         else if(rd_on_file->memsize != size) {
```



##### Test Plan
- Coverity should stop complaining
