### PR TITLE
Get rid of extra comma in OpenTSDB exporting

### DIFF
--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -286,8 +286,7 @@ int format_host_labels_opentsdb_http(struct instance *instance, RRDHOST *host) {
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
 
-    buffer_strcat(instance->labels_buffer, ",");
-    rrdlabels_to_buffer(host->host_labels, instance->labels_buffer, "", ":", "\"", ",",
+    rrdlabels_to_buffer(host->host_labels, instance->labels_buffer, ",", ":", "\"", "",
                         exporting_labels_filter_callback, instance,
                         NULL, sanitize_opentsdb_label_value);
     return 0;


### PR DESCRIPTION
##### Summary
There is an extra comma after the host name in the Graphite exporting output.
```text
[
{"metric":"netdata.system.processes.running","timestamp":1657531146,"value":1.0000000,"tags":{"host":"my_hostname",}},
{"metric":"netdata.system.processes.blocked","timestamp":1657531146,"value":0.0000000,"tags":{"host":"my_hostname",}}
]
```
The bug was introduced in #13070. We should remove the comma.

Fixes #13333

##### Test Plan
1. Configure an OpenTSDB HTTP exporting instance.
3. Check with `nc` if there are no commas after the host name.