### PR TITLE
Remove extra U from log message

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -79,7 +79,7 @@ _cannot_use_tmpdir() {
 if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}"; then
   if _cannot_use_tmpdir /tmp; then
     if _cannot_use_tmpdir "${PWD}"; then
-      fatal "UUnable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." I0000
+      fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." I0000
     else
       TMPDIR="${PWD}"
     fi


### PR DESCRIPTION
##### Summary
This is a minor cosmetic change that removes an extraneous `U` from a `fatal`-level log message.

##### Test Plan

Since this is a minor cosmetic change, I have no test plan.
