### PR TITLE
fix(packaging): respect CFLAGS arg when building Docker image

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /opt/netdata.git
 RUN chmod +x netdata-installer.sh && \
    cp -rp /deps/* /usr/local/ && \
    /bin/echo -e "INSTALL_TYPE='oci'\nPREBUILT_ARCH='$(uname -m)'" > ./system/.install-type && \
-   CFLAGS="-O2 -pipe" ./netdata-installer.sh --dont-wait --dont-start-it --use-system-protobuf \
+   CFLAGS=${CFLAGS:-"-O2 -pipe"} ./netdata-installer.sh --dont-wait --dont-start-it --use-system-protobuf \
    ${EXTRA_INSTALL_OPTS} --one-time-build "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
 
 # files to one directory


### PR DESCRIPTION
##### Summary

It is hardcoded to "-O2 -pipe" now.

https://github.com/netdata/netdata/blob/2cf65ad3774f697e1c618e2172eee9313c594575/packaging/docker/Dockerfile#L26-L29


##### Test Plan

Tested locally by adding a log message that prints CFLAGS to the installer script.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
