### PR TITLE
fix(health): disable go.d last collected alarm for prometheus module

### DIFF
--- a/health/health.d/go.d.plugin.conf
+++ b/health/health.d/go.d.plugin.conf
@@ -6,7 +6,7 @@
     class: Error
      type: Netdata
 component: go.d.plugin
-   module: *
+   module: !prometheus *
      calc: $now - $last_collected_t
     units: seconds ago
     every: 10s


### PR DESCRIPTION
##### Summary

There is a problem with that module in K8s. Will disable the alarm for prometheus until we get fixed it.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
