### PR TITLE
Keep rc before freeing it during labels unlink alarms

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -657,8 +657,13 @@ void rrdcalc_foreach_unlink_and_free(RRDHOST *host, RRDCALC *rc) {
 }
 
 static void rrdcalc_labels_unlink_alarm_loop(RRDHOST *host, RRDCALC *alarms) {
-    for(RRDCALC *rc = alarms ; rc ; rc = rc->next ) {
-        if (!rc->host_labels) continue;
+    for(RRDCALC *rc = alarms ; rc ; ) {
+        RRDCALC *rc_next = rc->next;
+
+        if (!rc->host_labels) {
+            rc = rc_next;
+            continue;
+        }
 
         if(!rrdlabels_match_simple_pattern_parsed(host->host_labels, rc->host_labels_pattern, '=')) {
             info("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
@@ -666,17 +671,12 @@ static void rrdcalc_labels_unlink_alarm_loop(RRDHOST *host, RRDCALC *alarms) {
                  host->hostname,
                  rc->host_labels);
 
-            RRDCALC *rc_old = rc->next;
-
             if(host->alarms == alarms)
                 rrdcalc_unlink_and_free(host, rc);
             else
                 rrdcalc_foreach_unlink_and_free(host, rc);
-
-            if (!rc_old)
-                break;
-            rc = rc_old;
         }
+        rc = rc_next;
     }
 }
 

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -666,10 +666,16 @@ static void rrdcalc_labels_unlink_alarm_loop(RRDHOST *host, RRDCALC *alarms) {
                  host->hostname,
                  rc->host_labels);
 
+            RRDCALC *rc_old = rc->next;
+
             if(host->alarms == alarms)
                 rrdcalc_unlink_and_free(host, rc);
             else
                 rrdcalc_foreach_unlink_and_free(host, rc);
+
+            if (!rc_old)
+                break;
+            rc = rc_old;
         }
     }
 }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #13284
Fixes #13304 

Keeps `rc` in another pointer, and uses that after freeing `rc`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Can be tested on a non k8s cluster. Just change the label of `oom_kill` alarm from `_is_k8s_node = false` to `_is_k8s_node = true`. Using master it should crash. Using this PR it should not.

Checking count of `curl 'http://localhost:19999/api/v1/alarms?all' | grep config_hash_id | wc -l` should be -1 when `_is_k8s_node = true`.

Also tested with single alert `oom_kill`. It should correctly remove the single alert and leave the agent with 0 alerts.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
