### PR TITLE
Check for protected when excluding mounts

### DIFF
--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -101,28 +101,6 @@ int mount_point_cleanup_cb(const char *name, void *entry, void *data) {
     return mount_point_cleanup(name, (struct mount_point_metadata *)entry, 0);
 }
 
-// for the full list of protected mount points look at
-// https://github.com/systemd/systemd/blob/1eb3ef78b4df28a9e9f464714208f2682f957e36/src/core/namespace.c#L142-L149
-// https://github.com/systemd/systemd/blob/1eb3ef78b4df28a9e9f464714208f2682f957e36/src/core/namespace.c#L180-L194
-static const char *systemd_protected_mount_points[] = {
-    "/home",
-    "/root",
-    "/usr",
-    "/boot",
-    "/efi",
-    "/etc",
-    NULL
-};
-
-int mount_point_is_protected(char *mount_point)
-{
-    for (size_t i = 0; systemd_protected_mount_points[i] != NULL; i++)
-        if (!strcmp(mount_point, systemd_protected_mount_points[i]))
-            return 1;
-
-    return 0;
-}
-
 // a copy of basic mountinfo fields
 struct basic_mountinfo {
     char *persistent_id;    
@@ -452,7 +430,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
     if (unlikely(
             mi->flags & MOUNTINFO_READONLY &&
-            !mount_point_is_protected(mi->mount_point) &&
+            !(mi->flags & MOUNTINFO_IS_PROTECTED) &&
             !m->collected &&
             m->do_space != CONFIG_BOOLEAN_YES &&
             m->do_inodes != CONFIG_BOOLEAN_YES))
@@ -687,7 +665,7 @@ void *diskspace_main(void *ptr) {
                 continue;
 
             // exclude mounts made by ProtectHome and ProtectSystem systemd hardening options
-            if(mi->flags & MOUNTINFO_READONLY && !strcmp(mi->root, mi->mount_point))
+            if(mi->flags & MOUNTINFO_READONLY && mi->flags & MOUNTINFO_IS_PROTECTED && !strcmp(mi->root, mi->mount_point))
                 continue;
 
             worker_is_busy(WORKER_JOB_MOUNTPOINT);

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -665,6 +665,7 @@ void *diskspace_main(void *ptr) {
                 continue;
 
             // exclude mounts made by ProtectHome and ProtectSystem systemd hardening options
+            // https://github.com/netdata/netdata/issues/11498#issuecomment-950982878
             if(mi->flags & MOUNTINFO_READONLY && mi->flags & MOUNTINFO_IS_IN_SYSD_PROTECTED_LIST && !strcmp(mi->root, mi->mount_point))
                 continue;
 

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -430,7 +430,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
     if (unlikely(
             mi->flags & MOUNTINFO_READONLY &&
-            !(mi->flags & MOUNTINFO_IS_PROTECTED) &&
+            !(mi->flags & MOUNTINFO_IS_IN_SYSD_PROTECTED_LIST) &&
             !m->collected &&
             m->do_space != CONFIG_BOOLEAN_YES &&
             m->do_inodes != CONFIG_BOOLEAN_YES))
@@ -665,7 +665,7 @@ void *diskspace_main(void *ptr) {
                 continue;
 
             // exclude mounts made by ProtectHome and ProtectSystem systemd hardening options
-            if(mi->flags & MOUNTINFO_READONLY && mi->flags & MOUNTINFO_IS_PROTECTED && !strcmp(mi->root, mi->mount_point))
+            if(mi->flags & MOUNTINFO_READONLY && mi->flags & MOUNTINFO_IS_IN_SYSD_PROTECTED_LIST && !strcmp(mi->root, mi->mount_point))
                 continue;
 
             worker_is_busy(WORKER_JOB_MOUNTPOINT);

--- a/collectors/proc.plugin/proc_self_mountinfo.c
+++ b/collectors/proc.plugin/proc_self_mountinfo.c
@@ -182,6 +182,28 @@ static inline int is_read_only(const char *s) {
     return 0;
 }
 
+// for the full list of protected mount points look at
+// https://github.com/systemd/systemd/blob/1eb3ef78b4df28a9e9f464714208f2682f957e36/src/core/namespace.c#L142-L149
+// https://github.com/systemd/systemd/blob/1eb3ef78b4df28a9e9f464714208f2682f957e36/src/core/namespace.c#L180-L194
+static const char *systemd_protected_mount_points[] = {
+    "/home",
+    "/root",
+    "/usr",
+    "/boot",
+    "/efi",
+    "/etc",
+    NULL
+};
+
+static inline int mount_point_is_protected(char *mount_point)
+{
+    for (size_t i = 0; systemd_protected_mount_points[i] != NULL; i++)
+        if (!strcmp(mount_point, systemd_protected_mount_points[i]))
+            return 1;
+
+    return 0;
+}
+
 // read the whole mountinfo into a linked list
 struct mountinfo *mountinfo_read(int do_statvfs) {
     char filename[FILENAME_MAX + 1];
@@ -251,6 +273,9 @@ struct mountinfo *mountinfo_read(int do_statvfs) {
 
         if(unlikely(is_read_only(mi->mount_options)))
             mi->flags |= MOUNTINFO_READONLY;
+
+        if(unlikely(mount_point_is_protected(mi->mount_point)))
+           mi->flags |= MOUNTINFO_IS_PROTECTED;
 
         // count the optional fields
 /*

--- a/collectors/proc.plugin/proc_self_mountinfo.c
+++ b/collectors/proc.plugin/proc_self_mountinfo.c
@@ -192,6 +192,11 @@ static const char *systemd_protected_mount_points[] = {
     "/boot",
     "/efi",
     "/etc",
+    "/run/user",
+    "/lib",
+    "/lib64",
+    "/bin",
+    "/sbin",
     NULL
 };
 

--- a/collectors/proc.plugin/proc_self_mountinfo.c
+++ b/collectors/proc.plugin/proc_self_mountinfo.c
@@ -275,7 +275,7 @@ struct mountinfo *mountinfo_read(int do_statvfs) {
             mi->flags |= MOUNTINFO_READONLY;
 
         if(unlikely(mount_point_is_protected(mi->mount_point)))
-           mi->flags |= MOUNTINFO_IS_PROTECTED;
+           mi->flags |= MOUNTINFO_IS_IN_SYSD_PROTECTED_LIST;
 
         // count the optional fields
 /*

--- a/collectors/proc.plugin/proc_self_mountinfo.h
+++ b/collectors/proc.plugin/proc_self_mountinfo.h
@@ -10,6 +10,7 @@
 #define MOUNTINFO_NO_STAT       0x00000010
 #define MOUNTINFO_NO_SIZE       0x00000020
 #define MOUNTINFO_READONLY      0x00000040
+#define MOUNTINFO_IS_PROTECTED  0x00000080
 
 struct mountinfo {
     long id;                // mount ID: unique identifier of the mount (may be reused after umount(2)).

--- a/collectors/proc.plugin/proc_self_mountinfo.h
+++ b/collectors/proc.plugin/proc_self_mountinfo.h
@@ -10,7 +10,7 @@
 #define MOUNTINFO_NO_STAT       0x00000010
 #define MOUNTINFO_NO_SIZE       0x00000020
 #define MOUNTINFO_READONLY      0x00000040
-#define MOUNTINFO_IS_PROTECTED  0x00000080
+#define MOUNTINFO_IS_IN_SYSD_PROTECTED_LIST 0x00000080
 
 struct mountinfo {
     long id;                // mount ID: unique identifier of the mount (may be reused after umount(2)).


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR adds an extra check when excluding mounts that are protected by systemd via ProtectHome and ProtectSystem. The check added is to make sure that the mount is indeed in the list of mounts protected by systemd.

Without this extra check when `/` is read-only (or appears as read-only to netdata via `ReadOnlyDirectories=/`) will be also skipped and there is no way to at least enable disk space monitoring via a configuration option.

With this check, an entry in `netdata.conf` is required:

```
[plugin:proc:diskspace:/]
	space usage = yes
	inodes usage = yes
```

but that seems to be [expected](https://github.com/netdata/netdata/tree/master/collectors/diskspace.plugin).

Seems a better "workaround" than what we did in #13383 .

The PR also moves the check whether a mount point is protected to a flag to avoid checking it via the loop.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Needs to be tested via a netdata that is run with a service file that includes `ReadOnlyDirectories=/`. By default it won't monitor disk space usage, but with the change in `netdata.conf` as above, it should.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

I'm not experienced in systemd, and don't have a system with different mounts for /home etc, so hopefully it doesn't break the fixes done by https://github.com/netdata/netdata/pull/11767.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
