### PR TITLE
Add basic runtime checks to static build process.

### DIFF
--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -15,30 +15,44 @@ if [ -z "${platform}" ]; then
     exit 1
 fi
 
+if command -v docker > /dev/null 2>&1; then
+    docker="docker"
+elif command -v podman > /dev/null 2>&1; then
+    docker="podman"
+else
+    echo "Could not find a usable OCI runtime, need either Docker or Podman."
+    exit 1
+fi
+
 DOCKER_IMAGE_NAME="netdata/static-builder"
 
 if [ "${BUILDARCH}" != "$(uname -m)" ] && [ "$(uname -m)" = 'x86_64' ] && [ -z "${SKIP_EMULATION}" ]; then
-    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
+    ${docker} run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
 fi
 
-if docker inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
-    img_platform="$(docker image inspect netdata/static-builder --format '{{.Os}}/{{.Architecture}}/{{.Variant}}')"
-    if [ "${img_platform%'/'}" != "${platform}" ]; then
-        docker image rm "${DOCKER_IMAGE_NAME}" || exit 1
+if ${docker} inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
+    if ${docker} image inspect "${DOCKER_IMAGE_NAME}" | grep -q 'Variant'; then
+        img_platform="$(${docker} image inspect "${DOCKER_IMAGE_NAME}" --format '{{.Os}}/{{.Architecture}}/{{.Variant}}')"
+    else
+        img_platform="$(${docker} image inspect "${DOCKER_IMAGE_NAME}" --format '{{.Os}}/{{.Architecture}}')"
+    fi
+
+    if [ "${img_platform}" != "${platform}" ]; then
+        ${docker} image rm "${DOCKER_IMAGE_NAME}" || exit 1
     fi
 fi
 
-if ! docker inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
-    docker pull --platform "${platform}" "${DOCKER_IMAGE_NAME}"
+if ! ${docker} inspect "${DOCKER_IMAGE_NAME}" > /dev/null 2>&1; then
+    ${docker} pull --platform "${platform}" "${DOCKER_IMAGE_NAME}"
 fi
 
 # Run the build script inside the container
 if [ -t 1 ]; then
-  run docker run --rm -e BUILDARCH="${BUILDARCH}" -a stdin -a stdout -a stderr -i -t -v "$(pwd)":/netdata:rw \
+  run ${docker} run --rm -e BUILDARCH="${BUILDARCH}" -a stdin -a stdout -a stderr -i -t -v "$(pwd)":/netdata:rw \
     "${DOCKER_IMAGE_NAME}" \
     /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 else
-  run docker run --rm -e BUILDARCH="${BUILDARCH}" -v "$(pwd)":/netdata:rw \
+  run ${docker} run --rm -e BUILDARCH="${BUILDARCH}" -v "$(pwd)":/netdata:rw \
     -e GITHUB_ACTIONS="${GITHUB_ACTIONS}" "${DOCKER_IMAGE_NAME}" \
     /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 fi

--- a/packaging/makeself/install-alpine-packages.sh
+++ b/packaging/makeself/install-alpine-packages.sh
@@ -24,6 +24,7 @@ apk add --no-cache -U \
   git \
   gnutls-dev \
   gzip \
+  jq \
   libelf-static \
   libmnl-dev \
   libnetfilter_acct-dev \

--- a/packaging/makeself/jobs/90-netdata-runtime-check.sh
+++ b/packaging/makeself/jobs/90-netdata-runtime-check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# shellcheck source=./packaging/makeself/functions.sh
+. "${NETDATA_MAKESELF_PATH}"/functions.sh "${@}" || exit 1
+
+dump_log() {
+  cat ./netdata.log
+}
+
+wait_for() {
+  host="${1}"
+  port="${2}"
+  name="${3}"
+  timeout="30"
+
+  if command -v nc > /dev/null ; then
+    netcat="nc"
+  elif command -v netcat > /dev/null ; then
+    netcat="netcat"
+  else
+    printf "Unable to find a usable netcat command.\n"
+    return 1
+  fi
+
+  printf "Waiting for %s on %s:%s ... " "${name}" "${host}" "${port}"
+
+  sleep 30
+
+  i=0
+  while ! ${netcat} -z "${host}" "${port}"; do
+    sleep 1
+    if [ "$i" -gt "$timeout" ]; then
+      printf "Timed out!\n"
+      return 1
+    fi
+    i="$((i + 1))"
+  done
+  printf "OK\n"
+}
+
+trap dump_log EXIT
+
+"${NETDATA_INSTALL_PATH}/bin/netdata" -D > ./netdata.log 2>&1 &
+
+wait_for localhost 19999 netdata || exit 1
+
+curl -sS http://127.0.0.1:19999/api/v1/info > ./response || exit 1
+
+cat ./response
+
+jq '.version' ./response || exit 1
+
+trap - EXIT


### PR DESCRIPTION
##### Summary

This adds basic runtime startup checks to the static build process, equivalent to the basic checks we have for our native packages. With these in place, the static build will fail if the resultant executable cannot be run at all, or does not start up and provide a usable REST API.

##### Test Plan

CI passes correctly on this PR.

##### Additional Info

This also adds support to the static build system for using Podman instead of Docker, with autodetection of which is available at build time, and provides a useful error message if neither is found.