### PR TITLE
docs(postfix): add a note about `authorized_mailq_users`

### DIFF
--- a/collectors/python.d.plugin/postfix/README.md
+++ b/collectors/python.d.plugin/postfix/README.md
@@ -6,22 +6,31 @@ sidebar_label: "Postfix"
 
 # Postfix monitoring with Netdata
 
-Monitors MTA email queue statistics using postqueue tool.  
+Monitors MTA email queue statistics using [postqueue](http://www.postfix.org/postqueue.1.html) tool.
 
-Execute `postqueue -p` to grab postfix queue.
+The collector executes  `postqueue -p` to get Postfix queue statistics.
+
+## Requirements
+
+Postfix has internal access controls that limit activities on the mail queue. By default, all users are allowed to view
+the queue. If your system is configured with stricter access controls, you need to grant the `netdata` user access to
+view the mail queue. In order to do it, add `netdata` to `authorized_mailq_users` in the `/etc/postfix/main.cf` file.
+
+See the `authorized_mailq_users` setting in
+the [Postfix documentation](https://www.postfix.org/postconf.5.html) for more details.
+
+## Charts
 
 It produces only two charts:
 
-1.  **Postfix Queue Emails**
+1. **Postfix Queue Emails**
 
-    -   emails
+    - emails
 
-2.  **Postfix Queue Emails Size** in KB
+2. **Postfix Queue Emails Size** in KB
 
-    -   size
+    - size
+
+## Configuration
 
 Configuration is not needed.
-
----
-
-


### PR DESCRIPTION
##### Summary

Suggested in https://community.netdata.cloud/t/advice-for-unfunctional-postfix-plugin/3172

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
