### PR TITLE
Handle cases where entries where stored as text (with strftime("%s"))

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -871,7 +871,7 @@ void sql_maint_aclk_sync_database(struct aclk_database_worker_config *wc, struct
     BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE);
 
     buffer_sprintf(sql,"DELETE FROM aclk_chart_%s WHERE date_submitted IS NOT NULL AND "
-        "date_updated < unixepoch()-%d;", wc->uuid_str, ACLK_DELETE_ACK_INTERNAL);
+        "CAST(date_updated AS INT) < unixepoch()-%d;", wc->uuid_str, ACLK_DELETE_ACK_INTERNAL);
     db_execute(buffer_tostring(sql));
     buffer_flush(sql);
 
@@ -882,17 +882,17 @@ void sql_maint_aclk_sync_database(struct aclk_database_worker_config *wc, struct
     buffer_flush(sql);
 
     buffer_sprintf(sql,"DELETE FROM aclk_alert_%s WHERE date_submitted IS NOT NULL AND "
-        "date_cloud_ack < unixepoch()-%d;", wc->uuid_str, ACLK_DELETE_ACK_ALERTS_INTERNAL);
+        "CAST(date_cloud_ack AS INT) < unixepoch()-%d;", wc->uuid_str, ACLK_DELETE_ACK_ALERTS_INTERNAL);
     db_execute(buffer_tostring(sql));
     buffer_flush(sql);
 
     buffer_sprintf(sql,"UPDATE aclk_chart_%s SET status = NULL, date_submitted=unixepoch() WHERE "
-            "date_submitted IS NULL AND date_created < unixepoch()-%d;", wc->uuid_str, ACLK_AUTO_MARK_SUBMIT_INTERVAL);
+            "date_submitted IS NULL AND CAST(date_created AS INT) < unixepoch()-%d;", wc->uuid_str, ACLK_AUTO_MARK_SUBMIT_INTERVAL);
     db_execute(buffer_tostring(sql));
     buffer_flush(sql);
 
     buffer_sprintf(sql,"UPDATE aclk_chart_%s SET date_updated = unixepoch() WHERE date_updated IS NULL"
-                " AND date_submitted IS NOT NULL AND date_submitted < unixepoch()-%d;",
+                " AND date_submitted IS NOT NULL AND CAST(date_submitted AS INT) < unixepoch()-%d;",
                 wc->uuid_str, ACLK_AUTO_MARK_UPDATED_INTERVAL);
     db_execute(buffer_tostring(sql));
 


### PR DESCRIPTION
##### Summary
Handle the cases where date_created, date_updated, date_submitted were stored as text
and the cleanup jobs may not work as expected.

With this PR explicit casting to integer will make sure it works as expected

##### Test Plan
- Agent should work as expected -- you will notice better cleanup of stale events in the various `aclk_chart_xxx` dates, especially when you have enabled rrdcontext