### PR TITLE
query engine: omit first point if not needed

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1026,7 +1026,7 @@ static inline void rrd2rrdr_do_dimension(
                 current_point = new_point;
                 query_interpolate_point(current_point, last1_point, now_end_time);
 
-                internal_error(current_point.id > 0 && last1_point.id == 0 && current_point.end_time > after_wanted && current_point.end_time < now_end_time,
+                internal_error(current_point.id > 0 && last1_point.id == 0 && current_point.end_time > after_wanted && current_point.end_time > now_end_time,
                                "QUERY: on '%s', dim '%s', after %ld, before %ld, view update every %ld, query granularity %ld,"
                                " interpolating point %zu (from %ld to %ld) at %ld, but we could really favor by having last_point1 in this query.",
                                rd->rrdset->name, rd->name, after_wanted, before_wanted, ops.view_update_every, ops.query_granularity,
@@ -1037,7 +1037,7 @@ static inline void rrd2rrdr_do_dimension(
                 current_point = last1_point;
                 query_interpolate_point(current_point, last2_point, now_end_time);
 
-                internal_error(current_point.id > 0 && last2_point.id == 0 && current_point.end_time > after_wanted && current_point.end_time < now_end_time,
+                internal_error(current_point.id > 0 && last2_point.id == 0 && current_point.end_time > after_wanted && current_point.end_time > now_end_time,
                                "QUERY: on '%s', dim '%s', after %ld, before %ld, view update every %ld, query granularity %ld,"
                                " interpolating point %zu (from %ld to %ld) at %ld, but we could really favor by having last_point2 in this query.",
                                rd->rrdset->name, rd->name, after_wanted, before_wanted, ops.view_update_every, ops.query_granularity,


### PR DESCRIPTION
When querying dbengine for time `t1` to `t2`, dbengine finds the latest page that its first point has an end time less or equal to `t1` and then within that page finds the latest point in the page that has end time less or equal to `t1`.

This works perfectly, but depending on the granularity of the database, it may have 1 issue:

The first point returned may not be useful for the query. It may be entirely past of it.

If the granularity of the database is not 1 (e.g. higher tiers), this point is still very useful and we want it. We use it to interpolate the next point that most likely will end within the query timeframe, so that we can find the exact value of the next point at the query boundaries. But still, this point, the first one that is entirely outside the query time-frame, should not be used otherwise.

This PR fixes it. The first point is omitted if it is entirely past the query time-frame, but it is still used if the next point needs to be interpolated.

I also added a lot of comments. And in case the first point needs to be interpolated but the query did not include the point before it, it logs a line saying so (internal checks only).
