### PR TITLE
Query queue only for queries

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -742,8 +742,8 @@ void aclk_host_state_update(RRDHOST *host, int cmd)
     }
     if (ret < 0) {
         // node_id not found
-        aclk_query_t create_query;
-        create_query = aclk_query_new(REGISTER_NODE);
+        size_t payload_len;
+
         rrdhost_aclk_state_lock(localhost);
         node_instance_creation_t node_instance_creation = {
             .claim_id = localhost->aclk_state.claimed_id,
@@ -751,16 +751,14 @@ void aclk_host_state_update(RRDHOST *host, int cmd)
             .hostname = host->hostname,
             .machine_guid = host->machine_guid
         };
-        create_query->data.bin_payload.payload = generate_node_instance_creation(&create_query->data.bin_payload.size, &node_instance_creation);
+        char *payload = generate_node_instance_creation(&payload_len, &node_instance_creation);
         rrdhost_aclk_state_unlock(localhost);
-        create_query->data.bin_payload.topic = ACLK_TOPICID_CREATE_NODE;
-        create_query->data.bin_payload.msg_name = "CreateNodeInstance";
+
         info("Registering host=%s, hops=%u",host->machine_guid, host->system_info->hops);
-        aclk_queue_query(create_query);
+        aclk_send_bin_message_subtopic_pid(mqttwss_client, payload, payload_len, ACLK_TOPICID_CREATE_NODE, "CreateNodeInstance");
         return;
     }
 
-    aclk_query_t query = aclk_query_new(NODE_STATE_UPDATE);
     node_instance_connection_t node_state_update = {
         .hops = host->system_info->hops,
         .live = cmd,
@@ -781,15 +779,14 @@ void aclk_host_state_update(RRDHOST *host, int cmd)
 
     rrdhost_aclk_state_lock(localhost);
     node_state_update.claim_id = localhost->aclk_state.claimed_id;
-    query->data.bin_payload.payload = generate_node_instance_connection(&query->data.bin_payload.size, &node_state_update);
+    size_t payload_len;
+    char *payload = generate_node_instance_connection(&payload_len, &node_state_update);
     rrdhost_aclk_state_unlock(localhost);
 
     info("Queuing status update for node=%s, live=%d, hops=%u",(char*)node_state_update.node_id, cmd,
          host->system_info->hops);
     freez((void*)node_state_update.node_id);
-    query->data.bin_payload.msg_name = "UpdateNodeInstanceConnection";
-    query->data.bin_payload.topic = ACLK_TOPICID_NODE_CONN;
-    aclk_queue_query(query);
+    aclk_send_bin_message_subtopic_pid(mqttwss_client, payload, payload_len, ACLK_TOPICID_NODE_CONN, "UpdateNodeInstanceConnection");
 }
 
 void aclk_send_node_instances()
