### PR TITLE
UpdateNodeCollectors message

### DIFF
--- a/aclk/aclk_charts_api.c
+++ b/aclk/aclk_charts_api.c
@@ -66,3 +66,12 @@ void aclk_update_node_info(struct update_node_info *info)
     query->data.bin_payload.msg_name = "UpdateNodeInfo";
     QUEUE_IF_PAYLOAD_PRESENT(query);
 }
+
+void aclk_update_node_collectors(struct update_node_collectors *collectors)
+{
+    aclk_query_t query = aclk_query_new(UPDATE_NODE_COLLECTORS);
+    query->data.bin_payload.topic = ACLK_TOPICID_NODE_COLLECTORS;
+    query->data.bin_payload.payload = generate_update_node_collectors_message(&query->data.bin_payload.size, collectors);
+    query->data.bin_payload.msg_name = "UpdateNodeCollectors";
+    QUEUE_IF_PAYLOAD_PRESENT(query);
+}

--- a/aclk/aclk_charts_api.h
+++ b/aclk/aclk_charts_api.h
@@ -17,4 +17,6 @@ void aclk_retention_updated(struct retention_updated *data);
 
 void aclk_update_node_info(struct update_node_info *info);
 
+void aclk_update_node_collectors(struct update_node_collectors *collectors);
+
 #endif /* ACLK_CHARTS_H */

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -277,6 +277,7 @@ const char *aclk_query_get_name(aclk_query_type_t qt)
         case ALARM_LOG_HEALTH:     return "alarm_log_health";
         case ALARM_PROVIDE_CFG:    return "provide_alarm_config";
         case ALARM_SNAPSHOT:       return "alarm_snapshot";
+        case UPDATE_NODE_COLLECTORS: return "update_node_collectors";
         default:
             error_report("Unknown query type used %d", (int) qt);
             return "unknown";

--- a/aclk/aclk_query_queue.c
+++ b/aclk/aclk_query_queue.c
@@ -121,6 +121,7 @@ void aclk_query_free(aclk_query_t query)
     case ALARM_LOG_HEALTH:
     case ALARM_PROVIDE_CFG:
     case ALARM_SNAPSHOT:
+    case UPDATE_NODE_COLLECTORS:
         if (!use_mqtt_5)
             freez(query->data.bin_payload.payload);
         break;

--- a/aclk/aclk_query_queue.h
+++ b/aclk/aclk_query_queue.h
@@ -22,6 +22,7 @@ typedef enum {
     ALARM_LOG_HEALTH,
     ALARM_PROVIDE_CFG,
     ALARM_SNAPSHOT,
+    UPDATE_NODE_COLLECTORS,
     ACLK_QUERY_TYPE_COUNT // always keep this as last
 } aclk_query_type_t;
 

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -123,6 +123,7 @@ struct topic_name {
     { .id = ACLK_TOPICID_ALARM_HEALTH,          .name = "alarm-health"             },
     { .id = ACLK_TOPICID_ALARM_CONFIG,          .name = "alarm-config"             },
     { .id = ACLK_TOPICID_ALARM_SNAPSHOT,        .name = "alarm-snapshot"           },
+    { .id = ACLK_TOPICID_NODE_COLLECTORS,       .name = "node-instance-collectors" },
     { .id = ACLK_TOPICID_UNKNOWN,               .name = NULL                       }
 };
 
@@ -145,6 +146,7 @@ enum aclk_topics compulsory_topics[] = {
     ACLK_TOPICID_ALARM_HEALTH,
     ACLK_TOPICID_ALARM_CONFIG,
     ACLK_TOPICID_ALARM_SNAPSHOT,
+    ACLK_TOPICID_NODE_COLLECTORS,
     ACLK_TOPICID_UNKNOWN
 };
 

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -87,7 +87,8 @@ enum aclk_topics {
     ACLK_TOPICID_ALARM_LOG             = 14,
     ACLK_TOPICID_ALARM_HEALTH          = 15,
     ACLK_TOPICID_ALARM_CONFIG          = 16,
-    ACLK_TOPICID_ALARM_SNAPSHOT        = 17
+    ACLK_TOPICID_ALARM_SNAPSHOT        = 17,
+    ACLK_TOPICID_NODE_COLLECTORS       = 18
 };
 
 const char *aclk_get_topic(enum aclk_topics topic);

--- a/aclk/schema-wrappers/node_info.cc
+++ b/aclk/schema-wrappers/node_info.cc
@@ -110,3 +110,27 @@ char *generate_update_node_info_message(size_t *len, struct update_node_info *in
 
     return bin;
 }
