### PR TITLE
Cid 379238 379238

### DIFF
--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -877,7 +877,8 @@ error_after_init_rrd_files:
     free_page_cache(ctx);
     if (!is_storage_engine_shared((STORAGE_INSTANCE *)ctx)) {
         freez(ctx);
-        *ctxp = NULL;
+        if (ctxp)
+            *ctxp = NULL;
     }
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
     return UV_EIO;


### PR DESCRIPTION
##### Summary
Fixes

```
*** CID 379239:  Null pointer dereferences  (FORWARD_NULL)
/database/engine/rrdengineapi.c: 880 in rrdeng_init()
874     error_after_rrdeng_worker:
875         finalize_rrd_files(ctx);
876     error_after_init_rrd_files:
877         free_page_cache(ctx);
878         if (!is_storage_engine_shared((STORAGE_INSTANCE *)ctx)) {
879             freez(ctx);
>>>     CID 379239:  Null pointer dereferences  (FORWARD_NULL)
>>>     Dereferencing null pointer "ctxp".
880             *ctxp = NULL;
881         }
882         rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, -RRDENG_FD_BUDGET_PER_INSTANCE);
883         return UV_EIO;
884     }
885     
```

and

```
*** CID 379238:  Null pointer dereferences  (NULL_RETURNS)
/database/sqlite/sqlite_functions.c: 1609 in create_rrdim_entry()
1603             rd->tiers[tier]->query_ops.init = rrdeng_load_metric_init;
1604             rd->tiers[tier]->query_ops.next_metric = rrdeng_load_metric_next;
1605             rd->tiers[tier]->query_ops.is_finished = rrdeng_load_metric_is_finished;
1606             rd->tiers[tier]->query_ops.finalize = rrdeng_load_metric_finalize;
1607             rd->tiers[tier]->query_ops.latest_time = rrdeng_metric_latest_time;
1608             rd->tiers[tier]->query_ops.oldest_time = rrdeng_metric_oldest_time;
>>>     CID 379238:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing "eng", which is known to be "NULL".
1609             rd->tiers[tier]->db_metric_handle = eng->api.init(rd, st->rrdhost->storage_instance[tier]);
1610         }
1611     
1612         return rd;
1613     }
1614     #endif
```


##### Test Plan
- N/A -- checks will clear the coverity issues
