### PR TITLE
chore(python.d): improve config file parsing error message

### DIFF
--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -572,8 +572,8 @@ class Plugin:
         try:
             statuses = JobsStatuses().from_file(abs_path)
         except Exception as error:
-            self.log.error("[{0}] error on loading '{1}': invalid YAML format: {2}".format(
-                module_name, abs_path, ' '.join(str(error).split('\n'))))
+            self.log.error("[{0}] config file invalid YAML format: {1}".format(
+                module_name, ' '.join([v.strip() for v in str(error).split('\n')])))
             return None
         self.log.debug("'{0}' is loaded".format(abs_path))
         return statuses

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -572,7 +572,8 @@ class Plugin:
         try:
             statuses = JobsStatuses().from_file(abs_path)
         except Exception as error:
-            self.log.warning("error on loading '{0}' : {1}".format(abs_path, repr(error)))
+            self.log.error("[{0}] error on loading '{1}': invalid YAML format: {2}".format(
+                module_name, abs_path, ' '.join(str(error).split('\n'))))
             return None
         self.log.debug("'{0}' is loaded".format(abs_path))
         return statuses


### PR DESCRIPTION
##### Summary

Fixes: #13360

Before

> 2022-07-11 19:32:48: python.d WARNING: plugin[main] : error on loading '/opt/netdata/etc/netdata/python.d/example.conf' : ParserError('while parsing a block mapping', <pyyaml3.error.Mark object at 0x7f509fc15e50>, "expected <block end>, but found '<block mapping start>'", <pyyaml3.error.Mark object at 0x7f509fb29dc0>)


After

> 2022-07-11 19:47:26: python.d ERROR: plugin[main] : [example] config file invalid YAML format: while parsing a block mapping in "/opt/netdata/etc/netdata/python.d/example.conf", line 72, column 1 expected <block end>, but found '<block mapping start>' in "/opt/netdata/etc/netdata/python.d/example.conf", line 74, column 5

##### Test Plan

Tested manually.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
