### PR TITLE
Fix tests so that the actual metadata database is not accessed

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1006,6 +1006,8 @@ int main(int argc, char **argv) {
                                 return 1;
                             if (rrdlabels_unittest())
                                 return 1;
+                            if (ctx_unittest())
+                                return 1;
                             fprintf(stderr, "\n\nALL TESTS PASSED\n\n");
                             return 0;
                         }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -768,9 +768,12 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         info("Skipping SQLITE metadata initialization since memory mode is not dbengine");
     }
 
-    if (unlikely(sql_init_context_database(0))) {
+    if (unlikely(sql_init_context_database(system_info ? 0 : 1))) {
         error_report("Failed to initialize context metadata database");
     }
+
+    if (unlikely(!system_info))
+        goto unittest;
 
 #ifdef ENABLE_DBENGINE
     storage_tiers = config_get_number(CONFIG_SECTION_DB, "storage tiers", storage_tiers);
@@ -894,6 +897,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
     health_init();
     rrdpush_init();
 
+unittest:
     debug(D_RRDHOST, "Initializing localhost with hostname '%s'", hostname);
     rrd_wrlock();
     localhost = rrdhost_create(
@@ -924,12 +928,13 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         return 1;
     }
 
-    if (likely(system_info))
-       migrate_localhost(&localhost->host_uuid);
     rrd_unlock();
-    sql_aclk_sync_init();
 
-    web_client_api_v1_management_init();
+    if (likely(system_info)) {
+        migrate_localhost(&localhost->host_uuid);
+        sql_aclk_sync_init();
+        web_client_api_v1_management_init();
+    }
     return localhost==NULL;
 }
 


### PR DESCRIPTION
##### Summary
Unittests (running the agent with `-W unittest` will access and/or create the `netdata-meta.db` and `context-meta.db` databases). 

This PR will allow the tests to run with in-memory databases so that those files are not created. 

##### Test Plan
- Before this PR -- install agent in the new directory and run `netdata -W unittest`. Go to the `/var/cache/netdata`  directory and notice there is a `netdata-meta.db` and `context-meta.db`
- Apply the PR and redo the test. The above mentioned files should not be created
- CI should report success on the unit tests
