### PR TITLE
Add Oracle Linux 9 to officially supported platforms.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -141,11 +141,12 @@ include:
     test:
       ebpf-core: false
 
-  - distro: oraclelinux
+  - &oracle
+    distro: oraclelinux
     version: "8"
     jsonc_removal: |
       dnf remove -y json-c-devel
-    packages:
+    packages: &oracle_packages
       type: rpm
       repo_distro: ol/8
       arches:
@@ -153,6 +154,11 @@ include:
         - aarch64
     test:
       ebpf-core: true
+  - <<: *oracle
+    version: "9"
+    packages:
+      <<: *oracle_packages
+      repo_distro: ol/9
 
   - &ubuntu
     distro: ubuntu

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -60,6 +60,7 @@ to work on these platforms with minimal user effort.
 | Fedora | 36 | x86\_64, ARMv7, AArch64 | |
 | Fedora | 35 | x86\_64, ARMv7, AArch64 | |
 | openSUSE | Leap 15.3 | x86\_64, AArch64 | |
+| Oracle Linux | 9.x | x86\_64, AArch64 | |
 | Oracle Linux | 8.x | x86\_64, AArch64 | |
 | Red Hat Enterprise Linux | 9.x | x86\_64, AArch64 | |
 | Red Hat Enterprise Linux | 8.x | x86\_64, AArch64 | |

--- a/packaging/installer/dependencies/ol.sh
+++ b/packaging/installer/dependencies/ol.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Package tree used for installing netdata on distribution:
-# << Oracle Linux: [8] >>
+# << Oracle Linux: [8, 9] >>
 
 set -e
 
@@ -90,13 +90,17 @@ check_flags() {
 }
 
 validate_tree_ol() {
-
   opts=
   if [ "${NON_INTERACTIVE}" -eq 1 ]; then
     echo >&2 "Running in non-interactive mode"
     opts="-y"
   fi
 
+  # shellcheck disable=SC1091
+  source /etc/os-release
+
+  # shellcheck disable=SC2153
+  version="$(echo "${VERSION}" | cut -f 1 -d '.')"
 
   echo >&2 " > Checking for config-manager ..."
   if ! dnf config-manager &> /dev/null; then
@@ -106,9 +110,17 @@ validate_tree_ol() {
   fi
 
   echo " > Checking for CodeReady Builder ..."
-  if ! dnf repolist | grep ol8_codeready_builder; then
-    if prompt "CodeReadyBuilder not found, shall I install it?"; then
-      dnf ${opts} config-manager --set-enabled ol8_codeready_builder || enable_repo
+  if [[ "${version}" =~ ^8(\..*)?$ ]]; then
+    if ! dnf repolist enabled | grep ol8_codeready_builder; then
+      if prompt "CodeReadyBuilder not found, shall I install it?"; then
+        dnf ${opts} config-manager --set-enabled ol8_codeready_builder || enable_repo
+      fi
+    fi
+  elif [[ "${version}" =~ ^9(\..*)?$ ]]; then
+    if ! dnf repolist enabled | grep ol9_codeready_builder; then
+      if prompt "CodeReadyBuilder not found, shall I install it?"; then
+        dnf ${opts} config-manager --set-enabled ol9_codeready_builder || enable_repo
+      fi
     fi
   fi
 

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1535,6 +1535,13 @@ validate_tree_ol() {
 	EOF
       fi
     fi
+  elif [[ "${version}" =~ ^9(\..*)?$ ]]; then
+    echo " > Checking for CodeReady Builder ..."
+    if ! run ${sudo} dnf repolist enabled | grep -q codeready; then
+      if prompt "CodeReady Builder not enabled, shall I enable it?"; then
+        run ${sudo} dnf config-manager --set-enabled ol9_codeready_builder
+      fi
+    fi
   fi
 }
 


### PR DESCRIPTION
##### Summary

As outlined in the title.

##### Test Plan

CI passes on this PR.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Oracle Linux 9 will be officially supported by the Netdata Agent team going forwards.
</details>
