### PR TITLE
Load host labels for archived hosts

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -313,6 +313,9 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
         , system_info
         , 1
     );
+    if (likely(host))
+        host->host_labels = sql_load_host_labels((uuid_t *)argv[IDX_HOST_ID]);
+
 #ifdef NETDATA_INTERNAL_CHECKS
     char node_str[UUID_STR_LEN] = "<none>";
     if (likely(host->node_id))

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -112,4 +112,5 @@ void migrate_localhost(uuid_t *host_uuid);
 extern void sql_store_host_system_info(uuid_t *host_id, const struct rrdhost_system_info *system_info);
 extern void sql_build_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info);
 void sql_store_host_labels(RRDHOST *host);
+DICTIONARY *sql_load_host_labels(uuid_t *host_id);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
When the agent start and `rrdcontexts = yes`, all archived hosts are loaded in memory

This PR is a followup to #13441 so that those hosts have their host label information available. 

##### Test Plan
- Setup a parent / child agent and make sure you have `rrdcontexts = yes`  on the parent. 
- Start the parent and the child 
  - Check the contexts for the child on the parent using `/host/child/api/v1/contexts?options=full` 
     - Notice the `host_labels` section in the output
  - Stop the parent / child and restart only the parent and check again. Notice the `host_labels` is empty
- Apply the PR, start only the parent and try again
  - You should see the `host_labels` of the child
