### PR TITLE
Print rrdcontexts versions with PRIu64

### DIFF
--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -1381,7 +1381,7 @@ static void rrdcontext_message_send_unsafe(RRDCONTEXT *rc, bool snapshot __maybe
     }
     else {
         if (ctx_store_context(&rc->rrdhost->host_uuid, &rc->hub) != 0)
-            error("RRDCONTEXT: failed to save context '%s' version %lu to SQL.", rc->hub.id, rc->hub.version);
+            error("RRDCONTEXT: failed to save context '%s' version %"PRIu64" to SQL.", rc->hub.id, rc->hub.version);
     }
 }
 
@@ -1425,7 +1425,7 @@ static bool check_if_cloud_version_changed_unsafe(RRDCONTEXT *rc, bool sending _
 
     if(unlikely(id_changed || title_changed || units_changed || family_changed || chart_type_changed || priority_changed || first_time_changed || last_time_changed || deleted_changed)) {
 
-        internal_error(true, "RRDCONTEXT: %s NEW VERSION '%s'%s, version %zu, title '%s'%s, units '%s'%s, family '%s'%s, chart type '%s'%s, priority %u%s, first_time_t %ld%s, last_time_t %ld%s, deleted '%s'%s, (queued for %llu ms, expected %llu ms)",
+        internal_error(true, "RRDCONTEXT: %s NEW VERSION '%s'%s, version %"PRIu64", title '%s'%s, units '%s'%s, family '%s'%s, chart type '%s'%s, priority %u%s, first_time_t %ld%s, last_time_t %ld%s, deleted '%s'%s, (queued for %llu ms, expected %llu ms)",
                        sending?"SENDING":"QUEUE",
                        string2str(rc->id), id_changed ? " (CHANGED)" : "",
                        rc->version,
@@ -1458,7 +1458,7 @@ static void rrdcontext_insert_callback(const char *id, void *value, void *data) 
         // we are loading data from the SQL database
 
         if(rc->version)
-            error("RRDCONTEXT: context '%s' is already initialized with version %lu, but it is loaded again from SQL with version %lu", string2str(rc->id), rc->version, rc->hub.version);
+            error("RRDCONTEXT: context '%s' is already initialized with version %"PRIu64", but it is loaded again from SQL with version %"PRIu64"", string2str(rc->id), rc->version, rc->hub.version);
 
         // IMPORTANT
         // replace all string pointers in rc->hub with our own versions
@@ -1942,7 +1942,7 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
     uint64_t our_version_hash = rrdcontext_version_hash(host);
 
     if(cmd->version_hash != our_version_hash) {
-        error("RRDCONTEXT: received version hash %lu for host '%s', does not match our version hash %lu. Sending snapshot of all contexts.",
+        error("RRDCONTEXT: received version hash %"PRIu64" for host '%s', does not match our version hash %"PRIu64". Sending snapshot of all contexts.",
               cmd->version_hash, host->hostname, our_version_hash);
 
 #ifdef ENABLE_ACLK
@@ -2339,8 +2339,8 @@ static inline int rrdcontext_to_json_callback(const char *id, void *value, void 
                        ",\n\t\t\t\"last_queued\":%llu"
                        ",\n\t\t\t\"scheduled_dispatch\":%llu"
                        ",\n\t\t\t\"last_dequeued\":%llu"
-                       ",\n\t\t\t\"hub_version\":%lu"
-                       ",\n\t\t\t\"version\":%lu"
+                       ",\n\t\t\t\"hub_version\":%"PRIu64""
+                       ",\n\t\t\t\"version\":%"PRIu64""
                        , rc->queue.queued_ut / USEC_PER_SEC
                        , rc->queue.scheduled_dispatch_ut / USEC_PER_SEC
                        , rc->queue.dequeued_ut / USEC_PER_SEC
@@ -2702,7 +2702,7 @@ void rrdcontext_delete_from_sql_unsafe(RRDCONTEXT *rc) {
 
     // delete it from SQL
     if(ctx_delete_context(&rc->rrdhost->host_uuid, &rc->hub) != 0)
-        error("RRDCONTEXT: failed to delete context '%s' version %lu from SQL.", rc->hub.id, rc->hub.version);
+        error("RRDCONTEXT: failed to delete context '%s' version %"PRIu64" from SQL.", rc->hub.id, rc->hub.version);
 }
 
 static void rrdcontext_garbage_collect(void) {

--- a/database/sqlite/sqlite_context.c
+++ b/database/sqlite/sqlite_context.c
@@ -445,13 +445,13 @@ static void dict_ctx_get_context_list_cb(VERSIONED_CONTEXT_DATA *context_data, v
 {
     (void)data;
     info("   Context id = %s "
-         "version = %lu "
+         "version = %"PRIu64" "
          "title = %s "
          "chart_type = %s "
          "units = %s "
-         "priority = %lu "
-         "first time = %lu "
-         "last time = %lu "
+         "priority = %"PRIu64" "
+         "first time = %"PRIu64" "
+         "last time = %"PRIu64" "
          "deleted = %d "
          "family = %s",
          context_data->id,


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR uses `PRIu64` whenever it is required to print rrdcontext's version which is `uint64_t`.

Without this patch the agent might crash in 32bit distributions (at least on arm 32bit) whenever a print is made that includes the version number.

It should not change any functionality other than fix the crashes.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

We need some tests on 32bit distributions. I have only checked on Raspbian 32bit, but without cloud functionality. Not sure if there is a problem on x86 32bit. I need to properly setup it to include cloud, but since rrdcontext runs even without cloud, I believe it should be ok.

1. Setup a 32bit environment. The problem exists at least on `Raspbian GNU/Linux 11` on rpi4.
2. Build the master, use `-DNETDATA_INTERNAL_CHECKS=1` which will cause rrdcontexts to print a lot of information in the log file. Check if agent crashes.
3. Apply the patch and check again.

1. Test the same setup (without `-DNETDATA_INTERNAL_CHECKS=1`) but claimed to the cloud.
2. Try to induce a mismatch in agent/cloud versions (delete netdata-meta.db)
3. Without this patch it could crash.

1. Check `/api/v1/rrdcontexts?options=queue` which includes versions.

If someone could also check on x86 32bit it would be great.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

There are also similar places that need change in other parts of the code. We should gradually do it, but I don't think they currently affect the agent.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
