### PR TITLE
Overhaul handling of installation of Netdata as a system service.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ system/netdata.plist
 system/netdata-freebsd
 system/edit-config
 system/netdata.crontab
+system/install-service.sh
 
 daemon/anonymous-statistics.sh
 daemon/get-kubernetes-labels.sh

--- a/build/subst.inc
+++ b/build/subst.inc
@@ -10,6 +10,7 @@
 		-e 's#[@]registrydir_POST@#$(registrydir)#g' \
 		-e 's#[@]varlibdir_POST@#$(varlibdir)#g' \
 		-e 's#[@]webdir_POST@#$(webdir)#g' \
+		-e 's#[@]libsysdir_POST@#$(libsysdir)#g' \
 		-e 's#[@]enable_aclk_POST@#$(enable_aclk)#g' \
 		-e 's#[@]enable_cloud_POST@#$(enable_cloud)#g' \
 		$< > $@.tmp; then \

--- a/configure.ac
+++ b/configure.ac
@@ -1541,6 +1541,7 @@ configdir="${sysconfdir}/netdata"
 libconfigdir="${libdir}/netdata/conf.d"
 logdir="${localstatedir}/log/netdata"
 pluginsdir="${libexecdir}/netdata/plugins.d"
+libsysdir="${libdir}/netdata/system"
 
 AC_SUBST([varlibdir])
 AC_SUBST([registrydir])
@@ -1552,6 +1553,7 @@ AC_SUBST([libconfigdir])
 AC_SUBST([logdir])
 AC_SUBST([pluginsdir])
 AC_SUBST([webdir])
