### PR TITLE
fix(apps.plugin): adjust `zmstat*` pattern to exclude zoneminder scripts

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -121,7 +121,7 @@ columndb: clickhouse-server*
 # -----------------------------------------------------------------------------
 # email servers
 
-email: dovecot imapd pop3d amavis* zmstat* zmmailboxdmgr saslauthd opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr
+email: dovecot imapd pop3d amavis* zmstat-* zmmailboxdmgr saslauthd opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr
 
 # -----------------------------------------------------------------------------
 # network, routing, VPN

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -121,7 +121,7 @@ columndb: clickhouse-server*
 # -----------------------------------------------------------------------------
 # email servers
 
-email: dovecot imapd pop3d amavis* zmstat-* zmmailboxdmgr saslauthd opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr
+email: dovecot imapd pop3d amavis* zmstat-* zmdiaglog zmmailboxdmgr saslauthd opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr
 
 # -----------------------------------------------------------------------------
 # network, routing, VPN


### PR DESCRIPTION
##### Summary

Fixes: https://github.com/netdata/netdata/issues/13292#issuecomment-1176108180

All the Zimbra Zmstats collection scripts [start with `zmstat-`](https://wiki.zimbra.com/wiki/Zmstats).

##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
