### PR TITLE
Remove the single threaded arrayallocator optiomization during agent startup

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -804,8 +804,6 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
     else
         rrdeng_page_descr_use_malloc();
 
-    rrdeng_page_descr_aral_go_singlethreaded();
-
     int created_tiers = 0;
     char dbenginepath[FILENAME_MAX + 1];
     char dbengineconfig[200 + 1];
@@ -881,7 +879,6 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
     else if(!created_tiers)
         fatal("DBENGINE on '%s', failed to initialize databases at '%s'.", hostname, netdata_configured_cache_dir);
 
-    rrdeng_page_descr_aral_go_multithreaded();
 #else
     storage_tiers = config_get_number(CONFIG_SECTION_DB, "storage tiers", 1);
     if(storage_tiers != 1) {


### PR DESCRIPTION
##### Summary
During agent initialization, if data rotation needs to happen, there is a chance to have data corruption in the array
allocator and cause a crash

```
#1  0x000055b3f5911172 in arrayalloc_freez (ar=0x55b3f62b8bc0 <page_descr_aral>, ptr=0x7f90373cb700) at libnetdata/arrayalloc/arrayalloc.c:330
#2  0x000055b3f5c5e3d8 in rrdeng_page_descr_freez (descr=0x7f90373cb700) at database/engine/pagecache.c:29
#3  0x000055b3f5c5f897 in pg_cache_punch_hole (ctx=0x55b3f62ce9a0 <multidb_ctx_storage_tier0>, descr=0x7f90373cb700, remove_dirty=0 '\000', is_exclusive_holder=0 '\000', metric_id=0x7f8ea8b03b70) at database/engine/pagecache.c:540
#4  0x000055b3f5c53def in delete_old_data (arg=0x55b3f62ce9a0 <multidb_ctx_storage_tier0>) at database/engine/rrdengine.c:982
#5  0x00007f9037e3ab43 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#6  0x00007f9037ecca00 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```

This PR removes the optimization that switches the array allocator to single threaded mode during startup (which causes this corruption and crash). 

##### Test Plan
- This is not easy to reproduce. Agent needs to be configured with multiple tiers, and data rotation needs to happen eg. on tier 0 while tier1 is initializing just at the right moment to cause data corruption. 