+AC_SUBST([libsysdir])
 
 CFLAGS="${originalCFLAGS} ${OPTIONAL_LTO_CFLAGS} ${OPTIONAL_PROTOBUF_CFLAGS} ${OPTIONAL_MATH_CFLAGS} ${OPTIONAL_NFACCT_CFLAGS} \
     ${OPTIONAL_ZLIB_CFLAGS} ${OPTIONAL_UUID_CFLAGS} \

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -480,9 +480,11 @@ install_netdata_service() {
     if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" ]; then
       # shellcheck disable=SC2154
       save_path="${tmpdir}/netdata-service-cmds"
-      run "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --cmds-only --save-cmds "${save_path}"
-      # shellcheck disable=SC1090
-      . "${save_path}"
+      run "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --save-cmds "${save_path}"
+      if [ -r "${save_path}" ]; then
+        # shellcheck disable=SC1090
+        . "${save_path}"
+      fi
 
       if [ -z "${NETDATA_INSTALLER_START_CMD}" ]; then
         if [ -n "${NETDATA_START_CMD}" ]; then
@@ -660,9 +662,11 @@ stop_all_netdata() {
   if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" ]; then
     # shellcheck disable=SC2154
     save_path="${tmpdir}/netdata-service-cmds"
-    "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --cmds-only --save-cmds "${save_path}"
-    # shellcheck disable=SC1090
-    . "${save_path}"
+    run "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --cmds-only --save-cmds "${save_path}"
+    if [ -r "${save_path}" ]; then
+      # shellcheck disable=SC1090
+      . "${save_path}"
+    fi
   fi
 
   if [ "${UID}" -eq 0 ]; then
@@ -725,9 +729,11 @@ restart_netdata() {
   if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" ]; then
     # shellcheck disable=SC2154
     save_path="${tmpdir}/netdata-service-cmds"
-    "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --cmds-only --save-cmds "${save_path}"
-    # shellcheck disable=SC1090
-    . "${save_path}"
+    run "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --cmds-only --save-cmds "${save_path}"
+    if [ -r "${save_path}" ]; then
+      # shellcheck disable=SC1090
+      . "${save_path}"
+    fi
   fi
 
   if [ -z "${NETDATA_INSTALLER_START_CMD}" ]; then

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -478,7 +478,11 @@ install_non_systemd_init() {
 install_netdata_service() {
   if [ "${UID}" -eq 0 ]; then
     if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" ]; then
-      run "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --export-cmds && return 0
+      # shellcheck disable=SC2154
+      save_path="${tmpdir}/netdata-service-cmds"
+      run "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --cmds-only --save-cmds "${save_path}"
+      # shellcheck disable=SC1090
+      . "${save_path}"
 
       if [ -z "${NETDATA_INSTALLER_START_CMD}" ]; then
         if [ -n "${NETDATA_START_CMD}" ]; then
@@ -654,7 +658,11 @@ stop_all_netdata() {
   stop_success=0
 
   if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" ]; then
-    "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --export-cmds --cmds-only
+    # shellcheck disable=SC2154
+    save_path="${tmpdir}/netdata-service-cmds"
+    "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --cmds-only --save-cmds "${save_path}"
+    # shellcheck disable=SC1090
+    . "${save_path}"
   fi
 
   if [ "${UID}" -eq 0 ]; then
@@ -715,7 +723,11 @@ restart_netdata() {
   progress "Restarting netdata instance"
 
   if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" ]; then
-    "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --export-cmds --cmds-only
+    # shellcheck disable=SC2154
+    save_path="${tmpdir}/netdata-service-cmds"
+    "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --cmds-only --save-cmds "${save_path}"
+    # shellcheck disable=SC1090
+    . "${save_path}"
   fi
 
   if [ -z "${NETDATA_INSTALLER_START_CMD}" ]; then

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -475,18 +475,26 @@ install_non_systemd_init() {
   return 1
 }
 
-# This is used by netdata-installer.sh
-# shellcheck disable=SC2034
-NETDATA_STOP_CMD="netdatacli shutdown-agent"
-
-NETDATA_START_CMD="netdata"
-NETDATA_INSTALLER_START_CMD=""
-
 install_netdata_service() {
   if [ "${UID}" -eq 0 ]; then
     if [ -x "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" ]; then
       run "${NETDATA_PREFIX}/usr/libexec/netdata/install-service.sh" --export-cmds && return 0
+
+      if [ -z "${NETDATA_INSTALLER_START_CMD}" ]; then
+        if [ -n "${NETDATA_START_CMD}" ]; then
+          NETDATA_INSTALLER_START_CMD="${NETDATA_START_CMD}"
+        else
+          NETDATA_INSTALLER_START_CMD="netdata"
+        fi
+      fi
     else
+      # This is used by netdata-installer.sh
+      # shellcheck disable=SC2034
+      NETDATA_STOP_CMD="netdatacli shutdown-agent"
+
+      NETDATA_START_CMD="netdata"
+      NETDATA_INSTALLER_START_CMD=""
+
       uname="$(uname 2> /dev/null)"
 
       if [ "${uname}" = "Darwin" ]; then

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -32,6 +32,11 @@ install-exec-local:
 	$(INSTALL) -d $(DESTDIR)$(configdir)
 	$(INSTALL) -d $(DESTDIR)$(libsysdir)
 
+libexecnetdatadir=$(libexecdir)/netdata
+nodist_libexecnetdata_SCRIPTS = \
+    install-service.sh \
+    $(NULL)
+
 nodist_libsys_DATA = \
     netdata-openrc \
     netdata.logrotate \
@@ -51,6 +56,7 @@ dist_libsys_DATA = \
 
 dist_noinst_DATA = \
     edit-config.in \
+    install-service.sh.in \
     netdata-openrc.in \
     netdata.logrotate.in \
     netdata.service.in \

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -30,8 +30,9 @@ dist_config_DATA = \
 # Explicitly install directories to avoid permission issues due to umask
 install-exec-local:
 	$(INSTALL) -d $(DESTDIR)$(configdir)
+	$(INSTALL) -d $(DESTDIR)$(libsysdir)
 
-nodist_noinst_DATA = \
+nodist_libsys_DATA = \
     netdata-openrc \
     netdata.logrotate \
     netdata.service \
@@ -42,6 +43,10 @@ nodist_noinst_DATA = \
     netdata.plist \
     netdata.crontab \
     netdata-updater.service \
+    $(NULL)
+
+dist_libsys_DATA = \
+    netdata-updater.timer \
     $(NULL)
 
 dist_noinst_DATA = \
@@ -57,5 +62,4 @@ dist_noinst_DATA = \
     netdata.conf \
     netdata.crontab.in \
     netdata-updater.service.in \
-    netdata-updater.timer \
     $(NULL)

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -143,6 +143,10 @@ export_cmds() {
   return 0
 }
 
+save_cmds() {
+  dump_cmds > "${SAVE_CMDS_PATH}"
+}
+
 # =====================================================================
 # Help functions
 
@@ -605,6 +609,15 @@ parse_args() {
           shift 1
         fi
         ;;
+      "--save-cmds")
+        if [ -z "${2}" ]; then
+          info "No path specified to save command variables."
+          exit 1
+        else
+          SAVE_CMDS_PATH="${2}"
+          shift 1
+        fi
+        ;;
       "--cmds" | "-c") DUMP_CMDS=1 ;;
       "--cmds-only") INSTALL=0 ;;
       "--export-cmds") EXPORT_CMDS=1 ;;
@@ -668,6 +681,7 @@ main() {
 
   [ "${DUMP_CMDS}" -eq 1 ] && dump_cmds
   [ "${EXPORT_CMDS}" -eq 1 ] && export_cmds
+  [ -n "${SAVE_CMDS_PATH}" ] && save_cmds
   exit 0
 }
 

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -12,6 +12,8 @@
 # 4 - Detected system service type, but could not install due to other issues.
 # 5 - Platform not supported.
 
+set -e
+
 SCRIPT_SOURCE="$(
     self=${0}
     while [ -L "${self}" ]
@@ -35,16 +37,36 @@ SVC_TYPE="detect"
 # =====================================================================
 # Utility functions
 
+cleanup() {
+  ec="${?}"
+
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    if [ -n "${NETDATA_PROPAGATE_WARNINGS}" ]; then
+      export NETDATA_WARNINGS="${NETDATA_WARNINGS}${SAVED_WARNINGS}"
+    fi
+  fi
+
+  trap - EXIT
+
+  exit "${ec}"
+}
+
 info() {
-  printf >&2 "%s\n" "${@}"
+  printf >&2 "%s\n" "${*}"
 }
 
 warning() {
-  printf >&2 "WARNING: %s\n" "${@}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${*}"
+  fi
+  printf >&2 "WARNING: %s\n" "${*}"
 }
 
 error() {
-  printf >&2 "ERROR: %s\n" "${@}"
+  if [ -n "${NETDATA_SAVE_WARNINGS}" ]; then
+    SAVED_WARNINGS="${SAVED_WARNINGS}\n  - ${*}"
+  fi
+  printf >&2 "ERROR: %s\n" "${*}"
 }
 
 get_os_key() {
@@ -619,6 +641,8 @@ parse_args() {
 # Core logic
 
 main() {
+  trap "cleanup" EXIT
+
   parse_args "${@}"
 
   case "${PLATFORM}" in

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -34,6 +34,18 @@ SVC_TYPE="detect"
 # =====================================================================
 # Utility functions
 
+info() {
+  printf >&2 "%s\n" "${@}"
+}
+
+warning() {
+  printf >&2 "WARNING: %s\n" "${@}"
+}
+
+error() {
+  printf >&2 "ERROR: %s\n" "${@}"
+}
+
 get_os_key() {
   if [ -f /etc/os-release ]; then
     # shellcheck disable=SC1091
@@ -71,24 +83,24 @@ install_generic_service() {
   svc_enable_hook="${4}"
   svc_disable_hook="${5}"
 
-  echo >&2 "Installing ${svc_type_name} service file."
+  info "Installing ${svc_type_name} service file."
   if [ ! -f "${svc_file}" ] && [ "${ENABLE}" = "auto" ]; then
     ENABLE="enable"
   fi
 
   if ! install -C -S -p -m 0755 -o 0 -g 0 "${SVC_SOURCE}/netdata-${svc_type}" /etc/init.d/netdata; then
-    echo >&2 "ERROR: Failed to install service file."
+    error "Failed to install service file."
     exit 4
   fi
 
   case "${ENABLE}" in
     auto) true ;;
     disable)
-      echo >&2 "Disabling Netdata service."
+      info "Disabling Netdata service."
       ${svc_disable_hook}
       ;;
     enable)
-      echo >&2 "Enabling Netdata service."
+      info "Enabling Netdata service."
       ${svc_enable_hook}
       ;;
   esac
@@ -177,7 +189,7 @@ get_systemd_service_dir() {
   elif [ -w "/etc/systemd/system" ]; then
     echo "/etc/systemd/system"
   else
-    echo >&2 "ERROR: Unable to detect systemd service directory."
+    error "Unable to detect systemd service directory."
     exit 4
   fi
 }
@@ -199,18 +211,18 @@ install_systemd_service() {
     fi
   fi
 
-  echo >&2 "Installing systemd service..."
+  info "Installing systemd service..."
   if ! install -C -S -p -m 0644 -o 0 -g 0 "${SRCFILE}" "$(get_systemd_service_dir)/netdata.service"; then
-    echo >&2 "ERROR: Failed to install systemd service file."
+    error "Failed to install systemd service file."
     exit 4
   fi
 
   if ! systemctl daemon-reload; then
-    echo >&2 "WARNING: Failed to reload systemd unit files."
+    warning "Failed to reload systemd unit files."
   fi
 
   if ! systemctl ${ENABLE} netdata; then
-    echo >&2 "WARNING: Failed to ${ENABLE} Netdata service."
+    warning "Failed to ${ENABLE} Netdata service."
   fi
 }
 
@@ -255,7 +267,7 @@ enable_openrc() {
   runlevel="$(rc-status -r)"
   runlevel="${runlevel:-default}"
   if ! rc-update add netdata "${runlevel}"; then
-    echo >&2 "WARNING: Failed to enable Netdata service in runlevel ${runlevel}."
+    warning "Failed to enable Netdata service in runlevel ${runlevel}."
   fi
 }
 
@@ -264,7 +276,7 @@ disable_openrc() {
     if [ -e "${runlevel}/netdata" ]; then
       runlevel="$(basename "${runlevel}")"
       if ! rc-update del netdata "${runlevel}"; then
-        echo >&2 "WARNING: Failed to disable Netdata service in runlevel ${runlevel}."
+        warning "Failed to disable Netdata service in runlevel ${runlevel}."
       fi
     fi
   done
@@ -306,15 +318,15 @@ check_lsb() {
 
 enable_lsb() {
   if ! update-rc.d netdata defaults; then
-    echo >&2 "WARNING: Failed to enable Netdata service."
+    warning "Failed to enable Netdata service."
   elif ! update-rc.d netdata defaults-disable; then
-    echo >&2 "WARNING: Failed to fully enable Netdata service."
+    warning "Failed to fully enable Netdata service."
   fi
 }
 
 disable_lsb() {
   if ! update-rc.d netdata remove; then
-    echo >&2 "WARNING: Failed to disable Netdata service."
+    warning "Failed to disable Netdata service."
   fi
 }
 
@@ -359,13 +371,13 @@ check_initd() {
 
 enable_initd() {
   if ! chkconfig netdata on; then
-    echo >&2 "WARNING: Failed to enable Netdata service."
+    warning "Failed to enable Netdata service."
   fi
 }
 
 disable_initd() {
   if ! chkconfig netdata off; then
-    echo >&2 "WARNING: Failed to disable Netdata service."
+    warning "Failed to disable Netdata service."
   fi
 }
 
@@ -414,12 +426,12 @@ check_runit() {
 }
 
 install_runit_service() {
-  echo "ERROR: Detected runit, which we do not currently support."
+  error "Detected runit, which we do not currently support."
   exit 3
 }
 
 runit_cmds() {
-  echo "ERROR: Detected runit, which we do not currently support."
+  error "Detected runit, which we do not currently support."
   exit 3
 }
 
@@ -450,12 +462,12 @@ check_wsl() {
 }
 
 install_wsl_service() {
-  echo "ERROR: We appear to be running in WSL. Netdata cannot be automatically installed as a service under WSL."
+  error "We appear to be running in WSL. Netdata cannot be automatically installed as a service under WSL."
   exit 3
 }
 
 wsl_cmds() {
-  echo "ERROR: We appear to be running in WSL. Netdata cannot be automatically installed as a service under WSL."
+  error "We appear to be running in WSL. Netdata cannot be automatically installed as a service under WSL."
   exit 3
 }
 
@@ -464,13 +476,13 @@ wsl_cmds() {
 
 enable_freebsd() {
   if ! sysrc netdata_enable=YES; then
-    echo >&2 "WARNING: Failed to enable netdata service."
+    warning "Failed to enable netdata service."
   fi
 }
 
 disable_freebsd() {
   if ! sysrc netdata_enable=NO; then
-    echo >&2 "WARNING: Failed to disable netdata service."
+    warning "Failed to disable netdata service."
   fi
 }
 
@@ -488,14 +500,14 @@ freebsd_cmds() {
 # macOS support functions
 
 install_darwin_service() {
-  echo >&2 "Installing macOS plist file for launchd."
+  info "Installing macOS plist file for launchd."
   if ! install -C -S -p -m 0644 -o 0 -g 0 system/netdata.plist /Library/LaunchDaemons/com.github.netdata.plist; then
-    echo >&2 "ERROR: Failed to copy plist file."
+    error "Failed to copy plist file."
     exit 4
   fi
 
   if ! launchctl load /Library/LaunchDaemons/com.github.netdata.plist; then
-    echo >&2 "ERROR: Failed to load plist file."
+    error "Failed to load plist file."
     exit 4
   fi
 }
@@ -518,7 +530,7 @@ detect_linux_svc_type() {
     done
 
     if [ "${SVC_TYPE}" = "detect" ]; then
-      echo >&2 "ERROR: Failed to detect what type of service manager is in use."
+      error "Failed to detect what type of service manager is in use."
       exit 2
     else
       echo "${SVC_TYPE}"
@@ -567,25 +579,25 @@ parse_args() {
         exit 0
         ;;
       *)
-        echo >&2 "Unrecognized option '${1}'."
+        info "Unrecognized option '${1}'."
         exit 1
         ;;
     esac
     shift 1
   done
 
-  if [ "${SVC_SOURCE%@}" = "libsysdir_POST@" ]; then
-    SVC_SOURCE="${SCRIPT_SOURCE}/../../lib/netdata/system"
-    echo "WARNING: SVC_SOURCE not templated, using ${SVC_SOURCE} as source directory."
+  if [ "${SVC_SOURCE#@}" = "libsysdir_POST@" ]; then
+    SVC_SOURCE="$(dirname "${SCRIPT_SOURCE}")/../../lib/netdata/system"
+    warning "SVC_SOURCE not templated, using ${SVC_SOURCE} as source directory."
   fi
 
-  if [ ! -d "${SVC_SOURCE}" ]; then
-    echo >&2 "ERROR: ${SVC_SOURCE} does not appear to be a directory. Please specify a valid source for service files with the --source option."
+  if [ ! -d "${SVC_SOURCE}" ] && [ "${INSTALL}" -eq 1 ]; then
+    error "${SVC_SOURCE} does not appear to be a directory. Please specify a valid source for service files with the --source option."
     exit 1
   fi
 
   if valid_types | grep -vw "${SVC_TYPE}"; then
-    echo >&2 "ERROR: ${SVC_TYPE} is not supported on this platform."
+    error "${SVC_TYPE} is not supported on this platform."
     help_types
     exit 1
   fi
@@ -623,7 +635,7 @@ main() {
       fi
       ;;
     *)
-      echo >&2 "ERROR: ${PLATFORM} is not supported by this script."
+      error "${PLATFORM} is not supported by this script."
       exit 5
   esac
 }

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -573,7 +573,6 @@ detect_linux_svc_type() {
 
     if [ "${SVC_TYPE}" = "detect" ]; then
       error "Failed to detect what type of service manager is in use."
-      exit 2
     else
       echo "${SVC_TYPE}"
     fi
@@ -583,11 +582,23 @@ detect_linux_svc_type() {
 }
 
 install_linux_service() {
-  "install_$(detect_linux_svc_type)_service"
+  t="$(detect_linux_svc_type)"
+
+  if [ -z "${t}" ]; then
+    exit 2
+  fi
+
+  "install_$(t)_service"
 }
 
 linux_cmds() {
-  "$(detect_linux_svc_type)_cmds"
+  t="$(detect_linux_svc_type)"
+
+  if [ -z "${t}" ]; then
+    exit 2
+  fi
+
+  "$(t)_cmds"
 }
 
 # =====================================================================

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -1,0 +1,631 @@
+#!/usr/bin/env sh
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Handle installation of the Netdata agent as a system service.
+#
+# Exit codes:
+# 0 - Successfully installed service.
+# 1 - Invalid arguments or other internal error.
+# 2 - Unable to detect system service type.
+# 3 - Detected system service type, but type not supported.
+# 4 - Detected system service type, but could not install due to other issues.
+# 5 - Platform not supported.
+
+SCRIPT_SOURCE="$(
+    self=${0}
+    while [ -L "${self}" ]
+    do
+        cd "${self%/*}" || exit 1
+        self=$(readlink "${self}")
+    done
+    cd "${self%/*}" || exit 1
+    echo "$(pwd -P)/${self##*/}"
+)"
+
+DUMP_CMDS=0
+ENABLE="auto"
+INSTALL=1
+LINUX_INIT_TYPES="wsl systemd openrc lsb initd runit"
+PLATFORM="$(uname -s)"
+SVC_SOURCE="@libsysdir_POST@"
+SVC_TYPE="detect"
+
+# =====================================================================
+# Utility functions
+
+get_os_key() {
+  if [ -f /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release || return 1
+    echo "${ID}-${VERSION_ID}"
+
+  elif [ -f /etc/redhat-release ]; then
+    cat /etc/redhat-release
+  else
+    echo "unknown"
+  fi
+}
+
+valid_types() {
+  case "${PLATFORM}" in
+    Linux)
+      echo "detect systemd openrc lsb initd"
+      ;;
+    FreeBSD)
+      echo "detect freebsd"
+      ;;
+    Darwin)
+      echo "detect launchd"
+      ;;
+    *)
+      echo "detect"
+      ;;
+  esac
+}
+
+install_generic_service() {
+  svc_type="${1}"
+  svc_type_name="${2}"
+  svc_file="${3}"
+  svc_enable_hook="${4}"
+  svc_disable_hook="${5}"
+
+  echo >&2 "Installing ${svc_type_name} service file."
+  if [ ! -f "${svc_file}" ] && [ "${ENABLE}" = "auto" ]; then
+    ENABLE="enable"
+  fi
+
+  if ! install -C -S -p -m 0755 -o 0 -g 0 "${SVC_SOURCE}/netdata-${svc_type}" /etc/init.d/netdata; then
+    echo >&2 "ERROR: Failed to install service file."
+    exit 4
+  fi
+
+  case "${ENABLE}" in
+    auto) true ;;
+    disable)
+      echo >&2 "Disabling Netdata service."
+      ${svc_disable_hook}
+      ;;
+    enable)
+      echo >&2 "Enabling Netdata service."
+      ${svc_enable_hook}
+      ;;
+  esac
+}
+
+# =====================================================================
+# Help functions
+
+usage() {
+  cat << HEREDOC
+USAGE: install-service.sh [options]
+       where options include:
+
+  --source      Specify where to find the service files to install (default ${SVC_SOURCE}).
+  --type        Specify the type of service file to install. Specify a type of 'help' to get a list of valid types for your platform.
+  --cmds        Additionally print a list of commands for starting and stopping the agent with the detected service type.
+  --cmds-only   Don't install, just produce the output for the --cmds option.
+  --enable      Explicitly enable the service on install (default is to enable if not already installed).
+  --disable     Explicitly disable the service on install.
+  --help        Print this help information.
+HEREDOC
+}
+
+help_types() {
+  cat << HEREDOC
+Valid service types for ${PLATFORM} are:
+$(valid_types)
+HEREDOC
+}
+
+# =====================================================================
+# systemd support functions
+
+issystemd() {
+  pids=''
+  p=''
+  myns=''
+  ns=''
+  systemctl=''
+
+  # if the directory /lib/systemd/system OR /usr/lib/systemd/system (SLES 12.x) does not exit, it is not systemd
+  if [ ! -d /lib/systemd/system ] && [ ! -d /usr/lib/systemd/system ]; then
+    return 1
+  fi
+
+  # if there is no systemctl command, it is not systemd
+  systemctl=$(command -v systemctl 2> /dev/null)
+  if [ -z "${systemctl}" ] || [ ! -x "${systemctl}" ]; then
+    return 1
+  fi
+
+  # if pid 1 is systemd, it is systemd
+  [ "$(basename "$(readlink /proc/1/exe)" 2> /dev/null)" = "systemd" ] && return 0
+
+  # if systemd is not running, it is not systemd
+  pids=$(safe_pidof systemd 2> /dev/null)
+  [ -z "${pids}" ] && return 1
+
+  # check if the running systemd processes are not in our namespace
+  myns="$(readlink /proc/self/ns/pid 2> /dev/null)"
+  for p in ${pids}; do
+    ns="$(readlink "/proc/${p}/ns/pid" 2> /dev/null)"
+
+    # if pid of systemd is in our namespace, it is systemd
+    [ -n "${myns}" ] && [ "${myns}" = "${ns}" ] && return 0
+  done
+
+  # else, it is not systemd
+  return 1
+}
+
+check_systemd() {
+  if [ -z "${IS_SYSTEMD}" ]; then
+    issystemd
+    IS_SYSTEMD="$?"
+  fi
+
+  return "${IS_SYSTEMD}"
+}
+
+get_systemd_service_dir() {
+  if [ -w "/lib/systemd/system" ]; then
+    echo "/lib/systemd/system"
+  elif [ -w "/usr/lib/systemd/system" ]; then
+    echo "/usr/lib/systemd/system"
+  elif [ -w "/etc/systemd/system" ]; then
+    echo "/etc/systemd/system"
+  else
+    echo >&2 "ERROR: Unable to detect systemd service directory."
+    exit 4
+  fi
+}
+
+install_systemd_service() {
+  SRCFILE="${SVC_SOURCE}/netdata.service"
+
+  if [ "$(systemctl version | head -n 1 | cut -f 2 -d ' ')" -le 235 ]; then
+    SRCFILE="${SVC_SOURCE}/netdata.service.v235"
+  fi
+
+  if [ "${ENABLE}" = "auto" ]; then
+    IS_NETDATA_ENABLED="$(systemctl is-enabled netdata 2> /dev/null || echo "Netdata not there")"
+
+    if [ "${IS_NETDATA_ENABLED}" = "disabled" ]; then
+      ENABLE="disable"
+    else
+      ENABLE="enable"
+    fi
+  fi
+
+  echo >&2 "Installing systemd service..."
+  if ! install -C -S -p -m 0644 -o 0 -g 0 "${SRCFILE}" "$(get_systemd_service_dir)/netdata.service"; then
+    echo >&2 "ERROR: Failed to install systemd service file."
+    exit 4
+  fi
+
+  if ! systemctl daemon-reload; then
+    echo >&2 "WARNING: Failed to reload systemd unit files."
+  fi
+
+  if ! systemctl ${ENABLE} netdata; then
+    echo >&2 "WARNING: Failed to ${ENABLE} Netdata service."
+  fi
+}
+
+systemd_cmds() {
+  echo "NETDATA_START_CMD='systemctl start netdata'"
+  echo "NETDATA_STOP_CMD='systemctl stop netdata'"
+}
+
+# =====================================================================
+# OpenRC support functions
+
+isopenrc() {
+  # if /lib/rc/sh/functions.sh does not exist, it's not OpenRC
+  [ ! -f /lib/rc/sh/functions.sh ] && return 1
+
+  # if there is no /etc/init.d, it's not OpenRC
+  [ ! -d /etc/init.d ] && return 1
+
+  # if PID 1 is openrc-init, it's OpenRC
+  [ "$(basename "$(readlink /proc/1/exe)" 2> /dev/null)" = "openrc-init" ] && return 0
+
+  # If /run/openrc/softlevel exists, it's OpenRC
+  [ -f /run/openrc/softlevel ] && return 0
+
+  # if there is an openrc command, it's OpenRC
+  command -v openrc > /dev/null 2>&1 && return 0
+
+  # Otherwise, it’s not OpenRC
+  return 1
+}
+
+check_openrc() {
+  if [ -z "${IS_OPENRC}" ]; then
+    isopenrc
+    IS_OPENRC="$?"
+  fi
+
+  return "${IS_OPENRC}"
+}
+
+enable_openrc() {
+  runlevel="$(rc-status -r)"
+  runlevel="${runlevel:-default}"
+  if ! rc-update add netdata "${runlevel}"; then
+    echo >&2 "WARNING: Failed to enable Netdata service in runlevel ${runlevel}."
+  fi
+}
+
+disable_openrc() {
+  for runlevel in /etc/runlevels/*; do
+    if [ -e "${runlevel}/netdata" ]; then
+      runlevel="$(basename "${runlevel}")"
+      if ! rc-update del netdata "${runlevel}"; then
+        echo >&2 "WARNING: Failed to disable Netdata service in runlevel ${runlevel}."
+      fi
+    fi
+  done
+}
+
+install_openrc_service() {
+  install_generic_service openrc OpenRC /etc/init.d/netdata enable_openrc disable_openrc
+}
+
+openrc_cmds() {
+  echo "NETDATA_START_CMD='rc-service netdata start'"
+  echo "NETDATA_STOP_CMD='rc-service netdata stop'"
+}
+
+# =====================================================================
+# LSB init script support functions
+
+islsb() {
+  # if there is no /etc/init.d directory, it’s not an LSB system
+  [ ! -d /etc/init.d ] && return 1
+
+  # If it's an OpenRC system, then it's not an LSB system
+  check_openrc && return 1
+
+  # If /lib/lsb/init-functions exists, it’s an LSB system
+  [ -f /lib/lsb/init-functions ] && return 0
+
+  return 1
+}
+
+check_lsb() {
+  if [ -z "${IS_LSB}" ]; then
+    islsb
+    IS_LSB="$?"
+  fi
+
+  return "${IS_LSB}"
+}
+
+enable_lsb() {
+  if ! update-rc.d netdata defaults; then
+    echo >&2 "WARNING: Failed to enable Netdata service."
+  elif ! update-rc.d netdata defaults-disable; then
+    echo >&2 "WARNING: Failed to fully enable Netdata service."
+  fi
+}
+
+disable_lsb() {
+  if ! update-rc.d netdata remove; then
+    echo >&2 "WARNING: Failed to disable Netdata service."
+  fi
+}
+
+install_lsb_service() {
+  install_generic_service lsb LSB /etc/init.d/netdata enable_lsb disable_lsb
+}
+
+lsb_cmds() {
+  if command -v service >/dev/null 2>&1; then
+    echo "NETDATA_START_CMD='service netdata start'"
+    echo "NETDATA_STOP_CMD='service netdata stop'"
+  else
+    echo "NETDATA_START_CMD='/etc/init.d/netdata start'"
+    echo "NETDATA_STOP_CMD='/etc/init.d/netdata stop'"
+  fi
+}
+
+# =====================================================================
+# init.d init script support functions
+
+isinitd() {
+  # if there is no /etc/init.d directory, it’s not an init.d system
+  [ ! -d /etc/init.d ] && return 1
+
+  # if there is no chkconfig command, it's not a (usable) init.d system
+  command -v chkconfig >/dev/null 2>&1 || return 1
+
+  # if it's not an LSB setup, it’s init.d
+  check_initd || return 0
+
+  return 1
+}
+
+check_initd() {
+  if [ -z "${IS_INITD}" ]; then
+    isinitd
+    IS_INITD="$?"
+  fi
+
+  return "${IS_INITD}"
+}
+
+enable_initd() {
+  if ! chkconfig netdata on; then
+    echo >&2 "WARNING: Failed to enable Netdata service."
+  fi
+}
+
+disable_initd() {
+  if ! chkconfig netdata off; then
+    echo >&2 "WARNING: Failed to disable Netdata service."
+  fi
+}
+
+install_initd_service() {
+  install_generic_service init-d init.d /etc/init.d/netdata enable_initd disable_initd
+}
+
+initd_cmds() {
+  if command -v service >/dev/null 2>&1; then
+    echo "NETDATA_START_CMD='service netdata start'"
+    echo "NETDATA_STOP_CMD='service netdata stop'"
+  else
+    echo "NETDATA_START_CMD='/etc/init.d/netdata start'"
+    echo "NETDATA_STOP_CMD='/etc/init.d/netdata stop'"
+  fi
+}
+
+# =====================================================================
+# runit support functions
+#
+# Currently not supported, this exists to provide useful error messages.
+
+isrunit() {
+  # if there is no /lib/rc/sv.d, then it's not runit
+  [ ! -d /lib/rc/sv.d ] && return 1
+
+  # if there is no runit command, then it's not runit
+  command -v runit >/dev/null 2>&1 || return 1
+
+  # if /run/runit exists, then it's runit
+  [ -d /run/runit ] && return 0
+
+  # if /etc/runit/1 exists and is executable, then it's runit
+  [ -x /etc/runit/1 ] && return 0
+
+  return 1
+}
+
+check_runit() {
+  if [ -z "${IS_RUNIT}" ]; then
+    isrunit
+    IS_RUNIT="$?"
+  fi
+
+  return "${IS_RUNIT}"
+}
+
+install_runit_service() {
+  echo "ERROR: Detected runit, which we do not currently support."
+  exit 3
+}
+
+runit_cmds() {
+  echo "ERROR: Detected runit, which we do not currently support."
+  exit 3
+}
+
+# =====================================================================
+# WSL support functions
+#
+# Cannot be supported, this exists to provide useful error messages.
+
+iswsl() {
+  # If uname -r contains the string WSL, then it's WSL.
+  uname -r | grep -q 'WSL' && return 0
+
+  # If uname -r contains the string Microsoft, then it's WSL.
+  # This probably throws a false positive on CBL-Mariner, but it's part of what MS officially recommends for
+  # detecting if you're running under WSL.
+  uname -r | grep -q "Microsoft" && return 0
+
+  return 1
+}
+
+check_wsl() {
+  if [ -z "${IS_WSL}" ]; then
+    iswsl
+    IS_WSL="$?"
+  fi
+
+  return "${IS_WSL}"
+}
+
+install_wsl_service() {
+  echo "ERROR: We appear to be running in WSL. Netdata cannot be automatically installed as a service under WSL."
+  exit 3
+}
+
+wsl_cmds() {
+  echo "ERROR: We appear to be running in WSL. Netdata cannot be automatically installed as a service under WSL."
+  exit 3
+}
+
+# =====================================================================
+# FreeBSD support functions
+
+enable_freebsd() {
+  if ! sysrc netdata_enable=YES; then
+    echo >&2 "WARNING: Failed to enable netdata service."
+  fi
+}
+
+disable_freebsd() {
+  if ! sysrc netdata_enable=NO; then
+    echo >&2 "WARNING: Failed to disable netdata service."
+  fi
+}
+
+install_freebsd_service() {
+  install_generic_service freebsd "FreeBSD rc.d" /usr/local/etc/rc.d/netdata enable_freebsd disable_freebsd
+}
+
+freebsd_cmds() {
+  echo "NETDATA_START_CMD='service netdata start'"
+  echo "NETDATA_STOP_CMD='service netdata stop'"
+  echo "NETDATA_INSTALLER_START_CMD='service netdata onestart'"
+}
+
+# =====================================================================
+# macOS support functions
+
+install_darwin_service() {
+  echo >&2 "Installing macOS plist file for launchd."
+  if ! install -C -S -p -m 0644 -o 0 -g 0 system/netdata.plist /Library/LaunchDaemons/com.github.netdata.plist; then
+    echo >&2 "ERROR: Failed to copy plist file."
+    exit 4
+  fi
+
+  if ! launchctl load /Library/LaunchDaemons/com.github.netdata.plist; then
+    echo >&2 "ERROR: Failed to load plist file."
+    exit 4
+  fi
+}
+
+darwin_cmds() {
+  echo "NETDATA_START_CMD='launchctl start com.github.netdata'"
+  echo "NETDATA_STOP_CMD='launchctl stop com.github.netdata'"
+}
+
+# =====================================================================
+# Linux support functions
+
+detect_linux_svc_type() {
+  if [ "${SVC_TYPE}" = "detect" ]; then
+    for t in ${LINUX_INIT_TYPES}; do
+      if "check_${t}"; then
+        SVC_TYPE="${t}"
+        break
+      fi
+    done
+
+    if [ "${SVC_TYPE}" = "detect" ]; then
+      echo >&2 "ERROR: Failed to detect what type of service manager is in use."
+      exit 2
+    else
+      echo "${SVC_TYPE}"
+    fi
+  else
+    echo "${SVC_TYPE}"
+  fi
+}
+
+install_linux_service() {
+  "install_$(detect_linux_svc_type)_service"
+}
+
+linux_cmds() {
+  "$(detect_linux_svc_type)_cmds"
+}
+
+# =====================================================================
+# Argument handling
+
+parse_args() {
+  while [ -n "${1}" ]; do
+    case "${1}" in
+      "--source" | "-s")
+        SVC_SOURCE="${2}"
+        shift 1
+        ;;
+      "--type" | "-t")
+        if [ "${2}" = "help" ]; then
+          help_types
+          exit 0
+        else
+          SVC_TYPE="${2}"
+          shift 1
+        fi
+        ;;
+      "--cmds" | "-c") DUMP_CMDS=1 ;;
+      "--cmds-only")
+        DUMP_CMDS=1
+        INSTALL=0
+        ;;
+      "--enable" | "-e") ENABLE="enable" ;;
+      "--disable" | "-d") ENABLE="disable" ;;
+      "--help" | "-h")
+        usage
+        exit 0
+        ;;
+      *)
+        echo >&2 "Unrecognized option '${1}'."
+        exit 1
+        ;;
+    esac
+    shift 1
+  done
+
+  if [ "${SVC_SOURCE%@}" = "libsysdir_POST@" ]; then
+    SVC_SOURCE="${SCRIPT_SOURCE}/../../lib/netdata/system"
+    echo "WARNING: SVC_SOURCE not templated, using ${SVC_SOURCE} as source directory."
+  fi
+
+  if [ ! -d "${SVC_SOURCE}" ]; then
+    echo >&2 "ERROR: ${SVC_SOURCE} does not appear to be a directory. Please specify a valid source for service files with the --source option."
+    exit 1
+  fi
+
+  if valid_types | grep -vw "${SVC_TYPE}"; then
+    echo >&2 "ERROR: ${SVC_TYPE} is not supported on this platform."
+    help_types
+    exit 1
+  fi
+}
+
+# =====================================================================
+# Core logic
+
+main() {
+  parse_args "${@}"
+
+  case "${PLATFORM}" in
+    FreeBSD)
+      if [ "${INSTALL}" -eq 1 ]; then
+        install_freebsd_service
+      fi
+      if [ "${DUMP_CMDS}" -eq 1 ]; then
+        freebsd_cmds
+      fi
+      ;;
+    Darwin)
+      if [ "${INSTALL}" -eq 1 ]; then
+        install_darwin_service
+      fi
+      if [ "${DUMP_CMDS}" -eq 1 ]; then
+        darwin_cmds
+      fi
+      ;;
+    Linux)
+      if [ "${INSTALL}" -eq 1 ]; then
+        install_linux_service
+      fi
+      if [ "${DUMP_CMDS}" -eq 1 ]; then
+        linux_cmds
+      fi
+      ;;
+    *)
+      echo >&2 "ERROR: ${PLATFORM} is not supported by this script."
+      exit 5
+  esac
+}
+
+main "${@}"

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -666,6 +666,7 @@ main() {
 
   [ "${DUMP_CMDS}" -eq 1 ] && dump_cmds
   [ "${EXPORT_CMDS}" -eq 1 ] && export_cmds
+  exit 0
 }
 
 main "${@}"

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -588,7 +588,7 @@ install_linux_service() {
     exit 2
   fi
 
-  "install_$(t)_service"
+  "install_${t}_service"
 }
 
 linux_cmds() {
@@ -598,7 +598,7 @@ linux_cmds() {
     exit 2
   fi
 
-  "$(t)_cmds"
+  "${t}_cmds"
 }
 
 # =====================================================================

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -89,7 +89,7 @@ install_generic_service() {
     ENABLE="enable"
   fi
 
-  if ! install -C -S -p -m 0755 -o 0 -g 0 "${SVC_SOURCE}/netdata-${svc_type}" /etc/init.d/netdata; then
+  if ! install -p -m 0755 -o 0 -g 0 "${SVC_SOURCE}/netdata-${svc_type}" /etc/init.d/netdata; then
     error "Failed to install service file."
     exit 4
   fi
@@ -226,7 +226,7 @@ install_systemd_service() {
   fi
 
   info "Installing systemd service..."
-  if ! install -C -S -p -m 0644 -o 0 -g 0 "${SRCFILE}" "$(get_systemd_service_dir)/netdata.service"; then
+  if ! install -p -m 0644 -o 0 -g 0 "${SRCFILE}" "$(get_systemd_service_dir)/netdata.service"; then
     error "Failed to install systemd service file."
     exit 4
   fi

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -133,12 +133,14 @@ dump_cmds() {
   [ -n "${NETDATA_START_CMD}" ] && echo "NETDATA_START_CMD='${NETDATA_START_CMD}'"
   [ -n "${NETDATA_STOP_CMD}" ] && echo "NETDATA_STOP_CMD='${NETDATA_STOP_CMD}'"
   [ -n "${NETDATA_INSTALLER_START_CMD}" ] && echo "NETDATA_INSTALLER_START_CMD='${NETDATA_INSTALLER_START_CMD}'"
+  return 0
 }
 
 export_cmds() {
-  [ -n "${NETDATA_START_CMD}" ] && export NETDATA_START_CMD
-  [ -n "${NETDATA_STOP_CMD}" ] && export NETDATA_STOP_CMD
-  [ -n "${NETDATA_INSTALLER_START_CMD}" ] && export NETDATA_INSTALLER_START_CMD
+  [ -n "${NETDATA_START_CMD}" ] && export NETDATA_START_CMD="${NETDATA_START_CMD}"
+  [ -n "${NETDATA_STOP_CMD}" ] && export NETDATA_STOP_CMD="${NETDATA_STOP_CMD}"
+  [ -n "${NETDATA_INSTALLER_START_CMD}" ] && export NETDATA_INSTALLER_START_CMD="${NETDATA_INSTALLER_START_COMMAND}"
+  return 0
 }
 
 # =====================================================================

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -25,6 +25,7 @@ SCRIPT_SOURCE="$(
 
 DUMP_CMDS=0
 ENABLE="auto"
+EXPORT_CMDS=0
 INSTALL=1
 LINUX_INIT_TYPES="wsl systemd openrc lsb initd runit"
 PLATFORM="$(uname -s)"
@@ -106,6 +107,18 @@ install_generic_service() {
   esac
 }
 
+dump_cmds() {
+  [ -n "${NETDATA_START_CMD}" ] && echo "NETDATA_START_CMD='${NETDATA_START_CMD}'"
+  [ -n "${NETDATA_STOP_CMD}" ] && echo "NETDATA_STOP_CMD='${NETDATA_STOP_CMD}'"
+  [ -n "${NETDATA_INSTALLER_START_CMD}" ] && echo "NETDATA_INSTALLER_START_CMD='${NETDATA_INSTALLER_START_CMD}'"
+}
+
+export_cmds() {
+  [ -n "${NETDATA_START_CMD}" ] && export NETDATA_START_CMD
+  [ -n "${NETDATA_STOP_CMD}" ] && export NETDATA_STOP_CMD
+  [ -n "${NETDATA_INSTALLER_START_CMD}" ] && export NETDATA_INSTALLER_START_CMD
+}
+
 # =====================================================================
 # Help functions
 
@@ -117,7 +130,8 @@ USAGE: install-service.sh [options]
   --source      Specify where to find the service files to install (default ${SVC_SOURCE}).
   --type        Specify the type of service file to install. Specify a type of 'help' to get a list of valid types for your platform.
   --cmds        Additionally print a list of commands for starting and stopping the agent with the detected service type.
-  --cmds-only   Don't install, just produce the output for the --cmds option.
+  --export-cmds Export the variables that would be printed by the --cmds option.
+  --cmds-only   Don't install, just handle the --cmds or --export-cmds option.
   --enable      Explicitly enable the service on install (default is to enable if not already installed).
   --disable     Explicitly disable the service on install.
   --help        Print this help information.
@@ -227,8 +241,8 @@ install_systemd_service() {
 }
 
 systemd_cmds() {
-  echo "NETDATA_START_CMD='systemctl start netdata'"
-  echo "NETDATA_STOP_CMD='systemctl stop netdata'"
+  NETDATA_START_CMD='systemctl start netdata'
+  NETDATA_STOP_CMD='systemctl stop netdata'
 }
 
 # =====================================================================
@@ -287,8 +301,8 @@ install_openrc_service() {
 }
 
 openrc_cmds() {
-  echo "NETDATA_START_CMD='rc-service netdata start'"
-  echo "NETDATA_STOP_CMD='rc-service netdata stop'"
+  NETDATA_START_CMD='rc-service netdata start'
+  NETDATA_STOP_CMD='rc-service netdata stop'
 }
 
 # =====================================================================
@@ -336,11 +350,11 @@ install_lsb_service() {
 
 lsb_cmds() {
   if command -v service >/dev/null 2>&1; then
-    echo "NETDATA_START_CMD='service netdata start'"
-    echo "NETDATA_STOP_CMD='service netdata stop'"
+    NETDATA_START_CMD='service netdata start'
+    NETDATA_STOP_CMD='service netdata stop'
   else
-    echo "NETDATA_START_CMD='/etc/init.d/netdata start'"
-    echo "NETDATA_STOP_CMD='/etc/init.d/netdata stop'"
+    NETDATA_START_CMD='/etc/init.d/netdata start'
+    NETDATA_STOP_CMD='/etc/init.d/netdata stop'
   fi
 }
 
@@ -387,11 +401,11 @@ install_initd_service() {
 
 initd_cmds() {
   if command -v service >/dev/null 2>&1; then
-    echo "NETDATA_START_CMD='service netdata start'"
-    echo "NETDATA_STOP_CMD='service netdata stop'"
+    NETDATA_START_CMD='service netdata start'
+    NETDATA_STOP_CMD='service netdata stop'
   else
-    echo "NETDATA_START_CMD='/etc/init.d/netdata start'"
-    echo "NETDATA_STOP_CMD='/etc/init.d/netdata stop'"
+    NETDATA_START_CMD='/etc/init.d/netdata start'
+    NETDATA_STOP_CMD='/etc/init.d/netdata stop'
   fi
 }
 
@@ -491,9 +505,9 @@ install_freebsd_service() {
 }
 
 freebsd_cmds() {
-  echo "NETDATA_START_CMD='service netdata start'"
-  echo "NETDATA_STOP_CMD='service netdata stop'"
-  echo "NETDATA_INSTALLER_START_CMD='service netdata onestart'"
+  NETDATA_START_CMD='service netdata start'
+  NETDATA_STOP_CMD='service netdata stop'
+  NETDATA_INSTALLER_START_CMD='service netdata onestart'
 }
 
 # =====================================================================
@@ -513,8 +527,8 @@ install_darwin_service() {
 }
 
 darwin_cmds() {
-  echo "NETDATA_START_CMD='launchctl start com.github.netdata'"
-  echo "NETDATA_STOP_CMD='launchctl stop com.github.netdata'"
+  NETDATA_START_CMD='launchctl start com.github.netdata'
+  NETDATA_STOP_CMD='launchctl stop com.github.netdata'
 }
 
 # =====================================================================
@@ -568,10 +582,8 @@ parse_args() {
         fi
         ;;
       "--cmds" | "-c") DUMP_CMDS=1 ;;
-      "--cmds-only")
-        DUMP_CMDS=1
-        INSTALL=0
-        ;;
+      "--cmds-only") INSTALL=0 ;;
+      "--export-cmds") EXPORT_CMDS=1 ;;
       "--enable" | "-e") ENABLE="enable" ;;
       "--disable" | "-d") ENABLE="disable" ;;
       "--help" | "-h")
@@ -611,33 +623,25 @@ main() {
 
   case "${PLATFORM}" in
     FreeBSD)
-      if [ "${INSTALL}" -eq 1 ]; then
-        install_freebsd_service
-      fi
-      if [ "${DUMP_CMDS}" -eq 1 ]; then
-        freebsd_cmds
-      fi
+      [ "${INSTALL}" -eq 1 ] && install_freebsd_service
+      freebsd_cmds
       ;;
     Darwin)
-      if [ "${INSTALL}" -eq 1 ]; then
-        install_darwin_service
-      fi
-      if [ "${DUMP_CMDS}" -eq 1 ]; then
-        darwin_cmds
-      fi
+      [ "${INSTALL}" -eq 1 ] && install_darwin_service
+      darwin_cmds
       ;;
     Linux)
-      if [ "${INSTALL}" -eq 1 ]; then
-        install_linux_service
-      fi
-      if [ "${DUMP_CMDS}" -eq 1 ]; then
-        linux_cmds
-      fi
+      [ "${INSTALL}" -eq 1 ] && install_linux_service
+      linux_cmds
       ;;
     *)
       error "${PLATFORM} is not supported by this script."
       exit 5
+      ;;
   esac
+
+  [ "${DUMP_CMDS}" -eq 1 ] && dump_cmds
+  [ "${EXPORT_CMDS}" -eq 1 ] && export_cmds
 }
 
 main "${@}"

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -233,7 +233,7 @@ get_systemd_service_dir() {
 install_systemd_service() {
   SRCFILE="${SVC_SOURCE}/netdata.service"
 
-  if [ "$(systemctl version | head -n 1 | cut -f 2 -d ' ')" -le 235 ]; then
+  if [ "$(systemctl --version | head -n 1 | cut -f 2 -d ' ')" -le 235 ]; then
     SRCFILE="${SVC_SOURCE}/netdata.service.v235"
   fi
 


### PR DESCRIPTION
##### Summary
This is a comprehensive overhaul of how we handle installation of the Netdata agent as a system service.

It involves the following changes:

- The templated files from `system/` are now installed to `/usr/lib/netdata/system`, allowing them to be utilized by scripts in the installed system instead of requiring them to be handled by the install script.
- A new script named `install-service.sh` has been added. It gets installed to `/usr/libexec/netdata` and bundles all of the logic for detecting what init system or service manager is in use and then actually installing the appropriate service files. It also supports providing information about how to properly start or stop the agent as a system service.
- The installer code has been updated to use the aforementioned script when it is present, both for installing the agent as a system service, and for determining how to restart it. Existing behavior is preserved when the script is not present.

The aforementioned script brings a handful of new features and improvements to our handling of the agent as a system service, including:
- We now properly detect if we’re running under WSL, and provide a more useful error message (this helps with, but does not completely fix #10666).
- We now properly detect if the system is using runit (this is the next most used service management stack on Linux after systemd and OpenRC), and provide a specific error message about it not being supported. Long-term I intend to provide proper support for this, which will be able to reuse the detection code.
- Instead of trying to reinvent the wheel when copying files around, we now use the `install` command which is provided as a standard part of all the platforms we officially support. This gets us proper handling of file ownership and permissions as part of the same command that is copying the data.
- We now use the correct location on FreeBSD for the Netdata service script (under `/usr/local/etc/rc.d` instead of `/etc/rc.d`), and also properly support enabling (or disabling) it when we install the script.
- We now have more robust handling of enabling/disabling the script on non-systemd Linux systems, including correct behavior on OpenRC (which was actually subtly broken).
- We now have full support on all supported platforms and init systems for starting and stopping the agent through the system service manager, instead of just blindly poking at commands and seeing if they work (and completely ignoring macOS and FreeBSD).
- Instead of matching on the distribution name, we now actually use proper detection logic to identify the init system. This resolves a long-standing bug resulting from us blindly assuming that a given system was using the distro's default init system (not always a guarantee, see Arch, Artix, Devuan, and Gentoo for examples of distros which support multiple init systems), and also avoids bogus claims of a lack of support (for example, when using Arch or Artix with OpenRC (which both do support), we would blindly claim we could not install as a system service because we assumed nothing but Gentoo or Alpine used OpenRC).
- Detection of OpenRC is reliant on actually seeing the system booted under OpenRC. This means that hybrid setups involving OpenRC installed alongside another init system will no longer blindly install an OpenRC init script unless OpenRC is actually being used.

##### Test Plan

The heart of the changes here is the new `system/install-service.sh` script. This will be automatically invoked by the installer when building/installing from this branch. Each supported init system needs separate testing, as follows:

- The new WSL error message handling can be tested with any distro running under WSL. It should properly detect both WSL 1 and WSL2.
- Systemd support needs tested across a number of distros using systemd. The primary worry here is ensuring we get the service file put in the right directory.
- OpenRC support can be tested easily on a standard install of Alpine or Gentoo. The adventurous can also relatively easily test on an Arch, Artix, or Devuan system that has been set up to use OpenRC.
- LSB init script support can be tested easily on a standard install of [Devuan](https://www.devuan.org/), which appears to be the only ‘major’ distro that still supports LSB-style init scripts.
- non-LSB init.d script support will require testing on a platform that actually uses such a setup. CentOS 6 theoretically would work here, but would require use of either a static install or a manual build of some of our external dependencies. I have not tested this case myself.
- The new runit detection can be most easily tested on [Void Linux](https://voidlinux.org/) or a runit-based install of [Artix](https://artixlinux.org/). Arch and Gentoo also support using runit in place of their default init systems, but both are somewhat complicated to set up.
- FreeBSD support needs tested on the latest stable releases of FreeBSD 12 and 13.
- macOS launchd support probably only needs tested on the latest version of macOS.

On all platforms listed above other than runit and WSL, once the install is complete the agent should be:

- Installed as a system service using the default service manager.
- Enabled in the default runlevel.
- Running correctly under the service manager.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
These changes improve how we handle integration with system service management tools to allow for more robust support for running Netdata as a system service.

They only affect local builds and static installs, not native packages.
</details>
