### PR TITLE
Delete aclk_alert table on start streaming from seq 1 batch 1

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -396,10 +396,11 @@ void sql_queue_existing_alerts_to_aclk(RRDHOST *host)
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
     BUFFER *sql = buffer_create(1024);
 
-    buffer_sprintf(sql,"insert into aclk_alert_%s (alert_unique_id, date_created) " \
+    buffer_sprintf(sql,"delete from aclk_alert_%s; " \
+                       "insert into aclk_alert_%s (alert_unique_id, date_created) " \
                        "select unique_id alert_unique_id, unixepoch() from health_log_%s " \
                        "where new_status <> 0 and new_status <> -2 and config_hash_id is not null and updated_by_id = 0 " \
-                       "order by unique_id asc on conflict (alert_unique_id) do nothing;", uuid_str, uuid_str);
+                       "order by unique_id asc on conflict (alert_unique_id) do nothing;", uuid_str, uuid_str, uuid_str);
 
     db_execute(buffer_tostring(sql));
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

When a node's metadata is deleted from the cloud, we need to re-sync the alerts. Currently, the metadata are deleted when a user deletes a node, or when some days have passed since a node was connected (this is a new feature under development - and granted, there is a timelimit after which the agent will skip filters and re-send everything to the cloud).

Because the agent is not aware that previous alerts where deleted from the cloud, it will still filter new alerts and not send them, if for example they where previously sent again with the same status. This can lead to the agent having raised alerts, but not on the cloud.

We agreed with the cloud to inform for this case the agent, by requesting to start streaming with batch_id 1 and sequence_id 1. When this occurs, the agent will delete the `aclk_alert` table, and start populating it again. Besides the obvious, it also needed because if we have deleted some old sequence id's from the table, the cloud will start snapshots.

Depending on when the connection occurred (before/after health), the bulk inserting of current alerts will make sure we don't miss any alerts to be propagated.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Claim an agent to the cloud.
Create an alert that will be raised consistently in the same status even after an agent's restart.
Go the cloud, notice the alert is there.
Stop the agent.
Delete the node from the cloud.
Restart the agent.

Without this PR the alert will not reach the cloud after the restart. With this PR it should.

Will also be tested with @car12o . Currently the functionality of sending batch_id 1 and sequence_id 1 after a delete is not present in production.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