@@ -802,7 +799,6 @@ void aclk_send_node_instances()
     }
     while (!uuid_is_null(list->host_id)) {
         if (!uuid_is_null(list->node_id)) {
-            aclk_query_t query = aclk_query_new(NODE_STATE_UPDATE);
             node_instance_connection_t node_state_update = {
                 .live = list->live,
                 .hops = list->hops,
@@ -827,34 +823,30 @@ void aclk_send_node_instances()
 
             rrdhost_aclk_state_lock(localhost);
             node_state_update.claim_id = localhost->aclk_state.claimed_id;
-            query->data.bin_payload.payload = generate_node_instance_connection(&query->data.bin_payload.size, &node_state_update);
+            size_t payload_len;
+            char *payload = generate_node_instance_connection(&payload_len, &node_state_update);
             rrdhost_aclk_state_unlock(localhost);
             info("Queuing status update for node=%s, live=%d, hops=%d",(char*)node_state_update.node_id,
                  list->live,
                  list->hops);
             freez((void*)node_state_update.node_id);
-            query->data.bin_payload.msg_name = "UpdateNodeInstanceConnection";
-            query->data.bin_payload.topic = ACLK_TOPICID_NODE_CONN;
-            aclk_queue_query(query);
+            aclk_send_bin_message_subtopic_pid(mqttwss_client, payload, payload_len, ACLK_TOPICID_NODE_CONN, "UpdateNodeInstanceConnection");
         } else {
-            aclk_query_t create_query;
-            create_query = aclk_query_new(REGISTER_NODE);
             node_instance_creation_t node_instance_creation = {
                 .hops = list->hops,
                 .hostname = list->hostname,
             };
             node_instance_creation.machine_guid = mallocz(UUID_STR_LEN);
             uuid_unparse_lower(list->host_id, (char*)node_instance_creation.machine_guid);
-            create_query->data.bin_payload.topic = ACLK_TOPICID_CREATE_NODE;
-            create_query->data.bin_payload.msg_name = "CreateNodeInstance";
             rrdhost_aclk_state_lock(localhost);
-            node_instance_creation.claim_id = localhost->aclk_state.claimed_id,
-            create_query->data.bin_payload.payload = generate_node_instance_creation(&create_query->data.bin_payload.size, &node_instance_creation);
+            node_instance_creation.claim_id = localhost->aclk_state.claimed_id;
+            size_t payload_len;
+            char *payload = generate_node_instance_creation(&payload_len, &node_instance_creation);
             rrdhost_aclk_state_unlock(localhost);
             info("Queuing registration for host=%s, hops=%d",(char*)node_instance_creation.machine_guid,
                  list->hops);
             freez(node_instance_creation.machine_guid);
-            aclk_queue_query(create_query);
+            aclk_send_bin_message_subtopic_pid(mqttwss_client, payload, payload_len, ACLK_TOPICID_CREATE_NODE, "CreateNodeInstance");
         }
         freez(list->hostname);
 

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -34,6 +34,17 @@ void aclk_send_node_instances(void);
 
 void aclk_send_bin_msg(char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname);
 
+#define GENERATE_AND_SEND_PAYLOAD(topic, msg_name, generator_fnc, generator_data...)                                   \
+    size_t payload_len;                                                                                                \
+    char *payload = generator_fnc(&payload_len, generator_data);                                                       \
+    if (unlikely(payload == NULL)) {                                                                                   \
+        error("Failed to generate payload (%s)", __FUNCTION__);                                                        \
+        return;                                                                                                        \
+    }                                                                                                                  \
+    aclk_send_bin_msg(payload, payload_len, topic, msg_name);                                                          \
+    if (!use_mqtt_5)                                                                                                   \
+        freez(payload);
+
 char *ng_aclk_state(void);
 char *ng_aclk_state_json(void);
 

--- a/aclk/aclk_alarm_api.c
+++ b/aclk/aclk_alarm_api.c
@@ -10,38 +10,20 @@
 
 void aclk_send_alarm_log_health(struct alarm_log_health *log_health)
 {
-    aclk_query_t query = aclk_query_new(ALARM_LOG_HEALTH);
-    query->data.bin_payload.payload = generate_alarm_log_health(&query->data.bin_payload.size, log_health);
-    query->data.bin_payload.topic = ACLK_TOPICID_ALARM_HEALTH;
-    query->data.bin_payload.msg_name = "AlarmLogHealth";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_ALARM_HEALTH, "AlarmLogHealth", generate_alarm_log_health, log_health);
 }
 
 void aclk_send_alarm_log_entry(struct alarm_log_entry *log_entry)
 {
-    size_t payload_size;
-    char *payload = generate_alarm_log_entry(&payload_size, log_entry);
-
-    aclk_send_bin_msg(payload, payload_size, ACLK_TOPICID_ALARM_LOG, "AlarmLogEntry");
-
-    if (!use_mqtt_5)
-        freez(payload);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_ALARM_LOG, "AlarmLogEntry", generate_alarm_log_entry, log_entry);
 }
 
 void aclk_send_provide_alarm_cfg(struct provide_alarm_configuration *cfg)
 {
-    aclk_query_t query = aclk_query_new(ALARM_PROVIDE_CFG);
-    query->data.bin_payload.payload = generate_provide_alarm_configuration(&query->data.bin_payload.size, cfg);
-    query->data.bin_payload.topic = ACLK_TOPICID_ALARM_CONFIG;
-    query->data.bin_payload.msg_name = "ProvideAlarmConfiguration";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_ALARM_CONFIG, "ProvideAlarmConfiguration", generate_provide_alarm_configuration, cfg);
 }
 
 void aclk_send_alarm_snapshot(alarm_snapshot_proto_ptr_t snapshot)
 {
-    aclk_query_t query = aclk_query_new(ALARM_SNAPSHOT);
-    query->data.bin_payload.payload = generate_alarm_snapshot_bin(&query->data.bin_payload.size, snapshot);
-    query->data.bin_payload.topic = ACLK_TOPICID_ALARM_SNAPSHOT;
-    query->data.bin_payload.msg_name = "AlarmSnapshot";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_ALARM_SNAPSHOT, "AlarmSnapshot", generate_alarm_snapshot_bin, snapshot);
 }

