### PR TITLE
Actually allow running a test release in a fork of the repo.

### DIFF
--- a/.github/scripts/prepare-release-base.sh
+++ b/.github/scripts/prepare-release-base.sh
@@ -6,6 +6,7 @@ REPO="${1}"
 EVENT_NAME="${2}"
 EVENT_TYPE="${3}"
 EVENT_VERSION="${4}"
+RELEASE_TEST="${5}"
 
 ##############################################################
 # Version validation functions
@@ -94,7 +95,7 @@ check_newer_patch_version() {
 git config user.name "netdatabot"
 git config user.email "bot@netdata.cloud"
 
-if [ "${REPO}" != "netdata/netdata" ]; then
+if [ "${REPO}" != "netdata/netdata" ] && [ -z "${RELEASE_TEST}" ]; then
     echo "::notice::Not running in the netdata/netdata repository, not queueing a release build."
     echo "::set-output name=run::false"
 elif [ "${EVENT_NAME}" = 'schedule' ] || [ "${EVENT_TYPE}" = 'nightly' ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,8 @@ jobs:
               ${{ github.repository }} \
               ${{ github.event_name }} \
               ${{ github.event.inputs.type }} \
-              ${{ github.event.inputs.version }}
+              ${{ github.event.inputs.version }} \
+              ${{ secrets.NETDATA_RELEASE_TEST }}
       - name: Generate Nightly Changleog
         id: nightly-changelog
         if: steps.target.outputs.run == 'true' && steps.target.outputs.type == 'nightly'


### PR DESCRIPTION
##### Summary

This adds a way to manually bypass the check that explicitly keeps the release code from running if run in a repo other than netdata/netdata. This is done by setting `NETDATA_RELEASE_TEST` to a non-empty value in the repository secrets.

##### Test Plan

The changes to the `prepare-release-base.sh` script can be verified by manually running it in an isolated checkout of the agent repo in the following manner: `.github/scripts/prepare-release-base.sh foo/bar schedule nightly nightly ''`. This should spit out a message about refusing to run due to not being on the `netdata/netdata` repository. Changing the final parameter from an empty string to any non-empty string should result in it instead producing output about preparing a nightly build.

##### Additional Information

Relevant to (but does not fix): https://github.com/netdata/netdata/issues/13222