### PR TITLE
Fix netdata-updater.sh sha256sum on BSDs

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -266,10 +266,10 @@ str_in_list() {
 safe_sha256sum() {
   # Within the context of the installer, we only use -c option that is common between the two commands
   # We will have to reconsider if we start non-common options
-  if command -v sha256sum > /dev/null 2>&1; then
-    sha256sum "$@"
-  elif command -v shasum > /dev/null 2>&1; then
+  if command -v shasum > /dev/null 2>&1; then
     shasum -a 256 "$@"
+  elif command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "$@"
   else
     fatal "I could not find a suitable checksum binary to use" U0002
   fi


### PR DESCRIPTION
##### Summary

On FreeBSD 13 (for example) the `sha256sum` program doesn't use `-` to represent stdin. Using the `netdata-updater.sh` script on a system like this fails as it tries to use `sha256sum` first. This PR makes it try to use `shasum` first instead (which does use `-` for stdin).

##### Test Plan

I've only tested this on my FreeBSD 13 system, not sure how it would affect other systems. **It needs to be tested on Unix-like systems and/or other BSDs before being merged.**

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>

If you use netdata on FreeBSD (or another system with the same issue), the `netdata-updater.sh` script will now be able to continue past verification of the downloaded tarball to successfully update netdata. Without this PR, that update might fail since it can't validate the checksum.

</details>