--- a/aclk/aclk_charts_api.c
+++ b/aclk/aclk_charts_api.c
@@ -3,75 +3,46 @@
 
 #include "aclk_query_queue.h"
 
+#include "aclk.h"
+
 #define CHART_DIM_UPDATE_NAME "ChartsAndDimensionsUpdated"
 
 void aclk_chart_inst_update(char **payloads, size_t *payload_sizes, struct aclk_message_position *new_positions)
 {
-    aclk_query_t query = aclk_query_new(CHART_DIMS_UPDATE);
-    query->data.bin_payload.payload = generate_charts_updated(&query->data.bin_payload.size, payloads, payload_sizes, new_positions);
-    query->data.bin_payload.msg_name = CHART_DIM_UPDATE_NAME;
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_CHART_DIMS, CHART_DIM_UPDATE_NAME, generate_charts_updated, payloads, payload_sizes, new_positions);
 }
 
 void aclk_chart_dim_update(char **payloads, size_t *payload_sizes, struct aclk_message_position *new_positions)
 {
-    aclk_query_t query = aclk_query_new(CHART_DIMS_UPDATE);
-    query->data.bin_payload.topic = ACLK_TOPICID_CHART_DIMS;
-    query->data.bin_payload.payload = generate_chart_dimensions_updated(&query->data.bin_payload.size, payloads, payload_sizes, new_positions);
-    query->data.bin_payload.msg_name = CHART_DIM_UPDATE_NAME;
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_CHART_DIMS, CHART_DIM_UPDATE_NAME, generate_chart_dimensions_updated, payloads, payload_sizes, new_positions);
 }
 
 void aclk_chart_inst_and_dim_update(char **payloads, size_t *payload_sizes, int *is_dim, struct aclk_message_position *new_positions, uint64_t batch_id)
 {
-    aclk_query_t query = aclk_query_new(CHART_DIMS_UPDATE);
-    query->data.bin_payload.topic = ACLK_TOPICID_CHART_DIMS;
-    query->data.bin_payload.payload = generate_charts_and_dimensions_updated(&query->data.bin_payload.size, payloads, payload_sizes, is_dim, new_positions, batch_id);
-    query->data.bin_payload.msg_name = CHART_DIM_UPDATE_NAME;
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_CHART_DIMS, CHART_DIM_UPDATE_NAME, generate_charts_and_dimensions_updated, payloads, payload_sizes, is_dim, new_positions, batch_id);
 }
 
 void aclk_chart_config_updated(struct chart_config_updated *config_list, int list_size)
 {
-    aclk_query_t query = aclk_query_new(CHART_CONFIG_UPDATED);
-    query->data.bin_payload.topic = ACLK_TOPICID_CHART_CONFIGS_UPDATED;
-    query->data.bin_payload.payload = generate_chart_configs_updated(&query->data.bin_payload.size, config_list, list_size);
-    query->data.bin_payload.msg_name = "ChartConfigsUpdated";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_CHART_CONFIGS_UPDATED, "ChartConfigsUpdated", generate_chart_configs_updated, config_list, list_size);
 }
 
 void aclk_chart_reset(chart_reset_t reset)
 {
-    aclk_query_t query = aclk_query_new(CHART_RESET);
-    query->data.bin_payload.topic = ACLK_TOPICID_CHART_RESET;
-    query->data.bin_payload.payload = generate_reset_chart_messages(&query->data.bin_payload.size, reset);
-    query->data.bin_payload.msg_name = "ResetChartMessages";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_CHART_RESET, "ResetChartMessages", generate_reset_chart_messages, reset);
 }
 
 void aclk_retention_updated(struct retention_updated *data)
 {
-    aclk_query_t query = aclk_query_new(RETENTION_UPDATED);
-    query->data.bin_payload.topic = ACLK_TOPICID_RETENTION_UPDATED;
-    query->data.bin_payload.payload = generate_retention_updated(&query->data.bin_payload.size, data);
-    query->data.bin_payload.msg_name = "RetentionUpdated";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_RETENTION_UPDATED, "RetentionUpdated", generate_retention_updated, data);
 }
 
 void aclk_update_node_info(struct update_node_info *info)
 {
-    aclk_query_t query = aclk_query_new(UPDATE_NODE_INFO);
-    query->data.bin_payload.topic = ACLK_TOPICID_NODE_INFO;
-    query->data.bin_payload.payload = generate_update_node_info_message(&query->data.bin_payload.size, info);
-    query->data.bin_payload.msg_name = "UpdateNodeInfo";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_NODE_INFO, "UpdateNodeInfo", generate_update_node_info_message, info);
 }
 
 void aclk_update_node_collectors(struct update_node_collectors *collectors)
 {
-    aclk_query_t query = aclk_query_new(UPDATE_NODE_COLLECTORS);
-    query->data.bin_payload.topic = ACLK_TOPICID_NODE_COLLECTORS;
-    query->data.bin_payload.payload = generate_update_node_collectors_message(&query->data.bin_payload.size, collectors);
-    query->data.bin_payload.msg_name = "UpdateNodeCollectors";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_NODE_COLLECTORS, "UpdateNodeCollectors", generate_update_node_collectors_message, collectors);
 }

