### PR TITLE
Add missing comma (handle coverity warning CID 379360)

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -33,7 +33,7 @@ const char *database_config[] = {
     "p_db_lookup_after int, p_db_lookup_before int, p_update_every int);",
 
     "CREATE TABLE IF NOT EXISTS host_info(host_id blob, system_key text NOT NULL, system_value text NOT NULL, "
-    "date_created INT, PRIMARY KEY(host_id, system_key));"
+    "date_created INT, PRIMARY KEY(host_id, system_key));",
 
     "CREATE TABLE IF NOT EXISTS chart_hash_map(chart_id blob , hash_id blob, UNIQUE (chart_id, hash_id));",
 


### PR DESCRIPTION
##### Summary
Handle coverity warning
```
*** CID 379360:  Incorrect expression  (MISSING_COMMA)
/database/sqlite/sqlite_functions.c: 35 in ()
29         "on_key text, class text, component text, type text, os text, hosts text, lookup text, "
30         "every text, units text, calc text, families text, plugin text, module text, charts text, green text, "
31         "red text, warn text, crit text, exec text, to_key text, info text, delay text, options text, "
32         "repeat text, host_labels text, p_db_lookup_dimensions text, p_db_lookup_method text, p_db_lookup_options int, "
33         "p_db_lookup_after int, p_db_lookup_before int, p_update_every int);",
34     
>>>     CID 379360:  Incorrect expression  (MISSING_COMMA)
>>>     In the initialization of "database_config", a suspicious concatenated string ""CREATE TABLE IF NOT EXISTS host_info(host_id blob, system_key text NOT NULL, system_value text NOT NULL, date_created INT, PRIMARY KEY(host_id, system_key));CREATE TABLE IF NOT EXISTS chart_hash_map(chart_id blob , hash_id blob, UNIQUE (chart_id, hash_id));"" is produced due to a missing comma between lines.
35         "CREATE TABLE IF NOT EXISTS host_info(host_id blob, system_key text NOT NULL, system_value text NOT NULL, "
36         "date_created INT, PRIMARY KEY(host_id, system_key));"
37     
38         "CREATE TABLE IF NOT EXISTS chart_hash_map(chart_id blob , hash_id blob, UNIQUE (chart_id, hash_id));",
39     
40         "CREATE TABLE IF NOT EXISTS chart_hash(hash_id blob PRIMARY KEY,type text, id text, name text, "
```

##### Test Plan
- Coverity warning will go away