+
+char *generate_update_node_collectors_message(size_t *len, struct update_node_collectors *upd_node_collectors)
+{
+    nodeinstance::info::v1::UpdateNodeCollectors msg;
+
+    msg.set_node_id(upd_node_collectors->node_id);
+    msg.set_claim_id(upd_node_collectors->claim_id);
+
+    void *colls;
+    dfe_start_read(upd_node_collectors->node_collectors, colls) {
+        struct collector_info *c =(struct collector_info *)colls;
+        nodeinstance::info::v1::CollectorInfo *col = msg.add_collectors();
+        col->set_plugin(c->plugin);
+        col->set_module(c->module);
+    }
+    dfe_done(colls);
+
+    *len = PROTO_COMPAT_MSG_SIZE(msg);
+    char *bin = (char*)malloc(*len);
+    if (bin)
+        msg.SerializeToArray(bin, *len);
+
+    return bin;
+}

--- a/aclk/schema-wrappers/node_info.cc
+++ b/aclk/schema-wrappers/node_info.cc
@@ -55,9 +55,6 @@ static int generate_node_info(nodeinstance::info::v1::NodeInfo *info, struct acl
     if (data->custom_info)
         info->set_custom_info(data->custom_info);
 
-    for (size_t i = 0; i < data->service_count; i++)
-        info->add_services(data->services[i]);
-
     if (data->machine_guid)
         info->set_machine_guid(data->machine_guid);
 

--- a/aclk/schema-wrappers/node_info.h
+++ b/aclk/schema-wrappers/node_info.h
@@ -50,9 +50,6 @@ struct aclk_node_info {
 
     char *custom_info;
 
-    char **services;
-    size_t service_count;
-
     char *machine_guid;
 
     DICTIONARY *host_labels_ptr;

--- a/aclk/schema-wrappers/node_info.h
+++ b/aclk/schema-wrappers/node_info.h
@@ -71,7 +71,20 @@ struct update_node_info {
     struct capability *node_instance_capabilities;
 };
 
+struct collector_info {
+    char *module;
+    char *plugin;
+};
+
+struct update_node_collectors {
+    char *claim_id;
+    char *node_id;
+    DICTIONARY *node_collectors;
+};
+
 char *generate_update_node_info_message(size_t *len, struct update_node_info *info);
+
+char *generate_update_node_collectors_message(size_t *len, struct update_node_collectors *collectors);
 
 #ifdef __cplusplus
 }

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -423,6 +423,7 @@ void aclk_database_worker(void *arg)
     worker_register_job_name(ACLK_DATABASE_CLEANUP,              "cleanup");
     worker_register_job_name(ACLK_DATABASE_DELETE_HOST,          "node delete");
     worker_register_job_name(ACLK_DATABASE_NODE_INFO,            "node info");
+    worker_register_job_name(ACLK_DATABASE_NODE_COLLECTORS,      "node collectors");
     worker_register_job_name(ACLK_DATABASE_PUSH_ALERT,           "alert push");
     worker_register_job_name(ACLK_DATABASE_PUSH_ALERT_CONFIG,    "alert conf push");
     worker_register_job_name(ACLK_DATABASE_PUSH_ALERT_SNAPSHOT,  "alert snapshot");
@@ -583,6 +584,10 @@ void aclk_database_worker(void *arg)
                     debug(D_ACLK_SYNC,"Sending node info for %s", wc->uuid_str);
                     sql_build_node_info(wc, cmd);
                     break;
+                case ACLK_DATABASE_NODE_COLLECTORS:
+                    debug(D_ACLK_SYNC,"Sending node collectors info for %s", wc->uuid_str);
+                    sql_build_node_collectors(wc);
+                    break;
 #ifdef ENABLE_ACLK
                 case ACLK_DATABASE_DIM_DELETION:
                     debug(D_ACLK_SYNC,"Sending dimension deletion information %s", wc->uuid_str);
@@ -633,6 +638,11 @@ void aclk_database_worker(void *arg)
                         cmd.opcode = ACLK_DATABASE_NODE_INFO;
                         cmd.completion = NULL;
                         wc->node_info_send = aclk_database_enq_cmd_noblock(wc, &cmd);
+                    }
+                    if (wc->node_collectors_send && wc->node_collectors_send + 30 < now_realtime_sec()) {
+                        cmd.opcode = ACLK_DATABASE_NODE_COLLECTORS;
+                        cmd.completion = NULL;
+                        wc->node_collectors_send = aclk_database_enq_cmd_noblock(wc, &cmd);
                     }
                     if (localhost == wc->host)
                         (void) sqlite3_wal_checkpoint(db_meta, NULL);

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -132,6 +132,7 @@ enum aclk_database_opcode {
     ACLK_DATABASE_PUSH_ALERT_CONFIG,
     ACLK_DATABASE_PUSH_ALERT_SNAPSHOT,
     ACLK_DATABASE_QUEUE_REMOVED_ALERTS,
+    ACLK_DATABASE_NODE_COLLECTORS,
     ACLK_DATABASE_TIMER,
 
     // leave this last
@@ -195,6 +196,7 @@ struct aclk_database_worker_config {
     int alert_updates;
     time_t batch_created;
     int node_info_send;
+    time_t node_collectors_send;
     int chart_pending;
     int chart_reset_count;
     int retention_running;

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -7,6 +7,45 @@
 #include "../../aclk/aclk_charts_api.h"
 #endif
 
+DICTIONARY *collectors_from_charts(RRDHOST *host, DICTIONARY *dict) {
+    RRDSET *st;
+    char name[500];
+
+    rrdhost_rdlock(host);
+    rrdset_foreach_read(st, host) {
+        if (rrdset_is_available_for_viewers(st)) {
+            struct collector_info col = {
+                    .plugin = st->plugin_name ? st->plugin_name : "",
+                    .module = st->module_name ? st->module_name : ""
+            };
+            snprintfz(name, 499, "%s:%s", col.plugin, col.module);
+            dictionary_set(dict, name, &col, sizeof(struct collector_info));
+        }
+    }
+    rrdhost_unlock(host);
+
+    return dict;
+}
+
+void sql_build_node_collectors(struct aclk_database_worker_config *wc)
+{
+    struct update_node_collectors upd_node_collectors;
+    DICTIONARY *dict = dictionary_create(DICTIONARY_FLAG_SINGLE_THREADED);
+
+    upd_node_collectors.node_id = wc->node_id;
+    upd_node_collectors.claim_id = is_agent_claimed();
+
+    upd_node_collectors.node_collectors = collectors_from_charts(wc->host, dict);
+    aclk_update_node_collectors(&upd_node_collectors);
+
+    dictionary_destroy(dict);
+    freez(upd_node_collectors.claim_id);
+
+    log_access("ACLK RES [%s (%s)]: NODE COLLECTORS SENT", wc->node_id, wc->host->hostname);
+
+    return;
+}
+
 void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
 {
     UNUSED(cmd);
@@ -81,6 +120,8 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     rrd_unlock();
     freez(node_info.claim_id);
     freez(host_version);
+
+    wc->node_collectors_send = now_realtime_sec();
 #else
     UNUSED(wc);
 #endif

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -61,8 +61,6 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     node_info.data.virtualization_type = host->system_info->virtualization ? host->system_info->virtualization : "unknown";
     node_info.data.container_type = host->system_info->container ? host->system_info->container : "unknown";
     node_info.data.custom_info = config_get(CONFIG_SECTION_WEB, "custom dashboard_info.js", "");
-    node_info.data.services = NULL;   // char **
-    node_info.data.service_count = 0;
     node_info.data.machine_guid = wc->host_guid;
 
     struct capability node_caps[] = {

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -7,6 +7,7 @@
 #include "../../aclk/aclk_charts_api.h"
 #endif
 
+#ifdef ENABLE_ACLK
 DICTIONARY *collectors_from_charts(RRDHOST *host, DICTIONARY *dict) {
     RRDSET *st;
     char name[500];
@@ -26,9 +27,11 @@ DICTIONARY *collectors_from_charts(RRDHOST *host, DICTIONARY *dict) {
 
     return dict;
 }
+#endif
 
 void sql_build_node_collectors(struct aclk_database_worker_config *wc)
 {
+#ifdef ENABLE_ACLK
     struct update_node_collectors upd_node_collectors;
     DICTIONARY *dict = dictionary_create(DICTIONARY_FLAG_SINGLE_THREADED);
 
@@ -42,7 +45,9 @@ void sql_build_node_collectors(struct aclk_database_worker_config *wc)
     freez(upd_node_collectors.claim_id);
 
     log_access("ACLK RES [%s (%s)]: NODE COLLECTORS SENT", wc->node_id, wc->host->hostname);
-
+#else
+    UNUSED(wc);
+#endif
     return;
 }
 

--- a/database/sqlite/sqlite_aclk_node.h
+++ b/database/sqlite/sqlite_aclk_node.h
@@ -4,4 +4,5 @@
 #define NETDATA_SQLITE_ACLK_NODE_H
 
 void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
+void sql_build_node_collectors(struct aclk_database_worker_config *wc);
 #endif //NETDATA_SQLITE_ACLK_NODE_H


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR adds a new `UpdateNodeCollectors` protobuf message. It will contain a list of collector's modules and plugins. From that list the FE will render a series of services, supported by the agent.

The message will follow 30 seconds after the `UpdateNodeInfo` message. This is to allow enough time for collectors to be activated and included in the message.

BE has been prepared to receive it.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

There should be a line stating `NODE COLLECTORS SENT` in `access.log`. It has been tested with @vkuznecovas in testing.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
