### PR TITLE
add AI_ADDRCONFIG flag to getaddrinfo hints

### DIFF
--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -615,6 +615,7 @@ int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t 
     hints.ai_family   = PF_UNSPEC;   /* Allow IPv4 or IPv6 */
     hints.ai_socktype = socktype;
     hints.ai_protocol = protocol;
+    hints.ai_flags |= AI_ADDRCONFIG;
 
     int ai_err = getaddrinfo(host, service, &hints, &ai_head);
     if (ai_err != 0) {


### PR DESCRIPTION
##### Summary

The problem:

> **Cannot resolve host ‘app.netdata.cloud’, port ‘443’: Try again (errno 11, Resource temporarily unavailable)**

https://github.com/netdata/netdata/blob/bd5f778838ff6b4206509a19b967f7b6eb6b16c7/aclk/https_client.c#L473

=>

https://github.com/netdata/netdata/blob/bd5f778838ff6b4206509a19b967f7b6eb6b16c7/libnetdata/socket/socket.c#L610-L619


It happens when

- using static builds (no problem when building from the source)
- DNS returns REFUSED for AAAA

tcpdump from a VM

```cmd
20:56:12.641180 IP 192.168.1.201.53929 > 192.168.1.1.53: 2170+ A? app.netdata.cloud. (35)
20:56:12.641194 IP 192.168.1.201.53929 > 192.168.1.1.53: 2327+ AAAA? app.netdata.cloud. (35)
20:56:12.643079 IP 192.168.1.1.53 > 192.168.1.201.53929: 2170 4/0/0 CNAME main-ingress-545609a41fcaf5d6.elb.us-east-1.amazonaws.com., A 54.198.178.11, A 44.196.50.41, A 44.207.131.212 (154)
20:56:12.653578 IP 192.168.1.1.53 > 192.168.1.201.53929: 2327 Refused 0/1/0 (207)
20:56:15.154302 IP 192.168.1.201.53929 > 192.168.1.1.53: 2327+ AAAA? app.netdata.cloud. (35)
20:56:15.166774 IP 192.168.1.1.53 > 192.168.1.201.53929: 2327 Refused 0/1/0 (207)
```

---

This PR adds `AI_ADDRCONFIG` flag

> If hints.ai_flags includes the AI_ADDRCONFIG flag, then IPv4
       addresses are returned in the list pointed to by res only if the
       local system has at least one IPv4 address configured, and IPv6
       addresses are returned only if the local system has at least one
       IPv6 address configured.  The loopback address is not considered
       for this case as valid as a configured address.  This flag is
       useful on, for example, IPv4-only systems, to ensure that
       getaddrinfo() does not return IPv6 socket addresses that would
       always fail in connect(2) or bind(2).


It is not a proper fix, but a workaround, and the flag seems good in general. It fixes the problem for all my (static build) Netdatas instances.

> **Warning** according to the https://fedoraproject.org/wiki/QA/Networking/NameResolution/ADDRCONFIG article AI_ADDRCONFIG is not reliable and something you do not want to use, but I didn't find any no-go for us.




##### Test Plan

Build a static image, install it, ensure that the node is online on the Cloud.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
