### PR TITLE
Add Fedora 37 to CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -99,12 +99,22 @@ include:
 
   - &fedora
     distro: fedora
-    version: "36"
+    version: "37"
     jsonc_removal: |
       dnf remove -y json-c-devel
     packages: &fedora_packages
       type: rpm
       repo_distro: fedora/36
+      arches:
+        - x86_64
+        - aarch64
+    test:
+      ebpf-core: true
+  - <<: *fedora
+    version: "36"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/35
       arches:
         - x86_64
         - armhfp
@@ -116,6 +126,10 @@ include:
     packages:
       <<: *fedora_packages
       repo_distro: fedora/35
+      arches:
+        - x86_64
+        - armhfp
+        - aarch64
     test:
       ebpf-core: true
 

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -57,6 +57,7 @@ to work on these platforms with minimal user effort.
 | Docker | 19.03 or newer | x86\_64, i386, ARMv7, AArch64, POWER8+ | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker |
 | Debian | 11.x | x86\_64, i386, ARMv7, AArch64 | |
 | Debian | 10.x | x86\_64, i386, ARMv7, AArch64 | |
+| Fedora | 37 | x86\_64, AArch64 | |
 | Fedora | 36 | x86\_64, ARMv7, AArch64 | |
 | Fedora | 35 | x86\_64, ARMv7, AArch64 | |
 | openSUSE | Leap 15.4 | x86\_64, AArch64 | |


### PR DESCRIPTION
##### Summary

Tentative beta release date is no earlier than 2022-09-13.
Tentative full release date is no earlier than 2022-10-18

##### Test Plan

CI passes on this PR.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
The Netdata team will officially start supporting Fedora 37.
</details>