### PR TITLE
fix(packaging): add CAP_NET_ADMIN for go.d.plugin

### DIFF
--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -63,6 +63,10 @@ case "$1" in
         setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin
     fi
 
+    if [ -f "/usr/libexec/netdata/plugins.d/go.d.plugin" ]; then
+      setcap cap_net_admin+epi /usr/libexec/netdata/plugins.d/go.d.plugin
+    fi
+
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network
     chmod 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1443,6 +1443,9 @@ install_go() {
     run chown "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
   fi
   run chmod 0750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
+  if command -v setcap 1>/dev/null 2>&1; then
+    run setcap cap_net_admin+epi "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
+  fi
   rm -rf "${tmp}"
 
   [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -515,6 +515,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 # freeipmi files
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 
+# go.d.plugin (the capability required for wireguard module)
+%caps(cap_net_admin=epi) %{_libexecdir}/%{name}/plugins.d/go.d.plugin
+
 # Enforce 0644 for files and 0755 for directories
 # for the netdata web directory
 %defattr(0644,root,root,0755)

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -214,6 +214,10 @@ for x in apps.plugin freeipmi.plugin ioping cgroup-network ebpf.plugin perf.plug
   fi
 done
 
+if [ -f "usr/libexec/netdata/plugins.d/go.d.plugin" ] && command -v setcap 1>/dev/null 2>&1; then
+  run setcap cap_net_admin+epi "usr/libexec/netdata/plugins.d/go.d.plugin"
+fi
+
 # fix the fping binary
 if [ -f bin/fping ]; then
   run chown root:${NETDATA_GROUP} bin/fping


### PR DESCRIPTION
##### Summary

Fixes: #13505

The capability required for [wireguard collector](https://github.com/netdata/go.d.plugin/tree/master/modules/wireguard#wireguard-monitoring-with-netdata).

Fixed install cases:
 - [x] from source
 - [X] deb package
 - [X] rpm package
 - [x] static build

##### Test Plan

Install and check go.d.plugin capabilities:

- deb package
- rpm package
- static build
- from source

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