--- a/aclk/aclk_contexts_api.c
+++ b/aclk/aclk_contexts_api.c
@@ -4,20 +4,14 @@
 
 #include "aclk_contexts_api.h"
 
+#include "aclk.h"
+
 void aclk_send_contexts_snapshot(contexts_snapshot_t data)
 {
-    aclk_query_t query = aclk_query_new(PROTO_BIN_MESSAGE);
-    query->data.bin_payload.topic = ACLK_TOPICID_CTXS_SNAPSHOT;
-    query->data.bin_payload.payload = contexts_snapshot_2bin(data, &query->data.bin_payload.size);
-    query->data.bin_payload.msg_name = "ContextsSnapshot";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_CTXS_SNAPSHOT, "ContextsSnapshot", contexts_snapshot_2bin, data);
 }
 
 void aclk_send_contexts_updated(contexts_updated_t data)
 {
-    aclk_query_t query = aclk_query_new(PROTO_BIN_MESSAGE);
-    query->data.bin_payload.topic = ACLK_TOPICID_CTXS_UPDATED;
-    query->data.bin_payload.payload = contexts_updated_2bin(data, &query->data.bin_payload.size);
-    query->data.bin_payload.msg_name = "ContextsUpdated";
-    QUEUE_IF_PAYLOAD_PRESENT(query);
+    GENERATE_AND_SEND_PAYLOAD(ACLK_TOPICID_CTXS_UPDATED, "ContextsUpdated", contexts_updated_2bin, data);
 }

--- a/aclk/aclk_query.h
+++ b/aclk/aclk_query.h
@@ -31,6 +31,4 @@ struct aclk_query_threads {
 void aclk_query_threads_start(struct aclk_query_threads *query_threads, mqtt_wss_client client);
 void aclk_query_threads_cleanup(struct aclk_query_threads *query_threads);
 
-const char *aclk_query_get_name(aclk_query_type_t qt);
-
 #endif //NETDATA_AGENT_CLOUD_LINK_H

--- a/aclk/aclk_query_queue.c
+++ b/aclk/aclk_query_queue.c
@@ -95,41 +95,16 @@ void aclk_queue_flush(void)
     };
 }
 
