### PR TITLE
/api/v1/weights endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,8 +774,6 @@ set(RRD_PLUGIN_FILES
         database/engine/metadata_log/compaction.h
         database/KolmogorovSmirnovDist.c
         database/KolmogorovSmirnovDist.h
-        database/metric_correlations.c
-        database/metric_correlations.h
         )
 
 set(WEB_PLUGIN_FILES
@@ -822,6 +820,8 @@ set(API_PLUGIN_FILES
         web/api/queries/ses/ses.h
         web/api/queries/des/des.c
         web/api/queries/des/des.h
+        web/api/queries/weights.c
+        web/api/queries/weights.h
         web/api/formatters/rrd2json.c
         web/api/formatters/rrd2json.h
         web/api/formatters/csv/csv.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -473,8 +473,6 @@ RRD_PLUGIN_FILES = \
     database/sqlite/sqlite3.h \
     database/KolmogorovSmirnovDist.c \
     database/KolmogorovSmirnovDist.h \
-    database/metric_correlations.c \
-    database/metric_correlations.h \
     $(NULL)
 
 database/sqlite/sqlite3.$(OBJEXT) : CFLAGS += -Wno-cast-function-type
@@ -599,6 +597,8 @@ API_PLUGIN_FILES = \
     web/api/queries/stddev/stddev.h \
     web/api/queries/sum/sum.c \
     web/api/queries/sum/sum.h \
+    web/api/queries/weights.c \
+    web/api/queries/weights.h \
     web/api/formatters/rrd2json.c \
     web/api/formatters/rrd2json.h \
     web/api/formatters/csv/csv.c \

--- a/configure.ac
+++ b/configure.ac
@@ -1681,6 +1681,8 @@ AC_CONFIG_FILES([
     database/Makefile
     database/engine/Makefile
     database/engine/metadata_log/Makefile
+    database/ram/Makefile
+    database/sqlite/Makefile
     diagrams/Makefile
     exporting/Makefile
     exporting/graphite/Makefile

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -84,9 +84,6 @@
 #include "commands.h"
 #include "analytics.h"
 
-// metric correlations
-#include "database/metric_correlations.h"
-
 // global netdata daemon variables
 extern char *netdata_configured_hostname;
 extern char *netdata_configured_user_config_dir;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -713,7 +713,9 @@ static void get_netdata_configured_variables() {
     // metric correlations
 
     enable_metric_correlations = config_get_boolean(CONFIG_SECTION_GLOBAL, "enable metric correlations", enable_metric_correlations);
-    default_metric_correlations_method = mc_string_to_method(config_get(CONFIG_SECTION_GLOBAL, "metric correlations method", mc_method_to_string(default_metric_correlations_method)));
+    default_metric_correlations_method = weights_string_to_method(config_get(
+        CONFIG_SECTION_GLOBAL, "metric correlations method",
+        weights_method_to_string(default_metric_correlations_method)));
 
     // --------------------------------------------------------------------
 

--- a/database/metric_correlations.c
+++ b/database/metric_correlations.c
@@ -613,7 +613,7 @@ static int rrdset_metric_correlations_volume(RRDSET *st, DICTIONARY *results,
 
         stats->db_queries++;
         NETDATA_DOUBLE baseline_average = NAN;
-        uint8_t base_anomaly_rate = 0;
+        NETDATA_DOUBLE base_anomaly_rate = 0;
         value_is_null = 1;
         ret = rrdset2value_api_v1(st, NULL, &baseline_average, d->id, 1,
                                   baseline_after, baseline_before,
@@ -629,7 +629,7 @@ static int rrdset_metric_correlations_volume(RRDSET *st, DICTIONARY *results,
 
         stats->db_queries++;
         NETDATA_DOUBLE highlight_average = NAN;
-        uint8_t high_anomaly_rate = 0;
+        NETDATA_DOUBLE high_anomaly_rate = 0;
         value_is_null = 1;
         ret = rrdset2value_api_v1(st, NULL, &highlight_average, d->id, 1,
                                   after, before,
@@ -697,7 +697,7 @@ static int rrdset_weights_anomaly_rate(RRDSET *st, DICTIONARY *results,
                                        long long after, long long before,
                                        RRDR_OPTIONS options, RRDR_GROUPING group, const char *group_options,
                                        int timeout, MC_STATS *stats) {
-    options |= RRDR_OPTION_MATCH_IDS | RRDR_OPTION_ABSOLUTE | RRDR_OPTION_NATURAL_POINTS | RRDR_OPTION_ANOMALY_BIT;
+    options |= RRDR_OPTION_MATCH_IDS | RRDR_OPTION_ANOMALY_BIT;
     long group_time = 0;
 
     int correlated_dimensions = 0;
@@ -719,7 +719,7 @@ static int rrdset_weights_anomaly_rate(RRDSET *st, DICTIONARY *results,
 
         stats->db_queries++;
         NETDATA_DOUBLE average = NAN;
-        uint8_t anomaly_rate = 0;
+        NETDATA_DOUBLE anomaly_rate = 0;
         value_is_null = 1;
         ret = rrdset2value_api_v1(st, NULL, &average, d->id, 1,
                                   after, before,
@@ -957,6 +957,8 @@ int web_api_v1_weights(RRDHOST *host, BUFFER *wb, WEIGHTS_METHOD method, WEIGHTS
 
         switch(method) {
             case WEIGHTS_METHOD_ANOMALY_RATE:
+                options |= RRDR_OPTION_ANOMALY_BIT|RRDR_OPTION_RETURN_RAW;
+                points = 1;
                 correlated_dimensions += rrdset_weights_anomaly_rate(st, results,
                                                                      after, before,
                                                                      options, group, group_options,
@@ -965,6 +967,7 @@ int web_api_v1_weights(RRDHOST *host, BUFFER *wb, WEIGHTS_METHOD method, WEIGHTS
                 break;
 
             case WEIGHTS_METHOD_MC_VOLUME:
+                points = 1;
                 correlated_dimensions += rrdset_metric_correlations_volume(st, results,
                                                                 baseline_after, baseline_before,
                                                                 after, before,

--- a/database/metric_correlations.h
+++ b/database/metric_correlations.h
@@ -6,22 +6,34 @@
 #include "web/api/queries/query.h"
 
 typedef enum {
-    METRIC_CORRELATIONS_KS2    = 1,
-    METRIC_CORRELATIONS_VOLUME = 2,
-} METRIC_CORRELATIONS_METHOD;
+    WEIGHTS_METHOD_MC_KS2       = 1,
+    WEIGHTS_METHOD_MC_VOLUME    = 2,
+    WEIGHTS_METHOD_ANOMALY_RATE = 3,
+} WEIGHTS_METHOD;
+
+typedef enum {
+    WEIGHTS_FORMAT_CHARTS    = 1,
+    WEIGHTS_FORMAT_CONTEXTS  = 2,
+} WEIGHTS_FORMAT;
 
 extern int enable_metric_correlations;
 extern int metric_correlations_version;
-extern METRIC_CORRELATIONS_METHOD default_metric_correlations_method;
+extern WEIGHTS_METHOD default_metric_correlations_method;
 
-extern int metric_correlations (RRDHOST *host, BUFFER *wb, METRIC_CORRELATIONS_METHOD method,
+extern int metric_correlations (RRDHOST *host, BUFFER *wb, WEIGHTS_METHOD method,
                                RRDR_GROUPING group, const char *group_options,
                                long long baseline_after, long long baseline_before,
                                long long after, long long before,
                                long long points, RRDR_OPTIONS options, int timeout);
 
-extern METRIC_CORRELATIONS_METHOD mc_string_to_method(const char *method);
-extern const char *mc_method_to_string(METRIC_CORRELATIONS_METHOD method);
+extern int web_api_v1_weights (RRDHOST *host, BUFFER *wb, WEIGHTS_METHOD method, WEIGHTS_FORMAT format,
+                               RRDR_GROUPING group, const char *group_options,
+                               long long baseline_after, long long baseline_before,
+                               long long after, long long before,
+                               long long points, RRDR_OPTIONS options, int timeout);
+
+extern WEIGHTS_METHOD weights_string_to_method(const char *method);
+extern const char *weights_method_to_string(WEIGHTS_METHOD method);
 extern int mc_unittest(void);
 
 #endif //NETDATA_METRIC_CORRELATIONS_H

--- a/database/metric_correlations.h
+++ b/database/metric_correlations.h
@@ -20,17 +20,11 @@ extern int enable_metric_correlations;
 extern int metric_correlations_version;
 extern WEIGHTS_METHOD default_metric_correlations_method;
 
-extern int metric_correlations (RRDHOST *host, BUFFER *wb, WEIGHTS_METHOD method,
-                               RRDR_GROUPING group, const char *group_options,
-                               long long baseline_after, long long baseline_before,
-                               long long after, long long before,
-                               long long points, RRDR_OPTIONS options, int timeout);
-
 extern int web_api_v1_weights (RRDHOST *host, BUFFER *wb, WEIGHTS_METHOD method, WEIGHTS_FORMAT format,
                                RRDR_GROUPING group, const char *group_options,
                                long long baseline_after, long long baseline_before,
                                long long after, long long before,
-                               long long points, RRDR_OPTIONS options, int timeout);
+                               long long points, RRDR_OPTIONS options, int tier, int timeout);
 
 extern WEIGHTS_METHOD weights_string_to_method(const char *method);
 extern const char *weights_method_to_string(WEIGHTS_METHOD method);

--- a/database/ram/Makefile.am
+++ b/database/ram/Makefile.am
@@ -4,9 +4,6 @@ AUTOMAKE_OPTIONS = subdir-objects
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 SUBDIRS = \
-    engine \
-    ram \
-    sqlite \
     $(NULL)
 
 dist_noinst_DATA = \

--- a/database/ram/README.md
+++ b/database/ram/README.md
@@ -1,0 +1,7 @@
+<!--
+title: "RAM database modes"
+description: "Netdata's RAM database modes."
+custom_edit_url: https://github.com/netdata/netdata/edit/master/database/ram/README.md
+-->
+
+# RAM modes

--- a/health/health.c
+++ b/health/health.c
@@ -858,7 +858,7 @@ void *health_main(void *ptr) {
                                                   rc->after, rc->before, rc->group, NULL,
                                                   0, rc->options,
                                                   &rc->db_after,&rc->db_before,
-                                                  NULL, NULL,
+                                                  NULL, NULL, NULL,
                                                   &value_is_null, NULL, 0, 0);
 
                     if (unlikely(ret != 200)) {

--- a/web/api/badges/web_buffer_svg.c
+++ b/web/api/badges/web_buffer_svg.c
@@ -1110,7 +1110,7 @@ int web_client_api_request_v1_badge(RRDHOST *host, struct web_client *w, char *u
                                       (dimensions) ? buffer_tostring(dimensions) : NULL,
                                       points, after, before, group, group_options, 0, options,
                                       NULL, &latest_timestamp,
-                                      NULL, NULL,
+                                      NULL, NULL, NULL,
                                       &value_is_null, NULL, 0, 0);
 
         // if the value cannot be calculated, show empty badge

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -162,7 +162,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable,  struct
     for(i = start; i != end ;i += step) {
         NETDATA_DOUBLE *cn = &r->v[ i * r->d ];
         RRDR_VALUE_FLAGS *co = &r->o[ i * r->d ];
-        uint8_t *ar = &r->ar[ i * r->d ];
+        NETDATA_DOUBLE *ar = &r->ar[ i * r->d ];
 
         time_t now = r->t[i];
 
@@ -225,7 +225,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable,  struct
             for(c = 0, rd = temp_rd?temp_rd:r->st->dimensions; rd && c < r->d ;c++, rd = rd->next) {
                 NETDATA_DOUBLE n;
                 if(unlikely(options & RRDR_OPTION_INTERNAL_AR))
-                    n = (NETDATA_DOUBLE)ar[c] / 2.0; // rrdr stores anomaly rates 0 - 200
+                    n = ar[c];
                 else
                     n = cn[c];
 
@@ -246,7 +246,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable,  struct
 
             NETDATA_DOUBLE n;
             if(unlikely(options & RRDR_OPTION_INTERNAL_AR))
-                n = (NETDATA_DOUBLE)ar[c] / 2.0; // rrdr stores anomaly rates 0 - 200
+                n = ar[c];
             else
                 n = cn[c];
 

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -195,7 +195,7 @@ int rrdset2value_api_v1(
         , size_t *db_points_read
         , size_t *result_points_generated
         , int *value_is_null
-        , uint8_t *anomaly_rate
+        , NETDATA_DOUBLE *anomaly_rate
         , int timeout
         , int tier
 ) {

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -193,6 +193,7 @@ int rrdset2value_api_v1(
         , time_t *db_after
         , time_t *db_before
         , size_t *db_points_read
+        , size_t *db_points_per_tier
         , size_t *result_points_generated
         , int *value_is_null
         , NETDATA_DOUBLE *anomaly_rate
@@ -215,6 +216,11 @@ int rrdset2value_api_v1(
 
     if(db_points_read)
         *db_points_read += r->internal.db_points_read;
+
+    if(db_points_per_tier) {
+        for(int t = 0; t < storage_tiers ;t++)
+            db_points_per_tier[t] += r->internal.tier_points_read[t];
+    }
 
     if(result_points_generated)
         *result_points_generated += r->internal.result_points_generated;

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -96,6 +96,7 @@ extern int rrdset2value_api_v1(
         , time_t *db_after
         , time_t *db_before
         , size_t *db_points_read
+        , size_t *db_points_per_tier
         , size_t *result_points_generated
         , int *value_is_null
         , NETDATA_DOUBLE *anomaly_rate

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -98,7 +98,7 @@ extern int rrdset2value_api_v1(
         , size_t *db_points_read
         , size_t *result_points_generated
         , int *value_is_null
-        , uint8_t *anomaly_rate
+        , NETDATA_DOUBLE *anomaly_rate
         , int timeout
         , int tier
 );

--- a/web/api/formatters/value/value.c
+++ b/web/api/formatters/value/value.c
@@ -3,19 +3,19 @@
 #include "value.h"
 
 
-inline NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null, uint8_t *anomaly_rate, RRDDIM *temp_rd) {
+inline NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null, NETDATA_DOUBLE *anomaly_rate, RRDDIM *temp_rd) {
     long c;
     RRDDIM *d;
 
     NETDATA_DOUBLE *cn = &r->v[ i * r->d ];
     RRDR_VALUE_FLAGS *co = &r->o[ i * r->d ];
-    uint8_t *ar = &r->ar[ i * r->d ];
+    NETDATA_DOUBLE *ar = &r->ar[ i * r->d ];
 
     NETDATA_DOUBLE sum = 0, min = 0, max = 0, v;
     int all_null = 1, init = 1;
 
     NETDATA_DOUBLE total = 1;
-    size_t total_anomaly_rate = 0;
+    NETDATA_DOUBLE total_anomaly_rate = 0;
 
     int set_min_max = 0;
     if(unlikely(options & RRDR_OPTION_PERCENTAGE)) {

--- a/web/api/formatters/value/value.h
+++ b/web/api/formatters/value/value.h
@@ -5,7 +5,6 @@
 
 #include "../rrd2json.h"
 
-extern NETDATA_DOUBLE
-rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null, uint8_t *anomaly_rate, RRDDIM *temp_rd);
+extern NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null, NETDATA_DOUBLE *anomaly_rate, RRDDIM *temp_rd);
 
 #endif //NETDATA_API_FORMATTER_VALUE_H

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -1318,6 +1318,13 @@ paths:
             type: number
             format: integer
             default: 0
+        - name: context
+          in: query
+          description: A simple pattern matching the contexts to evaluate.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: string
         - name: points
           in: query
           description: The number of points to be evaluated for the highlighted window.

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -1100,7 +1100,8 @@ paths:
   /metric_correlations:
     get:
       summary: "Analyze all the metrics to find their correlations"
-      description: "Given two time-windows (baseline, highlight), it goes
+      description: "THIS ENDPOINT IS OBSOLETE. Use the /weights endpoint.
+        Given two time-windows (baseline, highlight), it goes
         through all the available metrics, querying both windows and tries to find
         how these two windows relate to each other. It supports
         multiple algorithms to do so. The result is a list of all
@@ -1253,6 +1254,174 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/metric_correlations"
+        "400":
+          description: The given parameters are invalid.
+        "403":
+          description: metrics correlations are not enabled on this Netdata Agent.
+        "404":
+          description: No charts could be found, or the method
+            that correlated the metrics did not produce any result.
+        "504":
+          description: Timeout - the query took too long and has been cancelled.
+  /weights:
+    get:
+      summary: "Analyze all the metrics using an algorithm and score them accordingly"
+      description: "This endpoint goes through all metrics and scores them according to an algorithm."
+      parameters:
+        - name: baseline_after
+          in: query
+          description: This parameter can either be an absolute timestamp specifying the
+            starting point of baseline window, or a relative number of
+            seconds (negative, relative to parameter baseline_before). Netdata will
+            assume it is a relative number if it is less that 3 years (in seconds).
+            This parameter is used in KS2 and VOLUME algorithms.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+            default: -300
+        - name: baseline_before
+          in: query
+          description: This parameter can either be an absolute timestamp specifying the
+            ending point of the baseline window, or a relative number of
+            seconds (negative), relative to the last collected timestamp.
+            Netdata will assume it is a relative number if it is less than 3
+            years (in seconds).
+            This parameter is used in KS2 and VOLUME algorithms.
+          required: false
+          schema:
+            type: number
+            format: integer
+            default: -60
+        - name: after
+          in: query
+          description: This parameter can either be an absolute timestamp specifying the
+            starting point of highlighted window, or a relative number of
+            seconds (negative, relative to parameter highlight_before). Netdata will
+            assume it is a relative number if it is less that 3 years (in seconds).
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+            default: -60
+        - name: before
+          in: query
+          description: This parameter can either be an absolute timestamp specifying the
+            ending point of the highlighted window, or a relative number of
+            seconds (negative), relative to the last collected timestamp.
+            Netdata will assume it is a relative number if it is less than 3
+            years (in seconds).
+          required: false
+          schema:
+            type: number
+            format: integer
+            default: 0
+        - name: points
+          in: query
+          description: The number of points to be evaluated for the highlighted window.
+            The baseline window will be adjusted automatically to receive a proportional
+            amount of points.
+            This parameter is only used by the KS2 algorithm.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+            default: 500
+        - name: method
+          in: query
+          description: the algorithm to run
+          required: false
+          schema:
+            type: string
+            enum:
+              - ks2
+              - volume
+              - anomaly-rate
+            default: anomaly-rate
+        - name: tier
+          in: query
+          description: Use the specified database tier
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+        - name: timeout
+          in: query
+          description: Cancel the query if to takes more that this amount of milliseconds.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: number
+            format: integer
+            default: 60000
+        - name: options
+          in: query
+          description: Options that affect data generation.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - min2max
+                - abs
+                - absolute
+                - absolute-sum
+                - null2zero
+                - percentage
+                - unaligned
+                - nonzero
+                - anomaly-bit
+                - raw
+            default:
+              - null2zero
+              - nonzero
+              - unaligned
+        - name: group
+          in: query
+          description: The grouping method. If multiple collected values are to be grouped
+            in order to return fewer points, this parameters defines the method
+            of grouping. methods supported "min", "max", "average", "sum",
+            "incremental-sum". "max" is actually calculated on the absolute
+            value collected (so it works for both positive and negative
+            dimensions to return the most extreme value in either direction).
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: string
+            enum:
+              - min
+              - max
+              - average
+              - median
+              - stddev
+              - sum
+              - incremental-sum
+              - ses
+              - des
+              - cv
+              - countif
+            default: average
+        - name: group_options
+          in: query
+          description: When the group function supports additional parameters, this field
+            can be used to pass them to it. Currently only "countif" supports this.
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: JSON object with weights for each context, chart and dimension.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/weight"
         "400":
           description: The given parameters are invalid.
         "403":
@@ -2197,3 +2366,81 @@ components:
                       type: number
                     dimension2-name:
                       type: number
+    weight:
+      type: object
+      properties:
+        after:
+          description: the start time of the highlighted window
+          type: integer
+        before:
+          description: the end time of the highlighted window
+          type: integer
+        duration:
+          description: the duration of the highlighted window
+          type: integer
+        points:
+          description: the points of the highlighted window
+          type: integer
+        baseline_after:
+          description: the start time of the baseline window
+          type: integer
+        baseline_before:
+          description: the end time of the baseline window
+          type: integer
+        baseline_duration:
+          description: the duration of the baseline window
+          type: integer
+        baseline_points:
+          description: the points of the baseline window
+          type: integer
+        group:
+          description: the grouping method across time
+          type: string
+        method:
+          description: the correlation method used
+          type: string
+        options:
+          description: a comma separated list of the query options set
+          type: string
+        correlated_dimensions:
+          description: the number of dimensions returned in the result
+        total_dimensions_count:
+          description: the total number of dimensions evaluated
+          type: integer
+        statistics:
+          type: object
+          properties:
+            query_time_ms:
+              type: number
+            db_queries:
+              type: integer
+            db_points_read:
+              type: integer
+            query_result_points:
+              type: integer
+            binary_searches:
+              type: integer
+        contexts:
+          type: object
+          description: An object containing context objects.
+          properties:
+            contextX:
+              type: object
+              properties:
+                charts:
+                  type: object
+                  properties:
+                    chartX:
+                      type: object
+                      properties:
+                        dimensions:
+                          type: object
+                          properties:
+                            dimensionX:
+                              type: number
+                        weight:
+                          description: The average chart weight
+                          type: number
+                      weight:
+                        description: The average context weight
+                        type: number

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -82,7 +82,7 @@ RRDR *rrdr_create_for_x_dimensions(ONEWAYALLOC *owa, int dimensions, long points
     r->t = onewayalloc_callocz(owa, points, sizeof(time_t));
     r->v = onewayalloc_mallocz(owa, points * dimensions * sizeof(NETDATA_DOUBLE));
     r->o = onewayalloc_mallocz(owa, points * dimensions * sizeof(RRDR_VALUE_FLAGS));
-    r->ar = onewayalloc_mallocz(owa, points * dimensions * sizeof(uint8_t));
+    r->ar = onewayalloc_mallocz(owa, points * dimensions * sizeof(NETDATA_DOUBLE));
     r->od = onewayalloc_mallocz(owa, dimensions * sizeof(RRDR_DIMENSION_FLAGS));
 
     r->group = 1;

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -83,7 +83,7 @@ typedef struct rrdresult {
     time_t *t;                // array of n timestamps
     NETDATA_DOUBLE *v;        // array n x d values
     RRDR_VALUE_FLAGS *o;      // array n x d options for each value returned
-    uint8_t *ar;              // array n x d of anomaly rates (0 - 200)
+    NETDATA_DOUBLE *ar;       // array n x d of anomaly rates (0 - 100)
 
     long group;               // how many collected values were grouped for each row
     int update_every;         // what is the suggested update frequency in seconds

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "daemon/common.h"
-#include "KolmogorovSmirnovDist.h"
+#include "database/KolmogorovSmirnovDist.h"
 
 #define MAX_POINTS 10000
 int enable_metric_correlations = CONFIG_BOOLEAN_YES;

--- a/web/api/queries/weights.h
+++ b/web/api/queries/weights.h
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#ifndef NETDATA_METRIC_CORRELATIONS_H
-#define NETDATA_METRIC_CORRELATIONS_H 1
+#ifndef NETDATA_API_WEIGHTS_H
+#define NETDATA_API_WEIGHTS_H 1
 
-#include "web/api/queries/query.h"
+#include "query.h"
 
 typedef enum {
     WEIGHTS_METHOD_MC_KS2       = 1,
@@ -30,4 +30,4 @@ extern WEIGHTS_METHOD weights_string_to_method(const char *method);
 extern const char *weights_method_to_string(WEIGHTS_METHOD method);
 extern int mc_unittest(void);
 
-#endif //NETDATA_METRIC_CORRELATIONS_H
+#endif //NETDATA_API_WEIGHTS_H

--- a/web/api/queries/weights.h
+++ b/web/api/queries/weights.h
@@ -24,7 +24,7 @@ extern int web_api_v1_weights (RRDHOST *host, BUFFER *wb, WEIGHTS_METHOD method,
                                RRDR_GROUPING group, const char *group_options,
                                long long baseline_after, long long baseline_before,
                                long long after, long long before,
-                               long long points, RRDR_OPTIONS options, int tier, int timeout);
+                               long long points, RRDR_OPTIONS options, SIMPLE_PATTERN *contexts, int tier, int timeout);
 
 extern WEIGHTS_METHOD weights_string_to_method(const char *method);
 extern const char *weights_method_to_string(WEIGHTS_METHOD method);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1480,6 +1480,7 @@ static int web_client_api_request_v1_weights_internal(RRDHOST *host, struct web_
 
     long long baseline_after = 0, baseline_before = 0, after = 0, before = 0, points = 0;
     RRDR_OPTIONS options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_NONZERO | RRDR_OPTION_NULL2ZERO;
+    int options_count = 0;
     RRDR_GROUPING group = RRDR_GROUPING_AVERAGE;
     int timeout = 0;
     int tier = 0;
@@ -1517,8 +1518,11 @@ static int web_client_api_request_v1_weights_internal(RRDHOST *host, struct web_
         else if(!strcmp(name, "group"))
             group = web_client_api_request_v1_data_group(value, RRDR_GROUPING_AVERAGE);
 
-        else if(!strcmp(name, "options"))
+        else if(!strcmp(name, "options")) {
+            if(!options_count) options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_NULL2ZERO;
             options |= web_client_api_request_v1_data_options(value);
+            options_count++;
+        }
 
         else if(!strcmp(name, "method"))
             method = weights_string_to_method(value);
@@ -1546,7 +1550,7 @@ static int web_client_api_request_v1_weights_internal(RRDHOST *host, struct web_
 }
 
 int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_client *w, char *url) {
-    return web_client_api_request_v1_weights_internal(host, w, url, WEIGHTS_METHOD_MC_KS2, WEIGHTS_FORMAT_CHARTS);
+    return web_client_api_request_v1_weights_internal(host, w, url, default_metric_correlations_method, WEIGHTS_FORMAT_CHARTS);
 }
 
 int web_client_api_request_v1_weights(RRDHOST *host, struct web_client *w, char *url) {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1474,15 +1474,15 @@ static int web_client_api_request_v1_aclk_state(RRDHOST *host, struct web_client
     return HTTP_RESP_OK;
 }
 
-int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_client *w, char *url) {
+static int web_client_api_request_v1_weights_internal(RRDHOST *host, struct web_client *w, char *url, WEIGHTS_METHOD method, WEIGHTS_FORMAT format) {
     if (!netdata_ready)
         return HTTP_RESP_BACKEND_FETCH_FAILED;
 
     long long baseline_after = 0, baseline_before = 0, after = 0, before = 0, points = 0;
     RRDR_OPTIONS options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_NONZERO | RRDR_OPTION_NULL2ZERO;
-    WEIGHTS_METHOD method = default_metric_correlations_method;
     RRDR_GROUPING group = RRDR_GROUPING_AVERAGE;
     int timeout = 0;
+    int tier = 0;
     const char *group_options = NULL;
 
     while (url) {
@@ -1523,73 +1523,26 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
         else if(!strcmp(name, "method"))
             method = weights_string_to_method(value);
 
+        else if(!strcmp(name, "tier")) {
+            tier = str2i(value);
+            if(tier >= 0 && tier < storage_tiers)
+                options |= RRDR_OPTION_SELECTED_TIER;
+        }
     }
 
     BUFFER *wb = w->response.data;
     buffer_flush(wb);
     wb->contenttype = CT_APPLICATION_JSON;
-    buffer_no_cacheable(wb);
 
-    return metric_correlations(host, wb, method, group, group_options, baseline_after, baseline_before, after, before, points, options, timeout);
+    return web_api_v1_weights(host, wb, method, format, group, group_options, baseline_after, baseline_before, after, before, points, options, tier, timeout);
+}
+
+int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_client *w, char *url) {
+    return web_client_api_request_v1_weights_internal(host, w, url, WEIGHTS_METHOD_MC_KS2, WEIGHTS_FORMAT_CHARTS);
 }
 
 int web_client_api_request_v1_weights(RRDHOST *host, struct web_client *w, char *url) {
-    if (!netdata_ready)
-        return HTTP_RESP_BACKEND_FETCH_FAILED;
-
-    long long baseline_after = 0, baseline_before = 0, after = 0, before = 0, points = 0;
-    RRDR_OPTIONS options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_NONZERO | RRDR_OPTION_NULL2ZERO;
-    WEIGHTS_METHOD method = WEIGHTS_METHOD_ANOMALY_RATE;
-    RRDR_GROUPING group = RRDR_GROUPING_AVERAGE;
-    int timeout = 0;
-    const char *group_options = NULL;
-
-    while (url) {
-        char *value = mystrsep(&url, "&");
-        if (!value || !*value)
-            continue;
-
-        char *name = mystrsep(&value, "=");
-        if (!name || !*name)
-            continue;
-        if (!value || !*value)
-            continue;
-
-        if (!strcmp(name, "baseline_after"))
-            baseline_after = (long long) strtoul(value, NULL, 0);
-
-        else if (!strcmp(name, "baseline_before"))
-            baseline_before = (long long) strtoul(value, NULL, 0);
-
-        else if (!strcmp(name, "after") || !strcmp(name, "highlight_after"))
-            after = (long long) strtoul(value, NULL, 0);
-
-        else if (!strcmp(name, "before") || !strcmp(name, "highlight_before"))
-            before = (long long) strtoul(value, NULL, 0);
-
-        else if (!strcmp(name, "points") || !strcmp(name, "max_points"))
-            points = (long long) strtoul(value, NULL, 0);
-
-        else if (!strcmp(name, "timeout"))
-            timeout = (int) strtoul(value, NULL, 0);
-
-        else if(!strcmp(name, "group"))
-            group = web_client_api_request_v1_data_group(value, RRDR_GROUPING_AVERAGE);
-
-        else if(!strcmp(name, "options"))
-            options |= web_client_api_request_v1_data_options(value);
-
-        else if(!strcmp(name, "method"))
-            method = weights_string_to_method(value);
-
-    }
-
-    BUFFER *wb = w->response.data;
-    buffer_flush(wb);
-    wb->contenttype = CT_APPLICATION_JSON;
-    buffer_no_cacheable(wb);
-
-    return web_api_v1_weights(host, wb, method, WEIGHTS_FORMAT_CONTEXTS, group, group_options, baseline_after, baseline_before, after, before, points, options, timeout);
+    return web_client_api_request_v1_weights_internal(host, w, url, WEIGHTS_METHOD_ANOMALY_RATE, WEIGHTS_FORMAT_CONTEXTS);
 }
 
 #ifndef ENABLE_DBENGINE

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1480,7 +1480,7 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
 
     long long baseline_after = 0, baseline_before = 0, after = 0, before = 0, points = 0;
     RRDR_OPTIONS options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_NONZERO | RRDR_OPTION_NULL2ZERO;
-    METRIC_CORRELATIONS_METHOD method = default_metric_correlations_method;
+    WEIGHTS_METHOD method = default_metric_correlations_method;
     RRDR_GROUPING group = RRDR_GROUPING_AVERAGE;
     int timeout = 0;
     const char *group_options = NULL;
@@ -1521,7 +1521,7 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
             options |= web_client_api_request_v1_data_options(value);
 
         else if(!strcmp(name, "method"))
-            method = mc_string_to_method(value);
+            method = weights_string_to_method(value);
 
     }
 
@@ -1531,6 +1531,65 @@ int web_client_api_request_v1_metric_correlations(RRDHOST *host, struct web_clie
     buffer_no_cacheable(wb);
 
     return metric_correlations(host, wb, method, group, group_options, baseline_after, baseline_before, after, before, points, options, timeout);
+}
+
+int web_client_api_request_v1_weights(RRDHOST *host, struct web_client *w, char *url) {
+    if (!netdata_ready)
+        return HTTP_RESP_BACKEND_FETCH_FAILED;
+
+    long long baseline_after = 0, baseline_before = 0, after = 0, before = 0, points = 0;
+    RRDR_OPTIONS options = RRDR_OPTION_NOT_ALIGNED | RRDR_OPTION_NONZERO | RRDR_OPTION_NULL2ZERO;
+    WEIGHTS_METHOD method = WEIGHTS_METHOD_ANOMALY_RATE;
+    RRDR_GROUPING group = RRDR_GROUPING_AVERAGE;
+    int timeout = 0;
+    const char *group_options = NULL;
+
+    while (url) {
+        char *value = mystrsep(&url, "&");
+        if (!value || !*value)
+            continue;
+
+        char *name = mystrsep(&value, "=");
+        if (!name || !*name)
+            continue;
+        if (!value || !*value)
+            continue;
+
+        if (!strcmp(name, "baseline_after"))
+            baseline_after = (long long) strtoul(value, NULL, 0);
+
+        else if (!strcmp(name, "baseline_before"))
+            baseline_before = (long long) strtoul(value, NULL, 0);
+
+        else if (!strcmp(name, "after") || !strcmp(name, "highlight_after"))
+            after = (long long) strtoul(value, NULL, 0);
+
+        else if (!strcmp(name, "before") || !strcmp(name, "highlight_before"))
+            before = (long long) strtoul(value, NULL, 0);
+
+        else if (!strcmp(name, "points") || !strcmp(name, "max_points"))
+            points = (long long) strtoul(value, NULL, 0);
+
+        else if (!strcmp(name, "timeout"))
+            timeout = (int) strtoul(value, NULL, 0);
+
+        else if(!strcmp(name, "group"))
+            group = web_client_api_request_v1_data_group(value, RRDR_GROUPING_AVERAGE);
+
+        else if(!strcmp(name, "options"))
+            options |= web_client_api_request_v1_data_options(value);
+
+        else if(!strcmp(name, "method"))
+            method = weights_string_to_method(value);
+
+    }
+
+    BUFFER *wb = w->response.data;
+    buffer_flush(wb);
+    wb->contenttype = CT_APPLICATION_JSON;
+    buffer_no_cacheable(wb);
+
+    return web_api_v1_weights(host, wb, method, WEIGHTS_FORMAT_CONTEXTS, group, group_options, baseline_after, baseline_before, after, before, points, options, timeout);
 }
 
 #ifndef ENABLE_DBENGINE
@@ -1671,6 +1730,7 @@ static struct api_command {
         { "manage/health",       0, WEB_CLIENT_ACL_MGMT,      web_client_api_request_v1_mgmt_health         },
         { "aclk",                0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_aclk_state          },
         { "metric_correlations", 0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_metric_correlations },
+        { "weights",             0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_weights },
 
         { "dbengine_stats",      0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_dbengine_stats },
 

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -7,6 +7,7 @@
 #include "web/api/badges/web_buffer_svg.h"
 #include "web/api/formatters/rrd2json.h"
 #include "web/api/health/health_cmdapi.h"
+#include "web/api/queries/weights.h"
 
 #define MAX_CHART_LABELS_FILTER (32)
 extern RRDR_OPTIONS web_client_api_request_v1_data_options(char *o);


### PR DESCRIPTION
This PR introduces `/api/v1/weights` endpoint, as a more general method for querying anomaly rates and metric correlations.

It obsoletes the `/api/v1/metric_correlations` endpoint (although it still works).

The new `/api/v1/weights` accepts all the parameters of `/api/v1/metric_correlations` and supports 3 algorithms:

- [x] metric correlations using `ks2`
- [x] metric correlations using `volume`
- [x] metric rating using `anomaly-rate`

The following improvements have also been implemented:

- [x] When called using `/api/v1/weights`, the output is context->chart->dimensions, instead of chart->dimensions.
- [x] The output includes average weight per chart and context.
- [x] The query engine now calculates high-resolution anomaly-rate in parallel of all queries.
- [x] `tier=N` parameter has been added to force the use of a specific tier.
- [x] The output now shows db points read per tier.
- [x] Paramter `context` has been added, which is a simple pattern matching the contexts to be queried
- [x] `options=nonzero` is the default, but it is removed if `options=` is set and `nonzero` is not included 

Fixes: https://github.com/netdata/netdata/discussions/13446