### PR TITLE
Store host label information in the metadata database

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -201,6 +201,7 @@ PARSER_RC pluginsd_overwrite_action(void *user, RRDHOST *host, DICTIONARY *new_h
         host->host_labels = rrdlabels_create();
 
     rrdlabels_migrate_to_these(host->host_labels, new_host_labels);
+    sql_store_host_labels(host);
 
     return PARSER_RC_OK;
 }

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -209,6 +209,8 @@ typedef enum rrdlabel_source {
     RRDLABEL_FLAG_NEW       = (1 << 31)  // marks for rrdlabels internal use - they are not exposed outside rrdlabels
 } RRDLABEL_SRC;
 
+#define RRDLABEL_FLAG_INTERNAL (RRDLABEL_FLAG_OLD | RRDLABEL_FLAG_NEW | RRDLABEL_FLAG_PERMANENT)
+
 extern DICTIONARY *rrdlabels_create(void);
 extern void rrdlabels_destroy(DICTIONARY *labels_dict);
 extern void rrdlabels_add(DICTIONARY *dict, const char *name, const char *value, RRDLABEL_SRC ls);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1362,6 +1362,7 @@ void reload_host_labels(void) {
     rrdhost_load_auto_labels();
 
     rrdlabels_remove_all_unmarked(localhost->host_labels);
+    sql_store_host_labels(localhost);
 
     health_label_log_save(localhost);
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -77,6 +77,7 @@ const char *database_cleanup[] = {
     "DELETE FROM chart_hash WHERE hash_id NOT IN (SELECT hash_id FROM chart_hash_map);",
     "DELETE FROM node_instance WHERE host_id NOT IN (SELECT host_id FROM host);",
     "DELETE FROM host_info WHERE host_id NOT IN (SELECT host_id FROM host);",
+    "DELETE FROM host_label WHERE host_id NOT IN (SELECT host_id FROM host);",
     NULL
 };
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -42,6 +42,9 @@ const char *database_config[] = {
     "CREATE TABLE IF NOT EXISTS host_info(host_id blob, system_key text NOT NULL, system_value text NOT NULL, "
     "date_created INT, PRIMARY KEY(host_id, system_key));",
 
+    "CREATE TABLE IF NOT EXISTS host_label(host_id blob, source_type int, label_key text NOT NULL, "
+    "label_value text NOT NULL, date_created INT, PRIMARY KEY (host_id, label_key));",
+
     "CREATE TABLE IF NOT EXISTS chart_hash_map(chart_id blob , hash_id blob, UNIQUE (chart_id, hash_id));",
 
     "CREATE TABLE IF NOT EXISTS chart_hash(hash_id blob PRIMARY KEY,type text, id text, name text, "

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2647,17 +2647,14 @@ static int save_host_label_callback(const char *name, const char *value, RRDLABE
     return 0;
 }
 
+#define SQL_DELETE_HOST_LABELS  "DELETE FROM host_label WHERE host_id = @uuid;"
 void sql_store_host_labels(RRDHOST *host)
 {
-    char sql_cleanup[128];
-
-    time_t now = now_realtime_sec();
-    rrdlabels_walkthrough_read(host->host_labels, save_host_label_callback, host);
-    snprintfz(sql_cleanup, 127, "DELETE FROM host_label WHERE date_created < %ld AND host_id = @uuid;", now);
-
-    int rc = exec_statement_with_uuid(sql_cleanup, &host->host_uuid);
+    int rc = exec_statement_with_uuid(SQL_DELETE_HOST_LABELS, &host->host_uuid);
     if (rc != SQLITE_OK)
         error_report("Failed to remove old host labels for host %s", host->hostname);
+
+    rrdlabels_walkthrough_read(host->host_labels, save_host_label_callback, host);
 }
 
 // Utils

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -111,4 +111,5 @@ int init_database_batch(sqlite3 *database, int rebuild, int init_type, const cha
 void migrate_localhost(uuid_t *host_uuid);
 extern void sql_store_host_system_info(uuid_t *host_id, const struct rrdhost_system_info *system_info);
 extern void sql_build_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info);
+void sql_store_host_labels(RRDHOST *host);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
Currently we do not store the host label information in the database. A new table `host_label` is added to store the information. 
The host labels stored will be used to properly populate the host structure for archived hosts (in a followup PR)

##### Test Plan
- After applying this PR, notice a new table `host_label` in `netdata-meta.db`. It will contain information for the localhost and also any children 
