### PR TITLE
netdata.service: Update PIDFile to avoid systemd legacy path warning

### DIFF
--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -11,12 +11,12 @@ User=netdata
 Group=netdata
 RuntimeDirectory=netdata
 RuntimeDirectoryMode=0775
-PIDFile=@localstatedir_POST@/run/netdata/netdata.pid
-ExecStart=@sbindir_POST@/netdata -P @localstatedir_POST@/run/netdata/netdata.pid -D
+PIDFile=/run/netdata/netdata.pid
+ExecStart=@sbindir_POST@/netdata -P /run/netdata/netdata.pid -D
 ExecStartPre=/bin/mkdir -p @localstatedir_POST@/cache/netdata
 ExecStartPre=/bin/chown -R netdata:netdata @localstatedir_POST@/cache/netdata
-ExecStartPre=/bin/mkdir -p @localstatedir_POST@/run/netdata
-ExecStartPre=/bin/chown -R netdata:netdata @localstatedir_POST@/run/netdata
+ExecStartPre=/bin/mkdir -p /run/netdata
+ExecStartPre=/bin/chown -R netdata:netdata /run/netdata
 PermissionsStartOnly=true
 
 # saving a big db on slow disks may need some time


### PR DESCRIPTION
##### Summary
netdata.service: Update PIDFile to avoid systemd legacy path warning

Resolves warning logged by systemd:
systemd[1]: /lib/systemd/system/netdata.service:14: PIDFile= references a path below legacy directory /var/run/, updating /var/run/netdata/netdata.pid → /run/netdata/netdata.pid; please update the unit file accordingly.

##### Test Plan

Run the systemd service, note that it works, and no warning is logged.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
No visible change except that the systemd logged warning eliminated.

See: https://www.freedesktop.org/software/systemd/man/systemd.service.html#PIDFile=
</details>

Fixes: https://github.com/netdata/netdata/issues/10304