### PR TITLE
Store host system information in the database

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -689,7 +689,6 @@ RRDHOST *rrdhost_find_or_create(
            , rrdpush_api_key
            , rrdpush_send_charts_matching
            , system_info);
-        sql_store_host_system_info(&host->host_uuid, system_info);
     }
     if (host) {
         rrdhost_wrlock(host);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -487,6 +487,7 @@ RRDHOST *rrdhost_create(const char *hostname,
          , host->health_default_exec
          , host->health_default_recipient
     );
+    sql_store_host_system_info(&host->host_uuid, system_info);
 
     rrd_hosts_available++;
 
@@ -526,6 +527,7 @@ void rrdhost_update(RRDHOST *host
 
     rrdhost_system_info_free(host->system_info);
     host->system_info = system_info;
+    sql_store_host_system_info(&host->host_uuid, system_info);
 
     rrdhost_init_os(host, os);
     rrdhost_init_timezone(host, timezone, abbrev_timezone, utc_offset);
@@ -687,6 +689,7 @@ RRDHOST *rrdhost_find_or_create(
            , rrdpush_api_key
            , rrdpush_send_charts_matching
            , system_info);
+        sql_store_host_system_info(&host->host_uuid, system_info);
     }
     if (host) {
         rrdhost_wrlock(host);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2402,6 +2402,8 @@ skip_store:
 
 void sql_store_host_system_info(uuid_t *host_id, const struct rrdhost_system_info *system_info)
 {
+    if (unlikely(!system_info))
+        return;
 
     if (system_info->container_os_name)
         sql_store_host_system_info_key_value(host_id, "NETDATA_CONTAINER_OS_NAME", system_info->container_os_name);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2335,7 +2335,7 @@ void sql_build_host_system_info(uuid_t *host_id, struct rrdhost_system_info *sys
     rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind host parameter host information");
-        return;
+        goto skip_loading;
     }
 
     while (sqlite3_step(res) == SQLITE_ROW) {
@@ -2343,6 +2343,7 @@ void sql_build_host_system_info(uuid_t *host_id, struct rrdhost_system_info *sys
                                          (char *) sqlite3_column_text(res, 1));
     }
 
+skip_loading:
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
         error_report("Failed to finalize the prepared statement when reading host information");
     return;

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -32,6 +32,9 @@ const char *database_config[] = {
     "repeat text, host_labels text, p_db_lookup_dimensions text, p_db_lookup_method text, p_db_lookup_options int, "
     "p_db_lookup_after int, p_db_lookup_before int, p_update_every int);",
 
+    "CREATE TABLE IF NOT EXISTS host_info(host_id blob, system_key text, system_value text, "
+    "date_created int, PRIMARY KEY(host_id, system_key));"
+
     "CREATE TABLE IF NOT EXISTS chart_hash_map(chart_id blob , hash_id blob, UNIQUE (chart_id, hash_id));",
 
     "CREATE TABLE IF NOT EXISTS chart_hash(hash_id blob PRIMARY KEY,type text, id text, name text, "
@@ -2313,3 +2316,164 @@ failed:
 
     return;
 };
+
+#define SELECT_HOST_INFO "select system_key, system_value from host_info where host_id = @host_id;"
+
+void sql_build_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info)
+{
+    int rc;
+
+    sqlite3_stmt *res = NULL;
+
+    rc = sqlite3_prepare_v2(db_meta, SELECT_HOST_INFO, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement to read host information");
+        return;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host parameter host information");
+        return;
+    }
+
+    while (sqlite3_step(res) == SQLITE_ROW) {
+        rrdhost_set_system_info_variable(system_info, (char *) sqlite3_column_text(res, 0),
+                                         (char *) sqlite3_column_text(res, 1));
+    }
+
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when reading host information");
+    return;
+}
+
+
+#define SQL_INS_HOST_SYSTEM_INFO "insert or replace into host_info " \
+    "(host_id, system_key, system_value, date_created) " \
+    "values (@host, @key, @value, strftime('%s'));"
+
+void sql_store_host_system_info_key_value(uuid_t *host_id, char *name, char *value)
+{
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    if (unlikely(!db_meta)) {
+        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            error_report("Database has not been initialized");
+        return;
+    }
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_INS_HOST_SYSTEM_INFO, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement to store system info");
+        return;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, host_id, sizeof(*host_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind host parameter to store system information");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_text(res, 2, name, -1, SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind label parameter to store name information");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_text(res, 3, value, -1, SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind value parameter to store value information");
+        goto failed;
+    }
+
+    rc = execute_insert(res);
+    if (unlikely(rc != SQLITE_DONE))
+        error_report("Failed to store host system info, rc = %d", rc);
+
+failed:
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when storing  host system information");
+
+    return;
+}
+
+
+void sql_store_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info)
+{
+
+    if (system_info->container_os_name)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_CONTAINER_OS_NAME", system_info->container_os_name);
+
+    if (system_info->container_os_id)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_CONTAINER_OS_ID", system_info->container_os_id);
+
+    if (system_info->container_os_id_like)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_CONTAINER_OS_ID_LIKE", system_info->container_os_id_like);
+
+    if (system_info->container_os_version)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_CONTAINER_OS_VERSION", system_info->container_os_version);
+
+    if (system_info->container_os_version_id)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_CONTAINER_OS_VERSION_ID", system_info->container_os_version_id);
+
+    if (system_info->host_os_detection)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_CONTAINER_OS_DETECTION", system_info->host_os_detection);
+
+    if (system_info->host_os_name)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_HOST_OS_NAME", system_info->host_os_name);
+
+    if (system_info->host_os_id)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_HOST_OS_ID", system_info->host_os_id);
+
+    if (system_info->host_os_id_like)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_HOST_OS_ID_LIKE", system_info->host_os_id_like);
+
+    if (system_info->host_os_version)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_HOST_OS_VERSION", system_info->host_os_version);
+
+    if (system_info->host_os_version_id)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_HOST_OS_VERSION_ID", system_info->host_os_version_id);
+
+    if (system_info->host_os_detection)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_HOST_OS_DETECTION", system_info->host_os_detection);
+
+    if (system_info->kernel_name)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_KERNEL_NAME", system_info->kernel_name);
+
+    if (system_info->host_cores)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_CPU_LOGICAL_CPU_COUNT", system_info->host_cores);
+
+    if (system_info->host_cpu_freq)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_CPU_FREQ", system_info->host_cpu_freq);
+
+    if (system_info->host_ram_total)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_TOTAL_RAM", system_info->host_ram_total);
+
+    if (system_info->host_disk_space)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_TOTAL_DISK_SIZE", system_info->host_disk_space);
+
+    if (system_info->kernel_version)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_KERNEL_VERSION", system_info->kernel_version);
+
+    if (system_info->architecture)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_ARCHITECTURE", system_info->architecture);
+
+    if (system_info->virtualization)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_VIRTUALIZATION", system_info->virtualization);
+
+    if (system_info->virt_detection)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_VIRT_DETECTION", system_info->virt_detection);
+
+    if (system_info->container)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_CONTAINER", system_info->container);
+
+    if (system_info->container_detection)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_SYSTEM_CONTAINER_DETECTION", system_info->container_detection);
+
+    if (system_info->is_k8s_node)
+        sql_store_host_system_info_key_value(host_id, "NETDATA_HOST_IS_K8S_NODE", system_info->is_k8s_node);
+
+    return;
+}
+

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2353,7 +2353,7 @@ void sql_build_host_system_info(uuid_t *host_id, struct rrdhost_system_info *sys
     "(host_id, system_key, system_value, date_created) " \
     "VALUES (@host, @key, @value, unixepoch());"
 
-void sql_store_host_system_info_key_value(uuid_t *host_id, char *name, char *value)
+void sql_store_host_system_info_key_value(uuid_t *host_id, const char *name, const char *value)
 {
     sqlite3_stmt *res = NULL;
     int rc;
@@ -2400,7 +2400,7 @@ skip_store:
 }
 
 
-void sql_store_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info)
+void sql_store_host_system_info(uuid_t *host_id, const struct rrdhost_system_info *system_info)
 {
 
     if (system_info->container_os_name)

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -66,6 +66,7 @@ const char *database_cleanup[] = {
     "DELETE FROM chart_hash_map WHERE chart_id NOT IN (SELECT chart_id FROM chart);",
     "DELETE FROM chart_hash WHERE hash_id NOT IN (SELECT hash_id FROM chart_hash_map);",
     "DELETE FROM node_instance WHERE host_id NOT IN (SELECT host_id FROM host);",
+    "DELETE FROM host_info WHERE host_id NOT IN (SELECT host_id FROM host);",
     NULL
 };
 

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -106,4 +106,5 @@ char *get_hostname_by_node_id(char *node_id);
 void free_temporary_host(RRDHOST *host);
 int init_database_batch(int rebuild, int init_type, const char *batch[]);
 void migrate_localhost(uuid_t *host_uuid);
+extern void sql_store_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -106,5 +106,5 @@ char *get_hostname_by_node_id(char *node_id);
 void free_temporary_host(RRDHOST *host);
 int init_database_batch(int rebuild, int init_type, const char *batch[]);
 void migrate_localhost(uuid_t *host_uuid);
-extern void sql_store_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info);
+extern void sql_store_host_system_info(uuid_t *host_id, const struct rrdhost_system_info *system_info);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
Add a new `host_info` table to hold additional host information as key / value pairs. Those will be used to 
populate the host->system_info structure when the host is in archived mode.

This PR will only store the system info in the database table. A subsequent PR will make use the stored info to create archived 
hosts in memory. 

##### Test Plan
- Apply the PR and notice a new table `host_info` in the database. Check to see that the table is populated
  Use e.g. the sqlite3 CLI to check the table. 

