### PR TITLE
Send node info message sooner

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -473,7 +473,7 @@ void aclk_database_worker(void *arg)
     fatal_assert(0 == uv_timer_start(&timer_req, timer_cb, TIMER_PERIOD_MS, TIMER_PERIOD_MS));
 
 //    wc->retry_count = 0;
-    wc->node_info_send = (wc->host && !localhost);
+    wc->node_info_send = 1;
 //    aclk_add_worker_thread(wc);
     info("Starting ACLK sync thread for host %s -- scratch area %lu bytes", wc->host_guid, sizeof(*wc));
 
@@ -634,7 +634,7 @@ void aclk_database_worker(void *arg)
                             }
                         }
                     }
-                    if (wc->node_info_send && wc->host && localhost && claimed() && aclk_connected) {
+                    if (wc->node_info_send && localhost && claimed() && aclk_connected) {
                         cmd.opcode = ACLK_DATABASE_NODE_INFO;
                         cmd.completion = NULL;
                         wc->node_info_send = aclk_database_enq_cmd_noblock(wc, &cmd);

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -58,8 +58,10 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
 #ifdef ENABLE_ACLK
     struct update_node_info node_info;
 
-    if (!wc->host)
+    if (!wc->host) {
+        wc->node_info_send = 1;
         return;
+    }
 
     rrd_rdlock();
     node_info.node_id = wc->node_id;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR tries to fix #13101 where on the first agent connection to the cloud, the NODE INFO message will be delayed to be sent to the cloud.

If it's the value of `wc->host` that we're waiting before sending the NODE INFO message, then the check is moved inside the function. In essence it will try to queue the function until the `wc->host` is there.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

We need to test that NODE INFO is sent to the cloud as soon as possible, that is:

1) On an running agent's first claim and first connection.
2) On a first start of an agent after claim.
3) When a child is connected and indicated as active.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
