### PR TITLE
Silence compile warnings on external source

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -260,7 +260,7 @@ ML_FILES += \
     $(NULL)
 
 # Disable warnings from dlib library
-ml/kmeans/dlib/dlib/all/source.$(OBJEXT) : CXXFLAGS += -Wno-sign-compare -Wno-type-limits -Wno-aggressive-loop-optimizations
+ml/kmeans/dlib/dlib/all/source.$(OBJEXT) : CXXFLAGS += -Wno-sign-compare -Wno-type-limits -Wno-aggressive-loop-optimizations -Wno-stringop-overflow
 
 endif
 
@@ -473,6 +473,9 @@ RRD_PLUGIN_FILES = \
     database/metric_correlations.c \
     database/metric_correlations.h \
     $(NULL)
+
+database/sqlite/sqlite3.$(OBJEXT) : CFLAGS += -Wno-cast-function-type
+database/KolmogorovSmirnovDist.$(OBJEXT) : CFLAGS += -Wno-maybe-uninitialized
 
 if ENABLE_DBENGINE
     RRD_PLUGIN_FILES += \

--- a/Makefile.am
+++ b/Makefile.am
@@ -672,6 +672,8 @@ ACLK_FILES = \
     aclk/schema-wrappers/schema_wrapper_utils.h \
     $(NULL)
 
+mqtt_websockets/src/mqtt_wss_client.$(OBJEXT) : CFLAGS += -Wno-unused-result
+
 ACLK_PROTO_DEFINITIONS = \
     aclk/aclk-schemas/proto/aclk/v1/lib.proto \
     aclk/aclk-schemas/proto/agent/v1/disconnect.proto \


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Silences some compile warnings on `dlib`, `sqlite3` and `KolmogorovSmirnovDist`.

##### Test Plan

Compile warnings on those files should be gone.

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
