### PR TITLE
Fix coverity issue 379240 (Unchecked return value)

### DIFF
--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -317,7 +317,8 @@ void arrayalloc_freez(ARAL *ar, void *ptr) {
         // free it
         if(ar->internal.mmap) {
             munmap(page->data, page->size);
-            unlink(page->filename);
+            if (unlikely(unlink(page->filename) == 1))
+                error("Cannot delete file '%s'", page->filename);
             freez((void *)page->filename);
         }
         else


### PR DESCRIPTION
##### Summary
Fix coverity issue

```
*** CID 379240:  Error handling issues  (CHECKED_RETURN)
/libnetdata/arrayalloc/arrayalloc.c: 320 in arrayalloc_freez()
314         if(!page->used_elements) {
315             unlink_page(ar, page);
316     
317             // free it
318             if(ar->internal.mmap) {
319                 munmap(page->data, page->size);
>>>     CID 379240:  Error handling issues  (CHECKED_RETURN)
>>>     Calling "unlink" without checking return value (as is done elsewhere 14 out of 15 times).
320                 unlink(page->filename);
321                 freez((void *)page->filename);
322             }
323             else
324                 freez(page->data);
325     
```

##### Test Plan
- Coverity report silenced