### PR TITLE
fix(python.d): handle log rotation by performing force rescan on missing previously monitored log file

### DIFF
--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -630,6 +630,7 @@ class Service(SimpleService):
         self.exclude = configuration.get('exclude_disks', str()).split()
         self.disks = list()
         self.runs = 0
+        self.do_force_rescan = False
 
     def check(self):
         return self.scan() > 0
@@ -637,9 +638,10 @@ class Service(SimpleService):
     def get_data(self):
         self.runs += 1
 
-        if self.runs % DEF_RESCAN_INTERVAL == 0:
+        if self.do_force_rescan or self.runs % DEF_RESCAN_INTERVAL == 0:
             self.cleanup()
             self.scan()
+            self.do_force_rescan = False
 
         data = dict()
 
@@ -654,10 +656,12 @@ class Service(SimpleService):
 
             if changed is None:
                 disk.alive = False
+                self.do_force_rescan = True
                 continue
 
             if changed and disk.populate_attrs() is None:
                 disk.alive = False
+                self.do_force_rescan = True
                 continue
 
             data.update(disk.data())


### PR DESCRIPTION
##### Summary

Fixes: #11305

##### Test Plan

Changes are straightforward - tests are not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
