### PR TITLE
Address Coverity issues

### DIFF
--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1539,14 +1539,14 @@ char *find_and_replace(const char *src, const char *find, const char *replace, c
 bool bitmap256_get_bit(BITMAP256 *ptr, uint8_t idx) {
     if (unlikely(!ptr))
         return false;
-    return (ptr->data[idx / 64] & (1 << (idx % 64)));
+    return (ptr->data[idx / 64] & (1ULL << (idx % 64)));
 }
 
 void bitmap256_set_bit(BITMAP256 *ptr, uint8_t idx, bool value) {
     if (unlikely(!ptr))
         return;
     if (likely(value))
-        ptr->data[idx / 64] |= (1U << (idx % 64));
+        ptr->data[idx / 64] |= (1ULL << (idx % 64));
     else
-        ptr->data[idx / 64] &= ~(1U << (idx % 64));
+        ptr->data[idx / 64] &= ~(1ULL << (idx % 64));
 }


### PR DESCRIPTION
##### Summary

Address the following coverity issues
```
*** CID 379258:  Integer handling issues  (BAD_SHIFT)
/libnetdata/libnetdata.c: 1542 in bitmap256_get_bit()
1536     }
1537     
1538     
1539     bool bitmap256_get_bit(BITMAP256 *ptr, uint8_t idx) {
1540         if (unlikely(!ptr))
1541             return false;
>>>     CID 379258:  Integer handling issues  (BAD_SHIFT)
>>>     In expression "1 << idx % 64", left shifting by more than 31 bits has undefined behavior.  The shift amount, "idx % 64", is as much as 63.
1542         return (ptr->data[idx / 64] & (1 << (idx % 64)));
1543     }
1544     
1545     void bitmap256_set_bit(BITMAP256 *ptr, uint8_t idx, bool value) {
1546         if (unlikely(!ptr))
1547             return;
```

```
/libnetdata/libnetdata.c: 1551 in bitmap256_set_bit()
1545     void bitmap256_set_bit(BITMAP256 *ptr, uint8_t idx, bool value) {
1546         if (unlikely(!ptr))
1547             return;
1548         if (likely(value))
1549             ptr->data[idx / 64] |= (1U << (idx % 64));
1550         else
>>>     CID 379257:    (BAD_SHIFT)
>>>     In expression "1U << idx % 64", left shifting by more than 31 bits has undefined behavior.  The shift amount, "idx % 64", is as much as 63.
1551             ptr->data[idx / 64] &= ~(1U << (idx % 64));
/libnetdata/libnetdata.c: 1549 in bitmap256_set_bit()
1543     }
1544     
1545     void bitmap256_set_bit(BITMAP256 *ptr, uint8_t idx, bool value) {
1546         if (unlikely(!ptr))
1547             return;
1548         if (likely(value))
>>>     CID 379257:    (BAD_SHIFT)
>>>     In expression "1U << idx % 64", left shifting by more than 31 bits has undefined behavior.  The shift amount, "idx % 64", is as much as 63.
1549             ptr->data[idx / 64] |= (1U << (idx % 64));
1550         else
1551             ptr->data[idx / 64] &= ~(1U << (idx % 64));
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
