### PR TITLE
Dont duplicate buffered bytes

### DIFF
--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -392,7 +392,6 @@ int format_batch_prometheus_remote_write(struct instance *instance)
         return 1;
     }
     buffer->len = data_size;
-    instance->stats.buffered_bytes = (collected_number)buffer_strlen(buffer);
 
     simple_connector_end_batch(instance);
 


### PR DESCRIPTION
##### Summary
The number of buffered bytes in stats for the Prometheus remote write exporting connector is doubled. In addition to the fact that the data is incorrect, it also causes false alarms. We shouldn't update the counter in the remote write exporting connector because it is updated by means of the simple exporting connector that are used for buffer processing.

Fixes #13381

##### Test Plan
1. Configure a Prometheus remote write exporting connector instance.
2. Receive data using the [remote write adapter](https://github.com/prometheus/prometheus/tree/main/documentation/examples/remote_storage/example_write_adapter).
3. Check if buffered data is the same as sent in `netdata.exporting_my_prometheus_remote_write_instance_bytes`.