-aclk_query_t aclk_query_new(aclk_query_type_t type)
+aclk_query_t aclk_query_new()
 {
-    aclk_query_t query = callocz(1, sizeof(struct aclk_query));
-    query->type = type;
-    return query;
+    return callocz(1, sizeof(struct aclk_query));
 }
 
 void aclk_query_free(aclk_query_t query)
 {
-    switch (query->type) {
-    case HTTP_API_V2:
-        freez(query->data.http_api_v2.payload);
-        if (query->data.http_api_v2.query != query->dedup_id)
-            freez(query->data.http_api_v2.query);
-        break;
-
-    case NODE_STATE_UPDATE:
-    case REGISTER_NODE:
-    case CHART_DIMS_UPDATE:
-    case CHART_CONFIG_UPDATED:
-    case CHART_RESET:
-    case RETENTION_UPDATED:
-    case UPDATE_NODE_INFO:
-    case ALARM_LOG_HEALTH:
-    case ALARM_PROVIDE_CFG:
-    case ALARM_SNAPSHOT:
-    case UPDATE_NODE_COLLECTORS:
-    case PROTO_BIN_MESSAGE:
-        if (!use_mqtt_5)
-            freez(query->data.bin_payload.payload);
-        break;
-
-    default:
-        break;
-    }
+    freez(query->http_api_v2.payload);
+    if (query->http_api_v2.query != query->dedup_id)
+        freez(query->http_api_v2.query);
 
     freez(query->dedup_id);
     freez(query->callback_topic);

--- a/aclk/aclk_query_queue.h
+++ b/aclk/aclk_query_queue.h
@@ -9,24 +9,6 @@
 
 #include "aclk_util.h"
 
-typedef enum {
-    UNKNOWN = 0,
-    HTTP_API_V2,
-    REGISTER_NODE,
-    NODE_STATE_UPDATE,
-    CHART_DIMS_UPDATE,
-    CHART_CONFIG_UPDATED,
-    CHART_RESET,
-    RETENTION_UPDATED,
-    UPDATE_NODE_INFO,
-    ALARM_LOG_HEALTH,
-    ALARM_PROVIDE_CFG,
-    ALARM_SNAPSHOT,
-    UPDATE_NODE_COLLECTORS,
-    PROTO_BIN_MESSAGE,
-    ACLK_QUERY_TYPE_COUNT // always keep this as last
-} aclk_query_type_t;
-
 struct aclk_query_http_api_v2 {
     char *payload;
     char *query;
@@ -41,8 +23,6 @@ struct aclk_bin_payload {
 
 typedef struct aclk_query *aclk_query_t;
 struct aclk_query {
-    aclk_query_type_t type;
-
     // dedup_id is used to deduplicate queries in the list
     // if type and dedup_id is the same message is deduplicated
     // set dedup_id to NULL to never deduplicate the message
@@ -59,13 +39,11 @@ struct aclk_query {
 
     // TODO maybe remove?
     int version;
-    union {
-        struct aclk_query_http_api_v2 http_api_v2;
-        struct aclk_bin_payload bin_payload;
-    } data;
+
+    struct aclk_query_http_api_v2 http_api_v2;
 };
 
-aclk_query_t aclk_query_new(aclk_query_type_t type);
+aclk_query_t aclk_query_new();
 void aclk_query_free(aclk_query_t query);
 
 int aclk_queue_query(aclk_query_t query);
@@ -74,13 +52,5 @@ void aclk_queue_flush(void);
 
 void aclk_queue_lock(void);
 void aclk_queue_unlock(void);
-
-#define QUEUE_IF_PAYLOAD_PRESENT(query)                                                                                \
-    if (likely(query->data.bin_payload.payload)) {                                                                     \
-        aclk_queue_query(query);                                                                                       \
-    } else {                                                                                                           \
-        error("Failed to generate payload (%s)", __FUNCTION__);                                                        \
-        aclk_query_free(query);                                                                                        \
-    }
 
 #endif /* NETDATA_ACLK_QUERY_QUEUE_H */

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -118,28 +118,6 @@ static void aclk_stats_cloud_req(struct aclk_metrics_per_sample *per_sample)
     rrdset_done(st);
 }
 
-static void aclk_stats_cloud_req_type(struct aclk_metrics_per_sample *per_sample)
-{
-    static RRDSET *st = NULL;
-    static RRDDIM *dims[ACLK_QUERY_TYPE_COUNT];
-
-    if (unlikely(!st)) {
-        st = rrdset_create_localhost(
-            "netdata", "aclk_processed_query_type", NULL, "aclk", NULL, "Query thread commands processed by their type", "cmd/s",
-            "netdata", "stats", 200006, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
-
-        for (int i = 0; i < ACLK_QUERY_TYPE_COUNT; i++)
-            dims[i] = rrddim_add(st, aclk_query_get_name(i), NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
-
-    } else
-        rrdset_next(st);
-
-    for (int i = 0; i < ACLK_QUERY_TYPE_COUNT; i++)
-        rrddim_set_by_pointer(st, dims[i], per_sample->queries_per_type[i]);
-
-    rrdset_done(st);
-}
-
 static char *cloud_req_http_type_names[ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT] = {
     "other",
     "info",
@@ -351,7 +329,6 @@ void *aclk_stats_main_thread(void *ptr)
 #endif
 
         aclk_stats_cloud_req(&per_sample);
-        aclk_stats_cloud_req_type(&per_sample);
         aclk_stats_cloud_req_http_type(&per_sample);
 
         aclk_stats_query_threads(aclk_queries_per_thread_sample);

--- a/aclk/aclk_stats.h
+++ b/aclk/aclk_stats.h
@@ -51,9 +51,6 @@ extern struct aclk_metrics_per_sample {
     volatile uint32_t cloud_req_recvd;
     volatile uint32_t cloud_req_err;
 
-    // query types.
-    volatile uint32_t queries_per_type[ACLK_QUERY_TYPE_COUNT];
-
     // HTTP-specific request types.
     volatile uint32_t cloud_req_http_by_type[ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT];
 

--- a/aclk/schema-wrappers/context.cc
+++ b/aclk/schema-wrappers/context.cc
@@ -57,7 +57,7 @@ void contexts_snapshot_add_ctx_update(contexts_snapshot_t ctxs_snapshot, struct 
     fill_ctx_updated(ctx, ctx_update);
 }
 
-char *contexts_snapshot_2bin(contexts_snapshot_t ctxs_snapshot, size_t *len)
+char *contexts_snapshot_2bin(size_t *len, contexts_snapshot_t ctxs_snapshot)
 {
     ContextsSnapshot *ctxs_snap = (ContextsSnapshot *)ctxs_snapshot;
     *len = PROTO_COMPAT_MSG_SIZE_PTR(ctxs_snap);
@@ -109,7 +109,7 @@ void contexts_updated_add_ctx_update(contexts_updated_t ctxs_updated, struct con
     fill_ctx_updated(ctx, ctx_update);
 }
 
-char *contexts_updated_2bin(contexts_updated_t ctxs_updated, size_t *len)
+char *contexts_updated_2bin(size_t *len, contexts_updated_t ctxs_updated)
 {
     ContextsUpdated *ctxs_update = (ContextsUpdated *)ctxs_updated;
     *len = PROTO_COMPAT_MSG_SIZE_PTR(ctxs_update);

--- a/aclk/schema-wrappers/context.h
+++ b/aclk/schema-wrappers/context.h
@@ -36,14 +36,14 @@ contexts_snapshot_t contexts_snapshot_new(const char *claim_id, const char *node
 void contexts_snapshot_delete(contexts_snapshot_t ctxs_snapshot);
 void contexts_snapshot_set_version(contexts_snapshot_t ctxs_snapshot, uint64_t version);
 void contexts_snapshot_add_ctx_update(contexts_snapshot_t ctxs_snapshot, struct context_updated *ctx_update);
-char *contexts_snapshot_2bin(contexts_snapshot_t ctxs_snapshot, size_t *len);
+char *contexts_snapshot_2bin(size_t *len, contexts_snapshot_t ctxs_snapshot);
 
 // ContextS Updated related
 contexts_updated_t contexts_updated_new(const char *claim_id, const char *node_id, uint64_t version_hash, uint64_t created_at);
 void contexts_updated_delete(contexts_updated_t ctxs_updated);
 void contexts_updated_update_version_hash(contexts_updated_t ctxs_updated, uint64_t version_hash);
 void contexts_updated_add_ctx_update(contexts_updated_t ctxs_updated, struct context_updated *ctx_update);
-char *contexts_updated_2bin(contexts_updated_t ctxs_updated, size_t *len);
+char *contexts_updated_2bin(size_t *len, contexts_updated_t ctxs_updated);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
##### Summary
- Removes most types of messages from query queue. Those can be scheduled and sent immediately (queuing is done in MQTT).
- This cleans up and simplifies (+77 -253 lines) the code. Query threads now handle only HTTP queries (which might be long running due to IO etc.).
- This allows/simplifies further work on ACLK. Removes complexity that is not necessary anymore.

##### Test Plan
- no problems on the cloud

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
