### PR TITLE
feat(cgroups.plugin): resolve nomad containers name (docker driver only)

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -47,14 +47,11 @@ fatal() {
 
 function parse_docker_like_inspect_output() {
   local output="${1}"
-  nomad_ns="$(echo "$output" | grep NOMAD_NAMESPACE | cut -d= -f 2)"
-  nomad_job_name="$(echo "$output" | grep NOMAD_JOB_NAME | cut -d= -f 2)"
-  nomad_task_name="$(echo "$output" | grep NOMAD_TASK_NAME | cut -d= -f 2)"
-  nomad_alloc_id="$(echo "$output" | grep NOMAD_SHORT_ALLOC_ID | cut -d= -f 2)"
-  if [ -n "$nomad_ns" ] && [ -n "$nomad_job_name" ] && [ -n "$nomad_task_name" ] && [ -n "$nomad_alloc_id" ]; then
-    echo "${nomad_ns}-${nomad_job_name}-${nomad_task_name}-${nomad_alloc_id}"
+  eval "$(grep -E "^(NOMAD_NAMESPACE|NOMAD_JOB_NAME|NOMAD_TASK_NAME|NOMAD_SHORT_ALLOC_ID|CONT_NAME)=" <<<"$output")"
+  if [ -n "$NOMAD_NAMESPACE" ] && [ -n "$NOMAD_JOB_NAME" ] && [ -n "$NOMAD_TASK_NAME" ] && [ -n "$NOMAD_SHORT_ALLOC_ID" ]; then
+    echo "${NOMAD_NAMESPACE}-${NOMAD_JOB_NAME}-${NOMAD_TASK_NAME}-${NOMAD_SHORT_ALLOC_ID}"
   else
-    echo "$output" | grep -m 1 CONT_NAME | cut -d= -f 2 | sed 's|^/||'
+    echo "${CONT_NAME}" | sed 's|^/||'
   fi
 }
 


### PR DESCRIPTION
##### Summary

Fixes: #12419
Closes: #13475

This PR adds containers name resolution for Nomad tasks. Name: "NAMESPACE-JOBNAME-TASKNAME-SHORTALLOCID".

> **Note** It works only when using the [Docker driver](https://www.nomadproject.io/docs/drivers).

---

Before this PR:

- use `docker ps ...` if `docker` command **is available** (Netdata running on the host).
- use [ContainerInspect](https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerInspect) endpoint if `docker` command **is not available** (Netdata running inside a Docker container).

This PR changes:

- use `docker inspect ...` if `docker` command **is available**. This is equivalent to the ContainerInspect endpoint (but we can apply additional formatting).

##### Test Plan

- start several Docker containers and Nomad containers.
- check their names on the dashboard.

**Tested both scenarios**: Netdata is running in a Docker container/Netdata installed on the host.

1st one is nomad, 2nd one is docker.

<img width="225" alt="Screenshot 2022-08-03 at 17 00 27" src="https://user-images.githubusercontent.com/22274335/182627314-8ce7be15-d07c-4e43-a400-32afee6f0287.png">


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
