### PR TITLE
Fix cgroup name detection for docker containers in containerd cgroup

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -518,6 +518,11 @@ if [ -z "${NAME}" ]; then
     #shellcheck disable=SC1117
     DOCKERID="$(echo "${CGROUP}" | sed "s|^.*ecs[-_/].*[-_/]\([a-fA-F0-9]\+\)[-_\.]\?.*$|\1|")"
     docker_validate_id "${DOCKERID}"
+  elif [[ ${CGROUP} =~ system.slice_containerd.service_cpuset_[a-fA-F0-9]+[-_\.]?.*$ ]]; then
+    # docker containers under containerd
+    #shellcheck disable=SC1117
+    DOCKERID="$(echo "${CGROUP}" | sed "s|^.*ystem.slice_containerd.service_cpuset_\([a-fA-F0-9]\+\)[-_\.]\?.*$|\1|")"
+    docker_validate_id "${DOCKERID}"
   elif [[ ${CGROUP} =~ ^.*libpod-[a-fA-F0-9]+.*$ ]]; then
     # Podman
     PODMANID="$(echo "${CGROUP}" | sed "s|^.*libpod-\([a-fA-F0-9]\+\).*$|\1|")"


### PR DESCRIPTION
##### Summary

Fixes some cgroup names for containers running under Docker not being detected automatically by the cgroup-name.sh` script.

##### Test Plan

I've tested the modified script and resulting Netdata build on my nodes and verified that is runs without an issue and doesn't conflict with other existing cgroup rules.

##### Additional Information

Some Docker containers on a few systems I'm managing live under the `system.slice/containerd.service/cpuset/*` group namespace. These containers are correctly detected by Netdata and shown in the UI, however their names are not detected as they don't match the existing rules in the `cgroup-name.sh` script.

In the image below you can see the top 5 containers have their names correctly extracted (`nomad init *`), but the containers below are just displaying their cgroup paths (`system_slice containerd_service cpuset *`).

![image](https://user-images.githubusercontent.com/28452108/182010157-e59d1259-3afc-4c10-ae65-dcf8352efff5.png)

This pull requests adds a pattern to the `cgroup-name.sh` script that accounts for this alternative path, parses the container ID from the end of the path, and runs it through the docker-based container name detector to extract the correct container names/IDs. After the change, we can see the correct container names being displayed instead of the `system.slice_containerd.service_cpuset_...` path (i.e. `agent-*`, `connect-proxy-*`, etc).

![image](https://user-images.githubusercontent.com/28452108/182010184-24a93c35-22ac-4a30-9a28-6ccf666002ec.png)

I have not been able to establish why the containers live under this alternative group, but I suspected that it has something to do with the containers being spawned by Nomad. However only some containers are effected and others spawned by Nomad are under the expected `docker/` cgroup namespace. Also some containers manually spawned using the `docker` commands sometimes live under this alternative group but I've not found a correlation between any Docker flags and why they're placed under this other group.

<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
This change will make Netdata correctly detect Docker container names for container running under the containerd group and show the correct names on the dashboard instead of their cgroup paths.
</details>
