### PR TITLE
Store update every in dbengine metadata

### DIFF
--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -127,6 +127,8 @@ struct rrdeng_page_descr *pg_cache_create_descr(void)
 
     descr = rrdeng_page_descr_mallocz();
     descr->page_length = 0;
+    descr->type = 0;
+    descr->update_every = 0;
     descr->start_time = INVALID_TIME;
     descr->end_time = INVALID_TIME;
     descr->id = NULL;

--- a/database/engine/pagecache.h
+++ b/database/engine/pagecache.h
@@ -63,7 +63,8 @@ struct rrdeng_page_descr {
     usec_t start_time;
     usec_t end_time;
     uint32_t page_length;
-    uint8_t type;
+    uint32_t type:8;
+    uint32_t update_every:24;
 };
 
 #define PAGE_INFO_SCRATCH_SZ (8)

--- a/database/engine/pagecache.h
+++ b/database/engine/pagecache.h
@@ -42,6 +42,9 @@ struct page_cache_descr {
 #define PG_CACHE_DESCR_USERS_MASK   (((unsigned long)-1) << PG_CACHE_DESCR_SHIFT)
 #define PG_CACHE_DESCR_FLAGS_MASK   (((unsigned long)-1) >> (BITS_PER_ULONG - PG_CACHE_DESCR_SHIFT))
 
+#define PAGE_TYPE_FLAG_ALL          127
+#define PAGE_TYPE_FLAG_UPDATE_EVERY 128
+
 /*
  * Page cache descriptor state bits (works for both 32-bit and 64-bit architectures):
  *
@@ -63,7 +66,7 @@ struct rrdeng_page_descr {
     usec_t start_time;
     usec_t end_time;
     uint32_t page_length;
-    uint32_t type:8;
+    uint8_t type:8;
     uint32_t update_every:24;
 };
 

--- a/database/engine/rrddiskprotocol.h
+++ b/database/engine/rrddiskprotocol.h
@@ -47,7 +47,13 @@ struct rrdeng_extent_page_descr {
     uint8_t uuid[UUID_SZ];
     uint32_t page_length;
     uint64_t start_time;
-    uint64_t end_time;
+    union {
+        uint64_t end_time;
+        struct {
+            uint64_t end_time_delta:40;
+            uint64_t update_every:24;
+        } info;
+    };
 } __attribute__ ((packed));
 
 /*

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -16,7 +16,7 @@ uint8_t tier_page_type[RRD_STORAGE_TIERS] = {PAGE_METRICS, PAGE_TIER, PAGE_TIER,
 #if PAGE_TYPE_MAX != 1
 #error PAGE_TYPE_MAX is not 1 - you need to add allocations here
 #endif
-size_t page_type_size[256] = {sizeof(storage_number), sizeof(storage_number_tier1_t)};
+size_t page_type_size[128] = {sizeof(storage_number), sizeof(storage_number_tier1_t)};
 
 __attribute__((constructor)) void initialize_multidb_ctx(void) {
     multidb_ctx[0] = &multidb_ctx_storage_tier0;
@@ -267,6 +267,7 @@ void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *collection_handle, usec_t 
         rrdeng_store_metric_flush_current_page(collection_handle);
 
         page = rrdeng_create_page(ctx, &metric_handle->page_index->id, &descr);
+        descr->update_every = rd->update_every;
         fatal_assert(page);
 
         handle->descr = descr;


### PR DESCRIPTION
##### Summary
Stores the update within the page of the metadata. 
It reuses the entry for the page end time which is 64bit to store a delta from the page start time (40 bits and the update every 24 bits)

In a following PR the query engine will use this value
##### Test Plan
- TBA