### PR TITLE
Skip the anomaly_detection.anomaly_rates chart from the contexts cloud communication

### DIFF
--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -1710,91 +1710,103 @@ static void rrdcontext_trigger_updates(RRDCONTEXT *rc, bool force) {
     rrdcontext_unlock(rc);
 }
 
+// This will go away when we stop creating/maintaining the corresponding chart
+static int is_ar_chart(RRDSET *st)
+{
+    if (st->state && st->state->is_ar_chart)
+        return 1;
+    return 0;
+}
+
 // ----------------------------------------------------------------------------
 // public API
 
 void rrdcontext_updated_rrddim(RRDDIM *rd) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
-
-    rrdmetric_from_rrddim(rd);
+    if (likely(!is_ar_chart(rd->rrdset)))
+        rrdmetric_from_rrddim(rd);
 }
 
 void rrdcontext_removed_rrddim(RRDDIM *rd) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
 
-    rrdmetric_rrddim_is_freed(rd);
+    if (likely(!is_ar_chart(rd->rrdset)))
+        rrdmetric_rrddim_is_freed(rd);
 }
 
 void rrdcontext_updated_rrddim_algorithm(RRDDIM *rd) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
 
-    rrdmetric_updated_rrddim_flags(rd);
+    if (likely(!is_ar_chart(rd->rrdset)))
+        rrdmetric_updated_rrddim_flags(rd);
 }
 
 void rrdcontext_updated_rrddim_multiplier(RRDDIM *rd) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
 
-    rrdmetric_updated_rrddim_flags(rd);
+    if (likely(!is_ar_chart(rd->rrdset)))
+        rrdmetric_updated_rrddim_flags(rd);
 }
 
 void rrdcontext_updated_rrddim_divisor(RRDDIM *rd) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
-
-    rrdmetric_updated_rrddim_flags(rd);
+    if (likely(!is_ar_chart(rd->rrdset)))
+        rrdmetric_updated_rrddim_flags(rd);
 }
 
 void rrdcontext_updated_rrddim_flags(RRDDIM *rd) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
-
-    rrdmetric_updated_rrddim_flags(rd);
+    if (likely(!is_ar_chart(rd->rrdset)))
+        rrdmetric_updated_rrddim_flags(rd);
 }
 
 void rrdcontext_collected_rrddim(RRDDIM *rd) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
-
-    rrdmetric_collected_rrddim(rd);
+    if (likely(!is_ar_chart(rd->rrdset)))
+        rrdmetric_collected_rrddim(rd);
 }
 
 void rrdcontext_updated_rrdset(RRDSET *st) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
-
-    rrdinstance_from_rrdset(st);
+    if (likely(!is_ar_chart(st)))
+        rrdinstance_from_rrdset(st);
 }
 
 void rrdcontext_removed_rrdset(RRDSET *st) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
-
-    rrdinstance_rrdset_is_freed(st);
+    if (likely(!is_ar_chart(st)))
+        rrdinstance_rrdset_is_freed(st);
 }
 
 void rrdcontext_updated_rrdset_name(RRDSET *st) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
-
-    rrdinstance_updated_rrdset_name(st);
+    if (likely(!is_ar_chart(st)))
+        rrdinstance_updated_rrdset_name(st);
 }
 
 void rrdcontext_updated_rrdset_flags(RRDSET *st) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
 
-    rrdinstance_updated_rrdset_flags(st);
+    if (likely(!is_ar_chart(st)))
+        rrdinstance_updated_rrdset_flags(st);
 }
 
 void rrdcontext_collected_rrdset(RRDSET *st) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
-
-    rrdinstance_collected_rrdset(st);
+    if (likely(!is_ar_chart(st)))
+        rrdinstance_collected_rrdset(st);
 }
 
 void rrdcontext_host_child_connected(RRDHOST *host) {

--- a/database/sqlite/sqlite_context.c
+++ b/database/sqlite/sqlite_context.c
@@ -121,7 +121,8 @@ void sql_close_context_database(void)
 // Fetching data
 //
 #define CTX_GET_CHART_LIST  "SELECT c.chart_id, c.type||'.'||c.id, c.name, c.context, c.title, c.unit, c.priority, " \
-        "c.update_every, c.chart_type, c.family FROM meta.chart c WHERE c.host_id = @host_id; "
+        "c.update_every, c.chart_type, c.family FROM meta.chart c WHERE c.host_id = @host_id AND " \
+        "c.context <> '"ML_ANOMALY_RATES_CHART_ID"';"
 
 void ctx_get_chart_list(uuid_t *host_uuid, void (*dict_cb)(SQL_CHART_DATA *, void *), void *data)
 {


### PR DESCRIPTION
##### Summary
Temp fix to skip the processing of `anomaly_detection.anomaly_rates` chart from the contexts and submission to the cloud
(the chart will be removed from the agent soon)


##### Test Plan
- You shouldn't see the `anomaly_detection.anomaly_rates` in the /api/v1/contexts
- In the cloud dashboard, under **Anomaly Detection section**, you should not see the `anomaly rates` chart