### PR TITLE
fix(cgroups.plugin): adjust kubepods regex to fix name resolution in a kind cluster

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -185,6 +185,13 @@ function k8s_get_kubepod_name() {
   # |   |   |-- kubepods-besteffort-pod10fb5647_c724_400c_b9cc_0e6eae3110e7.slice
   # |   |   |   |-- docker-36e5eb5056dfdf6dbb75c0c44a1ecf23217fe2c50d606209d8130fcbb19fb5a7.scope
   #
+  # kind v0.14.0
+  # |-- kubelet.slice
+  # |   |-- kubelet-kubepods.slice
+  # |   |   |-- kubelet-kubepods-besteffort.slice
+  # |   |   |   |-- kubelet-kubepods-besteffort-pod7881ed9e_c63e_4425_b5e0_ac55a08ae939.slice
+  # |   |   |   |   |-- cri-containerd-00c7939458bffc416bb03451526e9fde13301d6654cfeadf5b4964a7fb5be1a9.scope
+  #
   # NOTE: cgroups plugin
   # - uses '_' to join dir names (so it is <parent>_<child>_<child>_...)
   # - replaces '.' with '-'
@@ -193,7 +200,7 @@ function k8s_get_kubepod_name() {
   local cgroup_path="${1}"
   local id="${2}"
 
-  if [[ ! $id =~ ^kubepods ]]; then
+  if [[ ! $id =~ ^.*kubepods.* ]]; then
     warning "${fn}: '${id}' is not kubepod cgroup."
     return 1
   fi

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2656,7 +2656,6 @@ static inline void discovery_process_cgroup(struct cgroup *cg) {
 
     if (strlen(cg->chart_id) >= RRD_ID_LENGTH_MAX) {
         info("cgroup '%s' (chart id '%s') disabled because chart_id exceeds the limit (RRD_ID_LENGTH_MAX)", cg->id, cg->chart_id);
-        cg->processed = 1;
         return;
     }
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2654,6 +2654,12 @@ static inline void discovery_process_cgroup(struct cgroup *cg) {
 
     cg->processed = 1;
 
+    if (strlen(cg->chart_id) >= RRD_ID_LENGTH_MAX) {
+        info("cgroup '%s' (chart id '%s') disabled because chart_id exceeds the limit (RRD_ID_LENGTH_MAX)", cg->id, cg->chart_id);
+        cg->processed = 1;
+        return;
+    }
+
     if (is_cgroup_systemd_service(cg)) {
         cg->enabled = 1;
         return;


### PR DESCRIPTION
##### Summary

Fixes: #13251

##### Test Plan

Test this fix by installing Netdata in [kind](https://github.com/kubernetes-sigs/kind#please-see-our-documentation-for-more-in-depth-installation-etc) cluster.

<details>
<summary>Before fix</summary>

<img width="1592" alt="Screenshot 2022-07-05 at 11 32 39" src="https://user-images.githubusercontent.com/22274335/177202763-1543db69-0028-48b4-9453-4448d2adb18e.png">

</details>

<details>
<summary>After the fix</summary>

<img width="1592" alt="Screenshot 2022-07-05 at 11 32 39" src="https://user-images.githubusercontent.com/22274335/177285867-751df3bb-3452-4607-93f7-b18792eda48c.png">

</details>


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
