### PR TITLE
Calculate name hash after rrdvar_fix_name

### DIFF
--- a/health/health_config.c
+++ b/health/health_config.c
@@ -686,7 +686,6 @@ static int health_readfile(const char *filename, void *data) {
             rc = callocz(1, sizeof(RRDCALC));
             rc->next_event_id = 1;
             rc->name = strdupz(value);
-            rc->hash = simple_hash(rc->name);
             rc->source = health_source_file(line, filename);
             rc->green = NAN;
             rc->red = NAN;
@@ -703,6 +702,7 @@ static int health_readfile(const char *filename, void *data) {
             if(rrdvar_fix_name(rc->name))
                 error("Health configuration renamed alarm '%s' to '%s'", value, rc->name);
 
+            rc->hash = simple_hash(rc->name);
             alert_cfg->alarm = strdupz(rc->name);
             ignore_this = 0;
         }
@@ -724,7 +724,6 @@ static int health_readfile(const char *filename, void *data) {
 
             rt = callocz(1, sizeof(RRDCALCTEMPLATE));
             rt->name = strdupz(value);
-            rt->hash_name = simple_hash(rt->name);
             rt->source = health_source_file(line, filename);
             rt->green = NAN;
             rt->red = NAN;
@@ -738,6 +737,7 @@ static int health_readfile(const char *filename, void *data) {
             if(rrdvar_fix_name(rt->name))
                 error("Health configuration renamed template '%s' to '%s'", value, rt->name);
 
+            rt->hash_name = simple_hash(rt->name);
             alert_cfg->template_key = strdupz(rt->name);
             ignore_this = 0;
         }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Moves the calculation of `simple_hash` for alarms and templates after the `rrdvar_fix_name` so that if it changes the name, the hash will be calculated on the changed name rather than on the original.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Change an alarm's name so that it will be fixed, e.g. change `alarm: load_average_15` to `alarm: load average_15`.

Without this PR if you go to the dashboard and list all alerts, the badge on this one will be `alarm not found`. With this PR it should appear correctly.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
