### PR TITLE
Fix agent crash when archived host has not been registered to the cloud

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -313,9 +313,12 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
         , system_info
         , 1
     );
+#ifdef NETDATA_INTERNAL_CHECKS
     char node_str[UUID_STR_LEN] = "<none>";
-    uuid_unparse_lower(*host->node_id, node_str);
+    if (likely(host->node_id))
+        uuid_unparse_lower(*host->node_id, node_str);
     internal_error(true, "Adding archived host \"%s\" with GUID \"%s\" node id = \"%s\"", host->hostname, host->machine_guid, node_str);
+#endif
     return 0;
 }
 #endif


### PR DESCRIPTION
##### Summary
When trying to report the node id, if the host has not been registered to the cloud, the agent will crash.
This PR addresses this issue (also enables this reporting only when compiled with NETDATA_INTERNAL_CHECKS)


##### Test Plan
- Enable rrdcontexts and do a `update node_instance set node_id = NULL;`  on `netdata-meta.db`. The agent will crash when trying to report the node_id
- Apply the PR and retry (needs to be compiled with NETDATA_INTERNAL_CHECKS) 