### PR TITLE
Set value to SN_EMPTY_SLOT if flags is SN_EMPTY_SLOT

### DIFF
--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -238,7 +238,7 @@ void read_cached_extent_cb(struct rrdengine_worker_config* wc, unsigned idx, str
 static void fill_page_with_nulls(void *page, uint32_t page_length, uint8_t type) {
     switch(type) {
         case PAGE_METRICS: {
-            storage_number n = SN_EMPTY_SLOT;
+            storage_number n = pack_storage_number(NAN, SN_FLAG_NONE);
             storage_number *array = (storage_number *)page;
             size_t slots = page_length / sizeof(n);
             for(size_t i = 0; i < slots ; i++)
@@ -248,9 +248,9 @@ static void fill_page_with_nulls(void *page, uint32_t page_length, uint8_t type)
 
         case PAGE_TIER: {
             storage_number_tier1_t n = {
-                .min_value = SN_EMPTY_SLOT,
-                .max_value = SN_EMPTY_SLOT,
-                .sum_value = SN_EMPTY_SLOT,
+                .min_value = NAN,
+                .max_value = NAN,
+                .sum_value = NAN,
                 .count = 1,
                 .anomaly_count = 0,
             };

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -183,7 +183,7 @@ static int page_has_only_empty_metrics(struct rrdeng_page_descr *descr)
 
     page = descr->pg_cache_descr->page;
     for (i = 0 ; i < descr->page_length / PAGE_POINT_SIZE_BYTES(descr); ++i) {
-        if (SN_EMPTY_SLOT != page[i]) {
+        if (does_storage_number_exist(page[i])) {
             has_only_empty_metrics = 0;
             break;
         }
@@ -222,7 +222,9 @@ void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *collection_h
     handle->descr = NULL;
 }
 
-void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *collection_handle, usec_t point_in_time, NETDATA_DOUBLE n,
+void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *collection_handle,
+                              usec_t point_in_time,
+                              NETDATA_DOUBLE n,
                               NETDATA_DOUBLE min_value,
                               NETDATA_DOUBLE max_value,
                               uint16_t count,
@@ -518,7 +520,7 @@ STORAGE_POINT rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle)
             sp.min = sp.max = sp.sum = unpack_storage_number(n);
             sp.flags = n & SN_ALL_FLAGS;
             sp.count = 1;
-            sp.anomaly_count = (n & SN_ANOMALY_BIT) ? 0 : 1;
+            sp.anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
         }
         break;
 

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -518,7 +518,7 @@ STORAGE_POINT rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle)
         case PAGE_METRICS: {
             storage_number n = handle->page[position];
             sp.min = sp.max = sp.sum = unpack_storage_number(n);
-            sp.flags = n & SN_ALL_FLAGS;
+            sp.flags = n & SN_USER_FLAGS;
             sp.count = 1;
             sp.anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
         }
@@ -526,7 +526,7 @@ STORAGE_POINT rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle)
 
         case PAGE_TIER: {
             tier1_value = ((storage_number_tier1_t *)handle->page)[position];
-            sp.flags = tier1_value.anomaly_count ? 0 : SN_ANOMALY_BIT;
+            sp.flags = tier1_value.anomaly_count ? SN_FLAG_NONE : SN_FLAG_NOT_ANOMALOUS;
             sp.count = tier1_value.count;
             sp.anomaly_count = tier1_value.anomaly_count;
             sp.min = tier1_value.min_value;

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -192,7 +192,7 @@ STORAGE_POINT rrddim_query_next_metric(struct rrddim_query_handle *handle) {
     h->slot_timestamp += h->dt;
 
     sp.anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
-    sp.flags = (n & SN_ALL_FLAGS);
+    sp.flags = (n & SN_USER_FLAGS);
     sp.min = sp.max = sp.sum = unpack_storage_number(n);
 
     return sp;

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -15,7 +15,7 @@ void rrddim_metric_free(STORAGE_METRIC_HANDLE *db_metric_handle __maybe_unused) 
 
 STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_handle) {
     RRDDIM *rd = (RRDDIM *)db_metric_handle;
-    rd->db[rd->rrdset->current_entry] = SN_EMPTY_SLOT;
+    rd->db[rd->rrdset->current_entry] = pack_storage_number(NAN, SN_FLAG_NONE);
     struct mem_collect_handle *ch = calloc(1, sizeof(struct mem_collect_handle));
     ch->rd = rd;
     return (STORAGE_COLLECT_HANDLE *)ch;
@@ -191,7 +191,7 @@ STORAGE_POINT rrddim_query_next_metric(struct rrddim_query_handle *handle) {
     h->slot = slot;
     h->slot_timestamp += h->dt;
 
-    sp.anomaly_count = (n & SN_ANOMALY_BIT) ? 0 : 1;
+    sp.anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
     sp.flags = (n & SN_ALL_FLAGS);
     sp.min = sp.max = sp.sum = unpack_storage_number(n);
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -378,7 +378,7 @@ typedef struct storage_point {
     (x).min = (x).max = (x).sum = NAN;                  \
     (x).count = 0;                                      \
     (x).anomaly_count = 0;                              \
-    (x).flags = SN_EMPTY_SLOT;                          \
+    (x).flags = SN_FLAG_NONE;                           \
     (x).start_time = 0;                                 \
     (x).end_time = 0;                                   \
     } while(0)
@@ -387,7 +387,7 @@ typedef struct storage_point {
     (x).min = (x).max = (x).sum = NAN;                  \
     (x).count = 1;                                      \
     (x).anomaly_count = 0;                              \
-    (x).flags = SN_EMPTY_SLOT;                          \
+    (x).flags = SN_FLAG_NONE;                           \
     (x).start_time = start_t;                           \
     (x).end_time = end_t;                               \
     } while(0)

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1041,8 +1041,7 @@ void store_metric_at_tier(RRDDIM *rd, struct rrddim_tier *t, STORAGE_POINT sp, u
                 NAN,
                 NAN,
                 0,
-                0,
-                SN_FLAG_NONE);
+                0, SN_FLAG_NONE);
         }
 
         t->virtual_point.count = 0;
@@ -1075,7 +1074,7 @@ static void store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
             .max = n,
             .sum = n,
             .count = 1,
-            .anomaly_count = (flags & SN_ANOMALY_BIT) ? 0 : 1,
+            .anomaly_count = (flags & SN_FLAG_NOT_ANOMALOUS) ? 0 : 1,
             .flags = flags
         };
 
@@ -1110,7 +1109,7 @@ static inline size_t rrdset_done_interpolate(
     SN_FLAGS storage_flags = SN_DEFAULT_FLAGS;
 
     if (has_reset_value)
-        storage_flags |= SN_EXISTS_RESET;
+        storage_flags |= SN_FLAG_RESET;
 
     for( ; next_store_ut <= now_collect_ut ; last_collect_ut = next_store_ut, next_store_ut += update_every_ut, iterations-- ) {
 
@@ -1216,7 +1215,7 @@ static inline size_t rrdset_done_interpolate(
 
                 if (ml_is_anomalous(rd, new_value, true)) {
                     // clear anomaly bit: 0 -> is anomalous, 1 -> not anomalous
-                    dim_storage_flags &= ~((storage_number)SN_ANOMALY_BIT);
+                    dim_storage_flags &= ~((storage_number)SN_FLAG_NOT_ANOMALOUS);
                 }
 
                 store_metric(rd, next_store_ut, new_value, dim_storage_flags);

--- a/libnetdata/storage_number/storage_number.c
+++ b/libnetdata/storage_number/storage_number.c
@@ -11,16 +11,12 @@ storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
     // bit 25 SN_ANOMALY_BIT = 0: anomalous, 1: not anomalous
     // bit 24 to bit 1 = the value
 
-    if (unlikely(flags == SN_EMPTY_SLOT)) {
-        return SN_EMPTY_SLOT;
-    }
-
-    storage_number r = flags & SN_ALL_FLAGS;
-
     // The isnormal() macro shall determine whether its argument value
     // is normal (neither zero, subnormal, infinite, nor NaN).
     if(unlikely(!isnormal(value)))
-        goto RET_SN;
+        return SN_EMPTY_SLOT;
+
+    storage_number r = flags & SN_ALL_FLAGS;
 
     int m = 0;
     NETDATA_DOUBLE n = value, factor = 10;
@@ -55,7 +51,7 @@ storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
             error("Number " NETDATA_DOUBLE_FORMAT " is too big.", value);
             #endif
             r += 0x00ffffff;
-            goto RET_SN;
+            return r;
         }
     }
     else {
@@ -85,10 +81,6 @@ storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
 #else
     r += (storage_number)n;
 #endif
-
-RET_SN:
-    if (r == SN_EMPTY_SLOT)
-        r = SN_ANOMALOUS_ZERO;
 
     return r;
 }

--- a/libnetdata/storage_number/storage_number.c
+++ b/libnetdata/storage_number/storage_number.c
@@ -11,6 +11,10 @@ storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
     // bit 25 SN_ANOMALY_BIT = 0: anomalous, 1: not anomalous
     // bit 24 to bit 1 = the value
 
+    if (unlikely(flags == SN_EMPTY_SLOT)) {
+        return SN_EMPTY_SLOT;
+    }
+
     storage_number r = flags & SN_ALL_FLAGS;
 
     // The isnormal() macro shall determine whether its argument value

--- a/libnetdata/storage_number/storage_number.c
+++ b/libnetdata/storage_number/storage_number.c
@@ -11,12 +11,16 @@ storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
     // bit 25 SN_ANOMALY_BIT = 0: anomalous, 1: not anomalous
     // bit 24 to bit 1 = the value
 
+    storage_number r = flags & SN_ALL_FLAGS;
+
     // The isnormal() macro shall determine whether its argument value
     // is normal (neither zero, subnormal, infinite, nor NaN).
-    if(unlikely(!isnormal(value)))
-        return SN_EMPTY_SLOT;
-
-    storage_number r = flags & SN_ALL_FLAGS;
+    if(unlikely(!isnormal(value))) {
+        if(!netdata_double_isnumber(value))
+            return SN_EMPTY_SLOT;
+        else
+            return r;
+    }
 
     int m = 0;
     NETDATA_DOUBLE n = value, factor = 10;

--- a/libnetdata/storage_number/storage_number.c
+++ b/libnetdata/storage_number/storage_number.c
@@ -16,7 +16,7 @@ storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
     // The isnormal() macro shall determine whether its argument value
     // is normal (neither zero, subnormal, infinite, nor NaN).
     if(unlikely(!isnormal(value))) {
-        if(!netdata_double_isnumber(value))
+        if(unlikely(!netdata_double_isnumber(value)))
             return SN_EMPTY_SLOT;
         else
             return r;

--- a/libnetdata/storage_number/storage_number.h
+++ b/libnetdata/storage_number/storage_number.h
@@ -99,7 +99,7 @@ typedef enum {
 #define did_storage_number_reset(value)  ((((storage_number)(value)) & SN_EXISTS_RESET))
 #define is_storage_number_anomalous(value)  (does_storage_number_exist(value) && !(((storage_number)(value)) & SN_ANOMALY_BIT))
 
-storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags);
+storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) __attribute__((const));
 static inline NETDATA_DOUBLE unpack_storage_number(storage_number value) __attribute__((const));
 
 int print_netdata_double(char *str, NETDATA_DOUBLE value);

--- a/libnetdata/storage_number/storage_number.h
+++ b/libnetdata/storage_number/storage_number.h
@@ -75,29 +75,31 @@ typedef struct storage_number_tier1 {
 #define STORAGE_NUMBER_FORMAT "%u"
 
 typedef enum {
-    SN_FLAG_NONE     = 0,
-    SN_ANOMALY_BIT   = (1 << 24), // the anomaly bit of the value
-    SN_EXISTS_RESET  = (1 << 25), // the value has been overflown
-    SN_EXISTS_100    = (1 << 26)  // very large value (multiplier is 100 instead of 10)
+    SN_FLAG_NONE              = 0,
+    SN_FLAG_NOT_ANOMALOUS     = (1 << 24), // the anomaly bit of the value (0:anomalous, 1:not anomalous)
+    SN_FLAG_RESET             = (1 << 25), // the value has been overflown
+    SN_FLAG_NOT_EXISTS_MUL100 = (1 << 26), // very large value (multiplier is 100 instead of 10)
+    SN_FLAG_MULTIPLY          = (1 << 30), // multiply, else divide
+    SN_FLAG_NEGATIVE          = (1 << 31), // negative, else positive
 } SN_FLAGS;
 
-#define SN_ALL_FLAGS (SN_ANOMALY_BIT|SN_EXISTS_RESET|SN_EXISTS_100)
+#define SN_USER_FLAGS (SN_FLAG_NOT_ANOMALOUS | SN_FLAG_RESET)
 
 // default flags for all storage numbers
 // anomaly bit is reversed, so we set it by default
-#define SN_DEFAULT_FLAGS SN_ANOMALY_BIT
+#define SN_DEFAULT_FLAGS SN_FLAG_NOT_ANOMALOUS
 
 // When the calculated number is zero and the value is anomalous (ie. it's bit
 // is zero) we want to return a storage_number representation that is
 // different from the empty slot. We achieve this by mapping zero to
 // SN_EXISTS_100. Unpacking the SN_EXISTS_100 value will return zero because
 // its fraction field (as well as its exponent factor field) will be zero.
-#define SN_EMPTY_SLOT SN_EXISTS_100
+#define SN_EMPTY_SLOT SN_FLAG_NOT_EXISTS_MUL100
 
 // checks
 #define does_storage_number_exist(value) (((storage_number)(value)) != SN_EMPTY_SLOT)
-#define did_storage_number_reset(value)  ((((storage_number)(value)) & SN_EXISTS_RESET))
-#define is_storage_number_anomalous(value)  (does_storage_number_exist(value) && !(((storage_number)(value)) & SN_ANOMALY_BIT))
+#define did_storage_number_reset(value)  ((((storage_number)(value)) & SN_FLAG_RESET))
+#define is_storage_number_anomalous(value)  (does_storage_number_exist(value) && !(((storage_number)(value)) & SN_FLAG_NOT_ANOMALOUS))
 
 storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) __attribute__((const));
 static inline NETDATA_DOUBLE unpack_storage_number(storage_number value) __attribute__((const));
@@ -129,19 +131,19 @@ static inline NETDATA_DOUBLE unpack_storage_number(storage_number value) {
     int factor = 0;
 
     // bit 32 = 0:positive, 1:negative
-    if(unlikely(value & (1 << 31)))
+    if(unlikely(value & SN_FLAG_NEGATIVE))
         sign = -1;
 
     // bit 31 = 0:divide, 1:multiply
-    if(unlikely(value & (1 << 30)))
+    if(unlikely(value & SN_FLAG_MULTIPLY))
         exp = 1;
 
-    // bit 27 SN_EXISTS_100
-    if(unlikely(value & (1 << 26)))
+    // bit 27 SN_FLAG_NOT_EXISTS_MUL100
+    if(unlikely(value & SN_FLAG_NOT_EXISTS_MUL100))
         factor = 1;
 
-    // bit 26 SN_EXISTS_RESET
-    // bit 25 SN_ANOMALY_BIT
+    // bit 26 SN_FLAG_RESET
+    // bit 25 SN_FLAG_NOT_ANOMALOUS
 
     // bit 30, 29, 28 = (multiplier or divider) 0-7 (8 total)
     int mul = (int)((value & ((1<<29)|(1<<28)|(1<<27))) >> 27);

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -826,7 +826,7 @@ static void query_plan(QUERY_ENGINE_OPS *ops, time_t after_wanted, time_t before
         if(likely((point).value != 0.0))                                \
             (ops).group_points_non_zero++;                              \
                                                                         \
-        if(unlikely((point).flags & SN_EXISTS_RESET))                   \
+        if(unlikely((point).flags & SN_FLAG_RESET))                   \
             (ops).group_value_flags |= RRDR_VALUE_RESET;                \
                                                                         \
         (ops).grouping_add(r, (point).value);                           \

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -823,10 +823,10 @@ static void query_plan(QUERY_ENGINE_OPS *ops, time_t after_wanted, time_t before
 
 #define query_add_point_to_group(r, point, ops)                   do {  \
     if(likely(netdata_double_isnumber((point).value))) {                \
-        if(likely((point).value != 0.0))                                \
+        if(likely(fpclassify((point).value) != FP_ZERO))                \
             (ops).group_points_non_zero++;                              \
                                                                         \
-        if(unlikely((point).flags & SN_FLAG_RESET))                   \
+        if(unlikely((point).flags & SN_FLAG_RESET))                     \
             (ops).group_value_flags |= RRDR_VALUE_RESET;                \
                                                                         \
         (ops).grouping_add(r, (point).value);                           \

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -579,7 +579,7 @@ QUERY_POINT QUERY_POINT_EMPTY = {
     .start_time = 0,
     .value = NAN,
     .anomaly = 0,
-    .flags = SN_EMPTY_SLOT,
+    .flags = SN_FLAG_NONE,
 #ifdef NETDATA_INTERNAL_CHECKS
     .id = 0,
 #endif
@@ -942,7 +942,7 @@ static inline void rrd2rrdr_do_dimension(
                 }
                 else {
                     new_point.value      = NAN;
-                    new_point.flags      = SN_EMPTY_SLOT;
+                    new_point.flags      = SN_FLAG_NONE;
                 }
             }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

_Tries_ to fix #13353 

`unpack_storage_number` has a check for the value being `SN_EMPTY_SLOT` here: https://github.com/netdata/netdata/blob/fccfc02d2c1966b814b6babcd8dddb0c6e822d45/libnetdata/storage_number/storage_number.h#L122-L123

However, `pack_storage_number` doesn't seem to ever store a value as `SN_EMPTY_SLOT`, so we never get NaNs. This PR merely adds a check if the flags is `SN_EMPTY_SLOT` (which is used when storing) it will also set the value to `SN_EMPTY_SLOT`.

It solves the problem on #13353 but I'm not sure if this is the right way to do it.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Setup a child/parent setup. Stream from child to parent. Stop the child for a bit then restart it. There should now be gaps instead of zeroes.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
