### PR TITLE
Remove Alpine 3.13 from CI and official support.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -32,8 +32,6 @@ include:
     version: "3.15"
   - <<: *alpine
     version: "3.14"
-  - <<: *alpine
-    version: "3.13"
 
   - distro: archlinux
     version: latest

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -85,7 +85,6 @@ with minimal user effort.
 | -------- | ------- | ------------------------ | ----- |
 | Alpine Linux | 3.15 | No | |
 | Alpine Linux | 3.14 | No | |
-| Alpine Linux | 3.13 | No | |
 | Arch Linux | Latest | No | We officially recommend the community packages available for Arch Linux |
 | Manjaro Linux | Latest | No | We officially recommend the community packages available for Arch Linux |
 
@@ -146,8 +145,8 @@ This is a list of platforms that we have supported in the recent past but no lon
 
 | Platform | Version | Notes |
 | -------- | ------- | ----- |
+| Alpine Linux | 3.13 | EOL as of 2022-11-01 |
 | Alpine Linux | 3.12 | EOL as of 2022-05-01 |
-| Alpine Linux | 3.11 | EOL as of 2021-11-01 |
 | Debian | 9.x | EOL as of 2022-06-30 |
 | Fedora | 34 | EOL as of 2022-06-07 |
 | Fedora | 33 | EOL as of 2021-11-30 |


### PR DESCRIPTION
##### Summary

To be merged on 2022-11-01 when it goes EOL upstream.

##### Test Plan

n/a

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
As of 2022-11-01, Alpine Linux 3.13 will no longer be officially supported by the Netdata team.
</details>
