### PR TITLE
fix 32bit calculation on array allocator

### DIFF
--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -50,14 +50,14 @@ static void arrayalloc_init(ARAL *ar) {
         ar->internal.element_size = natural_alignment(ar->element_size, sizeof(uintptr_t));
 
         // then add the size of a pointer to it
-        ar->internal.element_size = ar->internal.element_size + sizeof(uintptr_t);
+        ar->internal.element_size += sizeof(uintptr_t);
 
         // make sure it is at least what we need for an ARAL_FREE slot
         if (ar->internal.element_size < sizeof(ARAL_FREE))
             ar->internal.element_size = sizeof(ARAL_FREE);
 
         // and finally align it to the natural alignment
-        ar->internal.element_size = natural_alignment(ar->element_size, ARAL_NATURAL_ALIGNMENT);
+        ar->internal.element_size = natural_alignment(ar->internal.element_size, ARAL_NATURAL_ALIGNMENT);
 
         // this is where we should write the pointer
         ar->internal.page_ptr_offset = ar->internal.element_size - sizeof(uintptr_t);
@@ -151,11 +151,11 @@ static inline void link_page_last(ARAL *ar, ARAL_PAGE *page) {
 }
 
 static inline ARAL_PAGE *find_page_with_allocation(ARAL *ar, void *ptr) {
-    size_t seeking = (size_t)ptr;
+    uintptr_t seeking = (uintptr_t)ptr;
     ARAL_PAGE *page;
 
     for(page = ar->internal.first_page; page ; page = page->next) {
-        if(unlikely(seeking >= (size_t)page->data && seeking < (size_t)page->data + page->size))
+        if(unlikely(seeking >= (uintptr_t)page->data && seeking < (uintptr_t)page->data + page->size))
             break;
     }
 

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -145,11 +145,11 @@ void onewayalloc_freez(ONEWAYALLOC *owa __maybe_unused, const void *ptr __maybe_
 
     OWA_PAGE *head = (OWA_PAGE *)owa;
     OWA_PAGE *page;
-    size_t seeking = (size_t)ptr;
+    uintptr_t seeking = (uintptr_t)ptr;
 
     for(page = head; page ;page = page->next) {
-        size_t start = (size_t)page;
-        size_t end = start + page->size;
+        uintptr_t start = (uintptr_t)page;
+        uintptr_t end = start + page->size;
 
         if(seeking >= start && seeking <= end) {
             // found it - it is ours


### PR DESCRIPTION
Netdata fails to start on 32bit machines. It was a wrong calculation.

fixes https://github.com/netdata/netdata/issues/13337