### PR TITLE
fix(cgroups.plugin): adjust kubepods patterns to filter pods when using Kind cluster

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -449,15 +449,18 @@ void read_cgroup_plugin_configuration() {
                     " !/system.slice/run-*.scope "         // ignore system.slice/run-XXXX.scope
                     " *.scope "                            // we need all other *.scope for sure
 
+                    " */kubepods/pod*/* "                   // k8s containers
+                    " */kubepods/*/pod*/* "                 // k8s containers
+                    " */*-kubepods-pod*/* "                 // k8s containers
+                    " */*-kubepods-*-pod*/* "               // k8s containers
+                    " !*kubepods* !*kubelet*"               // all other k8s cgroups
+
             // ----------------------------------------------------------------
 
                     " /machine.slice/*.service "           // #3367 systemd-nspawn
-                    " */kubepods/pod*/* "                   // k8s containers
-                    " */kubepods/*/pod*/* "                 // k8s containers
 
             // ----------------------------------------------------------------
 
-                    " !*/kubepods* "                        // all other k8s cgroups
                     " !*/vcpu* "                           // libvirtd adds these sub-cgroups
                     " !*/emulator "                        // libvirtd adds these sub-cgroups
                     " !*.mount "
@@ -531,7 +534,9 @@ void read_cgroup_plugin_configuration() {
                     " *qemu* "
                     " */kubepods/pod*/* "                   // k8s containers
                     " */kubepods/*/pod*/* "                 // k8s containers
-                    " !*/kubepods* "                        // all other k8s cgroups
+                    " */*-kubepods-pod*/* "                 // k8s containers
+                    " */*-kubepods-*-pod*/* "               // k8s containers
+                    " !*kubepods* !*kubelet*"               // all other k8s cgroups
                     " *.libvirt-qemu "                    // #3010
                     " * "
             ), NULL, SIMPLE_PATTERN_EXACT);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -449,15 +449,17 @@ void read_cgroup_plugin_configuration() {
                     " !/system.slice/run-*.scope "         // ignore system.slice/run-XXXX.scope
                     " *.scope "                            // we need all other *.scope for sure
 
+            // ----------------------------------------------------------------
+
+                    " /machine.slice/*.service "           // #3367 systemd-nspawn
+
+            // ----------------------------------------------------------------
+
                     " */kubepods/pod*/* "                   // k8s containers
                     " */kubepods/*/pod*/* "                 // k8s containers
                     " */*-kubepods-pod*/* "                 // k8s containers
                     " */*-kubepods-*-pod*/* "               // k8s containers
                     " !*kubepods* !*kubelet*"               // all other k8s cgroups
-
-            // ----------------------------------------------------------------
-
-                    " /machine.slice/*.service "           // #3367 systemd-nspawn
 
             // ----------------------------------------------------------------
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -452,12 +452,12 @@ void read_cgroup_plugin_configuration() {
             // ----------------------------------------------------------------
 
                     " /machine.slice/*.service "           // #3367 systemd-nspawn
-                    " /kubepods/pod*/* "                   // k8s containers
-                    " /kubepods/*/pod*/* "                 // k8s containers
+                    " */kubepods/pod*/* "                   // k8s containers
+                    " */kubepods/*/pod*/* "                 // k8s containers
 
             // ----------------------------------------------------------------
 
-                    " !/kubepods* "                        // all other k8s cgroups
+                    " !*/kubepods* "                        // all other k8s cgroups
                     " !*/vcpu* "                           // libvirtd adds these sub-cgroups
                     " !*/emulator "                        // libvirtd adds these sub-cgroups
                     " !*.mount "
@@ -529,9 +529,9 @@ void read_cgroup_plugin_configuration() {
                     " *docker* "
                     " *lxc* "
                     " *qemu* "
-                    " /kubepods/pod*/* "                   // k8s containers
-                    " /kubepods/*/pod*/* "                 // k8s containers
-                    " !/kubepods* "                        // all other k8s cgroups
+                    " */kubepods/pod*/* "                   // k8s containers
+                    " */kubepods/*/pod*/* "                 // k8s containers
+                    " !*/kubepods* "                        // all other k8s cgroups
                     " *.libvirt-qemu "                    // #3010
                     " * "
             ), NULL, SIMPLE_PATTERN_EXACT);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -459,7 +459,7 @@ void read_cgroup_plugin_configuration() {
                     " */kubepods/*/pod*/* "                 // k8s containers
                     " */*-kubepods-pod*/* "                 // k8s containers
                     " */*-kubepods-*-pod*/* "               // k8s containers
-                    " !*kubepods* !*kubelet*"               // all other k8s cgroups
+                    " !*kubepods* !*kubelet* "              // all other k8s cgroups
 
             // ----------------------------------------------------------------
 
@@ -538,7 +538,7 @@ void read_cgroup_plugin_configuration() {
                     " */kubepods/*/pod*/* "                 // k8s containers
                     " */*-kubepods-pod*/* "                 // k8s containers
                     " */*-kubepods-*-pod*/* "               // k8s containers
-                    " !*kubepods* !*kubelet*"               // all other k8s cgroups
+                    " !*kubepods* !*kubelet* "              // all other k8s cgroups
                     " *.libvirt-qemu "                    // #3010
                     " * "
             ), NULL, SIMPLE_PATTERN_EXACT);


### PR DESCRIPTION
##### Summary

This PR adjusts `enable by default cgroups matching` and `run script to rename cgroups matching` simple patterns to filter out pods when using Kind cluster. Reported in https://github.com/netdata/netdata/issues/13251#issuecomment-1175370710.


##### Test Plan

Install Netdata in GCP and Kind cluster using a custom image built from this branch.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
