### PR TITLE
Get last_entry_t only when st changes

### DIFF
--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -62,10 +62,22 @@ void rebuild_context_param_list(ONEWAYALLOC *owa, struct context_param *context_
     RRDDIM *temp_rd = context_param_list->rd;
     RRDDIM *new_rd_list = NULL, *t;
     int is_archived = (context_param_list->flags & CONTEXT_FLAGS_ARCHIVE);
+
+    RRDSET *st = temp_rd->rrdset;
+    RRDSET *last_st = st;
+    time_t last_entry_t = is_archived ? st->last_entry_t : rrdset_last_entry_t(st);
+    time_t last_last_entry_t = last_entry_t;
     while (temp_rd) {
         t = temp_rd->next;
-        RRDSET *st = temp_rd->rrdset;
-        time_t last_entry_t = is_archived ? st->last_entry_t : rrdset_last_entry_t(st);
+
+        st = temp_rd->rrdset;
+        if (st == last_st) {
+            last_entry_t = last_last_entry_t;
+        }else {
+            last_entry_t = is_archived ? st->last_entry_t : rrdset_last_entry_t(st);
+            last_last_entry_t = last_entry_t;
+            last_st = st;
+        }
 
         if (last_entry_t >= after_requested) {
             temp_rd->next = new_rd_list;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

When a context is queried, the `rebuild_context_param_list` is called. Inside there is a loop for each dimension, which tries to get the `last_entry_t` of the chart, and compare it.

This PR gets `last_entry_t` it only when the chart changes. This can help to speed up queries especially in context of `anomaly_detection.anomaly_rates` where the chart stays the same while there are many dimensions.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Create an agent with many charts and dimensions (20.000 dimensions is good to re-create the issue.)
Do a query on `anomaly_detection.anomaly_rates`, e.g. `api/v1/data?before=1658998800&after=1658998230&context=anomaly_detection.anomaly_rates&dimensions&format=json&group=average&gtime=0&options=allow_past|flip|jsonwrap|ms&points=1`

Notice the time it takes to complete with or without this PR.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
