### PR TITLE
Skip repo-specific CI on forks.

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
+    if: github.repository == 'netdata/netdata'
     runs-on: ubuntu-latest
     steps:
       - name: Add issues to Agent project board

--- a/.github/workflows/cloud_regression.yml
+++ b/.github/workflows/cloud_regression.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   trigger_cloud_regression_tests:
     runs-on: ubuntu-latest
+    if: github.repository == 'netdata/netdata'
     steps:
       - name: Evaluate workflow dispatch parameters
         env:

--- a/.github/workflows/packagecloud.yml
+++ b/.github/workflows/packagecloud.yml
@@ -10,7 +10,7 @@ jobs:
   cleanup:
     name: PackageCloud Cleanup
     runs-on: ubuntu-latest
-    if: always()
+    if: github.repository == 'netdata/netdata'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
##### Summary

This will avoid pestering developers with failed workflow run messages for workflows that should not even be running in their repos.

##### Test Plan

n/a