### PR TITLE
Explicitly skip uploads and notifications in third-party repositories.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
             failure()
             && startsWith(github.ref, 'refs/heads/master')
             && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
           }}
 
   build-static: # Build the static binary archives, and store them as artifacts.
@@ -151,6 +152,7 @@ jobs:
             failure()
             && startsWith(github.ref, 'refs/heads/master')
             && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
           }}
 
   matrix: # Generate the shared build matrix for our build tests.
@@ -220,6 +222,7 @@ jobs:
             failure()
             && startsWith(github.ref, 'refs/heads/master')
             && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
           }}
 
   prepare-test-images: # Prepare the test environments for our build checks. This also checks dependency handling code for each tested environment.
@@ -319,6 +322,7 @@ jobs:
             failure()
             && startsWith(github.ref, 'refs/heads/master')
             && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
           }}
 
   source-build: # Test various source build arrangements.
@@ -391,6 +395,7 @@ jobs:
             failure()
             && startsWith(github.ref, 'refs/heads/master')
             && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
           }}
 
   updater-check: # Test the generated dist archive using the updater code.
@@ -468,6 +473,7 @@ jobs:
             failure()
             && startsWith(github.ref, 'refs/heads/master')
             && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
           }}
 
   prepare-upload: # Consolidate the artifacts for uploading or releasing.
@@ -534,6 +540,7 @@ jobs:
             failure()
             && startsWith(github.ref, 'refs/heads/master')
             && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
           }}
 
   artifact-verification-dist: # Verify the regular installer works with the consolidated artifacts.
@@ -582,6 +589,7 @@ jobs:
             failure()
             && startsWith(github.ref, 'refs/heads/master')
             && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
           }}
 
   artifact-verification-static: # Verify the static installer works with the consolidated artifacts.
@@ -630,12 +638,13 @@ jobs:
             failure()
             && startsWith(github.ref, 'refs/heads/master')
             && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
           }}
 
   upload-nightly: # Upload the nightly build artifacts to GCS.
     name: Upload Nightly Artifacts
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'nightly'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'nightly' && github.repository == 'netdata/netdata'
     needs:
       - updater-check
       - source-build
@@ -703,7 +712,7 @@ jobs:
   upload-release: # Create the draft release and upload the build artifacts.
     name: Create Release Draft
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'release'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'release' && github.repository == 'netdata/netdata'
     needs:
       - updater-check
       - source-build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,6 +59,7 @@ jobs:
             failure()
             && github.event_name != 'pull_request'
             && startsWith(github.ref, 'refs/heads/master')
+            && github.repository == 'netdata/netdata'
           }}
 
   docker-ci:
@@ -114,6 +115,7 @@ jobs:
             failure()
             && github.event_name != 'pull_request'
             && startsWith(github.ref, 'refs/heads/master')
+            && github.repository == 'netdata/netdata'
           }}
 
   normalize-tag: # Fix the release tag if needed
@@ -168,6 +170,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Docker Hub Login
         id: login
+        if: github.repository == 'netdata/netdata'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -177,7 +180,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           platforms: linux/amd64,linux/i386,linux/arm/v7,linux/arm64,linux/ppc64le
-          push: true
+          push: ${{ github.repository == 'netdata/netdata' }}
           tags: ${{ env.tags }}
           build-args: OFFICIAL_IMAGE=${{ env.OFFICIAL_IMAGE }}
       - name: Failure Notification
@@ -204,9 +207,10 @@ jobs:
             failure()
             && github.event_name != 'pull_request'
             && startsWith(github.ref, 'refs/heads/master')
+            && github.repository == 'netdata/netdata'
           }}
       - name: Trigger Helmchart PR
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != 'nightly'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != 'nightly' && github.repository == 'netdata/netdata'
         uses: benc-uk/workflow-dispatch@v1
         with:
           token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -94,6 +94,7 @@ jobs:
             failure()
             && github.event_name != 'pull_request'
             && startsWith(github.ref, 'refs/heads/master')
+            && github.repository == 'netdata/netdata'
           }}
 
   version-check:
@@ -149,6 +150,7 @@ jobs:
             failure()
             && github.event_name != 'pull_request'
             && startsWith(github.ref, 'refs/heads/master')
+            && github.repository == 'netdata/netdata'
           }}
 
   build:
@@ -216,7 +218,7 @@ jobs:
                      /netdata/.github/scripts/pkg-test.sh
       - name: SSH setup
         id: ssh-setup
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.repository == 'netdata/netdata'
         continue-on-error: true
         uses: shimataro/ssh-key-action@v2
         with:
@@ -226,7 +228,7 @@ jobs:
       - name: Upload to packages.netdata.cloud
         id: package-upload
         continue-on-error: true
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.repository == 'netdata/netdata'
         run: |
           .github/scripts/package-upload.sh \
           ${{ matrix.repo_distro }} \
@@ -235,7 +237,7 @@ jobs:
           ${{ needs.version-check.outputs.repo }}
       - name: Upload to PackageCloud
         id: upload
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.repository == 'netdata/netdata'
         shell: bash
         env:
           PKG_CLOUD_TOKEN: ${{ secrets.PACKAGE_CLOUD_API_KEY }}
@@ -270,4 +272,5 @@ jobs:
             failure()
             && github.event_name != 'pull_request'
             && startsWith(github.ref, 'refs/heads/master')
+            && github.repository == 'netdata/netdata'
           }}

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -75,6 +75,7 @@ jobs:
             failure()
             && github.event_name != 'pull_request'
             && startsWith(github.ref, 'refs/heads/master')
+            && github.repository == 'netdata/netdata'
           }}
 
   build:
@@ -161,7 +162,7 @@ jobs:
             .github/scripts/package_cloud_wrapper.sh push "${REPO_PREFIX}-repoconfig/${{ matrix.pkgclouddistro }}" "${pkgfile}"
           done
       - name: Failure Notification
-        if: ${{ failure() }}
+        if: ${{ failure() }} && github.repository == 'netdata/netdata'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: 'danger'

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -162,7 +162,7 @@ jobs:
             .github/scripts/package_cloud_wrapper.sh push "${REPO_PREFIX}-repoconfig/${{ matrix.pkgclouddistro }}" "${pkgfile}"
           done
       - name: Failure Notification
-        if: ${{ failure() }} && github.repository == 'netdata/netdata'
+        if: ${{ failure() && github.repository == 'netdata/netdata' }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: 'danger'


### PR DESCRIPTION
##### Summary

This changes how we handle uploads and Slack notifications in our release build workflows so that they are skipped when running in repositories other than our own.

This simplifies testing and verification of the core release code by enabling testers to run a mock release build or mock nightly build to completion without worrying about the uploads and slack notifications failing the whole workflow.

##### Test Plan

This can be tested by checking out the branch from this PR, pushing it to your local fork, and then running any of the modified workflows by hand using a workflow dispatch event.

##### Additional Information

Relevant to (but does not fix): https://github.com/netdata/netdata/issues/13222