### PR TITLE
array allocator for dbengine page descriptors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,8 @@ set(LIBNETDATA_FILES
         libnetdata/adaptive_resortable_list/adaptive_resortable_list.h
         libnetdata/config/appconfig.c
         libnetdata/config/appconfig.h
+        libnetdata/arrayalloc/arrayalloc.c
+        libnetdata/arrayalloc/arrayalloc.h
         libnetdata/avl/avl.c
         libnetdata/avl/avl.h
         libnetdata/buffer/buffer.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -136,6 +136,8 @@ LIBNETDATA_FILES = \
     libnetdata/adaptive_resortable_list/adaptive_resortable_list.h \
     libnetdata/config/appconfig.c \
     libnetdata/config/appconfig.h \
+    libnetdata/arrayalloc/arrayalloc.c \
+    libnetdata/arrayalloc/arrayalloc.h \
     libnetdata/avl/avl.c \
     libnetdata/avl/avl.h \
     libnetdata/buffer/buffer.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1724,6 +1724,7 @@ AC_CONFIG_FILES([
     libnetdata/Makefile
     libnetdata/tests/Makefile
     libnetdata/adaptive_resortable_list/Makefile
+    libnetdata/arrayalloc/Makefile
     libnetdata/avl/Makefile
     libnetdata/buffer/Makefile
     libnetdata/clocks/Makefile

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -5,7 +5,7 @@
 
 ARAL page_descr_aral = {
     .element_size = sizeof(struct rrdeng_page_descr),
-    .elements = 512*1024,
+    .elements = 20000,
     .filename = "page_descriptors",
     .cache_dir = &netdata_configured_cache_dir,
     .use_mmap = false,

--- a/database/engine/pagecache.h
+++ b/database/engine/pagecache.h
@@ -195,6 +195,9 @@ extern unsigned long pg_cache_hard_limit(struct rrdengine_instance *ctx);
 extern unsigned long pg_cache_soft_limit(struct rrdengine_instance *ctx);
 extern unsigned long pg_cache_committed_hard_limit(struct rrdengine_instance *ctx);
 
+extern struct rrdeng_page_descr *rrdeng_page_descr_mallocz(void);
+extern void rrdeng_page_descr_freez(struct rrdeng_page_descr *descr);
+
 static inline void
     pg_cache_atomic_get_pg_info(struct rrdeng_page_descr *descr, usec_t *end_timep, uint32_t *page_lengthp)
 {

--- a/database/engine/pagecache.h
+++ b/database/engine/pagecache.h
@@ -195,6 +195,11 @@ extern unsigned long pg_cache_hard_limit(struct rrdengine_instance *ctx);
 extern unsigned long pg_cache_soft_limit(struct rrdengine_instance *ctx);
 extern unsigned long pg_cache_committed_hard_limit(struct rrdengine_instance *ctx);
 
+extern void rrdeng_page_descr_aral_go_singlethreaded(void);
+extern void rrdeng_page_descr_aral_go_multithreaded(void);
+extern void rrdeng_page_descr_use_malloc(void);
+extern void rrdeng_page_descr_use_mmap(void);
+extern bool rrdeng_page_descr_is_mmap(void);
 extern struct rrdeng_page_descr *rrdeng_page_descr_mallocz(void);
 extern void rrdeng_page_descr_freez(struct rrdeng_page_descr *descr);
 

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -211,7 +211,7 @@ void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *collection_h
     } else {
         dbengine_page_free(descr->pg_cache_descr->page);
         rrdeng_destroy_pg_cache_descr(ctx, descr->pg_cache_descr);
-        freez(descr);
+        rrdeng_page_descr_freez(descr);
     }
     handle->descr = NULL;
 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -740,9 +740,6 @@ restart_after_removal:
 // ----------------------------------------------------------------------------
 // RRDHOST global / startup initialization
 
-extern void rrdeng_page_descr_aral_go_singlethreaded(void);
-extern void rrdeng_page_descr_aral_go_multithreaded(void);
-
 int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
 
 #ifdef ENABLE_DBENGINE
@@ -771,6 +768,11 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         default_rrdeng_page_fetch_retries = 1;
         config_set_number(CONFIG_SECTION_DB, "dbengine page fetch retries", default_rrdeng_page_fetch_retries);
     }
+
+    if(config_get_boolean(CONFIG_SECTION_DB, "dbengine page descriptors in file mapped memory", rrdeng_page_descr_is_mmap()) == CONFIG_BOOLEAN_YES)
+        rrdeng_page_descr_use_mmap();
+    else
+        rrdeng_page_descr_use_malloc();
 #endif
 
     rrdset_free_obsolete_time = config_get_number(CONFIG_SECTION_DB, "cleanup obsolete charts after secs", rrdset_free_obsolete_time);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -740,6 +740,9 @@ restart_after_removal:
 // ----------------------------------------------------------------------------
 // RRDHOST global / startup initialization
 
+extern void rrdeng_page_descr_aral_go_singlethreaded(void);
+extern void rrdeng_page_descr_aral_go_multithreaded(void);
+
 int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
 
 #ifdef ENABLE_DBENGINE
@@ -825,6 +828,8 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
     }
 
 #ifdef ENABLE_DBENGINE
+    rrdeng_page_descr_aral_go_singlethreaded();
+
     int created_tiers = 0;
     char dbenginepath[FILENAME_MAX + 1];
     char dbengineconfig[200 + 1];
@@ -905,6 +910,8 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         rrd_unlock();
         fatal("DBENGINE: Failed to be initialized.");
     }
+
+    rrdeng_page_descr_aral_go_multithreaded();
 #else
     storage_tiers = config_get_number(CONFIG_SECTION_DB, "storage tiers", 1);
     if(storage_tiers != 1) {

--- a/libnetdata/Makefile.am
+++ b/libnetdata/Makefile.am
@@ -5,6 +5,7 @@ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 SUBDIRS = \
     adaptive_resortable_list \
+    arrayalloc \
     avl \
     buffer \
     clocks \

--- a/libnetdata/arrayalloc/Makefile.am
+++ b/libnetdata/arrayalloc/Makefile.am
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+AUTOMAKE_OPTIONS = subdir-objects
+MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+
+dist_noinst_DATA = \
+    README.md \
+    $(NULL)

--- a/libnetdata/arrayalloc/README.md
+++ b/libnetdata/arrayalloc/README.md
@@ -1,0 +1,7 @@
+<!--
+title: "Array Allocator"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/libnetdata/arrayalloc/README.md
+-->
+
+# Array Allocator
+

--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -1,0 +1,152 @@
+#include "../libnetdata.h"
+#include "arrayalloc.h"
+#include "daemon/common.h"
+
+typedef struct arrayalloc_free {
+    size_t size;
+    struct arrayalloc_free *next;
+} ARAL_FREE;
+
+typedef struct arrayalloc_page {
+    size_t size;                  // the total size of the page
+    uint8_t *data;
+    struct arrayalloc_page *next; // the next page on the list
+} ARAL_PAGE;
+
+ARAL *arrayalloc_create(size_t element_size, size_t elements, const char *filename, char **cache_dir) {
+    ARAL *ar = callocz(1, sizeof(ARAL));
+    ar->element_size = element_size;
+    ar->elements = elements;
+    ar->filename = filename;
+    ar->cache_dir = cache_dir;
+    return ar;
+}
+
+#define ARAL_NATURAL_ALIGNMENT  (sizeof(uintptr_t) * 2)
+static inline size_t natural_alignment(size_t size) {
+    if(unlikely(size % ARAL_NATURAL_ALIGNMENT))
+        size = size + ARAL_NATURAL_ALIGNMENT - (size % ARAL_NATURAL_ALIGNMENT);
+
+    return size;
+}
+
+static void arrayalloc_init(ARAL *ar) {
+    static netdata_mutex_t mutex = NETDATA_MUTEX_INITIALIZER;
+    netdata_mutex_lock(&mutex);
+
+    if(!ar->internal.initialized) {
+        netdata_mutex_init(&ar->internal.mutex);
+
+        long int page_size = sysconf(_SC_PAGE_SIZE);
+        if (unlikely(page_size == -1))
+            ar->internal.natural_page_size = 4096;
+        else
+            ar->internal.natural_page_size = page_size;
+
+        if (ar->element_size < sizeof(ARAL_FREE))
+            ar->element_size = sizeof(ARAL_FREE);
+
+        ar->element_size = natural_alignment(ar->element_size);
+
+        if (ar->elements < 1000)
+            ar->elements = 1000;
+
+        ar->internal.pages = NULL;
+        ar->internal.free_list = NULL;
+        ar->internal.allocation_multiplier = 1;
+        ar->internal.file_number = 0;
+        ar->internal.total_allocated = 0;
+        ar->internal.initialized = true;
+
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "%s/array_alloc.mmap", *ar->cache_dir);
+        int r = mkdir(filename, 0775);
+        if (r != 0 && errno != EEXIST)
+            fatal("Cannot create directory '%s'", filename);
+
+    }
+
+    netdata_mutex_unlock(&mutex);
+}
+
+static void arrayalloc_free_checks(ARAL *ar, ARAL_FREE *fr) {
+    internal_error(fr->size < ar->element_size, "ARRAYALLOC: free item of size %zu, less than the expected element size %zu", fr->size, ar->element_size);
+    internal_error(fr->size % ar->element_size, "ARRAYALLOC: free item of size %zu is not multiple to element size %zu", fr->size, ar->element_size);
+    ;
+}
+
+static void arrayalloc_increase(ARAL *ar) {
+    if(unlikely(!ar->internal.initialized))
+        arrayalloc_init(ar);
+
+    ar->internal.file_number++;
+    char filename[FILENAME_MAX + 1];
+
+    ARAL_PAGE *page = mallocz(sizeof(ARAL_PAGE));
+    page->size = ar->elements * ar->element_size * ar->internal.allocation_multiplier;
+    ar->internal.allocation_multiplier *= 2;
+
+    snprintfz(filename, FILENAME_MAX, "%s/array_alloc.mmap/%s.%zu", *ar->cache_dir, ar->filename, ar->internal.file_number);
+    page->data = netdata_mmap(filename, page->size, MAP_SHARED, 0);
+    if(unlikely(!page->data)) fatal("Cannot allocate arrayalloc buffer of size %zu on filename '%s'", page->size, filename);
+
+    ARAL_FREE *fr = (ARAL_FREE *)page->data;
+    fr->size = page->size;
+    fr->next = ar->internal.free_list;
+    ar->internal.free_list = fr;
+
+    // link the new page
+    page->next = ar->internal.pages;
+    ar->internal.pages = page;
+
+    arrayalloc_free_checks(ar, fr);
+}
+
+
+static void arrayalloc_lock(ARAL *ar) {
+    if(!ar->internal.lockless)
+        netdata_mutex_lock(&ar->internal.mutex);
+}
+
+static void arrayalloc_unlock(ARAL *ar) {
+    if(!ar->internal.lockless)
+        netdata_mutex_unlock(&ar->internal.mutex);
+}
+
+void *arrayalloc_mallocz(ARAL *ar) {
+    arrayalloc_lock(ar);
+
+    if(unlikely(!ar->internal.free_list))
+        arrayalloc_increase(ar);
+
+    ARAL_FREE *fr = ar->internal.free_list;
+
+    internal_error(fr->size < ar->element_size, "ARRAYALLOC: free item size is too small %zu", fr->size);
+
+    if(fr->size - ar->element_size <= ar->element_size) {
+        // we are done with this space
+        ar->internal.free_list = fr->next;
+    }
+    else {
+        uint8_t *data = (uint8_t *)fr;
+        ARAL_FREE *fr2 = (ARAL_FREE *)&data[ar->element_size];
+        fr2->size = fr->size - ar->element_size;
+        fr2->next = fr->next;
+
+        ar->internal.free_list = fr2;
+        arrayalloc_free_checks(ar, fr2);
+    }
+
+    arrayalloc_unlock(ar);
+    return (void *)fr;
+}
+
+void arrayalloc_freez(ARAL *ar, void *ptr) {
+    if(!ptr) return;
+    arrayalloc_lock(ar);
+    ARAL_FREE *fr = (ARAL_FREE *)ptr;
+    fr->size = ar->element_size;
+    fr->next = ar->internal.free_list;
+    ar->internal.free_list = fr;
+    arrayalloc_unlock(ar);
+}

--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -2,13 +2,22 @@
 #include "arrayalloc.h"
 #include "daemon/common.h"
 
+// 1GB max file size
+#define ARAL_MAX_PAGE_SIZE_MMAP (1*1024*1024*1024)
+
+// 5MB max malloc size
+#define ARAL_MAX_PAGE_SIZE_MALLOC (5*1024*1024)
+
 typedef struct arrayalloc_free {
     size_t size;
+    struct arrayalloc_page *page;
     struct arrayalloc_free *next;
 } ARAL_FREE;
 
 typedef struct arrayalloc_page {
+    const char *filename;
     size_t size;                  // the total size of the page
+    size_t used_elements;         // the total number of used elements on this page
     uint8_t *data;
     struct arrayalloc_page *next; // the next page on the list
 } ARAL_PAGE;
@@ -43,13 +52,20 @@ static void arrayalloc_init(ARAL *ar) {
         else
             ar->internal.natural_page_size = page_size;
 
-        if (ar->element_size < sizeof(ARAL_FREE))
-            ar->element_size = sizeof(ARAL_FREE);
+        ar->internal.element_size = ar->element_size;
+        if (ar->internal.element_size < sizeof(ARAL_FREE))
+            ar->internal.element_size = sizeof(ARAL_FREE);
 
-        ar->element_size = natural_alignment(ar->element_size);
+        ar->internal.element_size = natural_alignment(ar->element_size);
 
         if (ar->elements < 1000)
             ar->elements = 1000;
+
+        ar->internal.mmap = (ar->use_mmap && ar->cache_dir && *ar->cache_dir) ? true : false;
+        ar->internal.max_alloc_size = (ar->internal.mmap) ? ARAL_MAX_PAGE_SIZE_MMAP : ARAL_MAX_PAGE_SIZE_MALLOC;
+
+        if(ar->internal.max_alloc_size % ar->internal.element_size)
+            ar->internal.max_alloc_size -= ar->internal.max_alloc_size % ar->internal.element_size;
 
         ar->internal.pages = NULL;
         ar->internal.free_list = NULL;
@@ -58,20 +74,21 @@ static void arrayalloc_init(ARAL *ar) {
         ar->internal.total_allocated = 0;
         ar->internal.initialized = true;
 
-        char filename[FILENAME_MAX + 1];
-        snprintfz(filename, FILENAME_MAX, "%s/array_alloc.mmap", *ar->cache_dir);
-        int r = mkdir(filename, 0775);
-        if (r != 0 && errno != EEXIST)
-            fatal("Cannot create directory '%s'", filename);
-
+        if(ar->internal.mmap) {
+            char filename[FILENAME_MAX + 1];
+            snprintfz(filename, FILENAME_MAX, "%s/array_alloc.mmap", *ar->cache_dir);
+            int r = mkdir(filename, 0775);
+            if (r != 0 && errno != EEXIST)
+                fatal("Cannot create directory '%s'", filename);
+        }
     }
 
     netdata_mutex_unlock(&mutex);
 }
 
 static void arrayalloc_free_checks(ARAL *ar, ARAL_FREE *fr) {
-    internal_error(fr->size < ar->element_size, "ARRAYALLOC: free item of size %zu, less than the expected element size %zu", fr->size, ar->element_size);
-    internal_error(fr->size % ar->element_size, "ARRAYALLOC: free item of size %zu is not multiple to element size %zu", fr->size, ar->element_size);
+    internal_error(fr->size < ar->internal.element_size, "ARRAYALLOC: free item of size %zu, less than the expected element size %zu", fr->size, ar->internal.element_size);
+    internal_error(fr->size % ar->internal.element_size, "ARRAYALLOC: free item of size %zu is not multiple to element size %zu", fr->size, ar->internal.element_size);
     ;
 }
 
@@ -79,19 +96,29 @@ static void arrayalloc_increase(ARAL *ar) {
     if(unlikely(!ar->internal.initialized))
         arrayalloc_init(ar);
 
-    ar->internal.file_number++;
-    char filename[FILENAME_MAX + 1];
+    ARAL_PAGE *page = callocz(1, sizeof(ARAL_PAGE));
+    page->size = ar->elements * ar->internal.element_size * ar->internal.allocation_multiplier;
+    if(page->size > ar->internal.max_alloc_size)
+        page->size = ar->internal.max_alloc_size;
+    else
+        ar->internal.allocation_multiplier *= 2;
 
-    ARAL_PAGE *page = mallocz(sizeof(ARAL_PAGE));
-    page->size = ar->elements * ar->element_size * ar->internal.allocation_multiplier;
-    ar->internal.allocation_multiplier *= 2;
-
-    snprintfz(filename, FILENAME_MAX, "%s/array_alloc.mmap/%s.%zu", *ar->cache_dir, ar->filename, ar->internal.file_number);
-    page->data = netdata_mmap(filename, page->size, MAP_SHARED, 0);
-    if(unlikely(!page->data)) fatal("Cannot allocate arrayalloc buffer of size %zu on filename '%s'", page->size, filename);
+    if(ar->internal.mmap) {
+        ar->internal.file_number++;
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "%s/array_alloc.mmap/%s.%zu", *ar->cache_dir, ar->filename, ar->internal.file_number);
+        page->filename = strdupz(filename);
+        page->data = netdata_mmap(page->filename, page->size, MAP_SHARED, 0);
+        if (unlikely(!page->data))
+            fatal("Cannot allocate arrayalloc buffer of size %zu on filename '%s'", page->size, page->filename);
+    }
+    else {
+        page->data = mallocz(page->size);
+    }
 
     ARAL_FREE *fr = (ARAL_FREE *)page->data;
     fr->size = page->size;
+    fr->page = page;
     fr->next = ar->internal.free_list;
     ar->internal.free_list = fr;
 
@@ -121,21 +148,24 @@ void *arrayalloc_mallocz(ARAL *ar) {
 
     ARAL_FREE *fr = ar->internal.free_list;
 
-    internal_error(fr->size < ar->element_size, "ARRAYALLOC: free item size is too small %zu", fr->size);
+    internal_error(fr->size < ar->internal.element_size, "ARRAYALLOC: free item size is too small %zu", fr->size);
 
-    if(fr->size - ar->element_size <= ar->element_size) {
+    if(fr->size - ar->internal.element_size <= ar->internal.element_size) {
         // we are done with this space
         ar->internal.free_list = fr->next;
     }
     else {
         uint8_t *data = (uint8_t *)fr;
-        ARAL_FREE *fr2 = (ARAL_FREE *)&data[ar->element_size];
-        fr2->size = fr->size - ar->element_size;
+        ARAL_FREE *fr2 = (ARAL_FREE *)&data[ar->internal.element_size];
+        fr2->page = fr->page;
+        fr2->size = fr->size - ar->internal.element_size;
         fr2->next = fr->next;
 
         ar->internal.free_list = fr2;
         arrayalloc_free_checks(ar, fr2);
     }
+
+    fr->page->used_elements++;
 
     arrayalloc_unlock(ar);
     return (void *)fr;
@@ -144,9 +174,64 @@ void *arrayalloc_mallocz(ARAL *ar) {
 void arrayalloc_freez(ARAL *ar, void *ptr) {
     if(!ptr) return;
     arrayalloc_lock(ar);
+
+    // find the page ptr belongs
+    size_t seeking = (size_t)ptr;
+    ARAL_PAGE *page, *last_page = NULL;
+    for(page = ar->internal.pages; page ; page = page->next) {
+        if(seeking >= (size_t)page->data && seeking < (size_t)page->data + page->size)
+            break;
+
+        last_page = page;
+    }
+
+    if(!page)
+        fatal("ARRAYALLOC: free of pointer %p is not in arrayalloc address space.", ptr);
+
+    if(!page->used_elements)
+        fatal("ARRAYALLOC: free of pointer %p is inside an already free page.", ptr);
+
+    page->used_elements--;
+
+    // make this element available
     ARAL_FREE *fr = (ARAL_FREE *)ptr;
-    fr->size = ar->element_size;
+    fr->page = page;
+    fr->size = ar->internal.element_size;
     fr->next = ar->internal.free_list;
     ar->internal.free_list = fr;
+
+    // if the page is empty, release it
+    if(!page->used_elements) {
+        // remove all the free elements from the list
+        ARAL_FREE *last_fr = NULL;
+        for(fr = ar->internal.free_list; fr ;fr = fr->next) {
+            if(fr->page == page) {
+                if(fr == ar->internal.free_list)
+                    ar->internal.free_list = fr->next;
+                else
+                    last_fr->next = fr->next;
+            }
+            else
+                last_fr = fr;
+        }
+
+        // unlink it
+        if(page == ar->internal.pages)
+            ar->internal.pages = page->next;
+        else
+            last_page->next = page->next;
+
+        // free it
+        if(ar->internal.mmap) {
+            munmap(page->data, page->size);
+            unlink(page->filename);
+            freez((void *)page->filename);
+        }
+        else
+            freez(page->data);
+
+        freez(page);
+    }
+
     arrayalloc_unlock(ar);
 }

--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -69,8 +69,8 @@ static void arrayalloc_init(ARAL *ar) {
         //info("ARRAYALLOC: element size %zu, sizeof(uintptr_t) %zu, natural alignment %zu, final element size %zu, page_ptr_offset %zu",
         //      ar->element_size, sizeof(uintptr_t), ARAL_NATURAL_ALIGNMENT, ar->internal.element_size, ar->internal.page_ptr_offset);
 
-        if (ar->elements < 1000)
-            ar->elements = 1000;
+        if (ar->elements < 10)
+            ar->elements = 10;
 
         ar->internal.mmap = (ar->use_mmap && ar->cache_dir && *ar->cache_dir) ? true : false;
         ar->internal.max_alloc_size = ar->internal.mmap ? ARAL_MAX_PAGE_SIZE_MMAP : ARAL_MAX_PAGE_SIZE_MALLOC;

--- a/libnetdata/arrayalloc/arrayalloc.h
+++ b/libnetdata/arrayalloc/arrayalloc.h
@@ -17,6 +17,7 @@ typedef struct arrayalloc {
         bool lockless;
         bool initialized;
         size_t element_size;
+        size_t page_ptr_offset;
         size_t file_number;
         size_t natural_page_size;
         size_t allocation_multiplier;

--- a/libnetdata/arrayalloc/arrayalloc.h
+++ b/libnetdata/arrayalloc/arrayalloc.h
@@ -21,10 +21,9 @@ typedef struct arrayalloc {
         size_t natural_page_size;
         size_t allocation_multiplier;
         size_t max_alloc_size;
-        size_t total_allocated;
         netdata_mutex_t mutex;
-        struct arrayalloc_page *pages;
-        void *free_list;
+        struct arrayalloc_page *first_page;
+        struct arrayalloc_page *last_page;
     } internal;
 } ARAL;
 

--- a/libnetdata/arrayalloc/arrayalloc.h
+++ b/libnetdata/arrayalloc/arrayalloc.h
@@ -9,12 +9,18 @@ typedef struct arrayalloc {
     size_t elements;
     const char *filename;
     char **cache_dir;
+    bool use_mmap;
+
+    // private members - do not touch
     struct {
+        bool mmap;
         bool lockless;
         bool initialized;
+        size_t element_size;
         size_t file_number;
         size_t natural_page_size;
         size_t allocation_multiplier;
+        size_t max_alloc_size;
         size_t total_allocated;
         netdata_mutex_t mutex;
         struct arrayalloc_page *pages;

--- a/libnetdata/arrayalloc/arrayalloc.h
+++ b/libnetdata/arrayalloc/arrayalloc.h
@@ -1,0 +1,29 @@
+
+#ifndef ARRAYALLOC_H
+#define ARRAYALLOC_H 1
+
+#include "../libnetdata.h"
+
+typedef struct arrayalloc {
+    size_t element_size;
+    size_t elements;
+    const char *filename;
+    char **cache_dir;
+    struct {
+        bool lockless;
+        bool initialized;
+        size_t file_number;
+        size_t natural_page_size;
+        size_t allocation_multiplier;
+        size_t total_allocated;
+        netdata_mutex_t mutex;
+        struct arrayalloc_page *pages;
+        void *free_list;
+    } internal;
+} ARAL;
+
+extern ARAL *arrayalloc_create(size_t element_size, size_t elements, const char *filename, char **cache_dir);
+extern void *arrayalloc_mallocz(ARAL *ar);
+extern void arrayalloc_freez(ARAL *ar, void *ptr);
+
+#endif // ARRAYALLOC_H

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -345,6 +345,7 @@ extern char *netdata_configured_host_prefix;
 #include "json/json.h"
 #include "health/health.h"
 #include "string/utf8.h"
+#include "arrayalloc/arrayalloc.h"
 #include "onewayalloc/onewayalloc.h"
 #include "worker_utilization/worker_utilization.h"
 

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -1,9 +1,7 @@
 #include "onewayalloc.h"
 
-static size_t OWA_NATURAL_PAGE_SIZE = 0;
-
 // https://www.gnu.org/software/libc/manual/html_node/Aligned-Memory-Blocks.html
-#define OWA_NATURAL_ALIGNMENT  (sizeof(void *) * 2)
+#define OWA_NATURAL_ALIGNMENT  (sizeof(uintptr_t) * 2)
 
 typedef struct owa_page {
     size_t stats_pages;
@@ -30,6 +28,8 @@ static inline size_t natural_alignment(size_t size) {
 // any number of times, for any amount of memory.
 
 static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
+    static size_t OWA_NATURAL_PAGE_SIZE = 0;
+
     if(unlikely(!OWA_NATURAL_PAGE_SIZE)) {
         long int page_size = sysconf(_SC_PAGE_SIZE);
         if (unlikely(page_size == -1))
@@ -82,11 +82,11 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     head->stats_pages++;
     head->stats_pages_size += size;
 
-    return (ONEWAYALLOC *)page;
+    return page;
 }
 
 ONEWAYALLOC *onewayalloc_create(size_t size_hint) {
-    return onewayalloc_create_internal(NULL, size_hint);
+    return (ONEWAYALLOC *)onewayalloc_create_internal(NULL, size_hint);
 }
 
 void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {


### PR DESCRIPTION
This is test to see the effects of moving dbengine page descriptors to a mmap'd file.

This version uses the array allocator either with `malloc()` or with `mmap()`. The configuration option to control this is:

```
[db]
   dbengine page descriptors in file mapped memory = no
```

When set to `no`, malloc is used with a max size of 10MB.
When set to `yes`, mmap is used with a max size of 1GB.
