### PR TITLE
Provide better container names for Nomad containers

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -57,7 +57,7 @@ function docker_like_get_name_command() {
 
   # Need to do this, in case the NAME is a bunch of spaces
   NAME_TEST="$(echo "${NAME}" | tr -d ' ')"
-  if [ -z "${NAME_TEST}" ] ; then NAME = ""; fi
+  if [ -z "${NAME_TEST}" ] ; then NAME=""; fi
 
   if [ -z "${NAME}" ] ; then
     info "Running command: ${command} ps --filter=id=\"${id}\" --format=\"{{.Names}}\""
@@ -94,7 +94,7 @@ function docker_like_get_name_api() {
 
   # Need to do this, in case the NAME is a bunch of spaces
   NAME_TEST="$(echo "${NAME}" | tr -d ' ')"
-  if [ -z "${NAME_TEST}" ] ; then NAME = ""; fi
+  if [ -z "${NAME_TEST}" ] ; then NAME=""; fi
 
   if [ -z "${NAME}" ]; then
     echo "Not a Nomad container. Setting container name via API"

--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -53,7 +53,7 @@ function docker_like_get_name_command() {
   # The following grabs the components of a Nomad container and makes environment variables out of them before attempting to generate a name.
   # It does this to not assume anything about the order in which the variables appear in the environment. 
   info "Nomad check: Running command: ${command} inspect --format '{{ .Config.Env }}' ${id} | tr ' ' '\n' | grep -e NOMAD_NAMESPACE -e NOMAD_JOB_ID -e NOMAD_SHORT_ALLOC_ID -e NOMAD_TASK_NAME | ..."
-  NAME="$(${command} inspect --format '{{ .Config.Env }}' ${id} | tr ' ' '\n' | grep -e NOMAD_NAMESPACE -e NOMAD_JOB_ID -e NOMAD_SHORT_ALLOC_ID -e NOMAD_TASK_NAME | tr '\n' ' ' | awk '{print $1 " && " $>
+  NAME="$(${command} inspect --format '{{ .Config.Env }}' ${id} | tr ' ' '\n' | grep -e NOMAD_NAMESPACE -e NOMAD_JOB_ID -e NOMAD_SHORT_ALLOC_ID -e NOMAD_TASK_NAME | tr '\n' ' ' | awk '{print $1 " && " $2 " && " $3 " && " $4 "&& echo \"$NOMAD_NAMESPACE $NOMAD_JOB_ID $NOMAD_SHORT_ALLOC_ID $NOMAD_TASK_NAME\""}'|sh)"
 
   # Need to do this, in case the NAME is a bunch of spaces
   NAME_TEST="$(echo "${NAME}" | tr -d ' ')"
@@ -90,7 +90,7 @@ function docker_like_get_name_api() {
   # Check if the container is scheduled by Nomad
   # Exactly the same logic as in docker_like_get_name_command
   info "Nomad check via API results"
-  NAME="$(echo "${JSON}" | jq -r '.Config.Env[] | select(contains("NOMAD_NAMESPACE", "NOMAD_JOB_ID", "NOMAD_SHORT_ALLOC_ID", "NOMAD_TASK_NAME"))' | tr '\n' ' ' | awk '{print $1 " && " $2 " && " $3 " && >
+  NAME="$(echo "${JSON}" | jq -r '.Config.Env[] | select(contains("NOMAD_NAMESPACE", "NOMAD_JOB_ID", "NOMAD_SHORT_ALLOC_ID", "NOMAD_TASK_NAME"))' | tr '\n' ' ' | awk '{print $1 " && " $2 " && " $3 " && " $4 "&& echo \"$NOMAD_NAMESPACE $NOMAD_JOB_ID $NOMAD_SHORT_ALLOC_ID $NOMAD_TASK_NAME\""}'|sh)"
 
   # Need to do this, in case the NAME is a bunch of spaces
   NAME_TEST="$(echo "${NAME}" | tr -d ' ')"


### PR DESCRIPTION
See #12419

##### Summary
Customize the name for containers that are scheduled by Nomad. 
The full discussion and specs are in #12419

##### Test Plan
Install nomad and run example. See https://learn.hashicorp.com/tutorials/nomad/get-started-run?in=nomad/get-started

Run netdata. The container name you see should be something like `default example 9a50c573 redis`
`grep cgroup-name.sh` in the log to validate the flow.

Default code path runs the docker command. Ensure you run both the code paths (also via the API) by changing the `hash docker` condition (e.g. commenting the lines shown below) and installing `jq`

```
#  if hash docker 2> /dev/null; then
 #   docker_like_get_name_command docker "${id}"
 # else
    docker_like_get_name_api DOCKER_HOST "${id}" || docker_like_get_name_command podman "${id}"
  #fi
```


##### Additional Information
Thanks to @xkisu and @ilyam8 