### PR TITLE
Show last 15 alerts in notification

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2898,7 +2898,7 @@ if [ -n "$total_crit_alarms" ]; then
    done <<<"$total_crit_alarms,"
 fi
 
-if (( $total_warnings + $total_critical > 15 )); then
+if (( total_warnings + total_critical > 15 )); then
     EXTRA_ALARMS_LIST_TEXT="(Showing latest 15 alerts)"
 fi
 

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2899,7 +2899,7 @@ if [ -n "$total_crit_alarms" ]; then
 fi
 
 if (( $total_warnings + $total_critical > 15 )); then
-    EXTRA_ALARMS_LIST_TEXT="(Showing latest 15 alarms)"
+    EXTRA_ALARMS_LIST_TEXT="(Showing latest 15 alerts)"
 fi
 
 if [ -n "$edit_command_line" ]; then

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2898,6 +2898,10 @@ if [ -n "$total_crit_alarms" ]; then
    done <<<"$total_crit_alarms,"
 fi
 
+if (( $total_warnings + $total_critical > 15 )); then
+    EXTRA_ALARMS_LIST_TEXT="(Showing latest 15 alarms)"
+fi
+
 if [ -n "$edit_command_line" ]; then
     IFS='=' read -r edit_command line s_host <<<"$edit_command_line"
 fi
@@ -3422,6 +3426,10 @@ Content-Transfer-Encoding: 8bit
                             and
                             <span style="font-weight:600">${total_critical} critical</span>
                             additional active alert(s)</div>
+                        </td>
+                        </tr>
+                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                          <div style="font-family:Open Sans, sans-serif;font-size:12px;line-height:1;text-align:center;color:#35414A;">${EXTRA_ALARMS_LIST_TEXT}</div>
                         </td>
                       </tr>
                       </tbody>


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #13380

This PR reduces the list on the email notification of the additional active alerts to 15. Such a change has already been done on the cloud.

When we have many active alerts the list can grow, thus growing the command that will be executed by the spawn server. If it reaches a large size, it can potentially error out in the spawn server.

There has been some tests to alleviate this problem from the spawn server, but cloud also reduced the list to 15 alerts, and also such a large list doesn't really make much sense to have in the notification.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Produce a lot of alerts, and watch their notifications. Alerts should be sorted by date in the additional alerts list, i.e.:

![image](https://user-images.githubusercontent.com/1905463/180985368-9a647298-8f79-486a-8067-5ddf2fe51815.png)

If the additional active alerts is more than 15, an additional text will appear in the notification:

![image](https://user-images.githubusercontent.com/1905463/180985532-663703fc-9d34-482a-bce3-ec94793c712e.png)

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
